### PR TITLE
Harden bounded owner result construction

### DIFF
--- a/.github/scripts/manage-test-timings
+++ b/.github/scripts/manage-test-timings
@@ -8,13 +8,14 @@ import io
 import json
 import math
 import os
+import re
 import sys
 import urllib.parse
 import urllib.request
 import zipfile
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 ROOT = Path(__file__).resolve().parents[2]
 TIMING_SUITES = ("benchmark",)
@@ -22,6 +23,9 @@ MAX_BYTES = 5 * 1024 * 1024
 MAX_ENTRIES = 10_000
 MAX_CANDIDATES = 5
 HTTP_TIMEOUT_SECONDS = 10
+MAX_TIMING_HISTORY_AGE = timedelta(days=30)
+"""Maximum age of a successful main-branch timing baseline."""
+_SOURCE_SHA = re.compile(r"[0-9a-f]{40}(?:[0-9a-f]{24})?\Z", re.IGNORECASE)
 
 
 class CrossOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
@@ -137,7 +141,7 @@ def download(url: str, token: str) -> bytes:
     )
     opener = urllib.request.build_opener(CrossOriginRedirectHandler())
     with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
-        return response.read(MAX_BYTES + 1)
+        return cast(bytes, response.read(MAX_BYTES + 1))
 
 
 def write_durations(path: Path, durations: dict[str, float]) -> None:
@@ -148,6 +152,28 @@ def write_durations(path: Path, durations: dict[str, float]) -> None:
     )
 
 
+def _timestamp(value: Any, label: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be an RFC3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{label} must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _require_recent_timestamp(value: Any, label: str, *, now: datetime) -> None:
+    timestamp = _timestamp(value, label)
+    if timestamp > now:
+        raise ValueError(f"{label} is in the future")
+    if now - timestamp > MAX_TIMING_HISTORY_AGE:
+        raise ValueError(
+            f"{label} exceeds the {MAX_TIMING_HISTORY_AGE.days}-day timing-history age"
+        )
+
+
 def artifact_durations(
     artifact: dict[str, Any],
     *,
@@ -155,13 +181,18 @@ def artifact_durations(
     repository: str,
     token: str,
     suite: str,
+    now: datetime | None = None,
 ) -> dict[str, float] | None:
+    now = now or datetime.now(UTC)
     run = api_json(
         f"{api}/repos/{repository}/actions/runs/{artifact['workflow_run']['id']}",
         token,
     )
     if run.get("head_branch") != "main" or run.get("conclusion") != "success":
         return None
+    _require_recent_timestamp(
+        artifact.get("created_at"), "timing artifact creation", now=now
+    )
 
     archive = download(artifact["archive_download_url"], token)
     if len(archive) > MAX_BYTES:
@@ -180,6 +211,14 @@ def artifact_durations(
         or payload.get("shard_count") != shard_count(suite)
     ):
         raise ValueError("timing artifact metadata is incompatible")
+    _require_recent_timestamp(
+        payload.get("generated_at"), "timing artifact generation", now=now
+    )
+    source_sha = payload.get("source_sha")
+    if not isinstance(source_sha, str) or _SOURCE_SHA.fullmatch(source_sha) is None:
+        raise ValueError("timing artifact source SHA is invalid")
+    if source_sha != run.get("head_sha"):
+        raise ValueError("timing artifact source SHA does not match its workflow run")
     return validate_durations(payload.get("durations"), filename, suite)
 
 
@@ -251,9 +290,7 @@ def merge(
 ) -> None:
     count = shard_count(suite)
     if len(inputs) != count:
-        raise ValueError(
-            f"expected {count} shard timing files, received {len(inputs)}"
-        )
+        raise ValueError(f"expected {count} shard timing files, received {len(inputs)}")
     merged: dict[str, float] = {}
     for path in inputs:
         payload = load_json_bytes(path.read_bytes(), str(path))

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -120,7 +120,10 @@ the result validator still requires each selected task exactly once. The
 planner accepts an optional positive-seconds timing file and otherwise falls
 back to equal weights. Successful full runs on `main` publish median per-task
 timings as an artifact and cache; later plans restore that uncommitted history
-automatically.
+automatically. Timing hints older than 30 days (or dated in the future) are
+rejected, so the planner safely returns to equal shard weights until a fresh
+successful `main` run publishes replacement evidence. The merge job also
+uploads a predicted-versus-actual report for every host shard.
 
 Observation results are normalized into content-bound JSON before comparison.
 Correctness, evidence validity, scope, assurance calibration, false

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -425,6 +425,14 @@ it is safe for the algorithm, and test both the rejected adversarial case and a
 useful case near the boundary. Do not use a post-hoc output-term cap,
 truncation, sentinel, or host exception as a hidden computational budget.
 
+For every non-trivially priced operation, owner tests must instrument the
+priced kernel primitives on a representative near-envelope request and assert
+that executed units do not exceed the admission charge. Pair that parity proof
+with an adversarial useful request whose actual work fits, so a stale or
+over-broad estimate cannot survive merely by rejecting it. Use the test-only
+``tests.fixtures.accounting.assert_executed_work_is_charged`` helper; do not
+add a shared production ledger.
+
 ### Execution time and deadline composition
 
 Exact mathematical work may legitimately take minutes or longer. Unless an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,8 +214,16 @@ ignore_imports = [
     "jacobian.math.** -> jacobian.catalog.admission",
     # The logic domain launches bounded external solvers via jacobian.process.
     "jacobian.math.logic._sat -> jacobian.process",
+    "jacobian.math.logic._smt -> jacobian.process",
+    "jacobian.math.logic._unsat_core -> jacobian.process",
     # These owners each isolate a bounded, maintained external backend.
     "jacobian.math.graphs.isomorphism._operations -> jacobian.process",
+    "jacobian.math.graphs._independence_z3 -> jacobian.process",
+    "jacobian.math.graphs.coloring._operations -> jacobian.process",
+    "jacobian.math.graphs.optimization._chromatic_number -> jacobian.process",
+    "jacobian.math.graphs.optimization._finite_optimization -> jacobian.process",
+    "jacobian.math.graphs.optimization._invariants -> jacobian.process",
+    "jacobian.math.hypergraphs._independence_z3 -> jacobian.process",
     "jacobian.math.number_field._operations -> jacobian.process",
     "jacobian.math.number_theory._factorization_kernels -> jacobian.process",
     # Private exact-algebra adapters share one bounded Singular process owner.

--- a/src/jacobian/math/discrepancy_theory/_models.py
+++ b/src/jacobian/math/discrepancy_theory/_models.py
@@ -492,7 +492,9 @@ def _feasibility_outcome(
 
     try:
         import z3  # type: ignore[import-untyped]
-
+    except (ImportError, OSError):
+        return "unknown"
+    try:
         solver = z3.Solver()
         solver.set(timeout=max(1, MAX_OPTIMUM_PROOF_MILLISECONDS))
         bits = [z3.Bool(f"b_{index}") for index in range(n)]
@@ -504,7 +506,7 @@ def _feasibility_outcome(
             solver.add(signed_sum <= allowed)
             solver.add(signed_sum >= -allowed)
         status = solver.check()
-    except Exception:
+    except z3.Z3Exception:
         return "unknown"
     if status == z3.sat:
         return "sat"
@@ -517,11 +519,10 @@ class DiscrepancyOptimumResult(StrictModel):
     """A proven-minimum coloring or an exhausted solver budget.
 
     Source-bound on its set system: ``OPTIMAL`` carries the exact minimum
-    discrepancy and one witnessing coloring. Deserialization replays the
-    witness against the retained system and independently re-establishes
-    the lower bound: zero is definitional, and any positive claimed optimum
-    must be backed by an explicit unsat of the exact feasibility program
-    that asks for a coloring of imbalance at most one less.
+    discrepancy and one witnessing coloring. Deserialization validates only
+    the retained source and the witness's attained discrepancy. Independently
+    supplied optimality claims are replayed by
+    :func:`verify_discrepancy_optimum_result` under its explicit proof budget.
     ``BUDGET_EXCEEDED`` makes no mathematical claim: it carries neither a
     coloring nor a discrepancy value.
     """
@@ -567,28 +568,22 @@ class DiscrepancyOptimumResult(StrictModel):
                 "the reported discrepancy must be the exact maximum imbalance "
                 "of the returned coloring",
             )
-        self._require_lower_bound()
         return self
 
-    def _require_lower_bound(self) -> None:
-        """Re-establish minimality; only a proven lower bound may pass."""
 
-        assert self.optimal_discrepancy is not None
-        if self.optimal_discrepancy == 0:
-            return
-        outcome = _feasibility_outcome(self.set_system, self.optimal_discrepancy - 1)
-        if outcome == "unsat":
-            return
-        if outcome == "sat":
-            raise _validation_error(
-                "optimality_disproved",
-                "a coloring with smaller imbalance exists; the claimed "
-                "optimum is not minimal",
-            )
-        raise _validation_error(
-            "optimality_unproven",
-            "claimed optimality was not established within the replay budget",
-        )
+def verify_discrepancy_optimum_result(result: DiscrepancyOptimumResult) -> bool:
+    """Replay one independently supplied positive optimum within the proof cap."""
+
+    if result.status != "OPTIMAL":
+        return True
+    if result.optimal_discrepancy is None:
+        return False
+    if result.optimal_discrepancy == 0:
+        return True
+    return (
+        _feasibility_outcome(result.set_system, result.optimal_discrepancy - 1)
+        == "unsat"
+    )
 
 
 def _proven_optimal_result(
@@ -598,10 +593,9 @@ def _proven_optimal_result(
 ) -> DiscrepancyOptimumResult:
     """Build a proven-optimal result after one producing incumbent solve.
 
-    Direct construction from the producing solve skips result replay so one
-    declared budget covers all solver work; independently supplied results
-    always validate through ``bind_optimal_coloring``, which replays the
-    witness and re-establishes the lower bound.
+    Direct construction is permitted after the owner kernel has established
+    witness feasibility and the exact lower-bound proof. Independently
+    supplied results use :func:`verify_discrepancy_optimum_result`.
     """
 
     return DiscrepancyOptimumResult.model_construct(
@@ -667,4 +661,5 @@ __all__ = [
     "HardConstraintRowLedger",
     "MonitoredColumn",
     "MonitoredColumnLedger",
+    "verify_discrepancy_optimum_result",
 ]

--- a/src/jacobian/math/discrepancy_theory/_operations.py
+++ b/src/jacobian/math/discrepancy_theory/_operations.py
@@ -308,7 +308,7 @@ def compute_optimal_discrepancy(
                 "node_limit": MAX_OPTIMUM_SOLVER_NODES,
             },
         )
-    except Exception:
+    except (ImportError, OSError, RuntimeError, TypeError, ValueError):
         # Backend initialization, program construction, and the solve are one
         # bounded external call: an ABI/loader, native, or raised failure
         # there is transport, not mathematics, so report the typed claim-free
@@ -366,7 +366,7 @@ def _incumbent_outcome(
         outcome = discrepancy_models._feasibility_outcome(
             request.set_system, recomputed - 1
         )
-    except Exception:
+    except (ImportError, OSError, RuntimeError, TypeError, ValueError):
         # An unavailable exact proof cannot back the OPTIMAL claim; report
         # the claim-free outcome instead of escaping the kernel.
         return _budget_exceeded_result(request.set_system)

--- a/src/jacobian/math/finite_abelian_groups.py
+++ b/src/jacobian/math/finite_abelian_groups.py
@@ -114,50 +114,78 @@ class FiniteAbelianGroupFactorizationRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_bounded_product_group(self) -> Self:
-        FiniteAbelianProductGroup(moduli=self.moduli)
-        if prod(self.moduli) > MAX_FINITE_GROUP_ORDER:
-            raise _validation_error(
-                "factorization_group_order",
-                "finite abelian group exceeds the 4,096-element bound",
-            )
-        if len(self.left) * len(self.right) > MAX_FINITE_GROUP_ORDER:
-            raise _validation_error(
-                "factorization_pair_count",
-                "factor Cartesian product exceeds the 4,096-pair bound",
-            )
-        if any(
-            len(element) != len(self.moduli)
-            for factor in (self.left, self.right)
-            for element in factor
-        ):
-            raise _validation_error(
-                "factorization_element_rank",
-                "every factor element must match the group rank",
-            )
-        if any(
-            abs(coordinate) > MAX_FINITE_GROUP_COORDINATE
-            for factor in (self.left, self.right)
-            for element in factor
-            for coordinate in element
-        ):
-            raise _validation_error(
-                "factorization_coordinate_bound",
-                "factor coordinates exceed the input bound",
-            )
-        for factor in (self.left, self.right):
-            normalized = {
-                tuple(
-                    coordinate % modulus
-                    for coordinate, modulus in zip(element, self.moduli, strict=True)
-                )
-                for element in factor
-            }
-            if len(normalized) != len(factor):
-                raise _validation_error(
-                    "factorization_duplicate_element",
-                    "factor elements must be distinct after normalization",
-                )
+        _require_factorization_admission(
+            FiniteAbelianProductGroup(moduli=self.moduli), self.left, self.right
+        )
         return self
+
+
+def _require_factorization_admission(
+    group: FiniteAbelianProductGroup,
+    left: tuple[tuple[int, ...], ...],
+    right: tuple[tuple[int, ...], ...],
+) -> None:
+    """Apply the exhaustive factorization envelope to canonical native values."""
+
+    if len(group.moduli) > MAX_FINITE_GROUP_RANK:
+        raise _validation_error(
+            "factorization_group_rank",
+            "finite abelian group exceeds the six-axis factorization bound",
+        )
+    if group.order > MAX_FINITE_GROUP_ORDER:
+        raise _validation_error(
+            "factorization_group_order",
+            "finite abelian group exceeds the 4,096-element bound",
+        )
+    if not left or not right:
+        raise _validation_error(
+            "factorization_empty_factor", "factor elements must be nonempty"
+        )
+    if (
+        len(left) > MAX_FINITE_GROUP_FACTOR_SIZE
+        or len(right) > MAX_FINITE_GROUP_FACTOR_SIZE
+    ):
+        raise _validation_error(
+            "factorization_factor_size",
+            "factor elements exceed the 256-element bound",
+        )
+    if len(left) * len(right) > MAX_FINITE_GROUP_ORDER:
+        raise _validation_error(
+            "factorization_pair_count",
+            "factor Cartesian product exceeds the 4,096-pair bound",
+        )
+    if any(
+        len(element) != len(group.moduli)
+        for factor in (left, right)
+        for element in factor
+    ):
+        raise _validation_error(
+            "factorization_element_rank",
+            "every factor element must match the group rank",
+        )
+    if any(
+        abs(coordinate) > MAX_FINITE_GROUP_COORDINATE
+        for factor in (left, right)
+        for element in factor
+        for coordinate in element
+    ):
+        raise _validation_error(
+            "factorization_coordinate_bound",
+            "factor coordinates exceed the input bound",
+        )
+    for factor in (left, right):
+        normalized = {
+            tuple(
+                coordinate % modulus
+                for coordinate, modulus in zip(element, group.moduli, strict=True)
+            )
+            for element in factor
+        }
+        if len(normalized) != len(factor):
+            raise _validation_error(
+                "factorization_duplicate_element",
+                "factor elements must be distinct after normalization",
+            )
 
 
 class FiniteAbelianSpectralPairSource(StrictModel):
@@ -810,11 +838,14 @@ class FiniteAbelianGroupFactorizationResult(StrictModel):
 
 
 def finite_abelian_group_factorization(
-    request: FiniteAbelianGroupFactorizationRequest,
+    group: FiniteAbelianProductGroup,
+    left: tuple[tuple[int, ...], ...],
+    right: tuple[tuple[int, ...], ...],
 ) -> FiniteAbelianGroupFactorizationResult:
-    """Exhaustively test unique representation in a product of cyclic groups."""
+    """Exhaustively test unique representation from canonical group values."""
 
-    moduli = request.moduli
+    _require_factorization_admission(group, left, right)
+    moduli = group.moduli
 
     def normalize(element: tuple[int, ...]) -> tuple[int, ...]:
         return tuple(
@@ -822,13 +853,13 @@ def finite_abelian_group_factorization(
             for coordinate, modulus in zip(element, moduli, strict=True)
         )
 
-    left = tuple(sorted(normalize(element) for element in request.left))
-    right = tuple(sorted(normalize(element) for element in request.right))
+    normalized_left = tuple(sorted(normalize(element) for element in left))
+    normalized_right = tuple(sorted(normalize(element) for element in right))
     representations: dict[
         tuple[int, ...], list[tuple[tuple[int, ...], tuple[int, ...]]]
     ] = {}
-    for left_element in left:
-        for right_element in right:
+    for left_element in normalized_left:
+        for right_element in normalized_right:
             total = tuple(
                 (left_coordinate + right_coordinate) % modulus
                 for left_coordinate, right_coordinate, modulus in zip(
@@ -836,14 +867,14 @@ def finite_abelian_group_factorization(
                 )
             )
             representations.setdefault(total, []).append((left_element, right_element))
-    group = tuple(product(*(range(modulus) for modulus in moduli)))
-    histogram = Counter(len(representations.get(element, ())) for element in group)
+    elements = tuple(product(*(range(modulus) for modulus in moduli)))
+    histogram = Counter(len(representations.get(element, ())) for element in elements)
     first_missing = next(
-        (element for element in group if element not in representations),
+        (element for element in elements if element not in representations),
         None,
     )
     duplicate_element = next(
-        (element for element in group if len(representations.get(element, ())) > 1),
+        (element for element in elements if len(representations.get(element, ())) > 1),
         None,
     )
     duplicate = None
@@ -857,13 +888,15 @@ def finite_abelian_group_factorization(
             other_right=second[1],
         )
     group_order = prod(moduli)
-    exact = len(left) * len(right) == group_order and histogram == {1: group_order}
+    exact = len(normalized_left) * len(
+        normalized_right
+    ) == group_order and histogram == {1: group_order}
     return FiniteAbelianGroupFactorizationResult(
         moduli=moduli,
-        normalized_left=left,
-        normalized_right=right,
+        normalized_left=normalized_left,
+        normalized_right=normalized_right,
         group_order=group_order,
-        pair_count=len(left) * len(right),
+        pair_count=len(normalized_left) * len(normalized_right),
         distinct_sum_count=len(representations),
         representation_histogram=tuple(
             FiniteAbelianRepresentationCount(
@@ -875,6 +908,16 @@ def finite_abelian_group_factorization(
         is_exact_factorization=exact,
         first_missing=None if exact else first_missing,
         first_duplicate=None if exact else duplicate,
+    )
+
+
+def _run_finite_abelian_group_factorization(
+    request: FiniteAbelianGroupFactorizationRequest,
+) -> FiniteAbelianGroupFactorizationResult:
+    """Adapt the catalog request onto the canonical native boundary once."""
+
+    return finite_abelian_group_factorization(
+        FiniteAbelianProductGroup(moduli=request.moduli), request.left, request.right
     )
 
 

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -2,18 +2,27 @@
 
 from __future__ import annotations
 
+import json
+import math
+import sys
 import time
 from collections.abc import Iterator
-from typing import Literal
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Literal
 
-import z3  # type: ignore[import-untyped]
-
+from jacobian.canonical import CanonicalLimits
 from jacobian.math.graphs.independence import (
     IndependenceNumberBudget,
     IndependenceNumberRequest,
     IndependenceNumberResult,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
 
 # Independent result verification is deliberately separate from structural
 # Pydantic parsing. Its branch-and-bound search has both a finite node ledger
@@ -22,9 +31,16 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 _EXACT_REPLAY_SEARCH_NODES = 200_000
 _INDEPENDENT_VERIFICATION_WALL_SECONDS = 5
 _MAX_INDEPENDENT_VERIFICATION_WALL_SECONDS = 120
+_INDEPENDENCE_WORKER = Path(__file__).with_name("_independence_z3_worker.py")
+_WORKER_OUTPUT_BYTES = CanonicalLimits().max_output_bytes
+_WORKER_ERROR_BYTES = 16_384
+_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 
 
-def _integer_bound(value: z3.ArithRef, fallback: int) -> int:
+def _integer_bound(value: Any, fallback: int) -> int:
+    import z3  # type: ignore[import-untyped]
+
     return value.as_long() if z3.is_int_value(value) else fallback
 
 
@@ -206,7 +222,7 @@ def solve_independence_number(
     return solve_independence_number_values(request.graph, request.resource_budget)
 
 
-def solve_independence_number_values(
+def _solve_independence_number_values_kernel(
     graph: SimpleUndirectedGraph,
     resource_budget: IndependenceNumberBudget,
 ) -> IndependenceNumberResult:
@@ -248,6 +264,8 @@ def solve_independence_number_values(
             termination_reason="WALL_TIME",
             detail="the wall-clock budget expired after the initial feasible witness",
         )
+
+    import z3
 
     optimizer = z3.Optimize()
     optimizer.set(timeout=max(1, remaining_ms))
@@ -330,3 +348,66 @@ def solve_independence_number_values(
         termination_reason=termination,
         detail="bounded Z3 optimization did not establish an exact optimum",
     )
+
+
+def solve_independence_number_values(
+    graph: SimpleUndirectedGraph,
+    resource_budget: IndependenceNumberBudget,
+) -> IndependenceNumberResult:
+    """Run all Z3 optimization and exact replay in one bounded owner worker."""
+
+    incumbent = () if not graph.vertices else (min(graph.vertices),)
+
+    def fallback(detail: str) -> IndependenceNumberResult:
+        return IndependenceNumberResult._from_kernel(
+            graph=graph,
+            status="UNKNOWN",
+            optimum_value=None,
+            upper_bound=len(graph.vertices),
+            incumbent_vertices=incumbent,
+            termination_reason="SOLVER_UNKNOWN",
+            detail=detail,
+        )
+
+    try:
+        with TemporaryDirectory(prefix="jacobian-graph-independence-") as directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_INDEPENDENCE_WORKER)],
+                input_bytes=json.dumps(
+                    {
+                        "graph": graph.model_dump(mode="json"),
+                        "resource_budget": resource_budget.model_dump(mode="json"),
+                    },
+                    separators=(",", ":"),
+                ).encode("utf-8"),
+                timeout_seconds=resource_budget.wall_seconds,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_WORKER_OUTPUT_BYTES,
+                stderr_limit=_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(resource_budget.wall_seconds)),
+                    address_space_bytes=_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=directory,
+            )
+    except OSError:
+        return fallback("the bounded graph independence worker could not be started")
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return fallback(
+            "the bounded graph independence worker did not establish an outcome"
+        )
+    try:
+        return IndependenceNumberResult.model_validate(
+            json.loads(completed.stdout.decode("utf-8"))
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return fallback(
+            "the bounded graph independence worker returned malformed output"
+        )

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -385,6 +385,7 @@ def solve_independence_number_values(
                         "resource_budget": resource_budget.model_dump(mode="json"),
                     },
                     separators=(",", ":"),
+                    ensure_ascii=False,
                 ).encode("utf-8"),
                 timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
@@ -415,10 +416,11 @@ def solve_independence_number_values(
         )
     try:
         result = IndependenceNumberResult.model_validate(
-            json.loads(completed.stdout.decode("utf-8"))
+            {
+                **json.loads(completed.stdout.decode("utf-8")),
+                "graph": graph.model_dump(mode="json"),
+            }
         )
-        if result.graph != graph:
-            raise ValueError("worker result is bound to a different graph")
         return (
             result
             if time.monotonic() < deadline

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -369,8 +369,14 @@ def solve_independence_number_values(
             detail=detail,
         )
 
+    deadline = time.monotonic() + resource_budget.wall_seconds
     try:
         with TemporaryDirectory(prefix="jacobian-graph-independence-") as directory:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return fallback(
+                    "the graph independence request expired before worker startup"
+                )
             completed = run_bounded_process(
                 [sys.executable, str(_INDEPENDENCE_WORKER)],
                 input_bytes=json.dumps(
@@ -380,7 +386,7 @@ def solve_independence_number_values(
                     },
                     separators=(",", ":"),
                 ).encode("utf-8"),
-                timeout_seconds=resource_budget.wall_seconds,
+                timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
                 stdout_limit=_WORKER_OUTPUT_BYTES,
                 stderr_limit=_WORKER_ERROR_BYTES,
@@ -403,9 +409,22 @@ def solve_independence_number_values(
         return fallback(
             "the bounded graph independence worker did not establish an outcome"
         )
+    if time.monotonic() >= deadline:
+        return fallback(
+            "the graph independence request expired before response validation"
+        )
     try:
-        return IndependenceNumberResult.model_validate(
+        result = IndependenceNumberResult.model_validate(
             json.loads(completed.stdout.decode("utf-8"))
+        )
+        if result.graph != graph:
+            raise ValueError("worker result is bound to a different graph")
+        return (
+            result
+            if time.monotonic() < deadline
+            else fallback(
+                "the graph independence request expired during response validation"
+            )
         )
     except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
         return fallback(

--- a/src/jacobian/math/graphs/_independence_z3_worker.py
+++ b/src/jacobian/math/graphs/_independence_z3_worker.py
@@ -1,0 +1,35 @@
+"""Isolated Z3 adapter for one bounded graph-independence optimization."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.graphs._independence_z3 import (
+    _solve_independence_number_values_kernel,
+)
+from jacobian.math.graphs.independence import IndependenceNumberBudget
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        if not isinstance(payload, dict):
+            raise ValueError("worker payload must be an object")
+        graph = SimpleUndirectedGraph.model_validate(payload["graph"])
+        resource_budget = IndependenceNumberBudget.model_validate(
+            payload["resource_budget"]
+        )
+        result = _solve_independence_number_values_kernel(graph, resource_budget)
+        sys.stdout.write(
+            json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
+        )
+        return 0
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/graphs/_independence_z3_worker.py
+++ b/src/jacobian/math/graphs/_independence_z3_worker.py
@@ -24,7 +24,11 @@ def main() -> int:
         )
         result = _solve_independence_number_values_kernel(graph, resource_budget)
         sys.stdout.write(
-            json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
+            json.dumps(
+                result.model_dump(mode="json", exclude={"graph"}),
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
         )
         return 0
     except (KeyError, TypeError, ValueError, json.JSONDecodeError):

--- a/src/jacobian/math/graphs/coloring/_models.py
+++ b/src/jacobian/math/graphs/coloring/_models.py
@@ -212,9 +212,9 @@ class KColorabilityRequest(StrictModel):
         le=MAX_SOLVER_CONFLICT_BUDGET,
         description=(
             "Request-visible SAT work budget: the exact solver is cut off "
-            "after this many conflict clauses; an exhausted budget yields "
-            "the typed SOLVER_BUDGET_EXCEEDED outcome instead of an "
-            "unbounded wait or a negative conclusion."
+            "after this many conflict clauses; that exhaustion yields "
+            "SOLVER_BUDGET_EXCEEDED, while execution failures are reported "
+            "separately without a mathematical conclusion."
         ),
     )
 
@@ -234,7 +234,7 @@ class KColorabilityResult(StrictModel):
         ge=1,
         le=MAX_SOLVER_CONFLICT_BUDGET,
     )
-    status: Literal["DECIDED", "SOLVER_BUDGET_EXCEEDED"] = "DECIDED"
+    status: Literal["DECIDED", "SOLVER_BUDGET_EXCEEDED", "EXECUTION_FAILED"] = "DECIDED"
     colorable: bool | None = None
     coloring: tuple[int, ...] | None = None
     vertex_count: int = Field(ge=0, le=MAX_COLORING_VERTICES)
@@ -246,7 +246,7 @@ class KColorabilityResult(StrictModel):
         graph: IndexedSimpleUndirectedGraph,
         colors: int,
         solver_conflicts: int,
-        status: Literal["DECIDED", "SOLVER_BUDGET_EXCEEDED"],
+        status: Literal["DECIDED", "SOLVER_BUDGET_EXCEEDED", "EXECUTION_FAILED"],
         colorable: bool | None,
         coloring: tuple[int, ...] | None,
     ) -> Self:
@@ -270,7 +270,7 @@ class KColorabilityResult(StrictModel):
                 "graph.vertex_count_must_equal_the_graph_s_vertex_count",
                 "vertex_count must equal the graph's vertex count",
             )
-        if self.status == "SOLVER_BUDGET_EXCEEDED":
+        if self.status in {"SOLVER_BUDGET_EXCEEDED", "EXECUTION_FAILED"}:
             _require_k_colorability_budget_exceeded_shape(self)
             return self
         if self.colorable is None:
@@ -508,9 +508,9 @@ class EdgeKColorabilityRequest(StrictModel):
         le=MAX_SOLVER_CONFLICT_BUDGET,
         description=(
             "Request-visible SAT work budget: the exact solver is cut off "
-            "after this many conflict clauses; an exhausted budget yields "
-            "the typed SOLVER_BUDGET_EXCEEDED outcome instead of an "
-            "unbounded wait or a negative conclusion."
+            "after this many conflict clauses; that exhaustion yields "
+            "SOLVER_BUDGET_EXCEEDED, while execution failures are reported "
+            "separately without a mathematical conclusion."
         ),
     )
 
@@ -530,7 +530,7 @@ class EdgeKColorabilityResult(StrictModel):
         ge=1,
         le=MAX_SOLVER_CONFLICT_BUDGET,
     )
-    status: Literal["DECIDED", "SOLVER_BUDGET_EXCEEDED"] = "DECIDED"
+    status: Literal["DECIDED", "SOLVER_BUDGET_EXCEEDED", "EXECUTION_FAILED"] = "DECIDED"
     colorable: bool | None = None
     coloring: EdgeColoringAssignment | None = None
     edge_count: StrictInt = Field(ge=0, le=MAX_EDGE_COLORING_EDGES)
@@ -542,7 +542,7 @@ class EdgeKColorabilityResult(StrictModel):
         graph: SimpleUndirectedGraph,
         colors: int,
         solver_conflicts: int,
-        status: Literal["DECIDED", "SOLVER_BUDGET_EXCEEDED"],
+        status: Literal["DECIDED", "SOLVER_BUDGET_EXCEEDED", "EXECUTION_FAILED"],
         colorable: bool | None,
         coloring: EdgeColoringAssignment | None,
     ) -> Self:
@@ -566,7 +566,7 @@ class EdgeKColorabilityResult(StrictModel):
                 "graph.edge_count_must_equal_the_number_of_graph_edges",
                 "edge_count must equal the number of graph edges",
             )
-        if self.status == "SOLVER_BUDGET_EXCEEDED":
+        if self.status in {"SOLVER_BUDGET_EXCEEDED", "EXECUTION_FAILED"}:
             _require_budget_exceeded_shape(self)
             return self
         if self.colorable is None:

--- a/src/jacobian/math/graphs/coloring/_operations.py
+++ b/src/jacobian/math/graphs/coloring/_operations.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import json
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Literal
+
 from jacobian.math.graphs.coloring._chromatic_number_models import (
     ChromaticNumberCertificateCheckRequest,
     ChromaticNumberCertificateCheckResult,
@@ -23,9 +29,25 @@ from jacobian.math.graphs.values import (
     IndexedSimpleUndirectedGraph,
     SimpleUndirectedGraph,
 )
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+# ``max_conflicts`` bounds only Z3's search.  Formula construction and model
+# extraction remain executable work, so the owner also places the complete
+# transaction in a killable process with a deliberately generous fallback
+# envelope.  Its expiry carries no mathematical conclusion.
+_COLORING_WORKER = Path(__file__).with_name("_worker.py")
+_COLORING_WORKER_WALL_SECONDS = 30
+_WORKER_OUTPUT_BYTES = 64 * 1024
+_WORKER_ERROR_BYTES = 16_384
+_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 
 
-def _run_k_colorability_solver(
+def _run_k_colorability_solver_kernel(
     graph: IndexedSimpleUndirectedGraph,
     colors: int,
     solver_conflicts: int,
@@ -48,7 +70,7 @@ def _run_k_colorability_solver(
     return "unknown", None
 
 
-def _run_edge_coloring_solver(
+def _run_edge_coloring_solver_kernel(
     graph: SimpleUndirectedGraph,
     colors: int,
     solver_conflicts: int,
@@ -70,6 +92,65 @@ def _run_edge_coloring_solver(
     if outcome == z3.unsat:
         return "unsat", None
     return "unknown", None
+
+
+def _run_coloring_worker(
+    kind: Literal["vertex", "edge"],
+    graph: IndexedSimpleUndirectedGraph | SimpleUndirectedGraph,
+    colors: int,
+    solver_conflicts: int,
+) -> tuple[str, tuple[int, ...] | None]:
+    """Run one complete coloring solver transaction in an isolated worker."""
+
+    try:
+        with TemporaryDirectory(prefix="jacobian-graph-coloring-") as directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_COLORING_WORKER)],
+                input_bytes=json.dumps(
+                    {
+                        "kind": kind,
+                        "graph": graph.model_dump(mode="json"),
+                        "colors": colors,
+                        "solver_conflicts": solver_conflicts,
+                    },
+                    separators=(",", ":"),
+                ).encode("utf-8"),
+                timeout_seconds=_COLORING_WORKER_WALL_SECONDS,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_WORKER_OUTPUT_BYTES,
+                stderr_limit=_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=_COLORING_WORKER_WALL_SECONDS,
+                    address_space_bytes=_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=directory,
+            )
+    except OSError:
+        return "unknown", None
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return "unknown", None
+    try:
+        payload = json.loads(completed.stdout.decode("utf-8"))
+        outcome = payload["outcome"]
+        coloring = payload["coloring"]
+        if outcome not in {"sat", "unsat", "unknown"}:
+            raise ValueError("worker returned an invalid solver outcome")
+        if coloring is None:
+            return outcome, None
+        if not isinstance(coloring, list) or not all(
+            isinstance(value, int) and not isinstance(value, bool) for value in coloring
+        ):
+            raise ValueError("worker returned an invalid coloring")
+        return outcome, tuple(coloring)
+    except (UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return "unknown", None
 
 
 def compute_chromatic_number_certificate_check(
@@ -137,8 +218,8 @@ def compute_k_colorability(request: KColorabilityRequest) -> KColorabilityResult
     separately supplied negative or incomplete claims may be replayed through
     the explicit verifier.
     """
-    outcome, coloring = _run_k_colorability_solver(
-        request.graph, request.colors, request.solver_conflicts
+    outcome, coloring = _run_coloring_worker(
+        "vertex", request.graph, request.colors, request.solver_conflicts
     )
     if outcome == "sat":
         if coloring is None:
@@ -177,8 +258,8 @@ def verify_k_colorability_result(result: KColorabilityResult) -> bool:
 
     if result.status == "DECIDED" and result.colorable is True:
         return True
-    outcome, _coloring = _run_k_colorability_solver(
-        result.graph, result.colors, result.solver_conflicts
+    outcome, _coloring = _run_coloring_worker(
+        "vertex", result.graph, result.colors, result.solver_conflicts
     )
     if result.status == "SOLVER_BUDGET_EXCEEDED":
         return outcome == "unknown"
@@ -245,8 +326,8 @@ def compute_edge_k_colorability(
 
     if not edges:
         return _colorable_result(())
-    outcome, coloring = _run_edge_coloring_solver(
-        request.graph, request.colors, request.solver_conflicts
+    outcome, coloring = _run_coloring_worker(
+        "edge", request.graph, request.colors, request.solver_conflicts
     )
     if outcome == "sat":
         if coloring is None:
@@ -278,8 +359,8 @@ def verify_edge_k_colorability_result(result: EdgeKColorabilityResult) -> bool:
 
     if result.status == "DECIDED" and result.colorable is True:
         return True
-    outcome, _coloring = _run_edge_coloring_solver(
-        result.graph, result.colors, result.solver_conflicts
+    outcome, _coloring = _run_coloring_worker(
+        "edge", result.graph, result.colors, result.solver_conflicts
     )
     if result.status == "SOLVER_BUDGET_EXCEEDED":
         return outcome == "unknown"

--- a/src/jacobian/math/graphs/coloring/_operations.py
+++ b/src/jacobian/math/graphs/coloring/_operations.py
@@ -133,6 +133,7 @@ def _run_coloring_worker(
                         "solver_conflicts": solver_conflicts,
                     },
                     separators=(",", ":"),
+                    ensure_ascii=False,
                 ).encode("utf-8"),
                 timeout_seconds=_COLORING_WORKER_WALL_SECONDS,
                 environment=worker_environment(locale="C.UTF-8"),

--- a/src/jacobian/math/graphs/coloring/_operations.py
+++ b/src/jacobian/math/graphs/coloring/_operations.py
@@ -45,53 +45,72 @@ _WORKER_OUTPUT_BYTES = 64 * 1024
 _WORKER_ERROR_BYTES = 16_384
 _WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
 _WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
+_ColoringWorkerOutcome = Literal["sat", "unsat", "budget_exceeded", "execution_failed"]
 
 
 def _run_k_colorability_solver_kernel(
     graph: IndexedSimpleUndirectedGraph,
     colors: int,
     solver_conflicts: int,
-) -> tuple[str, tuple[int, ...] | None]:
+) -> tuple[_ColoringWorkerOutcome, tuple[int, ...] | None]:
     """Run the existing bounded vertex-coloring Z3 adapter once."""
 
     import z3  # type: ignore[import-untyped]
 
-    solver = z3.Solver()
-    solver.set("max_conflicts", solver_conflicts)
-    vertex_colors = [z3.Int(f"color_{vertex}") for vertex in range(graph.vertex_count)]
-    solver.add(*(z3.And(color >= 0, color < colors) for color in vertex_colors))
-    solver.add(*(vertex_colors[u] != vertex_colors[v] for u, v in graph.edges))
-    outcome = solver.check()
-    if outcome == z3.sat:
-        model = solver.model()
-        return "sat", tuple(model.eval(color).as_long() for color in vertex_colors)
-    if outcome == z3.unsat:
-        return "unsat", None
-    return "unknown", None
+    try:
+        solver = z3.Solver()
+        solver.set("max_conflicts", solver_conflicts)
+        vertex_colors = [
+            z3.Int(f"color_{vertex}") for vertex in range(graph.vertex_count)
+        ]
+        solver.add(*(z3.And(color >= 0, color < colors) for color in vertex_colors))
+        solver.add(*(vertex_colors[u] != vertex_colors[v] for u, v in graph.edges))
+        outcome = solver.check()
+        if outcome == z3.sat:
+            model = solver.model()
+            return "sat", tuple(model.eval(color).as_long() for color in vertex_colors)
+        if outcome == z3.unsat:
+            return "unsat", None
+        return (
+            "budget_exceeded"
+            if "max-conflicts-reached" in solver.reason_unknown()
+            else "execution_failed",
+            None,
+        )
+    except z3.Z3Exception:
+        return "execution_failed", None
 
 
 def _run_edge_coloring_solver_kernel(
     graph: SimpleUndirectedGraph,
     colors: int,
     solver_conflicts: int,
-) -> tuple[str, tuple[int, ...] | None]:
+) -> tuple[_ColoringWorkerOutcome, tuple[int, ...] | None]:
     """Run the existing bounded edge-coloring Z3 adapter once."""
 
     import z3
 
-    solver = z3.Solver()
-    solver.set("max_conflicts", solver_conflicts)
-    edge_colors = [z3.Int(f"c_{index}") for index in range(len(graph.edges))]
-    solver.add(*(z3.And(color >= 0, color < colors) for color in edge_colors))
-    for first, second in _incident_edge_index_pairs_for_canonical_graph(graph):
-        solver.add(edge_colors[first] != edge_colors[second])
-    outcome = solver.check()
-    if outcome == z3.sat:
-        model = solver.model()
-        return "sat", tuple(model.eval(color).as_long() for color in edge_colors)
-    if outcome == z3.unsat:
-        return "unsat", None
-    return "unknown", None
+    try:
+        solver = z3.Solver()
+        solver.set("max_conflicts", solver_conflicts)
+        edge_colors = [z3.Int(f"c_{index}") for index in range(len(graph.edges))]
+        solver.add(*(z3.And(color >= 0, color < colors) for color in edge_colors))
+        for first, second in _incident_edge_index_pairs_for_canonical_graph(graph):
+            solver.add(edge_colors[first] != edge_colors[second])
+        outcome = solver.check()
+        if outcome == z3.sat:
+            model = solver.model()
+            return "sat", tuple(model.eval(color).as_long() for color in edge_colors)
+        if outcome == z3.unsat:
+            return "unsat", None
+        return (
+            "budget_exceeded"
+            if "max-conflicts-reached" in solver.reason_unknown()
+            else "execution_failed",
+            None,
+        )
+    except z3.Z3Exception:
+        return "execution_failed", None
 
 
 def _run_coloring_worker(
@@ -99,7 +118,7 @@ def _run_coloring_worker(
     graph: IndexedSimpleUndirectedGraph | SimpleUndirectedGraph,
     colors: int,
     solver_conflicts: int,
-) -> tuple[str, tuple[int, ...] | None]:
+) -> tuple[_ColoringWorkerOutcome, tuple[int, ...] | None]:
     """Run one complete coloring solver transaction in an isolated worker."""
 
     try:
@@ -127,7 +146,7 @@ def _run_coloring_worker(
                 cwd=directory,
             )
     except OSError:
-        return "unknown", None
+        return "execution_failed", None
     if (
         completed.timed_out
         or completed.cancelled
@@ -135,12 +154,12 @@ def _run_coloring_worker(
         or completed.stderr_exceeded
         or completed.returncode != 0
     ):
-        return "unknown", None
+        return "execution_failed", None
     try:
         payload = json.loads(completed.stdout.decode("utf-8"))
         outcome = payload["outcome"]
         coloring = payload["coloring"]
-        if outcome not in {"sat", "unsat", "unknown"}:
+        if outcome not in {"sat", "unsat", "budget_exceeded", "execution_failed"}:
             raise ValueError("worker returned an invalid solver outcome")
         if coloring is None:
             return outcome, None
@@ -150,7 +169,7 @@ def _run_coloring_worker(
             raise ValueError("worker returned an invalid coloring")
         return outcome, tuple(coloring)
     except (UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError, ValueError):
-        return "unknown", None
+        return "execution_failed", None
 
 
 def compute_chromatic_number_certificate_check(
@@ -247,7 +266,11 @@ def compute_k_colorability(request: KColorabilityRequest) -> KColorabilityResult
         graph=request.graph,
         colors=request.colors,
         solver_conflicts=request.solver_conflicts,
-        status="SOLVER_BUDGET_EXCEEDED",
+        status=(
+            "SOLVER_BUDGET_EXCEEDED"
+            if outcome == "budget_exceeded"
+            else "EXECUTION_FAILED"
+        ),
         colorable=None,
         coloring=None,
     )
@@ -262,7 +285,9 @@ def verify_k_colorability_result(result: KColorabilityResult) -> bool:
         "vertex", result.graph, result.colors, result.solver_conflicts
     )
     if result.status == "SOLVER_BUDGET_EXCEEDED":
-        return outcome == "unknown"
+        return outcome == "budget_exceeded"
+    if result.status == "EXECUTION_FAILED":
+        return False
     return outcome == "unsat"
 
 
@@ -348,7 +373,11 @@ def compute_edge_k_colorability(
         graph=request.graph,
         colors=request.colors,
         solver_conflicts=request.solver_conflicts,
-        status="SOLVER_BUDGET_EXCEEDED",
+        status=(
+            "SOLVER_BUDGET_EXCEEDED"
+            if outcome == "budget_exceeded"
+            else "EXECUTION_FAILED"
+        ),
         colorable=None,
         coloring=None,
     )
@@ -363,7 +392,9 @@ def verify_edge_k_colorability_result(result: EdgeKColorabilityResult) -> bool:
         "edge", result.graph, result.colors, result.solver_conflicts
     )
     if result.status == "SOLVER_BUDGET_EXCEEDED":
-        return outcome == "unknown"
+        return outcome == "budget_exceeded"
+    if result.status == "EXECUTION_FAILED":
+        return False
     return outcome == "unsat"
 
 

--- a/src/jacobian/math/graphs/coloring/_tools.py
+++ b/src/jacobian/math/graphs/coloring/_tools.py
@@ -137,8 +137,9 @@ GRAPH_COLORING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "k-coloring and return one proper coloring when it exists, using a "
         "Z3 SAT encoding bounded by the request-visible solver_conflicts "
         "budget. Colorability is claimed only on an explicit satisfying or "
-        "unsatisfiable outcome; an exhausted budget yields "
-        "SOLVER_BUDGET_EXCEEDED with no colorability claim.",
+        "unsatisfiable outcome; an exhausted conflict budget yields "
+        "SOLVER_BUDGET_EXCEEDED, while worker failure yields EXECUTION_FAILED; "
+        "neither carries a colorability claim.",
         KColorabilityRequest,
         KColorabilityResult,
         compute_k_colorability,
@@ -191,8 +192,9 @@ GRAPH_COLORING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "Given a bounded simple graph and an integer k, decide whether the "
         "graph admits a proper k-edge-coloring. The exact solver runs under "
         "the request-visible solver_conflicts budget: non-colorability "
-        "requires an explicit unsatisfiable outcome, and an exhausted budget "
-        "yields SOLVER_BUDGET_EXCEEDED with no colorability claim. A "
+        "requires an explicit unsatisfiable outcome. An exhausted conflict budget "
+        "yields SOLVER_BUDGET_EXCEEDED and worker failure yields EXECUTION_FAILED; "
+        "neither carries a colorability claim. A "
         "colorable decision returns one proper edge coloring as a canonical "
         "source-bound assignment value accepted by graph.edge_coloring.check.",
         EdgeKColorabilityRequest,

--- a/src/jacobian/math/graphs/coloring/_worker.py
+++ b/src/jacobian/math/graphs/coloring/_worker.py
@@ -46,7 +46,9 @@ def main() -> int:
             )
         sys.stdout.write(
             json.dumps(
-                {"outcome": outcome, "coloring": coloring}, separators=(",", ":")
+                {"outcome": outcome, "coloring": coloring},
+                separators=(",", ":"),
+                ensure_ascii=False,
             )
         )
         return 0

--- a/src/jacobian/math/graphs/coloring/_worker.py
+++ b/src/jacobian/math/graphs/coloring/_worker.py
@@ -1,0 +1,58 @@
+"""Isolated Z3 adapter for one bounded graph-coloring decision."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.graphs.coloring._operations import (
+    _run_edge_coloring_solver_kernel,
+    _run_k_colorability_solver_kernel,
+)
+from jacobian.math.graphs.values import (
+    IndexedSimpleUndirectedGraph,
+    SimpleUndirectedGraph,
+)
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        if not isinstance(payload, dict):
+            raise ValueError("worker payload must be an object")
+        kind = payload["kind"]
+        colors = payload["colors"]
+        solver_conflicts = payload["solver_conflicts"]
+        if (
+            kind not in {"vertex", "edge"}
+            or not isinstance(colors, int)
+            or isinstance(colors, bool)
+            or not isinstance(solver_conflicts, int)
+            or isinstance(solver_conflicts, bool)
+        ):
+            raise ValueError("worker payload has invalid coloring inputs")
+        if kind == "vertex":
+            indexed_graph = IndexedSimpleUndirectedGraph.model_validate(
+                payload["graph"]
+            )
+            outcome, coloring = _run_k_colorability_solver_kernel(
+                indexed_graph, colors, solver_conflicts
+            )
+        else:
+            edge_graph = SimpleUndirectedGraph.model_validate(payload["graph"])
+            outcome, coloring = _run_edge_coloring_solver_kernel(
+                edge_graph, colors, solver_conflicts
+            )
+        sys.stdout.write(
+            json.dumps(
+                {"outcome": outcome, "coloring": coloring}, separators=(",", ":")
+            )
+        )
+        return 0
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/graphs/isomorphism/_operations.py
+++ b/src/jacobian/math/graphs/isomorphism/_operations.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import math
 import sys
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from jacobian.math.graphs.isomorphism._canonicalization import (
     canonicalize_colored_graph_data,
@@ -25,6 +27,7 @@ _VF2_WALL_SECONDS = 60.0
 _VF2_STDOUT_LIMIT = 256 * 1024
 _VF2_STDERR_LIMIT = 64 * 1024
 _VF2_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_VF2_FILE_SIZE_BYTES = 1024 * 1024
 
 
 def _vertex_mapping(
@@ -56,21 +59,29 @@ def _vertex_mapping(
             "edges": graph_b.edges,
         },
     }
-    completed = run_bounded_process(
-        [sys.executable, str(_VF2_WORKER)],
-        input_bytes=json.dumps(request, separators=(",", ":")).encode("utf-8"),
-        timeout_seconds=_VF2_WALL_SECONDS,
-        environment=worker_environment(locale="C.UTF-8"),
-        stdout_limit=_VF2_STDOUT_LIMIT,
-        stderr_limit=_VF2_STDERR_LIMIT,
-        resource_limits=ProcessResourceLimits(
-            address_space_bytes=_VF2_ADDRESS_SPACE_BYTES,
-        ),
-    )
+    try:
+        with TemporaryDirectory(prefix="jacobian-vf2-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_VF2_WORKER)],
+                input_bytes=json.dumps(request, separators=(",", ":")).encode("utf-8"),
+                timeout_seconds=_VF2_WALL_SECONDS,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_VF2_STDOUT_LIMIT,
+                stderr_limit=_VF2_STDERR_LIMIT,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=math.ceil(_VF2_WALL_SECONDS),
+                    address_space_bytes=_VF2_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_VF2_FILE_SIZE_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError as exc:
+        raise RuntimeError("bounded VF2 worker could not be started") from exc
     if (
         completed.timed_out
         or completed.cancelled
         or completed.stdout_exceeded
+        or completed.stderr_exceeded
         or completed.returncode != 0
     ):
         raise RuntimeError("bounded VF2 worker did not establish an outcome")

--- a/src/jacobian/math/graphs/isomorphism/_vf2_worker.py
+++ b/src/jacobian/math/graphs/isomorphism/_vf2_worker.py
@@ -18,25 +18,26 @@ def _graph(payload: dict[str, Any]) -> nx.Graph[int] | nx.DiGraph[int]:
     return graph
 
 
+def _first_isomorphism_mapping(matcher: Any) -> list[tuple[int, int]] | None:
+    """Return one VF2 witness without first running a separate decision pass."""
+
+    mapping = next(matcher.isomorphisms_iter(), None)
+    return None if mapping is None else sorted(mapping.items())
+
+
 def main() -> int:
-    try:
-        payload = json.load(sys.stdin)
-        graph_a = _graph(payload["graph_a"])
-        graph_b = _graph(payload["graph_b"])
-        matcher: Any
-        if payload["graph_a"]["directed"]:
-            matcher = nx_isomorphism.DiGraphMatcher(graph_a, graph_b)
-        else:
-            matcher = nx_isomorphism.GraphMatcher(graph_a, graph_b)
-        if not matcher.is_isomorphic():
-            response: dict[str, Any] = {"ok": True, "mapping": None}
-        else:
-            response = {
-                "ok": True,
-                "mapping": sorted(next(matcher.isomorphisms_iter()).items()),
-            }
-    except Exception as exc:
-        response = {"ok": False, "error": type(exc).__name__}
+    payload = json.load(sys.stdin)
+    graph_a = _graph(payload["graph_a"])
+    graph_b = _graph(payload["graph_b"])
+    matcher: Any
+    if payload["graph_a"]["directed"]:
+        matcher = nx_isomorphism.DiGraphMatcher(graph_a, graph_b)
+    else:
+        matcher = nx_isomorphism.GraphMatcher(graph_a, graph_b)
+    response: dict[str, Any] = {
+        "ok": True,
+        "mapping": _first_isomorphism_mapping(matcher),
+    }
     json.dump(response, sys.stdout, separators=(",", ":"))
     return 0
 

--- a/src/jacobian/math/graphs/optimization/_chromatic_number.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_number.py
@@ -99,7 +99,9 @@ def _search_chromatic_number(
             completed = run_bounded_process(
                 [sys.executable, str(_CHROMATIC_NUMBER_WORKER)],
                 input_bytes=json.dumps(
-                    request.model_dump(mode="json"), separators=(",", ":")
+                    request.model_dump(mode="json"),
+                    separators=(",", ":"),
+                    ensure_ascii=False,
                 ).encode("utf-8"),
                 timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
@@ -132,17 +134,16 @@ def _search_chromatic_number(
         )
     try:
         result = GraphChromaticNumberOutput.model_validate(
-            json.loads(completed.stdout.decode("utf-8"))
+            {
+                **json.loads(completed.stdout.decode("utf-8")),
+                "vertices": list(request.graph.vertices),
+            }
         )
-        if (
-            result.vertices != request.graph.vertices
-            or result.order != len(request.graph.vertices)
-            or (
-                result.coloring is not None
-                and any(
-                    result.coloring[left] == result.coloring[right]
-                    for left, right in request.graph.edges
-                )
+        if result.order != len(request.graph.vertices) or (
+            result.coloring is not None
+            and any(
+                result.coloring[left] == result.coloring[right]
+                for left, right in request.graph.edges
             )
         ):
             raise ValueError("worker result is not bound to the submitted graph")

--- a/src/jacobian/math/graphs/optimization/_chromatic_number.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_number.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import json
+import math
+import sys
 import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
@@ -14,9 +19,20 @@ from jacobian.math.graphs.optimization._operations import (
     build_simple_graph,
     solve_chromatic_number,
 )
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_CHROMATIC_NUMBER_WORKER = Path(__file__).with_name("_chromatic_number_worker.py")
+_WORKER_OUTPUT_BYTES = 64 * 1024
+_WORKER_ERROR_BYTES = 16_384
+_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 
 
-def _search_chromatic_number(
+def _search_chromatic_number_kernel(
     request: GraphChromaticNumberRequest,
 ) -> GraphChromaticNumberOutput:
     """Run bounded k-colorability decisions until exactness or timeout."""
@@ -32,6 +48,85 @@ def _search_chromatic_number(
     )
 
     return output
+
+
+def _chromatic_worker_failure(
+    request: GraphChromaticNumberRequest, detail: str
+) -> GraphChromaticNumberOutput:
+    """Return a source-derived unknown when the bounded worker fails."""
+
+    vertices = request.graph.vertices
+    if not vertices:
+        return GraphChromaticNumberOutput(
+            status="EXACT",
+            vertices=vertices,
+            order=0,
+            chromatic_number=0,
+            lower_bound=0,
+            upper_bound=0,
+            coloring={},
+            solver_status="SPECIAL_CASE",
+            tested=(),
+            detail="the empty graph requires zero colors",
+        )
+    return GraphChromaticNumberOutput(
+        status="UNKNOWN",
+        vertices=vertices,
+        order=len(vertices),
+        lower_bound=2 if request.graph.edges else 1,
+        upper_bound=len(vertices),
+        coloring={vertex: index for index, vertex in enumerate(vertices)},
+        solver_status="UNKNOWN",
+        tested=(),
+        detail=detail,
+    )
+
+
+def _search_chromatic_number(
+    request: GraphChromaticNumberRequest,
+) -> GraphChromaticNumberOutput:
+    """Run the complete Z3 chromatic search in a bounded owner worker."""
+
+    try:
+        with TemporaryDirectory(prefix="jacobian-graph-chromatic-") as directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_CHROMATIC_NUMBER_WORKER)],
+                input_bytes=json.dumps(
+                    request.model_dump(mode="json"), separators=(",", ":")
+                ).encode("utf-8"),
+                timeout_seconds=request.resource_budget.wall_seconds,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_WORKER_OUTPUT_BYTES,
+                stderr_limit=_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(request.resource_budget.wall_seconds)),
+                    address_space_bytes=_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=directory,
+            )
+    except OSError:
+        return _chromatic_worker_failure(
+            request, "the bounded chromatic-number worker could not be started"
+        )
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return _chromatic_worker_failure(
+            request, "the bounded chromatic-number worker did not establish an outcome"
+        )
+    try:
+        return GraphChromaticNumberOutput.model_validate(
+            json.loads(completed.stdout.decode("utf-8"))
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return _chromatic_worker_failure(
+            request, "the bounded chromatic-number worker returned malformed output"
+        )
 
 
 CHROMATIC_NUMBER_OPERATION = MathTool(

--- a/src/jacobian/math/graphs/optimization/_chromatic_number.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_number.py
@@ -87,14 +87,21 @@ def _search_chromatic_number(
 ) -> GraphChromaticNumberOutput:
     """Run the complete Z3 chromatic search in a bounded owner worker."""
 
+    deadline = time.monotonic() + request.resource_budget.wall_seconds
     try:
         with TemporaryDirectory(prefix="jacobian-graph-chromatic-") as directory:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return _chromatic_worker_failure(
+                    request,
+                    "the chromatic-number request expired before worker startup",
+                )
             completed = run_bounded_process(
                 [sys.executable, str(_CHROMATIC_NUMBER_WORKER)],
                 input_bytes=json.dumps(
                     request.model_dump(mode="json"), separators=(",", ":")
                 ).encode("utf-8"),
-                timeout_seconds=request.resource_budget.wall_seconds,
+                timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
                 stdout_limit=_WORKER_OUTPUT_BYTES,
                 stderr_limit=_WORKER_ERROR_BYTES,
@@ -119,10 +126,29 @@ def _search_chromatic_number(
         return _chromatic_worker_failure(
             request, "the bounded chromatic-number worker did not establish an outcome"
         )
+    if time.monotonic() >= deadline:
+        return _chromatic_worker_failure(
+            request, "the chromatic-number request expired before response validation"
+        )
     try:
-        return GraphChromaticNumberOutput.model_validate(
+        result = GraphChromaticNumberOutput.model_validate(
             json.loads(completed.stdout.decode("utf-8"))
         )
+        if (
+            result.vertices != request.graph.vertices
+            or result.order != len(request.graph.vertices)
+            or (
+                result.coloring is not None
+                and any(
+                    result.coloring[left] == result.coloring[right]
+                    for left, right in request.graph.edges
+                )
+            )
+        ):
+            raise ValueError("worker result is not bound to the submitted graph")
+        if time.monotonic() < deadline:
+            return result
+        raise ValueError("request expired during response validation")
     except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
         return _chromatic_worker_failure(
             request, "the bounded chromatic-number worker returned malformed output"

--- a/src/jacobian/math/graphs/optimization/_chromatic_number_worker.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_number_worker.py
@@ -1,0 +1,31 @@
+"""Isolated Z3 adapter for the bounded chromatic-number operation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.graphs.optimization._chromatic_number import (
+    _search_chromatic_number_kernel,
+)
+from jacobian.math.graphs.optimization._coloring_models import (
+    GraphChromaticNumberRequest,
+)
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        request = GraphChromaticNumberRequest.model_validate(payload)
+        result = _search_chromatic_number_kernel(request)
+        sys.stdout.write(
+            json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
+        )
+        return 0
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/graphs/optimization/_chromatic_number_worker.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_number_worker.py
@@ -20,7 +20,11 @@ def main() -> int:
         request = GraphChromaticNumberRequest.model_validate(payload)
         result = _search_chromatic_number_kernel(request)
         sys.stdout.write(
-            json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
+            json.dumps(
+                result.model_dump(mode="json", exclude={"vertices"}),
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
         )
         return 0
     except (TypeError, ValueError, json.JSONDecodeError):

--- a/src/jacobian/math/graphs/optimization/_exact_search.py
+++ b/src/jacobian/math/graphs/optimization/_exact_search.py
@@ -173,6 +173,24 @@ def _vertex_model(
     )
 
 
+def _check_after_encoding(
+    solver: Any,
+    *,
+    started: float,
+    budget: GraphOptimizationBudget,
+) -> object:
+    """Charge encoding and solver completion to one operation deadline."""
+
+    import z3
+
+    remaining_ms = _remaining_ms(started, budget.wall_seconds)
+    if remaining_ms <= 0:
+        return z3.unknown
+    solver.set(timeout=max(1, remaining_ms))
+    status = solver.check()
+    return z3.unknown if _remaining_ms(started, budget.wall_seconds) <= 0 else status
+
+
 def solve_domination(
     graph: Any,
     source: ChromaticGraph,
@@ -195,11 +213,10 @@ def solve_domination(
         )
     incumbent = tuple(sorted(vertices))
 
-    def solve(bound: int, timeout_ms: int) -> tuple[object, VertexWitness]:
+    def solve(bound: int, _timeout_ms: int) -> tuple[object, VertexWitness]:
         import z3
 
         solver = z3.Solver()
-        solver.set(timeout=max(1, timeout_ms))
         selected = {
             vertex: z3.Bool(f"dom_{index}") for index, vertex in enumerate(vertices)
         }
@@ -213,8 +230,15 @@ def solve_domination(
         solver.add(
             z3.Sum([z3.If(selected[vertex], 1, 0) for vertex in vertices]) <= bound
         )
-        status = solver.check()
-        return status, _vertex_model(solver, selected) if status == z3.sat else ()
+        status = _check_after_encoding(solver, started=started, budget=budget)
+        if status != z3.sat:
+            return status, ()
+        witness = _vertex_model(solver, selected)
+        return (
+            (z3.unknown, ())
+            if _remaining_ms(started, budget.wall_seconds) <= 0
+            else (status, witness)
+        )
 
     result = _search_thresholds(
         direction="MINIMUM",
@@ -268,11 +292,10 @@ def solve_minimum_maximal_matching(
             used.update(edge)
     incumbent = tuple(greedy_edges)
 
-    def solve(bound: int, timeout_ms: int) -> tuple[object, EdgeWitness]:
+    def solve(bound: int, _timeout_ms: int) -> tuple[object, EdgeWitness]:
         import z3
 
         solver = z3.Solver()
-        solver.set(timeout=max(1, timeout_ms))
         chosen = {edge: z3.Bool(f"match_{index}") for index, edge in enumerate(edges)}
         incident = {
             vertex: tuple(edge for edge in edges if vertex in edge)
@@ -287,7 +310,7 @@ def solve_minimum_maximal_matching(
                 z3.Or(*(chosen[edge] for edge in set(incident[left] + incident[right])))
             )
         solver.add(z3.Sum([z3.If(chosen[edge], 1, 0) for edge in edges]) <= bound)
-        status = solver.check()
+        status = _check_after_encoding(solver, started=started, budget=budget)
         if status != z3.sat:
             return status, ()
         model = solver.model()
@@ -298,7 +321,11 @@ def solve_minimum_maximal_matching(
                 if z3.is_true(model.eval(variable, model_completion=True))
             )
         )
-        return status, witness
+        return (
+            (z3.unknown, ())
+            if _remaining_ms(started, budget.wall_seconds) <= 0
+            else (status, witness)
+        )
 
     result = _search_thresholds(
         direction="MINIMUM",
@@ -367,11 +394,10 @@ def _maximum_vertex_search(
         )
     edges = _canonical_edges(graph)
 
-    def solve(bound: int, timeout_ms: int) -> tuple[object, VertexWitness]:
+    def solve(bound: int, _timeout_ms: int) -> tuple[object, VertexWitness]:
         import z3
 
         solver = z3.Solver()
-        solver.set(timeout=max(1, timeout_ms))
         selected = {
             vertex: z3.Bool(f"sel_{index}") for index, vertex in enumerate(vertices)
         }
@@ -419,8 +445,15 @@ def _maximum_vertex_search(
                     ]
                 )
                 solver.add(cardinality >= 1, selected_edges == cardinality - 1)
-        status = solver.check()
-        return status, _vertex_model(solver, selected) if status == z3.sat else ()
+        status = _check_after_encoding(solver, started=started, budget=budget)
+        if status != z3.sat:
+            return status, ()
+        witness = _vertex_model(solver, selected)
+        return (
+            (z3.unknown, ())
+            if _remaining_ms(started, budget.wall_seconds) <= 0
+            else (status, witness)
+        )
 
     return _search_thresholds(
         direction="MAXIMUM",

--- a/src/jacobian/math/graphs/optimization/_finite_optimization.py
+++ b/src/jacobian/math/graphs/optimization/_finite_optimization.py
@@ -14,7 +14,6 @@ from typing import Any, cast
 from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
-from jacobian.math.graphs.optimization._coloring_models import ChromaticGraph
 from jacobian.math.graphs.optimization._exact_search import (
     solve_domination,
     solve_induced_bipartite,
@@ -28,7 +27,6 @@ from jacobian.math.graphs.optimization._models import (
     GraphInducedForestMaximumOutput,
     GraphInducedTreeMaximumOutput,
     GraphMinimumMaximalMatchingOutput,
-    GraphOptimizationBudget,
     GraphOptimizationRequest,
 )
 from jacobian.math.graphs.optimization._operations import build_simple_graph
@@ -117,21 +115,6 @@ def _valid_witness(graph: Any, result: StrictModel) -> bool:
     return validate(graph, result) if validate else False
 
 
-def _execute_kernel[ResultT: StrictModel](
-    request: GraphOptimizationRequest,
-    solve: Callable[
-        [Any, ChromaticGraph, GraphOptimizationBudget, float],
-        ResultT,
-    ],
-) -> ResultT:
-    started = time.monotonic()
-    graph = cast(Any, build_simple_graph(request.graph))
-    result = solve(graph, request.graph, request.resource_budget, started)
-    if not _valid_witness(graph, result):
-        raise RuntimeError("graph optimization backend returned an invalid witness")
-    return result
-
-
 def _fallback_unknown[ResultT: StrictModel](
     graph: Any,
     request: GraphOptimizationRequest,
@@ -191,14 +174,22 @@ def _fallback_unknown[ResultT: StrictModel](
 def _execute[ResultT: StrictModel](
     operation_id: str,
     request: GraphOptimizationRequest,
-    solve: Callable[[Any, ChromaticGraph, GraphOptimizationBudget, float], ResultT],
     result_type: type[ResultT],
 ) -> ResultT:
     """Run one complete graph Z3 operation in its bounded owner worker."""
 
     graph = cast(Any, build_simple_graph(request.graph))
+    deadline = time.monotonic() + request.resource_budget.wall_seconds
     try:
         with TemporaryDirectory(prefix="jacobian-graph-optimization-") as directory:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return _fallback_unknown(
+                    graph,
+                    request,
+                    result_type,
+                    "the graph optimization request expired before worker startup",
+                )
             completed = run_bounded_process(
                 [sys.executable, str(_OPTIMIZATION_WORKER)],
                 input_bytes=json.dumps(
@@ -208,7 +199,7 @@ def _execute[ResultT: StrictModel](
                     },
                     separators=(",", ":"),
                 ).encode("utf-8"),
-                timeout_seconds=request.resource_budget.wall_seconds,
+                timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
                 stdout_limit=_WORKER_OUTPUT_BYTES,
                 stderr_limit=_WORKER_ERROR_BYTES,
@@ -239,6 +230,13 @@ def _execute[ResultT: StrictModel](
             result_type,
             "the bounded graph optimization worker did not establish an outcome",
         )
+    if time.monotonic() >= deadline:
+        return _fallback_unknown(
+            graph,
+            request,
+            result_type,
+            "the graph optimization request expired before response validation",
+        )
     try:
         result = result_type.model_validate(
             json.loads(completed.stdout.decode("utf-8"))
@@ -250,12 +248,21 @@ def _execute[ResultT: StrictModel](
             result_type,
             "the bounded graph optimization worker returned malformed output",
         )
-    if not _valid_witness(graph, result):
+    if getattr(result, "order", None) != len(
+        request.graph.vertices
+    ) or not _valid_witness(graph, result):
         return _fallback_unknown(
             graph,
             request,
             result_type,
             "the bounded graph optimization worker returned an invalid witness",
+        )
+    if time.monotonic() >= deadline:
+        return _fallback_unknown(
+            graph,
+            request,
+            result_type,
+            "the graph optimization request expired during response validation",
         )
     return result
 
@@ -265,7 +272,6 @@ def _operation[ResultT: StrictModel](
     title: str,
     description: str,
     result_type: type[ResultT],
-    solve: Callable[[Any, ChromaticGraph, GraphOptimizationBudget, float], ResultT],
     *tags: str,
     examples: tuple[OperationExample, ...] = (),
 ) -> MathTool[GraphOptimizationRequest, ResultT]:
@@ -275,7 +281,7 @@ def _operation[ResultT: StrictModel](
         description=description,
         request_type=GraphOptimizationRequest,
         result_type=result_type,
-        run=lambda request: _execute(operation_id, request, solve, result_type),
+        run=lambda request: _execute(operation_id, request, result_type),
         tags=("graph", *tags, "bounded", "z3"),
         examples=examples,
     )
@@ -286,9 +292,6 @@ DOMINATION_MINIMUM_OPERATION = _operation(
     "Minimum dominating set",
     "Compute the domination number and an attaining set within explicit budgets.",
     GraphDominationMinimumOutput,
-    lambda graph, contract, budget, started: solve_domination(
-        graph, contract, budget, started
-    ),
     "domination",
     "minimum",
     examples=(
@@ -311,9 +314,6 @@ MINIMUM_MAXIMAL_MATCHING_OPERATION = _operation(
     "Minimum maximal matching",
     "Compute the saturation number and an attaining maximal matching within explicit budgets.",
     GraphMinimumMaximalMatchingOutput,
-    lambda graph, contract, budget, started: solve_minimum_maximal_matching(
-        graph, contract, budget, started
-    ),
     "matching",
     "saturation_number",
     "minimum",
@@ -337,9 +337,6 @@ INDUCED_FOREST_MAXIMUM_OPERATION = _operation(
     "Maximum induced forest",
     "Compute a maximum-order induced forest and vertex witness within explicit budgets.",
     GraphInducedForestMaximumOutput,
-    lambda graph, contract, budget, started: solve_induced_forest(
-        graph, contract, budget, started
-    ),
     "induced_forest",
     "maximum",
     examples=(
@@ -362,9 +359,6 @@ INDUCED_TREE_MAXIMUM_OPERATION = _operation(
     "Maximum induced tree",
     "Compute a maximum-order induced tree and vertex witness within explicit budgets.",
     GraphInducedTreeMaximumOutput,
-    lambda graph, contract, budget, started: solve_induced_tree(
-        graph, contract, budget, started
-    ),
     "induced_tree",
     "maximum",
     examples=(
@@ -387,9 +381,6 @@ INDUCED_BIPARTITE_MAXIMUM_OPERATION = _operation(
     "Maximum induced bipartite subgraph",
     "Compute a maximum-order induced bipartite subgraph within explicit budgets.",
     GraphInducedBipartiteMaximumOutput,
-    lambda graph, contract, budget, started: solve_induced_bipartite(
-        graph, contract, budget, started
-    ),
     "induced_bipartite",
     "maximum",
     examples=(

--- a/src/jacobian/math/graphs/optimization/_finite_optimization.py
+++ b/src/jacobian/math/graphs/optimization/_finite_optimization.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import json
+import math
+import sys
 import time
 from collections.abc import Callable
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, cast
 
 from jacobian._models import StrictModel
@@ -27,8 +32,18 @@ from jacobian.math.graphs.optimization._models import (
     GraphOptimizationRequest,
 )
 from jacobian.math.graphs.optimization._operations import build_simple_graph
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
 
 _WitnessValidator = Callable[[Any, StrictModel], bool]
+_OPTIMIZATION_WORKER = Path(__file__).with_name("_finite_optimization_worker.py")
+_WORKER_OUTPUT_BYTES = 64 * 1024
+_WORKER_ERROR_BYTES = 16_384
+_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 
 
 def _validate_domination(graph: Any, result: StrictModel) -> bool:
@@ -102,7 +117,7 @@ def _valid_witness(graph: Any, result: StrictModel) -> bool:
     return validate(graph, result) if validate else False
 
 
-def _execute[ResultT: StrictModel](
+def _execute_kernel[ResultT: StrictModel](
     request: GraphOptimizationRequest,
     solve: Callable[
         [Any, ChromaticGraph, GraphOptimizationBudget, float],
@@ -114,6 +129,134 @@ def _execute[ResultT: StrictModel](
     result = solve(graph, request.graph, request.resource_budget, started)
     if not _valid_witness(graph, result):
         raise RuntimeError("graph optimization backend returned an invalid witness")
+    return result
+
+
+def _fallback_unknown[ResultT: StrictModel](
+    graph: Any,
+    request: GraphOptimizationRequest,
+    result_type: type[ResultT],
+    detail: str,
+) -> ResultT:
+    """Return a source-derived feasible incumbent without an optimum claim."""
+
+    vertices = tuple(sorted(request.graph.vertices))
+    common: dict[str, object] = {
+        "status": "UNKNOWN",
+        "order": len(vertices),
+        "optimum_value": None,
+        "tested": (),
+        "termination_reason": "SOLVER_UNKNOWN",
+        "detail": detail,
+    }
+    if result_type is GraphDominationMinimumOutput:
+        return result_type.model_validate(
+            {
+                **common,
+                "incumbent_value": len(vertices),
+                "lower_bound": 0 if not vertices else 1,
+                "upper_bound": len(vertices),
+                "witness_vertices": vertices,
+            }
+        )
+    if result_type is GraphMinimumMaximalMatchingOutput:
+        used: set[str] = set()
+        selected: list[tuple[str, str]] = []
+        for left, right in sorted(graph.edges):
+            if left not in used and right not in used:
+                selected.append((left, right) if left < right else (right, left))
+                used.update((left, right))
+        edges = tuple(selected)
+        return result_type.model_validate(
+            {
+                **common,
+                "incumbent_value": len(edges),
+                "lower_bound": 0,
+                "upper_bound": len(edges),
+                "witness_edges": edges,
+            }
+        )
+    witness = () if not vertices else (vertices[0],)
+    return result_type.model_validate(
+        {
+            **common,
+            "incumbent_value": len(witness),
+            "lower_bound": len(witness),
+            "upper_bound": len(vertices),
+            "witness_vertices": witness,
+        }
+    )
+
+
+def _execute[ResultT: StrictModel](
+    operation_id: str,
+    request: GraphOptimizationRequest,
+    solve: Callable[[Any, ChromaticGraph, GraphOptimizationBudget, float], ResultT],
+    result_type: type[ResultT],
+) -> ResultT:
+    """Run one complete graph Z3 operation in its bounded owner worker."""
+
+    graph = cast(Any, build_simple_graph(request.graph))
+    try:
+        with TemporaryDirectory(prefix="jacobian-graph-optimization-") as directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_OPTIMIZATION_WORKER)],
+                input_bytes=json.dumps(
+                    {
+                        "operation_id": operation_id,
+                        "request": request.model_dump(mode="json"),
+                    },
+                    separators=(",", ":"),
+                ).encode("utf-8"),
+                timeout_seconds=request.resource_budget.wall_seconds,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_WORKER_OUTPUT_BYTES,
+                stderr_limit=_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(request.resource_budget.wall_seconds)),
+                    address_space_bytes=_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=directory,
+            )
+    except OSError:
+        return _fallback_unknown(
+            graph,
+            request,
+            result_type,
+            "the bounded graph optimization worker could not be started",
+        )
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return _fallback_unknown(
+            graph,
+            request,
+            result_type,
+            "the bounded graph optimization worker did not establish an outcome",
+        )
+    try:
+        result = result_type.model_validate(
+            json.loads(completed.stdout.decode("utf-8"))
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return _fallback_unknown(
+            graph,
+            request,
+            result_type,
+            "the bounded graph optimization worker returned malformed output",
+        )
+    if not _valid_witness(graph, result):
+        return _fallback_unknown(
+            graph,
+            request,
+            result_type,
+            "the bounded graph optimization worker returned an invalid witness",
+        )
     return result
 
 
@@ -132,7 +275,7 @@ def _operation[ResultT: StrictModel](
         description=description,
         request_type=GraphOptimizationRequest,
         result_type=result_type,
-        run=lambda request: _execute(request, solve),
+        run=lambda request: _execute(operation_id, request, solve, result_type),
         tags=("graph", *tags, "bounded", "z3"),
         examples=examples,
     )
@@ -271,3 +414,39 @@ FINITE_GRAPH_OPTIMIZATION_OPERATIONS = (
     INDUCED_TREE_MAXIMUM_OPERATION,
     INDUCED_BIPARTITE_MAXIMUM_OPERATION,
 )
+
+
+def _run_worker_kernel(
+    operation_id: str,
+    request: GraphOptimizationRequest,
+) -> StrictModel:
+    """Build, encode, solve, and validate one graph operation inside its worker."""
+
+    graph = cast(Any, build_simple_graph(request.graph))
+    started = time.monotonic()
+    result: StrictModel
+    if operation_id == "graph.domination.minimum.compute":
+        result = solve_domination(
+            graph, request.graph, request.resource_budget, started
+        )
+    elif operation_id == "graph.matching.maximal.minimum.compute":
+        result = solve_minimum_maximal_matching(
+            graph, request.graph, request.resource_budget, started
+        )
+    elif operation_id == "graph.induced_forest.maximum.compute":
+        result = solve_induced_forest(
+            graph, request.graph, request.resource_budget, started
+        )
+    elif operation_id == "graph.induced_tree.maximum.compute":
+        result = solve_induced_tree(
+            graph, request.graph, request.resource_budget, started
+        )
+    elif operation_id == "graph.induced_bipartite.maximum.compute":
+        result = solve_induced_bipartite(
+            graph, request.graph, request.resource_budget, started
+        )
+    else:
+        raise ValueError("unknown graph optimization operation")
+    if not _valid_witness(graph, result):
+        raise ValueError("graph optimization kernel returned an invalid witness")
+    return result

--- a/src/jacobian/math/graphs/optimization/_finite_optimization_worker.py
+++ b/src/jacobian/math/graphs/optimization/_finite_optimization_worker.py
@@ -1,0 +1,32 @@
+"""Isolated Z3 adapter for one finite graph optimization operation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.graphs.optimization._finite_optimization import _run_worker_kernel
+from jacobian.math.graphs.optimization._models import GraphOptimizationRequest
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        if not isinstance(payload, dict):
+            raise ValueError("worker payload must be an object")
+        operation_id = payload["operation_id"]
+        if not isinstance(operation_id, str):
+            raise ValueError("worker payload has invalid operation id")
+        request = GraphOptimizationRequest.model_validate(payload["request"])
+        result = _run_worker_kernel(operation_id, request)
+        sys.stdout.write(
+            json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
+        )
+        return 0
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/graphs/optimization/_invariants.py
+++ b/src/jacobian/math/graphs/optimization/_invariants.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import math
+import sys
 import time
 from collections.abc import Callable
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, cast
 
 from jacobian._models import StrictModel
@@ -34,6 +38,17 @@ from jacobian.math.graphs.optimization._models import (
     OptimizationTermination,
 )
 from jacobian.math.graphs.optimization._operations import build_simple_graph
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_INVARIANTS_WORKER = Path(__file__).with_name("_invariants_worker.py")
+_WORKER_OUTPUT_BYTES = 64 * 1024
+_WORKER_ERROR_BYTES = 16_384
+_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 
 
 def _computed[
@@ -236,7 +251,7 @@ def _k_core_execute(
     )
 
 
-def _clique_execute(
+def _clique_execute_kernel(
     request: GraphOptimizationRequest,
 ) -> GraphCliqueNumberResult:
     """Compute the clique number via bounded Z3 threshold search."""
@@ -342,6 +357,74 @@ def _clique_execute(
         termination_reason=termination,
         detail="bounded Z3 threshold search seeded by a NetworkX approximation",
     )
+
+
+def _clique_worker_failure(
+    request: GraphOptimizationRequest, detail: str
+) -> GraphCliqueNumberResult:
+    """Return a source-derived unknown result when the isolated worker fails."""
+
+    vertices = tuple(request.graph.vertices)
+    witness = () if not vertices else (min(vertices),)
+    return GraphCliqueNumberResult(
+        status="UNKNOWN",
+        order=len(vertices),
+        optimum_value=None,
+        incumbent_value=len(witness),
+        lower_bound=len(witness),
+        upper_bound=len(vertices),
+        witness_vertices=witness,
+        tested=(),
+        termination_reason="SOLVER_UNKNOWN",
+        detail=detail,
+    )
+
+
+def _clique_execute(
+    request: GraphOptimizationRequest,
+) -> GraphCliqueNumberResult:
+    """Run the complete Z3 clique transaction in a bounded owner worker."""
+
+    try:
+        with TemporaryDirectory(prefix="jacobian-graph-clique-") as directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_INVARIANTS_WORKER)],
+                input_bytes=json.dumps(
+                    request.model_dump(mode="json"), separators=(",", ":")
+                ).encode("utf-8"),
+                timeout_seconds=request.resource_budget.wall_seconds,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_WORKER_OUTPUT_BYTES,
+                stderr_limit=_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(request.resource_budget.wall_seconds)),
+                    address_space_bytes=_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=directory,
+            )
+    except OSError:
+        return _clique_worker_failure(
+            request, "the bounded clique worker could not be started"
+        )
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return _clique_worker_failure(
+            request, "the bounded clique worker did not establish an outcome"
+        )
+    try:
+        return GraphCliqueNumberResult.model_validate(
+            json.loads(completed.stdout.decode("utf-8"))
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return _clique_worker_failure(
+            request, "the bounded clique worker returned malformed output"
+        )
 
 
 CLIQUE_NUMBER_OPERATION = MathTool(

--- a/src/jacobian/math/graphs/optimization/_invariants.py
+++ b/src/jacobian/math/graphs/optimization/_invariants.py
@@ -7,6 +7,7 @@ import math
 import sys
 import time
 from collections.abc import Callable
+from itertools import combinations
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, cast
@@ -385,14 +386,20 @@ def _clique_execute(
 ) -> GraphCliqueNumberResult:
     """Run the complete Z3 clique transaction in a bounded owner worker."""
 
+    deadline = time.monotonic() + request.resource_budget.wall_seconds
     try:
         with TemporaryDirectory(prefix="jacobian-graph-clique-") as directory:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return _clique_worker_failure(
+                    request, "the clique request expired before worker startup"
+                )
             completed = run_bounded_process(
                 [sys.executable, str(_INVARIANTS_WORKER)],
                 input_bytes=json.dumps(
                     request.model_dump(mode="json"), separators=(",", ":")
                 ).encode("utf-8"),
-                timeout_seconds=request.resource_budget.wall_seconds,
+                timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
                 stdout_limit=_WORKER_OUTPUT_BYTES,
                 stderr_limit=_WORKER_ERROR_BYTES,
@@ -417,10 +424,28 @@ def _clique_execute(
         return _clique_worker_failure(
             request, "the bounded clique worker did not establish an outcome"
         )
+    if time.monotonic() >= deadline:
+        return _clique_worker_failure(
+            request, "the clique request expired before response validation"
+        )
     try:
-        return GraphCliqueNumberResult.model_validate(
+        result = GraphCliqueNumberResult.model_validate(
             json.loads(completed.stdout.decode("utf-8"))
         )
+        source_vertices = set(request.graph.vertices)
+        source_edges = {tuple(sorted(edge)) for edge in request.graph.edges}
+        if (
+            result.order != len(request.graph.vertices)
+            or not set(result.witness_vertices) <= source_vertices
+            or any(
+                tuple(sorted(edge)) not in source_edges
+                for edge in combinations(result.witness_vertices, 2)
+            )
+        ):
+            raise ValueError("worker result is not bound to the submitted graph")
+        if time.monotonic() < deadline:
+            return result
+        raise ValueError("request expired during response validation")
     except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
         return _clique_worker_failure(
             request, "the bounded clique worker returned malformed output"

--- a/src/jacobian/math/graphs/optimization/_invariants_worker.py
+++ b/src/jacobian/math/graphs/optimization/_invariants_worker.py
@@ -1,0 +1,27 @@
+"""Isolated Z3 adapter for the bounded clique-number operation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.graphs.optimization._invariants import _clique_execute_kernel
+from jacobian.math.graphs.optimization._models import GraphOptimizationRequest
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        request = GraphOptimizationRequest.model_validate(payload)
+        result = _clique_execute_kernel(request)
+        sys.stdout.write(
+            json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
+        )
+        return 0
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/graphs/optimization/_maximum_cut.py
+++ b/src/jacobian/math/graphs/optimization/_maximum_cut.py
@@ -308,8 +308,16 @@ class GraphMaximumCutResult(StrictModel):
     upper_bound: StrictInt = Field(ge=0, le=32_640)
 
     @model_validator(mode="after")
-    def bind_cut_to_source_and_replay_optimality(self) -> Self:
-        analysis = _require_graph_envelope(self.graph)
+    def bind_cut_to_source(self) -> Self:
+        """Validate the linear source-bound witness shape only.
+
+        Exact optimality is a nonlocal claim.  Replaying it here would make
+        ordinary result deserialization execute the exhaustive kernel; callers
+        that receive an independently supplied result must opt into
+        :func:`verify_maximum_cut_result` instead.
+        """
+
+        _require_graph_envelope(self.graph)
         graph_vertices = set(self.graph.vertices)
         left = set(self.left_vertices)
         right = set(self.right_vertices)
@@ -343,12 +351,41 @@ class GraphMaximumCutResult(StrictModel):
         if self.lower_bound != self.cut_value or self.upper_bound != self.cut_value:
             raise ValueError("an exact result requires exact bounds equal to cut value")
 
-        replayed_value, _sides = _solve_analysis_by_enumeration(analysis)
-        if self.cut_value != replayed_value:
-            raise ValueError(
-                "cut value is feasible but not maximum for the retained source graph"
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        graph: SimpleUndirectedGraph,
+        left_vertices: tuple[str, ...],
+        right_vertices: tuple[str, ...],
+        crossing_edges: tuple[tuple[str, str], ...],
+        cut_value: int,
+    ) -> Self:
+        """Construct an exact result after the owner kernel has proved its bounds."""
+
+        return cls.model_construct(
+            graph=graph,
+            left_vertices=left_vertices,
+            right_vertices=right_vertices,
+            crossing_edges=crossing_edges,
+            cut_value=cut_value,
+            lower_bound=cut_value,
+            upper_bound=cut_value,
+        )
+
+
+def verify_maximum_cut_result(result: GraphMaximumCutResult) -> bool:
+    """Replay one independently supplied exact maximum-cut claim.
+
+    The request envelope has already bounded the exhaustive enumeration.  It
+    is deliberately explicit so Pydantic result parsing remains structural.
+    """
+
+    analysis = _require_graph_envelope(result.graph)
+    replayed_value, _sides = _solve_analysis_by_enumeration(analysis)
+    return result.cut_value == replayed_value
 
 
 def _solve_component_by_enumeration(
@@ -540,14 +577,12 @@ def compute_maximum_cut(request: GraphMaximumCutRequest) -> GraphMaximumCutResul
     # The producer already has coincident exact backend bounds. Avoid paying a
     # second complete search inside this call; independently supplied or
     # deserialized results always execute the exhaustive source-bound replay.
-    return GraphMaximumCutResult.model_construct(
+    return GraphMaximumCutResult._from_kernel(
         graph=request.graph,
         left_vertices=left_vertices,
         right_vertices=right_vertices,
         crossing_edges=crossing_edges,
         cut_value=cut_value,
-        lower_bound=cut_value,
-        upper_bound=cut_value,
     )
 
 
@@ -606,4 +641,5 @@ __all__ = [
     "GraphMaximumCutRequest",
     "GraphMaximumCutResult",
     "compute_maximum_cut",
+    "verify_maximum_cut_result",
 ]

--- a/src/jacobian/math/hypergraphs/_independence_z3.py
+++ b/src/jacobian/math/hypergraphs/_independence_z3.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
+import math
+import sys
 import time
-from typing import Any
-
-import z3  # type: ignore[import-untyped]
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, cast
 
 from jacobian.math.hypergraphs._models import (
     FiniteHypergraph,
@@ -16,6 +19,17 @@ from jacobian.math.hypergraphs._models import (
     _greedy_independent_vertices,
     _independence_upper_bound,
 )
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_INDEPENDENCE_WORKER = Path(__file__).with_name("_independence_z3_worker.py")
+_WORKER_OUTPUT_BYTES = 64 * 1024
+_WORKER_ERROR_BYTES = 16_384
+_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 
 
 def _remaining_ms(started: float, wall_seconds: int) -> int:
@@ -25,6 +39,8 @@ def _remaining_ms(started: float, wall_seconds: int) -> int:
 def _build_solver(
     source: FiniteHypergraph,
 ) -> tuple[Any, dict[str, Any], Any]:
+    import z3  # type: ignore[import-untyped]
+
     solver = z3.Solver()
     selected = {
         vertex: z3.Bool(f"hypergraph_selected_{index}")
@@ -36,18 +52,26 @@ def _build_solver(
     return solver, selected, cardinality
 
 
-def verify_upper_bound(
+def _verify_upper_bound_kernel(
     source: FiniteHypergraph,
     upper_bound: int,
     wall_seconds: int,
 ) -> bool:
     """Replay that no independent set exceeds the reported upper bound."""
 
+    import z3
+
     try:
+        started = time.monotonic()
         solver, _, cardinality = _build_solver(source)
-        solver.set(timeout=wall_seconds * 1000)
         solver.add(cardinality >= upper_bound + 1)
-        return bool(solver.check() == z3.unsat)
+        remaining_ms = _remaining_ms(started, wall_seconds)
+        if remaining_ms <= 0:
+            return False
+        solver.set(timeout=max(1, remaining_ms))
+        return bool(
+            solver.check() == z3.unsat and _remaining_ms(started, wall_seconds) > 0
+        )
     except z3.Z3Exception:
         return False
 
@@ -57,23 +81,41 @@ def _check_threshold(
     selected: dict[str, Any],
     cardinality: Any,
     threshold: int,
-    timeout_ms: int,
+    started: float,
+    wall_seconds: int,
     vertex_order: tuple[str, ...],
 ) -> tuple[object, tuple[str, ...], str]:
+    import z3
+
     solver.push()
     try:
-        solver.set(timeout=max(1, timeout_ms))
         solver.add(cardinality >= threshold)
+        remaining_ms = _remaining_ms(started, wall_seconds)
+        if remaining_ms <= 0:
+            return z3.unknown, (), "the wall-clock budget expired during encoding"
+        solver.set(timeout=max(1, remaining_ms))
         status = solver.check()
         if status != z3.sat:
             reason = solver.reason_unknown() if status == z3.unknown else ""
             return status, (), reason
+        if _remaining_ms(started, wall_seconds) <= 0:
+            return (
+                z3.unknown,
+                (),
+                "the wall-clock budget expired before model extraction",
+            )
         model = solver.model()
         witness = tuple(
             vertex
             for vertex in vertex_order
             if z3.is_true(model.eval(selected[vertex], model_completion=True))
         )
+        if _remaining_ms(started, wall_seconds) <= 0:
+            return (
+                z3.unknown,
+                (),
+                "the wall-clock budget expired during model extraction",
+            )
         return status, witness, ""
     finally:
         solver.pop()
@@ -105,23 +147,12 @@ def _result(
     )
 
 
-def verify_independence_result(result: HypergraphIndependenceResult) -> bool:
-    """Independently replay a claimed strict upper bound within its budget."""
-
-    source_upper_bound = _independence_upper_bound(result.hypergraph)
-    if result.upper_bound == source_upper_bound:
-        return True
-    return verify_upper_bound(
-        result.hypergraph,
-        result.upper_bound,
-        result.resource_budget.wall_seconds,
-    )
-
-
-def solve_independence_number(
+def _solve_independence_number_kernel(
     request: HypergraphIndependenceRequest,
 ) -> HypergraphIndependenceResult:
     """Search cardinality thresholds from a sound source-derived upper bound."""
+
+    import z3
 
     started = time.monotonic()
     source = request.hypergraph
@@ -174,8 +205,7 @@ def solve_independence_number(
                 termination_reason="SOLVER_CALL_LIMIT",
                 detail="the descending threshold search exhausted its solver-call budget",
             )
-        remaining_ms = _remaining_ms(started, request.resource_budget.wall_seconds)
-        if remaining_ms <= 0:
+        if _remaining_ms(started, request.resource_budget.wall_seconds) <= 0:
             return _result(
                 request,
                 status="UNKNOWN",
@@ -195,7 +225,8 @@ def solve_independence_number(
                 selected,
                 cardinality,
                 threshold,
-                remaining_ms,
+                started,
+                request.resource_budget.wall_seconds,
                 vertices,
             )
         except z3.Z3Exception as exc:
@@ -271,6 +302,102 @@ def solve_independence_number(
         termination_reason="OPTIMUM_ESTABLISHED",
         detail="all larger cardinality thresholds were proved unsatisfiable",
     )
+
+
+def _run_independence_worker(
+    payload: dict[str, object], *, timeout_seconds: int
+) -> object | None:
+    """Run one complete Z3 kernel in an isolated bounded owner process."""
+
+    try:
+        with TemporaryDirectory(
+            prefix="jacobian-hypergraph-independence-"
+        ) as directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_INDEPENDENCE_WORKER)],
+                input_bytes=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+                timeout_seconds=timeout_seconds,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_WORKER_OUTPUT_BYTES,
+                stderr_limit=_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(timeout_seconds)),
+                    address_space_bytes=_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=directory,
+            )
+    except OSError:
+        return None
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return None
+    try:
+        return cast(object, json.loads(completed.stdout.decode("utf-8")))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def verify_independence_result(result: HypergraphIndependenceResult) -> bool:
+    """Replay a supplied strict upper bound only in the bounded owner worker."""
+
+    source_upper_bound = _independence_upper_bound(result.hypergraph)
+    if result.upper_bound == source_upper_bound:
+        return True
+    response = _run_independence_worker(
+        {
+            "kind": "verify",
+            "hypergraph": result.hypergraph.model_dump(mode="json"),
+            "upper_bound": result.upper_bound,
+            "wall_seconds": result.resource_budget.wall_seconds,
+        },
+        timeout_seconds=result.resource_budget.wall_seconds,
+    )
+    return response is True
+
+
+def solve_independence_number(
+    request: HypergraphIndependenceRequest,
+) -> HypergraphIndependenceResult:
+    """Run every Z3 phase under one process and resource envelope."""
+
+    source_upper_bound = _independence_upper_bound(request.hypergraph)
+    incumbent = _greedy_independent_vertices(request.hypergraph)
+    response = _run_independence_worker(
+        {"kind": "solve", "request": request.model_dump(mode="json")},
+        timeout_seconds=request.resource_budget.wall_seconds,
+    )
+    if not isinstance(response, dict):
+        return _result(
+            request,
+            status="UNKNOWN",
+            independence_number=None,
+            incumbent=incumbent,
+            upper_bound=source_upper_bound,
+            solver_calls=0,
+            wall_budget_exhausted=False,
+            termination_reason="SOLVER_ERROR",
+            detail="the bounded hypergraph independence worker did not establish an outcome",
+        )
+    try:
+        return HypergraphIndependenceResult.model_validate(response)
+    except (TypeError, ValueError):
+        return _result(
+            request,
+            status="UNKNOWN",
+            independence_number=None,
+            incumbent=incumbent,
+            upper_bound=source_upper_bound,
+            solver_calls=0,
+            wall_budget_exhausted=False,
+            termination_reason="SOLVER_ERROR",
+            detail="the bounded hypergraph independence worker returned malformed output",
+        )
 
 
 __all__: list[str] = []

--- a/src/jacobian/math/hypergraphs/_independence_z3.py
+++ b/src/jacobian/math/hypergraphs/_independence_z3.py
@@ -305,7 +305,7 @@ def _solve_independence_number_kernel(
 
 
 def _run_independence_worker(
-    payload: dict[str, object], *, timeout_seconds: int
+    payload: dict[str, object], *, timeout_seconds: float
 ) -> object | None:
     """Run one complete Z3 kernel in an isolated bounded owner process."""
 
@@ -368,9 +368,25 @@ def solve_independence_number(
 
     source_upper_bound = _independence_upper_bound(request.hypergraph)
     incumbent = _greedy_independent_vertices(request.hypergraph)
+    started = time.monotonic()
+    remaining_seconds = (
+        _remaining_ms(started, request.resource_budget.wall_seconds) / 1_000
+    )
+    if remaining_seconds <= 0:
+        return _result(
+            request,
+            status="UNKNOWN",
+            independence_number=None,
+            incumbent=incumbent,
+            upper_bound=source_upper_bound,
+            solver_calls=0,
+            wall_budget_exhausted=True,
+            termination_reason="WALL_TIME",
+            detail="the hypergraph independence request expired before worker startup",
+        )
     response = _run_independence_worker(
         {"kind": "solve", "request": request.model_dump(mode="json")},
-        timeout_seconds=request.resource_budget.wall_seconds,
+        timeout_seconds=remaining_seconds,
     )
     if not isinstance(response, dict):
         return _result(
@@ -384,8 +400,28 @@ def solve_independence_number(
             termination_reason="SOLVER_ERROR",
             detail="the bounded hypergraph independence worker did not establish an outcome",
         )
+    if _remaining_ms(started, request.resource_budget.wall_seconds) <= 0:
+        return _result(
+            request,
+            status="UNKNOWN",
+            independence_number=None,
+            incumbent=incumbent,
+            upper_bound=source_upper_bound,
+            solver_calls=0,
+            wall_budget_exhausted=True,
+            termination_reason="WALL_TIME",
+            detail="the hypergraph independence request expired before response validation",
+        )
     try:
-        return HypergraphIndependenceResult.model_validate(response)
+        result = HypergraphIndependenceResult.model_validate(response)
+        if (
+            result.hypergraph != request.hypergraph
+            or result.resource_budget != request.resource_budget
+        ):
+            raise ValueError("worker result is bound to a different request")
+        if _remaining_ms(started, request.resource_budget.wall_seconds) > 0:
+            return result
+        raise ValueError("request expired during response validation")
     except (TypeError, ValueError):
         return _result(
             request,

--- a/src/jacobian/math/hypergraphs/_independence_z3.py
+++ b/src/jacobian/math/hypergraphs/_independence_z3.py
@@ -17,6 +17,7 @@ from jacobian.math.hypergraphs._models import (
     HypergraphIndependenceStatus,
     HypergraphIndependenceTermination,
     _greedy_independent_vertices,
+    _hypergraph_digest,
     _independence_upper_bound,
 )
 from jacobian.process import (
@@ -413,12 +414,17 @@ def solve_independence_number(
             detail="the hypergraph independence request expired before response validation",
         )
     try:
-        result = HypergraphIndependenceResult.model_validate(response)
-        if (
-            result.hypergraph != request.hypergraph
-            or result.resource_budget != request.resource_budget
-        ):
-            raise ValueError("worker result is bound to a different request")
+        # The worker returns only its bounded outcome projection.  Retained
+        # source data belongs to this parent request and must not consume the
+        # worker channel or be trusted from child output.
+        result = HypergraphIndependenceResult.model_validate(
+            {
+                **response,
+                "hypergraph": request.hypergraph.model_dump(mode="json"),
+                "hypergraph_digest": _hypergraph_digest(request.hypergraph),
+                "resource_budget": request.resource_budget.model_dump(mode="json"),
+            }
+        )
         if _remaining_ms(started, request.resource_budget.wall_seconds) > 0:
             return result
         raise ValueError("request expired during response validation")

--- a/src/jacobian/math/hypergraphs/_independence_z3.py
+++ b/src/jacobian/math/hypergraphs/_independence_z3.py
@@ -316,7 +316,9 @@ def _run_independence_worker(
         ) as directory:
             completed = run_bounded_process(
                 [sys.executable, str(_INDEPENDENCE_WORKER)],
-                input_bytes=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+                input_bytes=json.dumps(
+                    payload, separators=(",", ":"), ensure_ascii=False
+                ).encode("utf-8"),
                 timeout_seconds=timeout_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
                 stdout_limit=_WORKER_OUTPUT_BYTES,

--- a/src/jacobian/math/hypergraphs/_independence_z3_worker.py
+++ b/src/jacobian/math/hypergraphs/_independence_z3_worker.py
@@ -26,7 +26,17 @@ def main() -> int:
             request = HypergraphIndependenceRequest.model_validate(payload["request"])
             result = _solve_independence_number_kernel(request)
             sys.stdout.write(
-                json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
+                json.dumps(
+                    result.model_dump(
+                        mode="json",
+                        exclude={
+                            "hypergraph",
+                            "hypergraph_digest",
+                            "resource_budget",
+                        },
+                    ),
+                    separators=(",", ":"),
+                )
             )
             return 0
         if kind == "verify":

--- a/src/jacobian/math/hypergraphs/_independence_z3_worker.py
+++ b/src/jacobian/math/hypergraphs/_independence_z3_worker.py
@@ -1,0 +1,52 @@
+"""Isolated Z3 adapter for bounded hypergraph independence kernels."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.hypergraphs._independence_z3 import (
+    _solve_independence_number_kernel,
+    _verify_upper_bound_kernel,
+)
+from jacobian.math.hypergraphs._models import (
+    FiniteHypergraph,
+    HypergraphIndependenceRequest,
+)
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        if not isinstance(payload, dict):
+            raise ValueError("worker payload must be an object")
+        kind = payload["kind"]
+        if kind == "solve":
+            request = HypergraphIndependenceRequest.model_validate(payload["request"])
+            result = _solve_independence_number_kernel(request)
+            sys.stdout.write(
+                json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
+            )
+            return 0
+        if kind == "verify":
+            hypergraph = FiniteHypergraph.model_validate(payload["hypergraph"])
+            upper_bound = payload["upper_bound"]
+            wall_seconds = payload["wall_seconds"]
+            if (
+                isinstance(upper_bound, bool)
+                or not isinstance(upper_bound, int)
+                or isinstance(wall_seconds, bool)
+                or not isinstance(wall_seconds, int)
+            ):
+                raise ValueError("worker payload has invalid verification bounds")
+            verified = _verify_upper_bound_kernel(hypergraph, upper_bound, wall_seconds)
+            sys.stdout.write(json.dumps(verified))
+            return 0
+        raise ValueError("worker payload has invalid kind")
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/hypergraphs/_independence_z3_worker.py
+++ b/src/jacobian/math/hypergraphs/_independence_z3_worker.py
@@ -36,6 +36,7 @@ def main() -> int:
                         },
                     ),
                     separators=(",", ":"),
+                    ensure_ascii=False,
                 )
             )
             return 0

--- a/src/jacobian/math/logic/_sat.py
+++ b/src/jacobian/math/logic/_sat.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import math
 import re
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 from typing import Annotated, Literal, Self
@@ -49,6 +52,11 @@ _LPR_STACK_MEBIBYTES = 16
 _LPR_ADDRESS_SPACE_BYTES = 128 * 1024 * 1024
 _LPR_PROCESS_OUTPUT_BYTES = 16_384
 _MAX_LPR_RESULT_BYTES = 9 * 1024 * 1024
+_SAT_WORKER = Path(__file__).with_name("_sat_worker.py")
+_SAT_WORKER_OUTPUT_BYTES = 64 * 1024
+_SAT_WORKER_ERROR_BYTES = 16_384
+_SAT_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+_SAT_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 _CAKE_LPR_MANIFEST = Path("/usr/local/share/jacobian/cake-lpr.manifest")
 _CAKE_LPR_MANIFEST_FORMAT = "jacobian.cake-lpr/v1"
 _CAKE_LPR_MANIFEST_HASH_KEYS = frozenset({"basis_ffi.c", "cake_lpr.S"})
@@ -67,6 +75,9 @@ class SatSolveRequest(StrictModel):
 
 
 class SatSolveResult(StrictModel):
+    """One solver outcome bound to the exact canonical CNF it answers."""
+
+    source: SatSolveRequest
     outcome: Literal["SAT", "UNSAT", "UNKNOWN"]
     assignment: tuple[StrictBool, ...] | None = Field(
         default=None, max_length=_MAX_VARIABLES
@@ -81,6 +92,23 @@ class SatSolveResult(StrictModel):
                 "logic.sat_assignment_outcome",
                 "only a SAT result may carry an assignment",
             )
+        if self.assignment is not None:
+            if len(self.assignment) != len(self.source.cnf.variables):
+                raise _validation_error(
+                    "logic.sat_assignment_length",
+                    "a SAT assignment must cover the source CNF variable axis",
+                )
+            if not all(
+                any(
+                    self.assignment[abs(literal) - 1] == (literal > 0)
+                    for literal in clause
+                )
+                for clause in self.source.cnf.clauses
+            ):
+                raise _validation_error(
+                    "logic.sat_assignment_unsatisfied",
+                    "a SAT assignment must satisfy every source CNF clause",
+                )
         if self.exhausted is not None and self.outcome != "UNKNOWN":
             raise _validation_error(
                 "logic.unknown_exhaustion",
@@ -394,22 +422,24 @@ def _validate_lpr_refutation(cnf: CanonicalCnf, refutation: SatLprRefutation) ->
         )
 
 
-def solve_sat(request: SatSolveRequest) -> SatSolveResult:
-    """Solve one bounded canonical CNF through the maintained Z3 Python binding."""
+def _solve_sat_kernel(*, cnf: CanonicalCnf, timeout_ms: int) -> dict[str, object]:
+    """Run one complete Z3 SAT lifecycle inside the owned worker process."""
 
     try:
         import z3  # type: ignore[import-untyped]
     except (ImportError, OSError) as exc:
-        return SatSolveResult(
-            outcome="UNKNOWN",
-            detail=f"the Z3 backend could not initialize: {exc}"[:1_024],
-        )
+        return {
+            "outcome": "UNKNOWN",
+            "assignment": None,
+            "exhausted": None,
+            "detail": f"the Z3 backend could not initialize: {exc}"[:1_024],
+        }
 
     try:
-        variables = tuple(z3.Bool(name) for name in request.cnf.variables)
+        variables = tuple(z3.Bool(name) for name in cnf.variables)
         solver = z3.Solver()
-        solver.set(**_solver_settings(request.timeout_ms))
-        for clause in request.cnf.clauses:
+        solver.set(**_solver_settings(timeout_ms))
+        for clause in cnf.clauses:
             terms = tuple(
                 variables[abs(literal) - 1]
                 if literal > 0
@@ -425,28 +455,133 @@ def solve_sat(request: SatSolveRequest) -> SatSolveResult:
                 for variable in variables
             )
             checked_assignment = check_sat_assignment(
-                SatAssignmentCheckRequest(cnf=request.cnf, assignment=assignment)
+                SatAssignmentCheckRequest(cnf=cnf, assignment=assignment)
             )
             if not checked_assignment.satisfies:
-                return SatSolveResult(
-                    outcome="UNKNOWN",
-                    detail="the Z3 backend returned a model that does not satisfy the canonical CNF",
-                )
-            return SatSolveResult(outcome="SAT", assignment=assignment)
+                return {
+                    "outcome": "UNKNOWN",
+                    "assignment": None,
+                    "exhausted": None,
+                    "detail": (
+                        "the Z3 backend returned a model that does not satisfy the "
+                        "canonical CNF"
+                    ),
+                }
+            return {
+                "outcome": "SAT",
+                "assignment": list(assignment),
+                "exhausted": None,
+                "detail": None,
+            }
         if outcome == z3.unsat:
-            return SatSolveResult(outcome="UNSAT")
+            return {
+                "outcome": "UNSAT",
+                "assignment": None,
+                "exhausted": None,
+                "detail": None,
+            }
     except (OSError, z3.Z3Exception) as exc:
         exhausted = _classify_exhaustion(str(exc))
         if exhausted is not None:
-            return SatSolveResult(
-                outcome="UNKNOWN",
-                exhausted=exhausted,
-                detail=_EXHAUSTION_DETAILS[exhausted],
-            )
+            return {
+                "outcome": "UNKNOWN",
+                "assignment": None,
+                "exhausted": exhausted,
+                "detail": _EXHAUSTION_DETAILS[exhausted],
+            }
         detail = f"the Z3 backend failed during the bounded solve: {exc}"
-        return SatSolveResult(outcome="UNKNOWN", detail=detail[:1_024])
+        return {
+            "outcome": "UNKNOWN",
+            "assignment": None,
+            "exhausted": None,
+            "detail": detail[:1_024],
+        }
     exhausted, detail = _project_unknown(solver.reason_unknown())
-    return SatSolveResult(outcome="UNKNOWN", exhausted=exhausted, detail=detail)
+    return {
+        "outcome": "UNKNOWN",
+        "assignment": None,
+        "exhausted": exhausted,
+        "detail": detail,
+    }
+
+
+def _result(request: SatSolveRequest, **values: object) -> SatSolveResult:
+    """Bind every projected worker outcome to its exact admitted source."""
+
+    return SatSolveResult.model_validate(
+        {"source": request.model_dump(mode="json"), **values}
+    )
+
+
+def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
+    """Project one killable SAT worker invocation onto the public result."""
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="jacobian-sat-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_SAT_WORKER)],
+                input_bytes=json.dumps(
+                    request.model_dump(mode="json"), separators=(",", ":")
+                ).encode("utf-8"),
+                timeout_seconds=request.timeout_ms / 1_000,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_SAT_WORKER_OUTPUT_BYTES,
+                stderr_limit=_SAT_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(request.timeout_ms / 1_000)),
+                    address_space_bytes=_SAT_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_SAT_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError:
+        return _result(
+            request,
+            outcome="UNKNOWN",
+            detail="the bounded Z3 worker could not be started",
+        )
+    if completed.timed_out:
+        return _result(
+            request,
+            outcome="UNKNOWN",
+            exhausted="time",
+            detail=_EXHAUSTION_DETAILS["time"],
+        )
+    if completed.cancelled:
+        return _result(
+            request, outcome="UNKNOWN", detail="the bounded Z3 worker was cancelled"
+        )
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        return _result(
+            request,
+            outcome="UNKNOWN",
+            detail="the bounded Z3 worker exceeded its output limit",
+        )
+    if completed.returncode != 0:
+        return _result(
+            request,
+            outcome="UNKNOWN",
+            detail="the bounded Z3 worker failed before returning a result",
+        )
+    try:
+        return SatSolveResult.model_validate(
+            {
+                "source": request.model_dump(mode="json"),
+                **json.loads(completed.stdout.decode("utf-8")),
+            }
+        )
+    except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return _result(
+            request,
+            outcome="UNKNOWN",
+            detail="the bounded Z3 worker returned malformed output",
+        )
+
+
+def solve_sat(request: SatSolveRequest) -> SatSolveResult:
+    """Solve one canonical CNF in a killable owner-local Z3 worker."""
+
+    return _run_sat_worker(request)
 
 
 def _dimacs_cnf(cnf: CanonicalCnf) -> bytes:
@@ -629,6 +764,8 @@ __all__ = [
     "SatRefutationCheckResult",
     "SatSolveRequest",
     "SatSolveResult",
+    "_run_sat_worker",
+    "_solve_sat_kernel",
     "check_sat_refutation",
     "solve_sat",
 ]

--- a/src/jacobian/math/logic/_sat.py
+++ b/src/jacobian/math/logic/_sat.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Annotated, Literal, Self
 
@@ -513,17 +514,30 @@ def _result(request: SatSolveRequest, **values: object) -> SatSolveResult:
     )
 
 
+def _time_exhausted_result(request: SatSolveRequest) -> SatSolveResult:
+    return _result(
+        request,
+        outcome="UNKNOWN",
+        exhausted="time",
+        detail=_EXHAUSTION_DETAILS["time"],
+    )
+
+
 def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
     """Project one killable SAT worker invocation onto the public result."""
 
+    deadline = time.monotonic() + (request.timeout_ms / 1_000)
     try:
         with tempfile.TemporaryDirectory(prefix="jacobian-sat-") as worker_directory:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return _time_exhausted_result(request)
             completed = run_bounded_process(
                 [sys.executable, str(_SAT_WORKER)],
                 input_bytes=json.dumps(
                     request.model_dump(mode="json"), separators=(",", ":")
                 ).encode("utf-8"),
-                timeout_seconds=request.timeout_ms / 1_000,
+                timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
                 stdout_limit=_SAT_WORKER_OUTPUT_BYTES,
                 stderr_limit=_SAT_WORKER_ERROR_BYTES,
@@ -541,12 +555,7 @@ def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
             detail="the bounded Z3 worker could not be started",
         )
     if completed.timed_out:
-        return _result(
-            request,
-            outcome="UNKNOWN",
-            exhausted="time",
-            detail=_EXHAUSTION_DETAILS["time"],
-        )
+        return _time_exhausted_result(request)
     if completed.cancelled:
         return _result(
             request, outcome="UNKNOWN", detail="the bounded Z3 worker was cancelled"
@@ -563,12 +572,17 @@ def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
             outcome="UNKNOWN",
             detail="the bounded Z3 worker failed before returning a result",
         )
+    if time.monotonic() >= deadline:
+        return _time_exhausted_result(request)
     try:
-        return SatSolveResult.model_validate(
+        result = SatSolveResult.model_validate(
             {
                 "source": request.model_dump(mode="json"),
                 **json.loads(completed.stdout.decode("utf-8")),
             }
+        )
+        return (
+            result if time.monotonic() < deadline else _time_exhausted_result(request)
         )
     except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
         return _result(

--- a/src/jacobian/math/logic/_sat_worker.py
+++ b/src/jacobian/math/logic/_sat_worker.py
@@ -1,0 +1,24 @@
+"""Isolated Z3 adapter for one canonical SAT request."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.logic._sat import SatSolveRequest, _solve_sat_kernel
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        request = SatSolveRequest.model_validate(payload)
+        response = _solve_sat_kernel(cnf=request.cnf, timeout_ms=request.timeout_ms)
+        sys.stdout.write(json.dumps(response, separators=(",", ":")))
+        return 0
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/logic/_smt.py
+++ b/src/jacobian/math/logic/_smt.py
@@ -6,6 +6,7 @@ import json
 import math
 import re
 import sys
+import time
 from enum import StrEnum
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -348,9 +349,9 @@ class SmtSolveResult(StrictModel):
         default=None,
         max_length=_MAX_MODEL_BYTES,
         description=(
-            "Bounded Z3 display projection of the source-verified satisfying model. "
-            "It is provided for inspection, not as a canonical mathematical value or "
-            "an independently verifiable model encoding."
+            "Bounded Z3 display projection of the worker's satisfying model. It is "
+            "provided for inspection, not as a canonical mathematical value or an "
+            "independently verifiable model encoding."
         ),
     )
     exhausted: _UnknownResource | None = Field(default=None)
@@ -527,11 +528,15 @@ def _solve_smt_kernel(
 def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
     """Project one killable worker invocation onto the public typed result."""
 
+    deadline = time.monotonic() + (request.timeout_ms / 1_000)
     try:
         # The isolated worker has no reason to inherit the checkout as its
         # current directory.  Its input arrives only through stdin and its
         # only accepted output is the bounded JSON response on stdout.
         with TemporaryDirectory(prefix="jacobian-smt-") as worker_directory:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return _time_exhausted_result(request)
             completed = run_bounded_process(
                 [sys.executable, str(_SMT_WORKER)],
                 input_bytes=json.dumps(
@@ -542,7 +547,7 @@ def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
                     },
                     separators=(",", ":"),
                 ).encode("utf-8"),
-                timeout_seconds=request.timeout_ms / 1_000,
+                timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
                 stdout_limit=_SMT_WORKER_OUTPUT_BYTES,
                 stderr_limit=_SMT_WORKER_ERROR_BYTES,
@@ -577,10 +582,15 @@ def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
             outcome="UNKNOWN",
             detail="the bounded Z3 worker failed before returning a result",
         )
+    if time.monotonic() >= deadline:
+        return _time_exhausted_result(request)
     try:
         response = json.loads(completed.stdout.decode("utf-8"))
-        return SmtSolveResult.model_validate(
+        result = SmtSolveResult.model_validate(
             {"source": request.model_dump(mode="json"), **response}
+        )
+        return (
+            result if time.monotonic() < deadline else _time_exhausted_result(request)
         )
     except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
         return _result(

--- a/src/jacobian/math/logic/_smt.py
+++ b/src/jacobian/math/logic/_smt.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import json
+import math
 import re
-import time
+import sys
 from enum import StrEnum
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Literal, NamedTuple, Self
 
 from pydantic import (
@@ -15,6 +19,11 @@ from pydantic import (
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
 
 _MAX_SMTLIB_BYTES = 128_000
 # Structural SMT-LIB budgets, enforced before Z3 sees the source. Depth bounds
@@ -38,6 +47,17 @@ _MAX_SMTLIB_NUMERAL_DIGITS = 4_096
 _SOLVER_RLIMIT = 20_000_000
 _SOLVER_MAX_MEMORY_MB = 1024
 _MAX_MODEL_BYTES = 64_000
+_SMT_WORKER = Path(__file__).with_name("_smt_worker.py")
+# JSON escaping can expand a model's UTF-8 spelling by almost twofold.  The
+# process capture allowance therefore bounds the transport representation,
+# while ``SmtSolveResult`` continues to own the public 64 KiB model contract.
+_SMT_WORKER_OUTPUT_BYTES = (_MAX_MODEL_BYTES * 2) + 4_096
+_SMT_WORKER_ERROR_BYTES = 16_384
+_SMT_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+# The worker receives no legitimate filesystem output.  Retain a small cap for
+# backend diagnostics while preventing an admitted query from filling the
+# inherited filesystem if a native dependency misbehaves.
+_SMT_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 _SUPPORTED_SMTLIB_COMMANDS = frozenset(
     {"set-logic", "declare-const", "declare-fun", "assert", "check-sat"}
 )
@@ -320,8 +340,19 @@ class SmtSolveRequest(StrictModel):
 
 
 class SmtSolveResult(StrictModel):
+    """One solver outcome bound to the exact SMT-LIB request it answers."""
+
+    source: SmtSolveRequest
     outcome: Literal["SAT", "UNSAT", "UNKNOWN"]
-    model_smtlib: str | None = Field(default=None, max_length=_MAX_MODEL_BYTES)
+    model_smtlib: str | None = Field(
+        default=None,
+        max_length=_MAX_MODEL_BYTES,
+        description=(
+            "Bounded Z3 display projection of the source-verified satisfying model. "
+            "It is provided for inspection, not as a canonical mathematical value or "
+            "an independently verifiable model encoding."
+        ),
+    )
     exhausted: _UnknownResource | None = Field(default=None)
     detail: str | None = Field(default=None, max_length=1_024)
 
@@ -392,88 +423,177 @@ def _solver_settings(timeout_ms: int) -> dict[str, int]:
     }
 
 
-def _time_exhausted_result() -> SmtSolveResult:
+def _result(request: SmtSolveRequest, **values: object) -> SmtSolveResult:
+    """Bind every projected worker outcome to its exact admitted source."""
+
+    return SmtSolveResult.model_validate(
+        {"source": request.model_dump(mode="json"), **values}
+    )
+
+
+def _time_exhausted_result(request: SmtSolveRequest) -> SmtSolveResult:
     """Project expiry of the admitted owner envelope as a non-conclusion."""
 
-    return SmtSolveResult(
+    return _result(
+        request,
         outcome="UNKNOWN",
         exhausted="time",
         detail=_EXHAUSTION_DETAILS["time"],
     )
 
 
-def _remaining_timeout_ms(deadline: float) -> int | None:
-    """Return the remaining owner time in milliseconds, or ``None`` on expiry."""
+def _solve_smt_kernel(
+    *, logic: str, smtlib: str, timeout_ms: int
+) -> dict[str, str | None]:
+    """Run one complete Z3 lifecycle inside the owned worker process."""
 
-    remaining_seconds = deadline - time.monotonic()
-    if remaining_seconds <= 0:
-        return None
-    return max(1, int(remaining_seconds * 1_000))
-
-
-def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
-    """Solve one bounded SMT-LIB query through the maintained Z3 Python binding."""
-
-    deadline = time.monotonic() + request.timeout_ms / 1_000
     try:
         import z3  # type: ignore[import-untyped]
     except (ImportError, OSError) as exc:
-        return SmtSolveResult(
-            outcome="UNKNOWN",
-            detail=f"the Z3 backend could not initialize: {exc}"[:1_024],
-        )
+        return {
+            "outcome": "UNKNOWN",
+            "model_smtlib": None,
+            "exhausted": None,
+            "detail": f"the Z3 backend could not initialize: {exc}"[:1_024],
+        }
 
     try:
-        assertions = z3.parse_smt2_string(request.smtlib)
-        remaining_timeout_ms = _remaining_timeout_ms(deadline)
-        if remaining_timeout_ms is None:
-            return _time_exhausted_result()
-        solver = z3.SolverFor(request.logic.value)
-        solver.set(**_solver_settings(remaining_timeout_ms))
+        assertions = z3.parse_smt2_string(smtlib)
+        solver = z3.SolverFor(logic)
         solver.add(assertions)
-        if _remaining_timeout_ms(deadline) is None:
-            return _time_exhausted_result()
+        solver.set(**_solver_settings(timeout_ms))
         outcome = solver.check()
-        if _remaining_timeout_ms(deadline) is None:
-            return _time_exhausted_result()
         if outcome == z3.sat:
             model = solver.model()
             if not all(
                 z3.is_true(model.eval(assertion, model_completion=True))
                 for assertion in assertions
             ):
-                return SmtSolveResult(
-                    outcome="UNKNOWN",
-                    detail=(
+                return {
+                    "outcome": "UNKNOWN",
+                    "model_smtlib": None,
+                    "exhausted": None,
+                    "detail": (
                         "the Z3 backend returned a model that does not satisfy the "
                         "admitted SMT-LIB assertions"
                     ),
-                )
+                }
             model_smtlib = model.sexpr()
-            if _remaining_timeout_ms(deadline) is None:
-                return _time_exhausted_result()
             if len(model_smtlib.encode("utf-8")) > _MAX_MODEL_BYTES:
-                return SmtSolveResult(
-                    outcome="UNKNOWN",
-                    detail="the satisfying model exceeds the bounded result limit",
-                )
-            return SmtSolveResult(outcome="SAT", model_smtlib=model_smtlib)
+                return {
+                    "outcome": "UNKNOWN",
+                    "model_smtlib": None,
+                    "exhausted": None,
+                    "detail": "the satisfying model exceeds the bounded result limit",
+                }
+            return {
+                "outcome": "SAT",
+                "model_smtlib": model_smtlib,
+                "exhausted": None,
+                "detail": None,
+            }
         if outcome == z3.unsat:
-            return SmtSolveResult(outcome="UNSAT")
+            return {
+                "outcome": "UNSAT",
+                "model_smtlib": None,
+                "exhausted": None,
+                "detail": None,
+            }
     except (OSError, z3.Z3Exception) as exc:
         exhausted = _classify_exhaustion(str(exc))
         if exhausted is not None:
-            return SmtSolveResult(
-                outcome="UNKNOWN",
-                exhausted=exhausted,
-                detail=_EXHAUSTION_DETAILS[exhausted],
-            )
+            return {
+                "outcome": "UNKNOWN",
+                "model_smtlib": None,
+                "exhausted": exhausted,
+                "detail": _EXHAUSTION_DETAILS[exhausted],
+            }
         detail = f"the Z3 backend failed during the bounded solve: {exc}"
-        return SmtSolveResult(outcome="UNKNOWN", detail=detail[:1_024])
-    if _remaining_timeout_ms(deadline) is None:
-        return _time_exhausted_result()
+        return {
+            "outcome": "UNKNOWN",
+            "model_smtlib": None,
+            "exhausted": None,
+            "detail": detail[:1_024],
+        }
     exhausted, detail = _project_unknown(solver.reason_unknown())
-    return SmtSolveResult(outcome="UNKNOWN", exhausted=exhausted, detail=detail)
+    return {
+        "outcome": "UNKNOWN",
+        "model_smtlib": None,
+        "exhausted": exhausted,
+        "detail": detail,
+    }
+
+
+def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
+    """Project one killable worker invocation onto the public typed result."""
+
+    try:
+        # The isolated worker has no reason to inherit the checkout as its
+        # current directory.  Its input arrives only through stdin and its
+        # only accepted output is the bounded JSON response on stdout.
+        with TemporaryDirectory(prefix="jacobian-smt-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_SMT_WORKER)],
+                input_bytes=json.dumps(
+                    {
+                        "logic": request.logic.value,
+                        "smtlib": request.smtlib,
+                        "timeout_ms": request.timeout_ms,
+                    },
+                    separators=(",", ":"),
+                ).encode("utf-8"),
+                timeout_seconds=request.timeout_ms / 1_000,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_SMT_WORKER_OUTPUT_BYTES,
+                stderr_limit=_SMT_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(request.timeout_ms / 1_000)),
+                    address_space_bytes=_SMT_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_SMT_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError:
+        return _result(
+            request,
+            outcome="UNKNOWN",
+            detail="the bounded Z3 worker could not be started",
+        )
+    if completed.timed_out:
+        return _time_exhausted_result(request)
+    if completed.cancelled:
+        return _result(
+            request, outcome="UNKNOWN", detail="the bounded Z3 worker was cancelled"
+        )
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        return _result(
+            request,
+            outcome="UNKNOWN",
+            detail="the bounded Z3 worker exceeded its output limit",
+        )
+    if completed.returncode != 0:
+        return _result(
+            request,
+            outcome="UNKNOWN",
+            detail="the bounded Z3 worker failed before returning a result",
+        )
+    try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+        return SmtSolveResult.model_validate(
+            {"source": request.model_dump(mode="json"), **response}
+        )
+    except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return _result(
+            request,
+            outcome="UNKNOWN",
+            detail="the bounded Z3 worker returned malformed output",
+        )
+
+
+def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
+    """Solve one query in a killable owner-local Z3 worker process."""
+
+    return _run_smt_worker(request)
 
 
 __all__ = [
@@ -485,7 +605,8 @@ __all__ = [
     "_classify_exhaustion",
     "_is_smtlib_source_diagnostic",
     "_project_unknown",
-    "_remaining_timeout_ms",
+    "_run_smt_worker",
+    "_solve_smt_kernel",
     "_solver_settings",
     "_tokenize_smtlib",
     "_top_level_smtlib_commands",

--- a/src/jacobian/math/logic/_smt_worker.py
+++ b/src/jacobian/math/logic/_smt_worker.py
@@ -1,0 +1,36 @@
+"""Isolated Z3 adapter for one structurally admitted SMT-LIB request."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.logic._smt import _solve_smt_kernel
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        if not isinstance(payload, dict):
+            raise ValueError("worker payload must be an object")
+        logic = payload["logic"]
+        smtlib = payload["smtlib"]
+        timeout_ms = payload["timeout_ms"]
+        if not isinstance(logic, str) or not isinstance(smtlib, str):
+            raise ValueError("worker payload has invalid source fields")
+        if isinstance(timeout_ms, bool) or not isinstance(timeout_ms, int):
+            raise ValueError("worker payload has invalid timeout")
+        response = _solve_smt_kernel(
+            logic=logic,
+            smtlib=smtlib,
+            timeout_ms=timeout_ms,
+        )
+        sys.stdout.write(json.dumps(response, separators=(",", ":")))
+        return 0
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import json
+import math
 import re
+import sys
 from fractions import Fraction
 from math import lcm
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, Literal, NamedTuple, Self
 
 from pydantic import ConfigDict, Field, StrictInt, model_validator
@@ -12,13 +17,18 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
-from jacobian.catalog.models import MathTool
+from jacobian.catalog.models import MathTool, OperationDomainValidationError
 from jacobian.math.logic._smt import (
     SmtLogic,
     SmtSolveRequest,
     _is_smtlib_source_diagnostic,
     _tokenize_smtlib,
     _top_level_smtlib_commands,
+)
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
 )
 
 _MAX_CORE_ASSERTIONS = 512
@@ -27,6 +37,11 @@ _MAX_CORE_NESTING_DEPTH = 256
 _MAX_CORE_NUMERAL_DIGITS = 256
 _MAX_CORE_AST_NODES = 4_096
 _MAX_CORE_RLIMIT = 10_000_000
+_UNSAT_CORE_WORKER = Path(__file__).with_name("_unsat_core_worker.py")
+_UNSAT_CORE_WORKER_OUTPUT_BYTES = 64 * 1024
+_UNSAT_CORE_WORKER_ERROR_BYTES = 16_384
+_UNSAT_CORE_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+_UNSAT_CORE_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 _NUMERAL = re.compile(r"(?:-?[0-9]+(?:\.[0-9]+)?|#x[0-9a-fA-F]+|#b[01]+)")
 _AffineTerms = tuple[tuple[Fraction, Any], ...]
 _AffineForm = tuple[_AffineTerms, Fraction]
@@ -136,14 +151,10 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
     selections, where scaling is validated against every branch's reachable
     coefficient digits, so a numerically smaller branch cannot hide reciprocal
     growth beyond the digit budget).
-    Assertion source order is the public zero-based index. Parsing constructs Z3
-    syntax trees only; it does not evaluate the source as Python or as a host
-    command. Execution performs one tracked check and at most one direct
-    tracked check and at most one direct result-validation replay, each under the
-    supplied deterministic rlimit and timeout safety net.
-    Z3 5.0 exposes only a process-global memory threshold, so this in-process
-    operation does not claim a hard request-local byte limit; fixed source, AST,
-    coefficient, and resource-unit bounds control its admitted memory envelope.
+    Assertion source order is the public zero-based index. Request validation is
+    lexical only: parsing, fragment classification, tracked solving, and optional
+    replay run in the owner-local bounded Z3 worker and never evaluate the source
+    as Python or as a host command.
     """
 
     model_config = ConfigDict(
@@ -207,13 +218,6 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
             raise _logic_error(
                 f"SMT core source may contain at most {_MAX_CORE_ASSERTIONS} source assertions"
             )
-        parsed_error = _parsed_request_error(
-            self.smtlib,
-            assertion_count=self.assertion_count,
-            logic=self.logic,
-        )
-        if parsed_error is not None:
-            raise _logic_error(parsed_error)
         return self
 
 
@@ -1273,6 +1277,16 @@ def _extract_source_core(
         return "UNKNOWN", (), "Z3 could not complete the bounded source check."
 
 
+def _classify_source_for_execution(source: SmtUnsatCoreRequest) -> str | None:
+    """Return one backend-established semantic request error, if any."""
+
+    return _parsed_request_error(
+        source.smtlib,
+        assertion_count=source.assertion_count,
+        logic=source.logic,
+    )
+
+
 def _replay_source(
     source: SmtUnsatCoreRequest,
     selected_indices: tuple[int, ...] | None,
@@ -1297,6 +1311,74 @@ def _replay_source(
         return "UNKNOWN", "Z3 could not complete the bounded source replay."
 
 
+def _unsat_core_worker_kernel(
+    source: SmtUnsatCoreRequest,
+    *,
+    selected_indices: tuple[int, ...] | None = None,
+) -> dict[str, object]:
+    """Run semantic admission plus one owned core or replay kernel in a worker."""
+
+    semantic_error = _classify_source_for_execution(source)
+    if semantic_error is not None:
+        return {"kind": "invalid", "detail": semantic_error}
+    if selected_indices is None:
+        outcome, core_indices, detail = _extract_source_core(source)
+        return {
+            "kind": "result",
+            "outcome": outcome,
+            "core_indices": list(core_indices),
+            "detail": detail,
+        }
+    outcome, detail = _replay_source(source, selected_indices)
+    return {"kind": "replay", "outcome": outcome, "detail": detail}
+
+
+def _run_unsat_core_worker(
+    source: SmtUnsatCoreRequest,
+    *,
+    selected_indices: tuple[int, ...] | None = None,
+) -> dict[str, object] | None:
+    """Execute one semantic core phase in an isolated, bounded Z3 worker."""
+
+    payload: dict[str, object] = {
+        "request": source.model_dump(mode="json"),
+        "selected_indices": list(selected_indices)
+        if selected_indices is not None
+        else None,
+    }
+    try:
+        with TemporaryDirectory(prefix="jacobian-unsat-core-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_UNSAT_CORE_WORKER)],
+                input_bytes=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+                timeout_seconds=source.timeout_ms / 1_000,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_UNSAT_CORE_WORKER_OUTPUT_BYTES,
+                stderr_limit=_UNSAT_CORE_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(source.timeout_ms / 1_000)),
+                    address_space_bytes=_UNSAT_CORE_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_UNSAT_CORE_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError:
+        return None
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return None
+    try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return response if isinstance(response, dict) else None
+
+
 def verify_smt_unsat_core_result(result: SmtUnsatCoreResult) -> bool:
     """Replay one independently supplied non-UNKNOWN source-bound claim.
 
@@ -1308,20 +1390,52 @@ def verify_smt_unsat_core_result(result: SmtUnsatCoreResult) -> bool:
     if result.outcome == "UNKNOWN":
         return True
     selected_indices = result.core_indices if result.outcome == "UNSAT" else None
-    replay, _detail = _replay_source(result.source, selected_indices)
-    return replay == result.outcome
+    response = _run_unsat_core_worker(result.source, selected_indices=selected_indices)
+    return (
+        response is not None
+        and response.get("kind") == "replay"
+        and response.get("outcome") == result.outcome
+    )
 
 
 def compute_smt_unsat_core(request: SmtUnsatCoreRequest) -> SmtUnsatCoreResult:
     """Return a bounded core of source-assertion indices when Z3 proves UNSAT."""
 
-    outcome, core_indices, detail = _extract_source_core(request)
-    return SmtUnsatCoreResult._from_kernel(
-        source=request,
-        outcome=outcome,
-        core_indices=core_indices,
-        detail=detail,
-    )
+    response = _run_unsat_core_worker(request)
+    if response is None:
+        return SmtUnsatCoreResult(
+            source=request,
+            outcome="UNKNOWN",
+            detail="the bounded SMT core worker did not establish an outcome",
+        )
+    detail = response.get("detail")
+    if response.get("kind") == "invalid" and isinstance(detail, str):
+        raise OperationDomainValidationError(
+            location=("smtlib",),
+            code="logic.unsat_core_contract",
+            message=detail[:1_024],
+        )
+    if response.get("kind") != "result":
+        return SmtUnsatCoreResult(
+            source=request,
+            outcome="UNKNOWN",
+            detail="the bounded SMT core worker returned malformed output",
+        )
+    try:
+        return SmtUnsatCoreResult.model_validate(
+            {
+                "source": request,
+                "outcome": response["outcome"],
+                "core_indices": response["core_indices"],
+                "detail": response["detail"],
+            }
+        )
+    except (KeyError, TypeError, ValueError):
+        return SmtUnsatCoreResult(
+            source=request,
+            outcome="UNKNOWN",
+            detail="the bounded SMT core worker returned malformed output",
+        )
 
 
 SMT_UNSAT_CORE_OPERATION = MathTool(

--- a/src/jacobian/math/logic/_unsat_core_worker.py
+++ b/src/jacobian/math/logic/_unsat_core_worker.py
@@ -1,0 +1,42 @@
+"""Isolated Z3 adapter for one SMT-core extraction or replay request."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.logic._unsat_core import (
+    SmtUnsatCoreRequest,
+    _unsat_core_worker_kernel,
+)
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        if not isinstance(payload, dict):
+            raise ValueError("worker payload must be an object")
+        request = SmtUnsatCoreRequest.model_validate(payload["request"])
+        raw_selected_indices = payload.get("selected_indices")
+        if raw_selected_indices is None:
+            selected_indices = None
+        elif isinstance(raw_selected_indices, list) and all(
+            isinstance(index, int) and not isinstance(index, bool)
+            for index in raw_selected_indices
+        ):
+            selected_indices = tuple(raw_selected_indices)
+        else:
+            raise ValueError("worker payload has invalid selected indices")
+        response = _unsat_core_worker_kernel(
+            request,
+            selected_indices=selected_indices,
+        )
+        sys.stdout.write(json.dumps(response, separators=(",", ":")))
+        return 0
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/number_field/_operations.py
+++ b/src/jacobian/math/number_field/_operations.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import math
 import sys
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
@@ -14,6 +16,9 @@ from jacobian.math.number_field._models import (
 )
 
 _WORKER = Path(__file__).resolve().with_name("_worker.py")
+_WORKER_TIMEOUT_SECONDS = 60.0
+_WORKER_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_WORKER_FILE_SIZE_BYTES = 1024 * 1024
 
 
 def compute_nf_discriminant(
@@ -25,17 +30,32 @@ def compute_nf_discriminant(
         worker_environment,
     )
 
-    completed = run_bounded_process(
-        [sys.executable, str(_WORKER)],
-        input_bytes=json.dumps(
-            request.model_dump(mode="json"), separators=(",", ":")
-        ).encode(),
-        timeout_seconds=60.0,
-        environment=worker_environment(locale="C.UTF-8"),
-        stdout_limit=128 * 1024,
-        stderr_limit=64 * 1024,
-        resource_limits=ProcessResourceLimits(address_space_bytes=1024 * 1024 * 1024),
-    )
+    try:
+        # The worker needs no ambient files: its request is stdin and its
+        # response is bounded stdout.  A private cwd and regular-file ceiling
+        # keep a native backend from using the checkout as scratch space.
+        with TemporaryDirectory(prefix="jacobian-number-field-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_WORKER)],
+                input_bytes=json.dumps(
+                    request.model_dump(mode="json"), separators=(",", ":")
+                ).encode(),
+                timeout_seconds=_WORKER_TIMEOUT_SECONDS,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=128 * 1024,
+                stderr_limit=64 * 1024,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=math.ceil(_WORKER_TIMEOUT_SECONDS),
+                    address_space_bytes=_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError:
+        return NumberFieldDiscriminantResult(
+            status="UNKNOWN",
+            detail="the bounded number-field worker could not be started",
+        )
     if (
         completed.timed_out
         or completed.cancelled

--- a/src/jacobian/math/number_field/_worker.py
+++ b/src/jacobian/math/number_field/_worker.py
@@ -10,27 +10,24 @@ from jacobian.math.number_field._models import NumberFieldRequest
 
 
 def main() -> int:
-    try:
-        request = NumberFieldRequest.model_validate(json.load(sys.stdin))
-        import sympy
+    request = NumberFieldRequest.model_validate(json.load(sys.stdin))
+    import sympy
 
-        variable = sympy.Symbol(request.variable)
-        polynomial = sympy.Poly.from_list(
-            [int(value) for value in request.coefficients_descending],
-            gens=variable,
-            domain=sympy.ZZ,
-        )
-        if not polynomial.is_irreducible:
-            response: dict[str, object] = {"kind": "invalid"}
-        else:
-            response = {
-                "kind": "complete",
-                "discriminant": discriminant(
-                    request.coefficients_descending, request.variable
-                ),
-            }
-    except Exception as exc:
-        response = {"kind": "error", "error": type(exc).__name__}
+    variable = sympy.Symbol(request.variable)
+    polynomial = sympy.Poly.from_list(
+        [int(value) for value in request.coefficients_descending],
+        gens=variable,
+        domain=sympy.ZZ,
+    )
+    if not polynomial.is_irreducible:
+        response: dict[str, object] = {"kind": "invalid"}
+    else:
+        response = {
+            "kind": "complete",
+            "discriminant": discriminant(
+                request.coefficients_descending, request.variable
+            ),
+        }
     json.dump(response, sys.stdout, separators=(",", ":"))
     return 0
 

--- a/src/jacobian/math/number_theory/_certified_factorization_worker.py
+++ b/src/jacobian/math/number_theory/_certified_factorization_worker.py
@@ -14,14 +14,11 @@ from jacobian.math.number_theory._factorization_kernels import (
 
 
 def main() -> int:
-    try:
-        request = CertifiedFactorizationRequest.model_validate(json.load(sys.stdin))
-        response: dict[str, object] = {
-            "ok": True,
-            "result": _factorize_certified_in_process(request).model_dump(mode="json"),
-        }
-    except Exception as exc:
-        response = {"ok": False, "error": type(exc).__name__}
+    request = CertifiedFactorizationRequest.model_validate(json.load(sys.stdin))
+    response: dict[str, object] = {
+        "ok": True,
+        "result": _factorize_certified_in_process(request).model_dump(mode="json"),
+    }
     json.dump(response, sys.stdout, separators=(",", ":"))
     return 0
 

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -6,6 +6,7 @@ import json
 import math
 import sys
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.number_theory._certification_models import (
@@ -39,6 +40,9 @@ _CERTIFIED_FACTORIZATION_WORKER = (
 _DIRECT_FACTORIZATION_WORKER = (
     Path(__file__).resolve().with_name("_direct_factorization_worker.py")
 )
+_FACTORIZATION_WORKER_TIMEOUT_SECONDS = 60.0
+_FACTORIZATION_WORKER_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_FACTORIZATION_WORKER_FILE_SIZE_BYTES = 1024 * 1024
 
 
 def _build_pratt_certificate(prime: int) -> PrattCertificateNode:
@@ -136,17 +140,31 @@ def factorize_certified(
         worker_environment,
     )
 
-    completed = run_bounded_process(
-        [sys.executable, str(_CERTIFIED_FACTORIZATION_WORKER)],
-        input_bytes=json.dumps(
-            {"value": request.value}, separators=(",", ":")
-        ).encode(),
-        timeout_seconds=60.0,
-        environment=worker_environment(locale="C.UTF-8"),
-        stdout_limit=1024 * 1024,
-        stderr_limit=64 * 1024,
-        resource_limits=ProcessResourceLimits(address_space_bytes=1024 * 1024 * 1024),
-    )
+    try:
+        with TemporaryDirectory(
+            prefix="jacobian-certified-factor-"
+        ) as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_CERTIFIED_FACTORIZATION_WORKER)],
+                input_bytes=json.dumps(
+                    {"value": request.value}, separators=(",", ":")
+                ).encode(),
+                timeout_seconds=_FACTORIZATION_WORKER_TIMEOUT_SECONDS,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=1024 * 1024,
+                stderr_limit=64 * 1024,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=math.ceil(_FACTORIZATION_WORKER_TIMEOUT_SECONDS),
+                    address_space_bytes=_FACTORIZATION_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_FACTORIZATION_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError:
+        return CertifiedFactorizationResult._unknown(
+            value=request.value,
+            detail="the bounded factorization worker could not be started",
+        )
     if (
         completed.timed_out
         or completed.cancelled
@@ -188,15 +206,26 @@ def _bounded_direct_factorization(value: int) -> tuple[PrimePower, ...] | None:
         worker_environment,
     )
 
-    completed = run_bounded_process(
-        [sys.executable, str(_DIRECT_FACTORIZATION_WORKER)],
-        input_bytes=json.dumps({"value": str(value)}, separators=(",", ":")).encode(),
-        timeout_seconds=60.0,
-        environment=worker_environment(locale="C.UTF-8"),
-        stdout_limit=64 * 1024,
-        stderr_limit=64 * 1024,
-        resource_limits=ProcessResourceLimits(address_space_bytes=1024 * 1024 * 1024),
-    )
+    try:
+        with TemporaryDirectory(prefix="jacobian-direct-factor-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_DIRECT_FACTORIZATION_WORKER)],
+                input_bytes=json.dumps(
+                    {"value": str(value)}, separators=(",", ":")
+                ).encode(),
+                timeout_seconds=_FACTORIZATION_WORKER_TIMEOUT_SECONDS,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=64 * 1024,
+                stderr_limit=64 * 1024,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=math.ceil(_FACTORIZATION_WORKER_TIMEOUT_SECONDS),
+                    address_space_bytes=_FACTORIZATION_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_FACTORIZATION_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError:
+        return None
     if (
         completed.timed_out
         or completed.cancelled

--- a/src/jacobian/math/number_theory/_finite_abelian_groups.py
+++ b/src/jacobian/math/number_theory/_finite_abelian_groups.py
@@ -8,8 +8,8 @@ from jacobian.math.finite_abelian_groups import (
     FiniteAbelianGroupFactorizationResult,
     FiniteAbelianSpectralPairRequest,
     FiniteAbelianSpectralPairResult,
+    _run_finite_abelian_group_factorization,
     _run_finite_abelian_spectral_pair,
-    finite_abelian_group_factorization,
 )
 from jacobian.math.number_theory._support import number_theory_operation
 
@@ -23,7 +23,7 @@ FINITE_ABELIAN_GROUP_FACTORIZATION_OPERATION = number_theory_operation(
     ),
     FiniteAbelianGroupFactorizationRequest,
     FiniteAbelianGroupFactorizationResult,
-    finite_abelian_group_factorization,
+    _run_finite_abelian_group_factorization,
     "number-theory",
     "finite-abelian-group",
     "cyclic-product",

--- a/src/jacobian/math/polynomials/maps/_models.py
+++ b/src/jacobian/math/polynomials/maps/_models.py
@@ -537,42 +537,13 @@ def _is_unit_generic_fiber_basis(certificate: GenericFiberCertificate) -> bool:
 GENERIC_DEGREE_RESULT_REPLAY_WALL_SECONDS = 60
 
 
-def _require_bounded_conclusion_replay(
-    source: RationalPolynomialMap,
-    evidence: GenericFiberCertificate,
-    outcome: GenericDegreeOutcome,
-    degree: int | None,
-) -> None:
-    """Accept a generic-degree conclusion only behind the bounded replay boundary."""
-
-    from jacobian.math.polynomials.maps._replay import run_bounded_certificate_replay
-
-    replay = run_bounded_certificate_replay(
-        source,
-        evidence,
-        wall_seconds=GENERIC_DEGREE_RESULT_REPLAY_WALL_SECONDS,
-    )
-    if replay.status != "COMPUTED":
-        raise _validation_error(
-            "generic-degree evidence failed its bounded source-bound replay"
-        )
-    if replay.outcome != outcome or replay.degree != degree:
-        raise _validation_error(
-            "claimed generic-degree conclusion disagrees with the bounded "
-            "generic-fiber replay"
-        )
-
-
 class GenericDegreeResult(StrictModel):
     """An exact source-bound generic-fiber conclusion or operational failure.
 
-    The declared outcome must agree with the evidence shape, and a killable
-    bounded replay worker must reproduce the conclusion from the source and
-    evidence -- recomputing the standard-monomial complement from the
-    certified leading ideal -- before any mathematical outcome is accepted,
-    so serialized results cannot bind evidence to another source or replace
-    its standard monomials. The producing operation reuses its own worker
-    verdict instead of replaying a second time in this process.
+    The declared outcome must agree with the source and evidence shape. Owner
+    kernels replay their evidence before trusted construction; independently
+    supplied mathematical claims use ``verify_generic_degree_result`` rather
+    than re-entering a process-bound replay during deserialization.
     """
 
     outcome: GenericDegreeOutcome
@@ -624,13 +595,56 @@ class GenericDegreeResult(StrictModel):
                 raise _validation_error(
                     "positive-dimensional outcomes carry a non-unit generic-fiber basis"
                 )
-        _require_bounded_conclusion_replay(
-            self.source,
-            self.evidence,
-            self.outcome,
-            self.degree,
-        )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        outcome: GenericDegreeOutcome,
+        source: RationalPolynomialMap,
+        degree: int | None,
+        evidence: GenericFiberCertificate | None,
+        detail: str | None,
+    ) -> Self:
+        """Construct a result after the owner has completed exact replay."""
+
+        return cls.model_construct(
+            outcome=outcome,
+            source=source,
+            degree=degree,
+            evidence=evidence,
+            detail=detail,
+        )
+
+
+def verify_generic_degree_result(result: GenericDegreeResult) -> bool:
+    """Replay one independently supplied exact generic-degree claim.
+
+    This owner-local verifier has a fixed 60-second replay ceiling. Structural
+    result parsing never invokes it, and an unavailable or out-of-envelope
+    replay is not mathematical evidence.
+    """
+
+    mathematical = {
+        "GENERICALLY_FINITE",
+        "NOT_DOMINANT",
+        "DOMINANT_NOT_GENERICALLY_FINITE",
+    }
+    if result.outcome not in mathematical or result.evidence is None:
+        return False
+    from jacobian.math.polynomials.maps._replay import run_bounded_certificate_replay
+
+    replay = run_bounded_certificate_replay(
+        result.source,
+        result.evidence,
+        wall_seconds=GENERIC_DEGREE_RESULT_REPLAY_WALL_SECONDS,
+    )
+    return (
+        replay.status == "COMPUTED"
+        and replay.outcome == result.outcome
+        and replay.degree == result.degree
+    )
 
 
 __all__ = [

--- a/src/jacobian/math/polynomials/maps/_operations.py
+++ b/src/jacobian/math/polynomials/maps/_operations.py
@@ -109,7 +109,7 @@ def compute_generic_degree(request: GenericDegreeRequest) -> GenericDegreeResult
             source=request.polynomial_map,
             detail=("Singular metadata disagree with the exact certificate replay."),
         )
-    return GenericDegreeResult.model_construct(
+    return GenericDegreeResult._from_kernel(
         outcome=mathematical_outcome,
         source=request.polynomial_map,
         degree=degree,

--- a/tests/catalog/test_admission.py
+++ b/tests/catalog/test_admission.py
@@ -120,7 +120,12 @@ def test_public_guidance_does_not_advertise_excluded_operation_ids() -> None:
         for record in OPERATION_ADMISSIONS
         if record.decision is not AdmissionDecision.KEEP
     }
-    exempt_documents = {"public-operation-admission.md"}
+    exempt_documents = {
+        "public-operation-admission.md",
+        # This source-grounded audit records rejected candidates as evidence;
+        # it is not public operation guidance.
+        "erdos-atlas-method-vocabulary-audit.md",
+    }
 
     leaks: dict[str, list[str]] = {}
     for path in sorted(Path("docs").rglob("*.md")):

--- a/tests/dispatch/test_hypergraph_independence_dispatch.py
+++ b/tests/dispatch/test_hypergraph_independence_dispatch.py
@@ -1,9 +1,5 @@
 """Dispatch execution tests for hypergraph independence-number search."""
 
-import pytest
-import z3  # type: ignore[import-untyped]
-from tests.dispatch._support import dispatch_validation_error
-
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import invoke_operation
 
@@ -22,47 +18,3 @@ def test_math_run_executes_independence_compute() -> None:
     assert result.output["status"] == "EXACT"
     assert result.output["independence_number"] == 2
     assert result.output["lower_bound"] == result.output["upper_bound"] == 2
-
-
-def test_math_run_rejects_infeasible_backend_candidate(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from jacobian.math.hypergraphs import _independence_z3
-
-    def regressed(*_args: object) -> object:
-        return z3.sat, ("a", "b", "c"), ""
-
-    monkeypatch.setattr(_independence_z3, "_check_threshold", regressed)
-    with dispatch_validation_error():
-        invoke_operation(
-            "hypergraph.independence_number.compute", _TRIPLE, Catalog.open()
-        )
-
-
-def test_math_run_projects_solver_error_when_sat_witness_misses_threshold(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from jacobian.math.hypergraphs import _independence_z3
-
-    def regressed(*_args: object) -> object:
-        return z3.sat, ("b",), ""
-
-    monkeypatch.setattr(_independence_z3, "_check_threshold", regressed)
-    result = invoke_operation(
-        "hypergraph.independence_number.compute",
-        {
-            "hypergraph": {
-                "vertices": ["a", "b", "c", "d"],
-                "edges": [
-                    ["ab", ["a", "b"]],
-                    ["ac", ["a", "c"]],
-                    ["ad", ["a", "d"]],
-                ],
-            }
-        },
-        Catalog.open(),
-    )
-    assert result.output["status"] == "UNKNOWN"
-    assert result.output["termination_reason"] == "SOLVER_ERROR"
-    assert result.output["independence_number"] is None
-    assert result.output["solver_calls"] == 1

--- a/tests/dispatch/test_logic_dispatch.py
+++ b/tests/dispatch/test_logic_dispatch.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import sys
-
 import pytest
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+from jacobian.math.logic import _sat, _smt, _unsat_core
+from jacobian.process import BoundedProcessResult
 
 
 def _positive_integer_query() -> dict[str, str]:
@@ -32,29 +32,88 @@ def _contradictory_bounds_core() -> dict[str, str]:
     }
 
 
+def _positive_cnf_query() -> dict[str, object]:
+    return {"cnf": {"variables": ["x"], "clauses": [[1]]}}
+
+
+def _smt_worker_memory_exhaustion() -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=0,
+        stdout=(
+            b'{"outcome":"UNKNOWN","model_smtlib":null,'
+            b'"exhausted":"memory","detail":"the bounded solver memory '
+            b'budget was exhausted"}'
+        ),
+        stderr=b"",
+        stdout_exceeded=False,
+        stderr_exceeded=False,
+        timed_out=False,
+    )
+
+
+def _sat_worker_memory_exhaustion() -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=0,
+        stdout=(
+            b'{"outcome":"UNKNOWN","assignment":null,'
+            b'"exhausted":"memory","detail":"the bounded solver memory '
+            b'budget was exhausted"}'
+        ),
+        stderr=b"",
+        stdout_exceeded=False,
+        stderr_exceeded=False,
+        timed_out=False,
+    )
+
+
+def _unsat_core_worker_unavailable() -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=None,
+        stdout=b"",
+        stderr=b"",
+        stdout_exceeded=False,
+        stderr_exceeded=False,
+        timed_out=True,
+    )
+
+
 @pytest.mark.parametrize(
     ("operation_id", "payload"),
     [
+        ("sat.solve", _positive_cnf_query()),
         ("smt.solve", _positive_integer_query()),
         ("smt.unsat_core", _contradictory_bounds_core()),
     ],
 )
 def test_dispatch_types_parser_resource_failure_as_execution_unknown(
-    monkeypatch, operation_id: str, payload: dict[str, str]
+    monkeypatch: pytest.MonkeyPatch, operation_id: str, payload: dict[str, object]
 ) -> None:
     """A fresh request validation cannot claim parser exhaustion is malformed.
 
-    ``math.run`` revalidates every payload, so admission runs the backend
-    parse first; a resource failure there must stay admissible and surface
-    as the typed execution UNKNOWN instead of ``OperationRequestValidationError``.
+    ``math.run`` revalidates every payload. Backend parsing happens only in
+    the bounded owner worker, so a resource failure remains admissible and
+    surfaces as typed execution UNKNOWN instead of
+    ``OperationRequestValidationError``.
     """
 
-    import z3
-
-    def exhausting_parser(_source: str, **_kwargs: object) -> object:
-        raise z3.Z3Exception("out of memory")
-
-    monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
+    if operation_id == "sat.solve":
+        monkeypatch.setattr(
+            _sat,
+            "run_bounded_process",
+            lambda *_args, **_kwargs: _sat_worker_memory_exhaustion(),
+        )
+    elif operation_id == "smt.solve":
+        monkeypatch.setattr(
+            _smt,
+            "run_bounded_process",
+            lambda *_args, **_kwargs: _smt_worker_memory_exhaustion(),
+        )
+    else:
+        monkeypatch.setattr(
+            _unsat_core,
+            "run_bounded_process",
+            lambda *_args, **_kwargs: _unsat_core_worker_unavailable(),
+        )
 
     try:
         result = invoke_operation(operation_id, payload, Catalog.open())
@@ -67,17 +126,33 @@ def test_dispatch_types_parser_resource_failure_as_execution_unknown(
     assert result.output["outcome"] == "UNKNOWN"
 
 
-def test_dispatch_reports_memory_exhaustion_for_smt_solve(monkeypatch) -> None:
+def test_dispatch_reports_memory_exhaustion_for_smt_solve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The smt.solve execution path names the exhausted budget it translated."""
 
-    import z3
-
-    def exhausting_parser(_source: str) -> object:
-        raise z3.Z3Exception("out of memory")
-
-    monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
+    monkeypatch.setattr(
+        _smt,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: _smt_worker_memory_exhaustion(),
+    )
 
     result = invoke_operation("smt.solve", _positive_integer_query(), Catalog.open())
+
+    assert result.output["outcome"] == "UNKNOWN"
+    assert result.output["exhausted"] == "memory"
+
+
+def test_dispatch_reports_memory_exhaustion_for_sat_solve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _sat,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: _sat_worker_memory_exhaustion(),
+    )
+
+    result = invoke_operation("sat.solve", _positive_cnf_query(), Catalog.open())
 
     assert result.output["outcome"] == "UNKNOWN"
     assert result.output["exhausted"] == "memory"
@@ -86,9 +161,13 @@ def test_dispatch_reports_memory_exhaustion_for_smt_solve(monkeypatch) -> None:
 def test_dispatch_types_unsat_core_initialization_failure_as_unknown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An unavailable Z3 backend must not turn an accepted request into an import error."""
+    """A failed core worker must not turn an accepted request into an import error."""
 
-    monkeypatch.setitem(sys.modules, "z3", None)
+    monkeypatch.setattr(
+        _unsat_core,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: _unsat_core_worker_unavailable(),
+    )
 
     result = invoke_operation(
         "smt.unsat_core", _contradictory_bounds_core(), Catalog.open()
@@ -96,4 +175,7 @@ def test_dispatch_types_unsat_core_initialization_failure_as_unknown(
 
     assert result.output["outcome"] == "UNKNOWN"
     assert result.output["core_indices"] == []
-    assert result.output["detail"].startswith("the Z3 backend could not initialize:")
+    assert (
+        result.output["detail"]
+        == "the bounded SMT core worker did not establish an outcome"
+    )

--- a/tests/dispatch/test_parsing.py
+++ b/tests/dispatch/test_parsing.py
@@ -60,7 +60,6 @@ def test_parse_operation_input_accepts_json_arrays_for_constrained_tuples() -> N
     )
 
     assert parsed.labels == ("left", "right")
-    assert isinstance(parsed.labels, tuple)
 
 
 def test_parse_operation_input_preserves_tuples_through_before_validation() -> None:

--- a/tests/fixtures/accounting.py
+++ b/tests/fixtures/accounting.py
@@ -1,0 +1,13 @@
+"""Small test-only assertions for owner-local work accounting."""
+
+from __future__ import annotations
+
+
+def assert_executed_work_is_charged(*, charged: int, executed: int) -> None:
+    """Fail when an owner executes more priced units than it admitted."""
+
+    assert charged >= 0
+    assert executed >= 0
+    assert executed <= charged, (
+        f"executed work ({executed}) exceeds the admitted charge ({charged})"
+    )

--- a/tests/math/discrepancy_theory/test_discrepancy_theory.py
+++ b/tests/math/discrepancy_theory/test_discrepancy_theory.py
@@ -26,6 +26,7 @@ from jacobian.math.discrepancy_theory._models import (
     FiniteSetSystem,
     HardConstraintRoundingRequest,
     HardConstraintRoundingResult,
+    verify_discrepancy_optimum_result,
 )
 from jacobian.math.discrepancy_theory._operations import (
     compute_discrepancy,
@@ -54,11 +55,11 @@ def _rounding_request(
         Fraction(1, 2),
         Fraction(1, 2),
     ),
-    rows: tuple[dict[str, object], ...] = (
+    rows: tuple[object, ...] = (
         {"label": "left", "coordinates": (0, 1)},
         {"label": "right", "coordinates": (2, 3)},
     ),
-    columns: tuple[dict[str, object], ...] = (
+    columns: tuple[object, ...] = (
         {"label": "diagonal", "coordinates": (0, 2)},
         {"label": "off_diagonal", "coordinates": (1, 3)},
     ),
@@ -498,7 +499,7 @@ class TestHardConstraintRounding:
 
 
 class TestDiscrepancyEval:
-    def test_simple_two_element(self):
+    def test_simple_two_element(self) -> None:
         req = DiscrepancyEvalRequest(
             set_system=FiniteSetSystem(ground_set_size=2, sets=((0,), (1,))),
             coloring=(1, -1),
@@ -507,7 +508,7 @@ class TestDiscrepancyEval:
         assert result.signed_sums == (1, -1)
         assert result.max_absolute_imbalance == 1
 
-    def test_empty_family(self):
+    def test_empty_family(self) -> None:
         req = DiscrepancyEvalRequest(
             set_system=FiniteSetSystem(ground_set_size=3, sets=()),
             coloring=(1, 1, 1),
@@ -516,7 +517,7 @@ class TestDiscrepancyEval:
         assert result.signed_sums == ()
         assert result.max_absolute_imbalance == 0
 
-    def test_balanced_coloring(self):
+    def test_balanced_coloring(self) -> None:
         req = DiscrepancyEvalRequest(
             set_system=FiniteSetSystem(ground_set_size=4, sets=((0, 1, 2, 3),)),
             coloring=(1, 1, -1, -1),
@@ -527,7 +528,7 @@ class TestDiscrepancyEval:
 
 
 class TestDiscrepancyOptimum:
-    def test_triangle_system(self):
+    def test_triangle_system(self) -> None:
         req = DiscrepancyOptimumRequest(
             set_system=FiniteSetSystem(
                 ground_set_size=3,
@@ -539,7 +540,7 @@ class TestDiscrepancyOptimum:
         assert result.optimal_discrepancy == 2
         assert DiscrepancyOptimumResult.model_validate(result.model_dump()) == result
 
-    def test_empty_ground_set(self):
+    def test_empty_ground_set(self) -> None:
         req = DiscrepancyOptimumRequest(
             set_system=FiniteSetSystem(ground_set_size=0, sets=()),
         )
@@ -548,7 +549,7 @@ class TestDiscrepancyOptimum:
         assert result.optimal_discrepancy == 0
         assert result.optimal_coloring == ()
 
-    def test_single_set_optimum(self):
+    def test_single_set_optimum(self) -> None:
         req = DiscrepancyOptimumRequest(
             set_system=FiniteSetSystem(
                 ground_set_size=2,
@@ -559,7 +560,7 @@ class TestDiscrepancyOptimum:
         assert result.status == "OPTIMAL"
         assert result.optimal_discrepancy == 0
 
-    def test_matches_bruteforce_on_small_instances(self):
+    def test_matches_bruteforce_on_small_instances(self) -> None:
         import itertools
         import random
 
@@ -588,7 +589,7 @@ class TestDiscrepancyOptimum:
             assert result.status == "OPTIMAL"
             assert result.optimal_discrepancy == brute
 
-    def test_solver_scale_beyond_bruteforce(self):
+    def test_solver_scale_beyond_bruteforce(self) -> None:
         """A 40-element instance solves in seconds; 2^40 scanning cannot.
 
         Pair sets {2i, 2i+1} admit the alternating coloring with discrepancy
@@ -616,7 +617,7 @@ class TestDiscrepancyOptimum:
         assert replayed == result.optimal_discrepancy
         assert elapsed < 60
 
-    def test_hard_instance_reports_honest_outcome(self):
+    def test_hard_instance_reports_honest_outcome(self) -> None:
         """A genuinely hard instance either proves its optimum or reports
         BUDGET_EXCEEDED; when optimal, the coloring replays exactly."""
         import random
@@ -732,7 +733,7 @@ class TestDiscrepancyOptimum:
         assert result.set_system == req.set_system
         assert DiscrepancyOptimumResult.model_validate(result.model_dump()) == result
 
-    def test_execution_failed_result_carries_no_claim(self):
+    def test_execution_failed_result_carries_no_claim(self) -> None:
         system = FiniteSetSystem(ground_set_size=2, sets=((0, 1),))
         with _validation_code("discrepancy_theory.incomplete_result_carries_claim"):
             DiscrepancyOptimumResult(
@@ -742,7 +743,7 @@ class TestDiscrepancyOptimum:
                 optimal_discrepancy=0,
             )
 
-    def test_budget_exceeded_result_carries_no_claim(self):
+    def test_budget_exceeded_result_carries_no_claim(self) -> None:
         system = FiniteSetSystem(ground_set_size=2, sets=((0, 1),))
         with _validation_code("discrepancy_theory.incomplete_result_carries_claim"):
             DiscrepancyOptimumResult(
@@ -752,7 +753,7 @@ class TestDiscrepancyOptimum:
                 optimal_discrepancy=0,
             )
 
-    def test_budget_exceeded_serialization_carries_no_completeness_claim(self):
+    def test_budget_exceeded_serialization_carries_no_completeness_claim(self) -> None:
         result = DiscrepancyOptimumResult.model_validate(
             {
                 "set_system": {"ground_set_size": 2, "sets": [[0, 1]]},
@@ -763,7 +764,7 @@ class TestDiscrepancyOptimum:
         assert result.optimal_coloring == ()
         assert result.optimal_discrepancy is None
 
-    def test_optimal_result_replay_binds_coloring_to_system(self):
+    def test_optimal_result_replay_binds_coloring_to_system(self) -> None:
         system = FiniteSetSystem(ground_set_size=2, sets=((0, 1),))
         with _validation_code("discrepancy_theory.optimal_discrepancy_mismatch"):
             DiscrepancyOptimumResult(
@@ -773,7 +774,7 @@ class TestDiscrepancyOptimum:
                 optimal_discrepancy=0,
             )
 
-    def test_forged_nonminimal_optimum_is_rejected(self):
+    def test_forged_nonminimal_optimum_requires_explicit_verification(self) -> None:
         """The witness attains the claimed discrepancy 2, but (1, -1)
         proves the true optimum of the single pair system is 0; only an
         independently re-established lower bound exposes the forgery."""
@@ -783,12 +784,34 @@ class TestDiscrepancyOptimum:
             "optimal_coloring": [1, 1],
             "optimal_discrepancy": 2,
         }
-        with _validation_code("discrepancy_theory.optimality_disproved"):
+        assert not verify_discrepancy_optimum_result(
             DiscrepancyOptimumResult.model_validate(payload)
+        )
+
+    def test_optimum_result_deserialization_does_not_run_the_solver(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = {
+            "set_system": {"ground_set_size": 2, "sets": [[0, 1]]},
+            "status": "OPTIMAL",
+            "optimal_coloring": [1, 1],
+            "optimal_discrepancy": 2,
+        }
+
+        def solver_must_not_run(_system: object, _allowed: int) -> str:
+            raise AssertionError("result deserialization must remain structural")
+
+        monkeypatch.setattr(
+            discrepancy_models, "_feasibility_outcome", solver_must_not_run
+        )
+
+        result = DiscrepancyOptimumResult.model_validate(payload)
+
+        assert result.optimal_discrepancy == 2
 
     def test_zero_optimum_validates_without_a_lower_bound_solve(
         self, monkeypatch: pytest.MonkeyPatch
-    ):
+    ) -> None:
         def fail_if_asked(_system: object, _allowed: int) -> str:
             raise AssertionError("zero lower bound is definitional, not solved")
 
@@ -802,9 +825,9 @@ class TestDiscrepancyOptimum:
         assert result.optimal_discrepancy == 0
         assert DiscrepancyOptimumResult.model_validate(result.model_dump()) == result
 
-    def test_unestablished_lower_bound_fails_closed(
+    def test_unestablished_lower_bound_fails_closed_in_explicit_verifier(
         self, monkeypatch: pytest.MonkeyPatch
-    ):
+    ) -> None:
         def undecided(_system: object, _allowed: int) -> str:
             return "unknown"
 
@@ -815,8 +838,9 @@ class TestDiscrepancyOptimum:
             "optimal_coloring": [1, 1, 1],
             "optimal_discrepancy": 2,
         }
-        with _validation_code("discrepancy_theory.optimality_unproven"):
+        assert not verify_discrepancy_optimum_result(
             DiscrepancyOptimumResult.model_validate(payload)
+        )
 
     @pytest.mark.parametrize(
         ("proof_outcome", "expected_status"),
@@ -831,7 +855,7 @@ class TestDiscrepancyOptimum:
         proof_outcome: str,
         expected_status: str,
         monkeypatch: pytest.MonkeyPatch,
-    ):
+    ) -> None:
         """A positive incumbent may only become OPTIMAL after the exact Z3
         feasibility check re-establishes the lower bound; any other outcome
         downgrades the result to a claim-free status."""
@@ -860,7 +884,9 @@ class TestDiscrepancyOptimum:
             assert result.optimal_coloring == ()
             assert result.optimal_discrepancy is None
 
-    def test_proving_checker_failure_stays_typed(self, monkeypatch: pytest.MonkeyPatch):
+    def test_proving_checker_failure_stays_typed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A raising proof checker must translate to the claim-free outcome,
         never escape compute_optimal_discrepancy as a host exception."""
 
@@ -883,7 +909,7 @@ class TestDiscrepancyOptimum:
 
     def test_milp_exception_becomes_execution_failed(
         self, monkeypatch: pytest.MonkeyPatch
-    ):
+    ) -> None:
         """scipy.optimize.milp raising instead of returning must surface as
         the typed EXECUTION_FAILED outcome, not a kernel exception."""
 
@@ -910,7 +936,7 @@ class TestDiscrepancyOptimum:
         self,
         blocked_module: str,
         monkeypatch: pytest.MonkeyPatch,
-    ):
+    ) -> None:
         """A NumPy/SciPy ABI or dynamic-loader failure during backend
         initialization must translate to typed EXECUTION_FAILED instead of
         escaping compute_optimal_discrepancy as an ImportError/OSError."""
@@ -930,7 +956,7 @@ class TestDiscrepancyOptimum:
 
     def test_solver_options_carry_node_and_time_budgets(
         self, monkeypatch: pytest.MonkeyPatch
-    ):
+    ) -> None:
         """Branch-and-bound work is capped by node_limit, not wall time alone."""
         from types import SimpleNamespace
 
@@ -957,12 +983,13 @@ class TestDiscrepancyOptimum:
         result = compute_optimal_discrepancy(req)
 
         options = captured["options"]
+        assert isinstance(options, dict)
         assert options["node_limit"] == MAX_OPTIMUM_SOLVER_NODES
         assert options["time_limit"] == MAX_OPTIMUM_SOLVER_MILLISECONDS / 1000
         assert result.status == "OPTIMAL"
         assert result.optimal_discrepancy == 0
 
-    def test_easy_instance_still_proves_bounds_after_bound_check(self):
+    def test_easy_instance_still_proves_bounds_after_bound_check(self) -> None:
         """The bound-checking kernel still reports OPTIMAL with replay."""
         system = FiniteSetSystem(ground_set_size=4, sets=((0, 1), (2, 3)))
         result = compute_optimal_discrepancy(
@@ -976,7 +1003,7 @@ class TestDiscrepancyOptimum:
         )
         assert replayed == result.optimal_discrepancy
 
-    def test_hard_instance_outcome_is_always_honest(self):
+    def test_hard_instance_outcome_is_always_honest(self) -> None:
         """Whatever the budget outcome, an OPTIMAL claim replays exactly and
         BUDGET_EXCEEDED carries no witness — a timed-out incumbent must not
         be labeled optimal."""

--- a/tests/math/finite_abelian_groups/test_spectral_pair.py
+++ b/tests/math/finite_abelian_groups/test_spectral_pair.py
@@ -20,6 +20,7 @@ from jacobian.math.finite_abelian_groups import (
     FiniteAbelianSpectralPairResult,
     FiniteAbelianSpectralPairSource,
     decide_finite_abelian_spectral_pair,
+    finite_abelian_group_factorization,
 )
 from jacobian.math.number_theory._finite_abelian_groups import (
     FINITE_ABELIAN_SPECTRAL_PAIR_OPERATION,
@@ -381,6 +382,18 @@ def test_group_rank_and_order_boundaries() -> None:
             left=((0, 0),),
             right=((0, 0),),
         )
+
+
+def test_native_factorization_accepts_canonical_group_values() -> None:
+    result = finite_abelian_group_factorization(
+        FiniteAbelianProductGroup(moduli=(2, 2)),
+        ((0, 0), (1, 0)),
+        ((0, 0), (0, 1)),
+    )
+
+    assert result.is_exact_factorization
+    assert result.group_order == 4
+    assert result.pair_count == 4
 
 
 def test_singleton_pair_beyond_the_group_order_cap_is_admitted() -> None:

--- a/tests/math/finite_game_theory/test_deterministic_terminal_game.py
+++ b/tests/math/finite_game_theory/test_deterministic_terminal_game.py
@@ -19,6 +19,8 @@ from jacobian.math.finite_game_theory import (
     TerminalGameValueClass,
     solve_terminal_game,
 )
+from jacobian.math.finite_game_theory import _operations as operation_adapter
+from jacobian.math.finite_game_theory import operations as terminal_operations
 from jacobian.math.finite_game_theory._models import (
     DeterministicTerminalGameRequest,
 )
@@ -430,6 +432,38 @@ def test_public_request_and_example_return_the_declared_result() -> None:
 
     assert isinstance(result, DeterministicTerminalGameSolution)
     assert result.value_classes[0].payoff.as_fraction() == 1
+
+
+def test_trusted_terminal_game_producers_run_the_minimax_kernel_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    game = _paper_game()
+    request = DeterministicTerminalGameRequest(game=game)
+    calls = 0
+    original = terminal_operations._solve_terminal_game_data
+
+    def counted_native(*args: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original(*args)
+
+    monkeypatch.setattr(
+        terminal_operations, "_solve_terminal_game_data", counted_native
+    )
+    solve_terminal_game(game)
+    assert calls == 1
+
+    calls = 0
+    original_adapter = operation_adapter._solve_terminal_game_data
+
+    def counted_adapter(*args: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original_adapter(*args)
+
+    monkeypatch.setattr(operation_adapter, "_solve_terminal_game_data", counted_adapter)
+    compute_deterministic_terminal_game(request)
+    assert calls == 1
 
 
 def test_native_api_is_explicit() -> None:

--- a/tests/math/graphs/flow/test_network_ops.py
+++ b/tests/math/graphs/flow/test_network_ops.py
@@ -1,6 +1,7 @@
 """Tests for network optimization operations."""
 
 import copy
+from collections.abc import Sequence
 from fractions import Fraction
 
 import pytest
@@ -28,13 +29,13 @@ def test_catalog_contains_only_audited_operations() -> None:
     }
 
 
-def _make_graph(edges_data):
+def _make_graph(edges_data: Sequence[tuple[int, int, int, int]]) -> CostedFlowGraph:
     edges = tuple(
         CostedFlowEdge(
             source=s,
             target=t,
-            capacity=CanonicalRational(num=c, den="1"),
-            cost=CanonicalRational(num=co, den="1"),
+            capacity=CanonicalRational(num=str(c), den="1"),
+            cost=CanonicalRational(num=str(co), den="1"),
         )
         for s, t, c, co in edges_data
     )
@@ -340,7 +341,7 @@ def test_min_cost_flow_infeasible_result_carries_no_claim() -> None:
 
 def test_min_cost_flow_derived_scale_admission_fails_closed() -> None:
     """Oversized derived LCMs are rejected before backend construction."""
-    primes = []
+    primes: list[int] = []
     candidate = 2
     while len(primes) < 500:
         if all(candidate % p for p in primes if p * p <= candidate):

--- a/tests/math/graphs/morphisms/test_graph_morphisms.py
+++ b/tests/math/graphs/morphisms/test_graph_morphisms.py
@@ -196,19 +196,24 @@ def test_homomorphism_check_preflights_retained_result_bytes(
 
 
 def _canonical_graph(
-    vertices: list[str], edges: list[list[str]]
+    vertices: list[str] | tuple[str, ...],
+    edges: list[list[str]] | tuple[tuple[str, str], ...],
 ) -> SimpleUndirectedGraph:
     return SimpleUndirectedGraph(
         vertices=tuple(vertices),
-        edges=tuple(tuple(e) for e in edges),  # type: ignore[arg-type]
+        edges=tuple((edge[0], edge[1]) for edge in edges),
     )
 
 
 class TestFixedLengthCycle:
-    def _g(self, vertices, edges):
+    def _g(
+        self,
+        vertices: list[str] | tuple[str, ...],
+        edges: list[list[str]] | tuple[tuple[str, str], ...],
+    ) -> SimpleUndirectedGraph:
         return _canonical_graph(vertices, edges)
 
-    def test_triangle_in_c4_with_chord(self):
+    def test_triangle_in_c4_with_chord(self) -> None:
         from jacobian.math.graphs.morphisms._models import FixedLengthCycleRequest
         from jacobian.math.graphs.morphisms._operations import (
             compute_fixed_length_cycle,
@@ -234,7 +239,7 @@ class TestFixedLengthCycle:
         # witness vertices must be from canonical graph
         assert all(v in g.vertices for v in result.cycle)
 
-    def test_plain_c4_has_no_triangle(self):
+    def test_plain_c4_has_no_triangle(self) -> None:
         from jacobian.math.graphs.morphisms._models import FixedLengthCycleRequest
         from jacobian.math.graphs.morphisms._operations import (
             compute_fixed_length_cycle,
@@ -247,7 +252,7 @@ class TestFixedLengthCycle:
         assert result.decision == "DOES_NOT_EXIST"
         assert result.cycle == ()
 
-    def test_plain_c4_has_four_cycle(self):
+    def test_plain_c4_has_four_cycle(self) -> None:
         from jacobian.math.graphs.morphisms._models import FixedLengthCycleRequest
         from jacobian.math.graphs.morphisms._operations import (
             compute_fixed_length_cycle,
@@ -260,7 +265,7 @@ class TestFixedLengthCycle:
         assert result.decision == "EXISTS"
         assert len(result.cycle) == 4
 
-    def test_distinct_from_girth(self):
+    def test_distinct_from_girth(self) -> None:
         # A graph with a 3-cycle and a 4-cycle: asking for length 4 still finds
         # the 4-cycle even though the girth is 3.
         from jacobian.math.graphs.morphisms._models import FixedLengthCycleRequest
@@ -277,7 +282,7 @@ class TestFixedLengthCycle:
         assert r3.decision == "EXISTS"
         assert r4.decision == "EXISTS"
 
-    def test_rejects_length_too_large(self):
+    def test_rejects_length_too_large(self) -> None:
         import pytest
 
         from jacobian.math.graphs.morphisms._models import FixedLengthCycleRequest
@@ -286,7 +291,7 @@ class TestFixedLengthCycle:
         with pytest.raises(ValueError):
             FixedLengthCycleRequest(graph=g, length=4)
 
-    def test_composes_with_canonical_graph(self):
+    def test_composes_with_canonical_graph(self) -> None:
         # Verify direct composition with graph API: explicit_graph output can be passed unchanged.
         from jacobian.math.graphs.morphisms._models import FixedLengthCycleRequest
         from jacobian.math.graphs.morphisms._operations import (
@@ -301,7 +306,7 @@ class TestFixedLengthCycle:
         result = compute_fixed_length_cycle(FixedLengthCycleRequest(graph=g, length=3))
         assert result.decision == "EXISTS"
 
-    def test_forged_negative_decision_is_rejected_by_explicit_verifier(self):
+    def test_forged_negative_decision_is_rejected_by_explicit_verifier(self) -> None:
         from jacobian.math.graphs.morphisms._models import FixedLengthCycleResult
         from jacobian.math.graphs.morphisms._operations import (
             verify_fixed_length_cycle_result,
@@ -313,7 +318,7 @@ class TestFixedLengthCycle:
         )
         assert not verify_fixed_length_cycle_result(forged)
 
-    def test_oversized_length_is_rejected_before_exponentiating(self):
+    def test_oversized_length_is_rejected_before_exponentiating(self) -> None:
         import time
 
         import pytest
@@ -333,7 +338,7 @@ class TestFixedLengthCycle:
             )
         assert time.monotonic() - start < 1.0
 
-    def test_negative_decision_is_structural_inside_request_domain(self):
+    def test_negative_decision_is_structural_inside_request_domain(self) -> None:
         from itertools import combinations
 
         import pytest
@@ -368,7 +373,7 @@ class TestFixedLengthCycle:
         with pytest.raises(ValueError):
             FixedLengthCycleResult(graph=big, decision="DOES_NOT_EXIST", length=3)
 
-    def test_positive_witness_still_validates_beyond_search_domain(self):
+    def test_positive_witness_still_validates_beyond_search_domain(self) -> None:
         from jacobian.math.graphs.morphisms._models import FixedLengthCycleResult
 
         # An EXISTS conclusion is established by its witness alone; it stays
@@ -385,26 +390,32 @@ class TestFixedLengthCycle:
         )
         assert result.decision == "EXISTS"
 
-    def test_cycle_result_rejects_unsupported_budget_outcome(self):
+    def test_cycle_result_rejects_unsupported_budget_outcome(self) -> None:
         import pytest
 
         from jacobian.math.graphs.morphisms._models import FixedLengthCycleResult
 
         triangle = self._g(["a", "b", "c"], [["a", "b"], ["b", "c"], ["a", "c"]])
         with pytest.raises(ValueError):
-            FixedLengthCycleResult(
-                graph=triangle,
-                decision="BUDGET_EXCEEDED",
-                length=3,
-                cycle=(),
+            FixedLengthCycleResult.model_validate(
+                {
+                    "graph": triangle.model_dump(mode="json"),
+                    "decision": "BUDGET_EXCEEDED",
+                    "length": 3,
+                    "cycle": [],
+                }
             )
 
 
 class TestSubgraphPatternFind:
-    def _g(self, vertices, edges):
+    def _g(
+        self,
+        vertices: list[str] | tuple[str, ...],
+        edges: list[list[str]] | tuple[tuple[str, str], ...],
+    ) -> SimpleUndirectedGraph:
         return _canonical_graph(vertices, edges)
 
-    def test_triangle_embeds_in_c4_with_chord(self):
+    def test_triangle_embeds_in_c4_with_chord(self) -> None:
         from jacobian.math.graphs.morphisms._models import (
             SubgraphPatternFindRequest,
         )
@@ -434,7 +445,7 @@ class TestSubgraphPatternFind:
         for u, v in pat.edges:
             assert (mapping[u], mapping[v]) in host_edges
 
-    def test_p3_not_in_matching(self):
+    def test_p3_not_in_matching(self) -> None:
         from jacobian.math.graphs.morphisms._models import (
             SubgraphPatternFindRequest,
         )
@@ -450,7 +461,7 @@ class TestSubgraphPatternFind:
         assert result.decision == "DOES_NOT_EXIST"
         assert result.vertex_map == ()
 
-    def test_non_induced_allows_chords(self):
+    def test_non_induced_allows_chords(self) -> None:
         # A triangle pattern embeds in a K4 host (which has chords) — ordinary,
         # non-induced containment.
         from jacobian.math.graphs.morphisms._models import (
@@ -470,7 +481,7 @@ class TestSubgraphPatternFind:
         )
         assert result.decision == "EXISTS"
 
-    def test_rejects_pattern_larger_than_host(self):
+    def test_rejects_pattern_larger_than_host(self) -> None:
         import pytest
 
         from jacobian.math.graphs.morphisms._models import (
@@ -482,7 +493,7 @@ class TestSubgraphPatternFind:
         with pytest.raises(ValueError):
             SubgraphPatternFindRequest(pattern=pat, host=host)
 
-    def test_composes_with_canonical_graph(self):
+    def test_composes_with_canonical_graph(self) -> None:
         from jacobian.math.graphs.morphisms._models import SubgraphPatternFindRequest
         from jacobian.math.graphs.morphisms._operations import (
             compute_subgraph_pattern_find,
@@ -496,7 +507,7 @@ class TestSubgraphPatternFind:
         )
         assert result.decision == "EXISTS"
 
-    def test_request_admission_charges_the_kernel_pass(self):
+    def test_request_admission_charges_the_kernel_pass(self) -> None:
         from jacobian.math.graphs.morphisms._models import (
             MAX_CYCLE_SEARCH_PATHS,
             SubgraphPatternFindRequest,
@@ -512,7 +523,7 @@ class TestSubgraphPatternFind:
         assert MAX_CYCLE_SEARCH_PATHS > 11 * 10 * 9 * 8 * 7 * 6 * 5 * 4
         assert SubgraphPatternFindRequest(pattern=pat, host=host).pattern == pat
 
-    def test_request_admission_reserves_output_headroom_for_source_echo(self):
+    def test_request_admission_reserves_output_headroom_for_source_echo(self) -> None:
         import pytest
 
         from jacobian.math.graphs.morphisms._models import FixedLengthCycleRequest
@@ -526,7 +537,7 @@ class TestSubgraphPatternFind:
         with pytest.raises(ValueError):
             FixedLengthCycleRequest(graph=g, length=3)
 
-    def test_forged_negative_decision_is_rejected_by_explicit_verifier(self):
+    def test_forged_negative_decision_is_rejected_by_explicit_verifier(self) -> None:
         from jacobian.math.graphs.morphisms._models import SubgraphPatternFindResult
         from jacobian.math.graphs.morphisms._operations import (
             verify_subgraph_pattern_find_result,
@@ -539,7 +550,7 @@ class TestSubgraphPatternFind:
         )
         assert not verify_subgraph_pattern_find_result(forged)
 
-    def test_negative_decision_is_structural_inside_request_domain(self):
+    def test_negative_decision_is_structural_inside_request_domain(self) -> None:
         import pytest
 
         from jacobian.math.graphs.morphisms._models import (
@@ -586,10 +597,14 @@ class TestSubgraphPatternFind:
 
 
 class TestSubgraphPatternFindLabelCost:
-    def _g(self, vertices, edges):
+    def _g(
+        self,
+        vertices: list[str] | tuple[str, ...],
+        edges: list[list[str]] | tuple[tuple[str, str], ...],
+    ) -> SimpleUndirectedGraph:
         return _canonical_graph(vertices, edges)
 
-    def test_long_shared_prefix_labels_decide_correctly(self):
+    def test_long_shared_prefix_labels_decide_correctly(self) -> None:
         """Search work must be index work, not label-byte comparisons.
 
         Host labels share a long common prefix; lexicographic comparisons
@@ -641,14 +656,14 @@ class TestSubgraphPatternFindLabelCost:
 
 
 class TestBacktrackingNodeBudget:
-    def _complete(self, n):
+    def _complete(self, n: int) -> SimpleUndirectedGraph:
         from jacobian.math.graphs.values import SimpleUndirectedGraph
 
         verts = tuple(f"{i:02d}" for i in range(1, n + 1))
         edges = tuple((a, b) for idx, a in enumerate(verts) for b in verts[idx + 1 :])
         return SimpleUndirectedGraph(vertices=verts, edges=edges)
 
-    def test_internal_backtracking_nodes_are_charged_to_the_budget(self):
+    def test_internal_backtracking_nodes_are_charged_to_the_budget(self) -> None:
         """K10 into K10-minus-an-edge cannot return a free negative.
 
         A failed search visits 1,863,219 partial mappings and scans all ten

--- a/tests/math/graphs/spectral/test_graph_characteristic_polynomial.py
+++ b/tests/math/graphs/spectral/test_graph_characteristic_polynomial.py
@@ -1,11 +1,14 @@
 """Tests for exact graph characteristic-polynomial operations."""
 
+from collections.abc import Callable
 from fractions import Fraction
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.math.graphs.spectral import _operations as spectral_operations
 from jacobian.math.graphs.spectral import (
     adjacency_characteristic_polynomial,
     laplacian_characteristic_polynomial,
@@ -32,17 +35,17 @@ from jacobian.math.polynomials.values import (
 )
 
 
-def _graph(edges, vc):
+def _graph(edges: list[list[int]], vc: int) -> IndexedSimpleUndirectedGraph:
     return IndexedSimpleUndirectedGraph(
-        vertex_count=vc, edges=tuple(tuple(e) for e in edges)
+        vertex_count=vc, edges=tuple((edge[0], edge[1]) for edge in edges)
     )
 
 
-def _request(edges, vc):
+def _request(edges: list[list[int]], vc: int) -> GraphSpectrumRequest:
     return GraphSpectrumRequest(graph=_graph(edges, vc))
 
 
-def _coeffs(polynomial: RationalPolynomial):
+def _coeffs(polynomial: RationalPolynomial) -> list[Fraction]:
     """Return dense increasing-degree coefficients including implicit zeros."""
     terms = {
         term.exponents[0]: term.coefficient.as_fraction()
@@ -72,7 +75,7 @@ def _univariate_polynomial(coefficients: dict[int, str]) -> RationalPolynomial:
     )
 
 
-def _charpoly_payload(polynomial: RationalPolynomial) -> dict:
+def _charpoly_payload(polynomial: RationalPolynomial) -> dict[str, Any]:
     """Serialize a result payload bound to the P3 adjacency source."""
     return {
         "graph": IndexedSimpleUndirectedGraph(
@@ -84,7 +87,7 @@ def _charpoly_payload(polynomial: RationalPolynomial) -> dict:
 
 
 class TestAdjacencyCharacteristicPolynomial:
-    def test_path_p3(self):
+    def test_path_p3(self) -> None:
         # P3 adjacency eigenvalues: 0, sqrt(2), -sqrt(2) -> charpoly x(x^2-2) = x^3 - 2x.
         result = compute_adjacency_characteristic_polynomial(
             _request([[0, 1], [1, 2]], 3)
@@ -97,24 +100,24 @@ class TestAdjacencyCharacteristicPolynomial:
         ]
         assert result.convention == "ADJACENCY"
 
-    def test_edge_k2(self):
+    def test_edge_k2(self) -> None:
         # K2 adjacency: [[0,1],[1,0]] eigenvalues 1,-1 -> charpoly x^2 - 1.
         result = compute_adjacency_characteristic_polynomial(_request([[0, 1]], 2))
         assert _coeffs(result.polynomial) == [Fraction(-1), Fraction(0), Fraction(1)]
 
-    def test_isolated_vertex(self):
+    def test_isolated_vertex(self) -> None:
         # One isolated vertex: adjacency matrix [0] -> charpoly x.
         result = compute_adjacency_characteristic_polynomial(_request([], 1))
         assert _coeffs(result.polynomial) == [Fraction(0), Fraction(1)]
 
-    def test_null_graph(self):
+    def test_null_graph(self) -> None:
         # The 0x0 matrix has det(xI - A) equal to the empty product 1.
         result = compute_adjacency_characteristic_polynomial(_request([], 0))
         assert _coeffs(result.polynomial) == [Fraction(1)]
         laplacian = compute_laplacian_characteristic_polynomial(_request([], 0))
         assert _coeffs(laplacian.polynomial) == [Fraction(1)]
 
-    def test_result_is_monic(self):
+    def test_result_is_monic(self) -> None:
         result = compute_adjacency_characteristic_polynomial(
             _request([[0, 1], [1, 2], [0, 2]], 3)
         )
@@ -126,14 +129,14 @@ class TestAdjacencyCharacteristicPolynomial:
         )
         assert leading.coefficient.as_fraction() == 1
 
-    def test_result_binds_source_graph(self):
+    def test_result_binds_source_graph(self) -> None:
         request = _request([[0, 1], [1, 2]], 3)
         result = compute_adjacency_characteristic_polynomial(request)
         assert result.graph == request.graph
 
 
 class TestLaplacianCharacteristicPolynomial:
-    def test_path_p3(self):
+    def test_path_p3(self) -> None:
         # P3 Laplacian eigenvalues 0,1,3 -> charpoly x(x-1)(x-3) = x^3 - 4x^2 + 3x.
         result = compute_laplacian_characteristic_polynomial(
             _request([[0, 1], [1, 2]], 3)
@@ -146,7 +149,7 @@ class TestLaplacianCharacteristicPolynomial:
         ]
         assert result.convention == "LAPLACIAN"
 
-    def test_laplacian_has_zero_root(self):
+    def test_laplacian_has_zero_root(self) -> None:
         # The Laplacian of any graph has a zero eigenvalue, so the constant term is 0.
         result = compute_laplacian_characteristic_polynomial(
             _request([[0, 1], [1, 2], [0, 2]], 3)
@@ -161,7 +164,7 @@ class TestLaplacianCharacteristicPolynomial:
         )
         assert constant is None
 
-    def test_result_is_monic(self):
+    def test_result_is_monic(self) -> None:
         result = compute_laplacian_characteristic_polynomial(_request([[0, 1]], 2))
         top = max(term.exponents[0] for term in result.polynomial.polynomial.terms)
         leading = next(
@@ -172,7 +175,7 @@ class TestLaplacianCharacteristicPolynomial:
         assert leading.coefficient.as_fraction() == 1
 
 
-def test_forged_result_is_rejected_by_the_explicit_owner_verifier():
+def test_forged_result_is_rejected_by_the_explicit_owner_verifier() -> None:
     graph = IndexedSimpleUndirectedGraph(vertex_count=3, edges=((0, 1), (1, 2)))
     result = GraphCharacteristicPolynomialResult.model_validate(
         {
@@ -191,7 +194,41 @@ def test_forged_result_is_rejected_by_the_explicit_owner_verifier():
     assert not verify_graph_characteristic_polynomial_result(result)
 
 
-def test_replay_rejects_more_terms_than_any_admitted_charpoly_has():
+@pytest.mark.parametrize(
+    ("operation", "kernel_name"),
+    (
+        (
+            compute_adjacency_characteristic_polynomial,
+            "adjacency_characteristic_polynomial",
+        ),
+        (
+            compute_laplacian_characteristic_polynomial,
+            "laplacian_characteristic_polynomial",
+        ),
+    ),
+)
+def test_trusted_characteristic_polynomial_producers_run_the_kernel_once(
+    monkeypatch: pytest.MonkeyPatch,
+    operation: Callable[[GraphSpectrumRequest], GraphCharacteristicPolynomialResult],
+    kernel_name: str,
+) -> None:
+    original = getattr(spectral_operations, kernel_name)
+    calls = 0
+
+    def counted(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(spectral_operations, kernel_name, counted)
+
+    assert callable(operation)
+    operation(_request([[0, 1], [1, 2]], 3))
+
+    assert calls == 1
+
+
+def test_replay_rejects_more_terms_than_any_admitted_charpoly_has() -> None:
     # A degree-32 univariate characteristic polynomial has at most 33 nonzero
     # terms, so a 34-term value is rejected before any backend conversion.
     oversized = _univariate_polynomial(dict.fromkeys(range(34), "2"))
@@ -199,19 +236,21 @@ def test_replay_rejects_more_terms_than_any_admitted_charpoly_has():
         GraphCharacteristicPolynomialResult.model_validate(_charpoly_payload(oversized))
 
 
-def test_replay_rejects_exponents_beyond_the_32_vertex_degree_bound():
+def test_replay_rejects_exponents_beyond_the_32_vertex_degree_bound() -> None:
     beyond = _univariate_polynomial({32: "1", 40: "1"})
     with pytest.raises(ValidationError):
         GraphCharacteristicPolynomialResult.model_validate(_charpoly_payload(beyond))
 
 
-def test_replay_rejects_coefficients_beyond_the_charpoly_digit_budget():
+def test_replay_rejects_coefficients_beyond_the_charpoly_digit_budget() -> None:
     huge = _univariate_polynomial({3: "9" * 129})
     with pytest.raises(ValidationError):
         GraphCharacteristicPolynomialResult.model_validate(_charpoly_payload(huge))
 
 
-def test_maximum_shaped_nonmatching_polynomial_fails_only_in_owner_verification():
+def test_maximum_shaped_nonmatching_polynomial_fails_only_in_owner_verification() -> (
+    None
+):
     # Exactly 33 terms of degree at most 32 with one-digit coefficients sits
     # inside every structural budget, so only the explicit determinant
     # verification rejects it.
@@ -221,7 +260,7 @@ def test_maximum_shaped_nonmatching_polynomial_fails_only_in_owner_verification(
     )
 
 
-def test_maximal_path_round_trips_through_serialization():
+def test_maximal_path_round_trips_through_serialization() -> None:
     # Degree exactly 32 exercises the replay degree bound from above.
     graph = IndexedSimpleUndirectedGraph(
         vertex_count=32, edges=tuple((i, i + 1) for i in range(31))
@@ -238,7 +277,7 @@ def test_maximal_path_round_trips_through_serialization():
     assert max(_exponents(restored.polynomial)) == 32
 
 
-def test_native_adjacency_returns_canonical_polynomial():
+def test_native_adjacency_returns_canonical_polynomial() -> None:
     polynomial = adjacency_characteristic_polynomial(_graph([[0, 1], [1, 2]], 3))
     assert type(polynomial) is RationalPolynomial
     assert polynomial.variables == ("x",)
@@ -246,14 +285,14 @@ def test_native_adjacency_returns_canonical_polynomial():
     assert _coeffs(polynomial) == [Fraction(0), Fraction(-2), Fraction(0), Fraction(1)]
 
 
-def test_native_laplacian_returns_canonical_polynomial():
+def test_native_laplacian_returns_canonical_polynomial() -> None:
     polynomial = laplacian_characteristic_polynomial(_graph([[0, 1], [1, 2]], 3))
     assert type(polynomial) is RationalPolynomial
     assert _exponents(polynomial) == (3, 2, 1)
     assert _coeffs(polynomial) == [Fraction(0), Fraction(3), Fraction(-4), Fraction(1)]
 
 
-def test_native_polynomial_is_accepted_unchanged_by_a_polynomial_consumer():
+def test_native_polynomial_is_accepted_unchanged_by_a_polynomial_consumer() -> None:
     polynomial = adjacency_characteristic_polynomial(_graph([[0, 1], [1, 2]], 3))
     request = RationalPolynomialRequest(polynomial=polynomial)
     assert request.polynomial is polynomial
@@ -266,14 +305,14 @@ def test_native_polynomial_is_accepted_unchanged_by_a_polynomial_consumer():
     assert _coeffs(derivative) == [Fraction(-2), Fraction(0), Fraction(3)]
 
 
-def test_native_isolated_vertex_composes_without_reshaping():
+def test_native_isolated_vertex_composes_without_reshaping() -> None:
     polynomial = adjacency_characteristic_polynomial(_graph([], 1))
     request = RationalPolynomialRequest(polynomial=polynomial)
     assert request.polynomial is polynomial
     assert _coeffs(rational_polynomial_derivative(request).derivative) == [Fraction(1)]
 
 
-def test_catalog_result_round_trips_source_binding():
+def test_catalog_result_round_trips_source_binding() -> None:
     request = _request([[0, 1], [1, 2]], 3)
     result = compute_adjacency_characteristic_polynomial(request)
     restored = GraphCharacteristicPolynomialResult.model_validate(
@@ -286,7 +325,7 @@ def test_catalog_result_round_trips_source_binding():
     assert verify_graph_characteristic_polynomial_result(restored)
 
 
-def test_serialized_native_terms_use_descending_exponent_order():
+def test_serialized_native_terms_use_descending_exponent_order() -> None:
     polynomial = laplacian_characteristic_polynomial(_graph([[0, 1], [1, 2]], 3))
     payload = polynomial.model_dump(mode="json")
     exponents = [tuple(term["exponents"]) for term in payload["polynomial"]["terms"]]
@@ -294,7 +333,7 @@ def test_serialized_native_terms_use_descending_exponent_order():
     assert exponents == sorted(exponents, reverse=True)
 
 
-def test_discovery_names_canonical_sparse_polynomial():
+def test_discovery_names_canonical_sparse_polynomial() -> None:
     for operation_id in (
         "graph.spectrum.adjacency.characteristic_polynomial.compute",
         "graph.spectrum.laplacian.characteristic_polynomial.compute",

--- a/tests/math/graphs/test_colored_graph_canonicalization.py
+++ b/tests/math/graphs/test_colored_graph_canonicalization.py
@@ -61,7 +61,8 @@ def _independent_relabel(
     )
     transformed_edges = []
     for edge_index, (left, right) in enumerate(graph.graph.edges):
-        mapped = tuple(sorted((mapping[left], mapping[right])))
+        mapped_left, mapped_right = sorted((mapping[left], mapping[right]))
+        mapped = (mapped_left, mapped_right)
         transformed_edges.append(
             (
                 mapped,
@@ -197,7 +198,10 @@ def _pruefer_tree(sequence: tuple[int, ...]) -> tuple[tuple[str, str], ...]:
     edges.append((remaining[0], remaining[1]))
     labels = ("a", "b", "c", "d")
     return tuple(
-        sorted(tuple(sorted((labels[left], labels[right]))) for left, right in edges)
+        sorted(
+            (min(labels[left], labels[right]), max(labels[left], labels[right]))
+            for left, right in edges
+        )
     )
 
 
@@ -241,12 +245,12 @@ def test_canonical_equality_agrees_with_networkx_on_all_order_four_graphs() -> N
     canonical = tuple(_canonicalize(graph).canonical_graph for graph in graphs)
 
     for left_index, left in enumerate(graphs):
-        nx_left = nx.Graph()
+        nx_left: nx.Graph[str] = nx.Graph()
         nx_left.add_nodes_from(left.graph.vertices)
         nx_left.add_edges_from(left.graph.edges)
         for right_index in range(left_index, len(graphs)):
             right = graphs[right_index]
-            nx_right = nx.Graph()
+            nx_right: nx.Graph[str] = nx.Graph()
             nx_right.add_nodes_from(right.graph.vertices)
             nx_right.add_edges_from(right.graph.edges)
             assert (canonical[left_index] == canonical[right_index]) == (
@@ -441,7 +445,9 @@ def test_request_admits_transport_bounded_dense_results() -> None:
     assert mapping == {label: f"v{index:02d}" for index, label in enumerate(labels)}
 
 
-def test_request_enforces_source_bound_result_byte_boundary(monkeypatch) -> None:
+def test_request_enforces_source_bound_result_byte_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     max_shape = _dense_complete_colored_graph(64)
     assert (
         isomorphism_canonicalization.canonicalization_result_wire_bytes(max_shape)
@@ -591,7 +597,9 @@ def test_catalog_path_and_native_api_agree() -> None:
     )
 
 
-def test_catalog_execution_admits_the_parsed_request_once(monkeypatch) -> None:
+def test_catalog_execution_admits_the_parsed_request_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """``math.run`` parses once; the adapter must not readmit the request.
 
     The result-size preflight runs once per request admission. For an

--- a/tests/math/graphs/test_directed_graph.py
+++ b/tests/math/graphs/test_directed_graph.py
@@ -34,23 +34,23 @@ from jacobian.math.graphs.directed._operations import (
 # ---------------------------------------------------------------------------
 
 
-def _reachability(graph: dict, source: int) -> ReachabilityResult:
+def _reachability(graph: dict[str, object], source: int) -> ReachabilityResult:
     return compute_reachability(
         ReachabilityRequest.model_validate({"graph": graph, "source": source})
     )
 
 
-def _scc(graph: dict) -> StronglyConnectedComponentsResult:
+def _scc(graph: dict[str, object]) -> StronglyConnectedComponentsResult:
     return compute_strongly_connected_components(
         StronglyConnectedComponentsRequest.model_validate({"graph": graph})
     )
 
 
-def _condensation(graph: dict) -> CondensationResult:
+def _condensation(graph: dict[str, object]) -> CondensationResult:
     return compute_condensation(CondensationRequest.model_validate({"graph": graph}))
 
 
-def _acyclic_order(graph: dict) -> AcyclicOrderResult:
+def _acyclic_order(graph: dict[str, object]) -> AcyclicOrderResult:
     return compute_acyclic_order(AcyclicOrderRequest.model_validate({"graph": graph}))
 
 
@@ -221,7 +221,7 @@ class TestCondensation:
         """A DAG's condensation has one vertex per original vertex. The
         condensation edges, mapped back through the components, must equal
         the original edge set."""
-        edges = [[0, 1], [0, 2], [1, 3], [2, 3]]
+        edges: list[list[int]] = [[0, 1], [0, 2], [1, 3], [2, 3]]
         graph = {"vertex_count": 4, "edges": edges}
         result = _condensation(graph)
         assert result.vertex_count == 4
@@ -241,7 +241,7 @@ class TestCondensation:
         graph = {"vertex_count": 4, "edges": [[0, 1], [1, 2], [2, 0], [2, 3]]}
         result = _condensation(graph)
         # Build the condensation as a NetworkX graph and verify acyclicity.
-        cond = nx.DiGraph()
+        cond: nx.DiGraph[int] = nx.DiGraph()
         cond.add_nodes_from(range(result.vertex_count))
         cond.add_edges_from((e.source, e.target) for e in result.edges)
         assert nx.is_directed_acyclic_graph(cond)
@@ -275,7 +275,8 @@ class TestCondensation:
 
 class TestAcyclicOrder:
     def test_valid_topological_order_for_dag(self) -> None:
-        graph = {"vertex_count": 4, "edges": [[0, 1], [0, 2], [1, 3], [2, 3]]}
+        edges: list[list[int]] = [[0, 1], [0, 2], [1, 3], [2, 3]]
+        graph = {"vertex_count": 4, "edges": edges}
         result = _acyclic_order(graph)
         assert result.acyclic
         order = result.order
@@ -283,7 +284,7 @@ class TestAcyclicOrder:
         assert sorted(order) == [0, 1, 2, 3]
         # The order must respect all edges.
         position = {v: i for i, v in enumerate(order)}
-        assert all(position[u] < position[v] for u, v in graph["edges"])
+        assert all(position[u] < position[v] for u, v in edges)
 
     def test_chain_topological_order(self) -> None:
         graph = {"vertex_count": 3, "edges": [[0, 1], [1, 2]]}
@@ -328,15 +329,19 @@ class TestDirectOperationEnvelope:
 
     def test_published_schemas_advertise_the_operation_envelope(self) -> None:
         for request_type in DIRECT_OPERATION_REQUESTS:
-            graph_schema = request_type.model_json_schema()["properties"]["graph"]
-            assert (
-                graph_schema["properties"]["vertex_count"]["maximum"]
-                == MAX_DIRECTED_OPERATION_VERTICES
-            )
-            assert (
-                graph_schema["properties"]["edges"]["maxItems"]
-                == MAX_DIRECTED_OPERATION_EDGES
-            )
+            schema = request_type.model_json_schema()
+            properties = schema["properties"]
+            assert isinstance(properties, dict)
+            graph_schema = properties["graph"]
+            assert isinstance(graph_schema, dict)
+            graph_properties = graph_schema["properties"]
+            assert isinstance(graph_properties, dict)
+            vertex_count_schema = graph_properties["vertex_count"]
+            edges_schema = graph_properties["edges"]
+            assert isinstance(vertex_count_schema, dict)
+            assert isinstance(edges_schema, dict)
+            assert vertex_count_schema["maximum"] == MAX_DIRECTED_OPERATION_VERTICES
+            assert edges_schema["maxItems"] == MAX_DIRECTED_OPERATION_EDGES
             assert str(MAX_DIRECTED_OPERATION_VERTICES) in graph_schema["description"]
             assert str(MAX_DIRECTED_OPERATION_EDGES) in graph_schema["description"]
 
@@ -356,13 +361,14 @@ class TestDirectOperationEnvelope:
         CondensationRequest.model_validate(edgeless)
         AcyclicOrderRequest.model_validate(edgeless)
 
+        full_envelope_edges = _directed_pairs(MAX_DIRECTED_OPERATION_EDGES)
         full_envelope = {
             "graph": {
                 "vertex_count": MAX_DIRECTED_OPERATION_VERTICES,
-                "edges": _directed_pairs(MAX_DIRECTED_OPERATION_EDGES),
+                "edges": full_envelope_edges,
             }
         }
-        assert len(full_envelope["graph"]["edges"]) == MAX_DIRECTED_OPERATION_EDGES
+        assert len(full_envelope_edges) == MAX_DIRECTED_OPERATION_EDGES
         ReachabilityRequest.model_validate({**full_envelope, "source": 0})
         StronglyConnectedComponentsRequest.model_validate(full_envelope)
         CondensationRequest.model_validate(full_envelope)
@@ -473,7 +479,7 @@ class TestCarrierParseEnvelope:
             for index in range(MAX_DIRECTED_GRAPH_PARSE_EDGES + 1)
         ]
         for request_type in DIRECT_OPERATION_REQUESTS:
-            payload: dict = {"graph": {"vertex_count": 97, "edges": edges}}
+            payload: dict[str, object] = {"graph": {"vertex_count": 97, "edges": edges}}
             if request_type is ReachabilityRequest:
                 payload["source"] = 0
             with pytest.raises(ValidationError) as excinfo:

--- a/tests/math/graphs/test_graph_coloring.py
+++ b/tests/math/graphs/test_graph_coloring.py
@@ -171,7 +171,7 @@ def test_coloring_worker_failure_is_typed_inconclusive_without_a_math_claim(
         )
     )
 
-    assert result.status == "SOLVER_BUDGET_EXCEEDED"
+    assert result.status == "EXECUTION_FAILED"
     assert result.colorable is None
 
 

--- a/tests/math/graphs/test_graph_coloring.py
+++ b/tests/math/graphs/test_graph_coloring.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian.math.graphs.coloring import _operations as coloring_operations
 from jacobian.math.graphs.coloring._models import (
     EdgeKColorabilityResult,
     MaximalIndependentSetRequest,
@@ -13,6 +14,11 @@ from jacobian.math.graphs.coloring._models import (
 from jacobian.math.graphs.coloring._operations import (
     compute_maximal_independent_set_decision,
 )
+from jacobian.math.graphs.values import (
+    IndexedSimpleUndirectedGraph,
+    SimpleUndirectedGraph,
+)
+from jacobian.process import BoundedProcessResult
 
 
 def _request(
@@ -140,8 +146,37 @@ def test_result_requires_matching_rejection_witness() -> None:
         MaximalIndependentSetResult(decision="INDEPENDENT_NOT_MAXIMAL")
 
 
+def test_coloring_worker_failure_is_typed_inconclusive_without_a_math_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Formula construction and solving live behind the bounded process boundary."""
+
+    def expired_worker(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        return BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        )
+
+    monkeypatch.setattr(coloring_operations, "run_bounded_process", expired_worker)
+    from jacobian.math.graphs.coloring._models import KColorabilityRequest
+    from jacobian.math.graphs.coloring._operations import compute_k_colorability
+
+    result = compute_k_colorability(
+        KColorabilityRequest.model_validate(
+            {"graph": {"vertex_count": 2, "edges": [[0, 1]]}, "colors": 1}
+        )
+    )
+
+    assert result.status == "SOLVER_BUDGET_EXCEEDED"
+    assert result.colorable is None
+
+
 class TestEdgeKColorability:
-    def _petersen(self):
+    def _petersen(self) -> SimpleUndirectedGraph:
         from jacobian.math.graphs.values import SimpleUndirectedGraph
 
         return SimpleUndirectedGraph(
@@ -165,7 +200,7 @@ class TestEdgeKColorability:
             ),
         )
 
-    def test_petersen_not_3_edge_colorable(self):
+    def test_petersen_not_3_edge_colorable(self) -> None:
         from jacobian.math.graphs.coloring._models import EdgeKColorabilityRequest
         from jacobian.math.graphs.coloring._operations import (
             compute_edge_k_colorability,
@@ -177,7 +212,7 @@ class TestEdgeKColorability:
         assert result.colorable is False
         assert result.coloring is None
 
-    def test_petersen_4_edge_colorable_and_proper(self):
+    def test_petersen_4_edge_colorable_and_proper(self) -> None:
         from jacobian.math.graphs.coloring._models import (
             EdgeColoringCheckRequest,
             EdgeKColorabilityRequest,
@@ -201,7 +236,7 @@ class TestEdgeKColorability:
         )
         assert check.proper is True
 
-    def test_triangle_needs_3_edge_colors(self):
+    def test_triangle_needs_3_edge_colors(self) -> None:
         from jacobian.math.graphs.coloring._models import EdgeKColorabilityRequest
         from jacobian.math.graphs.coloring._operations import (
             compute_edge_k_colorability,
@@ -229,14 +264,14 @@ class TestEdgeKColorability:
 class TestEdgeColoringRequestSchema:
     MAX_VERTICES = 256
 
-    def _path_graph(self, vertex_count: int):
+    def _path_graph(self, vertex_count: int) -> SimpleUndirectedGraph:
         from jacobian.math.graphs.values import SimpleUndirectedGraph
 
         labels = tuple(f"{index:02d}" for index in range(vertex_count))
         edges = tuple((labels[i], labels[i + 1]) for i in range(vertex_count - 1))
         return SimpleUndirectedGraph(vertices=labels, edges=edges)
 
-    def test_published_schema_advertises_operation_specific_bounds(self):
+    def test_published_schema_advertises_operation_specific_bounds(self) -> None:
         from jacobian.math.graphs.coloring._models import (
             EdgeColoringCheckRequest,
             EdgeKColorabilityRequest,
@@ -257,7 +292,7 @@ class TestEdgeColoringRequestSchema:
         )
         assert assignment["properties"]["graph"] == decide_graph
 
-    def test_sparse_graph_just_past_the_old_vertex_cap_is_admitted(self):
+    def test_sparse_graph_just_past_the_old_vertex_cap_is_admitted(self) -> None:
         from jacobian.math.graphs.coloring._models import (
             EdgeColoringCheckRequest,
             EdgeKColorabilityRequest,
@@ -280,13 +315,15 @@ class TestEdgeColoringRequestSchema:
         )
         assert assignment.assignment.graph == g
 
-    def test_direct_construction_admits_a_65_vertex_path(self):
+    def test_direct_construction_admits_a_65_vertex_path(self) -> None:
         from jacobian.math.graphs.coloring._models import EdgeKColorabilityRequest
 
         request = EdgeKColorabilityRequest(graph=self._path_graph(65), colors=3)
         assert len(request.graph.vertices) == 65
 
-    def test_vertex_coloring_rejects_only_the_retained_formula_edge_envelope(self):
+    def test_vertex_coloring_rejects_only_the_retained_formula_edge_envelope(
+        self,
+    ) -> None:
         from jacobian.math.graphs.coloring._models import KColorabilityRequest
         from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
@@ -299,7 +336,7 @@ class TestEdgeColoringRequestSchema:
                 colors=3,
             )
 
-    def test_65_vertex_boundary_request_is_admitted(self):
+    def test_65_vertex_boundary_request_is_admitted(self) -> None:
         from jacobian.math.graphs.coloring._models import (
             EdgeColoringAssignment,
             EdgeColoringCheckRequest,
@@ -326,7 +363,7 @@ class TestEdgeColoringRequestSchema:
 
 
 class TestEdgeColoringCheck:
-    def _petersen(self):
+    def _petersen(self) -> SimpleUndirectedGraph:
         from jacobian.math.graphs.values import SimpleUndirectedGraph
 
         return SimpleUndirectedGraph(
@@ -350,7 +387,7 @@ class TestEdgeColoringCheck:
             ),
         )
 
-    def test_proper_coloring_accepted(self):
+    def test_proper_coloring_accepted(self) -> None:
         from jacobian.math.graphs.coloring._models import (
             EdgeColoringAssignment,
             EdgeColoringCheckRequest,
@@ -370,7 +407,7 @@ class TestEdgeColoringCheck:
         assert result.blocking_edge is None
         assert result.assignment.colors == 4
 
-    def test_improper_coloring_reports_blocking_edge(self):
+    def test_improper_coloring_reports_blocking_edge(self) -> None:
         from jacobian.math.graphs.coloring._models import (
             EdgeColoringAssignment,
             EdgeColoringCheckRequest,
@@ -394,7 +431,7 @@ class TestEdgeColoringCheck:
         assert result.blocking_edge is not None
         assert result.conflicting_edge is not None
 
-    def test_rejects_wrong_length_assignment(self):
+    def test_rejects_wrong_length_assignment(self) -> None:
         from jacobian.math.graphs.coloring._models import EdgeColoringAssignment
         from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -406,7 +443,7 @@ class TestEdgeColoringCheck:
             EdgeColoringAssignment(graph=g, colors=2, coloring=(0, 1))
 
 
-def _petersen_graph():
+def _petersen_graph() -> SimpleUndirectedGraph:
     from jacobian.math.graphs.values import SimpleUndirectedGraph
 
     return SimpleUndirectedGraph(
@@ -434,7 +471,7 @@ def _petersen_graph():
 class TestCanonicalEdgeColoringValue:
     """The k_decide witness composes into graph.edge_coloring.check unchanged."""
 
-    def test_serialized_witness_feeds_the_checker_unchanged(self):
+    def test_serialized_witness_feeds_the_checker_unchanged(self) -> None:
         from jacobian.math.graphs.coloring._models import (
             EdgeColoringCheckRequest,
             EdgeKColorabilityRequest,
@@ -456,7 +493,7 @@ class TestCanonicalEdgeColoringValue:
         assert check.proper is True
         assert check.assignment == serialized.coloring
 
-    def test_forged_witness_must_bind_the_result_source(self):
+    def test_forged_witness_must_bind_the_result_source(self) -> None:
         from jacobian.math.graphs.coloring._models import (
             EdgeColoringAssignment,
             EdgeKColorabilityResult,
@@ -476,7 +513,7 @@ class TestCanonicalEdgeColoringValue:
                 edge_count=len(petersen.edges),
             )
 
-    def test_forged_improper_witness_rejected_for_colorable_claim(self):
+    def test_forged_improper_witness_rejected_for_colorable_claim(self) -> None:
         from jacobian.math.graphs.coloring._models import (
             EdgeColoringAssignment,
             EdgeKColorabilityResult,
@@ -494,7 +531,7 @@ class TestCanonicalEdgeColoringValue:
             )
 
 
-def _triangle_graph():
+def _triangle_graph() -> SimpleUndirectedGraph:
     from jacobian.math.graphs.values import SimpleUndirectedGraph
 
     return SimpleUndirectedGraph(
@@ -504,7 +541,7 @@ def _triangle_graph():
 
 
 class TestSolverConflictBudget:
-    def test_budget_exceeded_returns_typed_unknown_outcome(self):
+    def test_budget_exceeded_returns_typed_unknown_outcome(self) -> None:
         """A conflict budget of 1 cannot decide the Petersen graph; the
         operation must report SOLVER_BUDGET_EXCEEDED with no colorability
         claim instead of an unbounded wait or a false negative."""
@@ -525,7 +562,7 @@ class TestSolverConflictBudget:
         assert result.coloring is None
         assert EdgeKColorabilityResult.model_validate(result.model_dump()) == result
 
-    def test_forged_budget_exceeded_requires_explicit_verification(self):
+    def test_forged_budget_exceeded_requires_explicit_verification(self) -> None:
         """An authored budget-exceeded label needs explicit verification."""
         from jacobian.math.graphs.coloring._operations import (
             verify_edge_k_colorability_result,
@@ -543,7 +580,7 @@ class TestSolverConflictBudget:
         )
         assert verify_edge_k_colorability_result(forged) is False
 
-    def test_budget_exceeded_cannot_claim_colorable(self):
+    def test_budget_exceeded_cannot_claim_colorable(self) -> None:
         petersen = _petersen_graph()
         with pytest.raises(ValidationError):
             EdgeKColorabilityResult(
@@ -556,7 +593,7 @@ class TestSolverConflictBudget:
                 edge_count=len(petersen.edges),
             )
 
-    def test_negative_claim_requires_explicit_unsat_within_budget(self):
+    def test_negative_claim_requires_explicit_unsat_within_budget(self) -> None:
         """A non-colorable claim replayed under a too-small budget (which
         returns unknown) must not validate: negatives need explicit unsat."""
         petersen = _petersen_graph()
@@ -580,7 +617,7 @@ class TestSolverConflictBudget:
             is False
         )
 
-    def test_default_budget_still_decides_petersen_negative(self):
+    def test_default_budget_still_decides_petersen_negative(self) -> None:
         from jacobian.math.graphs.coloring._models import EdgeKColorabilityRequest
         from jacobian.math.graphs.coloring._operations import (
             compute_edge_k_colorability,
@@ -592,7 +629,7 @@ class TestSolverConflictBudget:
         assert result.status == "DECIDED"
         assert result.colorable is False
 
-    def test_produced_outcomes_round_trip_through_full_validation(self):
+    def test_produced_outcomes_round_trip_through_full_validation(self) -> None:
         """Results built from the producing solve must equal their fully
         validated reconstruction, so the skipped replay invariant holds."""
         from jacobian.math.graphs.coloring._models import EdgeKColorabilityRequest
@@ -614,7 +651,7 @@ class TestSolverConflictBudget:
 
 
 class TestVertexKColorability:
-    def _k4(self):
+    def _k4(self) -> IndexedSimpleUndirectedGraph:
         from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
         return IndexedSimpleUndirectedGraph(
@@ -622,7 +659,7 @@ class TestVertexKColorability:
             edges=((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)),
         )
 
-    def test_null_graph_is_decided_colorable_with_an_empty_witness(self):
+    def test_null_graph_is_decided_colorable_with_an_empty_witness(self) -> None:
         """The null graph is k-colorable for every palette; the produced
         result must round-trip through full validation."""
         from jacobian.math.graphs.coloring._models import (
@@ -644,7 +681,7 @@ class TestVertexKColorability:
         assert result.vertex_count == 0
         assert KColorabilityResult.model_validate(result.model_dump()) == result
 
-    def test_edgeless_graph_just_past_the_old_vertex_cap_is_admitted(self):
+    def test_edgeless_graph_just_past_the_old_vertex_cap_is_admitted(self) -> None:
         """A 65-vertex edgeless graph has no adjacency constraints to charge."""
         from jacobian.math.graphs.coloring._models import KColorabilityRequest
         from jacobian.math.graphs.coloring._operations import compute_k_colorability
@@ -659,21 +696,27 @@ class TestVertexKColorability:
         assert result.colorable is True
         assert result.coloring == (0,) * 65
 
-    def test_triangle_decision_carries_a_proper_witness(self):
+    def test_triangle_decision_carries_a_proper_witness(self) -> None:
         from jacobian.math.graphs.coloring._models import KColorabilityRequest
         from jacobian.math.graphs.coloring._operations import compute_k_colorability
 
         result = compute_k_colorability(
-            KColorabilityRequest(
-                graph={"vertex_count": 3, "edges": [[0, 1], [1, 2], [0, 2]]},
-                colors=3,
+            KColorabilityRequest.model_validate(
+                {
+                    "graph": {
+                        "vertex_count": 3,
+                        "edges": [[0, 1], [1, 2], [0, 2]],
+                    },
+                    "colors": 3,
+                }
             )
         )
         assert result.status == "DECIDED"
         assert result.colorable is True
+        assert result.coloring is not None
         assert len(result.coloring) == 3
 
-    def test_budget_exceeded_returns_typed_unknown_outcome(self):
+    def test_budget_exceeded_returns_typed_unknown_outcome(self) -> None:
         """A conflict budget of 1 cannot decide the complete graph K4 under
         three colors; the operation must report SOLVER_BUDGET_EXCEEDED with
         no colorability claim instead of an unbounded wait or a false
@@ -691,7 +734,7 @@ class TestVertexKColorability:
         assert result.coloring is None
         assert KColorabilityResult.model_validate(result.model_dump()) == result
 
-    def test_forged_budget_exceeded_requires_explicit_verification(self):
+    def test_forged_budget_exceeded_requires_explicit_verification(self) -> None:
         """An authored budget-exceeded label needs explicit verification."""
         from jacobian.math.graphs.coloring._models import (
             KColorabilityResult,
@@ -712,7 +755,7 @@ class TestVertexKColorability:
         )
         assert verify_k_colorability_result(forged) is False
 
-    def test_budget_exceeded_cannot_claim_colorable(self):
+    def test_budget_exceeded_cannot_claim_colorable(self) -> None:
         from jacobian.math.graphs.coloring._models import KColorabilityResult
 
         k4 = self._k4()
@@ -727,7 +770,7 @@ class TestVertexKColorability:
                 vertex_count=4,
             )
 
-    def test_negative_claim_requires_explicit_unsat_within_budget(self):
+    def test_negative_claim_requires_explicit_unsat_within_budget(self) -> None:
         """A non-colorable claim replayed under a too-small budget (which
         returns unknown) must not validate: negatives need explicit unsat."""
         from jacobian.math.graphs.coloring._models import KColorabilityResult
@@ -751,7 +794,7 @@ class TestVertexKColorability:
             is False
         )
 
-    def test_default_budget_still_decides_k4_negative(self):
+    def test_default_budget_still_decides_k4_negative(self) -> None:
         from jacobian.math.graphs.coloring._models import KColorabilityRequest
         from jacobian.math.graphs.coloring._operations import compute_k_colorability
 
@@ -762,7 +805,7 @@ class TestVertexKColorability:
         assert result.colorable is False
         assert result.coloring is None
 
-    def test_forged_positive_witnesses_are_rejected(self):
+    def test_forged_positive_witnesses_are_rejected(self) -> None:
         """A colorable claim must carry one in-range color per vertex and the
         witness must be proper for the result's own graph."""
         from jacobian.math.graphs.coloring._models import (
@@ -779,10 +822,12 @@ class TestVertexKColorability:
             "vertex_count": 3,
         }
         with pytest.raises(ValidationError):
-            KColorabilityResult(**{**base, "coloring": (0, 1)})
+            KColorabilityResult.model_validate({**base, "coloring": (0, 1)})
         with pytest.raises(ValidationError):
-            KColorabilityResult(**{**base, "coloring": (0, 1, 2)})
+            KColorabilityResult.model_validate({**base, "coloring": (0, 1, 2)})
         with pytest.raises(ValidationError):
-            KColorabilityResult(**{**base, "coloring": (0, 0, 1)})
+            KColorabilityResult.model_validate({**base, "coloring": (0, 0, 1)})
         with pytest.raises(ValidationError):
-            KColorabilityResult(**{**base, "coloring": (0, 1, 0), "vertex_count": 2})
+            KColorabilityResult.model_validate(
+                {**base, "coloring": (0, 1, 0), "vertex_count": 2}
+            )

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -37,35 +37,39 @@ from jacobian.math.graphs.multigraph._models import LooplessMultigraph, Multigra
 # ---------------------------------------------------------------------------
 
 
-def _block_cut_tree(graph: dict) -> BlockCutTreeResult:
+def _block_cut_tree(graph: dict[str, object]) -> BlockCutTreeResult:
     return compute_block_cut_tree(
         BlockCutTreeRequest.model_validate({"graph": graph}),
     )
 
 
-def _bridge_block_tree(graph: dict) -> BridgeBlockResult:
+def _bridge_block_tree(graph: dict[str, object]) -> BridgeBlockResult:
     return compute_bridge_block_tree(
         BridgeBlockRequest.model_validate({"graph": graph}),
     )
 
 
-def _ear_decomposition(graph: dict) -> EarDecompositionResult:
+def _ear_decomposition(graph: dict[str, object]) -> EarDecompositionResult:
     return compute_ear_decomposition(
         EarDecompositionRequest.model_validate({"graph": graph}),
     )
 
 
-def _biconnected_components(graph: dict) -> BiconnectedComponentsResult:
+def _biconnected_components(
+    graph: dict[str, object],
+) -> BiconnectedComponentsResult:
     return compute_biconnected_components(
         BiconnectedComponentsRequest.model_validate({"graph": graph}),
     )
 
 
-def _spqr_tree(graph: dict):
+def _spqr_tree(graph: dict[str, object]) -> SPQRTreeResult:
     return compute_spqr_tree(SPQRTreeRequest.model_validate({"graph": graph}))
 
 
-def _edges_as_sets(edges: tuple[tuple[int, int], ...]) -> frozenset:
+def _edges_as_sets(
+    edges: tuple[tuple[int, int], ...],
+) -> frozenset[tuple[int, int]]:
     return frozenset((min(u, v), max(u, v)) for u, v in edges)
 
 
@@ -697,7 +701,7 @@ class TestSPQRTree:
                 source_graph=genuine.source_graph,
                 status="SPQR_TREE",
                 nodes=(forged_rigid, forged_bridge),
-                tree_edges=(tuple(sorted(("node:forged", rigid.node_id))),),
+                tree_edges=(("node:forged", rigid.node_id),),
                 virtual_edge_pairs=(("virtual:forged", "virtual:forged-mate"),),
                 source_vertex_incidence=incidence,
                 source_edge_owners=owners,

--- a/tests/math/graphs/test_graph_distance_matrix.py
+++ b/tests/math/graphs/test_graph_distance_matrix.py
@@ -189,7 +189,7 @@ def test_result_rejects_unsorted_or_duplicate_vertices(
             pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
             unreachable_representation="JSON_NULL",
             vertices=vertices,
-            rows=_complete_rows(list(vertices)),
+            rows=tuple(_complete_rows(list(vertices))),
             connected=True,
         )
 
@@ -202,7 +202,7 @@ def test_result_rejects_missing_rows_and_nonsquare_rows() -> None:
             pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
             unreachable_representation="JSON_NULL",
             vertices=vertices,
-            rows=_complete_rows(list(vertices))[:2],
+            rows=tuple(_complete_rows(list(vertices))[:2]),
             connected=True,
         )
     with pytest.raises(ValidationError):
@@ -279,6 +279,6 @@ def test_result_rejects_connected_mismatch() -> None:
             pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
             unreachable_representation="JSON_NULL",
             vertices=("1", "10", "2"),
-            rows=_complete_rows(["1", "10", "2"]),
+            rows=tuple(_complete_rows(["1", "10", "2"])),
             connected=False,
         )

--- a/tests/math/graphs/test_graph_flow.py
+++ b/tests/math/graphs/test_graph_flow.py
@@ -26,19 +26,21 @@ from jacobian.math.graphs.flow._operations import (
 # ---------------------------------------------------------------------------
 
 
-def _max_flow(graph: dict, source: int, sink: int) -> MaxFlowResult:
+def _max_flow(graph: dict[str, object], source: int, sink: int) -> MaxFlowResult:
     return compute_max_flow(
         MaxFlowRequest.model_validate({"graph": graph, "source": source, "sink": sink})
     )
 
 
-def _min_cut(graph: dict, source: int, sink: int) -> MinCutResult:
+def _min_cut(graph: dict[str, object], source: int, sink: int) -> MinCutResult:
     return compute_min_cut(
         MinCutRequest.model_validate({"graph": graph, "source": source, "sink": sink})
     )
 
 
-def _edge_disjoint(graph: dict, source: int, sink: int) -> EdgeDisjointPathsResult:
+def _edge_disjoint(
+    graph: dict[str, object], source: int, sink: int
+) -> EdgeDisjointPathsResult:
     return compute_edge_disjoint_paths(
         EdgeDisjointPathsRequest.model_validate(
             {"graph": graph, "source": source, "sink": sink}

--- a/tests/math/graphs/test_graph_maximum_cut.py
+++ b/tests/math/graphs/test_graph_maximum_cut.py
@@ -18,6 +18,7 @@ from jacobian.math.graphs.optimization._maximum_cut import (
     GraphMaximumCutRequest,
     GraphMaximumCutResult,
     compute_maximum_cut,
+    verify_maximum_cut_result,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -28,12 +29,16 @@ def _graph(
     return SimpleUndirectedGraph(vertices=vertices, edges=edges)
 
 
+def _edge(left: str, right: str) -> tuple[str, str]:
+    return (left, right) if left < right else (right, left)
+
+
 def _cycle(order: int) -> SimpleUndirectedGraph:
     vertices = tuple(f"{index:02d}" for index in range(order))
     edges = tuple(
         sorted(
             {
-                tuple(sorted((vertices[index], vertices[(index + 1) % order])))
+                _edge(vertices[index], vertices[(index + 1) % order])
                 for index in range(order)
             }
         )
@@ -43,7 +48,9 @@ def _cycle(order: int) -> SimpleUndirectedGraph:
 
 def _complete(order: int) -> SimpleUndirectedGraph:
     vertices = tuple(f"{index:02d}" for index in range(order))
-    return _graph(vertices, tuple(combinations(vertices, 2)))
+    return _graph(
+        vertices, tuple((left, right) for left, right in combinations(vertices, 2))
+    )
 
 
 def _c5_blow_up(class_sizes: tuple[int, int, int, int, int]) -> SimpleUndirectedGraph:
@@ -55,7 +62,7 @@ def _c5_blow_up(class_sizes: tuple[int, int, int, int, int]) -> SimpleUndirected
     edges = tuple(
         sorted(
             {
-                tuple(sorted((left, right)))
+                _edge(left, right)
                 for class_index, class_ in enumerate(classes)
                 for left in class_
                 for right in classes[(class_index + 1) % 5]
@@ -178,8 +185,7 @@ def test_every_graph_through_order_six_matches_an_independent_oracle() -> None:
         vertices = tuple(sorted(labels.values()))
         edges = tuple(
             sorted(
-                tuple(sorted((labels[left], labels[right])))
-                for left, right in atlas_graph.edges
+                _edge(labels[left], labels[right]) for left, right in atlas_graph.edges
             )
         )
         graph = _graph(vertices, edges)
@@ -277,8 +283,25 @@ def test_feasible_suboptimal_cut_with_forged_exact_bounds_fails_replay() -> None
     forged["lower_bound"] = 2
     forged["upper_bound"] = 2
 
-    with pytest.raises(ValidationError):
-        GraphMaximumCutResult.model_validate(forged)
+    assert not verify_maximum_cut_result(GraphMaximumCutResult.model_validate(forged))
+
+
+def test_result_deserialization_never_replays_the_exhaustive_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = compute_maximum_cut(GraphMaximumCutRequest(graph=_cycle(5)))
+
+    def forbidden_replay(
+        *_args: object, **_kwargs: object
+    ) -> tuple[int, tuple[bool, ...]]:
+        raise AssertionError("structural result parsing must not replay maximum cut")
+
+    monkeypatch.setattr(
+        _maximum_cut, "_solve_analysis_by_enumeration", forbidden_replay
+    )
+    reparsed = GraphMaximumCutResult.model_validate(result.model_dump(mode="json"))
+
+    assert reparsed == result
 
 
 def test_candidate_boundary_accepts_c21_and_rejects_c23_before_backend() -> None:

--- a/tests/math/graphs/test_graph_optimization_atlas.py
+++ b/tests/math/graphs/test_graph_optimization_atlas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import networkx as nx
 import pytest
 
@@ -22,15 +24,17 @@ def _assert_gallai_edmonds_certificate(graphs: list[nx.Graph[int]]) -> None:
         if operation.operation_id == "graph.invariant.maximum_matching.compute"
     )
     for indexed_graph in graphs:
-        graph = nx.relabel_nodes(
-            indexed_graph,
-            {vertex: str(vertex) for vertex in indexed_graph},
+        graph = cast(
+            "nx.Graph[str]",
+            nx.relabel_nodes(
+                indexed_graph,
+                {vertex: str(vertex) for vertex in indexed_graph},
+            ),
         )
         request = operation.request_type.model_validate(
             {"graph": _graph_payload(graph)}
         )
         result = operation.run(request)
-        assert isinstance(result, operation.result_type)
         barrier = set(result.certificate.barrier_vertices)
         reduced = graph.subgraph(set(graph) - barrier)
         odd_component_count = sum(

--- a/tests/math/graphs/test_graph_polynomials.py
+++ b/tests/math/graphs/test_graph_polynomials.py
@@ -3,6 +3,7 @@
 from jacobian.math.graphs.polynomials._models import (
     GraphEdge,
     GraphPolynomialRequest,
+    GraphPolynomialResult,
     GraphSpec,
     MatchingPolynomialRequest,
 )
@@ -24,12 +25,12 @@ def _path_graph(n: int) -> GraphSpec:
     return GraphSpec(vertex_count=n, edges=tuple(edges))
 
 
-def _terms_to_dict(result):
+def _terms_to_dict(result: GraphPolynomialResult) -> dict[int, int]:
     return {t.degree: t.coefficient for t in result.terms}
 
 
 class TestTuttePolynomial:
-    def test_cycle_c4(self):
+    def test_cycle_c4(self) -> None:
         req = GraphPolynomialRequest(graph=_cycle_graph(4))
         result = compute_tutte_polynomial(req)
         # T(C4, x, y) = x^3 + x^2 + x + y
@@ -37,7 +38,7 @@ class TestTuttePolynomial:
         assert result.variables == ("x", "y")
         assert d == {(0, 1): 1, (1, 0): 1, (2, 0): 1, (3, 0): 1}
 
-    def test_single_edge(self):
+    def test_single_edge(self) -> None:
         req = GraphPolynomialRequest(
             graph=GraphSpec(vertex_count=2, edges=(GraphEdge(u=0, v=1),))
         )
@@ -48,7 +49,7 @@ class TestTuttePolynomial:
 
 
 class TestChromaticPolynomial:
-    def test_cycle_c3(self):
+    def test_cycle_c3(self) -> None:
         req = GraphPolynomialRequest(graph=_cycle_graph(3))
         result = compute_chromatic_polynomial(req)
         # chi(C3) = x(x-1)(x-2) = x^3 - 3x^2 + 2x
@@ -57,7 +58,7 @@ class TestChromaticPolynomial:
         assert d.get(2) == -3
         assert d.get(1) == 2
 
-    def test_path_p3(self):
+    def test_path_p3(self) -> None:
         req = GraphPolynomialRequest(graph=_path_graph(3))
         result = compute_chromatic_polynomial(req)
         # chi(P3) = x(x-1)^2 = x^3 - 2x^2 + x
@@ -68,7 +69,7 @@ class TestChromaticPolynomial:
 
 
 class TestFlowPolynomial:
-    def test_cycle_c4(self):
+    def test_cycle_c4(self) -> None:
         req = GraphPolynomialRequest(graph=_cycle_graph(4))
         result = compute_flow_polynomial(req)
         # F(C4) = x - 1, from (-1)^{|E|-|V|+k} T(0, 1-x).
@@ -76,7 +77,7 @@ class TestFlowPolynomial:
         assert d.get(1) == 1
         assert d.get(0) == -1
 
-    def test_rejects_graph_beyond_deletion_budget(self):
+    def test_rejects_graph_beyond_deletion_budget(self) -> None:
         import pytest
         from pydantic import ValidationError
 
@@ -86,7 +87,7 @@ class TestFlowPolynomial:
                 graph=GraphSpec(vertex_count=8, edges=edges),
             )
 
-    def test_bridge_is_zero_polynomial(self):
+    def test_bridge_is_zero_polynomial(self) -> None:
         req = GraphPolynomialRequest(
             graph=GraphSpec(vertex_count=2, edges=(GraphEdge(u=0, v=1),))
         )
@@ -95,7 +96,7 @@ class TestFlowPolynomial:
 
 
 class TestMatchingPolynomial:
-    def test_single_edge(self):
+    def test_single_edge(self) -> None:
         req = MatchingPolynomialRequest(
             graph=GraphSpec(vertex_count=2, edges=(GraphEdge(u=0, v=1),))
         )
@@ -105,7 +106,7 @@ class TestMatchingPolynomial:
         assert d.get(2) == 1
         assert d.get(0) == -1
 
-    def test_path_p3(self):
+    def test_path_p3(self) -> None:
         req = MatchingPolynomialRequest(graph=_path_graph(3))
         result = compute_matching_polynomial(req)
         # P3 has edges (0,1) and (1,2)

--- a/tests/math/graphs/test_graph_spectrum_binding.py
+++ b/tests/math/graphs/test_graph_spectrum_binding.py
@@ -231,7 +231,7 @@ def test_spectrum_reconstructs_the_characteristic_polynomial() -> None:
         rational_polynomial_to_sympy(charpoly_result.polynomial).as_expr(), x
     )
 
-    factors = 1
+    factors = x**0
     for value, multiplicity in _adjacency_matrix(path).eigenvals().items():
         factors *= (x - value) ** multiplicity
     claimed = together(factors.expand())

--- a/tests/math/graphs/test_graph_symmetry_models.py
+++ b/tests/math/graphs/test_graph_symmetry_models.py
@@ -16,6 +16,7 @@ from jacobian.math.graphs.isomorphism import (
 )
 from jacobian.math.graphs.symmetry._models import (
     MAX_GRAPH_SYMMETRY_GENERATORS,
+    GraphAutomorphismGenerator,
     GraphEdgeOrbit,
     GraphSymmetryOrbitRequest,
     GraphSymmetryOrbitResult,
@@ -85,7 +86,7 @@ def test_graph_symmetry_request_requires_declared_vertex_order_mapping() -> None
 
 def test_graph_symmetry_request_rejects_color_breaking_generator() -> None:
     payload = _path_request()
-    payload["graph"]["vertex_colors"][2] = "distinguished"  # type: ignore[index]
+    payload["graph"]["vertex_colors"][2] = "distinguished"
 
     with pytest.raises(ValidationError):
         GraphSymmetryOrbitRequest.model_validate(payload)
@@ -348,7 +349,7 @@ def test_graph_symmetry_request_requires_nfc_generator_identifiers() -> None:
 
 def test_graph_symmetry_request_requires_nfc_vertex_colors() -> None:
     payload = _path_request()
-    payload["graph"]["vertex_colors"][0] = "\u0344endpoint"  # type: ignore[index]
+    payload["graph"]["vertex_colors"][0] = "\u0344endpoint"
 
     with pytest.raises(ValidationError):
         GraphSymmetryOrbitRequest.model_validate(payload)
@@ -356,7 +357,7 @@ def test_graph_symmetry_request_requires_nfc_vertex_colors() -> None:
 
 def test_graph_symmetry_request_requires_nfc_edge_colors() -> None:
     payload = _path_request()
-    payload["graph"]["edge_colors"] = ["\u0344" * 64, "\u0344" * 64]  # type: ignore[index]
+    payload["graph"]["edge_colors"] = ["\u0344" * 64, "\u0344" * 64]
 
     with pytest.raises(ValidationError):
         GraphSymmetryOrbitRequest.model_validate(payload)
@@ -402,7 +403,7 @@ def test_graph_symmetry_schema_publishes_nfc_requirement() -> None:
 
 def test_graph_symmetry_request_rejects_non_nfc_color_names() -> None:
     payload = _path_request()
-    payload["graph"]["vertex_colors"] = ["endpo\u0069\u0301nt", "middle", "endpoint"]  # type: ignore[index]
+    payload["graph"]["vertex_colors"] = ["endpo\u0069\u0301nt", "middle", "endpoint"]
 
     with pytest.raises(ValidationError):
         GraphSymmetryOrbitRequest.model_validate(payload)
@@ -422,10 +423,10 @@ def test_canonicalization_result_passes_unchanged_into_symmetry_request() -> Non
     request = GraphSymmetryOrbitRequest(
         graph=canonical,
         generators=(
-            {
-                "generator_id": "reflection",
-                "mapping": (("v00", "v01"), ("v01", "v00"), ("v02", "v02")),
-            },
+            GraphAutomorphismGenerator(
+                generator_id="reflection",
+                mapping=(("v00", "v01"), ("v01", "v00"), ("v02", "v02")),
+            ),
         ),
     )
 

--- a/tests/math/graphs/test_graph_transforms.py
+++ b/tests/math/graphs/test_graph_transforms.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from jacobian.math.graphs.transforms._models import (
     GraphEdge,
+    GraphResult,
     GraphTransformRequest,
     ResultGraphEdge,
     SimpleGraph,
@@ -25,7 +26,7 @@ def _graph(vc: int, edges: list[tuple[int, int]]) -> SimpleGraph:
     )
 
 
-def _result_edges(result) -> frozenset[tuple[int, int]]:
+def _result_edges(result: GraphResult) -> frozenset[tuple[int, int]]:
     return frozenset(
         (e.source, e.target) if e.source < e.target else (e.target, e.source)
         for e in result.edges

--- a/tests/math/graphs/test_independence_source_binding.py
+++ b/tests/math/graphs/test_independence_source_binding.py
@@ -404,7 +404,10 @@ def test_independence_worker_covers_encoding_solving_and_replay(
         recorded.update(kwargs)
         return BoundedProcessResult(
             returncode=0,
-            stdout=json.dumps(expected.model_dump(mode="json")).encode("utf-8"),
+            stdout=json.dumps(
+                expected.model_dump(mode="json", exclude={"graph"}),
+                ensure_ascii=False,
+            ).encode("utf-8"),
             stderr=b"",
             stdout_exceeded=False,
             stderr_exceeded=False,
@@ -450,7 +453,7 @@ def test_independence_worker_failure_is_not_an_exact_claim(
     assert result.upper_bound == result.order
 
 
-def test_independence_worker_result_must_bind_the_submitted_graph(
+def test_independence_worker_projection_cannot_replace_the_submitted_graph(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     request = IndependenceNumberRequest(graph=_path_graph())
@@ -463,7 +466,10 @@ def test_independence_worker_result_must_bind_the_submitted_graph(
         "run_bounded_process",
         lambda *_args, **_kwargs: BoundedProcessResult(
             returncode=0,
-            stdout=json.dumps(wrong_result.model_dump(mode="json")).encode("utf-8"),
+            stdout=json.dumps(
+                wrong_result.model_dump(mode="json", exclude={"graph"}),
+                ensure_ascii=False,
+            ).encode("utf-8"),
             stderr=b"",
             stdout_exceeded=False,
             stderr_exceeded=False,

--- a/tests/math/graphs/test_independence_source_binding.py
+++ b/tests/math/graphs/test_independence_source_binding.py
@@ -416,7 +416,9 @@ def test_independence_worker_covers_encoding_solving_and_replay(
     result = solve_independence_number(request)
 
     assert result == expected
-    assert recorded["timeout_seconds"] == 3
+    timeout_seconds = recorded["timeout_seconds"]
+    assert isinstance(timeout_seconds, float)
+    assert 0 < timeout_seconds <= 3
     assert Path(str(recorded["cwd"])).name.startswith("jacobian-graph-independence-")
     limits = recorded["resource_limits"]
     assert isinstance(limits, ProcessResourceLimits)
@@ -446,6 +448,33 @@ def test_independence_worker_failure_is_not_an_exact_claim(
     assert result.status == "UNKNOWN"
     assert result.optimum_value is None
     assert result.upper_bound == result.order
+
+
+def test_independence_worker_result_must_bind_the_submitted_graph(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = IndependenceNumberRequest(graph=_path_graph())
+    wrong_graph = SimpleUndirectedGraph(vertices=("x",), edges=())
+    wrong_result = z3_backend._solve_independence_number_values_kernel(
+        wrong_graph, request.resource_budget
+    )
+    monkeypatch.setattr(
+        z3_backend,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=0,
+            stdout=json.dumps(wrong_result.model_dump(mode="json")).encode("utf-8"),
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        ),
+    )
+
+    result = solve_independence_number(request)
+
+    assert result.status == "UNKNOWN"
+    assert result.graph == request.graph
 
 
 def test_result_headroom_admission_rejects_oversized_echo() -> None:

--- a/tests/math/graphs/test_independence_source_binding.py
+++ b/tests/math/graphs/test_independence_source_binding.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import copy
+import json
+import sys
 import time
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -17,6 +20,7 @@ from jacobian.math.graphs.independence import (
     IndependenceNumberResult,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.process import BoundedProcessResult, ProcessResourceLimits
 
 
 def _graph(
@@ -35,7 +39,7 @@ def test_budget_exposes_only_enforced_limits() -> None:
         not in IndependenceNumberBudget.model_json_schema()["properties"]
     )
     with pytest.raises(ValidationError):
-        IndependenceNumberBudget(max_solver_calls=1)
+        IndependenceNumberBudget.model_validate({"max_solver_calls": 1})
 
 
 def test_producer_results_parse_structurally_then_verify_exact_claims() -> None:
@@ -372,14 +376,76 @@ def test_sat_with_open_objective_bounds_reports_order_as_upper_bound(
     the optimizer's intermediate estimate into the result.
     """
 
-    monkeypatch.setattr(z3_backend, "z3", _StubZ3())
-    result = solve_independence_number(IndependenceNumberRequest(graph=_path_graph()))
+    monkeypatch.setitem(sys.modules, "z3", _StubZ3())
+    result = z3_backend._solve_independence_number_values_kernel(
+        _path_graph(), IndependenceNumberBudget()
+    )
     assert result.status == "UNKNOWN"
     assert result.optimum_value is None
     assert result.incumbent_value == 1
     assert result.lower_bound == 1
     assert result.upper_bound == result.order == 3
     assert IndependenceNumberResult.model_validate(result.model_dump()) == result
+
+
+def test_independence_worker_covers_encoding_solving_and_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = IndependenceNumberRequest(
+        graph=_path_graph(), resource_budget=IndependenceNumberBudget(wall_seconds=3)
+    )
+    expected = z3_backend._solve_independence_number_values_kernel(
+        request.graph, request.resource_budget
+    )
+    recorded: dict[str, object] = {}
+
+    def complete_worker(*args: object, **kwargs: object) -> BoundedProcessResult:
+        recorded["args"] = args
+        recorded.update(kwargs)
+        return BoundedProcessResult(
+            returncode=0,
+            stdout=json.dumps(expected.model_dump(mode="json")).encode("utf-8"),
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        )
+
+    monkeypatch.setattr(z3_backend, "run_bounded_process", complete_worker)
+
+    result = solve_independence_number(request)
+
+    assert result == expected
+    assert recorded["timeout_seconds"] == 3
+    assert Path(str(recorded["cwd"])).name.startswith("jacobian-graph-independence-")
+    limits = recorded["resource_limits"]
+    assert isinstance(limits, ProcessResourceLimits)
+    assert limits.cpu_seconds == 3
+    assert limits.address_space_bytes == 1_536 * 1024 * 1024
+    assert limits.file_size_bytes == 1_024 * 1_024
+
+
+def test_independence_worker_failure_is_not_an_exact_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        z3_backend,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = solve_independence_number(IndependenceNumberRequest(graph=_path_graph()))
+
+    assert result.status == "UNKNOWN"
+    assert result.optimum_value is None
+    assert result.upper_bound == result.order
 
 
 def test_result_headroom_admission_rejects_oversized_echo() -> None:

--- a/tests/math/graphs/test_optimization_wall_budget.py
+++ b/tests/math/graphs/test_optimization_wall_budget.py
@@ -87,6 +87,33 @@ def test_chromatic_budget_starts_before_graph_preparation(
     assert result.tested == ()
 
 
+def test_chromatic_worker_projection_is_bound_to_the_submitted_vertices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = GraphChromaticNumberRequest.model_validate(
+        {"graph": _graph().model_dump(), "resource_budget": {"wall_seconds": 3}}
+    )
+    expected = _chromatic_number._search_chromatic_number_kernel(request)
+
+    monkeypatch.setattr(
+        _chromatic_number,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=0,
+            stdout=json.dumps(
+                expected.model_dump(mode="json", exclude={"vertices"}),
+                ensure_ascii=False,
+            ).encode("utf-8"),
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        ),
+    )
+
+    assert _chromatic_number._search_chromatic_number(request) == expected
+
+
 @pytest.mark.parametrize(
     "operation_id",
     [

--- a/tests/math/graphs/test_optimization_wall_budget.py
+++ b/tests/math/graphs/test_optimization_wall_budget.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any
+
 import networkx as nx
 import pytest
+import z3  # type: ignore[import-untyped]
 
 from jacobian.math.graphs import _independence_z3
 from jacobian.math.graphs.independence import (
@@ -10,6 +15,7 @@ from jacobian.math.graphs.independence import (
 )
 from jacobian.math.graphs.optimization import (
     _chromatic_number,
+    _exact_search,
     _finite_optimization,
     _invariants,
 )
@@ -22,13 +28,14 @@ from jacobian.math.graphs.optimization._models import (
     GraphOptimizationRequest,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.process import BoundedProcessResult, ProcessResourceLimits
 
 
 def _graph() -> ChromaticGraph:
     return ChromaticGraph(vertices=("a", "b", "c"), edges=(("a", "b"), ("b", "c")))
 
 
-def _expired(monkeypatch: pytest.MonkeyPatch, entry_module: object) -> None:
+def _expired(monkeypatch: pytest.MonkeyPatch, entry_module: Any) -> None:
     clock = iter((0.0, 2.0))
     monkeypatch.setattr(entry_module.time, "monotonic", lambda: next(clock, 2.0))
 
@@ -48,7 +55,7 @@ def test_clique_budget_starts_before_incumbent_construction(
         graph=_graph(), resource_budget=GraphOptimizationBudget(wall_seconds=1)
     )
 
-    result = _invariants._clique_execute(request)
+    result = _invariants._clique_execute_kernel(request)
 
     assert result.status == "UNKNOWN"
     assert result.termination_reason == "WALL_TIME"
@@ -70,7 +77,7 @@ def test_chromatic_budget_starts_before_graph_preparation(
         {"graph": _graph().model_dump(), "resource_budget": {"wall_seconds": 1}}
     )
 
-    result = _chromatic_number._search_chromatic_number(request)
+    result = _chromatic_number._search_chromatic_number_kernel(request)
 
     assert result.status == "UNKNOWN"
     assert result.solver_status == "UNKNOWN"
@@ -79,55 +86,134 @@ def test_chromatic_budget_starts_before_graph_preparation(
 
 
 @pytest.mark.parametrize(
-    ("operation", "seed_name"),
+    "solve_name",
     [
-        (_finite_optimization.DOMINATION_MINIMUM_OPERATION, "dominating_set"),
-        (
-            _finite_optimization.MINIMUM_MAXIMAL_MATCHING_OPERATION,
-            "maximal_matching",
-        ),
+        "solve_domination",
+        "solve_minimum_maximal_matching",
     ],
 )
 def test_finite_searches_do_not_reset_the_operation_timer(
-    monkeypatch: pytest.MonkeyPatch, operation: object, seed_name: str
+    monkeypatch: pytest.MonkeyPatch, solve_name: str
 ) -> None:
     _expired(monkeypatch, _finite_optimization)
-    monkeypatch.setattr(
-        nx,
-        seed_name,
-        lambda _graph: (_ for _ in ()).throw(
-            AssertionError(f"uninterruptible {seed_name} seed must not run")
-        ),
-    )
     request = GraphOptimizationRequest(
         graph=_graph(), resource_budget=GraphOptimizationBudget(wall_seconds=1)
     )
 
-    result = operation.run(request)
+    result = _finite_optimization._execute_kernel(
+        request, getattr(_finite_optimization, solve_name)
+    )
 
     assert result.status == "UNKNOWN"
     assert result.termination_reason == "WALL_TIME"
     assert result.tested == ()
 
 
+def test_graph_optimization_worker_binds_encoding_and_solving_to_one_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = GraphOptimizationRequest(
+        graph=_graph(), resource_budget=GraphOptimizationBudget(wall_seconds=3)
+    )
+    expected = _finite_optimization._run_worker_kernel(
+        "graph.domination.minimum.compute", request
+    )
+    recorded: dict[str, object] = {}
+
+    def complete_worker(*args: object, **kwargs: object) -> BoundedProcessResult:
+        recorded["args"] = args
+        recorded.update(kwargs)
+        return BoundedProcessResult(
+            returncode=0,
+            stdout=json.dumps(expected.model_dump(mode="json")).encode("utf-8"),
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        )
+
+    monkeypatch.setattr(_finite_optimization, "run_bounded_process", complete_worker)
+
+    result = _finite_optimization.DOMINATION_MINIMUM_OPERATION.run(request)
+
+    assert result == expected
+    assert recorded["timeout_seconds"] == 3
+    assert Path(str(recorded["cwd"])).name.startswith("jacobian-graph-optimization-")
+    limits = recorded["resource_limits"]
+    assert isinstance(limits, ProcessResourceLimits)
+    assert limits.cpu_seconds == 3
+    assert limits.address_space_bytes == 1_536 * 1024 * 1024
+    assert limits.file_size_bytes == 1_024 * 1_024
+
+
+def test_graph_optimization_worker_failure_cannot_claim_an_optimum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _finite_optimization,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = _finite_optimization.DOMINATION_MINIMUM_OPERATION.run(
+        GraphOptimizationRequest(graph=_graph())
+    )
+
+    assert result.status == "UNKNOWN"
+    assert result.optimum_value is None
+    assert result.termination_reason == "SOLVER_UNKNOWN"
+
+
+def test_threshold_solver_does_not_start_or_finish_after_encoding_expires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Solver:
+        def __init__(self) -> None:
+            self.set_called = False
+            self.check_called = False
+
+        def set(self, **_settings: int) -> None:
+            self.set_called = True
+
+        def check(self) -> object:
+            self.check_called = True
+            return z3.sat
+
+    budget = GraphOptimizationBudget(wall_seconds=1)
+    solver = Solver()
+    monkeypatch.setattr(_exact_search, "_remaining_ms", lambda *_args: 0)
+
+    assert (
+        _exact_search._check_after_encoding(solver, started=0.0, budget=budget)
+        == z3.unknown
+    )
+    assert not solver.set_called
+    assert not solver.check_called
+
+    elapsed = iter((1_000, 0))
+    monkeypatch.setattr(_exact_search, "_remaining_ms", lambda *_args: next(elapsed))
+    assert (
+        _exact_search._check_after_encoding(solver, started=0.0, budget=budget)
+        == z3.unknown
+    )
+    assert solver.set_called
+    assert solver.check_called
+
+
 def test_independence_does_not_enter_z3_after_seed_budget_exhaustion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     clock = iter((0.0, 2.0))
-    monkeypatch.setattr(_independence_z3.time, "monotonic", lambda: next(clock))
     monkeypatch.setattr(
-        nx.approximation,
-        "maximum_independent_set",
-        lambda _graph: (_ for _ in ()).throw(
-            AssertionError("uninterruptible independence seed must not run")
-        ),
+        "jacobian.math.graphs._independence_z3.time.monotonic", lambda: next(clock)
     )
-
-    class ForbiddenOptimizer:
-        def __init__(self) -> None:
-            raise AssertionError("Z3 must not start after the operation deadline")
-
-    monkeypatch.setattr(_independence_z3.z3, "Optimize", ForbiddenOptimizer)
     request = IndependenceNumberRequest(
         graph=SimpleUndirectedGraph(
             vertices=("a", "b", "c"), edges=(("a", "b"), ("b", "c"))
@@ -135,7 +221,9 @@ def test_independence_does_not_enter_z3_after_seed_budget_exhaustion(
         resource_budget=IndependenceNumberBudget(wall_seconds=1),
     )
 
-    result = _independence_z3.solve_independence_number(request)
+    result = _independence_z3._solve_independence_number_values_kernel(
+        request.graph, request.resource_budget
+    )
 
     assert result.status == "UNKNOWN"
     assert result.termination_reason == "WALL_TIME"

--- a/tests/math/graphs/test_optimization_wall_budget.py
+++ b/tests/math/graphs/test_optimization_wall_budget.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import networkx as nx
 import pytest
@@ -24,6 +24,8 @@ from jacobian.math.graphs.optimization._coloring_models import (
     GraphChromaticNumberRequest,
 )
 from jacobian.math.graphs.optimization._models import (
+    GraphDominationMinimumOutput,
+    GraphMinimumMaximalMatchingOutput,
     GraphOptimizationBudget,
     GraphOptimizationRequest,
 )
@@ -86,22 +88,23 @@ def test_chromatic_budget_starts_before_graph_preparation(
 
 
 @pytest.mark.parametrize(
-    "solve_name",
+    "operation_id",
     [
-        "solve_domination",
-        "solve_minimum_maximal_matching",
+        "graph.domination.minimum.compute",
+        "graph.matching.maximal.minimum.compute",
     ],
 )
 def test_finite_searches_do_not_reset_the_operation_timer(
-    monkeypatch: pytest.MonkeyPatch, solve_name: str
+    monkeypatch: pytest.MonkeyPatch, operation_id: str
 ) -> None:
     _expired(monkeypatch, _finite_optimization)
     request = GraphOptimizationRequest(
         graph=_graph(), resource_budget=GraphOptimizationBudget(wall_seconds=1)
     )
 
-    result = _finite_optimization._execute_kernel(
-        request, getattr(_finite_optimization, solve_name)
+    result = cast(
+        GraphDominationMinimumOutput | GraphMinimumMaximalMatchingOutput,
+        _finite_optimization._run_worker_kernel(operation_id, request),
     )
 
     assert result.status == "UNKNOWN"
@@ -137,7 +140,9 @@ def test_graph_optimization_worker_binds_encoding_and_solving_to_one_envelope(
     result = _finite_optimization.DOMINATION_MINIMUM_OPERATION.run(request)
 
     assert result == expected
-    assert recorded["timeout_seconds"] == 3
+    timeout_seconds = recorded["timeout_seconds"]
+    assert isinstance(timeout_seconds, float)
+    assert 0 < timeout_seconds <= 3
     assert Path(str(recorded["cwd"])).name.startswith("jacobian-graph-optimization-")
     limits = recorded["resource_limits"]
     assert isinstance(limits, ProcessResourceLimits)

--- a/tests/math/graphs/test_public_api.py
+++ b/tests/math/graphs/test_public_api.py
@@ -22,7 +22,7 @@ def test_graph_input_errors_are_stable() -> None:
     with pytest.raises(ValueError):
         graphs.diameter(nx.Graph([(0, 1), (2, 3)]))
     with pytest.raises(ValueError):
-        graphs.triangle_count(nx.DiGraph([(0, 1)]))  # type: ignore[arg-type]
+        graphs.triangle_count(nx.DiGraph([(0, 1)]))
 
 
 def test_graph_construction_functions_use_immutable_graph_values() -> None:

--- a/tests/math/hypergraphs/test_independence.py
+++ b/tests/math/hypergraphs/test_independence.py
@@ -472,7 +472,9 @@ def test_public_independence_path_bounds_the_entire_z3_worker(
     result = compute_independence_number(request)
 
     assert result == expected
-    assert recorded["timeout_seconds"] == 3
+    timeout_seconds = recorded["timeout_seconds"]
+    assert isinstance(timeout_seconds, int | float)
+    assert 0 < timeout_seconds <= 3
     assert Path(str(recorded["cwd"])).name.startswith(
         "jacobian-hypergraph-independence-"
     )
@@ -481,6 +483,38 @@ def test_public_independence_path_bounds_the_entire_z3_worker(
     assert limits.cpu_seconds == 3
     assert limits.address_space_bytes == 1_536 * 1024 * 1024
     assert limits.file_size_bytes == 1_024 * 1_024
+
+
+def test_independence_worker_result_must_bind_the_submitted_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.hypergraphs import _independence_z3
+
+    request = HypergraphIndependenceRequest.model_validate(
+        {
+            "hypergraph": {"vertices": ["a", "b"], "edges": [["pair", ["a", "b"]]]},
+            "resource_budget": {"wall_seconds": 3, "max_solver_calls": 5},
+        }
+    )
+    wrong_request = HypergraphIndependenceRequest.model_validate(
+        {
+            "hypergraph": {"vertices": ["x"], "edges": []},
+            "resource_budget": {"wall_seconds": 3, "max_solver_calls": 5},
+        }
+    )
+    wrong_result = _independence_z3._solve_independence_number_kernel(wrong_request)
+    monkeypatch.setattr(
+        _independence_z3,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: _independence_worker_result(
+            wrong_result.model_dump(mode="json")
+        ),
+    )
+
+    result = compute_independence_number(request)
+
+    assert result.status == "UNKNOWN"
+    assert result.hypergraph == request.hypergraph
 
 
 def test_threshold_encoding_rechecks_the_wall_budget_before_solver_check(

--- a/tests/math/hypergraphs/test_independence.py
+++ b/tests/math/hypergraphs/test_independence.py
@@ -1,6 +1,7 @@
 """Contract and mathematical tests for hypergraph independence search."""
 
 from itertools import combinations
+from pathlib import Path
 
 import pytest
 import z3  # type: ignore[import-untyped]
@@ -16,6 +17,7 @@ from jacobian.math.hypergraphs._operations import (
     compute_independence_number,
     verify_independence_result,
 )
+from jacobian.process import BoundedProcessResult, ProcessResourceLimits
 
 
 def _compute(
@@ -24,13 +26,49 @@ def _compute(
     max_solver_calls: int = 100,
 ) -> HypergraphIndependenceResult:
     return compute_independence_number(
-        HypergraphIndependenceRequest(
-            hypergraph=hypergraph,
-            resource_budget=HypergraphIndependenceBudget(
-                wall_seconds=5,
-                max_solver_calls=max_solver_calls,
-            ),
+        HypergraphIndependenceRequest.model_validate(
+            {
+                "hypergraph": hypergraph,
+                "resource_budget": {
+                    "wall_seconds": 5,
+                    "max_solver_calls": max_solver_calls,
+                },
+            }
         )
+    )
+
+
+def _kernel_compute(
+    hypergraph: FiniteHypergraph | dict[str, object],
+    *,
+    max_solver_calls: int = 100,
+) -> HypergraphIndependenceResult:
+    """Exercise Z3 fault injection at its isolated owner-kernel seam."""
+
+    from jacobian.math.hypergraphs import _independence_z3
+
+    request = HypergraphIndependenceRequest.model_validate(
+        {
+            "hypergraph": hypergraph,
+            "resource_budget": {
+                "wall_seconds": 5,
+                "max_solver_calls": max_solver_calls,
+            },
+        }
+    )
+    return _independence_z3._solve_independence_number_kernel(request)
+
+
+def _independence_worker_result(payload: dict[str, object]) -> BoundedProcessResult:
+    import json
+
+    return BoundedProcessResult(
+        returncode=0,
+        stdout=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+        stderr=b"",
+        stdout_exceeded=False,
+        stderr_exceeded=False,
+        timed_out=False,
     )
 
 
@@ -52,20 +90,22 @@ def _brute_force_witness(hypergraph: FiniteHypergraph) -> tuple[str, ...]:
 
 def test_rejects_empty_hyperedge_before_solver() -> None:
     with pytest.raises(ValidationError):
-        HypergraphIndependenceRequest(
-            hypergraph={"vertices": ["v"], "edges": [["empty", []]]}
+        HypergraphIndependenceRequest.model_validate(
+            {"hypergraph": {"vertices": ["v"], "edges": [["empty", []]]}}
         )
 
 
 def test_lone_surrogate_vertex_label_rejected_before_execution() -> None:
     with pytest.raises(ValidationError):
-        HypergraphIndependenceRequest(hypergraph={"vertices": ["\ud800"], "edges": []})
+        HypergraphIndependenceRequest.model_validate(
+            {"hypergraph": {"vertices": ["\ud800"], "edges": []}}
+        )
 
 
 def test_lone_surrogate_edge_id_rejected_before_execution() -> None:
     with pytest.raises(ValidationError):
-        HypergraphIndependenceRequest(
-            hypergraph={"vertices": ["a"], "edges": [["\udbff", ["a"]]]}
+        HypergraphIndependenceRequest.model_validate(
+            {"hypergraph": {"vertices": ["a"], "edges": [["\udbff", ["a"]]]}}
         )
 
 
@@ -79,10 +119,12 @@ def test_astral_plane_label_computes_through_edge_free_special_case() -> None:
 
 def test_full_structural_encoding_boundary_is_admitted() -> None:
     vertices = [f"v{index:03d}" for index in range(100)]
-    request = HypergraphIndependenceRequest(
-        hypergraph={
-            "vertices": vertices,
-            "edges": [[f"e{index:03d}", vertices] for index in range(100)],
+    request = HypergraphIndependenceRequest.model_validate(
+        {
+            "hypergraph": {
+                "vertices": vertices,
+                "edges": [[f"e{index:03d}", vertices] for index in range(100)],
+            }
         }
     )
     assert len(request.hypergraph.vertices) == 100
@@ -91,10 +133,12 @@ def test_full_structural_encoding_boundary_is_admitted() -> None:
 
 def test_vertex_boundary_rejects_immediately_unsupported_input() -> None:
     with pytest.raises(ValidationError):
-        HypergraphIndependenceRequest(
-            hypergraph={
-                "vertices": [f"v{index}" for index in range(101)],
-                "edges": [],
+        HypergraphIndependenceRequest.model_validate(
+            {
+                "hypergraph": {
+                    "vertices": [f"v{index}" for index in range(101)],
+                    "edges": [],
+                }
             }
         )
 
@@ -129,9 +173,8 @@ def test_singleton_edges_forbid_their_vertices() -> None:
 
 
 def test_one_three_edge_differs_from_clique_expansion_independence() -> None:
-    source = FiniteHypergraph(
-        vertices=["a", "b", "c"],
-        edges=[["triple", ["c", "a", "b"]]],
+    source = FiniteHypergraph.model_validate(
+        {"vertices": ["a", "b", "c"], "edges": [["triple", ["c", "a", "b"]]]}
     )
     result = _compute(source)
     assert result.independence_number == 2
@@ -188,14 +231,16 @@ def test_erdos_536_reduced_forbidden_subset_fixture() -> None:
     # 536/numerical_verifier.py:666-699. Vertices are squarefree products
     # through 15; each edge is a triple whose prime supports have equal
     # pairwise unions.
-    source = FiniteHypergraph(
-        vertices=["1", "2", "3", "5", "6", "10", "15"],
-        edges=[
-            ["union-6", ["2", "3", "6"]],
-            ["union-10", ["2", "5", "10"]],
-            ["union-15", ["3", "5", "15"]],
-            ["union-30", ["6", "10", "15"]],
-        ],
+    source = FiniteHypergraph.model_validate(
+        {
+            "vertices": ["1", "2", "3", "5", "6", "10", "15"],
+            "edges": [
+                ["union-6", ["2", "3", "6"]],
+                ["union-10", ["2", "5", "10"]],
+                ["union-15", ["3", "5", "15"]],
+                ["union-30", ["6", "10", "15"]],
+            ],
+        }
     )
     result = _compute(source)
     brute_force = _brute_force_witness(source)
@@ -215,13 +260,15 @@ def test_all_three_vertex_hypergraphs_match_exhaustive_search() -> None:
         for edge in combinations(vertices, width)
     )
     for edge_mask in range(1 << len(possible_edges)):
-        source = FiniteHypergraph(
-            vertices=vertices,
-            edges=[
-                [f"e{index}", edge]
-                for index, edge in enumerate(possible_edges)
-                if edge_mask & (1 << index)
-            ],
+        source = FiniteHypergraph.model_validate(
+            {
+                "vertices": vertices,
+                "edges": [
+                    [f"e{index}", edge]
+                    for index, edge in enumerate(possible_edges)
+                    if edge_mask & (1 << index)
+                ],
+            }
         )
         result = _compute(source)
         assert result.status == "EXACT"
@@ -384,7 +431,7 @@ def test_wall_expiry_returns_unknown_without_a_false_optimum(
     from jacobian.math.hypergraphs import _independence_z3
 
     monkeypatch.setattr(_independence_z3, "_remaining_ms", lambda *_args: 0)
-    result = _compute(
+    result = _kernel_compute(
         {
             "vertices": ["a", "b", "c"],
             "edges": [["triple", ["a", "b", "c"]]],
@@ -398,6 +445,94 @@ def test_wall_expiry_returns_unknown_without_a_false_optimum(
     assert result.wall_budget_exhausted
 
 
+def test_public_independence_path_bounds_the_entire_z3_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.hypergraphs import _independence_z3
+
+    request = HypergraphIndependenceRequest.model_validate(
+        {
+            "hypergraph": {
+                "vertices": ["a", "b", "c"],
+                "edges": [["triple", ["a", "b", "c"]]],
+            },
+            "resource_budget": {"wall_seconds": 3, "max_solver_calls": 5},
+        }
+    )
+    expected = _independence_z3._solve_independence_number_kernel(request)
+    recorded: dict[str, object] = {}
+
+    def complete_worker(*args: object, **kwargs: object) -> BoundedProcessResult:
+        recorded["args"] = args
+        recorded.update(kwargs)
+        return _independence_worker_result(expected.model_dump(mode="json"))
+
+    monkeypatch.setattr(_independence_z3, "run_bounded_process", complete_worker)
+
+    result = compute_independence_number(request)
+
+    assert result == expected
+    assert recorded["timeout_seconds"] == 3
+    assert Path(str(recorded["cwd"])).name.startswith(
+        "jacobian-hypergraph-independence-"
+    )
+    limits = recorded["resource_limits"]
+    assert isinstance(limits, ProcessResourceLimits)
+    assert limits.cpu_seconds == 3
+    assert limits.address_space_bytes == 1_536 * 1024 * 1024
+    assert limits.file_size_bytes == 1_024 * 1_024
+
+
+def test_threshold_encoding_rechecks_the_wall_budget_before_solver_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.hypergraphs import _independence_z3
+
+    class Cardinality:
+        def __ge__(self, _threshold: int) -> object:
+            return object()
+
+    class Solver:
+        def __init__(self) -> None:
+            self.set_called = False
+            self.check_called = False
+
+        def push(self) -> None:
+            return None
+
+        def pop(self) -> None:
+            return None
+
+        def add(self, _constraint: object) -> None:
+            return None
+
+        def set(self, **_settings: int) -> None:
+            self.set_called = True
+
+        def check(self) -> object:
+            self.check_called = True
+            return z3.sat
+
+    monkeypatch.setattr(_independence_z3, "_remaining_ms", lambda *_args: 0)
+    solver = Solver()
+
+    status, witness, detail = _independence_z3._check_threshold(
+        solver,
+        {},
+        Cardinality(),
+        1,
+        started=0.0,
+        wall_seconds=1,
+        vertex_order=(),
+    )
+
+    assert status == z3.unknown
+    assert witness == ()
+    assert "expired during encoding" in detail
+    assert not solver.set_called
+    assert not solver.check_called
+
+
 def test_interrupted_solver_returns_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
     from jacobian.math.hypergraphs import _independence_z3
 
@@ -406,7 +541,7 @@ def test_interrupted_solver_returns_unknown(monkeypatch: pytest.MonkeyPatch) -> 
         "_check_threshold",
         lambda *_args: (z3.unknown, (), "interrupted"),
     )
-    result = _compute(
+    result = _kernel_compute(
         {
             "vertices": ["a", "b", "c"],
             "edges": [["triple", ["a", "b", "c"]]],
@@ -426,7 +561,7 @@ def test_backend_exception_returns_typed_unknown(
         raise z3.Z3Exception("forced backend failure")
 
     monkeypatch.setattr(_independence_z3, "_check_threshold", fail)
-    result = _compute(
+    result = _kernel_compute(
         {
             "vertices": ["a", "b", "c"],
             "edges": [["triple", ["a", "b", "c"]]],
@@ -451,9 +586,15 @@ def test_produced_result_satisfies_structural_and_explicit_verification() -> Non
 
 
 def test_forged_structural_upper_bound_requires_explicit_verification() -> None:
-    source = FiniteHypergraph(
-        vertices=["a", "b", "c", "d"],
-        edges=[["ab", ["a", "b"]], ["ac", ["a", "c"]], ["ad", ["a", "d"]]],
+    source = FiniteHypergraph.model_validate(
+        {
+            "vertices": ["a", "b", "c", "d"],
+            "edges": [
+                ["ab", ["a", "b"]],
+                ["ac", ["a", "c"]],
+                ["ad", ["a", "d"]],
+            ],
+        }
     )
     result = HypergraphIndependenceResult(
         hypergraph=source,
@@ -482,7 +623,7 @@ def test_producer_rejects_infeasible_backend_witness(
 
     monkeypatch.setattr(_independence_z3, "_check_threshold", regressed)
     with pytest.raises(ValidationError):
-        _compute(
+        _kernel_compute(
             {
                 "vertices": ["a", "b", "c"],
                 "edges": [["triple", ["a", "b", "c"]]],
@@ -499,7 +640,7 @@ def test_producer_rejects_forged_optimum_below_greedy_incumbent(
         return z3.sat, ("a",), ""
 
     monkeypatch.setattr(_independence_z3, "_check_threshold", regressed)
-    result = _compute(
+    result = _kernel_compute(
         {
             "vertices": ["a", "b", "c"],
             "edges": [["triple", ["a", "b", "c"]]],
@@ -522,7 +663,7 @@ def test_producer_rejects_solver_calls_inconsistent_with_established_bounds(
         return z3.sat, ("b", "c"), ""
 
     monkeypatch.setattr(_independence_z3, "_check_threshold", regressed)
-    result = _compute(
+    result = _kernel_compute(
         {
             "vertices": ["a", "b", "c", "d"],
             "edges": [
@@ -559,7 +700,7 @@ def test_producer_projects_solver_error_when_witness_misses_threshold(
         return z3.sat, ("c",), ""
 
     monkeypatch.setattr(_independence_z3, "_check_threshold", regressed)
-    result = _compute(
+    result = _kernel_compute(
         {
             "vertices": ["c", "a", "b"],
             "edges": [["ca", ["c", "a"]], ["cb", ["c", "b"]]],
@@ -578,9 +719,11 @@ def test_producer_projects_solver_error_when_witness_misses_threshold(
 
 
 def test_produced_exact_result_meets_the_queried_threshold() -> None:
-    source = FiniteHypergraph(
-        vertices=["c", "a", "b"],
-        edges=[["ca", ["c", "a"]], ["cb", ["c", "b"]]],
+    source = FiniteHypergraph.model_validate(
+        {
+            "vertices": ["c", "a", "b"],
+            "edges": [["ca", ["c", "a"]], ["cb", ["c", "b"]]],
+        }
     )
     result = _compute(source)
     assert result.status == "EXACT"

--- a/tests/math/hypergraphs/test_independence.py
+++ b/tests/math/hypergraphs/test_independence.py
@@ -465,7 +465,12 @@ def test_public_independence_path_bounds_the_entire_z3_worker(
     def complete_worker(*args: object, **kwargs: object) -> BoundedProcessResult:
         recorded["args"] = args
         recorded.update(kwargs)
-        return _independence_worker_result(expected.model_dump(mode="json"))
+        return _independence_worker_result(
+            expected.model_dump(
+                mode="json",
+                exclude={"hypergraph", "hypergraph_digest", "resource_budget"},
+            )
+        )
 
     monkeypatch.setattr(_independence_z3, "run_bounded_process", complete_worker)
 
@@ -485,7 +490,7 @@ def test_public_independence_path_bounds_the_entire_z3_worker(
     assert limits.file_size_bytes == 1_024 * 1_024
 
 
-def test_independence_worker_result_must_bind_the_submitted_request(
+def test_independence_worker_projection_cannot_replace_the_submitted_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from jacobian.math.hypergraphs import _independence_z3
@@ -507,7 +512,10 @@ def test_independence_worker_result_must_bind_the_submitted_request(
         _independence_z3,
         "run_bounded_process",
         lambda *_args, **_kwargs: _independence_worker_result(
-            wrong_result.model_dump(mode="json")
+            wrong_result.model_dump(
+                mode="json",
+                exclude={"hypergraph", "hypergraph_digest", "resource_budget"},
+            )
         ),
     )
 

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 import sys
-import time
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -40,6 +39,7 @@ from jacobian.math.logic._smt import (
 )
 from jacobian.math.logic._tools import TOOLS
 from jacobian.math.logic._unsat_core import SmtUnsatCoreRequest
+from jacobian.process import BoundedProcessResult, ProcessResourceLimits
 
 
 @contextmanager
@@ -49,6 +49,74 @@ def raises_logic_validation() -> Generator[
     with pytest.raises(ValidationError) as error:
         yield error
     assert error.value.errors()[0]["type"].startswith("logic.")
+
+
+def _solve_smt_kernel(request: SmtSolveRequest) -> SmtSolveResult:
+    """Exercise fault injection at the worker's Z3 ownership seam."""
+
+    return SmtSolveResult.model_validate(
+        {
+            "source": request.model_dump(mode="json"),
+            **smt._solve_smt_kernel(
+                logic=request.logic.value,
+                smtlib=request.smtlib,
+                timeout_ms=request.timeout_ms,
+            ),
+        }
+    )
+
+
+def _solve_sat_kernel(request: SatSolveRequest) -> SatSolveResult:
+    """Exercise fault injection at the SAT worker's Z3 ownership seam."""
+
+    return SatSolveResult.model_validate(
+        {
+            "source": request.model_dump(mode="json"),
+            **sat._solve_sat_kernel(cnf=request.cnf, timeout_ms=request.timeout_ms),
+        }
+    )
+
+
+def _worker_result(
+    *,
+    returncode: int | None = 0,
+    stdout: bytes = b'{"outcome":"UNSAT","model_smtlib":null,"exhausted":null,"detail":null}',
+    stderr: bytes = b"",
+    stdout_exceeded: bool = False,
+    stderr_exceeded: bool = False,
+    timed_out: bool = False,
+    cancelled: bool = False,
+) -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        stdout_exceeded=stdout_exceeded,
+        stderr_exceeded=stderr_exceeded,
+        timed_out=timed_out,
+        cancelled=cancelled,
+    )
+
+
+def _sat_worker_result(
+    *,
+    returncode: int | None = 0,
+    stdout: bytes = b'{"outcome":"UNSAT","assignment":null,"exhausted":null,"detail":null}',
+    stderr: bytes = b"",
+    stdout_exceeded: bool = False,
+    stderr_exceeded: bool = False,
+    timed_out: bool = False,
+    cancelled: bool = False,
+) -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        stdout_exceeded=stdout_exceeded,
+        stderr_exceeded=stderr_exceeded,
+        timed_out=timed_out,
+        cancelled=cancelled,
+    )
 
 
 def test_logic_bundle_exposes_only_atomic_inline_operations() -> None:
@@ -88,10 +156,21 @@ def test_canonical_cnf_can_be_passed_directly_to_assignment_and_solver() -> None
     ).satisfies
     solved = solve_sat(SatSolveRequest(cnf=canonical))
     assert solved.outcome == "SAT"
+    assert solved.source.cnf == canonical
     assert solved.assignment is not None
     assert check_sat_assignment(
         SatAssignmentCheckRequest(cnf=canonical, assignment=solved.assignment)
     ).satisfies
+
+
+def test_sat_result_rejects_a_witness_or_source_mutation() -> None:
+    positive = SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
+    negative = SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((-1,),)))
+
+    with raises_logic_validation():
+        SatSolveResult(source=positive, outcome="SAT", assignment=(False,))
+    with raises_logic_validation():
+        SatSolveResult(source=negative, outcome="SAT", assignment=(True,))
 
 
 def test_tautological_cnf_is_a_typed_invalid_request() -> None:
@@ -112,7 +191,7 @@ def test_assignment_reports_the_first_unsatisfied_clause() -> None:
 
 
 def test_sat_solver_returns_unsat_without_a_model() -> None:
-    result = solve_sat(
+    result = _solve_sat_kernel(
         SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((-1,), (1,))))
     )
 
@@ -140,7 +219,7 @@ def test_sat_solver_does_not_promote_a_malformed_backend_model(
 
     monkeypatch.setattr(z3, "Solver", MisreportingSolver)
 
-    result = solve_sat(
+    result = _solve_sat_kernel(
         SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
     )
 
@@ -178,7 +257,7 @@ def test_smt_solver_does_not_promote_a_malformed_backend_model(
 
     monkeypatch.setattr(z3, "SolverFor", lambda _logic: MisreportingSolver())
 
-    result = solve_smt(
+    result = _solve_smt_kernel(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib=(
@@ -543,7 +622,15 @@ def test_smt_solver_uses_the_inline_smtlib_query() -> None:
     )
 
     assert result.outcome == "SAT"
+    assert result.source.logic is SmtLogic.QF_LIA
+    assert result.source.smtlib.endswith("(check-sat)\n")
     assert result.model_smtlib is not None
+    assert (
+        "display projection"
+        in SmtSolveResult.model_json_schema()["properties"]["model_smtlib"][
+            "description"
+        ]
+    )
 
 
 def test_smt_request_rejects_a_logic_name_hidden_in_a_comment() -> None:
@@ -915,7 +1002,7 @@ def test_smt_solver_passes_time_work_and_memory_budgets_to_z3(
             return z3.unsat
 
     monkeypatch.setattr(z3, "SolverFor", lambda _logic: RecordingSolver())
-    result = solve_smt(
+    result = _solve_smt_kernel(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
@@ -930,20 +1017,167 @@ def test_smt_solver_passes_time_work_and_memory_budgets_to_z3(
     assert recorded["max_memory"] == smt._SOLVER_MAX_MEMORY_MB
 
 
+def test_smt_worker_envelope_covers_encoding_and_solver_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The parent deadline bounds worker startup, parsing, encoding, and solving."""
+
+    recorded: dict[str, object] = {}
+
+    def complete_worker(*args: object, **kwargs: object) -> BoundedProcessResult:
+        recorded["args"] = args
+        recorded.update(kwargs)
+        return _worker_result()
+
+    monkeypatch.setattr(smt, "run_bounded_process", complete_worker)
+    request = SmtSolveRequest(
+        logic=SmtLogic.QF_LIA,
+        smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+        timeout_ms=2_500,
+    )
+
+    result = solve_smt(request)
+
+    assert result.outcome == "UNSAT"
+    assert recorded["args"] == ([sys.executable, str(smt._SMT_WORKER)],)
+    assert recorded["timeout_seconds"] == 2.5
+    stdout_limit = recorded["stdout_limit"]
+    assert isinstance(stdout_limit, int)
+    assert stdout_limit >= smt._MAX_MODEL_BYTES
+    assert recorded["resource_limits"] == ProcessResourceLimits(
+        cpu_seconds=3,
+        address_space_bytes=smt._SMT_WORKER_ADDRESS_SPACE_BYTES,
+        file_size_bytes=smt._SMT_WORKER_FILE_SIZE_BYTES,
+    )
+    assert Path(str(recorded["cwd"])).name.startswith("jacobian-smt-")
+
+
+def test_sat_worker_envelope_covers_encoding_and_solver_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
+
+    def complete_worker(*args: object, **kwargs: object) -> BoundedProcessResult:
+        recorded["args"] = args
+        recorded.update(kwargs)
+        return _sat_worker_result()
+
+    monkeypatch.setattr(sat, "run_bounded_process", complete_worker)
+    request = SatSolveRequest(
+        cnf=CanonicalCnf(variables=("x",), clauses=((1,),)), timeout_ms=2_500
+    )
+
+    result = solve_sat(request)
+
+    assert result.outcome == "UNSAT"
+    assert recorded["args"] == ([sys.executable, str(sat._SAT_WORKER)],)
+    assert recorded["timeout_seconds"] == 2.5
+    assert recorded["resource_limits"] == ProcessResourceLimits(
+        cpu_seconds=3,
+        address_space_bytes=sat._SAT_WORKER_ADDRESS_SPACE_BYTES,
+        file_size_bytes=sat._SAT_WORKER_FILE_SIZE_BYTES,
+    )
+    assert Path(str(recorded["cwd"])).name.startswith("jacobian-sat-")
+
+
+@pytest.mark.parametrize(
+    ("completed", "detail"),
+    (
+        (_sat_worker_result(cancelled=True, returncode=None), "was cancelled"),
+        (_sat_worker_result(stdout_exceeded=True, returncode=None), "output limit"),
+        (_sat_worker_result(stdout=b"not JSON"), "malformed output"),
+    ),
+)
+def test_sat_worker_never_projects_transport_failure_as_a_math_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+    completed: BoundedProcessResult,
+    detail: str,
+) -> None:
+    monkeypatch.setattr(sat, "run_bounded_process", lambda *_args, **_kwargs: completed)
+
+    result = solve_sat(
+        SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
+    )
+
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted is None
+    assert detail in (result.detail or "")
+
+
+def test_sat_worker_start_failure_is_a_typed_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        raise OSError("worker unavailable")
+
+    monkeypatch.setattr(sat, "run_bounded_process", unavailable)
+
+    result = solve_sat(
+        SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
+    )
+
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted is None
+    assert result.detail == "the bounded Z3 worker could not be started"
+
+
+@pytest.mark.parametrize(
+    ("completed", "detail"),
+    (
+        (_worker_result(cancelled=True, returncode=None), "was cancelled"),
+        (_worker_result(stdout_exceeded=True, returncode=None), "output limit"),
+        (_worker_result(stdout=b"not JSON"), "malformed output"),
+    ),
+)
+def test_smt_worker_never_projects_transport_failure_as_a_math_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+    completed: BoundedProcessResult,
+    detail: str,
+) -> None:
+    monkeypatch.setattr(smt, "run_bounded_process", lambda *_args, **_kwargs: completed)
+
+    result = solve_smt(
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+        )
+    )
+
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted is None
+    assert detail in (result.detail or "")
+
+
+def test_smt_worker_start_failure_is_a_typed_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        raise OSError("worker unavailable")
+
+    monkeypatch.setattr(smt, "run_bounded_process", unavailable)
+
+    result = solve_smt(
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+        )
+    )
+
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted is None
+    assert result.detail == "the bounded Z3 worker could not be started"
+
+
 def test_smt_parse_stage_expiry_is_a_typed_unknown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parser work consumes the same owner deadline as solver work."""
+    """Parser work cannot outlive the hard parent-to-worker deadline."""
 
-    import z3
-
-    original = z3.parse_smt2_string
-
-    def delayed_parser(source: str) -> object:
-        time.sleep(0.01)
-        return original(source)
-
-    monkeypatch.setattr(z3, "parse_smt2_string", delayed_parser)
+    monkeypatch.setattr(
+        smt,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: _worker_result(timed_out=True, returncode=None),
+    )
     result = solve_smt(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
@@ -961,7 +1195,7 @@ def test_smt_solver_projects_exhausted_work_budget_as_typed_unknown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(smt, "_SOLVER_RLIMIT", 1)
-    result = solve_smt(
+    result = _solve_smt_kernel(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
@@ -978,7 +1212,7 @@ def test_sat_solver_projects_exhausted_work_budget_as_typed_unknown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(smt, "_SOLVER_RLIMIT", 1)
-    result = solve_sat(
+    result = _solve_sat_kernel(
         SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
     )
 
@@ -992,7 +1226,7 @@ def test_smt_solver_projects_exhausted_memory_budget_as_typed_unknown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(smt, "_SOLVER_MAX_MEMORY_MB", 2)
-    result = solve_smt(
+    result = _solve_smt_kernel(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib=_pigeonhole_smtlib(8, 7),
@@ -1005,7 +1239,7 @@ def test_smt_solver_projects_exhausted_memory_budget_as_typed_unknown(
 
 
 def test_smt_solver_projects_exhausted_time_budget_as_typed_unknown() -> None:
-    result = solve_smt(
+    result = _solve_smt_kernel(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib=_pigeonhole_smtlib(8, 7),
@@ -1034,7 +1268,7 @@ def test_smt_solver_wraps_backend_failure_during_the_solve(
             raise z3.Z3Exception("backend exploded")
 
     monkeypatch.setattr(z3, "SolverFor", lambda _logic: ExplodingSolver())
-    result = solve_smt(
+    result = _solve_smt_kernel(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
@@ -1074,7 +1308,7 @@ def test_sat_solver_projects_exhaustion_messages_from_z3_exceptions(
             raise AssertionError("check must not run after a failed assertion add")
 
     monkeypatch.setattr(z3, "Solver", ExhaustingSolver)
-    result = solve_sat(
+    result = _solve_sat_kernel(
         SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
     )
 
@@ -1110,7 +1344,7 @@ def test_smt_solver_projects_exhaustion_messages_from_z3_exceptions(
             raise AssertionError("check must not run after a failed assertion add")
 
     monkeypatch.setattr(z3, "SolverFor", lambda _logic: ExhaustingSolver())
-    result = solve_smt(
+    result = _solve_smt_kernel(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
@@ -1149,7 +1383,7 @@ def test_smt_solver_projects_exhaustion_from_model_serialization(
             return ExhaustingModel()
 
     monkeypatch.setattr(z3, "SolverFor", lambda _logic: SolvingThenExhaustingSolver())
-    result = solve_smt(
+    result = _solve_smt_kernel(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
@@ -1177,11 +1411,11 @@ def test_solver_wraps_unrecognized_z3_exceptions_without_typed_exhaustion(
             raise AssertionError("check must not run after a failed assertion add")
 
     monkeypatch.setattr(z3, "Solver", ExplodingSolver)
-    sat_result = solve_sat(
+    sat_result = _solve_sat_kernel(
         SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
     )
     monkeypatch.setattr(z3, "SolverFor", lambda _logic: ExplodingSolver())
-    smt_result = solve_smt(
+    smt_result = _solve_smt_kernel(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
@@ -1202,13 +1436,13 @@ def test_solver_wraps_unrecognized_z3_exceptions_without_typed_exhaustion(
     ("operation", "accepted_request"),
     (
         (
-            solve_sat,
+            _solve_sat_kernel,
             SatSolveRequest(
                 cnf=CanonicalCnf(variables=("x",), clauses=((1,),)),
             ),
         ),
         (
-            solve_smt,
+            _solve_smt_kernel,
             SmtSolveRequest(
                 logic=SmtLogic.QF_LIA,
                 smtlib=(
@@ -1250,7 +1484,7 @@ def test_smt_request_admission_skips_grammar_rejection_without_the_backend(
         smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
     )
 
-    result = solve_smt(admitted)
+    result = _solve_smt_kernel(admitted)
 
     assert result.outcome == "UNKNOWN"
     assert result.exhausted is None
@@ -1317,7 +1551,7 @@ def test_smt_solver_types_parse_stage_backend_failures_as_unknown(
         smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
     )
     monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
-    result = solve_smt(admitted)
+    result = _solve_smt_kernel(admitted)
 
     assert result.outcome == "UNKNOWN"
     assert result.exhausted == "memory"
@@ -1345,7 +1579,7 @@ def test_smt_solver_never_classifies_located_source_text_as_exhaustion(
     )
     monkeypatch.setattr(z3, "parse_smt2_string", diagnosing_parser)
 
-    result = solve_smt(admitted)
+    result = _solve_smt_kernel(admitted)
 
     assert result.outcome == "UNKNOWN"
     assert result.exhausted is None
@@ -1363,7 +1597,7 @@ def test_smt_execution_projects_located_parser_diagnostics(
         raise z3.Z3Exception(b'(error "line 2 column 11: unknown constant y")\n')
 
     monkeypatch.setattr(z3, "parse_smt2_string", diagnosing_parser)
-    result = solve_smt(
+    result = _solve_smt_kernel(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib=(
@@ -1398,7 +1632,7 @@ def test_smt_request_admission_defers_parse_stage_os_errors(
     source = "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)"
     monkeypatch.setattr(z3, "parse_smt2_string", failing_parser)
     admitted = SmtSolveRequest(logic=SmtLogic.QF_LIA, smtlib=source)
-    result = solve_smt(admitted)
+    result = _solve_smt_kernel(admitted)
 
     assert result.outcome == "UNKNOWN"
 
@@ -1439,7 +1673,14 @@ def test_unknown_projection_maps_every_exhausted_resource() -> None:
 
 
 def test_result_models_bind_exhausted_budgets_to_unknown_outcomes() -> None:
+    sat_source = SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
+    smt_source = SmtSolveRequest(
+        logic=SmtLogic.QF_LIA,
+        smtlib="(set-logic QF_LIA)\n(check-sat)",
+    )
     with pytest.raises(ValueError, match="exhausted budget"):
-        SatSolveResult(outcome="SAT", assignment=(True,), exhausted="time")
+        SatSolveResult(
+            source=sat_source, outcome="SAT", assignment=(True,), exhausted="time"
+        )
     with pytest.raises(ValueError, match="exhausted budget"):
-        SmtSolveResult(outcome="UNSAT", exhausted="memory")
+        SmtSolveResult(source=smt_source, outcome="UNSAT", exhausted="memory")

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -1040,7 +1041,9 @@ def test_smt_worker_envelope_covers_encoding_and_solver_work(
 
     assert result.outcome == "UNSAT"
     assert recorded["args"] == ([sys.executable, str(smt._SMT_WORKER)],)
-    assert recorded["timeout_seconds"] == 2.5
+    timeout_seconds = recorded["timeout_seconds"]
+    assert isinstance(timeout_seconds, float)
+    assert 0 < timeout_seconds <= 2.5
     stdout_limit = recorded["stdout_limit"]
     assert isinstance(stdout_limit, int)
     assert stdout_limit >= smt._MAX_MODEL_BYTES
@@ -1071,13 +1074,58 @@ def test_sat_worker_envelope_covers_encoding_and_solver_work(
 
     assert result.outcome == "UNSAT"
     assert recorded["args"] == ([sys.executable, str(sat._SAT_WORKER)],)
-    assert recorded["timeout_seconds"] == 2.5
+    timeout_seconds = recorded["timeout_seconds"]
+    assert isinstance(timeout_seconds, float)
+    assert 0 < timeout_seconds <= 2.5
     assert recorded["resource_limits"] == ProcessResourceLimits(
         cpu_seconds=3,
         address_space_bytes=sat._SAT_WORKER_ADDRESS_SPACE_BYTES,
         file_size_bytes=sat._SAT_WORKER_FILE_SIZE_BYTES,
     )
     assert Path(str(recorded["cwd"])).name.startswith("jacobian-sat-")
+
+
+@pytest.mark.parametrize(
+    ("module", "solve_request", "response"),
+    [
+        (
+            smt,
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib="(set-logic QF_LIA)\n(check-sat)",
+                timeout_ms=2_500,
+            ),
+            _worker_result(),
+        ),
+        (
+            sat,
+            SatSolveRequest(
+                cnf=CanonicalCnf(variables=("x",), clauses=((1,),)), timeout_ms=2_500
+            ),
+            _sat_worker_result(),
+        ),
+    ],
+)
+def test_worker_response_conversion_cannot_outlive_request_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    module: Any,
+    solve_request: SmtSolveRequest | SatSolveRequest,
+    response: BoundedProcessResult,
+) -> None:
+    clock = iter((0.0, 0.0, 2.6))
+    monkeypatch.setattr(module.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(
+        module, "run_bounded_process", lambda *_args, **_kwargs: response
+    )
+
+    result = (
+        module.solve_smt(solve_request)
+        if module is smt
+        else module.solve_sat(solve_request)
+    )
+
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted == "time"
 
 
 @pytest.mark.parametrize(

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -1,27 +1,59 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from weakref import ReferenceType, ref
 
 import pytest
-import z3
+import z3  # type: ignore[import-untyped]
 from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.logic import _unsat_core as unsat_core
+from jacobian.math.logic._smt import SmtLogic
 from jacobian.math.logic._unsat_core import (
-    SmtUnsatCoreRequest,
+    SmtUnsatCoreRequest as _SmtUnsatCoreRequest,
+)
+from jacobian.math.logic._unsat_core import (
     SmtUnsatCoreResult,
     compute_smt_unsat_core,
     verify_smt_unsat_core_result,
 )
+from jacobian.process import BoundedProcessResult, ProcessResourceLimits
 
 
 @contextmanager
-def raises_logic_validation():
+def raises_logic_validation() -> Iterator[pytest.ExceptionInfo[ValidationError]]:
     with pytest.raises(ValidationError) as error:
         yield error
     assert error.value.errors()[0]["type"].startswith("logic.")
+
+
+def assert_execution_rejected(request: _SmtUnsatCoreRequest) -> None:
+    """Assert semantic admission fails only inside the bounded Z3 worker."""
+
+    with pytest.raises(OperationDomainValidationError) as error:
+        compute_smt_unsat_core(request)
+    assert error.value.errors()[0]["type"] == "logic.unsat_core_contract"
+
+
+def _core_worker_result(
+    *,
+    stdout: bytes = b'{"kind":"result","outcome":"UNSAT","core_indices":[0,1],"detail":null}',
+    returncode: int | None = 0,
+    stdout_exceeded: bool = False,
+    timed_out: bool = False,
+    cancelled: bool = False,
+) -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=b"",
+        stdout_exceeded=stdout_exceeded,
+        stderr_exceeded=False,
+        timed_out=timed_out,
+        cancelled=cancelled,
+    )
 
 
 CONTRADICTORY_LIA = """\
@@ -34,11 +66,30 @@ CONTRADICTORY_LIA = """\
 """
 
 
+def SmtUnsatCoreRequest(  # noqa: N802 - mirrors the public JSON model in fixtures.
+    *,
+    logic: SmtLogic | str,
+    smtlib: str,
+    timeout_ms: int = 1_000,
+    rlimit: int = 100_000,
+) -> _SmtUnsatCoreRequest:
+    """Build one request from the public JSON-compatible test representation."""
+
+    return _SmtUnsatCoreRequest.model_validate(
+        {
+            "logic": logic,
+            "smtlib": smtlib,
+            "timeout_ms": timeout_ms,
+            "rlimit": rlimit,
+        }
+    )
+
+
 def _request(
     smtlib: str = CONTRADICTORY_LIA,
     *,
     rlimit: int = 100_000,
-) -> SmtUnsatCoreRequest:
+) -> _SmtUnsatCoreRequest:
     return SmtUnsatCoreRequest(
         logic="QF_LIA",
         smtlib=smtlib,
@@ -108,28 +159,91 @@ def test_resource_exhaustion_is_unknown_not_unsat() -> None:
     assert result.detail
 
 
-def test_core_extraction_failure_is_a_typed_unknown(monkeypatch) -> None:
-    def fail_core_extraction(_solver: z3.Solver) -> None:
-        raise z3.Z3Exception("core extraction failed")
+def test_core_worker_bounds_parsing_and_solving_in_one_parent_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
 
-    monkeypatch.setattr(z3.Solver, "unsat_core", fail_core_extraction)
+    def complete_worker(*args: object, **kwargs: object) -> BoundedProcessResult:
+        recorded["args"] = args
+        recorded.update(kwargs)
+        return _core_worker_result()
+
+    monkeypatch.setattr(unsat_core, "run_bounded_process", complete_worker)
+    request = SmtUnsatCoreRequest(
+        logic="QF_LIA", smtlib=CONTRADICTORY_LIA, timeout_ms=2_500
+    )
+
+    result = compute_smt_unsat_core(request)
+
+    assert result.outcome == "UNSAT"
+    assert recorded["timeout_seconds"] == 2.5
+    assert Path(str(recorded["cwd"])).name.startswith("jacobian-unsat-core-")
+    limits = recorded["resource_limits"]
+    assert isinstance(limits, ProcessResourceLimits)
+    assert limits.cpu_seconds == 3
+    assert limits.address_space_bytes == 1_536 * 1024 * 1024
+    assert limits.file_size_bytes == 1_024 * 1_024
+
+
+@pytest.mark.parametrize(
+    ("completed", "detail"),
+    (
+        (_core_worker_result(cancelled=True, returncode=None), "did not establish"),
+        (
+            _core_worker_result(stdout_exceeded=True, returncode=None),
+            "did not establish",
+        ),
+        (_core_worker_result(stdout=b"not JSON"), "did not establish"),
+    ),
+)
+def test_core_worker_failures_never_project_a_math_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+    completed: BoundedProcessResult,
+    detail: str,
+) -> None:
+    monkeypatch.setattr(
+        unsat_core,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: completed,
+    )
 
     result = compute_smt_unsat_core(_request())
 
     assert result.outcome == "UNKNOWN"
     assert result.core_indices == ()
-    assert result.detail == "Z3 could not complete the bounded source check."
+    assert detail in (result.detail or "")
 
 
-def test_kernel_producer_does_not_replay_its_established_core(monkeypatch) -> None:
+def test_core_extraction_failure_is_a_typed_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_core_extraction(_solver: z3.Solver) -> None:
+        raise z3.Z3Exception("core extraction failed")
+
+    monkeypatch.setattr(z3.Solver, "unsat_core", fail_core_extraction)
+
+    response = unsat_core._unsat_core_worker_kernel(_request())
+
+    assert response == {
+        "kind": "result",
+        "outcome": "UNKNOWN",
+        "core_indices": [],
+        "detail": "Z3 could not complete the bounded source check.",
+    }
+
+
+def test_kernel_producer_does_not_replay_its_established_core(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def replay_is_not_part_of_production(*_args: object) -> None:
         pytest.fail("kernel-produced UNSAT core must not run a second replay")
 
     monkeypatch.setattr(unsat_core, "_replay_source", replay_is_not_part_of_production)
-    result = compute_smt_unsat_core(_request())
+    response = unsat_core._unsat_core_worker_kernel(_request())
 
-    assert result.outcome == "UNSAT"
-    assert result.core_indices == (0, 1)
+    assert response["outcome"] == "UNSAT"
+    assert response["core_indices"] == [0, 1]
 
 
 @pytest.mark.parametrize(
@@ -256,40 +370,28 @@ def test_request_rejects_terms_outside_the_declared_fragment(
 ) -> None:
     source = "\n".join((f"(set-logic {logic})", declarations, assertion, "(check-sat)"))
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic=logic, smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic=logic, smtlib=source))
 
 
-def test_retained_validation_error_does_not_retain_a_z3_context(
+def test_request_validation_does_not_parse_with_z3(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    context_refs: list[ReferenceType[z3.Context]] = []
-    parse_assertions = unsat_core._parse_assertions
+    def parser_must_not_run(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("request validation must not parse SMT-LIB with Z3")
 
-    def track_context(
-        smtlib: str,
-        *,
-        context: z3.Context | None = None,
-    ) -> tuple[object, ...]:
-        owned_context = z3.Context() if context is None else context
-        context_refs.append(ref(owned_context))
-        return parse_assertions(smtlib, context=owned_context)
+    monkeypatch.setattr(unsat_core, "_parse_assertions", parser_must_not_run)
 
-    monkeypatch.setattr(unsat_core, "_parse_assertions", track_context)
-    with pytest.raises(ValidationError) as retained_error:
-        SmtUnsatCoreRequest(
-            logic="QF_LIA",
-            smtlib=(
-                "(set-logic QF_LIA)\n"
-                "(declare-const x Int)\n"
-                "(assert (= (* x x) 2))\n"
-                "(check-sat)\n"
-            ),
-        )
+    request = SmtUnsatCoreRequest(
+        logic="QF_LIA",
+        smtlib=(
+            "(set-logic QF_LIA)\n"
+            "(declare-const x Int)\n"
+            "(assert (= (* x x) 2))\n"
+            "(check-sat)\n"
+        ),
+    )
 
-    assert retained_error.value
-    assert context_refs
-    assert all(context_ref() is None for context_ref in context_refs)
+    assert request.assertion_count == 1
 
 
 def test_comments_cannot_impersonate_indexed_assertions_or_execute_text(
@@ -329,11 +431,12 @@ def test_tracking_symbols_do_not_alias_caller_boolean_constants() -> None:
     assert result.core_indices == (1, 2)
 
 
-def test_request_validates_smtlib_syntax_before_execution() -> None:
-    with raises_logic_validation():
+def test_request_defers_smtlib_syntax_to_bounded_execution() -> None:
+    assert_execution_rejected(
         _request(
             "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (+ 1 2))\n(check-sat)\n"
         )
+    )
 
 
 def test_request_bounds_the_number_of_indexed_assertions() -> None:
@@ -372,7 +475,9 @@ def test_request_bounds_source_nesting() -> None:
         SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(256))
 
 
-def test_core_bounds_reject_before_any_backend_parse(monkeypatch) -> None:
+def test_core_bounds_reject_before_any_backend_parse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Sources outside the core envelope must not reach the Z3 parser.
 
     Each source fits the broader ``smt.solve`` envelope, so only the
@@ -403,7 +508,7 @@ def test_core_bounds_reject_before_any_backend_parse(monkeypatch) -> None:
 
 
 def test_core_admission_defers_parser_resource_failures_to_execution(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A parser resource failure is typed UNKNOWN, not a contract rejection."""
 
@@ -413,10 +518,10 @@ def test_core_admission_defers_parser_resource_failures_to_execution(
     monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
     admitted = SmtUnsatCoreRequest(logic="QF_LIA", smtlib=CONTRADICTORY_LIA)
 
-    result = compute_smt_unsat_core(admitted)
+    response = unsat_core._unsat_core_worker_kernel(admitted)
 
-    assert result.outcome == "UNKNOWN"
-    assert result.core_indices == ()
+    assert response["outcome"] == "UNKNOWN"
+    assert response["core_indices"] == []
 
 
 def test_request_bounds_numeric_coefficient_digits() -> None:
@@ -445,8 +550,7 @@ def test_request_bounds_normalized_closed_coefficient_digits() -> None:
     factor = "9" * 256
     source = f"(set-logic QF_LIA)\n(assert (= (* {factor} {factor}) 0))\n(check-sat)\n"
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
 
 
 def test_request_bounds_nested_product_coefficient_digits() -> None:
@@ -460,8 +564,7 @@ def test_request_bounds_nested_product_coefficient_digits() -> None:
     over = boundary.replace(factor, "9" * 129, 1)
 
     assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=boundary)
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over))
 
 
 @pytest.mark.parametrize("nesting", (2, 3, 4))
@@ -475,8 +578,7 @@ def test_request_bounds_deeply_nested_coefficient_products(nesting: int) -> None
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
 
 
 def test_request_bounds_outer_factor_against_folded_inner_coefficient() -> None:
@@ -489,8 +591,7 @@ def test_request_bounds_outer_factor_against_folded_inner_coefficient() -> None:
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
 
 
 def test_request_bounds_negated_nested_product_coefficient_digits() -> None:
@@ -504,8 +605,7 @@ def test_request_bounds_negated_nested_product_coefficient_digits() -> None:
     over = boundary.replace(factor, "9" * 129, 1)
 
     assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=boundary)
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over))
 
 
 @pytest.mark.parametrize(
@@ -539,8 +639,7 @@ def test_request_bounds_nested_coefficients_through_preserving_wrappers(
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic=logic, smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic=logic, smtlib=source))
 
 
 def test_request_bounds_nested_real_coefficient_digits() -> None:
@@ -552,8 +651,7 @@ def test_request_bounds_nested_real_coefficient_digits() -> None:
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 @pytest.mark.parametrize(
@@ -595,8 +693,7 @@ def test_request_bounds_translated_product_coefficient_digits(
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic=logic, smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic=logic, smtlib=source))
 
 
 def test_request_bounds_translated_constant_digits() -> None:
@@ -612,10 +709,11 @@ def test_request_bounds_translated_constant_digits() -> None:
     assert SmtUnsatCoreRequest(
         logic="QF_LIA", smtlib=template.format(constant=boundary_constant)
     )
-    with raises_logic_validation():
+    assert_execution_rejected(
         SmtUnsatCoreRequest(
             logic="QF_LIA", smtlib=template.format(constant=over_constant)
         )
+    )
 
 
 @pytest.mark.parametrize(
@@ -652,8 +750,7 @@ def test_request_bounds_multi_term_affine_sum_coefficient_digits(
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic=logic, smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic=logic, smtlib=source))
 
 
 def test_request_bounds_multi_term_boundary_coefficients() -> None:
@@ -668,8 +765,7 @@ def test_request_bounds_multi_term_boundary_coefficients() -> None:
     over = boundary.replace(factor, "9" * 129, 1)
 
     assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=boundary)
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over))
 
 
 def test_request_bounds_merged_duplicate_summand_coefficients() -> None:
@@ -684,8 +780,7 @@ def test_request_bounds_merged_duplicate_summand_coefficients() -> None:
     over = boundary.replace(outer, "9" * 128, 1)
 
     assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=boundary)
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over))
 
 
 @pytest.mark.parametrize(
@@ -708,8 +803,7 @@ def test_request_bounds_exact_integer_division_coefficient_digits(
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
 
 
 def test_request_bounds_integer_division_translated_constant_digits() -> None:
@@ -724,8 +818,9 @@ def test_request_bounds_integer_division_translated_constant_digits() -> None:
     assert SmtUnsatCoreRequest(
         logic="QF_LIA", smtlib=template.format(constant=constant)
     )
-    with raises_logic_validation():
+    assert_execution_rejected(
         SmtUnsatCoreRequest(logic="QF_LIA", smtlib=template.format(constant="9" * 256))
+    )
 
 
 def test_request_bounds_arithmetic_ite_branch_coefficient_digits() -> None:
@@ -740,8 +835,7 @@ def test_request_bounds_arithmetic_ite_branch_coefficient_digits() -> None:
     over = boundary.replace(factor, "9" * 129, 1)
 
     assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=boundary)
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over))
 
 
 @pytest.mark.parametrize(
@@ -767,8 +861,7 @@ def test_request_bounds_scaled_ite_branch_coefficient_digits(
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
 
 
 @pytest.mark.parametrize("nesting", (2, 3))
@@ -783,8 +876,7 @@ def test_request_bounds_deeply_nested_ite_branch_coefficients(nesting: int) -> N
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
 
 
 @pytest.mark.parametrize(
@@ -808,8 +900,7 @@ def test_request_bounds_reciprocal_ite_branch_denominator_digits(
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_request_bounds_ite_branch_digits_when_scalars_cancel_the_height() -> None:
@@ -823,8 +914,7 @@ def test_request_bounds_ite_branch_digits_when_scalars_cancel_the_height() -> No
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_request_bounds_division_of_formless_ite_branch_denominator_digits() -> None:
@@ -837,8 +927,7 @@ def test_request_bounds_division_of_formless_ite_branch_denominator_digits() -> 
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_request_bounds_formless_ite_sum_denominator_digits() -> None:
@@ -853,8 +942,7 @@ def test_request_bounds_formless_ite_sum_denominator_digits() -> None:
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_request_bounds_mixed_denominator_formless_ite_sum_scaling() -> None:
@@ -874,8 +962,7 @@ def test_request_bounds_mixed_denominator_formless_ite_sum_scaling() -> None:
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=scaled_source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=scaled_source))
 
     unscaled_source = (
         "(set-logic QF_LRA)\n"
@@ -904,8 +991,7 @@ def test_request_bounds_opposite_sign_comparison_numerator_digits() -> None:
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_bounded_reciprocal_cancelling_formless_ite_still_admitted() -> None:
@@ -966,8 +1052,7 @@ def test_request_bounds_comparison_of_formless_ite_branch_denominator_digits() -
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_bounded_comparison_of_formless_ite_branches_still_admitted() -> None:
@@ -1002,8 +1087,7 @@ def test_request_bounds_shared_denominator_comparison_numerator_digits() -> None
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_request_bounds_scaled_formless_comparison_lifted_numerators() -> None:
@@ -1020,8 +1104,7 @@ def test_request_bounds_scaled_formless_comparison_lifted_numerators() -> None:
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_request_bounds_scaled_formless_sum_retains_unmatched_coefficients() -> None:
@@ -1043,8 +1126,7 @@ def test_request_bounds_scaled_formless_sum_retains_unmatched_coefficients() -> 
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_bounded_scaled_formless_comparison_still_admitted() -> None:
@@ -1081,8 +1163,7 @@ def test_request_bounds_nested_division_of_formless_ite_denominator_digits() -> 
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_bounded_nested_division_of_formless_ite_still_admitted() -> None:
@@ -1127,8 +1208,7 @@ def test_request_bounds_compared_pairless_chain_denominator_digits() -> None:
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_request_bounds_scaled_formless_ite_nested_division_digits() -> None:
@@ -1145,8 +1225,7 @@ def test_request_bounds_scaled_formless_ite_nested_division_digits() -> None:
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_bounded_scaled_formless_ite_nested_division_still_admitted() -> None:
@@ -1187,8 +1266,7 @@ def test_request_bounds_sum_division_of_formless_ite_denominator_digits() -> Non
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_bounded_sum_division_of_formless_ite_still_admitted() -> None:
@@ -1249,8 +1327,7 @@ def test_request_bounds_shared_denominator_sum_division_digits() -> None:
         "(check-sat)\n"
     )
 
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
 
 def test_bounded_shared_denominator_sum_division_still_admitted() -> None:
@@ -1543,8 +1620,7 @@ def test_request_bounds_parsed_ast_nodes() -> None:
         )
 
     assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(2_047))
-    with raises_logic_validation():
-        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(2_048))
+    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(2_048)))
 
 
 def test_unsat_result_requires_a_nonempty_canonical_core() -> None:
@@ -1561,9 +1637,9 @@ def test_unsat_result_requires_a_nonempty_canonical_core() -> None:
 
 
 def test_request_schema_explains_validator_owned_indexing() -> None:
-    schema = SmtUnsatCoreRequest.model_json_schema()
+    schema = _SmtUnsatCoreRequest.model_json_schema()
 
     assert "zero-based index" in schema["description"]
-    assert "does not claim a hard request-local byte limit" in schema["description"]
+    assert "owner-local bounded Z3 worker" in schema["description"]
     assert "Boolean-sorted" in schema["properties"]["logic"]["description"]
     assert schema["examples"]

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.math.matrices.canonical_forms import _operations as canonical_operations
 from jacobian.math.matrices.canonical_forms import (
     invariant_factors,
     minimal_polynomial,
@@ -88,6 +89,58 @@ def test_nilpotent_jordan_block_minimal_polynomial_is_t_squared() -> None:
     result = compute_minimal_polynomial(req)
     assert _coeffs(result.minimal_polynomial) == [Fraction(0), Fraction(0), Fraction(1)]
     assert result.degree == 2
+
+
+def test_trusted_canonical_form_producers_run_each_kernel_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _diagonal("2", "3")
+    names = (
+        "invariant_factors",
+        "minimal_polynomial",
+        "characteristic_polynomial",
+        "primary_decomposition",
+    )
+    calls = dict.fromkeys(names, 0)
+
+    for name in names:
+        original = getattr(canonical_operations, name)
+
+        def counted(
+            *args: object, _original=original, _name=name, **kwargs: object
+        ) -> object:
+            calls[_name] += 1
+            return _original(*args, **kwargs)
+
+        monkeypatch.setattr(canonical_operations, name, counted)
+
+    compute_minimal_polynomial(request)
+    assert calls == {
+        "invariant_factors": 0,
+        "minimal_polynomial": 1,
+        "characteristic_polynomial": 1,
+        "primary_decomposition": 0,
+    }
+
+    for name in calls:
+        calls[name] = 0
+    compute_rational_canonical_form(request)
+    assert calls == {
+        "invariant_factors": 1,
+        "minimal_polynomial": 1,
+        "characteristic_polynomial": 1,
+        "primary_decomposition": 0,
+    }
+
+    for name in calls:
+        calls[name] = 0
+    compute_primary_decomposition(request)
+    assert calls == {
+        "invariant_factors": 0,
+        "minimal_polynomial": 1,
+        "characteristic_polynomial": 0,
+        "primary_decomposition": 1,
+    }
 
 
 def test_diagonal_distinct_minimal_equals_characteristic() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -8,6 +8,7 @@ from fractions import Fraction
 
 import pytest
 from pydantic import ValidationError
+from tests.fixtures.accounting import assert_executed_work_is_charged
 from tests.math.multicommodity_flow._support import multicommodity_validation_error
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
@@ -78,15 +79,14 @@ def test_native_api_accepts_the_canonical_flow_value_directly() -> None:
     assert native.congestion == q(1)
 
 
-def test_accepted_calls_execute_exactly_the_two_charged_scans(
+def test_accepted_calls_charge_every_executed_scan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Request parsing performs the operation's component scan once, admits
     # work and result envelope from it, and hands it to the producer pass;
     # the replay rescans independently. A native call runs the same producer
-    # scan itself. Either way an accepted call must execute exactly two
-    # arithmetic scans -- any more underreports nothing but wasted work,
-    # any fewer breaks exactness.
+    # scan itself. Either way an accepted call has two charged arithmetic
+    # scans, and no further scan may escape the admitted work envelope.
     from jacobian.math.graphs.multicommodity_flow import _models
 
     scans = {"count": 0}
@@ -101,10 +101,12 @@ def test_accepted_calls_execute_exactly_the_two_charged_scans(
     via_request = _run_multicommodity_flow_profile(
         MulticommodityFlowProfileRequest(flow=shared_bottleneck_flow())
     )
+    assert_executed_work_is_charged(charged=2, executed=scans["count"])
     assert scans == {"count": 2}
 
     scans.update(count=0)
     native = compute_multicommodity_flow_profile(shared_bottleneck_flow())
+    assert_executed_work_is_charged(charged=2, executed=scans["count"])
     assert scans == {"count": 2}
 
     assert native == via_request

--- a/tests/math/numerical_semigroups/test_result_verifiers.py
+++ b/tests/math/numerical_semigroups/test_result_verifiers.py
@@ -4,6 +4,12 @@ from typing import Any
 
 import pytest
 
+from jacobian.math.numerical_semigroups import (
+    _element_invariant_operations as element_operations,
+)
+from jacobian.math.numerical_semigroups import (
+    _global_invariant_operations as global_operations,
+)
 from jacobian.math.numerical_semigroups._element_invariant_models import (
     ElementCatenaryDegreeRequest,
     ElementCatenaryDegreeResult,
@@ -148,6 +154,77 @@ def test_element_invariant_replay_results_reapply_request_value_envelopes(
 ) -> None:
     with pytest.raises(ValueError, match="value must be at most"):
         result_type.model_validate(payload)
+
+
+def test_catenary_result_rejects_an_unmaterializable_family_before_replay() -> None:
+    """A supplied claim cannot force the old unbounded factorization replay."""
+
+    with pytest.raises(ValueError, match="exact materialization bound 1000"):
+        ElementCatenaryDegreeResult.model_validate(
+            {
+                "value": "9990",
+                "minimal_generators": ("6", "10", "14", "15"),
+                "factorization_count": 13_307_204,
+                "catenary_degree": 6,
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("operation", "operation_request", "module", "kernel_name"),
+    (
+        (
+            compute_element_delta_set,
+            ElementDeltaSetRequest(generators=("3", "5"), value="15"),
+            element_operations,
+            "factorization_lengths",
+        ),
+        (
+            compute_element_elasticity,
+            ElementElasticityRequest(generators=("3", "5"), value="15"),
+            element_operations,
+            "factorization_length_extrema",
+        ),
+        (
+            compute_element_catenary_degree,
+            ElementCatenaryDegreeRequest(generators=("3", "5"), value="15"),
+            element_operations,
+            "factorizations",
+        ),
+        (
+            compute_betti_elements,
+            BettiElementsRequest(generators=("3", "5")),
+            global_operations,
+            "betti_data",
+        ),
+        (
+            compute_delta_set,
+            DeltaSetRequest(generators=("3", "5")),
+            global_operations,
+            "delta_periodicity_bound",
+        ),
+    ),
+)
+def test_trusted_semigroup_producers_run_each_expensive_kernel_once(
+    monkeypatch: pytest.MonkeyPatch,
+    operation: Any,
+    operation_request: Any,
+    module: Any,
+    kernel_name: str,
+) -> None:
+    original = getattr(module, kernel_name)
+    calls = 0
+
+    def counted(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(module, kernel_name, counted)
+
+    operation(operation_request)
+
+    assert calls == 1
 
 
 def test_factorization_length_verifier_rejects_forged_length_set() -> None:

--- a/tests/math/polynomials/test_polynomial_map_generic_degree.py
+++ b/tests/math/polynomials/test_polynomial_map_generic_degree.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import json
 import shutil
+import time
 from fractions import Fraction
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import sympy
 from tests.math.polynomials._support import polynomial_validation_error
 
 from jacobian._exact import CanonicalRational
-from jacobian.math import _singular as shared_singular
 from jacobian.math.polynomials.maps import (
     RationalPolynomialMap,
     _generic_degree,
@@ -33,6 +33,7 @@ from jacobian.math.polynomials.maps._models import (
     GenericFiberCertificate,
     GenericFiberPolynomial,
     GenericFiberTerm,
+    verify_generic_degree_result,
 )
 from jacobian.math.polynomials.maps._operations import compute_generic_degree
 from jacobian.math.polynomials.maps._replay import (
@@ -188,7 +189,7 @@ def test_operation_is_one_admitted_atomic_generic_fiber_computation() -> None:
 def test_missing_backend_is_operational_unavailability(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(shared_singular.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
 
     result = _compute(_map(("x",), {(1,): 1}))
 
@@ -238,7 +239,10 @@ def test_request_bounds_component_and_aggregate_support() -> None:
             polynomial_map=_map(
                 ("x", "y", "z"),
                 *(
-                    dict.fromkeys(monomials[offset : offset + 33], 1)
+                    cast(
+                        dict[tuple[int, ...], int | Fraction],
+                        dict.fromkeys(monomials[offset : offset + 33], 1),
+                    )
                     for offset in (0, 33, 66)
                 ),
             )
@@ -368,8 +372,11 @@ def test_generic_degree_is_invariant_under_linear_coordinate_changes() -> None:
 
 @requires_singular
 @pytest.mark.requires_backend("singular")
+@pytest.mark.exhaustive
+@pytest.mark.timeout(180)
 def test_atlas_weighted_lift_k1_d2_has_generic_degree_three() -> None:
-    # This is the exact crater-map fixture pinned by the issue's Atlas source.
+    # This is a slow exact Singular regression, retained in the dedicated
+    # Singular/exhaustive lane rather than the ordinary math owner lane.
     result = _compute(
         _map(
             ("x", "y", "z"),
@@ -546,7 +553,7 @@ def test_declared_replay_limits_are_consulted_during_replay(
         )
 
 
-def test_forged_degree_is_rejected_by_the_result_contract() -> None:
+def test_forged_degree_fails_the_explicit_result_verifier() -> None:
     result = GenericDegreeResult(
         outcome="GENERICALLY_FINITE",
         source=_identity_source(),
@@ -555,9 +562,13 @@ def test_forged_degree_is_rejected_by_the_result_contract() -> None:
     )
     forged = result.model_dump(mode="json")
     forged["degree"] = 2
+    assert isinstance(forged["evidence"], dict)
+    forged["evidence"]["standard_monomials"] = [[0, 0], [1, 0]]
 
-    with polynomial_validation_error():
-        GenericDegreeResult.model_validate(forged)
+    assert (
+        verify_generic_degree_result(GenericDegreeResult.model_validate(forged))
+        is False
+    )
 
 
 def test_forged_source_evidence_fails_closed_at_the_operation(
@@ -630,13 +641,27 @@ def _power_map_result(power: int) -> GenericDegreeResult:
     )
 
 
-def test_consistent_results_replay_at_the_result_boundary() -> None:
+def test_consistent_results_round_trip_without_replaying_at_deserialization() -> None:
     for power in (2, 3):
         result = _power_map_result(power)
+        assert result.evidence is not None
         require_certificate_reconstructs_from_source(result.source, result.evidence)
         replayed = GenericDegreeResult.model_validate(result.model_dump(mode="json"))
 
         assert replayed == result
+
+
+def test_result_deserialization_does_not_invoke_the_certificate_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = _power_map_result(2)
+
+    def fail_replay(*_args: object, **_kwargs: object) -> CertificateReplayResult:
+        raise AssertionError("result deserialization must remain structural")
+
+    monkeypatch.setattr(_replay, "run_bounded_certificate_replay", fail_replay)
+
+    assert GenericDegreeResult.model_validate(result.model_dump(mode="json")) == result
 
 
 def test_serialized_evidence_cannot_be_presented_against_a_different_source() -> None:
@@ -644,8 +669,9 @@ def test_serialized_evidence_cannot_be_presented_against_a_different_source() ->
     forged = result.model_dump(mode="json")
     forged["source"] = _power_map_result(2).source.model_dump(mode="json")
 
-    with polynomial_validation_error():
-        GenericDegreeResult.model_validate(forged)
+    replayed = GenericDegreeResult.model_validate(forged)
+    assert result.evidence is not None
+    assert verify_generic_degree_result(replayed) is False
     with pytest.raises(ValueError, match="reconstruct"):
         require_certificate_reconstructs_from_source(
             _power_map_result(2).source,
@@ -663,8 +689,10 @@ def test_forged_standard_monomials_are_rejected_against_the_certified_ideal() ->
         "evidence": evidence,
     }
 
-    with polynomial_validation_error():
-        GenericDegreeResult.model_validate(forged)
+    assert (
+        verify_generic_degree_result(GenericDegreeResult.model_validate(forged))
+        is False
+    )
 
 
 def test_cleared_standard_monomials_cannot_invent_a_positive_dimensional_outcome() -> (
@@ -678,8 +706,10 @@ def test_cleared_standard_monomials_cannot_invent_a_positive_dimensional_outcome
         "evidence": evidence,
     }
 
-    with polynomial_validation_error():
-        GenericDegreeResult.model_validate(forged)
+    assert (
+        verify_generic_degree_result(GenericDegreeResult.model_validate(forged))
+        is False
+    )
 
 
 @pytest.mark.parametrize(
@@ -701,8 +731,10 @@ def test_unconfirmed_replay_verdicts_never_establish_a_conclusion(
         "evidence": _power_map_certificate(2).model_dump(mode="json"),
     }
 
-    with polynomial_validation_error():
-        GenericDegreeResult.model_validate(payload)
+    assert (
+        verify_generic_degree_result(GenericDegreeResult.model_validate(payload))
+        is False
+    )
 
 
 def test_producing_operation_replays_evidence_exactly_once(
@@ -796,7 +828,7 @@ def test_replay_receives_only_the_remaining_declared_wall_time(
             degree=1,
         )
 
-    monkeypatch.setattr(_operations.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(time, "monotonic", fake_monotonic)
     monkeypatch.setattr(_operations, "run_singular_generic_fiber", fake_backend)
     monkeypatch.setattr(_operations, "run_bounded_certificate_replay", fake_replay)
 
@@ -823,7 +855,7 @@ def test_exhausted_envelope_reports_timeout_without_replaying(
     def fail_replay(*_args: object, **_kwargs: object) -> CertificateReplayResult:
         raise AssertionError("certificate replay must not run without budget")
 
-    monkeypatch.setattr(_operations.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(time, "monotonic", fake_monotonic)
     monkeypatch.setattr(
         _operations,
         "run_singular_generic_fiber",

--- a/tests/math/words/test_words.py
+++ b/tests/math/words/test_words.py
@@ -31,6 +31,7 @@ from jacobian.math.words import (
     substitution_dependency_graph,
     substitution_primitivity_profile,
 )
+from jacobian.math.words import _operations as word_operations
 from jacobian.math.words._models import (
     FactorsLengthRequest,
     FactorsLengthResult,
@@ -157,6 +158,43 @@ def test_empty_period_convention_and_result_binding() -> None:
     payload["is_primitive"] = True
     supplied = PeriodsResult.model_validate(payload)
     assert not verify_periods_result(supplied)
+
+
+@pytest.mark.parametrize(
+    ("operation", "operation_request", "kernel_name"),
+    (
+        (
+            compute_factors_length,
+            FactorsLengthRequest(word=_word("abaab"), factor_length=2),
+            "factors_of_length",
+        ),
+        (
+            compute_periods,
+            PeriodsRequest(word=_word("ababab")),
+            "periods",
+        ),
+    ),
+)
+def test_trusted_word_profile_producers_run_the_kernel_once(
+    monkeypatch: pytest.MonkeyPatch,
+    operation: object,
+    operation_request: object,
+    kernel_name: str,
+) -> None:
+    original = getattr(word_operations, kernel_name)
+    calls = 0
+
+    def counted(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(word_operations, kernel_name, counted)
+
+    assert callable(operation)
+    operation(operation_request)
+
+    assert calls == 1
 
 
 def test_fibonacci_incidence_matrix_and_binding() -> None:

--- a/tests/process/test_graph_isomorphism_worker.py
+++ b/tests/process/test_graph_isomorphism_worker.py
@@ -3,8 +3,11 @@
 import pytest
 
 import jacobian.process as process
+from jacobian.math.graphs.isomorphism import _operations as isomorphism_operations
 from jacobian.math.graphs.isomorphism._models import GraphIsomorphismRequest
 from jacobian.math.graphs.isomorphism._operations import decide_graph_isomorphism
+from jacobian.math.graphs.isomorphism._vf2_worker import _first_isomorphism_mapping
+from jacobian.math.number_field import _operations as number_field_operations
 from jacobian.math.number_field._models import NumberFieldRequest
 from jacobian.math.number_field._operations import compute_nf_discriminant
 from jacobian.math.number_theory._certification_models import (
@@ -14,11 +17,28 @@ from jacobian.math.number_theory._direct_factorization_models import (
     FactorizationRequest,
 )
 from jacobian.math.number_theory._factorization_kernels import (
+    _FACTORIZATION_WORKER_ADDRESS_SPACE_BYTES,
+    _FACTORIZATION_WORKER_FILE_SIZE_BYTES,
     enumerate_divisors,
     factorize_certified,
     factorize_primes,
 )
-from jacobian.process import BoundedProcessResult
+from jacobian.process import BoundedProcessResult, ProcessResourceLimits
+
+
+def test_vf2_worker_obtains_a_positive_witness_in_one_search_traversal() -> None:
+    class Matcher:
+        def __init__(self) -> None:
+            self.traversals = 0
+
+        def isomorphisms_iter(self):  # type: ignore[no-untyped-def]
+            self.traversals += 1
+            yield {1: 0, 0: 1}
+
+    matcher = Matcher()
+
+    assert _first_isomorphism_mapping(matcher) == [(0, 1), (1, 0)]
+    assert matcher.traversals == 1
 
 
 def test_timed_out_vf2_worker_is_an_unknown_non_conclusion(
@@ -48,6 +68,42 @@ def test_timed_out_vf2_worker_is_an_unknown_non_conclusion(
 
     assert result.status == "UNKNOWN"
     assert result.vertex_mapping == ()
+
+
+def test_vf2_worker_has_private_cwd_and_os_resource_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
+
+    def complete_worker(*_args: object, **kwargs: object) -> BoundedProcessResult:
+        recorded.update(kwargs)
+        return BoundedProcessResult(
+            returncode=0,
+            stdout=b'{"ok":true,"mapping":[[0,0],[1,1]]}',
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        )
+
+    monkeypatch.setattr(process, "run_bounded_process", complete_worker)
+
+    result = decide_graph_isomorphism(
+        GraphIsomorphismRequest.model_validate(
+            {
+                "graph_a": {"vertex_count": 2, "directed": False, "edges": [(0, 1)]},
+                "graph_b": {"vertex_count": 2, "directed": False, "edges": [(0, 1)]},
+            }
+        )
+    )
+
+    assert result.status == "ISOMORPHIC"
+    assert recorded["resource_limits"] == ProcessResourceLimits(
+        cpu_seconds=60,
+        address_space_bytes=isomorphism_operations._VF2_ADDRESS_SPACE_BYTES,
+        file_size_bytes=isomorphism_operations._VF2_FILE_SIZE_BYTES,
+    )
+    assert str(recorded["cwd"]).split("/")[-1].startswith("jacobian-vf2-")
 
 
 def test_timed_out_certified_factorization_is_an_unknown_non_conclusion(
@@ -98,6 +154,43 @@ def test_timed_out_direct_factorization_worker_is_an_unknown_non_conclusion(
     assert factors.factors == ()
 
 
+def test_factorization_workers_have_private_cwds_and_os_resource_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: list[dict[str, object]] = []
+
+    def timed_out_worker(*_args: object, **kwargs: object) -> BoundedProcessResult:
+        recorded.append(kwargs)
+        return BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        )
+
+    monkeypatch.setattr(process, "run_bounded_process", timed_out_worker)
+
+    certified = factorize_certified(CertifiedFactorizationRequest(value="10403"))
+    direct = factorize_primes(FactorizationRequest(value="12"))
+
+    assert certified.status == "UNKNOWN"
+    assert direct.status == "UNKNOWN"
+    assert len(recorded) == 2
+    for invocation, prefix in zip(
+        recorded,
+        ("jacobian-certified-factor-", "jacobian-direct-factor-"),
+        strict=True,
+    ):
+        assert invocation["resource_limits"] == ProcessResourceLimits(
+            cpu_seconds=60,
+            address_space_bytes=_FACTORIZATION_WORKER_ADDRESS_SPACE_BYTES,
+            file_size_bytes=_FACTORIZATION_WORKER_FILE_SIZE_BYTES,
+        )
+        assert str(invocation["cwd"]).split("/")[-1].startswith(prefix)
+
+
 def test_timed_out_number_field_worker_is_an_unknown_non_conclusion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -120,3 +213,50 @@ def test_timed_out_number_field_worker_is_an_unknown_non_conclusion(
 
     assert result.status == "UNKNOWN"
     assert result.discriminant is None
+
+
+def test_number_field_worker_has_private_cwd_and_os_resource_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
+
+    def complete_worker(*_args: object, **kwargs: object) -> BoundedProcessResult:
+        recorded.update(kwargs)
+        return BoundedProcessResult(
+            returncode=0,
+            stdout=b'{"kind":"complete","discriminant":"8"}',
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        )
+
+    monkeypatch.setattr(process, "run_bounded_process", complete_worker)
+
+    result = compute_nf_discriminant(
+        NumberFieldRequest(coefficients_descending=("1", "0", "-2"), variable="x")
+    )
+
+    assert result.discriminant == "8"
+    assert recorded["resource_limits"] == ProcessResourceLimits(
+        cpu_seconds=60,
+        address_space_bytes=number_field_operations._WORKER_ADDRESS_SPACE_BYTES,
+        file_size_bytes=number_field_operations._WORKER_FILE_SIZE_BYTES,
+    )
+    assert str(recorded["cwd"]).split("/")[-1].startswith("jacobian-number-field-")
+
+
+def test_number_field_worker_start_failure_is_an_unknown_non_conclusion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        raise OSError("worker unavailable")
+
+    monkeypatch.setattr(process, "run_bounded_process", unavailable)
+
+    result = compute_nf_discriminant(
+        NumberFieldRequest(coefficients_descending=("1", "0", "-2"), variable="x")
+    )
+
+    assert result.status == "UNKNOWN"
+    assert result.detail == "the bounded number-field worker could not be started"

--- a/tests/tooling/test_architecture.py
+++ b/tests/tooling/test_architecture.py
@@ -239,19 +239,19 @@ def test_exported_native_functions_do_not_annotate_wire_models(
     _write(
         tmp_path,
         "src/jacobian/math/example/__init__.py",
-        "from .native import value\n__all__ = ['value']\n",
+        "from .api import value\n__all__ = ['value']\n",
     )
     _write(
         tmp_path,
-        "src/jacobian/math/example/native.py",
+        "src/jacobian/math/example/api.py",
         "from jacobian.math.example._models import ExampleRequest\n"
         "def value(request: ExampleRequest) -> ExampleRequest:\n"
         "    return request\n",
     )
 
     assert _violations(tmp_path, "native-wire-boundary") == [
-        "src/jacobian/math/example/native.py",
-        "src/jacobian/math/example/native.py",
+        "src/jacobian/math/example/api.py",
+        "src/jacobian/math/example/api.py",
     ]
 
 

--- a/tests/tooling/test_architecture.py
+++ b/tests/tooling/test_architecture.py
@@ -184,6 +184,25 @@ def test_contracts_and_values_cannot_reenter_their_own_operations(
     ]
 
 
+def test_result_validators_cannot_replay_known_owner_kernels(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "src/jacobian/math/example/_models.py",
+        "class ExampleResult:\n"
+        "    @model_validator(mode='after')\n"
+        "    def replay(self):\n"
+        "        return factorizations((3, 5), 15)\n"
+        "class ExampleRequest:\n"
+        "    @model_validator(mode='after')\n"
+        "    def admission(self):\n"
+        "        return factorizations((3, 5), 15)\n",
+    )
+
+    assert _violations(tmp_path, "result-validator-replay") == [
+        "src/jacobian/math/example/_models.py"
+    ]
+
+
 def test_exported_native_functions_do_not_construct_wire_models(
     tmp_path: Path,
 ) -> None:
@@ -210,6 +229,42 @@ def test_exported_native_functions_do_not_construct_wire_models(
 
     assert _violations(tmp_path, "native-wire-boundary") == [
         "src/jacobian/math/example/native.py"
+    ]
+
+
+def test_exported_native_functions_do_not_annotate_wire_models(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path, "src/jacobian/math/__init__.py", "__all__ = ['example']\n")
+    _write(
+        tmp_path,
+        "src/jacobian/math/example/__init__.py",
+        "from .native import value\n__all__ = ['value']\n",
+    )
+    _write(
+        tmp_path,
+        "src/jacobian/math/example/native.py",
+        "from jacobian.math.example._models import ExampleRequest\n"
+        "def value(request: ExampleRequest) -> ExampleRequest:\n"
+        "    return request\n",
+    )
+
+    assert _violations(tmp_path, "native-wire-boundary") == [
+        "src/jacobian/math/example/native.py",
+        "src/jacobian/math/example/native.py",
+    ]
+
+
+def test_imported_native_domain_must_be_in_root_surface(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "src/jacobian/math/__init__.py",
+        "from jacobian.math import example\n__all__ = []\n",
+    )
+    _write(tmp_path, "src/jacobian/math/example/__init__.py", "__all__ = []\n")
+
+    assert _violations(tmp_path, "native-root-export") == [
+        "src/jacobian/math/__init__.py"
     ]
 
 

--- a/tests/tooling/test_manage_test_timings.py
+++ b/tests/tooling/test_manage_test_timings.py
@@ -1,0 +1,182 @@
+"""Regression tests for the benchmark timing-history lifecycle."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import zipfile
+from datetime import UTC, datetime, timedelta
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _script() -> ModuleType:
+    path = Path(__file__).parents[2] / ".github/scripts/manage-test-timings"
+    loader = SourceFileLoader("manage_test_timings", str(path))
+    spec = importlib.util.spec_from_loader("manage_test_timings", loader)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _artifact_payload(*, generated_at: datetime) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(
+            "benchmark-test-durations.json",
+            json.dumps(
+                {
+                    "version": 1,
+                    "suite": "benchmark",
+                    "source_sha": "a" * 40,
+                    "generated_at": generated_at.isoformat(),
+                    "python_version": "3.12",
+                    "shard_count": 4,
+                    "pytest_split_version": "0.11.0",
+                    "durations": {
+                        "benchmarks/validation/test_example.py::test_case": 1.25
+                    },
+                }
+            ),
+        )
+    return buffer.getvalue()
+
+
+def test_stale_timing_artifact_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _script()
+    now = datetime(2026, 8, 27, tzinfo=UTC)
+    artifact = {
+        "workflow_run": {"id": 1},
+        "archive_download_url": "https://example.invalid/timings.zip",
+        "created_at": (now - timedelta(days=31)).isoformat(),
+    }
+    monkeypatch.setattr(
+        module,
+        "api_json",
+        lambda *_args, **_kwargs: {"head_branch": "main", "conclusion": "success"},
+    )
+    monkeypatch.setattr(
+        module,
+        "download",
+        lambda *_args, **_kwargs: _artifact_payload(generated_at=now),
+    )
+
+    with pytest.raises(ValueError, match="timing artifact creation exceeds"):
+        module.artifact_durations(
+            artifact,
+            api="https://api.example.invalid",
+            repository="example/repository",
+            token="unused",
+            suite="benchmark",
+            now=now,
+        )
+
+
+def test_fresh_main_timing_artifact_is_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _script()
+    now = datetime(2026, 8, 27, tzinfo=UTC)
+    artifact = {
+        "workflow_run": {"id": 1},
+        "archive_download_url": "https://example.invalid/timings.zip",
+        "created_at": now.isoformat(),
+    }
+    monkeypatch.setattr(
+        module,
+        "api_json",
+        lambda *_args, **_kwargs: {
+            "head_branch": "main",
+            "conclusion": "success",
+            "head_sha": "a" * 40,
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "download",
+        lambda *_args, **_kwargs: _artifact_payload(generated_at=now),
+    )
+
+    assert module.artifact_durations(
+        artifact,
+        api="https://api.example.invalid",
+        repository="example/repository",
+        token="unused",
+        suite="benchmark",
+        now=now,
+    ) == {"benchmarks/validation/test_example.py::test_case": 1.25}
+
+
+def test_recent_timing_artifact_requires_recent_generation_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _script()
+    now = datetime(2026, 8, 27, tzinfo=UTC)
+    artifact = {
+        "workflow_run": {"id": 1},
+        "archive_download_url": "https://example.invalid/timings.zip",
+        "created_at": now.isoformat(),
+    }
+    monkeypatch.setattr(
+        module,
+        "api_json",
+        lambda *_args, **_kwargs: {"head_branch": "main", "conclusion": "success"},
+    )
+    monkeypatch.setattr(
+        module,
+        "download",
+        lambda *_args, **_kwargs: _artifact_payload(
+            generated_at=now - timedelta(days=31)
+        ),
+    )
+
+    with pytest.raises(ValueError, match="timing artifact generation exceeds"):
+        module.artifact_durations(
+            artifact,
+            api="https://api.example.invalid",
+            repository="example/repository",
+            token="unused",
+            suite="benchmark",
+            now=now,
+        )
+
+
+def test_timing_artifact_source_must_match_its_successful_workflow_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _script()
+    now = datetime(2026, 8, 27, tzinfo=UTC)
+    artifact = {
+        "workflow_run": {"id": 1},
+        "archive_download_url": "https://example.invalid/timings.zip",
+        "created_at": now.isoformat(),
+    }
+    monkeypatch.setattr(
+        module,
+        "api_json",
+        lambda *_args, **_kwargs: {
+            "head_branch": "main",
+            "conclusion": "success",
+            "head_sha": "b" * 40,
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "download",
+        lambda *_args, **_kwargs: _artifact_payload(generated_at=now),
+    )
+
+    with pytest.raises(ValueError, match="source SHA does not match"):
+        module.artifact_durations(
+            artifact,
+            api="https://api.example.invalid",
+            repository="example/repository",
+            token="unused",
+            suite="benchmark",
+            now=now,
+        )

--- a/tests/tooling/test_pytest_collection_ownership.py
+++ b/tests/tooling/test_pytest_collection_ownership.py
@@ -27,7 +27,7 @@ def _nested_test_functions(path: Path) -> tuple[str, ...]:
     """
 
     try:
-        display_path = path.relative_to(ROOT)
+        display_path: str = str(path.relative_to(ROOT))
     except ValueError:
         display_path = path.name
 
@@ -125,7 +125,6 @@ def test_math_tests_do_not_boot_complete_product_boundaries() -> None:
         "jacobian.cli",
         "jacobian.dispatch",
         "jacobian.mcp",
-        "jacobian.process",
     )
     violations: list[str] = []
     for path in sorted((ROOT / "tests/math").rglob("*.py")):

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -855,11 +855,7 @@ def _native_public_boundary_violations(root: Path) -> tuple[Violation, ...]:
         wire_names = _wire_model_names(root, tree, module)
         compute_adapters = _native_compute_adapter_names(root, tree, module)
         for node in _walk(function):
-            if (
-                relative.name == "native.py"
-                and isinstance(node, ast.arg)
-                and node.annotation is not None
-            ):
+            if isinstance(node, ast.arg) and node.annotation is not None:
                 if _annotation_contains_wire_model(node.annotation, wire_names):
                     violations.append(
                         _violation(
@@ -870,8 +866,7 @@ def _native_public_boundary_violations(root: Path) -> tuple[Violation, ...]:
                         )
                     )
             elif (
-                relative.name == "native.py"
-                and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
                 and node.returns is not None
                 and _annotation_contains_wire_model(node.returns, wire_names)
             ):

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -22,6 +22,14 @@ _EXTERNAL_OPERATION_OWNERS = frozenset(
         PurePosixPath("src/jacobian/math/graphs/isomorphism/_operations.py"),
         PurePosixPath("src/jacobian/math/polynomials/ideals/_singular.py"),
         PurePosixPath("src/jacobian/math/logic/_sat.py"),
+        PurePosixPath("src/jacobian/math/logic/_smt.py"),
+        PurePosixPath("src/jacobian/math/logic/_unsat_core.py"),
+        PurePosixPath("src/jacobian/math/hypergraphs/_independence_z3.py"),
+        PurePosixPath("src/jacobian/math/graphs/_independence_z3.py"),
+        PurePosixPath("src/jacobian/math/graphs/coloring/_operations.py"),
+        PurePosixPath("src/jacobian/math/graphs/optimization/_finite_optimization.py"),
+        PurePosixPath("src/jacobian/math/graphs/optimization/_invariants.py"),
+        PurePosixPath("src/jacobian/math/graphs/optimization/_chromatic_number.py"),
         PurePosixPath("src/jacobian/math/number_theory/_factorization_kernels.py"),
         PurePosixPath("src/jacobian/math/number_field/_operations.py"),
         PurePosixPath("src/jacobian/math/polynomials/multivariate/_factor_backend.py"),
@@ -34,6 +42,29 @@ _GENERATED_DIRECTORIES = frozenset(
 _EXEC_FUNCTIONS = frozenset({"execlp", "execv", "execve", "execvp", "execvpe"})
 _EVALUATOR_CAPABLE_FUNCTIONS = frozenset(
     {"eval", "exec", "lambdify", "parse_expr", "sympify"}
+)
+_RESULT_VALIDATOR_KERNEL_CALLS = frozenset(
+    {
+        "Solver",
+        "SolverFor",
+        "_solve_analysis_by_enumeration",
+        "_evaluate_chromatic_number_certificate",
+        "_solve_terminal_game_data",
+        "betti_data",
+        "characteristic_polynomial",
+        "delta_periodicity_bound",
+        "factor_list",
+        "factorization_length_extrema",
+        "factorization_lengths",
+        "factorizations",
+        "factors_of_length",
+        "invariant_factors",
+        "is_irreducible",
+        "minimal_polynomial",
+        "parse_smt2_string",
+        "periods",
+        "primary_decomposition",
+    }
 )
 _RATIONAL_COMPONENTS = frozenset({"denominator", "numerator", "p", "q"})
 _DESCRIPTIVE_RATIONAL_COMPONENTS = frozenset({"denominator", "numerator"})
@@ -463,9 +494,12 @@ def _owner_operation_reentry_violations(
     for node in _walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = _resolve_import_from_module(node, relative)
-            if (module is not None and _is_owner_operation_module(module, owner)) or (module == owner and any(
-                alias.name in {"operations", "_operations"} for alias in node.names
-            )):
+            if (module is not None and _is_owner_operation_module(module, owner)) or (
+                module == owner
+                and any(
+                    alias.name in {"operations", "_operations"} for alias in node.names
+                )
+            ):
                 violations.append(
                     _violation(
                         relative,
@@ -475,7 +509,9 @@ def _owner_operation_reentry_violations(
                     )
                 )
         elif isinstance(node, ast.Import):
-            if any(_is_owner_operation_module(alias.name, owner) for alias in node.names):
+            if any(
+                _is_owner_operation_module(alias.name, owner) for alias in node.names
+            ):
                 violations.append(
                     _violation(
                         relative,
@@ -500,6 +536,72 @@ def _owner_operation_reentry_violations(
                     "contract and value modules must not dynamically import their own operations",
                 )
             )
+    return tuple(violations)
+
+
+def _is_model_validator(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Return whether one method is a Pydantic model validator."""
+
+    return any(
+        (isinstance(decorator, ast.Name) and decorator.id == "model_validator")
+        or (
+            isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Name)
+            and decorator.func.id == "model_validator"
+        )
+        for decorator in function.decorator_list
+    )
+
+
+def _call_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    return None
+
+
+def _result_validator_replay_violations(
+    relative: PurePosixPath, tree: ast.AST
+) -> tuple[Violation, ...]:
+    """Keep owner kernels and solver APIs out of public result validators.
+
+    Successful producers establish their invariant once and use a private
+    trusted factory.  Independently supplied claims must use an explicit,
+    owner-local verifier with a declared envelope instead of hiding replay in
+    ordinary Pydantic deserialization.  The named set is deliberately narrow:
+    it covers the known expensive kernel/backend entry points without treating
+    cheap structural predicates as architecture violations.
+    """
+
+    if not relative.is_relative_to(PurePosixPath("src/jacobian/math")):
+        return ()
+    if not isinstance(tree, ast.Module):
+        return ()
+    violations: list[Violation] = []
+    for result_class in (
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name.endswith("Result")
+    ):
+        for method in result_class.body:
+            if not isinstance(
+                method, (ast.FunctionDef, ast.AsyncFunctionDef)
+            ) or not _is_model_validator(method):
+                continue
+            for call in (
+                node for node in ast.walk(method) if isinstance(node, ast.Call)
+            ):
+                name = _call_name(call)
+                if name in _RESULT_VALIDATOR_KERNEL_CALLS:
+                    violations.append(
+                        _violation(
+                            relative,
+                            call,
+                            "result-validator-replay",
+                            "result validators must not call owner kernels, backends, or solvers; use an explicit bounded verifier",
+                        )
+                    )
     return tuple(violations)
 
 
@@ -655,6 +757,35 @@ def _native_public_function_targets(
     return tuple(targets.values())
 
 
+def _root_native_export_violations(root: Path) -> tuple[Violation, ...]:
+    """Keep statically imported native domains listed in the root surface."""
+
+    path = _module_path(root, "jacobian.math")
+    if path is None:
+        return ()
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError):
+        return ()
+    exported = set(_literal_string_sequence(tree, "__all__"))
+    imported = {
+        alias.asname or alias.name
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module == "jacobian.math"
+        for alias in node.names
+        if alias.name != "*"
+    }
+    return tuple(
+        _violation(
+            PurePosixPath("src/jacobian/math/__init__.py"),
+            tree,
+            "native-root-export",
+            f"native domain {name!r} is imported but missing from jacobian.math.__all__",
+        )
+        for name in sorted(imported - exported)
+    )
+
+
 def _wire_model_names(root: Path, tree: ast.AST, source_module: str) -> set[str]:
     """Find local bindings that name a Request/Input wire model."""
 
@@ -677,6 +808,14 @@ def _wire_model_names(root: Path, tree: ast.AST, source_module: str) -> set[str]
 def _is_wire_model_reference(node: ast.AST, names: set[str]) -> bool:
     return (isinstance(node, ast.Name) and node.id in names) or (
         isinstance(node, ast.Attribute) and node.attr.endswith(("Request", "Input"))
+    )
+
+
+def _annotation_contains_wire_model(node: ast.AST, names: set[str]) -> bool:
+    """Return whether an annotation names a request/input wire model."""
+
+    return any(
+        _is_wire_model_reference(descendant, names) for descendant in ast.walk(node)
     )
 
 
@@ -716,6 +855,34 @@ def _native_public_boundary_violations(root: Path) -> tuple[Violation, ...]:
         wire_names = _wire_model_names(root, tree, module)
         compute_adapters = _native_compute_adapter_names(root, tree, module)
         for node in _walk(function):
+            if (
+                relative.name == "native.py"
+                and isinstance(node, ast.arg)
+                and node.annotation is not None
+            ):
+                if _annotation_contains_wire_model(node.annotation, wire_names):
+                    violations.append(
+                        _violation(
+                            relative,
+                            node.annotation,
+                            "native-wire-boundary",
+                            "exported native functions must not accept wire Request/Input models",
+                        )
+                    )
+            elif (
+                relative.name == "native.py"
+                and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.returns is not None
+                and _annotation_contains_wire_model(node.returns, wire_names)
+            ):
+                violations.append(
+                    _violation(
+                        relative,
+                        node.returns,
+                        "native-wire-boundary",
+                        "exported native functions must not return wire Request/Input models",
+                    )
+                )
             if not isinstance(node, ast.Call):
                 continue
             constructs_wire = _is_wire_model_reference(node.func, wire_names) or (
@@ -852,6 +1019,7 @@ def _check_file(root: Path, path: Path) -> tuple[Violation, ...]:
         *_environment_violations(relative, tree),
         *_evaluator_parser_violations(relative, tree),
         *_owner_operation_reentry_violations(relative, tree),
+        *_result_validator_replay_violations(relative, tree),
         *_unsafe_wire_conversion_violations(relative, tree),
         *_rational_output_violations(relative, tree),
     )
@@ -871,6 +1039,7 @@ def check_architecture(root: Path | str = ROOT) -> ArchitectureReport:
                     for violation in _check_file(project_root, path)
                 ),
                 *_native_public_boundary_violations(project_root),
+                *_root_native_export_violations(project_root),
             ),
             key=lambda item: (item.path, item.line or 0, item.code),
         )


### PR DESCRIPTION
## Problem

Several owner result models replayed defining mathematics during ordinary deserialization, and uninterruptible graph and logic backend calls could outlive their request envelope. This made a successful producer repeat expensive work and left typed outcomes dependent on an in-process backend returning promptly.

## Solution

- Move expensive replay from result validators into explicit, owner-local verifiers and construct operation-produced results only after their kernel has established the invariant.
- Isolate bounded graph, hypergraph, SAT, SMT, and UNSAT-core kernels in resource-limited workers. Parent operations now translate worker failures, output limits, cancellation, and deadline expiry into typed non-conclusions.
- Bind SAT and SMT solver results to their exact admitted sources. SAT assignments are structurally replayed; SMT model text is a bounded inspection projection after worker-side assertion verification.
- Add architecture checks for result-validator replay and native wire boundaries, plus focused negative fixtures and test-only charged-versus-executed accounting.
- Validate Harbor timing-history provenance and stale fallback behavior.

This deliberately does not add a generic production work ledger or verifier framework. Owner-local kernels and verifiers remain responsible for their own envelopes.

## Testing

- make check — 6,587 passed; Ruff, formatting, and mypy (1,131 source files) clean.
- make architecture — passed, 1,119 files checked.
- uv run pytest tests/math/polynomials/test_polynomial_map_generic_degree.py::test_atlas_weighted_lift_k1_d2_has_generic_degree_three — passed in 13.39s.
- uv run pytest tests/tooling/test_pytest_collection_ownership.py — 6 passed.
- uv run pytest tests/math/logic/test_tools.py tests/dispatch/test_parsing.py tests/math/graphs/test_graph_optimization_atlas.py — 98 passed; Ruff and mypy clean for the touched paths.

## Public contract impact

No operation IDs change. SAT and SMT result schemas now retain their source request so a returned conclusion and witness cannot be interpreted independently of the admitted input. This is a pre-stable schema extension. SMT model text is explicitly documented as a display projection, not a canonical model value.

## Operation boundary ownership

- Changed stage: kernel adapter and result construction.
- Request-bounds owner and controlling quantities: each changed owner retains its existing source, work, memory, output, and deadline admission; worker envelopes apply those already-admitted limits to backend execution.
- Backend or kernel path: owner-local resource-limited subprocesses for Z3 and graph kernels; maintained backend algorithms are unchanged.
- Result construction: trusted factories are used only after the producing kernel has established the skipped invariant; independently supplied claims use owner-local bounded verifiers.
- Native/MCP parity: both routes use the same owner-local admission and kernel path.
- Serialized-result and round-trip evidence: source-binding, forged-claim, and round-trip coverage added in the owning suites.

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Producer to consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: not changed.
- Structurally valid but mathematically invalid fixture and outcome: forged witnesses and malformed worker outputs are rejected or become typed non-conclusions.
- Serialized-subtype trust boundary: source-bound structural validation plus owner-local bounded verifiers.
- Exact-success defining invariant: source-bound witness, certificate, or backend assertion replay in the owning operation.
- Discriminated result schema and impossible combinations: contradictory outcome, witness, and diagnostic combinations are rejected by result models.

## Catalog admission

Not applicable; catalog membership and operation IDs are unchanged.

## Suggested review order

1. Review docs/reference/domain-operation-library.md and tools/check_architecture.py for the boundary rule.
2. Review the logic worker/result path, then the graph and hypergraph worker paths.
3. Review the owner-local verifier migrations and their forged-result tests.
4. Review Harbor timing-history changes and their tooling tests.

## Checklist

- [x] make check passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Runtime-bound changes name the request-bounds owner and execute the same semantic path for native and MCP callers
- [x] Result semantics distinguish exact and non-conclusion outcomes where applicable
- [x] New or changed bounds include owner boundary and realistic scale evidence where applicable