### PR TITLE
Simplify math.find discovery routing

### DIFF
--- a/benchmarks/tooling/codex_telemetry.py
+++ b/benchmarks/tooling/codex_telemetry.py
@@ -540,8 +540,10 @@ def _build_operation_description(
         "query": (
             request.get("query") if isinstance(request.get("query"), str) else None
         ),
-        "domain": (
-            request.get("domain") if isinstance(request.get("domain"), str) else None
+        "namespace": (
+            request.get("namespace")
+            if isinstance(request.get("namespace"), str)
+            else None
         ),
         "operation_id": (
             request.get("operation_id")

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -69,6 +69,13 @@ search, and immutable lookup; `jacobian.dispatch` owns strict invocation;
 exact-scalar helpers contain only behavior genuinely shared by unrelated
 owners.
 
+An immutable declaration may carry a small `discovery_terms` vocabulary of
+reviewed, established names for its exact postcondition. Terms are catalog
+metadata used by deterministic `math.find` ranking; they do not alter the
+canonical title and description, operation ID, request syntax, or mathematical
+claim. This keeps ordinary morphology in the shared lexical normalizer and
+domain terminology with the owner that can review its meaning.
+
 Catalog admission decides publication and is not runtime planning. The
 mathematical owner decides request admission, builds the request-scoped
 execution plan, owns the backend adapter, and constructs the canonical result.

--- a/docs/how-to/invoke-domain-operations.md
+++ b/docs/how-to/invoke-domain-operations.md
@@ -3,8 +3,10 @@
 Use `math.find` progressively, then call `math.run` once with the selected
 operation ID and a `payload` matching its request model. The ordinary path is:
 
-1. Search for the mathematical outcome when the operation is unknown. Search
-   ranking is deterministic lexical retrieval, not a recommendation.
+1. Search globally for one atomic mathematical outcome when the operation is
+   unknown. Use a short phrase such as "integer nth root" or "real root
+   isolation", not a complete proof goal. Search ranking is deterministic
+   lexical retrieval, not a recommendation.
 2. Inspect the selected operation before forming an unfamiliar payload. Its
    schemas and examples are authoritative for that installed catalog.
 3. Run exactly that operation with one typed payload.
@@ -14,17 +16,20 @@ For example, search for a small number of matrix operations, then inspect an
 exact candidate:
 
 ```json
-{"request":{"op":"search","query":"exact matrix determinant","domain":"matrix","limit":3}}
+{"request":{"op":"search","query":"matrix determinant","namespace":"matrix","limit":3}}
 ```
 
 ```json
 {"request":{"op":"inspect","operation_id":"matrix.determinant.compute"}}
 ```
 
-Use `browse` instead to map an unfamiliar domain in operation-ID order:
+Use `browse` to map a known primary namespace in operation-ID order. A
+namespace matches only the first segment of an operation ID; tags do not filter
+the result set. Search and browse responses retain `catalog_resource` as the
+explicit fallback for a full catalog export:
 
 ```json
-{"request":{"op":"browse","domain":"matrix","limit":20}}
+{"request":{"op":"browse","namespace":"matrix","limit":20}}
 ```
 
 After inspection, run the selected operation. For example:

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -35,9 +35,10 @@ reporting a gap. A retry should state what changed: budget, backend,
 representation, or deterministic partition.
 
 Use `math.find` progressively: `search` finds a few relevance-ranked candidates,
-`browse` pages compact operation cards in operation-ID order (optionally within a
-domain), and `inspect` supplies the selected operation's exact input/output
-schemas and valid examples.
+`browse` pages compact operation cards in operation-ID order (optionally within
+one exact primary namespace), and `inspect` supplies the selected operation's
+exact input/output schemas and valid examples. Search and browse results retain
+`catalog_resource` as the explicit pointer to the bulk catalog export.
 
 ## Form a payload from an inspected contract
 

--- a/src/jacobian/catalog/catalog.py
+++ b/src/jacobian/catalog/catalog.py
@@ -94,7 +94,7 @@ class Catalog:
     def browse(
         self,
         *,
-        domain: str | None,
+        namespace: str | None,
         limit: int,
         cursor: str | None,
     ) -> OperationBrowseResult:
@@ -102,7 +102,7 @@ class Catalog:
 
         return browse_operations(
             tuple(self._operations.values()),
-            domain=domain,
+            namespace=namespace,
             limit=limit,
             cursor=cursor,
         )
@@ -140,6 +140,7 @@ def _descriptor(operation: MathTool[Any, Any]) -> OperationDescriptor:
         output_schema=operation.result_type.model_json_schema(),
         read_only=True,
         tags=operation.tags,
+        discovery_terms=operation.discovery_terms,
         examples=tuple(
             OperationExample(
                 name=example.name,

--- a/src/jacobian/catalog/models.py
+++ b/src/jacobian/catalog/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Any, Self
 
 from pydantic import Field, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
@@ -21,6 +21,9 @@ OperationId = Annotated[
         strict=True,
     ),
 ]
+
+_MAX_DISCOVERY_TERMS = 8
+_MAX_DISCOVERY_TERM_LENGTH = 96
 
 
 class OperationDomainValidationError(ValueError):
@@ -77,7 +80,7 @@ class OperationDiscoveryRequest(StrictModel):
     """Compact installed-portfolio search, independent of any transport."""
 
     query: str = Field(min_length=1)
-    domain: str | None = Field(
+    namespace: str | None = Field(
         default=None,
         pattern=r"^[A-Za-z][A-Za-z0-9_-]{0,127}$",
     )
@@ -90,9 +93,9 @@ class OperationDiscoveryRequest(StrictModel):
             raise _validation_error(
                 "blank_query", "query must contain a non-whitespace character"
             )
-        if self.domain is not None and not self.domain.strip():
+        if self.namespace is not None and not self.namespace.strip():
             raise _validation_error(
-                "blank_domain", "domain must contain a non-whitespace character"
+                "blank_namespace", "namespace must contain a non-whitespace character"
             )
         return self
 
@@ -104,22 +107,15 @@ class OperationDiscoveryMatch(StrictModel):
     title: str = Field(min_length=1, max_length=128)
     description: str = Field(min_length=1)
     tags: tuple[str, ...] = ()
-    relevance_score: int = Field(default=0, ge=0, strict=True)
-    applicability: Literal[
-        "INCOMPATIBLE",
-        "NEEDS_MORE_TYPED_REQUIREMENTS",
-    ]
-    applicability_code: Literal["FULL_REQUEST_REQUIRED",]
 
 
 class OperationDiscoveryResult(StrictModel):
     """Deterministically ranked compact installed outcomes."""
 
     query: str
-    domain: str | None = None
+    namespace: str | None = None
     matches: tuple[OperationDiscoveryMatch, ...]
     total_matches: int = Field(ge=0, strict=True)
-    truncated: bool
     next_cursor: OperationId | None = None
 
     @model_validator(mode="after")
@@ -132,10 +128,6 @@ class OperationDiscoveryResult(StrictModel):
         if self.total_matches < len(self.matches):
             raise _validation_error(
                 "match_count", "total_matches cannot be smaller than the returned page"
-            )
-        if self.truncated != (self.next_cursor is not None):
-            raise _validation_error(
-                "cursor_state", "truncated must agree with next_cursor"
             )
         if self.next_cursor is not None and (
             not operation_ids or self.next_cursor != operation_ids[-1]
@@ -158,10 +150,9 @@ class OperationBrowseCard(StrictModel):
 class OperationBrowseResult(StrictModel):
     """One cursor-paged, unranked view of the immutable operation library."""
 
-    domain: str | None = None
+    namespace: str | None = None
     operations: tuple[OperationBrowseCard, ...]
     total_operations: int = Field(ge=0, strict=True)
-    truncated: bool
     next_cursor: OperationId | None = None
 
     @model_validator(mode="after")
@@ -176,10 +167,6 @@ class OperationBrowseResult(StrictModel):
             raise _validation_error(
                 "browse_count",
                 "total_operations cannot be smaller than the returned page",
-            )
-        if self.truncated != (self.next_cursor is not None):
-            raise _validation_error(
-                "cursor_state", "truncated must agree with next_cursor"
             )
         if self.next_cursor is not None and (
             not operation_ids or self.next_cursor != operation_ids[-1]
@@ -201,10 +188,14 @@ class OperationDescriptor(StrictModel):
     output_schema: dict[str, Any]
     read_only: bool = False
     tags: tuple[str, ...] = ()
+    discovery_terms: tuple[str, ...] = Field(
+        default=(), max_length=_MAX_DISCOVERY_TERMS
+    )
     examples: tuple[OperationExample, ...] = ()
 
     @model_validator(mode="after")
     def require_canonical_schemas(self) -> Self:
+        _validate_discovery_terms(self.discovery_terms)
         if len({example.name for example in self.examples}) != len(self.examples):
             raise _validation_error(
                 "duplicate_example_name",
@@ -243,7 +234,12 @@ class OperationCatalogSnapshot(StrictModel):
 
 @dataclass(frozen=True, slots=True)
 class MathTool[RequestT: StrictModel, ResultT: StrictModel]:
-    """One discoverable mathematical function and its public typed contract."""
+    """One immutable mathematical declaration and its public typed contract.
+
+    ``discovery_terms`` contains a small reviewed vocabulary of established
+    names for this exact postcondition.  It is ranking metadata, not a query
+    rewrite language or a promise to accept alternate request syntax.
+    """
 
     operation_id: str
     title: str
@@ -252,6 +248,7 @@ class MathTool[RequestT: StrictModel, ResultT: StrictModel]:
     result_type: type[ResultT]
     run: Callable[[RequestT], ResultT]
     tags: tuple[str, ...] = ()
+    discovery_terms: tuple[str, ...] = ()
     examples: tuple[OperationExample, ...] = ()
 
     def __post_init__(self) -> None:
@@ -263,11 +260,31 @@ class MathTool[RequestT: StrictModel, ResultT: StrictModel]:
             raise ValueError("math tool tags must be unique")
         if any(not tag.strip() for tag in self.tags):
             raise ValueError("math tool tags must not be empty")
+        _validate_discovery_terms(self.discovery_terms)
         if len({example.name for example in self.examples}) != len(self.examples):
             raise ValueError("math tool example names must be unique")
 
 
 type MathTools = tuple[MathTool[Any, Any], ...]
+
+
+def _validate_discovery_terms(terms: tuple[str, ...]) -> None:
+    """Keep declaration-owned terminology small, concrete, and deterministic."""
+
+    if len(terms) > _MAX_DISCOVERY_TERMS:
+        raise ValueError(
+            f"math tools allow at most {_MAX_DISCOVERY_TERMS} discovery terms"
+        )
+    if len(set(terms)) != len(terms):
+        raise ValueError("math tool discovery terms must be unique")
+    if any(not term.strip() for term in terms):
+        raise ValueError("math tool discovery terms must not be empty")
+    if any(len(term) > _MAX_DISCOVERY_TERM_LENGTH for term in terms):
+        raise ValueError(
+            "math tool discovery terms must be at most "
+            f"{_MAX_DISCOVERY_TERM_LENGTH} characters"
+        )
+
 
 __all__ = [
     "MathTool",

--- a/src/jacobian/catalog/search.py
+++ b/src/jacobian/catalog/search.py
@@ -23,6 +23,9 @@ _DISCOVERY_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
 _DISCOVERY_STOP_WORDS = frozenset(
     {"a", "an", "and", "for", "find", "from", "in", "of", "on", "the", "to", "with"}
 )
+_INFLECTION_EXCLUSIONS = frozenset(
+    {"basis", "bases", "class", "classes", "grass", "series"}
+)
 
 
 class SearchableOperation(Protocol):
@@ -38,6 +41,9 @@ class SearchableOperation(Protocol):
     @property
     def tags(self) -> tuple[str, ...]: ...
 
+    @property
+    def discovery_terms(self) -> tuple[str, ...]: ...
+
 
 def discover_operations(
     operations: Sequence[SearchableOperation],
@@ -45,13 +51,15 @@ def discover_operations(
 ) -> OperationDiscoveryResult:
     """Search immutable operation declarations deterministically."""
 
-    normalized_domain = (
-        normalize_domain(request.domain) if request.domain is not None else None
+    normalized_namespace = (
+        normalize_namespace(request.namespace)
+        if request.namespace is not None
+        else None
     )
     ranked: list[tuple[int, OperationDiscoveryMatch]] = []
     for descriptor in operations:
-        if normalized_domain is not None and not matches_domain(
-            descriptor, normalized_domain
+        if normalized_namespace is not None and not matches_namespace(
+            descriptor, normalized_namespace
         ):
             continue
         score = discovery_relevance(descriptor, request.query)
@@ -60,9 +68,6 @@ def discover_operations(
             title=descriptor.title,
             description=descriptor.description,
             tags=descriptor.tags,
-            relevance_score=score,
-            applicability="NEEDS_MORE_TYPED_REQUIREMENTS",
-            applicability_code="FULL_REQUEST_REQUIRED",
         )
         if score > 0:
             ranked.append((score, match))
@@ -89,10 +94,9 @@ def discover_operations(
     )
     return OperationDiscoveryResult(
         query=request.query,
-        domain=normalized_domain,
+        namespace=normalized_namespace,
         matches=tuple(match for _, match in page),
         total_matches=total_matches,
-        truncated=next_cursor is not None,
         next_cursor=next_cursor,
     )
 
@@ -100,13 +104,15 @@ def discover_operations(
 def browse_operations(
     searchable_operations: Sequence[SearchableOperation],
     *,
-    domain: str | None,
+    namespace: str | None,
     limit: int,
     cursor: str | None,
 ) -> OperationBrowseResult:
     """Page a filtered immutable snapshot in operation-ID order without ranking."""
 
-    normalized_domain = normalize_domain(domain) if domain is not None else None
+    normalized_namespace = (
+        normalize_namespace(namespace) if namespace is not None else None
+    )
     operations = tuple(
         OperationBrowseCard(
             operation_id=descriptor.operation_id,
@@ -117,7 +123,8 @@ def browse_operations(
         for descriptor in sorted(
             searchable_operations, key=lambda operation: operation.operation_id
         )
-        if normalized_domain is None or matches_domain(descriptor, normalized_domain)
+        if normalized_namespace is None
+        or matches_namespace(descriptor, normalized_namespace)
     )
     start = 0
     if cursor is not None:
@@ -139,81 +146,124 @@ def browse_operations(
         page[-1].operation_id if page and start + len(page) < len(operations) else None
     )
     return OperationBrowseResult(
-        domain=normalized_domain,
+        namespace=normalized_namespace,
         operations=page,
         total_operations=len(operations),
-        truncated=next_cursor is not None,
         next_cursor=next_cursor,
     )
 
 
 def normalize_discovery_text(value: str) -> str:
-    return "-".join(_DISCOVERY_TOKEN_PATTERN.findall(value.casefold()))
+    return "-".join(_normalized_tokens(value))
 
 
-def discovery_terms(query: str) -> frozenset[str]:
+def normalized_discovery_terms(value: str) -> frozenset[str]:
     return frozenset(
-        term
-        for term in _DISCOVERY_TOKEN_PATTERN.findall(query.casefold())
-        if term not in _DISCOVERY_STOP_WORDS
+        term for term in _normalized_tokens(value) if term not in _DISCOVERY_STOP_WORDS
     )
 
 
 def token_set(value: str) -> frozenset[str]:
+    """Return the legacy exact lexical terms of one declaration field."""
+
     return frozenset(_DISCOVERY_TOKEN_PATTERN.findall(value.casefold()))
+
+
+def _normalized_tokens(value: str) -> tuple[str, ...]:
+    return tuple(
+        _normalize_inflection(term)
+        for term in _DISCOVERY_TOKEN_PATTERN.findall(value.casefold())
+    )
+
+
+def _normalize_inflection(term: str) -> str:
+    """Normalize only audited ordinary plural forms for lexical comparison."""
+
+    if term in _INFLECTION_EXCLUSIONS or len(term) < 4:
+        return term
+    if term.endswith("ies") and term != "series":
+        return term[:-3] + "y"
+    if term.endswith("s") and not term.endswith(("ss", "is")):
+        return term[:-1]
+    return term
 
 
 def discovery_relevance(
     operation: SearchableOperation,
     query: str,
 ) -> int:
-    query_terms = discovery_terms(query)
-    if not query_terms:
+    query_terms = frozenset(
+        term for term in token_set(query) if term not in _DISCOVERY_STOP_WORDS
+    )
+    normalized_query_terms = normalized_discovery_terms(query)
+    if not normalized_query_terms:
         return 0
     identifier_terms = token_set(operation.operation_id)
     tag_terms = frozenset(term for tag in operation.tags for term in token_set(tag))
+    declared_discovery_terms = frozenset(
+        term
+        for discovery_term in operation.discovery_terms
+        for term in token_set(discovery_term)
+    )
     title_terms = token_set(operation.title)
     description_terms = token_set(operation.description)
     score = 0
+    normalized_only = normalized_query_terms - query_terms
     for terms, weight in (
         (identifier_terms, 12),
         (tag_terms, 10),
+        (declared_discovery_terms, 10),
         (title_terms, 8),
         (description_terms, 3),
     ):
         overlap = query_terms & terms
         if overlap:
             score += weight * len(overlap)
+        normalized_overlap = normalized_only & frozenset(
+            _normalized_tokens(" ".join(terms))
+        )
+        if normalized_overlap:
+            score += max(1, weight // 2) * len(normalized_overlap)
     normalized_query = normalize_discovery_text(query)
     normalized_text = normalize_discovery_text(
         f"{operation.operation_id} {operation.title} {operation.description}"
     )
     if normalized_query and f"-{normalized_query}-" in f"-{normalized_text}-":
         score += 20
+    normalized_declared_terms = tuple(
+        normalize_discovery_text(discovery_term)
+        for discovery_term in operation.discovery_terms
+    )
+    matching_term_lengths = (
+        len(token_set(discovery_term))
+        for discovery_term in normalized_declared_terms
+        if discovery_term and f"-{discovery_term}-" in f"-{normalized_query}-"
+    )
+    score += 12 * max(matching_term_lengths, default=0)
     return score
 
 
-def normalize_domain(value: str) -> str:
+def normalize_namespace(value: str) -> str:
     return "_".join(_DISCOVERY_TOKEN_PATTERN.findall(value.casefold()))
 
 
-def operation_domain(operation: SearchableOperation) -> str:
+def operation_namespace(operation: SearchableOperation) -> str:
     return operation.operation_id.partition(".")[0]
 
 
-def matches_domain(operation: SearchableOperation, normalized_domain: str) -> bool:
-    normalized_tags = {normalize_domain(tag) for tag in operation.tags}
-    return (
-        normalized_domain == normalize_domain(operation_domain(operation))
-        or normalized_domain in normalized_tags
-    )
+def matches_namespace(
+    operation: SearchableOperation, normalized_namespace: str
+) -> bool:
+    """Match one explicit primary operation-ID namespace, never a tag."""
+
+    return normalized_namespace == normalize_namespace(operation_namespace(operation))
 
 
 __all__ = [
     "browse_operations",
     "discover_operations",
     "discovery_relevance",
-    "matches_domain",
-    "normalize_domain",
-    "operation_domain",
+    "matches_namespace",
+    "normalize_namespace",
+    "operation_namespace",
 ]

--- a/src/jacobian/math/incidence_structures/_tools.py
+++ b/src/jacobian/math/incidence_structures/_tools.py
@@ -52,6 +52,7 @@ def _op[RequestT: StrictModel, ResultT: StrictModel](
     result_model: type[ResultT],
     operation: Callable[[RequestT], ResultT],
     *tags: str,
+    discovery_terms: tuple[str, ...] = (),
     examples: tuple[OperationExample, ...] = (),
 ) -> MathTool[RequestT, ResultT]:
     return MathTool(
@@ -62,6 +63,7 @@ def _op[RequestT: StrictModel, ResultT: StrictModel](
         result_type=result_model,
         run=operation,
         tags=tags,
+        discovery_terms=discovery_terms,
         examples=examples,
     )
 
@@ -126,6 +128,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "combinatorics",
         "incidence",
         "exact",
+        discovery_terms=("t-codegree", "codegree profile"),
         examples=(
             example(
                 "triangle_t1",

--- a/src/jacobian/math/inverse_multiplicative/_tools.py
+++ b/src/jacobian/math/inverse_multiplicative/_tools.py
@@ -29,6 +29,7 @@ def _op[RequestT: StrictModel, ResultT: StrictModel](
     result_model: type[ResultT],
     operation: Callable[[RequestT], ResultT],
     *tags: str,
+    discovery_terms: tuple[str, ...] = (),
     examples: tuple[OperationExample, ...] = (),
 ) -> MathTool[RequestT, ResultT]:
     return MathTool(
@@ -39,6 +40,7 @@ def _op[RequestT: StrictModel, ResultT: StrictModel](
         result_type=result_model,
         run=operation,
         tags=tags,
+        discovery_terms=discovery_terms,
         examples=examples,
     )
 
@@ -55,6 +57,12 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "number-theory",
         "euler-phi",
         "exact",
+        discovery_terms=(
+            "inverse totient",
+            "inverse phi",
+            "totient inverse image",
+            "solve phi",
+        ),
         examples=(
             example(
                 "phi_preimage_1",

--- a/src/jacobian/math/number_theory/_divisibility.py
+++ b/src/jacobian/math/number_theory/_divisibility.py
@@ -121,6 +121,7 @@ DIVISIBILITY_OPERATIONS = (
         compute_divisor_sum,
         "number-theory",
         "divisibility",
+        discovery_terms=("aliquot sum", "sum of proper divisors"),
         examples=(
             example("divisor_sum_12", "Sum the positive divisors of 12.", {"n": 12}),
         ),

--- a/src/jacobian/math/number_theory/_factorization.py
+++ b/src/jacobian/math/number_theory/_factorization.py
@@ -85,6 +85,7 @@ def _operation[RequestT: StrictModel, ResultT: StrictModel](
     result_model: type[ResultT],
     implementation: Callable[[RequestT], ResultT],
     tags: tuple[str, ...],
+    discovery_terms: tuple[str, ...] = (),
     examples: tuple[OperationExample, ...] = (),
 ) -> MathTool[RequestT, ResultT]:
     return MathTool(
@@ -95,6 +96,7 @@ def _operation[RequestT: StrictModel, ResultT: StrictModel](
         result_type=result_model,
         run=implementation,
         tags=tags,
+        discovery_terms=discovery_terms,
         examples=examples,
     )
 
@@ -152,6 +154,7 @@ FACTORIZATION_OPERATIONS = (
         result_model=DivisorListResult,
         implementation=_compute_divisors,
         tags=("number-theory", "enumeration"),
+        discovery_terms=("proper divisor", "aliquot proper divisor list"),
         examples=(
             example(
                 "divisors_12", "Enumerate the positive divisors of 12.", {"value": "12"}

--- a/src/jacobian/math/number_theory/_support.py
+++ b/src/jacobian/math/number_theory/_support.py
@@ -17,6 +17,7 @@ def number_theory_operation[
     result_type: type[ResultT],
     operation: Callable[[RequestT], ResultT],
     *tags: str,
+    discovery_terms: tuple[str, ...] = (),
     examples: tuple[OperationExample, ...] = (),
 ) -> MathTool[RequestT, ResultT]:
     """Declare one number-theory math tool."""
@@ -29,5 +30,6 @@ def number_theory_operation[
         result_type=result_type,
         run=operation,
         tags=tags,
+        discovery_terms=discovery_terms,
         examples=examples,
     )

--- a/src/jacobian/mcp/guidance.py
+++ b/src/jacobian/mcp/guidance.py
@@ -10,36 +10,43 @@ SERVER_INSTRUCTIONS = (
     "Jacobian provides local typed operations for mathematical computation and "
     "structural analysis. Reach for math.find and math.run proactively when a problem "
     "contains an exact computation, finite search, or structural analysis that may "
-    "match an installed operation. Use math.find to discover or inspect operations and "
-    "math.run to execute them; compose returned values with Python for multi-step work."
+    "match a public MCP operation. Use math.find to discover or inspect operations and "
+    "math.run to execute them. Each call returns an operation-owned canonical "
+    "mathematical value that a caller may retain and reuse when a later contract accepts it."
 )
 
 MATH_FIND_DESCRIPTION = """\
-Search, browse, or inspect locally installed Jacobian math tools. This is authoritative
-for local discovery and exact operation inspection; internet search is not. Use math.find
-when a task may benefit from exact computation, search, or structural analysis.
+Search, browse, or inspect public Jacobian MCP operations. This is authoritative for
+their local discovery and exact operation inspection; it does not enumerate the broader
+native Python API. Use math.find when a task may benefit from one exact computation,
+finite search, or structural analysis.
 
 Forms:
-- `request.op="search"`: plain-language mathematical outcome (compact cards).
-- `request.op="browse"`: compact operation cards in operation-ID order, optionally
-  filtered to one domain; use this to map an unfamiliar domain.
-- `search` accepts optional `domain` and `limit` 1-20 (default 5); `browse` accepts
-  the same filters (default limit 20).
-- Follow `next_cursor` with the same search query or browse filters to continue.
-- Ranking is deterministic lexical retrieval; matches are not recommendations.
+- `request.op="search"`: a short atomic mathematical outcome (compact cards), not a
+  complete proof goal. Search globally unless the primary namespace is already known.
+- `request.op="browse"`: compact operation cards in operation-ID order for one known
+  primary namespace.
+- `search` accepts optional exact `namespace` and `limit` 1-20 (default 5); `browse`
+  accepts the same namespace filter (default limit 20). A namespace matches the first
+  operation-ID segment only; declaration tags never filter results.
+- Follow `next_cursor` with the same query or namespace filter to continue.
+- Ranking is deterministic lexical retrieval; ordered matches are candidates, not
+  recommendations or applicability claims.
 - `request.op="inspect"`: exact ID with authoritative schemas and examples.
-- `operation://catalog` remains an exact bulk export, not the ordinary discovery path.
+- `operation://catalog` is the exact bulk-export fallback when the full catalog is
+  needed, not the ordinary discovery path.
 
 Examples:
-- `{"request":{"op":"search","query":"exact matrix determinant","domain":"matrix","limit":3}}`
-- `{"request":{"op":"browse","domain":"matrix","limit":20}}`
+- `{"request":{"op":"search","query":"matrix determinant","namespace":"matrix","limit":3}}`
+- `{"request":{"op":"browse","namespace":"matrix","limit":20}}`
 - `{"request":{"op":"search","query":"counterexample to associativity"}}`
 - `{"request":{"op":"inspect","operation_id":"polynomial.compute.gcd"}}`
 """
 
 MATH_RUN_DESCRIPTION = """\
 Run one installed math tool by ID with its typed `payload`. A successful call returns
-the operation-owned mathematical value in `output`; read its fields to determine what
+the operation-owned canonical mathematical value in `output`; a later inspected
+operation may accept that complete value unchanged. Read its fields to determine what
 the calculation established. MCP reports malformed payloads, unknown IDs, and host
 failures as tool errors, not as mathematical results. If the payload shape is unknown,
 inspect the exact operation with math.find. When it publishes an `examples` item, copy

--- a/src/jacobian/mcp/models.py
+++ b/src/jacobian/mcp/models.py
@@ -18,7 +18,7 @@ from jacobian.catalog.models import (
 class OperationSearchRequest(StrictModel):
     op: Literal["search"]
     query: Annotated[str, Field(min_length=1)]
-    domain: Annotated[
+    namespace: Annotated[
         str | None,
         Field(pattern=r"^[A-Za-z][A-Za-z0-9_-]{0,127}$"),
     ] = None
@@ -34,7 +34,7 @@ class OperationSearchRequest(StrictModel):
 
 class OperationBrowseRequest(StrictModel):
     op: Literal["browse"]
-    domain: Annotated[
+    namespace: Annotated[
         str | None,
         Field(pattern=r"^[A-Za-z][A-Za-z0-9_-]{0,127}$"),
     ] = None
@@ -69,20 +69,18 @@ class OperationDiscoveryErrorDetail(StrictModel):
 class OperationSearchResult(StrictModel):
     kind: Literal["discovery"]
     query: str
-    domain: str | None = None
+    namespace: str | None = None
     matches: tuple[OperationDiscoveryMatch, ...]
     total_matches: StrictInt
-    truncated: bool
     next_cursor: str | None = None
     catalog_resource: Literal["operation://catalog"] = "operation://catalog"
 
 
 class OperationBrowseResult(StrictModel):
     kind: Literal["browse"]
-    domain: str | None = None
+    namespace: str | None = None
     operations: tuple[OperationBrowseCard, ...]
     total_operations: StrictInt
-    truncated: bool
     next_cursor: str | None = None
     catalog_resource: Literal["operation://catalog"] = "operation://catalog"
 

--- a/src/jacobian/mcp/projections.py
+++ b/src/jacobian/mcp/projections.py
@@ -13,13 +13,13 @@ def _operation_discovery_response(
     catalog: Catalog,
     *,
     query: str,
-    domain: str | None,
+    namespace: str | None,
     limit: int | None,
     cursor: str | None,
 ) -> dict[str, Any]:
     discovery_request = OperationDiscoveryRequest(
         query=query,
-        domain=domain,
+        namespace=namespace,
         limit=limit if limit is not None else 5,
         cursor=cursor,
     )
@@ -34,7 +34,7 @@ def _operation_discovery_response(
                 "message": "The operation discovery cursor is not in this result set.",
                 "hint": (
                     "Restart discovery without a cursor, or reuse the same query, "
-                    "domain and limit that produced "
+                    "namespace and limit that produced "
                     "next_cursor."
                 ),
             },
@@ -49,13 +49,13 @@ def _operation_discovery_response(
 def _operation_browse_response(
     catalog: Catalog,
     *,
-    domain: str | None,
+    namespace: str | None,
     limit: int | None,
     cursor: str | None,
 ) -> dict[str, Any]:
     try:
         browsed = catalog.browse(
-            domain=domain,
+            namespace=namespace,
             limit=limit if limit is not None else 20,
             cursor=cursor,
         )
@@ -67,7 +67,7 @@ def _operation_browse_response(
                 "stage": "operation_discovery",
                 "message": "The operation browse cursor is not in this result set.",
                 "hint": (
-                    "Restart browsing without a cursor, or reuse the same domain "
+                    "Restart browsing without a cursor, or reuse the same namespace "
                     "and limit that produced next_cursor."
                 ),
             },

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -60,7 +60,7 @@ def math_find(
         discovery_response = _operation_discovery_response(
             active_catalog,
             query=request.query,
-            domain=request.domain,
+            namespace=request.namespace,
             limit=request.limit,
             cursor=request.cursor,
         )
@@ -68,7 +68,7 @@ def math_find(
     if isinstance(request, OperationBrowseRequest):
         browse_response = _operation_browse_response(
             active_catalog,
-            domain=request.domain,
+            namespace=request.namespace,
             limit=request.limit,
             cursor=request.cursor,
         )

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -145,6 +145,30 @@ def test_checked_catalog_binding_rejects_result_subclass_extra_fields() -> None:
         invoke_operation("test.binding.subclass", {"value": 1}, Catalog((operation,)))
 
 
+@pytest.mark.parametrize(
+    ("discovery_terms", "message"),
+    (
+        (("inverse totient", "inverse totient"), "must be unique"),
+        ((" ",), "must not be empty"),
+        (tuple(f"term_{index}" for index in range(9)), "at most 8"),
+    ),
+)
+def test_math_tool_keeps_discovery_vocabulary_small_and_reviewable(
+    discovery_terms: tuple[str, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        MathTool(
+            operation_id="test.discovery.terms",
+            title="Test discovery terms",
+            description="Exercise immutable declaration terminology validation.",
+            request_type=_BindingRequest,
+            result_type=_BindingResult,
+            run=lambda _request: _BindingResult(doubled=2),
+            discovery_terms=discovery_terms,
+        )
+
+
 def test_explicit_binary_profile_remains_the_published_code_profile() -> None:
     operation = Catalog.open().operation("code.binary.explicit.profile.compute")
 
@@ -173,21 +197,21 @@ def test_compact_discovery_matches_full_descriptor_discovery() -> None:
         )
 
     expected_browse = browse_operations(
-        descriptors, domain="matrix", limit=2, cursor=None
+        descriptors, namespace="matrix", limit=2, cursor=None
     )
     assert (
-        browse_operations(operations, domain="matrix", limit=2, cursor=None)
+        browse_operations(operations, namespace="matrix", limit=2, cursor=None)
         == expected_browse
     )
     if expected_browse.next_cursor is not None:
         assert browse_operations(
             operations,
-            domain="matrix",
+            namespace="matrix",
             limit=2,
             cursor=expected_browse.next_cursor,
         ) == browse_operations(
             descriptors,
-            domain="matrix",
+            namespace="matrix",
             limit=2,
             cursor=expected_browse.next_cursor,
         )
@@ -204,10 +228,26 @@ def test_search_and_browse_do_not_materialize_descriptors(
     monkeypatch.setattr(catalog_module, "_descriptor", fail_descriptor)
 
     search = catalog.search(OperationDiscoveryRequest(query="matrix", limit=2))
-    browse = catalog.browse(domain="matrix", limit=2, cursor=None)
+    browse = catalog.browse(namespace="matrix", limit=2, cursor=None)
 
     assert search.matches
     assert browse.operations
+
+
+def test_namespace_filters_only_the_primary_operation_id_segment() -> None:
+    catalog = Catalog.open()
+
+    search = catalog.search(
+        OperationDiscoveryRequest(query="polynomial", namespace="polynomial", limit=20)
+    )
+    browse = catalog.browse(namespace="polynomial", limit=20, cursor=None)
+
+    assert search.matches
+    assert browse.operations
+    assert all(match.operation_id.startswith("polynomial.") for match in search.matches)
+    assert all(
+        card.operation_id.startswith("polynomial.") for card in browse.operations
+    )
 
 
 def test_natural_prime_power_query_ranks_factorization_before_prime_navigation() -> (
@@ -265,13 +305,12 @@ def test_catalog_runs_source_bound_powerful_decision() -> None:
     assert result.output["value"] == "12168"
 
 
-def test_search_finds_lattice_hnf_in_matrix_domain() -> None:
+def test_global_search_finds_lattice_hnf() -> None:
     catalog = Catalog.open()
 
     result = catalog.search(
         OperationDiscoveryRequest(
             query="row Hermite normal form",
-            domain="matrix",
             limit=10,
         )
     )
@@ -293,10 +332,10 @@ def test_search_finds_generalized_exact_cover() -> None:
     )
 
 
-def test_browse_includes_lattice_hnf_in_matrix_domain() -> None:
+def test_browse_includes_lattice_hnf_in_its_primary_namespace() -> None:
     catalog = Catalog.open()
 
-    result = catalog.browse(domain="matrix", limit=100, cursor=None)
+    result = catalog.browse(namespace="lattice", limit=100, cursor=None)
 
     assert "lattice.hermite_normal_form.compute" in {
         operation.operation_id for operation in result.operations

--- a/tests/catalog/test_catalog_invariants.py
+++ b/tests/catalog/test_catalog_invariants.py
@@ -7,7 +7,7 @@ import pytest
 from jacobian.catalog.builtins import BUILTIN_TOOLS
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationDiscoveryRequest
-from jacobian.catalog.search import matches_domain
+from jacobian.catalog.search import matches_namespace
 
 
 def test_catalog_rejects_duplicate_tool_ids() -> None:
@@ -101,7 +101,7 @@ def test_search_browse_and_inspect_results_stay_within_the_public_catalog() -> N
     search = catalog.search(
         OperationDiscoveryRequest(query="finite field factorization", limit=5)
     )
-    browse = catalog.browse(domain="graph", limit=5, cursor=None)
+    browse = catalog.browse(namespace="graph", limit=5, cursor=None)
     inspected = catalog.inspect("integer.compute.extended_gcd")
 
     assert search.matches
@@ -112,7 +112,7 @@ def test_search_browse_and_inspect_results_stay_within_the_public_catalog() -> N
     assert len(browse.operations) <= 5
     assert {operation.operation_id for operation in browse.operations} <= public_ids
     assert browse.total_operations == sum(
-        1 for tool in BUILTIN_TOOLS if matches_domain(tool, "graph")
+        1 for tool in BUILTIN_TOOLS if matches_namespace(tool, "graph")
     )
     assert browse.total_operations >= len(browse.operations)
 

--- a/tests/catalog/test_graph_independence_polynomial.py
+++ b/tests/catalog/test_graph_independence_polynomial.py
@@ -40,7 +40,7 @@ def test_catalog_search_discovers_independent_set_cardinality_distribution() -> 
     result = Catalog.open().search(
         OperationDiscoveryRequest(
             query="count independent vertex sets by cardinality in a tree",
-            domain="graph",
+            namespace="graph",
             limit=10,
         )
     )

--- a/tests/catalog/test_models.py
+++ b/tests/catalog/test_models.py
@@ -33,15 +33,16 @@ def test_catalog_discovery_text_has_no_arbitrary_character_cap() -> None:
 
     request = OperationDiscoveryRequest(query=long_text)
     descriptor = OperationDescriptor(
-        **{**_descriptor("integer.compute.gcd"), "description": long_text}
+        operation_id="integer.compute.gcd",
+        title="integer.compute.gcd",
+        description=long_text,
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
     )
     match = OperationDiscoveryMatch(
         operation_id="integer.compute.gcd",
         title="Compute gcd",
         description=long_text,
-        relevance_score=0,
-        applicability="NEEDS_MORE_TYPED_REQUIREMENTS",
-        applicability_code="FULL_REQUEST_REQUIRED",
     )
     card = OperationBrowseCard(
         operation_id="integer.compute.gcd",
@@ -63,27 +64,41 @@ def test_discovery_page_metadata_is_bound_to_returned_matches() -> None:
                 "operation_id": "integer.compute.gcd",
                 "title": "Compute gcd",
                 "description": "Compute one exact gcd.",
-                "relevance_score": 12,
-                "applicability": "NEEDS_MORE_TYPED_REQUIREMENTS",
-                "applicability_code": "FULL_REQUEST_REQUIRED",
             }
         ],
         "total_matches": 2,
     }
     with pytest.raises(ValidationError) as error:
         OperationDiscoveryResult.model_validate(
-            {**base, "truncated": True, "next_cursor": None}
-        )
-    assert _error_type(error.value) == "catalog.cursor_state"
-    with pytest.raises(ValidationError) as error:
-        OperationDiscoveryResult.model_validate(
-            {
-                **base,
-                "truncated": True,
-                "next_cursor": "integer.compute.lcm",
-            }
+            {**base, "next_cursor": "integer.compute.lcm"}
         )
     assert _error_type(error.value) == "catalog.cursor_position"
+
+
+@pytest.mark.parametrize(
+    "removed_field",
+    ("relevance_score", "applicability", "applicability_code"),
+)
+def test_discovery_match_rejects_removed_routing_metadata(removed_field: str) -> None:
+    with pytest.raises(ValidationError):
+        OperationDiscoveryMatch.model_validate(
+            {
+                "operation_id": "integer.compute.gcd",
+                "title": "Compute gcd",
+                "description": "Compute one exact gcd.",
+                removed_field: "obsolete",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "result_type", (OperationDiscoveryResult, OperationBrowseResult)
+)
+def test_discovery_pages_reject_removed_truncation_flag(
+    result_type: type[OperationDiscoveryResult] | type[OperationBrowseResult],
+) -> None:
+    with pytest.raises(ValidationError):
+        result_type.model_validate({"truncated": False})
 
 
 def test_browse_page_metadata_requires_sorted_compact_operation_cards() -> None:
@@ -99,15 +114,19 @@ def test_browse_page_metadata_requires_sorted_compact_operation_cards() -> None:
     }
     with pytest.raises(ValidationError) as error:
         OperationBrowseResult.model_validate(
-            {**base, "truncated": True, "next_cursor": None}
+            {**base, "next_cursor": "integer.compute.lcm"}
         )
-    assert _error_type(error.value) == "catalog.cursor_state"
+    assert _error_type(error.value) == "catalog.cursor_position"
     with pytest.raises(ValidationError) as error:
         OperationBrowseResult.model_validate(
             {
                 **base,
                 "operations": [
-                    *base["operations"],
+                    {
+                        "operation_id": "integer.compute.gcd",
+                        "title": "Compute gcd",
+                        "description": "Compute one exact gcd.",
+                    },
                     {
                         "operation_id": "integer.compute.factorial",
                         "title": "Compute factorial",
@@ -115,7 +134,6 @@ def test_browse_page_metadata_requires_sorted_compact_operation_cards() -> None:
                     },
                 ],
                 "total_operations": 2,
-                "truncated": False,
             }
         )
     assert _error_type(error.value) == "catalog.browse_order"
@@ -132,3 +150,13 @@ def test_catalog_rejects_duplicate_or_nondeterministic_operation_ids() -> None:
             }
         )
     assert _error_type(error.value) == "catalog.operation_order"
+
+
+def test_descriptor_rejects_unbounded_discovery_vocabulary() -> None:
+    with pytest.raises(ValidationError):
+        OperationDescriptor.model_validate(
+            {
+                **_descriptor("integer.compute.gcd"),
+                "discovery_terms": [f"term_{index}" for index in range(9)],
+            }
+        )

--- a/tests/catalog/test_search.py
+++ b/tests/catalog/test_search.py
@@ -1,8 +1,27 @@
 from __future__ import annotations
 
 from jacobian.catalog.catalog import Catalog
-from jacobian.catalog.models import OperationDescriptor, OperationDiscoveryRequest
-from jacobian.catalog.search import discovery_relevance
+from jacobian.catalog.models import (
+    OperationDescriptor,
+    OperationDiscoveryMatch,
+    OperationDiscoveryRequest,
+)
+from jacobian.catalog.search import discovery_relevance, normalized_discovery_terms
+
+
+def _positions(query: str) -> dict[str, int]:
+    catalog = Catalog.open()
+    cursor: str | None = None
+    matches: list[OperationDiscoveryMatch] = []
+    while True:
+        result = catalog.search(
+            OperationDiscoveryRequest(query=query, limit=20, cursor=cursor)
+        )
+        matches.extend(result.matches)
+        if result.next_cursor is None:
+            break
+        cursor = result.next_cursor
+    return {match.operation_id: index for index, match in enumerate(matches)}
 
 
 def test_discovery_phrase_matching_respects_token_boundaries() -> None:
@@ -27,7 +46,7 @@ def test_discovery_phrase_matching_respects_token_boundaries() -> None:
 def test_standard_det_abbreviation_ranks_determinants_before_charpolys() -> None:
     catalog = Catalog.open()
     cursor: str | None = None
-    matches = []
+    matches: list[OperationDiscoveryMatch] = []
     while True:
         result = catalog.search(
             OperationDiscoveryRequest(query="det", limit=20, cursor=cursor)
@@ -54,3 +73,84 @@ def test_standard_det_abbreviation_ranks_determinants_before_charpolys() -> None
         for determinant_id in determinant_ids
         for characteristic_polynomial_id in characteristic_polynomial_ids
     )
+
+
+def test_discovery_normalizes_only_audited_ordinary_plural_forms() -> None:
+    assert normalized_discovery_terms("subset sums and repeated representations") == {
+        "subset",
+        "sum",
+        "repeated",
+        "representation",
+    }
+    assert normalized_discovery_terms("basis class series") == {
+        "basis",
+        "class",
+        "series",
+    }
+
+
+def test_plural_queries_preserve_their_semantic_catalog_routing() -> None:
+    subset_positions = _positions(
+        "all subset sums and repeated representations of a finite integer set"
+    )
+    assert (
+        subset_positions["additive.subset_sum.profile.compute"]
+        < subset_positions["combinatorics.integer_set.sidon.decide"]
+    )
+
+    tree_positions = _positions(
+        "counts independent vertex sets by cardinalities in trees"
+    )
+    assert (
+        tree_positions["graph.polynomial.independence.compute"]
+        < tree_positions["graph.independent_set.maximal.decide"]
+    )
+
+
+def test_euler_phi_discovery_terms_outrank_generic_inverse_and_solver_operations() -> (
+    None
+):
+    for query, displaced in (
+        ("inverse totient preimages", "arithmetic.dirichlet_inverse.compute"),
+        ("totient inverse image", "matrix.inverse.compute"),
+        ("solve phi(n)=m", "matrix.symbolic.linear_system.solve"),
+    ):
+        positions = _positions(query)
+        assert (
+            positions["number_theory.euler_phi.preimages.compute"]
+            < positions[displaced]
+        )
+
+
+def test_divisor_discovery_terms_preserve_complete_divisor_postconditions() -> None:
+    for query, operation_id, displaced in (
+        (
+            "aliquot proper divisor list",
+            "integer.compute.divisors",
+            "graph.chip_firing.canonical_divisor.compute",
+        ),
+        (
+            "sum of proper divisors",
+            "integer.compute.divisor_sum",
+            "additive.subset_sum.profile.compute",
+        ),
+        (
+            "aliquot sum",
+            "integer.compute.divisor_sum",
+            "additive.subset_sum.profile.compute",
+        ),
+    ):
+        positions = _positions(query)
+        assert positions[operation_id] < positions[displaced]
+
+
+def test_t_codegree_discovery_terms_route_to_incidence_containment_profiles() -> None:
+    for query in (
+        "compute t-codegrees of a finite hypergraph",
+        "uniform codegree profile",
+    ):
+        positions = _positions(query)
+        assert (
+            positions["incidence.containment_profiles.compute"]
+            < positions["hypergraph.parameters.compute"]
+        )

--- a/tests/integration/graphs/test_exact_operations.py
+++ b/tests/integration/graphs/test_exact_operations.py
@@ -137,7 +137,7 @@ def test_catalog_retires_the_duplicate_and_discovers_independence_number() -> No
     assert retired_operation_id not in {
         operation.operation_id
         for operation in catalog.browse(
-            domain="graph", limit=20, cursor=None
+            namespace="graph", limit=20, cursor=None
         ).operations
     }
     assert retired_operation_id not in {

--- a/tests/mcp/test_catalog_isolation.py
+++ b/tests/mcp/test_catalog_isolation.py
@@ -18,7 +18,6 @@ class _Catalog:
             query=request.query,
             matches=(),
             total_matches=0,
-            truncated=False,
         )
 
     def inspect(self, operation_id: str) -> None:
@@ -30,7 +29,6 @@ class _Catalog:
         return OperationBrowseResult(
             operations=(),
             total_operations=0,
-            truncated=False,
         )
 
 

--- a/tests/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/mcp/test_mcp_sdk_2_conformance.py
@@ -227,13 +227,29 @@ def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources(
             }
             assert find.output_schema is not None
             assert find.output_schema["type"] == "object"
+            search_schema = find.input_schema["$defs"]["OperationSearchRequest"]
+            browse_schema = find.input_schema["$defs"]["OperationBrowseRequest"]
+            assert "namespace" in search_schema["properties"]
+            assert "domain" not in search_schema["properties"]
+            assert "namespace" in browse_schema["properties"]
+            assert "domain" not in browse_schema["properties"]
 
             browse = await client.call_tool(
                 "math.find",
-                {"request": {"op": "browse", "domain": "matrix", "limit": 1}},
+                {
+                    "request": {
+                        "op": "browse",
+                        "namespace": "matrix",
+                        "limit": 1,
+                    }
+                },
             )
             assert isinstance(browse.structured_content, dict)
             assert browse.structured_content["kind"] == "browse"
+            assert (
+                browse.structured_content["catalog_resource"] == "operation://catalog"
+            )
+            assert "truncated" not in browse.structured_content
 
             serialized_tools = serialize_server_result(
                 "tools/list",

--- a/tests/tooling/evaluations/test_codex_telemetry.py
+++ b/tests/tooling/evaluations/test_codex_telemetry.py
@@ -77,7 +77,7 @@ def test_agent_telemetry_preserves_discovery_to_invocation_dataflow(
                 "request": {
                     "op": "search",
                     "query": "find a graph counterexample",
-                    "domain": "graph",
+                    "namespace": "graph",
                 }
             },
             {
@@ -128,7 +128,7 @@ def test_agent_telemetry_preserves_discovery_to_invocation_dataflow(
         {
             "kind": "discovery",
             "query": "find a graph counterexample",
-            "domain": "graph",
+            "namespace": "graph",
             "operation_id": None,
             "match_ids": [
                 "graph.search.atlas",
@@ -138,7 +138,7 @@ def test_agent_telemetry_preserves_discovery_to_invocation_dataflow(
         {
             "kind": "operation",
             "query": None,
-            "domain": None,
+            "namespace": None,
             "operation_id": "graph.search.atlas",
             "match_ids": [],
         },


### PR DESCRIPTION
Fixes #2914
Fixes #2918

## Problem
`domain` mixed primary operation-ID families with declaration tags, so a namespace-like filter could return unrelated operations. Discovery responses also exposed lexical scores, applicability constants, and a duplicate pagination flag that did not help callers choose an operation.

## Solution
`namespace` now matches only the first operation-ID segment. Search remains global by default; tags remain display and ranking metadata. Declarations can carry a small reviewed `discovery_terms` vocabulary for established alternate mathematical names. Discovery responses retain the `catalog_resource` bulk-export pointer but remove score, applicability, and `truncated` fields.

The PR deliberately does not route aliquot or proper-divisor terminology to all-divisor operations: the exact public operations for those postconditions are not installed.

## Testing
- `make handoff-scoped LANE=catalog TESTS=tests/catalog PATHS="..."` — 64 passed; scoped Ruff and mypy passed.
- `make test-mcp TESTS="tests/mcp/test_catalog_isolation.py tests/mcp/test_mcp_sdk_2_conformance.py"` — 9 passed.
- `make docs-linkcheck` — passed.
- `uv run --locked pytest -q tests/catalog/test_search.py` — 6 passed after the alias correction.

## Public contract impact
Breaking pre-stable discovery-contract change: `domain` is renamed to exact `namespace`; search/browse cards no longer include relevance, applicability, or `truncated`. `catalog_resource` remains in ordinary search and browse results.