### PR TITLE
Centralize math operation admission

### DIFF
--- a/src/jacobian/dispatch.py
+++ b/src/jacobian/dispatch.py
@@ -112,7 +112,20 @@ def _invoke_prepared_operation(
 
     if started is None:
         started = time.monotonic()
-    result = prepared.run(prepared.request)
+    try:
+        result = prepared.run(prepared.request)
+    except OperationDomainValidationError:
+        raise
+    except ValueError as exc:
+        # Owner-local admission happens after structural parsing.  Preserve a
+        # schema-valid request that exceeds that envelope as an invalid
+        # request at the transport boundary, rather than disguising it as a
+        # host execution failure.
+        raise OperationDomainValidationError(
+            location=(),
+            code="operation.domain_validation",
+            message=str(exc),
+        ) from exc
     output = result.model_dump(mode="json")
 
     return OperationResult(

--- a/src/jacobian/math/additive_combinatorics/_models.py
+++ b/src/jacobian/math/additive_combinatorics/_models.py
@@ -22,7 +22,6 @@ from jacobian.math.additive_combinatorics import _multiset_sum
 from jacobian.math.additive_combinatorics._subset_sum_profile import (
     MAX_SUBSET_SUM_DP_TRANSITIONS,
     MAX_SUBSET_SUM_PROFILE_RESULT_BYTES,
-    subset_sum_profile_envelope,
 )
 from jacobian.math.additive_combinatorics.values import (
     MAX_SUBSET_SUM_ITEMS,
@@ -464,11 +463,6 @@ class RepresentationProfileRequest(StrictModel):
     left: FiniteIntegerSet
     right: FiniteIntegerSet
 
-    @model_validator(mode="after")
-    def require_bounded_cartesian_product(self) -> Self:
-        _require_bounded_cartesian_product(self.left, self.right)
-        return self
-
 
 class RepresentationProfileEntry(StrictModel):
     """One sum and its representation multiplicity."""
@@ -699,7 +693,7 @@ class SubsetSumProfileRequest(StrictModel):
             "positive_sum-negative_sum+1, product(m_v+1) over distinct "
             f"nonzero values v) must fit {MAX_SUBSET_SUM_PROFILE_ENTRIES:,} "
             f"rows, 4*n*S must not exceed {MAX_SUBSET_SUM_DP_TRANSITIONS:,} "
-            "dictionary transitions across construction and validation replay, "
+            "dictionary transitions during construction, "
             "and the conservative serialized-result estimate must not exceed "
             f"{MAX_SUBSET_SUM_PROFILE_RESULT_BYTES:,} bytes."
         ),
@@ -742,8 +736,15 @@ class SubsetSumProfileRequest(StrictModel):
         return prepared
 
     @model_validator(mode="after")
-    def require_admitted_profile_envelope(self) -> Self:
-        subset_sum_profile_envelope(self.source)
+    def require_bounded_source_shape(self) -> Self:
+        """Keep the declared request container limit for typed callers too."""
+
+        if len(self.source.items) > MAX_SUBSET_SUM_ITEMS:
+            raise _validation_error(
+                "bound_raw_source",
+                "subset-sum profile source exceeds the "
+                f"{MAX_SUBSET_SUM_ITEMS:,}-item profile bound",
+            )
         return self
 
 
@@ -760,11 +761,6 @@ class AdditiveEnergyRequest(StrictModel):
 
     left: FiniteIntegerSet
     right: FiniteIntegerSet
-
-    @model_validator(mode="after")
-    def require_bounded_cartesian_product(self) -> Self:
-        _require_bounded_cartesian_product(self.left, self.right)
-        return self
 
 
 class AdditiveEnergyResult(StrictModel):
@@ -813,11 +809,6 @@ class SumsetCardinalityRequest(StrictModel):
 
     left: FiniteIntegerSet
     right: FiniteIntegerSet
-
-    @model_validator(mode="after")
-    def require_bounded_cartesian_product(self) -> Self:
-        _require_bounded_cartesian_product(self.left, self.right)
-        return self
 
 
 class SumsetCardinalityResult(StrictModel):

--- a/src/jacobian/math/additive_combinatorics/_operations.py
+++ b/src/jacobian/math/additive_combinatorics/_operations.py
@@ -25,6 +25,7 @@ from jacobian.math.additive_combinatorics._models import (
     SumsetCardinalityRequest,
     SumsetCardinalityResult,
     _multiset_sum_source_values,
+    _require_bounded_cartesian_product,
     _vector_from_ints,
 )
 from jacobian.math.additive_combinatorics._multiset_sum import count_sums
@@ -68,6 +69,7 @@ def compute_representation_profile(
     ordered pairs ``(a, b)`` with ``a`` in ``A`` and ``b`` in ``B`` such that
     ``a + b = x``.  Empty sets produce an empty profile.
     """
+    _require_bounded_cartesian_product(request.left, request.right)
     left = _parse_set(request.left)
     right = _parse_set(request.right)
     counts = _representation_function(left, right)
@@ -152,6 +154,7 @@ def compute_additive_energy(
     Returns the exact additive energy together with its per-sum decomposition
     so that the squared multiplicities are individually inspectable.
     """
+    _require_bounded_cartesian_product(request.left, request.right)
     left = _parse_set(request.left)
     right = _parse_set(request.right)
     counts = _representation_function(left, right)
@@ -171,6 +174,7 @@ def compute_sumset_cardinality(
     request: SumsetCardinalityRequest,
 ) -> SumsetCardinalityResult:
     """Compute ``|A + B|`` (the support cardinality of ``r_{A+B}``)."""
+    _require_bounded_cartesian_product(request.left, request.right)
     left = _parse_set(request.left)
     right = _parse_set(request.right)
     counts = _representation_function(left, right)

--- a/src/jacobian/math/algebraic_combinatorics/_models.py
+++ b/src/jacobian/math/algebraic_combinatorics/_models.py
@@ -9,7 +9,6 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.math.algebraic_combinatorics._rsk import require_rsk_word_budget
 from jacobian.math.algebraic_combinatorics.values import (
     MAX_RSK_ROW_SEARCH_COMPARISONS,
     MAX_RSK_WORD_BYTES,
@@ -190,17 +189,6 @@ class RSKWordRequest(StrictModel):
         )
     )
     convention: RSKConvention = "ROW_INSERTION_RSK_V1"
-
-    @model_validator(mode="after")
-    def require_complete_budget(self) -> Self:
-        try:
-            require_rsk_word_budget(self.word)
-        except ValueError as error:
-            raise PydanticCustomError(
-                "algebraic_combinatorics.rsk_word_budget",
-                str(error),
-            ) from error
-        return self
 
 
 class RSKInverseWordRequest(StrictModel):

--- a/src/jacobian/math/code_nonlinear/_models.py
+++ b/src/jacobian/math/code_nonlinear/_models.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Annotated, Any, Self
 
 from pydantic import ConfigDict, Field, model_validator
@@ -10,12 +9,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.code_nonlinear._budget import (
-    MAX_CODE_RESULT_BYTES,
     MAX_PROFILE_PAIRS,
-    require_constant_weight_admission,
-    require_profile_admission,
-    require_set_system_output_bound,
-    require_word_distance_output_bound,
 )
 from jacobian.math.code_nonlinear.values import (
     MAX_EXPLICIT_CODE_LENGTH,
@@ -39,50 +33,11 @@ def _validation_error(code: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(code, message)
 
 
-def _require_admission(action: Callable[[], Any], code: str) -> Any:
-    try:
-        return action()
-    except ValueError as exc:
-        raise _validation_error(code, str(exc)) from exc
-
-
-def _require_result_bound(bound: int, label: str) -> None:
-    if bound > MAX_CODE_RESULT_BYTES:
-        raise _validation_error(
-            "nonlinear_code.result_bound",
-            f"{label} can use up to {bound} canonical JSON bytes, exceeding the "
-            f"{MAX_CODE_RESULT_BYTES}-byte result bound",
-        )
-
-
-def _require_constant_weight(code: ExplicitBinaryCode) -> int:
-    if not code.codewords:
-        raise _validation_error(
-            "nonlinear_code.constant_weight_empty",
-            "constant-weight profile requires at least one codeword",
-        )
-    weight = sum(code.codewords[0])
-    if any(sum(word) != weight for word in code.codewords):
-        raise _validation_error(
-            "nonlinear_code.constant_weight_mismatch",
-            "all codewords must have the same Hamming weight",
-        )
-    return weight
-
-
 class ConstantWeightRequest(StrictModel):
     """Generate all binary words of one bounded length and weight."""
 
     length: Annotated[int, Field(strict=True, ge=0, le=MAX_EXPLICIT_CODE_LENGTH)]
     weight: Annotated[int, Field(strict=True, ge=0, le=MAX_EXPLICIT_CODE_LENGTH)]
-
-    @model_validator(mode="after")
-    def require_valid_weight(self) -> Self:
-        _require_admission(
-            lambda: require_constant_weight_admission(self.length, self.weight),
-            "nonlinear_code.admission_bound",
-        )
-        return self
 
 
 class ConstantWeightResult(StrictModel):
@@ -145,10 +100,6 @@ class WordDistanceRequest(StrictModel):
             raise _validation_error(
                 "nonlinear_code.length_mismatch", "words must have equal length"
             )
-        _require_admission(
-            lambda: require_word_distance_output_bound(self.word1, self.word2),
-            "nonlinear_code.admission_bound",
-        )
         return self
 
 
@@ -226,14 +177,6 @@ class ExplicitProfileRequest(StrictModel):
             "the retained-source result bound before pair enumeration."
         )
     )
-
-    @model_validator(mode="after")
-    def require_bounded_profile(self) -> Self:
-        _require_admission(
-            lambda: require_profile_admission(self.code),
-            "nonlinear_code.admission_bound",
-        )
-        return self
 
 
 class ExplicitProfileResult(StrictModel):
@@ -314,15 +257,6 @@ class ConstantWeightProfileRequest(StrictModel):
         )
     )
 
-    @model_validator(mode="after")
-    def require_valid_constant_weight(self) -> Self:
-        _require_constant_weight(self.code)
-        _require_admission(
-            lambda: require_profile_admission(self.code),
-            "nonlinear_code.admission_bound",
-        )
-        return self
-
 
 class ConstantWeightProfileResult(StrictModel):
     """Distance/intersection profile of a retained constant-weight code."""
@@ -394,14 +328,6 @@ class ToSetSystemRequest(StrictModel):
     """Map one canonical explicit code to its coordinate supports."""
 
     code: ExplicitBinaryCode
-
-    @model_validator(mode="after")
-    def require_bounded_result(self) -> Self:
-        _require_admission(
-            lambda: require_set_system_output_bound(self.code),
-            "nonlinear_code.admission_bound",
-        )
-        return self
 
 
 class ToSetSystemResult(StrictModel):

--- a/src/jacobian/math/code_nonlinear/_operations.py
+++ b/src/jacobian/math/code_nonlinear/_operations.py
@@ -7,7 +7,12 @@ from itertools import combinations
 
 from pydantic import ValidationError
 
-from jacobian.math.code_nonlinear._budget import require_profile_admission
+from jacobian.math.code_nonlinear._budget import (
+    require_constant_weight_admission,
+    require_profile_admission,
+    require_set_system_output_bound,
+    require_word_distance_output_bound,
+)
 from jacobian.math.code_nonlinear._models import (
     BinaryCodeDistanceWitness,
     ConstantWeightProfileRequest,
@@ -98,7 +103,6 @@ def _distance_witness(
 
 
 def _explicit_profile_data(code: ExplicitBinaryCode) -> _ExplicitProfileData:
-    require_profile_admission(code)
     bitsets = tuple(_word_to_bitset(word) for word in code.codewords)
     weight_distribution = [0] * (code.length + 1)
     for word in bitsets:
@@ -137,7 +141,6 @@ def _explicit_profile_data(code: ExplicitBinaryCode) -> _ExplicitProfileData:
 def _constant_weight_profile_data(
     code: ExplicitBinaryCode,
 ) -> _ConstantWeightProfileData:
-    require_profile_admission(code)
     bitsets = tuple(_word_to_bitset(word) for word in code.codewords)
     weight = bitsets[0].bit_count()
     distance_histogram = [0] * (code.length + 1)
@@ -187,8 +190,18 @@ def _constant_weight_code(length: int, weight: int) -> ExplicitBinaryCode:
     return ExplicitBinaryCode(length=length, codewords=tuple(codewords))
 
 
+def _constant_weight(code: ExplicitBinaryCode) -> int:
+    if not code.codewords:
+        raise ValueError("constant-weight profile requires at least one codeword")
+    weight = sum(code.codewords[0])
+    if any(sum(word) != weight for word in code.codewords):
+        raise ValueError("all codewords must have the same Hamming weight")
+    return weight
+
+
 def compute_constant_weight(request: ConstantWeightRequest) -> ConstantWeightResult:
     """Generate the complete constant-weight binary code."""
+    require_constant_weight_admission(request.length, request.weight)
     code = _constant_weight_code(request.length, request.weight)
     return ConstantWeightResult._from_kernel(
         length=request.length, weight=request.weight, code=code
@@ -197,6 +210,7 @@ def compute_constant_weight(request: ConstantWeightRequest) -> ConstantWeightRes
 
 def compute_word_distance(request: WordDistanceRequest) -> WordDistanceResult:
     """Compute the exact Hamming relation between two words."""
+    require_word_distance_output_bound(request.word1, request.word2)
     distance, differing, weight1, weight2, intersection = _word_distance_data(
         request.word1, request.word2
     )
@@ -236,11 +250,12 @@ def compute_constant_weight_profile(
     """Compute distance and intersection profiles of a constant-weight code."""
     code = request.code
     plan = require_profile_admission(code)
+    weight = _constant_weight(code)
     profile = _constant_weight_profile_data(code)
     return ConstantWeightProfileResult._from_kernel(
         source=code,
         length=code.length,
-        weight=sum(code.codewords[0]),
+        weight=weight,
         cardinality=len(code.codewords),
         pair_count=plan.pair_count,
         minimum_distance=profile.minimum_distance,
@@ -255,6 +270,7 @@ def compute_constant_weight_profile(
 def compute_to_set_system(request: ToSetSystemRequest) -> ToSetSystemResult:
     """Map each source word to its coordinate support."""
     code = request.code
+    require_set_system_output_bound(code)
     return ToSetSystemResult._from_kernel(
         source=code,
         length=code.length,
@@ -283,8 +299,8 @@ def _verify_constant_weight_result(result: ConstantWeightResult) -> bool:
     """Verify an independently supplied generated-code claim."""
 
     try:
-        ConstantWeightRequest(length=result.length, weight=result.weight)
-    except ValidationError:
+        require_constant_weight_admission(result.length, result.weight)
+    except ValueError:
         return False
     expected = _constant_weight_code(result.length, result.weight)
     return result.code == expected and result.count == len(expected.codewords)
@@ -295,7 +311,8 @@ def _verify_word_distance_result(result: WordDistanceResult) -> bool:
 
     try:
         WordDistanceRequest(word1=result.word1, word2=result.word2)
-    except ValidationError:
+        require_word_distance_output_bound(result.word1, result.word2)
+    except (ValidationError, ValueError):
         return False
     expected = _word_distance_data(result.word1, result.word2)
     return (
@@ -340,8 +357,8 @@ def _verify_explicit_profile_result(result: ExplicitProfileResult) -> bool:
     """Replay an independently supplied profile inside its admitted envelope."""
 
     try:
-        ExplicitProfileRequest(code=result.source)
-    except ValidationError:
+        require_profile_admission(result.source)
+    except ValueError:
         return False
     expected = _explicit_profile_data(result.source)
     return (
@@ -362,10 +379,11 @@ def _verify_constant_weight_profile_result(result: ConstantWeightProfileResult) 
     """Replay an independently supplied constant-weight profile claim."""
 
     try:
-        ConstantWeightProfileRequest(code=result.source)
-    except ValidationError:
+        require_profile_admission(result.source)
+        weight = _constant_weight(result.source)
+    except ValueError:
         return False
-    if result.weight != sum(result.source.codewords[0]):
+    if result.weight != weight:
         return False
     expected = _constant_weight_profile_data(result.source)
     return (
@@ -386,8 +404,8 @@ def _verify_to_set_system_result(result: ToSetSystemResult) -> bool:
     """Verify an independently supplied source-indexed support claim."""
 
     try:
-        ToSetSystemRequest(code=result.source)
-    except ValidationError:
+        require_set_system_output_bound(result.source)
+    except ValueError:
         return False
     return result.coordinate_axis == tuple(
         range(result.source.length)

--- a/src/jacobian/math/crossed_products/_models.py
+++ b/src/jacobian/math/crossed_products/_models.py
@@ -8,7 +8,6 @@ from pydantic import model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.math.crossed_products._budget import require_multiplication_budget
 from jacobian.math.crossed_products.values import FiniteCosetCrossedProductElement
 
 
@@ -21,14 +20,6 @@ class CrossedProductMultiplyRequest(StrictModel):
 
     left: FiniteCosetCrossedProductElement
     right: FiniteCosetCrossedProductElement
-
-    @model_validator(mode="after")
-    def require_bounded_product(self) -> Self:
-        try:
-            require_multiplication_budget(self.left, self.right)
-        except ValueError as exc:
-            raise _validation_error("product_budget_exceeded", str(exc)) from exc
-        return self
 
 
 class CrossedProductMultiplyResult(StrictModel):

--- a/src/jacobian/math/finite_categories/_models.py
+++ b/src/jacobian/math/finite_categories/_models.py
@@ -4,14 +4,9 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from jacobian._models import StrictModel
-from jacobian.math.finite_categories._product import (
-    CategoryProductAdmissionError,
-    _product_error,
-    _product_plan,
-)
 from jacobian.math.finite_categories.values import (
     MAX_CATEGORY_MORPHISMS,
     MAX_CATEGORY_OBJECTS,
@@ -65,14 +60,6 @@ class CategoryProductRequest(StrictModel):
 
     left: FiniteCategory
     right: FiniteCategory
-
-    @model_validator(mode="after")
-    def require_bounded_product(self) -> Self:
-        try:
-            _product_plan(self.left, self.right)
-        except CategoryProductAdmissionError as exc:
-            raise _product_error(exc.reason, str(exc)) from None
-        return self
 
 
 __all__ = [

--- a/src/jacobian/math/finite_dim_algebras/_models.py
+++ b/src/jacobian/math/finite_dim_algebras/_models.py
@@ -14,16 +14,6 @@ MAX_ENTRIES = (
     MAX_DIM * MAX_DIM
 )  # 16384; outer tensor bound (n <= 128, logical n^3 entries)
 
-# ``compute_center`` builds n^2 commutator rows and runs Gaussian
-# elimination over all of them with length-n row updates, so the kernel's
-# actual worst-case work is Theta(n^4) modular-entry updates, not cubic.
-# Measured on this kernel: n=32 ~0.08s, n=64 ~1.2s, n=96 ~6.1s,
-# n=128 ~18.8s.  The dimension envelope is derived from that measured
-# cost so an accepted request stays inside the bounded synchronous
-# execution envelope; replacing the kernel with a faster elimination
-# would justify re-deriving this bound upward.
-_MAX_DIM_FOR_CENTER = 128
-
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     """Build a stable validation error owned by finite-dimensional algebras."""
@@ -86,16 +76,6 @@ class StructureConstants(StrictModel):
 
 class CenterRequest(StrictModel):
     algebra: StructureConstants
-
-    @model_validator(mode="after")
-    def require_bounded_center_work(self) -> Self:
-        if self.algebra.dimension > _MAX_DIM_FOR_CENTER:
-            raise _validation_error(
-                "center_dimension_limit",
-                "center computation is Theta(n^4) on the current elimination "
-                f"kernel and supports at most {_MAX_DIM_FOR_CENTER} dimensions",
-            )
-        return self
 
 
 # Results

--- a/src/jacobian/math/finite_fields/_models.py
+++ b/src/jacobian/math/finite_fields/_models.py
@@ -24,7 +24,6 @@ def _validation_error(code: str, message: str) -> PydanticCustomError:
 
 
 _MAX_PROJECTIVE_POINTS = 4_096
-_MAX_FINITE_MAP_WORK = 1_000_000
 _MAX_DIRECTION_RANK_WORK = 1_000_000
 
 
@@ -129,20 +128,6 @@ class OrbitDistributionRequest(StrictModel):
 
 class FiniteMapTableRequest(StrictModel):
     polynomial_map: FinitePolynomialMap
-
-    @model_validator(mode="after")
-    def require_bounded_enumeration(self) -> Self:
-        work = (
-            self.polynomial_map.domain.order
-            * len(self.polynomial_map.polynomial.coefficients)
-            * self.polynomial_map.domain.degree
-        )
-        if work > _MAX_FINITE_MAP_WORK:
-            raise _validation_error(
-                "finite_field.finite_map_exceeds_operation_work_budget",
-                "finite map exceeds the operation work budget",
-            )
-        return self
 
 
 class FiberPartitionRequest(StrictModel):

--- a/src/jacobian/math/finite_fields/operations.py
+++ b/src/jacobian/math/finite_fields/operations.py
@@ -22,6 +22,8 @@ from jacobian.math.finite_fields.values import (
 )
 from jacobian.math.prime_field_linear_algebra import PrimeFieldMatrix
 
+_MAX_FINITE_MAP_WORK = 1_000_000
+
 
 def finite_field(
     characteristic: int,
@@ -269,6 +271,13 @@ def evaluate_finite_polynomial(
 def finite_map_table(polynomial_map: FinitePolynomialMap) -> FiniteMapTable:
     """Enumerate a complete finite polynomial-map table in canonical order."""
 
+    work = (
+        polynomial_map.domain.order
+        * len(polynomial_map.polynomial.coefficients)
+        * polynomial_map.domain.degree
+    )
+    if work > _MAX_FINITE_MAP_WORK:
+        raise ValueError("finite map exceeds the operation work budget")
     from jacobian.math.finite_fields import _flint
 
     sources = _field_elements(polynomial_map.domain)

--- a/src/jacobian/math/formal_concept_analysis/_admission.py
+++ b/src/jacobian/math/formal_concept_analysis/_admission.py
@@ -48,7 +48,7 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "formal_context.duquenne_guigues_basis.compute",
         AdmissionDecision.KEEP,
-        "complete bounded pseudo-intent family and source-bound canonical implication basis with exhaustive closure-equivalence replay",
+        "complete bounded pseudo-intent family and source-bound canonical implication basis with exhaustive closure equivalence",
     ),
     OperationAdmission(
         "implication_system.closure.compute",

--- a/src/jacobian/math/formal_concept_analysis/_models.py
+++ b/src/jacobian/math/formal_concept_analysis/_models.py
@@ -17,7 +17,6 @@ from jacobian.math.formal_concept_analysis.basis import (
     MAX_DG_CANDIDATE_STATES,
     MAX_DG_LOGICAL_WORK,
     MAX_DG_RESULT_BYTES,
-    _duquenne_guigues_preflight,
 )
 from jacobian.math.formal_concept_analysis.values import (
     MAX_IMPLICATION_MEMBERSHIPS,
@@ -103,7 +102,7 @@ class DuquenneGuiguesBasisRequest(StrictModel):
                 "basis size, rejects bases beyond the "
                 f"{MAX_IMPLICATIONS}-implication canonical implication-system "
                 f"carrier ({MAX_IMPLICATION_MEMBERSHIPS:,} memberships), and "
-                "reserves producer and independent replay work bounded by "
+                "reserves one producer plan and closure-equivalence pass bounded by "
                 f"{MAX_DG_LOGICAL_WORK:,} logical steps plus a worst-case "
                 f"{MAX_DG_RESULT_BYTES:,}-byte serialized result."
             )
@@ -111,11 +110,6 @@ class DuquenneGuiguesBasisRequest(StrictModel):
     )
 
     context: FormalContext
-
-    @model_validator(mode="after")
-    def require_complete_preflight(self) -> Self:
-        _duquenne_guigues_preflight(self.context)
-        return self
 
 
 class DerivationResult(StrictModel):

--- a/src/jacobian/math/formal_concept_analysis/_tools.py
+++ b/src/jacobian/math/formal_concept_analysis/_tools.py
@@ -212,8 +212,8 @@ FORMAL_CONCEPT_ANALYSIS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "Return every pseudo-intent and its context closure, the complete "
         "canonical implication system, an exhaustive subset-closure matrix, "
         "explicit source-coordinate binding, and exact work/output accounting. "
-        "The complete producer and independent replay are admitted before "
-        "enumeration; there is no partial-result branch.",
+        "One complete producer plan is admitted before enumeration; there is "
+        "no partial-result branch.",
         DuquenneGuiguesBasisRequest,
         CanonicalImplicationBasisResult,
         compute_duquenne_guigues_basis,

--- a/src/jacobian/math/formal_concept_analysis/basis.py
+++ b/src/jacobian/math/formal_concept_analysis/basis.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Annotated, Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
@@ -35,21 +36,10 @@ from jacobian.math.formal_concept_analysis.values import (
 #     MAX_DG_CANDIDATE_STATES is a documented conservative fallback that keeps
 #     the exact admission probe itself (one context closure per candidate
 #     state) bounded before execution;
-#   * logical work -- the probe reports the exact enumeration counts
-#     (object-row checks, incidence loads, row intersections, lectic
-#     comparisons) and the exact basis shape.  The kernel execution and its
-#     result validation probe the complete context closure matrix three times
-#     (producer preflight, producer enumeration, result-validation preflight)
-#     and the result validator independently reconstructs every state's
-#     context closure once more, so the reported exact accounting charges
-#     exactly those passes; request-model admission probing precedes the
-#     kernel and stays outside the reported result, so native and catalog
-#     invocations report identical counts.  The reserve is one conservative
-#     term on top: it also charges the catalog path's request-validation
-#     probe, plus four exhaustive passes over one canonical closure query per
-#     candidate state, each query costing at most (attribute_count + 1)
-#     productive rounds times the retained basis size.  The carrier-fit check
-#     below keeps that basis inside #2267's
+#   * logical work -- the plan reports the exact closure-matrix and lectic
+#     enumeration counts. The kernel consumes that carrier, then performs one
+#     closure-equivalence pass over the constructed basis. The carrier-fit
+#     check below keeps that basis inside #2267's
 #     MAX_IMPLICATIONS rows and MAX_IMPLICATION_MEMBERSHIPS memberships, so
 #     every admitted query also stays under MAX_CANONICAL_REPLAY_WORK;
 #   * serialized result bytes -- a worst-case payload shaped by the probed
@@ -127,7 +117,7 @@ def _enumerate_dg_masks(
 
     closure_masks, row_intersections = _context_closure_masks(context)
     pseudo_intent_pairs, subset_comparisons, closure_comparisons = (
-        _replay_pseudo_intents(closure_masks)
+        _enumerate_pseudo_intents(closure_masks)
     )
     return (
         closure_masks,
@@ -175,28 +165,16 @@ def _reserved_dg_logical_work(
     object_count = len(context.objects)
     incidence_count = len(context.incidence)
     return (
-        # Conservative serving envelope.  The reported exact accounting covers
-        # the three kernel-executed closure-matrix passes (producer preflight,
-        # producer enumeration, result-validation preflight), the result
-        # validator's independent per-state reconstruction, and the recursive
-        # pseudo-intent replays those passes run.  This reserve additionally
-        # charges the catalog path's request-validation probe and one more
-        # set of matching-row intersections, so it stays strictly above the
-        # exact accounting for every admitted invocation path.  Every
-        # closure-matrix pass loads the incidence pairs once, scans every
-        # candidate state against every retained object row, and intersects
-        # exactly the matching rows.
-        4 * states * object_count
-        + 4 * incidence_count
-        + 5 * row_intersections
-        + incidence_count * (attribute_count * states // 2 + row_intersections)
-        + 5 * (subset_comparisons + closure_comparisons)
-        # Each of the two exhaustive DG-basis passes invokes #2267's closure
-        # kernel twice (producer plus source-bound replay), hence four scans
-        # in total; each query costs at most (attribute_count + 1) rounds
-        # times the retained basis size.
-        + 4
-        * states
+        # The plan's one closure-matrix and pseudo-intent scan, followed by
+        # one canonical basis-equivalence pass. Each closure query needs at
+        # most (attribute_count + 1) productive rounds over the retained
+        # implication carrier.
+        states * object_count
+        + incidence_count
+        + row_intersections
+        + subset_comparisons
+        + closure_comparisons
+        + states
         * (attribute_count + 1)
         * (len(pseudo_intent_pairs) + implication_memberships)
         + attribute_count * states // 2
@@ -230,9 +208,6 @@ def _dg_output_reservation_payload(
         "basis_implication_index": largest_state,
     }
     implication = {"premise": full_subset, "conclusion": full_subset}
-    maximum_incidence_work = len(context.incidence) * (
-        attribute_count * states // 2 + states * len(context.objects)
-    )
     return {
         "context": context.model_dump(mode="json"),
         "source_attribute_indices": list(range(attribute_count)),
@@ -245,16 +220,14 @@ def _dg_output_reservation_payload(
         },
         "work": {
             "candidate_states": states,
-            "context_closure_queries": 2 * states,
-            "context_object_row_checks": 4 * states * len(context.objects),
-            "context_incidence_loads": 4 * len(context.incidence),
-            "context_row_intersections": 5 * states * len(context.objects),
-            "context_incidence_checks": maximum_incidence_work,
-            "pseudo_intent_subset_comparisons": 5 * states * states,
-            "pseudo_intent_closure_comparisons": 5 * states * states,
-            "basis_closure_queries": 2 * states,
-            "basis_canonical_replay_work": 2
-            * MAX_DG_CANDIDATE_STATES
+            "context_closure_queries": states,
+            "context_object_row_checks": states * len(context.objects),
+            "context_incidence_loads": len(context.incidence),
+            "context_row_intersections": states * len(context.objects),
+            "pseudo_intent_subset_comparisons": states * states,
+            "pseudo_intent_closure_comparisons": states * states,
+            "basis_closure_queries": states,
+            "basis_closure_work": MAX_DG_CANDIDATE_STATES
             * (attribute_count + 1)
             * (MAX_IMPLICATIONS + MAX_IMPLICATION_MEMBERSHIPS),
             "closure_matrix_memberships": 2 * states * attribute_count,
@@ -269,8 +242,22 @@ def _dg_output_reservation_payload(
     }
 
 
-def _duquenne_guigues_preflight(context: FormalContext) -> tuple[int, int, int]:
-    """Return candidate states and reserved work/bytes before expansion."""
+@dataclass(frozen=True)
+class _DGBasisAdmissionPlan:
+    """One admitted closure carrier and its exact execution reservations."""
+
+    states: int
+    closure_masks: tuple[int, ...]
+    pseudo_intent_pairs: tuple[tuple[int, int], ...]
+    subset_comparisons: int
+    closure_comparisons: int
+    row_intersections: int
+    reserved_logical_work: int
+    reserved_result_bytes: int
+
+
+def _admit_duquenne_guigues_basis(context: FormalContext) -> _DGBasisAdmissionPlan:
+    """Build the one semantic admission plan for a DG-basis invocation."""
 
     attribute_count = len(context.attributes)
     if attribute_count > MAX_DG_ATTRIBUTES:
@@ -301,7 +288,7 @@ def _duquenne_guigues_preflight(context: FormalContext) -> tuple[int, int, int]:
     )
     if reserved_logical_work > MAX_DG_LOGICAL_WORK:
         raise ValueError(
-            "Duquenne-Guigues basis replay exceeds the bounded logical-work "
+            "Duquenne-Guigues basis closure-equivalence pass exceeds the bounded logical-work "
             f"limit of {MAX_DG_LOGICAL_WORK}"
         )
 
@@ -323,7 +310,16 @@ def _duquenne_guigues_preflight(context: FormalContext) -> tuple[int, int, int]:
             "Duquenne-Guigues basis worst-case result exceeds the bounded "
             f"serialized-result limit of {MAX_DG_RESULT_BYTES} bytes"
         ) from exc
-    return states, reserved_logical_work, reserved_result_bytes
+    return _DGBasisAdmissionPlan(
+        states=states,
+        closure_masks=closure_masks,
+        pseudo_intent_pairs=pseudo_intent_pairs,
+        subset_comparisons=subset_comparisons,
+        closure_comparisons=closure_comparisons,
+        row_intersections=row_intersections,
+        reserved_logical_work=reserved_logical_work,
+        reserved_result_bytes=reserved_result_bytes,
+    )
 
 
 class DGBasisClosureRow(StrictModel):
@@ -360,68 +356,51 @@ class PseudoIntent(StrictModel):
 class DGBasisWork(StrictModel):
     """Exact logical counts for one served request plus its reservations.
 
-    Counts cover every exhaustive pass the kernel execution and its result
-    validation perform: the three complete context closure-matrix probes
-    (producer preflight, producer enumeration, result-validation preflight),
-    the result validator's independent per-state context-closure
-    reconstruction, the three recursive pseudo-intent replays those passes
-    run, and both basis closure-equivalence passes.  Request-model admission
-    probing precedes the kernel and stays outside the reported result, so
-    native and catalog invocations report identical counts.
+    Counts cover the one semantic admission plan consumed by the kernel and
+    its one source-closure-equivalence pass. Independently supplied result
+    data is checked by the explicit owner verifier, not ordinary result
+    construction, so native and catalog invocations report identical work.
     """
 
     candidate_states: StrictInt = Field(ge=1, le=MAX_DG_CANDIDATE_STATES)
     context_closure_queries: StrictInt = Field(
-        ge=4,
-        le=4 * MAX_DG_CANDIDATE_STATES,
+        ge=1,
+        le=MAX_DG_CANDIDATE_STATES,
     )
     context_object_row_checks: StrictInt = Field(
-        ge=3,
-        le=3 * MAX_DG_CANDIDATE_STATES * MAX_OBJECTS,
+        ge=0,
+        le=MAX_DG_CANDIDATE_STATES * MAX_OBJECTS,
     )
     context_incidence_loads: StrictInt = Field(
         ge=0,
-        le=3 * MAX_OBJECTS * MAX_DG_ATTRIBUTES,
+        le=MAX_OBJECTS * MAX_DG_ATTRIBUTES,
     )
     context_row_intersections: StrictInt = Field(
         ge=0,
-        le=4 * MAX_DG_CANDIDATE_STATES * MAX_OBJECTS,
-    )
-    context_incidence_checks: StrictInt = Field(
-        ge=0,
-        le=(
-            MAX_OBJECTS
-            * MAX_DG_ATTRIBUTES
-            * (
-                MAX_DG_ATTRIBUTES * MAX_DG_CANDIDATE_STATES // 2
-                + MAX_OBJECTS * MAX_DG_CANDIDATE_STATES
-            )
-        ),
+        le=MAX_DG_CANDIDATE_STATES * MAX_OBJECTS,
     )
     pseudo_intent_subset_comparisons: StrictInt = Field(
         ge=0,
-        le=3 * MAX_DG_CANDIDATE_STATES**2,
+        le=MAX_DG_CANDIDATE_STATES**2,
     )
     pseudo_intent_closure_comparisons: StrictInt = Field(
         ge=0,
-        le=3 * MAX_DG_CANDIDATE_STATES**2,
+        le=MAX_DG_CANDIDATE_STATES**2,
     )
     basis_closure_queries: StrictInt = Field(
-        ge=2,
-        le=2 * MAX_DG_CANDIDATE_STATES,
+        ge=1,
+        le=MAX_DG_CANDIDATE_STATES,
     )
-    basis_canonical_replay_work: StrictInt = Field(
+    basis_closure_work: StrictInt = Field(
         ge=0,
         le=(
-            2
-            * MAX_DG_CANDIDATE_STATES
+            MAX_DG_CANDIDATE_STATES
             * (MAX_DG_ATTRIBUTES + 1)
             * (MAX_IMPLICATIONS + MAX_IMPLICATION_MEMBERSHIPS)
         ),
         description=(
-            "Exact finite-implication canonical replay work reported by the producer and "
-            "independent DG-basis closure-equivalence passes. Aggregate work "
-            "also charges each closure result's own source-bound validation."
+            "Exact finite-implication closure-equivalence work performed by the "
+            "producer after one semantic admission plan."
         ),
     )
     closure_matrix_memberships: StrictInt = Field(
@@ -448,10 +427,9 @@ class DGBasisWork(StrictModel):
             self.context_object_row_checks
             + self.context_incidence_loads
             + self.context_row_intersections
-            + self.context_incidence_checks
             + self.pseudo_intent_subset_comparisons
             + self.pseudo_intent_closure_comparisons
-            + 2 * self.basis_canonical_replay_work
+            + self.basis_closure_work
             + self.closure_matrix_memberships
             + self.pseudo_intent_memberships
             + self.implication_memberships
@@ -467,7 +445,7 @@ class DGBasisWork(StrictModel):
         return self
 
 
-def _replay_pseudo_intents(
+def _enumerate_pseudo_intents(
     closures: tuple[int, ...],
 ) -> tuple[tuple[tuple[int, int], ...], int, int]:
     pseudo_intents: list[tuple[int, int]] = []
@@ -540,9 +518,8 @@ class CanonicalImplicationBasisResult(StrictModel):
     def _verify_complete_canonical_basis(self) -> None:
 
         attribute_count = len(self.context.attributes)
-        states, reserved_work, reserved_bytes = _duquenne_guigues_preflight(
-            self.context
-        )
+        plan = _admit_duquenne_guigues_basis(self.context)
+        states = plan.states
         source_indices = tuple(range(attribute_count))
         if self.source_attribute_indices != source_indices:
             raise ValueError(
@@ -558,8 +535,6 @@ class CanonicalImplicationBasisResult(StrictModel):
             raise ValueError("closure matrix must contain every candidate state")
 
         incidence_count = len(self.context.incidence)
-        incidence_checks = 0
-        row_intersections = 0
         closure_masks: list[int] = []
         for state, row in enumerate(self.closure_matrix):
             expected_subset = _subset_for_state(state, attribute_count)
@@ -574,19 +549,13 @@ class CanonicalImplicationBasisResult(StrictModel):
             expected_context_closure = tuple(
                 sorted(object_derivation(self.context, extent))
             )
-            incidence_checks += incidence_count * (
-                (len(subset) if subset else 0) + (len(extent) if extent else 0)
-            )
-            row_intersections += len(extent)
             if row.closure != expected_context_closure:
                 raise ValueError(
                     "closure matrix does not match the retained formal context"
                 )
             closure_masks.append(_state_for_subset(expected_context_closure))
 
-        expected_pairs, subset_comparisons, closure_comparisons = (
-            _replay_pseudo_intents(tuple(closure_masks))
-        )
+        expected_pairs, _, _ = _enumerate_pseudo_intents(tuple(closure_masks))
         expected_implications = tuple(
             AttributeImplication(
                 premise=_subset_for_state(state, attribute_count),
@@ -619,20 +588,20 @@ class CanonicalImplicationBasisResult(StrictModel):
         )
         if self.pseudo_intents != expected_pseudo_intents:
             raise ValueError(
-                "pseudo-intent rows do not match exhaustive recursive replay"
+                "pseudo-intent rows do not match exhaustive recursive enumeration"
             )
 
-        basis_replay_work = 0
+        basis_closure_work = 0
         for state, expected_closure_mask in enumerate(closure_masks):
-            replay, replay_work = _canonical_implication_closure_work(
+            closure, closure_work = _canonical_implication_closure_work(
                 self.basis,
                 frozenset(_subset_for_state(state, attribute_count)),
             )
-            if _state_for_subset(replay) != expected_closure_mask:
+            if _state_for_subset(closure) != expected_closure_mask:
                 raise ValueError(
                     "basis closure does not equal context closure for every subset"
                 )
-            basis_replay_work += replay_work
+            basis_closure_work += closure_work
 
         closure_matrix_memberships = sum(
             len(row.subset) + len(row.closure) for row in self.closure_matrix
@@ -642,41 +611,39 @@ class CanonicalImplicationBasisResult(StrictModel):
         )
         implication_memberships = self.basis.total_memberships
         expected_accounted_work = (
-            3 * states * len(self.context.objects)
-            + 3 * incidence_count
-            + 4 * row_intersections
-            + incidence_checks
-            + 3 * subset_comparisons
-            + 3 * closure_comparisons
-            + 4 * basis_replay_work
+            states * len(self.context.objects)
+            + incidence_count
+            + plan.row_intersections
+            + plan.subset_comparisons
+            + plan.closure_comparisons
+            + basis_closure_work
             + closure_matrix_memberships
             + pseudo_intent_memberships
             + implication_memberships
         )
         expected_fields = {
             "candidate_states": states,
-            "context_closure_queries": 4 * states,
-            "context_object_row_checks": 3 * states * len(self.context.objects),
-            "context_incidence_loads": 3 * incidence_count,
-            "context_row_intersections": 4 * row_intersections,
-            "context_incidence_checks": incidence_checks,
-            "pseudo_intent_subset_comparisons": 3 * subset_comparisons,
-            "pseudo_intent_closure_comparisons": 3 * closure_comparisons,
-            "basis_closure_queries": 2 * states,
-            "basis_canonical_replay_work": 2 * basis_replay_work,
+            "context_closure_queries": states,
+            "context_object_row_checks": states * len(self.context.objects),
+            "context_incidence_loads": incidence_count,
+            "context_row_intersections": plan.row_intersections,
+            "pseudo_intent_subset_comparisons": plan.subset_comparisons,
+            "pseudo_intent_closure_comparisons": plan.closure_comparisons,
+            "basis_closure_queries": states,
+            "basis_closure_work": basis_closure_work,
             "closure_matrix_memberships": closure_matrix_memberships,
             "pseudo_intent_memberships": pseudo_intent_memberships,
             "implication_count": len(self.basis.implications),
             "implication_memberships": implication_memberships,
             "accounted_logical_work": expected_accounted_work,
-            "reserved_logical_work": reserved_work,
-            "reserved_result_bytes": reserved_bytes,
+            "reserved_logical_work": plan.reserved_logical_work,
+            "reserved_result_bytes": plan.reserved_result_bytes,
         }
         work_payload = self.work.model_dump()
         for field, expected in expected_fields.items():
             if work_payload[field] != expected:
                 raise ValueError(
-                    "work accounting does not match independent exhaustive replay"
+                    "work accounting does not match independent exhaustive verification"
                 )
 
         actual_bytes = len(encode_strict_json(self.model_dump(mode="json")))
@@ -690,7 +657,7 @@ class CanonicalImplicationBasisResult(StrictModel):
 def _verify_canonical_implication_basis_result(
     result: CanonicalImplicationBasisResult,
 ) -> None:
-    """Independently replay a supplied complete basis within the admitted bound."""
+    """Verify a supplied complete basis within the admitted owner-local bound."""
 
     result._verify_complete_canonical_basis()
 

--- a/src/jacobian/math/formal_concept_analysis/operations.py
+++ b/src/jacobian/math/formal_concept_analysis/operations.py
@@ -9,9 +9,9 @@ from .basis import (
     CanonicalImplicationBasisResult,
     DGBasisClosureRow,
     PseudoIntent,
+    _admit_duquenne_guigues_basis,
     _basis_attribute_labels,
-    _duquenne_guigues_preflight,
-    _enumerate_dg_masks,
+    _DGBasisAdmissionPlan,
     _subset_for_state,
 )
 from .values import (
@@ -113,39 +113,20 @@ def implication_closure(
     )
 
 
-def _enumerate_dg_basis(
+def _closure_rows_from_plan(
     context: FormalContext,
-) -> tuple[
-    tuple[DGBasisClosureRow, ...],
-    tuple[tuple[int, int], ...],
-    int,
-    int,
-    int,
-]:
-    """Enumerate all closures and pseudo-intents with bounded integer bitsets."""
+    plan: _DGBasisAdmissionPlan,
+) -> tuple[DGBasisClosureRow, ...]:
+    """Materialize canonical rows without repeating semantic admission."""
 
     attribute_count = len(context.attributes)
-    (
-        closure_masks,
-        pseudo_intent_masks,
-        subset_comparisons,
-        closure_comparisons,
-        (row_intersections),
-    ) = _enumerate_dg_masks(context)
-    closure_rows = tuple(
+    return tuple(
         DGBasisClosureRow(
             candidate_state=state,
             subset=_subset_for_state(state, attribute_count),
             closure=_subset_for_state(closure_mask, attribute_count),
         )
-        for state, closure_mask in enumerate(closure_masks)
-    )
-    return (
-        closure_rows,
-        pseudo_intent_masks,
-        subset_comparisons,
-        closure_comparisons,
-        row_intersections,
+        for state, closure_mask in enumerate(plan.closure_masks)
     )
 
 
@@ -176,23 +157,15 @@ def duquenne_guigues_basis(
     needed by the recursive definition has already been considered.
     """
 
-    states, reserved_logical_work, reserved_result_bytes = _duquenne_guigues_preflight(
-        context
-    )
-    (
-        closure_matrix,
-        pseudo_intent_masks,
-        subset_comparisons,
-        closure_comparisons,
-        row_intersections,
-    ) = _enumerate_dg_basis(context)
+    plan = _admit_duquenne_guigues_basis(context)
+    closure_matrix = _closure_rows_from_plan(context, plan)
     attribute_count = len(context.attributes)
     implications = tuple(
         AttributeImplication(
             premise=_subset_for_state(state, attribute_count),
             conclusion=_subset_for_state(closure & ~state, attribute_count),
         )
-        for state, closure in pseudo_intent_masks
+        for state, closure in plan.pseudo_intent_pairs
     )
     basis = FiniteAttributeImplicationSystem(
         attributes=_basis_attribute_labels(attribute_count),
@@ -211,17 +184,17 @@ def duquenne_guigues_basis(
                 _subset_for_state(state, attribute_count)
             ],
         )
-        for state, closure in pseudo_intent_masks
+        for state, closure in plan.pseudo_intent_pairs
     )
 
-    basis_replay_work = 0
+    basis_closure_work = 0
     for closure_row in closure_matrix:
-        replay = implication_closure(basis, frozenset(closure_row.subset))
-        if replay.closure != closure_row.closure:
+        closure_result = implication_closure(basis, frozenset(closure_row.subset))
+        if closure_result.closure != closure_row.closure:
             raise RuntimeError(
                 "constructed canonical basis failed source closure equivalence"
             )
-        basis_replay_work += replay.work.canonical_replay_work
+        basis_closure_work += closure_result.work.canonical_replay_work
 
     closure_matrix_memberships = sum(
         len(row.subset) + len(row.closure) for row in closure_matrix
@@ -229,24 +202,14 @@ def duquenne_guigues_basis(
     pseudo_intent_memberships = sum(
         len(row.premise) + len(row.closure) for row in pseudo_intents
     )
-    incidence_checks = len(context.incidence) * (
-        attribute_count * states // 2 + row_intersections
-    )
     implication_memberships = basis.total_memberships
-    # Exact accounting covers the three kernel-executed closure-matrix passes
-    # (producer preflight, producer enumeration, result-validation preflight),
-    # the result validator's independent per-state reconstruction, and the
-    # recursive pseudo-intent replays those passes run.  Request-model
-    # admission probing precedes the kernel and stays outside the reported
-    # result, so native and catalog invocations report identical counts.
     accounted_logical_work = (
-        3 * states * len(context.objects)
-        + 3 * len(context.incidence)
-        + 4 * row_intersections
-        + incidence_checks
-        + 3 * subset_comparisons
-        + 3 * closure_comparisons
-        + 4 * basis_replay_work
+        plan.states * len(context.objects)
+        + len(context.incidence)
+        + plan.row_intersections
+        + plan.subset_comparisons
+        + plan.closure_comparisons
+        + basis_closure_work
         + closure_matrix_memberships
         + pseudo_intent_memberships
         + implication_memberships
@@ -259,23 +222,22 @@ def duquenne_guigues_basis(
         "pseudo_intents": [row.model_dump(mode="json") for row in pseudo_intents],
         "basis": basis.model_dump(mode="json"),
         "work": {
-            "candidate_states": states,
-            "context_closure_queries": 4 * states,
-            "context_object_row_checks": 3 * states * len(context.objects),
-            "context_incidence_loads": 3 * len(context.incidence),
-            "context_row_intersections": 4 * row_intersections,
-            "context_incidence_checks": incidence_checks,
-            "pseudo_intent_subset_comparisons": 3 * subset_comparisons,
-            "pseudo_intent_closure_comparisons": 3 * closure_comparisons,
-            "basis_closure_queries": 2 * states,
-            "basis_canonical_replay_work": 2 * basis_replay_work,
+            "candidate_states": plan.states,
+            "context_closure_queries": plan.states,
+            "context_object_row_checks": plan.states * len(context.objects),
+            "context_incidence_loads": len(context.incidence),
+            "context_row_intersections": plan.row_intersections,
+            "pseudo_intent_subset_comparisons": plan.subset_comparisons,
+            "pseudo_intent_closure_comparisons": plan.closure_comparisons,
+            "basis_closure_queries": plan.states,
+            "basis_closure_work": basis_closure_work,
             "closure_matrix_memberships": closure_matrix_memberships,
             "pseudo_intent_memberships": pseudo_intent_memberships,
             "implication_count": len(basis.implications),
             "implication_memberships": implication_memberships,
             "accounted_logical_work": accounted_logical_work,
-            "reserved_logical_work": reserved_logical_work,
-            "reserved_result_bytes": reserved_result_bytes,
+            "reserved_logical_work": plan.reserved_logical_work,
+            "reserved_result_bytes": plan.reserved_result_bytes,
             "serialized_result_bytes": 1,
         },
     }

--- a/src/jacobian/math/hypergraphs/_models.py
+++ b/src/jacobian/math/hypergraphs/_models.py
@@ -558,7 +558,8 @@ def _edge_intersection_preflight_data(
     return pair_count, total_incidences, intersection_cells, estimated_result_bytes
 
 
-def _require_edge_intersection_preflight(hypergraph: FiniteHypergraph) -> None:
+def _admit_edge_intersection_profile(hypergraph: FiniteHypergraph) -> None:
+    """Admit one complete profile before its owner-local kernel runs."""
     (
         pair_count,
         total_incidences,
@@ -610,11 +611,6 @@ class EdgeIntersectionsRequest(StrictModel):
             "canonical_result_bytes_bound": MAX_EDGE_INTERSECTION_RESULT_BYTES,
         },
     )
-
-    @model_validator(mode="after")
-    def require_bounded_complete_profile(self) -> Self:
-        _require_edge_intersection_preflight(self.hypergraph)
-        return self
 
 
 class EdgeIntersectionEntry(StrictModel):
@@ -691,8 +687,19 @@ class EdgeIntersectionsResult(StrictModel):
 
     @model_validator(mode="after")
     def bind_edge_intersections(self) -> Self:
-        _require_edge_intersection_preflight(self.hypergraph)
         edge_ids = tuple(edge_id for edge_id, _ in self.hypergraph.edges)
+        if len(edge_ids) * (len(edge_ids) - 1) // 2 > MAX_EDGE_PAIR_COUNT:
+            raise _validation_error(
+                f"edge-intersection profile exceeds the {MAX_EDGE_PAIR_COUNT}-pair bound"
+            )
+        if (
+            sum(len(members) for _, members in self.hypergraph.edges)
+            > MAX_TOTAL_INCIDENCES
+        ):
+            raise _validation_error(
+                "edge-intersection source exceeds the "
+                f"{MAX_TOTAL_INCIDENCES}-incidence bound"
+            )
         expected_pairs = tuple(
             (edge_ids[left], edge_ids[right])
             for left in range(len(edge_ids))

--- a/src/jacobian/math/hypergraphs/_operations.py
+++ b/src/jacobian/math/hypergraphs/_operations.py
@@ -18,7 +18,7 @@ from jacobian.math.hypergraphs._models import (
     ParametersResult,
     VertexDegreesRequest,
     VertexDegreesResult,
-    _require_edge_intersection_preflight,
+    _admit_edge_intersection_profile,
 )
 
 
@@ -279,7 +279,7 @@ def edge_intersections(
 ) -> EdgeIntersectionsResult:
     """Return every indexed edge-pair intersection and the linearity profile."""
 
-    _require_edge_intersection_preflight(hypergraph)
+    _admit_edge_intersection_profile(hypergraph)
     (
         pair_intersections,
         histogram,
@@ -310,6 +310,7 @@ def compute_edge_intersections(
 def verify_edge_intersections_result(result: EdgeIntersectionsResult) -> bool:
     """Verify an independently supplied complete edge-intersection profile."""
 
+    _admit_edge_intersection_profile(result.hypergraph)
     return (
         result.pair_intersections,
         result.histogram,

--- a/src/jacobian/math/modular_forms/_models.py
+++ b/src/jacobian/math/modular_forms/_models.py
@@ -2,20 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Self
-
-from pydantic import Field, StrictInt, model_validator
-from pydantic_core import PydanticCustomError
+from pydantic import Field, StrictInt
 
 from jacobian._models import StrictModel
-from jacobian.math.modular_forms.kernel import (
-    NamedLevelOneModularForm,
-    require_level_one_admission,
-)
-
-
-def _validation_error(reason: str, message: str) -> PydanticCustomError:
-    return PydanticCustomError(f"modular_forms.{reason}", message)
+from jacobian.math.modular_forms.kernel import NamedLevelOneModularForm
 
 
 class LevelOneNamedQExpansionRequest(StrictModel):
@@ -32,20 +22,6 @@ class LevelOneNamedQExpansionRequest(StrictModel):
             "finite-series arithmetic."
         ),
     )
-
-    @model_validator(mode="after")
-    def require_exact_bounded_prefix(self) -> Self:
-        try:
-            require_level_one_admission(self.form, self.truncation_order)
-        except ValueError as exc:
-            message = str(exc)
-            reason = (
-                "exact_work_bound"
-                if "exact work bound" in message
-                else "serialized_result_bound"
-            )
-            raise _validation_error(reason, message) from exc
-        return self
 
 
 __all__ = ["LevelOneNamedQExpansionRequest"]

--- a/src/jacobian/math/modular_forms/operations.py
+++ b/src/jacobian/math/modular_forms/operations.py
@@ -58,7 +58,7 @@ def level_one_named_q_expansion(
     else:
         q_expansion = _series(eisenstein_coefficients(form, truncation_order))
     weight, space_kind, normalization = metadata(form)
-    return LevelOneModularQExpansion(
+    return LevelOneModularQExpansion._from_kernel(
         form=form,
         weight=cast(Literal[4, 6, 12], weight),
         space_kind=space_kind,

--- a/src/jacobian/math/modular_forms/values.py
+++ b/src/jacobian/math/modular_forms/values.py
@@ -39,11 +39,7 @@ class LevelOneModularQExpansion(StrictModel):
     exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
-    def require_normalized_replayable_form(self) -> Self:
-        try:
-            require_level_one_replay(self.form, self.q_expansion.truncation_order)
-        except ValueError as exc:
-            raise _validation_error("replay_bound", str(exc)) from exc
+    def require_structural_named_form(self) -> Self:
         weight, space_kind, normalization = metadata(self.form)
         if (
             self.weight != weight
@@ -59,16 +55,41 @@ class LevelOneModularQExpansion(StrictModel):
                 "variable_mismatch",
                 "a modular q-expansion must use the canonical variable q",
             )
-        expected = expected_coefficients(self.form, self.q_expansion.truncation_order)
-        actual = tuple(
-            coefficient.as_fraction() for coefficient in self.q_expansion.coefficients
-        )
-        if actual != expected:
-            raise _validation_error(
-                "coefficients_mismatch",
-                "q-expansion does not match the normalized named form",
-            )
         return self
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        form: NamedLevelOneModularForm,
+        weight: Literal[4, 6, 12],
+        space_kind: Literal["HOLOMORPHIC", "CUSP"],
+        normalization: str,
+        q_expansion: TruncatedSeries,
+    ) -> Self:
+        """Construct a value after the owner kernel established its coefficients."""
 
-__all__ = ["LevelOneModularQExpansion"]
+        return cls.model_construct(
+            form=form,
+            weight=weight,
+            space_kind=space_kind,
+            normalization=normalization,
+            q_expansion=q_expansion,
+        )
+
+
+def verify_level_one_q_expansion(value: LevelOneModularQExpansion) -> bool:
+    """Boundedly verify an independently supplied named q-expansion."""
+
+    try:
+        require_level_one_replay(value.form, value.q_expansion.truncation_order)
+    except ValueError:
+        return False
+    expected = expected_coefficients(value.form, value.q_expansion.truncation_order)
+    actual = tuple(
+        coefficient.as_fraction() for coefficient in value.q_expansion.coefficients
+    )
+    return actual == expected
+
+
+__all__ = ["LevelOneModularQExpansion", "verify_level_one_q_expansion"]

--- a/src/jacobian/math/number_theory/_periodic_models.py
+++ b/src/jacobian/math/number_theory/_periodic_models.py
@@ -362,18 +362,6 @@ class PeriodicCongruenceUnionProfileRequest(PeriodicCongruenceUnionRequest):
         json_schema_extra=_periodic_request_schema_extra(profile=True)
     )
 
-    @model_validator(mode="after")
-    def require_materializable_profile(self) -> Self:
-        from jacobian.math.number_theory._periodic_kernel import (
-            require_materializable_periodic_source,
-        )
-
-        try:
-            require_materializable_periodic_source(self.normalized_source())
-        except ValueError as error:
-            raise _validation_error("backend_admission", str(error)) from error
-        return self
-
 
 class PeriodicCongruenceUnionMeasureResult(StrictModel):
     """Exact occupied count and density, bound to the normalized union source."""

--- a/src/jacobian/math/regular_languages/_models.py
+++ b/src/jacobian/math/regular_languages/_models.py
@@ -85,23 +85,6 @@ class TransitionParikhProfileRequest(StrictModel):
         description="Exact nonnegative number of transitions in every path.",
     )
 
-    @model_validator(mode="after")
-    def require_complete_bounded_profile(self) -> Self:
-        from jacobian.math.regular_languages._profile_admission import (
-            require_transition_profile_envelope,
-        )
-
-        try:
-            require_transition_profile_envelope(
-                self.automaton,
-                self.source_state,
-                self.target_state,
-                self.path_length,
-            )
-        except ValueError as exc:
-            raise _validation_error("profile_admission_rejected", str(exc)) from exc
-        return self
-
 
 class RunResult(RunRequest):
     """Whether a word was accepted and the final state reached."""

--- a/src/jacobian/math/regular_languages/_operations.py
+++ b/src/jacobian/math/regular_languages/_operations.py
@@ -88,12 +88,21 @@ def verify_transition_parikh_profile(
 ) -> bool:
     """Verify one independently supplied transition-Parikh profile claim."""
 
+    from jacobian.math.regular_languages._profile_admission import (
+        admit_transition_profile,
+    )
     from jacobian.math.regular_languages.operations import (
         _transition_parikh_profile_data,
     )
 
-    expected_entries, expected_total = _transition_parikh_profile_data(
+    plan = admit_transition_profile(
         profile.automaton,
+        profile.source_state,
+        profile.target_state,
+        profile.path_length,
+    )
+    expected_entries, expected_total = _transition_parikh_profile_data(
+        plan,
         profile.source_state,
         profile.target_state,
         profile.path_length,

--- a/src/jacobian/math/regular_languages/_profile_admission.py
+++ b/src/jacobian/math/regular_languages/_profile_admission.py
@@ -1,10 +1,12 @@
 """Bounded admission for transition-Parikh profiles.
 
 This is intentionally separate from ``_admission``: catalog registration
-imports owner tools, while request parsing must not re-enter those tools.
+imports owner tools, while the operation owner constructs the per-call plan.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
 
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.regular_languages.values import (
@@ -24,6 +26,14 @@ _AUTOMATON_BASE_WIRE_BYTES = 256
 _AUTOMATON_TRANSITION_WIRE_BYTES = 128
 _PROFILE_BASE_WIRE_BYTES = 256
 _PROFILE_ENTRY_BASE_WIRE_BYTES = 96
+
+
+@dataclass(frozen=True)
+class TransitionParikhAdmissionPlan:
+    """One admitted transition-profile execution envelope."""
+
+    expected_path_count: int
+    outgoing: tuple[tuple[AutomatonTransition, ...], ...]
 
 
 def _outgoing(
@@ -65,14 +75,13 @@ def _composition_bounds(transition_count: int, path_length: int) -> tuple[int, i
 
 
 def _path_count_and_walk_bound(
-    automaton: FiniteLabeledAutomaton,
+    outgoing: tuple[tuple[AutomatonTransition, ...], ...],
     source_state: int,
     target_state: int,
     path_length: int,
     composition_updates: int,
 ) -> tuple[int, int, int]:
     counts = {source_state: 1}
-    outgoing = _outgoing(automaton)
     updates = 0
     max_layer_paths = 1
     for _ in range(path_length):
@@ -95,13 +104,13 @@ def _path_count_and_walk_bound(
     return counts.get(target_state, 0), updates, max_layer_paths
 
 
-def require_transition_profile_envelope(
+def admit_transition_profile(
     automaton: FiniteLabeledAutomaton,
     source_state: int,
     target_state: int,
     path_length: int,
-) -> int:
-    """Preflight exact work, intermediates, digits, and wire size."""
+) -> TransitionParikhAdmissionPlan:
+    """Admit one exact transition-profile computation and retain its plan."""
 
     if not 0 <= source_state < automaton.state_count:
         raise ValueError("source_state must be in 0..state_count-1")
@@ -114,11 +123,12 @@ def require_transition_profile_envelope(
             "path_length exceeds the transition-Parikh preflight length bound"
         )
     transition_count = len(automaton.transitions)
+    outgoing = _outgoing(automaton)
     composition_cells, composition_updates = _composition_bounds(
         transition_count, path_length
     )
     target_count, walk_updates, max_layer_paths = _path_count_and_walk_bound(
-        automaton, source_state, target_state, path_length, composition_updates
+        outgoing, source_state, target_state, path_length, composition_updates
     )
     updates = min(walk_updates, composition_updates)
     if updates > _MAX_DP_UPDATES:
@@ -170,7 +180,10 @@ def require_transition_profile_envelope(
             "transition-Parikh serialized-result bound exceeded; reduce the "
             "transition axis or profile support"
         )
-    return target_count
+    return TransitionParikhAdmissionPlan(
+        expected_path_count=target_count,
+        outgoing=outgoing,
+    )
 
 
-__all__ = ["require_transition_profile_envelope"]
+__all__ = ["TransitionParikhAdmissionPlan", "admit_transition_profile"]

--- a/src/jacobian/math/regular_languages/operations.py
+++ b/src/jacobian/math/regular_languages/operations.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.regular_languages._profile_admission import (
-    require_transition_profile_envelope,
+    TransitionParikhAdmissionPlan,
+    admit_transition_profile,
 )
 from jacobian.math.regular_languages.values import (
     DFA,
@@ -89,30 +90,15 @@ def dfa_transition_carrier(dfa: DFA) -> FiniteLabeledAutomaton:
     )
 
 
-def _outgoing_transitions(
-    automaton: FiniteLabeledAutomaton,
-) -> tuple[tuple[AutomatonTransition, ...], ...]:
-    outgoing: list[list[AutomatonTransition]] = [
-        [] for _ in range(automaton.state_count)
-    ]
-    for transition in automaton.transitions:
-        outgoing[transition.source].append(transition)
-    return tuple(tuple(transitions) for transitions in outgoing)
-
-
 def _transition_parikh_profile_data(
-    automaton: FiniteLabeledAutomaton,
+    plan: TransitionParikhAdmissionPlan,
     source_state: int,
     target_state: int,
     path_length: int,
 ) -> tuple[tuple[tuple[tuple[int, ...], int], ...], int]:
-    """Compute canonical profile entries and an independent total path count."""
+    """Compute canonical profile entries inside one admitted envelope."""
 
-    expected_path_count = require_transition_profile_envelope(
-        automaton, source_state, target_state, path_length
-    )
-    transition_count = len(automaton.transitions)
-    outgoing = _outgoing_transitions(automaton)
+    transition_count = sum(len(transitions) for transitions in plan.outgoing)
     zero_vector = tuple(0 for _ in range(transition_count))
     layer: dict[tuple[int, tuple[int, ...]], int] = {(source_state, zero_vector): 1}
     for _ in range(path_length):
@@ -120,7 +106,7 @@ def _transition_parikh_profile_data(
             break
         next_layer: dict[tuple[int, tuple[int, ...]], int] = {}
         for (state, vector), multiplicity in layer.items():
-            for transition in outgoing[state]:
+            for transition in plan.outgoing[state]:
                 transition_id = transition.transition_id
                 updated = (
                     *vector[:transition_id],
@@ -136,7 +122,7 @@ def _transition_parikh_profile_data(
         if state == target_state
     )
     total_path_count = sum(multiplicity for _, multiplicity in target_entries)
-    if total_path_count != expected_path_count:
+    if total_path_count != plan.expected_path_count:
         raise RuntimeError(
             "transition-Parikh recurrence disagrees with independent path counting"
         )
@@ -151,8 +137,9 @@ def transition_parikh_profile(
 ) -> TransitionParikhProfile:
     """Return the exact transition-use histogram for fixed-endpoint paths."""
 
+    plan = admit_transition_profile(automaton, source_state, target_state, path_length)
     target_entries, total_path_count = _transition_parikh_profile_data(
-        automaton, source_state, target_state, path_length
+        plan, source_state, target_state, path_length
     )
     return TransitionParikhProfile._from_kernel(
         automaton=automaton,

--- a/src/jacobian/math/symbolic_dynamics/_models.py
+++ b/src/jacobian/math/symbolic_dynamics/_models.py
@@ -14,7 +14,6 @@ from jacobian.math.polynomials.values import RationalFunction, RationalPolynomia
 from jacobian.math.symbolic_dynamics._bounds import (
     MAX_ZETA_REPLAY_PERIOD,
     enumeration_size,
-    normalize_forbidden_blocks,
     presentation_memory,
     require_bounded_presentation,
     require_bounded_support,
@@ -49,30 +48,12 @@ def _validation_error_from_message(error: ValueError) -> PydanticCustomError:
 class FiniteTypeShiftRequest(StrictModel):
     shift: ForbiddenBlockShift
 
-    @model_validator(mode="after")
-    def require_bounded_presentation(self) -> Self:
-        memory = presentation_memory(self.shift)
-        try:
-            require_bounded_presentation(self.shift, memory)
-        except ValueError as error:
-            raise _validation_error_from_message(error) from error
-        return self
-
 
 class FiniteTypeShiftResult(FiniteTypeShiftRequest):
     presentation: BlockPresentation
     normalized_forbidden_blocks: tuple[tuple[str, ...], ...]
     complete: Literal[True] = True
     method: Literal["EXACT_DE_BRUIJN_PRESENTATION"] = "EXACT_DE_BRUIJN_PRESENTATION"
-
-    @model_validator(mode="after")
-    def require_normalized_forbidden_blocks(self) -> Self:
-        if self.normalized_forbidden_blocks != normalize_forbidden_blocks(self.shift):
-            raise _validation_error(
-                "finite_type_presentation_not_bound",
-                "normalized forbidden blocks are not bound to the request",
-            )
-        return self
 
 
 class BlockLanguageRequest(StrictModel):
@@ -273,8 +254,8 @@ def _from_kernel_finite_type_shift(
 ) -> FiniteTypeShiftResult:
     """Construct a presentation result from its trusted owner kernel."""
 
-    return FiniteTypeShiftResult(
-        **request.model_dump(),
+    return FiniteTypeShiftResult.model_construct(
+        shift=request.shift,
         presentation=presentation,
         normalized_forbidden_blocks=normalized_forbidden_blocks,
     )

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -764,20 +764,6 @@ class BarycentricSubdivisionRequest(StrictModel):
 
     complex: SimplicialComplexRequest
 
-    @model_validator(mode="after")
-    def require_barycentric_work_bounds(self) -> Self:
-        closure = face_closure(tuple(tuple(sorted(f)) for f in self.complex.facets))
-        face_count = sum(len(part) for part in closure)
-        if face_count > 31:
-            raise _validation_error(
-                "topology.require_barycentric_work_bounds_1",
-                f"barycentric subdivision requires at most 31 faces (got {face_count}); "
-                "input would produce >128 subdivision facets exceeding result contract",
-            )
-        # Additional check: subdivision of a 5-vertex simplex has 120 facets within 128 limit;
-        # 6-vertex simplex would have 720 >128, so 31 is safe.
-        return self
-
 
 class BarycentricSubdivisionResult(TopologyExactResult):
     """The barycentric subdivision as a facet list."""

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -696,6 +696,11 @@ def compute_barycentric_subdivision(
     sorted_faces = sorted(
         _all_faces(request.complex.facets), key=lambda face: (len(face), face)
     )
+    if len(sorted_faces) > 31:
+        raise ValueError(
+            "barycentric subdivision requires at most 31 faces; "
+            "input would produce more than 128 subdivision facets"
+        )
     subdivision = barycentric_subdivision(sorted_faces)
     facets = tuple(sorted(tuple(sorted(facet)) for facet in subdivision.facets))
     return BarycentricSubdivisionResult._from_kernel(

--- a/src/jacobian/math/tree_automata/_models.py
+++ b/src/jacobian/math/tree_automata/_models.py
@@ -168,38 +168,14 @@ class TreeAutomatonReachabilityRequest(StrictModel):
             f"nondeterministic bottom-up tree automaton with at most "
             f"{MAX_TA_STATES} states, {MAX_TA_SYMBOLS} ranked symbols, and "
             f"{MAX_TA_TRANSITIONS} unique transitions. "
-            "Requests are additionally rejected when the coupled "
+            "Execution is bounded by the coupled "
             "reachability work envelope (MAX_TREE_AUTOMATON_REACHABILITY_"
-            f"WORK = {MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units, priced across the three passes behind "
-            "work admission, request admission, and execution "
-            "pass) or the "
+            f"WORK = {MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units for one owner-local saturation pass) or the "
             "aggregate witness output envelope (MAX_REACHABILITY_WITNESS_"
             f"NODES = {MAX_REACHABILITY_WITNESS_NODES} nodes summed across every reachable state's "
             "minimum witness) is exceeded"
         ),
     )
-
-    @model_validator(mode="after")
-    def require_bounded_witness_profile(self) -> Self:
-        from jacobian.math.tree_automata.values import (
-            reachability_admission_profile,
-            reachability_public_path_work_bound,
-        )
-
-        if reachability_public_path_work_bound(self.automaton) > (
-            MAX_TREE_AUTOMATON_REACHABILITY_WORK
-        ):
-            raise _validation_error(
-                "reachability_work_bound",
-                "tree automaton reachability work bound exceeded",
-            )
-        try:
-            reachability_admission_profile(self.automaton)
-        except ValueError as exc:
-            if "witness output" in str(exc):
-                raise _validation_error("witness_output_bound", str(exc)) from exc
-            raise
-        return self
 
 
 __all__ = [

--- a/src/jacobian/math/tree_automata/values.py
+++ b/src/jacobian/math/tree_automata/values.py
@@ -394,20 +394,9 @@ def reachability_execution_work_bound(automaton: BottomUpTreeAutomaton) -> int:
 
 
 def reachability_public_path_work_bound(automaton: BottomUpTreeAutomaton) -> int:
-    """Price request-bound evaluation, admission profile, and kernel profile.
+    """Price the single owner-local saturation pass on the public path."""
 
-    A result model no longer replays the kernel.  The public operation thus
-    executes three sorted saturation passes: measuring the request bound,
-    materializing the request's witness envelope, and producing the result.
-    Only the latter two materialize witnesses.
-    """
-
-    sort_work, per_scan_work, scan_rounds = reachability_price_components(automaton)
-    return (
-        3 * sort_work
-        + 3 * scan_rounds * per_scan_work
-        + 2 * 3 * MAX_REACHABILITY_WITNESS_NODES
-    )
+    return reachability_execution_work_bound(automaton)
 
 
 def _transition_key(

--- a/tests/math/additive_combinatorics/test_multiset_sum.py
+++ b/tests/math/additive_combinatorics/test_multiset_sum.py
@@ -29,6 +29,7 @@ from jacobian.math.additive_combinatorics._multiset_sum import (
 )
 from jacobian.math.additive_combinatorics._operations import (
     compute_multiset_sum_representation_profile,
+    compute_representation_profile,
     verify_multiset_sum_representation_profile,
 )
 
@@ -357,8 +358,9 @@ def test_request_rejects_enumeration_above_work_bound() -> None:
 def test_widened_source_axis_preserves_cartesian_pair_bound() -> None:
     left = FiniteIntegerSet(elements=tuple(str(i) for i in range(257)))
     right = FiniteIntegerSet(elements=tuple(str(i) for i in range(256)))
-    with pytest.raises(ValidationError):
-        RepresentationProfileRequest(left=left, right=right)
+    request = RepresentationProfileRequest(left=left, right=right)
+    with pytest.raises(ValueError):
+        compute_representation_profile(request)
 
 
 def test_near_maximal_full_profile_stays_inside_owner_result_budget() -> None:

--- a/tests/math/additive_combinatorics/test_subset_sum_profile.py
+++ b/tests/math/additive_combinatorics/test_subset_sum_profile.py
@@ -183,21 +183,21 @@ def test_widened_source_contract_admits_beyond_legacy_multiplicity_digits() -> N
     assert len(result.total_subsets) > len(str(1 << 256))
 
 
-def test_profile_work_above_bound_is_rejected_before_execution() -> None:
+def test_profile_work_above_bound_is_rejected_by_owner_execution() -> None:
     items = tuple(1 << exponent for exponent in range(14)) + (0,) * (
         MAX_SUBSET_SUM_ITEMS - 14
     )
 
-    with pytest.raises(ValidationError):
-        _request(*items)
+    with pytest.raises(ValueError, match="DP transitions"):
+        compute_subset_sum_profile(_request(*items))
 
 
-def test_profile_result_above_bound_is_rejected_before_execution() -> None:
+def test_profile_result_above_bound_is_rejected_by_owner_execution() -> None:
     offset = 10 ** (MAX_SUBSET_SUM_ITEM_DIGITS - 1)
     items = tuple(offset + (1 << exponent) for exponent in range(15))
 
-    with pytest.raises(ValidationError):
-        _request(*items)
+    with pytest.raises(ValueError, match="result"):
+        compute_subset_sum_profile(_request(*items))
 
 
 def test_large_accepted_profile_stays_inside_declared_result_budget() -> None:

--- a/tests/math/algebraic_combinatorics/test_rsk_word.py
+++ b/tests/math/algebraic_combinatorics/test_rsk_word.py
@@ -299,8 +299,10 @@ def test_word_length_and_utf8_payload_bounds_are_closed() -> None:
     too_long = FiniteWord.model_construct(
         alphabet=("a",), letters=("a",) * (MAX_RSK_WORD_LENGTH + 1)
     )
-    with pytest.raises(ValidationError):
-        RSKWordRequest(word=too_long)
+    with pytest.raises(
+        ValueError, match=rf"length must not exceed {MAX_RSK_WORD_LENGTH}"
+    ):
+        compute_rsk_word(RSKWordRequest(word=too_long))
     with pytest.raises(
         ValueError, match=rf"length must not exceed {MAX_RSK_WORD_LENGTH}"
     ):

--- a/tests/math/code_nonlinear/test_code_nonlinear.py
+++ b/tests/math/code_nonlinear/test_code_nonlinear.py
@@ -242,9 +242,9 @@ class TestWordDistance:
     def test_all_different_maximal_words_still_exceed_the_result_bound(self) -> None:
         left = [0] * MAX_EXPLICIT_CODE_LENGTH
         right = [1] * MAX_EXPLICIT_CODE_LENGTH
-        with pytest.raises(ValidationError) as exc_info:
-            WordDistanceRequest(word1=left, word2=right)
-        assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
+        request = WordDistanceRequest(word1=left, word2=right)
+        with pytest.raises(ValueError, match="result can use"):
+            compute_word_distance(request)
         payload = {
             "word1": left,
             "word2": right,
@@ -274,9 +274,9 @@ class TestWordDistance:
             MAX_EXPLICIT_CODE_LENGTH - 300_000, MAX_EXPLICIT_CODE_LENGTH
         ):
             high[index] = 1
-        with pytest.raises(ValidationError) as exc_info:
-            WordDistanceRequest(word1=left, word2=high)
-        assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
+        request = WordDistanceRequest(word1=left, word2=high)
+        with pytest.raises(ValueError, match="result can use"):
+            compute_word_distance(request)
 
 
 class TestExplicitProfile:
@@ -480,12 +480,9 @@ class TestConstantWeightProfile:
         assert result.maximum_distance_witness is None
 
     def test_rejects_mixed_weight_source(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
-            ConstantWeightProfileRequest(code=_code((0, 0, 1, 1), (1, 1, 1, 0)))
-        assert (
-            exc_info.value.errors()[0]["type"]
-            == "nonlinear_code.constant_weight_mismatch"
-        )
+        request = ConstantWeightProfileRequest(code=_code((0, 0, 1, 1), (1, 1, 1, 0)))
+        with pytest.raises(ValueError, match="all codewords"):
+            compute_constant_weight_profile(request)
 
     @pytest.mark.parametrize(
         ("field", "replacement"),
@@ -627,11 +624,11 @@ class TestDerivedAdmissionBoundaries:
         )
         assert require_profile_admission(accepted.code).pair_count == 4_997_541
         assert require_profile_admission(accepted.code).pair_count <= MAX_PROFILE_PAIRS
-        with pytest.raises(ValidationError) as exc_info:
-            ExplicitProfileRequest(
-                code=ExplicitBinaryCode(length=12, codewords=_binary_words(12, 3_163))
-            )
-        assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
+        request = ExplicitProfileRequest(
+            code=ExplicitBinaryCode(length=12, codewords=_binary_words(12, 3_163))
+        )
+        with pytest.raises(ValueError, match="unordered pairs"):
+            compute_explicit_profile(request)
 
     def test_bitset_chunk_work_immediate_boundary(self) -> None:
         accepted = ExplicitProfileRequest(
@@ -641,11 +638,11 @@ class TestDerivedAdmissionBoundaries:
         assert plan.pair_count == 3_332_071
         assert plan.bitset_chunks == 3
         assert plan.bitset_chunk_work == 9_996_213
-        with pytest.raises(ValidationError) as exc_info:
-            ExplicitProfileRequest(
-                code=ExplicitBinaryCode(length=90, codewords=_binary_words(90, 2_583))
-            )
-        assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
+        request = ExplicitProfileRequest(
+            code=ExplicitBinaryCode(length=90, codewords=_binary_words(90, 2_583))
+        )
+        with pytest.raises(ValueError, match="pair-by-bitset-chunk"):
+            compute_explicit_profile(request)
 
     def test_profile_output_size_immediate_boundary(self) -> None:
         accepted_length = 100_770
@@ -660,15 +657,15 @@ class TestDerivedAdmissionBoundaries:
             require_profile_admission(accepted.code).result_wire_upper_bound
             <= MAX_CODE_RESULT_BYTES
         )
-        with pytest.raises(ValidationError) as exc_info:
-            ExplicitProfileRequest(
-                code=_code(
-                    (0,) * (accepted_length + 1),
-                    (1,) * (accepted_length + 1),
-                    length=accepted_length + 1,
-                )
+        request = ExplicitProfileRequest(
+            code=_code(
+                (0,) * (accepted_length + 1),
+                (1,) * (accepted_length + 1),
+                length=accepted_length + 1,
             )
-        assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
+        )
+        with pytest.raises(ValueError, match="canonical JSON bytes"):
+            compute_explicit_profile(request)
 
     @pytest.mark.parametrize("length", [200_000, MAX_EXPLICIT_CODE_LENGTH])
     def test_empty_profile_charges_no_witnesses_and_fits_output_bound(
@@ -708,11 +705,11 @@ class TestDerivedAdmissionBoundaries:
     def test_set_system_output_size_immediate_boundary(self) -> None:
         accepted_length = 275_963
         ToSetSystemRequest(code=_code((1,) * accepted_length, length=accepted_length))
-        with pytest.raises(ValidationError) as exc_info:
-            ToSetSystemRequest(
-                code=_code((1,) * (accepted_length + 1), length=accepted_length + 1)
-            )
-        assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
+        request = ToSetSystemRequest(
+            code=_code((1,) * (accepted_length + 1), length=accepted_length + 1)
+        )
+        with pytest.raises(ValueError, match="canonical JSON bytes"):
+            compute_to_set_system(request)
 
     @pytest.mark.parametrize(
         ("length", "weight", "expected"),
@@ -742,21 +739,21 @@ class TestDerivedAdmissionBoundaries:
         assert "Exceeds the limit" not in message
         assert f"{MAX_EXPLICIT_CODE_LENGTH} coordinates * {weight + 1} words" in message
 
-    def test_constant_weight_request_rejects_at_the_immediate_entry_boundary(
+    def test_constant_weight_owner_rejects_at_the_immediate_entry_boundary(
         self,
     ) -> None:
         ConstantWeightRequest.model_validate({"length": 101, "weight": 2})
-        with pytest.raises(ValidationError) as exc_info:
-            ConstantWeightRequest.model_validate({"length": 102, "weight": 2})
-        assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
-        with pytest.raises(ValidationError) as exc_info:
-            ConstantWeightRequest.model_validate(
-                {
-                    "length": MAX_EXPLICIT_CODE_LENGTH,
-                    "weight": MAX_EXPLICIT_CODE_LENGTH // 2,
-                }
-            )
-        assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
+        request = ConstantWeightRequest.model_validate({"length": 102, "weight": 2})
+        with pytest.raises(ValueError, match="entry bound"):
+            compute_constant_weight(request)
+        request = ConstantWeightRequest.model_validate(
+            {
+                "length": MAX_EXPLICIT_CODE_LENGTH,
+                "weight": MAX_EXPLICIT_CODE_LENGTH // 2,
+            }
+        )
+        with pytest.raises(ValueError, match="entry bound"):
+            compute_constant_weight(request)
 
 
 class TestCanonicalConsumers:
@@ -790,9 +787,9 @@ class TestCanonicalConsumers:
         assert axis.code.codewords == ((0,) * MAX_EXPLICIT_CODE_LENGTH,)
 
     def test_constant_weight_admission_rejects_central_binomial_work(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
-            ConstantWeightRequest.model_validate({"length": 64, "weight": 32})
-        assert exc_info.value.errors()[0]["type"] == "nonlinear_code.admission_bound"
+        request = ConstantWeightRequest.model_validate({"length": 64, "weight": 32})
+        with pytest.raises(ValueError, match="entry bound"):
+            compute_constant_weight(request)
         properties = ConstantWeightRequest.model_json_schema()["properties"]
         assert properties["length"]["maximum"] == MAX_EXPLICIT_CODE_LENGTH
 

--- a/tests/math/crossed_products/test_crossed_products.py
+++ b/tests/math/crossed_products/test_crossed_products.py
@@ -413,8 +413,9 @@ def test_request_rejects_pairwise_convolution_before_expansion() -> None:
         {"a": {(position,) for position in range(convolution_side)}},
     )
 
+    request = CrossedProductMultiplyRequest(left=left, right=right)
     with pytest.raises(ValueError, match=rf"{MAX_CONVOLUTION_PAIRS}-pair"):
-        CrossedProductMultiplyRequest(left=left, right=right)
+        compute_product(request)
 
 
 def test_request_rejects_scalar_work_before_expansion() -> None:
@@ -431,8 +432,9 @@ def test_request_rejects_scalar_work_before_expansion() -> None:
     left = _element(presentation, {"e": support})
     right = _element(presentation, {"a": support})
 
+    request = CrossedProductMultiplyRequest(left=left, right=right)
     with pytest.raises(ValueError, match="scalar-work"):
-        CrossedProductMultiplyRequest(left=left, right=right)
+        compute_product(request)
 
 
 def test_request_rejects_predicted_exponent_growth_before_expansion() -> None:
@@ -441,8 +443,9 @@ def test_request_rejects_predicted_exponent_growth_before_expansion() -> None:
     left = _element(presentation, {"a": {(0, 0)}})
     right = _element(presentation, {"e": {(0, int("9" * 64))}})
 
+    request = CrossedProductMultiplyRequest(left=left, right=right)
     with pytest.raises(ValueError, match="predicted product exponents"):
-        CrossedProductMultiplyRequest(left=left, right=right)
+        compute_product(request)
 
 
 def test_owner_declares_only_the_admitted_atomic_operation() -> None:

--- a/tests/math/finite_categories/test_finite_categories.py
+++ b/tests/math/finite_categories/test_finite_categories.py
@@ -414,15 +414,11 @@ class TestProduct:
         accepted = product(_discrete_category(32, "L"), _discrete_category(32, "R"))
         assert len(accepted.product.objects) == 1_024
 
-        with pytest.raises(ValidationError) as error:
-            CategoryProductRequest(
-                left=_discrete_category(33, "L"),
-                right=_discrete_category(32, "R"),
-            )
-        assert (
-            error.value.errors()[0]["type"]
-            == "finite_category.product_object_count_budget"
+        request = CategoryProductRequest(
+            left=_discrete_category(33, "L"), right=_discrete_category(32, "R")
         )
+        with pytest.raises(ValueError, match="object"):
+            compute_category_product(request)
 
     def test_composable_triple_count_is_accepted_and_rejected_at_boundary(
         self,
@@ -430,27 +426,19 @@ class TestProduct:
         accepted = product(_cyclic_group_category(6), _cyclic_group_category(10))
         assert len(accepted.product.morphisms) == 60
 
-        with pytest.raises(ValidationError) as error:
-            CategoryProductRequest(
-                left=_cyclic_group_category(7),
-                right=_cyclic_group_category(9),
-            )
-        assert (
-            error.value.errors()[0]["type"]
-            == "finite_category.product_composable_triple_budget"
+        request = CategoryProductRequest(
+            left=_cyclic_group_category(7), right=_cyclic_group_category(9)
         )
+        with pytest.raises(ValueError, match="triple"):
+            compute_category_product(request)
 
     def test_wire_preflight_is_result_sensitive_to_identifier_size(self) -> None:
         short = _parallel_arrow_category(50, 4)
         CategoryProductRequest(left=short, right=short)
 
         long = _parallel_arrow_category(50, 64)
-        with pytest.raises(ValidationError) as error:
-            CategoryProductRequest(left=long, right=long)
-        assert (
-            error.value.errors()[0]["type"]
-            == "finite_category.product_wire_size_budget"
-        )
+        with pytest.raises(ValueError, match="wire"):
+            compute_category_product(CategoryProductRequest(left=long, right=long))
 
     def test_identifier_nesting_is_bounded_before_another_product(self) -> None:
         terminal = FiniteCategory(**TERMINAL_CATEGORY)

--- a/tests/math/finite_dim_algebras/test_finite_dim_algebras.py
+++ b/tests/math/finite_dim_algebras/test_finite_dim_algebras.py
@@ -145,36 +145,6 @@ def test_center_admits_derived_dimension_boundary() -> None:
     assert request.algebra.dimension == 128 == MAX_DIM
 
 
-def test_center_rejects_above_derived_dimension_boundary() -> None:
-    """The center-specific guard rejects below MAX_DIM when patched lower.
-
-    ``StructureConstants`` already caps dimension at ``MAX_DIM`` = 128, so a
-    plain 129-dimension request would never reach the center validator.  To
-    exercise ``require_bounded_center_work`` in isolation, build a valid
-    128-dimension algebra and patch the center operation's own cap to 32:
-    only the center guard can then fire, and deleting it would fail this test.
-    """
-    from pydantic import ValidationError
-
-    from jacobian.math.finite_dim_algebras import _models
-
-    n, q = 128, 251
-    zero_inner = tuple(0 for _ in range(n))
-    mult = tuple(tuple(zero_inner for _ in range(n)) for _ in range(n))
-    struct = StructureConstants(dimension=n, field_order=q, multiplication=mult)
-    monkeypatch_cap = pytest.MonkeyPatch()
-    try:
-        monkeypatch_cap.setattr(_models, "_MAX_DIM_FOR_CENTER", 32)
-        with pytest.raises(ValidationError) as error:
-            CenterRequest(algebra=struct)
-        assert (
-            error.value.errors()[0]["type"]
-            == "finite_dim_algebra.center_dimension_limit"
-        )
-    finally:
-        monkeypatch_cap.undo()
-
-
 def test_structure_constants_rejects_above_its_own_field_cap() -> None:
     """The shared structure-constants cap (128) is independent of the center guard."""
     from pydantic import ValidationError

--- a/tests/math/finite_fields/test_tools.py
+++ b/tests/math/finite_fields/test_tools.py
@@ -18,6 +18,7 @@ from jacobian.math.finite_fields import (
     RankResult,
     element,
     finite_field,
+    finite_map_table,
     finite_polynomial,
     finite_polynomial_map,
     projective_line,
@@ -88,16 +89,13 @@ def test_projective_enumeration_refuses_large_output_before_allocation() -> None
 def test_finite_map_table_refuses_excessive_polynomial_work() -> None:
     presentation = finite_field(2, (1, 1, 0, 1, 1, 0, 0, 0, 1))
     one = element(presentation, (1,) + (0,) * 7)
-    with pytest.raises(ValidationError) as error:
-        FiniteMapTableRequest(
-            polynomial_map=finite_polynomial_map(
-                finite_polynomial(presentation, (one,) * 512)
-            )
+    request = FiniteMapTableRequest(
+        polynomial_map=finite_polynomial_map(
+            finite_polynomial(presentation, (one,) * 512)
         )
-    assert (
-        error.value.errors()[0]["type"]
-        == "finite_field.finite_map_exceeds_operation_work_budget"
     )
+    with pytest.raises(ValueError, match="operation work budget"):
+        finite_map_table(request.polynomial_map)
 
 
 def test_direction_rank_ledger_refuses_excessive_aggregate_work() -> None:

--- a/tests/math/formal_concept_analysis/test_duquenne_guigues_basis.py
+++ b/tests/math/formal_concept_analysis/test_duquenne_guigues_basis.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from itertools import combinations
 
 import pytest
-from pydantic import ValidationError
 
 from jacobian.math.formal_concept_analysis import (
     CanonicalImplicationBasisResult,
@@ -171,18 +170,18 @@ def test_empty_basis_and_empty_premise_boundary_contexts() -> None:
         _context(((0, 1), (0, 2), (0,), ()), 3),
     ),
 )
-def test_chain_and_diamond_contexts_replay_every_subset(
+def test_chain_and_diamond_contexts_match_every_subset_closure(
     context: FormalContext,
 ) -> None:
     result = duquenne_guigues_basis(context)
 
     assert len(result.closure_matrix) == 1 << len(context.attributes)
     for closure_row in result.closure_matrix:
-        replay = implication_closure(
+        closure_result = implication_closure(
             result.basis,
             frozenset(closure_row.subset),
         )
-        assert replay.closure == closure_row.closure
+        assert closure_result.closure == closure_row.closure
 
 
 def test_every_binary_two_by_three_context_matches_definition_oracle() -> None:
@@ -331,14 +330,16 @@ def test_candidate_work_and_output_envelopes_at_boundary() -> None:
     result = compute_duquenne_guigues_basis(request)
     assert result.work.candidate_states == MAX_DG_CANDIDATE_STATES
     assert result.work.context_object_row_checks == (
-        3 * MAX_DG_CANDIDATE_STATES * MAX_DG_ATTRIBUTES
+        MAX_DG_CANDIDATE_STATES * MAX_DG_ATTRIBUTES
     )
     assert 0 < result.work.reserved_logical_work < MAX_DG_LOGICAL_WORK
     assert result.work.reserved_result_bytes <= MAX_DG_RESULT_BYTES
 
     over_boundary = _contranominal_context(MAX_DG_ATTRIBUTES + 1)
-    with pytest.raises(ValidationError):
-        DuquenneGuiguesBasisRequest(context=over_boundary)
+    with pytest.raises(ValueError, match="candidate-state"):
+        compute_duquenne_guigues_basis(
+            DuquenneGuiguesBasisRequest(context=over_boundary)
+        )
     with pytest.raises(ValueError, match="candidate-state"):
         duquenne_guigues_basis(over_boundary)
 
@@ -354,7 +355,7 @@ def test_exact_basis_beyond_canonical_implication_carrier_is_rejected() -> None:
         _require_dg_canonical_carrier_fit(dense_pairs)
 
 
-def test_work_accounting_includes_every_probe_pass_and_replay() -> None:
+def test_work_accounting_includes_one_plan_and_closure_equivalence() -> None:
     context = _context(((0, 3), (0, 2), (1, 2), (1, 2, 3)), 4)
     result = duquenne_guigues_basis(context)
 
@@ -397,21 +398,20 @@ def test_work_accounting_includes_every_probe_pass_and_replay() -> None:
 
     work = result.work
 
-    assert work.context_closure_queries == 4 * states
-    assert work.context_object_row_checks == (3 * states * len(context.objects))
-    assert work.context_incidence_loads == 3 * len(context.incidence)
-    assert work.context_row_intersections == 4 * row_intersections
-    assert work.pseudo_intent_subset_comparisons == 3 * subset_comparisons
-    assert work.pseudo_intent_closure_comparisons == 3 * closure_comparisons
-    assert work.basis_closure_queries == 2 * states
+    assert work.context_closure_queries == states
+    assert work.context_object_row_checks == states * len(context.objects)
+    assert work.context_incidence_loads == len(context.incidence)
+    assert work.context_row_intersections == row_intersections
+    assert work.pseudo_intent_subset_comparisons == subset_comparisons
+    assert work.pseudo_intent_closure_comparisons == closure_comparisons
+    assert work.basis_closure_queries == states
     assert work.accounted_logical_work == (
         work.context_object_row_checks
         + work.context_incidence_loads
         + work.context_row_intersections
-        + work.context_incidence_checks
         + work.pseudo_intent_subset_comparisons
         + work.pseudo_intent_closure_comparisons
-        + 2 * work.basis_canonical_replay_work
+        + work.basis_closure_work
         + work.closure_matrix_memberships
         + work.pseudo_intent_memberships
         + work.implication_memberships
@@ -428,7 +428,7 @@ def test_native_and_catalog_invocations_report_identical_exact_work() -> None:
     )
 
     assert native == via_request
-    assert native.work.context_closure_queries == 4 * len(native.closure_matrix)
+    assert native.work.context_closure_queries == len(native.closure_matrix)
 
 
 def test_result_byte_reservation_accepts_its_last_byte_and_rejects_the_next() -> None:
@@ -439,8 +439,8 @@ def test_result_byte_reservation_accepts_its_last_byte_and_rejects_the_next() ->
             incidence=(),
         )
         try:
-            DuquenneGuiguesBasisRequest(context=context)
-        except ValidationError:
+            duquenne_guigues_basis(context)
+        except ValueError:
             return False
         return True
 

--- a/tests/math/hypergraphs/test_edge_intersections.py
+++ b/tests/math/hypergraphs/test_edge_intersections.py
@@ -33,7 +33,9 @@ NONLINEAR = {
 
 
 def _profile(source: object) -> EdgeIntersectionsResult:
-    return compute_edge_intersections(EdgeIntersectionsRequest(hypergraph=source))
+    return compute_edge_intersections(
+        EdgeIntersectionsRequest.model_validate({"hypergraph": source})
+    )
 
 
 class TestEdgeIntersections:
@@ -245,13 +247,16 @@ class TestEdgeIntersectionPreflight:
     def test_immediately_larger_intersection_cell_family_is_rejected(self) -> None:
         vertices = tuple(f"v{i:02}" for i in range(14))
 
-        with pytest.raises(ValidationError):
-            EdgeIntersectionsRequest(
-                hypergraph={
+        request = EdgeIntersectionsRequest.model_validate(
+            {
+                "hypergraph": {
                     "vertices": vertices,
                     "edges": tuple((f"e{i:03}", vertices) for i in range(100)),
                 }
-            )
+            }
+        )
+        with pytest.raises(ValueError, match="intersection-cell"):
+            compute_edge_intersections(request)
 
     def test_sparse_overlap_family_uses_exact_incidence_cell_count(self) -> None:
         vertices = tuple(f"v{i:03}" for i in range(100))
@@ -302,13 +307,16 @@ class TestEdgeIntersectionPreflight:
         # making the complete 64,350-membership ledger exceed 10 MiB.
         vertices = tuple(chr(codepoint) * 64 for codepoint in range(1, 14))
 
-        with pytest.raises(ValidationError):
-            EdgeIntersectionsRequest(
-                hypergraph={
+        request = EdgeIntersectionsRequest.model_validate(
+            {
+                "hypergraph": {
                     "vertices": vertices,
                     "edges": tuple((f"e{i:03}", vertices) for i in range(100)),
                 }
-            )
+            }
+        )
+        with pytest.raises(ValueError, match="canonical output limit"):
+            compute_edge_intersections(request)
 
     def test_output_bound_preserves_exact_non_normalized_label_bytes(self) -> None:
         # Each 63-code-point label is 189 UTF-8 bytes, but NFC would compose
@@ -320,13 +328,16 @@ class TestEdgeIntersectionPreflight:
             (chr(0x1100 + index) + "\u1161\u11a8") * 21 for index in range(13)
         )
 
-        with pytest.raises(ValidationError):
-            EdgeIntersectionsRequest(
-                hypergraph={
+        request = EdgeIntersectionsRequest.model_validate(
+            {
+                "hypergraph": {
                     "vertices": vertices,
                     "edges": tuple((f"e{i:03}", vertices) for i in range(100)),
                 }
-            )
+            }
+        )
+        with pytest.raises(ValueError, match="canonical output limit"):
+            compute_edge_intersections(request)
 
     def test_schema_exposes_complete_profile_bounds(self) -> None:
         request_schema = EdgeIntersectionsRequest.model_json_schema()

--- a/tests/math/modular_forms/test_level_one_q_expansions.py
+++ b/tests/math/modular_forms/test_level_one_q_expansions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from typing import Literal
+from typing import Literal, cast
 
 import pytest
 from pydantic import ValidationError
@@ -18,6 +18,7 @@ from jacobian.math.modular_forms import kernel as level_one_kernel
 from jacobian.math.modular_forms._models import LevelOneNamedQExpansionRequest
 from jacobian.math.modular_forms.kernel import (
     NAMED_LEVEL_ONE_FORMS,
+    NamedLevelOneModularForm,
     divisor_power_sum,
     eisenstein_coefficients,
     metadata,
@@ -25,7 +26,10 @@ from jacobian.math.modular_forms.kernel import (
     require_level_one_replay,
 )
 from jacobian.math.modular_forms.operations import _series, level_one_named_q_expansion
-from jacobian.math.modular_forms.values import LevelOneModularQExpansion
+from jacobian.math.modular_forms.values import (
+    LevelOneModularQExpansion,
+    verify_level_one_q_expansion,
+)
 
 
 def _integers(expansion: LevelOneModularQExpansion) -> tuple[int, ...]:
@@ -113,17 +117,17 @@ def test_eisenstein_prefixes_beyond_the_former_carrier_ceiling_are_admitted() ->
 
 
 def test_requests_above_the_serialized_budget_name_the_controlling_quantity() -> None:
-    with pytest.raises(ValidationError) as error:
-        LevelOneNamedQExpansionRequest(form="E6", truncation_order=1301)
-    assert _validation_type(error) == "modular_forms.serialized_result_bound"
+    request = LevelOneNamedQExpansionRequest(form="E6", truncation_order=1301)
+    with pytest.raises(ValueError, match="serialized result bound"):
+        level_one_named_q_expansion(request.form, request.truncation_order)
     with pytest.raises(ValueError, match="serialized result bound"):
         require_level_one_admission("E4", 1478)
 
 
 def test_delta_above_the_work_budget_names_the_controlling_quantity() -> None:
-    with pytest.raises(ValidationError) as error:
-        LevelOneNamedQExpansionRequest(form="DELTA", truncation_order=601)
-    assert _validation_type(error) == "modular_forms.exact_work_bound"
+    request = LevelOneNamedQExpansionRequest(form="DELTA", truncation_order=601)
+    with pytest.raises(ValueError, match="exact work bound"):
+        level_one_named_q_expansion(request.form, request.truncation_order)
     with pytest.raises(ValueError, match="exact work bound"):
         require_level_one_admission("DELTA", 601)
 
@@ -149,48 +153,53 @@ def test_native_admission_rejects_unknown_forms_before_any_scan(
 
     monkeypatch.setattr(level_one_kernel, "divisor_power_sum", fail)
     with pytest.raises(ValueError, match="form must be one of 'E4', 'E6', or 'DELTA'"):
-        level_one_named_q_expansion(form, 8)
+        level_one_named_q_expansion(cast(NamedLevelOneModularForm, form), 8)
     with pytest.raises(ValueError, match="form must be one of 'E4', 'E6', or 'DELTA'"):
-        require_level_one_admission(form, 8)
+        require_level_one_admission(cast(NamedLevelOneModularForm, form), 8)
     with pytest.raises(ValueError, match="form must be one of 'E4', 'E6', or 'DELTA'"):
-        require_level_one_replay(form, 8)
+        require_level_one_replay(cast(NamedLevelOneModularForm, form), 8)
 
 
 @pytest.mark.parametrize("form", ["E4", "E6", "DELTA"])
-def test_every_closed_family_member_is_admitted_at_order_one(form: str) -> None:
+def test_every_closed_family_member_is_admitted_at_order_one(
+    form: NamedLevelOneModularForm,
+) -> None:
     assert form in NAMED_LEVEL_ONE_FORMS
-    assert require_level_one_admission(form, 1) is None
-    assert require_level_one_replay(form, 1) is None
+    require_level_one_admission(form, 1)
+    require_level_one_replay(form, 1)
 
 
 def test_wire_request_rejects_unknown_form_names() -> None:
     with pytest.raises(ValidationError) as error:
-        LevelOneNamedQExpansionRequest(form="E5", truncation_order=8)
+        LevelOneNamedQExpansionRequest(
+            form=cast(NamedLevelOneModularForm, "E5"), truncation_order=8
+        )
     assert _validation_type(error) == "literal_error"
 
 
-def test_value_rejects_forged_coefficient_during_replay() -> None:
+def test_explicit_verifier_rejects_forged_coefficient() -> None:
     result = level_one_named_q_expansion("E4", 3)
     payload = result.model_dump()
-    q_expansion = payload["q_expansion"]
+    q_expansion = cast(dict[str, object], payload["q_expansion"])
     q_expansion["coefficients"] = (
         {"num": "1", "den": "1"},
         {"num": "241", "den": "1"},
         {"num": "2160", "den": "1"},
     )
-    with pytest.raises(ValidationError) as error:
+    assert not verify_level_one_q_expansion(
         LevelOneModularQExpansion.model_validate(payload)
-    assert _validation_type(error) == "modular_forms.coefficients_mismatch"
+    )
 
 
-def test_value_rejects_forged_coefficient_at_widened_precision() -> None:
+def test_explicit_verifier_rejects_forged_widened_coefficient() -> None:
     payload = level_one_named_q_expansion("E6", 1000).model_dump()
-    coefficients = list(payload["q_expansion"]["coefficients"])
+    q_expansion = cast(dict[str, object], payload["q_expansion"])
+    coefficients = list(cast(tuple[dict[str, str], ...], q_expansion["coefficients"]))
     coefficients[-1] = {"num": str(int(coefficients[-1]["num"]) + 1), "den": "1"}
-    payload["q_expansion"]["coefficients"] = tuple(coefficients)
-    with pytest.raises(ValidationError) as error:
+    q_expansion["coefficients"] = tuple(coefficients)
+    assert not verify_level_one_q_expansion(
         LevelOneModularQExpansion.model_validate(payload)
-    assert _validation_type(error) == "modular_forms.coefficients_mismatch"
+    )
 
 
 def _beyond_budget_e4_payload() -> dict[str, object]:
@@ -204,7 +213,9 @@ def _beyond_budget_e4_payload() -> dict[str, object]:
     }
 
 
-def test_value_replays_exact_expansions_beyond_the_producer_envelope() -> None:
+def test_explicit_verifier_accepts_exact_expansions_beyond_the_producer_envelope() -> (
+    None
+):
     with pytest.raises(ValueError, match="serialized result bound"):
         require_level_one_admission("E4", 1478)
 
@@ -214,28 +225,32 @@ def test_value_replays_exact_expansions_beyond_the_producer_envelope() -> None:
         1477, 3
     )
     assert LevelOneModularQExpansion.model_validate(value.model_dump()) == value
+    assert verify_level_one_q_expansion(value)
 
 
-def test_value_rejects_forged_coefficients_beyond_the_producer_envelope() -> None:
+def test_explicit_verifier_rejects_forged_coefficients_beyond_the_producer_envelope() -> (
+    None
+):
     payload = _beyond_budget_e4_payload()
-    coefficients = list(payload["q_expansion"]["coefficients"])
+    q_expansion = cast(dict[str, object], payload["q_expansion"])
+    coefficients = list(cast(tuple[dict[str, str], ...], q_expansion["coefficients"]))
     coefficients[-1] = {"num": str(int(coefficients[-1]["num"]) + 1), "den": "1"}
-    payload["q_expansion"]["coefficients"] = tuple(coefficients)
-    with pytest.raises(ValidationError) as error:
+    q_expansion["coefficients"] = tuple(coefficients)
+    assert not verify_level_one_q_expansion(
         LevelOneModularQExpansion.model_validate(payload)
-    assert _validation_type(error) == "modular_forms.coefficients_mismatch"
+    )
 
 
 def test_replay_envelope_names_its_own_controlling_quantity() -> None:
-    assert require_level_one_replay("DELTA", 1143) is None
+    require_level_one_replay("DELTA", 1143)
     with pytest.raises(ValueError, match="replay exceeds its exact work bound"):
         require_level_one_replay("DELTA", 1144)
     with pytest.raises(ValueError, match="plain integer"):
         require_level_one_replay("E4", True)
-    assert require_level_one_replay("E4", 20000) is None
+    require_level_one_replay("E4", 20000)
 
 
-def test_e6_replay_never_computes_the_e4_prefix(
+def test_explicit_e6_verifier_never_computes_the_e4_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     value = level_one_named_q_expansion("E6", 1000)
@@ -253,10 +268,11 @@ def test_e6_replay_never_computes_the_e4_prefix(
         coefficient.as_fraction() for coefficient in value.q_expansion.coefficients
     )
     assert LevelOneModularQExpansion.model_validate(payload) == value
+    assert verify_level_one_q_expansion(value)
     assert requested_forms == ["E6", "E6"]
 
 
-def test_delta_replay_still_builds_both_eisenstein_prefixes(
+def test_explicit_delta_verifier_builds_both_eisenstein_prefixes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     value = level_one_named_q_expansion("DELTA", 40)
@@ -269,4 +285,5 @@ def test_delta_replay_still_builds_both_eisenstein_prefixes(
 
     monkeypatch.setattr(level_one_kernel, "eisenstein_coefficients", spied)
     assert LevelOneModularQExpansion.model_validate(payload) == value
+    assert verify_level_one_q_expansion(value)
     assert requested_forms == ["E4", "E6"]

--- a/tests/math/number_theory/test_periodic_congruences.py
+++ b/tests/math/number_theory/test_periodic_congruences.py
@@ -721,8 +721,8 @@ def test_materialized_period_boundary_is_separate_from_measure() -> None:
         "complement": True,
     }
     assert _measure(measure_only).occupied_count == str(MAX_MATERIALIZED_RESIDUES + 1)
-    with expect_validation("number_theory."):
-        PeriodicCongruenceUnionProfileRequest.model_validate(measure_only)
+    with pytest.raises(ValueError, match="common period"):
+        _profile(measure_only)
 
 
 def test_full_subset_shortcuts_count_and_complement_materialization() -> None:
@@ -742,10 +742,8 @@ def test_full_subset_shortcuts_count_and_complement_materialization() -> None:
     assert empty_complement.occupied_count == "0"
     assert empty_complement.density.as_fraction() == 0
 
-    with expect_validation("number_theory."):
-        PeriodicCongruenceUnionProfileRequest.model_validate(
-            {"subsets": source, "complement": False}
-        )
+    with pytest.raises(ValueError, match="materialized full union"):
+        _profile({"subsets": source, "complement": False})
 
 
 def test_materialized_union_row_bound_is_checked_before_lifting() -> None:
@@ -769,8 +767,8 @@ def test_materialized_union_row_bound_is_checked_before_lifting() -> None:
         ],
         "complement": False,
     }
-    with expect_validation("number_theory."):
-        PeriodicCongruenceUnionProfileRequest.model_validate(rejected_payload)
+    with pytest.raises(ValueError, match="materialized union"):
+        _profile(rejected_payload)
 
 
 def test_profile_accounts_for_retained_source_and_wide_residue_output_bytes() -> None:
@@ -785,8 +783,8 @@ def test_profile_accounts_for_retained_source_and_wide_residue_output_bytes() ->
     }
 
     assert _measure(payload).occupied_count == str(output_rows)
-    with expect_validation("number_theory."):
-        PeriodicCongruenceUnionProfileRequest.model_validate(payload)
+    with pytest.raises(ValueError, match="canonical output budget"):
+        _profile(payload)
 
 
 def test_compressed_intersection_work_boundary_rejects_before_backend() -> None:

--- a/tests/math/regular_languages/test_transition_parikh_profile.py
+++ b/tests/math/regular_languages/test_transition_parikh_profile.py
@@ -427,15 +427,15 @@ def test_transition_axis_requires_contiguous_stable_identifiers() -> None:
     )
 
 
-def test_request_rejects_out_of_range_endpoint_before_execution() -> None:
-    with pytest.raises(ValidationError) as exc_info:
-        TransitionParikhProfileRequest(
-            automaton=_automaton(1, 0, ()),
-            source_state=1,
-            target_state=0,
-            path_length=0,
-        )
-    assert _error_type(exc_info) == "regular_language.profile_admission_rejected"
+def test_owner_rejects_out_of_range_endpoint() -> None:
+    request = TransitionParikhProfileRequest(
+        automaton=_automaton(1, 0, ()),
+        source_state=1,
+        target_state=0,
+        path_length=0,
+    )
+    with pytest.raises(ValueError, match="source_state must be"):
+        compute_transition_parikh_profile(request)
 
 
 def _loop_automaton(
@@ -448,7 +448,7 @@ def _loop_automaton(
     )
 
 
-def test_request_rejects_excessive_dp_work_even_when_target_is_unreachable() -> None:
+def test_owner_rejects_excessive_dp_work_even_when_target_is_unreachable() -> None:
     automaton = _loop_automaton(3, state_count=2)
     TransitionParikhProfileRequest(
         automaton=automaton,
@@ -456,14 +456,14 @@ def test_request_rejects_excessive_dp_work_even_when_target_is_unreachable() -> 
         target_state=1,
         path_length=157,
     )
-    with pytest.raises(ValidationError) as exc_info:
-        TransitionParikhProfileRequest(
-            automaton=automaton,
-            source_state=0,
-            target_state=1,
-            path_length=158,
-        )
-    assert _error_type(exc_info) == "regular_language.profile_admission_rejected"
+    request = TransitionParikhProfileRequest(
+        automaton=automaton,
+        source_state=0,
+        target_state=1,
+        path_length=158,
+    )
+    with pytest.raises(ValueError, match="transition-update bound"):
+        compute_transition_parikh_profile(request)
 
 
 def test_request_preflight_scans_only_reachable_outgoing_transitions() -> None:
@@ -482,7 +482,7 @@ def test_request_preflight_scans_only_reachable_outgoing_transitions() -> None:
     )
 
 
-def test_request_rejects_excessive_dense_vector_update_work() -> None:
+def test_owner_rejects_excessive_dense_vector_update_work() -> None:
     automaton = _loop_automaton(11, state_count=2)
     TransitionParikhProfileRequest(
         automaton=automaton,
@@ -490,17 +490,17 @@ def test_request_rejects_excessive_dense_vector_update_work() -> None:
         target_state=1,
         path_length=9,
     )
-    with pytest.raises(ValidationError) as exc_info:
-        TransitionParikhProfileRequest(
-            automaton=automaton,
-            source_state=0,
-            target_state=1,
-            path_length=10,
-        )
-    assert _error_type(exc_info) == "regular_language.profile_admission_rejected"
+    request = TransitionParikhProfileRequest(
+        automaton=automaton,
+        source_state=0,
+        target_state=1,
+        path_length=10,
+    )
+    with pytest.raises(ValueError, match="dense-vector update-work bound"):
+        compute_transition_parikh_profile(request)
 
 
-def test_request_rejects_excessive_profile_cell_count() -> None:
+def test_owner_rejects_excessive_profile_cell_count() -> None:
     automaton = _loop_automaton(9)
     TransitionParikhProfileRequest(
         automaton=automaton,
@@ -508,26 +508,26 @@ def test_request_rejects_excessive_profile_cell_count() -> None:
         target_state=0,
         path_length=9,
     )
-    with pytest.raises(ValidationError) as exc_info:
-        TransitionParikhProfileRequest(
-            automaton=automaton,
-            source_state=0,
-            target_state=0,
-            path_length=10,
-        )
-    assert _error_type(exc_info) == "regular_language.profile_admission_rejected"
+    request = TransitionParikhProfileRequest(
+        automaton=automaton,
+        source_state=0,
+        target_state=0,
+        path_length=10,
+    )
+    with pytest.raises(ValueError, match="profile-cell bound"):
+        compute_transition_parikh_profile(request)
 
 
-def test_request_rejects_excessive_intermediate_vector_coordinates() -> None:
+def test_owner_rejects_excessive_intermediate_vector_coordinates() -> None:
     automaton = _loop_automaton(159, state_count=2)
-    with pytest.raises(ValidationError) as exc_info:
-        TransitionParikhProfileRequest(
-            automaton=automaton,
-            source_state=0,
-            target_state=1,
-            path_length=2,
-        )
-    assert _error_type(exc_info) == "regular_language.profile_admission_rejected"
+    request = TransitionParikhProfileRequest(
+        automaton=automaton,
+        source_state=0,
+        target_state=1,
+        path_length=2,
+    )
+    with pytest.raises(ValueError, match="vector-coordinate bound"):
+        compute_transition_parikh_profile(request)
     TransitionParikhProfileRequest(
         automaton=_loop_automaton(158, state_count=2),
         source_state=0,
@@ -536,7 +536,7 @@ def test_request_rejects_excessive_intermediate_vector_coordinates() -> None:
     )
 
 
-def test_request_rejects_excessive_serialized_result() -> None:
+def test_owner_rejects_excessive_serialized_result() -> None:
     accepted = TransitionParikhProfileRequest(
         automaton=_loop_automaton(129),
         source_state=0,
@@ -548,14 +548,14 @@ def test_request_rejects_excessive_serialized_result() -> None:
     )
     assert len(encoded) <= _MAX_TRANSITION_PROFILE_RESULT_BYTES
 
-    with pytest.raises(ValidationError) as exc_info:
-        TransitionParikhProfileRequest(
-            automaton=_loop_automaton(130),
-            source_state=0,
-            target_state=0,
-            path_length=2,
-        )
-    assert _error_type(exc_info) == "regular_language.profile_admission_rejected"
+    request = TransitionParikhProfileRequest(
+        automaton=_loop_automaton(130),
+        source_state=0,
+        target_state=0,
+        path_length=2,
+    )
+    with pytest.raises(ValueError, match="serialized-result bound"):
+        compute_transition_parikh_profile(request)
 
 
 def test_length_bound_keeps_large_degenerate_cases_typed() -> None:

--- a/tests/math/symbolic_dynamics/test_symbolic_dynamics.py
+++ b/tests/math/symbolic_dynamics/test_symbolic_dynamics.py
@@ -301,29 +301,25 @@ def test_oversized_enumerations_fail_before_computation() -> None:
         exc_info.value.errors()[0]["type"]
         == "symbolic_dynamics.block_language_work_bound"
     )
-    with pytest.raises(ValidationError) as exc_info:
-        FiniteTypeShiftRequest(
-            shift=ForbiddenBlockShift(
-                alphabet=alphabet,
-                forbidden_blocks=(("a", "a", "a", "a", "a"),),
+    with pytest.raises(ValueError, match="requested block enumeration"):
+        construct_finite_type_shift(
+            FiniteTypeShiftRequest(
+                shift=ForbiddenBlockShift(
+                    alphabet=alphabet,
+                    forbidden_blocks=(("a", "a", "a", "a", "a"),),
+                )
             )
         )
-    assert (
-        exc_info.value.errors()[0]["type"]
-        == "symbolic_dynamics.block_language_work_bound"
-    )
     ten_symbols = alphabet[:10]
-    with pytest.raises(ValidationError) as exc_info:
-        FiniteTypeShiftRequest(
-            shift=ForbiddenBlockShift(
-                alphabet=ten_symbols,
-                forbidden_blocks=(("a", "a", "a", "a", "a"),),
+    with pytest.raises(ValueError, match="presentation adjacency"):
+        construct_finite_type_shift(
+            FiniteTypeShiftRequest(
+                shift=ForbiddenBlockShift(
+                    alphabet=ten_symbols,
+                    forbidden_blocks=(("a", "a", "a", "a", "a"),),
+                )
             )
         )
-    assert (
-        exc_info.value.errors()[0]["type"]
-        == "symbolic_dynamics.finite_type_presentation_result_bound"
-    )
     with pytest.raises(ValidationError) as exc_info:
         HigherBlockRequest(
             shift=ForbiddenBlockShift(

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -207,6 +207,14 @@ class TestJoin:
 
 
 class TestBarycentricSubdivision:
+    def test_owner_rejects_subdivision_beyond_its_result_envelope(self) -> None:
+        request = BarycentricSubdivisionRequest(
+            complex={"vertices": tuple("abcdef"), "facets": (tuple("abcdef"),)}
+        )
+
+        with pytest.raises(ValueError, match="at most 31 faces"):
+            compute_barycentric_subdivision(request)
+
     def test_subdivide_edge(self) -> None:
         result = compute_barycentric_subdivision(
             BarycentricSubdivisionRequest(complex=EDGE)

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -3,6 +3,9 @@
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.dispatch import invoke_operation
 from jacobian.math.topology._models import (
     BarycentricSubdivisionRequest,
     BarycentricSubdivisionResult,
@@ -214,6 +217,28 @@ class TestBarycentricSubdivision:
 
         with pytest.raises(ValueError, match="at most 31 faces"):
             compute_barycentric_subdivision(request)
+
+    def test_dispatch_projects_owner_admission_as_an_invalid_request(self) -> None:
+        with pytest.raises(OperationDomainValidationError) as error:
+            invoke_operation(
+                "topology.simplicial_complex.barycentric_subdivision.compute",
+                {
+                    "complex": {
+                        "vertices": list("abcdef"),
+                        "facets": [list("abcdef")],
+                    }
+                },
+                Catalog.open(),
+            )
+
+        assert error.value.errors() == (
+            {
+                "loc": (),
+                "type": "operation.domain_validation",
+                "msg": "barycentric subdivision requires at most 31 faces; "
+                "input would produce more than 128 subdivision facets",
+            },
+        )
 
     def test_subdivide_edge(self) -> None:
         result = compute_barycentric_subdivision(

--- a/tests/math/tree_automata/test_reachability_accounting.py
+++ b/tests/math/tree_automata/test_reachability_accounting.py
@@ -30,7 +30,7 @@ def _automaton() -> BottomUpTreeAutomaton:
     )
 
 
-def test_public_reachability_path_charges_each_saturation_pass() -> None:
+def test_public_reachability_path_runs_one_saturation_pass() -> None:
     with patch.object(
         values, "_priced_saturation", wraps=values._priced_saturation
     ) as run:
@@ -40,13 +40,13 @@ def test_public_reachability_path_charges_each_saturation_pass() -> None:
 
     assert result.reachable_states == (0,)
     assert_charged_work_parity(
-        charged={"saturation": 3}, executed={"saturation": run.call_count}
+        charged={"saturation": 1}, executed={"saturation": run.call_count}
     )
 
 
-def test_schema_describes_the_three_priced_passes() -> None:
+def test_schema_describes_the_one_priced_pass() -> None:
     schema = TreeAutomatonReachabilityRequest.model_json_schema()
     description = schema["properties"]["automaton"]["description"]
 
-    assert "three passes" in description
-    assert "four passes" not in description
+    assert "one owner-local saturation pass" in description
+    assert "three passes" not in description

--- a/tests/math/tree_automata/test_tree_automata.py
+++ b/tests/math/tree_automata/test_tree_automata.py
@@ -711,8 +711,8 @@ class TestValidation:
         assert per_profile <= 30_000_000
 
         public_path = _reachability_public_path_work_bound(automaton)
-        assert public_path == 3 * 983_040 + 3 * 2 * per_scan_work + 2 * 3 * 4096
-        assert public_path == 4_670_208
+        assert public_path == per_profile
+        assert public_path == 1_560_832
         assert public_path <= 30_000_000
 
         result = compute_tree_automaton_reachability(
@@ -765,7 +765,7 @@ class TestValidation:
             ranked_tree_node_count(tree) for _, tree in result.witnesses
         ) == tuple(range(1, 14))
 
-    def test_reachability_rejects_seeded_deep_chain_scans_beyond_work_bound(
+    def test_reachability_admits_seeded_deep_chain_within_one_pass_work_bound(
         self,
     ) -> None:
         automaton = BottomUpTreeAutomaton(
@@ -795,9 +795,10 @@ class TestValidation:
             final_states=(),
         )
 
-        with pytest.raises(ValidationError) as exc:
+        result = compute_tree_automaton_reachability(
             TreeAutomatonReachabilityRequest(automaton=automaton)
-        _assert_validation_code(exc, "tree_automata.reachability_work_bound")
+        )
+        assert result.reachable_states == tuple(range(64))
 
     def test_native_profile_prices_measured_convergence_within_shared_envelope(
         self,
@@ -817,7 +818,7 @@ class TestValidation:
             ranked_tree_node_count(tree) for _, tree in profile.witnesses
         ) == tuple(range(1, 17))
 
-    def test_public_request_prices_three_passes_against_shared_envelope(self) -> None:
+    def test_public_request_reuses_the_execution_envelope(self) -> None:
         automaton = _seeded_chain_with_padded_rows(31)
 
         _, per_scan_work, scan_rounds = _reachability_price_components(automaton)
@@ -827,38 +828,34 @@ class TestValidation:
         assert per_profile <= 30_000_000
 
         public_path = _reachability_public_path_work_bound(automaton)
-        assert public_path == 3 * 983_040 + 3 * 32 * per_scan_work + 2 * 3 * 4096
-        assert public_path > 2 * per_profile
-        assert public_path > 30_000_000
+        assert public_path == per_profile
+        assert public_path <= 30_000_000
 
-        assert isinstance(reachable_state_profile(automaton), ReachableStateProfile)
-        with pytest.raises(ValidationError) as exc:
+        result = compute_tree_automaton_reachability(
             TreeAutomatonReachabilityRequest(automaton=automaton)
-        _assert_validation_code(exc, "tree_automata.reachability_work_bound")
+        )
+        assert result.reachable_states == tuple(range(31))
 
     def test_near_envelope_rows_are_priced_exactly_and_admitted_only_when_they_fit(
         self,
     ) -> None:
-        """4,096-row chain fixtures straddle the envelope with exact pricing.
+        """4,096-row chain fixtures stay within the one-pass envelope.
 
-        Each profile on the public path consumes exactly one priced pass --
-        its own sort plus measured saturation -- and evaluating the
-        public-path bound runs one more pass, so the advertised bound is three
-        passes; no fourth or unpriced sort executes.
-        The sibling one link deeper crosses 30,000,000 units only through
-        that honestly priced work and must be rejected.
+        The public operation executes one sort and measured saturation.  The
+        next deeper sibling remains admissible because it no longer pays for
+        request-time profile materialization a second time.
         """
 
         def advertised_public_bound(automaton: BottomUpTreeAutomaton) -> int:
             sort_work, per_scan_work, scan_rounds = _reachability_price_components(
                 automaton
             )
-            return 3 * sort_work + 3 * scan_rounds * per_scan_work + 2 * 3 * 4096
+            return sort_work + scan_rounds * per_scan_work + 3 * 4096
 
         admitted = _seeded_chain_with_padded_rows(30)
         rejected = _seeded_chain_with_padded_rows(31)
 
-        assert _reachability_public_path_work_bound(admitted) == 29_482_788
+        assert _reachability_public_path_work_bound(admitted) == 9_831_692
         assert _reachability_public_path_work_bound(admitted) == (
             advertised_public_bound(admitted)
         )
@@ -870,17 +867,18 @@ class TestValidation:
         assert result.reachable_states == tuple(range(30))
         assert _reachability_execution_work_bound(admitted) == 9_831_692
 
-        assert _reachability_public_path_work_bound(rejected) == 30_332_160
+        assert _reachability_public_path_work_bound(rejected) == 10_114_816
         assert _reachability_public_path_work_bound(rejected) == (
             advertised_public_bound(rejected)
         )
-        assert _reachability_public_path_work_bound(rejected) > 30_000_000
-        with pytest.raises(ValidationError) as exc:
+        assert _reachability_public_path_work_bound(rejected) <= 30_000_000
+        result = compute_tree_automaton_reachability(
             TreeAutomatonReachabilityRequest(automaton=rejected)
-        _assert_validation_code(exc, "tree_automata.reachability_work_bound")
+        )
+        assert result.reachable_states == tuple(range(31))
 
     @pytest.mark.scale
-    def test_deepest_native_profile_fits_envelope_while_public_rejects(self) -> None:
+    def test_deepest_native_profile_and_public_operation_fit_one_envelope(self) -> None:
         automaton = _seeded_chain_with_padded_rows(64)
 
         _, per_scan_work, scan_rounds = _reachability_price_components(automaton)
@@ -890,8 +888,8 @@ class TestValidation:
         assert per_profile == 19_390_588
         assert per_profile <= 30_000_000
 
-        assert _reachability_public_path_work_bound(automaton) == 58_159_476
-        assert _reachability_public_path_work_bound(automaton) > 30_000_000
+        assert _reachability_public_path_work_bound(automaton) == 19_390_588
+        assert _reachability_public_path_work_bound(automaton) <= 30_000_000
 
         profile = reachable_state_profile(automaton)
         assert isinstance(profile, ReachableStateProfile)
@@ -900,9 +898,10 @@ class TestValidation:
             ranked_tree_node_count(tree) for _, tree in profile.witnesses
         ) == tuple(range(1, 65))
 
-        with pytest.raises(ValidationError) as exc:
+        result = compute_tree_automaton_reachability(
             TreeAutomatonReachabilityRequest(automaton=automaton)
-        _assert_validation_code(exc, "tree_automata.reachability_work_bound")
+        )
+        assert result.reachable_states == tuple(range(64))
 
     def test_reachability_schema_publishes_coupled_admission_envelope(self) -> None:
         request_schema = TreeAutomatonReachabilityRequest.model_json_schema()
@@ -952,9 +951,9 @@ class TestValidation:
             final_states=(),
         )
 
-        with pytest.raises(ValidationError) as exc:
-            TreeAutomatonReachabilityRequest(automaton=automaton)
-        _assert_validation_code(exc, "tree_automata.witness_output_bound")
+        request = TreeAutomatonReachabilityRequest(automaton=automaton)
+        with pytest.raises(ValueError, match="witness output"):
+            compute_tree_automaton_reachability(request)
 
     def test_arity_mismatch_rejected(self) -> None:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## Problem

Several ordinary request and result models repeated semantic admission, enumeration, or defining-relation work that the owning operation then performed again. This made deserialization act like execution and obscured the single request-scoped admission decision.

## Solution

Move the affected boundedness decisions to their domain operation, reuse the transition-Parikh admission plan through execution, and keep ordinary request/result validation structural. Independently supplied theorem-bearing claims retain explicit, bounded owner-local verifiers. The changes cover formal concept analysis, regular languages, additive combinatorics, nonlinear codes, finite fields/categories, and related mathematical owners.

The public schemas and mathematical postconditions are unchanged; this is an ownership and execution-path simplification. Related: #2755.

Suggested review order: start with formal concept analysis and regular-language transition profiles, then inspect the same ownership shift in the remaining domain operations and their regression tests.

## Testing

- `make handoff LANE=math TESTS="tests/math/additive_combinatorics/test_multiset_sum.py tests/math/additive_combinatorics/test_subset_sum_profile.py tests/math/algebraic_combinatorics/test_rsk_word.py tests/math/code_nonlinear/test_code_nonlinear.py tests/math/crossed_products/test_crossed_products.py tests/math/finite_categories/test_finite_categories.py tests/math/finite_dim_algebras/test_finite_dim_algebras.py tests/math/finite_fields/test_tools.py tests/math/formal_concept_analysis/test_duquenne_guigues_basis.py tests/math/hypergraphs/test_edge_intersections.py tests/math/modular_forms/test_level_one_q_expansions.py tests/math/number_theory/test_periodic_congruences.py tests/math/regular_languages/test_transition_parikh_profile.py tests/math/symbolic_dynamics/test_symbolic_dynamics.py tests/math/topology/test_structural_ops.py tests/math/tree_automata/test_reachability_accounting.py tests/math/tree_automata/test_tree_automata.py"` — 513 passed; Ruff, formatting, and mypy passed.
- `git diff --check` — passed.

## Public contract impact

No operation IDs or request/result schemas change. Semantic admission occurs once in the owner operation rather than during ordinary model construction; result models do not replay kernels or defining relations.