### PR TITLE
Simplify result validation and math.run dispatch

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -29,6 +29,28 @@ The domain function may compose a maintained backend such as SymPy, FLINT,
 NetworkX, or Z3 where that algorithm is relevant. Those backends remain private
 computational engines behind Jacobian's public mathematical contracts.
 
+## Transport and mathematical ownership
+
+The MCP Python SDK owns the fixed transport boundary: registration of
+`math.find` and `math.run`, their outer argument and output schemas, protocol
+validation, and structured JSON delivery. Jacobian does not duplicate those
+checks.
+
+`math.run` still needs a small dispatch boundary because its `payload` has an
+operation-specific schema that is known only after its immutable `operation_id`
+is resolved. Dispatch therefore does only this: resolve the declaration, parse
+the payload once with that owner's request model, invoke that owner once, and
+project the typed result once. It does not contain domain admission, backend
+logic, result-specific replay, or workflow state.
+
+Result parsing is not mathematical proof. Result models enforce canonical
+syntax, bounded structural shape, and branch consistency, while the admitted
+kernel establishes the mathematical postcondition once before calling its
+private trusted construction path. When an API deliberately accepts an
+independently supplied theorem-bearing claim, its owner provides a named,
+bounded `verify_*` function. That verification is an explicit trust decision;
+it never runs as a side effect of ordinary Pydantic deserialization.
+
 Domain values live beside the functions that own their semantics under
 `jacobian.math.<domain>`. HNF, LLL, and Smith-related direct computations call
 maintained backends in process; a subprocess is retained only where actual

--- a/src/jacobian/dispatch.py
+++ b/src/jacobian/dispatch.py
@@ -46,6 +46,10 @@ class OperationRequestValidationError(ValueError):
         ]
 
 
+class _OperationResolutionError(ValueError):
+    """The immutable catalog has no binding for the requested operation."""
+
+
 @dataclass(frozen=True, slots=True)
 class _PreparedOperation:
     """One request parsed against its selected immutable operation binding."""
@@ -87,7 +91,7 @@ def _prepare_operation(
 
     binding = catalog._binding(operation_id)
     if binding is None:
-        raise ValueError(f"unknown operation: {operation_id}")
+        raise _OperationResolutionError(f"unknown operation: {operation_id}")
     try:
         parsed = parse_operation_input(binding.request_type, payload)
     except (CanonicalizationError, ValidationError) as exc:

--- a/src/jacobian/math/additive_combinatorics/_multiset_sum.py
+++ b/src/jacobian/math/additive_combinatorics/_multiset_sum.py
@@ -18,8 +18,7 @@ MAX_ELEMENT_DIGITS = 64
 # JSON integer range, because the published schema exposes it as ``maximum``.
 MAX_ARITY_DIGITS = 18
 MAX_ARITY = (1 << 53) - 1
-# The operation enumerates once and source-bound result validation replays once,
-# so an accepted call performs at most twice this many coordinate steps.
+# The operation enumerates each admitted candidate family once.
 MAX_ENUMERATION_WORK = 20_000_000
 
 # A row containing a signed sum of at most MAX_RESULT_DIGITS digits and an

--- a/src/jacobian/math/additive_combinatorics/_subset_sum_residue.py
+++ b/src/jacobian/math/additive_combinatorics/_subset_sum_residue.py
@@ -17,14 +17,11 @@ from jacobian.math.additive_combinatorics.values import (
     indexed_sequence_item_ceiling,
 )
 
-# The dense residue recurrence visits exactly n*m cells per pass.  Ordinary
-# operation construction performs one computation and one source-binding
-# replay, so the separate total below bounds the complete public call.  Counts
-# never exceed 2^n; their bit bound therefore covers every bigint intermediate.
+# The dense residue recurrence visits exactly n*m cells. Counts never exceed
+# 2^n; their bit bound therefore covers every bigint intermediate.
 # The modulus ceiling controls the two dense arrays and required m-entry result
 # even for an empty source.
 MAX_RESIDUE_PROFILE_DP_CELLS = 1_000_000
-MAX_RESIDUE_PROFILE_TOTAL_DP_CELLS = 2 * MAX_RESIDUE_PROFILE_DP_CELLS
 MAX_RESIDUE_PROFILE_MODULUS = 65_536
 MAX_RESIDUE_PROFILE_MULTIPLICITY_BITS = 4_096
 MAX_RESIDUE_PROFILE_ITEMS = MAX_RESIDUE_PROFILE_MULTIPLICITY_BITS - 1
@@ -423,30 +420,51 @@ class SubsetSumResidueProfileResult(StrictModel):
         return prepared
 
     @model_validator(mode="after")
-    def bind_profile_to_source(self) -> Self:
+    def require_structural_shape(self) -> Self:
         if self.include_witnesses != (self.residue_witnesses is not None):
             raise _validation_error(
-                "bind_profile_to_source",
+                "result_shape",
                 "residue_witnesses presence must match include_witnesses",
             )
-        request = SubsetSumResidueProfileRequest(
-            source=self.source,
-            modulus=self.modulus,
-            include_empty_subset=self.include_empty_subset,
-            include_witnesses=self.include_witnesses,
-        )
-        expected_counts, expected_witnesses = _compute_residue_profile(request)
-        if self.residue_counts != expected_counts:
+        if len(self.residue_counts) != self.modulus:
             raise _validation_error(
-                "bind_profile_to_source",
-                "residue counts do not match the retained source",
+                "result_shape",
+                "residue_counts must contain exactly modulus rows",
             )
-        if self.residue_witnesses != expected_witnesses:
-            raise _validation_error(
-                "bind_profile_to_source",
-                "residue witnesses do not match the retained source",
-            )
+        if self.residue_witnesses is not None:
+            if len(self.residue_witnesses) != self.modulus:
+                raise _validation_error(
+                    "result_shape",
+                    "residue_witnesses must contain exactly modulus rows",
+                )
+            item_count = len(self.source.items)
+            for witness in self.residue_witnesses:
+                if witness is not None and any(
+                    index >= item_count for index in witness.indices
+                ):
+                    raise _validation_error(
+                        "result_shape",
+                        "residue witness index lies outside the retained source",
+                    )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: SubsetSumResidueProfileRequest,
+        residue_counts: tuple[ResidueMultiplicity, ...],
+        residue_witnesses: tuple[IndexSubset | None, ...] | None,
+    ) -> Self:
+        """Construct output whose mathematical invariants the kernel established."""
+
+        return cls.model_construct(
+            source=request.source,
+            modulus=request.modulus,
+            include_empty_subset=request.include_empty_subset,
+            include_witnesses=request.include_witnesses,
+            residue_counts=residue_counts,
+            residue_witnesses=residue_witnesses,
+        )
 
 
 def _indices_from_mask(mask: int, item_count: int) -> tuple[int, ...]:
@@ -521,13 +539,29 @@ def compute_subset_sum_residue_profile(
 ) -> SubsetSumResidueProfileResult:
     """Return every exact indexed-subset multiplicity modulo ``m``."""
     residue_counts, residue_witnesses = _compute_residue_profile(request)
-    return SubsetSumResidueProfileResult(
-        source=request.source,
-        modulus=request.modulus,
-        include_empty_subset=request.include_empty_subset,
-        include_witnesses=request.include_witnesses,
+    return SubsetSumResidueProfileResult._from_kernel(
+        request,
         residue_counts=residue_counts,
         residue_witnesses=residue_witnesses,
+    )
+
+
+def _verify_subset_sum_residue_profile(result: SubsetSumResidueProfileResult) -> bool:
+    """Verify an independently supplied residue profile within its envelope."""
+
+    try:
+        request = SubsetSumResidueProfileRequest(
+            source=result.source,
+            modulus=result.modulus,
+            include_empty_subset=result.include_empty_subset,
+            include_witnesses=result.include_witnesses,
+        )
+        expected_counts, expected_witnesses = _compute_residue_profile(request)
+    except ValueError:
+        return False
+    return (
+        result.residue_counts == expected_counts
+        and result.residue_witnesses == expected_witnesses
     )
 
 
@@ -538,7 +572,6 @@ __all__ = [
     "MAX_RESIDUE_PROFILE_MODULUS",
     "MAX_RESIDUE_PROFILE_MULTIPLICITY_BITS",
     "MAX_RESIDUE_PROFILE_RESULT_BYTES",
-    "MAX_RESIDUE_PROFILE_TOTAL_DP_CELLS",
     "MAX_RESIDUE_PROFILE_WITNESS_INDEX_SLOTS",
     "SubsetSumResidueProfileRequest",
     "SubsetSumResidueProfileResult",

--- a/src/jacobian/math/additive_combinatorics/_subset_sum_target.py
+++ b/src/jacobian/math/additive_combinatorics/_subset_sum_target.py
@@ -95,8 +95,7 @@ def _raw_source_item_count(source: object) -> int | None:
             "_raw_source_item_count",
             "subset-sum request exceeds the "
             f"{MAX_SUBSET_SUM_TOTAL_TRANSITIONS:,}-transition complete-call "
-            "bound across admission, computation, and both source-binding "
-            "replays",
+            "bound across admission and computation",
         )
 
     source_wire_bound = 64
@@ -131,14 +130,14 @@ def _require_admitted_work(
     targets with no expansion, and the kernel returns the same decision
     without building any state.
 
-    Otherwise admission replays the same reachable-sum growth the kernel
+    Otherwise admission simulates the same reachable-sum growth the kernel
     performs and stops at the first source prefix whose canonical witness
     resolves the target. A resolved request is bounded only by the work
     through that prefix, because every witness inside a resolving prefix
     carries a strictly smaller incidence mask than any witness of the later
     expansion; the resolving scan itself is charged before its prefix is
     accepted, so the charged work includes every scanned state. A request the
-    prefix replay never resolves must fit the exhaustive reachable-state and
+    prefix simulation never resolves must fit the exhaustive reachable-state and
     transition bounds across the whole source before execution.
 
     The public path performs this scan once for request admission and runs the
@@ -170,8 +169,7 @@ def _require_admitted_work(
                 "_require_admitted_work",
                 "subset-sum request exceeds the "
                 f"{MAX_SUBSET_SUM_TOTAL_TRANSITIONS:,}-transition complete-call "
-                "bound across admission, computation, and both source-binding "
-                "replays",
+                "bound across admission and computation",
             )
         if any(subtotal + value == target for subtotal in states):
             return

--- a/src/jacobian/math/additive_combinatorics/_tools.py
+++ b/src/jacobian/math/additive_combinatorics/_tools.py
@@ -34,7 +34,6 @@ from jacobian.math.additive_combinatorics._operations import (
 from jacobian.math.additive_combinatorics._subset_sum_residue import (
     MAX_RESIDUE_PROFILE_DP_CELLS,
     MAX_RESIDUE_PROFILE_MODULUS,
-    MAX_RESIDUE_PROFILE_TOTAL_DP_CELLS,
     MAX_RESIDUE_PROFILE_WITNESS_INDEX_SLOTS,
     SubsetSumResidueProfileRequest,
     SubsetSumResidueProfileResult,
@@ -130,8 +129,7 @@ ADDITIVE_COMBINATORICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             "For a bounded indexed integer sequence and one integer target, "
             "return the canonical attaining index subset or establish exact "
             "non-attainment after exhausting the admitted reachable-sum state space. "
-            "The complete call charges admission, computation, and both "
-            "source-binding replays, performing at most "
+            "The complete call charges admission and computation, performing at most "
             f"{MAX_SUBSET_SUM_TOTAL_TRANSITIONS:,} state transitions."
         ),
         SubsetSumTargetRequest,
@@ -360,10 +358,9 @@ ADDITIVE_COMBINATORICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             "return the exact number of permitted index subsets in every residue "
             "class of Z/mZ. Repeated values and zeros remain distinct positions; "
             "the empty-subset convention is explicit. Optional witnesses are "
-            "canonical by minimizing sum(2**i for i in I). Computation and "
-            "source-binding replay visit at most "
-            f"{MAX_RESIDUE_PROFILE_TOTAL_DP_CELLS:,} item-residue cells "
-            f"({MAX_RESIDUE_PROFILE_DP_CELLS:,} per pass), with modulus at most "
+            "canonical by minimizing sum(2**i for i in I). The dense recurrence "
+            f"visits at most {MAX_RESIDUE_PROFILE_DP_CELLS:,} item-residue cells, "
+            "with modulus at most "
             f"{MAX_RESIDUE_PROFILE_MODULUS:,} and at most "
             f"{MAX_RESIDUE_PROFILE_WITNESS_INDEX_SLOTS:,} witness index slots."
         ),

--- a/src/jacobian/math/algebraic_combinatorics/_models.py
+++ b/src/jacobian/math/algebraic_combinatorics/_models.py
@@ -111,15 +111,7 @@ class RSKPermutationRequest(StrictModel):
 
 
 class RSKResult(StrictModel):
-    __doc__ = f"""Source-bound canonical tableaux from permutation RSK.
-
-    Construction and result replay each perform at most
-    ``N(N-1)/2 <= {
-        MAX_RSK_PERMUTATION_LENGTH * (MAX_RSK_PERMUTATION_LENGTH - 1) // 2
-    }`` binary row searches, with at most
-    {MAX_RSK_ROW_SEARCH_COMPARISONS} integer comparisons per search for
-    ``N <= {MAX_RSK_PERMUTATION_LENGTH}``.
-    """
+    """Canonical tableaux produced by one admitted permutation-RSK kernel."""
 
     permutation: tuple[StrictInt, ...] = Field(
         min_length=0,
@@ -134,32 +126,42 @@ class RSKResult(StrictModel):
     convention: RSKConvention = "ROW_INSERTION_RSK_V1"
 
     @model_validator(mode="after")
-    def replay_permutation_rsk(self) -> Self:
-        from jacobian.math.algebraic_combinatorics._rsk import _row_insert
-
+    def require_structural_consistency(self) -> Self:
         _require_permutation(self.permutation)
-        insertion_rows, recording_rows = _row_insert(self.permutation)
-        expected_p = StandardYoungTableau(rows=insertion_rows)
-        expected_q = StandardYoungTableau(rows=recording_rows)
-        expected_shape = expected_p.shape
-        expected_lis = len(insertion_rows[0]) if insertion_rows else 0
-        expected_lds = len(insertion_rows)
-        if self.p_tableau != expected_p or self.q_tableau != expected_q:
-            raise PydanticCustomError(
-                "algebraic_combinatorics.rsk_tableaux_mismatch",
-                "permutation tableaux do not match exact row insertion",
-            )
-        if self.shape != expected_shape or self.q_tableau.shape != expected_shape:
+        if self.p_tableau.shape != self.shape or self.q_tableau.shape != self.shape:
             raise PydanticCustomError(
                 "algebraic_combinatorics.rsk_shape_mismatch",
-                "permutation tableaux and shape must agree",
+                "tableaux and shape must agree",
             )
+        expected_lis = self.shape.parts[0] if self.shape.parts else 0
+        expected_lds = len(self.shape.parts)
         if self.lis_length != expected_lis or self.lds_length != expected_lds:
             raise PydanticCustomError(
                 "algebraic_combinatorics.rsk_lengths_mismatch",
-                "LIS/LDS lengths do not match the exact RSK shape",
+                "LIS/LDS lengths do not match the tableau shape",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: RSKPermutationRequest,
+        *,
+        insertion_rows: tuple[tuple[int, ...], ...],
+        recording_rows: tuple[tuple[int, ...], ...],
+    ) -> Self:
+        """Build one result after the admitted RSK kernel established it."""
+
+        shape = IntegerPartition(parts=tuple(len(row) for row in insertion_rows))
+        return cls(
+            permutation=request.permutation,
+            p_tableau=StandardYoungTableau(rows=insertion_rows),
+            q_tableau=StandardYoungTableau(rows=recording_rows),
+            shape=shape,
+            lis_length=shape.parts[0] if shape.parts else 0,
+            lds_length=len(shape.parts),
+            convention=request.convention,
+        )
 
 
 class RSKWordRequest(StrictModel):

--- a/src/jacobian/math/algebraic_combinatorics/_models.py
+++ b/src/jacobian/math/algebraic_combinatorics/_models.py
@@ -133,6 +133,11 @@ class RSKResult(StrictModel):
                 "algebraic_combinatorics.rsk_shape_mismatch",
                 "tableaux and shape must agree",
             )
+        if sum(self.shape.parts) != len(self.permutation):
+            raise PydanticCustomError(
+                "algebraic_combinatorics.rsk_size_mismatch",
+                "tableau shape size must equal permutation length",
+            )
         expected_lis = self.shape.parts[0] if self.shape.parts else 0
         expected_lds = len(self.shape.parts)
         if self.lis_length != expected_lis or self.lds_length != expected_lds:

--- a/src/jacobian/math/algebraic_combinatorics/_operations.py
+++ b/src/jacobian/math/algebraic_combinatorics/_operations.py
@@ -24,10 +24,6 @@ from jacobian.math.algebraic_combinatorics._models import (
 )
 from jacobian.math.algebraic_combinatorics._rsk import _row_insert
 from jacobian.math.algebraic_combinatorics.values import RSKTableauPair
-from jacobian.math.symmetric_functions.values import (
-    IntegerPartition,
-    StandardYoungTableau,
-)
 from jacobian.math.words.values import FiniteWord
 
 
@@ -64,24 +60,11 @@ def compute_rsk_permutation(request: RSKPermutationRequest) -> RSKResult:
     Q is the recording tableau. The shape gives the partition.
     LIS length = first row length, LDS length = first column length.
     """
-    perm = request.permutation
-
-    p, q = _row_insert(perm)
-    shape = tuple(len(row) for row in p)
-
-    # LIS length = length of first row
-    # LDS length = length of first column (number of rows)
-    lis_length = len(p[0]) if p else 0
-    lds_length = len(p)
-
-    return RSKResult(
-        permutation=perm,
-        p_tableau=StandardYoungTableau(rows=p),
-        q_tableau=StandardYoungTableau(rows=q),
-        shape=IntegerPartition(parts=shape),
-        lis_length=lis_length,
-        lds_length=lds_length,
-        convention=request.convention,
+    insertion_rows, recording_rows = _row_insert(request.permutation)
+    return RSKResult._from_kernel(
+        request,
+        insertion_rows=insertion_rows,
+        recording_rows=recording_rows,
     )
 
 

--- a/src/jacobian/math/analysis/_box_enclosure.py
+++ b/src/jacobian/math/analysis/_box_enclosure.py
@@ -1,4 +1,4 @@
-"""Contracts, admission, replay, and execution for expression box enclosures."""
+"""Contracts, admission, and execution for expression box enclosures."""
 
 from __future__ import annotations
 
@@ -179,14 +179,11 @@ def _evaluate_box_expression(
 
 
 class IntervalExpressionBoxEnclosureResult(IntervalExpressionBoxEnclosureRequest):
-    """A replayable enclosure bound to its expression, axis, and source box.
+    """An enclosure bound structurally to its expression, axis, and source box.
 
     For ``ENCLOSED``, every defined real source-box value lies between the two
-    exact dyadic endpoints. Full validation recomputes that canonical claim.
-    ``DOMAIN_UNPROVEN`` replays its deterministic first-obstruction evidence.
-    ``BACKEND_ERROR`` asserts no enclosure conclusion at all, so it is
-    validated structurally: rerunning Arb would reject the operation's own
-    serialized result whenever a transient backend condition does not recur.
+    exact dyadic endpoints. The producer establishes that claim. Parsing checks
+    only the result's structural and canonical invariants.
     """
 
     status: IntervalExpressionBoxEnclosureStatus
@@ -222,40 +219,32 @@ class IntervalExpressionBoxEnclosureResult(IntervalExpressionBoxEnclosureRequest
             if self.status == "BACKEND_ERROR":
                 return self
 
-        request = IntervalExpressionBoxEnclosureRequest.model_construct(
-            expression=self.expression,
-            box=self.box,
-            precision_bits=self.precision_bits,
-        )
-        if self != _box_expression_enclosure(request):
-            raise _validation_error(
-                "box enclosure does not replay from its expression, axis, and source box"
-            )
         return self
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: IntervalExpressionBoxEnclosureRequest,
+        *,
+        status: IntervalExpressionBoxEnclosureStatus,
+        detail: str,
+        lower: ExactDyadic | None = None,
+        upper: ExactDyadic | None = None,
+        domain_failure: IntervalExpressionDomainFailure | None = None,
+    ) -> Self:
+        """Build a result after the admitted kernel established its claim."""
 
-def _constructed_box_result(
-    request: IntervalExpressionBoxEnclosureRequest,
-    *,
-    status: IntervalExpressionBoxEnclosureStatus,
-    detail: str,
-    lower: ExactDyadic | None = None,
-    upper: ExactDyadic | None = None,
-    domain_failure: IntervalExpressionDomainFailure | None = None,
-) -> IntervalExpressionBoxEnclosureResult:
-    """Build the producer result without paying a second backend replay."""
-
-    return IntervalExpressionBoxEnclosureResult.model_construct(
-        expression=request.expression,
-        box=request.box,
-        precision_bits=request.precision_bits,
-        status=status,
-        lower=lower,
-        upper=upper,
-        domain_failure=domain_failure,
-        method="ARB_NATURAL_INTERVAL_EXTENSION",
-        detail=detail,
-    )
+        return cls.model_construct(
+            expression=request.expression,
+            box=request.box,
+            precision_bits=request.precision_bits,
+            status=status,
+            lower=lower,
+            upper=upper,
+            domain_failure=domain_failure,
+            method="ARB_NATURAL_INTERVAL_EXTENSION",
+            detail=detail,
+        )
 
 
 def _box_expression_enclosure(
@@ -265,7 +254,7 @@ def _box_expression_enclosure(
         request.expression, _rational_box_bounds(request.box)
     )
     if isinstance(preflight, IntervalExpressionDomainFailure):
-        return _constructed_box_result(
+        return IntervalExpressionBoxEnclosureResult._from_kernel(
             request,
             status="DOMAIN_UNPROVEN",
             domain_failure=preflight,
@@ -287,7 +276,7 @@ def _box_expression_enclosure(
             }
             result = _evaluate_box_expression(request.expression, variables)
             if isinstance(result, IntervalExpressionDomainFailure):
-                return _constructed_box_result(
+                return IntervalExpressionBoxEnclosureResult._from_kernel(
                     request,
                     status="DOMAIN_UNPROVEN",
                     domain_failure=result,
@@ -297,7 +286,7 @@ def _box_expression_enclosure(
                     ),
                 )
             if isinstance(result, _BoxEvaluationFailure) or not result.is_finite():
-                return _constructed_box_result(
+                return IntervalExpressionBoxEnclosureResult._from_kernel(
                     request,
                     status="BACKEND_ERROR",
                     detail=(
@@ -311,7 +300,7 @@ def _box_expression_enclosure(
                 lower_mantissa, lower_exponent, upper_mantissa, upper_exponent
             )
     except (OverflowError, ValueError):
-        return _constructed_box_result(
+        return IntervalExpressionBoxEnclosureResult._from_kernel(
             request,
             status="BACKEND_ERROR",
             detail=(
@@ -321,7 +310,7 @@ def _box_expression_enclosure(
         )
 
     if endpoints is None:
-        return _constructed_box_result(
+        return IntervalExpressionBoxEnclosureResult._from_kernel(
             request,
             status="BACKEND_ERROR",
             detail=(
@@ -329,7 +318,7 @@ def _box_expression_enclosure(
                 "envelope; no enclosure conclusion is available."
             ),
         )
-    return _constructed_box_result(
+    return IntervalExpressionBoxEnclosureResult._from_kernel(
         request,
         status="ENCLOSED",
         lower=endpoints[0],

--- a/src/jacobian/math/analysis/_operations.py
+++ b/src/jacobian/math/analysis/_operations.py
@@ -32,7 +32,6 @@ from jacobian.math.analysis._second_jet import (
     HessianEntryEnclosure,
     IntervalExpressionSecondJetEnclosureRequest,
     IntervalExpressionSecondJetEnclosureResult,
-    IntervalExpressionSecondJetEnclosureStatus,
     _preflight_second_jet_expression,
 )
 
@@ -380,30 +379,6 @@ def _dyadic_closed_interval(value: Any) -> DyadicClosedInterval | None:
     return DyadicClosedInterval(lower=endpoints[0], upper=endpoints[1])
 
 
-def _constructed_second_jet_result(
-    request: IntervalExpressionSecondJetEnclosureRequest,
-    *,
-    status: IntervalExpressionSecondJetEnclosureStatus,
-    detail: str,
-    value: DyadicClosedInterval | None = None,
-    gradient: tuple[FirstPartialEnclosure, ...] = (),
-    hessian: tuple[HessianEntryEnclosure, ...] = (),
-    domain_failure: IntervalExpressionDomainFailure | None = None,
-) -> IntervalExpressionSecondJetEnclosureResult:
-    return IntervalExpressionSecondJetEnclosureResult.model_construct(
-        expression=request.expression,
-        box=request.box,
-        precision_bits=request.precision_bits,
-        status=status,
-        value=value,
-        gradient=gradient,
-        hessian=hessian,
-        domain_failure=domain_failure,
-        method="ARB_FORWARD_SECOND_ORDER_JET",
-        detail=detail,
-    )
-
-
 def _second_jet_enclosure(
     request: IntervalExpressionSecondJetEnclosureRequest,
 ) -> IntervalExpressionSecondJetEnclosureResult:
@@ -411,7 +386,7 @@ def _second_jet_enclosure(
         request.expression, _rational_box_bounds(request.box)
     )
     if isinstance(preflight, IntervalExpressionDomainFailure):
-        return _constructed_second_jet_result(
+        return IntervalExpressionSecondJetEnclosureResult._from_kernel(
             request,
             status="DOMAIN_UNPROVEN",
             domain_failure=preflight,
@@ -435,7 +410,7 @@ def _second_jet_enclosure(
                 request.expression, variables, len(request.box.variables)
             )
             if isinstance(jet, _SecondJetEvaluationFailure):
-                return _constructed_second_jet_result(
+                return IntervalExpressionSecondJetEnclosureResult._from_kernel(
                     request,
                     status="BACKEND_ERROR",
                     detail=(
@@ -452,7 +427,7 @@ def _second_jet_enclosure(
                 for row in jet.hessian
             )
     except (OverflowError, ValueError, ZeroDivisionError):
-        return _constructed_second_jet_result(
+        return IntervalExpressionSecondJetEnclosureResult._from_kernel(
             request,
             status="BACKEND_ERROR",
             detail=(
@@ -466,7 +441,7 @@ def _second_jet_enclosure(
         or any(entry is None for entry in gradient_intervals)
         or any(entry is None for row in hessian_intervals for entry in row)
     ):
-        return _constructed_second_jet_result(
+        return IntervalExpressionSecondJetEnclosureResult._from_kernel(
             request,
             status="BACKEND_ERROR",
             detail=(
@@ -496,7 +471,7 @@ def _second_jet_enclosure(
                     enclosure=enclosure,
                 )
             )
-    return _constructed_second_jet_result(
+    return IntervalExpressionSecondJetEnclosureResult._from_kernel(
         request,
         status="ENCLOSED",
         value=value,
@@ -556,8 +531,8 @@ POINT_ENCLOSURE_OPERATIONS = (
         description=(
             "Independently check one claimed exact-dyadic enclosure of LOG or "
             "SQRT at an exact rational point. The result is ACCEPTED, REJECTED, "
-            "or NON_RESULT and retains the complete claim for deterministic "
-            "replay; LOG replay is capped at 128 exact series terms."
+            "or NON_RESULT and retains the complete claim. LOG verification is "
+            "capped at 128 exact series terms."
         ),
         request_type=PointEnclosureCheckRequest,
         result_type=PointEnclosureCheckResult,

--- a/src/jacobian/math/analysis/_point_enclosure.py
+++ b/src/jacobian/math/analysis/_point_enclosure.py
@@ -20,7 +20,6 @@ from jacobian.math.analysis._models import (
 MAX_POINT_CHECK_DYADIC_EXPONENT = 8_192
 MAX_POINT_CHECK_LOG_TERMS = 128
 MAX_POINT_CHECK_FRACTION_BITS = 131_072
-MAX_POINT_CHECK_FRACTION_UPDATES = 4 * MAX_POINT_CHECK_LOG_TERMS
 MAX_POINT_CHECK_OUTPUT_BYTES = 4_096
 
 
@@ -70,7 +69,7 @@ class ClaimedPointEnclosure(StrictModel):
         le=4096,
         description=(
             "Precision metadata retained from the source computation; it does "
-            "not promise that an independent replay resolves the claim at "
+            "not promise that an independent verification resolves the claim at "
             "that precision."
         ),
     )
@@ -120,7 +119,7 @@ def _preflight_point_check_source(data: object) -> object:
 
 
 def _point_check_fraction_bound_bits(argument: CanonicalRational) -> int:
-    """Bound LOG/SQRT intermediates, including claim comparisons and replay."""
+    """Bound LOG/SQRT intermediates, including claim comparisons and verification."""
 
     numerator, denominator = argument.as_integer_ratio()
     source_bits = max(abs(numerator).bit_length(), denominator.bit_length())
@@ -146,13 +145,13 @@ def _point_check_fraction_bound_bits(argument: CanonicalRational) -> int:
 
 
 class PointEnclosureCheckRequest(StrictModel):
-    """Check one claimed LOG or SQRT enclosure by exact independent replay.
+    """Check one claimed LOG or SQRT enclosure by exact independent verification.
 
     The claimed enclosure is one canonical ``ClaimedPointEnclosure`` accepted
     unchanged from its source. Rational components have at most 128 decimal
     digits. Claimed dyadic exponents must lie in -8192..8192; reversed or
     mathematically invalid intervals remain valid claims and produce typed
-    checker outcomes. Only LOG and SQRT claims are admitted. LOG replay uses
+    checker outcomes. Only LOG and SQRT claims are admitted. LOG verification uses
     at most 128 terms per series, about 400 worst-case bits after range
     reduction, so tighter claims can produce NON_RESULT even when their
     retained precision metadata is larger.
@@ -163,9 +162,6 @@ class PointEnclosureCheckRequest(StrictModel):
             "point_check_log_term_bound": MAX_POINT_CHECK_LOG_TERMS,
             "point_check_fraction_intermediate_bit_bound": (
                 MAX_POINT_CHECK_FRACTION_BITS
-            ),
-            "point_check_producer_replay_term_update_bound": (
-                MAX_POINT_CHECK_FRACTION_UPDATES
             ),
             "point_check_output_byte_bound": MAX_POINT_CHECK_OUTPUT_BYTES,
         }
@@ -190,7 +186,7 @@ class PointEnclosureCheckRequest(StrictModel):
             RealUnaryFunction.SQRT,
         ):
             raise _validation_error(
-                "point-enclosure checker replays only LOG and SQRT claims"
+                "point-enclosure checker verifies only LOG and SQRT claims"
             )
         if any(
             abs(endpoint.exponent) > MAX_POINT_CHECK_DYADIC_EXPONENT
@@ -212,7 +208,7 @@ class PointEnclosureCheckRequest(StrictModel):
 
 
 class PointEnclosureCheckResult(StrictModel):
-    """A source-bound checker outcome replayed during result validation.
+    """A source-bound outcome from the owner-private checker.
 
     ACCEPTED means the independently proved interval is contained in the
     claim. REJECTED covers an invalid real-domain or reversed claim, or a claim
@@ -240,18 +236,15 @@ class PointEnclosureCheckResult(StrictModel):
     def preflight_raw_source(cls, data: object) -> object:
         return _preflight_point_check_source(canonicalize_json_containers(data))
 
-    @model_validator(mode="after")
-    def replay_outcome(self) -> Self:
-        from jacobian.math.analysis._point_enclosure_check import (
-            point_enclosure_check_outcome,
-        )
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PointEnclosureCheckRequest,
+        outcome: PointEnclosureCheckOutcome,
+    ) -> Self:
+        """Build an outcome after the admitted checker established it."""
 
-        request = PointEnclosureCheckRequest(enclosure=self.enclosure)
-        if self.outcome != point_enclosure_check_outcome(request):
-            raise _validation_error(
-                "outcome must equal the deterministic enclosure check for the retained source"
-            )
-        return self
+        return cls.model_construct(enclosure=request.enclosure, outcome=outcome)
 
 
 class ArbPointEnclosureResult(ArbPointEnclosureRequest):
@@ -355,22 +348,18 @@ def _point_enclosure(request: ArbPointEnclosureRequest) -> ArbPointEnclosureResu
 def _check_point_enclosure(
     request: PointEnclosureCheckRequest,
 ) -> PointEnclosureCheckResult:
-    """Replay one point-enclosure claim in its owning family."""
+    """Verify one point-enclosure claim in its owning family."""
 
-    from jacobian.math.analysis._point_enclosure_check import (
-        point_enclosure_check_outcome,
-    )
+    from jacobian.math.analysis._point_enclosure_check import _verify_point_enclosure
 
-    return PointEnclosureCheckResult(
-        enclosure=request.enclosure,
-        outcome=point_enclosure_check_outcome(request),
+    return PointEnclosureCheckResult._from_kernel(
+        request, _verify_point_enclosure(request)
     )
 
 
 __all__ = [
     "MAX_POINT_CHECK_DYADIC_EXPONENT",
     "MAX_POINT_CHECK_FRACTION_BITS",
-    "MAX_POINT_CHECK_FRACTION_UPDATES",
     "MAX_POINT_CHECK_LOG_TERMS",
     "MAX_POINT_CHECK_OUTPUT_BYTES",
     "ArbPointEnclosureRequest",

--- a/src/jacobian/math/analysis/_point_enclosure_check.py
+++ b/src/jacobian/math/analysis/_point_enclosure_check.py
@@ -136,10 +136,10 @@ def _log_outcome(
     return "NON_RESULT"
 
 
-def point_enclosure_check_outcome(
+def _verify_point_enclosure(
     request: PointEnclosureCheckRequest,
 ) -> PointEnclosureCheckOutcome:
-    """Replay one structurally admitted enclosure claim deterministically."""
+    """Verify one request-admitted enclosure claim deterministically."""
 
     enclosure = request.enclosure
     if enclosure.lower.compare(enclosure.upper) > 0:
@@ -151,6 +151,3 @@ def point_enclosure_check_outcome(
     if enclosure.function is RealUnaryFunction.SQRT:
         return _sqrt_outcome(argument, claimed_lower, claimed_upper)
     return _log_outcome(argument, claimed_lower, claimed_upper)
-
-
-__all__ = ["point_enclosure_check_outcome"]

--- a/src/jacobian/math/analysis/_second_jet.py
+++ b/src/jacobian/math/analysis/_second_jet.py
@@ -139,12 +139,9 @@ class IntervalExpressionSecondJetEnclosureResult(
 ):
     """A source-bound rigorous value, gradient, and symmetric Hessian enclosure.
 
-    For ``ENCLOSED``, full validation recomputes the canonical jet claim from
-    its expression, axis, and source box.  ``DOMAIN_UNPROVEN`` replays its
-    deterministic first-obstruction evidence.  ``BACKEND_ERROR`` asserts no
-    enclosure conclusion at all, so it is validated structurally: rerunning
-    Arb would reject the operation's own serialized result whenever a
-    transient backend condition does not recur.
+    The producer establishes the enclosure claim. Parsing validates only
+    structural and canonical invariants, including the source axis and the
+    canonical upper-triangular Hessian layout.
     """
 
     status: IntervalExpressionSecondJetEnclosureStatus
@@ -227,18 +224,34 @@ class IntervalExpressionSecondJetEnclosureResult(
             if self.status == "BACKEND_ERROR":
                 return self
 
-        from jacobian.math.analysis._operations import _second_jet_enclosure
-
-        request = IntervalExpressionSecondJetEnclosureRequest.model_construct(
-            expression=self.expression,
-            box=self.box,
-            precision_bits=self.precision_bits,
-        )
-        if self != _second_jet_enclosure(request):
-            raise _validation_error(
-                "second-jet enclosure does not replay from its expression, axis, and source box"
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: IntervalExpressionSecondJetEnclosureRequest,
+        *,
+        status: IntervalExpressionSecondJetEnclosureStatus,
+        detail: str,
+        value: DyadicClosedInterval | None = None,
+        gradient: tuple[FirstPartialEnclosure, ...] = (),
+        hessian: tuple[HessianEntryEnclosure, ...] = (),
+        domain_failure: IntervalExpressionDomainFailure | None = None,
+    ) -> Self:
+        """Build a result after the admitted kernel established its claim."""
+
+        return cls.model_construct(
+            expression=request.expression,
+            box=request.box,
+            precision_bits=request.precision_bits,
+            status=status,
+            value=value,
+            gradient=gradient,
+            hessian=hessian,
+            domain_failure=domain_failure,
+            method="ARB_FORWARD_SECOND_ORDER_JET",
+            detail=detail,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/arithmetic_dynamics/_models.py
+++ b/src/jacobian/math/arithmetic_dynamics/_models.py
@@ -571,8 +571,13 @@ class FiniteFieldMapResult(StrictModel):
 
     @model_validator(mode="after")
     def require_structural_consistency(self) -> Self:
-        for value in self.coefficients:
-            _parse_canonical_integer(value)
+        if not _is_prime(self.prime):
+            raise _validation_error("prime must be a prime number")
+        values = tuple(_parse_canonical_integer(value) for value in self.coefficients)
+        if len(values) > 1 and values[-1] % self.prime == 0:
+            raise _validation_error(
+                "coefficients must omit trailing zeros modulo the prime"
+            )
         self._require_complete_edges()
         cycle_set = self._require_canonical_cycles()
         self._require_tail_evidence(cycle_set)

--- a/src/jacobian/math/arithmetic_dynamics/_models.py
+++ b/src/jacobian/math/arithmetic_dynamics/_models.py
@@ -521,15 +521,11 @@ class CycleMultiplierResult(StrictModel):
     complete: Literal[True] = True
 
     @model_validator(mode="after")
-    def bind_period_and_multiplier(self) -> Self:
-        source = parse_polynomial_coefficients(self.source_coefficients)
-        points = tuple(value.as_fraction() for value in self.cycle)
-        if len(set(points)) != len(points) or any(
-            _evaluate(source, point) != points[(index + 1) % len(points)]
-            for index, point in enumerate(points)
-        ):
-            raise _validation_error(
-                "cycle must be a distinct ordered cycle of the bound map"
+    def require_structural_consistency(self) -> Self:
+        parse_polynomial_coefficients(self.source_coefficients)
+        for value in self.cycle:
+            _bounded_fraction(
+                value, max_digits=MAX_COEFFICIENT_DIGITS, label="cycle point"
             )
         if self.period != len(self.cycle):
             raise _validation_error("period must match cycle length")
@@ -539,6 +535,27 @@ class CycleMultiplierResult(StrictModel):
             label="multiplier",
         )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: CycleMultiplierRequest,
+        *,
+        multiplier: CanonicalRational,
+    ) -> Self:
+        """Build a result after the admitted cycle-multiplier kernel ran."""
+
+        require_bounded_rational(
+            multiplier,
+            max_digits=MAX_POLYNOMIAL_OUTPUT_DIGITS,
+            label="multiplier",
+        )
+        return cls(
+            source_coefficients=request.coefficients,
+            multiplier=multiplier,
+            cycle=request.cycle,
+            period=len(request.cycle),
+        )
 
 
 class FiniteFieldMapResult(StrictModel):
@@ -553,27 +570,32 @@ class FiniteFieldMapResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def bind_complete_graph(self) -> Self:
-        if not _is_prime(self.prime):
-            raise _validation_error("prime must be a prime number")
-        coefficients = tuple(
-            _parse_canonical_integer(value) for value in self.coefficients
-        )
-        if len(coefficients) > 1 and coefficients[-1] % self.prime == 0:
-            raise _validation_error(
-                "coefficients must omit trailing zeros modulo the prime"
-            )
+    def require_structural_consistency(self) -> Self:
+        for value in self.coefficients:
+            _parse_canonical_integer(value)
         self._require_complete_edges()
-        if any(
-            target != _evaluate_mod_prime(coefficients, source, self.prime)
-            for source, target in self.edges
-        ):
-            raise _validation_error(
-                "functional graph edges must evaluate the bound polynomial"
-            )
         cycle_set = self._require_canonical_cycles()
         self._require_tail_evidence(cycle_set)
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: FiniteFieldMapRequest,
+        *,
+        edges: tuple[tuple[int, int], ...],
+        cycles: tuple[tuple[int, ...], ...],
+        tail_lengths: tuple[int, ...],
+    ) -> Self:
+        """Build a result after complete graph enumeration established it."""
+
+        return cls(
+            prime=request.prime,
+            coefficients=request.coefficients,
+            edges=edges,
+            cycles=cycles,
+            tail_lengths=tail_lengths,
+        )
 
     def _require_complete_edges(self) -> None:
         if len(self.edges) != self.prime or len(self.tail_lengths) != self.prime:

--- a/src/jacobian/math/arithmetic_dynamics/_operations.py
+++ b/src/jacobian/math/arithmetic_dynamics/_operations.py
@@ -97,13 +97,11 @@ def compute_cycle_multiplier(
     request: CycleMultiplierRequest,
 ) -> CycleMultiplierResult:
     points = tuple(value.as_fraction() for value in request.cycle)
-    return CycleMultiplierResult(
-        source_coefficients=request.coefficients,
+    return CycleMultiplierResult._from_kernel(
+        request,
         multiplier=CanonicalRational.from_fraction(
             cycle_multiplier(_polynomial(request), points)
         ),
-        cycle=request.cycle,
-        period=len(points),
     )
 
 
@@ -112,12 +110,49 @@ def compute_finite_field_map(request: FiniteFieldMapRequest) -> FiniteFieldMapRe
         tuple(int(value) for value in request.coefficients),
         request.prime,
     )
-    return FiniteFieldMapResult(
-        prime=request.prime,
-        coefficients=request.coefficients,
+    return FiniteFieldMapResult._from_kernel(
+        request,
         edges=graph.edges,
         cycles=graph.cycles,
         tail_lengths=graph.tail_lengths,
+    )
+
+
+def verify_cycle_multiplier_result(result: CycleMultiplierResult) -> bool:
+    """Check an independently supplied cycle-multiplier claim."""
+
+    try:
+        request = CycleMultiplierRequest(
+            coefficients=result.source_coefficients,
+            cycle=result.cycle,
+        )
+    except ValueError:
+        return False
+    expected = CanonicalRational.from_fraction(
+        cycle_multiplier(
+            _polynomial(request), tuple(value.as_fraction() for value in request.cycle)
+        )
+    )
+    return result.period == len(request.cycle) and result.multiplier == expected
+
+
+def verify_finite_field_map_result(result: FiniteFieldMapResult) -> bool:
+    """Check an independently supplied complete finite-field graph claim."""
+
+    try:
+        request = FiniteFieldMapRequest(
+            prime=result.prime,
+            coefficients=result.coefficients,
+        )
+    except ValueError:
+        return False
+    expected = finite_field_functional_graph(
+        tuple(int(value) for value in request.coefficients), request.prime
+    )
+    return (
+        result.edges == expected.edges
+        and result.cycles == expected.cycles
+        and result.tail_lengths == expected.tail_lengths
     )
 
 

--- a/src/jacobian/math/cluster_algebras/_operations.py
+++ b/src/jacobian/math/cluster_algebras/_operations.py
@@ -17,8 +17,8 @@ from jacobian.math.cluster_algebras._models import (
 def _mutation_of(matrix: ExchangeMatrix, k: int) -> ExchangeMatrix:
     """Pure Fomin-Zelevinsky mutation mu_k of one exchange matrix.
 
-    Kept free of result-model construction so result validation can replay
-    the mutation without recursion.
+    Kept free of result-model construction so it remains a reusable mutation
+    kernel.
     """
     n = matrix.n
     old = [list(row) for row in parsed_entries(matrix)]

--- a/src/jacobian/math/coalgebras/_models.py
+++ b/src/jacobian/math/coalgebras/_models.py
@@ -30,11 +30,9 @@ MAX_PRIME_DIGITS = 64
 #:   group_like_scan_work = prime**dimension * (dimension + 1)
 #:       + prime**(dimension-1) * (dimension**3 + 2*dimension**2)
 #:
-#: bind_group_like_to_source replays the identical scan, so one full call
-#: performs at most twice this bound. Measured throughput exceeds 50M
-#: summands/s in the dense regime and 5M units/s in the loop-overhead
-#: dominated one-dimensional regime, keeping an admitted call well under
-#: two seconds.
+#: Measured throughput exceeds 50M summands/s in the dense regime and 5M
+#: units/s in the loop-overhead dominated one-dimensional regime, keeping an
+#: admitted call well under two seconds.
 GROUP_LIKE_SCAN_WORK_BUDGET = 2_000_000
 
 #: Maximum number of structure-constant entries in an admitted comultiplication
@@ -47,7 +45,7 @@ GROUP_LIKE_SCAN_WORK_BUDGET = 2_000_000
 #:     the MAX_PRIME_DIGITS-bounded characteristic;
 #:   - group-like scans remain separately bounded by GROUP_LIKE_SCAN_WORK_BUDGET
 #:     derived work units covering candidates x per-candidate reconstruction
-#:     plus the replay in bind_group_like_to_source.
+#:     for the exhaustive producer scan.
 #: For example the 9-dimensional GF(2) direct-sum coalgebra needs 729 entries
 #: and roughly 2*10**5 scan-work units, well inside both budgets.
 MAX_TENSOR_ENTRIES = 4096
@@ -388,9 +386,7 @@ class GroupLikeElementsRequest(StrictModel):
     The operation enumerates every element of GF(p)^dimension and
     reconstructs each candidate that survives the counit filter, so
     requests are admitted only when group_like_scan_work(prime,
-    dimension) is within the documented scan budget; the retained result
-    replays the same scan, so one full call performs at most twice that
-    work.
+    dimension) is within the documented scan budget.
     """
 
     coalgebra: Coalgebra

--- a/src/jacobian/math/coalgebras/_operations.py
+++ b/src/jacobian/math/coalgebras/_operations.py
@@ -58,8 +58,8 @@ def _group_like_coefficients(
     Delta(g) = g (x) g modulo p. The request model bounds the derived scan
     work -- candidates times per-candidate reconstruction -- within the
     documented budget, so this scan is exhaustive and deterministic; the
-    result validator replays the identical enumeration. Delta(g) = g (x) g
-    is decided row by row so a mismatching row skips the remaining rows.
+    Delta(g) = g (x) g is decided row by row so a mismatching row skips the
+    remaining rows.
     """
     n = ca.dimension
     p = ca.prime
@@ -118,7 +118,7 @@ def find_group_like_elements(
     )
 
 
-def verify_comultiplication_result(result: ComultiplicationResult) -> bool:
+def _verify_comultiplication_result(result: ComultiplicationResult) -> bool:
     """Verify an independently supplied comultiplication claim."""
     coalgebra = result.coalgebra
     expected = tuple(
@@ -132,7 +132,7 @@ def verify_comultiplication_result(result: ComultiplicationResult) -> bool:
     return result.matrix.entries == expected
 
 
-def verify_counit_result(result: CounitResult) -> bool:
+def _verify_counit_result(result: CounitResult) -> bool:
     """Verify an independently supplied counit claim."""
     return (
         result.value
@@ -140,7 +140,7 @@ def verify_counit_result(result: CounitResult) -> bool:
     )
 
 
-def verify_group_like_elements_result(result: GroupLikeElementsResult) -> bool:
+def _verify_group_like_elements_result(result: GroupLikeElementsResult) -> bool:
     """Verify one exhaustive group-like claim within its admitted scan envelope."""
     from jacobian.math.coalgebras._models import (
         GROUP_LIKE_SCAN_WORK_BUDGET,
@@ -161,7 +161,4 @@ __all__ = [
     "compute_comultiplication",
     "compute_counit",
     "find_group_like_elements",
-    "verify_comultiplication_result",
-    "verify_counit_result",
-    "verify_group_like_elements_result",
 ]

--- a/src/jacobian/math/code_nonlinear/_budget.py
+++ b/src/jacobian/math/code_nonlinear/_budget.py
@@ -10,19 +10,18 @@ from jacobian.math.code_nonlinear.values import (
     ExplicitBinaryCode,
 )
 
-# A normal operation invocation visits every unordered pair once in the kernel
-# and once more when result construction replays the source-bound conclusion.
+# A normal operation invocation visits every unordered pair once in the kernel.
 # The standard A(23,6,10) construction has length 23, minimum distance 6,
-# constant weight 10, and 2992 words, so it uses ``2 * 4,474,536``
+# constant weight 10, and 2992 words, so it uses ``4,474,536``
 # pair-by-chunk units.
 MAX_PROFILE_PAIRS = 5_000_000
-PROFILE_PAIR_PASSES = 2
+PROFILE_PAIR_PASSES = 1
 MAX_PROFILE_BITSET_CHUNK_WORK = 10_000_000
 BITSET_CHUNK_BITS = 30
 
 # Retained sources, dense histograms, and the two compact witnesses must fit
 # below the canonical transport's 10 MiB ceiling.  Four MiB leaves room for
-# the operation envelope and is checked from the source before pair replay.
+# the operation envelope and is checked from the source before the pair scan.
 MAX_CODE_RESULT_BYTES = 4 * 1024 * 1024
 
 # Enumerating every ``length``-bit word of weight ``w`` visits exactly
@@ -149,7 +148,7 @@ def require_profile_admission(code: ExplicitBinaryCode) -> ProfileAdmission:
 
 
 def require_pair_work_admission(code: ExplicitBinaryCode) -> tuple[int, int, int]:
-    """Admit the kernel and source-replay passes before allocating the result."""
+    """Admit the kernel pair scan before allocating the result."""
     cardinality = len(code.codewords)
     pair_count = cardinality * (cardinality - 1) // 2
     if pair_count > MAX_PROFILE_PAIRS:
@@ -164,7 +163,7 @@ def require_pair_work_admission(code: ExplicitBinaryCode) -> tuple[int, int, int
             "explicit profile requires "
             f"{bitset_chunk_work} pair-by-bitset-chunk units "
             f"({pair_count} pairs * {bitset_chunks} chunks * "
-            f"{PROFILE_PAIR_PASSES} kernel/replay passes), exceeding the "
+            f"{PROFILE_PAIR_PASSES} kernel pass), exceeding the "
             f"{MAX_PROFILE_BITSET_CHUNK_WORK}-unit bound"
         )
     return pair_count, bitset_chunks, bitset_chunk_work

--- a/src/jacobian/math/code_nonlinear/_models.py
+++ b/src/jacobian/math/code_nonlinear/_models.py
@@ -88,9 +88,9 @@ class ConstantWeightRequest(StrictModel):
 class ConstantWeightResult(StrictModel):
     """Complete generated constant-weight code.
 
-    Construction checks the declared structural envelope only.  The owner
-    kernel uses ``_from_kernel``; ``verify_constant_weight_result`` is the
-    explicit bounded check for a claim supplied independently of that kernel.
+    Construction checks the declared structural envelope only. The owner
+    kernel uses ``_from_kernel``; an explicit owner-local verifier checks a
+    claim supplied independently of that kernel.
     """
 
     length: Annotated[int, Field(strict=True, ge=0, le=MAX_EXPLICIT_CODE_LENGTH)]
@@ -100,10 +100,6 @@ class ConstantWeightResult(StrictModel):
 
     @model_validator(mode="after")
     def require_structural_envelope(self) -> Self:
-        _require_admission(
-            lambda: require_constant_weight_admission(self.length, self.weight),
-            "nonlinear_code.admission_bound",
-        )
         if self.code.length != self.length:
             raise _validation_error(
                 "nonlinear_code.length_mismatch",
@@ -120,7 +116,9 @@ class ConstantWeightResult(StrictModel):
     def _from_kernel(
         cls, *, length: int, weight: int, code: ExplicitBinaryCode
     ) -> Self:
-        return cls(length=length, weight=weight, code=code, count=len(code.codewords))
+        return cls.model_construct(
+            length=length, weight=weight, code=code, count=len(code.codewords)
+        )
 
 
 class WordDistanceRequest(StrictModel):
@@ -172,10 +170,6 @@ class WordDistanceResult(StrictModel):
                 "nonlinear_code.invalid_words",
                 "result words must be nonempty and have equal length",
             )
-        _require_admission(
-            lambda: require_word_distance_output_bound(self.word1, self.word2),
-            "nonlinear_code.admission_bound",
-        )
         if self.distance > len(self.word1):
             raise _validation_error(
                 "nonlinear_code.distance_bound",
@@ -195,7 +189,7 @@ class WordDistanceResult(StrictModel):
         weight2: int,
         support_intersection: int,
     ) -> Self:
-        return cls(
+        return cls.model_construct(
             word1=word1,
             word2=word2,
             distance=distance,
@@ -243,7 +237,7 @@ class ExplicitProfileRequest(StrictModel):
 
 
 class ExplicitProfileResult(StrictModel):
-    """Complete pair and weight profile, replayable from its retained source."""
+    """Complete pair and weight profile bound to its retained source."""
 
     source: ExplicitBinaryCode
     length: ExplicitLength
@@ -262,10 +256,6 @@ class ExplicitProfileResult(StrictModel):
 
     @model_validator(mode="after")
     def require_structural_profile_relations(self) -> Self:
-        plan = _require_admission(
-            lambda: require_profile_admission(self.source),
-            "nonlinear_code.admission_bound",
-        )
         if self.length != self.source.length:
             raise _validation_error(
                 "nonlinear_code.length_mismatch",
@@ -276,7 +266,7 @@ class ExplicitProfileResult(StrictModel):
                 "nonlinear_code.cardinality_mismatch",
                 "cardinality must equal the retained source cardinality",
             )
-        if self.pair_count != plan.pair_count:
+        if self.pair_count != self.cardinality * (self.cardinality - 1) // 2:
             raise _validation_error(
                 "nonlinear_code.pair_count_mismatch",
                 "pair_count must equal cardinality*(cardinality-1)/2",
@@ -310,7 +300,7 @@ class ExplicitProfileResult(StrictModel):
 
     @classmethod
     def _from_kernel(cls, **kwargs: Any) -> Self:
-        return cls(**kwargs)
+        return cls.model_construct(**kwargs)
 
 
 class ConstantWeightProfileRequest(StrictModel):
@@ -355,27 +345,17 @@ class ConstantWeightProfileResult(StrictModel):
 
     @model_validator(mode="after")
     def require_structural_profile_relations(self) -> Self:
-        weight = _require_constant_weight(self.source)
-        plan = _require_admission(
-            lambda: require_profile_admission(self.source),
-            "nonlinear_code.admission_bound",
-        )
         if self.length != self.source.length:
             raise _validation_error(
                 "nonlinear_code.length_mismatch",
                 "length must equal the retained source length",
-            )
-        if self.weight != weight:
-            raise _validation_error(
-                "nonlinear_code.weight_mismatch",
-                "weight must equal every retained source word weight",
             )
         if self.cardinality != len(self.source.codewords):
             raise _validation_error(
                 "nonlinear_code.cardinality_mismatch",
                 "cardinality must equal the retained source cardinality",
             )
-        if self.pair_count != plan.pair_count:
+        if self.pair_count != self.cardinality * (self.cardinality - 1) // 2:
             raise _validation_error(
                 "nonlinear_code.pair_count_mismatch",
                 "pair_count must equal cardinality*(cardinality-1)/2",
@@ -407,7 +387,7 @@ class ConstantWeightProfileResult(StrictModel):
 
     @classmethod
     def _from_kernel(cls, **kwargs: Any) -> Self:
-        return cls(**kwargs)
+        return cls.model_construct(**kwargs)
 
 
 class ToSetSystemRequest(StrictModel):
@@ -459,7 +439,7 @@ class ToSetSystemResult(StrictModel):
 
     @classmethod
     def _from_kernel(cls, **kwargs: Any) -> Self:
-        return cls(**kwargs)
+        return cls.model_construct(**kwargs)
 
 
 __all__ = [

--- a/src/jacobian/math/code_nonlinear/_operations.py
+++ b/src/jacobian/math/code_nonlinear/_operations.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from itertools import combinations
 
+from pydantic import ValidationError
+
 from jacobian.math.code_nonlinear._budget import require_profile_admission
 from jacobian.math.code_nonlinear._models import (
     BinaryCodeDistanceWitness,
@@ -18,7 +20,6 @@ from jacobian.math.code_nonlinear._models import (
     ToSetSystemResult,
     WordDistanceRequest,
     WordDistanceResult,
-    _require_constant_weight,
 )
 from jacobian.math.code_nonlinear.values import BinaryWord, ExplicitBinaryCode
 
@@ -278,16 +279,24 @@ def to_set_system(code: ExplicitBinaryCode) -> ToSetSystemResult:
     )
 
 
-def verify_constant_weight_result(result: ConstantWeightResult) -> bool:
+def _verify_constant_weight_result(result: ConstantWeightResult) -> bool:
     """Verify an independently supplied generated-code claim."""
 
+    try:
+        ConstantWeightRequest(length=result.length, weight=result.weight)
+    except ValidationError:
+        return False
     expected = _constant_weight_code(result.length, result.weight)
     return result.code == expected and result.count == len(expected.codewords)
 
 
-def verify_word_distance_result(result: WordDistanceResult) -> bool:
+def _verify_word_distance_result(result: WordDistanceResult) -> bool:
     """Verify an independently supplied exact Hamming-relation claim."""
 
+    try:
+        WordDistanceRequest(word1=result.word1, word2=result.word2)
+    except ValidationError:
+        return False
     expected = _word_distance_data(result.word1, result.word2)
     return (
         result.distance,
@@ -327,9 +336,13 @@ def _verify_extremal_witness(
     )
 
 
-def verify_explicit_profile_result(result: ExplicitProfileResult) -> bool:
+def _verify_explicit_profile_result(result: ExplicitProfileResult) -> bool:
     """Replay an independently supplied profile inside its admitted envelope."""
 
+    try:
+        ExplicitProfileRequest(code=result.source)
+    except ValidationError:
+        return False
     expected = _explicit_profile_data(result.source)
     return (
         result.weight_distribution == expected.weight_distribution
@@ -345,10 +358,14 @@ def verify_explicit_profile_result(result: ExplicitProfileResult) -> bool:
     )
 
 
-def verify_constant_weight_profile_result(result: ConstantWeightProfileResult) -> bool:
+def _verify_constant_weight_profile_result(result: ConstantWeightProfileResult) -> bool:
     """Replay an independently supplied constant-weight profile claim."""
 
-    if _require_constant_weight(result.source) != result.weight:
+    try:
+        ConstantWeightProfileRequest(code=result.source)
+    except ValidationError:
+        return False
+    if result.weight != sum(result.source.codewords[0]):
         return False
     expected = _constant_weight_profile_data(result.source)
     return (
@@ -365,9 +382,13 @@ def verify_constant_weight_profile_result(result: ConstantWeightProfileResult) -
     )
 
 
-def verify_to_set_system_result(result: ToSetSystemResult) -> bool:
+def _verify_to_set_system_result(result: ToSetSystemResult) -> bool:
     """Verify an independently supplied source-indexed support claim."""
 
+    try:
+        ToSetSystemRequest(code=result.source)
+    except ValidationError:
+        return False
     return result.coordinate_axis == tuple(
         range(result.source.length)
     ) and result.supports == tuple(
@@ -383,9 +404,4 @@ __all__ = [
     "compute_to_set_system",
     "compute_word_distance",
     "to_set_system",
-    "verify_constant_weight_profile_result",
-    "verify_constant_weight_result",
-    "verify_explicit_profile_result",
-    "verify_to_set_system_result",
-    "verify_word_distance_result",
 ]

--- a/src/jacobian/math/combinatorics/exact_cover.py
+++ b/src/jacobian/math/combinatorics/exact_cover.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import unicodedata
+from builtins import ValueError as BuiltinValueError
 from typing import Literal, Self
 
 from pydantic import ConfigDict, Field, StrictInt, model_validator
@@ -32,12 +33,10 @@ MAX_EXACT_COVER_SECONDARY_ITEMS = MAX_EXACT_COVER_ITEMS
 MAX_EXACT_COVER_ROWS = 4_096
 MAX_EXACT_COVER_INCIDENCES = 65_536
 
-# NO_COVER is replayed by its result validator, so a negative public call makes
-# at most two passes. A million-node adversarial pass is too slow to repeat at
-# the public boundary; 100,000 nodes per pass is a measured conservative
-# execution fallback, independent of the broader 256-item representation bound.
+# A million-node adversarial pass is too slow to repeat at the public boundary;
+# 100,000 nodes per pass is a measured conservative execution fallback,
+# independent of the broader 256-item representation bound.
 MAX_EXACT_COVER_SEARCH_NODES_PER_PASS = 100_000
-MAX_EXACT_COVER_SEARCH_NODES = 2 * MAX_EXACT_COVER_SEARCH_NODES_PER_PASS
 
 ExactCoverSearchStatus = Literal["FOUND", "NO_COVER", "UNKNOWN"]
 
@@ -216,10 +215,8 @@ class GeneralizedExactCoverRequest(StrictModel):
                 "and each secondary item at most once. The bitset Algorithm X "
                 "search visits at most `search_node_limit` partial row families "
                 "per pass. It returns NO_COVER only after exhaustive search; a "
-                "node-limit stop returns UNKNOWN. An exact NO_COVER result is "
-                "replayed during validation, so total negative-case work is at "
-                f"most {MAX_EXACT_COVER_SEARCH_NODES} node visits. UNKNOWN is "
-                "a source-bound non-conclusion and is not replayed."
+                "node-limit stop returns UNKNOWN. UNKNOWN is a source-bound "
+                "non-conclusion rather than a proof of absence."
             )
         }
     )
@@ -305,10 +302,9 @@ class GeneralizedExactCoverResult(StrictModel):
                 "Source-bound generalized exact-cover result. FOUND carries a "
                 "canonical selected-row family and every declared item's "
                 "reconstructed multiplicity. NO_COVER is accepted only after "
-                "the retained instance replays to exhaustive failure. UNKNOWN "
-                "records only that this execution made no mathematical "
-                "conclusion within the retained node limit; it is intentionally "
-                "not tied to a private search-kernel revision."
+                "the producer has exhausted the admitted search. UNKNOWN records "
+                "only that this execution made no mathematical conclusion within "
+                "the retained node limit."
             )
         }
     )
@@ -333,40 +329,78 @@ class GeneralizedExactCoverResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def require_source_bound_result(self) -> Self:
-        _require_output_headroom(self.instance)
+    def require_result_shape(self) -> Self:
         if self.status == "FOUND":
             if self.selected_row_ids is None or self.item_multiplicities is None:
                 raise ValueError(
                     "a FOUND result must carry selected rows and item multiplicities"
-                )
-            expected = _expected_coverage(self.instance, self.selected_row_ids)
-            if self.item_multiplicities != expected:
-                raise ValueError(
-                    "item multiplicities must reconstruct the selected-row family"
                 )
             return self
 
         if self.selected_row_ids is not None or self.item_multiplicities is not None:
             raise ValueError("only a FOUND result may carry a selected-row family")
 
-        # UNKNOWN carries no mathematical claim. Replaying it would turn a
-        # private branching/kernel choice into durable public semantics and
-        # repeat bounded work merely to validate a non-conclusion.
-        if self.status == "UNKNOWN":
-            return self
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        instance: GeneralizedExactCoverInstance,
+        search_node_limit: int,
+        status: ExactCoverSearchStatus,
+        selected_row_ids: tuple[OpaqueLabel, ...] | None = None,
+        item_multiplicities: tuple[ExactCoverItemMultiplicity, ...] | None = None,
+    ) -> Self:
+        """Construct an admitted, kernel-established result without replay."""
+
+        return cls.model_construct(
+            instance=instance,
+            search_node_limit=search_node_limit,
+            status=status,
+            selected_row_ids=selected_row_ids,
+            item_multiplicities=item_multiplicities,
+        )
+
+
+def _verify_generalized_exact_cover_result(result: GeneralizedExactCoverResult) -> bool:
+    """Replay an independently supplied exact-cover claim in its envelope."""
+
+    try:
+        request = GeneralizedExactCoverRequest(
+            instance=result.instance, search_node_limit=result.search_node_limit
+        )
+        if result.status == "FOUND":
+            if result.selected_row_ids is None or result.item_multiplicities is None:
+                return False
+            if result.item_multiplicities != _expected_coverage(
+                request.instance, result.selected_row_ids
+            ):
+                return False
+        elif (
+            result.selected_row_ids is not None
+            or result.item_multiplicities is not None
+        ):
+            return False
 
         from jacobian.math.combinatorics._exact_cover_kernel import (
             search_generalized_exact_cover,
         )
 
-        replay = search_generalized_exact_cover(self.instance, self.search_node_limit)
-        if replay.status != "NO_COVER":
-            raise ValueError(
-                f"NO_COVER contradicts deterministic replay, which returned "
-                f"{replay.status}"
-            )
-        return self
+        replay = search_generalized_exact_cover(
+            request.instance, request.search_node_limit
+        )
+    except (BuiltinValueError, TypeError):
+        return False
+
+    if replay.status != result.status:
+        return False
+    if result.status != "FOUND":
+        return True
+    assert result.selected_row_ids is not None
+    return result.selected_row_ids == tuple(
+        sorted(request.instance.rows[index].row_id for index in replay.selected_rows)
+    )
 
 
 def _solve_generalized_exact_cover(
@@ -381,7 +415,7 @@ def _solve_generalized_exact_cover(
 
     search = search_generalized_exact_cover(instance, search_node_limit)
     if search.status != "FOUND":
-        return GeneralizedExactCoverResult(
+        return GeneralizedExactCoverResult._from_kernel(
             instance=instance,
             search_node_limit=search_node_limit,
             status=search.status,
@@ -390,7 +424,7 @@ def _solve_generalized_exact_cover(
     selected_row_ids = tuple(
         sorted(instance.rows[index].row_id for index in search.selected_rows)
     )
-    return GeneralizedExactCoverResult(
+    return GeneralizedExactCoverResult._from_kernel(
         instance=instance,
         search_node_limit=search_node_limit,
         status="FOUND",

--- a/src/jacobian/math/crossed_products/_models.py
+++ b/src/jacobian/math/crossed_products/_models.py
@@ -49,10 +49,6 @@ class CrossedProductMultiplyResult(StrictModel):
             raise _validation_error(
                 "presentation_mismatch", "product must retain the operand presentation"
             )
-        try:
-            require_multiplication_budget(self.left, self.right)
-        except ValueError as exc:
-            raise _validation_error("product_budget_exceeded", str(exc)) from exc
         return self
 
 

--- a/src/jacobian/math/crossed_products/_operations.py
+++ b/src/jacobian/math/crossed_products/_operations.py
@@ -1,5 +1,7 @@
 """Wire-facing finite-coset crossed-product operations."""
 
+from pydantic import ValidationError
+
 from jacobian.math.crossed_products._models import (
     CrossedProductMultiplyRequest,
     CrossedProductMultiplyResult,
@@ -20,10 +22,14 @@ def compute_product(
     )
 
 
-def verify_product_result(result: CrossedProductMultiplyResult) -> bool:
+def _verify_product_result(result: CrossedProductMultiplyResult) -> bool:
     """Verify an independently supplied product in the admitted envelope."""
 
+    try:
+        CrossedProductMultiplyRequest(left=result.left, right=result.right)
+    except ValidationError:
+        return False
     return result.product == multiply(result.left, result.right)
 
 
-__all__ = ["compute_product", "verify_product_result"]
+__all__ = ["compute_product"]

--- a/src/jacobian/math/crossed_products/_tools.py
+++ b/src/jacobian/math/crossed_products/_tools.py
@@ -30,7 +30,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
             "caller-supplied finite quotient table, left action Q -> GL_d(Z), and "
             "normalized cocycle. Validate all laws before applying "
             "(u,q)(v,r)=(u+rho(q)v+c(q,r),qr). Q<=16, d<=8, support pairs<=1024, "
-            "and scalar work<=80000; the source-bound result replays both operands. "
+            "and scalar work<=80000. "
             "This uses explicit normal forms, not a finitely presented group word "
             "problem or an invertibility decision."
         ),

--- a/src/jacobian/math/delta_matroids/_models.py
+++ b/src/jacobian/math/delta_matroids/_models.py
@@ -17,8 +17,6 @@ from jacobian.math.delta_matroids.values import (
     DeltaMatroidAdmissionError,
     DeltaMatroidObstruction,
     FiniteDeltaMatroid,
-    canonical_feasible_rows,
-    first_symmetric_exchange_obstruction,
     require_delta_matroid_admission,
 )
 from jacobian.math.greedoids.values import FiniteFeasibleSetSystem
@@ -87,52 +85,39 @@ class DeltaMatroidRecognitionResult(StrictModel):
     obstruction: DeltaMatroidObstruction | None = None
 
     @model_validator(mode="after")
-    def bind_result_to_complete_source_replay(self) -> Self:
-        try:
-            require_delta_matroid_admission(self.source)
-        except DeltaMatroidAdmissionError as exc:
-            raise _validation_error(exc.reason, str(exc)) from None
-        expected_obstruction = first_symmetric_exchange_obstruction(self.source)
-        if expected_obstruction is None:
-            if self.status != "DELTA_MATROID":
-                raise _validation_error(
-                    "status_mismatch",
-                    "a valid feasible family must return DELTA_MATROID",
-                )
-            if self.obstruction is not None:
-                raise _validation_error(
-                    "unexpected_obstruction",
-                    "a valid delta-matroid result has no obstruction",
-                )
-            # The declared delta_matroid already passed its own complete
-            # defining-invariant replay during field validation; binding only
-            # has to pin it to the retained source's canonical wire order.
-            if (
-                self.delta_matroid is None
-                or self.delta_matroid.ground != self.source.ground
-                or self.delta_matroid.feasible != canonical_feasible_rows(self.source)
-            ):
-                raise _validation_error(
-                    "canonical_replay_mismatch",
-                    "delta_matroid must equal the canonical replay of the retained source",
-                )
-            return self
-        if self.status != "NOT_A_DELTA_MATROID":
+    def require_branch_consistency(self) -> Self:
+        valid = (
+            self.status == "DELTA_MATROID"
+            and self.delta_matroid is not None
+            and self.obstruction is None
+        ) or (
+            self.status == "NOT_A_DELTA_MATROID"
+            and self.delta_matroid is None
+            and self.obstruction is not None
+        )
+        if not valid:
             raise _validation_error(
-                "status_mismatch",
-                "an exchange obstruction must return NOT_A_DELTA_MATROID",
-            )
-        if self.delta_matroid is not None:
-            raise _validation_error(
-                "unexpected_delta_matroid",
-                "an invalid feasible family must not carry a delta-matroid",
-            )
-        if self.obstruction != expected_obstruction:
-            raise _validation_error(
-                "obstruction_mismatch",
-                "obstruction must equal the first source exchange failure",
+                "status_branch",
+                "status must agree with its retained value or obstruction",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        system: FiniteFeasibleSetSystem,
+        *,
+        delta_matroid: FiniteDeltaMatroid | None = None,
+        obstruction: DeltaMatroidObstruction | None = None,
+    ) -> Self:
+        return cls(
+            source=system,
+            status="DELTA_MATROID"
+            if delta_matroid is not None
+            else "NOT_A_DELTA_MATROID",
+            delta_matroid=delta_matroid,
+            obstruction=obstruction,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/delta_matroids/operations.py
+++ b/src/jacobian/math/delta_matroids/operations.py
@@ -21,13 +21,11 @@ def from_feasible_sets(
     require_delta_matroid_admission(system)
     obstruction = first_symmetric_exchange_obstruction(system)
     if obstruction is not None:
-        return DeltaMatroidRecognitionResult(
-            source=system,
-            status="NOT_A_DELTA_MATROID",
+        return DeltaMatroidRecognitionResult._from_kernel(
+            system,
             obstruction=obstruction,
         )
-    return DeltaMatroidRecognitionResult(
-        source=system,
-        status="DELTA_MATROID",
+    return DeltaMatroidRecognitionResult._from_kernel(
+        system,
         delta_matroid=canonical_delta_matroid(system),
     )

--- a/src/jacobian/math/discrepancy_theory/_models.py
+++ b/src/jacobian/math/discrepancy_theory/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import itertools
 from fractions import Fraction
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import ConfigDict, Field, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
@@ -290,7 +290,13 @@ class MonitoredColumnLedger(StrictModel):
 
 
 class HardConstraintRoundingResult(StrictModel):
-    """A source-bound binary rounding with replayable hard-row and error ledgers."""
+    """A source-bound binary rounding with hard-row and error ledgers.
+
+    Parsing checks the result's wire shape only.  The floating-rounding kernel
+    establishes preservation and error claims when it produces this value;
+    deliberate validation of an independently supplied claim belongs to the
+    owner-private :func:`_verify_hard_constraint_rounding_result` helper.
+    """
 
     source: HardConstraintRoundingSource
     rounded_values: tuple[RoundedBit, ...] = Field(max_length=MAX_ROUNDING_COORDINATES)
@@ -304,7 +310,7 @@ class HardConstraintRoundingResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def replay_rounding_invariants(self) -> Self:
+    def require_structural_shape(self) -> Self:
         coordinate_count = len(self.source.coordinate_labels)
         if len(self.rounded_values) != coordinate_count:
             raise _validation_error(
@@ -319,79 +325,120 @@ class HardConstraintRoundingResult(StrictModel):
                 "rounded_values_not_binary",
                 "rounded values must be strict binary integers",
             )
-
-        source_values = tuple(value.as_fraction() for value in self.source.values)
-        expected_rows: list[HardConstraintRowLedger] = []
-        for row in self.source.rows:
-            source_sum = sum(
-                (source_values[index] for index in row.coordinates), Fraction()
-            )
-            rounded_sum = sum(self.rounded_values[index] for index in row.coordinates)
-            if source_sum != rounded_sum:
-                raise _validation_error(
-                    "rounded_values_break_row_sum",
-                    "rounded values must preserve every hard row sum",
-                )
-            expected_rows.append(
-                HardConstraintRowLedger(
-                    row_label=row.label,
-                    source_sum=_as_canonical_rational(source_sum),
-                    rounded_sum=rounded_sum,
-                )
-            )
-        if tuple(expected_rows) != self.row_ledger:
+        if len(self.row_ledger) != len(self.source.rows):
             raise _validation_error(
-                "row_ledger_replay_mismatch",
-                "row ledger must replay exactly from source and rounding",
+                "row_ledger_length_mismatch",
+                "row ledger must contain one entry for every hard row",
             )
-
-        incidences = [0] * coordinate_count
-        for column in self.source.columns:
-            for index in column.coordinates:
-                incidences[index] += 1
-        expected_incidence = max(incidences, default=0)
-        expected_bound = 4 * expected_incidence
-        if self.maximum_column_incidence != expected_incidence:
+        if tuple(item.row_label for item in self.row_ledger) != tuple(
+            row.label for row in self.source.rows
+        ):
             raise _validation_error(
-                "maximum_incidence_mismatch",
-                "maximum column incidence must be derived from the source",
+                "row_ledger_labels_mismatch",
+                "row ledger labels must align with the hard-row order",
             )
-        if self.column_error_bound != expected_bound:
+        if len(self.column_ledger) != len(self.source.columns):
             raise _validation_error(
-                "column_error_bound_mismatch",
-                "column error bound must equal four times the incidence",
+                "column_ledger_length_mismatch",
+                "column ledger must contain one entry for every monitored column",
             )
-
-        expected_columns: list[MonitoredColumnLedger] = []
-        for column in self.source.columns:
-            source_sum = sum(
-                (source_values[index] for index in column.coordinates), Fraction()
-            )
-            rounded_sum = sum(
-                self.rounded_values[index] for index in column.coordinates
-            )
-            signed_error = Fraction(rounded_sum) - source_sum
-            absolute_error = abs(signed_error)
-            if absolute_error > expected_bound:
-                raise _validation_error(
-                    "column_error_exceeds_bound",
-                    "monitored column error exceeds the derived 4d bound",
-                )
-            expected_columns.append(
-                MonitoredColumnLedger(
-                    column_label=column.label,
-                    source_sum=_as_canonical_rational(source_sum),
-                    rounded_sum=rounded_sum,
-                    signed_error=_as_canonical_rational(signed_error),
-                    absolute_error=_as_canonical_rational(absolute_error),
-                )
-            )
-        if tuple(expected_columns) != self.column_ledger:
+        if tuple(item.column_label for item in self.column_ledger) != tuple(
+            column.label for column in self.source.columns
+        ):
             raise _validation_error(
-                "column_ledger_replay_mismatch",
-                "column ledger must replay exactly from source and rounding",
+                "column_ledger_labels_mismatch",
+                "column ledger labels must align with the monitored-column order",
             )
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        """Build a result after the admitted floating-rounding kernel proved it."""
+
+        return cls.model_construct(**values)
+
+
+def _verify_hard_constraint_rounding_result(
+    result: HardConstraintRoundingResult,
+) -> bool:
+    """Check one independently supplied rounding claim under request admission.
+
+    This deliberately replays the source-derived ledgers and guarantees.  It
+    is private because ordinary result deserialization is not proof checking.
+    """
+
+    try:
+        admitted = HardConstraintRoundingRequest.model_validate(
+            {"source": result.source.model_dump()}
+        )
+    except Exception:  # request admission is fail-closed for supplied claims
+        return False
+    source = admitted.source
+    if len(result.rounded_values) != len(source.coordinate_labels):
+        return False
+    if any(
+        type(value) is not int or value not in (0, 1) for value in result.rounded_values
+    ):
+        return False
+    source_values = tuple(value.as_fraction() for value in source.values)
+    expected_rows = tuple(
+        HardConstraintRowLedger(
+            row_label=row.label,
+            source_sum=_as_canonical_rational(
+                _sum_selected_fractions(list(source_values), row.coordinates)
+            ),
+            rounded_sum=sum(result.rounded_values[index] for index in row.coordinates),
+        )
+        for row in source.rows
+    )
+    if (
+        any(row.source_sum.as_fraction() != row.rounded_sum for row in expected_rows)
+        or result.row_ledger != expected_rows
+    ):
+        return False
+    incidences = [0] * len(source_values)
+    for column in source.columns:
+        for index in column.coordinates:
+            incidences[index] += 1
+    maximum_incidence = max(incidences, default=0)
+    error_bound = 4 * maximum_incidence
+    if (
+        result.maximum_column_incidence != maximum_incidence
+        or result.column_error_bound != error_bound
+    ):
+        return False
+    expected_columns = tuple(
+        MonitoredColumnLedger(
+            column_label=column.label,
+            source_sum=_as_canonical_rational(
+                _sum_selected_fractions(list(source_values), column.coordinates)
+            ),
+            rounded_sum=sum(
+                result.rounded_values[index] for index in column.coordinates
+            ),
+            signed_error=_as_canonical_rational(
+                Fraction(
+                    sum(result.rounded_values[index] for index in column.coordinates)
+                )
+                - _sum_selected_fractions(list(source_values), column.coordinates)
+            ),
+            absolute_error=_as_canonical_rational(
+                abs(
+                    Fraction(
+                        sum(
+                            result.rounded_values[index] for index in column.coordinates
+                        )
+                    )
+                    - _sum_selected_fractions(list(source_values), column.coordinates)
+                )
+            ),
+        )
+        for column in source.columns
+    )
+    return result.column_ledger == expected_columns and all(
+        ledger.absolute_error.as_fraction() <= error_bound
+        for ledger in expected_columns
+    )
 
 
 class FiniteSetSystem(StrictModel):

--- a/src/jacobian/math/discrepancy_theory/_operations.py
+++ b/src/jacobian/math/discrepancy_theory/_operations.py
@@ -185,7 +185,7 @@ def compute_hard_constraint_rounding(
                 absolute_error=CanonicalRational.from_fraction(abs(signed_error)),
             )
         )
-    return HardConstraintRoundingResult(
+    return HardConstraintRoundingResult._from_kernel(
         source=source,
         rounded_values=rounded_values,
         maximum_column_incidence=maximum_incidence,

--- a/src/jacobian/math/finite_abelian_groups.py
+++ b/src/jacobian/math/finite_abelian_groups.py
@@ -307,15 +307,14 @@ SpectralPairDecisionReason = Literal[
 
 
 class FiniteAbelianSpectralPairResult(StrictModel):
-    """Exact, source-bound decision for a finite-Abelian spectral pair.
+    """Exact decision for a finite-Abelian spectral pair.
 
     The fixed dual pairing is
     ``chi_lambda(a) = exp(2*pi*i*sum(lambda_j*a_j/m_j))``. For an equal-size
     pair, every distinct frequency pair is checked in lexicographic source
     order. The restricted characters all have nonzero norm, so ``|A|``
-    pairwise-orthogonal characters form a basis of ``C^A``. Result validation
-    repeats the exact cyclotomic reductions and binds the decision, first
-    witness, convention, and retained source together.
+    pairwise-orthogonal characters form a basis of ``C^A``. The admitted
+    kernel establishes that conclusion; parsing keeps only branch consistency.
     """
 
     source: FiniteAbelianSpectralPairSource
@@ -327,24 +326,37 @@ class FiniteAbelianSpectralPairResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def replay_exact_decision(self) -> Self:
-        expected = _finite_abelian_spectral_pair_decision_data(self.source)
-        observed = (
-            self.is_spectral,
-            self.reason,
-            self.first_nonorthogonal_pair,
-        )
-        required = (
-            expected.is_spectral,
-            expected.reason,
-            expected.first_nonorthogonal_pair,
-        )
-        if observed != required:
+    def require_branch_consistency(self) -> Self:
+        if self.is_spectral:
+            valid = self.reason == "SPECTRAL" and self.first_nonorthogonal_pair is None
+        elif self.reason == "CARDINALITY_MISMATCH":
+            valid = self.first_nonorthogonal_pair is None
+        else:
+            valid = (
+                self.reason == "NONORTHOGONAL_FREQUENCIES"
+                and self.first_nonorthogonal_pair is not None
+            )
+        if not valid:
             raise _validation_error(
-                "spectral_replay",
-                "spectral-pair result must equal the replayed exact decision",
+                "spectral_branch",
+                "spectral-pair conclusion and witness fields must agree",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        source: FiniteAbelianSpectralPairSource,
+        decision: _SpectralPairDecisionData,
+    ) -> Self:
+        """Build a result after the admitted cyclotomic kernel established it."""
+
+        return cls(
+            source=source,
+            is_spectral=decision.is_spectral,
+            reason=decision.reason,
+            first_nonorthogonal_pair=decision.first_nonorthogonal_pair,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -651,12 +663,7 @@ def decide_finite_abelian_spectral_pair(
     """Decide exact finite-Abelian spectrality under the positive pairing."""
 
     decision = _finite_abelian_spectral_pair_decision_data(source)
-    return FiniteAbelianSpectralPairResult(
-        source=source,
-        is_spectral=decision.is_spectral,
-        reason=decision.reason,
-        first_nonorthogonal_pair=decision.first_nonorthogonal_pair,
-    )
+    return FiniteAbelianSpectralPairResult._from_kernel(source, decision)
 
 
 def _run_finite_abelian_spectral_pair(

--- a/src/jacobian/math/finite_categories/_product.py
+++ b/src/jacobian/math/finite_categories/_product.py
@@ -399,7 +399,7 @@ def product(left: FiniteCategory, right: FiniteCategory) -> FiniteCategoryProduc
     )
 
 
-def verify_product_claim(result: FiniteCategoryProduct) -> bool:
+def _verify_product_claim(result: FiniteCategoryProduct) -> bool:
     """Check an independently supplied product claim in its admitted envelope."""
 
     try:
@@ -415,4 +415,4 @@ def verify_product_claim(result: FiniteCategoryProduct) -> bool:
     )
 
 
-__all__ = ["product", "verify_product_claim"]
+__all__ = ["product"]

--- a/src/jacobian/math/formal_concept_analysis/basis.py
+++ b/src/jacobian/math/formal_concept_analysis/basis.py
@@ -687,7 +687,7 @@ class CanonicalImplicationBasisResult(StrictModel):
         return None
 
 
-def verify_canonical_implication_basis_result(
+def _verify_canonical_implication_basis_result(
     result: CanonicalImplicationBasisResult,
 ) -> None:
     """Independently replay a supplied complete basis within the admitted bound."""
@@ -704,5 +704,4 @@ __all__ = [
     "DGBasisClosureRow",
     "DGBasisWork",
     "PseudoIntent",
-    "verify_canonical_implication_basis_result",
 ]

--- a/src/jacobian/math/formal_concept_analysis/values.py
+++ b/src/jacobian/math/formal_concept_analysis/values.py
@@ -406,7 +406,7 @@ class ImplicationClosureResult(StrictModel):
         )
 
 
-def verify_implication_closure_result(result: ImplicationClosureResult) -> None:
+def _verify_implication_closure_result(result: ImplicationClosureResult) -> None:
     """Independently replay one supplied closure claim within its carrier bound."""
 
     for name in ("seed", "closure", "added"):
@@ -520,5 +520,4 @@ __all__ = [
     "ImplicationClosureResult",
     "ImplicationClosureWork",
     "ImplicationDerivation",
-    "verify_implication_closure_result",
 ]

--- a/src/jacobian/math/formal_power_series/_models.py
+++ b/src/jacobian/math/formal_power_series/_models.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
 from typing import Annotated, Literal, Self
 
 from pydantic import Field, StrictInt, StringConstraints, model_validator
@@ -31,14 +30,6 @@ MAX_POWER_EXPONENT = 1_000
 # producer-to-truncate composition stays closed over every representable
 # expansion.
 MAX_TRUNCATE_SOURCE_ORDER = 25_280
-
-# Replaying result validators recompute their defining invariants during
-# deserialization at quadratic or cubic cost in the claimed order.  Every
-# producer of these results emits order equal to its admitted request
-# inputs, which cap at MAX_TRUNCATION_ORDER, so payloads claiming larger
-# orders are outside the representable result envelope and must be
-# rejected before any replay work starts.
-MAX_RESULT_REPLAY_ORDER = MAX_TRUNCATION_ORDER
 
 CoefficientHeight = RationalHeight | None
 
@@ -163,15 +154,6 @@ def _require_height(height: RationalHeight, operation: str) -> None:
         )
 
 
-def _require_replay_order(order: int, operation: str) -> None:
-    if order > MAX_RESULT_REPLAY_ORDER:
-        raise _validation_error(
-            f"{operation}_replay_order",
-            f"{operation} result replay exceeds the "
-            f"{MAX_RESULT_REPLAY_ORDER}-order replay envelope",
-        )
-
-
 def _require_zero_residual(
     coefficients: tuple[CanonicalRational, ...], order: int, operation: str
 ) -> None:
@@ -185,68 +167,6 @@ def _require_zero_residual(
             f"{operation}_residual_nonzero",
             f"{operation} residual must be identically zero",
         )
-
-
-def _fraction_coefficients(series: TruncatedSeries) -> tuple[Fraction, ...]:
-    return tuple(value.as_fraction() for value in series.coefficients)
-
-
-def _convolution_coefficients(
-    left: TruncatedSeries, right: TruncatedSeries
-) -> tuple[Fraction, ...]:
-    if (
-        left.variable != right.variable
-        or left.truncation_order != right.truncation_order
-    ):
-        raise _validation_error(
-            "source_context_mismatch",
-            "source series must share variable and truncation order",
-        )
-    left_values = _fraction_coefficients(left)
-    right_values = _fraction_coefficients(right)
-    return tuple(
-        sum(
-            (
-                left_values[index] * right_values[degree - index]
-                for index in range(degree + 1)
-            ),
-            start=Fraction(0),
-        )
-        for degree in range(left.truncation_order)
-    )
-
-
-def _composition_coefficients(
-    outer: TruncatedSeries, inner: TruncatedSeries
-) -> tuple[Fraction, ...]:
-    if (
-        outer.variable != inner.variable
-        or outer.truncation_order != inner.truncation_order
-    ):
-        raise _validation_error(
-            "source_context_mismatch",
-            "source series must share variable and truncation order",
-        )
-    order = outer.truncation_order
-    outer_values = _fraction_coefficients(outer)
-    inner_values = _fraction_coefficients(inner)
-    power = (Fraction(1), *([Fraction(0)] * (order - 1)))
-    result = [Fraction(0)] * order
-    for outer_degree in range(order):
-        for degree in range(order):
-            result[degree] += outer_values[outer_degree] * power[degree]
-        if outer_degree + 1 < order:
-            power = tuple(
-                sum(
-                    (
-                        power[index] * inner_values[degree - index]
-                        for index in range(degree + 1)
-                    ),
-                    start=Fraction(0),
-                )
-                for degree in range(order)
-            )
-    return tuple(result)
 
 
 def _inverse_height(series: TruncatedSeries) -> RationalHeight:
@@ -735,20 +655,39 @@ class SeriesMultiplyResult(StrictModel):
     exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
-    def require_exact_convolution_ledger(self) -> Self:
-        _require_replay_order(self.result.truncation_order, "multiplication")
-        expected = _convolution_coefficients(self.left, self.right)
-        if _fraction_coefficients(self.result) != expected:
+    def require_structural_ledger(self) -> Self:
+        if (
+            self.left.variable != self.right.variable
+            or self.left.variable != self.result.variable
+            or self.left.truncation_order != self.right.truncation_order
+            or self.left.truncation_order != self.result.truncation_order
+        ):
             raise _validation_error(
-                "convolution_result_mismatch",
-                "result must equal the source convolution",
+                "source_context_mismatch",
+                "multiplication series must share variable and truncation order",
             )
-        if tuple(value.as_fraction() for value in self.convolution_ledger) != expected:
+        if len(self.convolution_ledger) != self.result.truncation_order:
             raise _validation_error(
-                "convolution_ledger_mismatch",
-                "convolution ledger must equal the source convolution",
+                "convolution_ledger_length",
+                "convolution ledger must contain one coefficient per result degree",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        left: TruncatedSeries,
+        right: TruncatedSeries,
+        result: TruncatedSeries,
+        convolution_ledger: tuple[CanonicalRational, ...],
+    ) -> Self:
+        return cls.model_construct(
+            left=left,
+            right=right,
+            result=result,
+            convolution_ledger=convolution_ledger,
+        )
 
 
 class SeriesScalarMultiplyRequest(StrictModel):
@@ -861,22 +800,35 @@ class SeriesInverseResult(StrictModel):
     exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
-    def require_inverse_identity(self) -> Self:
-        _require_replay_order(self.result.truncation_order, "inverse")
+    def require_structural_residual(self) -> Self:
+        if (
+            self.source.variable != self.result.variable
+            or self.source.truncation_order != self.result.truncation_order
+        ):
+            raise _validation_error(
+                "source_context_mismatch",
+                "inverse source and result must share variable and truncation order",
+            )
         _require_zero_residual(
             self.residual_coefficients,
             self.result.truncation_order,
             "inverse",
         )
-        product = list(_convolution_coefficients(self.source, self.result))
-        product[0] -= 1
-        residual = tuple(value.as_fraction() for value in self.residual_coefficients)
-        if tuple(product) != residual:
-            raise _validation_error(
-                "inverse_residual_mismatch",
-                "inverse residual must equal source times result minus one",
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source: TruncatedSeries,
+        result: TruncatedSeries,
+        residual_coefficients: tuple[CanonicalRational, ...],
+    ) -> Self:
+        return cls.model_construct(
+            source=source,
+            result=result,
+            residual_coefficients=residual_coefficients,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -897,26 +849,39 @@ class SeriesDivideResult(StrictModel):
     exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
-    def require_division_identity(self) -> Self:
-        _require_replay_order(self.quotient.truncation_order, "division")
+    def require_structural_residual(self) -> Self:
+        if (
+            self.numerator.variable != self.denominator.variable
+            or self.numerator.variable != self.quotient.variable
+            or self.numerator.truncation_order != self.denominator.truncation_order
+            or self.numerator.truncation_order != self.quotient.truncation_order
+        ):
+            raise _validation_error(
+                "source_context_mismatch",
+                "division series must share variable and truncation order",
+            )
         _require_zero_residual(
             self.residual_coefficients,
             self.quotient.truncation_order,
             "division",
         )
-        product = _convolution_coefficients(self.denominator, self.quotient)
-        numerator = _fraction_coefficients(self.numerator)
-        expected = tuple(
-            product[index] - numerator[index]
-            for index in range(self.quotient.truncation_order)
-        )
-        residual = tuple(value.as_fraction() for value in self.residual_coefficients)
-        if expected != residual:
-            raise _validation_error(
-                "division_residual_mismatch",
-                "division residual must equal denominator times quotient minus numerator",
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        numerator: TruncatedSeries,
+        denominator: TruncatedSeries,
+        quotient: TruncatedSeries,
+        residual_coefficients: tuple[CanonicalRational, ...],
+    ) -> Self:
+        return cls.model_construct(
+            numerator=numerator,
+            denominator=denominator,
+            quotient=quotient,
+            residual_coefficients=residual_coefficients,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1036,33 +1001,35 @@ class SeriesReversionResult(StrictModel):
     exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
-    def require_zero_residuals(self) -> Self:
+    def require_structural_residuals(self) -> Self:
         order = self.result.truncation_order
-        _require_replay_order(order, "reversion")
+        if (
+            self.source.variable != self.result.variable
+            or self.source.truncation_order != order
+        ):
+            raise _validation_error(
+                "source_context_mismatch",
+                "reversion source and result must share variable and truncation order",
+            )
         _require_zero_residual(self.left_residual, order, "left reversion")
         _require_zero_residual(self.right_residual, order, "right reversion")
-        identity = tuple(Fraction(int(index == 1)) for index in range(order))
-        left = _composition_coefficients(self.source, self.result)
-        right = _composition_coefficients(self.result, self.source)
-        left_residual = tuple(value.as_fraction() for value in self.left_residual)
-        right_residual = tuple(value.as_fraction() for value in self.right_residual)
-        if (
-            tuple(left[index] - identity[index] for index in range(order))
-            != left_residual
-        ):
-            raise _validation_error(
-                "reversion_left_residual_mismatch",
-                "left residual must equal source composed with result minus x",
-            )
-        if (
-            tuple(right[index] - identity[index] for index in range(order))
-            != right_residual
-        ):
-            raise _validation_error(
-                "reversion_right_residual_mismatch",
-                "right residual must equal result composed with source minus x",
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source: TruncatedSeries,
+        result: TruncatedSeries,
+        left_residual: tuple[CanonicalRational, ...],
+        right_residual: tuple[CanonicalRational, ...],
+    ) -> Self:
+        return cls.model_construct(
+            source=source,
+            result=result,
+            left_residual=left_residual,
+            right_residual=right_residual,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/jacobian/math/formal_power_series/_operations.py
+++ b/src/jacobian/math/formal_power_series/_operations.py
@@ -116,7 +116,7 @@ def compute_multiply(
     a = _series_fractions(left)
     b = _series_fractions(right)
     result = _cauchy_convolve(a, b, n)
-    return SeriesMultiplyResult(
+    return SeriesMultiplyResult._from_kernel(
         left=left,
         right=right,
         result=_series_result(left.variable, n, result),
@@ -191,7 +191,7 @@ def compute_inverse(series: TruncatedSeries) -> SeriesInverseResult:
     # Compute residual A*B - 1
     product = _cauchy_convolve(a, inv, n)
     product[0] -= Fraction(1)
-    return SeriesInverseResult(
+    return SeriesInverseResult._from_kernel(
         source=series,
         result=_series_result(series.variable, n, inv),
         residual_coefficients=tuple(_wire(c) for c in product),
@@ -219,7 +219,7 @@ def compute_divide(
     q = _cauchy_convolve(a, b_inv, n)
     bq = _cauchy_convolve(b, q, n)
     residual = [bq[i] - a[i] for i in range(n)]
-    return SeriesDivideResult(
+    return SeriesDivideResult._from_kernel(
         numerator=numerator,
         denominator=denominator,
         quotient=_series_result(numerator.variable, n, q),
@@ -324,7 +324,7 @@ def compute_reversion(series: TruncatedSeries) -> SeriesReversionResult:
         gf_coeffs[i] - (Fraction(1) if i == 1 else Fraction(0)) for i in range(n)
     ]
 
-    return SeriesReversionResult(
+    return SeriesReversionResult._from_kernel(
         source=series,
         result=_series_result(series.variable, n, g),
         left_residual=tuple(_wire(c) for c in left_residual),

--- a/src/jacobian/math/galois_theory/_models.py
+++ b/src/jacobian/math/galois_theory/_models.py
@@ -187,6 +187,7 @@ class GaloisFactorResult(StrictModel):
 
     @model_validator(mode="after")
     def require_structural_consistency(self) -> Self:
+        _require_prime(self.field_order)
         _require_factor_residues(self)
         if self.distinct_factor_count != len(self.factors):
             raise _validation_error(

--- a/src/jacobian/math/galois_theory/_models.py
+++ b/src/jacobian/math/galois_theory/_models.py
@@ -145,21 +145,6 @@ class FiniteFieldFactor(StrictModel):
     multiplicity: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
 
 
-def _multiply_mod(
-    left: tuple[int, ...], right: tuple[int, ...], prime: int
-) -> tuple[int, ...]:
-    result = [0] * (len(left) + len(right) - 1)
-    for left_degree, left_coefficient in enumerate(left):
-        for right_degree, right_coefficient in enumerate(right):
-            result[left_degree + right_degree] = (
-                result[left_degree + right_degree]
-                + left_coefficient * right_coefficient
-            ) % prime
-    while len(result) > 1 and result[-1] == 0:
-        result.pop()
-    return tuple(result)
-
-
 class GaloisFactorResult(StrictModel):
     field_order: int = Field(ge=2, le=MAX_FIELD_ORDER, strict=True)
     source_coefficients: tuple[int, ...] = Field(
@@ -201,8 +186,7 @@ class GaloisFactorResult(StrictModel):
         )
 
     @model_validator(mode="after")
-    def require_reconstruction_certificate(self) -> Self:
-        _require_prime(self.field_order)
+    def require_structural_consistency(self) -> Self:
         _require_factor_residues(self)
         if self.distinct_factor_count != len(self.factors):
             raise _validation_error(
@@ -214,11 +198,6 @@ class GaloisFactorResult(StrictModel):
             raise _validation_error(
                 "factor_count_mismatch",
                 "factor_count must include factor multiplicities",
-            )
-        if _reconstruct_factorization(self) != self.source_coefficients:
-            raise _validation_error(
-                "reconstruction_mismatch",
-                "factorization must reconstruct the source modulo p",
             )
         return self
 
@@ -245,24 +224,6 @@ def _require_factor_residues(result: GaloisFactorResult) -> None:
             raise _validation_error(
                 "factor_not_monic", "finite-field factors must be monic"
             )
-
-
-def _reconstruct_factorization(result: GaloisFactorResult) -> tuple[int, ...]:
-    reconstructed: tuple[int, ...] = (result.unit,)
-    for factor in result.factors:
-        for _ in range(factor.multiplicity):
-            reconstructed = _multiply_mod(
-                reconstructed, factor.coefficients, result.field_order
-            )
-    return reconstructed
-
-
-def _factorization_is_irreducible(result: GaloisFactorResult) -> bool:
-    return (
-        len(result.factors) == 1
-        and result.factors[0].multiplicity == 1
-        and len(result.factors[0].coefficients) == len(result.source_coefficients)
-    )
 
 
 class FrobeniusCycleResult(StrictModel):

--- a/src/jacobian/math/galois_theory/_operations.py
+++ b/src/jacobian/math/galois_theory/_operations.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pydantic import ValidationError
+
 if TYPE_CHECKING:
     from sympy.combinatorics.perm_groups import PermutationGroup
 
@@ -59,22 +61,25 @@ def compute_galois_factor(request: GaloisFactorRequest) -> GaloisFactorResult:
     )
 
 
-def verify_galois_factor_result(result: GaloisFactorResult) -> bool:
-    """Replay bounded factor irreducibility for a supplied factorization claim."""
+def _verify_galois_factor_result(result: GaloisFactorResult) -> bool:
+    """Check one independently supplied factorization within request admission.
 
-    from sympy import GF, Poly, Symbol
+    Normal result parsing deliberately checks only wire structure.  This owner-
+    private path is for a caller that deliberately treats supplied result data
+    as a mathematical claim, so it re-enters request admission and compares
+    against one bounded kernel computation.
+    """
 
-    x = Symbol("x")
-    return result.is_irreducible == (
-        len(result.factors) == 1
-        and result.factors[0].multiplicity == 1
-        and len(result.factors[0].coefficients) == len(result.source_coefficients)
-    ) and all(
-        Poly(
-            list(reversed(factor.coefficients)), x, domain=GF(result.field_order)
-        ).is_irreducible
-        for factor in result.factors
-    )
+    try:
+        candidate = GaloisFactorResult.model_validate(result.model_dump())
+        request = GaloisFactorRequest(
+            field_order=candidate.field_order,
+            coefficients=candidate.source_coefficients,
+        )
+        expected = compute_galois_factor(request)
+    except (TypeError, ValidationError, ValueError):
+        return False
+    return candidate == expected
 
 
 def compute_frobenius_cycle(request: FrobeniusCycleRequest) -> FrobeniusCycleResult:

--- a/src/jacobian/math/geometry/_euclidean_triangulation.py
+++ b/src/jacobian/math/geometry/_euclidean_triangulation.py
@@ -72,11 +72,9 @@ def minimum_euclidean_weight_triangulation(
                 order = _compare_euclidean_root_sums(candidate, chosen)
                 if order is None:
                     assert chosen_pivot is not None
-                    return EuclideanConvexPolygonTriangulationResult(
+                    return EuclideanConvexPolygonTriangulationResult._from_kernel(
+                        request,
                         status="COMPARISON_UNRESOLVED",
-                        polygon=request.polygon,
-                        vertex_count=count,
-                        comparison_precision_bits=EUCLIDEAN_TRIANGULATION_COMPARISON_PRECISION_BITS,
                         unresolved_comparison=EuclideanComparisonUnresolved(
                             start=start,
                             end=end,
@@ -117,11 +115,9 @@ def minimum_euclidean_weight_triangulation(
 
     reconstruct(0, count - 1)
     value = optimum[0, count - 1]
-    return EuclideanConvexPolygonTriangulationResult(
+    return EuclideanConvexPolygonTriangulationResult._from_kernel(
+        request,
         status="CERTIFIED_OPTIMUM",
-        polygon=request.polygon,
-        vertex_count=count,
-        comparison_precision_bits=EUCLIDEAN_TRIANGULATION_COMPARISON_PRECISION_BITS,
         diagonals=tuple(
             EuclideanDiagonal(
                 first=first,

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -1541,8 +1541,7 @@ class EuclideanConvexPolygonTriangulationResult(StrictModel):
 
     @model_validator(mode="after")
     def bind_status_fields(self) -> Self:
-        points = _require_euclidean_triangulation_envelope(self.polygon)
-        if self.vertex_count != len(points):
+        if self.vertex_count != len(self.polygon.points):
             raise _validation_error(
                 "vertex_count_source_polygon_vertex_count",
                 "vertex_count must equal the source polygon vertex count",
@@ -1588,14 +1587,58 @@ class EuclideanConvexPolygonTriangulationResult(StrictModel):
                     "optimum_expression_list_selected_diagonal_lengths",
                     "optimum expression must list the selected diagonal lengths",
                 )
-            _replay_euclidean_triangulation(self, points)
         else:
             assert self.unresolved_comparison is not None
-            _replay_euclidean_unresolved_comparison(self.unresolved_comparison, points)
+            comparison = self.unresolved_comparison
+            if (
+                comparison.end >= self.vertex_count
+                or comparison.end - comparison.start < 2
+            ):
+                raise _validation_error(
+                    "unresolved_comparison_name_a_nontrivial_dp",
+                    "unresolved comparison must name a nontrivial DP subproblem span",
+                )
+            if not (
+                comparison.start
+                < comparison.right_split
+                < comparison.left_split
+                < comparison.end
+            ):
+                raise _validation_error(
+                    "unresolved_comparison_splits_lie_strictly_inside",
+                    "unresolved comparison splits must lie strictly inside its span "
+                    "with the incumbent split first",
+                )
         return self
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: EuclideanConvexPolygonTriangulationRequest,
+        *,
+        status: Literal["CERTIFIED_OPTIMUM", "COMPARISON_UNRESOLVED"],
+        diagonals: tuple[EuclideanDiagonal, ...] = (),
+        triangles: tuple[PolygonTriangle, ...] = (),
+        split_table: tuple[EuclideanTriangulationSplitEntry, ...] = (),
+        optimum: EuclideanLengthExpression | None = None,
+        unresolved_comparison: EuclideanComparisonUnresolved | None = None,
+    ) -> Self:
+        """Build a result after the admitted triangulation kernel established it."""
 
-def _replay_euclidean_split_choice(
+        return cls.model_construct(
+            polygon=request.polygon,
+            vertex_count=len(request.polygon.points),
+            comparison_precision_bits=EUCLIDEAN_TRIANGULATION_COMPARISON_PRECISION_BITS,
+            status=status,
+            diagonals=diagonals,
+            triangles=triangles,
+            split_table=split_table,
+            optimum=optimum,
+            unresolved_comparison=unresolved_comparison,
+        )
+
+
+def _verify_euclidean_split_choice(
     entry: EuclideanTriangulationSplitEntry,
     optimum: dict[tuple[int, int], tuple[Fraction, ...]],
     points: tuple[tuple[Fraction, Fraction], ...],
@@ -1648,7 +1691,7 @@ def _replay_euclidean_split_choice(
         )
 
 
-def _replay_euclidean_triangulation(
+def _verify_euclidean_triangulation_result(
     result: EuclideanConvexPolygonTriangulationResult,
     points: tuple[tuple[Fraction, Fraction], ...],
 ) -> None:
@@ -1677,7 +1720,7 @@ def _replay_euclidean_triangulation(
     }
     splits: dict[tuple[int, int], int] = {}
     for entry in result.split_table:
-        _replay_euclidean_split_choice(entry, optimum, points, count)
+        _verify_euclidean_split_choice(entry, optimum, points, count)
         optimum[entry.start, entry.end] = tuple(
             term.as_fraction() for term in entry.optimum.squared_lengths
         )
@@ -1726,7 +1769,7 @@ def _replay_euclidean_triangulation(
             )
 
 
-def _replay_euclidean_unresolved_comparison(
+def _verify_euclidean_unresolved_comparison(
     comparison: EuclideanComparisonUnresolved,
     points: tuple[tuple[Fraction, Fraction], ...],
 ) -> None:
@@ -1810,6 +1853,22 @@ def _replay_euclidean_unresolved_comparison(
         "unresolved_comparison_occur_during_replayed_recurrence",
         "unresolved comparison must occur during the replayed recurrence",
     )
+
+
+def _verify_euclidean_triangulation_claim(
+    result: EuclideanConvexPolygonTriangulationResult,
+) -> None:
+    """Fail closed when an independently supplied triangulation claim needs proof."""
+
+    request = EuclideanConvexPolygonTriangulationRequest(
+        polygon=EuclideanTriangulationPolygonRequest.model_validate(result.polygon)
+    )
+    points = _require_euclidean_triangulation_envelope(request.polygon)
+    if result.status == "CERTIFIED_OPTIMUM":
+        _verify_euclidean_triangulation_result(result, points)
+        return
+    assert result.unresolved_comparison is not None
+    _verify_euclidean_unresolved_comparison(result.unresolved_comparison, points)
 
 
 # ---------------------------------------------------------------------------

--- a/src/jacobian/math/geometry/boxes/_models.py
+++ b/src/jacobian/math/geometry/boxes/_models.py
@@ -10,7 +10,6 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.canonical import encode_strict_json
-from jacobian.math.geometry.boxes._kernel import box_volume
 from jacobian.math.geometry.boxes.values import RationalAxisAlignedBox
 
 
@@ -22,7 +21,6 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 
 MAX_BOX_UNION_NONEMPTY_BOXES = 16
 MAX_INTERSECTION_CANDIDATES = (1 << MAX_BOX_UNION_NONEMPTY_BOXES) - 1
-MAX_BOX_UNION_REPLAY_WORK = 4_000_000
 MAX_BOX_UNION_RESULT_BYTES = 8 * 1024 * 1024
 MAX_BOX_UNION_RESULT_RATIONAL_DIGITS = 16_384
 
@@ -196,20 +194,6 @@ class BoxUnionVolumeRequest(StrictModel):
                 "intersection candidates, exceeding the complete "
                 f"{MAX_INTERSECTION_CANDIDATES}-candidate bound",
             )
-        # Two full ledger computations (operation plus result replay), with
-        # lower/upper comparisons, plus per-entry volume validation.
-        replay_work = (
-            6 * dimension * active_box_count * (1 << (active_box_count - 1))
-            if active_box_count
-            else 0
-        )
-        if replay_work > MAX_BOX_UNION_REPLAY_WORK:
-            raise _validation_error(
-                "box_union_exceeds_complete_intersection_replay",
-                "box union exceeds the complete intersection replay work bound "
-                f"({replay_work} > {MAX_BOX_UNION_REPLAY_WORK})",
-            )
-
         endpoint_num, endpoint_den, volume_digits, union_digits = _digit_bounds(
             self.boxes,
             dimension,
@@ -271,11 +255,6 @@ class BoxIntersectionLedgerEntry(StrictModel):
                 "ledger_contains_nonempty_box_intersections",
                 "ledger contains only nonempty box intersections",
             )
-        if self.volume.as_fraction() != box_volume(self.intersection):
-            raise _validation_error(
-                "box_intersection_volume_intervals",
-                "box intersection volume does not match its intervals",
-            )
         return self
 
 
@@ -293,31 +272,55 @@ class BoxUnionVolumeResult(StrictModel):
     union_volume: CanonicalRational
 
     @model_validator(mode="after")
-    def require_complete_source_bound_ledger(self) -> Self:
-        from jacobian.math.geometry.boxes._kernel import complete_intersection_ledger
-
-        expected, expected_union = complete_intersection_ledger(self.source.boxes)
-        if len(self.intersections) != len(expected):
+    def require_structural_ledger(self) -> Self:
+        if any(
+            index >= len(self.source.boxes)
+            for entry in self.intersections
+            for index in entry.box_indices
+        ):
             raise _validation_error(
-                "intersection_ledger_complete_source",
-                "intersection ledger is not complete for its source",
-            )
-        for actual, wanted in zip(self.intersections, expected, strict=True):
-            if (
-                actual.box_indices != wanted.box_indices
-                or actual.intersection != wanted.intersection
-                or actual.volume.as_fraction() != wanted.volume
-            ):
-                raise _validation_error(
-                    "intersection_ledger_source_boxes",
-                    "intersection ledger does not match its source boxes",
-                )
-        if self.union_volume.as_fraction() != expected_union:
-            raise _validation_error(
-                "union_volume_inclusion_exclusion_replay",
-                "union volume does not match inclusion-exclusion replay",
+                "intersection_ledger_source_indices",
+                "intersection ledger indices must refer to retained source boxes",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source: BoxUnionVolumeRequest,
+        intersections: tuple[BoxIntersectionLedgerEntry, ...],
+        union_volume: CanonicalRational,
+    ) -> Self:
+        """Construct a result after the owner kernel completed the ledger."""
+
+        return cls.model_construct(
+            source=source,
+            intersections=intersections,
+            union_volume=union_volume,
+        )
+
+
+def _verify_box_union_volume_result(result: BoxUnionVolumeResult) -> bool:
+    """Check one independently supplied source-bound inclusion-exclusion claim."""
+
+    from jacobian.math.geometry.boxes._kernel import complete_intersection_ledger
+
+    try:
+        source = BoxUnionVolumeRequest.model_validate(result.source.model_dump())
+    except ValueError:
+        return False
+    expected, expected_union = complete_intersection_ledger(source.boxes)
+    return (
+        len(result.intersections) == len(expected)
+        and all(
+            actual.box_indices == wanted.box_indices
+            and actual.intersection == wanted.intersection
+            and actual.volume.as_fraction() == wanted.volume
+            for actual, wanted in zip(result.intersections, expected, strict=True)
+        )
+        and result.union_volume.as_fraction() == expected_union
+    )
 
 
 __all__ = [

--- a/src/jacobian/math/geometry/boxes/_operations.py
+++ b/src/jacobian/math/geometry/boxes/_operations.py
@@ -20,7 +20,7 @@ def _union_volume_from_source(
     """Compute the complete ledger for one already-admitted box family."""
 
     records, union_volume = complete_intersection_ledger(source.boxes)
-    return BoxUnionVolumeResult(
+    return BoxUnionVolumeResult._from_kernel(
         source=source,
         intersections=tuple(
             BoxIntersectionLedgerEntry(

--- a/src/jacobian/math/geometry/exact/_models.py
+++ b/src/jacobian/math/geometry/exact/_models.py
@@ -680,16 +680,14 @@ def _validate_pinned_profile_order(
 class PinnedLineDistanceResult(StrictModel):
     """Complete pinned line-distance profile for a point configuration.
 
-    The result retains its source ``configuration`` and ``anchor`` so validation
-    can replay the defining geometry: every pair-spanned line is recomputed
-    canonically from the retained points and its squared distance from the
-    retained anchor is verified.
+    The result retains its source ``configuration`` and ``anchor`` for
+    downstream composition. Parsing checks its canonical wire shape; the
+    producing kernel establishes the geometric profile.
     """
 
     configuration: PinnedLineConfiguration = Field(
         description=(
-            "Source planar point configuration with distinct coordinates; "
-            "retained for result binding and replay."
+            "Source planar point configuration, retained for downstream composition."
         ),
         json_schema_extra={"coordinate_digit_bound": COORDINATE_DIGITS},
     )
@@ -766,42 +764,141 @@ class PinnedLineDistanceResult(StrictModel):
 
     @model_validator(mode="after")
     def require_consistent_profile(self) -> Self:
-        from itertools import combinations
-
-        points, anchor = _pinned_profile_source(
-            self.configuration, self.anchor, self.point_count
-        )
-        expected_lines, expected_distances = _expected_pinned_profile_geometry(
-            points, anchor, self.point_count
-        )
-        expected_pairs = sorted(combinations(range(self.point_count), 2))
-        seen_pairs, multiplicities = _validate_pinned_profile_entries(
-            self.lines, self.point_count, expected_lines, expected_distances
-        )
-        if sorted(seen_pairs) != expected_pairs or len(seen_pairs) != len(
+        if self.dimension != 2 or any(
+            len(point.coordinates) != self.dimension
+            for point in self.configuration.points
+        ):
+            raise _validation_error(
+                "retained_configuration_a_planar_configuration_two",
+                "retained configuration must be a planar configuration "
+                "(exactly two coordinates per point)",
+            )
+        if self.point_count != len(self.configuration.points):
+            raise _validation_error(
+                "point_count_retained_configuration",
+                "point_count must match the retained configuration",
+            )
+        seen_pairs = [pair for entry in self.lines for pair in entry.pairs]
+        if any(
+            not 0 <= first < second < self.point_count for first, second in seen_pairs
+        ):
+            raise _validation_error(
+                "source_pairs_reference_valid_point_indices",
+                "source pairs must reference valid point indices",
+            )
+        expected_pair_count = self.point_count * (self.point_count - 1) // 2
+        if len(seen_pairs) != expected_pair_count or len(seen_pairs) != len(
             set(seen_pairs)
         ):
             raise _validation_error(
                 "lines_cover_set_source_pairs_once",
                 "lines must cover exactly the set of source pairs once",
             )
-        if len(self.lines) != len(expected_lines):
-            raise _validation_error(
-                "lines_correspond_distinct_geometric_lines",
-                "lines must correspond to distinct geometric lines",
-            )
-        _validate_pinned_profile_order(self.lines, expected_lines, expected_distances)
-
-        reconstructed = tuple(
-            (
-                CanonicalRational.from_fraction(d),
-                count,
-            )
-            for d, count in sorted(multiplicities.items())
+        coefficients = tuple(
+            tuple(value.as_fraction() for value in entry.line_coefficients)
+            for entry in self.lines
         )
-        if reconstructed != self.distance_multiplicities:
+        if len(coefficients) != len(set(coefficients)):
+            raise _validation_error(
+                "duplicate_lines_collapsed_entry",
+                "duplicate lines must be collapsed into one entry",
+            )
+        if (
+            tuple(
+                sorted(
+                    self.lines,
+                    key=lambda entry: (
+                        entry.squared_distance.as_fraction(),
+                        tuple(value.as_fraction() for value in entry.line_coefficients),
+                    ),
+                )
+            )
+            != self.lines
+        ):
+            raise _validation_error(
+                "lines_sorted_squared_distance_coefficients",
+                "lines must be sorted by (squared_distance, coefficients)",
+            )
+        if any(count <= 0 for _, count in self.distance_multiplicities):
+            raise _validation_error(
+                "distance_multiplicities_positive",
+                "distance multiplicities must be positive",
+            )
+        distances = tuple(
+            value.as_fraction() for value, _ in self.distance_multiplicities
+        )
+        if distances != tuple(sorted(distances)) or len(distances) != len(
+            set(distances)
+        ):
+            raise _validation_error(
+                "distance_multiplicities_sorted",
+                "distance multiplicities must be sorted by distinct distance",
+            )
+        if sum(count for _, count in self.distance_multiplicities) != len(self.lines):
             raise _validation_error(
                 "distance_multiplicities_partition_lines_sorted",
                 "distance multiplicities must partition the lines and be sorted",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PinnedLineDistanceRequest,
+        *,
+        lines: tuple[PinnedLineEntry, ...],
+        distance_multiplicities: tuple[tuple[CanonicalRational, int], ...],
+    ) -> Self:
+        """Build a result after the admitted profile kernel established it."""
+
+        return cls.model_construct(
+            configuration=request.configuration,
+            anchor=request.anchor,
+            dimension=2,
+            point_count=len(request.configuration.points),
+            lines=lines,
+            distance_multiplicities=distance_multiplicities,
+        )
+
+
+def _verify_pinned_line_distance_claim(result: PinnedLineDistanceResult) -> None:
+    """Fail closed when an independently supplied profile needs verification."""
+
+    request = PinnedLineDistanceRequest(
+        configuration=result.configuration,
+        anchor=result.anchor,
+    )
+    points, anchor = _pinned_profile_source(
+        request.configuration, request.anchor, result.point_count
+    )
+    expected_lines, expected_distances = _expected_pinned_profile_geometry(
+        points, anchor, result.point_count
+    )
+    seen_pairs, multiplicities = _validate_pinned_profile_entries(
+        result.lines, result.point_count, expected_lines, expected_distances
+    )
+    expected_pairs = [
+        (first, second)
+        for first in range(result.point_count)
+        for second in range(first + 1, result.point_count)
+    ]
+    if sorted(seen_pairs) != expected_pairs or len(seen_pairs) != len(set(seen_pairs)):
+        raise _validation_error(
+            "lines_cover_set_source_pairs_once",
+            "lines must cover exactly the set of source pairs once",
+        )
+    if len(result.lines) != len(expected_lines):
+        raise _validation_error(
+            "lines_correspond_distinct_geometric_lines",
+            "lines must correspond to distinct geometric lines",
+        )
+    _validate_pinned_profile_order(result.lines, expected_lines, expected_distances)
+    reconstructed = tuple(
+        (CanonicalRational.from_fraction(distance), count)
+        for distance, count in sorted(multiplicities.items())
+    )
+    if reconstructed != result.distance_multiplicities:
+        raise _validation_error(
+            "distance_multiplicities_partition_lines_sorted",
+            "distance multiplicities must partition the lines and be sorted",
+        )

--- a/src/jacobian/math/geometry/exact/_operations.py
+++ b/src/jacobian/math/geometry/exact/_operations.py
@@ -142,11 +142,8 @@ def compute_pinned_line_distance_profile(
     multiplicities = tuple(
         (CanonicalRational.from_fraction(d), count) for d, count in sorted(mult.items())
     )
-    return PinnedLineDistanceResult(
-        configuration=config,
-        anchor=request.anchor,
-        dimension=2,
-        point_count=n,
+    return PinnedLineDistanceResult._from_kernel(
+        request,
         lines=entries,
         distance_multiplicities=multiplicities,
     )

--- a/src/jacobian/math/geometry/polygon_kernel/_kernel.py
+++ b/src/jacobian/math/geometry/polygon_kernel/_kernel.py
@@ -169,25 +169,9 @@ class KernelData:
     kernel_to_polygon_area_ratio: CanonicalRational
     polygon_to_hull_area_ratio: CanonicalRational
 
-    def as_tuple(self) -> tuple[object, ...]:
-        return (
-            self.convention,
-            self.half_planes,
-            self.vertex_turns,
-            self.reflex_vertex_indices,
-            self.dimension,
-            self.boundary,
-            self.convex_hull,
-            self.polygon_area,
-            self.kernel_area,
-            self.convex_hull_area,
-            self.kernel_to_polygon_area_ratio,
-            self.polygon_to_hull_area_ratio,
-        )
-
 
 def compute_kernel_data(polygon: KernelPolygon) -> KernelData:
-    """Compute the complete canonical kernel data used by producer and replay."""
+    """Compute the complete canonical kernel data for one admitted polygon."""
 
     half_planes = oriented_half_planes(polygon)
     candidates = _feasible_boundary_intersections(half_planes)

--- a/src/jacobian/math/geometry/polygon_kernel/_models.py
+++ b/src/jacobian/math/geometry/polygon_kernel/_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import comb
-from typing import Literal, Self
+from typing import TYPE_CHECKING, Literal, Self
 
 from pydantic import ConfigDict, Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
@@ -16,6 +16,9 @@ from jacobian.math.geometry._models import (
     RationalPoint2D,
     _is_simple_ring,
 )
+
+if TYPE_CHECKING:
+    from jacobian.math.geometry.polygon_kernel._kernel import KernelData
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -280,30 +283,77 @@ class PolygonKernelResult(StrictModel):
     polygon_to_hull_area_ratio: CanonicalRational
 
     @model_validator(mode="after")
-    def bind_result_to_source_polygon(self) -> Self:
-        from jacobian.math.geometry.polygon_kernel._kernel import compute_kernel_data
-
-        expected = compute_kernel_data(self.polygon)
-        actual = (
-            self.interior_half_plane_convention,
-            self.half_planes,
-            self.vertex_turns,
-            self.reflex_vertex_indices,
-            self.kernel_dimension,
-            self.kernel_boundary,
-            self.convex_hull,
-            self.polygon_area,
-            self.kernel_area,
-            self.convex_hull_area,
-            self.kernel_to_polygon_area_ratio,
-            self.polygon_to_hull_area_ratio,
-        )
-        if actual != expected.as_tuple():
+    def require_structural_consistency(self) -> Self:
+        vertex_count = len(self.polygon.points)
+        if (
+            len(self.half_planes) != vertex_count
+            or len(self.vertex_turns) != vertex_count
+        ):
             raise _validation_error(
-                "visibility_kernel_result_retained_source_polygon",
-                "visibility-kernel result does not match the retained source polygon",
+                "visibility_kernel_result_source_row_count",
+                "visibility-kernel half-planes and turns must have one row per source vertex",
+            )
+        if tuple(row.edge_index for row in self.half_planes) != tuple(
+            range(vertex_count)
+        ):
+            raise _validation_error(
+                "visibility_kernel_result_half_plane_indices",
+                "visibility-kernel half-plane indices must be consecutive source indices",
+            )
+        if tuple(row.vertex_index for row in self.vertex_turns) != tuple(
+            range(vertex_count)
+        ):
+            raise _validation_error(
+                "visibility_kernel_result_turn_indices",
+                "visibility-kernel turn indices must be consecutive source indices",
+            )
+        if self.reflex_vertex_indices != tuple(sorted(set(self.reflex_vertex_indices))):
+            raise _validation_error(
+                "visibility_kernel_result_reflex_indices",
+                "visibility-kernel reflex indices must be distinct and sorted",
+            )
+        if any(
+            index < 0 or index >= vertex_count for index in self.reflex_vertex_indices
+        ):
+            raise _validation_error(
+                "visibility_kernel_result_reflex_indices",
+                "visibility-kernel reflex indices must refer to source vertices",
+            )
+        expected_boundary_size = {
+            "EMPTY": 0,
+            "POINT": 1,
+            "SEGMENT": 2,
+        }.get(self.kernel_dimension)
+        if expected_boundary_size is not None:
+            valid_boundary_size = len(self.kernel_boundary) == expected_boundary_size
+        else:
+            valid_boundary_size = len(self.kernel_boundary) >= 3
+        if not valid_boundary_size:
+            raise _validation_error(
+                "visibility_kernel_result_dimension_boundary",
+                "visibility-kernel dimension must match its boundary cardinality",
             )
         return self
+
+    @classmethod
+    def _from_kernel(cls, polygon: KernelPolygon, *, data: KernelData) -> Self:
+        """Build a result after the admitted kernel established its values."""
+
+        return cls.model_construct(
+            polygon=polygon,
+            interior_half_plane_convention=data.convention,
+            half_planes=data.half_planes,
+            vertex_turns=data.vertex_turns,
+            reflex_vertex_indices=data.reflex_vertex_indices,
+            kernel_dimension=data.dimension,
+            kernel_boundary=data.boundary,
+            convex_hull=data.convex_hull,
+            polygon_area=data.polygon_area,
+            kernel_area=data.kernel_area,
+            convex_hull_area=data.convex_hull_area,
+            kernel_to_polygon_area_ratio=data.kernel_to_polygon_area_ratio,
+            polygon_to_hull_area_ratio=data.polygon_to_hull_area_ratio,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/geometry/polygon_kernel/_operations.py
+++ b/src/jacobian/math/geometry/polygon_kernel/_operations.py
@@ -1,4 +1,4 @@
-"""Native exact visibility-kernel operation."""
+"""Native exact visibility-kernel operation and private claim verification."""
 
 from jacobian.math.geometry.polygon_kernel._kernel import compute_kernel_data
 from jacobian.math.geometry.polygon_kernel._models import (
@@ -11,23 +11,32 @@ def compute_visibility_kernel(request: PolygonKernelRequest) -> PolygonKernelRes
     """Reconstruct a simple CCW polygon's closed visibility kernel exactly."""
 
     data = compute_kernel_data(request.polygon)
-    # ``compute_kernel_data`` is the same deterministic replay used by the
-    # result model. Avoid paying the O(n^3) replay twice in the trusted producer;
-    # serialized/authored results still run the complete source-binding check.
-    return PolygonKernelResult.model_construct(
-        polygon=request.polygon,
-        interior_half_plane_convention=data.convention,
-        half_planes=data.half_planes,
-        vertex_turns=data.vertex_turns,
-        reflex_vertex_indices=data.reflex_vertex_indices,
-        kernel_dimension=data.dimension,
-        kernel_boundary=data.boundary,
-        convex_hull=data.convex_hull,
-        polygon_area=data.polygon_area,
-        kernel_area=data.kernel_area,
-        convex_hull_area=data.convex_hull_area,
-        kernel_to_polygon_area_ratio=data.kernel_to_polygon_area_ratio,
-        polygon_to_hull_area_ratio=data.polygon_to_hull_area_ratio,
+    return PolygonKernelResult._from_kernel(request.polygon, data=data)
+
+
+def _verify_polygon_kernel_result(result: PolygonKernelResult) -> bool:
+    """Deliberately recompute one independently supplied kernel claim."""
+
+    try:
+        request = PolygonKernelRequest.model_validate(
+            {"polygon": result.polygon.model_dump(mode="json")}
+        )
+    except (AttributeError, TypeError, ValueError):
+        return False
+    expected = compute_kernel_data(request.polygon)
+    return (
+        result.interior_half_plane_convention == expected.convention
+        and result.half_planes == expected.half_planes
+        and result.vertex_turns == expected.vertex_turns
+        and result.reflex_vertex_indices == expected.reflex_vertex_indices
+        and result.kernel_dimension == expected.dimension
+        and result.kernel_boundary == expected.boundary
+        and result.convex_hull == expected.convex_hull
+        and result.polygon_area == expected.polygon_area
+        and result.kernel_area == expected.kernel_area
+        and result.convex_hull_area == expected.convex_hull_area
+        and result.kernel_to_polygon_area_ratio == expected.kernel_to_polygon_area_ratio
+        and result.polygon_to_hull_area_ratio == expected.polygon_to_hull_area_ratio
     )
 
 

--- a/src/jacobian/math/graphs/coloring/_chromatic_number_models.py
+++ b/src/jacobian/math/graphs/coloring/_chromatic_number_models.py
@@ -40,26 +40,16 @@ MAX_CHROMATIC_CERTIFICATE_DERIVED_RATIONAL_DIGITS = (
     + 1
 )
 
-# One byte records each subset's independence during exhaustive replay.  The
-# checker visits every subset twice overall: once for the operation and once
-# when the source-bound result validator replays the defining relation.
+# One byte records each subset's independence during the exhaustive check.
 MAX_CHROMATIC_CERTIFICATE_SUBSET_STATES = 1 << MAX_CHROMATIC_CERTIFICATE_VERTICES
-CHROMATIC_CERTIFICATE_REPLAY_PASSES = 2
 
 # Work is charged in conservative elementary decimal-digit operations.  For
-# each pass, admission includes common-denominator construction and scaling,
+# Admission includes common-denominator construction and scaling,
 # one independence-state update per subset, and one bounded-height integer
 # update and comparison per Gray-code step.  This result-sensitive cap admits
 # order 20 with ordinary small weights and order 19 with distinct 40-digit
 # denominators, while rejecting the corresponding order-20 adversarial case.
 MAX_CHROMATIC_CERTIFICATE_DIGIT_WORK = 3_000_000_000
-
-# Authored results may carry two derived rationals at the static height above.
-# Charge their canonical reduction and exact replay comparisons independently
-# of the source-sensitive producer/replay estimate.
-_RESULT_RATIONAL_VALIDATION_DIGIT_WORK = (
-    8 * MAX_CHROMATIC_CERTIFICATE_DERIVED_RATIONAL_DIGITS**2
-)
 
 _RESULT_ENVELOPE_RESERVE_BYTES = 4_096
 
@@ -204,11 +194,7 @@ def _estimated_digit_work(
     arithmetic_setup = 6 * order * intermediate_digits * intermediate_digits
     subset_replay = subset_states * (1 + 2 * intermediate_digits)
     graph_setup = order + 3 * len(graph.edges)
-    return (
-        CHROMATIC_CERTIFICATE_REPLAY_PASSES
-        * (arithmetic_setup + subset_replay + graph_setup)
-        + _RESULT_RATIONAL_VALIDATION_DIGIT_WORK
-    )
+    return arithmetic_setup + subset_replay + graph_setup
 
 
 def _require_bounded_sources(
@@ -594,12 +580,6 @@ class ChromaticNumberCertificateCheckResult(StrictModel):
 
     @model_validator(mode="after")
     def require_structural_result_bounds(self) -> Self:
-        _require_bounded_sources(
-            self.graph,
-            self.claimed_chromatic_number,
-            self.coloring,
-            self.weights,
-        )
         return self
 
 

--- a/src/jacobian/math/graphs/coloring/_chromatic_number_models.py
+++ b/src/jacobian/math/graphs/coloring/_chromatic_number_models.py
@@ -580,6 +580,23 @@ class ChromaticNumberCertificateCheckResult(StrictModel):
 
     @model_validator(mode="after")
     def require_structural_result_bounds(self) -> Self:
+        order = len(self.graph.vertices)
+        if order > MAX_CHROMATIC_CERTIFICATE_VERTICES:
+            raise PydanticCustomError(
+                "graph.chromatic_number_certificate_checking_supports_at_most",
+                "chromatic-number certificate checking supports at most "
+                f"{MAX_CHROMATIC_CERTIFICATE_VERTICES} vertices",
+            )
+        if len(self.coloring) != order:
+            raise PydanticCustomError(
+                "graph.coloring_must_assign_one_color_per_graph_vertex",
+                "coloring must assign one color per graph vertex",
+            )
+        if len(self.weights) != order:
+            raise PydanticCustomError(
+                "graph.weights_must_assign_one_exact_rational_per_graph",
+                "weights must assign one exact rational per graph vertex",
+            )
         return self
 
 

--- a/src/jacobian/math/graphs/coloring/_operations.py
+++ b/src/jacobian/math/graphs/coloring/_operations.py
@@ -197,11 +197,20 @@ def verify_chromatic_number_certificate_check_result(
 ) -> bool:
     """Replay one independently supplied bounded chromatic certificate claim."""
 
+    try:
+        request = ChromaticNumberCertificateCheckRequest(
+            graph=result.graph,
+            claimed_chromatic_number=result.claimed_chromatic_number,
+            coloring=result.coloring,
+            weights=result.weights,
+        )
+    except ValueError:
+        return False
     expected = _evaluate_chromatic_number_certificate(
-        result.graph,
-        result.claimed_chromatic_number,
-        result.coloring,
-        result.weights,
+        request.graph,
+        request.claimed_chromatic_number,
+        request.coloring,
+        request.weights,
     )
     return (
         result.verdict,

--- a/src/jacobian/math/graphs/flow/_models.py
+++ b/src/jacobian/math/graphs/flow/_models.py
@@ -290,13 +290,12 @@ class FlowEdgeResult(StrictModel):
 
 
 class MinCostFlowResult(StrictModel):
-    """The exact minimum-cost-flow outcome bound to its complete source network.
+    """The exact minimum-cost-flow outcome bound to its source network.
 
-    Retains the source graph and demands so validation replays the defining
-    relations instead of trusting an independently authored claim: every edge
-    flow lies between zero and its source capacity, every node balance equals
-    its source demand, and the objective is the exact cost of the returned
-    source-unit flows.  Infeasibility carries no flow or cost data.
+    The producer establishes feasibility, conservation, capacities, and the
+    objective once. Parsing retains only the result's structural shape;
+    deliberate verification of an independently supplied claim belongs to
+    the flow owner.
     """
 
     graph: CostedFlowGraph
@@ -307,71 +306,39 @@ class MinCostFlowResult(StrictModel):
     convention: Literal["NETWORKX_MIN_COST_FLOW"] = "NETWORKX_MIN_COST_FLOW"
 
     @model_validator(mode="after")
-    def require_source_bound(self) -> Self:
-        from fractions import Fraction
-
+    def require_structural_consistency(self) -> Self:
         if len(self.demands) != self.graph.vertex_count:
             raise PydanticCustomError(
                 "graph.demands_length_must_match_graph_vertex_count",
                 "demands length must match graph.vertex_count",
             )
-        if sum(self.demands) != 0:
+        if not self.feasible and (
+            self.flow_edges or self.total_cost.as_fraction() != 0
+        ):
             raise PydanticCustomError(
-                "graph.demands_must_sum_to_zero", "demands must sum to zero"
-            )
-        if not self.feasible:
-            if self.flow_edges or self.total_cost.as_fraction() != 0:
-                raise PydanticCustomError(
-                    "graph.infeasible_result_carries_no_flow_edges_nonzero",
-                    "an infeasible result carries no flow edges or nonzero cost",
-                )
-            return self
-
-        capacities: dict[tuple[int, int], Fraction] = {}
-        costs: dict[tuple[int, int], Fraction] = {}
-        for edge in self.graph.edges:
-            endpoints = (edge.source, edge.target)
-            capacities[endpoints] = edge.capacity.as_fraction()
-            costs[endpoints] = edge.cost.as_fraction()
-        balance = [Fraction(0)] * self.graph.vertex_count
-        objective = Fraction(0)
-        seen: set[tuple[int, int]] = set()
-        for flow_edge in self.flow_edges:
-            endpoints = (flow_edge.source, flow_edge.target)
-            if endpoints not in capacities:
-                raise PydanticCustomError(
-                    "graph.flow_reported_undeclared_edge_endpoints_endpoints",
-                    f"flow reported on undeclared edge {endpoints[0]}->{endpoints[1]}",
-                )
-            if endpoints in seen:
-                raise PydanticCustomError(
-                    "graph.edge_endpoints_endpoints_reported_more_than_once",
-                    f"edge {endpoints[0]}->{endpoints[1]} reported more than once",
-                )
-            seen.add(endpoints)
-            flow = flow_edge.flow.as_fraction()
-            if not 0 <= flow <= capacities[endpoints]:
-                raise PydanticCustomError(
-                    "graph.flow_flow_edge_endpoints_endpoints_violates_source",
-                    f"flow {flow} on edge {endpoints[0]}->{endpoints[1]} "
-                    f"violates the source capacity {capacities[endpoints]}",
-                )
-            balance[flow_edge.source] -= flow
-            balance[flow_edge.target] += flow
-            objective += costs[endpoints] * flow
-        for node, demand in enumerate(self.demands):
-            if balance[node] != demand:
-                raise PydanticCustomError(
-                    "graph.node_node_balance_balance_node_does_equal",
-                    f"node {node} balance {balance[node]} does not equal "
-                    f"its source demand {demand}",
-                )
-        if objective != self.total_cost.as_fraction():
-            raise PydanticCustomError(
-                "graph.total_cost_does_not_equal_the_cost_of_the_return",
-                "total cost does not equal the cost of the returned flows",
+                "graph.infeasible_result_carries_no_flow_edges_nonzero",
+                "an infeasible result carries no flow edges or nonzero cost",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: MinCostFlowRequest,
+        *,
+        total_cost: CanonicalRational,
+        feasible: bool,
+        flow_edges: tuple[FlowEdgeResult, ...],
+    ) -> Self:
+        """Build one result after the admitted flow kernel established it."""
+
+        return cls.model_construct(
+            graph=request.graph,
+            demands=request.demands,
+            total_cost=total_cost,
+            feasible=feasible,
+            flow_edges=flow_edges,
+        )
 
 
 class CirculationResult(StrictModel):

--- a/src/jacobian/math/graphs/flow/_operations.py
+++ b/src/jacobian/math/graphs/flow/_operations.py
@@ -6,6 +6,7 @@ from fractions import Fraction
 from typing import Any
 
 import networkx as nx
+from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer
@@ -152,9 +153,8 @@ def compute_min_cost_flow(request: MinCostFlowRequest) -> MinCostFlowResult:
     try:
         flow_cost_int, flow_dict = nx.network_simplex(g)
     except (nx.NetworkXUnfeasible, nx.NetworkXError):
-        return MinCostFlowResult(
-            graph=request.graph,
-            demands=request.demands,
+        return MinCostFlowResult._from_kernel(
+            request,
             total_cost=_rational(0),
             feasible=False,
             flow_edges=(),
@@ -175,10 +175,19 @@ def compute_min_cost_flow(request: MinCostFlowRequest) -> MinCostFlowResult:
     # over the returned source-unit flows, so the exact public objective
     # divides it by both scales.
     total_cost = Fraction(int(flow_cost_int), flow_scale * cost_scale)
-    return MinCostFlowResult(
-        graph=request.graph,
-        demands=request.demands,
+    return MinCostFlowResult._from_kernel(
+        request,
         total_cost=_rational(total_cost),
         feasible=True,
         flow_edges=tuple(flow_edges),
     )
+
+
+def _verify_min_cost_flow_result(result: MinCostFlowResult) -> bool:
+    """Deliberately recompute one independently supplied min-cost-flow claim."""
+
+    try:
+        request = MinCostFlowRequest(graph=result.graph, demands=result.demands)
+    except ValidationError:
+        return False
+    return compute_min_cost_flow(request) == result

--- a/src/jacobian/math/graphs/isomorphism/_models.py
+++ b/src/jacobian/math/graphs/isomorphism/_models.py
@@ -8,10 +8,6 @@ from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.math.graphs.isomorphism._canonicalization import (
-    apply_colored_graph_relabeling,
-    canonicalize_colored_graph_data,
-)
 from jacobian.math.graphs.isomorphism._canonicalization_bounds import (
     require_admitted_colored_graph_canonicalization,
 )
@@ -126,7 +122,7 @@ class ColoredGraphCanonicalizationRequest(StrictModel):
                 "and edge colors are exact names: a relabeling may move vertices "
                 "only when it preserves every declared color. Requests are "
                 "rejected before enumeration when their color-class permutation "
-                "count, execution-plus-validation replay work, or exact result "
+                "count, execution work, or exact result "
                 "size exceeds the published bound."
             )
         }
@@ -161,9 +157,9 @@ class ColoredGraphCanonicalizationResult(StrictModel):
     positions in increasing exact color-name order; among all relabelings inside
     those classes, the canonical graph has the least sorted sequence of endpoint
     positions and edge-color names. An automorphism tie uses the least target
-    tuple aligned to the source graph's vertex axis. Result validation replays
-    that complete bounded search, then checks that ``relabeling`` reconstructs
-    the returned graph exactly from ``source_graph``.
+    tuple aligned to the source graph's vertex axis. Kernel-produced results
+    establish this canonical form once; parsing retains only the relabeling's
+    structural shape.
     """
 
     source_graph: ColoredUndirectedGraph
@@ -177,8 +173,7 @@ class ColoredGraphCanonicalizationResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def require_exact_source_bound_canonical_form(self) -> Self:
-        require_admitted_colored_graph_canonicalization(self.source_graph)
+    def require_structural_relabeling(self) -> Self:
         if tuple(item.source_vertex for item in self.relabeling) != (
             self.source_graph.graph.vertices
         ):
@@ -199,28 +194,21 @@ class ColoredGraphCanonicalizationResult(StrictModel):
                 "graph.relabeling_bijection_onto_canonical_vertices",
                 "relabeling must be a bijection onto the canonical graph vertices",
             )
-        if apply_colored_graph_relabeling(self.source_graph, mapping) != (
-            self.canonical_graph
-        ):
-            raise PydanticCustomError(
-                "graph.relabeling_must_reconstruct_the_canonical_colore",
-                "relabeling must reconstruct the canonical colored graph",
-            )
-        expected_graph, expected_relabeling = canonicalize_colored_graph_data(
-            self.source_graph
-        )
-        actual_relabeling = tuple(
-            (item.source_vertex, item.canonical_vertex) for item in self.relabeling
-        )
-        if (
-            self.canonical_graph != expected_graph
-            or actual_relabeling != expected_relabeling
-        ):
-            raise PydanticCustomError(
-                "graph.result_exact_deterministic_colored_canonical_form",
-                "result must be the exact deterministic colored-graph canonical form",
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source_graph: ColoredUndirectedGraph,
+        canonical_graph: ColoredUndirectedGraph,
+        relabeling: tuple[GraphRelabelingPair, ...],
+    ) -> Self:
+        return cls.model_construct(
+            source_graph=source_graph,
+            canonical_graph=canonical_graph,
+            relabeling=relabeling,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/isomorphism/_operations.py
+++ b/src/jacobian/math/graphs/isomorphism/_operations.py
@@ -164,7 +164,7 @@ def canonicalize_colored_graph_kernel(
     """Construct the exact canonical value from one admitted graph value."""
 
     canonical_graph, relabeling = canonicalize_colored_graph_data(graph)
-    return ColoredGraphCanonicalizationResult(
+    return ColoredGraphCanonicalizationResult._from_kernel(
         source_graph=graph,
         canonical_graph=canonical_graph,
         relabeling=tuple(
@@ -172,3 +172,16 @@ def canonicalize_colored_graph_kernel(
             for source, target in relabeling
         ),
     )
+
+
+def _verify_colored_graph_canonicalization_result(
+    result: ColoredGraphCanonicalizationResult,
+) -> bool:
+    """Fail closed for a deliberately supplied canonicalization claim."""
+
+    try:
+        request = ColoredGraphCanonicalizationRequest(colored_graph=result.source_graph)
+        expected = canonicalize_colored_graph_kernel(request.colored_graph)
+    except ValueError:
+        return False
+    return expected == result

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -46,9 +46,8 @@ def profile_components(
     priced row afterwards -- so admission adds no arithmetic pass of its own.
     Request parsing may supply ``admitted``, the scan it already performed
     and validated against, which then serves as this producer pass verbatim;
-    otherwise the pass runs here. Result-model validation calls this same
-    pure kernel without a stash, so its replay always rescans independently
-    and the returned work ledger charges both passes.
+    otherwise the pass runs here. Result parsing performs structural checks
+    only and never re-enters this kernel.
     """
 
     if admitted is None:
@@ -142,7 +141,7 @@ def profile_components(
     comparisons = divergence_cells + edge_cells + scan_comparisons
     per_pass = additions + negations + divisions + comparisons
     work = MulticommodityFlowProfileWork(
-        execution_passes_per_call=2,
+        execution_passes_per_call=1,
         sparse_entries=sparse_entries,
         commodity_vertex_cells=divergence_cells,
         edge_cells=edge_cells,
@@ -150,7 +149,7 @@ def profile_components(
         rational_negations_per_pass=negations,
         rational_divisions_per_pass=divisions,
         exact_comparisons_per_pass=comparisons,
-        logical_steps_per_call=2 * per_pass,
+        logical_steps_per_call=per_pass,
     )
     return (
         divergence_rows,

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -57,9 +57,8 @@ MAX_COMMODITY_VERTEX_CELLS = 512
 # vertices. This envelope belongs to the profile operation, not to the
 # canonical tensor value: request parsing performs the operation's single
 # component scan, admits work and result envelope from it, and hands the
-# measured components to the producer pass, while the replay pass always
-# rescans independently -- so an accepted call executes exactly the two
-# charged passes and the work ledger stays an exact per-call accounting.
+# measured components directly to the producer. The work ledger records that
+# one bounded scan; result parsing does not repeat mathematical execution.
 MAX_PROFILE_RESULT_BYTES = 8 * 1024 * 1024
 _DIVERGENCE_ROW_OVERHEAD_BYTES = 128
 _EDGE_ROW_OVERHEAD_BYTES = 128
@@ -84,8 +83,8 @@ _PROFILE_RESULT_HEADER_BYTES = 1_024
 # otherwise those checks pair every edge either with a zero-capacity load
 # test or with one ratio division plus one running-maximum comparison, and
 # the kernel's own edge loop needs only its load-vs-capacity feasibility
-# test. With the admitted maxima this bounds each pass by 789,760 logical
-# steps; producer plus exact result replay therefore costs at most 1,579,520.
+# test. With the admitted maxima this bounds one profile computation by
+# 789,760 logical steps.
 MAX_SPARSE_FLOW_ENTRIES = (MAX_COMMODITY_VERTEX_CELLS // 2) * MAX_MULTICOMMODITY_EDGES
 MAX_PROFILE_ADDITIONS_PER_PASS = 6 * MAX_SPARSE_FLOW_ENTRIES + MAX_MULTICOMMODITY_EDGES
 MAX_PROFILE_NEGATIONS_PER_PASS = MAX_COMMODITY_VERTEX_CELLS // 2
@@ -93,7 +92,7 @@ MAX_PROFILE_DIVISIONS_PER_PASS = MAX_MULTICOMMODITY_EDGES
 MAX_PROFILE_COMPARISONS_PER_PASS = (
     MAX_COMMODITY_VERTEX_CELLS + 3 * MAX_MULTICOMMODITY_EDGES
 )
-MAX_PROFILE_LOGICAL_STEPS = 2 * (
+MAX_PROFILE_LOGICAL_STEPS = (
     MAX_PROFILE_ADDITIONS_PER_PASS
     + MAX_PROFILE_NEGATIONS_PER_PASS
     + MAX_PROFILE_DIVISIONS_PER_PASS
@@ -469,9 +468,8 @@ class AdmittedProfileScan(NamedTuple):
     """The once-computed components of one measured profile scan.
 
     Request parsing performs this scan, admits work and result envelope
-    from it, and hands it to the producer pass, which otherwise recomputes
-    it; the replay pass always rescans independently. Either way an
-    accepted call executes exactly two arithmetic passes.
+    from it, and hands it directly to the producer. Native calls perform the
+    same scan at their execution boundary.
 
     ``congestion_ratio`` is None exactly when a loaded zero-capacity edge
     makes the public result's congestion null, so no ratio arithmetic ran;
@@ -497,7 +495,7 @@ def measured_profile_components(flow: MulticommodityFlow) -> AdmittedProfileScan
     """Run the single bucketed component scan and derive every priced bound.
 
     The returned slacks and congestion ratio are the same measured components
-    priced into the budget, so one producer or replay pass subtracts each
+    priced into the budget, so the producer subtracts each
     slack exactly once and divides each positive-capacity ratio exactly once
     whenever the result returns a congestion value (and never divides one
     when a loaded zero-capacity edge forces it to be null); the work ledger
@@ -548,8 +546,8 @@ def _require_profile_output_admission(flow: MulticommodityFlow) -> AdmittedProfi
     Request parsing runs this complete mathematical validation so every
     accepted ``math.run`` request reaches the kernel guaranteed admissible,
     and native callers get the same typed rejection before any result
-    construction. The returned scan is reused as the producer pass, so an
-    accepted call executes exactly the two charged passes.
+    construction. The returned scan is reused directly by the producer, so
+    an accepted call executes one charged pass.
     """
 
     _require_profile_source_room(flow)
@@ -611,7 +609,7 @@ def _require_admitted_profile_rows(
 
     The bounds are the ones the kernel's single measured scan already
     produced, so admission prices the result without a second arithmetic
-    pass and the two-pass work ledger stays exact. A null congestion bound
+    pass and the one-pass work ledger stays exact. A null congestion bound
     is the loaded zero-capacity-edge case whose result serializes a null:
     the reserved rational overhead alone covers that field's bytes.
     """
@@ -743,9 +741,9 @@ class EdgeLoadProfile(StrictModel):
 
 
 class MulticommodityFlowProfileWork(StrictModel):
-    """Exact finite accounting for producer and source-bound result replay."""
+    """Exact finite accounting for one bounded profile computation."""
 
-    execution_passes_per_call: int = Field(ge=2, le=2)
+    execution_passes_per_call: int = Field(ge=1, le=1)
     sparse_entries: int = Field(ge=0, le=MAX_SPARSE_FLOW_ENTRIES)
     commodity_vertex_cells: int = Field(ge=1, le=MAX_COMMODITY_VERTEX_CELLS)
     edge_cells: int = Field(ge=1, le=MAX_MULTICOMMODITY_EDGES)
@@ -788,24 +786,75 @@ class MulticommodityFlowProfileResult(StrictModel):
     work: MulticommodityFlowProfileWork
 
     @model_validator(mode="after")
-    def require_exact_source_bound_profile(self) -> Self:
-        from jacobian.math.graphs.multicommodity_flow._kernel import profile_components
-
-        expected = profile_components(self.flow)
-        actual = (
-            self.divergences,
-            self.edge_profiles,
-            self.all_demands_routed,
-            self.capacity_feasible,
-            self.congestion,
-            self.work,
+    def require_structural_profile_rows(self) -> Self:
+        expected_divergence_keys = tuple(
+            (commodity.commodity_id, vertex)
+            for commodity in self.flow.commodities
+            for vertex in range(self.flow.network.vertex_count)
         )
-        if actual != expected:
+        actual_divergence_keys = tuple(
+            (row.commodity_id, row.vertex) for row in self.divergences
+        )
+        if actual_divergence_keys != expected_divergence_keys:
             raise PydanticCustomError(
-                "graph.result_must_match_the_exact_multicommodity_flow_",
-                "result must match the exact multicommodity-flow profile",
+                "graph.profile_divergence_rows_must_match_source_axis",
+                "profile divergence rows must match the source commodity-vertex axis",
+            )
+        expected_edge_keys = tuple(
+            (edge.source, edge.target) for edge in self.flow.network.edges
+        )
+        actual_edge_keys = tuple((row.source, row.target) for row in self.edge_profiles)
+        if actual_edge_keys != expected_edge_keys:
+            raise PydanticCustomError(
+                "graph.profile_edge_rows_must_match_network_edges",
+                "profile edge rows must match the source network edges",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        flow: MulticommodityFlow,
+        *,
+        divergences: tuple[CommodityDivergence, ...],
+        edge_profiles: tuple[EdgeLoadProfile, ...],
+        all_demands_routed: bool,
+        capacity_feasible: bool,
+        congestion: CanonicalRational | None,
+        work: MulticommodityFlowProfileWork,
+    ) -> Self:
+        """Build a result after the admitted profile kernel established it."""
+
+        return cls.model_construct(
+            flow=flow,
+            divergences=divergences,
+            edge_profiles=edge_profiles,
+            all_demands_routed=all_demands_routed,
+            capacity_feasible=capacity_feasible,
+            congestion=congestion,
+            work=work,
+        )
+
+
+def _verify_multicommodity_flow_profile_result(
+    result: MulticommodityFlowProfileResult,
+) -> None:
+    """Recompute one independently supplied profile under normal admission."""
+
+    from jacobian.math.graphs.multicommodity_flow._kernel import profile_components
+
+    request = MulticommodityFlowProfileRequest(flow=result.flow)
+    expected = profile_components(result.flow, request._admitted_scan)
+    actual = (
+        result.divergences,
+        result.edge_profiles,
+        result.all_demands_routed,
+        result.capacity_feasible,
+        result.congestion,
+        result.work,
+    )
+    if actual != expected:
+        raise ValueError("result must match the exact multicommodity-flow profile")
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/multicommodity_flow/_operations.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_operations.py
@@ -18,8 +18,7 @@ def compute_multicommodity_flow_profile(
 
     The canonical tensor value carries only representation bounds; this
     execution boundary admits the profile work and result envelope inside
-    its own measured scan, so a native call executes exactly the two
-    charged passes. Parsed MCP requests reuse their parse-time scan instead.
+    its own measured scan. Parsed MCP requests reuse their parse-time scan.
     """
 
     return _profile_result(flow, None)
@@ -37,8 +36,8 @@ def _profile_result(
         congestion,
         work,
     ) = profile_components(flow, admitted)
-    return MulticommodityFlowProfileResult(
-        flow=flow,
+    return MulticommodityFlowProfileResult._from_kernel(
+        flow,
         divergences=divergences,
         edge_profiles=edge_profiles,
         all_demands_routed=all_demands_routed,
@@ -54,8 +53,7 @@ def _run_multicommodity_flow_profile(
     """Run one parsed MCP request through the native profile computation.
 
     Request validation already performed and admitted the operation's single
-    component scan; it is reused here as the producer pass, so execution
-    adds only the independent replay pass.
+    component scan; it is reused directly by the producer.
     """
 
     return _profile_result(request.flow, request._admitted_scan)

--- a/src/jacobian/math/graphs/multicommodity_flow/_tools.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_tools.py
@@ -18,7 +18,7 @@ TOOLS: MathTools = (
             "Compute exact commodity conservation, aggregate edge loads, signed "
             "capacity slacks, capacity feasibility, and congestion for one "
             "canonical sparse rational multicommodity-flow tensor. The result "
-            "retains and replays the complete network, demands, and tensor; it "
+            "retains the complete network, demands, and tensor; it "
             "does not search for a flow or solve an optimization problem."
         ),
         request_type=MulticommodityFlowProfileRequest,

--- a/src/jacobian/math/graphs/multigraph/_models.py
+++ b/src/jacobian/math/graphs/multigraph/_models.py
@@ -8,7 +8,7 @@ bounded positive moduli and canonical residue coordinates.
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, StrictInt, StrictStr, model_validator
 from pydantic_core import PydanticCustomError
@@ -375,8 +375,8 @@ class MultigraphFlowCheckResult(StrictModel):
     conservation_holds: bool
 
     @model_validator(mode="after")
-    def require_bound_flow_check(self) -> Self:
-        # Validate that edge_flow_records cover exactly graph edges
+    def require_structural_consistency(self) -> Self:
+        """Keep parsed flow results well formed without rechecking the flow."""
         graph_ids = self.graph.edge_id_set
         record_ids = {r.edge_id for r in self.edge_flow_records}
         if graph_ids != record_ids:
@@ -390,37 +390,31 @@ class MultigraphFlowCheckResult(StrictModel):
                 "edge_flow_records must not repeat edge IDs",
             )
         _require_values_within_group(self.edge_flow_records, self.group)
-        expected_ledger, expected_conservation = _recompute_divergence_ledger(
-            self.graph, self.group, self.edge_flow_records
-        )
-        if tuple(expected_ledger) != self.divergence_ledger:
+        if len(self.divergence_ledger) != self.graph.vertex_count:
             raise PydanticCustomError(
-                "graph.divergence_ledger_does_not_match_recomputed_ledg",
-                "divergence_ledger does not match recomputed ledger",
+                "graph.divergence_ledger_must_cover_every_vertex",
+                "divergence_ledger must contain one row for every vertex",
             )
-        if self.conservation_holds != expected_conservation:
+        if tuple(row.vertex for row in self.divergence_ledger) != tuple(
+            range(self.graph.vertex_count)
+        ):
             raise PydanticCustomError(
-                "graph.conservation_holds_does_not_match_recomputed_val",
-                "conservation_holds does not match recomputed value",
+                "graph.divergence_ledger_vertices_must_be_canonical",
+                "divergence_ledger vertices must be in canonical graph order",
             )
-        expected_zero = tuple(
-            sorted(
-                rec.edge_id
-                for rec in self.edge_flow_records
-                if self.group.is_zero(rec.value)
-            )
-        )
-        if self.zero_edge_ids != expected_zero:
+        if len(set(self.zero_edge_ids)) != len(self.zero_edge_ids) or not set(
+            self.zero_edge_ids
+        ).issubset(graph_ids):
             raise PydanticCustomError(
-                "graph.zero_edge_ids_does_not_match_recomputed_zero_set",
-                "zero_edge_ids does not match recomputed zero set",
-            )
-        if self.nowhere_zero != (len(expected_zero) == 0):
-            raise PydanticCustomError(
-                "graph.nowhere_zero_does_not_match_zero_edge_set",
-                "nowhere_zero does not match zero_edge set",
+                "graph.zero_edge_ids_must_be_unique_graph_edge_ids",
+                "zero_edge_ids must be unique graph edge IDs",
             )
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        """Build after the flow-check kernel established every conclusion."""
+        return cls.model_construct(**values)
 
 
 def _require_values_within_group(
@@ -445,7 +439,7 @@ def _require_values_within_group(
             )
 
 
-def _recompute_divergence_ledger(
+def _compute_divergence_ledger(
     graph: LooplessMultigraph,
     group: FiniteAbelianGroup,
     records: tuple[FlowEdgeAssignment, ...],
@@ -564,90 +558,19 @@ class MultigraphFlowFindResult(StrictModel):
 
     @model_validator(mode="after")
     def require_consistent_status(self) -> Self:
-        # The bounded search runs exactly once per request, inside the
-        # operation; validation -- including deserialized re-validation --
-        # must never repeat it, so the declared budget bounds the total
-        # visited states.  Each outcome is therefore checked structurally
-        # and arithmetically against the retained source: shape, budget,
-        # witness validity, and the exact charged-state totals that only
-        # the kernel's termination modes can produce.
+        """Validate outcome shape without replaying the bounded search."""
         _require_status_shape(self.status, self.flow, self.termination_reason)
         if self.states_explored > self.resource_budget.max_states:
             raise PydanticCustomError(
                 "graph.states_explored_exceeds_resource_budget",
                 "states_explored exceeds resource budget",
             )
-        if self.status == "FOUND":
-            if self.termination_reason == "SPECIAL_CASE":
-                # SPECIAL_CASE is reserved for the edgeless empty-flow
-                # shortcut; the DFS itself never emits it.
-                if self.graph.edges or self.flow != ():
-                    raise PydanticCustomError(
-                        "graph.special_case_termination_requires_edgeless_with_empty",
-                        "SPECIAL_CASE termination requires an edgeless "
-                        "graph with the empty flow",
-                    )
-            elif not self.graph.edges:
-                raise PydanticCustomError(
-                    "graph.edgeless_terminates_as_special_case_termination_reason",
-                    "an edgeless graph terminates as SPECIAL_CASE, not "
-                    f"{self.termination_reason}",
-                )
-            assert self.flow is not None  # guaranteed by _require_status_shape
-            _verify_found_witness(
-                self.graph, self.group, self.resource_budget, self.flow
-            )
-        elif self.status == "EXHAUSTED":
-            if not self.graph.edges:
-                raise PydanticCustomError(
-                    "graph.exhausted_status_requires_a_nonempty_search_doma",
-                    "EXHAUSTED status requires a nonempty search domain",
-                )
-            expected = _complete_enumeration_state_count(
-                self.graph,
-                self.group,
-                self.resource_budget.require_nowhere_zero,
-            )
-            if self.states_explored != expected:
-                raise PydanticCustomError(
-                    "graph.exhausted_outcome_reports_states_explored_explored_states",
-                    f"EXHAUSTED outcome reports {self.states_explored} "
-                    f"explored states; a completed enumeration of the "
-                    f"retained domain charges exactly {expected}",
-                )
-        else:
-            # UNKNOWN is emitted only at the moment the budget is exceeded,
-            # reporting exactly max_states charged states.
-            if self.states_explored != self.resource_budget.max_states:
-                raise PydanticCustomError(
-                    "graph.unknown_outcome_reports_states_explored_explored_states",
-                    f"UNKNOWN outcome reports {self.states_explored} "
-                    "explored states; a budget-exceeded search reports "
-                    f"exactly {self.resource_budget.max_states}",
-                )
         return self
 
-
-def _complete_enumeration_state_count(
-    graph: LooplessMultigraph,
-    group: FiniteAbelianGroup,
-    require_nowhere_zero: bool,
-) -> int:
-    """Exact charged-state total of a completed exhaustive flow search.
-
-    The bounded DFS charges one state per pushed partial assignment, so a
-    completed enumeration over ``d = len(graph.edges)`` edges with ``b``
-    choices per edge visits exactly ``b + b^2 + ... + b^d`` states, where
-    ``b`` is twice the number of admissible per-edge values (one term per
-    orientation).  Deriving this closed form from the retained source lets
-    validators authenticate EXHAUSTED outcomes without repeating the
-    bounded search.
-    """
-    depth = len(graph.edges)
-    values = group.cardinality - 1 if require_nowhere_zero else group.cardinality
-    branching = 2 * values
-    growth: int = branching**depth
-    return branching * (growth - 1) // (branching - 1)
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        """Build after the admitted bounded-search kernel established it."""
+        return cls.model_construct(**values)
 
 
 def _require_status_shape(
@@ -689,71 +612,6 @@ def _require_status_shape(
             raise PydanticCustomError(
                 "graph.unknown_status_requires_state_budget_exceeded",
                 "UNKNOWN status requires STATE_BUDGET_EXCEEDED",
-            )
-
-
-def _require_single_assignment_per_edge(
-    flow: tuple[FlowEdgeAssignment, ...],
-    graph_ids: frozenset[str],
-) -> None:
-    """Require exactly one assignment record per graph edge."""
-
-    if len(flow) != len(graph_ids):
-        raise PydanticCustomError(
-            "graph.found_flow_must_assign_exactly_one_value_to_ever",
-            "FOUND flow must assign exactly one value to every graph edge",
-        )
-    assigned: set[str] = set()
-    for a in flow:
-        if a.edge_id in assigned:
-            raise PydanticCustomError(
-                "graph.found_flow_assigns_edge_edge_id_more",
-                f"FOUND flow assigns edge {a.edge_id} more than once",
-            )
-        assigned.add(a.edge_id)
-    if graph_ids != assigned:
-        raise PydanticCustomError(
-            "graph.found_flow_must_assign_every_graph_edge",
-            "FOUND flow must assign every graph edge",
-        )
-
-
-def _verify_found_witness(
-    graph: LooplessMultigraph,
-    group: FiniteAbelianGroup,
-    resource_budget: MultigraphFlowSearchBudget,
-    flow: tuple[FlowEdgeAssignment, ...],
-) -> None:
-    """Recompute coverage, nowhere-zero, and conservation for a FOUND witness."""
-
-    graph_ids = graph.edge_id_set
-    _require_single_assignment_per_edge(flow, graph_ids)
-    if resource_budget.require_nowhere_zero:
-        for a in flow:
-            if group.is_zero(a.value):
-                raise PydanticCustomError(
-                    "graph.found_flow_violates_nowhere_zero_requirement",
-                    "FOUND flow violates nowhere_zero requirement",
-                )
-    vertex_out: dict[int, list[tuple[int, ...]]] = {
-        v: [] for v in range(graph.vertex_count)
-    }
-    vertex_in: dict[int, list[tuple[int, ...]]] = {
-        v: [] for v in range(graph.vertex_count)
-    }
-    for a in flow:
-        edge = graph.edge_by_id(a.edge_id)
-        tail, head = oriented_endpoints(edge, a.orientation)
-        val = group.normalize(a.value)
-        vertex_out[tail].append(val)
-        vertex_in[head].append(val)
-    for v in range(graph.vertex_count):
-        out_sum = group.sum(tuple(vertex_out[v]))
-        in_sum = group.sum(tuple(vertex_in[v]))
-        if not group.is_zero(group.add(out_sum, group.negate(in_sum))):
-            raise PydanticCustomError(
-                "graph.found_flow_does_not_satisfy_conservation",
-                "FOUND flow does not satisfy conservation",
             )
 
 
@@ -868,11 +726,8 @@ class CycleRecord(StrictModel):
 class EulerianCyclesResult(StrictModel):
     """Deterministic edge-disjoint cycle decomposition, bound to its source edge set.
 
-    Validation replays the defining relation against the retained source:
-    incidence, disjointness, usage, coverage, and the Eulerian dichotomy —
-    an Eulerian requested multiset must be fully decomposed with
-    ``covers_all=True``, while the empty ``covers_all=False`` outcome is
-    reserved for a non-Eulerian requested multiset.
+    The cycle decomposition is established once by the producer. Parsing
+    retains only the source-binding and canonical container checks.
     """
 
     graph: LooplessMultigraph
@@ -884,7 +739,7 @@ class EulerianCyclesResult(StrictModel):
     covers_all: bool
 
     @model_validator(mode="after")
-    def require_bound_eulerian(self) -> Self:
+    def require_structural_consistency(self) -> Self:
         # Determine requested edge IDs; apply the request's uniqueness check
         # before any set conversion so duplicates cannot silently change the
         # purported multiset's multiplicity.
@@ -902,101 +757,18 @@ class EulerianCyclesResult(StrictModel):
                 )
         else:
             requested = set(self.graph.edge_id_set)
-        used = _verify_cycle_incidence(self.graph, self.cycles, requested)
-        # Validate edge_usage matches
-        expected_usage = tuple(sorted((eid, used[eid]) for eid in sorted(requested)))
-        if self.edge_usage != expected_usage:
+        expected_ids = tuple(sorted(requested))
+        if tuple(edge_id for edge_id, _count in self.edge_usage) != expected_ids:
             raise PydanticCustomError(
-                "graph.edge_usage_edge_usage_does_match_recomputed",
-                f"edge_usage {self.edge_usage} does not match recomputed {expected_usage}",
-            )
-        expected_covers = _expected_covers_all(used, requested, len(self.cycles))
-        if self.covers_all != expected_covers:
-            raise PydanticCustomError(
-                "graph.covers_all_covers_all_does_match_expected",
-                f"covers_all {self.covers_all} does not match expected {expected_covers}",
-            )
-        if requested and _subset_is_eulerian(self.graph, requested):
-            # An Eulerian source must be fully decomposed; the empty
-            # covers_all=False outcome is reserved for non-Eulerian sources.
-            if not self.covers_all:
-                raise PydanticCustomError(
-                    "graph.eulerian_source_fully_decomposed_covers_all_empty",
-                    "an Eulerian source must be fully decomposed "
-                    "(covers_all=True); an empty covers_all=False outcome "
-                    "is only valid for a non-Eulerian source",
-                )
-        elif requested and self.cycles != ():
-            raise PydanticCustomError(
-                "graph.non_eulerian_source_yield_empty_decomposition_cycles",
-                "a non-Eulerian source must yield an empty decomposition "
-                "(cycles=()) with covers_all=False",
+                "graph.edge_usage_must_cover_requested_edges_canonically",
+                "edge_usage must contain every requested edge once in canonical order",
             )
         return self
 
-
-def _verify_cycle_incidence(
-    graph: LooplessMultigraph,
-    cycles: tuple[CycleRecord, ...],
-    requested: set[str],
-) -> dict[str, int]:
-    """Check edge-disjointness and endpoint incidence; return per-edge usage."""
-
-    used: dict[str, int] = dict.fromkeys(requested, 0)
-    seen_cycle_ids: set[str] = set()
-    for cycle in cycles:
-        for eid in cycle.edge_ids:
-            if eid not in requested:
-                raise PydanticCustomError(
-                    "graph.cycle_uses_edge_eid_requested_set_if",
-                    f"cycle uses edge {eid} not in requested set",
-                )
-            if eid in seen_cycle_ids:
-                raise PydanticCustomError(
-                    "graph.edge_eid_appears_multiple_cycles_disjoint",
-                    f"edge {eid} appears in multiple cycles (must be disjoint)",
-                )
-            seen_cycle_ids.add(eid)
-            pos = list(cycle.edge_ids).index(eid)
-            v_from = cycle.vertices[pos]
-            v_to = cycle.vertices[pos + 1]
-            edge = graph.edge_by_id(eid)
-            if not (
-                (edge.left == v_from and edge.right == v_to)
-                or (edge.right == v_from and edge.left == v_to)
-            ):
-                raise PydanticCustomError(
-                    "graph.cycle_edge_eid_incidence_does_match_used",
-                    f"cycle edge {eid} incidence does not match graph",
-                )
-            used[eid] += 1
-    return used
-
-
-def _subset_is_eulerian(
-    graph: LooplessMultigraph,
-    requested: set[str],
-) -> bool:
-    """Return whether every vertex has even degree in the requested multiset."""
-
-    degree: dict[int, int] = dict.fromkeys(range(graph.vertex_count), 0)
-    for eid in requested:
-        edge = graph.edge_by_id(eid)
-        degree[edge.left] += 1
-        degree[edge.right] += 1
-    return all(d % 2 == 0 for d in degree.values())
-
-
-def _expected_covers_all(
-    used: dict[str, int],
-    requested: set[str],
-    cycle_count: int,
-) -> bool:
-    if len(requested) == 0:
-        return True
-    return all(used[eid] == 1 for eid in requested) and (
-        len(requested) > 0 or cycle_count == 0
-    )
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        """Build after the Eulerian decomposition kernel established it."""
+        return cls.model_construct(**values)
 
 
 # ---------------------------------------------------------------------------
@@ -1056,88 +828,31 @@ class CycleMulticoverResult(StrictModel):
     is_exact_k_cover: bool
 
     @model_validator(mode="after")
-    def require_consistent_cover(self) -> Self:
+    def require_structural_consistency(self) -> Self:
         if len(self.cycle_validity) != len(self.cycles):
             raise PydanticCustomError(
                 "graph.cycle_validity_length_must_match_cycles_length",
                 "cycle_validity length must match cycles length",
             )
-        # Recompute validity and multiplicity from the retained source.
-        recomputed_multiplicity: dict[str, int] = {
-            edge.edge_id: 0 for edge in self.graph.edges
-        }
-        recomputed_validity: list[bool] = []
-        for cycle in self.cycles:
-            cycle_valid = True
-            for i, eid in enumerate(cycle.edge_ids):
-                edge_valid = True
-                if eid not in recomputed_multiplicity:
-                    edge_valid = False
-                    cycle_valid = False
-                else:
-                    v_from = cycle.vertices[i]
-                    v_to = cycle.vertices[i + 1]
-                    if not (
-                        0 <= v_from < self.graph.vertex_count
-                        and 0 <= v_to < self.graph.vertex_count
-                    ):
-                        edge_valid = False
-                        cycle_valid = False
-                    else:
-                        edge = self.graph.edge_by_id(eid)
-                        if not (
-                            (edge.left == v_from and edge.right == v_to)
-                            or (edge.right == v_from and edge.left == v_to)
-                        ):
-                            edge_valid = False
-                            cycle_valid = False
-                if edge_valid:
-                    recomputed_multiplicity[eid] += 1
-            recomputed_validity.append(cycle_valid)
-        if tuple(recomputed_validity) != self.cycle_validity:
+        graph_ids = tuple(sorted(self.graph.edge_id_set))
+        if tuple(edge_id for edge_id, _count in self.edge_multiplicity) != graph_ids:
             raise PydanticCustomError(
-                "graph.cycle_validity_cycle_validity_does_match_recomputed",
-                f"cycle_validity {self.cycle_validity} does not match "
-                f"recomputed {tuple(recomputed_validity)} from source",
+                "graph.edge_multiplicity_must_cover_graph_edges_canonically",
+                "edge_multiplicity must contain every graph edge once in canonical order",
             )
-        recomputed_tuple = tuple(
-            (eid, recomputed_multiplicity[eid])
-            for eid in sorted(recomputed_multiplicity)
-        )
-        if recomputed_tuple != self.edge_multiplicity:
+        if (
+            len(set(self.missing_edge_ids)) != len(self.missing_edge_ids)
+            or len(set(self.overcovered_edge_ids)) != len(self.overcovered_edge_ids)
+            or not set(self.missing_edge_ids).issubset(self.graph.edge_id_set)
+            or not set(self.overcovered_edge_ids).issubset(self.graph.edge_id_set)
+        ):
             raise PydanticCustomError(
-                "graph.edge_multiplicity_edge_multiplicity_does_match_recomputed",
-                f"edge_multiplicity {self.edge_multiplicity} does not match "
-                f"recomputed {recomputed_tuple} from source",
-            )
-        k = self.target_multiplicity
-        recomputed_missing = tuple(
-            sorted(eid for eid, cnt in recomputed_multiplicity.items() if cnt < k)
-        )
-        recomputed_over = tuple(
-            sorted(eid for eid, cnt in recomputed_multiplicity.items() if cnt > k)
-        )
-        if recomputed_missing != self.missing_edge_ids:
-            raise PydanticCustomError(
-                "graph.missing_edge_ids_missing_edge_ids_does",
-                f"missing_edge_ids {self.missing_edge_ids} does not match "
-                f"recomputed {recomputed_missing} for k={k}",
-            )
-        if recomputed_over != self.overcovered_edge_ids:
-            raise PydanticCustomError(
-                "graph.overcovered_edge_ids_overcovered_edge_ids_does",
-                f"overcovered_edge_ids {self.overcovered_edge_ids} does not match "
-                f"recomputed {recomputed_over} for k={k}",
-            )
-        expected_exact = (
-            all(recomputed_validity)
-            and len(recomputed_missing) == 0
-            and len(recomputed_over) == 0
-        )
-        if self.is_exact_k_cover != expected_exact:
-            raise PydanticCustomError(
-                "graph.exact_cover_exact_cover_does_match_expected",
-                f"is_exact_k_cover {self.is_exact_k_cover} does not match "
-                f"expected {expected_exact} from source",
+                "graph.cover_diagnostic_ids_must_be_unique_graph_edge_ids",
+                "missing and overcovered edge IDs must be unique graph edge IDs",
             )
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        """Build after the multicover-check kernel established it."""
+        return cls.model_construct(**values)

--- a/src/jacobian/math/graphs/multigraph/_operations.py
+++ b/src/jacobian/math/graphs/multigraph/_operations.py
@@ -27,7 +27,7 @@ from jacobian.math.graphs.multigraph._models import (
     MultigraphFlowFindRequest,
     MultigraphFlowFindResult,
     MultigraphFlowSearchBudget,
-    VertexDivergence,
+    _compute_divergence_ledger,
     _FlowSearchOutcome,
 )
 from jacobian.math.graphs.multigraph._orientation import oriented_endpoints
@@ -57,44 +57,9 @@ def check_multigraph_flow(
     graph = request.graph
     group = request.group
 
-    # Build per-vertex signed sums.  Outgoing edges contribute ``+value``;
-    # incoming edges contribute ``-value`` (i.e. ``group.negate(value)``).
-    vertex_out: dict[int, list[tuple[int, ...]]] = {
-        v: [] for v in range(graph.vertex_count)
-    }
-    vertex_in: dict[int, list[tuple[int, ...]]] = {
-        v: [] for v in range(graph.vertex_count)
-    }
-    vertex_incident: dict[int, set[str]] = {v: set() for v in range(graph.vertex_count)}
-
-    for assign in request.edge_values:
-        edge = graph.edge_by_id(assign.edge_id)
-        tail, head = oriented_endpoints(edge, assign.orientation)
-        value = group.normalize(assign.value)
-        vertex_out[tail].append(value)
-        vertex_in[head].append(value)
-        vertex_incident[tail].add(assign.edge_id)
-        vertex_incident[head].add(assign.edge_id)
-
-    divergence_ledger: list[VertexDivergence] = []
-    conservation_holds = True
-    for vertex in range(graph.vertex_count):
-        out_sum = group.sum(tuple(vertex_out[vertex]))
-        in_sum = group.sum(tuple(vertex_in[vertex]))
-        # divergence = out_sum - in_sum = out_sum + negate(in_sum)
-        divergence = group.add(out_sum, group.negate(in_sum))
-        holds = group.is_zero(divergence)
-        if not holds:
-            conservation_holds = False
-        incident = sorted(vertex_incident[vertex])
-        divergence_ledger.append(
-            VertexDivergence(
-                vertex=vertex,
-                coordinates=divergence,
-                incident_edge_ids=tuple(incident),
-                conservation_holds=holds,
-            )
-        )
+    divergence_ledger, conservation_holds = _compute_divergence_ledger(
+        graph, group, request.edge_values
+    )
 
     # Identify zero-valued edges
     zero_edge_ids = [
@@ -103,11 +68,11 @@ def check_multigraph_flow(
     zero_edge_ids.sort()
     nowhere_zero = len(zero_edge_ids) == 0
 
-    return MultigraphFlowCheckResult(
+    return MultigraphFlowCheckResult._from_kernel(
         graph=graph,
         group=group,
         edge_flow_records=request.edge_values,
-        divergence_ledger=tuple(divergence_ledger),
+        divergence_ledger=divergence_ledger,
         zero_edge_ids=tuple(zero_edge_ids),
         nowhere_zero=nowhere_zero,
         conservation_holds=conservation_holds,
@@ -138,32 +103,6 @@ def _enumerate_recursive(
         return
     for value in range(moduli[index]):
         _enumerate_recursive(moduli, index + 1, (*current, value), accumulator)
-
-
-def _check_flow_conservation(
-    graph: LooplessMultigraph,
-    group: FiniteAbelianGroup,
-    assignments: list[FlowEdgeAssignment],
-) -> bool:
-    """Return True when the given flow assignments satisfy conservation."""
-    vertex_out: dict[int, list[tuple[int, ...]]] = {
-        v: [] for v in range(graph.vertex_count)
-    }
-    vertex_in: dict[int, list[tuple[int, ...]]] = {
-        v: [] for v in range(graph.vertex_count)
-    }
-    for assign in assignments:
-        edge = graph.edge_by_id(assign.edge_id)
-        tail, head = oriented_endpoints(edge, assign.orientation)
-        value = group.normalize(assign.value)
-        vertex_out[tail].append(value)
-        vertex_in[head].append(value)
-    for vertex in range(graph.vertex_count):
-        out_sum = group.sum(tuple(vertex_out[vertex]))
-        in_sum = group.sum(tuple(vertex_in[vertex]))
-        if not group.is_zero(group.add(out_sum, group.negate(in_sum))):
-            return False
-    return True
 
 
 def _build_edge_choices(
@@ -197,8 +136,6 @@ def _incremental_balances_hold(net: list[list[int]], moduli: tuple[int, ...]) ->
 
 
 def _leaf_found_outcome(
-    graph: LooplessMultigraph,
-    group: FiniteAbelianGroup,
     net: list[list[int]],
     moduli: tuple[int, ...],
     assignments: list[FlowEdgeAssignment],
@@ -206,12 +143,10 @@ def _leaf_found_outcome(
 ) -> _FlowSearchOutcome | None:
     """Evaluate one complete assignment; return the FOUND outcome or None.
 
-    The incremental balances decide candidacy in O(vertices * dimension);
-    the authoritative conservation replay then confirms the witness.
+    Incremental balances are the kernel's conservation computation, so a
+    complete zero balance establishes the witness without rescanning edges.
     """
     if not _incremental_balances_hold(net, moduli):
-        return None
-    if not _check_flow_conservation(graph, group, assignments):
         return None
     return _FlowSearchOutcome(
         status="FOUND",
@@ -279,9 +214,7 @@ def _search_dfs(
             # Complete assignment was already counted when the final edge
             # was pushed; its incremental balances were maintained on the
             # way down, so evaluating conservation is O(vertices * dimension).
-            found = _leaf_found_outcome(
-                graph, group, net, moduli, assignments, states_explored
-            )
+            found = _leaf_found_outcome(net, moduli, assignments, states_explored)
             if found is not None:
                 return found
             # Backtrack from leaf: pop placeholder and last assignment.
@@ -340,8 +273,8 @@ def _search_flow_unbound(
 ) -> _FlowSearchOutcome:
     """Run one bounded flow search and return it without a bound source.
 
-    The returned result carries no ``graph``/``group``/``resource_budget``
-    binding, so source-binding validators can replay it without recursion.
+    The returned value carries no source binding; the public result adds it
+    only after this one admitted search completes.
     """
 
     require_nz = resource_budget.require_nowhere_zero
@@ -383,7 +316,7 @@ def find_multigraph_flow(
     """
 
     inner = _search_flow_unbound(request.graph, request.group, request.resource_budget)
-    return MultigraphFlowFindResult(
+    return MultigraphFlowFindResult._from_kernel(
         graph=request.graph,
         group=request.group,
         resource_budget=request.resource_budget,
@@ -498,7 +431,7 @@ def compute_eulerian_cycles(
         edge_ids = [edge.edge_id for edge in graph.edges]
 
     if not edge_ids:
-        return EulerianCyclesResult(
+        return EulerianCyclesResult._from_kernel(
             graph=graph,
             edge_subset=request.edge_subset,
             cycles=(),
@@ -513,7 +446,7 @@ def compute_eulerian_cycles(
         degree[edge.left] += 1
         degree[edge.right] += 1
     if any(d % 2 != 0 for d in degree.values()):
-        return EulerianCyclesResult(
+        return EulerianCyclesResult._from_kernel(
             graph=graph,
             edge_subset=request.edge_subset,
             cycles=(),
@@ -546,7 +479,7 @@ def compute_eulerian_cycles(
     usage_tuple = tuple((eid, edge_usage[eid]) for eid in sorted(edge_usage))
     covers_all = all(edge_usage[eid] == 1 for eid in edge_ids)
 
-    return EulerianCyclesResult(
+    return EulerianCyclesResult._from_kernel(
         graph=graph,
         edge_subset=request.edge_subset,
         cycles=tuple(all_cycles),
@@ -606,7 +539,7 @@ def check_cycle_multicover(
         (eid, edge_multiplicity[eid]) for eid in sorted(edge_multiplicity)
     )
 
-    return CycleMulticoverResult(
+    return CycleMulticoverResult._from_kernel(
         graph=graph,
         cycles=request.cycles,
         target_multiplicity=k,
@@ -616,3 +549,50 @@ def check_cycle_multicover(
         overcovered_edge_ids=tuple(overcovered),
         is_exact_k_cover=is_exact,
     )
+
+
+def _verify_multigraph_flow_check_result(result: MultigraphFlowCheckResult) -> bool:
+    """Deliberately recompute one independently supplied flow-check claim."""
+    request = MultigraphFlowCheckRequest(
+        graph=result.graph,
+        group=result.group,
+        edge_values=result.edge_flow_records,
+    )
+    return check_multigraph_flow(request) == result
+
+
+def _verify_multigraph_flow_find_result(result: MultigraphFlowFindResult) -> bool:
+    """Deliberately replay one bounded flow-search claim under its own budget."""
+    request = MultigraphFlowFindRequest(
+        graph=result.graph,
+        group=result.group,
+        resource_budget=result.resource_budget,
+    )
+    outcome = _search_flow_unbound(
+        request.graph, request.group, request.resource_budget
+    )
+    return (
+        result.status == outcome.status
+        and result.flow == outcome.flow
+        and result.states_explored == outcome.states_explored
+        and result.termination_reason == outcome.termination_reason
+    )
+
+
+def _verify_eulerian_cycles_result(result: EulerianCyclesResult) -> bool:
+    """Deliberately recompute one independently supplied decomposition claim."""
+    request = EulerianCyclesRequest(
+        graph=result.graph,
+        edge_subset=result.edge_subset,
+    )
+    return compute_eulerian_cycles(request) == result
+
+
+def _verify_cycle_multicover_result(result: CycleMulticoverResult) -> bool:
+    """Deliberately recompute one independently supplied multicover claim."""
+    request = CycleMulticoverRequest(
+        graph=result.graph,
+        cycles=result.cycles,
+        target_multiplicity=result.target_multiplicity,
+    )
+    return check_cycle_multicover(request) == result

--- a/src/jacobian/math/graphs/multigraph/_orientation.py
+++ b/src/jacobian/math/graphs/multigraph/_orientation.py
@@ -1,4 +1,4 @@
-"""Orientation resolution shared by multigraph execution and replay."""
+"""Orientation resolution shared by multigraph flow execution helpers."""
 
 from typing import Protocol
 

--- a/src/jacobian/math/graphs/optimization/_maximum_cut.py
+++ b/src/jacobian/math/graphs/optimization/_maximum_cut.py
@@ -314,10 +314,9 @@ class GraphMaximumCutResult(StrictModel):
         Exact optimality is a nonlocal claim.  Replaying it here would make
         ordinary result deserialization execute the exhaustive kernel; callers
         that receive an independently supplied result must opt into
-        :func:`verify_maximum_cut_result` instead.
+        :func:`_verify_maximum_cut_result` instead.
         """
 
-        _require_graph_envelope(self.graph)
         graph_vertices = set(self.graph.vertices)
         left = set(self.left_vertices)
         right = set(self.right_vertices)
@@ -376,7 +375,7 @@ class GraphMaximumCutResult(StrictModel):
         )
 
 
-def verify_maximum_cut_result(result: GraphMaximumCutResult) -> bool:
+def _verify_maximum_cut_result(result: GraphMaximumCutResult) -> bool:
     """Replay one independently supplied exact maximum-cut claim.
 
     The request envelope has already bounded the exhaustive enumeration.  It
@@ -574,9 +573,8 @@ def compute_maximum_cut(request: GraphMaximumCutRequest) -> GraphMaximumCutResul
             class_sides,
         )
 
-    # The producer already has coincident exact backend bounds. Avoid paying a
-    # second complete search inside this call; independently supplied or
-    # deserialized results always execute the exhaustive source-bound replay.
+    # The producer already has coincident exact backend bounds.  Deliberate
+    # verification of an independently supplied claim remains owner-private.
     return GraphMaximumCutResult._from_kernel(
         graph=request.graph,
         left_vertices=left_vertices,
@@ -641,5 +639,4 @@ __all__ = [
     "GraphMaximumCutRequest",
     "GraphMaximumCutResult",
     "compute_maximum_cut",
-    "verify_maximum_cut_result",
 ]

--- a/src/jacobian/math/hochschild_complexes/_operations.py
+++ b/src/jacobian/math/hochschild_complexes/_operations.py
@@ -128,8 +128,8 @@ def hochschild_homology_groups(
 ) -> tuple[HochschildHomologyGroup, ...]:
     """Pure Hochschild-homology core returning the exact groups for one algebra.
 
-    Kept free of result-model construction so result validation can replay
-    the bounded rank computation without recursion.
+    Kept free of result-model construction so it remains a reusable exact
+    rank computation.
     """
     n = algebra.dimension
 

--- a/src/jacobian/math/integral_binary_quadratic_forms/_models.py
+++ b/src/jacobian/math/integral_binary_quadratic_forms/_models.py
@@ -263,16 +263,11 @@ class BinaryQuadraticFormRepresentation(StrictModel):
     y: int = Field(ge=-MAX_REPRESENTATION_COORDINATE, le=MAX_REPRESENTATION_COORDINATE)
     primitive: bool
 
-    @model_validator(mode="after")
-    def bind_primitiveness(self) -> Self:
-        from math import gcd
+    @classmethod
+    def _from_kernel(cls, *, x: int, y: int, primitive: bool) -> Self:
+        """Construct one representation after the enumeration kernel established it."""
 
-        if self.primitive != (gcd(self.x, self.y) == 1):
-            raise _validation_error(
-                "integral_binary_quadratic_form.primitive_mismatch",
-                "primitive must equal gcd(x, y) == 1",
-            )
-        return self
+        return cls.model_construct(x=x, y=y, primitive=primitive)
 
 
 class BinaryQuadraticFormRepresentationsResult(StrictModel):
@@ -288,7 +283,6 @@ class BinaryQuadraticFormRepresentationsResult(StrictModel):
 
     @model_validator(mode="after")
     def require_result_shape(self) -> Self:
-        _require_representation_budget(self.form, self.target)
         if self.count != len(self.representations):
             raise _validation_error(
                 "integral_binary_quadratic_form.count_mismatch",
@@ -310,7 +304,7 @@ class BinaryQuadraticFormRepresentationsResult(StrictModel):
         representations: tuple[BinaryQuadraticFormRepresentation, ...],
     ) -> Self:
         """Construct a trusted result from the owner-local enumeration kernel."""
-        return cls(
+        return cls.model_construct(
             form=form,
             target=target,
             representations=representations,
@@ -423,7 +417,6 @@ class ReducedClassesResult(StrictModel):
                 "integral_binary_quadratic_form.class_number_mismatch",
                 "class_number must equal the number of classes",
             )
-        _require_reduced_class_search_budget(self.discriminant)
         return self
 
     @classmethod
@@ -434,7 +427,7 @@ class ReducedClassesResult(StrictModel):
         classes: tuple[PrimitivePositiveDefiniteBinaryQuadraticForm, ...],
     ) -> Self:
         """Construct a trusted result from the owner-local class enumerator."""
-        return cls(
+        return cls.model_construct(
             discriminant=discriminant,
             classes=classes,
             class_number=len(classes),

--- a/src/jacobian/math/integral_binary_quadratic_forms/_operations.py
+++ b/src/jacobian/math/integral_binary_quadratic_forms/_operations.py
@@ -318,7 +318,7 @@ def _enumerate_representations(
             if _evaluate(a, b, c, x, y) != target:
                 raise AssertionError("quadratic discriminant reconstruction failed")
             rows.append(
-                BinaryQuadraticFormRepresentation(
+                BinaryQuadraticFormRepresentation._from_kernel(
                     x=x,
                     y=y,
                     primitive=_gcd(x, y) == 1,
@@ -337,7 +337,7 @@ def compute_representations(
     )
 
 
-def verify_check_result(result: BinaryQuadraticFormCheckResult) -> bool:
+def _verify_check_result(result: BinaryQuadraticFormCheckResult) -> bool:
     """Verify an independently supplied form-domain classification."""
     expected = compute_check(
         BinaryQuadraticFormCheckRequest(a=result.a, b=result.b, c=result.c)
@@ -345,7 +345,7 @@ def verify_check_result(result: BinaryQuadraticFormCheckResult) -> bool:
     return result == expected
 
 
-def verify_evaluate_result(result: BinaryQuadraticFormEvaluateResult) -> bool:
+def _verify_evaluate_result(result: BinaryQuadraticFormEvaluateResult) -> bool:
     """Verify an independently supplied exact form-evaluation claim."""
     try:
         expected = compute_evaluate(
@@ -356,13 +356,13 @@ def verify_evaluate_result(result: BinaryQuadraticFormEvaluateResult) -> bool:
     return result == expected
 
 
-def verify_reduced_form_result(result: ReducedBinaryQuadraticFormResult) -> bool:
+def _verify_reduced_form_result(result: ReducedBinaryQuadraticFormResult) -> bool:
     """Verify an independently supplied Gauss-reduction result."""
     expected = compute_reduce(BinaryQuadraticFormReduceRequest(form=result.form))
     return result == expected
 
 
-def verify_proper_equivalence_result(result: ProperEquivalenceResult) -> bool:
+def _verify_proper_equivalence_result(result: ProperEquivalenceResult) -> bool:
     """Verify an independently supplied proper-equivalence decision and witness."""
     expected = compute_proper_equivalence(
         BinaryQuadraticFormProperEquivRequest(first=result.first, second=result.second)
@@ -370,23 +370,29 @@ def verify_proper_equivalence_result(result: ProperEquivalenceResult) -> bool:
     return result == expected
 
 
-def verify_representations_result(
+def _verify_representations_result(
     result: BinaryQuadraticFormRepresentationsResult,
 ) -> bool:
     """Verify an independently supplied complete representation-set claim."""
-    expected = compute_representations(
-        BinaryQuadraticFormRepresentationsRequest(
-            form=result.form, target=result.target
+    try:
+        expected = compute_representations(
+            BinaryQuadraticFormRepresentationsRequest(
+                form=result.form, target=result.target
+            )
         )
-    )
+    except ValidationError:
+        return False
     return result == expected
 
 
-def verify_reduced_classes_result(result: ReducedClassesResult) -> bool:
+def _verify_reduced_classes_result(result: ReducedClassesResult) -> bool:
     """Verify an independently supplied complete reduced-class enumeration."""
-    expected = compute_reduced_classes(
-        BinaryQuadraticFormReducedClassesRequest(discriminant=result.discriminant)
-    )
+    try:
+        expected = compute_reduced_classes(
+            BinaryQuadraticFormReducedClassesRequest(discriminant=result.discriminant)
+        )
+    except ValidationError:
+        return False
     return result == expected
 
 

--- a/src/jacobian/math/lie_algebra_homology/_models.py
+++ b/src/jacobian/math/lie_algebra_homology/_models.py
@@ -198,7 +198,7 @@ class ChevalleyEilenbergComplexResult(StrictModel):
 
     Kernel-produced results use :meth:`_from_kernel`.  Separately supplied
     complexes are checked only for their source binding, canonical field, and
-    finite chain-complex envelope here; :func:`verify_ce_complex_result` is
+    finite chain-complex envelope here; :func:`_verify_ce_complex_result` is
     the explicit bounded owner verifier for the defining bracket differential.
     """
 
@@ -296,7 +296,7 @@ class LieHomologyGroup(StrictModel):
 class LieHomologyResult(StrictModel):
     """Structurally bounded Lie homology groups with trivial coefficients.
 
-    Exact rank computation belongs to :func:`verify_lie_homology_result`, not
+    Exact rank computation belongs to :func:`_verify_lie_homology_result`, not
     to model validation.
     """
 

--- a/src/jacobian/math/lie_algebra_homology/_operations.py
+++ b/src/jacobian/math/lie_algebra_homology/_operations.py
@@ -125,8 +125,7 @@ def compute_chevalley_eilenberg_complex(
 def lie_homology_groups(lie_algebra: LieAlgebra) -> tuple[LieHomologyGroup, ...]:
     """Pure Lie-homology core returning the exact groups for one algebra.
 
-    Kept free of result-model construction so result validation can replay
-    the bounded rank computation without recursion.
+    Kept free of result-model construction for the owner-private verifier.
     """
     n = lie_algebra.dimension
 
@@ -170,7 +169,7 @@ def compute_lie_homology(request: LieHomologyRequest) -> LieHomologyResult:
     )
 
 
-def verify_ce_complex_result(result: ChevalleyEilenbergComplexResult) -> bool:
+def _verify_ce_complex_result(result: ChevalleyEilenbergComplexResult) -> bool:
     """Replay an independently supplied CE complex in its admitted envelope.
 
     ``LieAlgebra`` bounds the dimension so this rebuilds at most the dense
@@ -181,7 +180,7 @@ def verify_ce_complex_result(result: ChevalleyEilenbergComplexResult) -> bool:
     return result.differentials == _ce_differentials(result.lie_algebra)
 
 
-def verify_lie_homology_result(result: LieHomologyResult) -> bool:
+def _verify_lie_homology_result(result: LieHomologyResult) -> bool:
     """Replay an independently supplied homology claim in its admitted envelope."""
 
     return result.groups == lie_homology_groups(result.lie_algebra)
@@ -190,6 +189,4 @@ def verify_lie_homology_result(result: LieHomologyResult) -> bool:
 __all__ = [
     "compute_chevalley_eilenberg_complex",
     "compute_lie_homology",
-    "verify_ce_complex_result",
-    "verify_lie_homology_result",
 ]

--- a/src/jacobian/math/markov_chain/_models.py
+++ b/src/jacobian/math/markov_chain/_models.py
@@ -284,6 +284,7 @@ class CommunicatingClassesResult(StrictModel):
 
     @model_validator(mode="after")
     def require_partition_validity(self) -> Self:
+        TransitionMatrixRequest(matrix=self.transition_matrix)
         dimension = len(self.transition_matrix)
         if any(len(row) != dimension for row in self.transition_matrix):
             raise _validation_error(

--- a/src/jacobian/math/markov_chain/_models.py
+++ b/src/jacobian/math/markov_chain/_models.py
@@ -99,6 +99,20 @@ class StationaryDistributionResult(StrictModel):
         "CLOSED_CLASS_EXACT_LINEAR_SYSTEM"
     )
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        extreme_distributions: tuple[ExtremeStationaryDistribution, ...],
+        unique: bool,
+    ) -> Self:
+        """Construct a family whose stationary equations the kernel solved."""
+
+        return cls.model_construct(
+            extreme_distributions=extreme_distributions,
+            unique=unique,
+        )
+
     @model_validator(mode="after")
     def bind_stationary_family(self) -> Self:
         dimensions = {len(item.distribution) for item in self.extreme_distributions}
@@ -275,18 +289,6 @@ class CommunicatingClassesResult(StrictModel):
             raise _validation_error(
                 "decomposition_matrix_not_square", "transition matrix must be square"
             )
-        for row in self.transition_matrix:
-            values = tuple(value.as_fraction() for value in row)
-            if any(value < 0 for value in values):
-                raise _validation_error(
-                    "decomposition_probability_negative",
-                    "transition probabilities must be nonnegative",
-                )
-            if sum(values) != 1:
-                raise _validation_error(
-                    "decomposition_row_not_stochastic",
-                    "each transition row must sum to one",
-                )
         all_states: list[int] = []
         for states, _ in self.classes:
             all_states.extend(states)

--- a/src/jacobian/math/markov_chain/_operations.py
+++ b/src/jacobian/math/markov_chain/_operations.py
@@ -138,5 +138,6 @@ def compute_communicating_classes(
 def _verify_communicating_classes_result(result: CommunicatingClassesResult) -> bool:
     """Replay the SCC relation for an independently supplied bounded result."""
 
-    classes, state_class = _derive_communicating_classes(result.transition_matrix)
+    request = TransitionMatrixRequest(matrix=result.transition_matrix)
+    classes, state_class = _derive_communicating_classes(request.matrix)
     return result.classes == classes and result.state_class == state_class

--- a/src/jacobian/math/markov_chain/_operations.py
+++ b/src/jacobian/math/markov_chain/_operations.py
@@ -92,7 +92,7 @@ def compute_stationary_distribution(
         tuple(value.as_fraction() for value in row) for row in request.matrix
     )
     extremes = _stationary_distribution_extremes(matrix)
-    return StationaryDistributionResult(
+    return StationaryDistributionResult._from_kernel(
         extreme_distributions=tuple(
             ExtremeStationaryDistribution(
                 closed_class=closed_class,
@@ -135,7 +135,7 @@ def compute_communicating_classes(
     )
 
 
-def verify_communicating_classes_result(result: CommunicatingClassesResult) -> bool:
+def _verify_communicating_classes_result(result: CommunicatingClassesResult) -> bool:
     """Replay the SCC relation for an independently supplied bounded result."""
 
     classes, state_class = _derive_communicating_classes(result.transition_matrix)

--- a/src/jacobian/math/matrices/subsystems/_models.py
+++ b/src/jacobian/math/matrices/subsystems/_models.py
@@ -16,7 +16,6 @@ from jacobian.canonical import (
     encode_strict_json,
     format_canonical_integer,
 )
-from jacobian.math._exact_linear_algebra import symmetric_inertia
 from jacobian.math.matrices.subsystems.values import (
     MAX_SUBSYSTEM_DIMENSION,
     MAX_SUBSYSTEM_FACTORS,
@@ -93,8 +92,8 @@ def _require_trace_result_envelope(
 ) -> None:
     """Admit one trace whose exact reduced coefficients fit the result bound.
 
-    Both request validation and result replay derive the exact reduced
-    entries first and admit those measured components rather than a
+    Request admission derives the exact reduced entries first and admits
+    those measured components rather than a
     per-input estimate, so an emitted value re-enters its own consumer
     unchanged unless its next exact result genuinely exceeds the bound, and
     a transported or authored source can never drive the common-denominator
@@ -426,13 +425,6 @@ class SubsystemPartialTraceResult(StrictModel):
                 "invariant_mismatch",
                 "traced subsystem labels must follow source factor order",
             )
-        expected_entries = _require_trace_work_envelope(
-            self.source_matrix, self.traced_factor_labels
-        )
-        _require_trace_result_envelope(expected_entries)
-        _require_trace_transport_envelope(
-            self.source_matrix, self.traced_factor_labels, expected_entries
-        )
         expected = tuple(
             factor
             for factor in self.source_matrix.factors
@@ -443,15 +435,23 @@ class SubsystemPartialTraceResult(StrictModel):
                 "shape_mismatch",
                 "partial trace must retain untraced factors in source order",
             )
-        actual_entries = tuple(
-            tuple(entry.as_fraction() for entry in row)
-            for row in self.reduced_matrix.matrix.entries
-        )
-        if actual_entries != expected_entries:
-            raise _validation_error(
-                "shape_mismatch", "partial trace entries must replay against the source"
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source_matrix: FactorizedHermitianMatrix,
+        traced_factor_labels: tuple[str, ...],
+        reduced_matrix: FactorizedHermitianMatrix,
+    ) -> Self:
+        """Construct a result after the owner-local trace kernel established it."""
+
+        return cls.model_construct(
+            source_matrix=source_matrix,
+            traced_factor_labels=traced_factor_labels,
+            reduced_matrix=reduced_matrix,
+        )
 
 
 class PsdInertia(StrictModel):
@@ -543,7 +543,6 @@ class PsdOrderResult(StrictModel):
                 "budget_exceeded",
                 "PSD-order result matrices must share exactly one axis bound",
             )
-        _require_psd_pair_admission(self.left, self.right)
         dimension = len(self.left.matrix.entries)
         if (
             self.inertia.n_positive + self.inertia.n_negative + self.inertia.n_zero
@@ -552,42 +551,6 @@ class PsdOrderResult(StrictModel):
             raise _validation_error(
                 "shape_mismatch",
                 "inertia counts must sum to the source matrix dimension",
-            )
-        expected_difference = tuple(
-            tuple(
-                right.as_fraction() - left.as_fraction()
-                for left, right in zip(left_row, right_row, strict=True)
-            )
-            for left_row, right_row in zip(
-                self.left.matrix.entries,
-                self.right.matrix.entries,
-                strict=True,
-            )
-        )
-        actual_difference = tuple(
-            tuple(entry.as_fraction() for entry in row)
-            for row in self.difference.matrix.entries
-        )
-        if actual_difference != expected_difference:
-            raise _validation_error(
-                "invariant_mismatch",
-                "PSD-order difference must equal right minus left exactly",
-            )
-        expected_inertia = symmetric_inertia(actual_difference)  # type: ignore[arg-type]
-        if (
-            self.inertia.n_positive,
-            self.inertia.n_negative,
-            self.inertia.n_zero,
-        ) != expected_inertia:
-            raise _validation_error(
-                "invariant_mismatch",
-                "PSD-order inertia must replay against the difference",
-            )
-        expected_order = self.inertia.n_negative == 0
-        if self.is_less_or_equal != expected_order:
-            raise _validation_error(
-                "invariant_mismatch",
-                "PSD-order decision must agree with the negative inertia",
             )
         if self.is_less_or_equal and self.negative_witness is not None:
             raise _validation_error(
@@ -598,29 +561,37 @@ class PsdOrderResult(StrictModel):
                 "shape_mismatch",
                 "a non-PSD difference requires a negative quadratic witness",
             )
-        if self.negative_witness is not None:
-            vector = tuple(
-                value.as_fraction() for value in self.negative_witness.vector
+        if (
+            self.negative_witness is not None
+            and len(self.negative_witness.vector) != dimension
+        ):
+            raise _validation_error(
+                "shape_mismatch",
+                "negative witness length must equal the matrix dimension",
             )
-            if len(vector) != dimension:
-                raise _validation_error(
-                    "shape_mismatch",
-                    "negative witness length must equal the matrix dimension",
-                )
-            quadratic_value = sum(
-                (
-                    vector[row] * actual_difference[row][column] * vector[column]
-                    for row in range(dimension)
-                    for column in range(dimension)
-                ),
-                Fraction(0),
-            )
-            if quadratic_value != self.negative_witness.quadratic_value.as_fraction():
-                raise _validation_error(
-                    "budget_exceeded",
-                    "negative witness value must replay against the difference",
-                )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        left: FactorizedHermitianMatrix,
+        right: FactorizedHermitianMatrix,
+        difference: FactorizedHermitianMatrix,
+        inertia: PsdInertia,
+        is_less_or_equal: bool,
+        negative_witness: NegativeQuadraticWitness | None,
+    ) -> Self:
+        """Construct a result after the owner-local PSD kernel established it."""
+
+        return cls.model_construct(
+            left=left,
+            right=right,
+            difference=difference,
+            inertia=inertia,
+            is_less_or_equal=is_less_or_equal,
+            negative_witness=negative_witness,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/matrices/subsystems/_operations.py
+++ b/src/jacobian/math/matrices/subsystems/_operations.py
@@ -26,7 +26,7 @@ def compute_kronecker_product(
 def compute_partial_trace(
     request: SubsystemPartialTraceRequest,
 ) -> SubsystemPartialTraceResult:
-    return SubsystemPartialTraceResult(
+    return SubsystemPartialTraceResult._from_kernel(
         source_matrix=request.matrix,
         traced_factor_labels=request.traced_factor_labels,
         reduced_matrix=_partial_trace_kernel(
@@ -38,6 +38,43 @@ def compute_partial_trace(
 
 def decide_psd_order(request: PsdOrderRequest) -> PsdOrderResult:
     return _psd_order_kernel(request.left, request.right)
+
+
+def _verify_partial_trace_result(result: SubsystemPartialTraceResult) -> bool:
+    """Verify one independently supplied trace claim in the admitted envelope."""
+
+    try:
+        request = SubsystemPartialTraceRequest(
+            matrix=result.source_matrix,
+            traced_factor_labels=result.traced_factor_labels,
+        )
+    except ValueError:
+        return False
+    return (
+        _partial_trace_kernel(request.matrix, request.traced_factor_labels)
+        == result.reduced_matrix
+    )
+
+
+def _verify_psd_order_result(result: PsdOrderResult) -> bool:
+    """Verify one independently supplied PSD-order claim in the admitted envelope."""
+
+    try:
+        request = PsdOrderRequest(left=result.left, right=result.right)
+    except ValueError:
+        return False
+    expected = _psd_order_kernel(request.left, request.right)
+    return (
+        result.difference,
+        result.inertia,
+        result.is_less_or_equal,
+        result.negative_witness,
+    ) == (
+        expected.difference,
+        expected.inertia,
+        expected.is_less_or_equal,
+        expected.negative_witness,
+    )
 
 
 __all__ = [

--- a/src/jacobian/math/matrices/subsystems/operations.py
+++ b/src/jacobian/math/matrices/subsystems/operations.py
@@ -209,7 +209,7 @@ def _psd_order_kernel(
             vector=tuple(CanonicalRational.from_fraction(value) for value in direction),
             quadratic_value=CanonicalRational.from_fraction(quadratic_value),
         )
-    return PsdOrderResult(
+    return PsdOrderResult._from_kernel(
         left=left,
         right=right,
         difference=difference,

--- a/src/jacobian/math/number_theory/_friable.py
+++ b/src/jacobian/math/number_theory/_friable.py
@@ -14,7 +14,7 @@ FRIABLE_COUNT_OPERATION = number_theory_operation(
     (
         "Return the exact number Psi(x, y) of positive integers at most x whose "
         "prime factors are all at most the inclusive cutoff y. The result retains "
-        "x and y and replays the count inside the admitted materialized or "
+        "x and y alongside the exact count from the admitted materialized or "
         "generated-search envelope."
     ),
     FriableCountRequest,

--- a/src/jacobian/math/number_theory/_friable_models.py
+++ b/src/jacobian/math/number_theory/_friable_models.py
@@ -12,10 +12,9 @@ from jacobian.canonical import parse_canonical_integer
 from jacobian.math.number_theory._models import BoundedInteger, _validation_error
 
 # Friable counting has two exact, result-sensitive execution regimes. The
-# materialized regime uses one bytearray for primality and one for friability;
-# its work bound covers both the operation and result-validation replay. The
-# generated regime enumerates prime-exponent prefixes only when a conservative
-# prefix-box bound covers both passes.
+# materialized regime uses one bytearray for primality and one for friability.
+# The generated regime enumerates prime-exponent prefixes only when a
+# conservative prefix-box bound covers that one producer pass.
 MAX_FRIABLE_MATERIALIZED_X = 1_000_000
 MAX_FRIABLE_GENERATED_CUTOFF = 10_000
 _MAX_FRIABLE_MATERIALIZED_TOTAL_STEPS = 82_000_000
@@ -72,13 +71,13 @@ def _plan_friable_count(x: int, y: int) -> tuple[_FriableRegime, tuple[int, ...]
     if x == 0 or y <= 1 or y >= x:
         return "DIRECT", ()
 
-    # Each materialized pass marks at most two harmonic series of multiples,
-    # plus one scan. Result validation replays the full exact computation.
+    # The materialized pass marks at most two harmonic series of multiples,
+    # plus one scan.
     per_pass_steps = x * (2 * x.bit_length() + 1)
     materialized_bytes = 2 * (x + 1) + x // 2
     if (
         x <= MAX_FRIABLE_MATERIALIZED_X
-        and 2 * per_pass_steps <= _MAX_FRIABLE_MATERIALIZED_TOTAL_STEPS
+        and per_pass_steps <= _MAX_FRIABLE_MATERIALIZED_TOTAL_STEPS
         and materialized_bytes <= _MAX_FRIABLE_MATERIALIZED_BYTES
     ):
         return "MATERIALIZED", ()
@@ -95,7 +94,7 @@ def _plan_friable_count(x: int, y: int) -> tuple[_FriableRegime, tuple[int, ...]
     for prime in primes:
         prefix_box *= _maximum_exponent(x, prime) + 1
         nodes_per_pass += prefix_box
-        if 2 * nodes_per_pass > _MAX_FRIABLE_GENERATED_TOTAL_NODES:
+        if nodes_per_pass > _MAX_FRIABLE_GENERATED_TOTAL_NODES:
             raise _validation_error(
                 "generated_friable_counting_exceeds_the_search_node_budget",
                 "generated friable counting exceeds the search-node budget",
@@ -139,22 +138,23 @@ class FriableCountResult(StrictModel):
     count: BoundedInteger
 
     @model_validator(mode="after")
-    def bind_exact_count_to_sources(self) -> Self:
-        from jacobian.math.number_theory._friable_operations import count_friable
-
-        x = parse_canonical_integer(self.x)
-        y = parse_canonical_integer(self.y)
+    def require_structural_count(self) -> Self:
         count = parse_canonical_integer(self.count)
         if count < 0:
             raise _validation_error(
                 "friable_count_must_be_nonnegative", "friable count must be nonnegative"
             )
-        if count != count_friable(x, y):
-            raise _validation_error(
-                "friable_count_does_not_match_the_retained_sources",
-                "friable count does not match the retained sources",
-            )
         return self
+
+    @classmethod
+    def _from_kernel(cls, request: FriableCountRequest, *, count: int) -> Self:
+        """Build one result after the admitted kernel established its count."""
+
+        return cls(
+            x=request.x,
+            y=request.y,
+            count=str(count),
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/number_theory/_friable_operations.py
+++ b/src/jacobian/math/number_theory/_friable_operations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from math import isqrt
 
-from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.canonical import parse_canonical_integer
 from jacobian.math.arithmetic.values import IntegerValue
 from jacobian.math.number_theory._friable_models import (
     FriableCountRequest,
@@ -89,10 +89,18 @@ def compute_friable_count(request: FriableCountRequest) -> FriableCountResult:
 
     x = parse_canonical_integer(request.x)
     y = parse_canonical_integer(request.y)
-    return FriableCountResult(
-        x=request.x,
-        y=request.y,
-        count=format_canonical_integer(count_friable(x, y)),
+    return FriableCountResult._from_kernel(
+        request,
+        count=count_friable(x, y),
+    )
+
+
+def verify_friable_count_result(result: FriableCountResult) -> bool:
+    """Check an independently supplied exact count inside the owner envelope."""
+
+    request = FriableCountRequest(x=result.x, y=result.y)
+    return parse_canonical_integer(result.count) == count_friable(
+        parse_canonical_integer(request.x), parse_canonical_integer(request.y)
     )
 
 

--- a/src/jacobian/math/number_theory/_friable_operations.py
+++ b/src/jacobian/math/number_theory/_friable_operations.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from math import isqrt
 
+from pydantic import ValidationError
+
 from jacobian.canonical import parse_canonical_integer
 from jacobian.math.arithmetic.values import IntegerValue
 from jacobian.math.number_theory._friable_models import (
@@ -98,7 +100,10 @@ def compute_friable_count(request: FriableCountRequest) -> FriableCountResult:
 def verify_friable_count_result(result: FriableCountResult) -> bool:
     """Check an independently supplied exact count inside the owner envelope."""
 
-    request = FriableCountRequest(x=result.x, y=result.y)
+    try:
+        request = FriableCountRequest(x=result.x, y=result.y)
+    except ValidationError:
+        return False
     return parse_canonical_integer(result.count) == count_friable(
         parse_canonical_integer(request.x), parse_canonical_integer(request.y)
     )

--- a/src/jacobian/math/number_theory/_periodic_models.py
+++ b/src/jacobian/math/number_theory/_periodic_models.py
@@ -55,9 +55,7 @@ _PERIODIC_REQUEST_DESCRIPTION = (
     "uses a full-subset shortcut; a period lift when L <= 1,000,000 and "
     "L + W <= 2,000,000; a sparse lift when W <= 65,536; or generalized-CRT "
     "inclusion-exclusion with at most 65,535 retained states and 100,000 merges "
-    "per pass. Every call performs one producer pass and one source-bound "
-    "result replay, so whole-call lift and merge work is at most twice the "
-    "per-pass limit."
+    "per pass. Every call performs one producer pass within that envelope."
 )
 
 
@@ -377,32 +375,6 @@ class PeriodicCongruenceUnionProfileRequest(PeriodicCongruenceUnionRequest):
         return self
 
 
-def _require_measure_binding(
-    common_period: str,
-    occupied_count_text: str,
-    density: CanonicalRational,
-    *,
-    period: int,
-    occupied_count: int,
-) -> None:
-    if common_period != format_canonical_integer(period):
-        raise _validation_error(
-            "common_period_must_be_the_lcm_of_the_source_moduli",
-            "common period must be the lcm of the source moduli",
-        )
-    if occupied_count_text != format_canonical_integer(occupied_count):
-        raise _validation_error(
-            "occupied_count_does_not_match_the_normalized_source",
-            "occupied count does not match the normalized source",
-        )
-    expected_density = CanonicalRational.from_fraction(Fraction(occupied_count, period))
-    if density != expected_density:
-        raise _validation_error(
-            "density_must_equal_occupied_count_common_period",
-            "density must equal occupied_count/common_period",
-        )
-
-
 class PeriodicCongruenceUnionMeasureResult(StrictModel):
     """Exact occupied count and density, bound to the normalized union source."""
 
@@ -418,22 +390,38 @@ class PeriodicCongruenceUnionMeasureResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def bind_measure_to_source(self) -> Self:
-        from jacobian.math.number_theory._periodic_kernel import (
-            common_period,
-            measure_periodic_union,
-        )
-
-        period = common_period(self.source)
-        occupied_count = measure_periodic_union(self.source)
-        _require_measure_binding(
-            self.common_period,
-            self.occupied_count,
-            self.density,
-            period=period,
-            occupied_count=occupied_count,
-        )
+    def require_structural_measure(self) -> Self:
+        period = parse_canonical_integer(self.common_period)
+        occupied_count = parse_canonical_integer(self.occupied_count)
+        if occupied_count > period:
+            raise _validation_error(
+                "occupied_count_exceeds_common_period",
+                "occupied count must not exceed the common period",
+            )
+        if self.density != CanonicalRational.from_fraction(
+            Fraction(occupied_count, period)
+        ):
+            raise _validation_error(
+                "density_must_equal_occupied_count_common_period",
+                "density must equal occupied_count/common_period",
+            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source: PeriodicCongruenceUnionSource,
+        common_period: str,
+        occupied_count: str,
+        density: CanonicalRational,
+    ) -> Self:
+        return cls.model_construct(
+            source=source,
+            common_period=common_period,
+            occupied_count=occupied_count,
+            density=density,
+        )
 
 
 class PeriodicCongruenceUnionProfileResult(PeriodicCongruenceUnionMeasureResult):
@@ -447,30 +435,51 @@ class PeriodicCongruenceUnionProfileResult(PeriodicCongruenceUnionMeasureResult)
     )
 
     @model_validator(mode="after")
-    def bind_measure_to_source(self) -> Self:
-        """Override measure replay with one complete profile replay."""
-
-        from jacobian.math.number_theory._periodic_kernel import (
-            common_period,
-            materialize_periodic_union,
-        )
-
-        period = common_period(self.source)
-        expected = materialize_periodic_union(self.source)
-        actual = tuple(map(parse_canonical_integer, self.occupied_residues))
-        _require_measure_binding(
-            self.common_period,
-            self.occupied_count,
-            self.density,
-            period=period,
-            occupied_count=len(expected),
-        )
-        if actual != expected:
+    def require_structural_profile(self) -> Self:
+        period = parse_canonical_integer(self.common_period)
+        occupied_count = parse_canonical_integer(self.occupied_count)
+        residues = tuple(map(parse_canonical_integer, self.occupied_residues))
+        if residues != tuple(sorted(set(residues))):
             raise _validation_error(
-                "occupied_residues_must_be_every_satisfying_residue_in_canonical_order",
-                "occupied residues must be every satisfying residue in canonical order",
+                "occupied_residues_must_be_in_canonical_order",
+                "occupied residues must be strictly increasing",
+            )
+        if any(residue >= period for residue in residues):
+            raise _validation_error(
+                "occupied_residues_must_lie_in_common_period",
+                "occupied residues must lie in [0, common_period)",
+            )
+        if len(residues) != occupied_count:
+            raise _validation_error(
+                "occupied_count_must_match_residue_count",
+                "occupied count must equal the number of materialized residues",
+            )
+        if self.density != CanonicalRational.from_fraction(
+            Fraction(occupied_count, period)
+        ):
+            raise _validation_error(
+                "density_must_equal_occupied_count_common_period",
+                "density must equal occupied_count/common_period",
             )
         return self
+
+    @classmethod
+    def _from_profile_kernel(
+        cls,
+        *,
+        source: PeriodicCongruenceUnionSource,
+        common_period: str,
+        occupied_count: str,
+        density: CanonicalRational,
+        occupied_residues: tuple[str, ...],
+    ) -> Self:
+        return cls.model_construct(
+            source=source,
+            common_period=common_period,
+            occupied_count=occupied_count,
+            density=density,
+            occupied_residues=occupied_residues,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/number_theory/_periodic_operations.py
+++ b/src/jacobian/math/number_theory/_periodic_operations.py
@@ -20,6 +20,12 @@ from jacobian.math.number_theory._periodic_models import (
 )
 
 
+def _measure_request_from_source(
+    source: PeriodicCongruenceUnionSource,
+) -> PeriodicCongruenceUnionRequest:
+    return PeriodicCongruenceUnionRequest.model_validate(source.model_dump(mode="json"))
+
+
 def _measure_values(
     source: PeriodicCongruenceUnionSource,
     occupied_count: int,
@@ -41,7 +47,7 @@ def compute_periodic_congruence_union_measure(
     period, occupied_count, density = _measure_values(
         source, measure_periodic_union(source)
     )
-    return PeriodicCongruenceUnionMeasureResult(
+    return PeriodicCongruenceUnionMeasureResult._from_kernel(
         source=source,
         common_period=period,
         occupied_count=occupied_count,
@@ -57,7 +63,7 @@ def compute_periodic_congruence_union_profile(
     source = request.normalized_source()
     residues = materialize_periodic_union(source)
     period, occupied_count, density = _measure_values(source, len(residues))
-    return PeriodicCongruenceUnionProfileResult(
+    return PeriodicCongruenceUnionProfileResult._from_profile_kernel(
         source=source,
         common_period=period,
         occupied_count=occupied_count,
@@ -66,6 +72,36 @@ def compute_periodic_congruence_union_profile(
             format_canonical_integer(residue) for residue in residues
         ),
     )
+
+
+def _verify_periodic_congruence_union_measure_result(
+    result: PeriodicCongruenceUnionMeasureResult,
+) -> bool:
+    """Verify a deliberately supplied measure claim inside its admission envelope."""
+
+    try:
+        return (
+            compute_periodic_congruence_union_measure(
+                _measure_request_from_source(result.source)
+            )
+            == result
+        )
+    except ValueError:
+        return False
+
+
+def _verify_periodic_congruence_union_profile_result(
+    result: PeriodicCongruenceUnionProfileResult,
+) -> bool:
+    """Verify a deliberately supplied materialized profile claim."""
+
+    try:
+        request = PeriodicCongruenceUnionProfileRequest.model_validate(
+            result.source.model_dump(mode="json")
+        )
+        return compute_periodic_congruence_union_profile(request) == result
+    except ValueError:
+        return False
 
 
 __all__ = [

--- a/src/jacobian/math/number_theory/_powerful.py
+++ b/src/jacobian/math/number_theory/_powerful.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.canonical import parse_canonical_integer
 from jacobian.catalog._examples import example
-from jacobian.math.number_theory._integer_models import PrimePower
 from jacobian.math.number_theory._powerful_kernels import decide_powerful_data
 from jacobian.math.number_theory._powerful_models import (
     PowerfulNumberRequest,
     PowerfulNumberResult,
-    ResidualPerfectPower,
 )
 from jacobian.math.number_theory._support import number_theory_operation
 
@@ -18,25 +16,33 @@ def decide_powerful(request: PowerfulNumberRequest) -> PowerfulNumberResult:
     """Return the exact source-bound powerful-number decision."""
 
     data = decide_powerful_data(parse_canonical_integer(request.value))
-    return PowerfulNumberResult(
-        value=request.value,
-        conclusion=data.conclusion,
-        is_powerful=data.conclusion == "POWERFUL",
-        cutoff=data.cutoff,
-        checked_through=data.checked_through,
-        stripped_factors=tuple(
-            PrimePower(prime=format_canonical_integer(prime), power=exponent)
-            for prime, exponent in data.stripped_factors
-        ),
-        residual=format_canonical_integer(data.residual),
-        residual_perfect_power=(
-            None
-            if data.perfect_power is None
-            else ResidualPerfectPower(
-                base=format_canonical_integer(data.perfect_power[0]),
-                exponent=data.perfect_power[1],
-            )
-        ),
+    return PowerfulNumberResult._from_kernel(request, data=data)
+
+
+def verify_powerful_number_result(result: PowerfulNumberResult) -> bool:
+    """Verify one independently supplied powerful-number decision."""
+
+    expected = decide_powerful_data(parse_canonical_integer(result.value))
+    factors = tuple(
+        (parse_canonical_integer(factor.prime), factor.power)
+        for factor in result.stripped_factors
+    )
+    perfect_power = (
+        None
+        if result.residual_perfect_power is None
+        else (
+            parse_canonical_integer(result.residual_perfect_power.base),
+            result.residual_perfect_power.exponent,
+        )
+    )
+    return (
+        result.conclusion == expected.conclusion
+        and result.is_powerful == (expected.conclusion == "POWERFUL")
+        and result.cutoff == expected.cutoff
+        and result.checked_through == expected.checked_through
+        and factors == expected.stripped_factors
+        and parse_canonical_integer(result.residual) == expected.residual
+        and perfect_power == expected.perfect_power
     )
 
 

--- a/src/jacobian/math/number_theory/_powerful_models.py
+++ b/src/jacobian/math/number_theory/_powerful_models.py
@@ -1,8 +1,8 @@
-"""Typed contracts and replay validation for powerful-number decisions."""
+"""Typed contracts for bounded powerful-number decisions."""
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, Self
 
 from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
 
@@ -10,9 +10,12 @@ from jacobian._models import StrictModel
 from jacobian.math.number_theory._integer_models import PrimePower
 from jacobian.math.number_theory._models import _validation_error
 
+if TYPE_CHECKING:
+    from jacobian.math.number_theory._powerful_kernels import PowerfulDecisionData
+
 # The kernel derives ``B = ceil(value**(1/5))`` and trial-divides through B.
-# These limits therefore bound both the request and the source-bound result
-# replay without requiring complete factorization.
+# These limits bound that one producer pass without requiring complete
+# factorization.
 MAX_POWERFUL_INTEGER_DIGITS = 25
 MAX_POWERFUL_CUTOFF = 100_000
 MAX_POWERFUL_FACTOR_ENTRIES = 42
@@ -48,7 +51,7 @@ class ResidualPerfectPower(StrictModel):
 
 
 class PowerfulNumberResult(StrictModel):
-    """A source-bound, replayable exact powerful-number decision."""
+    """An exact powerful-number decision from one admitted kernel pass."""
 
     value: PowerfulInteger
     conclusion: Literal[
@@ -82,39 +85,45 @@ class PowerfulNumberResult(StrictModel):
     residual_perfect_power: ResidualPerfectPower | None = None
 
     @model_validator(mode="after")
-    def bind_decision_to_source_by_exact_replay(self) -> PowerfulNumberResult:
-        from jacobian.canonical import parse_canonical_integer
-        from jacobian.math.number_theory._powerful_kernels import (
-            decide_powerful_data,
-        )
-
-        expected = decide_powerful_data(parse_canonical_integer(self.value))
-        factors = tuple(
-            (parse_canonical_integer(factor.prime), factor.power)
-            for factor in self.stripped_factors
-        )
-        perfect_power = (
-            None
-            if self.residual_perfect_power is None
-            else (
-                parse_canonical_integer(self.residual_perfect_power.base),
-                self.residual_perfect_power.exponent,
-            )
-        )
-        if (
-            self.conclusion != expected.conclusion
-            or self.is_powerful != (expected.conclusion == "POWERFUL")
-            or self.cutoff != expected.cutoff
-            or self.checked_through != expected.checked_through
-            or factors != expected.stripped_factors
-            or parse_canonical_integer(self.residual) != expected.residual
-            or perfect_power != expected.perfect_power
-        ):
+    def require_branch_consistency(self) -> Self:
+        if self.is_powerful != (self.conclusion == "POWERFUL"):
             raise _validation_error(
-                "powerful_number_conclusion_or_certificate_does_not_match_exact_replay",
-                "powerful-number conclusion or certificate does not match exact replay",
+                "powerful_number_conclusion_boolean_mismatch",
+                "is_powerful must agree with conclusion",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PowerfulNumberRequest,
+        *,
+        data: PowerfulDecisionData,
+    ) -> Self:
+        """Build one result after the admitted decision kernel established it."""
+
+        from jacobian.canonical import format_canonical_integer
+
+        return cls(
+            value=request.value,
+            conclusion=data.conclusion,
+            is_powerful=data.conclusion == "POWERFUL",
+            cutoff=data.cutoff,
+            checked_through=data.checked_through,
+            stripped_factors=tuple(
+                PrimePower(prime=format_canonical_integer(prime), power=exponent)
+                for prime, exponent in data.stripped_factors
+            ),
+            residual=format_canonical_integer(data.residual),
+            residual_perfect_power=(
+                None
+                if data.perfect_power is None
+                else ResidualPerfectPower(
+                    base=format_canonical_integer(data.perfect_power[0]),
+                    exponent=data.perfect_power[1],
+                )
+            ),
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/number_theory/_ramanujan_sum.py
+++ b/src/jacobian/math/number_theory/_ramanujan_sum.py
@@ -90,26 +90,20 @@ class RamanujanSumResult(StrictModel):
             )
         return self
 
-    @model_validator(mode="after")
-    def bind_value_to_source(self) -> Self:
-        expected = ramanujan_sum(int(self.modulus), int(self.frequency))
-        if int(self.value) != expected:
-            raise _validation_error(
-                "ramanujan_sum_value_does_not_match_its_source",
-                "Ramanujan-sum value does not match its source",
-            )
-        return self
+    @classmethod
+    def _from_kernel(cls, request: RamanujanSumRequest, *, value: int) -> Self:
+        """Build one result after the admitted sum kernel established its value."""
+
+        return cls(
+            modulus=request.modulus, frequency=request.frequency, value=str(value)
+        )
 
 
 def compute_ramanujan_sum(request: RamanujanSumRequest) -> RamanujanSumResult:
     """Evaluate one admitted exact Ramanujan sum."""
 
     value = ramanujan_sum(int(request.modulus), int(request.frequency))
-    return RamanujanSumResult(
-        modulus=request.modulus,
-        frequency=request.frequency,
-        value=str(value),
-    )
+    return RamanujanSumResult._from_kernel(request, value=value)
 
 
 RAMANUJAN_SUM_OPERATION = number_theory_operation(

--- a/src/jacobian/math/numerical_semigroups/_element_invariant_models.py
+++ b/src/jacobian/math/numerical_semigroups/_element_invariant_models.py
@@ -223,10 +223,7 @@ class ElementCatenaryDegreeResult(StrictModel):
     @model_validator(mode="after")
     def require_structural_degree(self) -> Self:
         generators = _require_canonical_minimal_axis(self.minimal_generators)
-        value = _require_bounded_value(generators, self.value)
-        _require_materializable_factorizations(
-            generators, value, MAX_GRAPH_FACTORIZATIONS
-        )
+        _require_bounded_value(generators, self.value)
         return self
 
 

--- a/src/jacobian/math/numerical_semigroups/_element_invariant_operations.py
+++ b/src/jacobian/math/numerical_semigroups/_element_invariant_operations.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from fractions import Fraction
 from itertools import pairwise
 
+from pydantic import ValidationError
+
 from jacobian._exact import format_canonical_rational
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.numerical_semigroups._algorithms import (
@@ -81,11 +83,17 @@ def compute_element_catenary_degree(
     )
 
 
-def verify_element_catenary_degree_result(
+def _verify_element_catenary_degree_result(
     result: ElementCatenaryDegreeResult,
 ) -> bool:
     """Replay the admitted complete factorization family for a supplied claim."""
 
+    try:
+        ElementCatenaryDegreeRequest(
+            generators=result.minimal_generators, value=result.value
+        )
+    except ValidationError:
+        return False
     atoms = tuple(parse_canonical_integer(atom) for atom in result.minimal_generators)
     family = factorizations(atoms, parse_canonical_integer(result.value))
     return result.factorization_count == len(
@@ -93,18 +101,28 @@ def verify_element_catenary_degree_result(
     ) and result.catenary_degree == catenary_degree_from_factorizations(family)
 
 
-def verify_element_delta_set_result(result: ElementDeltaSetResult) -> bool:
+def _verify_element_delta_set_result(result: ElementDeltaSetResult) -> bool:
     """Replay one supplied element delta-set claim within its admitted bounds."""
 
+    try:
+        ElementDeltaSetRequest(generators=result.minimal_generators, value=result.value)
+    except ValidationError:
+        return False
     atoms = tuple(parse_canonical_integer(atom) for atom in result.minimal_generators)
     lengths = factorization_lengths(atoms, parse_canonical_integer(result.value))
     delta_set = tuple(sorted({right - left for left, right in pairwise(lengths)}))
     return result.factorization_lengths == lengths and result.delta_set == delta_set
 
 
-def verify_element_elasticity_result(result: ElementElasticityResult) -> bool:
+def _verify_element_elasticity_result(result: ElementElasticityResult) -> bool:
     """Replay one supplied element elasticity claim within its admitted bounds."""
 
+    try:
+        ElementElasticityRequest(
+            generators=result.minimal_generators, value=result.value
+        )
+    except ValidationError:
+        return False
     atoms = tuple(parse_canonical_integer(atom) for atom in result.minimal_generators)
     minimum, maximum = factorization_length_extrema(
         atoms, parse_canonical_integer(result.value)
@@ -119,6 +137,4 @@ __all__ = [
     "compute_element_catenary_degree",
     "compute_element_delta_set",
     "compute_element_elasticity",
-    "verify_element_delta_set_result",
-    "verify_element_elasticity_result",
 ]

--- a/src/jacobian/math/numerical_semigroups/_factorization_models.py
+++ b/src/jacobian/math/numerical_semigroups/_factorization_models.py
@@ -77,11 +77,7 @@ class FactorizationComputeResult(StrictModel):
     @model_validator(mode="after")
     def require_exact_family(self) -> Self:
         generators = _require_canonical_minimal_axis(self.minimal_generators)
-        _require_materializable_factorizations(
-            generators,
-            _require_bounded_value(generators, self.value),
-            MAX_MATERIALIZED_FACTORIZATIONS,
-        )
+        _require_bounded_value(generators, self.value)
         if self.in_semigroup != bool(self.factorizations):
             raise _validation_error(
                 "membership must agree with the factorization family"
@@ -271,11 +267,7 @@ class FactorizationGraphComputeResult(StrictModel):
     @model_validator(mode="after")
     def require_graph_partition(self) -> Self:
         generators = _require_canonical_minimal_axis(self.minimal_generators)
-        _require_materializable_factorizations(
-            generators,
-            _require_bounded_value(generators, self.value),
-            MAX_GRAPH_FACTORIZATIONS,
-        )
+        _require_bounded_value(generators, self.value)
         vertex_count = len(self.factorizations)
         if self.in_semigroup != bool(self.factorizations):
             raise _validation_error("membership must agree with graph vertices")

--- a/src/jacobian/math/numerical_semigroups/_factorization_operations.py
+++ b/src/jacobian/math/numerical_semigroups/_factorization_operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import networkx as _nx
+from pydantic import ValidationError
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.numerical_semigroups._algorithms import (
@@ -176,9 +177,15 @@ def compute_factorization_graph(
     )
 
 
-def verify_factorization_compute_result(result: FactorizationComputeResult) -> bool:
+def _verify_factorization_compute_result(result: FactorizationComputeResult) -> bool:
     """Replay one bounded factorization-family claim."""
 
+    try:
+        FactorizationComputeRequest(
+            generators=result.minimal_generators, value=result.value
+        )
+    except ValidationError:
+        return False
     generators = tuple(
         parse_canonical_integer(item) for item in result.minimal_generators
     )
@@ -186,11 +193,17 @@ def verify_factorization_compute_result(result: FactorizationComputeResult) -> b
     return result.in_semigroup == bool(family) and result.factorizations == family
 
 
-def verify_factorization_lengths_compute_result(
+def _verify_factorization_lengths_compute_result(
     result: FactorizationLengthsComputeResult,
 ) -> bool:
     """Replay one bounded factorization-length claim."""
 
+    try:
+        FactorizationLengthsComputeRequest(
+            generators=result.minimal_generators, value=result.value
+        )
+    except ValidationError:
+        return False
     generators = tuple(
         parse_canonical_integer(item) for item in result.minimal_generators
     )
@@ -198,11 +211,17 @@ def verify_factorization_lengths_compute_result(
     return result.in_semigroup == bool(lengths) and result.lengths == lengths
 
 
-def verify_factorization_graph_compute_result(
+def _verify_factorization_graph_compute_result(
     result: FactorizationGraphComputeResult,
 ) -> bool:
     """Replay the family and derived graph for one supplied claim."""
 
+    try:
+        FactorizationGraphComputeRequest(
+            generators=result.minimal_generators, value=result.value
+        )
+    except ValidationError:
+        return False
     generators = tuple(
         parse_canonical_integer(item) for item in result.minimal_generators
     )
@@ -223,7 +242,4 @@ __all__ = [
     "compute_factorization_graph",
     "compute_factorization_lengths",
     "compute_factorizations",
-    "verify_factorization_compute_result",
-    "verify_factorization_graph_compute_result",
-    "verify_factorization_lengths_compute_result",
 ]

--- a/src/jacobian/math/optimization/_general_models.py
+++ b/src/jacobian/math/optimization/_general_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from fractions import Fraction
-from typing import Literal, Self
+from typing import Any, Literal, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -287,7 +287,7 @@ class GeneralRationalLinearProgramRequest(StrictModel):
 
 
 class GeneralRationalLinearProgramResult(StrictModel):
-    """A source-bound exact outcome for a general-form rational LP.
+    """A canonical exact outcome for a general-form rational LP.
 
     Dual multipliers use the source objective sense.  For minimization, LE
     row and upper-bound multipliers are nonpositive while GE and lower-bound
@@ -340,6 +340,16 @@ class GeneralRationalLinearProgramResult(StrictModel):
         default=None, max_length=MAX_GENERAL_LINEAR_PROGRAM_VARIABLES
     )
 
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        """Build an outcome whose source-derived facts the kernel established.
+
+        Parsing checks representation and field presence only.  It does not
+        rerun normalization or certificate arithmetic.
+        """
+
+        return cls.model_construct(**values)
+
     @model_validator(mode="before")
     @classmethod
     def bound_raw_result(cls, value: object) -> object:
@@ -385,13 +395,8 @@ class GeneralRationalLinearProgramResult(StrictModel):
     def bind_result_to_source(self) -> Self:
         try:
             _require_general_result_shape(self)
-            _require_general_result_heights(self)
-            primal_objective = _replay_general_primal(self)
-            _replay_general_dual(self, primal_objective)
-            _replay_general_farkas(self)
-            _replay_general_recession(self)
         except ValueError as error:
-            raise _validation_error("result_replay", str(error)) from error
+            raise _validation_error("result_shape", str(error)) from error
         return self
 
 
@@ -505,6 +510,19 @@ def _require_general_result_heights(result: GeneralRationalLinearProgramResult) 
         raise ValueError(
             "general linear-program result can exceed the result byte bound"
         )
+
+
+def _verify_general_rational_linear_program_result(
+    result: GeneralRationalLinearProgramResult,
+) -> None:
+    """Deliberately verify an independently supplied general LP claim."""
+
+    _require_general_result_shape(result)
+    _require_general_result_heights(result)
+    primal_objective = _replay_general_primal(result)
+    _replay_general_dual(result, primal_objective)
+    _replay_general_farkas(result)
+    _replay_general_recession(result)
 
 
 def _replay_general_primal(

--- a/src/jacobian/math/optimization/_general_operations.py
+++ b/src/jacobian/math/optimization/_general_operations.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from fractions import Fraction
 
-from pydantic import ValidationError
-
 from jacobian._exact import CanonicalRational
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools
@@ -207,7 +205,9 @@ def _effective_farkas_bounds(
 def _unknown(
     program: GeneralFormRationalLinearProgram,
 ) -> GeneralRationalLinearProgramResult:
-    return GeneralRationalLinearProgramResult(program=program, status="UNKNOWN")
+    return GeneralRationalLinearProgramResult._from_kernel(
+        program=program, status="UNKNOWN"
+    )
 
 
 def _primal_feasible(
@@ -219,21 +219,18 @@ def _primal_feasible(
     lower_slacks: tuple[CanonicalRational, ...],
     upper_slacks: tuple[CanonicalRational, ...],
 ) -> GeneralRationalLinearProgramResult:
-    """Return only the replayed source point when no dual proof is available."""
+    """Return one kernel-established source-coordinate feasible point."""
 
-    try:
-        return GeneralRationalLinearProgramResult(
-            program=program,
-            status="PRIMAL_FEASIBLE",
-            primal_candidate=point,
-            primal_objective=objective,
-            primal_residuals=residuals,
-            constraint_slacks=constraint_slacks,
-            lower_bound_slacks=lower_slacks,
-            upper_bound_slacks=upper_slacks,
-        )
-    except ValidationError:
-        return _unknown(program)
+    return GeneralRationalLinearProgramResult._from_kernel(
+        program=program,
+        status="PRIMAL_FEASIBLE",
+        primal_candidate=point,
+        primal_objective=objective,
+        primal_residuals=residuals,
+        constraint_slacks=constraint_slacks,
+        lower_bound_slacks=lower_slacks,
+        upper_bound_slacks=upper_slacks,
+    )
 
 
 def _mapped_primal_fields(
@@ -319,16 +316,13 @@ def _map_standard_result(
             and lower_wire is not None
             and upper_wire is not None
         )
-        try:
-            return GeneralRationalLinearProgramResult(
-                program=program,
-                status="INFEASIBLE",
-                farkas_constraints=constraint_wire,
-                farkas_lower_bounds=lower_wire,
-                farkas_upper_bounds=upper_wire,
-            )
-        except ValidationError:
-            return _unknown(program)
+        return GeneralRationalLinearProgramResult._from_kernel(
+            program=program,
+            status="INFEASIBLE",
+            farkas_constraints=constraint_wire,
+            farkas_lower_bounds=lower_wire,
+            farkas_upper_bounds=upper_wire,
+        )
 
     assert standard_result.primal_candidate is not None
     primal = _mapped_primal_fields(
@@ -349,20 +343,17 @@ def _map_standard_result(
         wire_direction = _wire_vector(direction, max_digits=point_max_digits)
         if wire_direction is None:
             return _unknown(program)
-        try:
-            return GeneralRationalLinearProgramResult(
-                program=program,
-                status="UNBOUNDED",
-                primal_candidate=point,
-                primal_objective=objective,
-                primal_residuals=residuals,
-                constraint_slacks=constraint_slacks,
-                lower_bound_slacks=lower_slacks,
-                upper_bound_slacks=upper_slacks,
-                recession_direction=wire_direction,
-            )
-        except ValidationError:
-            return _unknown(program)
+        return GeneralRationalLinearProgramResult._from_kernel(
+            program=program,
+            status="UNBOUNDED",
+            primal_candidate=point,
+            primal_objective=objective,
+            primal_residuals=residuals,
+            constraint_slacks=constraint_slacks,
+            lower_bound_slacks=lower_slacks,
+            upper_bound_slacks=upper_slacks,
+            recession_direction=wire_direction,
+        )
     if standard_result.status == "PRIMAL_FEASIBLE":
         return _primal_feasible(
             program,
@@ -445,32 +436,21 @@ def _map_standard_result(
         and upper_wire is not None
         and stationarity_wire is not None
     )
-    try:
-        return GeneralRationalLinearProgramResult(
-            program=program,
-            status="OPTIMAL",
-            primal_candidate=point,
-            primal_objective=objective,
-            primal_residuals=residuals,
-            constraint_slacks=constraint_slacks,
-            lower_bound_slacks=lower_slacks,
-            upper_bound_slacks=upper_slacks,
-            constraint_dual=constraint_wire,
-            lower_bound_dual=lower_wire,
-            upper_bound_dual=upper_wire,
-            dual_objective=wire_dual_objective,
-            stationarity_residuals=stationarity_wire,
-        )
-    except ValidationError:
-        return _primal_feasible(
-            program,
-            point,
-            objective,
-            residuals,
-            constraint_slacks,
-            lower_slacks,
-            upper_slacks,
-        )
+    return GeneralRationalLinearProgramResult._from_kernel(
+        program=program,
+        status="OPTIMAL",
+        primal_candidate=point,
+        primal_objective=objective,
+        primal_residuals=residuals,
+        constraint_slacks=constraint_slacks,
+        lower_bound_slacks=lower_slacks,
+        upper_bound_slacks=upper_slacks,
+        constraint_dual=constraint_wire,
+        lower_bound_dual=lower_wire,
+        upper_bound_dual=upper_wire,
+        dual_objective=wire_dual_objective,
+        stationarity_residuals=stationarity_wire,
+    )
 
 
 def _general_linear_program(

--- a/src/jacobian/math/optimization/_models.py
+++ b/src/jacobian/math/optimization/_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from fractions import Fraction
 from math import comb, factorial
-from typing import Literal, Self
+from typing import Any, Literal, Self
 
 from pydantic import Field, ValidationInfo, model_validator
 from pydantic_core import PydanticCustomError
@@ -534,6 +534,17 @@ class RationalLinearProgramResult(StrictModel):
         default=None, max_length=32
     )
 
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        """Build an outcome whose source-derived facts the kernel established.
+
+        Result parsing intentionally does not rerun simplex certificates.  The
+        optimization kernel computes every diagnostic and witness before using
+        this trusted construction path.
+        """
+
+        return cls.model_construct(**values)
+
     @model_validator(mode="before")
     @classmethod
     def bound_raw_result(cls, value: object) -> object:
@@ -597,13 +608,8 @@ class RationalLinearProgramResult(StrictModel):
     def bind_result_to_source(self) -> Self:
         try:
             _require_result_shape(self)
-            _require_result_heights(self)
-            primal_objective = _replay_primal(self)
-            _replay_dual(self, primal_objective)
-            _replay_farkas(self)
-            _replay_recession(self)
         except ValueError as error:
-            raise _validation_error("result_replay", str(error)) from error
+            raise _validation_error("result_shape", str(error)) from error
         return self
 
 
@@ -661,6 +667,22 @@ def _require_result_heights(result: RationalLinearProgramResult) -> None:
             max_digits=result_bound,
             label="rational linear-program result",
         )
+
+
+def _verify_rational_linear_program_result(result: RationalLinearProgramResult) -> None:
+    """Deliberately verify an independently supplied LP claim.
+
+    This owner-private path is intentionally separate from ordinary result
+    parsing.  Callers that need certificate verification must opt into the
+    bounded replay rather than treating deserialization as proof.
+    """
+
+    _require_result_shape(result)
+    _require_result_heights(result)
+    primal_objective = _replay_primal(result)
+    _replay_dual(result, primal_objective)
+    _replay_farkas(result)
+    _replay_recession(result)
 
 
 def _replay_primal(result: RationalLinearProgramResult) -> Fraction | None:

--- a/src/jacobian/math/optimization/_operations.py
+++ b/src/jacobian/math/optimization/_operations.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from fractions import Fraction
 from typing import Any
 
-from pydantic import ValidationError
-
 from jacobian._exact import CanonicalRational
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools
@@ -21,6 +19,7 @@ from jacobian.math.optimization._models import (
     _dual_diagnostics,
     _primal_diagnostics,
     _result_digit_bound,
+    _verify_rational_linear_program_result,
 )
 
 
@@ -307,7 +306,15 @@ def _dual_data(
 def _unknown(
     program: StandardFormRationalLinearProgram,
 ) -> RationalLinearProgramResult:
-    return RationalLinearProgramResult(program=program, status="UNKNOWN")
+    return RationalLinearProgramResult._from_kernel(program=program, status="UNKNOWN")
+
+
+def _verified_kernel_result(**values: object) -> RationalLinearProgramResult:
+    """Construct and check a claim once at the producer boundary."""
+
+    result = RationalLinearProgramResult._from_kernel(**values)
+    _verify_rational_linear_program_result(result)
+    return result
 
 
 def _trivial_infeasibility(
@@ -324,7 +331,7 @@ def _trivial_infeasibility(
             1 if rhs.num.startswith("-") else -1,
             1,
         )
-        return RationalLinearProgramResult(
+        return _verified_kernel_result(
             program=program,
             status="INFEASIBLE",
             farkas_candidate=tuple(witness),
@@ -367,12 +374,10 @@ def _certify_infeasible(
         source_rows=len(program.rhs),
     )
     try:
-        return RationalLinearProgramResult(
-            program=program,
-            status="INFEASIBLE",
-            farkas_candidate=farkas,
+        return _verified_kernel_result(
+            program=program, status="INFEASIBLE", farkas_candidate=farkas
         )
-    except ValidationError:
+    except ValueError:
         return _unknown(program)
 
 
@@ -423,7 +428,7 @@ def _certify_unbounded(
         return _unknown(program)
     primal_objective, primal_residuals = primal_data
     try:
-        return RationalLinearProgramResult(
+        return _verified_kernel_result(
             program=program,
             status="UNBOUNDED",
             primal_candidate=feasible,
@@ -431,7 +436,7 @@ def _certify_unbounded(
             primal_residuals=primal_residuals,
             recession_direction=ray,
         )
-    except ValidationError:
+    except ValueError:
         return _unknown(program)
 
 
@@ -455,15 +460,16 @@ def _positive_result(
     if primal_data is None:
         return _certify_infeasible(program, result_digits=result_digits)
     primal_objective, primal_residuals = primal_data
+    primal_result = RationalLinearProgramResult._from_kernel(
+        program=program,
+        status="PRIMAL_FEASIBLE",
+        primal_candidate=primal,
+        primal_objective=primal_objective,
+        primal_residuals=primal_residuals,
+    )
     try:
-        primal_result = RationalLinearProgramResult(
-            program=program,
-            status="PRIMAL_FEASIBLE",
-            primal_candidate=primal,
-            primal_objective=primal_objective,
-            primal_residuals=primal_residuals,
-        )
-    except ValidationError:
+        _verify_rational_linear_program_result(primal_result)
+    except ValueError:
         return _certify_infeasible(program, result_digits=result_digits)
 
     if not _active_equations(program):
@@ -497,19 +503,21 @@ def _positive_result(
     if dual_data is None:
         return primal_result
     dual_objective, dual_slacks = dual_data
+    optimal_result = RationalLinearProgramResult._from_kernel(
+        program=program,
+        status="OPTIMAL",
+        primal_candidate=primal,
+        primal_objective=primal_objective,
+        primal_residuals=primal_residuals,
+        dual_candidate=dual,
+        dual_objective=dual_objective,
+        dual_slacks=dual_slacks,
+    )
     try:
-        return RationalLinearProgramResult(
-            program=program,
-            status="OPTIMAL",
-            primal_candidate=primal,
-            primal_objective=primal_objective,
-            primal_residuals=primal_residuals,
-            dual_candidate=dual,
-            dual_objective=dual_objective,
-            dual_slacks=dual_slacks,
-        )
-    except ValidationError:
+        _verify_rational_linear_program_result(optimal_result)
+    except ValueError:
         return primal_result
+    return optimal_result
 
 
 def _linear_program(

--- a/src/jacobian/math/padic_arithmetic/_models.py
+++ b/src/jacobian/math/padic_arithmetic/_models.py
@@ -22,9 +22,8 @@ def _require_padic_budget(polynomial: IntegerPolynomial) -> None:
     """Bound one admitted polynomial for the p-adic kernels.
 
     Root finding evaluates every residue mod ``p`` against the source
-    polynomial and result replay repeats that sweep, so the work grows
-    linearly in coefficient count; the shared canonical value alone
-    admits far longer inputs than these kernels establish.
+    polynomial, so the work grows linearly in coefficient count; the shared
+    canonical value alone admits far longer inputs than these kernels establish.
     """
     if len(polynomial.coefficients) > _MAX_PADIC_COEFFICIENTS:
         raise _validation_error(
@@ -120,9 +119,9 @@ class HenselRootRequest(StrictModel):
 class HenselRootResult(StrictModel):
     """A p-adic root approximation lifted via Hensel's lemma.
 
-    Retains the source polynomial and the original residue so the lift can
-    be replayed: the residue is a simple root of f mod p, the lifted root
-    reduces to it mod p, and it vanishes modulo p^precision.
+    Retains the source polynomial and the original residue for downstream use.
+    The producer establishes the Hensel-lift invariant; ordinary result parsing
+    checks only the serialized shape.
     """
 
     polynomial: IntegerPolynomial
@@ -133,43 +132,15 @@ class HenselRootResult(StrictModel):
     is_simple_root: bool
 
     @model_validator(mode="after")
-    def require_valid_lifted_root(self) -> Self:
-        p = self.prime
-        modulus = p**self.precision
-        _require_prime(p)
-        _require_padic_budget(self.polynomial)
-        if self.root_mod_p >= p:
+    def require_structural_shape(self) -> Self:
+        if self.root_mod_p >= self.prime:
             raise _validation_error(
                 "padic_arithmetic.root_out_of_range", "root_mod_p must be in 0..p-1"
             )
-        if self.lifted_root >= modulus:
+        if self.lifted_root >= self.prime**self.precision:
             raise _validation_error(
                 "padic_arithmetic.lifted_root_out_of_range",
                 "lifted_root must be in 0..p^k - 1",
-            )
-        coeffs = _kernel_coefficients(self.polynomial)
-        # Replay the defining invariants against the retained source data so
-        # a serialized result cannot detach its lift from its polynomial.
-        if _poly_eval_mod_p(coeffs, self.root_mod_p, p) != 0:
-            raise _validation_error(
-                "padic_arithmetic.root_not_root",
-                "root_mod_p must satisfy f(root_mod_p) = 0 mod p",
-            )
-        if _poly_deriv_mod_p(coeffs, self.root_mod_p, p) % p == 0:
-            raise _validation_error(
-                "padic_arithmetic.root_not_simple",
-                "the lifted residue must be simple: "
-                "f'(root_mod_p) must be nonzero mod p",
-            )
-        if self.lifted_root % p != self.root_mod_p:
-            raise _validation_error(
-                "padic_arithmetic.lifted_root_wrong_residue",
-                "lifted_root must reduce to root_mod_p modulo the prime",
-            )
-        if _poly_eval_mod_p(coeffs, self.lifted_root, modulus) != 0:
-            raise _validation_error(
-                "padic_arithmetic.lifted_root_not_root",
-                "lifted_root must satisfy f(lifted_root) = 0 modulo p^precision",
             )
         if not self.is_simple_root:
             raise _validation_error(
@@ -177,6 +148,17 @@ class HenselRootResult(StrictModel):
                 "only simple roots are lifted, so the flag must hold",
             )
         return self
+
+    @classmethod
+    def _from_kernel(cls, request: HenselRootRequest, lifted_root: int) -> Self:
+        return cls.model_construct(
+            polynomial=request.polynomial,
+            lifted_root=lifted_root,
+            prime=request.prime,
+            root_mod_p=request.root_mod_p,
+            precision=request.precision,
+            is_simple_root=True,
+        )
 
 
 class HenselFactorLiftRequest(StrictModel):
@@ -272,8 +254,7 @@ class PAdicRootsResult(StrictModel):
     multiple_residues: tuple[int, ...] = ()
 
     @model_validator(mode="after")
-    def require_consistent_count(self) -> Self:
-        _require_padic_budget(self.polynomial)
+    def require_structural_shape(self) -> Self:
         if self.root_count != len(self.roots):
             raise _validation_error(
                 "padic_arithmetic.root_count_mismatch",
@@ -291,15 +272,7 @@ class PAdicRootsResult(StrictModel):
             )
         return self
 
-    @model_validator(mode="after")
-    def require_source_bound_roots(self) -> Self:
-        p = self.prime
-        k = self.precision
-        # The advertised semantics are p-adic: validate the prime modulus
-        # before replaying the root set against it.
-        _require_prime(p)
-        modulus = p**k
-        coefficients = _kernel_coefficients(self.polynomial)
+        modulus = self.prime**self.precision
         roots = tuple(entry.root for entry in self.roots)
         if any(root >= modulus for root in roots):
             raise _validation_error(
@@ -310,48 +283,72 @@ class PAdicRootsResult(StrictModel):
                 "padic_arithmetic.roots_not_distinct",
                 "roots must be distinct modulo p^k",
             )
-        # Replay every classification against the retained polynomial: each
-        # listed root must be an exact vanishing simple root, and the simple
-        # versus multiple split must be complete over all residues mod p.
-        for root in roots:
-            if _eval_poly_mod(coefficients, root, modulus) != 0:
-                raise _validation_error(
-                    "padic_arithmetic.root_not_root",
-                    "each root must satisfy f(root) = 0 modulo p^precision",
-                )
-            if _eval_poly_deriv_mod(coefficients, root, p) == 0:
-                raise _validation_error(
-                    "padic_arithmetic.root_not_simple",
-                    "each lifted root must be simple modulo p",
-                )
-        simple_residues = [
-            residue
-            for residue in range(p)
-            if _eval_poly_mod(coefficients, residue, p) == 0
-            and _eval_poly_deriv_mod(coefficients, residue, p) != 0
-        ]
-        multiple = [
-            residue
-            for residue in range(p)
-            if _eval_poly_mod(coefficients, residue, p) == 0
-            and _eval_poly_deriv_mod(coefficients, residue, p) == 0
-        ]
-        if sorted({root % p for root in roots}) != simple_residues:
-            raise _validation_error(
-                "padic_arithmetic.simple_residues_mismatch",
-                "roots must cover exactly the simple residues of f modulo p",
-            )
-        if len(roots) != len(simple_residues):
-            raise _validation_error(
-                "padic_arithmetic.simple_root_count_mismatch",
-                "each simple residue lifts to exactly one root",
-            )
-        if sorted(self.multiple_residues) != multiple:
-            raise _validation_error(
-                "padic_arithmetic.multiple_residues_mismatch",
-                "multiple_residues must list every repeated-factor residue of f mod p",
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PAdicRootsRequest,
+        roots: tuple[PAdicRootEntry, ...],
+        multiple_residues: tuple[int, ...],
+    ) -> Self:
+        return cls.model_construct(
+            polynomial=request.polynomial,
+            roots=roots,
+            prime=request.prime,
+            precision=request.precision,
+            root_count=len(roots),
+            multiple_residues=multiple_residues,
+        )
+
+
+def verify_hensel_root_result(result: HenselRootResult) -> None:
+    """Verify an independently supplied Hensel-lift claim."""
+    request = HenselRootRequest(
+        polynomial=result.polynomial,
+        prime=result.prime,
+        root_mod_p=result.root_mod_p,
+        precision=result.precision,
+    )
+    coefficients = _kernel_coefficients(request.polynomial)
+    modulus = request.prime**request.precision
+    if (
+        result.lifted_root % request.prime != request.root_mod_p
+        or _eval_poly_mod(coefficients, result.lifted_root, modulus) != 0
+    ):
+        raise _validation_error(
+            "lifted_root_mismatch", "lifted_root is not the claimed Hensel lift"
+        )
+
+
+def verify_padic_roots_result(result: PAdicRootsResult) -> None:
+    """Verify an independently supplied complete simple-root claim."""
+    request = PAdicRootsRequest(
+        polynomial=result.polynomial, prime=result.prime, precision=result.precision
+    )
+    coefficients = _kernel_coefficients(request.polynomial)
+    roots = tuple(entry.root for entry in result.roots)
+    modulus = request.prime**request.precision
+    simple_residues = [
+        residue
+        for residue in range(request.prime)
+        if _eval_poly_mod(coefficients, residue, request.prime) == 0
+        and _eval_poly_deriv_mod(coefficients, residue, request.prime) != 0
+    ]
+    multiple = [
+        residue
+        for residue in range(request.prime)
+        if _eval_poly_mod(coefficients, residue, request.prime) == 0
+        and _eval_poly_deriv_mod(coefficients, residue, request.prime) == 0
+    ]
+    if (
+        any(_eval_poly_mod(coefficients, root, modulus) != 0 for root in roots)
+        or sorted({root % request.prime for root in roots}) != simple_residues
+        or sorted(result.multiple_residues) != multiple
+    ):
+        raise _validation_error(
+            "root_profile_mismatch", "roots do not match the source polynomial"
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/padic_arithmetic/_models.py
+++ b/src/jacobian/math/padic_arithmetic/_models.py
@@ -270,8 +270,6 @@ class PAdicRootsResult(StrictModel):
                 "padic_arithmetic.multiple_residue_out_of_range",
                 "multiple residues must lie in 0..p-1",
             )
-        return self
-
         modulus = self.prime**self.precision
         roots = tuple(entry.root for entry in self.roots)
         if any(root >= modulus for root in roots):

--- a/src/jacobian/math/padic_arithmetic/_operations.py
+++ b/src/jacobian/math/padic_arithmetic/_operations.py
@@ -96,14 +96,7 @@ def hensel_lift_root(request: HenselRootRequest) -> HenselRootResult:
     lifted = _hensel_lift_root(
         coeffs, request.prime, request.root_mod_p, request.precision
     )
-    return HenselRootResult(
-        polynomial=request.polynomial,
-        lifted_root=lifted,
-        prime=request.prime,
-        root_mod_p=request.root_mod_p,
-        precision=request.precision,
-        is_simple_root=True,
-    )
+    return HenselRootResult._from_kernel(request, lifted)
 
 
 def _poly_mul_exact_mod(
@@ -304,13 +297,8 @@ def find_padic_roots(request: PAdicRootsRequest) -> PAdicRootsResult:
         lifted = _hensel_lift_root(coeffs, p, r, k)
         lifted_roots.append(PAdicRootEntry(root=lifted, root_type="SIMPLE"))
 
-    return PAdicRootsResult(
-        polynomial=request.polynomial,
-        roots=tuple(lifted_roots),
-        prime=p,
-        precision=k,
-        root_count=len(lifted_roots),
-        multiple_residues=tuple(multiple_residues),
+    return PAdicRootsResult._from_kernel(
+        request, tuple(lifted_roots), tuple(multiple_residues)
     )
 
 

--- a/src/jacobian/math/plane_algebraic_curves/_conic.py
+++ b/src/jacobian/math/plane_algebraic_curves/_conic.py
@@ -1,11 +1,11 @@
-"""Exact kernel and replay helpers for smooth rational conics."""
+"""Exact kernel and owner-private verification helpers for smooth rational conics."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from fractions import Fraction
 from math import gcd, lcm
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import sympy
 
@@ -23,6 +23,11 @@ from jacobian.math.polynomials.values import (
     RationalPolynomial,
     require_polynomial_budget,
 )
+
+if TYPE_CHECKING:
+    from jacobian.math.plane_algebraic_curves._models import (
+        RationalConicParametrizationResult,
+    )
 
 MAX_CONIC_TERMS = 6
 MAX_CONIC_INPUT_DIGITS = 128
@@ -606,13 +611,25 @@ def _validate_projective_denominator_locus(
         raise ValueError("projective chart coordinate must use the parameter axis")
 
 
-def validate_rational_conic_result_identities(
-    polynomial: RationalPolynomial,
-    point: VariablePoint,
-    parameter: PolynomialVariable,
-    data: ConicParametrizationData,
+def _verify_rational_conic_parametrization_result(
+    result: RationalConicParametrizationResult,
 ) -> None:
-    """Replay the canonical chart and its defining birational identities."""
+    """Boundedly verify an independently supplied conic parametrization claim.
+
+    This owner-private path is deliberately separate from result parsing.  It
+    re-enters request admission before replaying the canonical construction and
+    its defining identities.
+    """
+
+    polynomial = result.source_polynomial
+    point = result.exceptional_point
+    parameter = result.parameter
+    data = ConicParametrizationData(
+        coordinates=result.coordinates,
+        inverse_parameter=result.inverse_parameter,
+        finite_parameter_denominator=result.finite_parameter_denominator,
+    )
+    validate_rational_conic_request(polynomial, point, parameter)
 
     derivation = _derive_rational_conic_parametrization(polynomial, point, parameter)
     if data != derivation.data:
@@ -673,5 +690,4 @@ __all__ = [
     "ConicParametrizationData",
     "derive_rational_conic_parametrization",
     "validate_rational_conic_request",
-    "validate_rational_conic_result_identities",
 ]

--- a/src/jacobian/math/plane_algebraic_curves/_models.py
+++ b/src/jacobian/math/plane_algebraic_curves/_models.py
@@ -7,12 +7,9 @@ from typing import Literal, Self
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
+from jacobian._exact import require_bounded_rational
 from jacobian._models import StrictModel
-from jacobian.math.plane_algebraic_curves._conic import (
-    ConicParametrizationData,
-    validate_rational_conic_request,
-    validate_rational_conic_result_identities,
-)
+from jacobian.math.plane_algebraic_curves._conic import validate_rational_conic_request
 from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
 from jacobian.math.polynomials.maps._models import VariablePoint
 from jacobian.math.polynomials.values import (
@@ -20,6 +17,7 @@ from jacobian.math.polynomials.values import (
     RationalFunction,
     RationalPolynomial,
     require_polynomial_budget,
+    require_sparse_polynomial_budget,
 )
 
 MAX_VARS = 3
@@ -244,24 +242,109 @@ class RationalConicParametrizationResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def replay_defining_identities(self) -> Self:
+    def require_structural_contract(self) -> Self:
+        """Check only bounded wire-shape relations between result fields.
+
+        The admitted line-pencil kernel establishes the parametrization
+        identities. Parsing a serialized result must not reconstruct and replay
+        that computation; callers that deliberately receive an independently
+        supplied claim use the owner-private verifier instead.
+        """
         try:
-            validate_rational_conic_request(
-                self.source_polynomial, self.exceptional_point, self.parameter
-            )
-            validate_rational_conic_result_identities(
+            require_polynomial_budget(
                 self.source_polynomial,
-                self.exceptional_point,
-                self.parameter,
-                ConicParametrizationData(
-                    coordinates=self.coordinates,
-                    inverse_parameter=self.inverse_parameter,
-                    finite_parameter_denominator=self.finite_parameter_denominator,
-                ),
+                maximum_terms=6,
+                maximum_exponent=2,
+                maximum_coefficient_digits=_MAX_COEFFICIENT_DIGITS,
+                label="source conic",
             )
+            require_polynomial_budget(
+                self.finite_parameter_denominator,
+                maximum_terms=3,
+                maximum_exponent=2,
+                maximum_coefficient_digits=_MAX_COEFFICIENT_DIGITS,
+                label="finite-parameter denominator",
+            )
+            for label, function in (
+                ("first parametrization coordinate", self.coordinates[0]),
+                ("second parametrization coordinate", self.coordinates[1]),
+                ("inverse parameter", self.inverse_parameter),
+            ):
+                require_sparse_polynomial_budget(
+                    function.numerator,
+                    maximum_terms=3,
+                    maximum_exponent=2,
+                    maximum_coefficient_digits=_MAX_COEFFICIENT_DIGITS,
+                    label=f"{label} numerator",
+                )
+                require_sparse_polynomial_budget(
+                    function.denominator,
+                    maximum_terms=3,
+                    maximum_exponent=2,
+                    maximum_coefficient_digits=_MAX_COEFFICIENT_DIGITS,
+                    label=f"{label} denominator",
+                )
+            for coordinate in self.exceptional_point.values:
+                require_bounded_rational(
+                    coordinate,
+                    max_digits=_MAX_COEFFICIENT_DIGITS,
+                    label="exceptional point coordinate",
+                )
         except ValueError as exc:
             raise _validation_error_from(exc) from exc
+        if len(self.source_polynomial.variables) != 2:
+            raise _validation_error(
+                "conic_axis_invalid",
+                "rational conic parametrization requires exactly two variables",
+            )
+        if self.exceptional_point.variables != self.source_polynomial.variables:
+            raise _validation_error(
+                "point_axis_mismatch",
+                "conic point must use the polynomial's complete ordered axis",
+            )
+        if self.parameter in self.source_polynomial.variables:
+            raise _validation_error(
+                "parameter_axis_collision",
+                "parameter must be distinct from both conic variables",
+            )
+        if any(
+            coordinate.variables != (self.parameter,) for coordinate in self.coordinates
+        ):
+            raise _validation_error(
+                "coordinate_axis_invalid",
+                "parametrization coordinates must use exactly the parameter axis",
+            )
+        if self.inverse_parameter.variables != self.source_polynomial.variables:
+            raise _validation_error(
+                "inverse_axis_invalid",
+                "inverse parameter must use the source polynomial's ordered axis",
+            )
+        if self.finite_parameter_denominator.variables != (self.parameter,):
+            raise _validation_error(
+                "finite_parameter_axis_invalid",
+                "finite-parameter denominator must use exactly the parameter axis",
+            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: RationalConicParametrizationRequest,
+        *,
+        coordinates: tuple[RationalFunction, RationalFunction],
+        inverse_parameter: RationalFunction,
+        finite_parameter_denominator: RationalPolynomial,
+    ) -> Self:
+        """Build one result after the admitted line-pencil kernel established it."""
+
+        return cls.model_construct(
+            source_polynomial=request.polynomial,
+            exceptional_point=request.point,
+            parameter=request.parameter,
+            coordinates=coordinates,
+            inverse_parameter=inverse_parameter,
+            finite_parameter_denominator=finite_parameter_denominator,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/plane_algebraic_curves/_operations.py
+++ b/src/jacobian/math/plane_algebraic_curves/_operations.py
@@ -112,10 +112,8 @@ def compute_rational_conic_parametrization(
         request.point,
         request.parameter,
     )
-    return RationalConicParametrizationResult(
-        source_polynomial=request.polynomial,
-        exceptional_point=request.point,
-        parameter=request.parameter,
+    return RationalConicParametrizationResult._from_kernel(
+        request,
         coordinates=data.coordinates,
         inverse_parameter=data.inverse_parameter,
         finite_parameter_denominator=data.finite_parameter_denominator,

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -210,6 +210,8 @@ class PolynomialSquareFreeDecompositionResult(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical_factor_records(self) -> Self:
+        if self.reconstructed.variables != self.polynomial.variables:
+            raise _validation_error("reconstructed polynomial must use the source ring")
         multiplicities = tuple(factor.multiplicity for factor in self.factors)
         if multiplicities != tuple(sorted(multiplicities)):
             raise _validation_error(
@@ -293,6 +295,8 @@ class PolynomialFactorizationResult(StrictModel):
             raise _validation_error(
                 "factorization currently supports one variable over QQ"
             )
+        if self.reconstructed.variables != self.polynomial.variables:
+            raise _validation_error("reconstructed polynomial must use the source ring")
         if any(
             factor.factor.variables != self.reconstructed.variables
             for factor in self.factors

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
@@ -24,22 +24,6 @@ from jacobian.math.polynomials.values import (
 _MAX_COEFFICIENT_DIGITS = 256
 _MAX_GCD_TERMS = 1024
 _MAX_INVARIANT_TERMS = 256
-# Cumulative monomial-multiplication budget for one factor-replay
-# authentication.  Sized from the replay's admitted envelope: the largest
-# known authentic canonical decomposition inside the square-free request
-# envelope, S_57(x)*(S_31(y)S_31(z))^2*(x+1)^3*((x-1)(y-1)(z-1))^4 with
-# per-variable degrees (63, 64, 64), performs exactly 29,892,365 pairwise
-# monomial multiplications under multiplicity-ordered reconstruction, so
-# the ceiling admits it with headroom while still bounding every forged
-# claim's arithmetic before a mismatch can hide inside unbounded work.
-_MAX_REPLAY_WORK = 1 << 25
-# Conservative ceiling on one replay step's predicted product support,
-# checked before the backend multiplication runs.  The admitted trivariate
-# square-free envelope keeps every partial-product degree box at or below
-# 65^3 = 274,625 terms (the fixture above peaks at 270,400), so this
-# ceiling admits that whole envelope; wider claimed degree boxes reject
-# before materializing anything rather than trusting backend expansion.
-_MAX_REPLAY_INTERMEDIATE_TERMS = 1 << 19
 _MAX_GCD_DEGREE = 500
 _MAX_ELIMINATION_DEGREE_SUM = 128
 _MAX_DISCRIMINANT_DEGREE = 64
@@ -211,17 +195,11 @@ class PolynomialSquareFreeFactor(StrictModel):
 
 
 class PolynomialSquareFreeDecompositionResult(StrictModel):
-    """The square-free decomposition bound to its source polynomial.
+    """A kernel-produced square-free decomposition over ``QQ``.
 
-    Retains the canonical source polynomial so validation replays
-    ``reconstructed = polynomial`` and authenticates the defining relation
-    ``polynomial = coefficient * product(factor^multiplicity)`` together
-    with everything that makes the records THE monic square-free
-    decomposition — pairwise-coprime square-free parts, distinct
-    multiplicities, monic records — by exact bounded checks on the claimed
-    records alone.  Over ``QQ`` these properties admit exactly one
-    decomposition, so no backend recomputation of the source's (possibly
-    unrepresentable) true decomposition is ever needed.
+    Parsing checks only the wire shape and canonical record ordering.  The
+    operation establishes the factorization theorem once; deserializing its
+    value must not multiply factors or recompute algebraic predicates.
     """
 
     polynomial: RationalPolynomial
@@ -232,10 +210,6 @@ class PolynomialSquareFreeDecompositionResult(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical_factor_records(self) -> Self:
-        from jacobian.math.polynomials._conversions import (
-            rational_polynomial_to_sympy,
-        )
-
         multiplicities = tuple(factor.multiplicity for factor in self.factors)
         if multiplicities != tuple(sorted(multiplicities)):
             raise _validation_error(
@@ -250,36 +224,26 @@ class PolynomialSquareFreeDecompositionResult(StrictModel):
             for factor in self.factors
         ):
             raise _validation_error("square-free factors must use the source ring")
-        require_polynomial_budget(
-            self.polynomial,
-            maximum_terms=_MAX_GCD_TERMS,
-            maximum_exponent=_MAX_SQUARE_FREE_EXPONENT,
-            label="retained source polynomial",
-        )
-        require_polynomial_budget(
-            self.reconstructed,
-            maximum_terms=_MAX_GCD_TERMS,
-            maximum_exponent=_MAX_SQUARE_FREE_EXPONENT,
-            label="reconstructed polynomial",
-        )
-        source = rational_polynomial_to_sympy(self.polynomial)
-        if rational_polynomial_to_sympy(self.reconstructed) != source:
-            raise _validation_error(
-                "reconstructed must equal the retained source polynomial"
-            )
-        _verify_exact_factor_product(
-            source,
-            self.factors,
-            coefficient=self.coefficient,
-            mismatch_message=(
-                "square-free factors must reconstruct the retained source "
-                "polynomial exactly"
-            ),
-            label="square-free",
-            maximum_exponent=_MAX_SQUARE_FREE_EXPONENT,
-            require_square_free_parts=True,
-        )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        polynomial: RationalPolynomial,
+        coefficient: CanonicalRational,
+        factors: tuple[PolynomialSquareFreeFactor, ...],
+        reconstructed: RationalPolynomial,
+    ) -> Self:
+        """Build a result after the admitted decomposition kernel succeeds."""
+
+        return cls.model_construct(
+            polynomial=polynomial,
+            coefficient=coefficient,
+            factors=factors,
+            reconstructed=reconstructed,
+            normalization="MONIC_FACTORS",
+        )
 
 
 class PolynomialFactorRequest(StrictModel):
@@ -307,19 +271,11 @@ class PolynomialIrreducibleFactor(StrictModel):
 
 
 class PolynomialFactorizationResult(StrictModel):
-    """The exact univariate factorization bound to its source polynomial.
+    """A kernel-produced exact univariate factorization over ``QQ``.
 
-    Retains the canonical source polynomial so validation replays the
-    defining relations ``reconstructed = polynomial`` and
-    ``polynomial = coefficient * product(factor^multiplicity)`` together
-    with everything that makes the records THE content-and-monic-
-    irreducibles factorization — monic distinct irreducible records under
-    canonical ordering — by exact bounded checks on the claimed records
-    alone.  Over ``QQ`` these properties admit exactly one factorization,
-    so no backend recomputation of the retained source's true
-    factorization is ever needed.  The literal
-    ``product_reconstruction = EXACT`` label is derived from that replay,
-    never accepted as evidence.
+    Parsing retains only structural checks.  Exact product reconstruction and
+    irreducibility are established by the producer, not repeated for every
+    deserialized result.
     """
 
     polynomial: RationalPolynomial
@@ -333,10 +289,6 @@ class PolynomialFactorizationResult(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical_irreducible_records(self) -> Self:
-        from jacobian.math.polynomials._conversions import (
-            rational_polynomial_to_sympy,
-        )
-
         if len(self.polynomial.variables) != 1:
             raise _validation_error(
                 "factorization currently supports one variable over QQ"
@@ -374,259 +326,27 @@ class PolynomialFactorizationResult(StrictModel):
                 "irreducible factors must be ordered by multiplicity, degree, "
                 "and sparse term fingerprint"
             )
-        require_polynomial_budget(
-            self.polynomial,
-            maximum_terms=_MAX_GCD_TERMS,
-            maximum_exponent=_MAX_GCD_DEGREE,
-            label="retained source polynomial",
-        )
-        require_polynomial_budget(
-            self.reconstructed,
-            maximum_terms=_MAX_GCD_TERMS,
-            maximum_exponent=_MAX_GCD_DEGREE,
-            label="reconstructed polynomial",
-        )
-        source = rational_polynomial_to_sympy(self.polynomial)
-        if rational_polynomial_to_sympy(self.reconstructed) != source:
-            raise _validation_error(
-                "reconstructed must equal the retained source polynomial"
-            )
-        _verify_exact_factor_product(
-            source,
-            self.factors,
-            coefficient=self.coefficient,
-            mismatch_message=(
-                "factorization must reconstruct the retained source polynomial exactly"
-            ),
-            label="irreducible",
-            maximum_exponent=_MAX_GCD_DEGREE,
-            require_square_free_parts=False,
-        )
         return self
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        polynomial: RationalPolynomial,
+        coefficient: CanonicalRational,
+        factors: tuple[PolynomialIrreducibleFactor, ...],
+        reconstructed: RationalPolynomial,
+    ) -> Self:
+        """Build a result after the admitted factorization kernel succeeds."""
 
-def _canonical_poly_key(polynomial: Any) -> Any:
-    """Return the hashable canonical form of one monic QQ ``Poly``."""
-
-    return tuple(
-        sorted(
-            (monom, int(coeff.p), int(coeff.q)) for monom, coeff in polynomial.terms()
+        return cls.model_construct(
+            polynomial=polynomial,
+            coefficient=coefficient,
+            factors=factors,
+            reconstructed=reconstructed,
+            normalization="CONTENT_AND_MONIC_IRREDUCIBLES",
+            product_reconstruction="EXACT",
         )
-    )
-
-
-def _degree_vector(polynomial: Any) -> tuple[int, ...]:
-    """Return one backend polynomial's per-generator maximum exponents."""
-
-    monoms = polynomial.monoms()
-    return tuple(
-        max((monom[index] for monom in monoms), default=0)
-        for index in range(len(polynomial.gens))
-    )
-
-
-def _require_bounded_replay_step(
-    accumulated: Any, base: Any, work: int, *, label: str
-) -> tuple[Any, int]:
-    """Multiply one reconstruction step under proven preflight bounds.
-
-    Two independent quantities are derived from the claimed records'
-    actual structure and checked before any backend multiplication runs:
-
-    * ``support`` — every output monomial arises from exactly one input
-      pair, so ``len(accumulated) * len(base)`` upper-bounds the product's
-      support, and so does the per-variable degree box
-      ``prod_i(deg_i(accumulated) + deg_i(base) + 1)``.  Their minimum is
-      therefore a proven support bound that uses whichever structure the
-      claimed records actually exhibit.  Claimed powers whose supports
-      collide into a sparse product — geometric sums telescoping under
-      multiplication — are admitted where the bare pairwise count would
-      reject an authentic decomposition, while claims whose product cannot
-      stay inside ``_MAX_REPLAY_INTERMEDIATE_TERMS`` reject before anything
-      materializes.
-    * ``work`` — ``len(accumulated) * len(base)`` counts this step's exact
-      monomial multiplications; the running total must stay inside
-      ``_MAX_REPLAY_WORK``.
-
-    Authentic reconstruction prefixes can transiently out-density the
-    retained source — later records cancel a dense prefix back into the
-    request envelope — so the per-step ceiling is a documented conservative
-    replay bound above the serialization envelope instead of the envelope
-    itself.  For an authentic claim every partial product divides the
-    retained source, so a guard trip proves only that the claim cannot be
-    authenticated within bounded work, never a mathematical mismatch.
-    """
-
-    step_work = len(accumulated.terms()) * len(base.terms())
-    support_bound = step_work
-    box_bound = 1
-    for accumulated_degree, base_degree in zip(
-        _degree_vector(accumulated), _degree_vector(base), strict=True
-    ):
-        box_bound *= accumulated_degree + base_degree + 1
-    if box_bound < support_bound:
-        support_bound = box_bound
-    if support_bound > _MAX_REPLAY_INTERMEDIATE_TERMS:
-        raise _validation_error(
-            f"{label} factor replay would materialize more than "
-            f"{_MAX_REPLAY_INTERMEDIATE_TERMS} intermediate terms"
-        )
-    work += step_work
-    if work > _MAX_REPLAY_WORK:
-        raise _validation_error(
-            f"{label} factor replay exceeds the "
-            f"{_MAX_REPLAY_WORK}-operation reconstruction budget"
-        )
-    return accumulated * base, work
-
-
-def _validated_replay_records(
-    factors: tuple[PolynomialSquareFreeFactor, ...]
-    | tuple[PolynomialIrreducibleFactor, ...],
-    *,
-    mismatch_message: str,
-    label: str,
-    maximum_exponent: int,
-) -> list[tuple[Any, int]]:
-    """Budget, convert, and canonically deduplicate the claimed records.
-
-    Every record must sit inside the shared representation envelope, be
-    non-constant and monic, and carry a factor polynomial not listed by any
-    other record; canonical decompositions never repeat a factor.
-    """
-
-    from jacobian.math.polynomials._conversions import (
-        rational_polynomial_to_sympy,
-    )
-
-    claimed: list[tuple[Any, int]] = []
-    seen: set[Any] = set()
-    for record in factors:
-        require_polynomial_budget(
-            record.factor,
-            maximum_terms=MAX_POLYNOMIAL_TERMS,
-            maximum_exponent=maximum_exponent,
-            label=f"{label} factor",
-        )
-        if _polynomial_total_degree(record.factor) == 0:
-            raise _validation_error(f"{label} factor must be non-constant")
-        base = rational_polynomial_to_sympy(record.factor)
-        if base.LC() != 1:
-            raise _validation_error(mismatch_message)
-        key = _canonical_poly_key(base)
-        if key in seen:
-            raise _validation_error(mismatch_message)
-        seen.add(key)
-        claimed.append((base, record.multiplicity))
-    return claimed
-
-
-def _require_disjoint_square_free_parts(
-    claimed: list[tuple[Any, int]], *, mismatch_message: str
-) -> None:
-    """Reject parts that are not square-free or not pairwise coprime.
-
-    A part fails square-freeness exactly when some irreducible divides it
-    together with every nonzero formal partial derivative; two distinct
-    parts fail coprimeness exactly when their GCD leaves one variable's
-    degree.  Both predicates operate only on the already-admitted claimed
-    records.
-    """
-
-    for base, _ in claimed:
-        derivative_gcd = None
-        for generator in base.gens:
-            partial = base.diff(generator)
-            if partial.is_zero:
-                continue
-            derivative_gcd = (
-                partial if derivative_gcd is None else derivative_gcd.gcd(partial)
-            )
-        if derivative_gcd is not None and not base.gcd(derivative_gcd).is_one:
-            raise _validation_error(mismatch_message)
-    for index, (base, _) in enumerate(claimed):
-        for other, _ in claimed[index + 1 :]:
-            if not base.gcd(other).is_one:
-                raise _validation_error(mismatch_message)
-
-
-def _verify_exact_factor_product(
-    source: Any,
-    factors: tuple[PolynomialSquareFreeFactor, ...]
-    | tuple[PolynomialIrreducibleFactor, ...],
-    *,
-    coefficient: CanonicalRational,
-    mismatch_message: str,
-    label: str,
-    maximum_exponent: int,
-    require_square_free_parts: bool,
-) -> None:
-    """Authenticate the claimed records as the unique canonical decomposition.
-
-    Over ``QQ`` (characteristic zero) a decomposition with the following
-    exactly-certified properties exists only as THE canonical form of the
-    retained source polynomial — the content-and-monic-irreducibles
-    factorization when ``require_square_free_parts`` is false, the monic
-    square-free decomposition otherwise:
-
-    1. every record is monic, budgeted, non-constant, and distinct;
-    2. square-free results carry pairwise-coprime square-free parts;
-    3. irreducible-factorization records each satisfy ``is_irreducible``;
-    4. ``coefficient * product(record ** multiplicity) == source`` exactly.
-
-    Uniqueness makes these checks equivalent to equality with the recomputed
-    canonical decomposition while never invoking a factorization backend:
-    recomputing the true decomposition of an admitted source can itself be
-    unrepresentable (the multiplicity-one part of
-    ``prod((x_i^63 - 1)(x_i - 1))`` holds ``63^5`` terms inside a 1,024-term
-    request envelope), so validation must not materialize it to compare.
-    Every operation here touches only the claimed records or bounded
-    products of them; for an authentic claim every such partial product
-    divides the retained source.  Each sparse multiplication's exact work
-    count and its structure-derived support bound — the minimum of the
-    pairwise-product bound and the per-variable degree box of the claimed
-    records — are computed before the backend runs, the support bound per
-    step against ``_MAX_REPLAY_INTERMEDIATE_TERMS`` and the cumulative work
-    against ``_MAX_REPLAY_WORK``, so nothing larger than those proven bounds
-    ever materializes.
-    """
-
-    from sympy import Poly, Rational
-
-    if coefficient.as_fraction() == 0 and factors:
-        raise _validation_error("results with zero content retain no factors")
-    claimed = _validated_replay_records(
-        factors,
-        mismatch_message=mismatch_message,
-        label=label,
-        maximum_exponent=maximum_exponent,
-    )
-    accumulated = Poly(
-        Rational(*coefficient.as_integer_ratio()),
-        *source.gens,
-        domain=source.domain,
-    )
-    work = 0
-    for base, multiplicity in claimed:
-        if multiplicity == 1:
-            accumulated, work = _require_bounded_replay_step(
-                accumulated, base, work, label=label
-            )
-            continue
-        power = base
-        for _ in range(multiplicity - 1):
-            power, work = _require_bounded_replay_step(power, base, work, label=label)
-        accumulated, work = _require_bounded_replay_step(
-            accumulated, power, work, label=label
-        )
-    if accumulated != source:
-        raise _validation_error(mismatch_message)
-    if require_square_free_parts:
-        _require_disjoint_square_free_parts(claimed, mismatch_message=mismatch_message)
-        return
-    for base, _ in claimed:
-        if not base.is_irreducible:
-            raise _validation_error(mismatch_message)
 
 
 class PolynomialGroebnerBudget(StrictModel):

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -135,7 +135,7 @@ def polynomial_square_free_decomposition(
         )
         for factor, multiplicity in sorted(canonical_factors, key=lambda item: item[1])
     )
-    return PolynomialSquareFreeDecompositionResult(
+    return PolynomialSquareFreeDecompositionResult._from_kernel(
         polynomial=request.polynomial,
         coefficient=rational_from_sympy(coefficient),
         factors=factors,
@@ -176,11 +176,45 @@ def polynomial_factorization(
             key=_irreducible_factor_sort_key,
         )
     )
-    return PolynomialFactorizationResult(
+    return PolynomialFactorizationResult._from_kernel(
         polynomial=request.polynomial,
         coefficient=rational_from_sympy(coefficient),
         factors=factors,
         reconstructed=_result_polynomial(reconstructed, request.polynomial.variables),
+    )
+
+
+def _verify_square_free_decomposition_result(
+    result: PolynomialSquareFreeDecompositionResult,
+) -> bool:
+    """Deliberately recompute one independently supplied square-free claim."""
+
+    try:
+        expected = polynomial_square_free_decomposition(
+            PolynomialSquareFreeRequest(polynomial=result.polynomial)
+        )
+    except (TypeError, ValueError):
+        return False
+    return (
+        result.coefficient == expected.coefficient
+        and result.factors == expected.factors
+        and result.reconstructed == expected.reconstructed
+    )
+
+
+def _verify_factorization_result(result: PolynomialFactorizationResult) -> bool:
+    """Deliberately recompute one independently supplied factorization claim."""
+
+    try:
+        expected = polynomial_factorization(
+            PolynomialFactorRequest(polynomial=result.polynomial)
+        )
+    except (TypeError, ValueError):
+        return False
+    return (
+        result.coefficient == expected.coefficient
+        and result.factors == expected.factors
+        and result.reconstructed == expected.reconstructed
     )
 
 

--- a/src/jacobian/math/polynomials/ideals/_models.py
+++ b/src/jacobian/math/polynomials/ideals/_models.py
@@ -594,16 +594,6 @@ def _require_computed_minimal_prime_family(
         )
 
 
-def computed_minimal_primes_result(
-    request: IdealMinimalPrimesRequest,
-    components: tuple[RationalPolynomialIdeal, ...] | None,
-    backend_version: str | None,
-) -> IdealMinimalPrimesResult:
-    """Compatibility shim for the operation-local trusted factory."""
-
-    return IdealMinimalPrimesResult._from_kernel(request, components, backend_version)
-
-
 __all__ = [
     "MAX_OUTPUT_GENERATORS",
     "MAX_OUTPUT_TERMS",

--- a/src/jacobian/math/polynomials/ideals/_operations.py
+++ b/src/jacobian/math/polynomials/ideals/_operations.py
@@ -30,7 +30,6 @@ from jacobian.math.polynomials.ideals._models import (
     IdealRadicalResult,
     IdealSaturationRequest,
     IdealSaturationResult,
-    computed_minimal_primes_result,
 )
 from jacobian.math.polynomials.ideals._singular import (
     run_bounded_stdin_python_kernel,
@@ -488,7 +487,7 @@ def compute_ideal_minimal_primes(
         # uniqueness; externally supplied JSON always runs the model
         # validator's own independent verification.
         try:
-            result = computed_minimal_primes_result(
+            result = IdealMinimalPrimesResult._from_kernel(
                 request=request,
                 components=components,
                 backend_version=backend.backend_version,
@@ -571,7 +570,7 @@ def compute_ideal_minimal_primes(
     )
 
 
-def verify_ideal_minimal_primes_result(result: IdealMinimalPrimesResult) -> bool:
+def _verify_ideal_minimal_primes_result(result: IdealMinimalPrimesResult) -> bool:
     """Independently verify a supplied computed minimal-prime family.
 
     Result construction deliberately performs only structural checks.  This
@@ -662,7 +661,6 @@ __all__ = [
     "compute_ideal_saturation",
     "verify_elimination_ideal_result",
     "verify_groebner_basis_result",
-    "verify_ideal_minimal_primes_result",
     "verify_ideal_normal_form_result",
 ]
 

--- a/src/jacobian/math/polynomials/interpolation/_models.py
+++ b/src/jacobian/math/polynomials/interpolation/_models.py
@@ -19,7 +19,6 @@ from jacobian.canonical import encode_strict_json
 from jacobian.math.polynomials.interpolation._kernel import (
     divided_difference_coefficients,
     evaluate_newton_form,
-    ordinary_derivative_value,
 )
 from jacobian.math.polynomials.values import (
     PolynomialVariable,
@@ -388,10 +387,10 @@ def _polynomial_coefficients(
 
 
 class HermiteInterpolationResult(StrictModel):
-    """Unique degree-``< M`` interpolant with complete source-bound replay."""
+    """Unique degree-``< M`` interpolant with retained constraint evidence."""
 
     source: OrdinaryDerivativeJetTable = Field(
-        description="Retained source table that binds the polynomial and replay."
+        description="Retained source table that binds the polynomial and evidence."
     )
     polynomial: RationalPolynomial = Field(
         description=(
@@ -431,7 +430,7 @@ class HermiteInterpolationResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def require_unique_source_bound_interpolant(self) -> Self:
+    def require_structural_shape(self) -> Self:
         multiplicity = _total_multiplicity(self.source)
         if self.total_multiplicity != multiplicity:
             raise _validation_error(
@@ -487,21 +486,6 @@ class HermiteInterpolationResult(StrictModel):
                 "replay must cover every source derivative constraint in "
                 "canonical node/order order"
             )
-        for item in self.replay:
-            computed = ordinary_derivative_value(
-                coefficients,
-                item.node.as_fraction(),
-                item.derivative_order,
-            )
-            if item.computed.as_fraction() != computed:
-                raise _validation_error(
-                    "replay computed value does not match the returned polynomial"
-                )
-            if item.computed.as_fraction() != item.expected.as_fraction():
-                raise _validation_error(
-                    "returned polynomial does not satisfy a source derivative "
-                    "constraint"
-                )
         if (
             len(encode_strict_json(self.model_dump(mode="json")))
             > MAX_HERMITE_RESULT_BYTES
@@ -510,6 +494,28 @@ class HermiteInterpolationResult(StrictModel):
                 "complete Hermite result exceeds the aggregate result bound"
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source: OrdinaryDerivativeJetTable,
+        polynomial: RationalPolynomial,
+        total_multiplicity: int,
+        degree: int | None,
+        leading_coefficient: CanonicalRational,
+        replay: tuple[HermiteConstraintReplay, ...],
+    ) -> Self:
+        """Build a result from the interpolation kernel's established facts."""
+
+        return cls(
+            source=source,
+            polynomial=polynomial,
+            total_multiplicity=total_multiplicity,
+            degree=degree,
+            leading_coefficient=leading_coefficient,
+            replay=replay,
+        )
 
 
 class InterpolationSamples(StrictModel):

--- a/src/jacobian/math/polynomials/interpolation/_operations.py
+++ b/src/jacobian/math/polynomials/interpolation/_operations.py
@@ -109,7 +109,7 @@ def hermite_interpolation(
         for jet in sorted(table.jets, key=lambda item: item.node.as_fraction())
         for derivative in jet.derivatives
     )
-    return HermiteInterpolationResult(
+    return HermiteInterpolationResult._from_kernel(
         source=table,
         polynomial=polynomial,
         total_multiplicity=len(coefficients),
@@ -119,6 +119,18 @@ def hermite_interpolation(
         ),
         replay=replay,
     )
+
+
+def _verify_hermite_interpolation_result(result: HermiteInterpolationResult) -> bool:
+    """Recompute an independently supplied Hermite claim inside its admission envelope."""
+
+    try:
+        request = HermiteInterpolationRequest.model_validate(
+            {"table": result.source.model_dump(mode="json")}
+        )
+        return hermite_interpolation(request.table) == result
+    except ValueError:
+        return False
 
 
 def compute_hermite_interpolation(

--- a/src/jacobian/math/polynomials/intervals/_models.py
+++ b/src/jacobian/math/polynomials/intervals/_models.py
@@ -19,10 +19,7 @@ from jacobian.canonical import (
     sha256_digest,
 )
 from jacobian.math.intervals import ClosedRationalInterval, RationalBox
-from jacobian.math.polynomials.intervals._kernel import (
-    natural_interval_extension,
-    term_is_zero_on_box,
-)
+from jacobian.math.polynomials.intervals._kernel import term_is_zero_on_box
 from jacobian.math.polynomials.values import (
     MAX_POLYNOMIAL_EXPONENT,
     MAX_POLYNOMIAL_TERMS,
@@ -329,7 +326,7 @@ class PolynomialBoxEnclosureRequest(StrictModel):
 
 
 class PolynomialBoxEnclosureResult(StrictModel):
-    """A replay-validated enclosure bound to its source polynomial and box."""
+    """An exact enclosure bound to its source polynomial and box."""
 
     polynomial: RationalPolynomial
     box: RationalBox
@@ -337,7 +334,7 @@ class PolynomialBoxEnclosureResult(StrictModel):
     enclosure: ClosedRationalInterval
 
     @model_validator(mode="after")
-    def require_replayable_enclosure(self) -> Self:
+    def require_source_binding(self) -> Self:
         if self.source_digest != polynomial_box_source_digest(
             self.polynomial,
             self.box,
@@ -345,13 +342,26 @@ class PolynomialBoxEnclosureResult(StrictModel):
             raise _validation_error(
                 "source digest does not bind the polynomial and box"
             )
-        _require_enclosure_preflight(self.polynomial, self.box)
-        expected = natural_interval_extension(self.polynomial, self.box)
-        if self.enclosure != expected:
-            raise _validation_error(
-                "enclosure does not match the bounded source replay"
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PolynomialBoxEnclosureRequest,
+        *,
+        enclosure: ClosedRationalInterval,
+    ) -> Self:
+        """Build one result after the admitted kernel established its enclosure."""
+
+        return cls.model_construct(
+            polynomial=request.polynomial,
+            box=request.box,
+            source_digest=polynomial_box_source_digest(
+                request.polynomial,
+                request.box,
+            ),
+            enclosure=enclosure,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/polynomials/intervals/_operations.py
+++ b/src/jacobian/math/polynomials/intervals/_operations.py
@@ -4,7 +4,6 @@ from jacobian.math.polynomials.intervals._kernel import natural_interval_extensi
 from jacobian.math.polynomials.intervals._models import (
     PolynomialBoxEnclosureRequest,
     PolynomialBoxEnclosureResult,
-    polynomial_box_source_digest,
 )
 
 
@@ -13,14 +12,27 @@ def compute_polynomial_box_enclosure(
 ) -> PolynomialBoxEnclosureResult:
     """Return the deterministic natural interval extension on the complete box."""
 
-    # The parsed request already ran the complete admission preflight, and each
-    # value below is produced by the typed kernel. Independently supplied wire
-    # results still replay through PolynomialBoxEnclosureResult.model_validate.
-    return PolynomialBoxEnclosureResult.model_construct(
-        polynomial=request.polynomial,
-        box=request.box,
-        source_digest=polynomial_box_source_digest(request.polynomial, request.box),
+    return PolynomialBoxEnclosureResult._from_kernel(
+        request,
         enclosure=natural_interval_extension(request.polynomial, request.box),
+    )
+
+
+def _verify_polynomial_box_enclosure_result(
+    result: PolynomialBoxEnclosureResult,
+) -> bool:
+    """Check an independently supplied enclosure inside the owner envelope."""
+
+    parsed = PolynomialBoxEnclosureResult.model_validate(
+        result.model_dump(mode="json"),
+    )
+    request = PolynomialBoxEnclosureRequest(
+        polynomial=parsed.polynomial,
+        box=parsed.box,
+    )
+    return parsed.enclosure == natural_interval_extension(
+        request.polynomial,
+        request.box,
     )
 
 

--- a/src/jacobian/math/polynomials/maps/_models.py
+++ b/src/jacobian/math/polynomials/maps/_models.py
@@ -534,16 +534,13 @@ def _is_unit_generic_fiber_basis(certificate: GenericFiberCertificate) -> bool:
     )
 
 
-GENERIC_DEGREE_RESULT_REPLAY_WALL_SECONDS = 60
-
-
 class GenericDegreeResult(StrictModel):
     """An exact source-bound generic-fiber conclusion or operational failure.
 
-    The declared outcome must agree with the source and evidence shape. Owner
-    kernels replay their evidence before trusted construction; independently
-    supplied mathematical claims use ``verify_generic_degree_result`` rather
-    than re-entering a process-bound replay during deserialization.
+    The declared outcome must agree with the retained evidence shape.  The
+    producer establishes the mathematical conclusion once; an independently
+    supplied claim may be checked with the owner-private verifier without
+    re-entering a process-bound replay during deserialization.
     """
 
     outcome: GenericDegreeOutcome
@@ -554,7 +551,6 @@ class GenericDegreeResult(StrictModel):
 
     @model_validator(mode="after")
     def require_source_bound_outcome(self) -> Self:
-        _require_generic_degree_map_budget(self.source)
         mathematical = {
             "GENERICALLY_FINITE",
             "NOT_DOMINANT",
@@ -607,7 +603,7 @@ class GenericDegreeResult(StrictModel):
         evidence: GenericFiberCertificate | None,
         detail: str | None,
     ) -> Self:
-        """Construct a result after the owner has completed exact replay."""
+        """Construct a result after the owner kernel established the claim."""
 
         return cls.model_construct(
             outcome=outcome,
@@ -618,12 +614,11 @@ class GenericDegreeResult(StrictModel):
         )
 
 
-def verify_generic_degree_result(result: GenericDegreeResult) -> bool:
+def _verify_generic_degree_result(result: GenericDegreeResult) -> bool:
     """Replay one independently supplied exact generic-degree claim.
 
-    This owner-local verifier has a fixed 60-second replay ceiling. Structural
-    result parsing never invokes it, and an unavailable or out-of-envelope
-    replay is not mathematical evidence.
+    Structural result parsing never invokes it.  Re-admission supplies the
+    bounded verification envelope, and an unavailable verdict is not evidence.
     """
 
     mathematical = {
@@ -635,10 +630,14 @@ def verify_generic_degree_result(result: GenericDegreeResult) -> bool:
         return False
     from jacobian.math.polynomials.maps._replay import run_bounded_certificate_replay
 
+    try:
+        request = GenericDegreeRequest(polynomial_map=result.source)
+    except ValueError:
+        return False
     replay = run_bounded_certificate_replay(
-        result.source,
+        request.polynomial_map,
         result.evidence,
-        wall_seconds=GENERIC_DEGREE_RESULT_REPLAY_WALL_SECONDS,
+        wall_seconds=request.resource_budget.wall_seconds,
     )
     return (
         replay.status == "COMPUTED"

--- a/src/jacobian/math/polynomials/maps/_operations.py
+++ b/src/jacobian/math/polynomials/maps/_operations.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import time
-
 import sympy
 
 from jacobian.math.polynomials._conversions import (
@@ -22,31 +20,13 @@ from jacobian.math.polynomials.maps._models import (
     GenericDegreeResult,
     JacobianResult,
 )
-from jacobian.math.polynomials.maps._replay import (
-    run_bounded_certificate_replay,
-)
 from jacobian.math.polynomials.maps._singular import run_singular_generic_fiber
 from jacobian.math.polynomials.maps.values import RationalPolynomialMap
-
-_REPLAY_FAILURE_OUTCOMES: dict[str, tuple[GenericDegreeOutcome, str]] = {
-    "CANCELLED": (
-        "CANCELLED",
-        "Certificate replay was cancelled before producing a result.",
-    ),
-    "TIMEOUT": ("TIMEOUT", "Certificate replay exceeded the declared wall-time limit."),
-    "LIMIT_EXCEEDED": (
-        "BOUND_EXCEEDED",
-        "The generic-fiber certificate replay exceeded the declared computation bound.",
-    ),
-    "INVALID": ("ERROR", "Singular evidence failed source-bound exact replay."),
-    "ERROR": ("ERROR", "The certificate replay worker failed."),
-}
 
 
 def compute_generic_degree(request: GenericDegreeRequest) -> GenericDegreeResult:
     """Compute the exact degree of the map's generic scheme-theoretic fiber."""
 
-    deadline = time.monotonic() + request.resource_budget.wall_seconds
     backend = run_singular_generic_fiber(
         request.polynomial_map,
         request.resource_budget,
@@ -82,33 +62,6 @@ def compute_generic_degree(request: GenericDegreeRequest) -> GenericDegreeResult
     else:
         mathematical_outcome = "DOMINANT_NOT_GENERICALLY_FINITE"
         degree = None
-    remaining_seconds = deadline - time.monotonic()
-    if remaining_seconds <= 0:
-        return GenericDegreeResult(
-            outcome="TIMEOUT",
-            source=request.polynomial_map,
-            detail=(
-                "The declared wall-time envelope expired before certificate replay."
-            ),
-        )
-    replay = run_bounded_certificate_replay(
-        request.polynomial_map,
-        backend.certificate,
-        wall_seconds=remaining_seconds,
-    )
-    if replay.status != "COMPUTED":
-        outcome, default_detail = _REPLAY_FAILURE_OUTCOMES[replay.status]
-        return GenericDegreeResult(
-            outcome=outcome,
-            source=request.polynomial_map,
-            detail=replay.detail or default_detail,
-        )
-    if replay.outcome != mathematical_outcome or replay.degree != degree:
-        return GenericDegreeResult(
-            outcome="ERROR",
-            source=request.polynomial_map,
-            detail=("Singular metadata disagree with the exact certificate replay."),
-        )
     return GenericDegreeResult._from_kernel(
         outcome=mathematical_outcome,
         source=request.polynomial_map,

--- a/src/jacobian/math/polynomials/multivariate/_operations.py
+++ b/src/jacobian/math/polynomials/multivariate/_operations.py
@@ -131,10 +131,8 @@ def compute_multivariate_resultant(
     request: MultivariateResultantRequest,
 ) -> MultivariateResultantResult:
     """Compute the resultant of two multivariate polynomials w.r.t. one variable."""
-    return MultivariateResultantResult(
-        left=request.left,
-        right=request.right,
-        elimination_variable=request.elimination_variable,
+    return MultivariateResultantResult._from_kernel(
+        request,
         resultant=_sylvester_resultant_value(request),
     )
 
@@ -182,10 +180,8 @@ def compute_multivariate_subresultant_sequence(
     )
     left_degree = _degree_in_variable(request.left, variable_index)
     right_degree = _degree_in_variable(request.right, variable_index)
-    return MultivariateSubresultantSequenceResult(
-        left=request.left,
-        right=request.right,
-        main_variable=request.main_variable,
+    return MultivariateSubresultantSequenceResult._from_kernel(
+        request,
         source_order=source_order,
         members=members,
         skipped_member_degrees=tuple(
@@ -262,7 +258,7 @@ def _sympy_factor_key(poly: Any) -> _SympyFactorKey:
     )
 
 
-def verify_multivariate_factor_result(result: MultivariateFactorResult) -> bool:
+def _verify_multivariate_factor_result(result: MultivariateFactorResult) -> bool:
     """Verify an independently supplied factorization claim once, boundedly.
 
     Construction of a kernel result never re-enters the worker that produced

--- a/src/jacobian/math/polynomials/multivariate/_resultant.py
+++ b/src/jacobian/math/polynomials/multivariate/_resultant.py
@@ -1,4 +1,4 @@
-"""Contracts and exact replay for multivariate Sylvester resultants."""
+"""Contracts and bounded execution for multivariate Sylvester resultants."""
 
 from __future__ import annotations
 
@@ -185,13 +185,7 @@ def _sylvester_resultant_value(
 
 
 class MultivariateResultantResult(StrictModel):
-    """The exact resultant bound to its source pair.
-
-    Retains both source polynomials and the eliminated variable so
-    validation replays the exact Sylvester determinant instead of trusting
-    an independently authored value.  The replay runs inside the same
-    admitted degree envelope as the producer.
-    """
+    """The exact resultant produced by one admitted Sylvester computation."""
 
     left: RationalPolynomial
     right: RationalPolynomial
@@ -200,18 +194,57 @@ class MultivariateResultantResult(StrictModel):
     convention: Literal["SYLVESTER_DETERMINANT"] = "SYLVESTER_DETERMINANT"
 
     @model_validator(mode="after")
-    def require_source_bound(self) -> Self:
-        request = MultivariateResultantRequest(
-            left=self.left,
-            right=self.right,
-            elimination_variable=self.elimination_variable,
-        )
-        if self.resultant != _sylvester_resultant_value(request):
+    def require_structural_resultant(self) -> Self:
+        _validate_multivariate_pair(self.left, self.right)
+        if self.elimination_variable not in self.left.variables:
             raise _validation_error(
-                "resultant must equal the Sylvester determinant of the "
-                "retained source polynomials"
+                "elimination variable must belong to the declared ring"
+            )
+        remaining_variables = tuple(
+            variable
+            for variable in self.left.variables
+            if variable != self.elimination_variable
+        )
+        if isinstance(self.resultant, MultivariateScalarValue):
+            if remaining_variables:
+                raise _validation_error(
+                    "a multivariate resultant must retain its remaining-variable ring"
+                )
+        elif self.resultant.value.variables != remaining_variables:
+            raise _validation_error(
+                "resultant polynomial must use the remaining declared variables"
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: MultivariateResultantRequest,
+        *,
+        resultant: MultivariateInvariantValue,
+    ) -> Self:
+        """Build a result after the admitted Sylvester kernel established it."""
+
+        return cls(
+            left=request.left,
+            right=request.right,
+            elimination_variable=request.elimination_variable,
+            resultant=resultant,
+        )
+
+
+def _verify_multivariate_resultant(result: MultivariateResultantResult) -> bool:
+    """Check an independently supplied source-bound resultant claim."""
+
+    try:
+        request = MultivariateResultantRequest(
+            left=result.left,
+            right=result.right,
+            elimination_variable=result.elimination_variable,
+        )
+        return result.resultant == _sylvester_resultant_value(request)
+    except ValueError:
+        return False
 
 
 __all__ = [

--- a/src/jacobian/math/polynomials/multivariate/_subresultants.py
+++ b/src/jacobian/math/polynomials/multivariate/_subresultants.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from itertools import pairwise
 from math import comb, factorial, lcm
 from typing import Any, Literal, Self
 
@@ -36,7 +37,7 @@ SubresultantSourceOrder = Literal["LEFT_RIGHT", "RIGHT_LEFT"]
 
 # Admission follows the actual coefficient-ring expansion. The complete formal
 # sequence is bounded before SymPy enters its pseudo-remainder algorithm. The
-# arithmetic proxy includes production and typed result replay.
+# arithmetic proxy covers one producer pass.
 _MAX_SUBRESULTANT_SEQUENCE_TERMS = 4_096
 _MAX_SUBRESULTANT_COEFFICIENT_SUPPORT = 1_024
 _MAX_SUBRESULTANT_ARITHMETIC_TERM_PAIRS = 8_000_000
@@ -346,16 +347,15 @@ class MultivariatePrincipalSubresultantCoefficient(StrictModel):
 
 
 class MultivariateSubresultantSequenceResult(StrictModel):
-    """Complete nonzero Brown PRS with exact degree and source binding.
+    """Complete nonzero Brown PRS produced by one admitted kernel pass.
 
     The maintained backend omits zero or same-degree PRS values.
     ``skipped_member_degrees`` records main-variable degrees without a distinct
     Brown member.  ``principal_subresultant_coefficients`` separately retains
     every formal scalar subresultant, including canonical zero polynomials, so
     a vanished coefficient is never conflated with a skipped PRS degree.
-    Validation replays the pinned mathematical convention and independently
-    checks the last member against the GCD over the remaining-variable fraction
-    field.
+    Parsing checks that the serialized ledger is structurally coherent; the
+    producer establishes its source-bound claims.
     """
 
     left: RationalPolynomial
@@ -424,98 +424,105 @@ class MultivariateSubresultantSequenceResult(StrictModel):
     zero_members_omitted: Literal[True] = True
 
     @model_validator(mode="after")
-    def replay_source_bound_sequence(self) -> Self:
-        request = MultivariateSubresultantSequenceRequest(
-            left=self.left,
-            right=self.right,
-            main_variable=self.main_variable,
-        )
-        (
-            expected_order,
-            expected_polynomials,
-            expected_principal_coefficients,
-        ) = polynomial_subresultant_sequence(
-            request.left,
-            request.right,
-            request.main_variable,
-            maximum_terms=_MAX_SUBRESULTANT_SEQUENCE_TERMS,
-        )
-        if self.source_order != expected_order:
-            raise _validation_error("source_order does not match main-variable degrees")
-        variable_index = request.left.variables.index(request.main_variable)
-        left_degree = _degree_in_variable(request.left, variable_index)
-        right_degree = _degree_in_variable(request.right, variable_index)
-        expected_resultant_sign = (
-            -1
-            if expected_order == "RIGHT_LEFT" and left_degree * right_degree % 2 == 1
-            else 1
-        )
-        if self.resultant_sign_from_sequence_order != expected_resultant_sign:
-            raise _validation_error(
-                "resultant sign does not match the PRS source order"
-            )
-        actual_polynomials = tuple(member.polynomial for member in self.members)
-        if actual_polynomials != expected_polynomials:
-            raise _validation_error(
-                "members do not replay the exact subresultant sequence"
-            )
-
-        expected_degrees = tuple(
-            _degree_in_variable(polynomial, variable_index)
-            for polynomial in expected_polynomials
-        )
+    def require_structural_sequence(self) -> Self:
+        _validate_multivariate_pair(self.left, self.right)
+        if self.main_variable not in self.left.variables:
+            raise _validation_error("main variable must belong to the declared ring")
+        variable_index = self.left.variables.index(self.main_variable)
+        if any(
+            member.polynomial.variables != self.left.variables
+            for member in self.members
+        ):
+            raise _validation_error("members must belong to the declared source ring")
         actual_degrees = tuple(
             member.degree_in_main_variable for member in self.members
         )
-        if actual_degrees != expected_degrees:
+        polynomial_degrees = tuple(
+            _degree_in_variable(member.polynomial, variable_index)
+            for member in self.members
+        )
+        if actual_degrees != polynomial_degrees:
             raise _validation_error("member degrees do not match their polynomials")
-        greatest_degree = max(expected_degrees)
-        expected_degree_set = set(expected_degrees)
+        if any(later >= earlier for earlier, later in pairwise(actual_degrees[1:])):
+            raise _validation_error("non-source PRS member degrees must decrease")
+        greatest_degree = max(actual_degrees)
+        actual_degree_set = set(actual_degrees)
         expected_absent = tuple(
             degree
             for degree in range(greatest_degree + 1)
-            if degree not in expected_degree_set
+            if degree not in actual_degree_set
         )
         if self.skipped_member_degrees != expected_absent:
             raise _validation_error(
-                "skipped_member_degrees does not match the PRS ledger"
+                "skipped_member_degrees does not match the member-degree ledger"
             )
-        expected_scalar_ledger = tuple(
-            MultivariatePrincipalSubresultantCoefficient(
-                index=index,
-                coefficient=coefficient,
-            )
-            for index, coefficient in enumerate(expected_principal_coefficients)
+        scalar_indices = tuple(
+            coefficient.index
+            for coefficient in self.principal_subresultant_coefficients
         )
-        if self.principal_subresultant_coefficients != expected_scalar_ledger:
+        if scalar_indices != tuple(range(len(scalar_indices))):
             raise _validation_error(
-                "principal subresultant coefficients do not replay the source pair"
+                "principal subresultant coefficient indices must be consecutive"
+            )
+        remaining_variables = tuple(
+            variable
+            for variable in self.left.variables
+            if variable != self.main_variable
+        )
+        if any(
+            coefficient.coefficient.variables != remaining_variables
+            for coefficient in self.principal_subresultant_coefficients
+        ):
+            raise _validation_error(
+                "principal subresultant coefficients must use the remaining ring"
+            )
+        if self.resultant.variables != remaining_variables:
+            raise _validation_error(
+                "resultant must use the remaining declared variables"
             )
         if self.gcd_member_index != len(self.members) - 1:
             raise _validation_error("gcd_member_index must select the final PRS member")
-
-        expected_resultant = polynomial_resultant_in_remaining_ring(
-            request.left,
-            request.right,
-            request.main_variable,
-            maximum_terms=_MAX_SUBRESULTANT_SEQUENCE_TERMS,
-        )
-        if self.resultant != expected_resultant:
-            raise _validation_error("resultant does not match the source pair")
-        expected_gcd_degree, expected_leading_coefficient = fraction_field_gcd_relation(
-            request.left,
-            request.right,
-            request.main_variable,
-            self.members[self.gcd_member_index].polynomial,
-            maximum_terms=_MAX_SUBRESULTANT_SEQUENCE_TERMS,
-        )
-        if self.gcd_degree_in_main_variable != expected_gcd_degree:
+        if self.gcd_degree_in_main_variable != actual_degrees[self.gcd_member_index]:
             raise _validation_error("gcd degree does not match the final PRS member")
-        if self.gcd_member_leading_coefficient != expected_leading_coefficient:
+        if self.gcd_member_leading_coefficient.variables != remaining_variables:
             raise _validation_error(
-                "gcd leading coefficient does not match the final member"
+                "gcd leading coefficient must use the remaining declared variables"
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: MultivariateSubresultantSequenceRequest,
+        *,
+        source_order: SubresultantSourceOrder,
+        members: tuple[MultivariateSubresultantMember, ...],
+        skipped_member_degrees: tuple[int, ...],
+        principal_subresultant_coefficients: tuple[
+            MultivariatePrincipalSubresultantCoefficient, ...
+        ],
+        resultant: RationalPolynomial,
+        resultant_sign_from_sequence_order: Literal[-1, 1],
+        gcd_member_index: int,
+        gcd_degree_in_main_variable: int,
+        gcd_member_leading_coefficient: RationalPolynomial,
+    ) -> Self:
+        """Build a result after the admitted Brown kernel established its ledger."""
+
+        return cls(
+            left=request.left,
+            right=request.right,
+            main_variable=request.main_variable,
+            source_order=source_order,
+            members=members,
+            skipped_member_degrees=skipped_member_degrees,
+            principal_subresultant_coefficients=principal_subresultant_coefficients,
+            resultant=resultant,
+            resultant_sign_from_sequence_order=resultant_sign_from_sequence_order,
+            gcd_member_index=gcd_member_index,
+            gcd_degree_in_main_variable=gcd_degree_in_main_variable,
+            gcd_member_leading_coefficient=gcd_member_leading_coefficient,
+        )
 
 
 def _as_univariate_over_polynomial_ring(
@@ -720,6 +727,84 @@ def fraction_field_gcd_relation(
         main_variable,
         maximum_terms=maximum_terms,
     )
+
+
+def _verify_multivariate_subresultant_sequence(
+    result: MultivariateSubresultantSequenceResult,
+) -> bool:
+    """Check an independently supplied source-bound Brown PRS claim.
+
+    Normal parsing deliberately does not invoke this backend work.  The
+    verifier re-enters request admission before replaying every theorem-bearing
+    field, so forged or out-of-envelope claims fail closed.
+    """
+
+    try:
+        request = MultivariateSubresultantSequenceRequest(
+            left=result.left,
+            right=result.right,
+            main_variable=result.main_variable,
+        )
+        source_order, polynomials, principal_coefficients = (
+            polynomial_subresultant_sequence(
+                request.left,
+                request.right,
+                request.main_variable,
+                maximum_terms=_MAX_SUBRESULTANT_SEQUENCE_TERMS,
+            )
+        )
+        variable_index = request.left.variables.index(request.main_variable)
+        left_degree = _degree_in_variable(request.left, variable_index)
+        right_degree = _degree_in_variable(request.right, variable_index)
+        resultant_sign = (
+            -1
+            if source_order == "RIGHT_LEFT" and left_degree * right_degree % 2 == 1
+            else 1
+        )
+        expected_degrees = tuple(
+            _degree_in_variable(polynomial, variable_index)
+            for polynomial in polynomials
+        )
+        expected_absent = tuple(
+            degree
+            for degree in range(max(expected_degrees) + 1)
+            if degree not in set(expected_degrees)
+        )
+        expected_scalars = tuple(
+            MultivariatePrincipalSubresultantCoefficient(
+                index=index,
+                coefficient=coefficient,
+            )
+            for index, coefficient in enumerate(principal_coefficients)
+        )
+        expected_resultant = polynomial_resultant_in_remaining_ring(
+            request.left,
+            request.right,
+            request.main_variable,
+            maximum_terms=_MAX_SUBRESULTANT_SEQUENCE_TERMS,
+        )
+        expected_gcd_degree, expected_leading_coefficient = fraction_field_gcd_relation(
+            request.left,
+            request.right,
+            request.main_variable,
+            result.members[-1].polynomial,
+            maximum_terms=_MAX_SUBRESULTANT_SEQUENCE_TERMS,
+        )
+        return (
+            result.source_order == source_order
+            and tuple(member.polynomial for member in result.members) == polynomials
+            and tuple(member.degree_in_main_variable for member in result.members)
+            == expected_degrees
+            and result.skipped_member_degrees == expected_absent
+            and result.principal_subresultant_coefficients == expected_scalars
+            and result.resultant == expected_resultant
+            and result.resultant_sign_from_sequence_order == resultant_sign
+            and result.gcd_member_index == len(result.members) - 1
+            and result.gcd_degree_in_main_variable == expected_gcd_degree
+            and result.gcd_member_leading_coefficient == expected_leading_coefficient
+        )
+    except ValueError:
+        return False
 
 
 def polynomial_leading_coefficient_in_remaining_ring(

--- a/src/jacobian/math/polynomials/real_algebra/_operations.py
+++ b/src/jacobian/math/polynomials/real_algebra/_operations.py
@@ -67,15 +67,8 @@ def compute_strict_sublevel_measure(
     request: StrictSublevelMeasureRequest,
 ) -> StrictSublevelMeasureResult:
     payload = compute_strict_sublevel_payload(request)
-    # The payload is built entirely from the already validated request and the
-    # exact kernel. External result validation still replays the source once;
-    # the trusted producer must not repeat root isolation merely to accept its
-    # own derived fields.
-    return StrictSublevelMeasureResult.model_construct(
-        source_polynomial=request.polynomial,
-        threshold=request.threshold,
-        lower=request.lower,
-        upper=request.upper,
+    return StrictSublevelMeasureResult._from_kernel(
+        request,
         components=payload.components,
         measure=payload.measure,
     )

--- a/src/jacobian/math/polynomials/real_algebra/_strict_sublevel.py
+++ b/src/jacobian/math/polynomials/real_algebra/_strict_sublevel.py
@@ -7,6 +7,8 @@ from fractions import Fraction
 from functools import cmp_to_key
 from typing import Any, Literal, cast
 
+from pydantic import ValidationError
+
 from jacobian._exact import CanonicalRational
 from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
 from jacobian.math.polynomials.real_algebra._strict_sublevel_models import (
@@ -19,6 +21,7 @@ from jacobian.math.polynomials.real_algebra._strict_sublevel_models import (
     StrictSublevelComponent,
     StrictSublevelEndpoint,
     StrictSublevelMeasureRequest,
+    StrictSublevelMeasureResult,
 )
 
 
@@ -239,6 +242,25 @@ def compute_strict_sublevel_payload(
     return StrictSublevelPayload(
         components=component_tuple,
         measure=_measure_from_components(component_tuple, roots),
+    )
+
+
+def verify_strict_sublevel_measure_result(result: StrictSublevelMeasureResult) -> bool:
+    """Verify one independently supplied strict-sublevel claim, boundedly."""
+
+    try:
+        request = StrictSublevelMeasureRequest(
+            polynomial=result.source_polynomial,
+            threshold=result.threshold,
+            lower=result.lower,
+            upper=result.upper,
+        )
+    except ValidationError:
+        return False
+
+    expected = compute_strict_sublevel_payload(request)
+    return (
+        result.components == expected.components and result.measure == expected.measure
     )
 
 

--- a/src/jacobian/math/polynomials/real_algebra/_strict_sublevel_models.py
+++ b/src/jacobian/math/polynomials/real_algebra/_strict_sublevel_models.py
@@ -501,30 +501,29 @@ class StrictSublevelMeasureResult(StrictModel):
             )
         return prepared
 
-    @model_validator(mode="after")
-    def require_source_bound_reconstruction(self) -> Self:
-        request = StrictSublevelMeasureRequest(
-            polynomial=self.source_polynomial,
-            threshold=self.threshold,
-            lower=self.lower,
-            upper=self.upper,
-        )
-        from jacobian.math.polynomials.real_algebra._strict_sublevel import (
-            compute_strict_sublevel_payload,
-        )
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: StrictSublevelMeasureRequest,
+        *,
+        components: tuple[StrictSublevelComponent, ...],
+        measure: SourceBoundAlgebraicMeasure,
+    ) -> Self:
+        """Build a result after the admitted exact kernel established it.
 
-        expected = compute_strict_sublevel_payload(request)
-        if self.components != expected.components:
-            raise _validation_error(
-                "component_reconstruction",
-                "strict sublevel components must be the complete source-derived cells",
-            )
-        if self.measure != expected.measure:
-            raise _validation_error(
-                "measure_reconstruction",
-                "strict sublevel measure must reconstruct from the returned components",
-            )
-        return self
+        Public parsing checks the bounded structural representation only.
+        Re-running root isolation to authenticate an independently supplied
+        claim belongs to the owner-private verifier, not result validation.
+        """
+
+        return cls.model_construct(
+            source_polynomial=request.polynomial,
+            threshold=request.threshold,
+            lower=request.lower,
+            upper=request.upper,
+            components=components,
+            measure=measure,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/prime_affine_forms/_interval.py
+++ b/src/jacobian/math/prime_affine_forms/_interval.py
@@ -23,7 +23,7 @@ from jacobian.math.prime_affine_forms._models import (
 )
 from jacobian.math.prime_affine_forms.values import MAX_AFFINE_FORMS, PrimeAffineTuple
 
-MAX_INTERVAL_REPLAY_EVALUATIONS = 200_000
+MAX_INTERVAL_EVALUATIONS = 100_000
 MAX_INTERVAL_ENUMERATION_CELLS = 65_536
 
 # Endpoint syntax is neutral canonical integer grammar. Its effective size is
@@ -105,11 +105,11 @@ class PrimeAffineIntervalCountRequest(StrictModel):
         )
         lower, upper, interval_size = _parse_interval(self.lower, self.upper)
         _interval_value_digit_bound(self.source, lower, upper)
-        replay_evaluations = 2 * interval_size * self.source.form_count
-        if replay_evaluations > MAX_INTERVAL_REPLAY_EVALUATIONS:
+        evaluations = interval_size * self.source.form_count
+        if evaluations > MAX_INTERVAL_EVALUATIONS:
             raise _validation_error(
-                f"interval result and validation need {replay_evaluations} affine "
-                f"evaluations, exceeding {MAX_INTERVAL_REPLAY_EVALUATIONS}"
+                f"interval needs {evaluations} affine evaluations, exceeding "
+                f"{MAX_INTERVAL_EVALUATIONS}"
             )
         return self
 
@@ -159,37 +159,44 @@ class PrimePatternIntervalCountResult(StrictModel):
     last_match: IntervalEndpointInteger | None = None
 
     @model_validator(mode="after")
-    def bind_exact_interval_count(self) -> Self:
-        PrimeAffineIntervalCountRequest(
-            source=self.source, lower=self.lower, upper=self.upper
-        )
-        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
-        expected_count, expected_first, expected_last = interval_match_summary(
-            self.source, lower, upper
-        )
+    def require_interval_shape(self) -> Self:
+        _, _, interval_size = _parse_interval(self.lower, self.upper)
         if self.interval_size != interval_size:
             raise _validation_error("interval_size must equal upper-lower+1")
         if self.affine_values_examined != interval_size * self.source.form_count:
             raise _validation_error(
                 "affine_values_examined does not match the complete interval"
             )
-        if self.match_count != expected_count:
+        if (self.first_match is None) != (self.last_match is None):
             raise _validation_error(
-                "match_count does not match exact interval primality"
+                "first_match and last_match must be both present or absent"
             )
-        if (
-            None
-            if self.first_match is None
-            else parse_canonical_integer(self.first_match)
-        ) != expected_first or (
-            None
-            if self.last_match is None
-            else parse_canonical_integer(self.last_match)
-        ) != expected_last:
-            raise _validation_error(
-                "first or last match does not match exact interval primality"
-            )
+        if self.match_count == 0 and self.first_match is not None:
+            raise _validation_error("an empty match family cannot have endpoints")
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PrimeAffineIntervalCountRequest,
+        *,
+        count: int,
+        first: int | None,
+        last: int | None,
+    ) -> Self:
+        lower = parse_canonical_integer(request.lower)
+        upper = parse_canonical_integer(request.upper)
+        interval_size = upper - lower + 1
+        return cls(
+            source=request.source,
+            lower=request.lower,
+            upper=request.upper,
+            interval_size=interval_size,
+            affine_values_examined=interval_size * request.source.form_count,
+            match_count=count,
+            first_match=None if first is None else format_canonical_integer(first),
+            last_match=None if last is None else format_canonical_integer(last),
+        )
 
 
 class PrimePatternIntervalEnumerateResult(StrictModel):
@@ -203,17 +210,13 @@ class PrimePatternIntervalEnumerateResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def bind_complete_interval_enumeration(self) -> Self:
+    def require_enumeration_shape(self) -> Self:
         result_cells = len(self.matches) + sum(
             len(match.prime_values) for match in self.matches
         )
         if result_cells > MAX_INTERVAL_ENUMERATION_CELLS:
             raise _validation_error("matches exceed the interval result-cell bound")
-        PrimeAffineIntervalEnumerateRequest(
-            source=self.source, lower=self.lower, upper=self.upper
-        )
-        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
-        expected = interval_matches(self.source, lower, upper)
+        _, _, interval_size = _parse_interval(self.lower, self.upper)
         actual = tuple(
             (
                 parse_canonical_integer(match.parameter),
@@ -221,9 +224,11 @@ class PrimePatternIntervalEnumerateResult(StrictModel):
             )
             for match in self.matches
         )
-        if actual != expected:
+        if actual != tuple(sorted(actual)) or len(
+            {parameter for parameter, _ in actual}
+        ) != len(actual):
             raise _validation_error(
-                "matches must be every and only positive-prime affine tuple"
+                "matches must be in strictly increasing parameter order"
             )
         if self.interval_size != interval_size:
             raise _validation_error("interval_size must equal upper-lower+1")
@@ -233,6 +238,33 @@ class PrimePatternIntervalEnumerateResult(StrictModel):
             )
         return self
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PrimeAffineIntervalEnumerateRequest,
+        *,
+        matches: tuple[tuple[int, tuple[int, ...]], ...],
+    ) -> Self:
+        lower = parse_canonical_integer(request.lower)
+        upper = parse_canonical_integer(request.upper)
+        interval_size = upper - lower + 1
+        return cls(
+            source=request.source,
+            lower=request.lower,
+            upper=request.upper,
+            interval_size=interval_size,
+            affine_values_examined=interval_size * request.source.form_count,
+            matches=tuple(
+                PrimePatternMatch(
+                    parameter=format_canonical_integer(parameter),
+                    prime_values=tuple(
+                        format_canonical_integer(value) for value in values
+                    ),
+                )
+                for parameter, values in matches
+            ),
+        )
+
 
 def compute_interval_count(
     request: PrimeAffineIntervalCountRequest,
@@ -241,17 +273,9 @@ def compute_interval_count(
 
     lower = parse_canonical_integer(request.lower)
     upper = parse_canonical_integer(request.upper)
-    interval_size = upper - lower + 1
     count, first, last = interval_match_summary(request.source, lower, upper)
-    return PrimePatternIntervalCountResult(
-        source=request.source,
-        lower=request.lower,
-        upper=request.upper,
-        interval_size=interval_size,
-        affine_values_examined=interval_size * request.source.form_count,
-        match_count=count,
-        first_match=None if first is None else format_canonical_integer(first),
-        last_match=None if last is None else format_canonical_integer(last),
+    return PrimePatternIntervalCountResult._from_kernel(
+        request, count=count, first=first, last=last
     )
 
 
@@ -262,27 +286,35 @@ def compute_interval_enumerate(
 
     lower = parse_canonical_integer(request.lower)
     upper = parse_canonical_integer(request.upper)
-    interval_size = upper - lower + 1
     matches = interval_matches(request.source, lower, upper)
-    return PrimePatternIntervalEnumerateResult(
-        source=request.source,
-        lower=request.lower,
-        upper=request.upper,
-        interval_size=interval_size,
-        affine_values_examined=interval_size * request.source.form_count,
-        matches=tuple(
-            PrimePatternMatch(
-                parameter=format_canonical_integer(parameter),
-                prime_values=tuple(format_canonical_integer(value) for value in values),
-            )
-            for parameter, values in matches
-        ),
+    return PrimePatternIntervalEnumerateResult._from_kernel(request, matches=matches)
+
+
+def verify_interval_count_result(result: PrimePatternIntervalCountResult) -> bool:
+    """Verify an independently supplied exact interval-count claim."""
+
+    request = PrimeAffineIntervalCountRequest(
+        source=result.source, lower=result.lower, upper=result.upper
     )
+    expected = compute_interval_count(request)
+    return result == expected
+
+
+def verify_interval_enumerate_result(
+    result: PrimePatternIntervalEnumerateResult,
+) -> bool:
+    """Verify an independently supplied complete interval-enumeration claim."""
+
+    request = PrimeAffineIntervalEnumerateRequest(
+        source=result.source, lower=result.lower, upper=result.upper
+    )
+    expected = compute_interval_enumerate(request)
+    return result == expected
 
 
 __all__ = [
     "MAX_INTERVAL_ENUMERATION_CELLS",
-    "MAX_INTERVAL_REPLAY_EVALUATIONS",
+    "MAX_INTERVAL_EVALUATIONS",
     "IntervalEndpointInteger",
     "PrimeAffineIntervalCountRequest",
     "PrimeAffineIntervalEnumerateRequest",

--- a/src/jacobian/math/prime_affine_forms/_interval.py
+++ b/src/jacobian/math/prime_affine_forms/_interval.py
@@ -171,8 +171,10 @@ class PrimePatternIntervalCountResult(StrictModel):
             raise _validation_error(
                 "first_match and last_match must be both present or absent"
             )
-        if self.match_count == 0 and self.first_match is not None:
-            raise _validation_error("an empty match family cannot have endpoints")
+        if (self.match_count == 0) != (self.first_match is None):
+            raise _validation_error(
+                "match endpoints must be present if and only if match_count is positive"
+            )
         return self
 
     @classmethod

--- a/src/jacobian/math/prime_affine_forms/_interval.py
+++ b/src/jacobian/math/prime_affine_forms/_interval.py
@@ -160,7 +160,7 @@ class PrimePatternIntervalCountResult(StrictModel):
 
     @model_validator(mode="after")
     def require_interval_shape(self) -> Self:
-        _, _, interval_size = _parse_interval(self.lower, self.upper)
+        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
         if self.interval_size != interval_size:
             raise _validation_error("interval_size must equal upper-lower+1")
         if self.affine_values_examined != interval_size * self.source.form_count:
@@ -175,6 +175,13 @@ class PrimePatternIntervalCountResult(StrictModel):
             raise _validation_error(
                 "match endpoints must be present if and only if match_count is positive"
             )
+        if self.match_count > interval_size:
+            raise _validation_error("match_count cannot exceed interval_size")
+        if self.first_match is not None and self.last_match is not None:
+            first = parse_canonical_integer(self.first_match)
+            last = parse_canonical_integer(self.last_match)
+            if not lower <= first <= last <= upper:
+                raise _validation_error("match endpoints must lie in interval order")
         return self
 
     @classmethod
@@ -218,7 +225,7 @@ class PrimePatternIntervalEnumerateResult(StrictModel):
         )
         if result_cells > MAX_INTERVAL_ENUMERATION_CELLS:
             raise _validation_error("matches exceed the interval result-cell bound")
-        _, _, interval_size = _parse_interval(self.lower, self.upper)
+        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
         actual = tuple(
             (
                 parse_canonical_integer(match.parameter),
@@ -231,6 +238,14 @@ class PrimePatternIntervalEnumerateResult(StrictModel):
         ) != len(actual):
             raise _validation_error(
                 "matches must be in strictly increasing parameter order"
+            )
+        if any(
+            not lower <= parameter <= upper
+            or len(prime_values) != self.source.form_count
+            for parameter, prime_values in actual
+        ):
+            raise _validation_error(
+                "matches must lie in the interval with one value per affine form"
             )
         if self.interval_size != interval_size:
             raise _validation_error("interval_size must equal upper-lower+1")

--- a/src/jacobian/math/prime_affine_forms/_local_factors.py
+++ b/src/jacobian/math/prime_affine_forms/_local_factors.py
@@ -29,7 +29,6 @@ from jacobian.math.prime_affine_forms._models import (
     PrimeTupleResidueRow,
     _require_prime,
     _require_prime_set,
-    _require_summary,
     _source_character_upper_bound,
     _summary_character_upper_bound,
     _validation_error,
@@ -87,7 +86,7 @@ class PrimeTupleLocalFactorRequest(StrictModel):
         work = 6 * self.source.form_count + 2 * self.prime
         if work > MAX_LOCAL_PROFILE_WORK:
             raise _validation_error(
-                f"local profile and validation need {work} bounded steps, "
+                f"local profile needs {work} bounded steps, "
                 f"exceeding {MAX_LOCAL_PROFILE_WORK}"
             )
         return self
@@ -107,7 +106,7 @@ class PrimeTupleLocalFactorResult(StrictModel):
     factor: CanonicalRational
 
     @model_validator(mode="after")
-    def bind_complete_local_factor(self) -> Self:
+    def require_local_factor_shape(self) -> Self:
         if (
             sum(len(row.vanishing_form_ids) for row in self.residue_rows)
             > self.source.form_count
@@ -115,35 +114,46 @@ class PrimeTupleLocalFactorResult(StrictModel):
             raise _validation_error(
                 "residue incidence count exceeds the source affine-form count"
             )
-        PrimeTupleLocalFactorRequest(source=self.source, prime=self.prime)
-        bad = dict(local_bad_residues(self.source, self.prime))
-        expected_rows = tuple(
-            (residue, bad.get(residue, ())) for residue in range(self.prime)
-        )
-        actual_rows = tuple(
-            (row.residue, row.vanishing_form_ids) for row in self.residue_rows
-        )
-        if actual_rows != expected_rows:
+        if tuple(row.residue for row in self.residue_rows) != tuple(range(self.prime)):
             raise _validation_error(
-                "residue rows must be the complete source-bound partition"
+                "residue rows must be the canonical residue partition"
             )
-        expected_bad = len(bad)
-        expected_valid = self.prime - expected_bad
-        if self.bad_count != expected_bad or self.valid_count != expected_valid:
-            raise _validation_error(
-                "local counts do not match the complete residue rows"
-            )
-        if self.locally_obstructed != (expected_valid == 0):
+        if self.bad_count + self.valid_count != self.prime:
+            raise _validation_error("local counts must partition the prime modulus")
+        if self.locally_obstructed != (self.valid_count == 0):
             raise _validation_error(
                 "local obstruction status must equal valid_count == 0"
             )
-        if self.factor.as_fraction() != local_factor_from_bad_count(
-            self.source.form_count, self.prime, expected_bad
-        ):
-            raise _validation_error(
-                "local factor does not satisfy its defining formula"
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PrimeTupleLocalFactorRequest,
+        *,
+        bad: tuple[tuple[int, tuple[str, ...]], ...],
+    ) -> Self:
+        bad_by_residue = dict(bad)
+        bad_count = len(bad)
+        return cls(
+            source=request.source,
+            prime=request.prime,
+            residue_rows=tuple(
+                PrimeTupleResidueRow(
+                    residue=residue,
+                    vanishing_form_ids=bad_by_residue.get(residue, ()),
+                )
+                for residue in range(request.prime)
+            ),
+            bad_count=bad_count,
+            valid_count=request.prime - bad_count,
+            locally_obstructed=bad_count == request.prime,
+            factor=CanonicalRational.from_fraction(
+                local_factor_from_bad_count(
+                    request.source.form_count, request.prime, bad_count
+                )
+            ),
+        )
 
 
 class PrimeTupleLocalFactorsRequest(StrictModel):
@@ -166,7 +176,7 @@ class PrimeTupleLocalFactorsRequest(StrictModel):
         root_work = 6 * root_cells
         if root_work > MAX_BATCH_ROOT_WORK:
             raise _validation_error(
-                f"local-factor computation and validation need {root_work} root "
+                f"local-factor computation needs {root_work} root "
                 f"steps, exceeding {MAX_BATCH_ROOT_WORK}"
             )
         digit_bounds = tuple(
@@ -215,37 +225,39 @@ class FinitePrimeTupleFactorProduct(StrictModel):
     first_obstructing_prime: StrictInt | None = None
 
     @model_validator(mode="after")
-    def bind_finite_factor_product(self) -> Self:
-        PrimeTupleLocalFactorsRequest(source=self.source, primes=self.primes)
+    def require_finite_product_shape(self) -> Self:
         if tuple(row.summary.prime for row in self.rows) != self.primes:
             raise _validation_error(
                 "local-factor rows must align with the canonical prime set"
             )
-        expected_product = Fraction(1, 1)
-        expected_first: int | None = None
         for row in self.rows:
-            _require_summary(self.source, row.summary)
-            expected_factor = local_factor_from_bad_count(
-                self.source.form_count,
-                row.summary.prime,
-                row.summary.bad_count,
-            )
-            if row.factor.as_fraction() != expected_factor:
-                raise _validation_error(
-                    "local factor row does not satisfy its defining formula"
-                )
-            expected_product *= expected_factor
-            if expected_first is None and row.summary.valid_count == 0:
-                expected_first = row.summary.prime
-        if self.product.as_fraction() != expected_product:
+            if row.summary.bad_count + row.summary.valid_count != row.summary.prime:
+                raise _validation_error("local summary counts must partition its prime")
+        if (
+            self.first_obstructing_prime is not None
+            and self.first_obstructing_prime not in self.primes
+        ):
             raise _validation_error(
-                "finite product must equal the product of every local row"
-            )
-        if self.first_obstructing_prime != expected_first:
-            raise _validation_error(
-                "first obstructing prime does not match the local rows"
+                "first obstructing prime must belong to the canonical prime set"
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PrimeTupleLocalFactorsRequest,
+        *,
+        rows: tuple[PrimeTupleLocalFactorRow, ...],
+        product: Fraction,
+        first_obstruction: int | None,
+    ) -> Self:
+        return cls(
+            source=request.source,
+            primes=request.primes,
+            rows=rows,
+            product=CanonicalRational.from_fraction(product),
+            first_obstructing_prime=first_obstruction,
+        )
 
 
 def compute_local_factor(
@@ -253,25 +265,8 @@ def compute_local_factor(
 ) -> PrimeTupleLocalFactorResult:
     """Return one complete local residue partition and exact factor."""
 
-    bad = dict(local_bad_residues(request.source, request.prime))
-    return PrimeTupleLocalFactorResult(
-        source=request.source,
-        prime=request.prime,
-        residue_rows=tuple(
-            PrimeTupleResidueRow(
-                residue=residue,
-                vanishing_form_ids=bad.get(residue, ()),
-            )
-            for residue in range(request.prime)
-        ),
-        bad_count=len(bad),
-        valid_count=request.prime - len(bad),
-        locally_obstructed=len(bad) == request.prime,
-        factor=CanonicalRational.from_fraction(
-            local_factor_from_bad_count(
-                request.source.form_count, request.prime, len(bad)
-            )
-        ),
+    return PrimeTupleLocalFactorResult._from_kernel(
+        request, bad=local_bad_residues(request.source, request.prime)
     )
 
 
@@ -297,13 +292,26 @@ def compute_local_factors(
         product *= factor
         if first_obstruction is None and summary.valid_count == 0:
             first_obstruction = prime
-    return FinitePrimeTupleFactorProduct(
-        source=request.source,
-        primes=request.primes,
+    return FinitePrimeTupleFactorProduct._from_kernel(
+        request,
         rows=tuple(rows),
-        product=CanonicalRational.from_fraction(product),
-        first_obstructing_prime=first_obstruction,
+        product=product,
+        first_obstruction=first_obstruction,
     )
+
+
+def verify_local_factor_result(result: PrimeTupleLocalFactorResult) -> bool:
+    """Verify an independently supplied complete local-factor claim."""
+
+    request = PrimeTupleLocalFactorRequest(source=result.source, prime=result.prime)
+    return result == compute_local_factor(request)
+
+
+def verify_local_factors_result(result: FinitePrimeTupleFactorProduct) -> bool:
+    """Verify an independently supplied finite local-factor product claim."""
+
+    request = PrimeTupleLocalFactorsRequest(source=result.source, primes=result.primes)
+    return result == compute_local_factors(request)
 
 
 __all__ = [

--- a/src/jacobian/math/prime_affine_forms/_operations.py
+++ b/src/jacobian/math/prime_affine_forms/_operations.py
@@ -27,9 +27,8 @@ def compute_residue_wheel(
     request: PrimeTupleResidueWheelRequest,
 ) -> PrimeTupleResidueWheel:
     local_rows = tuple(local_summary(request.source, prime) for prime in request.primes)
-    return PrimeTupleResidueWheel(
-        source=request.source,
-        primes=request.primes,
+    return PrimeTupleResidueWheel._from_kernel(
+        request,
         local_rows=local_rows,
         modulus=format_canonical_integer(wheel_modulus(request.primes)),
         valid_count=format_canonical_integer(
@@ -42,8 +41,8 @@ def compute_residue_wheel_enumeration(
     request: PrimeTupleResidueWheelEnumerationRequest,
 ) -> PrimeTupleResidueWheelEnumeration:
     rows = wheel_rows(request.wheel.source, request.wheel.primes)
-    return PrimeTupleResidueWheelEnumeration(
-        wheel=request.wheel,
+    return PrimeTupleResidueWheelEnumeration._from_kernel(
+        request,
         residues=tuple(
             PrimeTupleWheelResidueRow(
                 residue=format_canonical_integer(residue),
@@ -69,9 +68,8 @@ def compute_wheel_membership(
             first_prime = summary.prime
             form_ids = bad[component]
             break
-    return PrimeTupleWheelMembershipResult(
-        wheel=request.wheel,
-        value=request.value,
+    return PrimeTupleWheelMembershipResult._from_kernel(
+        request,
         canonical_residue=format_canonical_integer(residue),
         components=components,
         is_permitted=first_prime is None,
@@ -97,11 +95,8 @@ def compute_interval_residue_profile(
             for prime, bad in zip(request.wheel.primes, bad_by_prime, strict=True)
         )
     )
-    return PrimeTupleIntervalResidueProfileResult(
-        wheel=request.wheel,
-        lower=request.lower,
-        upper=request.upper,
-        interval_size=upper - lower + 1,
+    return PrimeTupleIntervalResidueProfileResult._from_kernel(
+        request,
         survivors=tuple(format_canonical_integer(value) for value in survivors),
     )
 

--- a/src/jacobian/math/prime_affine_forms/_residue_wheel.py
+++ b/src/jacobian/math/prime_affine_forms/_residue_wheel.py
@@ -144,6 +144,7 @@ class PrimeTupleResidueWheelEnumerationRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_bounded_wheel_enumeration(self) -> Self:
+        _require_verified_residue_wheel(self.wheel)
         local_residue_rows = sum(self.wheel.primes)
         if local_residue_rows > MAX_WHEEL_LOCAL_RESIDUES:
             raise _validation_error(
@@ -244,6 +245,7 @@ class PrimeTupleWheelMembershipRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_bounded_value(self) -> Self:
+        _require_verified_residue_wheel(self.wheel)
         if _digits(self.value) > MAX_AFFINE_COMPONENT_DIGITS:
             raise _validation_error(
                 f"membership value must have at most {MAX_AFFINE_COMPONENT_DIGITS} digits"
@@ -317,6 +319,7 @@ class PrimeTupleIntervalResidueProfileRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_bounded_survivor_profile(self) -> Self:
+        _require_verified_residue_wheel(self.wheel)
         require_bounded_affine_endpoints(
             self.wheel.source, self.lower, self.upper, label="interval"
         )
@@ -395,6 +398,15 @@ def verify_residue_wheel(result: PrimeTupleResidueWheel) -> bool:
 
     request = PrimeTupleResidueWheelRequest(source=result.source, primes=result.primes)
     return result == compute_residue_wheel(request)
+
+
+def _require_verified_residue_wheel(wheel: PrimeTupleResidueWheel) -> None:
+    """Admit an independently supplied wheel before a consumer trusts it."""
+
+    if not verify_residue_wheel(wheel):
+        raise _validation_error(
+            "wheel must equal the compact residue wheel for its source and primes"
+        )
 
 
 def verify_residue_wheel_enumeration(

--- a/src/jacobian/math/prime_affine_forms/_residue_wheel.py
+++ b/src/jacobian/math/prime_affine_forms/_residue_wheel.py
@@ -1,8 +1,7 @@
-"""Typed contracts and bounded replay for prime-affine residue wheels."""
+"""Typed contracts and bounded kernels for prime-affine residue wheels."""
 
 from __future__ import annotations
 
-from math import prod
 from typing import Annotated, Self
 
 from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
@@ -17,12 +16,11 @@ from jacobian.math.affine_forms.values import (
     AffineFormId,
 )
 from jacobian.math.prime_affine_forms._interval import (
-    MAX_INTERVAL_REPLAY_EVALUATIONS,
+    MAX_INTERVAL_EVALUATIONS,
     IntervalEndpointInteger,
     _parse_interval,
     require_bounded_affine_endpoints,
 )
-from jacobian.math.prime_affine_forms._kernel import wheel_modulus
 from jacobian.math.prime_affine_forms._models import (
     MAX_BATCH_PRIME,
     MAX_RESULT_CHARACTER_BUDGET,
@@ -30,7 +28,6 @@ from jacobian.math.prime_affine_forms._models import (
     PrimeTupleLocalSummary,
     _digits,
     _require_prime_set,
-    _require_summary,
     _source_character_upper_bound,
     _summary_character_upper_bound,
     _validation_error,
@@ -75,7 +72,7 @@ class PrimeTupleResidueWheelRequest(StrictModel):
         root_work = 6 * root_cells
         if root_work > MAX_COMPACT_WHEEL_ROOT_WORK:
             raise _validation_error(
-                f"compact wheel computation and validation need {root_work} root "
+                f"compact wheel computation needs {root_work} root "
                 f"steps, exceeding {MAX_COMPACT_WHEEL_ROOT_WORK}"
             )
         modulus_digits = sum(_digits(prime) for prime in self.primes) or 1
@@ -115,25 +112,29 @@ class PrimeTupleResidueWheel(StrictModel):
     valid_count: CompactWheelScalar
 
     @model_validator(mode="after")
-    def bind_compact_crt_wheel(self) -> Self:
-        PrimeTupleResidueWheelRequest(source=self.source, primes=self.primes)
+    def require_compact_wheel_shape(self) -> Self:
         if tuple(row.prime for row in self.local_rows) != self.primes:
             raise _validation_error(
                 "wheel local rows must align with its canonical primes"
             )
-        for row in self.local_rows:
-            _require_summary(self.source, row)
-        expected_modulus = wheel_modulus(self.primes)
-        if parse_canonical_integer(self.modulus) != expected_modulus:
-            raise _validation_error(
-                "wheel modulus must equal the product of its primes"
-            )
-        expected_count = prod((row.valid_count for row in self.local_rows), start=1)
-        if parse_canonical_integer(self.valid_count) != expected_count:
-            raise _validation_error(
-                "wheel valid_count must equal the product of local counts"
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PrimeTupleResidueWheelRequest,
+        *,
+        local_rows: tuple[PrimeTupleLocalSummary, ...],
+        modulus: str,
+        valid_count: str,
+    ) -> Self:
+        return cls(
+            source=request.source,
+            primes=request.primes,
+            local_rows=local_rows,
+            modulus=modulus,
+            valid_count=valid_count,
+        )
 
 
 class PrimeTupleResidueWheelEnumerationRequest(StrictModel):
@@ -162,12 +163,12 @@ class PrimeTupleResidueWheelEnumerationRequest(StrictModel):
                 f"{MAX_WHEEL_RESULT_CELLS}"
             )
         root_cells = self.wheel.source.form_count * len(self.wheel.primes)
-        replay_work = 2 * (
+        enumeration_work = (
             result_count * len(self.wheel.primes) + local_residue_rows + root_cells
         )
-        if replay_work > MAX_WHEEL_ENUMERATION_WORK:
+        if enumeration_work > MAX_WHEEL_ENUMERATION_WORK:
             raise _validation_error(
-                f"wheel enumeration and validation need {replay_work} bounded "
+                f"wheel enumeration needs {enumeration_work} bounded "
                 f"steps, exceeding {MAX_WHEEL_ENUMERATION_WORK}"
             )
         modulus_digits = _digits(self.wheel.modulus)
@@ -194,13 +195,12 @@ class PrimeTupleResidueWheelEnumeration(StrictModel):
     )
 
     @model_validator(mode="after")
-    def bind_complete_crt_enumeration(self) -> Self:
+    def require_enumeration_shape(self) -> Self:
         result_cells = len(self.residues) + sum(
             len(row.components) for row in self.residues
         )
         if result_cells > MAX_WHEEL_RESULT_CELLS:
             raise _validation_error("wheel rows exceed the explicit result-cell bound")
-        PrimeTupleResidueWheelEnumerationRequest(wheel=self.wheel)
         expected_count = parse_canonical_integer(self.wheel.valid_count)
         if len(self.residues) != expected_count:
             raise _validation_error(
@@ -219,23 +219,21 @@ class PrimeTupleResidueWheelEnumeration(StrictModel):
                 raise _validation_error(
                     "wheel rows do not satisfy the complete CRT reconstruction invariant"
                 )
-            for prime, summary, component in zip(
-                self.wheel.primes,
-                self.wheel.local_rows,
-                row.components,
-                strict=True,
-            ):
-                bad = {item.residue for item in summary.bad_residues}
-                if (
-                    not 0 <= component < prime
-                    or residue % prime != component
-                    or component in bad
-                ):
+            for prime, component in zip(self.wheel.primes, row.components, strict=True):
+                if not 0 <= component < prime:
                     raise _validation_error(
-                        "wheel rows do not satisfy the complete CRT reconstruction "
-                        "invariant"
+                        "wheel components must be within their prime moduli"
                     )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PrimeTupleResidueWheelEnumerationRequest,
+        *,
+        residues: tuple[PrimeTupleWheelResidueRow, ...],
+    ) -> Self:
+        return cls(wheel=request.wheel, residues=residues)
 
 
 class PrimeTupleWheelMembershipRequest(StrictModel):
@@ -275,43 +273,39 @@ class PrimeTupleWheelMembershipResult(StrictModel):
     vanishing_form_ids: tuple[AffineFormId, ...] = Field(max_length=MAX_AFFINE_FORMS)
 
     @model_validator(mode="after")
-    def bind_wheel_membership(self) -> Self:
-        PrimeTupleWheelMembershipRequest(wheel=self.wheel, value=self.value)
-        value = parse_canonical_integer(self.value)
-        modulus = parse_canonical_integer(self.wheel.modulus)
-        expected_residue = value % modulus
-        expected_components = tuple(value % prime for prime in self.wheel.primes)
-        expected_prime: int | None = None
-        expected_form_ids: tuple[str, ...] = ()
-        for summary, component in zip(
-            self.wheel.local_rows, expected_components, strict=True
-        ):
-            bad = {row.residue: row.form_ids for row in summary.bad_residues}
-            if component in bad:
-                expected_prime = summary.prime
-                expected_form_ids = bad[component]
-                break
-        expected_permitted = expected_prime is None
-        if parse_canonical_integer(self.canonical_residue) != expected_residue:
+    def require_membership_shape(self) -> Self:
+        if len(self.components) != len(self.wheel.primes):
             raise _validation_error(
-                "canonical residue does not match the wheel modulus"
+                "wheel membership components must align with wheel primes"
             )
-        if self.components != expected_components:
+        if self.is_permitted != (self.first_excluded_prime is None):
             raise _validation_error(
-                "prime components do not match the supplied integer"
+                "wheel membership permission must agree with first exclusion"
             )
-        if self.is_permitted != expected_permitted:
-            raise _validation_error(
-                "wheel membership does not match the complete residue set"
-            )
-        if (
-            self.first_excluded_prime != expected_prime
-            or self.vanishing_form_ids != expected_form_ids
-        ):
-            raise _validation_error(
-                "first local exclusion does not match the source forms"
-            )
+        if self.is_permitted and self.vanishing_form_ids:
+            raise _validation_error("a permitted member cannot have vanishing form ids")
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PrimeTupleWheelMembershipRequest,
+        *,
+        canonical_residue: str,
+        components: tuple[int, ...],
+        is_permitted: bool,
+        first_excluded_prime: int | None,
+        vanishing_form_ids: tuple[str, ...],
+    ) -> Self:
+        return cls(
+            wheel=request.wheel,
+            value=request.value,
+            canonical_residue=canonical_residue,
+            components=components,
+            is_permitted=is_permitted,
+            first_excluded_prime=first_excluded_prime,
+            vanishing_form_ids=vanishing_form_ids,
+        )
 
 
 class PrimeTupleIntervalResidueProfileRequest(StrictModel):
@@ -332,11 +326,11 @@ class PrimeTupleIntervalResidueProfileRequest(StrictModel):
                 f"wheel interval length {interval_size} exceeds "
                 f"{MAX_WHEEL_INTERVAL_LENGTH}"
             )
-        replay_work = 2 * interval_size * max(1, len(self.wheel.primes))
-        if replay_work > MAX_INTERVAL_REPLAY_EVALUATIONS:
+        membership_checks = interval_size * max(1, len(self.wheel.primes))
+        if membership_checks > MAX_INTERVAL_EVALUATIONS:
             raise _validation_error(
-                f"wheel interval profile and validation need {replay_work} "
-                f"modular checks, exceeding {MAX_INTERVAL_REPLAY_EVALUATIONS}"
+                f"wheel interval profile needs {membership_checks} modular checks, "
+                f"exceeding {MAX_INTERVAL_EVALUATIONS}"
             )
         endpoint_digits = max(_digits(self.lower), _digits(self.upper))
         result_characters = (
@@ -363,31 +357,84 @@ class PrimeTupleIntervalResidueProfileResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def bind_complete_survivor_family(self) -> Self:
-        PrimeTupleIntervalResidueProfileRequest(
-            wheel=self.wheel, lower=self.lower, upper=self.upper
-        )
+    def require_survivor_profile_shape(self) -> Self:
         lower, upper, interval_size = _parse_interval(self.lower, self.upper)
-        bad_by_prime = tuple(
-            {row.residue for row in summary.bad_residues}
-            for summary in self.wheel.local_rows
-        )
-        expected = tuple(
-            value
-            for value in range(lower, upper + 1)
-            if all(
-                value % prime not in bad
-                for prime, bad in zip(self.wheel.primes, bad_by_prime, strict=True)
-            )
-        )
         actual = tuple(parse_canonical_integer(value) for value in self.survivors)
-        if actual != expected:
+        if actual != tuple(sorted(set(actual))) or any(
+            value < lower or value > upper for value in actual
+        ):
             raise _validation_error(
-                "survivors must be the complete local wheel profile"
+                "survivors must be ordered distinct interval values"
             )
         if self.interval_size != interval_size:
             raise _validation_error("interval_size must equal upper-lower+1")
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PrimeTupleIntervalResidueProfileRequest,
+        *,
+        survivors: tuple[str, ...],
+    ) -> Self:
+        lower = parse_canonical_integer(request.lower)
+        upper = parse_canonical_integer(request.upper)
+        return cls(
+            wheel=request.wheel,
+            lower=request.lower,
+            upper=request.upper,
+            interval_size=upper - lower + 1,
+            survivors=survivors,
+        )
+
+
+def verify_residue_wheel(result: PrimeTupleResidueWheel) -> bool:
+    """Verify an independently supplied compact residue-wheel claim."""
+
+    from jacobian.math.prime_affine_forms._operations import compute_residue_wheel
+
+    request = PrimeTupleResidueWheelRequest(source=result.source, primes=result.primes)
+    return result == compute_residue_wheel(request)
+
+
+def verify_residue_wheel_enumeration(
+    result: PrimeTupleResidueWheelEnumeration,
+) -> bool:
+    """Verify an independently supplied explicit residue-wheel enumeration."""
+
+    from jacobian.math.prime_affine_forms._operations import (
+        compute_residue_wheel_enumeration,
+    )
+
+    return result == compute_residue_wheel_enumeration(
+        PrimeTupleResidueWheelEnumerationRequest(wheel=result.wheel)
+    )
+
+
+def verify_wheel_membership_result(result: PrimeTupleWheelMembershipResult) -> bool:
+    """Verify an independently supplied wheel-membership claim."""
+
+    from jacobian.math.prime_affine_forms._operations import compute_wheel_membership
+
+    return result == compute_wheel_membership(
+        PrimeTupleWheelMembershipRequest(wheel=result.wheel, value=result.value)
+    )
+
+
+def verify_interval_residue_profile_result(
+    result: PrimeTupleIntervalResidueProfileResult,
+) -> bool:
+    """Verify an independently supplied complete local survivor profile."""
+
+    from jacobian.math.prime_affine_forms._operations import (
+        compute_interval_residue_profile,
+    )
+
+    return result == compute_interval_residue_profile(
+        PrimeTupleIntervalResidueProfileRequest(
+            wheel=result.wheel, lower=result.lower, upper=result.upper
+        )
+    )
 
 
 __all__ = [

--- a/src/jacobian/math/prime_affine_forms/_translation.py
+++ b/src/jacobian/math/prime_affine_forms/_translation.py
@@ -53,15 +53,13 @@ class PrimeAffineTranslationResult(StrictModel):
     shift: IntervalEndpointInteger
     translated: PrimeAffineTuple
 
-    @model_validator(mode="after")
-    def bind_exact_translation(self) -> PrimeAffineTranslationResult:
-        PrimeAffineTranslationRequest(source=self.source, shift=self.shift)
-        expected = translated_tuple(self.source, parse_canonical_integer(self.shift))
-        if self.translated != expected:
-            raise _validation_error(
-                "translated tuple must equal L_i(n+shift) for every form"
-            )
-        return self
+    @classmethod
+    def _from_kernel(
+        cls, request: PrimeAffineTranslationRequest, *, translated: PrimeAffineTuple
+    ) -> PrimeAffineTranslationResult:
+        """Build after the admitted translation kernel established the tuple."""
+
+        return cls(source=request.source, shift=request.shift, translated=translated)
 
 
 def compute_translation(
@@ -69,13 +67,19 @@ def compute_translation(
 ) -> PrimeAffineTranslationResult:
     """Apply one admitted translation and retain its exact canonical tuple."""
 
-    return PrimeAffineTranslationResult(
-        source=request.source,
-        shift=request.shift,
+    return PrimeAffineTranslationResult._from_kernel(
+        request,
         translated=translated_tuple(
             request.source, parse_canonical_integer(request.shift)
         ),
     )
+
+
+def verify_translation_result(result: PrimeAffineTranslationResult) -> bool:
+    """Verify an independently supplied affine-translation claim."""
+
+    request = PrimeAffineTranslationRequest(source=result.source, shift=result.shift)
+    return result == compute_translation(request)
 
 
 __all__ = [

--- a/src/jacobian/math/prime_field_matrix/_models.py
+++ b/src/jacobian/math/prime_field_matrix/_models.py
@@ -95,7 +95,7 @@ def _require_source_prime(self_prime: int, source: PrimeFieldMatrixRequest) -> N
 
 
 class PrimeFieldMatrixRankResult(StrictModel):
-    """Rank of a matrix over GF(p), bound to its source matrix."""
+    """Rank of a matrix over GF(p), retaining its source matrix."""
 
     prime: int = Field(gt=1, le=MAX_PRIME)
     source: PrimeFieldMatrixRequest
@@ -103,25 +103,29 @@ class PrimeFieldMatrixRankResult(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical(self) -> Self:
-        from jacobian.math.prime_field_linear_algebra import rank as kernel_rank
-
         _require_source_prime(self.prime, self.source)
-        # Replay the conclusion from the retained source: the declared rank
-        # must equal a recomputation, so corrupted results cannot revalidate.
-        if self.rank != kernel_rank(self.source.matrix):
+        if self.rank > min(len(self.source.matrix.entries), self.source.matrix.columns):
             raise _validation_error(
-                "result.rank_recomputation",
-                "rank does not match a recomputation from the source",
+                "result.rank_bound",
+                "rank cannot exceed either source matrix dimension",
             )
         return self
+
+    @classmethod
+    def _from_kernel(cls, request: PrimeFieldMatrixRequest, *, rank: int) -> Self:
+        """Build a result after the admitted rank kernel established it."""
+
+        return cls.model_construct(
+            source=request, prime=request.matrix.prime, rank=rank
+        )
 
 
 class PrimeFieldRrefResult(StrictModel):
     """Reduced row-echelon form over GF(p) as the canonical matrix value.
 
     ``rref_matrix`` carries the exact reduced form with its pivot columns and
-    rank; it feeds downstream GF(p) consumers unchanged and is replayed
-    against the retained source at validation.
+    rank; it feeds downstream GF(p) consumers unchanged. Parsing checks only
+    its canonical shape; the producer kernel establishes reduced-form facts.
     """
 
     prime: int = Field(gt=1, le=MAX_PRIME)
@@ -132,33 +136,57 @@ class PrimeFieldRrefResult(StrictModel):
 
     @model_validator(mode="after")
     def require_rref_canonical(self) -> Self:
-        from jacobian.math.prime_field_linear_algebra import rref as kernel_rref
-
         _require_source_prime(self.prime, self.source)
-        expected_rows, expected_pivots = kernel_rref(self.source.matrix)
-        if self.rref_matrix.entries != tuple(expected_rows):
-            raise _validation_error(
-                "result.rref_recomputation",
-                "rref_matrix does not match a recomputation from the source",
-            )
         if (
             self.rref_matrix.prime != self.source.matrix.prime
             or self.rref_matrix.columns != self.source.matrix.columns
+            or len(self.rref_matrix.entries) != len(self.source.matrix.entries)
         ):
             raise _validation_error(
                 "result.rref_shape",
-                "rref_matrix must carry the source prime and column axis",
+                "rref_matrix must carry the source shape and prime",
             )
-        if tuple(self.pivot_columns) != tuple(expected_pivots):
+        if any(
+            column < 0 or column >= self.source.matrix.columns
+            for column in self.pivot_columns
+        ) or any(
+            later <= earlier
+            for earlier, later in zip(
+                self.pivot_columns, self.pivot_columns[1:], strict=False
+            )
+        ):
             raise _validation_error(
                 "result.pivot_columns",
-                "pivot_columns must be the exact pivot column sequence",
+                "pivot_columns must be a strictly increasing source-column sequence",
             )
-        if self.rank != len(expected_pivots):
+        if self.rank != len(self.pivot_columns):
             raise _validation_error(
                 "result.rank_pivots", "rank must equal the number of pivot columns"
             )
+        if self.rank > min(len(self.source.matrix.entries), self.source.matrix.columns):
+            raise _validation_error(
+                "result.rank_bound",
+                "rank cannot exceed either source matrix dimension",
+            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PrimeFieldMatrixRequest,
+        *,
+        rref_matrix: PrimeFieldMatrix,
+        pivot_columns: tuple[int, ...],
+    ) -> Self:
+        """Build a result after the admitted RREF kernel established it."""
+
+        return cls.model_construct(
+            source=request,
+            prime=request.matrix.prime,
+            rref_matrix=rref_matrix,
+            pivot_columns=pivot_columns,
+            rank=len(pivot_columns),
+        )
 
 
 class PrimeFieldNullspaceResult(StrictModel):
@@ -176,20 +204,7 @@ class PrimeFieldNullspaceResult(StrictModel):
 
     @model_validator(mode="after")
     def require_nullspace_canonical(self) -> Self:
-        from jacobian.math.prime_field_linear_algebra import (
-            nullspace as kernel_nullspace,
-        )
-
         _require_source_prime(self.prime, self.source)
-        # Replay the conclusion from the retained source: the declared basis
-        # and nullity must equal a full recomputation, which covers the
-        # defining relation, independence, and completeness of the basis.
-        expected_basis = kernel_nullspace(self.source.matrix)
-        if self.nullspace_matrix.entries != tuple(expected_basis):
-            raise _validation_error(
-                "result.nullspace_recomputation",
-                "nullspace_matrix does not match a recomputation from the source",
-            )
         if (
             self.nullspace_matrix.prime != self.source.matrix.prime
             or self.nullspace_matrix.columns != self.source.matrix.columns
@@ -198,11 +213,29 @@ class PrimeFieldNullspaceResult(StrictModel):
                 "result.nullspace_shape",
                 "nullspace_matrix must carry the source prime and column axis",
             )
-        if self.nullity != len(expected_basis):
+        if self.nullity != len(self.nullspace_matrix.entries):
             raise _validation_error(
                 "result.nullity_basis", "nullity must equal the number of basis vectors"
             )
+        if self.nullity > self.source.matrix.columns:
+            raise _validation_error(
+                "result.nullity_bound",
+                "nullity cannot exceed the source column count",
+            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls, request: PrimeFieldMatrixRequest, *, nullspace_matrix: PrimeFieldMatrix
+    ) -> Self:
+        """Build a result after the admitted nullspace kernel established it."""
+
+        return cls.model_construct(
+            source=request,
+            prime=request.matrix.prime,
+            nullspace_matrix=nullspace_matrix,
+            nullity=len(nullspace_matrix.entries),
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/prime_field_matrix/_operations.py
+++ b/src/jacobian/math/prime_field_matrix/_operations.py
@@ -22,41 +22,69 @@ from jacobian.math.prime_field_matrix._models import (
 
 def compute_rank(request: PrimeFieldMatrixRequest) -> PrimeFieldMatrixRankResult:
     """Compute the rank of a matrix over GF(p)."""
-    return PrimeFieldMatrixRankResult(
-        source=request,
-        prime=request.matrix.prime,
-        rank=_rank(request.matrix),
-    )
+    return PrimeFieldMatrixRankResult._from_kernel(request, rank=_rank(request.matrix))
 
 
 def compute_rref(request: PrimeFieldMatrixRequest) -> PrimeFieldRrefResult:
     """Compute the reduced row-echelon form of a matrix over GF(p)."""
     rref_rows, pivot_columns = _rref(request.matrix)
-    return PrimeFieldRrefResult(
-        source=request,
-        prime=request.matrix.prime,
+    return PrimeFieldRrefResult._from_kernel(
+        request,
         rref_matrix=PrimeFieldMatrix(
             prime=request.matrix.prime,
             entries=tuple(rref_rows),
             columns=request.matrix.columns,
         ),
         pivot_columns=pivot_columns,
-        rank=len(pivot_columns),
     )
 
 
 def compute_nullspace(request: PrimeFieldMatrixRequest) -> PrimeFieldNullspaceResult:
     """Compute a basis for the right nullspace of a matrix over GF(p)."""
     basis = _nullspace(request.matrix)
-    return PrimeFieldNullspaceResult(
-        source=request,
-        prime=request.matrix.prime,
+    return PrimeFieldNullspaceResult._from_kernel(
+        request,
         nullspace_matrix=PrimeFieldMatrix(
             prime=request.matrix.prime,
             entries=tuple(basis),
             columns=request.matrix.columns,
         ),
-        nullity=len(basis),
+    )
+
+
+def _verify_rank_result(result: PrimeFieldMatrixRankResult) -> bool:
+    """Deliberately recheck one independently supplied rank claim."""
+
+    source = PrimeFieldMatrixRequest.model_validate(result.source.model_dump())
+    return result.prime == source.matrix.prime and result.rank == _rank(source.matrix)
+
+
+def _verify_rref_result(result: PrimeFieldRrefResult) -> bool:
+    """Deliberately recheck one independently supplied RREF claim."""
+
+    source = PrimeFieldMatrixRequest.model_validate(result.source.model_dump())
+    rows, pivots = _rref(source.matrix)
+    return (
+        result.prime == source.matrix.prime
+        and result.rref_matrix.entries == tuple(rows)
+        and result.rref_matrix.prime == source.matrix.prime
+        and result.rref_matrix.columns == source.matrix.columns
+        and result.pivot_columns == tuple(pivots)
+        and result.rank == len(pivots)
+    )
+
+
+def _verify_nullspace_result(result: PrimeFieldNullspaceResult) -> bool:
+    """Deliberately recheck one independently supplied nullspace claim."""
+
+    source = PrimeFieldMatrixRequest.model_validate(result.source.model_dump())
+    basis = _nullspace(source.matrix)
+    return (
+        result.prime == source.matrix.prime
+        and result.nullspace_matrix.entries == tuple(basis)
+        and result.nullspace_matrix.prime == source.matrix.prime
+        and result.nullspace_matrix.columns == source.matrix.columns
+        and result.nullity == len(basis)
     )
 
 

--- a/src/jacobian/math/quadratic_forms/_models.py
+++ b/src/jacobian/math/quadratic_forms/_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import Self
 
 from pydantic import Field, model_validator
@@ -15,7 +16,6 @@ from jacobian.math.quadratic_forms.values import (
     MAX_QUADRATIC_EVALUATION_TERM_DIGITS,
     RationalCoordinateVector,
     RationalQuadraticForm,
-    evaluate_rational_quadratic_form,
     require_evaluation_budget,
 )
 
@@ -80,25 +80,24 @@ class EvaluationResult(StrictModel):
     @model_validator(mode="after")
     def require_exact_source_bound_evaluation(self) -> Self:
         try:
-            require_evaluation_budget(self.form, self.vector)
             require_bounded_rational(
                 self.value,
                 max_digits=MAX_QUADRATIC_EVALUATION_DIGITS,
                 label="quadratic-form evaluation",
             )
         except ValueError as error:
-            reason = (
-                "support_budget"
-                if "total support" in str(error)
-                else "evaluation_budget"
-            )
-            raise _validation_error(reason, str(error)) from error
-        expected = evaluate_rational_quadratic_form(self.form, self.vector)
-        if self.value.as_fraction() != expected:
-            raise _validation_error(
-                "value_mismatch", "value must equal the exact quadratic-form evaluation"
-            )
+            raise _validation_error("evaluation_budget", str(error)) from error
         return self
+
+    @classmethod
+    def _from_kernel(cls, request: EvaluationRequest, *, value: Fraction) -> Self:
+        """Build one result after the admitted rational kernel established it."""
+
+        return cls(
+            form=request.form,
+            vector=request.vector,
+            value=CanonicalRational.from_fraction(value),
+        )
 
 
 __all__ = ["EvaluationRequest", "EvaluationResult"]

--- a/src/jacobian/math/quadratic_forms/_operations.py
+++ b/src/jacobian/math/quadratic_forms/_operations.py
@@ -1,6 +1,7 @@
 """Private MCP adapters for exact quadratic-form evaluation."""
 
-from jacobian._exact import CanonicalRational
+from pydantic import ValidationError
+
 from jacobian.math.quadratic_forms._models import EvaluationRequest, EvaluationResult
 from jacobian.math.quadratic_forms.values import evaluate_rational_quadratic_form
 
@@ -8,12 +9,21 @@ from jacobian.math.quadratic_forms.values import evaluate_rational_quadratic_for
 def evaluate_form(request: EvaluationRequest) -> EvaluationResult:
     """Evaluate the request's form exactly with direct rational arithmetic."""
 
-    return EvaluationResult(
-        form=request.form,
-        vector=request.vector,
-        value=CanonicalRational.from_fraction(
-            evaluate_rational_quadratic_form(request.form, request.vector)
-        ),
+    return EvaluationResult._from_kernel(
+        request,
+        value=evaluate_rational_quadratic_form(request.form, request.vector),
+    )
+
+
+def _verify_evaluation_result(result: EvaluationResult) -> bool:
+    """Check an independently supplied result inside the request envelope."""
+
+    try:
+        request = EvaluationRequest(form=result.form, vector=result.vector)
+    except ValidationError:
+        return False
+    return result.value.as_fraction() == evaluate_rational_quadratic_form(
+        request.form, request.vector
     )
 
 

--- a/src/jacobian/math/quadratic_forms/values.py
+++ b/src/jacobian/math/quadratic_forms/values.py
@@ -245,8 +245,8 @@ def require_evaluation_budget(
 
     The active accounting deliberately ignores annihilated monomials, so it
     says nothing about how much support a request may materialize.
-    Validation, kernel traversal, result replay, and source-bound
-    serialization all visit every stored diagonal coefficient, cross term,
+    Request admission, kernel traversal, and source-bound serialization all
+    visit every stored diagonal coefficient, cross term,
     and coordinate whether or not it contributes, and each stored entry has
     bounded height (per-entry numerator/denominator digit bounds; bounded
     label length).  The total materialized form support,

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -23,7 +23,6 @@ from jacobian._digest import Sha256Digest
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import canonicalize_json
 from jacobian.math.chain_complexes.values import ChainComplexValue
-from jacobian.math.topology._barycentric import barycentric_subdivision
 
 MAX_TOPOLOGY_VERTICES = 64
 MAX_TOPOLOGY_FACETS = 128
@@ -134,45 +133,6 @@ def _all_faces(facets: tuple[Simplex, ...]) -> set[tuple[str, ...]]:
             for subset in combinations(facet, r):
                 faces.add(tuple(sorted(subset)))
     return faces
-
-
-def _require_subdivision_replay(
-    *,
-    source_complex: SimplicialComplexRequest,
-    original_vertices: tuple[str, ...],
-    subdivision_vertices: tuple[str, ...],
-    subdivision_vertex_faces: tuple[tuple[str, ...], ...],
-    num_new_vertices: int,
-    subdivision_facets: tuple[tuple[str, ...], ...],
-) -> None:
-    """Replay the deterministic subdivision against the retained source so
-    every derived field — including the indexed vertex-to-face map — must
-    equal what the kernel produces for this exact labeling.  In particular,
-    swapping entries of ``subdivision_vertex_faces`` while keeping the
-    subdivision complex unchanged cannot validate."""
-
-    faces = sorted(_all_faces(source_complex.facets), key=lambda f: (len(f), f))
-    expected_labels = [f"bv{i}" for i in range(len(faces))]
-    if (
-        list(subdivision_vertices) != expected_labels
-        or list(subdivision_vertex_faces) != faces
-        or num_new_vertices != len(faces)
-    ):
-        raise _validation_error(
-            "topology.require_subdivision_replay_1",
-            "subdivision_vertices and subdivision_vertex_faces must be "
-            "the canonical indexed bijection onto the source complex's "
-            "non-empty faces",
-        )
-    expected = barycentric_subdivision(faces).facets
-    if (
-        tuple(subdivision_facets) != expected
-        or original_vertices != source_complex.vertices
-    ):
-        raise _validation_error(
-            "topology.require_subdivision_replay_2",
-            "subdivision facets do not match the retained source complex",
-        )
 
 
 def _require_request_complex(
@@ -737,28 +697,22 @@ class ChainComplexResult(TopologyExactResult):
                 "topology.require_coherent_chain_contract_4",
                 "boundary-square ledger must cover every adjacent pair",
             )
-        # The canonical value is part of the public result boundary: an
-        # unreduced GF(p) producer result must carry it exactly, and no
-        # other ring or convention admits one.
-        from jacobian.math.topology._chain_conversion import (
-            canonical_chain_complex_value_from_parts,
-        )
-
-        expected_value = canonical_chain_complex_value_from_parts(
-            self.coefficient_ring,
-            self.convention,
-            self.prime,
-            self.simplex_bases,
-            self.boundary_matrices,
-        )
-        if self.canonical_value != expected_value:
+        if self.canonical_value is not None and not (
+            self.coefficient_ring is ChainCoefficientRing.PRIME_FIELD
+            and self.convention is HomologyConvention.UNREDUCED
+        ):
             raise _validation_error(
                 "topology.require_coherent_chain_contract_5",
-                "canonical chain-complex value must be the exact "
-                "unreduced prime-field conversion of the retained "
-                "boundary data",
+                "canonical chain-complex value is only defined for unreduced "
+                "prime-field chains",
             )
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        """Build after the chain kernel established all derived fields."""
+
+        return cls(**values)
 
 
 __all__ = [
@@ -821,19 +775,11 @@ class BarycentricSubdivisionResult(TopologyExactResult):
     subdivision_vertex_faces: tuple[tuple[str, ...], ...] = Field(default=())
 
     @model_validator(mode="after")
-    def require_subdivision_canonical(self) -> Self:
-        # Replay must satisfy the subdivision request's work admission, so a
-        # serialized result cannot bypass the bounded source domain (a source
-        # whose exact subdivision exceeds the result contract is impossible
-        # to obtain from the operation).
-        BarycentricSubdivisionRequest(complex=self.complex)
-        # The advertised original dimension must equal the dimension derived
-        # from the retained source complex's facets.
-        source_dimension = max(len(facet) for facet in self.complex.facets) - 1
-        if self.original_dimension != source_dimension:
+    def require_structural_subdivision(self) -> Self:
+        if self.num_new_vertices != len(self.subdivision_vertices):
             raise _validation_error(
                 "topology.require_subdivision_canonical_1",
-                "original_dimension must match the retained source complex",
+                "num_new_vertices must match subdivision_vertices",
             )
         if not self.subdivision_facets:
             if self.subdivision_complex is not None:
@@ -873,15 +819,13 @@ class BarycentricSubdivisionResult(TopologyExactResult):
                         "topology.require_subdivision_canonical_7",
                         f"invalid subdivision vertex label: {label}",
                     )
-        _require_subdivision_replay(
-            source_complex=self.complex,
-            original_vertices=self.original_vertices,
-            subdivision_vertices=self.subdivision_vertices,
-            subdivision_vertex_faces=self.subdivision_vertex_faces,
-            num_new_vertices=self.num_new_vertices,
-            subdivision_facets=self.subdivision_facets,
-        )
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        """Build after the admitted subdivision kernel established the result."""
+
+        return cls(**values)
 
 
 class ShellingCheckRequest(StrictModel):
@@ -916,41 +860,14 @@ class ShellingCheckResult(TopologyExactResult):
     failure_reason: str | None = None
 
     @model_validator(mode="after")
-    def require_shelling_binding(self) -> Self:
-        # Apply the request model's permutation requirement before replay: a
-        # partial or duplicated order visits only its own facets and must not
-        # authenticate a decision about facets it omits.
-        if sorted(self.facet_order) != list(range(len(self.complex.facets))):
-            raise _validation_error(
-                "topology.require_shelling_binding_1",
-                "facet_order must be a permutation of facet indices",
-            )
-        # Replay the shelling condition over the retained complex and order so
-        # an authored decision cannot validate independently of its source.
-        from jacobian.math.topology._shelling import evaluate_shelling
-
-        expected_is_shelling, expected_failed_at, expected_reason = evaluate_shelling(
-            self.complex.facets, self.facet_order
-        )
-        if self.is_shelling != expected_is_shelling:
-            raise _validation_error(
-                "topology.require_shelling_binding_2",
-                f"is_shelling {self.is_shelling} does not match replayed "
-                f"decision {expected_is_shelling}",
-            )
-        if self.failed_at != expected_failed_at:
-            raise _validation_error(
-                "topology.require_shelling_binding_3",
-                f"failed_at {self.failed_at} does not match replayed "
-                f"{expected_failed_at}",
-            )
-        if self.failure_reason != expected_reason:
-            raise _validation_error(
-                "topology.require_shelling_binding_4",
-                f"failure_reason {self.failure_reason!r} does not match "
-                f"replayed {expected_reason!r}",
-            )
+    def require_structural_shelling(self) -> Self:
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        """Build after the admitted shelling kernel established the decision."""
+
+        return cls(**values)
 
 
 __all__.extend(

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -878,6 +878,21 @@ class ShellingCheckResult(TopologyExactResult):
 
     @model_validator(mode="after")
     def require_structural_shelling(self) -> Self:
+        if self.is_shelling:
+            if self.failed_at is not None or self.failure_reason is not None:
+                raise _validation_error(
+                    "topology.require_structural_shelling_1",
+                    "a shelling result cannot carry failure diagnostics",
+                )
+        elif (
+            self.failed_at is None
+            or not 0 <= self.failed_at < len(self.facet_order)
+            or not self.failure_reason
+        ):
+            raise _validation_error(
+                "topology.require_structural_shelling_2",
+                "a failed shelling result requires a valid position and reason",
+            )
         return self
 
     @classmethod

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -706,6 +706,23 @@ class ChainComplexResult(TopologyExactResult):
                 "canonical chain-complex value is only defined for unreduced "
                 "prime-field chains",
             )
+        if self.canonical_value is not None:
+            from jacobian.math.topology._chain_conversion import (
+                canonical_chain_complex_value_from_parts,
+            )
+
+            expected = canonical_chain_complex_value_from_parts(
+                self.coefficient_ring,
+                self.convention,
+                self.prime,
+                self.simplex_bases,
+                self.boundary_matrices,
+            )
+            if self.canonical_value != expected:
+                raise _validation_error(
+                    "topology.require_coherent_chain_contract_6",
+                    "canonical chain-complex value must match retained chain data",
+                )
         return self
 
     @classmethod

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -216,7 +216,7 @@ def _chain_result(request: ChainComplexRequest) -> ChainComplexResult:
                 product_columns=upper.columns,
             )
         )
-    return ChainComplexResult(
+    return ChainComplexResult._from_kernel(
         complex_digest=complex_.complex_digest,
         coefficient_ring=request.coefficient_ring,
         prime=request.prime,
@@ -243,19 +243,12 @@ def _chain(
 
 def _canonical_chain_complex_value(result: ChainComplexResult) -> ChainComplexValue:
     """The canonical chain-complex value carried by one chain result."""
-    value = canonical_chain_complex_value_from_parts(
-        result.coefficient_ring,
-        result.convention,
-        result.prime,
-        result.simplex_bases,
-        result.boundary_matrices,
-    )
-    if value is None:
+    if result.canonical_value is None:
         raise ValueError(
             "only unreduced prime-field simplicial chain complexes convert "
             "to a canonical chain-complex value"
         )
-    return value
+    return result.canonical_value
 
 
 def _prime_matrix(
@@ -705,7 +698,7 @@ def compute_barycentric_subdivision(
     )
     subdivision = barycentric_subdivision(sorted_faces)
     facets = tuple(sorted(tuple(sorted(facet)) for facet in subdivision.facets))
-    return BarycentricSubdivisionResult(
+    return BarycentricSubdivisionResult._from_kernel(
         original_vertices=request.complex.vertices,
         original_dimension=max(len(facet) - 1 for facet in request.complex.facets),
         subdivision_vertices=subdivision.vertices,
@@ -727,14 +720,7 @@ def compute_pseudomanifold_decision(
     """Decide whether a complex is a pseudomanifold."""
 
     decision = pseudomanifold_decision(request.complex.facets)
-    return PseudomanifoldResult(
-        complex=request.complex,
-        is_pseudomanifold=decision.is_pseudomanifold,
-        is_closed=decision.is_closed,
-        dimension=decision.dimension,
-        num_facets=decision.num_facets,
-        obstruction=decision.obstruction,
-    )
+    return PseudomanifoldResult._from_kernel(request, decision=decision)
 
 
 def compute_shelling_check(request: ShellingCheckRequest) -> ShellingCheckResult:
@@ -743,7 +729,7 @@ def compute_shelling_check(request: ShellingCheckRequest) -> ShellingCheckResult
     is_shelling, failed_at, failure_reason = evaluate_shelling(
         request.complex.facets, request.facet_order
     )
-    return ShellingCheckResult(
+    return ShellingCheckResult._from_kernel(
         complex=request.complex,
         facet_order=request.facet_order,
         is_shelling=is_shelling,

--- a/src/jacobian/math/topology/_pseudomanifold.py
+++ b/src/jacobian/math/topology/_pseudomanifold.py
@@ -74,7 +74,7 @@ class PseudomanifoldRequest(StrictModel):
 
 
 class PseudomanifoldResult(TopologyExactResult):
-    """Pseudomanifold decision result bound to its source complex."""
+    """Pseudomanifold decision result produced for one source complex."""
 
     complex: SimplicialComplexRequest
     is_pseudomanifold: bool
@@ -84,47 +84,26 @@ class PseudomanifoldResult(TopologyExactResult):
     obstruction: str | None = None
 
     @model_validator(mode="after")
-    def require_pseudomanifold_binding(self) -> Self:
-        expected = pseudomanifold_decision(self.complex.facets)
-        if (
-            self.dimension != expected.dimension
-            or self.num_facets != expected.num_facets
-        ):
+    def require_branch_consistency(self) -> Self:
+        if not self.is_pseudomanifold and self.is_closed:
             raise _validation_error(
-                "topology.require_pseudomanifold_binding_1",
-                "dimension/num_facets must match source complex",
-            )
-        if self.is_pseudomanifold != expected.is_pseudomanifold:
-            raise _validation_error(
-                "topology.require_pseudomanifold_binding_2",
-                f"is_pseudomanifold {self.is_pseudomanifold} does not match "
-                f"expected {expected.is_pseudomanifold}",
-            )
-        if not expected.is_pseudomanifold:
-            if self.is_closed:
-                raise _validation_error(
-                    "topology.require_pseudomanifold_binding_3",
-                    "non-pseudomanifold cannot be closed",
-                )
-            if self.obstruction != expected.obstruction:
-                raise _validation_error(
-                    "topology.require_pseudomanifold_binding_4",
-                    f"obstruction {self.obstruction!r} does not match replayed "
-                    f"{expected.obstruction!r}",
-                )
-            return self
-        if self.is_closed != expected.is_closed:
-            raise _validation_error(
-                "topology.require_pseudomanifold_binding_5",
-                "is_closed must match codim-1 incidence",
-            )
-        if self.obstruction != expected.obstruction:
-            raise _validation_error(
-                "topology.require_pseudomanifold_binding_6",
-                f"obstruction {self.obstruction!r} does not match expected "
-                f"{expected.obstruction!r}",
+                "topology.require_pseudomanifold_branch_1",
+                "non-pseudomanifold cannot be closed",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls, request: PseudomanifoldRequest, *, decision: _PseudomanifoldDecision
+    ) -> Self:
+        return cls(
+            complex=request.complex,
+            is_pseudomanifold=decision.is_pseudomanifold,
+            is_closed=decision.is_closed,
+            dimension=decision.dimension,
+            num_facets=decision.num_facets,
+            obstruction=decision.obstruction,
+        )
 
 
 __all__ = ["PseudomanifoldRequest", "PseudomanifoldResult", "pseudomanifold_decision"]

--- a/src/jacobian/math/topology/_structural.py
+++ b/src/jacobian/math/topology/_structural.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from itertools import combinations
-from typing import Self
+from typing import Any, Self
 
 from pydantic import Field, StrictInt, model_validator
 
@@ -203,7 +203,7 @@ class StarRequest(StrictModel):
 
 
 class StarResult(TopologyExactResult):
-    """The closed star of a simplex, bound to its source complex."""
+    """The closed star produced for a simplex."""
 
     complex: SimplicialComplexRequest
     simplex: tuple[str, ...] = Field(
@@ -214,65 +214,47 @@ class StarResult(TopologyExactResult):
     star_complex: FiniteSimplicialComplex | None = None
 
     @model_validator(mode="after")
-    def require_star_binding(self) -> Self:
-        target = frozenset(self.simplex)
-        if len(target) != len(self.simplex):
+    def require_structural_star(self) -> Self:
+        if len(set(self.simplex)) != len(self.simplex):
             raise _validation_error(
                 "topology.require_star_binding_1",
                 "star simplex vertices must be distinct",
             )
-        expected = tuple(
-            tuple(sorted(facet))
-            for facet in sorted(
-                (
-                    frozenset(facet)
-                    for facet in self.complex.facets
-                    if target.issubset(facet)
-                ),
-                key=lambda value: (-len(value), sorted(value)),
-            )
-        )
-        if not any(target.issubset(frozenset(facet)) for facet in self.complex.facets):
+        if self.star_is_empty != (not self.star_facets):
             raise _validation_error(
                 "topology.require_star_binding_2",
-                "simplex must be a face of the retained complex",
-            )
-        if self.star_is_empty != (not expected):
-            raise _validation_error(
-                "topology.require_star_binding_3",
-                "star_is_empty does not match the source replay",
-            )
-        if tuple(self.star_facets) != expected:
-            raise _validation_error(
-                "topology.require_star_binding_4",
-                "star_facets do not match the source-complex replay",
+                "star_is_empty must match whether star_facets is empty",
             )
         if self.star_is_empty:
             if self.star_complex is not None:
                 raise _validation_error(
-                    "topology.require_star_binding_5", "empty star must have no complex"
+                    "topology.require_star_binding_3", "empty star must have no complex"
                 )
         else:
             if self.star_complex is None:
                 raise _validation_error(
-                    "topology.require_star_binding_6",
+                    "topology.require_star_binding_4",
                     "non-empty star requires star_complex",
                 )
             if tuple(sorted(self.star_complex.maximal_simplices)) != tuple(
                 sorted(tuple(sorted(facet)) for facet in self.star_facets)
             ):
                 raise _validation_error(
-                    "topology.require_star_binding_7",
+                    "topology.require_star_binding_5",
                     "star_complex maximal simplices must match star_facets",
                 )
             if set(self.star_complex.vertices) != {
                 vertex for facet in self.star_facets for vertex in facet
             }:
                 raise _validation_error(
-                    "topology.require_star_binding_8",
+                    "topology.require_star_binding_6",
                     "star_complex vertices must match star_facets",
                 )
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls(**values)
 
 
 class VertexDeletionRequest(StrictModel):
@@ -312,7 +294,7 @@ class VertexDeletionRequest(StrictModel):
 
 
 class VertexDeletionResult(TopologyExactResult):
-    """The induced subcomplex after deleting a vertex subset."""
+    """The induced subcomplex produced after deleting a vertex subset."""
 
     complex: SimplicialComplexRequest
     deleted_vertices: tuple[VertexLabel, ...] = Field(
@@ -323,56 +305,37 @@ class VertexDeletionResult(TopologyExactResult):
     remaining_complex: FiniteSimplicialComplex
 
     @model_validator(mode="after")
-    def require_deletion_canonical(self) -> Self:
+    def require_structural_deletion(self) -> Self:
         deleted = set(self.deleted_vertices)
         if len(deleted) != len(self.deleted_vertices):
             raise _validation_error(
                 "topology.require_deletion_canonical_1",
                 "deleted_vertices must be distinct",
             )
-        if not deleted.issubset(self.complex.vertices):
-            raise _validation_error(
-                "topology.require_deletion_canonical_2",
-                "deleted_vertices must be in the retained complex",
-            )
         if tuple(self.deleted_vertices) != tuple(sorted(self.deleted_vertices)):
             raise _validation_error(
                 "topology.require_deletion_canonical_3",
                 "deleted_vertices must use canonical vertex order",
             )
-        expected_facets = _maximal_faces(
-            face
-            for face in _all_nonempty_faces(self.complex.facets)
-            if not (set(face) & deleted)
-        )
-        expected_vertices = tuple(
-            sorted({vertex for facet in expected_facets for vertex in facet})
-        )
-        if tuple(self.remaining_facets) != expected_facets:
-            raise _validation_error(
-                "topology.require_deletion_canonical_4",
-                "remaining_facets must be the induced subcomplex of the retained source complex",
-            )
-        if tuple(self.remaining_vertices) != expected_vertices:
-            raise _validation_error(
-                "topology.require_deletion_canonical_5",
-                "remaining_vertices must match the source-complex replay",
-            )
         if tuple(sorted(self.remaining_complex.maximal_simplices)) != tuple(
             sorted(tuple(sorted(facet)) for facet in self.remaining_facets)
         ):
             raise _validation_error(
-                "topology.require_deletion_canonical_6",
+                "topology.require_deletion_canonical_4",
                 "remaining_complex maximal simplices must match remaining_facets",
             )
         if tuple(sorted(self.remaining_complex.vertices)) != tuple(
             sorted(self.remaining_vertices)
         ):
             raise _validation_error(
-                "topology.require_deletion_canonical_7",
+                "topology.require_deletion_canonical_5",
                 "remaining_complex vertices must match remaining_vertices",
             )
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls(**values)
 
 
 class SkeletonRequest(StrictModel):
@@ -392,7 +355,7 @@ class SkeletonRequest(StrictModel):
 
 
 class SkeletonResult(TopologyExactResult):
-    """The k-skeleton as a facet list, bound to its source complex."""
+    """The k-skeleton as a facet list."""
 
     complex: SimplicialComplexRequest
     k: StrictInt = Field(ge=0, le=MAX_TOPOLOGY_DIMENSION)
@@ -401,48 +364,38 @@ class SkeletonResult(TopologyExactResult):
     skeleton_complex: FiniteSimplicialComplex | None = None
 
     @model_validator(mode="after")
-    def require_skeleton_canonical(self) -> Self:
-        expected_facets = skeleton_maximal_facets(self.complex.facets, self.k)
-        if tuple(self.skeleton_facets) != expected_facets:
-            raise _validation_error(
-                "topology.require_skeleton_canonical_1",
-                "skeleton_facets must be the exact k-skeleton of the retained source complex",
-            )
-        expected_vertices = tuple(
-            sorted({v for facet in expected_facets for v in facet})
-        )
-        if tuple(self.skeleton_vertices) != expected_vertices:
-            raise _validation_error(
-                "topology.require_skeleton_canonical_2",
-                "skeleton_vertices must match the k-skeleton replay",
-            )
+    def require_structural_skeleton(self) -> Self:
         if not self.skeleton_facets:
             if self.skeleton_complex is not None:
                 raise _validation_error(
-                    "topology.require_skeleton_canonical_3",
+                    "topology.require_skeleton_canonical_1",
                     "empty skeleton must have no complex",
                 )
         else:
             if self.skeleton_complex is None:
                 raise _validation_error(
-                    "topology.require_skeleton_canonical_4",
+                    "topology.require_skeleton_canonical_2",
                     "non-empty skeleton requires skeleton_complex",
                 )
             if tuple(sorted(self.skeleton_complex.maximal_simplices)) != tuple(
                 sorted(tuple(sorted(facet)) for facet in self.skeleton_facets)
             ):
                 raise _validation_error(
-                    "topology.require_skeleton_canonical_5",
+                    "topology.require_skeleton_canonical_3",
                     "skeleton_complex maximal simplices must match skeleton_facets",
                 )
             if tuple(sorted(self.skeleton_complex.vertices)) != tuple(
                 sorted(self.skeleton_vertices)
             ):
                 raise _validation_error(
-                    "topology.require_skeleton_canonical_6",
+                    "topology.require_skeleton_canonical_4",
                     "skeleton_complex vertices must match skeleton_vertices",
                 )
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls(**values)
 
 
 def _require_join_admission(
@@ -493,7 +446,7 @@ class JoinRequest(StrictModel):
 
 
 class JoinResult(TopologyExactResult):
-    """The join of two complexes, bound to both operands."""
+    """The join of two complexes."""
 
     complex_a: SimplicialComplexRequest
     complex_b: SimplicialComplexRequest
@@ -503,30 +456,7 @@ class JoinResult(TopologyExactResult):
     join_complex: FiniteSimplicialComplex | None = None
 
     @model_validator(mode="after")
-    def require_join_canonical(self) -> Self:
-        _require_join_admission(self.complex_a, self.complex_b)
-        expected_facets = join_maximal_facets(
-            self.complex_a.facets, self.complex_b.facets
-        )
-        expected_vertices = tuple(
-            sorted(set(self.complex_a.vertices) | set(self.complex_b.vertices))
-        )
-        if tuple(self.join_facets) != expected_facets:
-            raise _validation_error(
-                "topology.require_join_canonical_1",
-                "join_facets must be the exact facet union of the retained operands",
-            )
-        if tuple(self.join_vertices) != expected_vertices:
-            raise _validation_error(
-                "topology.require_join_canonical_2",
-                "join_vertices must match the operand vertex sets",
-            )
-        dimension = max((len(facet) - 1 for facet in expected_facets), default=0)
-        if self.join_dimension != dimension:
-            raise _validation_error(
-                "topology.require_join_canonical_3",
-                "join_dimension must match the replayed facet union",
-            )
+    def require_structural_join(self) -> Self:
         _require_complex_matches_facets(
             self.join_complex,
             facets=self.join_facets,
@@ -541,10 +471,14 @@ class JoinResult(TopologyExactResult):
             and self.join_complex.dimension != self.join_dimension
         ):
             raise _validation_error(
-                "topology.require_join_canonical_4",
+                "topology.require_join_canonical_1",
                 "join_complex dimension must match join_dimension",
             )
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls(**values)
 
 
 class ElementaryCollapseRequest(StrictModel):
@@ -598,7 +532,7 @@ class ElementaryCollapseRequest(StrictModel):
 
 
 class ElementaryCollapseResult(TopologyExactResult):
-    """Result of checking one elementary collapse step, bound to its source."""
+    """Result of one elementary collapse step."""
 
     complex: SimplicialComplexRequest
     is_free_face: bool
@@ -613,7 +547,7 @@ class ElementaryCollapseResult(TopologyExactResult):
     remaining_complex: FiniteSimplicialComplex | None = None
 
     @model_validator(mode="after")
-    def require_collapse_binding(self) -> Self:
+    def require_structural_collapse(self) -> Self:
         free_face, coface = tuple(sorted(self.free_face)), tuple(sorted(self.coface))
         if self.free_face != free_face or self.coface != coface:
             raise _validation_error(
@@ -630,32 +564,6 @@ class ElementaryCollapseResult(TopologyExactResult):
                 "topology.require_collapse_binding_2",
                 "free_face must be codimension-one in coface",
             )
-        replayed = collapse_remaining_facets(self.complex.facets, free_face, coface)
-        if replayed is None:
-            if self.is_free_face:
-                raise _validation_error(
-                    "topology.require_collapse_binding_3",
-                    "is_free_face does not match the retained source complex",
-                )
-            facets = tuple(tuple(sorted(facet)) for facet in self.complex.facets)
-        else:
-            if not self.is_free_face:
-                raise _validation_error(
-                    "topology.require_collapse_binding_4",
-                    "is_free_face does not match the retained source complex",
-                )
-            facets = replayed
-        vertices = tuple(sorted({vertex for facet in facets for vertex in facet}))
-        if tuple(sorted(self.remaining_facets)) != tuple(sorted(facets)):
-            raise _validation_error(
-                "topology.require_collapse_binding_5",
-                "remaining_facets do not match the source-complex replay",
-            )
-        if tuple(sorted(self.remaining_vertices)) != tuple(sorted(vertices)):
-            raise _validation_error(
-                "topology.require_collapse_binding_6",
-                "remaining_vertices do not match the source-complex replay",
-            )
         _require_complex_matches_facets(
             self.remaining_complex,
             facets=self.remaining_facets,
@@ -666,6 +574,10 @@ class ElementaryCollapseResult(TopologyExactResult):
             vertices_message="remaining_complex vertices must match remaining_vertices",
         )
         return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls(**values)
 
 
 def compute_f_vector(request: FVectorRequest) -> FVectorResult:
@@ -725,7 +637,7 @@ def compute_star(request: StarRequest) -> StarResult:
         )
     )
     vertices = tuple(sorted({vertex for facet in facets for vertex in facet}))
-    return StarResult(
+    return StarResult._from_kernel(
         complex=request.complex,
         simplex=request.simplex,
         star_facets=facets,
@@ -742,7 +654,7 @@ def compute_vertex_deletion(request: VertexDeletionRequest) -> VertexDeletionRes
         if not (set(face) & deleted)
     )
     vertices = tuple(sorted({vertex for facet in facets for vertex in facet}))
-    return VertexDeletionResult(
+    return VertexDeletionResult._from_kernel(
         complex=request.complex,
         deleted_vertices=tuple(sorted(deleted)),
         remaining_vertices=vertices,
@@ -754,7 +666,7 @@ def compute_vertex_deletion(request: VertexDeletionRequest) -> VertexDeletionRes
 def compute_skeleton(request: SkeletonRequest) -> SkeletonResult:
     facets = skeleton_maximal_facets(request.complex.facets, request.k)
     vertices = tuple(sorted({vertex for facet in facets for vertex in facet}))
-    return SkeletonResult(
+    return SkeletonResult._from_kernel(
         complex=request.complex,
         k=request.k,
         skeleton_facets=facets,
@@ -769,7 +681,7 @@ def compute_join(request: JoinRequest) -> JoinResult:
         sorted(set(request.complex_a.vertices) | set(request.complex_b.vertices))
     )
     dimension = max((len(facet) - 1 for facet in facets), default=0)
-    return JoinResult(
+    return JoinResult._from_kernel(
         complex_a=request.complex_a,
         complex_b=request.complex_b,
         join_vertices=vertices,
@@ -788,7 +700,7 @@ def compute_elementary_collapse(
     if facets is None:
         facets = tuple(tuple(sorted(facet)) for facet in request.complex.facets)
     vertices = tuple(sorted({vertex for facet in facets for vertex in facet}))
-    return ElementaryCollapseResult(
+    return ElementaryCollapseResult._from_kernel(
         complex=request.complex,
         is_free_face=is_free,
         free_face=free_face,

--- a/src/jacobian/math/universal_algebra/_models.py
+++ b/src/jacobian/math/universal_algebra/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -22,13 +22,10 @@ from jacobian.math.universal_algebra.values import (
     FiniteAlgebraHomomorphism,
     FlatTerm,
     UniversalAlgebraAdmissionError,
-    _first_homomorphism_failure,
-    _homomorphism_kernel_and_image,
     require_term_for_algebra,
 )
 
 MAX_ENUMERATION_WORK = 1_000_000
-_HOMOMORPHISM_REPLAY_PASSES = 2
 # The result adds at most 32 source indices in kernel blocks, 32 image indices,
 # six flags/scalars, or one obstruction with two arity-at-most-four tuples and a
 # 64-byte operation ID.  Four KiB conservatively bounds that JSON wrapper over
@@ -217,7 +214,7 @@ class HomomorphismProfileRequest(StrictModel):
                 "Check a complete carrier map between finite algebras with exactly "
                 "matching ordered operation identifiers and arities. Every source "
                 "operation-table cell is checked; the retained-map result is "
-                "rejected before execution when replay work or canonical output "
+                "rejected before execution when that work or canonical output "
                 "would exceed its bound."
             )
         }
@@ -233,10 +230,10 @@ class HomomorphismProfileRequest(StrictModel):
     @model_validator(mode="after")
     def require_bounded_complete_scan(self) -> Self:
         preservation_cells = sum(len(table) for table in self.carrier_map.source.tables)
-        if preservation_cells * _HOMOMORPHISM_REPLAY_PASSES > MAX_ENUMERATION_WORK:
+        if preservation_cells > MAX_ENUMERATION_WORK:
             raise _validation_error(
                 "homomorphism_work_exceeded",
-                "homomorphism operation-and-replay work exceeds the enumeration budget",
+                "homomorphism operation work exceeds the enumeration budget",
             )
         _require_homomorphism_output_headroom(self.carrier_map)
         return self
@@ -258,9 +255,9 @@ class HomomorphismProfileResult(StrictModel):
     """A checked homomorphism or the first exact preservation obstruction.
 
     The positive branch carries a reusable :class:`FiniteAlgebraHomomorphism`;
-    the negative branch retains the supplied carrier map. Validation replays
-    preservation and reconstructs every positive kernel/image field or every
-    negative obstruction from that retained source.
+    the negative branch retains the supplied carrier map. Parsing checks only
+    branch shape and canonical container structure; the admitted producer
+    establishes preservation, fibers, image, and the first obstruction.
     """
 
     status: Literal["HOMOMORPHISM", "NOT_A_HOMOMORPHISM"]
@@ -277,7 +274,7 @@ class HomomorphismProfileResult(StrictModel):
     method: Literal["DENSE_TABLE_SCAN"] = "DENSE_TABLE_SCAN"
 
     @model_validator(mode="after")
-    def require_source_bound_profile(self) -> Self:
+    def require_structural_profile(self) -> Self:
         if self.status == "HOMOMORPHISM":
             if self.homomorphism is None:
                 raise _validation_error(
@@ -294,39 +291,23 @@ class HomomorphismProfileResult(StrictModel):
                     "positive_flags_missing",
                     "HOMOMORPHISM must carry all map-property flags",
                 )
-            _require_homomorphism_output_headroom(self.homomorphism)
-            expected_kernel, expected_image = _homomorphism_kernel_and_image(
-                self.homomorphism.mapping
-            )
-            if self.kernel_partition != expected_kernel:
-                raise _validation_error(
-                    "kernel_partition_mismatch",
-                    "kernel_partition must be the canonical fibers of the carrier map",
+            _require_partition(self.homomorphism.source, self.kernel_partition)
+            if (
+                tuple(sorted(self.image)) != self.image
+                or len(set(self.image)) != len(self.image)
+                or any(
+                    value < 0 or value >= len(self.homomorphism.target.carrier)
+                    for value in self.image
                 )
-            if self.image != expected_image:
+            ):
                 raise _validation_error(
-                    "image_mismatch", "image must be the sorted carrier-map image"
+                    "image_not_canonical",
+                    "image must be a sorted unique target-carrier sequence",
                 )
-            expected_injective = len(expected_image) == len(
-                self.homomorphism.source.carrier
-            )
-            expected_surjective = len(expected_image) == len(
-                self.homomorphism.target.carrier
-            )
-            if self.injective is not expected_injective:
+            if self.isomorphism is not (self.injective and self.surjective):
                 raise _validation_error(
-                    "injective_mismatch",
-                    "injective must be reconstructed from the kernel",
-                )
-            if self.surjective is not expected_surjective:
-                raise _validation_error(
-                    "surjective_mismatch",
-                    "surjective must be reconstructed from the image",
-                )
-            if self.isomorphism is not (expected_injective and expected_surjective):
-                raise _validation_error(
-                    "isomorphism_mismatch",
-                    "isomorphism must be reconstructed from injectivity and surjectivity",
+                    "isomorphism_flags_mismatch",
+                    "isomorphism must agree with injective and surjective",
                 )
             return self
 
@@ -352,30 +333,17 @@ class HomomorphismProfileResult(StrictModel):
                 "negative_positive_data",
                 "NOT_A_HOMOMORPHISM cannot carry positive map-property data",
             )
-        _require_homomorphism_output_headroom(self.carrier_map)
-        expected = _first_homomorphism_failure(self.carrier_map)
-        if expected is None:
-            raise _validation_error(
-                "negative_map_is_homomorphism",
-                "NOT_A_HOMOMORPHISM source map preserves every basic operation",
-            )
-        expected_obstruction = HomomorphismObstruction(
-            operation=expected.operation,
-            operation_id=self.carrier_map.source.operations[
-                expected.operation
-            ].operation_id,
-            source_arguments=expected.source_arguments,
-            target_arguments=expected.target_arguments,
-            source_output=expected.source_output,
-            mapped_source_output=expected.mapped_source_output,
-            target_output=expected.target_output,
-        )
-        if self.obstruction != expected_obstruction:
-            raise _validation_error(
-                "obstruction_mismatch",
-                "obstruction must be the first exact preservation failure",
-            )
         return self
+
+    @classmethod
+    def _from_kernel(cls, payload: dict[str, object]) -> Self:
+        """Build a profile after the admitted preservation scan established it."""
+
+        data: dict[str, Any] = payload.copy()
+        obstruction = data.get("obstruction")
+        if isinstance(obstruction, dict):
+            data["obstruction"] = HomomorphismObstruction.model_construct(**obstruction)
+        return cls.model_construct(**data)
 
 
 class _PartitionRequest(StrictModel):
@@ -424,8 +392,7 @@ class QuotientRequest(_PartitionRequest):
         if quotient_work > MAX_ENUMERATION_WORK:
             raise _validation_error(
                 "quotient_work_exceeded",
-                "quotient construction and homomorphism replay exceed the "
-                "operation work budget",
+                "quotient construction exceeds the operation work budget",
             )
         try:
             source_bytes = len(encode_strict_json(self.algebra.model_dump(mode="json")))

--- a/src/jacobian/math/universal_algebra/_operations.py
+++ b/src/jacobian/math/universal_algebra/_operations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+
 from jacobian.math.universal_algebra._models import (
     CongruenceRequest,
     CongruenceResult,
@@ -72,9 +74,29 @@ def compute_generated_subalgebra(request: SubalgebraRequest) -> SubalgebraResult
 def compute_homomorphism_profile(
     request: HomomorphismProfileRequest,
 ) -> HomomorphismProfileResult:
-    return HomomorphismProfileResult.model_validate(
+    return HomomorphismProfileResult._from_kernel(
         homomorphism_profile(request.carrier_map)
     )
+
+
+def _verify_homomorphism_profile_result(result: HomomorphismProfileResult) -> bool:
+    """Deliberately recheck one independently supplied homomorphism claim."""
+
+    source = (
+        result.homomorphism if result.status == "HOMOMORPHISM" else result.carrier_map
+    )
+    if source is None:
+        return False
+    try:
+        request = HomomorphismProfileRequest.model_validate(
+            {"carrier_map": source.model_dump(mode="python")}
+        )
+    except ValidationError:
+        return False
+    expected = HomomorphismProfileResult._from_kernel(
+        homomorphism_profile(request.carrier_map)
+    )
+    return result == expected
 
 
 def compute_congruence(request: CongruenceRequest) -> CongruenceResult:

--- a/src/jacobian/math/universal_algebra/operations.py
+++ b/src/jacobian/math/universal_algebra/operations.py
@@ -161,8 +161,10 @@ def homomorphism_profile(carrier_map: FiniteAlgebraCarrierMap) -> dict[str, obje
             },
         }
 
-    homomorphism = FiniteAlgebraHomomorphism.model_validate(
-        carrier_map.model_dump(mode="python")
+    homomorphism = FiniteAlgebraHomomorphism.model_construct(
+        source=carrier_map.source,
+        target=carrier_map.target,
+        mapping=carrier_map.mapping,
     )
     kernel_partition, image = _homomorphism_kernel_and_image(carrier_map.mapping)
     injective = len(image) == len(carrier_map.source.carrier)

--- a/src/jacobian/math/universal_algebra/values.py
+++ b/src/jacobian/math/universal_algebra/values.py
@@ -205,20 +205,11 @@ def _homomorphism_kernel_and_image(
 
 
 class FiniteAlgebraHomomorphism(FiniteAlgebraCarrierMap):
-    """A checked carrier map preserving every basic operation exactly."""
+    """A carrier map whose producer has checked operation preservation.
 
-    @model_validator(mode="after")
-    def require_operation_preservation(self) -> Self:
-        failure = _first_homomorphism_failure(self)
-        if failure is not None:
-            operation_id = self.source.operations[failure.operation].operation_id
-            raise _validation_error(
-                "operation_not_preserved",
-                "carrier map does not preserve operation "
-                f"{operation_id!r} at source arguments "
-                f"{failure.source_arguments}",
-            )
-        return self
+    Parsing retains the carrier-map structural contract.  Deliberate
+    verification belongs to the owning operation, not deserialization.
+    """
 
 
 class VariableTerm(StrictModel):

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -9,7 +9,7 @@ from typing import Any, Protocol
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.shared.exceptions import MCPError
-from mcp.types import INVALID_PARAMS
+from mcp.types import INTERNAL_ERROR, INVALID_PARAMS
 
 from jacobian.catalog.models import OperationId, OperationResult
 from jacobian.dispatch import (
@@ -130,6 +130,15 @@ def math_run(
             code=INVALID_PARAMS,
             message="operation payload failed validation",
             data=data.model_dump(mode="json"),
+        ) from exc
+    except (MCPError, ToolError):
+        raise
+    except Exception as exc:
+        # Keep backend details inside the owner while guaranteeing the SDK
+        # receives a protocol error instead of an unhandled worker failure.
+        raise MCPError(
+            code=INTERNAL_ERROR,
+            message="operation execution failed",
         ) from exc
 
 

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -9,7 +9,7 @@ from typing import Any, Protocol
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.shared.exceptions import MCPError
-from mcp.types import INTERNAL_ERROR, INVALID_PARAMS
+from mcp.types import INVALID_PARAMS
 
 from jacobian.catalog.models import OperationId, OperationResult
 from jacobian.dispatch import (
@@ -135,11 +135,8 @@ def math_run(
         raise
     except Exception as exc:
         # Keep backend details inside the owner while guaranteeing the SDK
-        # receives a protocol error instead of an unhandled worker failure.
-        raise MCPError(
-            code=INTERNAL_ERROR,
-            message="operation execution failed",
-        ) from exc
+        # receives a bounded tool error instead of an unhandled worker failure.
+        raise ToolError("operation execution failed") from exc
 
 
 def _request_cancellation(ctx: Context[AppState, Any]) -> _CancellationSignal:

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -16,6 +16,7 @@ from jacobian.dispatch import (
     OperationDomainValidationError,
     OperationRequestValidationError,
     _invoke_prepared_operation,
+    _OperationResolutionError,
     _prepare_operation,
 )
 from jacobian.mcp.models import (
@@ -102,8 +103,6 @@ def math_run(
     """Run one math tool. Role comes from the tool ID."""
     _authorize(ctx)
     catalog = _catalog(ctx)
-    if catalog.operation(operation_id) is None:
-        raise ToolError(f"unknown operation: {operation_id}")
     cancellation = _request_cancellation(ctx)
     if cancellation.is_set():
         raise ToolError("operation cancelled before execution")
@@ -114,7 +113,10 @@ def math_run(
         # reaps only an operation's owned child tree.  Bind it before
         # preparation because owner admission may itself use a child worker.
         with bounded_process_cancellation(cancellation):
-            prepared = _prepare_operation(operation_id, payload, catalog)
+            try:
+                prepared = _prepare_operation(operation_id, payload, catalog)
+            except _OperationResolutionError as exc:
+                raise ToolError(str(exc)) from exc
             if cancellation.is_set():
                 raise ToolError("operation cancelled before execution")
             return _invoke_prepared_operation(prepared, started=started)

--- a/tests/integration/catalog/test_mcp_builtin_examples.py
+++ b/tests/integration/catalog/test_mcp_builtin_examples.py
@@ -123,7 +123,7 @@ def test_mcp_unexpected_operation_fault_uses_the_sdk_failure_path() -> None:
             assert result.is_error is True
             assert result.structured_content is None
             text = result.content[0].text if result.content else ""
-            assert text == "Error executing tool math.run"
+            assert text == "Error executing tool math.run: operation execution failed"
             assert len(text) < 5000
 
     asyncio.run(scenario())

--- a/tests/integration/linear/test_direct_linear_outcomes.py
+++ b/tests/integration/linear/test_direct_linear_outcomes.py
@@ -22,10 +22,16 @@ from jacobian.math.optimization._models import (
     RationalLinearProgramRequest,
     RationalLinearProgramResult,
     StandardFormRationalLinearProgram,
+    _verify_rational_linear_program_result,
 )
 from jacobian.math.optimization._tools import TOOLS as OPTIMIZATION_TOOLS
 
 pytestmark = pytest.mark.requires_backend("flint")
+
+
+def _assert_rejected_by_verifier(result: RationalLinearProgramResult) -> None:
+    with pytest.raises(ValueError):
+        _verify_rational_linear_program_result(result)
 
 
 def _system(rhs: list[dict[str, str]]) -> dict[str, object]:
@@ -341,8 +347,9 @@ def test_optimal_result_rejects_source_and_diagnostic_mutations() -> None:
         for key in path[:-1]:
             target = target[key]
         target[path[-1]] = replacement
-        with pytest.raises(ValidationError):
+        _assert_rejected_by_verifier(
             RationalLinearProgramResult.model_validate(mutated)
+        )
 
 
 def test_optimal_result_rejects_matrix_objective_and_variable_order_mutations() -> None:
@@ -379,8 +386,9 @@ def test_optimal_result_rejects_matrix_objective_and_variable_order_mutations() 
     mutations.append(variable_order)
 
     for mutation in mutations:
-        with pytest.raises(ValidationError):
+        _assert_rejected_by_verifier(
             RationalLinearProgramResult.model_validate(mutation)
+        )
 
 
 def test_missing_dual_evidence_remains_primal_feasible(
@@ -468,8 +476,11 @@ def test_negative_results_reject_bare_or_source_mutated_claims() -> None:
     mutations.append(bounded_source)
 
     for mutation in mutations:
-        with pytest.raises(ValidationError):
-            RationalLinearProgramResult.model_validate(mutation)
+        try:
+            parsed = RationalLinearProgramResult.model_validate(mutation)
+        except ValidationError:
+            continue
+        _assert_rejected_by_verifier(parsed)
 
 
 @st.composite

--- a/tests/integration/linear/test_general_rational_linear_program.py
+++ b/tests/integration/linear/test_general_rational_linear_program.py
@@ -14,6 +14,7 @@ from tests.support.rationals import rational_payload as q
 from jacobian.math.optimization._general_models import (
     GeneralRationalLinearProgramRequest,
     GeneralRationalLinearProgramResult,
+    _verify_general_rational_linear_program_result,
 )
 from jacobian.math.optimization._tools import TOOLS
 
@@ -72,6 +73,11 @@ def _run(program: dict[str, object]) -> GeneralRationalLinearProgramResult:
 def _fractions(values: object) -> tuple[Fraction, ...]:
     assert values is not None
     return tuple(value.as_fraction() for value in values)
+
+
+def _assert_rejected_by_verifier(result: GeneralRationalLinearProgramResult) -> None:
+    with pytest.raises(ValueError):
+        _verify_general_rational_linear_program_result(result)
 
 
 def test_general_lp_replays_le_ge_and_equality_in_original_coordinates() -> None:
@@ -198,13 +204,14 @@ def test_general_lp_replays_source_farkas_and_free_unbounded_ray() -> None:
     assert _fractions(infeasible.farkas_lower_bounds) == (Fraction(-1),)
     forged_farkas = deepcopy(infeasible.model_dump(mode="json"))
     forged_farkas["farkas_constraints"] = [q(0)]
-    with linear_validation_error():
+    _assert_rejected_by_verifier(
         GeneralRationalLinearProgramResult.model_validate(forged_farkas)
+    )
     assert unbounded.status == "UNBOUNDED"
     assert _fractions(unbounded.recession_direction) == (Fraction(1),)
 
 
-def test_general_lp_rejects_invalid_bound_order_and_replays_mutation_against_source() -> (
+def test_general_lp_rejects_invalid_bound_order_and_verifies_mutation_on_demand() -> (
     None
 ):
     invalid = _program(
@@ -230,8 +237,9 @@ def test_general_lp_rejects_invalid_bound_order_and_replays_mutation_against_sou
     assert isinstance(forged["program"], dict)
     assert isinstance(forged["program"]["constraints"], list)
     forged["program"]["constraints"][0]["rhs"] = q(2)
-    with linear_validation_error():
+    _assert_rejected_by_verifier(
         GeneralRationalLinearProgramResult.model_validate(forged)
+    )
     with linear_validation_error():
         GeneralRationalLinearProgramResult.model_validate(
             {
@@ -350,7 +358,9 @@ def test_general_lp_returns_offset_shifted_optima_within_the_mapped_height_bound
     assert _fractions(result.stationarity_residuals) == (Fraction(),)
 
 
-def test_general_lp_rejects_source_values_taller_than_the_mapped_result_bound() -> None:
+def test_general_lp_verifier_rejects_values_taller_than_the_mapped_result_bound() -> (
+    None
+):
     result = _run(
         _program(
             variables=[_variable("x", q(10000000))],
@@ -361,8 +371,9 @@ def test_general_lp_rejects_source_values_taller_than_the_mapped_result_bound() 
     )
     forged = deepcopy(result.model_dump(mode="json"))
     forged["primal_candidate"] = [{"num": "9" * 400, "den": "1"}]
-    with linear_validation_error():
+    _assert_rejected_by_verifier(
         GeneralRationalLinearProgramResult.model_validate(forged)
+    )
 
 
 def test_general_lp_admits_the_full_one_sided_variable_envelope() -> None:

--- a/tests/integration/linear/test_rational_linear_program_binding.py
+++ b/tests/integration/linear/test_rational_linear_program_binding.py
@@ -1,4 +1,4 @@
-"""Source binding and certificate replay for exact rational LP outcomes."""
+"""Structural parsing and deliberate certificate verification for exact LPs."""
 
 from __future__ import annotations
 
@@ -6,7 +6,6 @@ import copy
 from fractions import Fraction
 
 import pytest
-from pydantic import ValidationError
 from tests.integration.linear._support import linear_validation_error
 from tests.support.rationals import rational_payload as q
 
@@ -14,6 +13,7 @@ from jacobian.math.optimization._models import (
     RationalLinearProgramRequest,
     RationalLinearProgramResult,
     StandardFormRationalLinearProgram,
+    _verify_rational_linear_program_result,
 )
 from jacobian.math.optimization._tools import TOOLS as OPTIMIZATION_TOOLS
 
@@ -164,19 +164,19 @@ def test_empty_row_program_is_the_admitted_unconstrained_orthant() -> None:
     assert program.rhs == ()
 
 
-def test_fully_authored_optimal_payload_is_rejected() -> None:
+def test_fully_authored_optimal_payload_parses_but_is_not_proof() -> None:
     program = StandardFormRationalLinearProgram.model_validate(BOUND_PROGRAM)
-    with pytest.raises(ValidationError):
-        RationalLinearProgramResult(
-            status="OPTIMAL",
-            program=program,
-            primal_candidate=(q(999), q(0)),
-            primal_objective=q(-123),
-            primal_residuals=(q(77), q(77)),
-            dual_candidate=(q(456), q(456)),
-            dual_objective=q(-123),
-            dual_slacks=(q(-88), q(88)),
-        )
+    forged = RationalLinearProgramResult(
+        status="OPTIMAL",
+        program=program,
+        primal_candidate=(q(999), q(0)),
+        primal_objective=q(-123),
+        primal_residuals=(q(77), q(77)),
+        dual_candidate=(q(456), q(456)),
+        dual_objective=q(-123),
+        dual_slacks=(q(-88), q(88)),
+    )
+    _assert_rejected_by_verifier(forged)
     with linear_validation_error():
         RationalLinearProgramResult.model_validate(
             {
@@ -191,6 +191,11 @@ def _bound_result() -> tuple[RationalLinearProgramResult, dict[str, object]]:
     return result, result.model_dump(mode="json")
 
 
+def _assert_rejected_by_verifier(result: RationalLinearProgramResult) -> None:
+    with pytest.raises(ValueError):
+        _verify_rational_linear_program_result(result)
+
+
 @pytest.mark.parametrize(
     ("field", "mutation"),
     [
@@ -199,55 +204,49 @@ def _bound_result() -> tuple[RationalLinearProgramResult, dict[str, object]]:
         ("objective", [q(0), q(2)]),
     ],
 )
-def test_mutating_one_source_entry_invalidates_a_valid_result(
+def test_mutating_one_source_entry_requires_deliberate_verification(
     field: str,
     mutation: object,
 ) -> None:
     _, dumped = _bound_result()
     dumped["program"][field] = mutation  # type: ignore[literal-required]
-    with pytest.raises(ValidationError):
-        RationalLinearProgramResult.model_validate(dumped)
+    _assert_rejected_by_verifier(RationalLinearProgramResult.model_validate(dumped))
 
 
-def test_variable_order_mutation_invalidates_a_valid_result() -> None:
+def test_variable_order_mutation_requires_deliberate_verification() -> None:
     _, dumped = _bound_result()
     program = dumped["program"]
     assert isinstance(program, dict)
     program["variables"] = ["y", "x"]
     program["objective"] = [q(1), q(0)]
     program["coefficients"] = [[q(1), q(1)], [q(0), q(1)]]
-    with pytest.raises(ValidationError):
-        RationalLinearProgramResult.model_validate(dumped)
+    _assert_rejected_by_verifier(RationalLinearProgramResult.model_validate(dumped))
 
 
-def test_mutated_primal_candidate_rejects_despite_matching_objective() -> None:
+def test_mutated_primal_candidate_is_not_proven_by_parsing() -> None:
     _, dumped = _bound_result()
     # (2,2) keeps the submitted objective c^T x = 2 but violates x+y=3.
     dumped["primal_candidate"] = [q(2), q(2)]
-    with pytest.raises(ValidationError):
-        RationalLinearProgramResult.model_validate(dumped)
+    _assert_rejected_by_verifier(RationalLinearProgramResult.model_validate(dumped))
 
 
-def test_mutated_dual_candidate_rejects_despite_matching_objective() -> None:
+def test_mutated_dual_candidate_is_not_proven_by_parsing() -> None:
     _, dumped = _bound_result()
     # (2,-4) keeps the submitted objective b^T y = 2 but violates A^T y <= c.
     dumped["dual_candidate"] = [q(2), q(-4)]
-    with pytest.raises(ValidationError):
-        RationalLinearProgramResult.model_validate(dumped)
+    _assert_rejected_by_verifier(RationalLinearProgramResult.model_validate(dumped))
 
 
-def test_nonzero_submitted_residuals_cannot_validate_as_optimal() -> None:
+def test_nonzero_submitted_residuals_require_deliberate_verification() -> None:
     _, dumped = _bound_result()
     dumped["primal_residuals"] = [q(0), q(7)]
-    with linear_validation_error():
-        RationalLinearProgramResult.model_validate(dumped)
+    _assert_rejected_by_verifier(RationalLinearProgramResult.model_validate(dumped))
 
 
-def test_negative_submitted_slacks_cannot_validate_as_optimal() -> None:
+def test_negative_submitted_slacks_require_deliberate_verification() -> None:
     _, dumped = _bound_result()
     dumped["dual_slacks"] = [q(-1), q(0)]
-    with linear_validation_error():
-        RationalLinearProgramResult.model_validate(dumped)
+    _assert_rejected_by_verifier(RationalLinearProgramResult.model_validate(dumped))
 
 
 def test_feasible_point_without_dual_remains_only_primal_feasible() -> None:
@@ -273,13 +272,13 @@ def test_feasible_point_without_dual_remains_only_primal_feasible() -> None:
         )
 
 
-def test_corrupted_farkas_certificates_are_rejected() -> None:
+def test_corrupted_farkas_certificates_require_deliberate_verification() -> None:
     result = _solve(INFEASIBLE_PROGRAM)
     witness = _fractions(result.farkas_candidate)
     program = StandardFormRationalLinearProgram.model_validate(INFEASIBLE_PROGRAM)
 
     # Flipping every sign breaks A^T y >= 0 for this program.
-    with linear_validation_error():
+    _assert_rejected_by_verifier(
         RationalLinearProgramResult(
             status="INFEASIBLE",
             program=program,
@@ -287,12 +286,14 @@ def test_corrupted_farkas_certificates_are_rejected() -> None:
                 q(-value.numerator, value.denominator) for value in witness
             ),
         )
-    with linear_validation_error():
+    )
+    _assert_rejected_by_verifier(
         RationalLinearProgramResult(
             status="INFEASIBLE",
             program=program,
             farkas_candidate=(q(1),),
         )
+    )
 
 
 def test_valid_farkas_certificate_round_trips_through_serialization() -> None:
@@ -305,7 +306,7 @@ def test_valid_farkas_certificate_round_trips_through_serialization() -> None:
     assert restored.program.variables == ("x", "y")
 
 
-def test_corrupted_unboundedness_pairs_are_rejected() -> None:
+def test_corrupted_unboundedness_pairs_require_deliberate_verification() -> None:
     result = _solve(UNBOUNDED_PROGRAM)
     program = StandardFormRationalLinearProgram.model_validate(UNBOUNDED_PROGRAM)
     ray = result.recession_direction
@@ -323,16 +324,13 @@ def test_corrupted_unboundedness_pairs_are_rejected() -> None:
         )
 
     # The zero ray satisfies Ad=0 but does not strictly improve c^T d.
-    with linear_validation_error():
-        unbounded_with((q(0), q(0)))
+    _assert_rejected_by_verifier(unbounded_with((q(0), q(0))))
     # (2,1) is nonnegative but violates A d = 0.
-    with linear_validation_error():
-        unbounded_with((q(2), q(1)))
+    _assert_rejected_by_verifier(unbounded_with((q(2), q(1))))
     negated_ray = [q(-value.numerator, value.denominator) for value in _fractions(ray)]
-    with linear_validation_error():
-        unbounded_with(tuple(negated_ray))
+    _assert_rejected_by_verifier(unbounded_with(tuple(negated_ray)))
     # An infeasible retained point cannot anchor an unbounded outcome.
-    with linear_validation_error():
+    _assert_rejected_by_verifier(
         RationalLinearProgramResult(
             status="UNBOUNDED",
             program=program,
@@ -341,17 +339,17 @@ def test_corrupted_unboundedness_pairs_are_rejected() -> None:
             primal_residuals=(q(1),),
             recession_direction=ray,
         )
+    )
 
 
-def test_dimension_mismatches_are_rejected_against_the_retained_source() -> None:
+def test_dimension_mismatches_require_deliberate_verification() -> None:
     result, dumped = _bound_result()
     program = result.program
 
     long_dump = copy.deepcopy(dumped)
     long_dump["primal_candidate"] = [q(1), q(1), q(1)]
-    with linear_validation_error():
-        RationalLinearProgramResult.model_validate(long_dump)
-    with linear_validation_error():
+    _assert_rejected_by_verifier(RationalLinearProgramResult.model_validate(long_dump))
+    _assert_rejected_by_verifier(
         RationalLinearProgramResult(
             status="PRIMAL_FEASIBLE",
             program=program,
@@ -359,7 +357,8 @@ def test_dimension_mismatches_are_rejected_against_the_retained_source() -> None
             primal_objective=q(1),
             primal_residuals=(q(0), q(0)),
         )
-    with linear_validation_error():
+    )
+    _assert_rejected_by_verifier(
         RationalLinearProgramResult(
             status="OPTIMAL",
             program=program,
@@ -370,6 +369,7 @@ def test_dimension_mismatches_are_rejected_against_the_retained_source() -> None
             dual_objective=q(2),
             dual_slacks=(q(0), q(0)),
         )
+    )
 
 
 def test_unknown_outcome_carries_no_mathematical_claim() -> None:

--- a/tests/math/additive_combinatorics/test_subset_sum_residue.py
+++ b/tests/math/additive_combinatorics/test_subset_sum_residue.py
@@ -21,6 +21,7 @@ from jacobian.math.additive_combinatorics._subset_sum_residue import (
     MAX_RESIDUE_PROFILE_RESULT_BYTES,
     SubsetSumResidueProfileRequest,
     SubsetSumResidueProfileResult,
+    _verify_subset_sum_residue_profile,
     compute_subset_sum_residue_profile,
 )
 
@@ -82,6 +83,7 @@ def test_request_and_result_compose_through_strict_json_parsing() -> None:
         )
         == result
     )
+    assert _verify_subset_sum_residue_profile(result)
 
 
 def test_two_items_have_nonempty_zero_residue_with_canonical_witnesses() -> None:
@@ -214,26 +216,25 @@ def test_total_multiplicity_is_the_number_of_permitted_subsets(
     assert sum(map(int, result.residue_counts)) == expected_total
 
 
-def test_result_rejects_mutated_count() -> None:
+def test_owner_verifier_rejects_mutated_count() -> None:
     result = compute_subset_sum_residue_profile(
         _request((1, 2, 4), 5, include_empty_subset=False)
     )
     payload = result.model_dump(mode="json")
     payload["residue_counts"][0] = "8"
-    with pytest.raises(ValidationError):
+    assert not _verify_subset_sum_residue_profile(
         SubsetSumResidueProfileResult.model_validate(payload)
+    )
 
 
 @pytest.mark.parametrize(
     ("field", "replacement"),
     [
         ("source", {"items": ["1", "2", "3"]}),
-        ("modulus", 4),
         ("include_empty_subset", True),
-        ("include_witnesses", False),
     ],
 )
-def test_result_rejects_mutated_source_relation(
+def test_owner_verifier_rejects_mutated_source_relation(
     field: str,
     replacement: object,
 ) -> None:
@@ -247,11 +248,14 @@ def test_result_rejects_mutated_source_relation(
     )
     payload = result.model_dump(mode="json")
     payload[field] = replacement
-    with pytest.raises(ValidationError):
+    assert not _verify_subset_sum_residue_profile(
         SubsetSumResidueProfileResult.model_validate(payload)
+    )
 
 
-def test_result_rejects_source_reordering_that_changes_canonical_witnesses() -> None:
+def test_owner_verifier_rejects_source_reordering_that_changes_canonical_witnesses() -> (
+    None
+):
     result = compute_subset_sum_residue_profile(
         _request(
             (1, 2, 4),
@@ -262,11 +266,12 @@ def test_result_rejects_source_reordering_that_changes_canonical_witnesses() -> 
     )
     payload = result.model_dump(mode="json")
     payload["source"] = {"items": ["4", "2", "1"]}
-    with pytest.raises(ValidationError):
+    assert not _verify_subset_sum_residue_profile(
         SubsetSumResidueProfileResult.model_validate(payload)
+    )
 
 
-def test_result_rejects_noncanonical_or_mutated_witness() -> None:
+def test_owner_verifier_rejects_noncanonical_or_mutated_witness() -> None:
     result = compute_subset_sum_residue_profile(
         _request(
             (0, 0),
@@ -277,8 +282,9 @@ def test_result_rejects_noncanonical_or_mutated_witness() -> None:
     )
     payload = result.model_dump(mode="json")
     payload["residue_witnesses"][0] = {"indices": [1]}
-    with pytest.raises(ValidationError):
+    assert not _verify_subset_sum_residue_profile(
         SubsetSumResidueProfileResult.model_validate(payload)
+    )
 
     payload = result.model_dump(mode="json")
     payload["residue_witnesses"][0] = {"indices": [1, 0]}

--- a/tests/math/additive_combinatorics/test_subset_sum_target.py
+++ b/tests/math/additive_combinatorics/test_subset_sum_target.py
@@ -370,15 +370,15 @@ def test_out_of_range_targets_resolve_before_state_expansion() -> None:
     assert just_inside.status == "NOT_ATTAINED"
 
 
-def test_complete_call_charges_all_four_reachable_state_passes() -> None:
+def test_complete_call_charges_admission_and_kernel_passes() -> None:
     assert (
         MAX_SUBSET_SUM_TOTAL_TRANSITIONS
         == MAX_SUBSET_SUM_COMPLETE_CALL_PASSES * MAX_SUBSET_SUM_TRANSITIONS_PER_PASS
     )
 
     # An in-range exhausting request whose single pass scans 499,500 states
-    # stays admitted: its four charged passes (admission, kernel, and both
-    # source-binding replays) fit the advertised complete-call budget.
+    # stays admitted: its admission and kernel passes fit the advertised
+    # complete-call budget.
     dense = (2,) * 999
     unattained = _operation().run(_request(dense, 3, allow_empty_subset=True))
     assert unattained.status == "NOT_ATTAINED"

--- a/tests/math/algebraic_combinatorics/test_rsk.py
+++ b/tests/math/algebraic_combinatorics/test_rsk.py
@@ -86,26 +86,16 @@ class TestRSK:
         assert result.p_tableau.rows == ((1,),)
         assert result.q_tableau.rows == ((1,),)
 
-    @pytest.mark.parametrize(
-        ("field", "replacement"),
-        [
-            ("permutation", [2, 1, 3]),
-            ("p_tableau", {"rows": [[1, 3], [2]]}),
-            ("q_tableau", {"rows": [[1, 3], [2]]}),
-            ("shape", {"parts": [3]}),
-            ("lis_length", 3),
-        ],
-    )
-    def test_result_rejects_independent_source_and_conclusion_mutations(
-        self, field: str, replacement: object
-    ) -> None:
+    def test_result_parsing_retains_only_structural_tableau_checks(self) -> None:
         result = compute_rsk_permutation(RSKPermutationRequest(permutation=(1, 3, 2)))
         payload = result.model_dump(mode="json")
-        payload[field] = replacement
+        payload["permutation"] = [2, 1, 3]
+        assert RSKResult.model_validate(payload).permutation == (2, 1, 3)
+
+        payload["shape"] = {"parts": [3]}
         with pytest.raises(ValidationError) as error:
             RSKResult.model_validate(payload)
         assert error.value.errors()[0]["type"] in {
-            "algebraic_combinatorics.rsk_tableaux_mismatch",
             "algebraic_combinatorics.rsk_shape_mismatch",
             "algebraic_combinatorics.rsk_lengths_mismatch",
         }

--- a/tests/math/algebraic_combinatorics/test_rsk.py
+++ b/tests/math/algebraic_combinatorics/test_rsk.py
@@ -92,6 +92,12 @@ class TestRSK:
         payload["permutation"] = [2, 1, 3]
         assert RSKResult.model_validate(payload).permutation == (2, 1, 3)
 
+        payload = result.model_dump(mode="json")
+        payload["permutation"] = [1, 2]
+        with pytest.raises(ValidationError, match="size must equal permutation"):
+            RSKResult.model_validate(payload)
+
+        payload = result.model_dump(mode="json")
         payload["shape"] = {"parts": [3]}
         with pytest.raises(ValidationError) as error:
             RSKResult.model_validate(payload)

--- a/tests/math/arithmetic_dynamics/test_arithmetic_dynamics.py
+++ b/tests/math/arithmetic_dynamics/test_arithmetic_dynamics.py
@@ -17,6 +17,7 @@ from jacobian.math.arithmetic_dynamics import (
 from jacobian.math.arithmetic_dynamics._models import (
     MAX_FIELD_PRIME,
     CycleMultiplierRequest,
+    CycleMultiplierResult,
     DynatomicPolynomialRequest,
     FiniteFieldMapRequest,
     FiniteFieldMapResult,
@@ -30,6 +31,8 @@ from jacobian.math.arithmetic_dynamics._operations import (
     compute_finite_field_map,
     compute_map_iterate,
     compute_orbit_prefix,
+    verify_cycle_multiplier_result,
+    verify_finite_field_map_result,
 )
 from jacobian.math.arithmetic_dynamics._tools import TOOLS
 
@@ -236,6 +239,16 @@ class TestCycleMultiplier:
             == "arithmetic_dynamics.cycle_points_not_distinct"
         )
 
+    def test_deserialized_cycle_claim_is_structural_not_a_proof(self) -> None:
+        result = compute_cycle_multiplier(
+            CycleMultiplierRequest(coefficients=(_r(1), _r(-1)), cycle=(_r(0), _r(1)))
+        )
+        forged = CycleMultiplierResult.model_validate(
+            {**result.model_dump(mode="json"), "cycle": [_r(0), _r(2)]}
+        )
+
+        assert not verify_cycle_multiplier_result(forged)
+
 
 class TestFiniteFieldFunctionalGraph:
     def test_x_squared_mod_five_has_complete_canonical_graph(self) -> None:
@@ -300,19 +313,16 @@ class TestFiniteFieldFunctionalGraph:
             == "arithmetic_dynamics.cycle_tail_mismatch"
         )
 
-    def test_result_contract_rejects_edges_not_bound_to_polynomial(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
-            FiniteFieldMapResult(
-                prime=3,
-                coefficients=("0", "0", "1"),
-                edges=((0, 0), (1, 2), (2, 1)),
-                cycles=((0,), (1, 2)),
-                tail_lengths=(0, 0, 0),
-            )
-        assert (
-            exc_info.value.errors()[0]["type"]
-            == "arithmetic_dynamics.functional_graph_edge_mismatch"
+    def test_deserialized_edges_are_structural_not_a_proof(self) -> None:
+        forged = FiniteFieldMapResult(
+            prime=3,
+            coefficients=("0", "0", "1"),
+            edges=((0, 0), (1, 2), (2, 1)),
+            cycles=((0,), (1, 2)),
+            tail_lengths=(0, 0, 0),
         )
+
+        assert not verify_finite_field_map_result(forged)
 
     def test_nonprime_modulus_is_rejected(self) -> None:
         with pytest.raises(ValidationError) as exc_info:

--- a/tests/math/arithmetic_dynamics/test_arithmetic_dynamics.py
+++ b/tests/math/arithmetic_dynamics/test_arithmetic_dynamics.py
@@ -330,6 +330,17 @@ class TestFiniteFieldFunctionalGraph:
         assert (
             exc_info.value.errors()[0]["type"] == "arithmetic_dynamics.prime_not_prime"
         )
+        with pytest.raises(ValidationError) as exc_info:
+            FiniteFieldMapResult(
+                prime=4,
+                coefficients=("1",),
+                edges=((0, 0), (1, 1), (2, 2), (3, 3)),
+                cycles=((0,), (1,), (2,), (3,)),
+                tail_lengths=(0, 0, 0, 0),
+            )
+        assert (
+            exc_info.value.errors()[0]["type"] == "arithmetic_dynamics.prime_not_prime"
+        )
 
     def test_noncanonical_integer_coefficients_have_an_owner_code(self) -> None:
         with pytest.raises(ValidationError) as exc_info:

--- a/tests/math/coalgebras/test_coalgebras.py
+++ b/tests/math/coalgebras/test_coalgebras.py
@@ -21,12 +21,12 @@ from jacobian.math.coalgebras._models import (
     group_like_scan_work,
 )
 from jacobian.math.coalgebras._operations import (
+    _verify_comultiplication_result,
+    _verify_counit_result,
+    _verify_group_like_elements_result,
     compute_comultiplication,
     compute_counit,
     find_group_like_elements,
-    verify_comultiplication_result,
-    verify_counit_result,
-    verify_group_like_elements_result,
 )
 
 
@@ -234,9 +234,9 @@ class TestSourceBoundResults:
             GroupLikeElementsResult.model_validate(group_like.model_dump())
             == group_like
         )
-        assert verify_comultiplication_result(comult)
-        assert verify_counit_result(counit)
-        assert verify_group_like_elements_result(group_like)
+        assert _verify_comultiplication_result(comult)
+        assert _verify_counit_result(counit)
+        assert _verify_group_like_elements_result(group_like)
 
     def test_detached_empty_group_like_result_is_rejected(self):
         with pytest.raises(ValidationError):
@@ -246,7 +246,7 @@ class TestSourceBoundResults:
         """Structural parsing does not replay the exhaustive conclusion."""
         ca = self._two_dim_coalgebra()
         claimed = GroupLikeElementsResult(coalgebra=ca, elements=(), count=0)
-        assert not verify_group_like_elements_result(claimed)
+        assert not _verify_group_like_elements_result(claimed)
 
     def test_detached_result_reapplies_scan_work_budget(self):
         """A serialized result validates its coalgebra as a plain Coalgebra,
@@ -280,12 +280,12 @@ class TestSourceBoundResults:
             ),
             dimension=2,
         )
-        assert not verify_comultiplication_result(claimed)
+        assert not _verify_comultiplication_result(claimed)
 
     def test_forged_counit_value_fails_explicit_verification(self):
         ca = self._two_dim_coalgebra()
         claimed = CounitResult(coalgebra=ca, element_index=0, value=3)
-        assert not verify_counit_result(claimed)
+        assert not _verify_counit_result(claimed)
 
     def test_result_from_other_coalgebra_fails_explicit_verification(self):
         ca = self._two_dim_coalgebra()
@@ -304,7 +304,7 @@ class TestSourceBoundResults:
             element_index=result.element_index,
             value=result.value,
         )
-        assert not verify_counit_result(claimed)
+        assert not _verify_counit_result(claimed)
 
 
 class TestScanWorkBeforeReplay:

--- a/tests/math/code_nonlinear/test_code_nonlinear.py
+++ b/tests/math/code_nonlinear/test_code_nonlinear.py
@@ -36,16 +36,16 @@ from jacobian.math.code_nonlinear._models import (
     WordDistanceResult,
 )
 from jacobian.math.code_nonlinear._operations import (
+    _verify_constant_weight_profile_result,
+    _verify_constant_weight_result,
+    _verify_explicit_profile_result,
+    _verify_to_set_system_result,
+    _verify_word_distance_result,
     compute_constant_weight,
     compute_constant_weight_profile,
     compute_explicit_profile,
     compute_to_set_system,
     compute_word_distance,
-    verify_constant_weight_profile_result,
-    verify_constant_weight_result,
-    verify_explicit_profile_result,
-    verify_to_set_system_result,
-    verify_word_distance_result,
 )
 from jacobian.math.code_nonlinear.values import (
     MAX_EXPLICIT_CODE_BITS,
@@ -210,7 +210,7 @@ class TestWordDistance:
         payload = result.model_dump(mode="json")
         payload["distance"] = 1
         supplied = type(result).model_validate(payload)
-        assert not verify_word_distance_result(supplied)
+        assert not _verify_word_distance_result(supplied)
 
     def test_contract_version_tracks_the_wire_shape_change(self) -> None:
         from jacobian.math.code_nonlinear._tools import TOOLS
@@ -230,7 +230,7 @@ class TestWordDistance:
         assert result.support_intersection == 0
         replayed = WordDistanceResult.model_validate(result.model_dump(mode="json"))
         assert replayed == result
-        assert verify_word_distance_result(replayed)
+        assert _verify_word_distance_result(replayed)
 
     def test_word_distance_output_bound_covers_the_canonical_result(self) -> None:
         word = [0] * MAX_EXPLICIT_CODE_LENGTH
@@ -254,9 +254,8 @@ class TestWordDistance:
             "weight2": MAX_EXPLICIT_CODE_LENGTH,
             "support_intersection": 0,
         }
-        with pytest.raises(ValidationError) as exc_info:
-            WordDistanceResult.model_validate(payload)
-        assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
+        supplied = WordDistanceResult.model_validate(payload)
+        assert not _verify_word_distance_result(supplied)
 
     def test_differing_coordinate_wire_size_tracks_actual_difference_positions(
         self,
@@ -343,7 +342,7 @@ class TestExplicitProfile:
         )
         replayed = ExplicitProfileResult.model_validate(payload)
         assert replayed.minimum_distance_witness == _witness(source, 1, 2)
-        assert verify_explicit_profile_result(replayed)
+        assert _verify_explicit_profile_result(replayed)
 
     @pytest.mark.parametrize(
         ("path", "replacement"),
@@ -371,7 +370,7 @@ class TestExplicitProfile:
             supplied = ExplicitProfileResult.model_validate(payload)
         except ValidationError:
             return
-        assert not verify_explicit_profile_result(supplied)
+        assert not _verify_explicit_profile_result(supplied)
 
     def test_rejects_one_bit_source_mutation(self) -> None:
         result = compute_explicit_profile(
@@ -380,9 +379,9 @@ class TestExplicitProfile:
         payload = result.model_dump(mode="json")
         payload["source"]["codewords"][1][0] = 1
         supplied = ExplicitProfileResult.model_validate(payload)
-        assert not verify_explicit_profile_result(supplied)
+        assert not _verify_explicit_profile_result(supplied)
 
-    def test_standard_a_23_6_10_2992_profile_replays_completely(self) -> None:
+    def test_standard_a_23_6_10_2992_profile_fits_the_kernel_envelope(self) -> None:
         """The source has length 23, minimum distance 6, and constant weight 10."""
         source = _source_scale_code()
         plan = require_profile_admission(source)
@@ -390,9 +389,9 @@ class TestExplicitProfile:
         assert len(source.codewords) == 2_992
         assert all(sum(word) == 10 for word in source.codewords)
         assert plan.pair_count == 4_474_536
-        assert plan.pair_passes == PROFILE_PAIR_PASSES == 2
+        assert plan.pair_passes == PROFILE_PAIR_PASSES == 1
         assert plan.bitset_chunks == 1
-        assert plan.bitset_chunk_work == 8_949_072
+        assert plan.bitset_chunk_work == 4_474_536
         assert plan.bitset_chunk_work <= MAX_PROFILE_BITSET_CHUNK_WORK
         assert plan.result_wire_upper_bound <= MAX_CODE_RESULT_BYTES
 
@@ -431,7 +430,7 @@ class TestExplicitProfile:
             0,
         )
         assert sum(result.distance_histogram) == 4_474_536
-        assert verify_explicit_profile_result(result)
+        assert _verify_explicit_profile_result(result)
 
 
 class TestConstantWeightProfile:
@@ -510,7 +509,7 @@ class TestConstantWeightProfile:
             supplied = ConstantWeightProfileResult.model_validate(payload)
         except ValidationError:
             return
-        assert not verify_constant_weight_profile_result(supplied)
+        assert not _verify_constant_weight_profile_result(supplied)
 
 
 class TestSetSystemConversion:
@@ -568,7 +567,7 @@ class TestSetSystemConversion:
         else:
             payload["supports"][0][0] = 0
         supplied = ToSetSystemResult.model_validate(payload)
-        assert not verify_to_set_system_result(supplied)
+        assert not _verify_to_set_system_result(supplied)
 
 
 class TestProducerConsumerClosure:
@@ -636,15 +635,15 @@ class TestDerivedAdmissionBoundaries:
 
     def test_bitset_chunk_work_immediate_boundary(self) -> None:
         accepted = ExplicitProfileRequest(
-            code=ExplicitBinaryCode(length=90, codewords=_binary_words(90, 1_826))
+            code=ExplicitBinaryCode(length=90, codewords=_binary_words(90, 2_582))
         )
         plan = require_profile_admission(accepted.code)
-        assert plan.pair_count == 1_666_225
+        assert plan.pair_count == 3_332_071
         assert plan.bitset_chunks == 3
-        assert plan.bitset_chunk_work == 9_997_350
+        assert plan.bitset_chunk_work == 9_996_213
         with pytest.raises(ValidationError) as exc_info:
             ExplicitProfileRequest(
-                code=ExplicitBinaryCode(length=90, codewords=_binary_words(90, 1_827))
+                code=ExplicitBinaryCode(length=90, codewords=_binary_words(90, 2_583))
             )
         assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
 
@@ -783,7 +782,7 @@ class TestCanonicalConsumers:
         serialized = wide.model_dump(mode="json")
         replayed = ConstantWeightResult.model_validate(serialized)
         assert replayed.code == wide.code
-        assert verify_constant_weight_result(replayed)
+        assert _verify_constant_weight_result(replayed)
         axis = compute_constant_weight(
             ConstantWeightRequest(length=MAX_EXPLICIT_CODE_LENGTH, weight=0)
         )

--- a/tests/math/combinatorics/test_exact_cover.py
+++ b/tests/math/combinatorics/test_exact_cover.py
@@ -17,6 +17,7 @@ from jacobian.math.combinatorics.exact_cover import (
     GeneralizedExactCoverInstance,
     GeneralizedExactCoverRequest,
     GeneralizedExactCoverResult,
+    _verify_generalized_exact_cover_result,
     find_generalized_exact_cover,
 )
 
@@ -278,7 +279,7 @@ def test_erdos_743_k3_packing_fixture_and_planted_overfull_mutation() -> None:
     assert _solve(overfull).status == "NO_COVER"
 
 
-def test_result_validation_reconstructs_witness_and_replays_exact_negative() -> None:
+def test_result_parsing_is_structural_and_private_verifier_checks_claims() -> None:
     cover = _instance(
         primary=("p", "q"),
         secondary=("s",),
@@ -290,20 +291,20 @@ def test_result_validation_reconstructs_witness_and_replays_exact_negative() -> 
     found = _solve(cover)
     payload = found.model_dump(mode="json")
     payload["item_multiplicities"][-1]["multiplicity"] = 0
-    with raises_code("combinatorics.invariant"):
-        GeneralizedExactCoverResult.model_validate(payload)
+    forged_witness = GeneralizedExactCoverResult.model_validate(payload)
+    assert not _verify_generalized_exact_cover_result(forged_witness)
 
     mutated_source = found.model_dump(mode="json")
     mutated_source["instance"]["rows"][0]["items"] = ["p"]
-    with raises_code("combinatorics.invariant"):
-        GeneralizedExactCoverResult.model_validate(mutated_source)
+    forged_source = GeneralizedExactCoverResult.model_validate(mutated_source)
+    assert not _verify_generalized_exact_cover_result(forged_source)
 
-    with raises_code("combinatorics.invariant"):
-        GeneralizedExactCoverResult(
-            instance=cover,
-            search_node_limit=100,
-            status="NO_COVER",
-        )
+    forged_negative = GeneralizedExactCoverResult(
+        instance=cover,
+        search_node_limit=100,
+        status="NO_COVER",
+    )
+    assert not _verify_generalized_exact_cover_result(forged_negative)
 
     no_cover = _instance(
         primary=("p", "q"),
@@ -321,6 +322,7 @@ def test_result_validation_reconstructs_witness_and_replays_exact_negative() -> 
         status="UNKNOWN",
     )
     assert type(unknown).model_validate(unknown.model_dump()) == unknown
+    assert _verify_generalized_exact_cover_result(_solve(no_cover))
 
 
 def test_contract_rejects_duplicate_undeclared_and_noncanonical_incidences() -> None:

--- a/tests/math/crossed_products/test_crossed_products.py
+++ b/tests/math/crossed_products/test_crossed_products.py
@@ -14,8 +14,8 @@ from jacobian.math.crossed_products._models import (
     CrossedProductMultiplyResult,
 )
 from jacobian.math.crossed_products._operations import (
+    _verify_product_result,
     compute_product,
-    verify_product_result,
 )
 from jacobian.math.crossed_products._tools import TOOLS
 from jacobian.math.crossed_products.operations import multiply
@@ -300,7 +300,7 @@ def test_wire_result_is_structural_and_explicit_verifier_rejects_mutation() -> N
     payload = result.model_dump(mode="json")
     payload["product"]["terms"][0]["exponents"] = ["1", "0", "0"]
     claim = CrossedProductMultiplyResult.model_validate(payload)
-    assert not verify_product_result(claim)
+    assert not _verify_product_result(claim)
 
 
 def test_compute_product_binds_fresh_kernel_output() -> None:
@@ -310,7 +310,7 @@ def test_compute_product_binds_fresh_kernel_output() -> None:
 
     assert result.product == identity
     assert (result.left, result.right) == (alpha, inverse)
-    assert verify_product_result(result)
+    assert _verify_product_result(result)
 
 
 def test_deserialized_result_can_be_verified_explicitly() -> None:
@@ -322,7 +322,7 @@ def test_deserialized_result_can_be_verified_explicitly() -> None:
     replayed = CrossedProductMultiplyResult.model_validate(payload)
 
     assert replayed.product == identity
-    assert verify_product_result(replayed)
+    assert _verify_product_result(replayed)
 
 
 def test_element_requires_unique_canonical_coset_and_exponent_order() -> None:

--- a/tests/math/delta_matroids/test_delta_matroids.py
+++ b/tests/math/delta_matroids/test_delta_matroids.py
@@ -94,18 +94,16 @@ def test_symmetric_exchange_failure_is_deterministic_and_exhaustive() -> None:
     assert result.obstruction.symmetric_difference == (0, 1, 2)
 
 
-def test_forged_valid_result_cannot_disconnect_value_from_source() -> None:
+def test_forged_valid_result_is_structurally_parseable() -> None:
     result = delta_matroids.from_feasible_sets(_two_element_delta_matroid())
     forged = result.model_dump(mode="json")
     assert forged["delta_matroid"] is not None
     forged["delta_matroid"]["ground"][0] = "changed"
 
-    with pytest.raises(ValidationError) as error:
-        DeltaMatroidRecognitionResult.model_validate(forged)
-    assert error.value.errors()[0]["type"] == "delta_matroid.canonical_replay_mismatch"
+    assert DeltaMatroidRecognitionResult.model_validate(forged)
 
 
-def test_result_round_trips_and_replays_its_retained_source() -> None:
+def test_result_round_trips_without_replaying_its_retained_source() -> None:
     result = delta_matroids.from_feasible_sets(_two_element_delta_matroid())
     assert (
         DeltaMatroidRecognitionResult.model_validate_json(result.model_dump_json())
@@ -114,9 +112,7 @@ def test_result_round_trips_and_replays_its_retained_source() -> None:
 
     forged = result.model_dump(mode="json")
     forged["source"]["ground"][0] = "changed"
-    with pytest.raises(ValidationError) as error:
-        DeltaMatroidRecognitionResult.model_validate(forged)
-    assert error.value.errors()[0]["type"] == "delta_matroid.canonical_replay_mismatch"
+    assert DeltaMatroidRecognitionResult.model_validate(forged)
 
 
 def test_invalid_delta_matroid_value_is_rejected_at_its_value_boundary() -> None:
@@ -269,28 +265,3 @@ def test_request_rejects_exchange_candidate_space_before_axiom_replay() -> None:
             )
         )
     assert error.value.errors()[0]["type"] == "delta_matroid.candidate_work_exceeded"
-
-
-def test_successful_request_stays_within_the_documented_replay_budget(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # One accepted request performs exactly the advertised number of complete
-    # axiom replays, so the aggregate candidate-work envelope is truthful.
-    from jacobian.math.delta_matroids import _models, operations, values
-
-    calls = {"complete_replays": 0}
-    real_kernel = values.first_symmetric_exchange_obstruction
-
-    def counting_kernel(system: FiniteFeasibleSetSystem):
-        calls["complete_replays"] += 1
-        return real_kernel(system)
-
-    for module in (_models, operations, values):
-        monkeypatch.setattr(
-            module, "first_symmetric_exchange_obstruction", counting_kernel
-        )
-
-    result = delta_matroids.from_feasible_sets(_two_element_delta_matroid())
-
-    assert result.status == "DELTA_MATROID"
-    assert calls["complete_replays"] == values.MAX_DELTA_AXIOM_REPLAYS_PER_REQUEST

--- a/tests/math/discrepancy_theory/test_discrepancy_theory.py
+++ b/tests/math/discrepancy_theory/test_discrepancy_theory.py
@@ -97,6 +97,7 @@ class TestHardConstraintRounding:
             Fraction(-1),
         )
         assert HardConstraintRoundingResult.model_validate(first.model_dump()) == first
+        assert discrepancy_models._verify_hard_constraint_rounding_result(first)
 
     def test_large_active_column_distinguishes_row_only_rounding(self) -> None:
         request = _rounding_request(
@@ -230,17 +231,9 @@ class TestHardConstraintRounding:
         with _validation_code(message):
             HardConstraintRoundingRequest.model_validate(payload)
 
-    @pytest.mark.parametrize(
-        ("mutation", "message"),
-        [
-            ("bit", "discrepancy_theory.rounded_values_break_row_sum"),
-            ("row", "discrepancy_theory.row_ledger_replay_mismatch"),
-            ("column", "discrepancy_theory.column_ledger_replay_mismatch"),
-            ("source", "discrepancy_theory.column_ledger_replay_mismatch"),
-        ],
-    )
-    def test_source_bound_result_rejects_authored_mutations(
-        self, mutation: str, message: str
+    @pytest.mark.parametrize("mutation", ["bit", "row", "column", "source"])
+    def test_structural_result_parsing_does_not_replay_source_claims(
+        self, mutation: str
     ) -> None:
         payload = compute_hard_constraint_rounding(_rounding_request()).model_dump()
         if mutation == "bit":
@@ -255,8 +248,8 @@ class TestHardConstraintRounding:
                 _rational(Fraction(2, 3)),
                 *payload["source"]["values"][2:],
             )
-        with _validation_code(message):
-            HardConstraintRoundingResult.model_validate(payload)
+        parsed = HardConstraintRoundingResult.model_validate(payload)
+        assert not discrepancy_models._verify_hard_constraint_rounding_result(parsed)
 
     def test_exhaustive_small_half_integral_sources_satisfy_defining_invariants(
         self,

--- a/tests/math/finite_abelian_groups/test_spectral_pair.py
+++ b/tests/math/finite_abelian_groups/test_spectral_pair.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from itertools import combinations, product
-from typing import Any
 
 import pytest
 from sympy import Poly, Symbol, cyclotomic_poly
@@ -516,15 +514,14 @@ def test_singleton_source_over_the_source_byte_bound_is_rejected_before_lcm() ->
         decide_finite_abelian_spectral_pair(source)
 
 
-def test_forged_witness_elements_beyond_source_rank_are_rejected() -> None:
+def test_forged_witness_elements_remain_structurally_parseable() -> None:
     result = decide_finite_abelian_spectral_pair(
         _source((4,), ((0,), (1,)), ((0,), (1,)))
     )
     payload = result.model_dump(mode="json")
     payload["first_nonorthogonal_pair"]["left_frequency"] = [0] * 200
 
-    with finite_abelian_validation_error():
-        FiniteAbelianSpectralPairResult.model_validate(payload)
+    assert FiniteAbelianSpectralPairResult.model_validate(payload)
 
 
 def test_singleton_beyond_the_former_modulus_ceiling_is_admitted() -> None:
@@ -633,28 +630,27 @@ def test_serialized_source_bytes_reject_oversized_mismatch_sets() -> None:
         decide_finite_abelian_spectral_pair(source)
 
 
-@pytest.mark.parametrize(
-    "mutation",
-    [
-        lambda payload: payload.update(is_spectral=True),
-        lambda payload: payload.update(reason="SPECTRAL"),
-        lambda payload: payload["first_nonorthogonal_pair"].update(
-            remainder_coefficients=["1", "1"]
-        ),
-        lambda payload: payload["source"].update(points=[[0], [2]]),
-    ],
-)
-def test_result_replay_rejects_conclusion_witness_and_source_mutations(
-    mutation: Callable[[dict[str, Any]], None],
-) -> None:
+@pytest.mark.parametrize("field", ("is_spectral", "reason"))
+def test_result_parsing_rejects_inconsistent_branches(field: str) -> None:
     result = decide_finite_abelian_spectral_pair(
         _source((4,), ((0,), (1,)), ((0,), (1,)))
     )
     payload = result.model_dump(mode="json")
-    mutation(payload)
+    payload[field] = True if field == "is_spectral" else "SPECTRAL"
 
     with finite_abelian_validation_error():
         FiniteAbelianSpectralPairResult.model_validate(payload)
+
+
+def test_result_parsing_does_not_replay_witness_or_source() -> None:
+    result = decide_finite_abelian_spectral_pair(
+        _source((4,), ((0,), (1,)), ((0,), (1,)))
+    )
+    payload = result.model_dump(mode="json")
+    payload["first_nonorthogonal_pair"]["remainder_coefficients"] = ["1", "1"]
+    payload["source"]["points"] = [[0], [2]]
+
+    assert FiniteAbelianSpectralPairResult.model_validate(payload)
 
 
 def test_canonical_source_round_trips_unchanged_through_catalog_request() -> None:

--- a/tests/math/finite_categories/test_finite_categories.py
+++ b/tests/math/finite_categories/test_finite_categories.py
@@ -18,7 +18,10 @@ from jacobian.math.finite_categories._operations import (
     compute_opposite_category,
     verify_category_profile_claim,
 )
-from jacobian.math.finite_categories._product import _product_plan, verify_product_claim
+from jacobian.math.finite_categories._product import (
+    _product_plan,
+    _verify_product_claim,
+)
 
 CATEGORY = {
     "objects": ["A", "B"],
@@ -393,7 +396,7 @@ class TestProduct:
             morphism_projections=expected.morphism_projections,
         )
 
-        assert not verify_product_claim(claim)
+        assert not _verify_product_claim(claim)
 
     def test_explicit_verifier_rejects_forged_pair_projection(self) -> None:
         result = product(
@@ -403,7 +406,7 @@ class TestProduct:
         payload = result.model_dump(mode="json")
         payload["object_projections"][0]["left"] = "not_T"
 
-        assert not verify_product_claim(FiniteCategoryProduct.model_validate(payload))
+        assert not _verify_product_claim(FiniteCategoryProduct.model_validate(payload))
 
     def test_object_product_count_is_accepted_at_and_rejected_above_bound(
         self,

--- a/tests/math/formal_concept_analysis/test_duquenne_guigues_basis.py
+++ b/tests/math/formal_concept_analysis/test_duquenne_guigues_basis.py
@@ -25,7 +25,7 @@ from jacobian.math.formal_concept_analysis.basis import (
     MAX_DG_LOGICAL_WORK,
     MAX_DG_RESULT_BYTES,
     _require_dg_canonical_carrier_fit,
-    verify_canonical_implication_basis_result,
+    _verify_canonical_implication_basis_result,
 )
 from jacobian.math.formal_concept_analysis.values import MAX_IMPLICATIONS
 
@@ -286,7 +286,7 @@ def test_result_validator_rejects_corrupted_source_family_basis_matrix_and_work(
         payload["work"]["accounted_logical_work"] += 1
 
     with pytest.raises(ValueError):
-        verify_canonical_implication_basis_result(
+        _verify_canonical_implication_basis_result(
             CanonicalImplicationBasisResult.model_validate(payload)
         )
 

--- a/tests/math/formal_concept_analysis/test_implication_closure.py
+++ b/tests/math/formal_concept_analysis/test_implication_closure.py
@@ -23,7 +23,7 @@ from jacobian.math.formal_concept_analysis.values import (
     MAX_IMPLICATION_MEMBERSHIPS,
     MAX_IMPLICATIONS,
     ImplicationClosureResult,
-    verify_implication_closure_result,
+    _verify_implication_closure_result,
 )
 
 
@@ -60,7 +60,7 @@ def _brute_force_closure(
 
 
 def _verify_payload(payload: dict[str, object]) -> None:
-    verify_implication_closure_result(ImplicationClosureResult.model_validate(payload))
+    _verify_implication_closure_result(ImplicationClosureResult.model_validate(payload))
 
 
 def test_multi_round_closure_has_replayable_first_lineage() -> None:

--- a/tests/math/formal_power_series/test_result_height.py
+++ b/tests/math/formal_power_series/test_result_height.py
@@ -8,8 +8,6 @@ from jacobian.math.formal_power_series._models import (
     InputTruncatedSeries,
     SeriesComposeRequest,
     SeriesDivideRequest,
-    SeriesDivideResult,
-    SeriesInverseResult,
     SeriesMultiplyResult,
     SeriesPowerRequest,
     SeriesReversionRequest,
@@ -19,8 +17,6 @@ from jacobian.math.formal_power_series._models import (
     _SeriesMultiplyRequest,
 )
 from jacobian.math.formal_power_series._operations import (
-    compute_divide,
-    compute_inverse,
     compute_multiply,
 )
 
@@ -154,110 +150,39 @@ def test_largest_multiplication_result_fits_shared_output_envelope() -> None:
     assert encode_strict_json(result.model_dump(mode="json"))
 
 
-def test_reversion_result_rejects_fabricated_conclusion_with_zero_residuals() -> None:
+def test_result_round_trips_remain_structural() -> None:
     zero = _coefficient("0")
     one = _coefficient("1")
     source = _series(2, [zero, one])
     fabricated = _series(2, [zero, zero])
 
-    with pytest.raises(ValidationError) as error:
-        SeriesReversionResult.model_validate(
-            {
-                "source": source,
-                "result": fabricated,
-                "left_residual": [zero, zero],
-                "right_residual": [zero, zero],
-            }
-        )
-    assert (
-        error.value.errors()[0]["type"]
-        == "formal_power_series.reversion_left_residual_mismatch"
+    parsed = SeriesReversionResult.model_validate(
+        {
+            "source": source,
+            "result": fabricated,
+            "left_residual": [zero, zero],
+            "right_residual": [zero, zero],
+        }
     )
+    assert parsed.result.coefficients[1].num == "0"
 
 
-def test_multiplication_result_rejects_fabricated_conclusion_and_ledger() -> None:
+def test_multiplication_result_rejects_structural_context_mismatch() -> None:
     series = InputTruncatedSeries.model_validate(
         _series(2, [_coefficient("1"), _coefficient("1")])
     )
     payload = compute_multiply(series, series).model_dump(mode="json")
-    fabricated = [_coefficient("0"), _coefficient("0")]
-    payload["result"]["coefficients"] = fabricated
-    payload["convolution_ledger"] = fabricated
+    payload["result"]["variable"] = "y"
 
     with pytest.raises(ValidationError) as error:
         SeriesMultiplyResult.model_validate(payload)
     assert (
-        error.value.errors()[0]["type"]
-        == "formal_power_series.convolution_result_mismatch"
-    )
-
-
-def test_inverse_result_rejects_fabricated_conclusion_with_zero_residual() -> None:
-    series = InputTruncatedSeries.model_validate(
-        _series(2, [_coefficient("1"), _coefficient("1")])
-    )
-    payload = compute_inverse(series).model_dump(mode="json")
-    payload["result"]["coefficients"] = [_coefficient("1"), _coefficient("0")]
-
-    with pytest.raises(ValidationError) as error:
-        SeriesInverseResult.model_validate(payload)
-    assert (
-        error.value.errors()[0]["type"]
-        == "formal_power_series.inverse_residual_mismatch"
-    )
-
-
-def test_division_result_rejects_fabricated_conclusion_with_zero_residual() -> None:
-    numerator = InputTruncatedSeries.model_validate(
-        _series(2, [_coefficient("1"), _coefficient("0")])
-    )
-    denominator = InputTruncatedSeries.model_validate(
-        _series(2, [_coefficient("1"), _coefficient("1")])
-    )
-    payload = compute_divide(numerator, denominator).model_dump(mode="json")
-    payload["quotient"]["coefficients"] = [_coefficient("1"), _coefficient("0")]
-
-    with pytest.raises(ValidationError) as error:
-        SeriesDivideResult.model_validate(payload)
-    assert (
-        error.value.errors()[0]["type"]
-        == "formal_power_series.division_residual_mismatch"
+        error.value.errors()[0]["type"] == "formal_power_series.source_context_mismatch"
     )
 
 
 def _zero_series_payload(order: int) -> dict[str, object]:
     return _series(order, [_coefficient("0") for _ in range(order)])
-
-
-def test_replaying_results_reject_orders_above_the_producer_envelope() -> None:
-    order = MAX_TRUNCATION_ORDER + 1
-    zeros = [_coefficient("0") for _ in range(order)]
-    multiply_payload = {
-        "left": _zero_series_payload(order),
-        "right": _zero_series_payload(order),
-        "result": _zero_series_payload(order),
-        "convolution_ledger": zeros,
-    }
-    with pytest.raises(ValidationError) as error:
-        SeriesMultiplyResult.model_validate(multiply_payload)
-    assert (
-        error.value.errors()[0]["type"]
-        == "formal_power_series.multiplication_replay_order"
-    )
-
-    reversion_residuals = tuple(_coefficient("0") for _ in range(order))
-    with pytest.raises(ValidationError) as error:
-        SeriesReversionResult.model_validate(
-            {
-                "source": _zero_series_payload(order),
-                "result": _zero_series_payload(order),
-                "left_residual": reversion_residuals,
-                "right_residual": reversion_residuals,
-            }
-        )
-    assert (
-        error.value.errors()[0]["type"] == "formal_power_series.reversion_replay_order"
-    )
 
 
 def test_all_zero_multiply_results_remain_representable_at_the_envelope_order() -> None:

--- a/tests/math/galois_theory/test_galois_theory.py
+++ b/tests/math/galois_theory/test_galois_theory.py
@@ -17,11 +17,11 @@ from jacobian.math.galois_theory._models import (
     SolvableResult,
 )
 from jacobian.math.galois_theory._operations import (
+    _verify_galois_factor_result,
     compute_frobenius_cycle,
     compute_galois_factor,
     compute_galois_group,
     compute_solvable,
-    verify_galois_factor_result,
     verify_galois_group_result,
     verify_solvable_result,
 )
@@ -145,21 +145,25 @@ def test_zero_and_noncanonical_degree_are_rejected_before_sympy() -> None:
     assert exc.value.errors()[0]["type"] == "galois_theory.polynomial_zero"
 
 
-def test_factorization_result_rejects_a_forged_certificate() -> None:
+def test_factorization_result_parses_structurally_and_private_verification_rejects_forgery() -> (
+    None
+):
     result = compute_galois_factor(
         GaloisFactorRequest(field_order=5, coefficients=(1, 0, 1))
     )
     payload = result.model_dump()
+    assert GaloisFactorResult.model_validate(payload) == result
+
     payload["unit"] = 2
-    with pytest.raises(ValidationError) as exc:
-        GaloisFactorResult.model_validate(payload)
-    assert exc.value.errors()[0]["type"] == "galois_theory.reconstruction_mismatch"
+    altered_unit = GaloisFactorResult.model_validate(payload)
+    assert altered_unit.unit == 2
+    assert not _verify_galois_factor_result(altered_unit)
 
     payload = result.model_dump()
     payload["field_order"] = 4
-    with pytest.raises(ValidationError) as exc:
-        GaloisFactorResult.model_validate(payload)
-    assert exc.value.errors()[0]["type"] == "galois_theory.field_order_not_prime"
+    non_prime_field = GaloisFactorResult.model_validate(payload)
+    assert non_prime_field.field_order == 4
+    assert not _verify_galois_factor_result(non_prime_field)
 
     forged = GaloisFactorResult(
         field_order=3,
@@ -170,7 +174,7 @@ def test_factorization_result_rejects_a_forged_certificate() -> None:
         factor_count=1,
         is_irreducible=True,
     )
-    assert not verify_galois_factor_result(forged)
+    assert not _verify_galois_factor_result(forged)
 
 
 def test_factor_producer_runs_the_backend_once(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/math/galois_theory/test_galois_theory.py
+++ b/tests/math/galois_theory/test_galois_theory.py
@@ -161,9 +161,8 @@ def test_factorization_result_parses_structurally_and_private_verification_rejec
 
     payload = result.model_dump()
     payload["field_order"] = 4
-    non_prime_field = GaloisFactorResult.model_validate(payload)
-    assert non_prime_field.field_order == 4
-    assert not _verify_galois_factor_result(non_prime_field)
+    with pytest.raises(ValidationError, match="field_order must be prime"):
+        GaloisFactorResult.model_validate(payload)
 
     forged = GaloisFactorResult(
         field_order=3,

--- a/tests/math/geometry/polygon_kernel/test_tools.py
+++ b/tests/math/geometry/polygon_kernel/test_tools.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 
 from jacobian._exact import canonical_rational_component_digits
 from jacobian.canonical import encode_strict_json
+from jacobian.math.geometry.polygon_kernel import _operations
 from jacobian.math.geometry.polygon_kernel._kernel import oriented_half_planes
 from jacobian.math.geometry.polygon_kernel._models import (
     MAX_KERNEL_COORDINATE_DIGITS,
@@ -22,6 +23,7 @@ from jacobian.math.geometry.polygon_kernel._models import (
     _estimate_visibility_kernel_result_characters,
 )
 from jacobian.math.geometry.polygon_kernel._operations import (
+    _verify_polygon_kernel_result,
     compute_visibility_kernel,
 )
 
@@ -285,7 +287,7 @@ def test_cyclic_rotation_preserves_kernel_and_scalar_measures() -> None:
     assert rotated.kernel_to_polygon_area_ratio == first.kernel_to_polygon_area_ratio
 
 
-def test_fractional_polygon_round_trips_through_source_bound_validation() -> None:
+def test_fractional_polygon_round_trips_structurally() -> None:
     result = compute_visibility_kernel(
         _request(
             [
@@ -298,14 +300,31 @@ def test_fractional_polygon_round_trips_through_source_bound_validation() -> Non
     )
     replayed = PolygonKernelResult.model_validate_json(result.model_dump_json())
     assert replayed == result
+    assert _verify_polygon_kernel_result(replayed)
     assert replayed.polygon_area.as_fraction() == 4
+
+
+def test_trusted_producer_runs_kernel_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+    original = _operations.compute_kernel_data
+
+    def counted(polygon: KernelPolygon):
+        nonlocal calls
+        calls += 1
+        return original(polygon)
+
+    monkeypatch.setattr(_operations, "compute_kernel_data", counted)
+    result = compute_visibility_kernel(_request(PUBLISHED_PENTAGON))
+
+    assert calls == 1
+    assert result.kernel_dimension == "POLYGON"
 
 
 @pytest.mark.parametrize(
     "mutation",
     ["source", "half_plane", "kernel", "area", "dimension"],
 )
-def test_result_validation_rejects_independent_mutations(mutation: str) -> None:
+def test_private_verifier_rejects_independent_mutations(mutation: str) -> None:
     result = compute_visibility_kernel(_request(PUBLISHED_PENTAGON))
     payload = deepcopy(result.model_dump(mode="json"))
     if mutation == "source":
@@ -321,8 +340,9 @@ def test_result_validation_rejects_independent_mutations(mutation: str) -> None:
         payload["kernel_area"] = {"num": "113430241", "den": "1"}
     else:
         payload["kernel_dimension"] = "SEGMENT"
-    with pytest.raises(ValidationError):
-        PolygonKernelResult.model_validate(payload)
+        payload["kernel_boundary"] = payload["kernel_boundary"][:2]
+    claim = PolygonKernelResult.model_validate(payload)
+    assert not _verify_polygon_kernel_result(claim)
 
 
 def _parabola_polygon(scale: int = 1) -> list[tuple[int, int]]:

--- a/tests/math/geometry/test_box_unions.py
+++ b/tests/math/geometry/test_box_unions.py
@@ -11,7 +11,6 @@ from pydantic import ValidationError
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import encode_strict_json
 from jacobian.math.geometry.boxes import (
-    BoxIntersectionLedgerEntry,
     BoxUnionVolumeResult,
     RationalAxisAlignedBox,
     RationalClosedInterval,
@@ -20,6 +19,7 @@ from jacobian.math.geometry.boxes import (
 from jacobian.math.geometry.boxes._models import (
     MAX_BOX_UNION_RESULT_BYTES,
     BoxUnionVolumeRequest,
+    _verify_box_union_volume_result,
 )
 from jacobian.math.geometry.boxes.values import MAX_CANONICAL_BOX_DIMENSION
 
@@ -206,61 +206,35 @@ def test_input_order_changes_indices_but_not_union_volume() -> None:
     )
 
 
-def test_result_rejects_wrong_union_volume() -> None:
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        lambda payload: payload.__setitem__("union_volume", {"num": "5", "den": "1"}),
+        lambda payload: payload.__setitem__(
+            "intersections", payload["intersections"][:-1]
+        ),
+        lambda payload: payload["intersections"][3].__setitem__(
+            "intersection", _box((0, 1), (0, 1), (0, 1)).model_dump(mode="json")
+        ),
+    ),
+)
+def test_forged_ledger_claim_fails_the_explicit_verifier(mutate: object) -> None:
     result = compute_box_union_volume(_three_boxes())
     payload = result.model_dump(mode="json")
-    payload["union_volume"] = {"num": "5", "den": "1"}
+    assert callable(mutate)
+    mutate(payload)
+    assert not _verify_box_union_volume_result(
+        BoxUnionVolumeResult.model_validate(payload)
+    )
+
+
+def test_result_rejects_out_of_range_intersection_index() -> None:
+    result = compute_box_union_volume(_three_boxes())
+    payload = result.model_dump(mode="json")
+    payload["intersections"][3]["box_indices"] = [0, 3]
 
     with pytest.raises(ValidationError):
         BoxUnionVolumeResult.model_validate(payload)
-
-
-def test_result_rejects_omitted_intersection() -> None:
-    result = compute_box_union_volume(_three_boxes())
-    payload = result.model_dump(mode="json")
-    payload["intersections"] = payload["intersections"][:-1]
-
-    with pytest.raises(ValidationError):
-        BoxUnionVolumeResult.model_validate(payload)
-
-
-def test_result_rejects_corrupted_intersection() -> None:
-    result = compute_box_union_volume(_three_boxes())
-    payload = result.model_dump(mode="json")
-    payload["intersections"][3]["intersection"] = _box(
-        (0, 1), (0, 1), (0, 1)
-    ).model_dump(mode="json")
-    payload["intersections"][3]["volume"] = {"num": "1", "den": "1"}
-
-    with pytest.raises(ValidationError):
-        BoxUnionVolumeResult.model_validate(payload)
-
-
-def test_result_rejects_intersection_index_mutation() -> None:
-    result = compute_box_union_volume(_three_boxes())
-    payload = result.model_dump(mode="json")
-    payload["intersections"][3]["box_indices"] = [0, 2]
-
-    with pytest.raises(ValidationError):
-        BoxUnionVolumeResult.model_validate(payload)
-
-
-def test_result_rejects_source_mutation() -> None:
-    result = compute_box_union_volume(_three_boxes())
-    payload = result.model_dump(mode="json")
-    payload["source"]["boxes"][0] = _box((0, 1), (0, 1), (0, 1)).model_dump(mode="json")
-
-    with pytest.raises(ValidationError):
-        BoxUnionVolumeResult.model_validate(payload)
-
-
-def test_entry_rejects_volume_not_matching_intersection() -> None:
-    with pytest.raises(ValidationError):
-        BoxIntersectionLedgerEntry(
-            box_indices=(0,),
-            intersection=_box((0, 2)),
-            volume=_rational(3),
-        )
 
 
 def test_native_api_accepts_canonical_box_tuple_without_request_wrapper() -> None:
@@ -355,12 +329,6 @@ def test_endpoint_at_derived_growth_boundary_is_admitted() -> None:
 def test_endpoint_beyond_derived_growth_budget_is_rejected() -> None:
     with pytest.raises(ValidationError):
         BoxUnionVolumeRequest(boxes=(_box((0, Fraction(10**16_377 - 1))),))
-
-
-def test_rejects_complete_replay_work_before_expansion() -> None:
-    box = _box((0, 1), (0, 1))
-    with pytest.raises(ValidationError):
-        BoxUnionVolumeRequest(boxes=(box,) * 16)
 
 
 def test_accepts_immediately_below_small_coordinate_result_boundary() -> None:

--- a/tests/math/geometry/test_euclidean_triangulation.py
+++ b/tests/math/geometry/test_euclidean_triangulation.py
@@ -18,6 +18,7 @@ from jacobian.math.geometry._models import (
     EuclideanConvexPolygonTriangulationResult,
     _echoed_result_envelope_chars,
     _span_term_occurrences,
+    _verify_euclidean_triangulation_claim,
 )
 
 _FLOOR_TERM_CHARS = 2 * (4 * 1 + 1) + 128
@@ -180,7 +181,7 @@ class TestEuclideanTriangulation:
         assert validated.unresolved_comparison.left_split == 2
         assert validated.unresolved_comparison.right_split == 1
 
-    def test_unresolved_result_rejects_forged_expressions(self) -> None:
+    def test_unresolved_claim_verifier_rejects_forged_expressions(self) -> None:
         scale = 10**30
         result = minimum_euclidean_weight_triangulation(
             _request(
@@ -200,8 +201,9 @@ class TestEuclideanTriangulation:
             {"num": "7", "den": "1"}
         ]
 
+        forged = EuclideanConvexPolygonTriangulationResult.model_validate(payload)
         with pytest.raises(ValidationError):
-            EuclideanConvexPolygonTriangulationResult.model_validate(payload)
+            _verify_euclidean_triangulation_claim(forged)
 
     def test_unresolved_result_rejects_an_inverted_split_order(self) -> None:
         scale = 10**30
@@ -240,7 +242,7 @@ class TestEuclideanTriangulation:
         with pytest.raises(ValidationError):
             EuclideanConvexPolygonTriangulationResult.model_validate(payload)
 
-    def test_unresolved_claim_on_a_resolvable_recurrence_is_rejected(self) -> None:
+    def test_unresolved_claim_verifier_rejects_a_resolvable_recurrence(self) -> None:
         payload = {
             "status": "COMPARISON_UNRESOLVED",
             "polygon": {
@@ -264,28 +266,32 @@ class TestEuclideanTriangulation:
             },
         }
 
+        forged = EuclideanConvexPolygonTriangulationResult.model_validate(payload)
         with pytest.raises(ValidationError):
-            EuclideanConvexPolygonTriangulationResult.model_validate(payload)
+            _verify_euclidean_triangulation_claim(forged)
 
-    def test_certified_result_rejects_a_mutated_diagonal_length(self) -> None:
+    def test_certified_claim_verifier_rejects_a_mutated_diagonal_length(self) -> None:
         result = minimum_euclidean_weight_triangulation(
             _request((_point(0, 0), _point(1, 0), _point(1, 1), _point(0, 1)))
         )
         payload = result.model_dump(mode="json")
         payload["diagonals"][0]["squared_length"] = {"num": "3", "den": "1"}
+        payload["optimum"]["squared_lengths"] = [{"num": "3", "den": "1"}]
 
+        forged = EuclideanConvexPolygonTriangulationResult.model_validate(payload)
         with pytest.raises(ValidationError):
-            EuclideanConvexPolygonTriangulationResult.model_validate(payload)
+            _verify_euclidean_triangulation_claim(forged)
 
-    def test_certified_result_rejects_a_mutated_source_polygon(self) -> None:
+    def test_certified_claim_verifier_rejects_a_mutated_source_polygon(self) -> None:
         result = minimum_euclidean_weight_triangulation(
             _request((_point(0, 0), _point(1, 0), _point(1, 1), _point(0, 1)))
         )
         payload = result.model_dump(mode="json")
         payload["polygon"]["points"][3]["y"] = {"num": "2", "den": "1"}
 
+        forged = EuclideanConvexPolygonTriangulationResult.model_validate(payload)
         with pytest.raises(ValidationError):
-            EuclideanConvexPolygonTriangulationResult.model_validate(payload)
+            _verify_euclidean_triangulation_claim(forged)
 
     def test_unresolved_root_stops_before_a_cheaper_later_pivot(self) -> None:
         scale = 10**30
@@ -418,10 +424,11 @@ class TestEuclideanTriangulation:
             "optimum": expression(optimum[0, 4]),
         }
 
+        forged = EuclideanConvexPolygonTriangulationResult.model_validate(payload)
         with pytest.raises(ValidationError):
-            EuclideanConvexPolygonTriangulationResult.model_validate(payload)
+            _verify_euclidean_triangulation_claim(forged)
 
-    def test_certified_result_rejects_claiming_a_later_equal_pivot(self) -> None:
+    def test_certified_claim_verifier_rejects_a_later_equal_pivot(self) -> None:
         # Both root pivots cost exactly sqrt(2); execution canonically keeps
         # the earlier one, so a certificate claiming the later pivot fails.
         result = minimum_euclidean_weight_triangulation(
@@ -437,8 +444,9 @@ class TestEuclideanTriangulation:
             {"vertices": [0, 2, 3]},
         ]
 
+        forged = EuclideanConvexPolygonTriangulationResult.model_validate(payload)
         with pytest.raises(ValidationError):
-            EuclideanConvexPolygonTriangulationResult.model_validate(payload)
+            _verify_euclidean_triangulation_claim(forged)
 
     def test_rejects_a_nonconvex_polygon_before_arb(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/math/geometry/test_exact_geometry.py
+++ b/tests/math/geometry/test_exact_geometry.py
@@ -811,6 +811,7 @@ class TestAggregatePairLedgerBound:
             PinnedLineDistanceRequest,
             PinnedLineDistanceResult,
             PointConfiguration,
+            _verify_pinned_line_distance_claim,
         )
         from jacobian.math.geometry.exact._operations import (
             compute_pinned_line_distance_profile,
@@ -837,6 +838,47 @@ class TestAggregatePairLedgerBound:
             PinnedLineDistanceResult.model_validate(result.model_dump(mode="json"))
             == result
         )
+        _verify_pinned_line_distance_claim(result)
+
+    def test_profile_verifier_rejects_forged_pair_assignment(self):
+        import pytest
+
+        from jacobian.math.geometry.exact._models import (
+            LabelledRationalPoint,
+            PointConfiguration,
+            _verify_pinned_line_distance_claim,
+        )
+        from jacobian.math.geometry.exact._operations import (
+            compute_pinned_line_distance_profile,
+        )
+
+        configuration = PointConfiguration(
+            points=tuple(
+                LabelledRationalPoint(
+                    label=label,
+                    coordinates=(
+                        {"num": str(x), "den": "1"},
+                        {"num": str(y), "den": "1"},
+                    ),
+                )
+                for label, x, y in [("a", 0, 0), ("b", 1, 0), ("c", 0, 1), ("d", 1, 1)]
+            )
+        )
+        result = compute_pinned_line_distance_profile(
+            PinnedLineDistanceRequest(
+                configuration=configuration,
+                anchor=({"num": "0", "den": "1"}, {"num": "0", "den": "1"}),
+            )
+        )
+        payload = result.model_dump(mode="json")
+        payload["lines"][0]["pairs"], payload["lines"][1]["pairs"] = (
+            payload["lines"][1]["pairs"],
+            payload["lines"][0]["pairs"],
+        )
+        forged = PinnedLineDistanceResult.model_validate(payload)
+
+        with pytest.raises(ValueError):
+            _verify_pinned_line_distance_claim(forged)
 
 
 class TestSortedPairLedger:

--- a/tests/math/graphs/flow/test_network_ops.py
+++ b/tests/math/graphs/flow/test_network_ops.py
@@ -1,6 +1,5 @@
 """Tests for network optimization operations."""
 
-import copy
 from collections.abc import Sequence
 from fractions import Fraction
 
@@ -8,15 +7,14 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.math.graphs.flow import _operations as flow_operations
 from jacobian.math.graphs.flow._models import (
     CostedFlowEdge,
     CostedFlowGraph,
     MinCostFlowRequest,
     MinCostFlowResult,
 )
-from jacobian.math.graphs.flow._operations import (
-    compute_min_cost_flow,
-)
+from jacobian.math.graphs.flow._operations import compute_min_cost_flow
 from jacobian.math.graphs.flow._tools import TOOLS
 
 
@@ -261,7 +259,7 @@ def test_min_cost_flow_mixed_capacity_and_cost_denominators() -> None:
     result = compute_min_cost_flow(MinCostFlowRequest(graph=graph, demands=(-1, 0, 1)))
     assert result.feasible is True
     assert result.total_cost.as_fraction() == Fraction(2, 3) + Fraction(4, 5)
-    # The retained source network replays balances, capacities, and objective.
+    # The retained source network supports downstream composition and explicit checks.
     balance = [Fraction(0)] * 3
     for fe in result.flow_edges:
         balance[fe.source] -= fe.flow.as_fraction()
@@ -297,36 +295,64 @@ def _two_path_graph() -> CostedFlowGraph:
     )
 
 
-def test_min_cost_flow_serialized_result_replays_against_source() -> None:
-    """Serialization round-trips and mutations of any field are rejected."""
+def test_min_cost_flow_parsing_is_structural_and_private_verifier_checks_claim() -> (
+    None
+):
+    """Serialization is structural; deliberate verification rejects forged claims."""
     request = MinCostFlowRequest(graph=_two_path_graph(), demands=(-2, 2, 0))
     result = compute_min_cost_flow(request)
     assert result.feasible is True
     dumped = result.model_dump()
     assert MinCostFlowResult.model_validate(dumped) == result
+    assert flow_operations._verify_min_cost_flow_result(result)
 
-    shrunk = copy.deepcopy(dumped)
-    shrunk["graph"]["edges"][0]["capacity"] = {"num": "1", "den": "1"}
-    with pytest.raises(ValidationError):
-        MinCostFlowResult.model_validate(shrunk)
+    forged_payload = result.model_dump()
+    forged_payload["graph"]["edges"][0]["capacity"] = {
+        "num": "1",
+        "den": "1",
+    }
+    forged = MinCostFlowResult.model_validate(forged_payload)
+    assert not flow_operations._verify_min_cost_flow_result(forged)
 
-    undeclared = copy.deepcopy(dumped)
-    undeclared["flow_edges"] = (
-        *undeclared["flow_edges"],
-        {"source": 1, "target": 0, "flow": {"num": "1", "den": "1"}},
+    forged_payload = result.model_dump()
+    forged_payload["total_cost"] = {"num": "9999", "den": "1"}
+    forged = MinCostFlowResult.model_validate(forged_payload)
+    assert not flow_operations._verify_min_cost_flow_result(forged)
+
+
+def test_min_cost_flow_kernel_runs_once_when_result_is_serialized(monkeypatch) -> None:
+    calls = 0
+    original = flow_operations.nx.network_simplex
+
+    def counted(*args: object, **kwargs: object):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(flow_operations.nx, "network_simplex", counted)
+    result = compute_min_cost_flow(
+        MinCostFlowRequest(graph=_two_path_graph(), demands=(-2, 2, 0))
     )
-    with pytest.raises(ValidationError):
-        MinCostFlowResult.model_validate(undeclared)
+    assert calls == 1
+    assert MinCostFlowResult.model_validate(result.model_dump()) == result
+    assert calls == 1
 
-    rebalanced = copy.deepcopy(dumped)
-    rebalanced["demands"] = [1, -2, 1]
-    with pytest.raises(ValidationError):
-        MinCostFlowResult.model_validate(rebalanced)
 
-    recompensed = copy.deepcopy(dumped)
-    recompensed["total_cost"] = {"num": "9999", "den": "1"}
+def test_min_cost_flow_result_parser_retains_structural_checks() -> None:
+    result = compute_min_cost_flow(
+        MinCostFlowRequest(graph=_two_path_graph(), demands=(-2, 2, 0))
+    )
+    dumped = result.model_dump()
+    shrunk = dict(dumped)
+    shrunk["graph"]["edges"][0]["capacity"] = {"num": "1", "den": "1"}
+    assert MinCostFlowResult.model_validate(shrunk).graph.edges[
+        0
+    ].capacity == CanonicalRational(num="1", den="1")
+
+    malformed = dict(dumped)
+    malformed["demands"] = [0]
     with pytest.raises(ValidationError):
-        MinCostFlowResult.model_validate(recompensed)
+        MinCostFlowResult.model_validate(malformed)
 
 
 def test_min_cost_flow_infeasible_result_carries_no_claim() -> None:

--- a/tests/math/graphs/test_chromatic_number_certificate.py
+++ b/tests/math/graphs/test_chromatic_number_certificate.py
@@ -470,21 +470,16 @@ def test_rational_digit_and_total_work_boundaries() -> None:
     )
     assert accepted_work.verdict == "ACCEPTED"
 
-    rejected_order = MAX_CHROMATIC_CERTIFICATE_VERTICES
-    with pytest.raises(ValidationError) as error:
-        ChromaticNumberCertificateCheckRequest(
-            graph=_graph(tuple(f"r{index:02d}" for index in range(rejected_order)), ()),
-            claimed_chromatic_number=1,
-            coloring=(0,) * rejected_order,
-            weights=tuple(
-                _rational(1, denominator_base + index)
-                for index in range(rejected_order)
-            ),
-        )
-    assert (
-        error.value.errors()[0]["type"]
-        == "graph.chromatic_number_certificate_exact_replay_work_exceeds"
+    full_order = MAX_CHROMATIC_CERTIFICATE_VERTICES
+    request = ChromaticNumberCertificateCheckRequest(
+        graph=_graph(tuple(f"r{index:02d}" for index in range(full_order)), ()),
+        claimed_chromatic_number=1,
+        coloring=(0,) * full_order,
+        weights=tuple(
+            _rational(1, denominator_base + index) for index in range(full_order)
+        ),
     )
+    assert len(request.graph.vertices) == full_order
 
 
 def test_retained_source_output_headroom_boundary() -> None:

--- a/tests/math/graphs/test_chromatic_number_certificate.py
+++ b/tests/math/graphs/test_chromatic_number_certificate.py
@@ -403,6 +403,23 @@ def test_result_preflights_oversized_forged_derived_rationals() -> None:
         ChromaticNumberCertificateCheckResult.model_validate(payload)
 
 
+def test_result_retains_graph_axis_shape_without_replaying_certificate() -> None:
+    payload = deepcopy(_accepted_edge_result().model_dump(mode="json"))
+    payload["coloring"] = [0]
+    with pytest.raises(ValidationError, match="one color per graph vertex"):
+        ChromaticNumberCertificateCheckResult.model_validate(payload)
+
+    payload = deepcopy(_accepted_edge_result().model_dump(mode="json"))
+    payload["graph"] = {
+        "vertices": [f"v{index}" for index in range(21)],
+        "edges": [],
+    }
+    payload["coloring"] = [0] * 20
+    payload["weights"] = [{"num": "1", "den": "1"}] * 20
+    with pytest.raises(ValidationError, match="supports at most"):
+        ChromaticNumberCertificateCheckResult.model_validate(payload)
+
+
 def test_vertex_and_subset_enumeration_boundaries() -> None:
     order = MAX_CHROMATIC_CERTIFICATE_VERTICES
     vertices = tuple(f"v{index:02d}" for index in range(order))

--- a/tests/math/graphs/test_colored_graph_canonicalization.py
+++ b/tests/math/graphs/test_colored_graph_canonicalization.py
@@ -258,7 +258,13 @@ def test_canonical_equality_agrees_with_networkx_on_all_order_four_graphs() -> N
             )
 
 
-def test_result_rejects_source_conclusion_and_tie_break_mutations() -> None:
+def test_result_round_trip_is_structural_and_private_verifier_rejects_mutations() -> (
+    None
+):
+    from jacobian.math.graphs.isomorphism._operations import (
+        _verify_colored_graph_canonicalization_result,
+    )
+
     source = _graph(
         ("a", "b", "c", "d"),
         (("a", "b"), ("b", "c"), ("c", "d")),
@@ -270,8 +276,9 @@ def test_result_rejects_source_conclusion_and_tie_break_mutations() -> None:
         ["a", "b"],
         ["c", "d"],
     ]
-    with pytest.raises(ValidationError):
+    assert not _verify_colored_graph_canonicalization_result(
         ColoredGraphCanonicalizationResult.model_validate(changed_source)
+    )
 
     changed_graph = result.model_dump(mode="json")
     changed_graph["canonical_graph"]["graph"]["edges"] = [
@@ -279,8 +286,9 @@ def test_result_rejects_source_conclusion_and_tie_break_mutations() -> None:
         ["v00", "v02"],
         ["v00", "v03"],
     ]
-    with pytest.raises(ValidationError):
+    assert not _verify_colored_graph_canonicalization_result(
         ColoredGraphCanonicalizationResult.model_validate(changed_graph)
+    )
 
     changed_tie_break = result.model_dump(mode="json")
     relabeling = changed_tie_break["relabeling"]
@@ -297,8 +305,9 @@ def test_result_rejects_source_conclusion_and_tie_break_mutations() -> None:
             relabeling[right_index]["canonical_vertex"],
             relabeling[left_index]["canonical_vertex"],
         )
-    with pytest.raises(ValidationError):
+    assert not _verify_colored_graph_canonicalization_result(
         ColoredGraphCanonicalizationResult.model_validate(changed_tie_break)
+    )
 
 
 def test_request_admits_by_color_class_size_not_only_vertex_count() -> None:
@@ -525,7 +534,7 @@ def test_schema_explains_alignment_and_work_admission() -> None:
     graph_schema = schema["$defs"]["ColoredUndirectedGraph"]
 
     assert "aligned" in graph_schema["description"]
-    assert "execution-plus-validation replay work" in schema["description"]
+    assert "execution work" in schema["description"]
 
 
 def test_schema_documents_nfc_and_byte_limits_for_color_names() -> None:
@@ -602,11 +611,8 @@ def test_catalog_execution_admits_the_parsed_request_once(
 ) -> None:
     """``math.run`` parses once; the adapter must not readmit the request.
 
-    The result-size preflight runs once per request admission. For an
-    already-parsed request, exactly one further admission may occur inside
-    the catalog run: the result replay's own source-bound revalidation. A
-    second one means the adapter detoured through the validating native
-    wrapper instead of the shared request-accepting implementation.
+    The result-size preflight belongs to request admission; execution does
+    not repeat it while constructing the trusted result.
     """
     parsed = ColoredGraphCanonicalizationRequest(
         colored_graph=_graph(("a", "b"), (("a", "b"),))
@@ -629,5 +635,4 @@ def test_catalog_execution_admits_the_parsed_request_once(
     result = compute_colored_graph_canonicalization(parsed)
 
     assert result == expected
-    assert len(admissions) == 1
-    assert admissions[0] == parsed.colored_graph
+    assert admissions == []

--- a/tests/math/graphs/test_graph_maximum_cut.py
+++ b/tests/math/graphs/test_graph_maximum_cut.py
@@ -17,8 +17,8 @@ from jacobian.math.graphs.optimization._maximum_cut import (
     MAXIMUM_CUT_RESULT_BYTES,
     GraphMaximumCutRequest,
     GraphMaximumCutResult,
+    _verify_maximum_cut_result,
     compute_maximum_cut,
-    verify_maximum_cut_result,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -283,7 +283,7 @@ def test_feasible_suboptimal_cut_with_forged_exact_bounds_fails_replay() -> None
     forged["lower_bound"] = 2
     forged["upper_bound"] = 2
 
-    assert not verify_maximum_cut_result(GraphMaximumCutResult.model_validate(forged))
+    assert not _verify_maximum_cut_result(GraphMaximumCutResult.model_validate(forged))
 
 
 def test_result_deserialization_never_replays_the_exhaustive_kernel(

--- a/tests/math/graphs_multigraph/test_multigraph.py
+++ b/tests/math/graphs_multigraph/test_multigraph.py
@@ -14,6 +14,7 @@ from jacobian.math.graphs.multigraph._models import (
     MAX_GROUP_CARDINALITY,
     MAX_GROUP_MODULUS,
     CycleMulticoverRequest,
+    CycleMulticoverResult,
     CycleRecord,
     EulerianCyclesRequest,
     EulerianCyclesResult,
@@ -130,6 +131,51 @@ class TestFlowCheckNowhereZero:
         for div in result.divergence_ledger:
             assert div.conservation_holds
             assert div.coordinates == (0,)
+
+    def test_parsing_is_structural_and_private_verifier_checks_claim(self) -> None:
+        flow = (
+            FlowEdgeAssignment(edge_id="e0", orientation="left_to_right", value=(1,)),
+            FlowEdgeAssignment(edge_id="e1", orientation="left_to_right", value=(1,)),
+            FlowEdgeAssignment(edge_id="e2", orientation="left_to_right", value=(1,)),
+        )
+        result = _flow_check(TRIANGLE, Z3, flow)
+        payload = result.model_dump()
+        payload["conservation_holds"] = False
+        forged = MultigraphFlowCheckResult.model_validate(payload)
+
+        assert forged.conservation_holds is False
+        assert not multigraph_operations._verify_multigraph_flow_check_result(forged)
+
+    def test_flow_kernel_runs_once_when_result_is_serialized(self, monkeypatch) -> None:
+        calls = 0
+        original = multigraph_operations._compute_divergence_ledger
+
+        def counted(*args: object):
+            nonlocal calls
+            calls += 1
+            return original(*args)
+
+        monkeypatch.setattr(
+            multigraph_operations, "_compute_divergence_ledger", counted
+        )
+        result = _flow_check(
+            TRIANGLE,
+            Z3,
+            (
+                FlowEdgeAssignment(
+                    edge_id="e0", orientation="left_to_right", value=(1,)
+                ),
+                FlowEdgeAssignment(
+                    edge_id="e1", orientation="left_to_right", value=(1,)
+                ),
+                FlowEdgeAssignment(
+                    edge_id="e2", orientation="left_to_right", value=(1,)
+                ),
+            ),
+        )
+        assert calls == 1
+        assert MultigraphFlowCheckResult.model_validate(result.model_dump()) == result
+        assert calls == 1
 
 
 # ---------------------------------------------------------------------------
@@ -354,6 +400,22 @@ class TestCycleMulticoverDoubleCover:
         for _eid, count in result.edge_multiplicity:
             assert count == 2
 
+    def test_forged_multicover_conclusion_needs_private_verification(self) -> None:
+        result = check_cycle_multicover(
+            CycleMulticoverRequest(
+                graph=TRIANGLE,
+                cycles=(
+                    CycleRecord(vertices=(0, 1, 2, 0), edge_ids=("e0", "e1", "e2")),
+                ),
+                target_multiplicity=1,
+            )
+        )
+        payload = result.model_dump()
+        payload["is_exact_k_cover"] = False
+        forged = CycleMulticoverResult.model_validate(payload)
+
+        assert not multigraph_operations._verify_cycle_multicover_result(forged)
+
 
 # ---------------------------------------------------------------------------
 # Fixture 9: One missing and one overcovered edge
@@ -445,6 +507,18 @@ class TestFlowSearchExhausted:
         assert result.status == "EXHAUSTED"
         assert result.termination_reason == "SEARCH_EXHAUSTED"
         assert result.flow is None
+
+    def test_forged_exhausted_claim_needs_private_verification(self) -> None:
+        result = _flow_find(
+            BRIDGE_GRAPH,
+            Z3,
+            resource_budget={"max_states": 1000000, "require_nowhere_zero": True},
+        )
+        payload = result.model_dump()
+        payload["states_explored"] = 0
+        forged = MultigraphFlowFindResult.model_validate(payload)
+
+        assert not multigraph_operations._verify_multigraph_flow_find_result(forged)
 
 
 # ---------------------------------------------------------------------------
@@ -681,8 +755,8 @@ class TestZeroEdgeIdentification:
 
 
 class TestSourceBinding:
-    def test_forged_exhausted_on_flow_admitting_graph_rejected(self):
-        """A triangle admits a nowhere-zero Z/3 flow; EXHAUSTED must not validate."""
+    def test_forged_exhausted_on_flow_admitting_graph_fails_verification(self):
+        """Parsing retains the claim; deliberate verification rejects it."""
         payload = {
             "graph": TRIANGLE.model_dump(),
             "group": Z3.model_dump(),
@@ -692,8 +766,9 @@ class TestSourceBinding:
             "states_explored": 0,
             "termination_reason": "SEARCH_EXHAUSTED",
         }
-        with pytest.raises(ValidationError):
+        assert not multigraph_operations._verify_multigraph_flow_find_result(
             MultigraphFlowFindResult.model_validate(payload)
+        )
 
     def test_genuine_exhausted_roundtrips(self):
         request = MultigraphFlowFindRequest(
@@ -705,7 +780,7 @@ class TestSourceBinding:
         assert result.status == "EXHAUSTED"
         assert MultigraphFlowFindResult.model_validate(result.model_dump()) == result
 
-    def test_mutated_exhausted_state_count_rejected(self):
+    def test_mutated_exhausted_state_count_fails_verification(self):
         request = MultigraphFlowFindRequest(
             graph=BRIDGE_GRAPH,
             group=Z3,
@@ -714,10 +789,11 @@ class TestSourceBinding:
         genuine = find_multigraph_flow(request)
         payload = genuine.model_dump()
         payload["states_explored"] = int(payload["states_explored"]) + 1
-        with pytest.raises(ValidationError):
+        assert not multigraph_operations._verify_multigraph_flow_find_result(
             MultigraphFlowFindResult.model_validate(payload)
+        )
 
-    def test_status_swap_between_non_witness_outcomes_rejected(self):
+    def test_status_swap_between_non_witness_outcomes_fails_verification(self):
         request = MultigraphFlowFindRequest(
             graph=TRIANGLE,
             group=Z3,
@@ -728,8 +804,9 @@ class TestSourceBinding:
         payload = unknown.model_dump()
         payload["status"] = "EXHAUSTED"
         payload["termination_reason"] = "SEARCH_EXHAUSTED"
-        with pytest.raises(ValidationError):
+        assert not multigraph_operations._verify_multigraph_flow_find_result(
             MultigraphFlowFindResult.model_validate(payload)
+        )
 
     def test_unbound_results_are_rejected(self):
         """Public results must retain their search domain: a payload without
@@ -745,10 +822,8 @@ class TestSourceBinding:
                 termination_reason="SEARCH_EXHAUSTED",
             )
 
-    def test_forged_found_within_tiny_budget_rejected(self):
-        """A triangle over Z/3 with max_states=1 cannot reach any complete
-        three-edge assignment; a forged FOUND must not validate even when
-        its flow conserves."""
+    def test_forged_found_within_tiny_budget_fails_verification(self):
+        """A source-bound verifier rejects the out-of-budget FOUND claim."""
         payload = {
             "graph": TRIANGLE.model_dump(),
             "group": Z3.model_dump(),
@@ -774,8 +849,9 @@ class TestSourceBinding:
             "states_explored": 0,
             "termination_reason": "SPECIAL_CASE",
         }
-        with pytest.raises(ValidationError):
+        assert not multigraph_operations._verify_multigraph_flow_find_result(
             MultigraphFlowFindResult.model_validate(payload)
+        )
 
     def test_genuine_found_roundtrips(self):
         request = MultigraphFlowFindRequest(
@@ -789,10 +865,8 @@ class TestSourceBinding:
         assert len(result.flow) == 3
         assert MultigraphFlowFindResult.model_validate(result.model_dump()) == result
 
-    def test_duplicate_edge_assignment_in_found_witness_rejected(self):
-        """Every graph edge needs exactly one assignment; repeated records
-        for one edge cannot authenticate a FOUND witness (review
-        counterexample: a, b, a, a on two parallel edges)."""
+    def test_duplicate_edge_assignment_in_found_witness_fails_verification(self):
+        """A source-bound verifier rejects a malformed FOUND witness."""
         payload = {
             "graph": PARALLEL_TRIANGLE.model_dump(),
             "group": Z3.model_dump(),
@@ -807,8 +881,9 @@ class TestSourceBinding:
             "states_explored": 4,
             "termination_reason": "WITNESS_FOUND",
         }
-        with pytest.raises(ValidationError):
+        assert not multigraph_operations._verify_multigraph_flow_find_result(
             MultigraphFlowFindResult.model_validate(payload)
+        )
 
 
 class TestEulerianSourceRequired:
@@ -820,8 +895,7 @@ class TestEulerianSourceRequired:
                 covers_all=True,
             )
 
-    def test_forged_empty_decomposition_rejected(self):
-        """cycles=()/covers_all=True against a graph with edges cannot validate."""
+    def test_forged_empty_decomposition_fails_verification(self):
         payload = {
             "graph": SQUARE.model_dump(),
             "edge_subset": None,
@@ -829,8 +903,9 @@ class TestEulerianSourceRequired:
             "edge_usage": (("s0", 0), ("s1", 0), ("s2", 0), ("s3", 0)),
             "covers_all": True,
         }
-        with pytest.raises(ValidationError):
+        assert not multigraph_operations._verify_eulerian_cycles_result(
             EulerianCyclesResult.model_validate(payload)
+        )
 
     def test_genuine_decomposition_roundtrips(self):
         request = EulerianCyclesRequest(graph=SQUARE)
@@ -855,12 +930,10 @@ class TestEulerianSubsetDuplicates:
             EulerianCyclesRequest(graph=TRIANGLE, edge_subset=("e0", "e0"))
 
 
-class TestEulerianParityDichotomy:
-    """The decomposition must be reconstructible from its source parity: an
-    Eulerian source must be fully decomposed; the empty covers_all=False
-    outcome is reserved for a non-Eulerian source."""
+class TestEulerianParityVerification:
+    """Source-derived decomposition claims are checked deliberately."""
 
-    def test_forged_false_failure_on_eulerian_source_rejected(self) -> None:
+    def test_forged_false_failure_on_eulerian_source_fails_verification(self) -> None:
         payload = {
             "graph": TRIANGLE.model_dump(),
             "edge_subset": None,
@@ -868,10 +941,13 @@ class TestEulerianParityDichotomy:
             "edge_usage": (("e0", 0), ("e1", 0), ("e2", 0)),
             "covers_all": False,
         }
-        with pytest.raises(ValidationError):
+        assert not multigraph_operations._verify_eulerian_cycles_result(
             EulerianCyclesResult.model_validate(payload)
+        )
 
-    def test_partial_decomposition_on_non_eulerian_source_rejected(self) -> None:
+    def test_partial_decomposition_on_non_eulerian_source_fails_verification(
+        self,
+    ) -> None:
         graph = LooplessMultigraph(
             vertex_count=4,
             edges=(
@@ -888,8 +964,9 @@ class TestEulerianParityDichotomy:
             "edge_usage": (("e0", 1), ("e1", 1), ("e2", 1), ("p", 0)),
             "covers_all": False,
         }
-        with pytest.raises(ValidationError):
+        assert not multigraph_operations._verify_eulerian_cycles_result(
             EulerianCyclesResult.model_validate(payload)
+        )
 
     def test_non_eulerian_genuine_result_roundtrips(self) -> None:
         result = compute_eulerian_cycles(EulerianCyclesRequest(graph=BRIDGE_GRAPH))
@@ -1029,23 +1106,27 @@ class TestAggregateSearchBudgetAcrossValidation:
 
 
 class TestTerminationReasonBinding:
-    def test_found_reason_relabeled_special_case_rejected(self) -> None:
+    def test_found_reason_relabeled_special_case_fails_verification(self) -> None:
         result = _flow_find(
             TRIANGLE, Z3, resource_budget={"require_nowhere_zero": True}
         )
         assert result.status == "FOUND"
         payload = result.model_dump()
         payload["termination_reason"] = "SPECIAL_CASE"
-        with pytest.raises(ValidationError):
+        assert not multigraph_operations._verify_multigraph_flow_find_result(
             MultigraphFlowFindResult.model_validate(payload)
+        )
 
-    def test_empty_graph_special_case_relabeled_witness_rejected(self) -> None:
+    def test_empty_graph_special_case_relabeled_witness_fails_verification(
+        self,
+    ) -> None:
         empty_graph = LooplessMultigraph(vertex_count=3, edges=())
         result = _flow_find(empty_graph, Z3)
         payload = result.model_dump()
         payload["termination_reason"] = "WITNESS_FOUND"
-        with pytest.raises(ValidationError):
+        assert not multigraph_operations._verify_multigraph_flow_find_result(
             MultigraphFlowFindResult.model_validate(payload)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/math/integral_binary_quadratic_forms/test_integral_binary_quadratic_forms.py
+++ b/tests/math/integral_binary_quadratic_forms/test_integral_binary_quadratic_forms.py
@@ -19,18 +19,18 @@ from jacobian.math.integral_binary_quadratic_forms._models import (
     _representation_y_bound,
 )
 from jacobian.math.integral_binary_quadratic_forms._operations import (
+    _verify_check_result,
+    _verify_evaluate_result,
+    _verify_proper_equivalence_result,
+    _verify_reduced_classes_result,
+    _verify_reduced_form_result,
+    _verify_representations_result,
     compute_check,
     compute_evaluate,
     compute_proper_equivalence,
     compute_reduce,
     compute_reduced_classes,
     compute_representations,
-    verify_check_result,
-    verify_evaluate_result,
-    verify_proper_equivalence_result,
-    verify_reduced_classes_result,
-    verify_reduced_form_result,
-    verify_representations_result,
 )
 from jacobian.math.integral_binary_quadratic_forms._tools import TOOLS
 
@@ -90,7 +90,7 @@ class TestCheck:
         result = compute_check(BinaryQuadraticFormCheckRequest(a=1, b=1, c=1))
         forged = result.model_dump(mode="json")
         forged["form"]["b"] = 0
-        assert not verify_check_result(type(result).model_validate(forged))
+        assert not _verify_check_result(type(result).model_validate(forged))
 
 
 class TestEvaluate:
@@ -191,7 +191,7 @@ class TestEvaluate:
         )
         forged = result.model_dump(mode="json")
         forged["x"] = 100_000_000
-        assert not verify_evaluate_result(
+        assert not _verify_evaluate_result(
             BinaryQuadraticFormEvaluateResult.model_validate(forged)
         )
 
@@ -467,18 +467,15 @@ class TestRepresentations:
             exc_info, "integral_binary_quadratic_form.representation_candidate_budget"
         )
 
-    def test_result_replay_reuses_the_preflight_budget(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
-            BinaryQuadraticFormRepresentationsResult(
-                form=_positive_form(1_000_000, 0, 1),
-                target=1_000_000_000_000,
-                representations=(),
-                count=0,
-                primitive_count=0,
-            )
-        _assert_error_type(
-            exc_info, "integral_binary_quadratic_form.representation_candidate_budget"
+    def test_result_parsing_does_not_repeat_the_representation_admission(self) -> None:
+        result = BinaryQuadraticFormRepresentationsResult(
+            form=_positive_form(1_000_000, 0, 1),
+            target=1_000_000_000_000,
+            representations=(),
+            count=0,
+            primitive_count=0,
         )
+        assert not _verify_representations_result(result)
 
     def test_explicit_representation_verifier_rejects_missing_row(self) -> None:
         result = compute_representations(
@@ -490,7 +487,7 @@ class TestRepresentations:
         forged["representations"] = forged["representations"][1:]
         forged["count"] -= 1
         forged["primitive_count"] -= 1
-        assert not verify_representations_result(type(result).model_validate(forged))
+        assert not _verify_representations_result(type(result).model_validate(forged))
 
 
 class TestCanonicalFormComposition:
@@ -513,12 +510,12 @@ class TestCanonicalFormComposition:
             BinaryQuadraticFormReducedClassesRequest(discriminant=-11)
         )
 
-        assert verify_check_result(checked)
-        assert verify_evaluate_result(evaluated)
-        assert verify_reduced_form_result(reduced)
-        assert verify_proper_equivalence_result(equivalent)
-        assert verify_representations_result(representation_set)
-        assert verify_reduced_classes_result(classes)
+        assert _verify_check_result(checked)
+        assert _verify_evaluate_result(evaluated)
+        assert _verify_reduced_form_result(reduced)
+        assert _verify_proper_equivalence_result(equivalent)
+        assert _verify_representations_result(representation_set)
+        assert _verify_reduced_classes_result(classes)
 
     def test_checked_form_serializes_into_every_form_consumer(self) -> None:
         checked = compute_check(BinaryQuadraticFormCheckRequest(a=5, b=3, c=1))
@@ -572,4 +569,4 @@ class TestCanonicalFormComposition:
         )
         forged = result.model_dump(mode="json")
         forged["reduced_form"]["b"] = -1
-        assert not verify_reduced_form_result(type(result).model_validate(forged))
+        assert not _verify_reduced_form_result(type(result).model_validate(forged))

--- a/tests/math/lie_algebra_homology/test_lie_algebra_homology.py
+++ b/tests/math/lie_algebra_homology/test_lie_algebra_homology.py
@@ -14,10 +14,10 @@ from jacobian.math.lie_algebra_homology._models import (
     LieHomologyResult,
 )
 from jacobian.math.lie_algebra_homology._operations import (
+    _verify_ce_complex_result,
+    _verify_lie_homology_result,
     compute_chevalley_eilenberg_complex,
     compute_lie_homology,
-    verify_ce_complex_result,
-    verify_lie_homology_result,
 )
 from jacobian.math.prime_field_linear_algebra import PrimeFieldMatrix, rank
 
@@ -324,7 +324,7 @@ class TestComplexResultBinding:
             prime=result.prime,
         )
         assert replayed == result
-        assert verify_ce_complex_result(replayed)
+        assert _verify_ce_complex_result(replayed)
 
     def test_reviewer_payload_shape_rejected(self):
         """A complex without its source algebra cannot validate."""
@@ -387,7 +387,7 @@ class TestComplexResultBinding:
             differentials=(others[0], broken, others[1]),
             prime=5,
         )
-        assert not verify_ce_complex_result(claimed)
+        assert not _verify_ce_complex_result(claimed)
 
     def test_broken_d_squared_composition_rejected(self):
         """Tampering one d_2 entry must fail the bracket reconstruction.
@@ -419,7 +419,7 @@ class TestComplexResultBinding:
             differentials=(others[0], forged_d2, others[1]),
             prime=5,
         )
-        assert not verify_ce_complex_result(claimed)
+        assert not _verify_ce_complex_result(claimed)
 
     def test_non_residue_entries_rejected(self):
         g = _sl2_gf5()
@@ -445,7 +445,7 @@ class TestComplexResultBinding:
 class TestHomologySourceBinding:
     def test_kernel_homology_verifies(self):
         result = compute_lie_homology(LieHomologyRequest(lie_algebra=_sl2_gf5()))
-        assert verify_lie_homology_result(result)
+        assert _verify_lie_homology_result(result)
 
     def test_forged_groups_require_explicit_verification(self):
         genuine = compute_lie_homology(LieHomologyRequest(lie_algebra=_sl2_gf5()))
@@ -457,7 +457,7 @@ class TestHomologySourceBinding:
             {"degree": 3, "betti": 1, "chain_dimension": 1},
         ]
         claimed = LieHomologyResult.model_validate(payload)
-        assert not verify_lie_homology_result(claimed)
+        assert not _verify_lie_homology_result(claimed)
 
     def test_dimension_mismatch_with_source_rejected(self):
         from pydantic import ValidationError

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -737,7 +737,11 @@ def test_smt_request_admits_a_large_shallow_formula_and_still_solves() -> None:
         + ["(assert (= x (+ 1 1)))"] * 5_000
     )
     result = solve_smt(
-        SmtSolveRequest(logic=SmtLogic.QF_LIA, smtlib=assertions + "\n(check-sat)")
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib=assertions + "\n(check-sat)",
+            timeout_ms=10_000,
+        )
     )
 
     assert result.outcome == "SAT"

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -1619,8 +1619,12 @@ def test_request_bounds_parsed_ast_nodes() -> None:
             "(check-sat)\n"
         )
 
-    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(2_047))
-    assert_execution_rejected(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(2_048)))
+    assert SmtUnsatCoreRequest(
+        logic="QF_LIA", smtlib=source(2_047), timeout_ms=5_000
+    )
+    assert_execution_rejected(
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(2_048), timeout_ms=5_000)
+    )
 
 
 def test_unsat_result_requires_a_nonempty_canonical_core() -> None:

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -1619,9 +1619,7 @@ def test_request_bounds_parsed_ast_nodes() -> None:
             "(check-sat)\n"
         )
 
-    assert SmtUnsatCoreRequest(
-        logic="QF_LIA", smtlib=source(2_047), timeout_ms=5_000
-    )
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(2_047), timeout_ms=5_000)
     assert_execution_rejected(
         SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(2_048), timeout_ms=5_000)
     )

--- a/tests/math/markov_chain/test_communicating_classes.py
+++ b/tests/math/markov_chain/test_communicating_classes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fractions import Fraction
 
 import pytest
+from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.markov_chain import _operations
@@ -120,3 +121,8 @@ def test_explicit_verifier_rejects_forged_scc_claim() -> None:
 
     assert _verify_communicating_classes_result(produced) is True
     assert _verify_communicating_classes_result(forged) is False
+
+    payload = produced.model_dump(mode="json")
+    payload["transition_matrix"] = [[{"num": "2", "den": "1"}]]
+    with pytest.raises(ValidationError, match="must sum to one"):
+        CommunicatingClassesResult.model_validate(payload)

--- a/tests/math/markov_chain/test_communicating_classes.py
+++ b/tests/math/markov_chain/test_communicating_classes.py
@@ -13,8 +13,8 @@ from jacobian.math.markov_chain._models import (
     TransitionMatrixRequest,
 )
 from jacobian.math.markov_chain._operations import (
+    _verify_communicating_classes_result,
     compute_communicating_classes,
-    verify_communicating_classes_result,
 )
 from jacobian.math.markov_chain._tools import TOOLS
 
@@ -118,5 +118,5 @@ def test_explicit_verifier_rejects_forged_scc_claim() -> None:
     payload["classes"] = [((0,), True), ((1,), True)]
     forged = CommunicatingClassesResult.model_validate(payload)
 
-    assert verify_communicating_classes_result(produced) is True
-    assert verify_communicating_classes_result(forged) is False
+    assert _verify_communicating_classes_result(produced) is True
+    assert _verify_communicating_classes_result(forged) is False

--- a/tests/math/matrices/test_subsystem_operations.py
+++ b/tests/math/matrices/test_subsystem_operations.py
@@ -23,6 +23,8 @@ from jacobian.math.matrices.subsystems._models import (
     SubsystemPartialTraceResult,
 )
 from jacobian.math.matrices.subsystems._operations import (
+    _verify_partial_trace_result,
+    _verify_psd_order_result,
     compute_kronecker_product,
     compute_partial_trace,
     decide_psd_order,
@@ -147,8 +149,7 @@ def test_partial_trace_binds_the_yz_linearization_canary_to_factor_labels() -> N
     )
     forged = wire.model_dump(mode="python")
     forged["reduced_matrix"] = _matrix([[1, 0], [0, 1]], (z,))
-    with pytest.raises(ValidationError):
-        wire.__class__.model_validate(forged)
+    assert not _verify_partial_trace_result(wire.__class__.model_validate(forged))
 
     differently_bound = _matrix(diagonal, (z, y))
     wrong = partial_trace(differently_bound, ("Y",))
@@ -188,7 +189,9 @@ def test_partial_trace_rejects_unknown_and_repeated_factor_labels() -> None:
         SubsystemPartialTraceRequest(matrix=source, traced_factor_labels=("q", "q"))
 
 
-def test_partial_trace_result_replays_exact_entries_and_bounds_forged_sources() -> None:
+def test_partial_trace_result_round_trips_structurally_and_verifies_forged_claims() -> (
+    None
+):
     q = MatrixSubsystem(label="q", dimension=2)
     base = compute_partial_trace(
         SubsystemPartialTraceRequest(
@@ -202,8 +205,9 @@ def test_partial_trace_result_replays_exact_entries_and_bounds_forged_sources() 
 
     forged = base.model_dump(mode="python")
     forged["reduced_matrix"] = _matrix([[1]], ())
-    with pytest.raises(ValidationError):
+    assert not _verify_partial_trace_result(
         SubsystemPartialTraceResult.model_validate(forged)
+    )
 
     beyond_envelope = _matrix(
         [
@@ -214,8 +218,9 @@ def test_partial_trace_result_replays_exact_entries_and_bounds_forged_sources() 
     )
     forged = base.model_dump(mode="python")
     forged["source_matrix"] = beyond_envelope
-    with pytest.raises(ValidationError):
+    assert not _verify_partial_trace_result(
         SubsystemPartialTraceResult.model_validate(forged)
+    )
 
 
 def test_partial_trace_boundary_result_components_round_trip() -> None:
@@ -537,7 +542,7 @@ def test_traced_label_arrays_are_bounded_during_parsing() -> None:
     assert result_schema["properties"]["traced_factor_labels"]["maxItems"] == 4
 
 
-def test_psd_order_is_source_bound_and_returns_a_replayable_negative_witness() -> None:
+def test_psd_order_is_source_bound_and_verifies_forged_claims() -> None:
     q = MatrixSubsystem(label="q", dimension=2)
     zero = _matrix([[0, 0], [0, 0]], (q,))
     positive = _matrix([[1, 0], [0, 2]], (q,))
@@ -556,14 +561,12 @@ def test_psd_order_is_source_bound_and_returns_a_replayable_negative_witness() -
 
     forged = rejected.model_dump(mode="python")
     forged["difference"] = positive
-    with pytest.raises(ValidationError):
-        PsdOrderResult.model_validate(forged)
+    assert not _verify_psd_order_result(PsdOrderResult.model_validate(forged))
     forged = rejected.model_dump(mode="python")
     forged["inertia"] = {"n_positive": 2, "n_negative": 0, "n_zero": 0}
     forged["is_less_or_equal"] = True
     forged["negative_witness"] = None
-    with pytest.raises(ValidationError):
-        PsdOrderResult.model_validate(forged)
+    assert not _verify_psd_order_result(PsdOrderResult.model_validate(forged))
 
 
 def test_psd_order_rejects_same_shape_but_different_subsystem_identity() -> None:
@@ -808,11 +811,7 @@ def test_kronecker_product_admits_asymmetric_operand_digit_growth() -> None:
         )
 
 
-def test_psd_order_result_admits_retained_sources_before_inertia_replay(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from jacobian.math.matrices.subsystems import _models
-
+def test_psd_order_result_round_trip_does_not_replay_source_admission() -> None:
     q = MatrixSubsystem(label="q", dimension=2)
     zero = _matrix([[0, 0], [0, 0]], (q,))
     positive = _matrix([[1, 0], [0, 2]], (q,))
@@ -834,17 +833,8 @@ def test_psd_order_result_admits_retained_sources_before_inertia_replay(
     forged["right"] = wide_right
     forged["difference"] = zero
     forged["inertia"] = {"n_positive": 0, "n_negative": 0, "n_zero": 2}
-    replayed: list[object] = []
-    real_inertia = _models.symmetric_inertia
-
-    def counted(matrix: object) -> tuple[int, int, int]:
-        replayed.append(matrix)
-        return real_inertia(matrix)  # type: ignore[arg-type]
-
-    monkeypatch.setattr(_models, "symmetric_inertia", counted)
-    with pytest.raises(ValidationError):
-        PsdOrderResult.model_validate(forged)
-    assert replayed == []
+    structural = PsdOrderResult.model_validate(forged)
+    assert not _verify_psd_order_result(structural)
 
 
 def test_kronecker_product_replays_through_trace_and_psd_order_at_derived_bound() -> (

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -24,6 +24,7 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlowProfileRequest,
     MulticommodityFlowProfileResult,
     _profile_component_digit_bounds,
+    _verify_multicommodity_flow_profile_result,
     derived_profile_digit_budget,
 )
 from jacobian.math.graphs.multicommodity_flow._operations import (
@@ -83,10 +84,8 @@ def test_accepted_calls_charge_every_executed_scan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Request parsing performs the operation's component scan once, admits
-    # work and result envelope from it, and hands it to the producer pass;
-    # the replay rescans independently. A native call runs the same producer
-    # scan itself. Either way an accepted call has two charged arithmetic
-    # scans, and no further scan may escape the admitted work envelope.
+    # work and result envelope from it, then hands it to the producer. A
+    # native call runs that same one charged scan at its execution boundary.
     from jacobian.math.graphs.multicommodity_flow import _models
 
     scans = {"count": 0}
@@ -101,18 +100,18 @@ def test_accepted_calls_charge_every_executed_scan(
     via_request = _run_multicommodity_flow_profile(
         MulticommodityFlowProfileRequest(flow=shared_bottleneck_flow())
     )
-    assert_executed_work_is_charged(charged=2, executed=scans["count"])
-    assert scans == {"count": 2}
+    assert_executed_work_is_charged(charged=1, executed=scans["count"])
+    assert scans == {"count": 1}
 
     scans.update(count=0)
     native = compute_multicommodity_flow_profile(shared_bottleneck_flow())
-    assert_executed_work_is_charged(charged=2, executed=scans["count"])
-    assert scans == {"count": 2}
+    assert_executed_work_is_charged(charged=1, executed=scans["count"])
+    assert scans == {"count": 1}
 
     assert native == via_request
 
 
-def test_exact_shared_bottleneck_profile_replays_its_source() -> None:
+def test_exact_shared_bottleneck_profile_has_its_expected_values() -> None:
     result = compute_multicommodity_flow_profile(shared_bottleneck_flow())
 
     assert result.all_demands_routed is True
@@ -139,8 +138,8 @@ def test_exact_shared_bottleneck_profile_replays_its_source() -> None:
         ("b", 2, Fraction(0)),
         ("b", 3, Fraction(-2)),
     ]
-    # Producer and replay both scan the four sparse entries, four-by-two dense
-    # divergence cells, and three edges; the ledger is exact rather than a cap.
+    # The producer scans the four sparse entries, four-by-two dense divergence
+    # cells, and three edges; the ledger is exact rather than a cap.
     # Every entry shares denominator 1, so the bucket fold performs one
     # fraction addition per nonempty bucket: six touched divergence cells and
     # three edges add nine folds to the twelve numerator additions, plus the
@@ -154,7 +153,7 @@ def test_exact_shared_bottleneck_profile_replays_its_source() -> None:
     assert result.work.rational_negations_per_pass == 2
     assert result.work.rational_divisions_per_pass == 3
     assert result.work.exact_comparisons_per_pass == 8 + 3 * 3
-    assert result.work.logical_steps_per_call == 2 * (24 + 2 + 3 + 17)
+    assert result.work.logical_steps_per_call == 24 + 2 + 3 + 17
 
 
 def test_profile_distinguishes_capacity_and_conservation_failures() -> None:
@@ -209,7 +208,7 @@ def test_zero_capacity_positive_load_has_no_finite_congestion() -> None:
     # and one edge bucket: three fold additions beyond 3*1 + 1.
     assert result.work.rational_divisions_per_pass == 0
     assert result.work.exact_comparisons_per_pass == 2 + 1 + 2
-    assert result.work.logical_steps_per_call == 2 * ((3 + 3 + 1) + 1 + 0 + 5)
+    assert result.work.logical_steps_per_call == (3 + 3 + 1) + 1 + 0 + 5
 
 
 def test_early_divergence_mismatch_still_executes_every_counted_comparison() -> None:
@@ -230,7 +229,7 @@ def test_early_divergence_mismatch_still_executes_every_counted_comparison() -> 
     assert result.work.commodity_vertex_cells == 8
     assert result.work.edge_cells == 3
     assert result.work.exact_comparisons_per_pass == 8 + 3 * 3
-    assert result.work.logical_steps_per_call == 2 * (24 + 2 + 3 + 17)
+    assert result.work.logical_steps_per_call == 24 + 2 + 3 + 17
 
 
 def test_mixed_zero_and_positive_capacities_execute_every_counted_comparison() -> None:
@@ -269,7 +268,7 @@ def test_mixed_zero_and_positive_capacities_execute_every_counted_comparison() -
         assert result.congestion is None
         assert result.work.rational_divisions_per_pass == 0
         assert result.work.exact_comparisons_per_pass == 4 + 3 + (3 + 1)
-        assert result.work.logical_steps_per_call == 2 * ((9 + 7 + 3) + 1 + 0 + 11)
+        assert result.work.logical_steps_per_call == (9 + 7 + 3) + 1 + 0 + 11
 
 
 def test_fractional_split_flow_uses_exact_rational_loads_and_congestion() -> None:
@@ -341,7 +340,7 @@ def test_low_commodity_networks_admit_vertices_up_to_the_cell_budget() -> None:
     assert len(result.divergences) == 33
     assert result.work.commodity_vertex_cells == 33
     assert result.work.exact_comparisons_per_pass == 33 + 3
-    assert result.work.logical_steps_per_call == 2 * ((3 + 3 + 1) + 1 + 1 + 36)
+    assert result.work.logical_steps_per_call == (3 + 3 + 1) + 1 + 1 + 36
 
     # Eight commodities over all 64 FlowGraph vertices reach exactly 512
     # returned cells; a ninth commodity exceeds the dense divergence budget.
@@ -375,8 +374,8 @@ def test_large_exact_scalars_are_admitted_when_derived_digits_stay_bounded() -> 
     # 33-digit slack; operand-derived digit budgets, not a fixed input cap,
     # decide whether such exact scalars are admitted. Even on this one-edge
     # flow the single slack subtraction and the single congestion division
-    # execute exactly once per pass because the kernel reuses the measured
-    # components of the shared derivative scan.
+    # execute once because the kernel reuses the measured components of the
+    # shared derivative scan.
     big_capacity = q(10**32)
     flow = MulticommodityFlow(
         network=FlowGraph(
@@ -397,7 +396,7 @@ def test_large_exact_scalars_are_admitted_when_derived_digits_stay_bounded() -> 
     assert result.work.rational_negations_per_pass == 1
     assert result.work.rational_divisions_per_pass == 1
     assert result.work.exact_comparisons_per_pass == 5
-    assert result.work.logical_steps_per_call == 16
+    assert result.work.logical_steps_per_call == 8
 
 
 def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
@@ -602,13 +601,13 @@ def test_derived_quantities_admit_edges_without_a_fixed_ceiling() -> None:
     assert result.work.edge_cells == 129
     assert result.work.rational_additions_per_pass == 129
     assert result.work.exact_comparisons_per_pass == 12 + 3 * 129
-    assert result.work.logical_steps_per_call == 2 * (129 + 1 + 129 + 12 + 3 * 129)
+    assert result.work.logical_steps_per_call == 129 + 1 + 129 + 12 + 3 * 129
 
     # The ledger and returned rows inherit FlowGraph's own 512-edge maximum:
     # a full 512-edge network is admitted and accounted exactly.
     full = compute_multicommodity_flow_profile(many_edge_flow(64, 512))
     assert len(full.edge_profiles) == 512
-    assert full.work.logical_steps_per_call == 2 * (512 + 1 + 512 + 64 + 3 * 512)
+    assert full.work.logical_steps_per_call == 512 + 1 + 512 + 64 + 3 * 512
 
     # Eight commodities over the same full 512-edge graph fill the dense
     # divergence budget alongside every edge: 512 cells plus three comparisons
@@ -704,7 +703,7 @@ def test_entry_count_is_bounded_by_distinct_cells_not_a_fixed_ceiling() -> None:
         3 * 129 + unit_fold_additions(flow) + 129
     )
     assert result.work.exact_comparisons_per_pass == 13 + 3 * 129
-    assert result.work.logical_steps_per_call == 2 * (
+    assert result.work.logical_steps_per_call == (
         3 * 129 + unit_fold_additions(flow) + 129 + 1 + 129 + (13 + 3 * 129)
     )
 
@@ -756,7 +755,7 @@ def test_sparse_scan_admits_commodities_over_a_full_edge_graph() -> None:
     assert result.work.rational_negations_per_pass == 5
     assert result.work.rational_divisions_per_pass == 512
     assert result.work.exact_comparisons_per_pass == 120 + 3 * 512
-    assert result.work.logical_steps_per_call == 2 * (512 + 5 + 512 + 120 + 3 * 512)
+    assert result.work.logical_steps_per_call == 512 + 5 + 512 + 120 + 3 * 512
 
 
 def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
@@ -784,7 +783,7 @@ def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
     assert len(unrouted.divergences) == 34
     assert unrouted.work.commodity_vertex_cells == 34
     assert unrouted.work.rational_negations_per_pass == 17
-    assert unrouted.work.logical_steps_per_call == 2 * (1 + 17 + 1 + 34 + 3)
+    assert unrouted.work.logical_steps_per_call == 1 + 17 + 1 + 34 + 3
 
     # Each commodity occupies at least two distinct commodity-vertex cells,
     # so exactly half of the 512-cell divergence budget, 256 commodities, is
@@ -792,7 +791,7 @@ def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
     full = compute_multicommodity_flow_profile(dense_commodities(256))
     assert len(full.divergences) == MAX_COMMODITY_VERTEX_CELLS
     assert full.work.rational_negations_per_pass == 256
-    assert full.work.logical_steps_per_call == 2 * (1 + 256 + 1 + 512 + 3)
+    assert full.work.logical_steps_per_call == 1 + 256 + 1 + 512 + 3
 
     with multicommodity_validation_error():
         dense_commodities(257)
@@ -997,7 +996,7 @@ def test_null_congestion_admits_ratios_the_result_omits() -> None:
     assert result.work.rational_additions_per_pass == 3 * 2 + 6 + 2
     assert result.work.rational_divisions_per_pass == 0
     assert result.work.exact_comparisons_per_pass == 6 + 2 + (2 + 1)
-    assert result.work.logical_steps_per_call == 2 * (14 + 2 + 0 + 11)
+    assert result.work.logical_steps_per_call == 14 + 2 + 0 + 11
 
 
 def test_returned_congestion_ratio_is_still_capped() -> None:
@@ -1287,7 +1286,7 @@ def test_ledger_charges_every_performed_bucket_fold_addition() -> None:
     assert result.work.rational_negations_per_pass == 2
     assert result.work.rational_divisions_per_pass == 4
     assert result.work.exact_comparisons_per_pass == 8 + 3 * 4
-    assert result.work.logical_steps_per_call == 2 * (33 + 2 + 4 + 20)
+    assert result.work.logical_steps_per_call == 33 + 2 + 4 + 20
     # The exact values stay the known answers even though the fold order
     # follows ascending denominator bit length rather than entry order.
     divergence = {
@@ -1412,7 +1411,7 @@ def test_folding_intermediates_cancel_beneath_the_completed_cap() -> None:
     assert result.work.commodity_vertex_cells == 8
     assert result.work.rational_additions_per_pass == 3 * 4 + (8 + 4) + 1
     assert result.work.exact_comparisons_per_pass == 8 + 3
-    assert result.work.logical_steps_per_call == 2 * (25 + 4 + 1 + 11)
+    assert result.work.logical_steps_per_call == 25 + 4 + 1 + 11
 
 
 def test_folds_are_bounded_by_the_intermediate_budget_not_the_component_cap() -> None:
@@ -1515,21 +1514,26 @@ def test_near_cap_coprime_growth_aborts_within_budget_sized_arithmetic() -> None
         compute_multicommodity_flow_profile(near_cap_growth)
 
 
-def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:
+def test_structural_round_trip_and_private_verifier_rejects_forged_claims() -> None:
     result = compute_multicommodity_flow_profile(shared_bottleneck_flow())
     payload = result.model_dump(mode="json")
 
+    assert MulticommodityFlowProfileResult.model_validate(payload) == result
+
     forged_load = deepcopy(payload)
     forged_load["edge_profiles"][2]["load"] = {"num": "2", "den": "1"}
-    with multicommodity_validation_error():
-        MulticommodityFlowProfileResult.model_validate(forged_load)
+    parsed_load = MulticommodityFlowProfileResult.model_validate(forged_load)
+    with pytest.raises(ValueError, match="must match"):
+        _verify_multicommodity_flow_profile_result(parsed_load)
 
     forged_source = deepcopy(payload)
     forged_source["flow"]["commodities"][1]["demand"] = {"num": "1", "den": "1"}
-    with multicommodity_validation_error():
-        MulticommodityFlowProfileResult.model_validate(forged_source)
+    parsed_source = MulticommodityFlowProfileResult.model_validate(forged_source)
+    with pytest.raises(ValueError, match="must match"):
+        _verify_multicommodity_flow_profile_result(parsed_source)
 
     forged_work = deepcopy(payload)
     forged_work["work"]["logical_steps_per_call"] = 1
-    with multicommodity_validation_error():
-        MulticommodityFlowProfileResult.model_validate(forged_work)
+    parsed_work = MulticommodityFlowProfileResult.model_validate(forged_work)
+    with pytest.raises(ValueError, match="must match"):
+        _verify_multicommodity_flow_profile_result(parsed_work)

--- a/tests/math/number_theory/test_friable_count.py
+++ b/tests/math/number_theory/test_friable_count.py
@@ -166,19 +166,50 @@ def test_request_rejects_generated_search_above_node_budget() -> None:
         FriableCountRequest(x=str(_MAX_FRIABLE_SOURCE_ABS // 10), y="5")
 
 
-def test_result_rejects_a_nearby_estimate_presented_as_exact() -> None:
-    with expect_validation("number_theory."):
-        FriableCountResult(x="100", y="5", count="35")
+def test_result_validation_is_structural_and_owner_verifier_rejects_forgery() -> None:
+    from jacobian.math.number_theory._friable_operations import (
+        verify_friable_count_result,
+    )
+
+    forged = FriableCountResult(x="100", y="5", count="35")
+    assert not verify_friable_count_result(forged)
 
 
-def test_result_replays_count_and_binds_both_source_fields() -> None:
+def test_owner_verifier_binds_exact_count_to_both_sources() -> None:
+    from jacobian.math.number_theory._friable_operations import (
+        verify_friable_count_result,
+    )
+
     result = compute_friable_count(FriableCountRequest(x="100", y="5"))
     assert result == FriableCountResult(x="100", y="5", count="34")
+    assert verify_friable_count_result(result)
 
-    with expect_validation("number_theory."):
+    assert not verify_friable_count_result(
         FriableCountResult(x="125", y="5", count=result.count)
-    with expect_validation("number_theory."):
+    )
+    assert not verify_friable_count_result(
         FriableCountResult(x="100", y="3", count=result.count)
+    )
+
+
+def test_producer_executes_the_friable_kernel_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jacobian.math.number_theory._friable_operations as operations
+
+    calls = 0
+    original = operations.count_friable
+
+    def observed_count(x: int, y: int) -> int:
+        nonlocal calls
+        calls += 1
+        return original(x, y)
+
+    monkeypatch.setattr(operations, "count_friable", observed_count)
+    result = operations.compute_friable_count(FriableCountRequest(x="100", y="5"))
+
+    assert result.count == "34"
+    assert calls == 1
 
 
 def test_operation_is_discoverable_with_one_executable_example() -> None:

--- a/tests/math/number_theory/test_friable_count.py
+++ b/tests/math/number_theory/test_friable_count.py
@@ -173,6 +173,7 @@ def test_result_validation_is_structural_and_owner_verifier_rejects_forgery() ->
 
     forged = FriableCountResult(x="100", y="5", count="35")
     assert not verify_friable_count_result(forged)
+    assert not verify_friable_count_result(FriableCountResult(x="-1", y="5", count="0"))
 
 
 def test_owner_verifier_binds_exact_count_to_both_sources() -> None:

--- a/tests/math/number_theory/test_periodic_congruences.py
+++ b/tests/math/number_theory/test_periodic_congruences.py
@@ -371,7 +371,11 @@ def test_small_profiles_match_exhaustive_membership_replay() -> None:
                 assert result.density.as_fraction() == Fraction(len(expected), 6)
 
 
-def test_measure_result_rejects_independent_source_and_conclusion_mutations() -> None:
+def test_measure_result_is_structural_and_private_verifier_rejects_mutations() -> None:
+    from jacobian.math.number_theory._periodic_operations import (
+        _verify_periodic_congruence_union_measure_result,
+    )
+
     result = _measure(
         {
             "subsets": [{"modulus": "5", "residues": ["0", "2"]}],
@@ -392,11 +396,16 @@ def test_measure_result_rejects_independent_source_and_conclusion_mutations() ->
 
     bad_source = copy.deepcopy(serialized)
     bad_source["source"]["complement"] = True
-    with expect_validation("number_theory."):
+    assert not _verify_periodic_congruence_union_measure_result(
         PeriodicCongruenceUnionMeasureResult.model_validate(bad_source)
+    )
 
 
-def test_profile_result_rejects_omitted_or_forged_residues() -> None:
+def test_profile_private_verifier_rejects_omitted_or_forged_residues() -> None:
+    from jacobian.math.number_theory._periodic_operations import (
+        _verify_periodic_congruence_union_profile_result,
+    )
+
     result = _profile(
         {
             "subsets": [{"modulus": "5", "residues": ["0", "2"]}],
@@ -405,14 +414,21 @@ def test_profile_result_rejects_omitted_or_forged_residues() -> None:
     )
     serialized = result.model_dump(mode="json")
 
-    for residues in (["0"], ["0", "1", "2"]):
+    for residues in (["0", "1"], ["1", "2"]):
         forged = copy.deepcopy(serialized)
         forged["occupied_residues"] = residues
-        with expect_validation("number_theory."):
+        assert not _verify_periodic_congruence_union_profile_result(
             PeriodicCongruenceUnionProfileResult.model_validate(forged)
+        )
 
 
-def test_profile_result_rejects_independent_source_and_measure_mutations() -> None:
+def test_profile_result_is_structural_and_private_verifier_rejects_source_mutation() -> (
+    None
+):
+    from jacobian.math.number_theory._periodic_operations import (
+        _verify_periodic_congruence_union_profile_result,
+    )
+
     result = _profile(
         {
             "subsets": [{"modulus": "5", "residues": ["0", "2"]}],
@@ -423,8 +439,9 @@ def test_profile_result_rejects_independent_source_and_measure_mutations() -> No
 
     bad_source = copy.deepcopy(serialized)
     bad_source["source"]["subsets"][0]["residues"] = ["1", "3"]
-    with expect_validation("number_theory."):
+    assert not _verify_periodic_congruence_union_profile_result(
         PeriodicCongruenceUnionProfileResult.model_validate(bad_source)
+    )
 
     bad_period = copy.deepcopy(serialized)
     bad_period["common_period"] = "6"

--- a/tests/math/number_theory/test_powerful.py
+++ b/tests/math/number_theory/test_powerful.py
@@ -212,7 +212,7 @@ def test_request_rejects_nonpositive_noncanonical_or_nonstring_values(
         ),
     ],
 )
-def test_result_rejects_mutated_source_or_certificate(
+def test_owner_verifier_rejects_mutated_source_or_certificate(
     value: int,
     mutation: PayloadMutation,
 ) -> None:
@@ -220,8 +220,11 @@ def test_result_rejects_mutated_source_or_certificate(
     payload = deepcopy(genuine.model_dump(mode="json"))
     mutation(payload)
 
-    with expect_validation("number_theory."):
+    from jacobian.math.number_theory._powerful import verify_powerful_number_result
+
+    assert not verify_powerful_number_result(
         PowerfulNumberResult.model_validate(payload)
+    )
 
 
 @pytest.mark.exhaustive

--- a/tests/math/number_theory/test_ramanujan_sums.py
+++ b/tests/math/number_theory/test_ramanujan_sums.py
@@ -78,19 +78,18 @@ def test_ramanujan_sum_complete_period_orthogonality(
     assert inner_product == expected
 
 
-def test_operation_returns_a_source_bound_exact_result() -> None:
+def test_operation_returns_an_exact_result_without_replaying_it_on_parse() -> None:
     result = RAMANUJAN_SUM_OPERATION.run(
         RamanujanSumRequest(modulus="4", frequency="2")
     )
     assert result == RamanujanSumResult(modulus="4", frequency="2", value="-2")
 
-    for mutation in (
-        {"modulus": "4", "frequency": "1", "value": "-2"},
-        {"modulus": "3", "frequency": "2", "value": "-2"},
-        {"modulus": "4", "frequency": "2", "value": "2"},
-    ):
-        with expect_validation("number_theory."):
-            RamanujanSumResult.model_validate(mutation)
+    assert (
+        RamanujanSumResult.model_validate(
+            {"modulus": "4", "frequency": "1", "value": "-2"}
+        ).value
+        == "-2"
+    )
 
 
 def test_zero_sum_binds_the_canonical_zero_string() -> None:

--- a/tests/math/numerical_semigroups/test_result_verifiers.py
+++ b/tests/math/numerical_semigroups/test_result_verifiers.py
@@ -19,12 +19,12 @@ from jacobian.math.numerical_semigroups._element_invariant_models import (
     ElementElasticityResult,
 )
 from jacobian.math.numerical_semigroups._element_invariant_operations import (
+    _verify_element_catenary_degree_result,
+    _verify_element_delta_set_result,
+    _verify_element_elasticity_result,
     compute_element_catenary_degree,
     compute_element_delta_set,
     compute_element_elasticity,
-    verify_element_catenary_degree_result,
-    verify_element_delta_set_result,
-    verify_element_elasticity_result,
 )
 from jacobian.math.numerical_semigroups._factorization_models import (
     FactorizationComputeRequest,
@@ -35,12 +35,12 @@ from jacobian.math.numerical_semigroups._factorization_models import (
     FactorizationLengthsComputeResult,
 )
 from jacobian.math.numerical_semigroups._factorization_operations import (
+    _verify_factorization_compute_result,
+    _verify_factorization_graph_compute_result,
+    _verify_factorization_lengths_compute_result,
     compute_factorization_graph,
     compute_factorization_lengths,
     compute_factorizations,
-    verify_factorization_compute_result,
-    verify_factorization_graph_compute_result,
-    verify_factorization_lengths_compute_result,
 )
 from jacobian.math.numerical_semigroups._global_invariant_models import (
     BettiElementsRequest,
@@ -80,7 +80,7 @@ def test_factorization_verifier_rejects_forged_complete_family() -> None:
         _forged(result, factorizations=((5, 0),))
     )
 
-    assert not verify_factorization_compute_result(forged)
+    assert not _verify_factorization_compute_result(forged)
 
 
 @pytest.mark.parametrize(
@@ -156,18 +156,52 @@ def test_element_invariant_replay_results_reapply_request_value_envelopes(
         result_type.model_validate(payload)
 
 
-def test_catenary_result_rejects_an_unmaterializable_family_before_replay() -> None:
-    """A supplied claim cannot force the old unbounded factorization replay."""
-
-    with pytest.raises(ValueError, match="exact materialization bound 1000"):
-        ElementCatenaryDegreeResult.model_validate(
+@pytest.mark.parametrize(
+    ("result_type", "payload", "verify"),
+    (
+        (
+            FactorizationComputeResult,
+            {
+                "value": "9990",
+                "minimal_generators": ("6", "10", "14", "15"),
+                "in_semigroup": False,
+                "factorizations": (),
+            },
+            _verify_factorization_compute_result,
+        ),
+        (
+            FactorizationGraphComputeResult,
+            {
+                "value": "9990",
+                "minimal_generators": ("6", "10", "14", "15"),
+                "in_semigroup": False,
+                "factorizations": (),
+                "edges": (),
+                "connected_components": (),
+                "is_connected": True,
+            },
+            _verify_factorization_graph_compute_result,
+        ),
+        (
+            ElementCatenaryDegreeResult,
             {
                 "value": "9990",
                 "minimal_generators": ("6", "10", "14", "15"),
                 "factorization_count": 13_307_204,
                 "catenary_degree": 6,
-            }
-        )
+            },
+            _verify_element_catenary_degree_result,
+        ),
+    ),
+)
+def test_materialization_results_parse_structurally_but_verification_reapplies_admission(
+    result_type: type[Any], payload: dict[str, Any], verify: Any
+) -> None:
+    """Parsing a claim never counts or enumerates its factorization family."""
+
+    result = result_type.model_validate(payload)
+
+    assert not verify(result)
 
 
 @pytest.mark.parametrize(
@@ -235,7 +269,7 @@ def test_factorization_length_verifier_rejects_forged_length_set() -> None:
         _forged(result, lengths=(3,))
     )
 
-    assert not verify_factorization_lengths_compute_result(forged)
+    assert not _verify_factorization_lengths_compute_result(forged)
 
 
 def test_element_invariant_verifiers_reject_forged_claims() -> None:
@@ -263,10 +297,10 @@ def test_element_invariant_verifiers_reject_forged_claims() -> None:
         _forged(catenary, catenary_degree=0)
     )
 
-    assert not verify_element_delta_set_result(forged_delta)
-    assert not verify_element_elasticity_result(forged_elasticity)
-    assert verify_element_catenary_degree_result(catenary)
-    assert not verify_element_catenary_degree_result(forged_catenary)
+    assert not _verify_element_delta_set_result(forged_delta)
+    assert not _verify_element_elasticity_result(forged_elasticity)
+    assert _verify_element_catenary_degree_result(catenary)
+    assert not _verify_element_catenary_degree_result(forged_catenary)
 
 
 def test_factorization_graph_verifier_rejects_forged_edge_set() -> None:
@@ -277,7 +311,7 @@ def test_factorization_graph_verifier_rejects_forged_edge_set() -> None:
         _forged(result, edges=((0, 1),))
     )
 
-    assert not verify_factorization_graph_compute_result(forged)
+    assert not _verify_factorization_graph_compute_result(forged)
 
 
 def test_global_invariant_verifiers_reject_forged_claims() -> None:

--- a/tests/math/padic_arithmetic/test_padic.py
+++ b/tests/math/padic_arithmetic/test_padic.py
@@ -156,6 +156,22 @@ class TestPAdicRoots:
         with pytest.raises(PydanticCustomError):
             verify_padic_roots_result(PAdicRootsResult.model_validate(forged))
 
+    def test_roots_profile_rejects_out_of_range_structural_entries(self):
+        result = find_padic_roots(
+            PAdicRootsRequest(
+                polynomial=IntegerPolynomial(coefficients=("1", "0", "0", "-1")),
+                prime=5,
+                precision=2,
+            )
+        )
+        forged = result.model_dump()
+        forged["roots"][0]["root"] = 25
+        with pytest.raises(ValidationError) as exc_info:
+            PAdicRootsResult.model_validate(forged)
+        assert (
+            exc_info.value.errors()[0]["type"] == "padic_arithmetic.root_out_of_range"
+        )
+
     def test_multiple_root_lift_rejected(self):
         """f=x^2+5, p=5: r=0 is a multiple root; lifting is refused."""
         poly = IntegerPolynomial(coefficients=("1", "0", "5"))

--- a/tests/math/padic_arithmetic/test_padic.py
+++ b/tests/math/padic_arithmetic/test_padic.py
@@ -6,6 +6,7 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import ValidationError
+from pydantic_core import PydanticCustomError
 
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.padic_arithmetic._models import (
@@ -13,9 +14,10 @@ from jacobian.math.padic_arithmetic._models import (
     HenselRootRequest,
     HenselRootResult,
     IntegerPolynomial,
-    PAdicRootEntry,
     PAdicRootsRequest,
     PAdicRootsResult,
+    verify_hensel_root_result,
+    verify_padic_roots_result,
 )
 from jacobian.math.padic_arithmetic._operations import (
     find_padic_roots,
@@ -101,24 +103,8 @@ class TestPAdicRoots:
             HenselRootRequest(polynomial=poly, prime=4, root_mod_p=1, precision=2)
         assert exc_info.value.errors()[0]["type"] == "padic_arithmetic.prime_not_prime"
 
-    def test_result_rejects_composite_modulus(self):
-        """A serialized root set cannot validate against a composite modulus
-        even when its completeness and derivative replay would succeed."""
-        with pytest.raises(ValidationError) as exc_info:
-            PAdicRootsResult(
-                polynomial=IntegerPolynomial(coefficients=("1", "-1")),
-                roots=(PAdicRootEntry(root=1),),
-                prime=4,
-                precision=2,
-                root_count=1,
-            )
-        assert exc_info.value.errors()[0]["type"] == "padic_arithmetic.prime_not_prime"
-
-    def test_result_binds_to_source_polynomial(self):
-        """The exact result retains polynomial and residue and replays them:
-        genuine lifts round-trip through serialization, while forged lifts,
-        wrong residues, detached polynomials, and a False simple flag are
-        rejected at validation."""
+    def test_result_is_structural_and_owner_verifier_binds_source(self):
+        """Parsing retains shape checks; deliberate claim checks stay private."""
         poly = IntegerPolynomial(coefficients=("1", "0", "1"))  # x^2 + 1
         result = hensel_lift_root(
             HenselRootRequest(polynomial=poly, prime=5, root_mod_p=2, precision=4)
@@ -129,28 +115,24 @@ class TestPAdicRoots:
 
         roundtrip = HenselRootResult.model_validate(result.model_dump())
         assert roundtrip == result
+        verify_hensel_root_result(roundtrip)
 
         detached = result.model_dump()
         detached["polynomial"]["coefficients"] = ["1", "0", "2"]
-        with pytest.raises(ValidationError) as exc_info:
-            HenselRootResult.model_validate(detached)
-        assert exc_info.value.errors()[0]["type"] == "padic_arithmetic.root_not_root"
+        with pytest.raises((PydanticCustomError, ValidationError)):
+            verify_hensel_root_result(HenselRootResult.model_validate(detached))
 
         forged = result.model_dump()
         forged["lifted_root"] = (forged["lifted_root"] + 1) % 625
-        with pytest.raises(ValidationError):
-            HenselRootResult.model_validate(forged)
+        with pytest.raises(PydanticCustomError):
+            verify_hensel_root_result(HenselRootResult.model_validate(forged))
 
         wrong_residue = result.model_dump()
         # residue 3 is itself a simple root of x^2+1 mod 5, so only the
         # congruence of the lift to its residue can reject this tampering
         wrong_residue["root_mod_p"] = 3
-        with pytest.raises(ValidationError) as exc_info:
-            HenselRootResult.model_validate(wrong_residue)
-        assert (
-            exc_info.value.errors()[0]["type"]
-            == "padic_arithmetic.lifted_root_wrong_residue"
-        )
+        with pytest.raises(PydanticCustomError):
+            verify_hensel_root_result(HenselRootResult.model_validate(wrong_residue))
 
         not_simple = result.model_dump()
         not_simple["is_simple_root"] = False
@@ -159,6 +141,20 @@ class TestPAdicRoots:
         assert (
             exc_info.value.errors()[0]["type"] == "padic_arithmetic.simple_flag_invalid"
         )
+
+    def test_roots_profile_verifier_rejects_forged_source(self):
+        result = find_padic_roots(
+            PAdicRootsRequest(
+                polynomial=IntegerPolynomial(coefficients=("1", "0", "0", "-1")),
+                prime=7,
+                precision=3,
+            )
+        )
+        verify_padic_roots_result(PAdicRootsResult.model_validate(result.model_dump()))
+        forged = result.model_dump()
+        forged["multiple_residues"] = [0]
+        with pytest.raises(PydanticCustomError):
+            verify_padic_roots_result(PAdicRootsResult.model_validate(forged))
 
     def test_multiple_root_lift_rejected(self):
         """f=x^2+5, p=5: r=0 is a multiple root; lifting is refused."""

--- a/tests/math/plane_algebraic_curves/test_plane_algebraic_curves.py
+++ b/tests/math/plane_algebraic_curves/test_plane_algebraic_curves.py
@@ -487,7 +487,7 @@ def test_exact_preflight_admits_rational_point_on_hyperbola() -> None:
     )
 
 
-def test_result_rejects_independently_forged_source_point_and_coordinates() -> None:
+def test_result_parses_structurally_and_owner_verifier_rejects_forged_claims() -> None:
     source = _polynomial(
         ("x", "y"),
         (1, (2, 0)),
@@ -497,11 +497,14 @@ def test_result_rejects_independently_forged_source_point_and_coordinates() -> N
     )
     result = _parametrize(source, (_rational(1), _rational(0)))
     payload = result.model_dump(mode="json")
+    assert RationalConicParametrizationResult.model_validate(payload) == result
 
     forged_coordinates = deepcopy(payload)
     forged_coordinates["coordinates"][0] = payload["coordinates"][1]
-    with _raises_code("parametrization_not_canonical"):
-        RationalConicParametrizationResult.model_validate(forged_coordinates)
+    with pytest.raises(ValueError):
+        _conic._verify_rational_conic_parametrization_result(
+            RationalConicParametrizationResult.model_validate(forged_coordinates)
+        )
 
     forged_source = deepcopy(payload)
     forged_source["source_polynomial"] = _polynomial(
@@ -510,28 +513,36 @@ def test_result_rejects_independently_forged_source_point_and_coordinates() -> N
         (1, (0, 2)),
         (-1, (0, 0)),
     ).model_dump(mode="json")
-    with _raises_code("parametrization_not_canonical"):
-        RationalConicParametrizationResult.model_validate(forged_source)
+    with pytest.raises(ValueError):
+        _conic._verify_rational_conic_parametrization_result(
+            RationalConicParametrizationResult.model_validate(forged_source)
+        )
 
     forged_point = deepcopy(payload)
     forged_point["exceptional_point"] = _point(
         source.variables, (_rational(-1), _rational(0))
     ).model_dump(mode="json")
-    with _raises_code("parametrization_not_canonical"):
-        RationalConicParametrizationResult.model_validate(forged_point)
+    with pytest.raises(ValueError):
+        _conic._verify_rational_conic_parametrization_result(
+            RationalConicParametrizationResult.model_validate(forged_point)
+        )
 
     forged_inverse = deepcopy(payload)
     forged_inverse["inverse_parameter"] = payload["coordinates"][0]
-    with _raises_code("parametrization_not_canonical"):
-        RationalConicParametrizationResult.model_validate(forged_inverse)
+    with pytest.raises(ValueError):
+        _conic._verify_rational_conic_parametrization_result(
+            RationalConicParametrizationResult.model_validate(forged_inverse)
+        )
 
     forged_denominator = deepcopy(payload)
     denominator_terms = forged_denominator["finite_parameter_denominator"][
         "polynomial"
     ]["terms"]
     denominator_terms[-1]["coefficient"]["num"] = "-2"
-    with _raises_code("parametrization_not_canonical"):
-        RationalConicParametrizationResult.model_validate(forged_denominator)
+    with pytest.raises(ValueError):
+        _conic._verify_rational_conic_parametrization_result(
+            RationalConicParametrizationResult.model_validate(forged_denominator)
+        )
 
 
 def test_parametrization_schema_guides_cross_field_contract() -> None:

--- a/tests/math/polynomials/ideals/test_minimal_primes.py
+++ b/tests/math/polynomials/ideals/test_minimal_primes.py
@@ -15,11 +15,10 @@ from jacobian.math.polynomials.ideals._models import (
     MAX_OUTPUT_TERMS,
     IdealMinimalPrimesRequest,
     IdealMinimalPrimesResult,
-    computed_minimal_primes_result,
 )
 from jacobian.math.polynomials.ideals._operations import (
+    _verify_ideal_minimal_primes_result,
     compute_ideal_minimal_primes,
-    verify_ideal_minimal_primes_result,
 )
 from jacobian.math.polynomials.ideals._singular import SingularMinimalPrimesResult
 from jacobian.math.polynomials.values import (
@@ -159,7 +158,7 @@ def test_result_construction_is_structural_and_explicit_verifier_checks_family(
 
     assert result.components == components
     assert seen == []
-    assert verify_ideal_minimal_primes_result(result)
+    assert _verify_ideal_minimal_primes_result(result)
     assert seen == [(request.ideal, components)]
 
 
@@ -178,7 +177,7 @@ def test_non_verified_verdicts_fail_explicit_verification(
         components=components,
         backend_version="4.4.0",
     )
-    assert not verify_ideal_minimal_primes_result(result)
+    assert not _verify_ideal_minimal_primes_result(result)
 
 
 def test_explicit_verifier_rejects_incomplete_family_by_radical_intersection(
@@ -195,7 +194,7 @@ def test_explicit_verifier_rejects_incomplete_family_by_radical_intersection(
         components=components[:1],
         backend_version="4.4.0",
     )
-    assert not verify_ideal_minimal_primes_result(result)
+    assert not _verify_ideal_minimal_primes_result(result)
 
 
 def test_missing_backend_is_typed_and_makes_no_component_claim(
@@ -338,20 +337,24 @@ def test_trusted_factory_enforces_shape_ring_ordering_and_uniqueness() -> None:
     components = _axes_components()
     foreign_ring = (_ideal(("y", "x"), _poly(("y", "x"), (1, 1, (0, 1)))),)
 
-    computed = computed_minimal_primes_result(request, components, "4.4.0")
+    computed = IdealMinimalPrimesResult._from_kernel(request, components, "4.4.0")
     assert computed.outcome == "COMPUTED"
     assert computed.components == components
     assert computed.backend_version == "4.4.0"
     assert computed.detail is None
 
     with pytest.raises(ValueError, match="ordered ring"):
-        computed_minimal_primes_result(request, foreign_ring, "4.4.0")
+        IdealMinimalPrimesResult._from_kernel(request, foreign_ring, "4.4.0")
     with pytest.raises(ValueError, match="unique and canonically ordered"):
-        computed_minimal_primes_result(request, tuple(reversed(components)), "4.4.0")
+        IdealMinimalPrimesResult._from_kernel(
+            request, tuple(reversed(components)), "4.4.0"
+        )
     with pytest.raises(ValueError, match="unique and canonically ordered"):
-        computed_minimal_primes_result(request, (components[0], components[0]), "4.4.0")
+        IdealMinimalPrimesResult._from_kernel(
+            request, (components[0], components[0]), "4.4.0"
+        )
     with pytest.raises(ValueError, match="requires components and backend version"):
-        computed_minimal_primes_result(request, None, None)
+        IdealMinimalPrimesResult._from_kernel(request, None, None)
 
 
 def test_external_family_must_respect_the_generator_and_term_envelopes() -> None:
@@ -368,7 +371,7 @@ def test_external_family_must_respect_the_generator_and_term_envelopes() -> None
             ),
         ),
     )
-    computed = computed_minimal_primes_result(request, wide, "4.4.0")
+    computed = IdealMinimalPrimesResult._from_kernel(request, wide, "4.4.0")
     assert computed.outcome == "COMPUTED"
     assert computed.components == wide
 
@@ -392,7 +395,7 @@ def test_external_family_must_respect_the_generator_and_term_envelopes() -> None
     with pytest.raises(
         ValueError, match=rf"{MAX_OUTPUT_GENERATORS}-generator exact-result envelope"
     ):
-        computed_minimal_primes_result(request, over_generators, "4.4.0")
+        IdealMinimalPrimesResult._from_kernel(request, over_generators, "4.4.0")
 
     heavy_terms = tuple(
         sorted(
@@ -408,7 +411,7 @@ def test_external_family_must_respect_the_generator_and_term_envelopes() -> None
     with pytest.raises(
         ValueError, match=rf"{MAX_OUTPUT_TERMS}-term exact-result envelope"
     ):
-        computed_minimal_primes_result(request, oversized, "4.4.0")
+        IdealMinimalPrimesResult._from_kernel(request, oversized, "4.4.0")
 
 
 def test_validator_rejects_duplicate_components_before_any_replay(
@@ -971,7 +974,7 @@ def test_forged_well_shaped_family_fails_explicit_verification() -> None:
         components=forged,
         backend_version="4.4.0",
     )
-    assert not verify_ideal_minimal_primes_result(result)
+    assert not _verify_ideal_minimal_primes_result(result)
 
 
 @pytest.mark.skipif(

--- a/tests/math/polynomials/interpolation/test_hermite_interpolation.py
+++ b/tests/math/polynomials/interpolation/test_hermite_interpolation.py
@@ -30,6 +30,7 @@ from jacobian.math.polynomials.interpolation._models import (
     HermiteInterpolationRequest,
 )
 from jacobian.math.polynomials.interpolation._operations import (
+    _verify_hermite_interpolation_result,
     compute_hermite_interpolation,
 )
 
@@ -280,26 +281,29 @@ def test_duplicate_nodes_and_incomplete_prefixes_are_rejected() -> None:
         )
 
 
-def test_forged_replay_and_retained_source_are_rejected() -> None:
+def test_forged_claims_round_trip_structurally_and_fail_explicit_verification() -> None:
     result = hermite_interpolation(
         _table(_jet(0, (0, 1), (0, 1)), _jet(1, (1, 1), (2, 1)))
     )
 
     forged_replay = result.model_dump(mode="json")
     forged_replay["replay"][0]["computed"] = {"num": "1", "den": "1"}
-    with pytest.raises(ValidationError):
-        HermiteInterpolationResult.model_validate(forged_replay)
+    parsed_replay = HermiteInterpolationResult.model_validate(forged_replay)
+    assert not _verify_hermite_interpolation_result(parsed_replay)
 
     forged_source = result.model_dump(mode="json")
     forged_source["source"]["jets"][0]["derivatives"][0]["value"] = {
         "num": "1",
         "den": "1",
     }
-    with pytest.raises(ValidationError):
-        HermiteInterpolationResult.model_validate(forged_source)
+    forged_source["replay"][0]["expected"] = {"num": "1", "den": "1"}
+    parsed_source = HermiteInterpolationResult.model_validate(forged_source)
+    assert not _verify_hermite_interpolation_result(parsed_source)
 
 
-def test_forged_polynomial_degree_and_leading_coefficient_are_rejected() -> None:
+def test_forged_polynomial_fails_explicit_verification_but_bad_summaries_do_not_parse() -> (
+    None
+):
     result = hermite_interpolation(_table(_jet(0, (1, 1), (1, 1))))
 
     forged_polynomial = result.model_dump(mode="json")
@@ -307,8 +311,8 @@ def test_forged_polynomial_degree_and_leading_coefficient_are_rejected() -> None
         "num": "2",
         "den": "1",
     }
-    with pytest.raises(ValidationError):
-        HermiteInterpolationResult.model_validate(forged_polynomial)
+    parsed_polynomial = HermiteInterpolationResult.model_validate(forged_polynomial)
+    assert not _verify_hermite_interpolation_result(parsed_polynomial)
 
     forged_summary = result.model_dump(mode="json")
     forged_summary["leading_coefficient"] = {"num": "2", "den": "1"}

--- a/tests/math/polynomials/multivariate/test_factor.py
+++ b/tests/math/polynomials/multivariate/test_factor.py
@@ -12,8 +12,8 @@ from jacobian.math.polynomials.multivariate._factor_models import (
     MultivariateIrreducibleFactor,
 )
 from jacobian.math.polynomials.multivariate._operations import (
+    _verify_multivariate_factor_result,
     multivariate_factor,
-    verify_multivariate_factor_result,
 )
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
@@ -101,7 +101,7 @@ class TestMultivariateFactorResultInvariants:
         restored = MultivariateFactorResult.model_validate(result.model_dump())
         assert restored == result
         assert calls == 1
-        assert verify_multivariate_factor_result(restored)
+        assert _verify_multivariate_factor_result(restored)
         assert calls == 2
 
     def test_rejects_zero_coefficient_with_zero_reconstruction(self):
@@ -136,13 +136,13 @@ class TestMultivariateFactorResultInvariants:
             factors=(),
             reconstructed=reconstructed,
         )
-        assert not verify_multivariate_factor_result(wrong_content)
+        assert not _verify_multivariate_factor_result(wrong_content)
         forged = MultivariateFactorResult(
             coefficient=CanonicalRational.from_fraction(Fraction(1)),
             factors=(),
             reconstructed=reconstructed,
         )
-        assert not verify_multivariate_factor_result(forged)
+        assert not _verify_multivariate_factor_result(forged)
 
     def test_factorized_outcome_requires_invariant_markers(self):
         """A FACTORIZED result without the public contract's normalization
@@ -203,7 +203,7 @@ class TestOutputBudgetOutcome:
             normalization=None,
             product_reconstruction=None,
         )
-        assert not verify_multivariate_factor_result(forged)
+        assert not _verify_multivariate_factor_result(forged)
 
     def test_budget_exceeded_cannot_carry_factors(self):
         poly = _poly(("x", "y"), ((2, 1, (2, 1)), (-2, 1, (1, 0))))
@@ -306,7 +306,7 @@ class TestBoundedReconstructionReplay:
             factors=tuple(records),
             reconstructed=target,
         )
-        assert not verify_multivariate_factor_result(forged)
+        assert not _verify_multivariate_factor_result(forged)
 
     def test_telescoped_geometric_product_replays_boundedly(self):
         """(x^64-1)(y^64-1)(z^64-1) reconstructs through many geometric-sum
@@ -342,7 +342,7 @@ class TestBoundedReconstructionReplay:
             factors=(factor,),
             reconstructed=reconstructed,
         )
-        assert not verify_multivariate_factor_result(forged)
+        assert not _verify_multivariate_factor_result(forged)
 
     def test_scaled_constant_coefficient_verified(self):
         """coefficient * product must equal reconstructed exactly, including
@@ -361,14 +361,14 @@ class TestBoundedReconstructionReplay:
             factors=records,
             reconstructed=reconstructed,
         )
-        assert not verify_multivariate_factor_result(forged)
+        assert not _verify_multivariate_factor_result(forged)
         accepted = MultivariateFactorResult(
             coefficient=CanonicalRational.from_fraction(Fraction(3)),
             factors=records,
             reconstructed=reconstructed,
         )
         assert accepted.product_reconstruction == "EXACT"
-        assert verify_multivariate_factor_result(accepted)
+        assert _verify_multivariate_factor_result(accepted)
 
 
 class TestBudgetOutcomeCoefficientBinding:
@@ -467,7 +467,7 @@ class TestUniqueFactorizationReplay:
             factors=tuple(records),
             reconstructed=result.reconstructed,
         )
-        assert not verify_multivariate_factor_result(forged)
+        assert not _verify_multivariate_factor_result(forged)
 
     def test_multiplicity_shift_between_equal_degree_factors_rejected(self):
         """Moving multiplicity between equal-degree factors preserves the
@@ -503,7 +503,7 @@ class TestUniqueFactorizationReplay:
             factors=tuple(records),
             reconstructed=result.reconstructed,
         )
-        assert not verify_multivariate_factor_result(forged)
+        assert not _verify_multivariate_factor_result(forged)
 
 
 def _prime_denominator_poly(prime_count):
@@ -833,7 +833,7 @@ class TestKillableFactorBackend:
             normalization=None,
             product_reconstruction=None,
         )
-        assert not verify_multivariate_factor_result(claim)
+        assert not _verify_multivariate_factor_result(claim)
 
     def test_memory_exhausted_budget_claim_replay_rejected(self, monkeypatch):
         """An authored OUTPUT_BUDGET_EXCEEDED claim whose verification
@@ -869,7 +869,7 @@ class TestKillableFactorBackend:
             normalization=None,
             product_reconstruction=None,
         )
-        assert not verify_multivariate_factor_result(claim)
+        assert not _verify_multivariate_factor_result(claim)
 
 
 class TestSignedBudgetOutcomeContent:

--- a/tests/math/polynomials/test_multivariate_polynomial.py
+++ b/tests/math/polynomials/test_multivariate_polynomial.py
@@ -26,10 +26,12 @@ from jacobian.math.polynomials.multivariate._operations import (
 from jacobian.math.polynomials.multivariate._resultant import (
     MultivariateResultantRequest,
     MultivariateResultantResult,
+    _verify_multivariate_resultant,
 )
 from jacobian.math.polynomials.multivariate._subresultants import (
     MultivariateSubresultantSequenceRequest,
     MultivariateSubresultantSequenceResult,
+    _verify_multivariate_subresultant_sequence,
 )
 from jacobian.math.polynomials.values import RationalPolynomial
 
@@ -517,8 +519,10 @@ class TestMultivariateResultant:
             )
             assert together(expected - claimed) == 0
 
-    def test_resultant_source_bound_replay_rejects_mutations(self) -> None:
-        """Serialized results replay against their retained source pair."""
+    def test_resultant_parsing_is_structural_and_verification_is_deliberate(
+        self,
+    ) -> None:
+        """Deserialization does not replay the determinant of retained sources."""
 
         left = _poly(("x", "y"), (("1/1", (1, 1)), ("-1/1", (0, 0))))
         right = _poly(("x", "y"), (("1/1", (2, 0)), ("-1/1", (0, 0))))
@@ -528,18 +532,26 @@ class TestMultivariateResultant:
         result = compute_multivariate_resultant(request)
         dumped = result.model_dump()
         assert MultivariateResultantResult.model_validate(dumped) == result
+        assert _verify_multivariate_resultant(result)
 
         forged = copy.deepcopy(dumped)
         forged["resultant"]["value"]["polynomial"]["terms"] = [
             {"coefficient": {"num": "9999", "den": "1"}, "exponents": [0]}
         ]
-        with polynomial_validation_error():
-            MultivariateResultantResult.model_validate(forged)
+        forged_result = MultivariateResultantResult.model_validate(forged)
+        assert not _verify_multivariate_resultant(forged_result)
 
         swapped = copy.deepcopy(dumped)
         swapped["left"] = dumped["right"]
-        with polynomial_validation_error():
-            MultivariateResultantResult.model_validate(swapped)
+        swapped_result = MultivariateResultantResult.model_validate(swapped)
+        assert not _verify_multivariate_resultant(swapped_result)
+
+        out_of_envelope = copy.deepcopy(dumped)
+        out_of_envelope["left"]["polynomial"]["terms"][0]["exponents"] = (100, 1)
+        parsed_out_of_envelope = MultivariateResultantResult.model_validate(
+            out_of_envelope
+        )
+        assert not _verify_multivariate_resultant(parsed_out_of_envelope)
 
     def test_resultant_rejects_univariate(self) -> None:
         """Univariate polynomials are rejected for multivariate operations."""
@@ -1221,7 +1233,9 @@ class TestMultivariateSubresultantSequence:
                 main_variable="x",
             )
 
-    def test_result_validation_rejects_corrupted_source_bound_fields(self) -> None:
+    def test_result_parsing_is_structural_and_verification_rejects_forgery(
+        self,
+    ) -> None:
         left = _poly(
             ("x", "y"),
             (("1/1", (2, 0)), ("-1/1", (0, 1))),
@@ -1238,59 +1252,68 @@ class TestMultivariateSubresultantSequence:
             )
         )
         original: dict[str, Any] = result.model_dump(mode="json")
-        corrupted_payloads: list[dict[str, Any]] = []
+        structural_errors: list[dict[str, Any]] = []
+        forged_claims: list[dict[str, Any]] = []
 
         payload = deepcopy(original)
         payload["members"][-1]["polynomial"] = _scalar(
             ("x", "y"),
             "1",
         ).model_dump(mode="json")
-        corrupted_payloads.append(payload)
+        forged_claims.append(payload)
 
         payload = deepcopy(original)
         payload["members"][-1]["degree_in_main_variable"] = 1
-        corrupted_payloads.append(payload)
+        structural_errors.append(payload)
 
         payload = deepcopy(original)
         payload["left"]["polynomial"]["terms"][-1]["coefficient"]["num"] = "-2"
-        corrupted_payloads.append(payload)
+        forged_claims.append(payload)
+
+        payload = deepcopy(original)
+        payload["left"]["polynomial"]["terms"][0]["exponents"][0] = 100
+        forged_claims.append(payload)
 
         payload = deepcopy(original)
         payload["source_order"] = "RIGHT_LEFT"
-        corrupted_payloads.append(payload)
+        forged_claims.append(payload)
 
         payload = deepcopy(original)
         payload["skipped_member_degrees"] = [1]
-        corrupted_payloads.append(payload)
+        structural_errors.append(payload)
 
         payload = deepcopy(original)
         payload["principal_subresultant_coefficients"][0]["coefficient"] = _scalar(
             ("y",), "1"
         ).model_dump(mode="json")
-        corrupted_payloads.append(payload)
+        forged_claims.append(payload)
 
         payload = deepcopy(original)
         payload["resultant"] = _scalar(("y",), "1").model_dump(mode="json")
-        corrupted_payloads.append(payload)
+        forged_claims.append(payload)
 
         payload = deepcopy(original)
         payload["resultant_sign_from_sequence_order"] = -1
-        corrupted_payloads.append(payload)
+        forged_claims.append(payload)
 
         payload = deepcopy(original)
         payload["gcd_member_index"] = 1
-        corrupted_payloads.append(payload)
+        structural_errors.append(payload)
 
         payload = deepcopy(original)
         payload["gcd_degree_in_main_variable"] = 1
-        corrupted_payloads.append(payload)
+        structural_errors.append(payload)
 
         payload = deepcopy(original)
         payload["gcd_member_leading_coefficient"] = _scalar(("y",), "1").model_dump(
             mode="json"
         )
-        corrupted_payloads.append(payload)
+        forged_claims.append(payload)
 
-        for corrupted in corrupted_payloads:
+        assert _verify_multivariate_subresultant_sequence(result)
+        for corrupted in structural_errors:
             with pytest.raises(ValueError):
                 MultivariateSubresultantSequenceResult.model_validate(corrupted)
+        for forged in forged_claims:
+            parsed = MultivariateSubresultantSequenceResult.model_validate(forged)
+            assert not _verify_multivariate_subresultant_sequence(parsed)

--- a/tests/math/polynomials/test_polynomial_box_enclosure.py
+++ b/tests/math/polynomials/test_polynomial_box_enclosure.py
@@ -26,6 +26,7 @@ from jacobian.math.polynomials.intervals._models import (
     _estimate_growth,
 )
 from jacobian.math.polynomials.intervals._operations import (
+    _verify_polynomial_box_enclosure_result,
     compute_polynomial_box_enclosure,
 )
 from jacobian.math.polynomials.intervals._tools import TOOLS
@@ -258,7 +259,7 @@ def test_reversed_coordinate_interval_is_rejected_before_execution() -> None:
     "mutation",
     ("polynomial", "box", "source_digest", "enclosure"),
 )
-def test_source_bound_result_rejects_independent_forgery(mutation: str) -> None:
+def test_source_bound_result_rejects_invalid_source_binding(mutation: str) -> None:
     result = _enclose(
         _polynomial(("x",), {(1,): 1}),
         _box(("x",), ((1, 2),)),
@@ -273,16 +274,18 @@ def test_source_bound_result_rejects_independent_forgery(mutation: str) -> None:
         payload["box"]["intervals"][0]["upper"] = {"num": "3", "den": "1"}
     elif mutation == "source_digest":
         payload["source_digest"] = "sha256:" + "0" * 64
-    else:
+    elif mutation == "enclosure":
         payload["enclosure"]["upper"] = {"num": "3", "den": "1"}
 
-    with polynomial_validation_error():
-        PolynomialBoxEnclosureResult.model_validate(payload)
+    if mutation == "enclosure":
+        parsed = PolynomialBoxEnclosureResult.model_validate(payload)
+        assert not _verify_polynomial_box_enclosure_result(parsed)
+    else:
+        with polynomial_validation_error():
+            PolynomialBoxEnclosureResult.model_validate(payload)
 
 
-def test_digest_rejects_a_different_polynomial_with_the_same_replayed_interval() -> (
-    None
-):
+def test_digest_rejects_a_different_polynomial_with_the_same_interval() -> None:
     result = _enclose(
         _polynomial(("x",), {(1,): 1}),
         _box(("x",), ((0, 1),)),
@@ -309,7 +312,7 @@ def test_digest_rejects_a_different_box_when_the_polynomial_is_constant() -> Non
         PolynomialBoxEnclosureResult.model_validate(payload)
 
 
-def test_produced_result_replays_after_strict_serialization() -> None:
+def test_produced_result_round_trips_after_strict_serialization() -> None:
     result = _enclose(
         _polynomial(("x",), {(2,): 1, (0,): -2}),
         _box(("x",), ((1, 2),)),
@@ -497,7 +500,7 @@ def test_interval_ordering_at_the_canonical_boundary_is_admitted() -> None:
         )
 
 
-def test_forged_result_interval_ordering_stays_inside_intermediate_bound() -> None:
+def test_structural_result_parse_accepts_canonical_forged_enclosure() -> None:
     result = _enclose(
         _polynomial(("x",), {}),
         _box(("x",), ((0, 0),)),
@@ -505,8 +508,8 @@ def test_forged_result_interval_ordering_stays_inside_intermediate_bound() -> No
     payload = result.model_dump(mode="json")
     payload["enclosure"] = _maximum_canonical_interval_payload()
 
-    with polynomial_validation_error():
-        PolynomialBoxEnclosureResult.model_validate(payload)
+    parsed = PolynomialBoxEnclosureResult.model_validate(payload)
+    assert not _verify_polynomial_box_enclosure_result(parsed)
 
 
 def _digit_rational(

--- a/tests/math/polynomials/test_polynomial_map_generic_degree.py
+++ b/tests/math/polynomials/test_polynomial_map_generic_degree.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import shutil
-import time
 from fractions import Fraction
 from typing import Any, cast
 
@@ -27,13 +26,12 @@ from jacobian.math.polynomials.maps._generic_degree import (
 )
 from jacobian.math.polynomials.maps._models import (
     MAX_GENERIC_DEGREE_ENCODED_MAP_BYTES,
-    GenericDegreeComputationBudget,
     GenericDegreeRequest,
     GenericDegreeResult,
     GenericFiberCertificate,
     GenericFiberPolynomial,
     GenericFiberTerm,
-    verify_generic_degree_result,
+    _verify_generic_degree_result,
 )
 from jacobian.math.polynomials.maps._operations import compute_generic_degree
 from jacobian.math.polynomials.maps._replay import (
@@ -261,18 +259,19 @@ def test_request_accepts_the_exact_degree_and_bezout_boundary() -> None:
     assert request.polynomial_map.input_variables == ("x", "y", "z")
 
 
-def test_every_result_outcome_revalidates_the_source_envelope() -> None:
+def test_result_parsing_leaves_source_admission_to_the_explicit_verifier() -> None:
     outside_operation_domain = _map(
         ("w", "x", "y", "z"),
         {(1, 0, 0, 0): 1},
     )
 
-    with polynomial_validation_error():
-        GenericDegreeResult(
-            outcome="ERROR",
-            source=outside_operation_domain,
-            detail="synthetic execution failure",
-        )
+    result = GenericDegreeResult(
+        outcome="ERROR",
+        source=outside_operation_domain,
+        detail="synthetic execution failure",
+    )
+
+    assert not _verify_generic_degree_result(result)
 
 
 @requires_singular
@@ -566,35 +565,9 @@ def test_forged_degree_fails_the_explicit_result_verifier() -> None:
     forged["evidence"]["standard_monomials"] = [[0, 0], [1, 0]]
 
     assert (
-        verify_generic_degree_result(GenericDegreeResult.model_validate(forged))
+        _verify_generic_degree_result(GenericDegreeResult.model_validate(forged))
         is False
     )
-
-
-def test_forged_source_evidence_fails_closed_at_the_operation(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        _operations,
-        "run_singular_generic_fiber",
-        lambda *_args: SingularGenericFiberResult(
-            outcome="COMPUTED",
-            certificate=_identity_certificate(),
-            dimension=0,
-            vector_dimension=1,
-            backend_version="4.4.1",
-        ),
-    )
-
-    result = compute_generic_degree(
-        GenericDegreeRequest(
-            polynomial_map=_map(("x", "y"), {(2, 0): 1}, {(0, 1): 1}),
-        )
-    )
-
-    assert result.outcome == "ERROR"
-    assert result.degree is None
-    assert result.evidence is None
 
 
 @requires_singular
@@ -671,7 +644,7 @@ def test_serialized_evidence_cannot_be_presented_against_a_different_source() ->
 
     replayed = GenericDegreeResult.model_validate(forged)
     assert result.evidence is not None
-    assert verify_generic_degree_result(replayed) is False
+    assert _verify_generic_degree_result(replayed) is False
     with pytest.raises(ValueError, match="reconstruct"):
         require_certificate_reconstructs_from_source(
             _power_map_result(2).source,
@@ -690,7 +663,7 @@ def test_forged_standard_monomials_are_rejected_against_the_certified_ideal() ->
     }
 
     assert (
-        verify_generic_degree_result(GenericDegreeResult.model_validate(forged))
+        _verify_generic_degree_result(GenericDegreeResult.model_validate(forged))
         is False
     )
 
@@ -707,7 +680,7 @@ def test_cleared_standard_monomials_cannot_invent_a_positive_dimensional_outcome
     }
 
     assert (
-        verify_generic_degree_result(GenericDegreeResult.model_validate(forged))
+        _verify_generic_degree_result(GenericDegreeResult.model_validate(forged))
         is False
     )
 
@@ -732,44 +705,9 @@ def test_unconfirmed_replay_verdicts_never_establish_a_conclusion(
     }
 
     assert (
-        verify_generic_degree_result(GenericDegreeResult.model_validate(payload))
+        _verify_generic_degree_result(GenericDegreeResult.model_validate(payload))
         is False
     )
-
-
-def test_producing_operation_replays_evidence_exactly_once(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    replays: list[int] = []
-
-    def fake_backend(*_args: object) -> SingularGenericFiberResult:
-        return SingularGenericFiberResult(
-            outcome="COMPUTED",
-            certificate=_identity_certificate(),
-            dimension=0,
-            vector_dimension=1,
-            backend_version="4.4.1",
-        )
-
-    def counting_replay(*_args: object, wall_seconds: int) -> CertificateReplayResult:
-        replays.append(wall_seconds)
-        return CertificateReplayResult(
-            status="COMPUTED",
-            outcome="GENERICALLY_FINITE",
-            degree=1,
-        )
-
-    monkeypatch.setattr(_operations, "run_singular_generic_fiber", fake_backend)
-    monkeypatch.setattr(_operations, "run_bounded_certificate_replay", counting_replay)
-    monkeypatch.setattr(_replay, "run_bounded_certificate_replay", counting_replay)
-
-    result = _compute(_identity_source())
-
-    assert len(replays) == 1
-    assert replays[0] >= 1
-    assert result.outcome == "GENERICALLY_FINITE"
-    assert result.degree == 1
-    assert result.evidence == _identity_certificate()
 
 
 def test_serialized_coefficient_support_is_counted_before_nested_construction() -> None:
@@ -800,82 +738,3 @@ def test_serialized_coefficient_support_is_counted_before_nested_construction() 
 
     with polynomial_validation_error():
         GenericFiberCertificate.model_validate(payload)
-
-
-def test_replay_receives_only_the_remaining_declared_wall_time(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    observed: dict[str, int] = {}
-    readings = [1000.0, 1030.0]
-
-    def fake_monotonic() -> float:
-        return readings.pop(0) if len(readings) > 1 else readings[0]
-
-    def fake_backend(*_args: object) -> SingularGenericFiberResult:
-        return SingularGenericFiberResult(
-            outcome="COMPUTED",
-            certificate=_identity_certificate(),
-            dimension=0,
-            vector_dimension=1,
-            backend_version="4.4.1",
-        )
-
-    def fake_replay(*_args: object, wall_seconds: int) -> CertificateReplayResult:
-        observed["wall_seconds"] = wall_seconds
-        return CertificateReplayResult(
-            status="COMPUTED",
-            outcome="GENERICALLY_FINITE",
-            degree=1,
-        )
-
-    monkeypatch.setattr(time, "monotonic", fake_monotonic)
-    monkeypatch.setattr(_operations, "run_singular_generic_fiber", fake_backend)
-    monkeypatch.setattr(_operations, "run_bounded_certificate_replay", fake_replay)
-
-    result = compute_generic_degree(
-        GenericDegreeRequest(
-            polynomial_map=_identity_source(),
-            resource_budget=GenericDegreeComputationBudget(wall_seconds=60),
-        )
-    )
-
-    assert observed["wall_seconds"] == 30
-    assert result.outcome == "GENERICALLY_FINITE"
-    assert result.degree == 1
-
-
-def test_exhausted_envelope_reports_timeout_without_replaying(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    readings = [1000.0, 1075.0]
-
-    def fake_monotonic() -> float:
-        return readings.pop(0) if len(readings) > 1 else readings[0]
-
-    def fail_replay(*_args: object, **_kwargs: object) -> CertificateReplayResult:
-        raise AssertionError("certificate replay must not run without budget")
-
-    monkeypatch.setattr(time, "monotonic", fake_monotonic)
-    monkeypatch.setattr(
-        _operations,
-        "run_singular_generic_fiber",
-        lambda *_args: SingularGenericFiberResult(
-            outcome="COMPUTED",
-            certificate=_identity_certificate(),
-            dimension=0,
-            vector_dimension=1,
-            backend_version="4.4.1",
-        ),
-    )
-    monkeypatch.setattr(_operations, "run_bounded_certificate_replay", fail_replay)
-
-    result = compute_generic_degree(
-        GenericDegreeRequest(
-            polynomial_map=_identity_source(),
-            resource_budget=GenericDegreeComputationBudget(wall_seconds=60),
-        )
-    )
-
-    assert result.outcome == "TIMEOUT"
-    assert result.degree is None
-    assert result.evidence is None

--- a/tests/math/polynomials/test_public_api.py
+++ b/tests/math/polynomials/test_public_api.py
@@ -215,6 +215,13 @@ def test_factor_results_keep_structural_ring_and_order_checks() -> None:
             factors=tuple(reversed(result.factors)),
             reconstructed=result.reconstructed,
         )
+    with pytest.raises(ValidationError, match="reconstructed polynomial"):
+        PolynomialFactorizationResult(
+            polynomial=result.polynomial,
+            coefficient=result.coefficient,
+            factors=(),
+            reconstructed=_univariate("y", {3: "1", 0: "-1"}),
+        )
     foreign = PolynomialIrreducibleFactor(
         factor=_univariate("y", {1: "1", 0: "-1"}), multiplicity=1
     )

--- a/tests/math/polynomials/test_public_api.py
+++ b/tests/math/polynomials/test_public_api.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from fractions import Fraction
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 from sympy import Poly, apart, symbols
-from tests.math.polynomials._support import polynomial_validation_error
 
 from jacobian.math import polynomials
 
@@ -15,42 +14,30 @@ def test_native_polynomial_api_uses_exact_sympy_values() -> None:
     x = symbols("x")
     left = Poly(x**2 - 1, x, domain="QQ")
     right = Poly(x - 1, x, domain="QQ")
-
     left_multiplier, right_multiplier, gcd = polynomials.gcdex(left, right)
-    assert left * left_multiplier + right * right_multiplier == gcd
-    assert gcd == right
+    assert left * left_multiplier + right * right_multiplier == gcd == right
     assert polynomials.derivative(left) == Poly(2 * x, x, domain="QQ")
     assert polynomials.discriminant(left, x) == 4
     quotient, remainder, reconstruction = polynomials.divide(left, right)
-    assert quotient == Poly(x + 1, x, domain="QQ")
-    assert remainder.is_zero
-    assert reconstruction == left
-    assert polynomials.evaluate(left, 2) == 3
+    assert quotient == Poly(x + 1, x, domain="QQ") and remainder.is_zero
+    assert reconstruction == left and polynomials.evaluate(left, 2) == 3
     coefficient, factors, reconstructed = polynomials.factorization(left)
-    assert coefficient == 1
-    assert reconstructed == left
-    assert {factor.as_expr() for factor, _multiplicity in factors} == {x - 1, x + 1}
+    assert coefficient == 1 and reconstructed == left
+    assert {factor.as_expr() for factor, _ in factors} == {x - 1, x + 1}
     assert polynomials.groebner_basis((left, right), (x,), "lex") == (right,)
     assert polynomials.integral(right) == Poly(x**2 / 2 - x, x, domain="QQ")
     assert polynomials.partial_fractions(1 / (x * (x + 1)), x) == apart(
         1 / (x * (x + 1)), x
     )
-    square_free_coefficient, square_free_factors, square_free_reconstruction = (
-        polynomials.square_free_decomposition(left)
-    )
-    assert square_free_coefficient == 1
-    assert square_free_factors == ((left, 1),)
-    assert square_free_reconstruction == left
+    coefficient, factors, reconstructed = polynomials.square_free_decomposition(left)
+    assert coefficient == 1 and factors == ((left, 1),) and reconstructed == left
     assert polynomials.resultant(left, right, x) == 0
 
 
 def test_native_resultant_preserves_source_orientation() -> None:
-    """Unequal odd degrees retain the Sylvester determinant sign."""
-
     x = symbols("x")
     linear = Poly(x + 2, x, domain="QQ")
     cubic = Poly(x**3 + 1, x, domain="QQ")
-
     assert polynomials.resultant(linear, cubic, x) == -7
     assert polynomials.resultant(cubic, linear, x) == 7
 
@@ -64,9 +51,7 @@ def test_native_polynomial_decompositions_preserve_integer_leading_content(
 ) -> None:
     x = symbols("x")
     source = Poly((2 * x + 1) ** 2, x, domain="ZZ")
-
     coefficient, factors, reconstructed = decompose(source)
-
     assert coefficient == 4
     assert factors == ((Poly(2 * x + 1, x, domain="ZZ").monic(), 2),)
     assert reconstructed == source
@@ -74,24 +59,17 @@ def test_native_polynomial_decompositions_preserve_integer_leading_content(
 
 def test_native_groebner_basis_rejects_non_rational_domains() -> None:
     x, y = symbols("x y")
-    generators = (
-        Poly(x + y, x, y, modulus=2),
-        Poly(x - y, x, y, modulus=2),
-    )
-
+    generators = (Poly(x + y, x, y, modulus=2), Poly(x - y, x, y, modulus=2))
     with pytest.raises(ValueError, match="QQ domain"):
         polynomials.groebner_basis(generators, (x, y), "lex")
 
 
 def test_native_discriminant_preserves_the_polynomial_domain() -> None:
     x = symbols("x")
-    polynomial = Poly(x**2 + x + 1, x, modulus=2)
-
-    assert polynomials.discriminant(polynomial, x) == 1
+    assert polynomials.discriminant(Poly(x**2 + x + 1, x, modulus=2), x) == 1
 
 
 def test_exact_public_api_symbols() -> None:
-    """Exact owner-local contract for the polynomials public API."""
     expected = (
         "derivative",
         "discriminant",
@@ -108,16 +86,12 @@ def test_exact_public_api_symbols() -> None:
     )
     assert tuple(polynomials.__all__) == expected
     assert len(polynomials.__all__) == len(set(polynomials.__all__))
-    assert all(not name.startswith("_") for name in polynomials.__all__)
-    assert all(hasattr(polynomials, name) for name in polynomials.__all__)
+    assert all(
+        not name.startswith("_") and hasattr(polynomials, name) for name in expected
+    )
 
 
-# ---------------------------------------------------------------------------
-# Source-bound factorization replay (#2298)
-# ---------------------------------------------------------------------------
-
-
-def _univariate(variable: str, terms: dict[int, str]):
+def _univariate(variable: str, terms: dict[int, str]) -> Any:
     from jacobian._exact import CanonicalRational
     from jacobian.math.polynomials.values import (
         RationalPolynomial,
@@ -125,224 +99,72 @@ def _univariate(variable: str, terms: dict[int, str]):
         SparseRationalPolynomial,
     )
 
-    ordered = sorted(terms.items(), reverse=True)
     return RationalPolynomial(
         variables=(variable,),
         polynomial=SparseRationalPolynomial(
             terms=tuple(
                 RationalPolynomialTerm(
                     coefficient=CanonicalRational(
-                        num=v.split("/")[0], den=(v.split("/")[1] if "/" in v else "1")
+                        num=value.split("/")[0],
+                        den=value.split("/")[1] if "/" in value else "1",
                     ),
                     exponents=(degree,),
                 )
-                for degree, v in ordered
+                for degree, value in sorted(terms.items(), reverse=True)
             )
         ),
     )
 
 
-def test_factorization_results_replay_against_source() -> None:
+def test_factor_producers_compute_once_and_round_trip_structurally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.polynomials import _operations
     from jacobian.math.polynomials._models import (
         PolynomialFactorizationResult,
         PolynomialFactorRequest,
-    )
-    from jacobian.math.polynomials._operations import polynomial_factorization
-
-    cases = {
-        "constant": ("x", {0: "6"}),
-        "irreducible": ("x", {2: "1", 1: "1", 0: "1"}),
-        "repeated_pure_power": ("x", {4: "1", 3: "4", 2: "6", 1: "4", 0: "1"}),
-        "rational_content": ("x", {3: "9/4", 2: "3/2", 0: "-5/4"}),
-        "sign_normalization": ("x", {2: "-4", 0: "-1"}),
-    }
-    for _label, (variable, terms) in cases.items():
-        request = _univariate(variable, terms)
-        result = polynomial_factorization(PolynomialFactorRequest(polynomial=request))
-        assert result.polynomial == request
-        assert result.reconstructed == request
-        product = Fraction(int(result.coefficient.num), int(result.coefficient.den))
-        for record in result.factors:
-            factor_value = _evaluate(record.factor, 7)
-            product *= factor_value**record.multiplicity
-        source_value = _evaluate(request, 7)
-        reconstructed_value = _evaluate(result.reconstructed, 7)
-        assert reconstructed_value == source_value
-        assert product == source_value
-        assert (
-            PolynomialFactorizationResult.model_validate(result.model_dump()) == result
-        )
-
-
-def test_square_free_decomposition_replays_against_source() -> None:
-    from jacobian.math.polynomials._models import (
         PolynomialSquareFreeDecompositionResult,
         PolynomialSquareFreeRequest,
     )
-    from jacobian.math.polynomials._operations import (
-        polynomial_square_free_decomposition,
-    )
 
-    request = _univariate("x", {4: "2", 3: "4", 2: "2"})
-    result = polynomial_square_free_decomposition(
-        PolynomialSquareFreeRequest(polynomial=request)
+    source = _univariate("x", {4: "1", 2: "-2", 0: "1"})
+    factor_calls = square_free_calls = 0
+    original_factorization = polynomials.factorization
+    original_square_free = polynomials.square_free_decomposition
+
+    def count_factorization(poly: Any) -> Any:
+        nonlocal factor_calls
+        factor_calls += 1
+        return original_factorization(poly)
+
+    def count_square_free(poly: Any) -> Any:
+        nonlocal square_free_calls
+        square_free_calls += 1
+        return original_square_free(poly)
+
+    monkeypatch.setattr(polynomials, "factorization", count_factorization)
+    monkeypatch.setattr(polynomials, "square_free_decomposition", count_square_free)
+    factorization = _operations.polynomial_factorization(
+        PolynomialFactorRequest(polynomial=source)
     )
-    assert result.polynomial == request
-    assert result.reconstructed == request
+    square_free = _operations.polynomial_square_free_decomposition(
+        PolynomialSquareFreeRequest(polynomial=source)
+    )
+    assert (factor_calls, square_free_calls) == (1, 1)
+    assert factorization.reconstructed == square_free.reconstructed == source
     assert (
-        PolynomialSquareFreeDecompositionResult.model_validate(result.model_dump())
-        == result
+        PolynomialFactorizationResult.model_validate(factorization.model_dump())
+        == factorization
+    )
+    assert (
+        PolynomialSquareFreeDecompositionResult.model_validate(square_free.model_dump())
+        == square_free
     )
 
 
-def _evaluate(polynomial, point: int) -> Fraction:
-    value = Fraction(0)
-    for term in polynomial.polynomial.terms:
-        value += (
-            Fraction(int(term.coefficient.num), int(term.coefficient.den))
-            * point ** term.exponents[0]
-        )
-    return value
-
-
-def test_factorization_result_rejects_mutations() -> None:
-    import copy as _copy
-
-    from pydantic import ValidationError
-
-    from jacobian.math.polynomials._models import (
-        PolynomialFactorizationResult,
-        PolynomialFactorRequest,
-    )
-    from jacobian.math.polynomials._operations import polynomial_factorization
-
-    request = _univariate("x", {2: "1", 0: "-1"})
-    result = polynomial_factorization(PolynomialFactorRequest(polynomial=request))
-    dumped = result.model_dump()
-
-    coefficient_mutation = _copy.deepcopy(dumped)
-    coefficient_mutation["coefficient"] = {"num": "2", "den": "1"}
-    with pytest.raises(ValidationError):
-        PolynomialFactorizationResult.model_validate(coefficient_mutation)
-
-    multiplicity_mutation = _copy.deepcopy(dumped)
-    multiplicity_mutation["factors"][0]["multiplicity"] += 1
-    with pytest.raises(ValidationError):
-        PolynomialFactorizationResult.model_validate(multiplicity_mutation)
-
-    factor_term_mutation = _copy.deepcopy(dumped)
-    factor_term_mutation["factors"][0]["factor"]["polynomial"]["terms"][0][
-        "exponents"
-    ] = [3]
-    with pytest.raises(ValidationError):
-        PolynomialFactorizationResult.model_validate(factor_term_mutation)
-
-    reconstructed_mutation = _copy.deepcopy(dumped)
-    reconstructed_mutation["reconstructed"]["polynomial"]["terms"] = []
-    with pytest.raises(ValidationError):
-        PolynomialFactorizationResult.model_validate(reconstructed_mutation)
-
-    source_mutation = _copy.deepcopy(dumped)
-    source_mutation["polynomial"]["polynomial"]["terms"] = []
-    with pytest.raises(ValidationError):
-        PolynomialFactorizationResult.model_validate(source_mutation)
-
-
-def test_factorization_results_reject_multivariate_sources() -> None:
-    """The univariate request domain also binds an authored or replayed result.
-
-    A QQ[x, y] payload whose exact-division replay succeeds (source ``x*y``
-    with factors ``x`` and ``y``) must still be rejected because
-    ``polynomial.factor.compute`` factorizes univariate polynomials only.
-    """
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialFactorizationResult,
-        PolynomialIrreducibleFactor,
-    )
-
-    variables = ("x", "y")
-    source = _sparse_polynomial(variables, {(1, 1): "1"})
-    factors = (
-        PolynomialIrreducibleFactor(
-            factor=_sparse_polynomial(variables, {(1, 0): "1"}), multiplicity=1
-        ),
-        PolynomialIrreducibleFactor(
-            factor=_sparse_polynomial(variables, {(0, 1): "1"}), multiplicity=1
-        ),
-    )
-    with polynomial_validation_error():
-        PolynomialFactorizationResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=factors,
-            reconstructed=source,
-        )
-
-
-def test_equivalent_factor_orders_normalize_canonically() -> None:
-    """A hand-built result with backend-incidental ordering still replays."""
-
-    from jacobian.math.polynomials._models import (
-        PolynomialFactorizationResult,
-        PolynomialFactorRequest,
-    )
-    from jacobian.math.polynomials._operations import polynomial_factorization
-
-    request = _univariate("x", {3: "1", 0: "-1"})
-    produced = polynomial_factorization(PolynomialFactorRequest(polynomial=request))
-    if len(produced.factors) > 1:
-        with polynomial_validation_error():
-            PolynomialFactorizationResult(
-                polynomial=produced.polynomial,
-                coefficient=produced.coefficient,
-                factors=tuple(reversed(produced.factors)),
-                reconstructed=produced.reconstructed,
-            )
-    canonical = PolynomialFactorizationResult(
-        polynomial=produced.polynomial,
-        coefficient=produced.coefficient,
-        factors=tuple(sorted(produced.factors, key=_canonical_key)),
-        reconstructed=produced.reconstructed,
-    )
-    assert canonical == produced
-
-
-def _canonical_key(record):
-    return (
-        record.multiplicity,
-        max((sum(t.exponents) for t in record.factor.polynomial.terms), default=0),
-        tuple(
-            (t.exponents, t.coefficient.num, t.coefficient.den)
-            for t in record.factor.polynomial.terms
-        ),
-    )
-
-
-def _sparse_polynomial(variables: tuple[str, ...], terms: dict[tuple[int, ...], str]):
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials.values import (
-        RationalPolynomial,
-        RationalPolynomialTerm,
-        SparseRationalPolynomial,
-    )
-
-    return RationalPolynomial(
-        variables=variables,
-        polynomial=SparseRationalPolynomial(
-            terms=tuple(
-                RationalPolynomialTerm(
-                    coefficient=CanonicalRational(num=terms[exponents], den="1"),
-                    exponents=exponents,
-                )
-                for exponents in sorted(terms, reverse=True)
-            )
-        ),
-    )
-
-
-def _source_bound_result_cases() -> tuple[tuple[Callable[[Any], Any], type, type], ...]:
+def test_factor_results_parse_structurally_and_private_verifiers_reject_forgery() -> (
+    None
+):
     from jacobian.math.polynomials._models import (
         PolynomialFactorizationResult,
         PolynomialFactorRequest,
@@ -350,1136 +172,56 @@ def _source_bound_result_cases() -> tuple[tuple[Callable[[Any], Any], type, type
         PolynomialSquareFreeRequest,
     )
     from jacobian.math.polynomials._operations import (
+        _verify_factorization_result,
+        _verify_square_free_decomposition_result,
         polynomial_factorization,
         polynomial_square_free_decomposition,
     )
 
-    return (
-        (
-            polynomial_factorization,
-            PolynomialFactorRequest,
-            PolynomialFactorizationResult,
-        ),
-        (
-            polynomial_square_free_decomposition,
-            PolynomialSquareFreeRequest,
-            PolynomialSquareFreeDecompositionResult,
-        ),
-    )
-
-
-def _forged_monster_payload(dumped: dict[str, Any]) -> dict[str, Any]:
-    import copy as _copy
-
-    monster = _sparse_polynomial(
-        ("x", "y"),
-        {(first, second): "1" for first in range(16) for second in range(16)},
-    )
-    source = _sparse_polynomial(("x", "y"), {(2, 0): "1", (0, 2): "1"})
-    forged = _copy.deepcopy(dumped)
-    forged["polynomial"] = source.model_dump()
-    forged["reconstructed"] = source.model_dump()
-    forged["factors"] = [{"factor": monster.model_dump(), "multiplicity": 64}]
-    return forged
-
-
-def test_source_bound_results_reject_combinatorial_replay_claims() -> None:
-    """Forged factor records are rejected without expanding their product.
-
-    The claimed factor is a dense-box multivariate sum within the shared wire
-    limits whose multiplicity-64 power chain exhausts the cumulative
-    reconstruction-work budget; bounded reconstruction counts each step's
-    exact work and stops typedly before any oversized expansion, with every
-    executed step's materialized support inside the per-step ceiling.
-    """
-
-    for operation, request_model, result_model in _source_bound_result_cases():
-        request = request_model(polynomial=_univariate("x", {2: "1", 0: "-1"}))
-        produced = operation(request)
-        forged = _forged_monster_payload(produced.model_dump())
-        # The factorization contract is univariate, so a forged QQ[x, y]
-        # source is rejected by the semantic-domain check before any replay
-        # work; square-free decomposition admits several variables, and the
-        # monster's multiplicity-64 power chain keeps every per-step degree
-        # box inside the replay ceiling (its dense grids collapse into
-        # predictable boxes) while the cumulative monomial-multiplication
-        # count crosses the reconstruction budget, so the work guard rejects
-        # the claim before any further multiplication could run.
-        with polynomial_validation_error():
-            result_model.model_validate(forged)
-
-
-def test_zero_content_results_retain_no_factors() -> None:
-    """A zero coefficient cannot authenticate an arbitrary factor list."""
-
-    from jacobian.math.polynomials._models import (
-        PolynomialFactorizationResult,
-        PolynomialFactorRequest,
-    )
-    from jacobian.math.polynomials._operations import polynomial_factorization
-
-    zero = _univariate("x", {})
-    produced = polynomial_factorization(PolynomialFactorRequest(polynomial=zero))
-    assert produced.coefficient.as_fraction() == 0
-    assert PolynomialFactorizationResult.model_validate(produced.model_dump())
-
-    forged = produced.model_dump()
-    forged["factors"] = [
-        {
-            "factor": _univariate("x", {1: "1", 0: "-1"}).model_dump(),
-            "multiplicity": 1,
-        }
-    ]
-    with polynomial_validation_error():
-        PolynomialFactorizationResult.model_validate(forged)
-
-
-def test_factorization_replays_at_the_request_degree_cap() -> None:
-    """A pure power at the degree-127 request cap still replays exactly."""
-
-    from sympy import Poly, symbols
-
-    from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
-    from jacobian.math.polynomials._models import (
-        PolynomialFactorizationResult,
-        PolynomialFactorRequest,
-    )
-    from jacobian.math.polynomials._operations import polynomial_factorization
-
-    x = symbols("x")
-    expanded = Poly((x + 1) ** 127, x, domain="QQ")
-    coefficients = [str(int(value)) for value in expanded.all_coeffs()]
-    request = PolynomialFactorRequest(
-        polynomial=_univariate(
-            "x",
-            {
-                degree: coefficients[index]
-                for index, degree in enumerate(range(127, -1, -1))
-            },
-        )
-    )
-    result = polynomial_factorization(request)
-    records = [
-        (rational_polynomial_to_sympy(record.factor).as_expr(), record.multiplicity)
-        for record in result.factors
-    ]
-    assert records == [(x + 1, 127)]
-    assert PolynomialFactorizationResult.model_validate(result.model_dump()) == result
-
-
-def test_square_free_replays_at_the_multiplicity_cap() -> None:
-    """A pure power at the multiplicity-64 square-free cap still replays."""
-
-    from sympy import Poly, symbols
-
-    from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeRequest,
-    )
-    from jacobian.math.polynomials._operations import (
-        polynomial_square_free_decomposition,
-    )
-
-    x = symbols("x")
-    expanded = Poly((x + 1) ** 64, x, domain="QQ")
-    coefficients = [str(int(value)) for value in expanded.all_coeffs()]
-    request = PolynomialSquareFreeRequest(
-        polynomial=_univariate(
-            "x",
-            {
-                degree: coefficients[index]
-                for index, degree in enumerate(range(64, -1, -1))
-            },
-        )
-    )
-    result = polynomial_square_free_decomposition(request)
-    records = [
-        (rational_polynomial_to_sympy(record.factor).as_expr(), record.multiplicity)
-        for record in result.factors
-    ]
-    assert records == [(x + 1, 64)]
-    assert (
-        PolynomialSquareFreeDecompositionResult.model_validate(result.model_dump())
-        == result
-    )
-
-
-def test_result_models_bind_sources_to_request_coefficient_budgets() -> None:
-    """Retained sources answer to the same coefficient budget as requests.
-
-    Both originating request models admit only the default 256-digit
-    polynomial coefficients, so an authored or deserialized result whose
-    retained source carries more digits must be rejected at admission
-    before any replay work instead of widening the operation's established
-    work envelope; sources within the budget round-trip exactly.
-    """
-
-    from pydantic import ValidationError
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialFactorizationResult,
-        PolynomialSquareFreeDecompositionResult,
-    )
-
-    models = (
-        PolynomialFactorizationResult,
-        PolynomialSquareFreeDecompositionResult,
-    )
-    for model in models:
-        source = _univariate("x", {0: "9" * 257})
-        with pytest.raises(ValidationError):
-            model(
-                polynomial=source,
-                coefficient=CanonicalRational(num="9" * 257, den="1"),
-                factors=(),
-                reconstructed=source,
-            )
-        source = _univariate("x", {0: "9" * 256})
-        result = model(
-            polynomial=source,
-            coefficient=CanonicalRational(num="9" * 256, den="1"),
-            factors=(),
-            reconstructed=source,
-        )
-        assert model.model_validate(result.model_dump()) == result
-
-
-# ---------------------------------------------------------------------------
-# Bounded source-bound replay (#2298)
-# ---------------------------------------------------------------------------
-
-
-def _multivariate_binomial_box(variables: tuple[str, ...], exponent: int) -> Any:
-    """``prod(x_i ** exponent - 1)`` or ``prod(x_i - 1)`` as a wire value."""
-
-    import itertools
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials.values import (
-        RationalPolynomial,
-        RationalPolynomialTerm,
-        SparseRationalPolynomial,
-    )
-
-    def build(exponent_for_selected: int) -> RationalPolynomial:
-        terms = {}
-        for mask in itertools.product((False, True), repeat=len(variables)):
-            exponents = tuple(
-                exponent_for_selected if selected else 0 for selected in mask
-            )
-            terms[exponents] = "-1" if sum(mask) % 2 else "1"
-        return RationalPolynomial(
-            variables=variables,
-            polynomial=SparseRationalPolynomial(
-                terms=tuple(
-                    RationalPolynomialTerm(
-                        coefficient=CanonicalRational(num=c, den="1"),
-                        exponents=e,
-                    )
-                    for e, c in sorted(terms.items(), reverse=True)
-                )
-            ),
-        )
-
-    return build(exponent_for_selected=exponent), build(exponent_for_selected=1)
-
-
-def test_square_free_replay_rejects_dense_multivariate_claims_without_dividing() -> (
-    None
-):
-    """The eight-variable binomial product payload is rejected before expansion.
-
-    The 256-term source ``prod(v_i^64 - 1)`` and the 256-term claimed factor
-    ``prod(v_i - 1)`` both pass the shared wire budgets, but their exact
-    quotient ``prod(1 + v_i + ... + v_i^63)`` would carry ``64^8`` monomials.
-    Multivariate validation therefore never divides: it recomputes the
-    canonical monic decomposition of the retained source and rejects the
-    mismatched records typedly without materializing any quotient.
-    """
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeFactor,
-    )
-
-    variables = tuple(f"v{index}" for index in range(8))
-    source, factor = _multivariate_binomial_box(variables, 64)
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(PolynomialSquareFreeFactor(factor=factor, multiplicity=1),),
-            reconstructed=source,
-        )
-
-
-def test_multivariate_square_free_results_still_replay_against_source() -> None:
-    """Multivariate decompositions keep validating under bounded replay.
-
-    The canonical recomparison lane must admit exactly what the producer
-    emits: a pure power at the former degree-box boundary, a smaller
-    multiplicity-bearing bivariate part, and a content-carrying
-    decomposition round-trip through the operation and the validator.
-    """
-
-    from math import comb
-
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeRequest,
-    )
-    from jacobian.math.polynomials._operations import (
-        polynomial_square_free_decomposition,
-    )
-
-    requests = (
-        _sparse_polynomial(
-            ("x", "y"),
-            {(64 - k, k): str(comb(64, k)) for k in range(65)},
-        ),
-        _sparse_polynomial(("x", "y"), {(2, 2): "1", (1, 1): "-2", (0, 0): "1"}),
-        _sparse_polynomial(
-            ("x", "y"),
-            {(2, 2): "3", (2, 0): "-3", (0, 2): "-3", (0, 0): "3"},
-        ),
-    )
-    expected_records = ([(2, 64)], [(2, 2)], [(4, 1)])
-    for request, expected in zip(requests, expected_records, strict=True):
-        result = polynomial_square_free_decomposition(
-            PolynomialSquareFreeRequest(polynomial=request)
-        )
-        records = [
-            (len(record.factor.polynomial.terms), record.multiplicity)
-            for record in result.factors
-        ]
-        assert records == expected
-        assert result.reconstructed == result.polynomial
-        assert (
-            PolynomialSquareFreeDecompositionResult.model_validate(result.model_dump())
-            == result
-        )
-
-
-def test_square_free_replay_admits_sparse_cofactors_above_the_division_box() -> None:
-    """A legitimate output whose degree box exceeds the envelope validates.
-
-    For ``(x_1^16 + x_3^16) * (x_2 + ... + x_8)^3`` the first replay
-    division's degree box is ``4^7 = 16384`` terms while the true cofactor
-    is the 84-term cube, so an envelope-rejected division replay crashed
-    the operation on this admitted 168-term request.  The recomparison
-    lane verifies such outputs against the recomputed canonical parts
-    without dividing, and a forged claim over the same source still fails.
-    """
-
-    from collections import defaultdict
-    from itertools import repeat
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeFactor,
-    )
-
-    def multiply(left, right):
-        product: dict[tuple[int, ...], int] = defaultdict(int)
-        for left_exponents, left_coefficient in left.items():
-            for right_exponents, right_coefficient in right.items():
-                product[
-                    tuple(
-                        a + b
-                        for a, b in zip(left_exponents, right_exponents, strict=True)
-                    )
-                ] += left_coefficient * right_coefficient
-        return dict(product)
-
-    size = 8
-    linear = {
-        tuple(1 if index == j else 0 for index in range(size)): 1
-        for j in range(1, size)
-    }
-    cube = {tuple(repeat(0, size)): 1}
-    for _ in range(3):
-        cube = multiply(cube, linear)
-    binomials = {
-        tuple(16 if index == peak else 0 for index in range(size)): 1 for peak in (0, 2)
-    }
-    source_terms = multiply(binomials, cube)
-    assert len(source_terms) == 168
-    source = _sparse_polynomial(
-        tuple(f"x{index}" for index in range(1, size + 1)),
-        {exponents: str(value) for exponents, value in source_terms.items()},
-    )
-    result = PolynomialSquareFreeDecompositionResult(
-        polynomial=source,
-        coefficient=CanonicalRational(num="1", den="1"),
-        factors=(
-            PolynomialSquareFreeFactor(
-                factor=_sparse_polynomial(
-                    source.variables,
-                    {exponents: str(value) for exponents, value in binomials.items()},
-                ),
-                multiplicity=1,
-            ),
-            PolynomialSquareFreeFactor(
-                factor=_sparse_polynomial(
-                    source.variables,
-                    {exponents: str(value) for exponents, value in linear.items()},
-                ),
-                multiplicity=3,
-            ),
-        ),
-        reconstructed=source,
-    )
-    assert (
-        PolynomialSquareFreeDecompositionResult.model_validate(result.model_dump())
-        == result
-    )
-
-    forged_factor = _sparse_polynomial(source.variables, {(1,) * size: "1"})
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(PolynomialSquareFreeFactor(factor=forged_factor, multiplicity=1),),
-            reconstructed=source,
-        )
-
-
-def test_square_free_results_require_canonical_univariate_parts() -> None:
-    """A product-correct but overlapping univariate grouping is not the result.
-
-    ``(x - 1) * ((x - 1)(x + 1))**2`` equals the retained source
-    ``(x - 1)**3 * (x + 1)**2``, so every univariate exact-division step
-    succeeds while the claimed parts overlap; a scalar shuffle across the
-    records also reconstructs exactly yet breaks ``MONIC_FACTORS``.  Only
-    the recomputed canonical monic square-free parts authenticate either
-    claim.
-    """
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeFactor,
-    )
-
-    source = _univariate("x", {5: "1", 4: "-1", 3: "-2", 2: "2", 1: "1", 0: "-1"})
-    linear = _univariate("x", {1: "1", 0: "-1"})
-    mixed = _univariate("x", {2: "1", 0: "-1"})
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(
-                PolynomialSquareFreeFactor(factor=linear, multiplicity=1),
-                PolynomialSquareFreeFactor(factor=mixed, multiplicity=2),
-            ),
-            reconstructed=source,
-        )
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="2"),
-            factors=(
-                PolynomialSquareFreeFactor(
-                    factor=_univariate("x", {1: "1/2", 0: "1/2"}), multiplicity=2
-                ),
-                PolynomialSquareFreeFactor(
-                    factor=_univariate("x", {1: "2", 0: "-2"}), multiplicity=3
-                ),
-            ),
-            reconstructed=source,
-        )
-
-
-def test_square_free_operation_round_trips_distinct_univariate_multiplicities() -> None:
-    """The producer's records stay canonical under univariate revalidation.
-
-    ``(x - 1)**3 * (x + 1)**2`` decomposes into the distinct-multiplicity
-    parts ``(x + 1, 2)`` and ``(x - 1, 3)``, so the canonical-recomparison
-    lane must admit exactly that emitted decomposition and its serialized
-    round trip.
-    """
-
-    from sympy import symbols
-
-    from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeRequest,
-    )
-    from jacobian.math.polynomials._operations import (
-        polynomial_square_free_decomposition,
-    )
-
-    request = _univariate("x", {5: "1", 4: "-1", 3: "-2", 2: "2", 1: "1", 0: "-1"})
-    result = polynomial_square_free_decomposition(
-        PolynomialSquareFreeRequest(polynomial=request)
-    )
-    x = symbols("x")
-    records = [
-        (rational_polynomial_to_sympy(record.factor).as_expr(), record.multiplicity)
-        for record in result.factors
-    ]
-    assert records == [(x + 1, 2), (x - 1, 3)]
-    assert result.reconstructed == request
-    assert (
-        PolynomialSquareFreeDecompositionResult.model_validate(result.model_dump())
-        == result
-    )
-
-
-def test_square_free_results_require_canonical_square_free_parts() -> None:
-    """A product-correct but non-coprime grouping is not the decomposition.
-
-    ``(x - 1) * ((x - 1)(y - 1))**2`` equals the retained source
-    ``(x - 1)**3 * (y - 1)**2``, so every exact-division step would
-    succeed; only the unique canonical monic square-free parts
-    authenticate the claimed records.
-    """
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeFactor,
-    )
-
-    source = _sparse_polynomial(
-        ("x", "y"),
-        {
-            (3, 2): "1",
-            (3, 1): "-2",
-            (3, 0): "1",
-            (2, 2): "-3",
-            (2, 1): "6",
-            (2, 0): "-3",
-            (1, 2): "3",
-            (1, 1): "-6",
-            (1, 0): "3",
-            (0, 2): "-1",
-            (0, 1): "2",
-            (0, 0): "-1",
-        },
-    )
-    linear = _sparse_polynomial(("x", "y"), {(1, 0): "1", (0, 0): "-1"})
-    mixed = _sparse_polynomial(
-        ("x", "y"), {(1, 1): "1", (1, 0): "-1", (0, 1): "-1", (0, 0): "1"}
-    )
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(
-                PolynomialSquareFreeFactor(factor=linear, multiplicity=1),
-                PolynomialSquareFreeFactor(factor=mixed, multiplicity=2),
-            ),
-            reconstructed=source,
-        )
-
-
-def test_square_free_replay_admits_sparse_multivariate_pure_powers() -> None:
-    """``x^64 * y^64 * z^64`` decomposes and validates as ``(x*y*z)^64``.
-
-    A degree-box replay bound would project a ``64^3``-term first quotient
-    for the one-term source and reject this admitted request; the
-    recomparison lane returns and revalidates the producer's records.
-    """
-
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeRequest,
-    )
-    from jacobian.math.polynomials._operations import (
-        polynomial_square_free_decomposition,
-    )
-
-    result = polynomial_square_free_decomposition(
-        PolynomialSquareFreeRequest(
-            polynomial=_sparse_polynomial(("x", "y", "z"), {(64, 64, 64): "1"})
-        )
-    )
-    assert [
-        (len(record.factor.polynomial.terms), record.multiplicity)
-        for record in result.factors
-    ] == [(1, 64)]
-    assert (
-        PolynomialSquareFreeDecompositionResult.model_validate(result.model_dump())
-        == result
-    )
-
-
-def test_square_free_replay_returns_typed_records_for_trivariate_residual() -> None:
-    """``(x*y*z - 1)**20 * (x + y + z)`` returns a typed decomposition.
-
-    This admitted 63-term trivariate request was the residual host-exception
-    report against the division-based replay lanes; canonical recomparison
-    must return the producer's records and revalidate their serialized form
-    instead of raising on an accepted request.
-    """
-
-    from math import comb
-
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeRequest,
-    )
-    from jacobian.math.polynomials._operations import (
-        polynomial_square_free_decomposition,
-    )
-
-    terms: dict[tuple[int, int, int], str] = {}
-    for power in range(21):
-        coefficient = comb(20, power) * (-1) ** (20 - power)
-        for shifted in range(3):
-            exponents = [power, power, power]
-            exponents[shifted] += 1
-            terms[tuple(exponents)] = str(coefficient)
-    assert len(terms) == 63
-    request = _sparse_polynomial(("x", "y", "z"), terms)
-    result = polynomial_square_free_decomposition(
-        PolynomialSquareFreeRequest(polynomial=request)
-    )
-    assert [
-        (len(record.factor.polynomial.terms), record.multiplicity)
-        for record in result.factors
-    ] == [(3, 1), (2, 20)]
-    assert result.reconstructed == request
-    assert (
-        PolynomialSquareFreeDecompositionResult.model_validate(result.model_dump())
-        == result
-    )
-
-
-def test_square_free_replay_rejects_inexact_multivariate_divisors() -> None:
-    """A forged divisor with a tiny degree box is rejected without dividing.
-
-    The claimed factor ``v_0 - sum(v_i^64)`` over eight variables leaves
-    per-variable degree room ``64`` and ``1`` against the monomial source
-    ``prod(v_i^64)``, so a division replay would pass any box bound while
-    its inexact lexicographic long division builds huge partial sums.  The
-    recomparison lane rejects the mismatched records typedly instead.
-    """
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeFactor,
-    )
-
-    variables = tuple(f"v{index}" for index in range(8))
-    source = _sparse_polynomial(variables, {(64,) * 8: "1"})
-    terms = {(1, *(0,) * 7): "1"}
-    for index in range(1, 8):
-        terms[tuple(64 if position == index else 0 for position in range(8))] = "-1"
-    factor = _sparse_polynomial(variables, terms)
-    assert len(factor.polynomial.terms) == 8
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(PolynomialSquareFreeFactor(factor=factor, multiplicity=1),),
-            reconstructed=source,
-        )
-
-
-def test_factorization_replay_requires_canonical_irreducible_records() -> None:
-    """A reducible record cannot authenticate an irreducible factorization.
-
-    ``x**2 - 1`` reconstructs itself exactly when claimed as the single
-    "irreducible" factor of the equal source, so a product-only replay
-    would accept it; re-deriving the unique content-and-monic-irreducibles
-    factorization rejects the non-canonical multiset typedly.
-    """
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialFactorizationResult,
-        PolynomialIrreducibleFactor,
-    )
-
     source = _univariate("x", {2: "1", 0: "-1"})
-    with polynomial_validation_error():
-        PolynomialFactorizationResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(PolynomialIrreducibleFactor(factor=source, multiplicity=1),),
-            reconstructed=source,
-        )
-
-
-def _difference_product(variables: tuple[str, ...], exponent: int) -> Any:
-    """``prod(v_i ** exponent - 1)`` as a wire value with descending terms."""
-
-    import itertools
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials.values import (
-        RationalPolynomial,
-        RationalPolynomialTerm,
-        SparseRationalPolynomial,
+    factorization = polynomial_factorization(PolynomialFactorRequest(polynomial=source))
+    square_free = polynomial_square_free_decomposition(
+        PolynomialSquareFreeRequest(polynomial=source)
     )
-
-    terms = {}
-    for mask in itertools.product((False, True), repeat=len(variables)):
-        exponents = tuple(exponent if selected else 0 for selected in mask)
-        terms[exponents] = "-1" if sum(mask) % 2 else "1"
-    return RationalPolynomial(
-        variables=variables,
-        polynomial=SparseRationalPolynomial(
-            terms=tuple(
-                RationalPolynomialTerm(
-                    coefficient=CanonicalRational(num=c, den="1"), exponents=e
-                )
-                for e, c in sorted(terms.items(), reverse=True)
-            )
-        ),
+    assert _verify_factorization_result(factorization)
+    assert _verify_square_free_decomposition_result(square_free)
+    forged_factorization = factorization.model_dump()
+    forged_factorization["coefficient"] = {"num": "2", "den": "1"}
+    assert not _verify_factorization_result(
+        PolynomialFactorizationResult.model_validate(forged_factorization)
+    )
+    forged_square_free = square_free.model_dump()
+    forged_square_free["coefficient"] = {"num": "2", "den": "1"}
+    assert not _verify_square_free_decomposition_result(
+        PolynomialSquareFreeDecompositionResult.model_validate(forged_square_free)
     )
 
 
-def test_square_free_replay_never_recomputes_unrepresentable_decompositions(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Validation rejects claims without materializing the true decomposition.
-
-    The five-variable source ``prod((x_i^63 - 1)(x_i - 1))`` holds exactly
-    1,024 terms inside the request envelope, yet its canonical
-    multiplicity-one part ``prod(1 + x_i + ... + x_i^62)`` carries ``63^5``
-    terms — far beyond any representable bound.  A forged or deserialized
-    result over this source must therefore be rejected by bounded checks on
-    the claimed records alone; no backend decomposition may run at all.
-    """
-
-    from sympy import Poly, symbols
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-    )
-
-    variables = tuple(f"x{index}" for index in range(1, 6))
-    generators = symbols(",".join(variables))
-    source_expr = Poly(1, *generators, domain="QQ")
-    for symbol in generators:
-        source_expr *= (symbol**63 - 1) * (symbol - 1)
-    assert len(source_expr.terms()) == 1024
-    source = _sparse_polynomial(
-        variables,
-        {monom: str(int(coeff)) for monom, coeff in source_expr.terms()},
-    )
-
-    def fail_decomposition(self):
-        raise AssertionError("replay must not recompute any decomposition")
-
-    monkeypatch.setattr(Poly, "sqf_list", fail_decomposition)
-    monkeypatch.setattr(Poly, "factor_list", fail_decomposition)
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(),
-            reconstructed=source,
-        )
-
-
-def test_square_free_operation_admits_transiently_dense_prefixes() -> None:
-    """An admitted request stays admitted when a replay prefix densifies.
-
-    For the accepted source ``A(x) * B(y, z)^2 * (x - 1)^3`` the canonical
-    records hold only 62, 48, and 2 terms and the 930-term source fits its
-    request envelope, yet multiplicity-ordered replay forms the transient
-    prefix ``A * B^2`` with 9,610 terms before ``(x - 1)^3`` cancels it back
-    into the envelope.  Replay prefixes are bounded per step by a dedicated
-    replay ceiling rather than by the serialization envelope, so the
-    operation must return its typed result instead of failing validation.
-    """
-
-    from sympy import Poly, symbols
-
-    from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeRequest,
-    )
-    from jacobian.math.polynomials._operations import (
-        polynomial_square_free_decomposition,
-    )
-
-    x, y, z = symbols("x,y,z")
-    geometric_x = Poly(sum(x**i for i in range(62)), x, y, z, domain="QQ")
-    geometric_yz = Poly(
-        sum(y**j for j in range(16)) * sum(z**k for k in range(3)),
-        x,
-        y,
-        z,
-        domain="QQ",
-    )
-    source = Poly(
-        (geometric_x * geometric_yz**2 * (x - 1) ** 3).as_expr(),
-        x,
-        y,
-        z,
-        domain="QQ",
-    )
-    assert len(source.terms()) == 930
-    request = PolynomialSquareFreeRequest(
-        polynomial=_sparse_polynomial(
-            ("x", "y", "z"),
-            {monom: str(int(coeff)) for monom, coeff in source.terms()},
-        )
-    )
-    result = polynomial_square_free_decomposition(request)
-    records = sorted(
-        (len(rational_polynomial_to_sympy(r.factor).terms()), r.multiplicity)
-        for r in result.factors
-    )
-    assert records == [(2, 3), (48, 2), (62, 1)]
-    assert (
-        PolynomialSquareFreeDecompositionResult.model_validate(result.model_dump())
-        == result
-    )
-
-
-@pytest.mark.scale
-def test_square_free_operation_admits_telescoping_geometric_decomposition() -> None:
-    """The reported admitted source returns its typed decomposition.
-
-    ``S_57(x) * (S_31(y) S_31(z))^2 * (x+1)^3 * ((x-1)(y-1)(z-1))^4`` with
-    ``S_n(t) = 1 + t + ... + t^(n-1)`` expands to 648 terms with per-variable
-    degrees (63, 64, 64), inside the request envelope, and all four claimed
-    canonical records fit their representation limits.  Its multiplicity-2
-    record holds 961 terms whose squared support collapses to the full
-    ``[0, 60]^2`` grid of 3,721 terms — a collision structure the former
-    pairwise-product estimate (923,521 for that step alone) rejected as an
-    intermediate overflow even though the authentic replay peaks at
-    270,400 materialized terms and finishes inside the work budget.  The
-    operation must return its typed, source-bound result.
-    """
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
-    from jacobian.math.polynomials._models import PolynomialSquareFreeRequest
-    from jacobian.math.polynomials._operations import (
-        polynomial_square_free_decomposition,
-    )
-
-    def convolve_ints(left: dict[int, int], right: dict[int, int]) -> dict[int, int]:
-        product: dict[int, int] = {}
-        for left_degree, left_coeff in left.items():
-            for right_degree, right_coeff in right.items():
-                product[left_degree + right_degree] = (
-                    product.get(left_degree + right_degree, 0)
-                    + left_coeff * right_coeff
-                )
-        return {degree: c for degree, c in product.items() if c}
-
-    def convolve(
-        left: dict[tuple[int, ...], int], right: dict[tuple[int, ...], int]
-    ) -> dict[tuple[int, ...], int]:
-        product: dict[tuple[int, ...], int] = {}
-        for left_exps, left_coeff in left.items():
-            for right_exps, right_coeff in right.items():
-                key = tuple(a + b for a, b in zip(left_exps, right_exps, strict=True))
-                product[key] = product.get(key, 0) + left_coeff * right_coeff
-        return {exps: c for exps, c in product.items() if c}
-
-    def on_axis(axis: int, part: dict[int, int]) -> dict[tuple[int, ...], int]:
-        lifted: dict[tuple[int, ...], int] = {}
-        for degree, coefficient in part.items():
-            exps = [0, 0, 0]
-            exps[axis] = degree
-            lifted[tuple(exps)] = coefficient
-        return lifted
-
-    # Per-variable telescoped parts of the source:
-    #   x: S_57(x)(x+1)^3(x-1)^4 = (x^57 - 1)(x^2 - 1)^3          -> 8 terms
-    #   y: S_31(y)^2 (y-1)^4     = (y^62 - 2 y^31 + 1)(y^2-2y+1)  -> 9 terms
-    #   z: same as y                                              -> 9 terms
-    part_x = convolve_ints({57: 1, 0: -1}, {6: 1, 4: -3, 2: 3, 0: -1})
-    part_y = convolve_ints({62: 1, 31: -2, 0: 1}, {2: 1, 1: -2, 0: 1})
-    source_terms = convolve(
-        convolve(on_axis(0, part_x), on_axis(1, part_y)), on_axis(2, part_y)
-    )
-    assert len(source_terms) == 648
-    assert [max(exps[i] for exps in source_terms) for i in range(3)] == [63, 64, 64]
-    request = PolynomialSquareFreeRequest(
-        polynomial=_sparse_polynomial(
-            ("x", "y", "z"),
-            {exps: str(coefficient) for exps, coefficient in source_terms.items()},
-        )
-    )
-    result = polynomial_square_free_decomposition(request)
-    assert result.polynomial == request.polynomial
-    assert result.reconstructed == request.polynomial
-    assert result.coefficient == CanonicalRational(num="1", den="1")
-    records = sorted(
-        (
-            (len(rational_polynomial_to_sympy(r.factor).terms()), r.multiplicity)
-            for r in result.factors
-        ),
-        key=lambda record: record[1],
-    )
-    assert records == [(57, 1), (961, 2), (2, 3), (8, 4)]
-
-
-def test_square_free_replay_rejects_forged_disjoint_grid_claims() -> None:
-    """A forged disjoint-grid claim still rejects before materializing.
-
-    Two schema-valid 1,296-term grid factors live on disjoint variable
-    groups of one 8-variable ring at multiplicities 1 and 2.  Their merge's
-    pairwise bound (about 19 million) and degree box (11^8) both exceed the
-    per-step support ceiling, so the structure-derived preflight refuses the
-    claim typedly before any backend multiplication can expand it.
-    """
-
-    import itertools
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeFactor,
-    )
-
-    variables = tuple(f"x{index}" for index in range(8))
-    grid = list(itertools.product(range(6), repeat=4))
-    assert len(grid) == 1_296
-    left = _sparse_polynomial(
-        variables, {exponents + (0,) * 4: "1" for exponents in grid}
-    )
-    right = _sparse_polynomial(
-        variables, {(0,) * 4 + exponents: "1" for exponents in grid}
-    )
-    constant = _sparse_polynomial(variables, {(0,) * 8: "1"})
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=constant,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(
-                PolynomialSquareFreeFactor(factor=left, multiplicity=1),
-                PolynomialSquareFreeFactor(factor=right, multiplicity=2),
-            ),
-            reconstructed=constant,
-        )
-
-
-def test_square_free_replay_support_prediction_keeps_colliding_claims_bounded() -> None:
-    """Trusting the degree box admits only provably bounded products.
-
-    A 729-term monic grid factor and a distinct 512-term grid factor live in
-    one 3-variable ring at multiplicities 1 and 2.  The replay merge's
-    pairwise bound (about 3.6 million) exceeds the per-step estimate that
-    rejected authentic collisions before this fix, while the degree boxes
-    prove every executed step's support stays inside the ceiling — so the
-    steps run safely, and the forged constant-source claim is then rejected
-    by the exact reconstruction equality instead.
-    """
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeFactor,
-    )
-
-    low_grid = {(a, b, c): "1" for a in range(9) for b in range(9) for c in range(9)}
-    high_grid = {
-        (a, b, c): "1" for a in range(9, 17) for b in range(9, 17) for c in range(9, 17)
-    }
-    assert len(low_grid) == 729 and len(high_grid) == 512
-    first = _sparse_polynomial(("x", "y", "z"), low_grid)
-    second = _sparse_polynomial(("x", "y", "z"), high_grid)
-    constant = _sparse_polynomial(("x", "y", "z"), {(0, 0, 0): "1"})
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=constant,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(
-                PolynomialSquareFreeFactor(factor=first, multiplicity=1),
-                PolynomialSquareFreeFactor(factor=second, multiplicity=2),
-            ),
-            reconstructed=constant,
-        )
-
-
-def test_replay_preflights_support_before_multiplying(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Forged disjoint-support claims reject before any large materialization.
-
-    Two schema-valid square-free factors each hold all 4,095 monomials of
-    ``[0, 7]^4`` minus one on disjoint variable groups, at multiplicities 1
-    and 2.  Their Cartesian merge has a 16,777,216-term degree box and a
-    16,769,025-term pairwise bound, so both structure-derived support
-    predictions exceed the per-step ceiling and the replay must refuse the
-    merge before it materializes the product.  Squaring ``right`` is a
-    different story its structure proves safe: the degree box of that step
-    collapses to ``8^4 = 4,096`` terms, so it runs — and every operand of
-    every multiplication that executes stays inside the ceiling.
-    """
-
-    import itertools
-
-    from sympy import Poly
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials import _models
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeFactor,
-    )
-
-    variables = tuple(f"x{index}" for index in range(8))
-    box = [
-        exponents
-        for exponents in itertools.product(range(8), repeat=4)
-        if exponents != (0, 0, 0, 0)
-    ]
-    assert len(box) == 4_095
-    left = _sparse_polynomial(
-        variables, {exponents + (0,) * 4: "1" for exponents in box}
-    )
-    right = _sparse_polynomial(
-        variables, {(0,) * 4 + exponents: "1" for exponents in box}
-    )
-    constant = _sparse_polynomial(variables, {(0,) * 8: "1"})
-
-    original_mul = Poly.__mul__
-    observed_operands: list[int] = []
-
-    def spy_mul(self, other):
-        observed_operands.append(len(self.terms()))
-        observed_operands.append(len(other.terms()))
-        return original_mul(self, other)
-
-    monkeypatch.setattr(Poly, "__mul__", spy_mul)
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=constant,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(
-                PolynomialSquareFreeFactor(factor=left, multiplicity=1),
-                PolynomialSquareFreeFactor(factor=right, multiplicity=2),
-            ),
-            reconstructed=constant,
-        )
-    # The left merge ran (trivially), then the right square ran under its
-    # collapsed degree-box prediction, and the Cartesian merge was refused
-    # before any backend multiplication: no operand ever exceeded the
-    # materialization ceiling.
-    assert observed_operands[-2:] == [4_095, 4_095]
-    assert max(observed_operands) <= _models._MAX_REPLAY_INTERMEDIATE_TERMS
-
-
-def test_square_free_operation_admits_envelope_scale_parts() -> None:
-    """A 16-term admitted request yields its 3,969-term square-free part.
-
-    For ``((x^63 - 1)(x - 1))((y^63 - 1)(y - 1))`` the multiplicity-one
-    part ``((x^63 - 1)/(x - 1))((y^63 - 1)/(y - 1))`` holds 3,969 terms —
-    inside the shared representation envelope and emitted by the backend —
-    so an accepted request form of this decomposition must validate and
-    round-trip instead of being rejected for its part size.
-    """
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeFactor,
-    )
-
-    geometric = _sparse_polynomial(
-        ("x", "y"),
-        {(a, b): "1" for a in range(63) for b in range(63)},
-    )
-    assert len(geometric.polynomial.terms) == 3_969
-    # (x^64 - x^63 - x + 1)(y^64 - y^63 - y + 1), 16 terms, exponents <= 64.
-    one_dimension = {0: 1, 1: -1, 63: -1, 64: 1}
-    accumulated: dict[tuple[int, int], int] = {(0, 0): 1}
-    for axis in (0, 1):
-        shifted: dict[tuple[int, int], int] = {}
-        for exps, coeff in accumulated.items():
-            for degree, factor_coefficient in one_dimension.items():
-                target = list(exps)
-                target[axis] += degree
-                key = tuple(target)
-                shifted[key] = shifted.get(key, 0) + coeff * factor_coefficient
-        accumulated = {exps: c for exps, c in shifted.items() if c}
-    assert len(accumulated) == 16
-    source = _sparse_polynomial(
-        ("x", "y"),
-        {exps: str(c) for exps, c in sorted(accumulated.items(), reverse=True)},
-    )
-    result = PolynomialSquareFreeDecompositionResult(
-        polynomial=source,
-        coefficient=CanonicalRational(num="1", den="1"),
-        factors=(
-            PolynomialSquareFreeFactor(factor=geometric, multiplicity=1),
-            PolynomialSquareFreeFactor(
-                factor=_sparse_polynomial(
-                    ("x", "y"),
-                    {(1, 1): "1", (1, 0): "-1", (0, 1): "-1", (0, 0): "1"},
-                ),
-                multiplicity=2,
-            ),
-        ),
-        reconstructed=source,
-    )
-    assert (
-        PolynomialSquareFreeDecompositionResult.model_validate(result.model_dump())
-        == result
-    )
-
-
-def test_factorization_replay_rejects_split_duplicate_records() -> None:
-    """Two identical records never equal one multiplicity-2 record.
-
-    ``(x - 1)^2`` claimed as two separate multiplicity-1 records of the
-    same factor reconstructs exactly, but the canonical irreducible
-    factorization lists one record; repeating a factor key is rejected.
-    """
-
-    from jacobian._exact import CanonicalRational
+def test_factor_results_keep_structural_ring_and_order_checks() -> None:
     from jacobian.math.polynomials._models import (
         PolynomialFactorizationResult,
+        PolynomialFactorRequest,
         PolynomialIrreducibleFactor,
     )
+    from jacobian.math.polynomials._operations import polynomial_factorization
 
-    factor = _univariate("x", {1: "1", 0: "-1"})
-    source = _univariate("x", {2: "1", 1: "-2", 0: "1"})
-    with polynomial_validation_error():
-        PolynomialFactorizationResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(
-                PolynomialIrreducibleFactor(factor=factor, multiplicity=1),
-                PolynomialIrreducibleFactor(factor=factor, multiplicity=1),
-            ),
-            reconstructed=source,
-        )
-
-
-def test_square_free_replay_rejects_repeated_part_keys() -> None:
-    """The same part listed at two multiplicities is not a decomposition.
-
-    ``(x - 1)^3`` claimed as ``(x - 1)`` at multiplicities 1 and 2
-    reconstructs exactly, but the parts overlap, so the repeated key is
-    rejected before any coprimality work.
-    """
-
-    from jacobian._exact import CanonicalRational
-    from jacobian.math.polynomials._models import (
-        PolynomialSquareFreeDecompositionResult,
-        PolynomialSquareFreeFactor,
+    result = polynomial_factorization(
+        PolynomialFactorRequest(polynomial=_univariate("x", {3: "1", 0: "-1"}))
     )
-
-    factor = _univariate("x", {1: "1", 0: "-1"})
-    source = _univariate("x", {3: "1", 2: "-3", 1: "3", 0: "-1"})
-    with polynomial_validation_error():
-        PolynomialSquareFreeDecompositionResult(
-            polynomial=source,
-            coefficient=CanonicalRational(num="1", den="1"),
-            factors=(
-                PolynomialSquareFreeFactor(factor=factor, multiplicity=1),
-                PolynomialSquareFreeFactor(factor=factor, multiplicity=2),
-            ),
-            reconstructed=source,
+    with pytest.raises(ValidationError):
+        PolynomialFactorizationResult(
+            polynomial=result.polynomial,
+            coefficient=result.coefficient,
+            factors=tuple(reversed(result.factors)),
+            reconstructed=result.reconstructed,
+        )
+    foreign = PolynomialIrreducibleFactor(
+        factor=_univariate("y", {1: "1", 0: "-1"}), multiplicity=1
+    )
+    with pytest.raises(ValidationError):
+        PolynomialFactorizationResult(
+            polynomial=result.polynomial,
+            coefficient=result.coefficient,
+            factors=(foreign,),
+            reconstructed=result.reconstructed,
         )

--- a/tests/math/polynomials/test_strict_sublevel_measure.py
+++ b/tests/math/polynomials/test_strict_sublevel_measure.py
@@ -125,7 +125,7 @@ def test_quadratic_measure_retains_exact_irrational_boundary_sum() -> None:
     assert _resolve_measure(result) - reconstructed_length == 0
 
 
-def test_producer_isolates_once_and_external_validation_replays(
+def test_producer_isolates_once_and_result_parsing_stays_structural(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import jacobian.math.polynomials.real_algebra._operations as operations
@@ -147,7 +147,7 @@ def test_producer_isolates_once_and_external_validation_replays(
     assert calls == 1
 
     StrictSublevelMeasureResult.model_validate(result.model_dump(mode="json"))
-    assert calls == 2
+    assert calls == 1
 
 
 def test_request_and_result_compose_through_strict_json_transport() -> None:
@@ -440,7 +440,7 @@ def test_small_integer_polynomials_match_sympy_inequality_sets_exhaustively() ->
                 assert simplify(_resolve_measure(result) - expected_set.measure) == 0
 
 
-def test_source_bound_result_rejects_independent_forged_fields() -> None:
+def test_owner_verifier_rejects_independent_forged_fields() -> None:
     result = compute_strict_sublevel_measure(_request(_polynomial((1, 2)), threshold=2))
     payload = result.model_dump(mode="json")
     mutations = []
@@ -470,9 +470,13 @@ def test_source_bound_result_rejects_independent_forged_fields() -> None:
     changed_measure["measure"]["root_terms"][0]["coefficient"] = 1
     mutations.append(changed_measure)
 
+    from jacobian.math.polynomials.real_algebra._strict_sublevel import (
+        verify_strict_sublevel_measure_result,
+    )
+
     for mutation in mutations:
-        with pytest.raises(ValidationError):
-            StrictSublevelMeasureResult.model_validate(mutation)
+        parsed = StrictSublevelMeasureResult.model_validate(mutation)
+        assert not verify_strict_sublevel_measure_result(parsed)
 
 
 def test_measure_root_incidence_rejects_boolean_coefficient() -> None:

--- a/tests/math/prime_affine_forms/test_prime_affine_forms.py
+++ b/tests/math/prime_affine_forms/test_prime_affine_forms.py
@@ -548,6 +548,12 @@ def test_interval_count_and_enumeration_are_exact_and_aligned() -> None:
     ) == (("3", ("3", "5")), ("5", ("5", "7")), ("11", ("11", "13")))
     assert count.match_count == len(enumeration.matches)
 
+    missing_endpoints = count.model_dump(mode="json")
+    missing_endpoints["first_match"] = None
+    missing_endpoints["last_match"] = None
+    with pytest.raises(ValidationError, match="if and only if match_count is positive"):
+        PrimePatternIntervalCountResult.model_validate(missing_endpoints)
+
     payload = enumeration.model_dump(mode="json")
     payload["matches"][0]["prime_values"][1] = "7"
     forged = PrimePatternIntervalEnumerateResult.model_validate(payload)

--- a/tests/math/prime_affine_forms/test_prime_affine_forms.py
+++ b/tests/math/prime_affine_forms/test_prime_affine_forms.py
@@ -508,6 +508,23 @@ def test_wheel_result_rejects_component_and_source_mutations() -> None:
         )
 
 
+def test_wheel_consumers_reject_a_structurally_valid_forged_wheel() -> None:
+    wheel = compute_residue_wheel(
+        PrimeTupleResidueWheelRequest(source=TWIN_PRIMES, primes=(2, 3))
+    )
+    forged = wheel.model_dump(mode="json")
+    forged["modulus"] = "0"
+
+    with pytest.raises(ValidationError, match="must equal the compact residue wheel"):
+        PrimeTupleResidueWheelEnumerationRequest.model_validate({"wheel": forged})
+    with pytest.raises(ValidationError, match="must equal the compact residue wheel"):
+        PrimeTupleWheelMembershipRequest.model_validate({"wheel": forged, "value": "5"})
+    with pytest.raises(ValidationError, match="must equal the compact residue wheel"):
+        PrimeTupleIntervalResidueProfileRequest.model_validate(
+            {"wheel": forged, "lower": "0", "upper": "12"}
+        )
+
+
 def test_interval_count_and_enumeration_are_exact_and_aligned() -> None:
     count = compute_interval_count(
         PrimeAffineIntervalCountRequest(

--- a/tests/math/prime_affine_forms/test_prime_affine_forms.py
+++ b/tests/math/prime_affine_forms/test_prime_affine_forms.py
@@ -26,6 +26,7 @@ from jacobian.math.prime_affine_forms._interval import (
     PrimePatternIntervalEnumerateResult,
     compute_interval_count,
     compute_interval_enumerate,
+    verify_interval_enumerate_result,
 )
 from jacobian.math.prime_affine_forms._local_factors import (
     FinitePrimeTupleFactorProduct,
@@ -34,6 +35,8 @@ from jacobian.math.prime_affine_forms._local_factors import (
     PrimeTupleLocalFactorsRequest,
     compute_local_factor,
     compute_local_factors,
+    verify_local_factor_result,
+    verify_local_factors_result,
 )
 from jacobian.math.prime_affine_forms._models import PrimeTupleLocalSummary
 from jacobian.math.prime_affine_forms._operations import (
@@ -49,12 +52,15 @@ from jacobian.math.prime_affine_forms._residue_wheel import (
     PrimeTupleResidueWheelEnumerationRequest,
     PrimeTupleResidueWheelRequest,
     PrimeTupleWheelMembershipRequest,
+    verify_residue_wheel,
+    verify_residue_wheel_enumeration,
 )
 from jacobian.math.prime_affine_forms._tools import TOOLS
 from jacobian.math.prime_affine_forms._translation import (
     PrimeAffineTranslationRequest,
     PrimeAffineTranslationResult,
     compute_translation,
+    verify_translation_result,
 )
 from jacobian.math.prime_affine_forms.values import MAX_AFFINE_AGGREGATE_DIGITS
 
@@ -185,7 +191,9 @@ def test_local_factor_agrees_with_direct_residue_oracle(prime: int) -> None:
     assert result.factor.as_fraction() == expected_factor
 
 
-def test_local_factor_result_rejects_source_and_conclusion_mutations() -> None:
+def test_local_factor_result_round_trips_structurally_and_verifier_rejects_forgery() -> (
+    None
+):
     result = compute_local_factor(
         PrimeTupleLocalFactorRequest(source=TWIN_PRIMES, prime=3)
     )
@@ -193,18 +201,23 @@ def test_local_factor_result_rejects_source_and_conclusion_mutations() -> None:
 
     wrong_factor = deepcopy(payload)
     wrong_factor["factor"] = {"num": "1", "den": "1"}
-    with pytest.raises(ValidationError):
+    assert PrimeTupleLocalFactorResult.model_validate(wrong_factor) != result
+    assert not verify_local_factor_result(
         PrimeTupleLocalFactorResult.model_validate(wrong_factor)
+    )
 
     wrong_source = deepcopy(payload)
     wrong_source["source"]["forms"][1]["constant"] = "4"
-    with pytest.raises(ValidationError):
+    assert not verify_local_factor_result(
         PrimeTupleLocalFactorResult.model_validate(wrong_source)
+    )
 
     wrong_row = deepcopy(payload)
     wrong_row["residue_rows"][1]["vanishing_form_ids"] = []
-    with pytest.raises(ValidationError):
+    assert not verify_local_factor_result(
         PrimeTupleLocalFactorResult.model_validate(wrong_row)
+    )
+    assert PrimeTupleLocalFactorResult.model_validate(payload) == result
 
 
 def test_finite_local_factor_product_and_obstruction() -> None:
@@ -227,8 +240,8 @@ def test_finite_local_factor_product_and_obstruction() -> None:
 
     payload = zero.model_dump(mode="json")
     payload["first_obstructing_prime"] = 2
-    with pytest.raises(ValidationError):
-        FinitePrimeTupleFactorProduct.model_validate(payload)
+    forged = FinitePrimeTupleFactorProduct.model_validate(payload)
+    assert not verify_local_factors_result(forged)
 
 
 def test_local_admissibility_uses_complete_finite_cutoff() -> None:
@@ -317,8 +330,8 @@ def test_translation_preserves_local_factors_and_form_ids() -> None:
 
     payload = translated.model_dump(mode="json")
     payload["translated"]["forms"][0]["constant"] = "2"
-    with pytest.raises(ValidationError):
-        PrimeAffineTranslationResult.model_validate(payload)
+    forged = PrimeAffineTranslationResult.model_validate(payload)
+    assert not verify_translation_result(forged)
 
 
 def test_translation_rejects_translated_tuple_exceeding_aggregate_digit_bound() -> None:
@@ -474,16 +487,18 @@ def test_wheel_result_rejects_component_and_source_mutations() -> None:
 
     wrong_source = deepcopy(payload)
     wrong_source["source"]["forms"][1]["constant"] = "4"
-    with pytest.raises(ValidationError):
-        PrimeTupleResidueWheel.model_validate(wrong_source)
+    forged_wheel = PrimeTupleResidueWheel.model_validate(wrong_source)
+    assert not verify_residue_wheel(forged_wheel)
 
     enumeration = compute_residue_wheel_enumeration(
         PrimeTupleResidueWheelEnumerationRequest(wheel=wheel)
     )
     wrong_component = enumeration.model_dump(mode="json")
     wrong_component["residues"][0]["components"] = [0, 2]
-    with pytest.raises(ValidationError):
-        PrimeTupleResidueWheelEnumeration.model_validate(wrong_component)
+    forged_enumeration = PrimeTupleResidueWheelEnumeration.model_validate(
+        wrong_component
+    )
+    assert not verify_residue_wheel_enumeration(forged_enumeration)
 
     oversized_scalar = deepcopy(payload)
     oversized_scalar["modulus"] = "9" * 4_097
@@ -518,8 +533,8 @@ def test_interval_count_and_enumeration_are_exact_and_aligned() -> None:
 
     payload = enumeration.model_dump(mode="json")
     payload["matches"][0]["prime_values"][1] = "7"
-    with pytest.raises(ValidationError):
-        PrimePatternIntervalEnumerateResult.model_validate(payload)
+    forged = PrimePatternIntervalEnumerateResult.model_validate(payload)
+    assert not verify_interval_enumerate_result(forged)
 
 
 def test_wheel_survival_is_not_mislabelled_as_primality() -> None:
@@ -665,7 +680,7 @@ def test_request_boundaries_reject_before_expansion() -> None:
         )
 
 
-def test_result_validation_reapplies_request_bounds_before_replay() -> None:
+def test_private_verification_reapplies_request_bounds() -> None:
     count = compute_interval_count(
         PrimeAffineIntervalCountRequest(
             source=_tuple(_form("n", 1, 0)), lower="0", upper="10"
@@ -674,7 +689,9 @@ def test_result_validation_reapplies_request_bounds_before_replay() -> None:
     overbound_count = count.model_dump(mode="json")
     overbound_count["upper"] = "100000"
     with pytest.raises(ValidationError):
-        PrimePatternIntervalCountResult.model_validate(overbound_count)
+        interval_contracts.verify_interval_count_result(
+            PrimePatternIntervalCountResult.model_validate(overbound_count)
+        )
 
     wheel = compute_residue_wheel(
         PrimeTupleResidueWheelRequest(source=TWIN_PRIMES, primes=(2, 3))
@@ -682,7 +699,7 @@ def test_result_validation_reapplies_request_bounds_before_replay() -> None:
     overbound_wheel = wheel.model_dump(mode="json")
     overbound_wheel["primes"] = [9_007_199_254_740_993]
     with pytest.raises(ValidationError):
-        PrimeTupleResidueWheel.model_validate(overbound_wheel)
+        verify_residue_wheel(PrimeTupleResidueWheel.model_validate(overbound_wheel))
 
 
 def test_prime_sets_and_interval_relations_are_schema_visible() -> None:

--- a/tests/math/prime_affine_forms/test_prime_affine_forms.py
+++ b/tests/math/prime_affine_forms/test_prime_affine_forms.py
@@ -554,10 +554,26 @@ def test_interval_count_and_enumeration_are_exact_and_aligned() -> None:
     with pytest.raises(ValidationError, match="if and only if match_count is positive"):
         PrimePatternIntervalCountResult.model_validate(missing_endpoints)
 
+    impossible_count = count.model_dump(mode="json")
+    impossible_count["lower"] = "3"
+    impossible_count["upper"] = "3"
+    impossible_count["interval_size"] = 1
+    impossible_count["affine_values_examined"] = 2
+    impossible_count["match_count"] = 2
+    impossible_count["first_match"] = "3"
+    impossible_count["last_match"] = "3"
+    with pytest.raises(ValidationError, match="cannot exceed interval_size"):
+        PrimePatternIntervalCountResult.model_validate(impossible_count)
+
     payload = enumeration.model_dump(mode="json")
     payload["matches"][0]["prime_values"][1] = "7"
     forged = PrimePatternIntervalEnumerateResult.model_validate(payload)
     assert not verify_interval_enumerate_result(forged)
+
+    payload = enumeration.model_dump(mode="json")
+    payload["matches"][0]["parameter"] = "-1"
+    with pytest.raises(ValidationError, match="must lie in the interval"):
+        PrimePatternIntervalEnumerateResult.model_validate(payload)
 
 
 def test_wheel_survival_is_not_mislabelled_as_primality() -> None:

--- a/tests/math/prime_field_matrix/test_prime_field_matrix.py
+++ b/tests/math/prime_field_matrix/test_prime_field_matrix.py
@@ -10,6 +10,9 @@ from jacobian.math.prime_field_matrix._models import (
     PrimeFieldRrefResult,
 )
 from jacobian.math.prime_field_matrix._operations import (
+    _verify_nullspace_result,
+    _verify_rank_result,
+    _verify_rref_result,
     compute_nullspace,
     compute_rank,
     compute_rref,
@@ -297,45 +300,38 @@ class TestRequestValidation:
             PrimeFieldMatrixRequest(matrix=canonical)
 
 
-class TestResultReplay:
-    """Serialized results must revalidate only when they match the source."""
+class TestResultStructure:
+    """Parsing checks result structure; deliberate verification checks claims."""
 
-    def test_forged_rank_rejected(self):
+    def test_forged_rank_requires_deliberate_verification(self):
         request = pfm(prime=2, entries=((1, 0), (0, 1)))
-        with pytest.raises(ValidationError) as exc_info:
-            PrimeFieldMatrixRankResult(prime=2, source=request, rank=0)
-        assert_error_type(exc_info, "prime_field_matrix.result.rank_recomputation")
+        result = PrimeFieldMatrixRankResult(prime=2, source=request, rank=0)
+        assert not _verify_rank_result(result)
 
-    def test_forged_rref_rejected(self):
+    def test_forged_rref_requires_deliberate_verification(self):
         from jacobian.math.prime_field_linear_algebra import PrimeFieldMatrix
 
         request = pfm(prime=2, entries=((1, 0), (0, 1)))
-        with pytest.raises(ValidationError) as exc_info:
-            PrimeFieldRrefResult(
-                prime=2,
-                source=request,
-                rref_matrix=PrimeFieldMatrix(
-                    prime=2, entries=((0, 0), (0, 0)), columns=2
-                ),
-                pivot_columns=(),
-                rank=0,
-            )
-        assert_error_type(exc_info, "prime_field_matrix.result.rref_recomputation")
+        result = PrimeFieldRrefResult(
+            prime=2,
+            source=request,
+            rref_matrix=PrimeFieldMatrix(prime=2, entries=((0, 0), (0, 0)), columns=2),
+            pivot_columns=(),
+            rank=0,
+        )
+        assert not _verify_rref_result(result)
 
-    def test_forged_nullspace_rejected(self):
+    def test_forged_nullspace_requires_deliberate_verification(self):
         from jacobian.math.prime_field_linear_algebra import PrimeFieldMatrix
 
         request = pfm(prime=2, entries=((0, 0),))
-        with pytest.raises(ValidationError) as exc_info:
-            PrimeFieldNullspaceResult(
-                prime=2,
-                source=request,
-                nullspace_matrix=PrimeFieldMatrix(
-                    prime=2, entries=((1, 0),), columns=2
-                ),
-                nullity=0,
-            )
-        assert_error_type(exc_info, "prime_field_matrix.result.nullspace_recomputation")
+        result = PrimeFieldNullspaceResult(
+            prime=2,
+            source=request,
+            nullspace_matrix=PrimeFieldMatrix(prime=2, entries=((1, 0),), columns=2),
+            nullity=1,
+        )
+        assert not _verify_nullspace_result(result)
 
     def test_prime_mismatch_rejected(self):
         request = pfm(prime=2, entries=((1, 0), (0, 1)))
@@ -363,14 +359,40 @@ class TestResultReplay:
             )
         assert_error_type(exc_info, "prime_field_matrix.result.source_prime")
 
-    def test_genuine_results_round_trip(self):
+    def test_genuine_results_round_trip_structurally(self):
         request = pfm(prime=5, entries=((1, 2, 3), (2, 4, 1)))
         rank_result = compute_rank(request)
-        assert rank_result.rank == 1
         rref_result = compute_rref(request)
-        assert rref_result.rank == 1
         ns_result = compute_nullspace(request)
-        assert len(ns_result.nullspace_matrix.entries) == 2
+        assert (
+            PrimeFieldMatrixRankResult.model_validate(rank_result.model_dump())
+            == rank_result
+        )
+        assert (
+            PrimeFieldRrefResult.model_validate(rref_result.model_dump()) == rref_result
+        )
+        assert (
+            PrimeFieldNullspaceResult.model_validate(ns_result.model_dump())
+            == ns_result
+        )
+        assert _verify_rank_result(rank_result)
+        assert _verify_rref_result(rref_result)
+        assert _verify_nullspace_result(ns_result)
+
+    def test_producer_executes_rank_kernel_once(self, monkeypatch: pytest.MonkeyPatch):
+        import jacobian.math.prime_field_matrix._operations as operations
+
+        calls = 0
+        original_rank = operations._rank
+
+        def observed_rank(matrix):
+            nonlocal calls
+            calls += 1
+            return original_rank(matrix)
+
+        monkeypatch.setattr(operations, "_rank", observed_rank)
+        assert compute_rank(pfm(prime=2, entries=((1, 0), (0, 1)))).rank == 2
+        assert calls == 1
 
 
 class TestCanonicalValueComposition:

--- a/tests/math/quadratic_forms/test_quadratic_forms.py
+++ b/tests/math/quadratic_forms/test_quadratic_forms.py
@@ -13,7 +13,10 @@ from jacobian.math.quadratic_forms import (
     evaluate_rational_quadratic_form,
 )
 from jacobian.math.quadratic_forms._models import EvaluationRequest, EvaluationResult
-from jacobian.math.quadratic_forms._operations import evaluate_form
+from jacobian.math.quadratic_forms._operations import (
+    _verify_evaluation_result,
+    evaluate_form,
+)
 from jacobian.math.quadratic_forms._tools import TOOLS
 from jacobian.math.quadratic_forms.values import (
     MAX_QUADRATIC_EVALUATION_DIGITS,
@@ -149,12 +152,10 @@ def test_cross_terms_are_nonzero_unique_and_canonically_ordered() -> None:
     assert error.value.errors()[0]["type"] == "quadratic_form.cross_term_out_of_range"
 
 
-def test_result_replays_the_source_bound_value() -> None:
-    with pytest.raises(ValidationError) as error:
-        EvaluationResult.model_validate(
-            {"form": _form(), "vector": _vector(), "value": _rational(1)}
-        )
-    assert error.value.errors()[0]["type"] == "quadratic_form.value_mismatch"
+def test_result_parsing_keeps_the_bounded_structural_contract() -> None:
+    assert EvaluationResult.model_validate(
+        {"form": _form(), "vector": _vector(), "value": _rational(1)}
+    ).value.as_fraction() == Fraction(1)
 
 
 def test_digit_bounds_reject_before_exact_arithmetic() -> None:
@@ -340,11 +341,10 @@ def test_total_support_bound_rejects_unbounded_annihilated_support() -> None:
     with pytest.raises(ValidationError) as error:
         EvaluationRequest.model_validate({"form": form, "vector": vector})
     assert error.value.errors()[0]["type"] == "quadratic_form.support_budget"
-    with pytest.raises(ValidationError) as error:
-        EvaluationResult.model_validate(
-            {"form": form, "vector": vector, "value": _rational(0)}
-        )
-    assert error.value.errors()[0]["type"] == "quadratic_form.support_budget"
+    result = EvaluationResult.model_validate(
+        {"form": form, "vector": vector, "value": _rational(0)}
+    )
+    assert not _verify_evaluation_result(result)
 
 
 def test_total_support_admits_the_boundary_and_rejects_one_past_it() -> None:

--- a/tests/math/test_analysis_expression_box_enclosure.py
+++ b/tests/math/test_analysis_expression_box_enclosure.py
@@ -341,7 +341,7 @@ def test_first_domain_rejection_short_circuits_later_preflight_growth() -> None:
     assert result.domain_failure.node_path == (0,)
 
 
-def test_producer_result_round_trips_through_source_replay() -> None:
+def test_producer_result_round_trips_structurally() -> None:
     result = _run(
         {"op": "exp", "children": [_var("x")]},
         (("x", Fraction(0), Fraction(1)),),
@@ -354,7 +354,7 @@ def test_producer_result_round_trips_through_source_replay() -> None:
 
 
 @pytest.mark.parametrize("mutation", ["expression", "box", "endpoint"])
-def test_source_or_endpoint_mutation_is_rejected_by_replay(mutation: str) -> None:
+def test_source_derived_fields_deserialize_without_replaying(mutation: str) -> None:
     result = _run(
         {"op": "exp", "children": [_var("x")]},
         (("x", Fraction(0), Fraction(1)),),
@@ -367,11 +367,11 @@ def test_source_or_endpoint_mutation_is_rejected_by_replay(mutation: str) -> Non
     else:
         payload["lower"] = {"mantissa": "0", "exponent": 0}
 
-    with analysis_validation_error():
-        IntervalExpressionBoxEnclosureResult.model_validate(payload)
+    parsed = IntervalExpressionBoxEnclosureResult.model_validate(payload)
+    assert parsed != result
 
 
-def test_domain_rejection_is_also_bound_to_its_source() -> None:
+def test_domain_rejection_round_trips_without_replaying_its_source() -> None:
     result = _run(
         {"op": "div", "children": [_const(1), _var("x")]},
         (("x", Fraction(-1), Fraction(1)),),
@@ -388,8 +388,8 @@ def test_domain_rejection_is_also_bound_to_its_source() -> None:
         },
     )
 
-    with analysis_validation_error():
-        IntervalExpressionBoxEnclosureResult.model_validate(payload)
+    parsed = IntervalExpressionBoxEnclosureResult.model_validate(payload)
+    assert parsed != result
 
 
 def test_producer_does_not_pay_a_second_backend_replay(

--- a/tests/math/test_analysis_expression_second_jet_enclosure.py
+++ b/tests/math/test_analysis_expression_second_jet_enclosure.py
@@ -244,7 +244,7 @@ def test_sqrt_touching_zero_is_a_typed_second_derivative_nonconclusion() -> None
     )
 
 
-def test_source_bound_result_round_trips_and_rejects_mutated_partial() -> None:
+def test_source_bound_result_round_trips_without_replaying_mutated_partials() -> None:
     result = _run(
         {"op": "div", "children": [_const(1), _var("x")]},
         (("x", Fraction(1), Fraction(2)),),
@@ -259,8 +259,8 @@ def test_source_bound_result_round_trips_and_rejects_mutated_partial() -> None:
     )
     payload = deepcopy(payload)
     payload["hessian"][0]["enclosure"]["lower"] = {"mantissa": "0", "exponent": 0}
-    with analysis_validation_error():
-        IntervalExpressionSecondJetEnclosureResult.model_validate(payload)
+    parsed = IntervalExpressionSecondJetEnclosureResult.model_validate(payload)
+    assert parsed.model_dump(mode="json") == payload
 
 
 def test_request_strict_json_transport_round_trip() -> None:

--- a/tests/math/test_analysis_point_enclosure_check.py
+++ b/tests/math/test_analysis_point_enclosure_check.py
@@ -11,7 +11,6 @@ from jacobian.math.analysis._models import ExactDyadic
 from jacobian.math.analysis._point_enclosure import (
     MAX_POINT_CHECK_DYADIC_EXPONENT,
     MAX_POINT_CHECK_FRACTION_BITS,
-    MAX_POINT_CHECK_FRACTION_UPDATES,
     MAX_POINT_CHECK_LOG_TERMS,
     MAX_POINT_CHECK_OUTPUT_BYTES,
     ArbPointEnclosureRequest,
@@ -413,7 +412,7 @@ def test_fraction_intermediates_fit_the_preflighted_bit_bound_at_the_source_limi
     )
 
 
-def test_result_validation_rejects_forged_verdicts_and_wrong_sources() -> None:
+def test_result_parsing_is_structural_and_checker_verifies_claims() -> None:
     result = _run(
         "LOG",
         "137",
@@ -424,23 +423,44 @@ def test_result_validation_rejects_forged_verdicts_and_wrong_sources() -> None:
 
     forged_verdict = result.model_dump(mode="json")
     forged_verdict["outcome"] = "REJECTED"
-    with analysis_validation_error():
-        PointEnclosureCheckResult.model_validate(forged_verdict)
+    parsed_forged_verdict = PointEnclosureCheckResult.model_validate(forged_verdict)
+    assert parsed_forged_verdict.outcome == "REJECTED"
+    assert (
+        _check_point_enclosure(
+            PointEnclosureCheckRequest(enclosure=parsed_forged_verdict.enclosure)
+        ).outcome
+        == "ACCEPTED"
+    )
 
     tampered_interval = result.model_dump(mode="json")
     tampered_interval["enclosure"]["upper"] = {"mantissa": "1", "exponent": -1}
-    with analysis_validation_error():
-        PointEnclosureCheckResult.model_validate(tampered_interval)
+    parsed_interval = PointEnclosureCheckResult.model_validate(tampered_interval)
+    assert (
+        _check_point_enclosure(
+            PointEnclosureCheckRequest(enclosure=parsed_interval.enclosure)
+        ).outcome
+        == "REJECTED"
+    )
 
     wrong_function = result.model_dump(mode="json")
     wrong_function["enclosure"]["function"] = "SQRT"
-    with analysis_validation_error():
-        PointEnclosureCheckResult.model_validate(wrong_function)
+    parsed_function = PointEnclosureCheckResult.model_validate(wrong_function)
+    assert (
+        _check_point_enclosure(
+            PointEnclosureCheckRequest(enclosure=parsed_function.enclosure)
+        ).outcome
+        == "REJECTED"
+    )
 
     wrong_argument = result.model_dump(mode="json")
     wrong_argument["enclosure"]["argument"] = {"num": "0", "den": "1"}
-    with analysis_validation_error():
-        PointEnclosureCheckResult.model_validate(wrong_argument)
+    parsed_argument = PointEnclosureCheckResult.model_validate(wrong_argument)
+    assert (
+        _check_point_enclosure(
+            PointEnclosureCheckRequest(enclosure=parsed_argument.enclosure)
+        ).outcome
+        == "REJECTED"
+    )
 
     oversized_source = result.model_dump(mode="json")
     oversized_source["enclosure"]["argument"] = {"num": "1" + "0" * 128, "den": "1"}
@@ -566,11 +586,6 @@ def test_request_schema_publishes_work_and_precision_limits() -> None:
     assert (
         schema["point_check_fraction_intermediate_bit_bound"]
         == MAX_POINT_CHECK_FRACTION_BITS
-    )
-    assert (
-        schema["point_check_producer_replay_term_update_bound"]
-        == MAX_POINT_CHECK_FRACTION_UPDATES
-        == 512
     )
     assert schema["point_check_output_byte_bound"] == MAX_POINT_CHECK_OUTPUT_BYTES
     precision_description = enclosure_schema["properties"]["precision_bits"][

--- a/tests/math/topology/test_native.py
+++ b/tests/math/topology/test_native.py
@@ -4,6 +4,7 @@ the canonical chain-complex consumers unchanged."""
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from jacobian.catalog.models import MathTool
 from jacobian.math.chain_complexes._models import (
@@ -75,9 +76,8 @@ def test_producer_result_carries_its_canonical_value() -> None:
 
     payload = result.model_dump()
     payload["canonical_value"]["prime"] = 3
-    restored = type(result).model_validate(payload)
-    assert restored.canonical_value is not None
-    assert simplicial_chain_complex_value(restored).prime == 3
+    with pytest.raises(ValidationError, match="must match retained chain data"):
+        type(result).model_validate(payload)
 
 
 def test_integral_producer_result_admits_no_canonical_value() -> None:

--- a/tests/math/topology/test_native.py
+++ b/tests/math/topology/test_native.py
@@ -67,8 +67,6 @@ def test_gf_p_chain_result_enters_homology_unchanged() -> None:
 def test_producer_result_carries_its_canonical_value() -> None:
     """The public GF(p) producer exposes the canonical chain-complex
     value on the serialized result boundary itself."""
-    from pydantic import ValidationError
-
     result = _prime_field_chain(_circle(), 2)
     assert result.canonical_value is not None
     assert result.canonical_value == simplicial_chain_complex_value(result)
@@ -77,8 +75,9 @@ def test_producer_result_carries_its_canonical_value() -> None:
 
     payload = result.model_dump()
     payload["canonical_value"]["prime"] = 3
-    with pytest.raises(ValidationError):
-        type(result).model_validate(payload)
+    restored = type(result).model_validate(payload)
+    assert restored.canonical_value is not None
+    assert simplicial_chain_complex_value(restored).prime == 3
 
 
 def test_integral_producer_result_admits_no_canonical_value() -> None:

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -73,28 +73,25 @@ class TestStar:
         assert result.complex == request.complex
         assert StarResult.model_validate(result.model_dump()) == result
 
-    def test_forged_simplex_outside_source_rejected(self) -> None:
-        """The reviewer counterexample: a star for ('z',) presented on the
-        edge {a, b} cannot validate because 'z' is not a face of the source."""
-        with pytest.raises(ValidationError):
-            StarResult(
-                complex=EDGE,
-                simplex=("z",),
-                star_facets=(("a", "b"),),
-                star_is_empty=False,
-                star_complex=_canonical_complex(("a", "b"), (("a", "b"),)),
-            )
+    def test_structural_result_parsing_does_not_replay_source(self) -> None:
+        result = StarResult(
+            complex=EDGE,
+            simplex=("z",),
+            star_facets=(("a", "b"),),
+            star_is_empty=False,
+            star_complex=_canonical_complex(("a", "b"), (("a", "b"),)),
+        )
+        assert result.simplex == ("z",)
 
-    def test_truncated_star_facets_rejected(self) -> None:
-        """Dropping one containing facet must fail the source replay."""
-        with pytest.raises(ValidationError):
-            StarResult(
-                complex=CIRCLE,
-                simplex=("a",),
-                star_facets=(("a", "b"),),
-                star_is_empty=False,
-                star_complex=_canonical_complex(("a", "b"), (("a", "b"),)),
-            )
+    def test_structural_star_roundtrip_accepts_claim_shape(self) -> None:
+        result = StarResult(
+            complex=CIRCLE,
+            simplex=("a",),
+            star_facets=(("a", "b"),),
+            star_is_empty=False,
+            star_complex=_canonical_complex(("a", "b"), (("a", "b"),)),
+        )
+        assert StarResult.model_validate(result.model_dump()) == result
 
 
 class TestVertexDeletion:
@@ -248,17 +245,14 @@ class TestBarycentricSubdivision:
             f"bv{i}" for i in range(len(faces))
         ]
 
-    def test_swapped_vertex_face_map_rejected(self) -> None:
-        """Swapping entries of the indexed vertex-to-face map must not
-        validate while the subdivision complex stays unchanged."""
+    def test_subdivision_map_roundtrip_does_not_replay_source(self) -> None:
         result = compute_barycentric_subdivision(
             BarycentricSubdivisionRequest(complex=CIRCLE)
         )
         payload = result.model_dump(mode="json")
         faces = payload["subdivision_vertex_faces"]
         faces[0], faces[2] = faces[2], faces[0]
-        with pytest.raises(ValidationError):
-            BarycentricSubdivisionResult.model_validate(payload)
+        assert BarycentricSubdivisionResult.model_validate(payload)
 
 
 class TestCanonicalComplexFeeding:
@@ -407,35 +401,32 @@ class TestPseudomanifold:
         assert not result.is_pseudomanifold
         assert "3 facets" in result.obstruction
 
-    def test_forged_zero_dimensional_decision_rejected(self) -> None:
-        """A serialized negative decision for a singleton cannot validate."""
+    def test_result_parsing_does_not_replay_pseudomanifold_decision(self) -> None:
         point = {"vertices": ["a"], "facets": [["a"]]}
-        with pytest.raises(ValidationError):
-            PseudomanifoldResult(
-                complex=point,
-                is_pseudomanifold=False,
-                is_closed=False,
-                dimension=0,
-                num_facets=1,
-                obstruction="dimension must be at least 1",
-            )
+        result = PseudomanifoldResult(
+            complex=point,
+            is_pseudomanifold=False,
+            is_closed=False,
+            dimension=0,
+            num_facets=1,
+            obstruction="dimension must be at least 1",
+        )
+        assert not result.is_pseudomanifold
 
-    def test_forged_negative_obstruction_must_match_replay(self) -> None:
-        """A purity failure cannot be revalidated with a foreign non-null
-        obstruction: negative conclusions replay their exact description."""
+    def test_obstruction_text_is_not_replayed_at_parse_time(self) -> None:
         nonpure = {
             "vertices": ["a", "b", "c", "d", "e"],
             "facets": [["a", "b", "c"], ["d", "e"]],
         }
-        with pytest.raises(ValidationError):
-            PseudomanifoldResult(
-                complex=nonpure,
-                is_pseudomanifold=False,
-                is_closed=False,
-                dimension=2,
-                num_facets=2,
-                obstruction="codim-1 face [] is in 3 facets",
-            )
+        result = PseudomanifoldResult(
+            complex=nonpure,
+            is_pseudomanifold=False,
+            is_closed=False,
+            dimension=2,
+            num_facets=2,
+            obstruction="codim-1 face [] is in 3 facets",
+        )
+        assert result.obstruction == "codim-1 face [] is in 3 facets"
 
 
 class TestShellingCheck:
@@ -456,32 +447,29 @@ class TestShellingCheck:
         with pytest.raises(ValidationError):
             ShellingCheckRequest(complex=EDGE, facet_order=[1, 0])
 
-    def test_partial_order_cannot_authenticate_decision(self) -> None:
-        """A two-facet complex revalidated with facet_order=[0] must not
-        accept is_shelling=True: the omitted disjoint facet makes the full
-        order non-shelling (review counterexample)."""
+    def test_result_parsing_does_not_replay_shelling_decision(self) -> None:
         two_facets = {
             "vertices": ["a", "b", "c", "d"],
             "facets": [["a", "b"], ["c", "d"]],
         }
-        with pytest.raises(ValidationError):
-            ShellingCheckResult(
-                complex=two_facets,
-                facet_order=[0],
-                is_shelling=True,
-                failed_at=None,
-                failure_reason=None,
-            )
+        result = ShellingCheckResult(
+            complex=two_facets,
+            facet_order=[0],
+            is_shelling=True,
+            failed_at=None,
+            failure_reason=None,
+        )
+        assert result.is_shelling
 
-    def test_duplicate_indices_rejected_in_result(self) -> None:
-        with pytest.raises(ValidationError):
-            ShellingCheckResult(
-                complex=CIRCLE,
-                facet_order=[0, 0, 1],
-                is_shelling=False,
-                failed_at=1,
-                failure_reason="facet 1 restriction is not an interval",
-            )
+    def test_result_keeps_serialized_order_without_revalidating_request(self) -> None:
+        result = ShellingCheckResult(
+            complex=CIRCLE,
+            facet_order=[0, 0, 1],
+            is_shelling=False,
+            failed_at=1,
+            failure_reason="facet 1 restriction is not an interval",
+        )
+        assert result.facet_order == (0, 0, 1)
 
 
 class TestElementaryCollapse:
@@ -529,22 +517,18 @@ class TestElementaryCollapse:
         assert result.complex == request.complex
         assert ElementaryCollapseResult.model_validate(result.model_dump()) == result
 
-    def test_forged_free_face_with_empty_residual_rejected(self) -> None:
-        """A serialized free-face decision with an empty residual cannot
-        validate: collapsing ('a',) from the edge {a, b} must leave {b}
-        (review counterexample)."""
-        with pytest.raises(ValidationError):
-            ElementaryCollapseResult(
-                complex=EDGE,
-                is_free_face=True,
-                free_face=("a",),
-                coface=("a", "b"),
-                remaining_facets=(),
-                remaining_vertices=(),
-            )
+    def test_collapse_result_parsing_does_not_replay_source(self) -> None:
+        result = ElementaryCollapseResult(
+            complex=EDGE,
+            is_free_face=True,
+            free_face=("a",),
+            coface=("a", "b"),
+            remaining_facets=(),
+            remaining_vertices=(),
+        )
+        assert result.is_free_face
 
-    def test_forged_non_free_decision_rejected(self) -> None:
-        """A free pair replayed against its source must stay positive."""
+    def test_nonempty_collapse_requires_its_canonical_complex(self) -> None:
         with pytest.raises(ValidationError):
             ElementaryCollapseResult(
                 complex=EDGE,
@@ -744,36 +728,31 @@ class TestShellingSourceBinding:
         payload = result.model_dump()
         assert ShellingCheckResult.model_validate(payload) == result
 
-    def test_forged_shelling_decision_rejected(self) -> None:
-        """Two disjoint edges in order [0, 1] is not a shelling order; a
-        forged is_shelling=True cannot validate against the retained source."""
+    def test_shelling_result_parsing_is_structural(self) -> None:
         two_edges = {
             "vertices": ["a", "b", "c", "d"],
             "facets": [["a", "b"], ["c", "d"]],
         }
-        with pytest.raises(ValidationError):
-            ShellingCheckResult(
-                complex=two_edges,
-                facet_order=[0, 1],
-                is_shelling=True,
-                failed_at=None,
-                failure_reason=None,
-            )
+        result = ShellingCheckResult(
+            complex=two_edges,
+            facet_order=[0, 1],
+            is_shelling=True,
+            failed_at=None,
+            failure_reason=None,
+        )
+        assert result.is_shelling
 
 
-class TestResultSourceBindingRegression:
-    """Serialized results must replay against their retained sources."""
+class TestResultStructuralParsing:
+    """Serialized results retain only owner-local structural checks."""
 
-    def test_forged_deletion_keeping_deleted_vertex_rejected(self) -> None:
+    def test_deletion_source_mutation_does_not_replay(self) -> None:
         payload = compute_vertex_deletion(
             VertexDeletionRequest(complex=TRIANGLE, vertices_to_delete=["v0"])
         ).model_dump()
         assert payload["deleted_vertices"] == ("v0",)
-        # The reviewer counterexample: a singleton source still carrying the
-        # allegedly deleted vertex cannot validate against the claimed output.
         payload["complex"] = {"vertices": ["v0"], "facets": [["v0"]]}
-        with pytest.raises(ValidationError):
-            VertexDeletionResult.model_validate(payload)
+        assert VertexDeletionResult.model_validate(payload)
 
     def test_deletion_roundtrip(self) -> None:
         result = compute_vertex_deletion(
@@ -782,36 +761,36 @@ class TestResultSourceBindingRegression:
         assert result.remaining_facets == (("a", "c"),)
         assert VertexDeletionResult.model_validate(result.model_dump()) == result
 
-    def test_edge_in_zero_skeleton_rejected(self) -> None:
+    def test_skeleton_claim_parses_without_replay(self) -> None:
         request = SkeletonRequest(complex=EDGE, k=0)
-        with pytest.raises(ValidationError):
-            SkeletonResult(
-                complex=request.complex,
-                k=0,
-                skeleton_facets=(("a", "b"),),
-                skeleton_vertices=("a", "b"),
-                skeleton_complex=_canonical_complex(("a", "b"), (("a", "b"),)),
-            )
+        result = SkeletonResult(
+            complex=request.complex,
+            k=0,
+            skeleton_facets=(("a", "b"),),
+            skeleton_vertices=("a", "b"),
+            skeleton_complex=_canonical_complex(("a", "b"), (("a", "b"),)),
+        )
+        assert result.skeleton_facets == (("a", "b"),)
 
     def test_skeleton_roundtrip(self) -> None:
         result = compute_skeleton(SkeletonRequest(complex=TRIANGLE, k=1))
         assert result.skeleton_facets == (("v0", "v1"), ("v0", "v2"), ("v1", "v2"))
         assert SkeletonResult.model_validate(result.model_dump()) == result
 
-    def test_single_point_join_result_rejected(self) -> None:
+    def test_join_claim_parses_without_replay(self) -> None:
         request = JoinRequest(
             complex_a={"vertices": ["a"], "facets": [["a"]]},
             complex_b={"vertices": ["b"], "facets": [["b"]]},
         )
-        with pytest.raises(ValidationError):
-            JoinResult(
-                complex_a=request.complex_a,
-                complex_b=request.complex_b,
-                join_vertices=("a",),
-                join_facets=(("a",),),
-                join_dimension=0,
-                join_complex=_canonical_complex(("a",), (("a",),)),
-            )
+        result = JoinResult(
+            complex_a=request.complex_a,
+            complex_b=request.complex_b,
+            join_vertices=("a",),
+            join_facets=(("a",),),
+            join_dimension=0,
+            join_complex=_canonical_complex(("a",), (("a",),)),
+        )
+        assert result.join_dimension == 0
 
     def test_join_roundtrip(self) -> None:
         result = compute_join(
@@ -823,12 +802,11 @@ class TestResultSourceBindingRegression:
         assert result.join_facets == (("a", "b", "c"),)
         assert JoinResult.model_validate(result.model_dump()) == result
 
-    def test_subdivision_original_dimension_tamper_rejected(self) -> None:
+    def test_subdivision_source_derived_fields_are_not_replayed(self) -> None:
         request = BarycentricSubdivisionRequest(complex=EDGE)
         payload = compute_barycentric_subdivision(request).model_dump()
         payload["original_dimension"] = 7
-        with pytest.raises(ValidationError):
-            BarycentricSubdivisionResult.model_validate(payload)
+        assert BarycentricSubdivisionResult.model_validate(payload)
 
     def test_collapse_result_empty_free_face_rejected(self) -> None:
         with pytest.raises(ValidationError):
@@ -886,9 +864,7 @@ class TestResultDomainMirrorsRequest:
                 ),
             )
 
-    def test_subdivision_result_oversized_source_rejected(self) -> None:
-        """The retained source must satisfy the subdivision request's
-        31-face work admission, which the bare complex type does not carry."""
+    def test_subdivision_result_does_not_repeat_request_admission(self) -> None:
         result = compute_barycentric_subdivision(
             BarycentricSubdivisionRequest(complex=CIRCLE)
         )
@@ -898,8 +874,7 @@ class TestResultDomainMirrorsRequest:
             "facets": [["v0", "v1", "v2", "v3", "v4"], ["p"]],
         }
         payload["complex"] = simplex4_plus_point
-        with pytest.raises(ValidationError):
-            BarycentricSubdivisionResult.model_validate(payload)
+        assert BarycentricSubdivisionResult.model_validate(payload)
 
     def test_subdivision_roundtrip_still_admitted(self) -> None:
         result = compute_barycentric_subdivision(

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -471,6 +471,22 @@ class TestShellingCheck:
         )
         assert result.facet_order == (0, 0, 1)
 
+    def test_result_retains_shelling_branch_consistency(self) -> None:
+        with pytest.raises(ValidationError, match="cannot carry failure diagnostics"):
+            ShellingCheckResult(
+                complex=EDGE,
+                facet_order=[0],
+                is_shelling=True,
+                failed_at=0,
+                failure_reason="unexpected",
+            )
+        with pytest.raises(ValidationError, match="requires a valid position"):
+            ShellingCheckResult(
+                complex=EDGE,
+                facet_order=[0],
+                is_shelling=False,
+            )
+
 
 class TestElementaryCollapse:
     def test_collapse_free_vertex_from_edge(self) -> None:

--- a/tests/math/universal_algebra/test_universal_algebra.py
+++ b/tests/math/universal_algebra/test_universal_algebra.py
@@ -25,6 +25,7 @@ from jacobian.math.universal_algebra._models import (
     SubalgebraRequest,
 )
 from jacobian.math.universal_algebra._operations import (
+    _verify_homomorphism_profile_result,
     compute_congruence,
     compute_equation_profile,
     compute_evaluate,
@@ -316,7 +317,7 @@ class TestHomomorphismProfile:
         assert result.obstruction.mapped_source_output == 0
         assert result.obstruction.target_output == 1
 
-    def test_result_validation_rejects_forged_positive_and_negative_data(
+    def test_result_round_trip_is_structural_and_verifier_rejects_forged_claims(
         self,
     ) -> None:
         positive = compute_homomorphism_profile(
@@ -328,12 +329,11 @@ class TestHomomorphismProfile:
                 )
             )
         ).model_dump(mode="json")
+        parsed_positive = HomomorphismProfileResult.model_validate(positive)
+        assert parsed_positive.kernel_partition == ((0, 2), (1, 3))
         positive["kernel_partition"] = [[0, 1], [2, 3]]
-        with pytest.raises(ValidationError) as error:
+        assert not _verify_homomorphism_profile_result(
             HomomorphismProfileResult.model_validate(positive)
-        assert (
-            error.value.errors()[0]["type"]
-            == "universal_algebra.kernel_partition_mismatch"
         )
 
         symbol = (OperationSymbol(operation_id="flip", arity=1),)
@@ -351,13 +351,11 @@ class TestHomomorphismProfile:
             )
         ).model_dump(mode="json")
         negative["obstruction"]["target_output"] = 1
-        with pytest.raises(ValidationError) as error:
+        assert not _verify_homomorphism_profile_result(
             HomomorphismProfileResult.model_validate(negative)
-        assert (
-            error.value.errors()[0]["type"] == "universal_algebra.obstruction_mismatch"
         )
 
-    def test_source_mutation_invalidates_negative_conclusion(self) -> None:
+    def test_verifier_rejects_source_mutation(self) -> None:
         symbol = (OperationSymbol(operation_id="flip", arity=1),)
         payload = compute_homomorphism_profile(
             HomomorphismProfileRequest(
@@ -373,14 +371,38 @@ class TestHomomorphismProfile:
             )
         ).model_dump(mode="json")
         payload["carrier_map"]["target"]["tables"] = [[1, 0]]
-        with pytest.raises(ValidationError) as error:
+        assert not _verify_homomorphism_profile_result(
             HomomorphismProfileResult.model_validate(payload)
-        assert (
-            error.value.errors()[0]["type"]
-            == "universal_algebra.negative_map_is_homomorphism"
         )
 
-    def test_source_mutation_invalidates_positive_homomorphism(self) -> None:
+    def test_verifier_accepts_producer_result_and_producer_scans_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import jacobian.math.universal_algebra.operations as operations
+
+        calls = 0
+        original_scan = operations._first_homomorphism_failure
+
+        def observed_scan(carrier_map: FiniteAlgebraCarrierMap):
+            nonlocal calls
+            calls += 1
+            return original_scan(carrier_map)
+
+        monkeypatch.setattr(operations, "_first_homomorphism_failure", observed_scan)
+        result = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=_cyclic_addition_algebra(4),
+                    target=_cyclic_addition_algebra(2),
+                    mapping=(0, 1, 0, 1),
+                )
+            )
+        )
+        assert calls == 1
+        assert _verify_homomorphism_profile_result(result)
+        assert calls == 2
+
+    def test_verifier_rejects_positive_source_mutation(self) -> None:
         payload = compute_homomorphism_profile(
             HomomorphismProfileRequest(
                 carrier_map=FiniteAlgebraCarrierMap(
@@ -391,11 +413,8 @@ class TestHomomorphismProfile:
             )
         ).model_dump(mode="json")
         payload["homomorphism"]["target"]["tables"][0][0] = 1
-        with pytest.raises(ValidationError) as error:
+        assert not _verify_homomorphism_profile_result(
             HomomorphismProfileResult.model_validate(payload)
-        assert (
-            error.value.errors()[0]["type"]
-            == "universal_algebra.operation_not_preserved"
         )
 
     def test_maximum_source_table_budget_is_scanned_completely(self) -> None:
@@ -512,7 +531,7 @@ class TestQuotient:
             == "universal_algebra.quotient_output_exceeded"
         )
 
-    def test_quotient_charges_construction_and_map_replay_work(self) -> None:
+    def test_quotient_charges_construction_work(self) -> None:
         def constant_ternary_algebra(size: int) -> FiniteAlgebra:
             return FiniteAlgebra(
                 carrier=tuple(f"a{index}" for index in range(size)),

--- a/tests/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/mcp/test_mcp_sdk_2_conformance.py
@@ -9,13 +9,15 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+from mcp.shared.exceptions import MCPError
 from mcp.types import TextContent, TextResourceContents
 from mcp.types.methods import serialize_server_result
 
 import jacobian.mcp.server as server_module
 from jacobian.catalog.catalog import Catalog
-from jacobian.catalog.models import OperationCatalogSnapshot, OperationResult
-from jacobian.mcp.server import create_server
+from jacobian.catalog.models import MathTool, OperationCatalogSnapshot, OperationResult
+from jacobian.mcp.runtime import AppState
+from jacobian.mcp.server import _build_server, create_server
 from jacobian.mcp.tools import math_run
 
 
@@ -96,6 +98,53 @@ def test_math_run_encloses_logarithm_on_a_positive_box() -> None:
             output = result.structured_content["output"]
             assert output["status"] == "ENCLOSED"
             assert output["lower"] is not None and output["upper"] is not None
+
+    asyncio.run(scenario())
+
+
+def test_math_run_projects_unexpected_operation_failures() -> None:
+    """An owner crash must not escape the MCP worker as a TaskGroup failure."""
+
+    from jacobian._models import StrictModel
+    from jacobian.catalog.builtins import BUILTIN_TOOLS
+
+    class Request(StrictModel):
+        value: int
+
+    class Result(StrictModel):
+        value: int
+
+    def crashing_kernel(_request: Request) -> Result:
+        raise RuntimeError("private backend failure")
+
+    operation = MathTool(
+        operation_id="test.mcp.crashing_kernel",
+        title="Crashing kernel sentinel",
+        description="Exercises MCP execution-failure projection.",
+        request_type=Request,
+        result_type=Result,
+        run=crashing_kernel,
+    )
+    server = _build_server(
+        state=AppState(operation_catalog=Catalog((*BUILTIN_TOOLS, operation)))
+    )
+
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(server, raise_exceptions=True) as client:
+            with pytest.raises(MCPError) as error:
+                await client.call_tool(
+                    "math.run",
+                    {
+                        "operation_id": "test.mcp.crashing_kernel",
+                        "payload": {"value": 1},
+                    },
+                )
+        assert error.value.code == -32603
+        assert error.value.message == "operation execution failed"
+        assert error.value.data is None
+        assert "private backend failure" not in error.value.message
 
     asyncio.run(scenario())
 

--- a/tests/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/mcp/test_mcp_sdk_2_conformance.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from mcp.shared.exceptions import MCPError
 from mcp.types import TextContent, TextResourceContents
 from mcp.types.methods import serialize_server_result
 
@@ -171,19 +170,19 @@ def test_math_run_projects_unexpected_operation_failures() -> None:
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(server, raise_exceptions=True) as client:
-            with pytest.raises(MCPError) as error:
-                await client.call_tool(
-                    "math.run",
-                    {
-                        "operation_id": "test.mcp.crashing_kernel",
-                        "payload": {"value": 1},
-                    },
-                )
-        assert error.value.code == -32603
-        assert error.value.message == "operation execution failed"
-        assert error.value.data is None
-        assert "private backend failure" not in error.value.message
+        async with Client(server, raise_exceptions=False) as client:
+            result = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "test.mcp.crashing_kernel",
+                    "payload": {"value": 1},
+                },
+            )
+        assert result.is_error is True
+        assert result.structured_content is None
+        text = result.content[0].text if result.content else ""
+        assert text == "Error executing tool math.run: operation execution failed"
+        assert "private backend failure" not in text
 
     asyncio.run(scenario())
 

--- a/tests/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/mcp/test_mcp_sdk_2_conformance.py
@@ -102,6 +102,45 @@ def test_math_run_encloses_logarithm_on_a_positive_box() -> None:
     asyncio.run(scenario())
 
 
+def test_math_run_encloses_logarithm_second_jet_on_a_positive_box() -> None:
+    """The parallel Arb enclosure must also cross the MCP boundary as a result."""
+
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(create_server(), raise_exceptions=True) as client:
+            result = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "interval.expression.second_jet_enclosure.compute",
+                    "payload": {
+                        "expression": {
+                            "op": "log",
+                            "children": [{"op": "var", "variable": "x"}],
+                        },
+                        "box": {
+                            "variables": ["x"],
+                            "intervals": [
+                                {
+                                    "lower": {"num": "1", "den": "1"},
+                                    "upper": {"num": "2", "den": "1"},
+                                }
+                            ],
+                        },
+                        "precision_bits": 1024,
+                    },
+                },
+            )
+            assert isinstance(result.structured_content, dict)
+            output = result.structured_content["output"]
+            assert output["status"] == "ENCLOSED"
+            assert output["value"] is not None
+            assert len(output["gradient"]) == 1
+            assert len(output["hessian"]) == 1
+
+    asyncio.run(scenario())
+
+
 def test_math_run_projects_unexpected_operation_failures() -> None:
     """An owner crash must not escape the MCP worker as a TaskGroup failure."""
 

--- a/tests/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/mcp/test_mcp_sdk_2_conformance.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import inspect
+from types import SimpleNamespace
+from typing import Any, cast
 
+import pytest
+from mcp.types import TextContent, TextResourceContents
 from mcp.types.methods import serialize_server_result
 
 import jacobian.mcp.server as server_module
+from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationCatalogSnapshot, OperationResult
 from jacobian.mcp.server import create_server
 from jacobian.mcp.tools import math_run
@@ -19,8 +24,84 @@ def test_mcp_sdk_is_exactly_pinned_and_v2_bindings_are_used() -> None:
     assert not inspect.iscoroutinefunction(math_run)
 
 
+def test_math_run_resolves_the_selected_operation_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dynamic payload parsing needs the private binding, not a prior public lookup."""
+
+    import jacobian.mcp.tools as tools
+
+    catalog = Catalog.open()
+    bindings = 0
+    original_binding = catalog._binding
+
+    def observe_binding(operation_id: str) -> Any:
+        nonlocal bindings
+        bindings += 1
+        return original_binding(operation_id)
+
+    def unexpected_public_lookup(operation_id: str) -> Any:
+        raise AssertionError(f"unexpected public lookup: {operation_id}")
+
+    monkeypatch.setattr(catalog, "_binding", observe_binding)
+    monkeypatch.setattr(catalog, "operation", unexpected_public_lookup)
+    monkeypatch.setattr(tools, "_authorize", lambda _ctx: None)
+    monkeypatch.setattr(tools, "_catalog", lambda _ctx: catalog)
+    monkeypatch.setattr(
+        tools,
+        "_request_cancellation",
+        lambda _ctx: SimpleNamespace(is_set=lambda: False),
+    )
+
+    result = math_run(
+        "integer.compute.extended_gcd",
+        {"left": "84", "right": "30"},
+        ctx=cast(Any, SimpleNamespace()),
+    )
+
+    assert result.output["gcd"] == "6"
+    assert bindings == 1
+
+
+def test_math_run_encloses_logarithm_on_a_positive_box() -> None:
+    """A valid Arb enclosure must cross the MCP worker boundary as a result."""
+
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(create_server(), raise_exceptions=True) as client:
+            result = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "interval.expression.box_enclosure.compute",
+                    "payload": {
+                        "expression": {
+                            "op": "log",
+                            "children": [{"op": "var", "variable": "x"}],
+                        },
+                        "box": {
+                            "variables": ["x"],
+                            "intervals": [
+                                {
+                                    "lower": {"num": "1", "den": "1"},
+                                    "upper": {"num": "2", "den": "1"},
+                                }
+                            ],
+                        },
+                        "precision_bits": 1024,
+                    },
+                },
+            )
+            assert isinstance(result.structured_content, dict)
+            output = result.structured_content["output"]
+            assert output["status"] == "ENCLOSED"
+            assert output["lower"] is not None and output["upper"] is not None
+
+    asyncio.run(scenario())
+
+
 def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delattr(server_module, "Context", raising=False)
 
@@ -57,6 +138,7 @@ def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources(
                 },
                 "propertyName": "op",
             }
+            assert find.output_schema is not None
             assert find.output_schema["type"] == "object"
 
             browse = await client.call_tool(
@@ -81,7 +163,7 @@ def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources(
             assert any(
                 "request" in item.text
                 for item in invalid_request.content
-                if getattr(item, "text", None) is not None
+                if isinstance(item, TextContent)
             ), "error text must identify the missing request field"
 
             contract_result = await client.call_tool(
@@ -110,9 +192,9 @@ def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources(
             assert "determinant" in result.structured_content["output"]
 
             catalog = await client.read_resource("operation://catalog")
-            snapshot = OperationCatalogSnapshot.model_validate_json(
-                catalog.contents[0].text
-            )
+            content = catalog.contents[0]
+            assert isinstance(content, TextResourceContents)
+            snapshot = OperationCatalogSnapshot.model_validate_json(content.text)
             assert snapshot.operations
 
     asyncio.run(scenario())

--- a/tests/process/polynomial_maps/test_generic_degree_singular_process.py
+++ b/tests/process/polynomial_maps/test_generic_degree_singular_process.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import sys
 import threading
-import time
 from pathlib import Path
 
 import pytest
@@ -311,7 +310,7 @@ def _stripe_certificate() -> GenericFiberCertificate:
     )
 
 
-def test_heavy_certificate_replay_is_killably_bounded(
+def test_heavy_certificate_returns_the_owner_kernel_conclusion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -333,13 +332,10 @@ def test_heavy_certificate_replay_is_killably_bounded(
         )
     )
 
-    assert result.outcome == "TIMEOUT"
-    assert result.detail in (
-        "Certificate replay exceeded the declared wall-time limit.",
-        "The declared wall-time envelope expired before certificate replay.",
-    )
+    assert result.outcome == "DOMINANT_NOT_GENERICALLY_FINITE"
+    assert result.detail is None
     assert result.degree is None
-    assert result.evidence is None
+    assert result.evidence == _stripe_certificate()
 
 
 def test_one_second_budget_still_replays_a_light_certificate(
@@ -381,37 +377,6 @@ def test_one_second_budget_still_replays_a_light_certificate(
     assert result.outcome == "GENERICALLY_FINITE"
     assert result.degree == 1
     assert result.evidence is not None
-
-
-def test_expired_deadline_after_the_backend_still_reports_pre_replay_timeout(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def slow_backend(*_args):
-        time.sleep(1.5)
-        return _singular.SingularGenericFiberResult(
-            outcome="COMPUTED",
-            certificate=_stripe_certificate(),
-            dimension=0,
-            vector_dimension=3,
-            backend_version="4.4.1",
-        )
-
-    monkeypatch.setattr(_operations, "run_singular_generic_fiber", slow_backend)
-
-    result = compute_generic_degree(
-        GenericDegreeRequest(
-            polynomial_map=_two_variable_map(),
-            resource_budget=GenericDegreeComputationBudget(wall_seconds=1),
-        )
-    )
-
-    assert result.outcome == "TIMEOUT"
-    assert (
-        result.detail
-        == "The declared wall-time envelope expired before certificate replay."
-    )
-    assert result.degree is None
-    assert result.evidence is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Many result models re-ran domain kernels, enumerations, or source-derived checks while parsing serialized output. That duplicated bounded work, made deserialization act as proof, and left replay-specific budgets and helpers spread across owners. `math.run` also resolved an operation twice before parsing its dynamic payload, and unexpected admitted-operation exceptions could escape the MCP worker as an SDK `ExceptionGroup`.

## Solution

Move mathematical postconditions to the admitted producer kernel. Result models retain canonical syntax, bounded structural shape, and branch consistency; owner-private bounded verifiers re-enter request admission only for deliberately supplied theorem-bearing claims. Remove replay-only helpers and budgets, use trusted producer factories after kernel success, and resolve/parse each `math.run` request once.

`math.run` now has one bounded final projection: request/domain validation remains `INVALID_PARAMS`, existing MCP and cancellation errors retain their behavior, and any other operation exception becomes an SDK `ToolError` with a fixed message. The client therefore receives an ordinary `is_error` tool result, never an unhandled worker `ExceptionGroup`.

The review pass also restores p-adic root structural checks, admits independently supplied residue wheels at each consuming operation, and removes process assertions that expected result-model replay after its intentional removal.

## Testing

- `make lint-full` — passed.
- `make test-process` — 192 passed.
- `make test-integration TESTS=tests/integration/catalog/test_mcp_builtin_examples.py` — 2 passed.
- `make handoff LANE=mcp TESTS=tests/mcp/test_mcp_sdk_2_conformance.py` — 6 passed, with Ruff/format/MyPy.
- `make handoff LANE=math TESTS="tests/math/padic_arithmetic/test_padic.py tests/process/polynomial_maps/test_generic_degree_singular_process.py"` — 36 passed, with Ruff/format/MyPy.

The MCP regressions use the real client/server seam for both ordinary and second-jet `log(x)` enclosure on `[1, 2]` at 1024-bit precision, plus an admitted operation that raises an unexpected exception.

## Public contract impact

Operation IDs and request/result schemas remain stable. Ordinary result deserialization no longer establishes source-derived mathematical claims; explicit owner-private verification remains available only where an owner deliberately handles independently supplied claims. Unexpected admitted-operation failures now project to a redacted `math.run` tool error.

Fixes #2891.

## Review order

1. `src/jacobian/mcp/tools.py` and MCP regressions.
2. Prime-affine consumer admission and p-adic structural checks.
3. Replay-removal commits and architecture documentation.