### PR TITLE
fix(mcp): isolate remaining native solver paths

### DIFF
--- a/deploy/smoke_remote.py
+++ b/deploy/smoke_remote.py
@@ -10,19 +10,20 @@ import os
 from typing import Any
 
 import httpx2
-from mcp import Client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.types import Implementation, TextContent, TextResourceContents
 
-from .smoke import exit_for_smoke_failure, raise_for_http_error
 from jacobian import __version__
 from jacobian.canonical import canonicalize_json
+from jacobian.mcp.models import OperationFindResponse, OperationSearchResult
+from mcp import Client
+
+from .smoke import exit_for_smoke_failure, raise_for_http_error
 
 REQUIRED_TOOLS = {
     "math.find",
     "math.run",
 }
-DISCOVERY_RESPONSE_BYTE_LIMIT = 16_384
 
 
 def _require_server_info(server_info: Implementation | None) -> Implementation:
@@ -101,6 +102,31 @@ def _validate_server_version(
         )
 
 
+def _validate_discovery_response(
+    discovery: dict[str, Any],
+    discovery_text: str,
+    failures: list[str],
+) -> tuple[str, ...]:
+    try:
+        response = OperationFindResponse.model_validate(discovery)
+    except ValueError as exc:
+        failures.append(f"deployed operation discovery violates its schema: {exc}")
+        return ()
+    if not isinstance(response.root, OperationSearchResult):
+        failures.append("deployed operation search returned a non-search response")
+        return ()
+    try:
+        model_visible = json.loads(discovery_text)
+    except json.JSONDecodeError as exc:
+        failures.append(f"deployed operation discovery text is not JSON: {exc}")
+        return ()
+    if model_visible != discovery:
+        failures.append(
+            "deployed operation discovery text and structured content disagree"
+        )
+    return tuple(match.operation_id for match in response.root.matches)
+
+
 async def inspect(
     *,
     url: str,
@@ -172,10 +198,11 @@ async def inspect(
             json.dumps(discovery, ensure_ascii=False, indent=2).encode("utf-8")
         )
         discovery_model_visible_bytes = len(discovery_text.encode("utf-8"))
-        if discovery["response_byte_limit"] != DISCOVERY_RESPONSE_BYTE_LIMIT:
-            failures.append("deployed discovery byte limit does not match the contract")
-        if discovery_bytes > DISCOVERY_RESPONSE_BYTE_LIMIT:
-            failures.append("deployed discovery response exceeds its byte limit")
+        discovery_matches = _validate_discovery_response(
+            discovery,
+            discovery_text,
+            failures,
+        )
 
         report = {
             "url": url,
@@ -192,7 +219,7 @@ async def inspect(
             "discovery": {
                 "bytes": discovery_bytes,
                 "model_visible_bytes": discovery_model_visible_bytes,
-                "matches": [match["operation_id"] for match in discovery["matches"]],
+                "matches": list(discovery_matches),
             },
         }
     if failures:

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -77,8 +77,10 @@ source control.
 
 Run `uv run python -m deploy.smoke_remote <url>` against the private listener
 and public endpoint before directing traffic to the new artifact. The probe
-implementation lives in [`deploy/`](../../deploy/). Roll back by selecting the
-previous immutable artifact and rerunning the probe.
+implementation lives in [`deploy/`](../../deploy/). It validates discovery
+against the checkout's current typed response model and requires the text and
+structured MCP projections to agree. Roll back by selecting the previous
+immutable artifact and rerunning the probe.
 
 When moving hosts, provision the same pinned artifact, transfer operator-owned
 configuration and secrets, run the probes, and move traffic.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,7 +227,9 @@ ignore_imports = [
     "jacobian.math.graphs.optimization._chromatic_number -> jacobian.process",
     "jacobian.math.graphs.optimization._finite_optimization -> jacobian.process",
     "jacobian.math.graphs.optimization._invariants -> jacobian.process",
+    "jacobian.math.graphs.optimization._maximum_cut_process -> jacobian.process",
     "jacobian.math.hypergraphs._independence_z3 -> jacobian.process",
+    "jacobian.math.discrepancy_theory._optimum_process -> jacobian.process",
     "jacobian.math.number_field._operations -> jacobian.process",
     "jacobian.math.number_theory._factorization_kernels -> jacobian.process",
     # Private exact-algebra adapters share one bounded Singular process owner.

--- a/src/jacobian/math/discrepancy_theory/_operations.py
+++ b/src/jacobian/math/discrepancy_theory/_operations.py
@@ -321,6 +321,18 @@ def compute_optimal_discrepancy(
     return _incumbent_outcome(request, result, variable_count)
 
 
+def _compute_optimal_discrepancy_isolated(
+    request: DiscrepancyOptimumRequest,
+) -> DiscrepancyOptimumResult:
+    """Run the complete HiGHS/Z3 transaction in a bounded owner worker."""
+
+    from jacobian.math.discrepancy_theory._optimum_process import (
+        compute_optimal_discrepancy_isolated,
+    )
+
+    return compute_optimal_discrepancy_isolated(request)
+
+
 def _incumbent_outcome(
     request: DiscrepancyOptimumRequest,
     result: Any,

--- a/src/jacobian/math/discrepancy_theory/_optimum_process.py
+++ b/src/jacobian/math/discrepancy_theory/_optimum_process.py
@@ -1,0 +1,88 @@
+"""Bounded process owner for discrepancy minimization backends."""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from jacobian.canonical import CanonicalLimits
+from jacobian.math.discrepancy_theory._models import (
+    MAX_OPTIMUM_PROOF_MILLISECONDS,
+    MAX_OPTIMUM_SOLVER_MILLISECONDS,
+    DiscrepancyOptimumRequest,
+    DiscrepancyOptimumResult,
+    _budget_exceeded_result,
+    _execution_failed_result,
+)
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_OPTIMUM_WORKER = Path(__file__).with_name("_optimum_worker.py")
+_OPTIMUM_WORKER_WALL_SECONDS = (
+    math.ceil(
+        (MAX_OPTIMUM_SOLVER_MILLISECONDS + MAX_OPTIMUM_PROOF_MILLISECONDS) / 1_000
+    )
+    + 5
+)
+_WORKER_OUTPUT_BYTES = CanonicalLimits().max_output_bytes
+_WORKER_ERROR_BYTES = 16_384
+_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
+
+
+def compute_optimal_discrepancy_isolated(
+    request: DiscrepancyOptimumRequest,
+) -> DiscrepancyOptimumResult:
+    """Run the complete HiGHS/Z3 transaction in a bounded owner worker."""
+
+    deadline = time.monotonic() + _OPTIMUM_WORKER_WALL_SECONDS
+    try:
+        with TemporaryDirectory(prefix="jacobian-discrepancy-optimum-") as directory:
+            payload = json.dumps(
+                request.model_dump(mode="json"),
+                separators=(",", ":"),
+            ).encode("utf-8")
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return _budget_exceeded_result(request.set_system)
+            completed = run_bounded_process(
+                [sys.executable, str(_OPTIMUM_WORKER)],
+                input_bytes=payload,
+                timeout_seconds=remaining_seconds,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_WORKER_OUTPUT_BYTES,
+                stderr_limit=_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=math.ceil(_OPTIMUM_WORKER_WALL_SECONDS),
+                    address_space_bytes=_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=directory,
+            )
+    except OSError:
+        return _execution_failed_result(request.set_system)
+    if completed.timed_out or time.monotonic() >= deadline:
+        return _budget_exceeded_result(request.set_system)
+    if (
+        completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return _execution_failed_result(request.set_system)
+    try:
+        result = DiscrepancyOptimumResult.model_validate(
+            json.loads(completed.stdout.decode("utf-8"))
+        )
+        if result.set_system != request.set_system:
+            raise ValueError("worker result is not bound to the submitted set system")
+        return result
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return _execution_failed_result(request.set_system)

--- a/src/jacobian/math/discrepancy_theory/_optimum_worker.py
+++ b/src/jacobian/math/discrepancy_theory/_optimum_worker.py
@@ -1,0 +1,27 @@
+"""Isolated maintained-backend adapter for discrepancy minimization."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.discrepancy_theory._models import DiscrepancyOptimumRequest
+from jacobian.math.discrepancy_theory._operations import compute_optimal_discrepancy
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        request = DiscrepancyOptimumRequest.model_validate(payload)
+        result = compute_optimal_discrepancy(request)
+        sys.stdout.write(
+            json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
+        )
+        return 0
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/discrepancy_theory/_tools.py
+++ b/src/jacobian/math/discrepancy_theory/_tools.py
@@ -15,9 +15,9 @@ from jacobian.math.discrepancy_theory._models import (
     HardConstraintRoundingResult,
 )
 from jacobian.math.discrepancy_theory._operations import (
+    _compute_optimal_discrepancy_isolated,
     compute_discrepancy,
     compute_hard_constraint_rounding,
-    compute_optimal_discrepancy,
 )
 
 
@@ -126,7 +126,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "claim.",
         DiscrepancyOptimumRequest,
         DiscrepancyOptimumResult,
-        compute_optimal_discrepancy,
+        _compute_optimal_discrepancy_isolated,
         "discrepancy",
         "set-system",
         "combinatorial-search",

--- a/src/jacobian/math/graphs/optimization/_maximum_cut.py
+++ b/src/jacobian/math/graphs/optimization/_maximum_cut.py
@@ -504,6 +504,20 @@ def _solve_analysis(
     return _combine_component_solutions(analysis, tuple(solutions))
 
 
+def _solve_analysis_by_enumeration(
+    analysis: _MaximumCutAnalysis,
+) -> tuple[bool, ...]:
+    """Complete the admitted exact search without entering a native backend."""
+
+    return _combine_component_solutions(
+        analysis,
+        tuple(
+            _solve_component_by_enumeration(analysis, component_index)
+            for component_index in range(len(analysis.components))
+        ),
+    )
+
+
 def _partition_from_class_sides(
     graph: SimpleUndirectedGraph,
     analysis: _MaximumCutAnalysis,
@@ -547,6 +561,39 @@ def compute_maximum_cut(request: GraphMaximumCutRequest) -> GraphMaximumCutResul
     )
 
 
+def _compute_maximum_cut_without_z3(
+    request: GraphMaximumCutRequest,
+) -> GraphMaximumCutResult:
+    """Compute the same exact result through the admitted exhaustive fallback."""
+
+    analysis = _analyze_graph(request.graph)
+    class_sides = _solve_analysis_by_enumeration(analysis)
+    left_vertices, right_vertices, crossing_edges = _partition_from_class_sides(
+        request.graph,
+        analysis,
+        class_sides,
+    )
+    return GraphMaximumCutResult._from_kernel(
+        graph=request.graph,
+        left_vertices=left_vertices,
+        right_vertices=right_vertices,
+        crossing_edges=crossing_edges,
+        cut_value=len(crossing_edges),
+    )
+
+
+def _compute_maximum_cut_isolated(
+    request: GraphMaximumCutRequest,
+) -> GraphMaximumCutResult:
+    """Run the Z3 acceleration in a bounded worker, never in the service host."""
+
+    from jacobian.math.graphs.optimization._maximum_cut_process import (
+        compute_maximum_cut_isolated,
+    )
+
+    return compute_maximum_cut_isolated(request)
+
+
 MAXIMUM_CUT_OPERATION: MathTool[
     GraphMaximumCutRequest,
     GraphMaximumCutResult,
@@ -561,7 +608,7 @@ MAXIMUM_CUT_OPERATION: MathTool[
     ),
     request_type=GraphMaximumCutRequest,
     result_type=GraphMaximumCutResult,
-    run=compute_maximum_cut,
+    run=_compute_maximum_cut_isolated,
     tags=(
         "graph",
         "cut",

--- a/src/jacobian/math/graphs/optimization/_maximum_cut_process.py
+++ b/src/jacobian/math/graphs/optimization/_maximum_cut_process.py
@@ -1,0 +1,80 @@
+"""Bounded process owner for the maximum-cut Z3 acceleration."""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from jacobian.math.graphs.optimization._maximum_cut import (
+    MAXIMUM_CUT_RESULT_BYTES,
+    GraphMaximumCutRequest,
+    GraphMaximumCutResult,
+    _compute_maximum_cut_without_z3,
+)
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_MAXIMUM_CUT_WORKER = Path(__file__).with_name("_maximum_cut_worker.py")
+_MAXIMUM_CUT_WORKER_WALL_SECONDS = 120
+_WORKER_ERROR_BYTES = 16_384
+_WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
+_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
+
+
+def compute_maximum_cut_isolated(
+    request: GraphMaximumCutRequest,
+) -> GraphMaximumCutResult:
+    """Run Z3 outside the host and retain the admitted exact fallback."""
+
+    deadline = time.monotonic() + _MAXIMUM_CUT_WORKER_WALL_SECONDS
+    try:
+        with TemporaryDirectory(prefix="jacobian-maximum-cut-") as directory:
+            payload = json.dumps(
+                request.model_dump(mode="json"),
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return _compute_maximum_cut_without_z3(request)
+            completed = run_bounded_process(
+                [sys.executable, str(_MAXIMUM_CUT_WORKER)],
+                input_bytes=payload,
+                timeout_seconds=remaining_seconds,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=MAXIMUM_CUT_RESULT_BYTES,
+                stderr_limit=_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=math.ceil(_MAXIMUM_CUT_WORKER_WALL_SECONDS),
+                    address_space_bytes=_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=directory,
+            )
+    except OSError:
+        return _compute_maximum_cut_without_z3(request)
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+        or time.monotonic() >= deadline
+    ):
+        return _compute_maximum_cut_without_z3(request)
+    try:
+        result = GraphMaximumCutResult.model_validate(
+            json.loads(completed.stdout.decode("utf-8"))
+        )
+        if result.graph != request.graph:
+            raise ValueError("worker result is not bound to the submitted graph")
+        return result
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return _compute_maximum_cut_without_z3(request)

--- a/src/jacobian/math/graphs/optimization/_maximum_cut_worker.py
+++ b/src/jacobian/math/graphs/optimization/_maximum_cut_worker.py
@@ -1,0 +1,33 @@
+"""Isolated Z3 adapter for the exact maximum-cut operation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from jacobian.math.graphs.optimization._maximum_cut import (
+    GraphMaximumCutRequest,
+    compute_maximum_cut,
+)
+
+
+def main() -> int:
+    try:
+        payload: Any = json.loads(sys.stdin.buffer.read())
+        request = GraphMaximumCutRequest.model_validate(payload)
+        result = compute_maximum_cut(request)
+        sys.stdout.write(
+            json.dumps(
+                result.model_dump(mode="json"),
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/math/discrepancy_theory/test_discrepancy_theory.py
+++ b/tests/math/discrepancy_theory/test_discrepancy_theory.py
@@ -12,6 +12,8 @@ import pytest
 from pydantic import ValidationError
 
 import jacobian.math.discrepancy_theory._models as discrepancy_models
+import jacobian.math.discrepancy_theory._operations as discrepancy_operations
+import jacobian.math.discrepancy_theory._optimum_process as optimum_process
 from jacobian.math.discrepancy_theory._models import (
     MAX_COLUMN_INCIDENCES,
     MAX_MONITORED_COLUMNS,
@@ -32,6 +34,7 @@ from jacobian.math.discrepancy_theory._operations import (
     compute_hard_constraint_rounding,
     compute_optimal_discrepancy,
 )
+from jacobian.process import BoundedProcessResult
 
 
 @contextmanager
@@ -930,6 +933,45 @@ class TestDiscrepancyOptimum:
             for subset in system.sets
         )
         assert replayed == result.optimal_discrepancy
+
+    @pytest.mark.parametrize(
+        ("timed_out", "expected_status"),
+        ((False, "EXECUTION_FAILED"), (True, "BUDGET_EXCEEDED")),
+    )
+    def test_tool_worker_failure_stays_claim_free(
+        self,
+        timed_out: bool,
+        expected_status: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def failed_worker(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+            return BoundedProcessResult(
+                returncode=None if timed_out else -11,
+                stdout=b"",
+                stderr=b"ASSERTION VIOLATION",
+                stdout_exceeded=False,
+                stderr_exceeded=False,
+                timed_out=timed_out,
+            )
+
+        monkeypatch.setattr(
+            optimum_process,
+            "run_bounded_process",
+            failed_worker,
+        )
+        request = DiscrepancyOptimumRequest(
+            set_system=FiniteSetSystem(
+                ground_set_size=3,
+                sets=((0, 1), (1, 2), (0, 2)),
+            )
+        )
+
+        result = discrepancy_operations._compute_optimal_discrepancy_isolated(request)
+
+        assert result.status == expected_status
+        assert result.set_system == request.set_system
+        assert result.optimal_coloring == ()
+        assert result.optimal_discrepancy is None
 
     @pytest.mark.scale
     def test_hard_instance_outcome_is_honest(self) -> None:

--- a/tests/math/graphs/test_graph_maximum_cut.py
+++ b/tests/math/graphs/test_graph_maximum_cut.py
@@ -11,7 +11,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.canonical import encode_strict_json
-from jacobian.math.graphs.optimization import _maximum_cut
+from jacobian.math.graphs.optimization import _maximum_cut, _maximum_cut_process
 from jacobian.math.graphs.optimization._maximum_cut import (
     MAXIMUM_CUT_CANDIDATE_PARTITIONS,
     MAXIMUM_CUT_RESULT_BYTES,
@@ -20,6 +20,7 @@ from jacobian.math.graphs.optimization._maximum_cut import (
     compute_maximum_cut,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.process import BoundedProcessResult
 
 
 def _graph(
@@ -377,6 +378,33 @@ def test_bounded_exhaustive_fallback_preserves_an_exact_result(
     result = _validated_result(_complete(7))
 
     assert result.cut_value == 12
+
+
+def test_tool_worker_segfault_falls_back_to_the_bounded_exact_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def segfaulted_worker(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        return BoundedProcessResult(
+            returncode=-11,
+            stdout=b"",
+            stderr=b"ASSERTION VIOLATION",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        )
+
+    monkeypatch.setattr(
+        _maximum_cut_process,
+        "run_bounded_process",
+        segfaulted_worker,
+    )
+
+    result = _maximum_cut.MAXIMUM_CUT_OPERATION.run(
+        GraphMaximumCutRequest(graph=_cycle(5))
+    )
+
+    assert result.cut_value == 4
+    _assert_cut_invariant(result)
 
 
 def test_operation_is_deterministic_on_a_nonunique_optimum() -> None:

--- a/tests/process/test_z3_tool_isolation.py
+++ b/tests/process/test_z3_tool_isolation.py
@@ -1,0 +1,84 @@
+"""Native solver crashes must remain inside request-owned tool workers."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def test_concurrent_z3_tools_do_not_load_z3_in_the_service_host() -> None:
+    script = textwrap.dedent(
+        """
+        import json
+        import sys
+        from concurrent.futures import ThreadPoolExecutor
+
+        from jacobian.catalog.catalog import Catalog
+
+        catalog = Catalog.open()
+        maximum_cut = catalog.operation("graph.cut.maximum.compute")
+        discrepancy = catalog.operation("discrepancy.theory.optimum.compute")
+        assert maximum_cut is not None
+        assert discrepancy is not None
+
+        maximum_cut_payload = {
+            "graph": {
+                "vertices": [str(index) for index in range(12)],
+                "edges": sorted(
+                    {
+                        tuple(sorted((str(index), str((index + 1) % 12))))
+                        for index in range(12)
+                    }
+                    | {
+                        tuple(sorted((str(index), str((index + 3) % 12))))
+                        for index in range(12)
+                    }
+                ),
+            }
+        }
+        discrepancy_payload = {
+            "set_system": {
+                "ground_set_size": 15,
+                "sets": [
+                    sorted({index, (index + step) % 15, (index + 2 * step) % 15})
+                    for step in range(1, 6)
+                    for index in range(15)
+                ],
+            }
+        }
+
+        def invoke(index):
+            operation, payload = (
+                (maximum_cut, maximum_cut_payload)
+                if index % 2
+                else (discrepancy, discrepancy_payload)
+            )
+            request = operation.request_type.model_validate(payload)
+            return operation.run(request).model_dump(mode="json")
+
+        with ThreadPoolExecutor(max_workers=16) as executor:
+            results = tuple(executor.map(invoke, range(16)))
+
+        assert all(result for result in results)
+        assert "z3" not in sys.modules
+        print(json.dumps({"results": len(results), "host_loaded_z3": False}))
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        env={**os.environ, "SYMPY_GROUND_TYPES": "python"},
+        text=True,
+        timeout=180,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout) == {
+        "results": 16,
+        "host_loaded_z3": False,
+    }

--- a/tests/process/tooling/test_deploy_helpers.py
+++ b/tests/process/tooling/test_deploy_helpers.py
@@ -8,6 +8,8 @@ they do not exercise installation, state migration, or rollout machinery.
 
 from __future__ import annotations
 
+import json
+
 import httpx2
 import pytest
 from deploy.smoke import (
@@ -17,6 +19,73 @@ from deploy.smoke import (
     is_transient_transport_failure,
     raise_for_http_error,
 )
+from deploy.smoke_remote import _validate_discovery_response
+
+
+def _current_discovery_payload() -> dict[str, object]:
+    return {
+        "kind": "discovery",
+        "query": "exact determinant",
+        "namespace": None,
+        "matches": [
+            {
+                "operation_id": "matrix.determinant.compute",
+                "title": "Exact determinant",
+                "description": "Compute one exact determinant.",
+                "tags": ["matrix", "determinant"],
+            }
+        ],
+        "total_matches": 1,
+        "next_cursor": None,
+        "catalog_resource": "operation://catalog",
+    }
+
+
+def test_remote_smoke_accepts_the_current_typed_discovery_response() -> None:
+    discovery = _current_discovery_payload()
+    failures: list[str] = []
+
+    matches = _validate_discovery_response(
+        discovery,
+        json.dumps(discovery),
+        failures,
+    )
+
+    assert matches == ("matrix.determinant.compute",)
+    assert failures == []
+
+
+def test_remote_smoke_rejects_divergent_model_visible_discovery() -> None:
+    discovery = _current_discovery_payload()
+    failures: list[str] = []
+
+    _validate_discovery_response(
+        discovery,
+        json.dumps({**discovery, "matches": []}),
+        failures,
+    )
+
+    assert failures == [
+        "deployed operation discovery text and structured content disagree"
+    ]
+
+
+def test_remote_smoke_reports_the_removed_discovery_limit_as_schema_drift() -> None:
+    discovery = {
+        **_current_discovery_payload(),
+        "response_byte_limit": 16_384,
+    }
+    failures: list[str] = []
+
+    matches = _validate_discovery_response(
+        discovery,
+        json.dumps(discovery),
+        failures,
+    )
+
+    assert matches == ()
+    assert len(failures) == 1
+    assert failures[0].startswith("deployed operation discovery violates its schema:")
 
 
 def test_smoke_retry_classification_is_transport_only() -> None:

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -30,6 +30,8 @@ _EXTERNAL_OPERATION_OWNERS = frozenset(
         PurePosixPath("src/jacobian/math/graphs/optimization/_finite_optimization.py"),
         PurePosixPath("src/jacobian/math/graphs/optimization/_invariants.py"),
         PurePosixPath("src/jacobian/math/graphs/optimization/_chromatic_number.py"),
+        PurePosixPath("src/jacobian/math/graphs/optimization/_maximum_cut_process.py"),
+        PurePosixPath("src/jacobian/math/discrepancy_theory/_optimum_process.py"),
         PurePosixPath("src/jacobian/math/number_theory/_factorization_kernels.py"),
         PurePosixPath("src/jacobian/math/number_field/_operations.py"),
         PurePosixPath("src/jacobian/math/polynomials/multivariate/_factor_backend.py"),


### PR DESCRIPTION
## Problem

The deployed remote MCP host can still enter Z3 from `graph.cut.maximum.compute` and `discrepancy.theory.optimum.compute`. On z3-solver 5.1.0, mixed concurrent calls reproducibly abort the service process in `libz3` with the `ast.cpp:375` assertion. The existing systemd restart policy recovers, but active MCP sessions are disconnected.

The remote smoke script also reads the removed `response_byte_limit` discovery field, so the rollout probe crashes instead of validating the current discovery contract.

## Changes

- run both remaining native solver paths in bounded, request-owned workers
- retain the already-admitted exact enumeration fallback for maximum cut
- map discrepancy worker timeout/crash to claim-free typed outcomes
- keep native Python API kernels unchanged
- validate remote discovery through `OperationFindResponse` and require text/structured projection parity
- add a real concurrent catalog-tool regression proving the service host never imports Z3

## Validation

- `make handoff LANE=math TESTS="tests/math/graphs/test_graph_maximum_cut.py tests/math/discrepancy_theory/test_discrepancy_theory.py"` (83 passed; Ruff and mypy passed)
- `make test-process TESTS="tests/process/test_z3_tool_isolation.py tests/process/tooling/test_deploy_helpers.py"` (14 passed)
- `make test-tooling TESTS="tests/tooling/test_architecture.py"` (31 passed)
- `make test-catalog` (117 passed)
- `make test-integration TESTS="tests/integration/catalog/test_mcp_builtin_examples.py"` (2 passed)
- `make test-mcp TESTS="tests/mcp/test_mcp_sdk_2_conformance.py"` (6 passed)
- `make import-contracts architecture repository-hygiene docs-linkcheck` passed
- `make build` and wheel-content validation passed
- streamable-HTTP stress: 320 mixed calls, 0 errors, host remained live, no child workers remained
- remote smoke against the candidate: version 0.15.1, 637 operations, typed discovery parity passed

`make affected` also ran its complete selected math lane. It reached 5900 passes and 53 failures, all in the unchanged `tests/math/logic/test_unsat_core.py`; three representative failures reproduce unchanged on an isolated exact `origin/main@d9e838796` worktree because the VPS exceeds that operation's 1-second request deadline during worker cold start. Those typed `UNKNOWN` baseline outcomes are unrelated to this diff.
