### PR TITLE
Refactor math packages around canonical owners

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -151,6 +151,24 @@ subjects such as matrices, graphs, polynomials, probability, and number theory
 over vague umbrellas that would contain much of the library. Keep the top level
 free of ticket-shaped feature packages, backend names, and workflow groupings.
 
+The target first-level taxonomy is deliberately restrained:
+
+```text
+jacobian.math
+  matrices            polynomials          finite_fields
+  groups              lattices             graphs
+  combinatorics       number_theory        geometry
+  topology            analysis             probability
+  optimization        dynamics             logic
+```
+
+This list is the package-migration target, not a claim that every current
+package has already been folded. A subject may remain first-level only when it
+cannot be represented honestly as a mathematical subdivision of one of these
+owners; do not force an independent subject into an inaccurate parent merely
+to reduce the directory count. Record that exception here when it becomes a
+durable part of the public taxonomy.
+
 Decide by evidence, in this order:
 
 1. **Canonical value ownership.** Each mathematical value has one package that
@@ -209,6 +227,13 @@ old path in the same change, and lands as one family per change. A proposed
 repository-wide taxonomy remains a migration plan until each fold establishes
 its value owner, operation owner, and mathematical-subdivision relationship; do
 not document an aspirational directory tree as current behavior.
+
+Because Jacobian is pre-stable, a fold updates repository imports and public
+examples atomically and does not retain forwarding packages at the former path.
+Do not maintain parallel old and new import surfaces, migration registries, or
+hard-coded path aliases. Catalog discovery remains recursive and derives owner
+modules from packaged `_admission.py` files, so adding a mathematical nesting
+level must not require a central package inventory.
 
 Logic follows the same rule. CNF canonicalization and assignment checks are
 pure direct operations. SAT and bounded QF SMT-LIB solving use the maintained

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -21,6 +21,16 @@ or a maintained backend type when it already carries the complete mathematical
 meaning. Private backend modules perform lazy conversions and calls to SymPy,
 NetworkX, FLINT, or Z3.
 
+Public import paths follow mathematical ownership. Large owners expose
+recognizable subdivisions, for example
+`jacobian.math.graphs.chip_firing` or
+`jacobian.math.polynomials.interpolation`; backend and transport structure does
+not appear in the public path. When a pre-stable package is folded into its
+canonical owner, callers move to the owner path in the same release. The old
+path is removed rather than retained as a forwarding package, and operation IDs
+and wire schemas remain unchanged unless their mathematical contract changes
+independently.
+
 Native values are mathematical values rather than wire envelopes. Native and
 MCP calls use the same domain-owned request admission, kernel path, canonical
 result construction, and typed outcome semantics. Most native functions simply


### PR DESCRIPTION
## Problem

`jacobian.math` currently exposes many narrow implementation-sized packages at the first level. That makes mathematical ownership and native import paths difficult to predict before the package-folding work begins.

## Solution

This initial draft establishes the package-migration rules in the existing architecture and Python API references:

- use a restrained set of recognizable first-level mathematical owners;
- choose nesting from canonical value and operation ownership;
- treat the documented taxonomy as a migration target rather than current-state documentation;
- update imports atomically without forwarding packages, alias registries, or a central discovery inventory;
- preserve operation IDs and wire schemas across package-only folds.

The draft intentionally contains no new migration document or temporary architecture artifact. Subsequent package moves will be added as independently reviewable family commits.

## Testing

- `make docs-linkcheck` — passed
- `git diff --check` — passed

## Public contract impact

The current documentation commit does not change runtime behavior. Later package folds on this draft will change pre-stable native Python import paths while preserving operation IDs, request/result schemas, and mathematical semantics.

## Operation boundary ownership

Not applicable to the current documentation-only commit.

## Canonical value audit

Not applicable to the current documentation-only commit. Each later fold will identify its canonical value and operation owners before moving code.

## Catalog admission

Not applicable. Catalog membership is unchanged.

## Closure matrix

None.

## Checklist

- [x] Documentation validation passes
- [x] No new migration or compatibility artifacts were added
- [x] Operation IDs and wire contracts are explicitly preserved by package-only folds