### PR TITLE
Add 3-term progression hypergraph constructor

### DIFF
--- a/src/jacobian/math/combinatorics/_admission.py
+++ b/src/jacobian/math/combinatorics/_admission.py
@@ -157,6 +157,10 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
     ),
+    OperationAdmission(
+        "combinatorics.finite_abelian.3term_progression_hypergraph.construct",
+        AdmissionDecision.KEEP,
+        "distinct source-bound hypergraph constructor for 3-term arithmetic progressions in finite cyclic groups",
+    ),
 )
-
 REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/combinatorics/_progression_hypergraph.py
+++ b/src/jacobian/math/combinatorics/_progression_hypergraph.py
@@ -1,0 +1,32 @@
+"""Declarations for 3-term progression hypergraph construction."""
+
+from jacobian.catalog._examples import example
+from jacobian.math.combinatorics._progression_hypergraph_models import (
+    ProgressionHypergraphRequest,
+    ProgressionHypergraphResult,
+)
+from jacobian.math.combinatorics._progression_hypergraph_operations import (
+    construct_3term_progression_hypergraph,
+)
+from jacobian.math.combinatorics._support import combinatorics_operation
+
+PROGRESSION_HYPERGRAPH_OPERATION = combinatorics_operation(
+    "combinatorics.finite_abelian.3term_progression_hypergraph.construct",
+    "Construct 3-term progression hypergraph of a finite cyclic group",
+    "Construct the 3-uniform hypergraph whose edges are all 3-term arithmetic progressions in Z/nZ.",
+    ProgressionHypergraphRequest,
+    ProgressionHypergraphResult,
+    construct_3term_progression_hypergraph,
+    "combinatorics",
+    "additive-combinatorics",
+    "hypergraph",
+    examples=(
+        example(
+            "three_ap_z5",
+            "Construct the 3-AP hypergraph of Z/5Z; the group order must be at least 2.",
+            {"group_order": 5},
+        ),
+    ),
+)
+
+__all__ = ["PROGRESSION_HYPERGRAPH_OPERATION"]

--- a/src/jacobian/math/combinatorics/_progression_hypergraph_models.py
+++ b/src/jacobian/math/combinatorics/_progression_hypergraph_models.py
@@ -1,0 +1,30 @@
+"""Typed contracts for 3-term progression hypergraph construction."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from jacobian._models import StrictModel
+from jacobian.math.hypergraphs._models import FiniteHypergraph
+
+MAX_GROUP_ORDER: int = 200
+
+
+class ProgressionHypergraphRequest(StrictModel):
+    """Order of the cyclic group Z/nZ for 3-AP hypergraph construction."""
+
+    group_order: int = Field(ge=2, le=MAX_GROUP_ORDER)
+
+
+class ProgressionHypergraphResult(StrictModel):
+    """The 3-uniform hypergraph of all 3-term arithmetic progressions in Z/nZ."""
+
+    group_order: int
+    hypergraph: FiniteHypergraph
+
+
+__all__ = [
+    "ProgressionHypergraphRequest",
+    "ProgressionHypergraphResult",
+    "MAX_GROUP_ORDER",
+]

--- a/src/jacobian/math/combinatorics/_progression_hypergraph_models.py
+++ b/src/jacobian/math/combinatorics/_progression_hypergraph_models.py
@@ -5,9 +5,39 @@ from __future__ import annotations
 from pydantic import Field
 
 from jacobian._models import StrictModel
-from jacobian.math.hypergraphs._models import FiniteHypergraph
+from jacobian.math.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_TOTAL_INCIDENCES,
+    MAX_VERTICES,
+    FiniteHypergraph,
+)
 
-MAX_GROUP_ORDER: int = 200
+
+def _progression_edge_count(group_order: int) -> int:
+    """Return the exact number of distinct 3-AP edges in ``Z/group_order Z``.
+
+    The ordered construction has two encodings for an ordinary edge.  When
+    three divides the group order, each coset of the order-three subgroup has
+    six encodings, so those exceptional edges require a correction.
+    """
+    valid_differences = group_order - 2 if group_order % 2 == 0 else group_order - 1
+    ordered_progressions = group_order * valid_differences
+    edge_count = ordered_progressions // 2
+    if group_order % 3 == 0:
+        edge_count -= 2 * (group_order // 3)
+    return edge_count
+
+
+def _fits_hypergraph_representation(group_order: int) -> bool:
+    edge_count = _progression_edge_count(group_order)
+    return edge_count <= MAX_EDGES and 3 * edge_count <= MAX_TOTAL_INCIDENCES
+
+
+MAX_GROUP_ORDER: int = max(
+    group_order
+    for group_order in range(2, MAX_VERTICES + 1)
+    if _fits_hypergraph_representation(group_order)
+)
 
 
 class ProgressionHypergraphRequest(StrictModel):

--- a/src/jacobian/math/combinatorics/_progression_hypergraph_models.py
+++ b/src/jacobian/math/combinatorics/_progression_hypergraph_models.py
@@ -24,7 +24,7 @@ class ProgressionHypergraphResult(StrictModel):
 
 
 __all__ = [
+    "MAX_GROUP_ORDER",
     "ProgressionHypergraphRequest",
     "ProgressionHypergraphResult",
-    "MAX_GROUP_ORDER",
 ]

--- a/src/jacobian/math/combinatorics/_progression_hypergraph_operations.py
+++ b/src/jacobian/math/combinatorics/_progression_hypergraph_operations.py
@@ -1,0 +1,45 @@
+"""Exact 3-term progression hypergraph kernel for finite cyclic groups."""
+
+from __future__ import annotations
+
+from jacobian.math.combinatorics._progression_hypergraph_models import (
+    ProgressionHypergraphRequest,
+    ProgressionHypergraphResult,
+)
+from jacobian.math.hypergraphs._models import FiniteHypergraph
+
+
+def construct_3term_progression_hypergraph(
+    request: ProgressionHypergraphRequest,
+) -> ProgressionHypergraphResult:
+    """Construct the 3-uniform hypergraph of 3-APs in Z/nZ.
+
+    Vertices: 0, 1, ..., n-1.
+    Edges: all {a, a+d, a+2d} for d = 1, ..., n-1 (mod n), with a in Z/nZ.
+    Each edge is a set of 3 distinct elements forming an arithmetic progression.
+    """
+    n = request.group_order
+    vertices = tuple(str(i) for i in range(n))
+
+    edges_set: set[frozenset[int]] = set()
+    for d in range(1, n):
+        for a in range(n):
+            v0 = a
+            v1 = (a + d) % n
+            v2 = (a + 2 * d) % n
+            if len({v0, v1, v2}) == 3:
+                edges_set.add(frozenset({v0, v1, v2}))
+
+    sorted_edges = sorted(edges_set, key=lambda s: tuple(sorted(s)))
+    edges = tuple(
+        (f"e{i}", tuple(sorted(str(v) for v in edge)))
+        for i, edge in enumerate(sorted_edges)
+    )
+
+    return ProgressionHypergraphResult(
+        group_order=n,
+        hypergraph=FiniteHypergraph(vertices=vertices, edges=edges),
+    )
+
+
+__all__ = ["construct_3term_progression_hypergraph"]

--- a/src/jacobian/math/combinatorics/_tools.py
+++ b/src/jacobian/math/combinatorics/_tools.py
@@ -5,6 +5,9 @@ from jacobian.math.combinatorics._counting import COUNTING_OPERATIONS
 from jacobian.math.combinatorics._difference_sets import DIFFERENCE_SET_OPERATIONS
 from jacobian.math.combinatorics._exact_cover import GENERALIZED_EXACT_COVER_OPERATION
 from jacobian.math.combinatorics._partitions import PARTITION_OPERATIONS
+from jacobian.math.combinatorics._progression_hypergraph import (
+    PROGRESSION_HYPERGRAPH_OPERATION,
+)
 from jacobian.math.combinatorics._recurrence import RECURRENCE_OPERATIONS
 
 __all__ = ["TOOLS"]
@@ -15,4 +18,5 @@ TOOLS: MathTools = (
     *RECURRENCE_OPERATIONS,
     *DIFFERENCE_SET_OPERATIONS,
     GENERALIZED_EXACT_COVER_OPERATION,
+    PROGRESSION_HYPERGRAPH_OPERATION,
 )

--- a/src/jacobian/math/number_theory/_divisibility.py
+++ b/src/jacobian/math/number_theory/_divisibility.py
@@ -124,6 +124,7 @@ DIVISIBILITY_OPERATIONS = (
         compute_divisor_sum,
         "number-theory",
         "divisibility",
+        discovery_terms=("sum positive divisors",),
         examples=(
             example("divisor_sum_12", "Sum the positive divisors of 12.", {"n": 12}),
         ),

--- a/src/jacobian/math/number_theory/_factorization.py
+++ b/src/jacobian/math/number_theory/_factorization.py
@@ -155,6 +155,7 @@ FACTORIZATION_OPERATIONS = (
         result_model=DivisorListResult,
         implementation=_compute_divisors,
         tags=("number-theory", "enumeration"),
+        discovery_terms=("positive divisors",),
         examples=(
             example(
                 "divisors_12", "Enumerate the positive divisors of 12.", {"value": "12"}

--- a/tests/math/combinatorics/test_progression_hypergraph.py
+++ b/tests/math/combinatorics/test_progression_hypergraph.py
@@ -1,0 +1,32 @@
+"""Tests for 3-term progression hypergraph construction."""
+
+from jacobian.math.combinatorics._progression_hypergraph_models import ProgressionHypergraphRequest
+from jacobian.math.combinatorics._progression_hypergraph_operations import construct_3term_progression_hypergraph
+
+
+def test_z3() -> None:
+    """Z/3Z has 3 vertices. The only 3-AP is {0,1,2}."""
+    result = construct_3term_progression_hypergraph(ProgressionHypergraphRequest(group_order=3))
+    assert len(result.hypergraph.vertices) == 3
+    assert len(result.hypergraph.edges) == 1
+
+
+def test_z5() -> None:
+    """Z/5Z has 5 vertices and 10 edges (C(5,3) = 10, all triples are 3-APs)."""
+    result = construct_3term_progression_hypergraph(ProgressionHypergraphRequest(group_order=5))
+    assert len(result.hypergraph.vertices) == 5
+    assert len(result.hypergraph.edges) == 10
+
+
+def test_z7_count() -> None:
+    """Z/7Z: n*(n-1)/2 = 21 edges."""
+    result = construct_3term_progression_hypergraph(ProgressionHypergraphRequest(group_order=7))
+    assert len(result.hypergraph.edges) == 21
+
+
+def test_all_edges_are_3_uniform() -> None:
+    """Every edge should have exactly 3 distinct vertices."""
+    result = construct_3term_progression_hypergraph(ProgressionHypergraphRequest(group_order=7))
+    for _, members in result.hypergraph.edges:
+        assert len(members) == 3
+        assert len(set(members)) == 3

--- a/tests/math/combinatorics/test_progression_hypergraph.py
+++ b/tests/math/combinatorics/test_progression_hypergraph.py
@@ -1,6 +1,10 @@
 """Tests for 3-term progression hypergraph construction."""
 
+import pytest
+from pydantic import ValidationError
+
 from jacobian.math.combinatorics._progression_hypergraph_models import (
+    MAX_GROUP_ORDER,
     ProgressionHypergraphRequest,
 )
 from jacobian.math.combinatorics._progression_hypergraph_operations import (
@@ -42,3 +46,21 @@ def test_all_edges_are_3_uniform() -> None:
     for _, members in result.hypergraph.edges:
         assert len(members) == 3
         assert len(set(members)) == 3
+
+
+def test_maximum_admitted_order_fits_hypergraph_representation() -> None:
+    """The request ceiling admits the largest representable cyclic group."""
+    result = construct_3term_progression_hypergraph(
+        ProgressionHypergraphRequest(group_order=MAX_GROUP_ORDER)
+    )
+    assert MAX_GROUP_ORDER == 156
+    assert len(result.hypergraph.edges) == 11_908
+    assert 3 * len(result.hypergraph.edges) == 35_724
+
+
+def test_first_order_beyond_representation_ceiling_is_rejected() -> None:
+    """The former public maximum would overflow FiniteHypergraph at 157."""
+    with pytest.raises(ValidationError) as exc_info:
+        ProgressionHypergraphRequest(group_order=MAX_GROUP_ORDER + 1)
+
+    assert exc_info.value.errors()[0]["type"] == "less_than_equal"

--- a/tests/math/combinatorics/test_progression_hypergraph.py
+++ b/tests/math/combinatorics/test_progression_hypergraph.py
@@ -1,32 +1,44 @@
 """Tests for 3-term progression hypergraph construction."""
 
-from jacobian.math.combinatorics._progression_hypergraph_models import ProgressionHypergraphRequest
-from jacobian.math.combinatorics._progression_hypergraph_operations import construct_3term_progression_hypergraph
+from jacobian.math.combinatorics._progression_hypergraph_models import (
+    ProgressionHypergraphRequest,
+)
+from jacobian.math.combinatorics._progression_hypergraph_operations import (
+    construct_3term_progression_hypergraph,
+)
 
 
 def test_z3() -> None:
     """Z/3Z has 3 vertices. The only 3-AP is {0,1,2}."""
-    result = construct_3term_progression_hypergraph(ProgressionHypergraphRequest(group_order=3))
+    result = construct_3term_progression_hypergraph(
+        ProgressionHypergraphRequest(group_order=3)
+    )
     assert len(result.hypergraph.vertices) == 3
     assert len(result.hypergraph.edges) == 1
 
 
 def test_z5() -> None:
     """Z/5Z has 5 vertices and 10 edges (C(5,3) = 10, all triples are 3-APs)."""
-    result = construct_3term_progression_hypergraph(ProgressionHypergraphRequest(group_order=5))
+    result = construct_3term_progression_hypergraph(
+        ProgressionHypergraphRequest(group_order=5)
+    )
     assert len(result.hypergraph.vertices) == 5
     assert len(result.hypergraph.edges) == 10
 
 
 def test_z7_count() -> None:
     """Z/7Z: n*(n-1)/2 = 21 edges."""
-    result = construct_3term_progression_hypergraph(ProgressionHypergraphRequest(group_order=7))
+    result = construct_3term_progression_hypergraph(
+        ProgressionHypergraphRequest(group_order=7)
+    )
     assert len(result.hypergraph.edges) == 21
 
 
 def test_all_edges_are_3_uniform() -> None:
     """Every edge should have exactly 3 distinct vertices."""
-    result = construct_3term_progression_hypergraph(ProgressionHypergraphRequest(group_order=7))
+    result = construct_3term_progression_hypergraph(
+        ProgressionHypergraphRequest(group_order=7)
+    )
     for _, members in result.hypergraph.edges:
         assert len(members) == 3
         assert len(set(members)) == 3


### PR DESCRIPTION
Implements combinatorics.finite_abelian.3term_progression_hypergraph.construct (#2827). Given Z/nZ, construct the 3-uniform hypergraph of all 3-term arithmetic progressions. Closes #2827.