### PR TITLE
Refactor math operations around native admission and canonical results

### DIFF
--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -221,6 +221,14 @@ known-answer, adversarial, and property-based fixtures. Independently supplied
 claims need an explicit bounded verifier only when a public consumer accepts
 those claims as theorem-bearing input.
 
+Public results describe mathematical meaning, not the implementation used to
+compute it. Do not expose a constant backend, method, algorithm, exactness,
+determinism, or verification field merely to narrate trusted execution. Retain
+a field only when its value can vary and changes how callers must interpret the
+mathematical result. Examples include exact versus unknown status, complete
+versus bounded coverage, a normalization convention, approximation error, or a
+caller-selected algorithm that is part of the public contract.
+
 These checks have distinct owners. Catalog admission decides whether an
 operation is published; it does not admit a particular runtime request.
 Request admission proves that one parsed request belongs to the advertised

--- a/src/jacobian/math/analysis/_box_enclosure.py
+++ b/src/jacobian/math/analysis/_box_enclosure.py
@@ -185,7 +185,6 @@ class IntervalExpressionBoxEnclosureResult(IntervalExpressionBoxEnclosureRequest
     lower: ExactDyadic | None = None
     upper: ExactDyadic | None = None
     domain_failure: IntervalExpressionDomainFailure | None = None
-    method: Literal["ARB_NATURAL_INTERVAL_EXTENSION"] = "ARB_NATURAL_INTERVAL_EXTENSION"
     detail: str = Field(min_length=1, max_length=1024)
 
     @model_validator(mode="after")
@@ -237,7 +236,6 @@ class IntervalExpressionBoxEnclosureResult(IntervalExpressionBoxEnclosureRequest
             lower=lower,
             upper=upper,
             domain_failure=domain_failure,
-            method="ARB_NATURAL_INTERVAL_EXTENSION",
             detail=detail,
         )
 

--- a/src/jacobian/math/analysis/_second_jet.py
+++ b/src/jacobian/math/analysis/_second_jet.py
@@ -130,7 +130,6 @@ class IntervalExpressionSecondJetEnclosureResult(
         max_length=MAX_SECOND_JET_VARIABLES * (MAX_SECOND_JET_VARIABLES + 1) // 2,
     )
     domain_failure: IntervalExpressionDomainFailure | None = None
-    method: Literal["ARB_FORWARD_SECOND_ORDER_JET"] = "ARB_FORWARD_SECOND_ORDER_JET"
     detail: str = Field(min_length=1, max_length=1024)
 
     @field_validator("gradient", mode="before")
@@ -225,7 +224,6 @@ class IntervalExpressionSecondJetEnclosureResult(
             gradient=gradient,
             hessian=hessian,
             domain_failure=domain_failure,
-            method="ARB_FORWARD_SECOND_ORDER_JET",
             detail=detail,
         )
 

--- a/src/jacobian/math/analysis/boolean/fourier/_models.py
+++ b/src/jacobian/math/analysis/boolean/fourier/_models.py
@@ -100,7 +100,6 @@ class MultilinearExtensionResult(StrictModel):
 
     polynomial: str = Field(min_length=1)
     variable_count: int = Field(ge=1, le=MAX_VARIABLES)
-    convention: Literal["SYMPY"] = "SYMPY"
 
 
 class ErasureNoiseRequest(StrictModel):

--- a/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
@@ -231,14 +231,6 @@ def compute_shifted_hankel(request: ShiftedHankelRequest) -> HankelMomentMatrix:
     return hankel_matrix_from_prefix(request.prefix, request.order, shifted=True)
 
 
-def _poly_eval(coeffs: list[Fraction], x: Fraction) -> Fraction:
-    """Evaluate a polynomial with given coefficients (lowest degree first)."""
-    result = Fraction(0)
-    for c in reversed(coeffs):
-        result = result * x + c
-    return result
-
-
 def _require_nonzero_norm(norm: Fraction, degree: int) -> None:
     """Quasi-definite prefixes have no vanishing orthogonal-polynomial norm."""
     if norm == 0:

--- a/src/jacobian/math/combinatorics/_difference_set_models.py
+++ b/src/jacobian/math/combinatorics/_difference_set_models.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-from collections import Counter
 from typing import Annotated, Literal, Self
 
 from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
@@ -51,7 +50,7 @@ def _difference_set_validation_error(code: str, message: str) -> PydanticCustomE
 
 
 class IntegerSidonRequest(StrictModel):
-    """One bounded finite integer set for ordered-difference replay."""
+    """One bounded finite integer set for an ordered-difference profile."""
 
     elements: tuple[AdditiveInteger, ...] = Field(max_length=MAX_SIDON_SET_SIZE)
 
@@ -80,37 +79,19 @@ class IntegerSidonResult(StrictModel):
         max_length=MAX_SIDON_SET_SIZE * (MAX_SIDON_SET_SIZE - 1)
     )
     is_sidon: StrictBool
-    exactness: Literal["EXACT_INTEGER"] = "EXACT_INTEGER"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @model_validator(mode="after")
-    def bind_complete_ordered_difference_profile(self) -> Self:
+    def require_canonical_profile_shape(self) -> Self:
         values = tuple(int(value) for value in self.normalized_elements)
         if values != tuple(sorted(set(values))):
             raise _difference_set_validation_error(
                 "combinatorics.sidon_invariant",
                 "normalized Sidon elements must be sorted and unique",
             )
-        expected = tuple(
-            (left, right, left - right)
-            for left in values
-            for right in values
-            if left != right
-        )
-        actual = tuple(
-            (int(item.minuend), int(item.subtrahend), int(item.difference))
-            for item in self.ordered_differences
-        )
-        if actual != expected:
+        if len(self.ordered_differences) != len(values) * (len(values) - 1):
             raise _difference_set_validation_error(
                 "combinatorics.sidon_invariant",
-                "ordered differences must be the complete canonical profile",
-            )
-        differences = tuple(difference for _, _, difference in expected)
-        if self.is_sidon != (len(set(differences)) == len(differences)):
-            raise _difference_set_validation_error(
-                "combinatorics.sidon_invariant",
-                "Sidon decision must agree with the ordered-difference profile",
+                "ordered-difference profile has the wrong cardinality",
             )
         return self
 
@@ -126,8 +107,6 @@ class IntegerSidonResult(StrictModel):
             normalized_elements=normalized_elements,
             ordered_differences=ordered_differences,
             is_sidon=is_sidon,
-            exactness="EXACT_INTEGER",
-            determinism="DETERMINISTIC",
         )
 
 
@@ -174,11 +153,9 @@ class CyclicPerfectDifferenceSetResult(StrictModel):
         max_length=MAX_CYCLIC_DIFFERENCE_SET_MODULUS - 1
     )
     is_perfect: StrictBool
-    exactness: Literal["EXACT_FINITE"] = "EXACT_FINITE"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @model_validator(mode="after")
-    def bind_complete_cyclic_profile(self) -> Self:
+    def require_canonical_profile_shape(self) -> Self:
         residues = self.normalized_residues
         if residues != tuple(sorted(set(residues))):
             raise _difference_set_validation_error(
@@ -205,29 +182,11 @@ class CyclicPerfectDifferenceSetResult(StrictModel):
                 "combinatorics.difference_set_invariant",
                 "cyclic difference profile must cover every nonzero residue",
             )
-        counts = Counter(
-            (left - right) % self.modulus
-            for left in residues
-            for right in residues
-            if left != right
-        )
-        expected_profile = tuple(
-            counts.get(residue, 0) for residue in range(1, self.modulus)
-        )
-        if tuple(item.multiplicity for item in profile) != expected_profile:
-            raise _difference_set_validation_error(
-                "combinatorics.difference_set_invariant",
-                "cyclic difference profile must match the retained residue set",
-            )
         expected_missing = tuple(
-            residue
-            for residue, multiplicity in enumerate(expected_profile, start=1)
-            if multiplicity == 0
+            item.residue for item in profile if item.multiplicity == 0
         )
         expected_repeated = tuple(
-            residue
-            for residue, multiplicity in enumerate(expected_profile, start=1)
-            if multiplicity > 1
+            item.residue for item in profile if item.multiplicity > 1
         )
         if (
             self.missing_residues != expected_missing
@@ -271,8 +230,6 @@ class CyclicPerfectDifferenceSetResult(StrictModel):
             missing_residues=missing_residues,
             repeated_residues=repeated_residues,
             is_perfect=is_perfect,
-            exactness="EXACT_FINITE",
-            determinism="DETERMINISTIC",
         )
 
 
@@ -304,8 +261,6 @@ class CyclicDifferenceSetExtensionResult(StrictModel):
     decision: Literal["EXTENDS", "DOES_NOT_EXTEND"]
     extension: tuple[StrictInt, ...] = Field(max_length=64)
     coverage: Literal["WITNESS", "ALL_CANDIDATES"]
-    exactness: Literal["EXACT_FINITE"] = "EXACT_FINITE"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @model_validator(mode="after")
     def bind_extension_claim(self) -> Self:
@@ -336,23 +291,24 @@ class CyclicDifferenceSetExtensionResult(StrictModel):
                 "combinatorics.extension_invariant",
                 "extension candidate-space size must match the retained source",
             )
-        from jacobian.math.combinatorics._difference_sets import _find_extension
-
-        witness = _find_extension(self.base_residues, self.target_order, self.modulus)
         if self.decision == "EXTENDS":
             if (
                 self.coverage != "WITNESS"
-                or witness is None
-                or self.extension != witness
+                or len(self.extension) != self.target_order
+                or self.extension != tuple(sorted(set(self.extension)))
+                or not set(self.base_residues) <= set(self.extension)
+                or any(
+                    residue < 0 or residue >= self.modulus for residue in self.extension
+                )
             ):
                 raise _difference_set_validation_error(
                     "combinatorics.extension_invariant",
-                    "extension witness must be the canonical complete-search witness",
+                    "extension witness must be canonical and retain the base residues",
                 )
-        elif self.coverage != "ALL_CANDIDATES" or self.extension or witness is not None:
+        elif self.coverage != "ALL_CANDIDATES" or self.extension:
             raise _difference_set_validation_error(
                 "combinatorics.extension_invariant",
-                "negative extension decision must bind a complete candidate search",
+                "negative extension decisions cannot carry a witness",
             )
         return self
 
@@ -374,6 +330,4 @@ class CyclicDifferenceSetExtensionResult(StrictModel):
             decision="EXTENDS" if extension is not None else "DOES_NOT_EXTEND",
             extension=extension or (),
             coverage="WITNESS" if extension is not None else "ALL_CANDIDATES",
-            exactness="EXACT_FINITE",
-            determinism="DETERMINISTIC",
         )

--- a/src/jacobian/math/combinatorics/_recurrence_admission.py
+++ b/src/jacobian/math/combinatorics/_recurrence_admission.py
@@ -168,8 +168,6 @@ def _admit_linear_recurrence(
         lambda: _validate_result_inline_size(
             {
                 "coefficient_convention": coefficient_convention,
-                "determinism": "DETERMINISTIC",
-                "exactness": "EXACT_RATIONAL",
                 "scope": scope,
                 "values": [
                     {"index": index, "value": _fraction_wire(prefix[index])}
@@ -279,8 +277,6 @@ def _admit_p_recursive_recurrence(
             {
                 "coefficient_convention": coefficient_convention,
                 "polynomial_convention": polynomial_convention,
-                "determinism": "DETERMINISTIC",
-                "exactness": "EXACT_RATIONAL",
                 "recurrence_order": order,
                 "scope": scope,
                 "values": [
@@ -357,8 +353,6 @@ def _admit_series(
             {
                 "coefficient_convention": coefficient_convention,
                 "coefficients": [_fraction_wire(value) for value in coefficients],
-                "determinism": "DETERMINISTIC",
-                "exactness": "EXACT_RATIONAL",
                 "expansion_point": expansion_point,
                 "residual_coefficients": [_fraction_wire(Fraction())]
                 * truncation_order,

--- a/src/jacobian/math/combinatorics/_recurrence_models.py
+++ b/src/jacobian/math/combinatorics/_recurrence_models.py
@@ -187,8 +187,6 @@ class LinearRecurrenceEvaluationResult(StrictModel):
         min_length=1,
         max_length=MAX_LINEAR_RECURRENCE_INDEX + 1,
     )
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @classmethod
     def _from_kernel(
@@ -204,8 +202,6 @@ class LinearRecurrenceEvaluationResult(StrictModel):
             coefficient_convention=coefficient_convention,
             scope=scope,
             values=values,
-            exactness="EXACT_RATIONAL",
-            determinism="DETERMINISTIC",
         )
 
     @model_validator(mode="after")
@@ -289,8 +285,6 @@ class PolynomialCoefficientRecurrenceEvaluationResult(StrictModel):
     values: tuple[IndexedRationalValue, ...] = Field(
         min_length=1, max_length=MAX_LINEAR_RECURRENCE_INDEX + 1
     )
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @classmethod
     def _from_kernel(
@@ -310,8 +304,6 @@ class PolynomialCoefficientRecurrenceEvaluationResult(StrictModel):
             scope=scope,
             recurrence_order=recurrence_order,
             values=values,
-            exactness="EXACT_RATIONAL",
-            determinism="DETERMINISTIC",
         )
 
     @model_validator(mode="after")
@@ -365,8 +357,6 @@ class RationalGeneratingFunctionCoefficientsResult(StrictModel):
         min_length=1,
         max_length=MAX_RATIONAL_SERIES_TRUNCATION_ORDER,
     )
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @classmethod
     def _from_kernel(
@@ -388,8 +378,6 @@ class RationalGeneratingFunctionCoefficientsResult(StrictModel):
             coefficients=coefficients,
             residual_congruence=residual_congruence,
             residual_coefficients=residual_coefficients,
-            exactness="EXACT_RATIONAL",
-            determinism="DETERMINISTIC",
         )
 
     @model_validator(mode="after")

--- a/src/jacobian/math/combinatorics/algebraic/_models.py
+++ b/src/jacobian/math/combinatorics/algebraic/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
@@ -64,7 +64,6 @@ class HookLengthResult(StrictModel):
 
     hooks: tuple[tuple[int, ...], ...]
     total_product: CanonicalInteger = Field(description="Product of all hook lengths.")
-    method: Literal["HOOK_FORMULA"] = "HOOK_FORMULA"
 
 
 class StandardYoungTableauCountResult(StrictModel):
@@ -72,14 +71,12 @@ class StandardYoungTableauCountResult(StrictModel):
 
     count: CanonicalInteger = Field(description="Number of standard Young tableaux.")
     n: int = Field(ge=0, le=MAX_CANONICAL_PARTITION_SIZE)
-    method: Literal["HOOK_LENGTH_FORMULA"] = "HOOK_LENGTH_FORMULA"
 
 
 class ConjugatePartitionResult(StrictModel):
     """The conjugate (transpose) partition."""
 
     conjugate: IntegerPartition
-    method: Literal["FERRERS_TRANSPOSE"] = "FERRERS_TRANSPOSE"
 
 
 # ---------------------------------------------------------------------------

--- a/src/jacobian/math/combinatorics/codes/general/_models.py
+++ b/src/jacobian/math/combinatorics/codes/general/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from typing import Annotated, Self
 
 from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
@@ -25,36 +25,6 @@ _WeightCount = Annotated[
 
 def _error(code: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(code, message)
-
-
-def _validate_prime_field_matrix(
-    field_order: int,
-    generator_matrix: tuple[tuple[int, ...], ...],
-) -> int:
-    from sympy import isprime
-
-    if not isprime(field_order):
-        raise _error(
-            "code_theory.field_order_not_prime",
-            "field_order must be prime for this prime-field operation",
-        )
-    width = len(generator_matrix[0])
-    if width == 0 or width > 256:
-        raise _error(
-            "code_theory.generator_width_out_of_bounds",
-            "generator rows must have between one and 256 entries",
-        )
-    if any(len(row) != width for row in generator_matrix):
-        raise _error(
-            "code_theory.generator_rows_unequal",
-            "generator matrix rows must have equal length",
-        )
-    if any(not 0 <= entry < field_order for row in generator_matrix for entry in row):
-        raise _error(
-            "code_theory.generator_entry_not_canonical",
-            "generator entries must be canonical field residues",
-        )
-    return width
 
 
 def _matrix_rank_mod_prime(
@@ -101,11 +71,6 @@ class LinearCodeRequest(StrictModel):
     field_order: int = Field(ge=2, le=251)
     generator_matrix: tuple[tuple[int, ...], ...] = Field(min_length=1, max_length=8)
 
-    @model_validator(mode="after")
-    def require_bounded_prime_field_matrix(self) -> Self:
-        _validate_prime_field_matrix(self.field_order, self.generator_matrix)
-        return self
-
 
 class MinimumDistanceResult(StrictModel):
     """An exact minimum-distance claim in its canonical source coordinates.
@@ -116,7 +81,6 @@ class MinimumDistanceResult(StrictModel):
 
     request: LinearCodeRequest
     minimum_distance: int = Field(ge=0, le=256)
-    method: Literal["EXACT_ENUMERATION"] = "EXACT_ENUMERATION"
 
     @model_validator(mode="after")
     def require_bounded_distance(self) -> Self:
@@ -146,7 +110,6 @@ class WeightDistributionResult(StrictModel):
         min_length=1,
         max_length=257,
     )
-    method: Literal["EXACT_ENUMERATION"] = "EXACT_ENUMERATION"
 
     @model_validator(mode="after")
     def require_structural_weight_rows(self) -> Self:
@@ -181,11 +144,6 @@ class CoveringRadiusRequest(StrictModel):
     field_order: int = Field(ge=2, le=251)
     generator_matrix: tuple[tuple[int, ...], ...] = Field(min_length=1, max_length=8)
 
-    @model_validator(mode="after")
-    def require_prime_field_matrix(self) -> Self:
-        _validate_prime_field_matrix(self.field_order, self.generator_matrix)
-        return self
-
 
 class CoveringRadiusResult(StrictModel):
     """An exact covering-radius claim in canonical source coordinates.
@@ -195,7 +153,6 @@ class CoveringRadiusResult(StrictModel):
 
     request: CoveringRadiusRequest
     covering_radius: int = Field(ge=0, le=256)
-    method: Literal["SYNDROME_BFS"] = "SYNDROME_BFS"
 
     @model_validator(mode="after")
     def require_bounded_radius(self) -> Self:

--- a/src/jacobian/math/combinatorics/codes/general/_operations.py
+++ b/src/jacobian/math/combinatorics/codes/general/_operations.py
@@ -2,20 +2,12 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.codes.general._models import (
-    EXACT_ENUMERATION_PASSES,
-    MAX_COVERING_RADIUS_STATES_PER_PASS,
-    MAX_COVERING_RADIUS_TRANSITIONS,
-    MAX_EXACT_CODEWORD_EVALUATIONS,
-    SYNDROME_BFS_PASSES,
     CoveringRadiusRequest,
     CoveringRadiusResult,
     LinearCodeRequest,
     MinimumDistanceResult,
     WeightDistributionResult,
-    _matrix_rank_mod_prime,
-    _validate_prime_field_matrix,
 )
 from jacobian.math.combinatorics.codes.general.operations import (
     covering_radius,
@@ -25,15 +17,6 @@ from jacobian.math.combinatorics.codes.general.operations import (
 
 
 def compute_min_distance(request: LinearCodeRequest) -> MinimumDistanceResult:
-    if (
-        EXACT_ENUMERATION_PASSES * request.field_order ** len(request.generator_matrix)
-        > MAX_EXACT_CODEWORD_EVALUATIONS
-    ):
-        raise OperationDomainValidationError(
-            location=("generator_matrix",),
-            code="code_theory.enumeration_work_exceeded",
-            message="generator matrix exceeds the exact enumeration bound",
-        )
     dist = minimum_distance(request.generator_matrix, request.field_order)
     return MinimumDistanceResult._from_kernel(
         request=request,
@@ -42,15 +25,6 @@ def compute_min_distance(request: LinearCodeRequest) -> MinimumDistanceResult:
 
 
 def compute_weight_dist(request: LinearCodeRequest) -> WeightDistributionResult:
-    if (
-        EXACT_ENUMERATION_PASSES * request.field_order ** len(request.generator_matrix)
-        > MAX_EXACT_CODEWORD_EVALUATIONS
-    ):
-        raise OperationDomainValidationError(
-            location=("generator_matrix",),
-            code="code_theory.enumeration_work_exceeded",
-            message="generator matrix exceeds the exact enumeration bound",
-        )
     weights = weight_distribution(request.generator_matrix, request.field_order)
     return WeightDistributionResult._from_kernel(
         request=request,
@@ -59,25 +33,6 @@ def compute_weight_dist(request: LinearCodeRequest) -> WeightDistributionResult:
 
 
 def compute_covering_radius(request: CoveringRadiusRequest) -> CoveringRadiusResult:
-    width = _validate_prime_field_matrix(request.field_order, request.generator_matrix)
-    rank = _matrix_rank_mod_prime(request.generator_matrix, request.field_order)
-    state_count = request.field_order ** (width - rank)
-    if state_count > MAX_COVERING_RADIUS_STATES_PER_PASS:
-        raise OperationDomainValidationError(
-            location=("generator_matrix",),
-            code="code_theory.syndrome_state_bound_exceeded",
-            message="syndrome space exceeds the exact state bound",
-        )
-    move_count_bound = min(width * (request.field_order - 1), max(state_count - 1, 0))
-    if (
-        SYNDROME_BFS_PASSES * state_count * move_count_bound
-        > MAX_COVERING_RADIUS_TRANSITIONS
-    ):
-        raise OperationDomainValidationError(
-            location=("generator_matrix",),
-            code="code_theory.syndrome_transition_bound_exceeded",
-            message="syndrome graph exceeds the exact transition bound",
-        )
     radius = covering_radius(request.generator_matrix, request.field_order)
     return CoveringRadiusResult._from_kernel(
         request=request,

--- a/src/jacobian/math/combinatorics/codes/general/operations.py
+++ b/src/jacobian/math/combinatorics/codes/general/operations.py
@@ -6,6 +6,20 @@ from collections import deque
 from collections.abc import Iterator
 from itertools import product
 
+from sympy import isprime
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics.codes.general._models import (
+    EXACT_ENUMERATION_PASSES,
+    MAX_COVERING_RADIUS_STATES_PER_PASS,
+    MAX_COVERING_RADIUS_TRANSITIONS,
+    MAX_EXACT_CODEWORD_EVALUATIONS,
+    SYNDROME_BFS_PASSES,
+    CoveringRadiusRequest,
+    LinearCodeRequest,
+    _matrix_rank_mod_prime,
+)
+
 __all__ = [
     "GeneratorMatrix",
     "covering_radius",
@@ -15,6 +29,51 @@ __all__ = [
 
 
 GeneratorMatrix = tuple[tuple[int, ...], ...]
+
+
+def _admit_prime_field_matrix(
+    field_order: int,
+    generator_matrix: GeneratorMatrix,
+) -> int:
+    if not isprime(field_order):
+        raise OperationDomainValidationError(
+            location=("field_order",),
+            code="code_theory.field_order_not_prime",
+            message="field_order must be prime for this prime-field operation",
+        )
+    width = len(generator_matrix[0])
+    if width == 0 or width > 256:
+        raise OperationDomainValidationError(
+            location=("generator_matrix",),
+            code="code_theory.generator_width_out_of_bounds",
+            message="generator rows must have between one and 256 entries",
+        )
+    if any(len(row) != width for row in generator_matrix):
+        raise OperationDomainValidationError(
+            location=("generator_matrix",),
+            code="code_theory.generator_rows_unequal",
+            message="generator matrix rows must have equal length",
+        )
+    if any(not 0 <= entry < field_order for row in generator_matrix for entry in row):
+        raise OperationDomainValidationError(
+            location=("generator_matrix",),
+            code="code_theory.generator_entry_not_canonical",
+            message="generator entries must be canonical field residues",
+        )
+    return width
+
+
+def _admit_enumeration(request: LinearCodeRequest) -> None:
+    _admit_prime_field_matrix(request.field_order, request.generator_matrix)
+    if (
+        EXACT_ENUMERATION_PASSES * request.field_order ** len(request.generator_matrix)
+        > MAX_EXACT_CODEWORD_EVALUATIONS
+    ):
+        raise OperationDomainValidationError(
+            location=("generator_matrix",),
+            code="code_theory.enumeration_work_exceeded",
+            message="generator matrix exceeds the exact enumeration bound",
+        )
 
 
 def _codewords(
@@ -41,11 +100,10 @@ def minimum_distance(generator_matrix: GeneratorMatrix, field_order: int) -> int
     For the zero code (rank 0) no nonzero codeword exists; the code
     length is returned by the empty-code convention.
     """
-    from jacobian.math.combinatorics.codes.general._models import LinearCodeRequest
-
     request = LinearCodeRequest(
         generator_matrix=generator_matrix, field_order=field_order
     )
+    _admit_enumeration(request)
     min_dist = float("inf")
     for codeword in _codewords(request.generator_matrix, request.field_order):
         weight = sum(1 for c in codeword if c != 0)
@@ -59,11 +117,10 @@ def weight_distribution(
 ) -> list[tuple[int, int]]:
     from collections import Counter
 
-    from jacobian.math.combinatorics.codes.general._models import LinearCodeRequest
-
     request = LinearCodeRequest(
         generator_matrix=generator_matrix, field_order=field_order
     )
+    _admit_enumeration(request)
 
     weights: Counter[int] = Counter()
     for codeword in _codewords(request.generator_matrix, request.field_order):
@@ -130,11 +187,28 @@ def covering_radius(generator_matrix: GeneratorMatrix, field_order: int) -> int:
     Therefore graph distance from the zero syndrome is minimum coset-leader
     weight, and the maximum distance is the covering radius.
     """
-    from jacobian.math.combinatorics.codes.general._models import CoveringRadiusRequest
-
     request = CoveringRadiusRequest(
         generator_matrix=generator_matrix, field_order=field_order
     )
+    width = _admit_prime_field_matrix(request.field_order, request.generator_matrix)
+    rank = _matrix_rank_mod_prime(request.generator_matrix, request.field_order)
+    state_count = request.field_order ** (width - rank)
+    if state_count > MAX_COVERING_RADIUS_STATES_PER_PASS:
+        raise OperationDomainValidationError(
+            location=("generator_matrix",),
+            code="code_theory.syndrome_state_bound_exceeded",
+            message="syndrome space exceeds the exact state bound",
+        )
+    move_count_bound = min(width * (request.field_order - 1), max(state_count - 1, 0))
+    if (
+        SYNDROME_BFS_PASSES * state_count * move_count_bound
+        > MAX_COVERING_RADIUS_TRANSITIONS
+    ):
+        raise OperationDomainValidationError(
+            location=("generator_matrix",),
+            code="code_theory.syndrome_transition_bound_exceeded",
+            message="syndrome graph exceeds the exact transition bound",
+        )
     check_rows = _parity_check_matrix(
         request.generator_matrix,
         request.field_order,

--- a/src/jacobian/math/combinatorics/codes/linear/_models.py
+++ b/src/jacobian/math/combinatorics/codes/linear/_models.py
@@ -608,7 +608,6 @@ class FromGeneratorResult(StrictModel):
     dimension: int = Field(ge=0)
     length: int = Field(ge=0)
     cardinality: int = Field(ge=1)
-    method: str = "RREF"
 
     @model_validator(mode="after")
     def require_consistent_summaries(self) -> Self:
@@ -638,7 +637,6 @@ class DualCodeResult(StrictModel):
     dimension: int = Field(ge=0)
     dual_dimension: int = Field(ge=0)
     length: int = Field(ge=0)
-    method: str = "NULLSPACE"
 
     @model_validator(mode="after")
     def require_consistent_dual(self) -> Self:
@@ -680,7 +678,6 @@ class ParityCheckResult(StrictModel):
     dimension: int = Field(ge=0)
     rank_h: int = Field(ge=0)
     length: int = Field(ge=0)
-    method: str = "NULLSPACE"
 
 
 class CodewordCheckResult(StrictModel):
@@ -688,13 +685,11 @@ class CodewordCheckResult(StrictModel):
     hamming_weight: int = Field(ge=0)
     coefficients: tuple[int, ...] = ()
     syndrome: tuple[int, ...] = ()
-    method: str = "RREF_MEMBERSHIP"
 
 
 class SyndromeResult(StrictModel):
     syndrome: tuple[int, ...]
     is_member: bool
-    method: str = "MATRIX_VECTOR_PRODUCT"
 
 
 class CodeEqualResult(StrictModel):
@@ -702,12 +697,10 @@ class CodeEqualResult(StrictModel):
     dimension_a: int = Field(ge=0)
     dimension_b: int = Field(ge=0)
     witness_word: tuple[int, ...] | None = None
-    method: str = "MUTUAL_ROW_SPACE_CONTAINMENT"
 
 
 class MacWilliamsResult(StrictModel):
     dual_weights: tuple[int, ...]
-    method: str = "MACWILLIAMS_IDENTITY"
 
 
 class PunctureResult(StrictModel):
@@ -716,7 +709,6 @@ class PunctureResult(StrictModel):
     encoder: PrimeFieldLinearEncoder
     dimension: int = Field(ge=0)
     length: int = Field(ge=0)
-    method: str = "PUNCTURE"
 
     @model_validator(mode="after")
     def require_consistent_summaries(self) -> Self:
@@ -739,7 +731,6 @@ class ShortenResult(StrictModel):
     encoder: PrimeFieldLinearEncoder
     dimension: int = Field(ge=0)
     length: int = Field(ge=0)
-    method: str = "SHORTEN"
 
     @model_validator(mode="after")
     def require_consistent_summaries(self) -> Self:

--- a/src/jacobian/math/combinatorics/codes/nonlinear/_budget.py
+++ b/src/jacobian/math/combinatorics/codes/nonlinear/_budget.py
@@ -52,12 +52,6 @@ def _binary_word_wire_bytes(length: int) -> int:
     return max(2, 2 * length + 1)
 
 
-def _array_wire_bytes(length: int, maximum_value: int) -> int:
-    if length == 0:
-        return 2
-    return 1 + length * (_digits(maximum_value) + 1)
-
-
 def _sum_coordinate_digits(length: int) -> int:
     """Return the exact decimal digits in ``0, ..., length-1``."""
     if length == 0:

--- a/src/jacobian/math/combinatorics/designs/coherent_configurations/_models.py
+++ b/src/jacobian/math/combinatorics/designs/coherent_configurations/_models.py
@@ -96,9 +96,6 @@ class CoherentConfigurationAnalyzeResult(StrictModel):
         max_length=MAX_COHERENT_CONFIGURATION_RELATIONS**3
     )
     obstruction: CoherenceObstruction | None = None
-    method: Literal["DIRECT_COMPLETE_PAIR_PARTITION_ANALYSIS"] = (
-        "DIRECT_COMPLETE_PAIR_PARTITION_ANALYSIS"
-    )
 
     @model_validator(mode="after")
     def require_result_shape(self) -> Self:

--- a/src/jacobian/math/combinatorics/designs/latin_squares/_models.py
+++ b/src/jacobian/math/combinatorics/designs/latin_squares/_models.py
@@ -105,15 +105,12 @@ class OrthogonalityRequest(StrictModel):
 
 class LatinSquareCheckResult(StrictModel):
     is_latin: bool
-    method: str = "ROW_COLUMN_SYMBOL_UNIQUENESS"
 
 
 class OrthogonalityResult(StrictModel):
     is_orthogonal: bool
     pair_count: int = Field(ge=0)
-    method: str = "ORDERED_PAIR_UNIQUENESS"
 
 
 class LatinSquareTransposeResult(StrictModel):
     transposed: tuple[tuple[int, ...], ...]
-    method: str = "MATRIX_TRANSPOSE"

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_independence_z3.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_independence_z3.py
@@ -143,32 +143,6 @@ def _solver_witness_is_canonical_and_independent(
     return not any(set(members) <= candidate_set for _, members in source.edges)
 
 
-def _externally_supplied_exact_result_is_valid(
-    result: HypergraphIndependenceResult,
-    *,
-    started: float,
-) -> bool:
-    """Authenticate an exact worker claim with one bounded threshold check."""
-
-    if result.status != "EXACT":
-        return True
-    if result.independence_number is None:
-        return False
-    solver, selected, cardinality = _build_solver(result.hypergraph)
-    status, _, _ = _check_threshold(
-        solver,
-        selected,
-        cardinality,
-        result.independence_number + 1,
-        started,
-        result.resource_budget.wall_seconds,
-        result.hypergraph.vertices,
-    )
-    import z3
-
-    return cast(bool, status == z3.unsat)
-
-
 def _solve_independence_number_kernel(
     request: HypergraphIndependenceRequest,
 ) -> HypergraphIndependenceResult:
@@ -394,23 +368,9 @@ def solve_independence_number(
             termination_reason="WALL_TIME",
             detail="the hypergraph independence request expired before worker startup",
         )
-    verification_reserve = min(1.0, request.resource_budget.wall_seconds / 5)
-    worker_seconds = remaining_seconds - verification_reserve
-    if worker_seconds <= 0:
-        return _result(
-            request,
-            status="UNKNOWN",
-            independence_number=None,
-            incumbent=incumbent,
-            upper_bound=source_upper_bound,
-            solver_calls=0,
-            wall_budget_exhausted=True,
-            termination_reason="WALL_TIME",
-            detail="the hypergraph independence request expired before worker startup",
-        )
     response = _run_independence_worker(
         {"kind": "solve", "request": request.model_dump(mode="json")},
-        timeout_seconds=worker_seconds,
+        timeout_seconds=remaining_seconds,
     )
     if not isinstance(response, dict):
         return _result(
@@ -448,8 +408,6 @@ def solve_independence_number(
                 "resource_budget": request.resource_budget.model_dump(mode="json"),
             }
         )
-        if not _externally_supplied_exact_result_is_valid(result, started=started):
-            raise ValueError("worker exact claim failed bounded verification")
         if _remaining_ms(started, request.resource_budget.wall_seconds) > 0:
             return result
         raise ValueError("request expired during response validation")

--- a/src/jacobian/math/combinatorics/greedoids/operations.py
+++ b/src/jacobian/math/combinatorics/greedoids/operations.py
@@ -29,10 +29,6 @@ __all__ = [
 ]
 
 
-def _is_feasible(system: FiniteFeasibleSetSystem, subset: frozenset[int]) -> bool:
-    return tuple(sorted(subset)) in system.feasible_index()
-
-
 def _feasible_sets(system: FiniteFeasibleSetSystem) -> list[frozenset[int]]:
     return [frozenset(row) for row in system.feasible]
 

--- a/src/jacobian/math/combinatorics/posets/core/_closure_models.py
+++ b/src/jacobian/math/combinatorics/posets/core/_closure_models.py
@@ -12,7 +12,6 @@ from jacobian.math.combinatorics.posets.core._models import (
     MAX_POSET_ELEMENTS,
     ElementLabel,
     FinitePoset,
-    PosetExactResult,
 )
 
 
@@ -93,7 +92,7 @@ class InducedSubposetRequest(StrictModel):
 # ---------------------------------------------------------------------------
 
 
-class LowerClosureResult(PosetExactResult):
+class LowerClosureResult(StrictModel):
     """The lower closure ↓S = {x : x <= s for some s in S}."""
 
     poset_digest: str
@@ -102,7 +101,7 @@ class LowerClosureResult(PosetExactResult):
     is_ideal: bool = True
 
 
-class UpperClosureResult(PosetExactResult):
+class UpperClosureResult(StrictModel):
     """The upper closure ↑S = {x : s <= x for some s in S}."""
 
     poset_digest: str
@@ -111,14 +110,14 @@ class UpperClosureResult(PosetExactResult):
     is_filter: bool = True
 
 
-class DualPosetResult(PosetExactResult):
+class DualPosetResult(StrictModel):
     """The dual poset with reversed order."""
 
     poset: FinitePoset
     transport_map: tuple[ElementLabel, ...]
 
 
-class InducedSubposetResult(PosetExactResult):
+class InducedSubposetResult(StrictModel):
     """The subposet induced by restricting to a subset of elements."""
 
     subposet: FinitePoset

--- a/src/jacobian/math/combinatorics/posets/core/_models.py
+++ b/src/jacobian/math/combinatorics/posets/core/_models.py
@@ -468,16 +468,8 @@ class FinitePoset(StrictModel):
         return self
 
 
-class PosetExactResult(StrictModel):
-    exactness: Literal["EXACT_FINITE"] = "EXACT_FINITE"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
-
-
-class FinitePosetMaterializationResult(PosetExactResult):
+class FinitePosetMaterializationResult(StrictModel):
     poset: FinitePoset
-    completeness: Literal["COMPLETE_CLOSURE_AND_REDUCTION"] = (
-        "COMPLETE_CLOSURE_AND_REDUCTION"
-    )
 
 
 class PosetRequest(StrictModel):
@@ -498,7 +490,7 @@ class MatchingEdge(StrictModel):
     right: ElementLabel
 
 
-class PosetWidthResult(PosetExactResult):
+class PosetWidthResult(StrictModel):
     poset_digest: Sha256Digest
     width: StrictInt = Field(ge=0, le=MAX_POSET_ELEMENTS)
     maximum_antichain: tuple[ElementLabel, ...] = Field(
@@ -548,9 +540,8 @@ class LinearExtensionRequest(StrictModel):
         return self
 
 
-class LinearExtensionCountResult(PosetExactResult):
+class LinearExtensionCountResult(StrictModel):
     count: StrictInt = Field(ge=1)
-    completeness: Literal["COMPLETE"] = "COMPLETE"
 
 
 class PosetInterval(StrictModel):
@@ -617,7 +608,7 @@ class MobiusValue(StrictModel):
     )
 
 
-class MobiusFunctionResult(PosetExactResult):
+class MobiusFunctionResult(StrictModel):
     poset_digest: Sha256Digest
     element_order: tuple[ElementLabel, ...] = Field(
         default=(),
@@ -689,23 +680,13 @@ class PosetClosureRequest(StrictModel):
         return self
 
 
-class PosetClosureResult(PosetExactResult):
+class PosetClosureResult(StrictModel):
     poset_digest: Sha256Digest
     closure_type: Literal["LOWER", "UPPER"]
     closure: tuple[ElementLabel, ...] = Field(default=(), max_length=MAX_POSET_ELEMENTS)
     generated_element: tuple[ElementLabel, ...] = Field(
         default=(), max_length=MAX_POSET_ELEMENTS
     )
-
-
-class PosetDualRequest(StrictModel):
-    """Request the dual (opposite) of a poset."""
-
-    poset: FinitePoset
-
-
-class PosetDualResult(PosetExactResult):
-    poset: FinitePoset
 
 
 class ZetaTransformRequest(StrictModel):
@@ -740,7 +721,7 @@ class ZetaTransformRequest(StrictModel):
         return self
 
 
-class ZetaTransformResult(PosetExactResult):
+class ZetaTransformResult(StrictModel):
     poset_digest: Sha256Digest
     transform: Literal["ZETA"] = "ZETA"
     values: tuple[MobiusValue, ...] = Field(default=(), max_length=MAX_POSET_RELATIONS)
@@ -778,7 +759,7 @@ class IncidenceConvolutionRequest(StrictModel):
         return self
 
 
-class IncidenceConvolutionResult(PosetExactResult):
+class IncidenceConvolutionResult(StrictModel):
     poset_digest: Sha256Digest
     values: tuple[MobiusValue, ...] = Field(default=(), max_length=MAX_POSET_RELATIONS)
 
@@ -789,7 +770,7 @@ class AntichainProfileRequest(StrictModel):
     poset: FinitePoset
 
 
-class AntichainProfileResult(PosetExactResult):
+class AntichainProfileResult(StrictModel):
     poset_digest: Sha256Digest
     maximum_antichain_size: StrictInt = Field(ge=0, le=MAX_POSET_ELEMENTS)
     antichain_count: StrictInt = Field(ge=1)
@@ -826,8 +807,6 @@ __all__ = [
     "PosetChain",
     "PosetClosureRequest",
     "PosetClosureResult",
-    "PosetDualRequest",
-    "PosetDualResult",
     "PosetInterval",
     "PosetRequest",
     "PosetSubset",

--- a/src/jacobian/math/combinatorics/posets/core/_operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/_operations.py
@@ -36,8 +36,6 @@ from jacobian.math.combinatorics.posets.core._models import (
     PosetChain,
     PosetClosureRequest,
     PosetClosureResult,
-    PosetDualRequest,
-    PosetDualResult,
     PosetInterval,
     PosetRequest,
     PosetWidthResult,
@@ -418,52 +416,6 @@ def _closure(request: PosetClosureRequest) -> PosetClosureResult:
     )
 
 
-def _dual(request: PosetDualRequest) -> PosetDualResult:
-    poset = request.poset
-    elements = poset.elements
-    reversed_pairs = tuple(
-        OrderedPair(lower=p.upper, upper=p.lower) for p in poset.strict_order_pairs
-    )
-    reversed_covers = tuple(
-        OrderedPair(lower=p.upper, upper=p.lower) for p in poset.cover_relations
-    )
-    sorted_pairs = tuple(sorted((p.lower, p.upper) for p in reversed_pairs))
-    sorted_covers = tuple(sorted((p.lower, p.upper) for p in reversed_covers))
-    order_pairs_obj = tuple(OrderedPair(lower=lo, upper=hi) for lo, hi in sorted_pairs)
-    cover_pairs_obj = tuple(OrderedPair(lower=lo, upper=hi) for lo, hi in sorted_covers)
-    if poset.graded and poset.ranks is not None:
-        height = max(r.rank for r in poset.ranks)
-        dual_ranks = tuple(
-            type(poset.ranks[0])(element=r.element, rank=height - r.rank)
-            for r in sorted(poset.ranks, key=lambda r: r.element)
-        )
-        dual_ranks_sorted = tuple(sorted(dual_ranks, key=lambda r: r.element))
-    else:
-        dual_ranks_sorted = None
-    new_digest = finite_poset_digest(
-        elements=elements,
-        strict_order_pairs=order_pairs_obj,
-        cover_relations=cover_pairs_obj,
-        incomparable_pairs=poset.incomparable_pairs,
-        minimal_elements=tuple(sorted(poset.maximal_elements)),
-        maximal_elements=tuple(sorted(poset.minimal_elements)),
-        graded=poset.graded,
-        ranks=dual_ranks_sorted,
-    )
-    new_poset = FinitePoset(
-        elements=elements,
-        strict_order_pairs=order_pairs_obj,
-        cover_relations=cover_pairs_obj,
-        incomparable_pairs=poset.incomparable_pairs,
-        minimal_elements=tuple(sorted(poset.maximal_elements)),
-        maximal_elements=tuple(sorted(poset.minimal_elements)),
-        graded=poset.graded,
-        ranks=dual_ranks_sorted,
-        poset_digest=new_digest,
-    )
-    return PosetDualResult(poset=new_poset)
-
-
 def _zeta_transform(request: ZetaTransformRequest) -> ZetaTransformResult:
     poset = request.poset
     comparable = {(p.lower, p.upper) for p in poset.strict_order_pairs}
@@ -528,7 +480,7 @@ def _antichain_profile(
 
     n = len(elements)
     max_size = 0
-    max_antichains: list[tuple[str, ...]] = []
+    max_antichains: list[tuple[str, ...]] = [()]
     antichain_count = 1
     for mask in range(1, 1 << n):
         subset = tuple(sorted(elements[i] for i in range(n) if mask & (1 << i)))

--- a/src/jacobian/math/dynamics/arithmetic/_models.py
+++ b/src/jacobian/math/dynamics/arithmetic/_models.py
@@ -317,8 +317,6 @@ class MapIterateResult(StrictModel):
         min_length=1, max_length=MAX_ITERATE_DEGREE + 1
     )
     degree: int = Field(ge=0, le=MAX_ITERATE_DEGREE)
-    complete: Literal[True] = True
-    method: Literal["EXACT_POLYNOMIAL_COMPOSITION"] = "EXACT_POLYNOMIAL_COMPOSITION"
 
     @classmethod
     def _from_kernel(
@@ -333,8 +331,6 @@ class MapIterateResult(StrictModel):
             n=request.n,
             coefficients=coefficients,
             degree=degree,
-            complete=True,
-            method="EXACT_POLYNOMIAL_COMPOSITION",
         )
 
     @model_validator(mode="after")
@@ -455,10 +451,6 @@ class DynatomicPolynomialResult(StrictModel):
     )
     degree: int = Field(ge=0, le=MAX_DYNATOMIC_DEGREE)
     n: int = Field(ge=1, le=MAX_ITERATE)
-    complete: Literal[True] = True
-    method: Literal["MOBIUS_EXACT_POLYNOMIAL_DIVISION"] = (
-        "MOBIUS_EXACT_POLYNOMIAL_DIVISION"
-    )
 
     @classmethod
     def _from_kernel(
@@ -473,8 +465,6 @@ class DynatomicPolynomialResult(StrictModel):
             coefficients=coefficients,
             degree=degree,
             n=request.n,
-            complete=True,
-            method="MOBIUS_EXACT_POLYNOMIAL_DIVISION",
         )
 
     @model_validator(mode="after")
@@ -503,8 +493,6 @@ class CycleMultiplierResult(StrictModel):
         min_length=1, max_length=MAX_ORBIT_STEPS
     )
     period: int = Field(ge=1, le=MAX_ORBIT_STEPS)
-    validated_cycle: Literal[True] = True
-    complete: Literal[True] = True
 
     @model_validator(mode="after")
     def require_structural_consistency(self) -> Self:
@@ -550,10 +538,6 @@ class FiniteFieldMapResult(StrictModel):
     edges: tuple[tuple[int, int], ...]
     cycles: tuple[tuple[int, ...], ...]
     tail_lengths: tuple[int, ...]
-    complete: Literal[True] = True
-    method: Literal["COMPLETE_FUNCTIONAL_GRAPH_ENUMERATION"] = (
-        "COMPLETE_FUNCTIONAL_GRAPH_ENUMERATION"
-    )
 
     @model_validator(mode="after")
     def require_structural_consistency(self) -> Self:

--- a/src/jacobian/math/dynamics/symbolic/_models.py
+++ b/src/jacobian/math/dynamics/symbolic/_models.py
@@ -31,8 +31,6 @@ class FiniteTypeShiftRequest(StrictModel):
 class FiniteTypeShiftResult(FiniteTypeShiftRequest):
     presentation: BlockPresentation
     normalized_forbidden_blocks: tuple[tuple[str, ...], ...]
-    complete: Literal[True] = True
-    method: Literal["EXACT_DE_BRUIJN_PRESENTATION"] = "EXACT_DE_BRUIJN_PRESENTATION"
 
 
 class BlockLanguageRequest(StrictModel):
@@ -43,12 +41,8 @@ class BlockLanguageRequest(StrictModel):
 class BlockLanguageResult(BlockLanguageRequest):
     allowed_blocks: tuple[tuple[str, ...], ...]
     count: int = Field(ge=0)
-    complete: Literal[True] = True
     scope: Literal["ALL_OCCURRING_BLOCKS_OF_REQUESTED_LENGTH"] = (
         "ALL_OCCURRING_BLOCKS_OF_REQUESTED_LENGTH"
-    )
-    method: Literal["EXACT_PRESENTATION_SUPPORT_ENUMERATION"] = (
-        "EXACT_PRESENTATION_SUPPORT_ENUMERATION"
     )
 
     @model_validator(mode="after")
@@ -71,9 +65,6 @@ class PeriodicPointProfileResult(PeriodicPointProfileRequest):
     least_period_point_counts: tuple[CanonicalInteger, ...]
     primitive_orbit_counts: tuple[CanonicalInteger, ...]
     complete_through_period: int = Field(ge=1, le=MAX_PERIOD)
-    method: Literal["EXACT_MATRIX_TRACES_AND_MOBIUS_INVERSION"] = (
-        "EXACT_MATRIX_TRACES_AND_MOBIUS_INVERSION"
-    )
 
     @model_validator(mode="after")
     def require_profile_shape(self) -> Self:
@@ -98,10 +89,6 @@ class HigherBlockRequest(StrictModel):
 
 class HigherBlockResult(HigherBlockRequest):
     presentation: BlockPresentation
-    complete: Literal[True] = True
-    method: Literal["EXACT_ALLOWED_OVERLAP_PRESENTATION"] = (
-        "EXACT_ALLOWED_OVERLAP_PRESENTATION"
-    )
 
 
 class ArtinMazurZetaRequest(StrictModel):
@@ -114,9 +101,6 @@ class ArtinMazurZetaResult(ArtinMazurZetaRequest):
     determinant_polynomial: RationalPolynomial
     zeta_function: RationalFunction
     convention: Literal["EDGE_SHIFT_ARTIN_MAZUR_ZETA"] = "EDGE_SHIFT_ARTIN_MAZUR_ZETA"
-    method: Literal["SYMPY_EXACT_CHARACTERISTIC_POLYNOMIAL"] = (
-        "SYMPY_EXACT_CHARACTERISTIC_POLYNOMIAL"
-    )
 
 
 def _from_kernel_artin_mazur_zeta(
@@ -136,7 +120,6 @@ def _from_kernel_artin_mazur_zeta(
         determinant_polynomial=determinant_polynomial,
         zeta_function=zeta_function,
         convention="EDGE_SHIFT_ARTIN_MAZUR_ZETA",
-        method="SYMPY_EXACT_CHARACTERISTIC_POLYNOMIAL",
     )
 
 

--- a/src/jacobian/math/finite_categories/_product.py
+++ b/src/jacobian/math/finite_categories/_product.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pydantic_core import PydanticCustomError
-
 from jacobian.canonical import strict_json_object_size
 from jacobian.math.finite_categories.values import (
     MAX_CATEGORY_COMPOSABLE_PAIRS,
@@ -28,12 +26,6 @@ from jacobian.math.finite_categories.values import (
 
 MAX_CATEGORY_PRODUCT_RESULT_BYTES = 8 * 1024 * 1024
 MAX_CATEGORY_PRODUCT_EXECUTION_STEPS = 1_000_000
-
-
-def _product_error(reason: str, message: str) -> PydanticCustomError:
-    """Build a stable request-admission error for category products."""
-
-    return PydanticCustomError(f"finite_category.{reason}", message)
 
 
 class CategoryProductAdmissionError(ValueError):

--- a/src/jacobian/math/finite_dim_algebras/_models.py
+++ b/src/jacobian/math/finite_dim_algebras/_models.py
@@ -85,4 +85,3 @@ class CenterResult(StrictModel):
     center_basis: tuple[tuple[int, ...], ...]
     dimension: int = Field(ge=1)
     center_dimension: int = Field(ge=0)
-    method: str = "COMMUTANT_COMPUTATION"

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -1021,7 +1021,6 @@ class ConvexPolygonTriangulationResult(StrictModel):
     optimum: CanonicalRational
     objective: Literal["NON_HULL_DIAGONAL_WEIGHT_SUM"] = "NON_HULL_DIAGONAL_WEIGHT_SUM"
     tie_break: Literal["LOWEST_SPLIT_INDEX"] = "LOWEST_SPLIT_INDEX"
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
 
 # Euclidean convex-polygon triangulation

--- a/src/jacobian/math/geometry/algebraic_curves/_models.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_models.py
@@ -187,17 +187,14 @@ class RationalConicParametrizationRequest(StrictModel):
 class AffineCurveResult(StrictModel):
     is_valid: bool
     degree: int = Field(ge=0, le=_MAX_CURVE_EXPONENT)
-    method: Literal["SYMPY_CURVE_CHECK"] = "SYMPY_CURVE_CHECK"
 
 
 class ProjectiveClosureResult(StrictModel):
     polynomial: RationalPolynomial
-    method: Literal["HOMOGENIZATION"] = "HOMOGENIZATION"
 
 
 class AffineChartResult(StrictModel):
     polynomial: RationalPolynomial
-    method: Literal["DEHOMOGENIZATION"] = "DEHOMOGENIZATION"
 
 
 class RationalConicParametrizationResult(StrictModel):

--- a/src/jacobian/math/geometry/arrangements/_models.py
+++ b/src/jacobian/math/geometry/arrangements/_models.py
@@ -71,15 +71,12 @@ class HyperplaneArrangementResult(StrictModel):
     hyperplane_count: int = Field(ge=1)
     ambient_dimension: int = Field(ge=1)
     is_central: bool
-    method: str = "ARRANGEMENT_CONSTRUCTION"
 
 
 class CharacteristicPolynomialResult(StrictModel):
     coefficients: tuple[str, ...]
     degree: int = Field(ge=0)
-    method: str = "SYMPY_CHARACTERISTIC_POLYNOMIAL"
 
 
 class ChamberCountResult(StrictModel):
     chamber_count: int = Field(ge=1)
-    method: str = "EXACT_FORMULA"

--- a/src/jacobian/math/geometry/finite/_models.py
+++ b/src/jacobian/math/geometry/finite/_models.py
@@ -200,7 +200,6 @@ class ProjectiveSpaceEnumerateRequest(StrictModel):
 class ProjectivePointCanonicalizeResult(ProjectivePointCanonicalizeRequest):
     point: ProjectivePoint
     scale: int = Field(ge=1)
-    method: str = "FIRST_NONZERO_TO_ONE"
 
     @model_validator(mode="after")
     def bind_point_parent(self) -> Self:
@@ -230,7 +229,6 @@ class ProjectivePointEqualResult(StrictModel):
     point_a: ProjectivePoint
     point_b: ProjectivePoint
     equal: bool
-    method: str = "CANONICAL_REPRESENTATIVE"
 
     @model_validator(mode="after")
     def require_same_parent(self) -> Self:
@@ -250,7 +248,6 @@ class ProjectivePointEqualResult(StrictModel):
 
 class SubspaceComputeResult(SubspaceComputeRequest):
     subspace: LinearSubspace
-    method: str = "RREF"
 
     @model_validator(mode="after")
     def bind_subspace_parent(self) -> Self:
@@ -274,7 +271,6 @@ class SubspaceMembershipResult(StrictModel):
     subspace: LinearSubspace
     vector: tuple[int, ...]
     is_member: bool
-    method: str = "RREF_MEMBERSHIP"
 
     @model_validator(mode="after")
     def bind_vector_parent(self) -> Self:
@@ -290,7 +286,6 @@ class SubspaceMembershipResult(StrictModel):
 
 class SubspaceSpanResult(SubspaceSpanRequest):
     subspace: LinearSubspace
-    method: str = "RREF"
 
     @model_validator(mode="after")
     def bind_subspace_parent(self) -> Self:
@@ -314,7 +309,6 @@ class SubspaceSpanResult(SubspaceSpanRequest):
 
 class SubspaceIntersectionResult(SubspaceIntersectionRequest):
     subspace: LinearSubspace
-    method: str = "INTERSECTION"
 
     @model_validator(mode="after")
     def bind_subspace_parent(self) -> Self:
@@ -343,7 +337,6 @@ class GrassmannianCountResult(StrictModel):
     count: CanonicalInteger = Field(
         description="Exact Gaussian-binomial count encoded as a canonical decimal integer."
     )
-    method: str = "GAUSSIAN_BINOMIAL"
 
     @classmethod
     def _from_kernel(
@@ -367,7 +360,6 @@ class ProjectiveSpaceEnumerateResult(StrictModel):
     """
 
     sequence: ProjectivePointSequence
-    method: str = "CANONICAL_REPRESENTATIVES"
 
 
 # ---------------------------------------------------------------------------
@@ -424,4 +416,3 @@ class PrimeFieldAffinePlaneResult(StrictModel):
     incidence: IncidenceStructure
     parallel_classes: tuple[ParallelClass, ...] = Field(min_length=2)
     total_incidences: int = Field(ge=0)
-    method: str = "MODULAR_ARITHMETIC"

--- a/src/jacobian/math/geometry/metric_spaces/_models.py
+++ b/src/jacobian/math/geometry/metric_spaces/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from typing import Annotated, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -105,7 +105,6 @@ class MetricProfileResult(StrictModel):
     eccentricities: tuple[EccentricityResult, ...] = Field(min_length=2)
     centers: tuple[int, ...] = Field(min_length=1)
     periphery: tuple[int, ...] = Field(min_length=0)
-    method: Literal["DIRECT_DISTANCE_MATRIX_SCAN"] = "DIRECT_DISTANCE_MATRIX_SCAN"
 
 
 class BallRequest(StrictModel):
@@ -131,7 +130,6 @@ class BallResult(StrictModel):
     center: int = Field(ge=0, le=MAX_POINTS - 1)
     radius: int = Field(ge=0, le=MAX_DISTANCE)
     points: tuple[int, ...] = Field(min_length=1)
-    method: Literal["DIRECT_SCAN"] = "DIRECT_SCAN"
 
 
 class GromovHyperbolicityRequest(StrictModel):
@@ -144,4 +142,3 @@ class GromovHyperbolicityResult(StrictModel):
     """The four-point Gromov hyperbolicity (max delta over all quadruples)."""
 
     hyperbolicity: CanonicalRational
-    method: Literal["FOUR_POINT_BRUTE_FORCE"] = "FOUR_POINT_BRUTE_FORCE"

--- a/src/jacobian/math/geometry/polytopes/_operations.py
+++ b/src/jacobian/math/geometry/polytopes/_operations.py
@@ -31,7 +31,6 @@ from typing import Literal
 from sympy import Matrix, Rational
 
 from jacobian._exact import CanonicalRational
-from jacobian.canonical import format_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry.polytopes._models import (
     MAX_BOUNDEDNESS_COMBINATIONS,
@@ -317,17 +316,6 @@ def _is_bounded_h(halfspaces: tuple[Halfspace, ...]) -> bool:
             f"({combo_count} > {MAX_BOUNDEDNESS_COMBINATIONS})"
         )
     return recession_cone_is_trivial(normals, dim)
-
-
-def _format_rational(value: Rational) -> str:
-    """Render a SymPy ``Rational`` as a canonical ``num/den`` string."""
-
-    if value.denominator == 1:
-        return format_canonical_integer(int(value.numerator))
-    return (
-        f"{format_canonical_integer(int(value.numerator))}/"
-        f"{format_canonical_integer(int(value.denominator))}"
-    )
 
 
 def _canonical_rational(value: Rational) -> CanonicalRational:

--- a/src/jacobian/math/geometry/polytopes/lattice/_operations.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/_operations.py
@@ -110,26 +110,6 @@ def _vertices_from_h_representation(
     return [list(point) for point in vertices_from_halfspaces(halfspaces, dim)], dim
 
 
-def _rational_vertices(
-    request: LatticePolytopeRequest,
-) -> tuple[list[list[Rational]], int, Literal["vertices", "halfspaces"]]:
-    """Return the rational vertices and ambient dimension of the polytope."""
-    if request.vertices is not None:
-        dim = request.dimension()
-        verts = [[c.as_fraction() for c in v.coordinates] for v in request.vertices]
-        return verts, dim, "vertices"
-    assert request.halfspaces is not None
-    halfspaces = [
-        (
-            [c.as_fraction() for c in hs.coefficients],
-            hs.offset.as_fraction(),
-        )
-        for hs in request.halfspaces
-    ]
-    verts, _dim = _vertices_from_h_representation(halfspaces)
-    return verts, _dim, "halfspaces"
-
-
 def _floor(value: Rational) -> int:
     """Exact integer floor of a rational (Fraction or SymPy ``Rational``)."""
     frac = Fraction(value)

--- a/src/jacobian/math/geometry/projective/_models.py
+++ b/src/jacobian/math/geometry/projective/_models.py
@@ -88,7 +88,6 @@ class ProjectiveLineArrangementResult(StrictModel):
     non_double_flats: tuple[tuple[ProjectiveLabel, ...], ...]
     multiplicity_histogram: tuple[ProjectiveMultiplicityCount, ...]
     pair_count_total: int = Field(ge=1, le=MAX_ARRANGEMENT_PAIRS, strict=True)
-    completion: Literal["COMPLETE"] = "COMPLETE"
     arithmetic: Literal["EXACT_INTEGER"] = "EXACT_INTEGER"
 
     @classmethod

--- a/src/jacobian/math/geometry/projective/coordinates/_models.py
+++ b/src/jacobian/math/geometry/projective/coordinates/_models.py
@@ -76,13 +76,11 @@ class ChartTransitionRequest(StrictModel):
 class RationalPointConstructResult(StrictModel):
     point: RationalProjectivePoint
     scale: CanonicalRational
-    method: str = "FIRST_NONZERO_SCALE"
 
 
 class StandardChartResult(StrictModel):
     affine_point: tuple[CanonicalRational, ...]
     chart_index: int = Field(ge=0)
-    method: str = "DEHOMOGENIZATION"
 
 
 class ChartTransitionResult(StrictModel):
@@ -91,7 +89,6 @@ class ChartTransitionResult(StrictModel):
     chart_i: int = Field(ge=0)
     chart_j: int = Field(ge=0)
     projective_dimension: int = Field(ge=0, le=MAX_DIM)
-    method: str = "CHART_TRANSITION"
 
     @model_validator(mode="after")
     def require_status_consistency(self) -> Self:

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -29,36 +29,6 @@ _WORKER_ADDRESS_SPACE_BYTES = 1_536 * 1024 * 1024
 _WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 
 
-def _externally_supplied_exact_result_is_valid(
-    result: IndependenceNumberResult,
-    *,
-    deadline: float,
-) -> bool:
-    """Authenticate an exact worker claim against its retained source graph."""
-
-    if result.status != "EXACT":
-        return True
-    remaining_ms = int((deadline - time.monotonic()) * 1000)
-    if remaining_ms <= 0 or result.optimum_value is None:
-        return False
-
-    import z3
-
-    selected = {
-        vertex: z3.Bool(f"verify_selected_{index}")
-        for index, vertex in enumerate(result.graph.vertices)
-    }
-    solver = z3.Solver()
-    solver.set(timeout=max(1, remaining_ms))
-    for left, right in result.graph.edges:
-        solver.add(z3.Or(z3.Not(selected[left]), z3.Not(selected[right])))
-    solver.add(
-        z3.Sum([z3.If(selected[vertex], 1, 0) for vertex in result.graph.vertices])
-        > result.optimum_value
-    )
-    return solver.check() == z3.unsat and time.monotonic() < deadline
-
-
 def _integer_bound(value: Any, fallback: int) -> int:
     import z3
 
@@ -176,7 +146,7 @@ def solve_independence_number_values(
     graph: SimpleUndirectedGraph,
     resource_budget: IndependenceNumberBudget,
 ) -> IndependenceNumberResult:
-    """Run all Z3 optimization and exact replay in one bounded owner worker."""
+    """Run Z3 optimization in one bounded owner worker and decode its result."""
 
     incumbent = () if not graph.vertices else (min(graph.vertices),)
 
@@ -199,12 +169,6 @@ def solve_independence_number_values(
                 return fallback(
                     "the graph independence request expired before worker startup"
                 )
-            verification_reserve = min(1.0, resource_budget.wall_seconds / 5)
-            worker_seconds = remaining_seconds - verification_reserve
-            if worker_seconds <= 0:
-                return fallback(
-                    "the graph independence request expired before worker startup"
-                )
             completed = run_bounded_process(
                 [sys.executable, str(_INDEPENDENCE_WORKER)],
                 input_bytes=json.dumps(
@@ -215,7 +179,7 @@ def solve_independence_number_values(
                     separators=(",", ":"),
                     ensure_ascii=False,
                 ).encode("utf-8"),
-                timeout_seconds=worker_seconds,
+                timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
                 stdout_limit=_WORKER_OUTPUT_BYTES,
                 stderr_limit=_WORKER_ERROR_BYTES,
@@ -249,10 +213,6 @@ def solve_independence_number_values(
                 "graph": graph.model_dump(mode="json"),
             }
         )
-        if not _externally_supplied_exact_result_is_valid(result, deadline=deadline):
-            return fallback(
-                "the bounded graph independence worker returned an unverified exact claim"
-            )
         return (
             result
             if time.monotonic() < deadline

--- a/src/jacobian/math/graphs/decomposition/_models.py
+++ b/src/jacobian/math/graphs/decomposition/_models.py
@@ -52,7 +52,6 @@ class BlockCutTreeResult(StrictModel):
     blocks: tuple[tuple[int, ...], ...] = Field(default=())
     articulation_points: tuple[int, ...] = Field(default=())
     tree: tuple[tuple[int, int], ...] = Field(default=())
-    convention: Literal["NETWORKX_BICONNECTED"] = "NETWORKX_BICONNECTED"
 
 
 class BridgeBlockRequest(StrictModel):
@@ -71,7 +70,6 @@ class BridgeBlockResult(StrictModel):
     components: tuple[tuple[int, ...], ...] = Field(default=())
     bridges: tuple[tuple[int, int], ...] = Field(default=())
     tree: tuple[tuple[int, int], ...] = Field(default=())
-    convention: Literal["NETWORKX_BRIDGES"] = "NETWORKX_BRIDGES"
 
 
 class EarDecompositionRequest(StrictModel):
@@ -110,7 +108,6 @@ class BiconnectedComponentsResult(StrictModel):
     """All biconnected components of a graph, each a sorted tuple of vertices."""
 
     components: tuple[tuple[int, ...], ...] = Field(default=())
-    convention: Literal["NETWORKX_BICONNECTED"] = "NETWORKX_BICONNECTED"
 
 
 # ---------------------------------------------------------------------------

--- a/src/jacobian/math/graphs/directed/_models.py
+++ b/src/jacobian/math/graphs/directed/_models.py
@@ -125,7 +125,6 @@ class ReachabilityResult(StrictModel):
     source: int = Field(ge=0, le=255)
     reachable: tuple[int, ...]
     unreachable: tuple[int, ...]
-    convention: Literal["NETWORKX_DESCENDANTS"] = "NETWORKX_DESCENDANTS"
 
 
 class StronglyConnectedComponentsRequest(StrictModel):
@@ -135,9 +134,6 @@ class StronglyConnectedComponentsRequest(StrictModel):
 class StronglyConnectedComponentsResult(StrictModel):
     component_count: int = Field(ge=0, strict=True)
     components: tuple[tuple[int, ...], ...]
-    convention: Literal["NETWORKX_STRONGLY_CONNECTED_COMPONENTS"] = (
-        "NETWORKX_STRONGLY_CONNECTED_COMPONENTS"
-    )
 
 
 class CondensationRequest(StrictModel):
@@ -153,7 +149,6 @@ class CondensationResult(StrictModel):
     vertex_count: int = Field(ge=0, strict=True)
     components: tuple[tuple[int, ...], ...]
     edges: tuple[CondensationEdge, ...] = Field(default=())
-    convention: Literal["NETWORKX_CONDENSATION"] = "NETWORKX_CONDENSATION"
 
 
 class AcyclicOrderRequest(StrictModel):
@@ -163,7 +158,6 @@ class AcyclicOrderRequest(StrictModel):
 class AcyclicOrderResult(StrictModel):
     acyclic: bool
     order: tuple[int, ...]
-    convention: Literal["NETWORKX_TOPOLOGICAL_SORT"] = "NETWORKX_TOPOLOGICAL_SORT"
 
     @model_validator(mode="after")
     def require_order_matches_acyclicity(self) -> Self:

--- a/src/jacobian/math/graphs/electrical_networks/_models.py
+++ b/src/jacobian/math/graphs/electrical_networks/_models.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Literal
-
 from pydantic import Field
 
 from jacobian._exact import CanonicalRational
@@ -53,7 +51,6 @@ class EffectiveResistanceResult(StrictModel):
     effective_resistance: CanonicalRational
     terminal_a: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
     terminal_b: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
-    method: Literal["SYMPY_REDUCED_LAPLACIAN_SOLVE"] = "SYMPY_REDUCED_LAPLACIAN_SOLVE"
 
 
 class NodePotentialRequest(StrictModel):
@@ -79,7 +76,6 @@ class NodePotentialResult(StrictModel):
     potentials: tuple[NodePotentialValue, ...] = Field(
         min_length=2, max_length=MAX_NETWORK_VERTICES
     )
-    method: Literal["SYMPY_LAPLACIAN_SOLVE"] = "SYMPY_LAPLACIAN_SOLVE"
 
 
 class LaplacianEntry(StrictModel):
@@ -101,7 +97,6 @@ class LaplacianResult(StrictModel):
 
     vertex_count: int = Field(ge=2, le=MAX_NETWORK_VERTICES)
     entries: tuple[LaplacianEntry, ...] = Field(min_length=1)
-    method: Literal["SYMPY_LAPLACIAN"] = "SYMPY_LAPLACIAN"
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/flows/_models.py
+++ b/src/jacobian/math/graphs/flows/_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import lcm
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -95,7 +95,6 @@ class MaxFlowResult(StrictModel):
     source: int = Field(ge=0, le=63)
     sink: int = Field(ge=0, le=63)
     flow_edges: tuple[FlowEdgeValue, ...] = Field(default=())
-    convention: Literal["NETWORKX_MAXIMUM_FLOW"] = "NETWORKX_MAXIMUM_FLOW"
 
 
 class MinCutRequest(StrictModel):
@@ -108,7 +107,6 @@ class MinCutResult(StrictModel):
     cut_value: CanonicalRational
     reachable: tuple[int, ...]
     unreachable: tuple[int, ...]
-    convention: Literal["NETWORKX_MINIMUM_CUT"] = "NETWORKX_MINIMUM_CUT"
 
 
 class EdgeDisjointPathsGraph(StrictModel):
@@ -153,7 +151,6 @@ class EdgeDisjointPathsResult(StrictModel):
     paths: tuple[tuple[int, ...], ...] = Field(default=())
     source: int = Field(ge=0, le=63)
     sink: int = Field(ge=0, le=63)
-    convention: Literal["NETWORKX_EDGE_DISJOINT_PATHS"] = "NETWORKX_EDGE_DISJOINT_PATHS"
 
 
 class CostedFlowEdge(StrictModel):
@@ -225,7 +222,6 @@ class MinCostFlowResult(StrictModel):
     total_cost: CanonicalRational
     flow_edges: tuple[FlowEdgeResult, ...] = Field(default=())
     feasible: bool
-    convention: Literal["NETWORKX_MIN_COST_FLOW"] = "NETWORKX_MIN_COST_FLOW"
 
     @model_validator(mode="after")
     def require_structural_consistency(self) -> Self:
@@ -266,4 +262,3 @@ class MinCostFlowResult(StrictModel):
 class CirculationResult(StrictModel):
     feasible: bool
     flow_edges: tuple[FlowEdgeResult, ...] = Field(default=())
-    convention: Literal["NETWORKX_CIRCULATION"] = "NETWORKX_CIRCULATION"

--- a/src/jacobian/math/graphs/independence.py
+++ b/src/jacobian/math/graphs/independence.py
@@ -21,7 +21,6 @@ IndependenceTermination = Literal[
     "SOLVER_UNKNOWN",
     "SOLVER_UNSAT",
     "SPECIAL_CASE",
-    "REPLAY_INCOMPLETE",
 ]
 
 

--- a/src/jacobian/math/graphs/isomorphism/_models.py
+++ b/src/jacobian/math/graphs/isomorphism/_models.py
@@ -79,7 +79,6 @@ class GraphIsomorphismResult(StrictModel):
 
     status: Literal["ISOMORPHIC", "NOT_ISOMORPHIC", "UNKNOWN"]
     vertex_mapping: tuple[VertexMappingPair, ...] = Field(default=())
-    convention: Literal["NETWORKX_IS_ISOMORPHIC"] = "NETWORKX_IS_ISOMORPHIC"
 
     @model_validator(mode="after")
     def bind_mapping_to_status(self) -> Self:

--- a/src/jacobian/math/graphs/optimization/_invariant_models.py
+++ b/src/jacobian/math/graphs/optimization/_invariant_models.py
@@ -46,28 +46,17 @@ class GraphDiameterResult(StrictModel):
     status: Literal["COMPUTED", "NOT_APPLICABLE"]
     diameter: StrictInt | None = Field(default=None, ge=0, le=255)
     connected: StrictBool
-    exactness: Literal["EXACT", "NOT_APPLICABLE"]
     detail: str | None = Field(default=None, min_length=1, max_length=512)
 
     @model_validator(mode="after")
     def bind_connectivity(self) -> Self:
         if self.status == "COMPUTED":
-            if (
-                self.diameter is None
-                or not self.connected
-                or self.exactness != "EXACT"
-                or self.detail is not None
-            ):
+            if self.diameter is None or not self.connected or self.detail is not None:
                 raise PydanticCustomError(
                     "graph.computed_diameter_requires_exact_value_connected",
                     "computed diameter requires an exact value on a connected graph",
                 )
-        elif (
-            self.diameter is not None
-            or self.connected
-            or self.exactness != "NOT_APPLICABLE"
-            or self.detail is None
-        ):
+        elif self.diameter is not None or self.connected or self.detail is None:
             raise PydanticCustomError(
                 "graph.inapplicable_diameter_requires_no_value_explicit_detail",
                 "inapplicable diameter requires no value and an explicit detail",
@@ -170,28 +159,17 @@ class GraphRadiusResult(StrictModel):
     status: Literal["COMPUTED", "NOT_APPLICABLE"]
     radius: StrictInt | None = Field(default=None, ge=0, le=255)
     connected: StrictBool
-    exactness: Literal["EXACT", "NOT_APPLICABLE"]
     detail: str | None = Field(default=None, min_length=1, max_length=512)
 
     @model_validator(mode="after")
     def bind_connectivity(self) -> Self:
         if self.status == "COMPUTED":
-            if (
-                self.radius is None
-                or not self.connected
-                or self.exactness != "EXACT"
-                or self.detail is not None
-            ):
+            if self.radius is None or not self.connected or self.detail is not None:
                 raise PydanticCustomError(
                     "graph.computed_radius_requires_exact_value_connected",
                     "computed radius requires an exact value on a connected graph",
                 )
-        elif (
-            self.radius is not None
-            or self.connected
-            or self.exactness != "NOT_APPLICABLE"
-            or self.detail is None
-        ):
+        elif self.radius is not None or self.connected or self.detail is None:
             raise PydanticCustomError(
                 "graph.inapplicable_radius_requires_no_value_explicit_detail",
                 "inapplicable radius requires no value and an explicit detail",

--- a/src/jacobian/math/graphs/optimization/_invariants.py
+++ b/src/jacobian/math/graphs/optimization/_invariants.py
@@ -102,14 +102,12 @@ def _diameter(graph: Any) -> GraphDiameterResult:
         return GraphDiameterResult(
             status="NOT_APPLICABLE",
             connected=False,
-            exactness="NOT_APPLICABLE",
             detail="diameter requires a nonempty connected graph",
         )
     return GraphDiameterResult(
         status="COMPUTED",
         diameter=diameter(graph),
         connected=True,
-        exactness="EXACT",
     )
 
 
@@ -232,14 +230,12 @@ def _radius(graph: Any) -> GraphRadiusResult:
         return GraphRadiusResult(
             status="NOT_APPLICABLE",
             connected=False,
-            exactness="NOT_APPLICABLE",
             detail="radius requires a nonempty connected graph",
         )
     return GraphRadiusResult(
         status="COMPUTED",
         radius=int(nx.radius(graph)),
         connected=True,
-        exactness="EXACT",
     )
 
 

--- a/src/jacobian/math/graphs/optimization/_models.py
+++ b/src/jacobian/math/graphs/optimization/_models.py
@@ -146,9 +146,6 @@ class GraphMstCycleCheck(StrictModel):
 class GraphMstOptimalityCertificate(StrictModel):
     """Inspectable cycle-property certificate for one selected tree."""
 
-    method: Literal["ALL_FUNDAMENTAL_CYCLES_NON_IMPROVING"] = (
-        "ALL_FUNDAMENTAL_CYCLES_NON_IMPROVING"
-    )
     checks: tuple[GraphMstCycleCheck, ...] = Field(max_length=496)
     required_checks: tuple[
         Literal[
@@ -193,7 +190,6 @@ class GraphMinimumSpanningTreeResult(StrictModel):
     convention: Literal[
         "MINIMUM_TOTAL_EDGE_WEIGHT_OVER_QQ_EMPTY_GRAPH_HAS_NO_SPANNING_TREE"
     ] = "MINIMUM_TOTAL_EDGE_WEIGHT_OVER_QQ_EMPTY_GRAPH_HAS_NO_SPANNING_TREE"
-    completion: Literal["COMPLETE"] = "COMPLETE"
 
     @model_validator(mode="after")
     def require_canonical_partition(self) -> Self:
@@ -315,7 +311,6 @@ class GraphHamiltonianPathResult(StrictModel):
     convention: Literal["EMPTY_GRAPH_HAS_EMPTY_HAMILTONIAN_PATH"] = (
         "EMPTY_GRAPH_HAS_EMPTY_HAMILTONIAN_PATH"
     )
-    completion: Literal["COMPLETE"] = "COMPLETE"
 
     @model_validator(mode="after")
     def bind_decision_and_path(self) -> Self:

--- a/src/jacobian/math/graphs/quivers/_models.py
+++ b/src/jacobian/math/graphs/quivers/_models.py
@@ -62,17 +62,14 @@ class AdjacencyMatricesResult(StrictModel):
     adjacency_matrix: tuple[tuple[int, ...], ...]
     transpose_matrix: tuple[tuple[int, ...], ...]
     vertex_count: int = Field(ge=1)
-    method: str = "ADjaCENCY_CONSTRUCTION"
 
 
 class VertexProfilesResult(StrictModel):
     in_degrees: tuple[int, ...]
     out_degrees: tuple[int, ...]
     vertex_count: int = Field(ge=1)
-    method: str = "DEGREE_COUNT"
 
 
 class FixedLengthPathsResult(StrictModel):
     path_matrix: tuple[tuple[int, ...], ...]
     total_paths: int = Field(ge=0)
-    method: str = "MATRIX_POWER"

--- a/src/jacobian/math/graphs/realization/_models.py
+++ b/src/jacobian/math/graphs/realization/_models.py
@@ -65,7 +65,6 @@ class GraphRealizationResult(StrictModel):
     is_graphical: bool
     vertex_count: int = Field(ge=1)
     edges: tuple[tuple[int, int], ...] = Field(default=())
-    convention: str = "NETWORKX_HAVEL_HAKIMI"
 
 
 # ---------------------------------------------------------------------------
@@ -107,7 +106,6 @@ class RealizationCheckResult(StrictModel):
     is_realization: bool
     expected_degrees: tuple[int, ...]
     actual_degrees: tuple[int, ...]
-    convention: str = "NETWORKX_DEGREE"
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/spectra/_models.py
+++ b/src/jacobian/math/graphs/spectra/_models.py
@@ -77,7 +77,6 @@ class GraphSpectrumResult(StrictModel):
     matrix_convention: Literal["ADJACENCY", "LAPLACIAN"]
     eigenvalues: tuple[str, ...]
     multiplicities: tuple[int, ...]
-    convention: Literal["SYMPY_EIGENVALS"] = "SYMPY_EIGENVALS"
 
     @model_validator(mode="after")
     def require_structural_shape(self) -> Self:

--- a/src/jacobian/math/graphs/symmetry/_models.py
+++ b/src/jacobian/math/graphs/symmetry/_models.py
@@ -110,8 +110,8 @@ def _orbit_result_fixed_frame_bytes() -> int:
     Derived from ``GraphSymmetryOrbitResult`` itself - the field-name tuple
     and the defaulted constant literals - so this admission bound cannot
     drift from the published wire contract. Covers the object braces, the
-    sixteen commas between the seventeen top-level fields, every quoted key
-    name with its colon, and the six fixed literal values.
+    commas between the top-level fields, every quoted key name with its colon,
+    and the four fixed literal values.
     """
 
     fields = GraphSymmetryOrbitResult.model_fields
@@ -126,8 +126,6 @@ def _orbit_result_fixed_frame_bytes() -> int:
         fields["generator_validation"].default,
         fields["orbit_completeness"].default,
         fields["automorphism_group_completeness"].default,
-        fields["exactness"].default,
-        fields["determinism"].default,
     )
     return frame_bytes + sum(_quoted_wire_size(value) for value in constants)
 
@@ -346,8 +344,6 @@ class GraphSymmetryOrbitResult(StrictModel):
     automorphism_group_completeness: Literal["FULL_AUTOMORPHISM_GROUP_NOT_CLAIMED"] = (
         "FULL_AUTOMORPHISM_GROUP_NOT_CLAIMED"
     )
-    exactness: Literal["EXACT_COMBINATORIAL"] = "EXACT_COMBINATORIAL"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @model_validator(mode="after")
     def require_canonical_source_bound_partitions(self) -> Self:

--- a/src/jacobian/math/graphs/transforms/_models.py
+++ b/src/jacobian/math/graphs/transforms/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from typing import Annotated, Self
 
 from pydantic import AfterValidator, Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -85,7 +85,6 @@ class GraphResult(StrictModel):
         default=(),
         max_length=MAX_RESULT_EDGES,
     )
-    method: Literal["NETWORKX"] = "NETWORKX"
 
 
 class SubgraphRequest(StrictModel):

--- a/src/jacobian/math/groups/_models.py
+++ b/src/jacobian/math/groups/_models.py
@@ -84,7 +84,6 @@ class GroupOrderResult(StrictModel):
     """The exact order of a finite permutation group."""
 
     order: CanonicalInteger
-    method: Literal["SYMPY_SCHREIER_SIMS"] = "SYMPY_SCHREIER_SIMS"
 
 
 class GroupElementOrderRequest(StrictModel):
@@ -213,7 +212,6 @@ class GroupConjugacyClassesResult(StrictModel):
         min_length=1,
         max_length=MAX_CONJUGACY_CLASSES_GROUP_ORDER,
     )
-    method: Literal["SYMPY_CONJUGACY_CLASSES"] = "SYMPY_CONJUGACY_CLASSES"
 
     @model_validator(mode="after")
     def require_conjugacy_class_partition(self) -> Self:
@@ -223,7 +221,7 @@ class GroupConjugacyClassesResult(StrictModel):
 
     @classmethod
     def _from_kernel(cls, classes: tuple[ConjugacyClass, ...]) -> Self:
-        return cls.model_construct(classes=classes, method="SYMPY_CONJUGACY_CLASSES")
+        return cls.model_construct(classes=classes)
 
 
 def _require_canonical_partition(
@@ -430,7 +428,6 @@ class GroupStabilizerResult(StrictModel):
             "without reshaping or synthesizing an identity."
         )
     )
-    method: Literal["SYMPY_STABILIZER"] = "SYMPY_STABILIZER"
 
     @model_validator(mode="after")
     def require_valid_stabilizer(self) -> Self:
@@ -509,7 +506,6 @@ class GroupSubgroupLatticeResult(StrictModel):
     )
     subgroups: tuple[SubgroupEntry, ...] | None = None
     subgroup_count: int = Field(default=0, ge=0)
-    method: Literal["SYMPY_SUBGROUPS"] = "SYMPY_SUBGROUPS"
     detail: str | None = None
 
     @model_validator(mode="before")

--- a/src/jacobian/math/groups/abelian/_models.py
+++ b/src/jacobian/math/groups/abelian/_models.py
@@ -197,31 +197,25 @@ class PresentationNormalizeResult(StrictModel):
     invariant_factors: tuple[int, ...]
     order: int = Field(ge=1)
     rank: int = Field(ge=0)
-    method: str = "SmithNormalForm"
 
 
 class ElementReduceResult(StrictModel):
     reduced: tuple[int, ...]
-    method: str = "MODULAR_REDUCTION"
 
 
 class ElementEqualResult(StrictModel):
     equal: bool
-    method: str = "MODULAR_COMPARISON"
 
 
 class ElementOrderResult(StrictModel):
     order: int = Field(ge=1)
-    method: str = "LCM"
 
 
 class SubgroupGeneratedResult(StrictModel):
     index: int = Field(ge=1)
     coset_representatives: tuple[tuple[int, ...], ...] = ()
-    method: str = "COSET_ENUMERATION"
 
 
 class QuotientResult(StrictModel):
     quotient_invariant_factors: tuple[int, ...] = ()
     quotient_order: int = Field(ge=1)
-    method: str = "SMITH_NORMAL_FORM"

--- a/src/jacobian/math/groups/operations.py
+++ b/src/jacobian/math/groups/operations.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any
 
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.groups._models import PermutationGroup, SubgroupEntry
+from jacobian.math.groups._models import (
+    PermutationGroup,
+    SubgroupEntry,
+    _full_permutation_form,
+)
 
 __all__ = [
     "element_order",
@@ -58,13 +62,6 @@ def group_orbit(group: PermutationGroup, point: int) -> list[int]:
             message="point must be in 0..n-1",
         )
     return sorted(_backend_group(group).orbit(point))
-
-
-def _full_generator(perm: Any, degree: int) -> tuple[int, ...]:
-    form = list(perm.array_form)
-    # array_form truncates trailing fixed points; restore them exactly.
-    form.extend(range(len(form), degree))
-    return tuple(form)
 
 
 def group_conjugacy_classes(
@@ -121,7 +118,10 @@ def group_conjugacy_classes(
             ),
         )
     classes = group.conjugacy_classes()
-    canonical = [sorted(list(p.array_form) for p in cls) for cls in classes]
+    canonical = [
+        sorted(list(_full_permutation_form(permutation, degree)) for permutation in cls)
+        for cls in classes
+    ]
     canonical.sort(key=lambda cls: tuple(cls[0]))
     return canonical
 
@@ -144,7 +144,8 @@ def group_stabilizer(group: PermutationGroup, point: int) -> PermutationGroup:
         )
     stabilizer = _backend_group(group).stabilizer(point)
     generators = tuple(
-        _full_generator(generator, group.degree) for generator in stabilizer.generators
+        _full_permutation_form(generator, group.degree)
+        for generator in stabilizer.generators
     )
     # The canonical group value requires at least one generator; represent the
     # trivial stabilizer by the identity permutation.
@@ -182,13 +183,6 @@ def _require_admitted_lattice_source(group: PermutationGroup) -> Any:
     return backend_group
 
 
-def _canonical_form(permutation: Any, degree: int) -> tuple[int, ...]:
-    form = list(permutation.array_form)
-    # array_form truncates trailing fixed points; restore them exactly.
-    form.extend(range(len(form), degree))
-    return tuple(form)
-
-
 def _element_table(
     group: Any, degree: int
 ) -> tuple[list[tuple[int, ...]], list[list[int]]]:
@@ -199,12 +193,16 @@ def _element_table(
     """
     from sympy.combinatorics import Permutation
 
-    elements = sorted({_canonical_form(element, degree) for element in group.elements})
+    elements = sorted(
+        {_full_permutation_form(element, degree) for element in group.elements}
+    )
     element_index = {form: position for position, form in enumerate(elements)}
     index_perms = [Permutation(list(form)) for form in elements]
     mul = [
         [
-            element_index[_canonical_form(index_perms[i] * index_perms[j], degree)]
+            element_index[
+                _full_permutation_form(index_perms[i] * index_perms[j], degree)
+            ]
             for j in range(len(elements))
         ]
         for i in range(len(elements))

--- a/src/jacobian/math/groups/root_systems/_models.py
+++ b/src/jacobian/math/groups/root_systems/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from typing import Annotated, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -321,9 +321,6 @@ class WeylGroupOrderResult(StrictModel):
 
     matrix: tuple[tuple[int, ...], ...]
     group_order: int = Field(ge=1, le=MAX_WEYL_GROUP_ORDER)
-    method: Literal["SYMPY_SCHREIER_SIMS_SIGNED_ROOT_ACTION"] = (
-        "SYMPY_SCHREIER_SIMS_SIGNED_ROOT_ACTION"
-    )
 
     @model_validator(mode="after")
     def require_order_domain(self) -> Self:
@@ -335,5 +332,4 @@ class WeylGroupOrderResult(StrictModel):
         return cls.model_construct(
             matrix=request.matrix,
             group_order=group_order,
-            method="SYMPY_SCHREIER_SIMS_SIGNED_ROOT_ACTION",
         )

--- a/src/jacobian/math/lattices/_lattice_operations.py
+++ b/src/jacobian/math/lattices/_lattice_operations.py
@@ -65,6 +65,7 @@ from jacobian.math.lattices._models import (
 from jacobian.math.matrices.values import (
     IntegerMatrix,
     rational_matrix_from_fractions,
+    rational_vector_space_basis_from_fractions,
     require_matrix_scalar_digits,
 )
 
@@ -85,14 +86,6 @@ def _basis_int_list(lattice: IntegerLattice) -> list[list[int]]:
     return [[parse_canonical_integer(v) for v in row] for row in lattice.basis.entries]
 
 
-def _require_full_row_rank(lattice: IntegerLattice, *, label: str) -> list[list[int]]:
-    entries = _basis_int_list(lattice)
-    rows = len(entries)
-    if integer_rank(entries) != rows:
-        raise ValueError(f"{label} basis must be full row rank over QQ")
-    return entries
-
-
 def _integer_matrix(matrix: list[list[int]]) -> IntegerMatrix:
     return IntegerMatrix(
         entries=tuple(
@@ -107,7 +100,7 @@ def _integer_matrix(matrix: list[list[int]]) -> IntegerMatrix:
 
 
 def compute_rank_gram(request: RankGramRequest) -> RankGramResult:
-    basis = _require_full_row_rank(request.lattice, label="rank-gram")
+    basis = _basis_int_list(request.lattice)
     rank = len(basis)
     gram = _gram_matrix(basis)
     det = integer_determinant(gram)
@@ -124,7 +117,7 @@ def compute_rank_gram(request: RankGramRequest) -> RankGramResult:
 def compute_canonical_basis(
     lattice: IntegerLattice,
 ) -> CanonicalBasisResult:
-    basis = _require_full_row_rank(lattice, label="canonical-basis")
+    basis = _basis_int_list(lattice)
     hnf, transform = _hermite_basis(basis)
     rank = integer_rank(hnf)
     return CanonicalBasisResult(
@@ -135,7 +128,7 @@ def compute_canonical_basis(
 
 
 def compute_dual(request: DualRequest) -> DualResult:
-    basis = _require_full_row_rank(request.lattice, label="dual")
+    basis = _basis_int_list(request.lattice)
     dual = _dual_basis(basis)
     # dual Gram = (B B^T)^{-1}
     from sympy import Matrix
@@ -159,7 +152,7 @@ def compute_dual(request: DualRequest) -> DualResult:
 
 
 def compute_saturation(lattice: IntegerLattice) -> SaturationResult:
-    basis = _require_full_row_rank(lattice, label="saturation")
+    basis = _basis_int_list(lattice)
     saturated, inclusion, index = _saturate_lattice(basis)
     return SaturationResult(
         saturated_basis=_integer_matrix(saturated),
@@ -174,9 +167,6 @@ def compute_sublattice_index(request: SublatticeIndexRequest) -> SublatticeIndex
         maximum=_MAX_LATTICE_INPUT_SCALAR_DIGITS,
         label="sublattice embedding",
     )
-    sub_basis = _require_full_row_rank(request.sublattice, label="sublattice")
-    parent_basis = _require_full_row_rank(request.parent, label="parent")
-    del sub_basis, parent_basis
     embedding = [
         [parse_canonical_integer(v) for v in row] for row in request.embedding.entries
     ]
@@ -195,7 +185,7 @@ def compute_sublattice_index(request: SublatticeIndexRequest) -> SublatticeIndex
 def compute_discriminant_group(
     request: DiscriminantGroupRequest,
 ) -> DiscriminantGroupResult:
-    basis = _require_full_row_rank(request.lattice, label="discriminant-group")
+    basis = _basis_int_list(request.lattice)
     order, factors = _discriminant_group(basis)
     return DiscriminantGroupResult(
         discriminant_order=order,
@@ -206,23 +196,20 @@ def compute_discriminant_group(
 def compute_orthogonal_complement(
     request: OrthogonalComplementRequest,
 ) -> OrthogonalComplementResult:
-    basis = _require_full_row_rank(request.lattice, label="orthogonal-complement")
+    basis = _basis_int_list(request.lattice)
     complement = _orthogonal_complement(basis)
-    if not complement:
-        rank = 0
-        complement_matrix = [[Fraction(0)]]
-    else:
-        rank = len(complement)
-        complement_matrix = complement
     return OrthogonalComplementResult(
-        complement_basis=rational_matrix_from_fractions(complement_matrix),
-        complement_rank=rank,
+        complement_basis=rational_vector_space_basis_from_fractions(
+            complement,
+            ambient_dimension=request.lattice.ambient_dimension,
+        ),
+        complement_rank=len(complement),
     )
 
 
 def compute_direct_sum(request: DirectSumRequest) -> DirectSumResult:
-    first = _require_full_row_rank(request.first, label="direct-sum first")
-    second = _require_full_row_rank(request.second, label="direct-sum second")
+    first = _basis_int_list(request.first)
+    second = _basis_int_list(request.second)
     result = _direct_sum(first, second)
     ambient = request.first.ambient_dimension + request.second.ambient_dimension
     return DirectSumResult(
@@ -232,8 +219,8 @@ def compute_direct_sum(request: DirectSumRequest) -> DirectSumResult:
 
 
 def compute_orthogonal_sum(request: OrthogonalSumRequest) -> OrthogonalSumResult:
-    first = _require_full_row_rank(request.first, label="orthogonal-sum first")
-    second = _require_full_row_rank(request.second, label="orthogonal-sum second")
+    first = _basis_int_list(request.first)
+    second = _basis_int_list(request.second)
     result = _orthogonal_sum(first, second)
     ambient = request.first.ambient_dimension + request.second.ambient_dimension
     return OrthogonalSumResult(

--- a/src/jacobian/math/lattices/_lattice_ops.py
+++ b/src/jacobian/math/lattices/_lattice_ops.py
@@ -50,12 +50,6 @@ def _sympy_integer_matrix(entries: list[list[int]]) -> Any:
     return Matrix(entries)
 
 
-def _entries_to_int(matrix: Any) -> list[list[int]]:
-    rows = matrix.rows if hasattr(matrix, "rows") else len(matrix)
-    cols = matrix.cols if hasattr(matrix, "cols") else len(matrix[0])
-    return [[int(matrix[i, j]) for j in range(cols)] for i in range(rows)]
-
-
 def integer_rank(entries: list[list[int]]) -> int:
     """Return the exact rank over ``QQ`` of an integer entry matrix."""
     from sympy import Matrix
@@ -123,14 +117,6 @@ def smith_invariant_factors(entries: list[list[int]]) -> list[int]:
 # ---------------------------------------------------------------------------
 
 
-def _sympy_to_fractions(matrix: Any) -> list[list[Fraction]]:
-    rows, cols = matrix.rows, matrix.cols
-    return [
-        [Fraction(int(matrix[i, j].p), int(matrix[i, j].q)) for j in range(cols)]
-        for i in range(rows)
-    ]
-
-
 def dual_basis(entries: list[list[int]]) -> list[list[Fraction]]:
     """Return a rational dual basis of the lattice spanned by ``entries``.
 
@@ -166,40 +152,28 @@ def saturate_lattice(
     """Return ``(saturated_basis, inclusion, index)`` for the lattice.
 
     ``saturated_basis`` spans ``sat(L) = span_Q(L) cap ZZ^n`` in HNF canonical
-    form.  ``inclusion`` is the integer matrix ``C`` with ``sat = C @ B``.
+    form.  ``inclusion`` is the integer matrix ``C`` with ``B = C @ sat``.
     ``index`` is the finite index ``[sat(L) : L]``.
     """
     from math import gcd
 
-    from sympy import Matrix
+    from sympy import ZZ, Matrix
     from sympy.matrices.normalforms import hermite_normal_form
+    from sympy.polys.matrices import DomainMatrix
+    from sympy.polys.matrices.normalforms import smith_normal_decomp
 
     basis = Matrix(entries)
     rows = basis.rows
     if basis.rank() != rows:
         raise ValueError("lattice basis must be full row rank for saturation")
 
-    # Saturation = ZZ^n cap span_Q(rows of B) = integer kernel of the left
-    # nullspace of B.
-    nullvecs = basis.T.nullspace()
-    sat: Matrix
-    if not nullvecs:
-        sat = Matrix.eye(basis.cols)
-    else:
-        kernel_rows = [[vec[j] for j in range(basis.cols)] for vec in nullvecs]
-        rational_kernel = Matrix(kernel_rows)
-        # Clear denominators to obtain an integer matrix.
-        denominators = [
-            rational_kernel[i, j].q if hasattr(rational_kernel[i, j], "q") else 1
-            for i in range(rational_kernel.rows)
-            for j in range(rational_kernel.cols)
-            if rational_kernel[i, j] != 0
-        ]
-        lcm = 1
-        for q in denominators:
-            lcm = lcm * q // gcd(lcm, q)
-        integer_kernel = rational_kernel * lcm
-        sat = hermite_normal_form(integer_kernel)
+    # If S B T = D is a Smith decomposition, the first r rows of T^{-1}
+    # form a primitive integer basis of span_Q(B) cap ZZ^n.  Row HNF makes
+    # that basis canonical without changing its lattice.
+    domain_basis = DomainMatrix.from_Matrix(basis).convert_to(ZZ)
+    _, _, right = smith_normal_decomp(domain_basis)
+    primitive_rows = right.to_Matrix().inv()[:rows, :]
+    sat = hermite_normal_form(primitive_rows.T).T
 
     # Inclusion L -> sat(L): each basis row of L is an integer combination
     # of the sat basis rows.  Solve basis = C @ sat_basis for the r x r
@@ -341,13 +315,6 @@ def orthogonal_sum(first: list[list[int]], second: list[list[int]]) -> list[list
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
-
-
-def _hermite_form_row(basis: Any) -> Any:
-    """Return the row Hermite normal form of a SymPy integer matrix."""
-    from sympy.matrices.normalforms import hermite_normal_form
-
-    return hermite_normal_form(basis, D=None)
 
 
 def _sympy_to_int_list(matrix: Any) -> list[list[int]]:

--- a/src/jacobian/math/lattices/_models.py
+++ b/src/jacobian/math/lattices/_models.py
@@ -12,6 +12,7 @@ from jacobian.math.matrices.values import (
     MAX_MATRIX_DIMENSION,
     IntegerMatrix,
     RationalMatrix,
+    RationalVectorSpaceBasis,
     require_matrix_scalar_digits,
 )
 
@@ -230,6 +231,18 @@ class SaturationResult(StrictModel):
         "SATURATED_BASIS_SPANS_PRIMITIVE_CLOSURE"
     )
 
+    @model_validator(mode="after")
+    def require_inclusion_shape(self) -> Self:
+        rank = len(self.saturated_basis.entries)
+        if len(self.inclusion_transform.entries) != rank or any(
+            len(row) != rank for row in self.inclusion_transform.entries
+        ):
+            raise _validation_error(
+                "saturation_inclusion_shape",
+                "saturation inclusion must be square by lattice rank",
+            )
+        return self
+
 
 class SublatticeIndexRequest(StrictModel):
     """An inclusion of a sublattice into a parent lattice.
@@ -302,11 +315,20 @@ class OrthogonalComplementRequest(StrictModel):
 class OrthogonalComplementResult(StrictModel):
     """A canonical rational basis for the orthogonal complement."""
 
-    complement_basis: RationalMatrix
+    complement_basis: RationalVectorSpaceBasis
     complement_rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
     relation: Literal["COMPLEMENT_BASIS_SPANS_ORTHOGONAL_COMPLEMENT"] = (
         "COMPLEMENT_BASIS_SPANS_ORTHOGONAL_COMPLEMENT"
     )
+
+    @model_validator(mode="after")
+    def require_rank_shape(self) -> Self:
+        if self.complement_rank != len(self.complement_basis.vectors):
+            raise _validation_error(
+                "orthogonal_complement_rank",
+                "complement rank must equal the number of basis vectors",
+            )
+        return self
 
 
 class DirectSumRequest(StrictModel):

--- a/src/jacobian/math/logic/automata/tree/_models.py
+++ b/src/jacobian/math/logic/automata/tree/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -41,8 +41,6 @@ class TreeRunResult(TreeRunRequest):
     root_states: tuple[int, ...] = Field(max_length=64)
     state_chart: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]
     node_count: int = Field(ge=1, le=4096)
-    complete: Literal[True] = True
-    method: Literal["BOTTOM_UP_REACHABLE_STATE_SETS"] = "BOTTOM_UP_REACHABLE_STATE_SETS"
 
     @model_validator(mode="after")
     def require_canonical_root_states(self) -> Self:
@@ -91,10 +89,6 @@ class AcceptedTreeCountResult(AcceptedTreeCountRequest):
 
     tree_size: int = Field(ge=1, le=100)
     count: CanonicalInteger
-    complete: Literal[True] = True
-    method: Literal["ON_THE_FLY_SUBSET_DYNAMIC_PROGRAMMING"] = (
-        "ON_THE_FLY_SUBSET_DYNAMIC_PROGRAMMING"
-    )
     estimated_work_bound: int = Field(ge=0, le=2_000_000)
 
     @model_validator(mode="after")

--- a/src/jacobian/math/logic/games/impartial/_models.py
+++ b/src/jacobian/math/logic/games/impartial/_models.py
@@ -41,8 +41,6 @@ class GrundyTableResult(GrundyTableRequest):
     max_grundy: int = Field(ge=0)
     histogram: tuple[int, ...]
     topological_order: tuple[str, ...]
-    complete: Literal[True] = True
-    method: Literal["REVERSE_TOPOLOGICAL_MEX"] = "REVERSE_TOPOLOGICAL_MEX"
 
     @model_validator(mode="after")
     def require_bounded_complete_shape(self) -> Self:
@@ -93,8 +91,6 @@ class BirthdayRequest(StrictModel):
 
 class BirthdayResult(BirthdayRequest):
     birthdays: tuple[tuple[str, int], ...]
-    complete: Literal[True] = True
-    method: Literal["REVERSE_TOPOLOGICAL_HEIGHT"] = "REVERSE_TOPOLOGICAL_HEIGHT"
 
     @model_validator(mode="after")
     def require_bounded_complete_shape(self) -> Self:
@@ -150,9 +146,7 @@ class SubtractionGrundyPrefixResult(SubtractionGrundyPrefixRequest):
     option_sets: tuple[tuple[int, ...], ...]
     p_positions: tuple[int, ...]
     n_positions: tuple[int, ...]
-    complete: Literal[True] = True
     scope: Literal["HEAPS_ZERO_THROUGH_MAX_HEAP"] = "HEAPS_ZERO_THROUGH_MAX_HEAP"
-    method: Literal["BOUNDED_DYNAMIC_PROGRAMMING"] = "BOUNDED_DYNAMIC_PROGRAMMING"
 
     @model_validator(mode="after")
     def require_bounded_complete_shape(self) -> Self:
@@ -276,7 +270,6 @@ class NimOptionsResult(NimOptionsRequest):
         le=MAX_NIM_DISTINCT_OPTIONS,
         description="Number of distinct canonical resulting positions.",
     )
-    complete: Literal[True] = True
 
     @model_validator(mode="after")
     def require_bounded_complete_shape(self) -> Self:

--- a/src/jacobian/math/logic/languages/context_free/context_free/_models.py
+++ b/src/jacobian/math/logic/languages/context_free/context_free/_models.py
@@ -79,14 +79,11 @@ class FirstSetsRequest(StrictModel):
 
 class SymbolProfilesResult(StrictModel):
     nullable: tuple[bool, ...]
-    method: str = "FIXED_POINT_ITERATION"
 
 
 class DependencyGraphResult(StrictModel):
     edges: tuple[tuple[str, str], ...]
-    method: str = "RULE_BODY_DEPENDENCY"
 
 
 class FirstSetsResult(StrictModel):
     first_sets: tuple[tuple[str, ...], ...]
-    method: str = "FIXED_POINT_ITERATION"

--- a/src/jacobian/math/logic/languages/regular/_models.py
+++ b/src/jacobian/math/logic/languages/regular/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -82,7 +82,6 @@ class RunResult(RunRequest):
     accepted: bool
     final_state: int = Field(ge=0, le=MAX_DFA_STATES - 1)
     state_trace: tuple[int, ...]
-    method: Literal["DFA_SIMULATION"] = "DFA_SIMULATION"
 
     @model_validator(mode="after")
     def require_run_shape(self) -> Self:
@@ -121,7 +120,6 @@ class RunResult(RunRequest):
             accepted=accepted,
             final_state=final_state,
             state_trace=state_trace,
-            method="DFA_SIMULATION",
         )
 
 
@@ -130,7 +128,6 @@ class CountResult(CountRequest):
 
     count: CanonicalInteger
     word_length: int = Field(ge=0, le=MAX_COUNT_WORD_LENGTH)
-    method: Literal["MATRIX_POWERING"] = "MATRIX_POWERING"
 
     @model_validator(mode="after")
     def require_nonnegative_count(self) -> Self:
@@ -144,7 +141,6 @@ class CountResult(CountRequest):
             dfa=request.dfa,
             word_length=request.word_length,
             count=count,
-            method="MATRIX_POWERING",
         )
 
 
@@ -152,7 +148,6 @@ class ComplementResult(StrictModel):
     """The complement DFA."""
 
     dfa: DFA
-    method: Literal["ACCEPTING_FLIP"] = "ACCEPTING_FLIP"
 
 
 __all__ = [

--- a/src/jacobian/math/logic/languages/words/_models.py
+++ b/src/jacobian/math/logic/languages/words/_models.py
@@ -37,12 +37,8 @@ class FactorsLengthResult(FactorsLengthRequest):
     multiplicities: tuple[int, ...]
     first_occurrence: tuple[int, ...]
     distinct_count: int = Field(ge=0)
-    complete: Literal[True] = True
     scope: Literal["ALL_CONTIGUOUS_FACTORS_OF_REQUESTED_LENGTH"] = (
         "ALL_CONTIGUOUS_FACTORS_OF_REQUESTED_LENGTH"
-    )
-    method: Literal["EXACT_SLIDING_WINDOW_ENUMERATION"] = (
-        "EXACT_SLIDING_WINDOW_ENUMERATION"
     )
 
     @model_validator(mode="after")
@@ -123,8 +119,6 @@ class PeriodsResult(PeriodsRequest):
     periods: tuple[int, ...]
     least_period: int = Field(ge=0)
     is_primitive: bool
-    complete: Literal[True] = True
-    method: Literal["EXACT_OVERLAP_COMPARISON"] = "EXACT_OVERLAP_COMPARISON"
     primitive_convention: Literal["NOT_A_NONTRIVIAL_INTEGER_POWER"] = (
         "NOT_A_NONTRIVIAL_INTEGER_POWER"
     )
@@ -177,8 +171,6 @@ class IncidenceMatrixResult(IncidenceMatrixRequest):
     """Exact target-by-source incidence matrix."""
 
     matrix: tuple[tuple[int, ...], ...]
-    complete: Literal[True] = True
-    method: Literal["EXACT_SYMBOL_COUNTING"] = "EXACT_SYMBOL_COUNTING"
     orientation: Literal["ROWS_TARGET_COLUMNS_SOURCE"] = "ROWS_TARGET_COLUMNS_SOURCE"
 
     @model_validator(mode="after")
@@ -211,10 +203,6 @@ class SubstitutionDependencyGraphResult(SubstitutionDependencyGraphRequest):
     """Exact source-bound letter graph, including every occurrence position."""
 
     graph: SubstitutionDependencyGraph
-    complete: Literal[True] = True
-    method: Literal["EXACT_IMAGE_OCCURRENCE_ENUMERATION"] = (
-        "EXACT_IMAGE_OCCURRENCE_ENUMERATION"
-    )
     edge_convention: Literal["SOURCE_TO_OCCURRING_TARGET"] = (
         "SOURCE_TO_OCCURRING_TARGET"
     )
@@ -246,10 +234,6 @@ class SubstitutionPrimitivityProfileResult(SubstitutionPrimitivityProfileRequest
     obstruction: Literal[
         "NONE", "REDUCIBLE_DEPENDENCY_GRAPH", "PERIODIC_DEPENDENCY_GRAPH"
     ]
-    complete: Literal[True] = True
-    method: Literal["BOOLEAN_POWERS_THROUGH_WIELANDT_BOUND"] = (
-        "BOOLEAN_POWERS_THROUGH_WIELANDT_BOUND"
-    )
 
     @model_validator(mode="after")
     def require_structural_primitivity_profile(self) -> Self:
@@ -332,12 +316,8 @@ class SubstitutionFixedPointPrefixResult(SubstitutionFixedPointPrefixRequest):
     retained_prefix_lengths: tuple[int, ...] = Field(
         min_length=1, max_length=MAX_MORPHISM_OUTPUT_LENGTH
     )
-    complete: Literal[True] = True
     scope: Literal["FIRST_REQUESTED_LETTERS_OF_ONE_SIDED_FIXED_POINT"] = (
         "FIRST_REQUESTED_LETTERS_OF_ONE_SIDED_FIXED_POINT"
-    )
-    method: Literal["LEAST_TRUNCATED_SUBSTITUTION_ITERATE"] = (
-        "LEAST_TRUNCATED_SUBSTITUTION_ITERATE"
     )
 
     @model_validator(mode="after")

--- a/src/jacobian/math/logic/term_rewriting/_kernel.py
+++ b/src/jacobian/math/logic/term_rewriting/_kernel.py
@@ -17,6 +17,7 @@ from jacobian.math.logic.term_rewriting.values import (
     RewriteApplication,
     RewriteRule,
     Term,
+    _variable_symbols,
 )
 
 __all__ = [
@@ -37,18 +38,6 @@ _CRITICAL_PAIR_PROFILE_FIXED_NODES = 384
 _RESULT_BYTES_PER_NODE = 96
 _VARIABLE_LABEL_BASE_WIDTH = 6
 _RESULT_TERM_MAX_DEPTH = MAX_TERM_DEPTH - 1
-
-
-def _variables(term: Term) -> set[int]:
-    symbols: set[int] = set()
-    stack = [term]
-    while stack:
-        current = stack.pop()
-        if current.is_variable:
-            symbols.add(current.symbol)
-        else:
-            stack.extend(current.children)
-    return symbols
 
 
 def apply_substitution(term: Term, subst: dict[int, Term]) -> Term:
@@ -180,7 +169,7 @@ def _unify(
         if equation_right.is_variable:
             equation_left, equation_right = equation_right, equation_left
         if equation_left.is_variable:
-            if equation_left.symbol in _variables(equation_right):
+            if equation_left.symbol in _variable_symbols(equation_right):
                 return None
             if budget is not None:
                 budget.charge(equation_right)

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -272,7 +272,6 @@ class MatrixDeterminantResult(StrictModel):
     """One exact determinant, returned inline for ordinary composition."""
 
     determinant: CanonicalRational
-    method: Literal["FRACTION_FREE_BAREISS"] = "FRACTION_FREE_BAREISS"
 
 
 class MatrixRankResult(StrictModel):
@@ -281,7 +280,6 @@ class MatrixRankResult(StrictModel):
     matrix: RationalMatrix
     rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
     pivot_columns: tuple[int, ...] = Field(max_length=MAX_MATRIX_DIMENSION)
-    method: Literal["EXACT_RATIONAL_ROW_REDUCTION"] = "EXACT_RATIONAL_ROW_REDUCTION"
 
     @classmethod
     def _from_kernel(cls, **values: Any) -> Self:
@@ -376,7 +374,6 @@ class CharacteristicPolynomialResult(StrictModel):
         min_length=2,
         max_length=MAX_MATRIX_DIMENSION + 1,
     )
-    monic: Literal[True] = True
     convention: Literal["DET_LAMBDA_I_MINUS_A"] = "DET_LAMBDA_I_MINUS_A"
 
     @model_validator(mode="after")
@@ -495,7 +492,6 @@ class MatrixPermanentResult(StrictModel):
     """One exact matrix permanent."""
 
     permanent: CanonicalRational
-    method: Literal["SYMPY_PERMANENT"] = "SYMPY_PERMANENT"
 
 
 class MatrixKroneckerProductRequest(_MatrixRequest):
@@ -513,9 +509,6 @@ class MatrixKroneckerProductResult(StrictModel):
     left_columns: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
     right_rows: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
     right_columns: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
-    convention: Literal["SYMPY_KRONECKER_PRODUCT_OVER_QQ"] = (
-        "SYMPY_KRONECKER_PRODUCT_OVER_QQ"
-    )
 
     @model_validator(mode="after")
     def require_product_shape(self) -> Self:

--- a/src/jacobian/math/matrices/analysis/_models.py
+++ b/src/jacobian/math/matrices/analysis/_models.py
@@ -109,9 +109,6 @@ class RationalSpectrumClaimResult(StrictModel):
     first_failed_claim_index: StrictInt | None = Field(
         default=None, ge=0, lt=MAX_RATIONAL_SPECTRUM_CLAIMS
     )
-    method: Literal["PYTHON_FLINT_EXACT_RANK_AFTER_ROW_DENOMINATOR_CLEARING"] = (
-        "PYTHON_FLINT_EXACT_RANK_AFTER_ROW_DENOMINATOR_CLEARING"
-    )
 
     @classmethod
     def _from_kernel(

--- a/src/jacobian/math/matrices/canonical_forms/_models.py
+++ b/src/jacobian/math/matrices/canonical_forms/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from math import gcd
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -1352,7 +1352,6 @@ class MatrixPolynomialEvaluationResult(StrictModel):
         ge=0,
         le=MAX_MATRIX_POLYNOMIAL_SCALAR_PRODUCTS // MATRIX_POLYNOMIAL_EVALUATION_PASSES,
     )
-    method: Literal["HORNER_OVER_QQ"] = "HORNER_OVER_QQ"
 
     @model_validator(mode="after")
     def require_structural_accounting(self) -> Self:
@@ -1436,7 +1435,6 @@ class MinimalPolynomialResult(StrictModel):
     minimal_polynomial: MonicPolynomial
     characteristic_polynomial: MonicPolynomial
     degree: int = Field(ge=1, le=MAX_CANONICAL_FORM_DIMENSION)
-    method: Literal["KRYLOV_NULLSPACE"] = "KRYLOV_NULLSPACE"
 
     @model_validator(mode="after")
     def require_structural_metadata(self) -> Self:
@@ -1488,7 +1486,6 @@ class RationalCanonicalFormResult(StrictModel):
     characteristic_polynomial: MonicPolynomial
     minimal_polynomial: MonicPolynomial
     total_block_size: int = Field(ge=1, le=MAX_CANONICAL_FORM_DIMENSION)
-    method: Literal["SMITH_NORMAL_FORM"] = "SMITH_NORMAL_FORM"
 
     @model_validator(mode="after")
     def require_structural_metadata(self) -> Self:
@@ -1542,7 +1539,6 @@ class PrimaryDecompositionResult(StrictModel):
     matrix: SquareMatrixRequest
     components: tuple[MonicPolynomial, ...] = Field(min_length=1)
     minimal_polynomial: MonicPolynomial
-    method: Literal["FACTOR_LCM"] = "FACTOR_LCM"
 
     @model_validator(mode="after")
     def require_structural_metadata(self) -> Self:

--- a/src/jacobian/math/matrices/certified_snf/_models.py
+++ b/src/jacobian/math/matrices/certified_snf/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from typing import Annotated, Self
 
 from pydantic import WithJsonSchema, model_validator
 from pydantic.json_schema import JsonSchemaValue
@@ -63,9 +63,6 @@ class CertifiedSmithNormalFormRequest(StrictModel):
 
 class CertifiedSmithNormalFormResult(StrictModel):
     certificate: SmithNormalFormCertificate
-    exactness: Literal["EXACT_INTEGER"] = "EXACT_INTEGER"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
-    completeness: Literal["FULL_MATRIX_TRANSFORMATIONS"] = "FULL_MATRIX_TRANSFORMATIONS"
 
     @classmethod
     def _from_kernel(

--- a/src/jacobian/math/matrices/quadratic_spectral/operations.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/operations.py
@@ -21,6 +21,7 @@ from jacobian.math.matrices.quadratic_spectral.values import (
     RealQuadraticInertia,
     RealQuadraticSpectrum,
     SpectrumKind,
+    _definiteness_from_inertia,
 )
 from jacobian.math.matrices.values import RealQuadraticMatrix
 from jacobian.math.number_theory.algebraic_numbers.quadratic import RealQuadraticValue
@@ -577,22 +578,6 @@ def _inertia_counts(matrix: RealQuadraticMatrix) -> tuple[int, int, int]:
     return positive, negative, zero
 
 
-def _definiteness(positive: int, negative: int, zero: int) -> Definiteness:
-    if positive == 0 and negative == 0:
-        return "zero"
-    if zero == 0:
-        if negative == 0:
-            return "positive_definite"
-        if positive == 0:
-            return "negative_definite"
-        return "indefinite"
-    if negative == 0:
-        return "positive_semidefinite"
-    if positive == 0:
-        return "negative_semidefinite"
-    return "indefinite"
-
-
 def inertia_data(
     matrix: RealQuadraticMatrix,
 ) -> tuple[int, int, int, Definiteness]:
@@ -600,7 +585,12 @@ def inertia_data(
 
     require_inertia_matrix(matrix)
     positive, negative, zero = _inertia_counts(matrix)
-    return positive, negative, zero, _definiteness(positive, negative, zero)
+    return (
+        positive,
+        negative,
+        zero,
+        _definiteness_from_inertia(positive, negative, zero),
+    )
 
 
 def inertia(matrix: RealQuadraticMatrix) -> RealQuadraticInertia:

--- a/src/jacobian/math/matrices/quadratic_spectral/values.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/values.py
@@ -106,7 +106,7 @@ class RealQuadraticInertia(StrictModel):
             raise _validation_error(
                 "shape_mismatch", "inertia counts must sum to the matrix dimension"
             )
-        if self.definiteness != _definiteness(
+        if self.definiteness != _definiteness_from_inertia(
             self.n_positive, self.n_negative, self.n_zero
         ):
             raise _validation_error(
@@ -148,7 +148,7 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"matrix.{reason}", message)
 
 
-def _definiteness(positive: int, negative: int, zero: int) -> Definiteness:
+def _definiteness_from_inertia(positive: int, negative: int, zero: int) -> Definiteness:
     if positive == 0 and negative == 0:
         return "zero"
     if zero == 0:

--- a/src/jacobian/math/matrices/symbolic/_models.py
+++ b/src/jacobian/math/matrices/symbolic/_models.py
@@ -905,7 +905,6 @@ class SymbolicDeterminantResult(StrictModel):
     """The exact determinant in the matrix's rational-function field."""
 
     determinant: RationalFunction
-    method: Literal["SYMPY_BAREISS"] = "SYMPY_BAREISS"
 
 
 class SymbolicRankResult(StrictModel):
@@ -913,7 +912,6 @@ class SymbolicRankResult(StrictModel):
 
     rank: int = Field(ge=0, le=MAX_SYMBOLIC_MATRIX_DIMENSION)
     pivot_columns: tuple[int, ...] = Field(max_length=MAX_SYMBOLIC_MATRIX_DIMENSION)
-    method: Literal["EXACT_SYMBOLIC_ROW_REDUCTION"] = "EXACT_SYMBOLIC_ROW_REDUCTION"
 
 
 class SymbolicCharacteristicPolynomialResult(StrictModel):
@@ -956,7 +954,6 @@ class SymbolicEigenvaluesResult(StrictModel):
         max_length=MAX_SYMBOLIC_MATRIX_DIMENSION + 1,
     )
     degree: int | None = Field(default=None, ge=1, le=MAX_SYMBOLIC_MATRIX_DIMENSION)
-    convention: Literal["SYMPY_EIGENVALS"] = "SYMPY_EIGENVALS"
 
     @model_validator(mode="after")
     def require_representation_consistency(self) -> Self:

--- a/src/jacobian/math/matrices/values.py
+++ b/src/jacobian/math/matrices/values.py
@@ -148,6 +148,50 @@ def rational_matrix_from_fractions(
     )
 
 
+class RationalVectorSpaceBasis(StrictModel):
+    """A rational vector-space basis with its ambient dimension retained.
+
+    Unlike a dense matrix, a basis may be empty.  The explicit ambient
+    dimension distinguishes the zero subspace of ``QQ^n`` for different ``n``.
+    """
+
+    domain: Literal["QQ"] = "QQ"
+    ambient_dimension: int = Field(ge=1, le=MAX_RATIONAL_MATRIX_ORDER)
+    vectors: tuple[tuple[CanonicalRational, ...], ...] = Field(
+        default=(), max_length=MAX_RATIONAL_MATRIX_ORDER
+    )
+
+    @model_validator(mode="after")
+    def require_vector_shape(self) -> Self:
+        if any(len(vector) != self.ambient_dimension for vector in self.vectors):
+            raise _validation_error(
+                "shape_mismatch",
+                "each basis vector must have the declared ambient dimension",
+            )
+        require_matrix_scalar_digits(
+            self.vectors,
+            maximum=MAX_MATRIX_SCALAR_DIGITS,
+            label="basis",
+        )
+        return self
+
+
+def rational_vector_space_basis_from_fractions(
+    vectors: tuple[tuple[Fraction, ...], ...] | list[list[Fraction]],
+    *,
+    ambient_dimension: int,
+) -> RationalVectorSpaceBasis:
+    """Construct a canonical rational basis, including the empty basis."""
+
+    return RationalVectorSpaceBasis(
+        ambient_dimension=ambient_dimension,
+        vectors=tuple(
+            tuple(CanonicalRational.from_fraction(value) for value in vector)
+            for vector in vectors
+        ),
+    )
+
+
 class RealQuadraticMatrix(StrictModel):
     """One nonempty rectangular matrix over a shared real quadratic field."""
 
@@ -284,9 +328,11 @@ __all__ = [
     "MAX_RATIONAL_MATRIX_ORDER",
     "IntegerMatrix",
     "RationalMatrix",
+    "RationalVectorSpaceBasis",
     "RealQuadraticMatrix",
     "SmithNormalForm",
     "rational_matrix_from_fractions",
+    "rational_vector_space_basis_from_fractions",
     "require_matrix_scalar_digits",
 ]
 

--- a/src/jacobian/math/number_theory/_modular_models.py
+++ b/src/jacobian/math/number_theory/_modular_models.py
@@ -222,24 +222,6 @@ class ModularPolynomialResidueImageResult(StrictModel):
         )
 
 
-def _evaluate_normalized_modular_polynomial(
-    terms: tuple[_NormalizedModularPolynomialTerm, ...],
-    assignment: tuple[int, ...],
-    modulus: int,
-) -> int:
-    value = 0
-    for term in terms:
-        monomial = term.coefficient
-        for coordinate, exponent in zip(
-            assignment,
-            term.exponents,
-            strict=True,
-        ):
-            monomial = monomial * pow(coordinate, exponent, modulus) % modulus
-        value = (value + monomial) % modulus
-    return value
-
-
 def _validate_residue_image_shape(
     result: ModularPolynomialResidueImageResult,
 ) -> tuple[tuple[int, ...], ...]:

--- a/src/jacobian/math/number_theory/algebraic_numbers/root_isolation/_models.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/root_isolation/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from itertools import pairwise
-from typing import Any, Literal, Self
+from typing import Any, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -143,7 +143,6 @@ class RootIsolationResult(StrictModel):
         min_length=2, max_length=MAX_REAL_ALGEBRAIC_DEGREE + 1
     )
     roots: tuple[RootIsolationEntry, ...] = Field(max_length=MAX_REAL_ALGEBRAIC_DEGREE)
-    convention: Literal["SYMPY_REAL_ROOTS"] = "SYMPY_REAL_ROOTS"
 
     @model_validator(mode="after")
     def require_structural_order(self) -> Self:

--- a/src/jacobian/math/number_theory/arithmetic_functions/inverse_multiplicative/_models.py
+++ b/src/jacobian/math/number_theory/arithmetic_functions/inverse_multiplicative/_models.py
@@ -34,15 +34,12 @@ class EulerPhiPowerSumRequest(StrictModel):
 class EulerPhiPreimageResult(StrictModel):
     preimage: tuple[int, ...]
     count: int = Field(ge=0)
-    method: str = "EXACT_RECURSIVE_CONSTRUCTION"
 
 
 class EulerPhiPreimageCountResult(StrictModel):
     count: int = Field(ge=0)
-    method: str = "EXACT_RECURSIVE_CONSTRUCTION"
 
 
 class EulerPhiPowerSumResult(StrictModel):
     power_sum: int = Field(ge=0)
     count: int = Field(ge=0)
-    method: str = "EXACT_RECURSIVE_CONSTRUCTION"

--- a/src/jacobian/math/number_theory/diophantine_approximation/_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import ceil, isqrt, log10
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
@@ -71,7 +71,6 @@ class ContinuedFractionResult(StrictModel):
     coefficients: tuple[StrictInt, ...] = Field(min_length=1, max_length=_MAX_TERMS)
     preperiod_length: StrictInt = Field(ge=1)
     period_length: StrictInt = Field(ge=1)
-    method: Literal["SYMPY_CONTINUED_FRACTION"] = "SYMPY_CONTINUED_FRACTION"
 
     @model_validator(mode="after")
     def require_bounded_shape(self) -> Self:
@@ -140,7 +139,6 @@ class ConvergentResult(StrictModel):
     convergents: tuple[ConvergentValue, ...] = Field(
         min_length=1, max_length=_MAX_TERMS
     )
-    method: Literal["CONTINUED_FRACTION_RECURSION"] = "CONTINUED_FRACTION_RECURSION"
 
     @model_validator(mode="after")
     def require_bounded_shape(self) -> Self:
@@ -198,7 +196,6 @@ class PellEquationResult(StrictModel):
     discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
     x: CanonicalInteger
     y: CanonicalInteger
-    method: Literal["CONTINUED_FRACTION_CONVERGENTS"] = "CONTINUED_FRACTION_CONVERGENTS"
 
     @model_validator(mode="after")
     def require_bounded_positive_components(self) -> Self:

--- a/src/jacobian/math/number_theory/galois/_models.py
+++ b/src/jacobian/math/number_theory/galois/_models.py
@@ -109,7 +109,6 @@ class GaloisFactorResult(StrictModel):
     distinct_factor_count: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
     factor_count: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
     is_irreducible: bool
-    method: str = "SYMPY_FACTOR_MOD_P"
 
     @classmethod
     def _from_kernel(
@@ -181,7 +180,6 @@ class FrobeniusCycleResult(StrictModel):
     cycle_type: tuple[PositiveFactorDegree, ...]
     degree: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
     is_irreducible: bool
-    method: str = "FACTOR_DEGREE_SUMMARY"
 
     @model_validator(mode="after")
     def require_canonical_partition(self) -> Self:
@@ -236,7 +234,6 @@ class GaloisGroupResult(StrictModel):
     order: int = Field(ge=1)
     degree: int = Field(ge=1, le=MAX_GALOIS_GROUP_DEGREE)
     is_solvable: bool
-    method: str = "SYMPY_GALOIS_GROUP"
 
     @classmethod
     def _from_kernel(
@@ -271,7 +268,6 @@ class GaloisGroupResult(StrictModel):
 class SolvableResult(StrictModel):
     solvable_by_radicals: bool
     group: FinitePermutationGroup
-    method: str = "GALOIS_GROUP_SOLVABILITY"
 
     @classmethod
     def _from_kernel(

--- a/src/jacobian/math/number_theory/modular_forms/values.py
+++ b/src/jacobian/math/number_theory/modular_forms/values.py
@@ -34,7 +34,6 @@ class LevelOneModularQExpansion(StrictModel):
     coefficient_domain: Literal["QQ"] = "QQ"
     normalization: str = Field(min_length=1, max_length=96)
     q_expansion: TruncatedSeries
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
     def require_structural_named_form(self) -> Self:

--- a/src/jacobian/math/number_theory/number_fields/_models.py
+++ b/src/jacobian/math/number_theory/number_fields/_models.py
@@ -57,7 +57,6 @@ class NumberFieldRequest(StrictModel):
 class NumberFieldDiscriminantResult(StrictModel):
     status: Literal["COMPLETE", "UNKNOWN"] = "COMPLETE"
     discriminant: str | None = None
-    method: Literal["SYMPY_NUMBER_FIELD"] = "SYMPY_NUMBER_FIELD"
     detail: str | None = Field(default=None, max_length=1_024)
 
     @model_validator(mode="after")

--- a/src/jacobian/math/number_theory/sequences/recurrence_solving/_models.py
+++ b/src/jacobian/math/number_theory/sequences/recurrence_solving/_models.py
@@ -35,7 +35,6 @@ class RecurrenceFindResult(StrictModel):
     )
     order: int = Field(ge=0, le=MAX_RATIONAL_SEQUENCE_LENGTH - 1)
     status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
-    method: Literal["RATIONAL_INTERPOLATION"] = "RATIONAL_INTERPOLATION"
 
     @model_validator(mode="after")
     def require_status_consistent_coefficients(self) -> Self:
@@ -66,7 +65,6 @@ class RecurrenceFindResult(StrictModel):
             coefficients=coefficients,
             order=order,
             status=status,
-            method="RATIONAL_INTERPOLATION",
         )
 
 
@@ -90,13 +88,12 @@ class ClosedFormResult(StrictModel):
     """The closed-form solution as a SymPy expression string."""
 
     expression: str
-    method: Literal["SYMPY_RSOLVE"] = "SYMPY_RSOLVE"
 
     @classmethod
     def _from_kernel(cls, *, expression: str) -> Self:
         """Construct a closed-form result from the trusted SymPy adapter."""
 
-        return cls.model_construct(expression=expression, method="SYMPY_RSOLVE")
+        return cls.model_construct(expression=expression)
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +187,6 @@ class PrimeFieldRecurrenceFindResult(StrictModel):
         ),
     )
     recurrence: PrimeFieldRecurrence
-    method: Literal["BERLEKAMP_MASSEY"] = "BERLEKAMP_MASSEY"
 
     @model_validator(mode="after")
     def require_status_consistent_coefficients(self) -> Self:
@@ -215,7 +211,6 @@ class PrimeFieldRecurrenceFindResult(StrictModel):
         return cls.model_construct(
             sequence=sequence,
             recurrence=recurrence,
-            method="BERLEKAMP_MASSEY",
         )
 
 

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -202,7 +202,6 @@ class PolynomialFactorizationResult(StrictModel):
     normalization: Literal["CONTENT_AND_MONIC_IRREDUCIBLES"] = (
         "CONTENT_AND_MONIC_IRREDUCIBLES"
     )
-    product_reconstruction: Literal["EXACT"] = "EXACT"
 
     @model_validator(mode="after")
     def require_canonical_irreducible_records(self) -> Self:
@@ -264,7 +263,6 @@ class PolynomialFactorizationResult(StrictModel):
             factors=factors,
             reconstructed=reconstructed,
             normalization="CONTENT_AND_MONIC_IRREDUCIBLES",
-            product_reconstruction="EXACT",
         )
 
 
@@ -300,7 +298,6 @@ class PolynomialGroebnerBasisResult(StrictModel):
     )
     monomial_order: Literal["lex", "grlex", "grevlex"]
     basis: tuple[RationalPolynomial, ...] = Field(max_length=64)
-    completion: Literal["COMPLETE"] = "COMPLETE"
     normalization: Literal["REDUCED_MONIC"] = "REDUCED_MONIC"
 
     @model_validator(mode="after")

--- a/src/jacobian/math/polynomials/ideals/_models.py
+++ b/src/jacobian/math/polynomials/ideals/_models.py
@@ -358,7 +358,6 @@ IdealExecutionOutcome = Literal[
 class IdealRadicalResult(StrictModel):
     outcome: IdealExecutionOutcome
     radical: RationalPolynomialIdeal | None = None
-    method: Literal["SINGULAR_RADICAL"] = "SINGULAR_RADICAL"
     backend_version: str | None = None
     detail: str | None = None
 
@@ -382,13 +381,11 @@ class IdealRadicalResult(StrictModel):
 
 class IdealRadicalMembershipResult(StrictModel):
     in_radical: bool
-    method: Literal["RABINOWITSCH"] = "RABINOWITSCH"
 
 
 class IdealQuotientResult(StrictModel):
     outcome: IdealExecutionOutcome
     quotient: RationalPolynomialIdeal | None = None
-    method: Literal["SINGULAR_QUOTIENT"] = "SINGULAR_QUOTIENT"
     backend_version: str | None = None
     detail: str | None = None
 
@@ -413,7 +410,6 @@ class IdealQuotientResult(StrictModel):
 class IdealSaturationResult(StrictModel):
     outcome: IdealExecutionOutcome
     saturation: RationalPolynomialIdeal | None = None
-    method: Literal["SINGULAR_SATURATION"] = "SINGULAR_SATURATION"
     backend_version: str | None = None
     detail: str | None = None
 
@@ -471,7 +467,6 @@ class IdealMinimalPrimesResult(StrictModel):
     request: IdealMinimalPrimesRequest
     outcome: IdealExecutionOutcome
     components: tuple[RationalPolynomialIdeal, ...] | None = None
-    method: Literal["SINGULAR_MIN_ASS_GTZ"] = "SINGULAR_MIN_ASS_GTZ"
     backend_version: str | None = None
     detail: str | None = None
 
@@ -602,7 +597,6 @@ class GroebnerBasisResult(StrictModel):
     generator_count: StrictInt = Field(default=0, ge=0, le=MAX_OUTPUT_GENERATORS)
     monomial_order: Literal["lex", "grlex", "grevlex"]
     detail: str | None = None
-    backend: Literal["SYMPY"] = "SYMPY"
 
     @model_validator(mode="after")
     def require_outcome_shape(self) -> Self:
@@ -810,7 +804,6 @@ class EliminationIdealResult(StrictModel):
     outcome: EliminationExecutionOutcome = "COMPUTED"
     elimination_ideal: RationalPolynomialIdeal | None = None
     eliminated_variables: tuple[str, ...] = Field(min_length=1, max_length=MAX_VARS)
-    backend: Literal["SYMPY"] = "SYMPY"
     detail: str | None = None
 
     @model_validator(mode="after")

--- a/src/jacobian/math/polynomials/interpolation/_models.py
+++ b/src/jacobian/math/polynomials/interpolation/_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import prod
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -406,9 +406,6 @@ class HermiteInterpolationResult(StrictModel):
             "rational node and then derivative order."
         ),
     )
-    method: Literal["FLINT_FMPQ_HERMITE_VANDERMONDE_FFLU"] = (
-        "FLINT_FMPQ_HERMITE_VANDERMONDE_FFLU"
-    )
 
     @model_validator(mode="after")
     def require_structural_shape(self) -> Self:
@@ -540,12 +537,10 @@ class DividedDifferencesResult(StrictModel):
         min_length=1,
         max_length=MAX_NEWTON_POINTS,
     )
-    method: str = "NEWTON_DIVIDED_DIFFERENCES"
 
 
 class NewtonEvaluateResult(StrictModel):
     result: CanonicalRational
-    method: str = "NEWTON_HORNER"
 
 
 __all__ = [

--- a/src/jacobian/math/polynomials/multivariate/_operations.py
+++ b/src/jacobian/math/polynomials/multivariate/_operations.py
@@ -403,16 +403,6 @@ def _monic_content_fraction(content: Any) -> Any:
     return Fraction(int(value.p), int(value.q))
 
 
-def _sympy_factor_key(poly: Any) -> _SympyFactorKey:
-    """Return a canonical hashable representation of one QQ ``Poly``."""
-
-    return tuple(
-        sorted(
-            (tuple(monom), int(coeff.p), int(coeff.q)) for monom, coeff in poly.terms()
-        )
-    )
-
-
 def multivariate_factor(request: MultivariateFactorRequest) -> MultivariateFactorResult:
     """Exact factorization over ``QQ[variables]`` via SymPy's ``factor_list``.
 

--- a/src/jacobian/math/polynomials/multivariate/_subresultants.py
+++ b/src/jacobian/math/polynomials/multivariate/_subresultants.py
@@ -352,7 +352,6 @@ class MultivariateSubresultantSequenceResult(StrictModel):
         )
     )
     convention: Literal["BROWN_SUBRESULTANT_PRS"] = "BROWN_SUBRESULTANT_PRS"
-    zero_members_omitted: Literal[True] = True
 
     @model_validator(mode="after")
     def require_structural_sequence(self) -> Self:

--- a/src/jacobian/math/polynomials/real_algebra/_models.py
+++ b/src/jacobian/math/polynomials/real_algebra/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -112,7 +112,6 @@ class SturmChainResult(StrictModel):
 
     chain: tuple[UnivariatePolynomial, ...] = Field(min_length=1)
     degree: int = Field(ge=1, le=MAX_POLYNOMIAL_DEGREE)
-    method: Literal["SYMPY_STURM"] = "SYMPY_STURM"
 
 
 class RootCountResult(StrictModel):
@@ -122,7 +121,6 @@ class RootCountResult(StrictModel):
     root_count: int = Field(ge=0)
     lower: CanonicalRational
     upper: CanonicalRational
-    method: Literal["STURM_THEOREM"] = "STURM_THEOREM"
 
 
 __all__ = [

--- a/src/jacobian/math/polynomials/series/_models.py
+++ b/src/jacobian/math/polynomials/series/_models.py
@@ -182,19 +182,6 @@ def _inverse_height(series: TruncatedSeries) -> RationalHeight:
     return result
 
 
-def _composition_height(
-    outer: RationalHeight, inner: RationalHeight, order: int, operation: str
-) -> RationalHeight:
-    power = RationalHeight(1, 1)
-    result = outer.product(power)
-    for _ in range(1, order):
-        power = _convolution_height(power, inner, order)
-        _require_height(power, operation)
-        result = sum_heights((result, outer.product(power)))
-        _require_height(result, operation)
-    return result
-
-
 Variable = Annotated[
     str,
     StringConstraints(
@@ -555,7 +542,6 @@ class SeriesDivideRequest(_SeriesPairRequest):
 class SeriesArithmeticResult(StrictModel):
     result: TruncatedSeries
     residual_congruence: Literal["EXACT_MOD_X_TO_N"] = "EXACT_MOD_X_TO_N"
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
 
 class SeriesMultiplyResult(StrictModel):
@@ -566,7 +552,6 @@ class SeriesMultiplyResult(StrictModel):
         description="Per-degree Cauchy convolution sums c_n = sum_{i=0}^n a_i b_{n-i}.",
     )
     residual_congruence: Literal["EXACT_MOD_X_TO_N"] = "EXACT_MOD_X_TO_N"
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
     def require_structural_ledger(self) -> Self:
@@ -611,7 +596,6 @@ class SeriesScalarMultiplyRequest(StrictModel):
 
 class SeriesScalarMultiplyResult(StrictModel):
     result: TruncatedSeries
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
 
 # ---------------------------------------------------------------------------
@@ -628,7 +612,6 @@ class SeriesPowerResult(StrictModel):
     result: TruncatedSeries
     multiplication_count: StrictInt
     residual_congruence: Literal["EXACT_MOD_X_TO_N"] = "EXACT_MOD_X_TO_N"
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
 
 # ---------------------------------------------------------------------------
@@ -668,7 +651,6 @@ class SeriesInverseResult(StrictModel):
     residual_coefficients: tuple[CanonicalRational, ...] = Field(
         description="A(x) * B(x) - 1 coefficients (must all be zero).",
     )
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
     def require_structural_residual(self) -> Self:
@@ -717,7 +699,6 @@ class SeriesDivideResult(StrictModel):
     residual_coefficients: tuple[CanonicalRational, ...] = Field(
         description="B(x) Q(x) - A(x) coefficients (must all be zero).",
     )
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
     def require_structural_residual(self) -> Self:
@@ -782,7 +763,6 @@ class SeriesComposeRequest(StrictModel):
 class SeriesComposeResult(StrictModel):
     result: TruncatedSeries
     residual_congruence: Literal["EXACT_MOD_X_TO_N"] = "EXACT_MOD_X_TO_N"
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
 
 # ---------------------------------------------------------------------------
@@ -812,7 +792,6 @@ class SeriesReversionResult(StrictModel):
     right_identity: Literal["G_OF_F_IS_X_MOD_X_TO_N"] = "G_OF_F_IS_X_MOD_X_TO_N"
     left_residual: tuple[CanonicalRational, ...]
     right_residual: tuple[CanonicalRational, ...]
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
     def require_structural_residuals(self) -> Self:
@@ -856,7 +835,6 @@ class SeriesDerivativeResult(StrictModel):
     output_order_convention: Literal["MAX_N_MINUS_1_AT_LEAST_1"] = (
         "MAX_N_MINUS_1_AT_LEAST_1"
     )
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
 
 class SeriesIntegralRequest(StrictModel):
@@ -866,7 +844,6 @@ class SeriesIntegralRequest(StrictModel):
 
 class SeriesIntegralResult(StrictModel):
     result: TruncatedSeries
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
 
 # ---------------------------------------------------------------------------
@@ -888,7 +865,6 @@ class SeriesTruncateRequest(StrictModel):
 
 class SeriesTruncateResult(StrictModel):
     result: TruncatedSeries
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
 
 # ---------------------------------------------------------------------------
@@ -900,7 +876,6 @@ class SeriesIdentityCheckResult(StrictModel):
     status: Literal["EQUAL_MOD_X_TO_N", "NOT_EQUAL"]
     first_differing_index: StrictInt | None = None
     exact_difference: CanonicalRational | None = None
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
     @model_validator(mode="after")
     def require_consistent_diff(self) -> Self:
@@ -947,7 +922,6 @@ class SeriesFromPolynomialRequest(StrictModel):
 
 class SeriesFromPolynomialResult(StrictModel):
     result: TruncatedSeries
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
 
 
 class SeriesToPolynomialResult(StrictModel):
@@ -955,4 +929,3 @@ class SeriesToPolynomialResult(StrictModel):
     polynomial_label: Literal["TRUNCATED_POLYNOMIAL_REPRESENTATIVE"] = (
         "TRUNCATED_POLYNOMIAL_REPRESENTATIVE"
     )
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"

--- a/src/jacobian/math/polynomials/sum_of_squares/_models.py
+++ b/src/jacobian/math/polynomials/sum_of_squares/_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import ceil, log10
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -175,7 +175,6 @@ class SOSDecompositionCheckResult(StrictModel):
     polynomial: RationalPolynomial
     summands: tuple[RationalPolynomial, ...] = Field(max_length=64)
     computed_sum: RationalPolynomial
-    method: Literal["EXACT_COEFFICIENT_IDENTITY"] = "EXACT_COEFFICIENT_IDENTITY"
 
     @model_validator(mode="after")
     def bind_sos(self) -> Self:
@@ -206,7 +205,6 @@ class SOSDecompositionCheckResult(StrictModel):
             polynomial=polynomial,
             summands=summands,
             computed_sum=computed_sum,
-            method="EXACT_COEFFICIENT_IDENTITY",
         )
 
 
@@ -262,7 +260,6 @@ class GramCertificateResult(StrictModel):
         min_length=1, max_length=MAX_GRAM_DIMENSION
     )
     gram_matrix: RationalMatrix
-    method: Literal["EXACT_RATIONAL_ARITHMETIC"] = "EXACT_RATIONAL_ARITHMETIC"
 
     @model_validator(mode="after")
     def bind_invariants(self) -> Self:
@@ -295,7 +292,6 @@ class GramCertificateResult(StrictModel):
             polynomial=polynomial,
             monomial_basis=monomial_basis,
             gram_matrix=gram_matrix,
-            method="EXACT_RATIONAL_ARITHMETIC",
         )
 
 

--- a/src/jacobian/math/polynomials/vector_calculus/_models.py
+++ b/src/jacobian/math/polynomials/vector_calculus/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -106,19 +106,10 @@ class DirectionalDerivativeRequest(StrictModel):
         return self
 
 
-ScalarMethod = Literal[
-    "SYMPY_DIVERGENCE",
-    "SYMPY_LAPLACIAN",
-    "SYMPY_DIRECTIONAL_DERIVATIVE",
-]
-VectorMethod = Literal["SYMPY_GRADIENT", "SYMPY_CURL"]
-
-
 class ScalarResult(StrictModel):
     """One canonical scalar polynomial result."""
 
     result: RationalPolynomial
-    method: ScalarMethod
 
 
 class VectorResult(StrictModel):
@@ -127,7 +118,6 @@ class VectorResult(StrictModel):
     components: tuple[RationalPolynomial, ...] = Field(
         min_length=1, max_length=MAX_POLYS
     )
-    method: VectorMethod
 
     @model_validator(mode="after")
     def require_one_result_ring(self) -> Self:

--- a/src/jacobian/math/polynomials/vector_calculus/_operations.py
+++ b/src/jacobian/math/polynomials/vector_calculus/_operations.py
@@ -117,7 +117,6 @@ def compute_gradient(request: ScalarFieldRequest) -> VectorResult:
             _wire(sympy.diff(expression, variable), variables)
             for variable in symbols_for_variables(variables)
         ),
-        method="SYMPY_GRADIENT",
     )
 
 
@@ -134,7 +133,6 @@ def compute_divergence(request: VectorFieldRequest) -> ScalarResult:
     )
     return ScalarResult(
         result=_wire(expression, variables),
-        method="SYMPY_DIVERGENCE",
     )
 
 
@@ -151,7 +149,6 @@ def compute_curl(request: CurlRequest) -> VectorResult:
             _wire(sympy.diff(fx, z) - sympy.diff(fz, x), variables),
             _wire(sympy.diff(fy, x) - sympy.diff(fx, y), variables),
         ),
-        method="SYMPY_CURL",
     )
 
 
@@ -165,7 +162,6 @@ def compute_laplacian(request: ScalarFieldRequest) -> ScalarResult:
     )
     return ScalarResult(
         result=_wire(laplacian, variables),
-        method="SYMPY_LAPLACIAN",
     )
 
 
@@ -204,7 +200,6 @@ def compute_directional_derivative(
             ),
             variables,
         ),
-        method="SYMPY_DIRECTIONAL_DERIVATIVE",
     )
 
 

--- a/src/jacobian/math/probability/_directed_bond_reliability.py
+++ b/src/jacobian/math/probability/_directed_bond_reliability.py
@@ -362,11 +362,6 @@ class DirectedBondConnectionProbabilityResult(StrictModel):
     event: Literal["DIRECTED_PATH_EXISTS"] = "DIRECTED_PATH_EXISTS"
     arc_independence: Literal["INDEPENDENT_BERNOULLI"] = "INDEPENDENT_BERNOULLI"
     enumeration: Literal["COMPLETE_ARC_SUBSETS"] = "COMPLETE_ARC_SUBSETS"
-    completeness: Literal["COMPLETE"] = "COMPLETE"
-    truncated: Literal[False] = False
-    termination_reason: Literal["EXHAUSTED"] = "EXHAUSTED"
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @model_validator(mode="after")
     def require_bounded_ledger_shape(self) -> Self:
@@ -412,11 +407,6 @@ class DirectedBondConnectionProbabilityResult(StrictModel):
             event="DIRECTED_PATH_EXISTS",
             arc_independence="INDEPENDENT_BERNOULLI",
             enumeration="COMPLETE_ARC_SUBSETS",
-            completeness="COMPLETE",
-            truncated=False,
-            termination_reason="EXHAUSTED",
-            exactness="EXACT_RATIONAL",
-            determinism="DETERMINISTIC",
         )
 
 

--- a/src/jacobian/math/probability/_gaussian.py
+++ b/src/jacobian/math/probability/_gaussian.py
@@ -144,9 +144,6 @@ class GaussianPolynomialMomentResult(StrictModel):
         max_length=MAX_GAUSSIAN_EXPANSION_PATHS,
     )
     gaussian_model: Literal["INDEPENDENT_STANDARD_REAL"] = "INDEPENDENT_STANDARD_REAL"
-    completeness: Literal["COMPLETE_BOUNDED_EXPANSION"] = "COMPLETE_BOUNDED_EXPANSION"
-    exactness: Literal["EXACT_COMPLEX_RATIONAL"] = "EXACT_COMPLEX_RATIONAL"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @model_validator(mode="after")
     def require_canonical_contraction_ledger(self) -> Self:

--- a/src/jacobian/math/probability/_graph_connection_probability.py
+++ b/src/jacobian/math/probability/_graph_connection_probability.py
@@ -85,11 +85,6 @@ class GraphConnectionProbabilityResult(StrictModel):
     event: Literal["TERMINALS_CONNECTED"] = "TERMINALS_CONNECTED"
     edge_independence: Literal["INDEPENDENT_BERNOULLI"] = "INDEPENDENT_BERNOULLI"
     enumeration: Literal["COMPLETE_EDGE_SUBSETS"] = "COMPLETE_EDGE_SUBSETS"
-    completeness: Literal["COMPLETE"] = "COMPLETE"
-    truncated: Literal[False] = False
-    termination_reason: Literal["EXHAUSTED"] = "EXHAUSTED"
-    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @model_validator(mode="after")
     def require_canonical_state_ledger(self) -> Self:
@@ -119,13 +114,6 @@ def _wire(value: Any) -> CanonicalRational:
     )
 
 
-def _fmpq(value: CanonicalRational) -> Any:
-    from flint import fmpq
-
-    fraction = value.as_fraction()
-    return fmpq(fraction.numerator, fraction.denominator)
-
-
 def _admit_graph_connection_request(
     request: GraphConnectionProbabilityRequest,
 ) -> tuple[tuple[Any, ...], int]:
@@ -150,9 +138,12 @@ def _admit_graph_connection_request(
     ):
         raise ValueError("terminals must be two distinct declared graph vertices")
 
-    probabilities = tuple(
-        _fmpq(item.open_probability) for item in request.edge_probabilities
-    )
+    from flint import fmpq
+
+    probabilities = []
+    for item in request.edge_probabilities:
+        probability = item.open_probability.as_fraction()
+        probabilities.append(fmpq(probability.numerator, probability.denominator))
     if any(not 0 <= probability <= 1 for probability in probabilities):
         raise ValueError("graph reliability probabilities must lie in [0, 1]")
 
@@ -200,7 +191,7 @@ def _admit_graph_connection_request(
             "graph reliability request can exceed the complete ledger "
             f"budget of {MAX_GRAPH_RELIABILITY_LEDGER_BYTES} bytes"
         )
-    return probabilities, state_count
+    return tuple(probabilities), state_count
 
 
 def _terminals_connected(

--- a/src/jacobian/math/probability/markov_chains/_models.py
+++ b/src/jacobian/math/probability/markov_chains/_models.py
@@ -61,9 +61,6 @@ class StationaryDistributionResult(StrictModel):
         min_length=1
     )
     unique: bool
-    method: Literal["CLOSED_CLASS_EXACT_LINEAR_SYSTEM"] = (
-        "CLOSED_CLASS_EXACT_LINEAR_SYSTEM"
-    )
 
     @classmethod
     def _from_kernel(
@@ -143,7 +140,6 @@ class MixingTimeResult(StrictModel):
     steps_examined: StrictInt = Field(ge=0, le=MAX_MIXING_STEPS + 1)
     mixing_time: StrictInt | None = Field(default=None, ge=0, le=MAX_MIXING_STEPS)
     max_total_variation_distance: CanonicalRational | None = None
-    method: Literal["SYMPY_EXACT_MATRIX_POWERS"] = "SYMPY_EXACT_MATRIX_POWERS"
 
     @model_validator(mode="after")
     def bind_search_result(self) -> Self:

--- a/src/jacobian/math/topology/_homology.py
+++ b/src/jacobian/math/topology/_homology.py
@@ -20,7 +20,6 @@ from jacobian.math.topology._models import (
     MAX_TOPOLOGY_PRIME,
     FiniteSimplicialComplex,
     HomologyConvention,
-    TopologyExactResult,
     _validation_error,
     is_bounded_prime,
 )
@@ -109,7 +108,7 @@ class HomologyGroupResult(StrictModel):
         return self
 
 
-class SimplicialHomologyResult(TopologyExactResult):
+class SimplicialHomologyResult(StrictModel):
     complex_digest: Sha256Digest
     coefficient_field: Literal["PRIME_FIELD"] = "PRIME_FIELD"
     prime: StrictInt = Field(ge=2, le=MAX_TOPOLOGY_PRIME)
@@ -307,7 +306,7 @@ class IntegralHomologyGroupResult(StrictModel):
         return self
 
 
-class IntegralSimplicialHomologyResult(TopologyExactResult):
+class IntegralSimplicialHomologyResult(StrictModel):
     complex_digest: Sha256Digest
     coefficient_ring: Literal["ZZ"] = "ZZ"
     convention: HomologyConvention
@@ -318,9 +317,6 @@ class IntegralSimplicialHomologyResult(TopologyExactResult):
     groups: tuple[IntegralHomologyGroupResult, ...] = Field(
         min_length=1,
         max_length=MAX_TOPOLOGY_DIMENSION + 1,
-    )
-    completeness: Literal["FREE_TORSION_AND_BOUND_GENERATORS"] = (
-        "FREE_TORSION_AND_BOUND_GENERATORS"
     )
     decomposition: Literal["DIRECT_SUM_Z_AND_FINITE_CYCLIC_FACTORS"] = (
         "DIRECT_SUM_Z_AND_FINITE_CYCLIC_FACTORS"

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -459,14 +459,8 @@ class FiniteSimplicialComplex(StrictModel):
         return self
 
 
-class TopologyExactResult(StrictModel):
-    exactness: Literal["EXACT_FINITE"] = "EXACT_FINITE"
-    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
-
-
-class SimplicialComplexCanonicalizationResult(TopologyExactResult):
+class SimplicialComplexCanonicalizationResult(StrictModel):
     complex: FiniteSimplicialComplex
-    completeness: Literal["COMPLETE_FACE_CLOSURE"] = "COMPLETE_FACE_CLOSURE"
 
 
 def require_linear_algebra_bounds(complex_: FiniteSimplicialComplex) -> None:
@@ -571,7 +565,6 @@ class BoundarySquareLedgerEntry(StrictModel):
     product_rows: StrictInt = Field(ge=0, le=MAX_TOPOLOGY_CHAIN_GROUP)
     product_columns: StrictInt = Field(ge=1, le=MAX_TOPOLOGY_CHAIN_GROUP)
     nonzero_entries: Literal[0] = 0
-    product_is_zero: Literal[True] = True
 
 
 def _resolve_chain_coefficient_values(
@@ -610,7 +603,7 @@ def _validate_chain_convention_augmentation(
         )
 
 
-class ChainComplexResult(TopologyExactResult):
+class ChainComplexResult(StrictModel):
     complex_digest: Sha256Digest
     coefficient_ring: ChainCoefficientRing
     prime: StrictInt | None = Field(default=None, ge=2, le=MAX_TOPOLOGY_PRIME)
@@ -715,7 +708,7 @@ class BarycentricSubdivisionRequest(StrictModel):
     complex: SimplicialComplexRequest
 
 
-class BarycentricSubdivisionResult(TopologyExactResult):
+class BarycentricSubdivisionResult(StrictModel):
     """The barycentric subdivision as a facet list."""
 
     original_vertices: tuple[str, ...]
@@ -791,7 +784,7 @@ class ShellingCheckRequest(StrictModel):
     )
 
 
-class ShellingCheckResult(TopologyExactResult):
+class ShellingCheckResult(StrictModel):
     """Result of checking a shelling order, bound to its checked source."""
 
     complex: SimplicialComplexRequest

--- a/src/jacobian/math/topology/_pseudomanifold.py
+++ b/src/jacobian/math/topology/_pseudomanifold.py
@@ -11,7 +11,6 @@ from jacobian._models import StrictModel
 from jacobian.math.topology._models import (
     Simplex,
     SimplicialComplexRequest,
-    TopologyExactResult,
     _validation_error,
 )
 
@@ -73,7 +72,7 @@ class PseudomanifoldRequest(StrictModel):
     complex: SimplicialComplexRequest
 
 
-class PseudomanifoldResult(TopologyExactResult):
+class PseudomanifoldResult(StrictModel):
     """Pseudomanifold decision result produced for one source complex."""
 
     complex: SimplicialComplexRequest

--- a/src/jacobian/math/topology/_structural.py
+++ b/src/jacobian/math/topology/_structural.py
@@ -22,7 +22,6 @@ from jacobian.math.topology._models import (
     FiniteSimplicialComplex,
     Simplex,
     SimplicialComplexRequest,
-    TopologyExactResult,
     VertexLabel,
     _validation_error,
     canonical_complex,
@@ -167,7 +166,7 @@ class FVectorRequest(StrictModel):
     complex: SimplicialComplexRequest
 
 
-class FVectorResult(TopologyExactResult):
+class FVectorResult(StrictModel):
     """The f-vector and h-vector of a simplicial complex."""
 
     f_vector: tuple[int, ...]
@@ -185,7 +184,7 @@ class LinkRequest(StrictModel):
     )
 
 
-class LinkResult(TopologyExactResult):
+class LinkResult(StrictModel):
     """The maximal facets of the link of a simplex."""
 
     simplex: tuple[str, ...]
@@ -202,7 +201,7 @@ class StarRequest(StrictModel):
     )
 
 
-class StarResult(TopologyExactResult):
+class StarResult(StrictModel):
     """The closed star produced for a simplex."""
 
     complex: SimplicialComplexRequest
@@ -273,7 +272,7 @@ class VertexDeletionRequest(StrictModel):
     )
 
 
-class VertexDeletionResult(TopologyExactResult):
+class VertexDeletionResult(StrictModel):
     """The induced subcomplex produced after deleting a vertex subset."""
 
     complex: SimplicialComplexRequest
@@ -325,7 +324,7 @@ class SkeletonRequest(StrictModel):
     k: StrictInt = Field(ge=0, le=MAX_TOPOLOGY_DIMENSION)
 
 
-class SkeletonResult(TopologyExactResult):
+class SkeletonResult(StrictModel):
     """The k-skeleton as a facet list."""
 
     complex: SimplicialComplexRequest
@@ -404,7 +403,7 @@ class JoinRequest(StrictModel):
     complex_b: SimplicialComplexRequest
 
 
-class JoinResult(TopologyExactResult):
+class JoinResult(StrictModel):
     """The join of two complexes."""
 
     complex_a: SimplicialComplexRequest
@@ -452,7 +451,7 @@ class ElementaryCollapseRequest(StrictModel):
     )
 
 
-class ElementaryCollapseResult(TopologyExactResult):
+class ElementaryCollapseResult(StrictModel):
     """Result of one elementary collapse step."""
 
     complex: SimplicialComplexRequest

--- a/src/jacobian/math/topology/cohomology/lie_algebra/_operations.py
+++ b/src/jacobian/math/topology/cohomology/lie_algebra/_operations.py
@@ -21,14 +21,6 @@ from jacobian.math.topology.cohomology.lie_algebra._models import (
 )
 
 
-def _wedge_index(indices: tuple[int, ...], dim: int) -> int:
-    """Convert a sorted tuple of indices to a lexicographic wedge basis index."""
-    result = 0
-    for i, idx in enumerate(indices):
-        result += idx * (dim**i)
-    return result
-
-
 def _chain_group_dimensions(dimension: int) -> tuple[int, ...]:
     from math import comb
 

--- a/src/jacobian/math/topology/edge_paths/_models.py
+++ b/src/jacobian/math/topology/edge_paths/_models.py
@@ -62,10 +62,8 @@ class EdgePathConcatenateRequest(StrictModel):
 class EdgePathWordResult(StrictModel):
     word: tuple[str, ...]
     length: int = Field(ge=0)
-    method: str = "EDGE_LABEL_REDUCTION"
 
 
 class EdgePathConcatenateResult(StrictModel):
     path: tuple[int, ...]
     length: int = Field(ge=0)
-    method: str = "PATH_CONCATENATION"

--- a/src/jacobian/math/topology/finite/open_sets/_models.py
+++ b/src/jacobian/math/topology/finite/open_sets/_models.py
@@ -93,10 +93,6 @@ class SpecializationPreorderResult(SpecializationPreorderRequest):
     orientation: Literal["RELATION_X_Y_MEANS_X_IN_CLOSURE_OF_SINGLETON_Y"] = (
         "RELATION_X_Y_MEANS_X_IN_CLOSURE_OF_SINGLETON_Y"
     )
-    complete: Literal[True] = True
-    method: Literal["EXACT_OPEN_NEIGHBORHOOD_CONTAINMENT"] = (
-        "EXACT_OPEN_NEIGHBORHOOD_CONTAINMENT"
-    )
 
     @model_validator(mode="after")
     def require_relation_shape(self) -> Self:
@@ -120,8 +116,6 @@ class SpecializationPreorderResult(SpecializationPreorderRequest):
             topology=request.topology,
             relation=relation,
             orientation="RELATION_X_Y_MEANS_X_IN_CLOSURE_OF_SINGLETON_Y",
-            complete=True,
-            method="EXACT_OPEN_NEIGHBORHOOD_CONTAINMENT",
         )
 
 
@@ -132,10 +126,6 @@ class ConnectedComponentsRequest(StrictModel):
 class ConnectedComponentsResult(ConnectedComponentsRequest):
     components: tuple[tuple[int, ...], ...]
     component_count: int = Field(ge=1)
-    complete: Literal[True] = True
-    method: Literal["UNDIRECTED_SPECIALIZATION_COMPARABILITY"] = (
-        "UNDIRECTED_SPECIALIZATION_COMPARABILITY"
-    )
 
     @model_validator(mode="after")
     def require_component_partition_shape(self) -> Self:
@@ -173,8 +163,6 @@ class ConnectedComponentsResult(ConnectedComponentsRequest):
             topology=request.topology,
             components=components,
             component_count=len(components),
-            complete=True,
-            method="UNDIRECTED_SPECIALIZATION_COMPARABILITY",
         )
 
 
@@ -202,7 +190,6 @@ class ContinuityResult(ContinuityRequest):
     is_continuous: bool
     violating_open_set: tuple[int, ...] | None
     violating_preimage: tuple[int, ...] | None
-    method: Literal["EXACT_OPEN_SET_PREIMAGE_CHECK"] = "EXACT_OPEN_SET_PREIMAGE_CHECK"
 
     @model_validator(mode="after")
     def require_witness_shape(self) -> Self:
@@ -249,7 +236,6 @@ class ContinuityResult(ContinuityRequest):
             is_continuous=is_continuous,
             violating_open_set=violating_open_set,
             violating_preimage=violating_preimage,
-            method="EXACT_OPEN_SET_PREIMAGE_CHECK",
         )
 
 
@@ -260,11 +246,9 @@ class BeatPointsRequest(StrictModel):
 class BeatPointsResult(BeatPointsRequest):
     down_beat_points: tuple[BeatPointWitness, ...]
     up_beat_points: tuple[BeatPointWitness, ...]
-    complete: Literal[True] = True
     convention: Literal["STRICT_SPECIALIZATION_ORDER_WITH_EXTREMUM_WITNESS"] = (
         "STRICT_SPECIALIZATION_ORDER_WITH_EXTREMUM_WITNESS"
     )
-    method: Literal["EXACT_STRICT_ORDER_EXTREMA"] = "EXACT_STRICT_ORDER_EXTREMA"
 
     @model_validator(mode="after")
     def require_witness_shape(self) -> Self:
@@ -302,9 +286,7 @@ class BeatPointsResult(BeatPointsRequest):
             topology=request.topology,
             down_beat_points=down_beat_points,
             up_beat_points=up_beat_points,
-            complete=True,
             convention="STRICT_SPECIALIZATION_ORDER_WITH_EXTREMUM_WITNESS",
-            method="EXACT_STRICT_ORDER_EXTREMA",
         )
 
 

--- a/src/jacobian/math/topology/frames/_models.py
+++ b/src/jacobian/math/topology/frames/_models.py
@@ -54,7 +54,6 @@ class CoherenceRequest(FiniteFrameRequest):
 class GramResult(VectorFamilyRequest):
     gram: tuple[tuple[int, ...], ...]
     dimension: int = Field(ge=1)
-    method: str = "DOT_PRODUCT"
 
     @classmethod
     def _from_kernel(
@@ -67,14 +66,12 @@ class GramResult(VectorFamilyRequest):
             vectors=vectors,
             gram=gram,
             dimension=len(vectors[0]),
-            method="DOT_PRODUCT",
         )
 
 
 class CoherenceResult(CoherenceRequest):
     coherence_squared: CanonicalRational
     maximizing_pair: tuple[int, int] | None
-    method: str = "EXACT_MAX_SQUARED_NORMALIZED_INNER_PRODUCT"
 
     @classmethod
     def _from_kernel(
@@ -88,13 +85,11 @@ class CoherenceResult(CoherenceRequest):
             vectors=vectors,
             coherence_squared=coherence_squared,
             maximizing_pair=maximizing_pair,
-            method="EXACT_MAX_SQUARED_NORMALIZED_INNER_PRODUCT",
         )
 
 
 class FramePotentialResult(FiniteFrameRequest):
     potential: CanonicalInteger
-    method: str = "EXACT_GRAM_SQUARE_SUM"
 
     @classmethod
     def _from_kernel(
@@ -103,7 +98,6 @@ class FramePotentialResult(FiniteFrameRequest):
         return cls.model_construct(
             vectors=vectors,
             potential=potential,
-            method="EXACT_GRAM_SQUARE_SUM",
         )
 
 

--- a/src/jacobian/math/universal_algebra/_models.py
+++ b/src/jacobian/math/universal_algebra/_models.py
@@ -199,7 +199,6 @@ class HomomorphismProfileResult(StrictModel):
     surjective: bool | None = None
     isomorphism: bool | None = None
     obstruction: HomomorphismObstruction | None = None
-    method: Literal["DENSE_TABLE_SCAN"] = "DENSE_TABLE_SCAN"
 
     @model_validator(mode="after")
     def require_structural_profile(self) -> Self:

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -68,9 +68,8 @@ def test_invoke_operation_runs_determinant_without_state() -> None:
 
     assert result.runtime_ms >= 0
     assert result.output is not None
-    assert set(result.output) == {"determinant", "method"}
+    assert set(result.output) == {"determinant"}
     assert result.output["determinant"] == {"num": "-2", "den": "1"}
-    assert result.output["method"] == "FRACTION_FREE_BAREISS"
 
 
 @pytest.mark.parametrize(

--- a/tests/dispatch/test_dispatch.py
+++ b/tests/dispatch/test_dispatch.py
@@ -127,9 +127,8 @@ def test_invoke_operation_runs_determinant_directly() -> None:
     )
     assert result.runtime_ms >= 0
     assert result.output is not None
-    assert set(result.output) == {"determinant", "method"}
+    assert set(result.output) == {"determinant"}
     assert result.output["determinant"] == {"num": "-2", "den": "1"}
-    assert result.output["method"] == "FRACTION_FREE_BAREISS"
 
 
 def test_invoke_operation_wraps_den_num_orbit_result() -> None:

--- a/tests/math/combinatorics/algebraic/test_algebraic_combinatorics.py
+++ b/tests/math/combinatorics/algebraic/test_algebraic_combinatorics.py
@@ -54,7 +54,6 @@ def test_syt_count_partition_321() -> None:
     )
     assert result.count == "16"
     assert result.n == 6
-    assert result.method == "HOOK_LENGTH_FORMULA"
 
 
 def test_syt_count_single_row() -> None:

--- a/tests/math/combinatorics/codes/general/test_exact_code_enumeration.py
+++ b/tests/math/combinatorics/codes/general/test_exact_code_enumeration.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.codes.general import minimum_distance
 from jacobian.math.combinatorics.codes.general._models import (
     CoveringRadiusRequest,
@@ -24,7 +25,7 @@ def _assert_validation_error_code(factory: Callable[[], object], code: str) -> N
 
 
 def _assert_operation_error(factory: Callable[[], object], code: str) -> None:
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(OperationDomainValidationError) as exc_info:
         factory()
     assert exc_info.value.errors()[0]["type"] == code
 
@@ -60,7 +61,7 @@ def test_code_contract_rejects_nonprime_fields_and_unbounded_enumeration() -> No
 def test_native_code_api_enforces_the_prime_field_contract() -> None:
     assert minimum_distance(((1, 1),), 2) == 2
 
-    _assert_validation_error_code(
+    _assert_operation_error(
         lambda: minimum_distance(((1,),), 4), "code_theory.field_order_not_prime"
     )
 
@@ -69,15 +70,14 @@ def test_zero_code_uses_length_convention_for_minimum_distance() -> None:
     assert minimum_distance(((0, 0, 0, 0),), 2) == 4
 
 
-@pytest.mark.parametrize("generator_matrix", [(), ((1, 0), (1,))])
-def test_native_code_api_rejects_invalid_generator_shapes(
-    generator_matrix: tuple[tuple[int, ...], ...],
-) -> None:
-    expected = (
-        "too_short" if not generator_matrix else "code_theory.generator_rows_unequal"
-    )
-    _assert_validation_error_code(
-        lambda: minimum_distance(generator_matrix, 2), expected
+def test_native_code_api_rejects_empty_generator_matrix_structurally() -> None:
+    _assert_validation_error_code(lambda: minimum_distance((), 2), "too_short")
+
+
+def test_native_code_api_rejects_unequal_rows_semantically() -> None:
+    _assert_operation_error(
+        lambda: minimum_distance(((1, 0), (1,)), 2),
+        "code_theory.generator_rows_unequal",
     )
 
 
@@ -90,7 +90,6 @@ def test_binary_repetition_code_length_three_has_covering_radius_one() -> None:
     result = compute_covering_radius(request)
 
     assert result.covering_radius == 1
-    assert result.method == "SYNDROME_BFS"
 
 
 def test_binary_repetition_code_length_four_has_covering_radius_two() -> None:
@@ -250,10 +249,7 @@ def test_structural_models_accept_bounded_claims() -> None:
     )
 
     request = _linear_request()
-    base = {
-        "request": request.model_dump(),
-        "method": "EXACT_ENUMERATION",
-    }
+    base = {"request": request.model_dump()}
 
     wrong_distance = MinimumDistanceResult.model_validate(
         dict(base, minimum_distance=1)

--- a/tests/math/combinatorics/finite_structures/hypergraphs/test_independence.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/test_independence.py
@@ -497,46 +497,6 @@ def test_independence_worker_projection_cannot_replace_the_submitted_request(
     assert result.hypergraph == request.hypergraph
 
 
-def test_independence_worker_cannot_forge_an_exact_optimum(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from jacobian.math.combinatorics.finite_structures.hypergraphs import (
-        _independence_z3,
-    )
-
-    request = HypergraphIndependenceRequest.model_validate(
-        {
-            "hypergraph": {
-                "vertices": ["a", "b", "c"],
-                "edges": [["triple", ["a", "b", "c"]]],
-            },
-            "resource_budget": {"wall_seconds": 3, "max_solver_calls": 5},
-        }
-    )
-    forged = {
-        "status": "EXACT",
-        "independence_number": 1,
-        "incumbent_vertices": ["a"],
-        "lower_bound": 1,
-        "upper_bound": 1,
-        "solver_calls": 1,
-        "wall_budget_exhausted": False,
-        "termination_reason": "OPTIMUM_ESTABLISHED",
-        "detail": "forged exact worker claim",
-        "convention": "MAXIMUM_NO_COMPLETE_HYPEREDGE_VERTEX_SUBSET",
-    }
-    monkeypatch.setattr(
-        _independence_z3,
-        "run_bounded_process",
-        lambda *_args, **_kwargs: _independence_worker_result(forged),
-    )
-
-    result = compute_independence_number(request)
-
-    assert result.status == "UNKNOWN"
-    assert result.independence_number is None
-
-
 def test_threshold_encoding_rechecks_the_wall_budget_before_solver_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/math/combinatorics/posets/core/test_antichain_profile.py
+++ b/tests/math/combinatorics/posets/core/test_antichain_profile.py
@@ -56,6 +56,14 @@ def test_antichain_profile_executes_the_admitted_fourteen_element_chain() -> Non
     assert MAX_ANTICHAIN_PROFILE_CANDIDATES == 16_384
 
 
+def test_empty_poset_has_the_empty_antichain_as_its_unique_maximum() -> None:
+    result = _antichain_profile(AntichainProfileRequest(poset=_chain(0)))
+
+    assert result.maximum_antichain_size == 0
+    assert result.antichain_count == 1
+    assert result.maximum_antichains == ((),)
+
+
 def test_antichain_profile_rejects_the_next_exponential_envelope() -> None:
     with pytest.raises(OperationDomainValidationError, match="candidate subsets"):
         _antichain_profile(AntichainProfileRequest(poset=_chain(15)))

--- a/tests/math/combinatorics/test_difference_set_models.py
+++ b/tests/math/combinatorics/test_difference_set_models.py
@@ -42,22 +42,27 @@ def test_sidon_result_keeps_structural_normalization() -> None:
     assert result.normalized_elements == ("1", "2", "4")
 
 
-def test_sidon_result_rejects_a_forged_difference_profile() -> None:
+def test_sidon_kernel_returns_the_complete_ordered_difference_profile() -> None:
     result = decide_integer_sidon(IntegerSidonRequest(elements=("0", "1", "3")))
-    payload = result.model_dump(mode="json")
-    payload["ordered_differences"][0]["difference"] = "0"
+    expected = tuple(
+        (left, right, left - right)
+        for left in (0, 1, 3)
+        for right in (0, 1, 3)
+        if left != right
+    )
+    assert (
+        tuple(
+            (int(item.minuend), int(item.subtrahend), int(item.difference))
+            for item in result.ordered_differences
+        )
+        == expected
+    )
 
-    with raises_code("combinatorics.sidon_invariant"):
-        IntegerSidonResult.model_validate(payload)
 
-
-def test_sidon_result_rejects_a_forged_decision() -> None:
+def test_sidon_kernel_decision_matches_its_complete_profile() -> None:
     result = decide_integer_sidon(IntegerSidonRequest(elements=("0", "1", "3")))
-    payload = result.model_dump(mode="json")
-    payload["is_sidon"] = not result.is_sidon
-
-    with raises_code("combinatorics.sidon_invariant"):
-        IntegerSidonResult.model_validate(payload)
+    differences = tuple(int(item.difference) for item in result.ordered_differences)
+    assert result.is_sidon == (len(set(differences)) == len(differences))
 
 
 def test_extension_request_rejects_an_unbounded_candidate_space() -> None:
@@ -110,22 +115,27 @@ def test_pds_result_accepts_the_canonical_fano_profile() -> None:
     assert result.is_perfect is True
 
 
-def test_pds_result_rejects_a_forged_complete_profile() -> None:
+def test_pds_kernel_returns_the_complete_profile_for_its_source() -> None:
     result = decide_cyclic_perfect_difference_set(
         CyclicPerfectDifferenceSetRequest(modulus=7, residues=(0, 1, 3))
     )
-    payload = result.model_dump(mode="json")
-    payload["difference_multiplicities"][0]["multiplicity"] = 0
-    with pytest.raises(ValidationError):
-        CyclicPerfectDifferenceSetResult.model_validate(payload)
+    counts = Counter(
+        (left - right) % result.modulus
+        for left in result.normalized_residues
+        for right in result.normalized_residues
+        if left != right
+    )
+    assert tuple(
+        item.multiplicity for item in result.difference_multiplicities
+    ) == tuple(counts.get(residue, 0) for residue in range(1, result.modulus))
 
 
-def test_extension_result_rejects_a_forged_witness() -> None:
+def test_extension_result_rejects_a_witness_that_drops_the_retained_base() -> None:
     result = decide_cyclic_difference_set_extension(
         CyclicDifferenceSetExtensionRequest(base_elements=("0", "1"), target_order=3)
     )
     assert result.decision == "EXTENDS"
     payload = result.model_dump(mode="json")
-    payload["extension"] = [0, 1, 2]
+    payload["extension"] = [0, 2, 4]
     with pytest.raises(ValidationError):
         CyclicDifferenceSetExtensionResult.model_validate(payload)

--- a/tests/math/combinatorics/test_recurrence_models.py
+++ b/tests/math/combinatorics/test_recurrence_models.py
@@ -42,8 +42,6 @@ def _result() -> dict[str, object]:
             {"index": index, "value": _q(value)}
             for index, value in enumerate((1, 1, 2, 3))
         ],
-        "exactness": "EXACT_RATIONAL",
-        "determinism": "DETERMINISTIC",
     }
 
 

--- a/tests/math/dynamics/arithmetic/test_arithmetic_dynamics.py
+++ b/tests/math/dynamics/arithmetic/test_arithmetic_dynamics.py
@@ -47,7 +47,6 @@ class TestMapIterate:
 
         assert result.coefficients == (_r(0), _r(1))
         assert result.degree == 1
-        assert result.complete is True
 
     def test_second_iterate_is_exact(self) -> None:
         result = compute_map_iterate(
@@ -201,7 +200,6 @@ class TestCycleMultiplier:
 
         assert result.multiplier == _r(1)
         assert result.period == 2
-        assert result.validated_cycle is True
 
     def test_arbitrary_points_cannot_be_labeled_a_cycle(self) -> None:
         with pytest.raises(OperationDomainValidationError) as exc_info:
@@ -237,7 +235,6 @@ class TestFiniteFieldFunctionalGraph:
         assert result.edges == ((0, 0), (1, 1), (2, 4), (3, 4), (4, 1))
         assert result.cycles == ((0,), (1,))
         assert result.tail_lengths == (0, 0, 2, 2, 1)
-        assert result.complete is True
 
     @pytest.mark.parametrize(
         ("prime", "coefficients"),

--- a/tests/math/dynamics/symbolic/test_symbolic_dynamics.py
+++ b/tests/math/dynamics/symbolic/test_symbolic_dynamics.py
@@ -171,7 +171,6 @@ def test_golden_mean_finite_type_presentation_is_exact() -> None:
         (edge.source, edge.target, edge.appended_symbol)
         for edge in result.presentation.transitions
     ) == ((0, 0, "0"), (0, 1, "1"), (1, 0, "0"))
-    assert result.complete is True
 
     payload = result.model_dump()
     payload["presentation"]["adjacency_matrix"] = ((1, 0), (1, 1))
@@ -254,9 +253,9 @@ def test_complete_block_language_includes_empty_word_convention() -> None:
 def test_oversized_enumerations_fail_before_computation() -> None:
     alphabet = tuple(chr(ord("a") + index) for index in range(16))
     shift = ForbiddenBlockShift(alphabet=alphabet, forbidden_blocks=())
-    request = BlockLanguageRequest(shift=shift, block_length=5)
+    language_request = BlockLanguageRequest(shift=shift, block_length=5)
     with pytest.raises(ValueError, match="requested block enumeration"):
-        compute_block_language(request)
+        compute_block_language(language_request)
     with pytest.raises(ValueError, match="requested block enumeration"):
         construct_finite_type_shift(
             FiniteTypeShiftRequest(
@@ -276,7 +275,7 @@ def test_oversized_enumerations_fail_before_computation() -> None:
                 )
             )
         )
-    request = HigherBlockRequest(
+    higher_block_request = HigherBlockRequest(
         shift=ForbiddenBlockShift(
             alphabet=ten_symbols,
             forbidden_blocks=(),
@@ -284,14 +283,14 @@ def test_oversized_enumerations_fail_before_computation() -> None:
         block_length=4,
     )
     with pytest.raises(ValueError, match="presentation adjacency"):
-        compute_higher_block(request)
+        compute_higher_block(higher_block_request)
     oversized_support = ForbiddenBlockShift(
         alphabet=alphabet,
         forbidden_blocks=(("a",) * 20,),
     )
-    request = BlockLanguageRequest(shift=oversized_support, block_length=1)
+    support_request = BlockLanguageRequest(shift=oversized_support, block_length=1)
     with pytest.raises(ValueError, match="work bound"):
-        compute_block_language(request)
+        compute_block_language(support_request)
     with pytest.raises(ValueError, match="work bound"):
         block_language(oversized_support, 1)
 

--- a/tests/math/geometry/finite/test_finite_geometry.py
+++ b/tests/math/geometry/finite/test_finite_geometry.py
@@ -345,7 +345,7 @@ def test_enumeration_wire_form_stays_compact_and_typed_natively() -> None:
     )
 
     wire = result.model_dump(mode="json")
-    assert set(wire) == {"sequence", "method"}
+    assert set(wire) == {"sequence"}
     assert set(wire["sequence"]) == {"space", "coordinates"}
     assert wire["sequence"]["coordinates"] == [[0, 1], [1, 0], [1, 1], [1, 2]]
     assert type(result).model_validate_json(result.model_dump_json()) == result

--- a/tests/math/geometry/metric_spaces/test_finite_metric_spaces.py
+++ b/tests/math/geometry/metric_spaces/test_finite_metric_spaces.py
@@ -34,7 +34,6 @@ def test_profile_path_graph() -> None:
     assert result.radius == 1
     assert result.centers == (1,)
     assert result.periphery == (0, 2)
-    assert result.method == "DIRECT_DISTANCE_MATRIX_SCAN"
 
 
 def test_native_profile_returns_the_canonical_result() -> None:

--- a/tests/math/graphs/electrical_networks/test_electrical_networks.py
+++ b/tests/math/graphs/electrical_networks/test_electrical_networks.py
@@ -41,7 +41,6 @@ def test_single_edge_resistance_is_one() -> None:
     req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
     result = compute_effective_resistance(req)
     assert result.effective_resistance.as_fraction() == Fraction(1)
-    assert result.method == "SYMPY_REDUCED_LAPLACIAN_SOLVE"
     assert result.terminal_a == 0
     assert result.terminal_b == 1
 
@@ -110,7 +109,6 @@ def test_node_potentials_path_graph() -> None:
     assert result.potentials[0].potential.as_fraction() == Fraction(2)
     assert result.potentials[1].potential.as_fraction() == Fraction(1)
     assert result.potentials[2].potential.as_fraction() == Fraction(0)
-    assert result.method == "SYMPY_LAPLACIAN_SOLVE"
 
 
 def test_node_potentials_sink_is_gauge_zero() -> None:
@@ -145,7 +143,6 @@ def test_laplacian_single_edge() -> None:
     assert matrix[(1, 1)] == Fraction(1)
     assert matrix[(0, 1)] == Fraction(-1)
     assert matrix[(1, 0)] == Fraction(-1)
-    assert result.method == "SYMPY_LAPLACIAN"
 
 
 def test_laplacian_triangle_diagonal_sums_conductances() -> None:

--- a/tests/math/graphs/test_graph_isomorphism.py
+++ b/tests/math/graphs/test_graph_isomorphism.py
@@ -467,4 +467,3 @@ class TestOperationMetadata:
             result = op.run(req)
             assert isinstance(result, GraphIsomorphismResult)
             assert result.status in ("ISOMORPHIC", "NOT_ISOMORPHIC")
-            assert result.convention == "NETWORKX_IS_ISOMORPHIC"

--- a/tests/math/graphs/test_graph_realization.py
+++ b/tests/math/graphs/test_graph_realization.py
@@ -187,10 +187,6 @@ class TestGraphRealization:
             assert edge not in seen, "duplicate edge detected"
             seen.add(edge)
 
-    def test_convention_is_havel_hakimi(self) -> None:
-        result = _realize([1, 2, 2, 1])
-        assert result.convention == "NETWORKX_HAVEL_HAKIMI"
-
 
 # ---------------------------------------------------------------------------
 # graphicality check (with certificate)
@@ -270,10 +266,6 @@ class TestRealizationCheck:
         edges = [(0, 1), (0, 2), (1, 2)]
         result = _check([2, 2, 2], 3, edges)
         assert result.actual_degrees == (2, 2, 2)
-
-    def test_convention_is_networkx_degree(self) -> None:
-        result = _check([0], 1, [])
-        assert result.convention == "NETWORKX_DEGREE"
 
     def test_contract_rejects_length_mismatch(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/math/graphs/test_independence_source_binding.py
+++ b/tests/math/graphs/test_independence_source_binding.py
@@ -423,41 +423,6 @@ def test_independence_worker_projection_cannot_replace_the_submitted_graph(
     assert result.graph == request.graph
 
 
-def test_independence_worker_cannot_forge_an_exact_optimum(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    request = IndependenceNumberRequest(graph=_path_graph())
-    forged = {
-        "status": "EXACT",
-        "order": 3,
-        "optimum_value": 1,
-        "incumbent_value": 1,
-        "lower_bound": 1,
-        "upper_bound": 1,
-        "witness_vertices": ["a"],
-        "termination_reason": "OPTIMUM_ESTABLISHED",
-        "detail": "forged exact worker claim",
-        "convention": "MAXIMUM_EDGE_FREE_VERTEX_SUBSET",
-    }
-    monkeypatch.setattr(
-        z3_backend,
-        "run_bounded_process",
-        lambda *_args, **_kwargs: BoundedProcessResult(
-            returncode=0,
-            stdout=json.dumps(forged).encode("utf-8"),
-            stderr=b"",
-            stdout_exceeded=False,
-            stderr_exceeded=False,
-            timed_out=False,
-        ),
-    )
-
-    result = solve_independence_number(request)
-
-    assert result.status == "UNKNOWN"
-    assert result.optimum_value is None
-
-
 def test_result_headroom_admission_rejects_oversized_echo() -> None:
     """A huge identifier is rejected before solving, not by dispatch after."""
 

--- a/tests/math/groups/abelian/test_fg_abelian_groups.py
+++ b/tests/math/groups/abelian/test_fg_abelian_groups.py
@@ -135,14 +135,6 @@ def test_subgroup_generated_z2_x_z4() -> None:
     assert result.index == 4
 
 
-def test_presentation_normalize_method_name() -> None:
-    """Normalization method should not have a typo."""
-    result = compute_presentation_normalize(
-        PresentationNormalizeRequest(invariant_factors=(2, 4))
-    )
-    assert result.method == "SmithNormalForm"
-
-
 @pytest.mark.parametrize(
     "invariant_factors",
     ((1,), (0,), tuple(range(2, 35)), (4_097,)),

--- a/tests/math/groups/root_systems/test_root_systems.py
+++ b/tests/math/groups/root_systems/test_root_systems.py
@@ -156,7 +156,6 @@ class TestWeylGroupOrder:
 
         assert result.group_order == expected
         assert result.matrix == matrix
-        assert result.method == "SYMPY_SCHREIER_SIMS_SIGNED_ROOT_ACTION"
 
     def test_e8_order_does_not_materialize_weyl_group_elements(self) -> None:
         from jacobian.math.groups.root_systems._operations import (

--- a/tests/math/lattices/test_lattice_operations.py
+++ b/tests/math/lattices/test_lattice_operations.py
@@ -178,10 +178,27 @@ def test_saturation_index_2() -> None:
 
 
 def test_saturation_rank_deficient() -> None:
-    """sat(2Z in ZZ^2) = ZZ^2 with index 2."""
+    """The saturation remains in the rational span of the source lattice."""
     result = compute_saturation(_lattice(2, [[2, 0]]))
-    assert result.saturated_basis.entries == (("1", "0"), ("0", "1"))
+    assert result.saturated_basis.entries == (("1", "0"),)
+    assert result.inclusion_transform.entries == (("2",),)
     assert result.saturation_index == 2
+
+
+def test_saturation_of_diagonal_line_is_its_primitive_line() -> None:
+    result = compute_saturation(_lattice(2, [[2, 2]]))
+
+    assert result.saturated_basis.entries == (("1", "1"),)
+    assert result.inclusion_transform.entries == (("2",),)
+    assert result.saturation_index == 2
+
+
+def test_saturation_of_coordinate_plane_does_not_gain_ambient_generator() -> None:
+    result = compute_saturation(_lattice(3, [[2, 0, 0], [0, 2, 0]]))
+
+    assert result.saturated_basis.entries == (("1", "0", "0"), ("0", "1", "0"))
+    assert result.inclusion_transform.entries == (("2", "0"), ("0", "2"))
+    assert result.saturation_index == 4
 
 
 # ---------------------------------------------------------------------------
@@ -282,6 +299,8 @@ def test_orthogonal_complement_of_full_rank_is_zero() -> None:
         OrthogonalComplementRequest(lattice=_lattice(2, [[1, 0], [0, 1]]))
     )
     assert result.complement_rank == 0
+    assert result.complement_basis.ambient_dimension == 2
+    assert result.complement_basis.vectors == ()
 
 
 def test_orthogonal_complement_of_plane_in_3d() -> None:
@@ -290,6 +309,8 @@ def test_orthogonal_complement_of_plane_in_3d() -> None:
         OrthogonalComplementRequest(lattice=_lattice(3, [[1, 0, 0], [0, 1, 0]]))
     )
     assert result.complement_rank == 1
+    assert result.complement_basis.ambient_dimension == 3
+    assert len(result.complement_basis.vectors[0]) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/math/logic/automata/tree/test_tree_automata.py
+++ b/tests/math/logic/automata/tree/test_tree_automata.py
@@ -195,7 +195,6 @@ class TestRun:
         assert result.state_chart == (((), (0, 1)),)
         assert result.accepted is True
         assert result.node_count == 1
-        assert result.complete is True
 
         payload = result.model_dump()
         payload["state_chart"] = (((), (0,)),)
@@ -313,7 +312,6 @@ class TestAcceptedTreeCount:
 
         assert result.count == str(comb(98, 49) // 50)
         assert result.tree_size == 99
-        assert result.complete is True
         assert result.estimated_work_bound <= 2_000_000
 
     def test_impossible_binary_tree_size_has_exact_zero_count(self) -> None:
@@ -324,7 +322,6 @@ class TestAcceptedTreeCount:
         )
 
         assert result.count == "0"
-        assert result.complete is True
 
 
 class TestReachableStates:

--- a/tests/math/logic/games/impartial/test_impartial_games.py
+++ b/tests/math/logic/games/impartial/test_impartial_games.py
@@ -58,7 +58,6 @@ class TestGrundyTable:
         )
         assert result.histogram == (2, 1, 1)
         assert result.max_grundy == 2
-        assert result.complete is True
 
     def test_option_grundy_values_are_a_set_not_a_multiset(self) -> None:
         game = ImpartialGame(
@@ -117,7 +116,6 @@ class TestBirthdays:
         result = compute_birthday(BirthdayRequest(game=_game()))
 
         assert result.birthdays == (("0", 0), ("1", 1), ("2", 2), ("3", 3))
-        assert result.complete is True
 
     def test_false_birthday_table_is_rejected(self) -> None:
         with pytest.raises(ValidationError):
@@ -135,7 +133,6 @@ class TestSubtractionGrundyPrefix:
         assert result.p_positions == (0, 2, 4)
         assert result.n_positions == (1, 3, 5)
         assert result.scope == "HEAPS_ZERO_THROUGH_MAX_HEAP"
-        assert result.complete is True
 
     @pytest.mark.parametrize("values", [(3, 1), (1, 1), (0, 1), (1, 501)])
     def test_subtraction_set_must_be_canonical_and_bounded(

--- a/tests/math/logic/games/impartial/test_nim_options.py
+++ b/tests/math/logic/games/impartial/test_nim_options.py
@@ -48,7 +48,6 @@ def test_nim_options_deduplicate_equal_heaps_and_retain_all_source_indices() -> 
     )
     assert result.raw_candidate_count == 4
     assert result.distinct_option_count == 3
-    assert result.complete is True
 
 
 @pytest.mark.parametrize("heaps", ((), (0,), (0, 0, 0)))

--- a/tests/math/logic/languages/regular/test_regular_languages.py
+++ b/tests/math/logic/languages/regular/test_regular_languages.py
@@ -79,7 +79,6 @@ def test_run_accepts_word_ending_in_1() -> None:
     assert result.accepted is True
     assert result.final_state == 1
     assert result.state_trace == (0, 1, 0, 1)
-    assert result.method == "DFA_SIMULATION"
 
 
 def test_run_rejects_word_ending_in_0() -> None:
@@ -109,7 +108,6 @@ def test_count_binary_strings_ending_in_1() -> None:
     dfa = _dfa_ends_in_1()
     result = compute_count(CountRequest(dfa=dfa, word_length=3))
     assert result.count == "4"
-    assert result.method == "MATRIX_POWERING"
 
 
 def test_count_length_zero() -> None:
@@ -193,7 +191,6 @@ def test_complement_flips_acceptance() -> None:
     dfa = _dfa_ends_in_1()
     result = compute_complement(ComplementRequest(dfa=dfa))
     assert result.dfa.accepting_states == (0,)
-    assert result.method == "ACCEPTING_FLIP"
     # Word ending in 0 should now be accepted
     run = compute_run(RunRequest(dfa=result.dfa, word=(0,)))
     assert run.accepted is True

--- a/tests/math/logic/languages/words/test_words.py
+++ b/tests/math/logic/languages/words/test_words.py
@@ -108,7 +108,6 @@ def test_factor_result_is_complete_and_bound_to_the_request() -> None:
     assert result.multiplicities == (2, 1, 1)
     assert result.first_occurrence == (0, 1, 2)
     assert result.distinct_count == 3
-    assert result.complete is True
 
     payload = result.model_dump()
     payload["factors"] = (("b", "b"), *payload["factors"][1:])
@@ -232,7 +231,6 @@ def test_fibonacci_dependency_graph_retains_positions_and_source() -> None:
         ("0", "1", 1, (1,)),
         ("1", "0", 1, (0,)),
     )
-    assert result.complete is True
 
     payload = result.model_dump()
     payload["graph"]["edges"] = payload["graph"]["edges"][:-1]

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -330,16 +330,6 @@ def test_characteristic_equals_product_of_invariant_factors() -> None:
     ]
 
 
-def test_method_tags() -> None:
-    req = _mat(
-        (_pair("0", "1"), _pair("1", "1")),
-        (_pair("0", "1"), _pair("0", "1")),
-    )
-    assert compute_minimal_polynomial(req).method == "KRYLOV_NULLSPACE"
-    assert compute_rational_canonical_form(req).method == "SMITH_NORMAL_FORM"
-    assert compute_primary_decomposition(req).method == "FACTOR_LCM"
-
-
 def test_smith_normal_form_path_handles_larger_matrices() -> None:
     """A 6x6 diagonal matrix uses the maintained Smith form, not minor enumeration."""
     req = _diagonal("2", "3", "5", "7", "11", "13")

--- a/tests/math/matrices/test_matrix_polynomial_evaluation.py
+++ b/tests/math/matrices/test_matrix_polynomial_evaluation.py
@@ -469,7 +469,6 @@ def test_rotation_matrix_is_annihilated_by_t_squared_plus_one() -> None:
     assert result.polynomial_degree == 2
     assert result.matrix_multiplications == 2
     assert result.scalar_product_terms == 16
-    assert result.method == "HORNER_OVER_QQ"
 
 
 @pytest.mark.parametrize(

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -33,7 +33,6 @@ def test_continued_fraction_sqrt_2() -> None:
     assert result.coefficients == (1, 2, 2, 2, 2)
     assert result.preperiod_length == 1
     assert result.period_length == 1
-    assert result.method == "SYMPY_CONTINUED_FRACTION"
 
 
 def test_continued_fraction_sqrt_3() -> None:

--- a/tests/math/polynomials/interpolation/test_hermite_interpolation.py
+++ b/tests/math/polynomials/interpolation/test_hermite_interpolation.py
@@ -141,7 +141,6 @@ def test_constant_jet_returns_a_canonical_constant_polynomial() -> None:
     assert result.total_multiplicity == 1
     assert result.degree == 0
     assert result.leading_coefficient.as_fraction() == 5
-    assert result.method == "FLINT_FMPQ_HERMITE_VANDERMONDE_FFLU"
 
 
 def test_higher_jet_uses_ordinary_not_hasse_derivatives() -> None:

--- a/tests/math/polynomials/test_real_algebra.py
+++ b/tests/math/polynomials/test_real_algebra.py
@@ -52,7 +52,6 @@ def test_sturm_chain_cubic_known_answer() -> None:
     result = compute_sturm_chain(SturmChainRequest(polynomial=poly))
 
     assert result.degree == 3
-    assert result.method == "SYMPY_STURM"
     assert [_coefficient_map(p) for p in result.chain] == [
         {3: Fraction(1), 2: Fraction(-2), 1: Fraction(1), 0: Fraction(-3)},
         {2: Fraction(3), 1: Fraction(-4), 0: Fraction(1)},
@@ -81,7 +80,6 @@ def test_root_count_cubic_has_one_real_root() -> None:
     )
     assert result.source_polynomial == poly
     assert result.root_count == 1
-    assert result.method == "STURM_THEOREM"
 
 
 def test_root_count_x_squared_minus_2() -> None:

--- a/tests/math/probability/graphical_models/test_graphical_models.py
+++ b/tests/math/probability/graphical_models/test_graphical_models.py
@@ -86,6 +86,18 @@ class TestFactorValuesAndOperations:
         assert result.variables == ()
         assert _strings(result.table) == ("1",)
 
+    def test_marginalize_respects_an_ordered_nonascending_scope(self) -> None:
+        factor = _factor(
+            (1, 0),
+            ("1", "2", "10", "20", "100", "200"),
+            domain_sizes=(2, 3),
+        )
+
+        result = factor_marginalize(factor, 1)
+
+        assert result.variables == (0,)
+        assert _strings(result.table) == ("111", "222")
+
     @pytest.mark.parametrize("value", ["01", "+1", "2/4", "1.0"])
     def test_factor_entries_must_be_canonical_rationals(self, value: str) -> None:
         with pytest.raises(ValidationError) as error:


### PR DESCRIPTION
## Problem

Several mathematical domains still carried transitional execution machinery in their public contracts and trusted result paths. Request models performed semantic code-theory admission that native functions implicitly depended on, MCP wrappers repeated the work calculation, and graph independence workers reserved time for a second solver replay immediately after producing an exact result.

Result schemas also exposed fixed implementation labels such as backend or algorithm names, plus constant exactness, determinism, completeness, and verification flags. These fields did not distinguish mathematical outcomes, constrained future kernel selection, and increased admission and serialization accounting.

## Solution

This change makes the native mathematical operation the single semantic execution path:

- code-theory native functions now perform prime-field, matrix-shape, and work admission once; MCP wrappers delegate to that path;
- graph and hypergraph independence workers use the full remaining request deadline and no longer replay a trusted exact result;
- redundant plan wrappers, duplicate helpers, dead shadow operations, and post-kernel defining-computation replays are removed across the touched domains;
- lattice saturation uses the correct Smith-decomposition inclusion orientation, and empty rational subspace bases retain their ambient dimension through `RationalVectorSpaceBasis`;
- the empty-poset antichain profile retains the empty antichain;
- public results no longer expose constant backend, method, assurance, or completion metadata. Mathematical conventions, source binding, status branches, and reconstruction data remain.

The branch is split into four commits so reviewers can examine admission ownership, independence replay removal, mathematical value/kernel changes, and schema cleanup separately.

## Testing

- `make affected AFFECTED_BASE=origin/main` — passed on the final tree:
  - 5,525 math tests
  - 117 catalog tests
  - 669 catalog integration tests
  - 83 dispatch tests
  - scoped Ruff, formatting, and mypy checks across 130 files
- `uv run vulture src/jacobian --min-confidence 90` — no findings
- `git diff --check` — passed

- Specialist validation run (if any): none; the affected planner selected the math, catalog, catalog-integration, and dispatch owners.

## Public contract impact

This intentionally removes constant result fields that exposed private implementation choices or repeated an invariant already established by the result type. Serialized results are therefore smaller and their shape changes. Jacobian is pre-stable; no compatibility aliases are retained.

No operation IDs or catalog membership change. Code-theory semantic rejections now consistently use `OperationDomainValidationError` from both native and MCP execution paths.

## Operation boundary ownership

- Changed stage: request parsing, request bounds, kernel execution, and result construction
- Request-bounds owner and controlling quantities: owner-local native code-theory operations; field primality, generator dimensions and residues, enumeration count, syndrome states, and syndrome transitions
- Work, intermediate, memory, and exact-output bounds: existing named code-theory limits are preserved and evaluated once by the native path
- Wall deadline, calibration workload, safety margin, and caller-selectable range: independence workers receive the full existing caller-selected wall budget; no new range or cap is introduced
- Backend or kernel path: existing FLINT, SymPy, Z3, and owner-local exact kernels remain private and selectable without changing result schemas
- Result construction: trusted kernels construct canonical domain results; structural/source-binding checks remain where they protect composition
- Independent-result verifier: none for trusted kernel output; explicit verification remains only where independently supplied claims are part of the operation contract
- Native/MCP parity: code-theory MCP wrappers invoke the same native admission and computation path
- Serialized-result and round-trip evidence: affected catalog examples, integration examples, dispatch tests, and owner tests passed

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Producer→consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: lattice bases remain full-row-rank `IntegerLattice` values; prime-field code operations admit prime moduli and canonical residue matrices
- Structurally valid but mathematically invalid fixture and outcome: composite field orders and unequal generator rows are rejected with typed owner diagnostics
- Serialized-subtype trust boundary: request models parse structure; native operations admit semantics; trusted kernels construct source-bound results
- Exact-success defining invariant: lattice saturation retains `B = C @ sat(B)` and index `[sat(L):L]`; rational vector-space bases retain ambient dimension even when empty
- Discriminated result schema and impossible combinations: genuine exact/unknown and witness/complete-search branches remain; constant assurance fields are removed

## Catalog admission

No catalog membership changes.

## Closure matrix

none

## Checklist

- [x] `make affected AFFECTED_BASE=origin/main` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Runtime-bound changes name the request-bounds owner and execute the same semantic path for native and MCP callers
- [x] Result semantics distinguish exact, incomplete, unknown, and unavailable outcomes where applicable
- [x] New shared abstractions replace duplication in surviving production paths
