### PR TITLE
Type remaining owner-local admission failures

### DIFF
--- a/src/jacobian/math/crossed_products/_budget.py
+++ b/src/jacobian/math/crossed_products/_budget.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from jacobian.canonical import parse_canonical_integer
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math._labels import MAX_OPAQUE_LABEL_LENGTH
 from jacobian.math.crossed_products.values import (
     MAX_EXPONENT_DIGITS,
@@ -15,6 +16,14 @@ MAX_CONVOLUTION_PAIRS = 1_024
 MAX_MULTIPLICATION_SCALAR_WORK = 80_000
 MAX_COEFFICIENT_INTERMEDIATE_DIGITS = 19
 MAX_SERIALIZED_RESULT_BYTES = 10 * 1024 * 1024
+
+
+def _reject(*, location: tuple[str, ...], code: str, message: str) -> None:
+    raise OperationDomainValidationError(
+        location=location,
+        code=f"crossed_product.{code}",
+        message=message,
+    )
 
 
 def _maximum_absolute(values: tuple[int, ...]) -> int:
@@ -66,25 +75,40 @@ def require_multiplication_budget(
     """Preflight all work, intermediate, support, exponent, and output bounds."""
 
     if left.presentation != right.presentation:
-        raise ValueError("crossed-product operands must have the same presentation")
+        _reject(
+            location=("left", "right"),
+            code="presentation_mismatch",
+            message="crossed-product operands must have the same presentation",
+        )
 
     pair_count = len(left.terms) * len(right.terms)
     if pair_count > MAX_CONVOLUTION_PAIRS:
-        raise ValueError(
-            "operand supports exceed the 1024-pair sparse convolution budget"
+        _reject(
+            location=("left", "right"),
+            code="convolution_work_bound",
+            message=(
+                f"operand supports exceed the {MAX_CONVOLUTION_PAIRS}-pair "
+                "sparse convolution budget"
+            ),
         )
 
     dimension = left.presentation.lattice_rank
     scalar_work = pair_count * (dimension**2 + 3 * dimension + 1)
     if scalar_work > MAX_MULTIPLICATION_SCALAR_WORK:
-        raise ValueError(
-            "crossed-product multiplication exceeds its scalar-work budget"
+        _reject(
+            location=("left", "right"),
+            code="scalar_work_bound",
+            message="crossed-product multiplication exceeds its scalar-work budget",
         )
 
     characteristic = left.presentation.characteristic
     coefficient_intermediate = (characteristic - 1) ** 2 + characteristic - 1
     if len(str(coefficient_intermediate)) > MAX_COEFFICIENT_INTERMEDIATE_DIGITS:
-        raise ValueError("coefficient accumulation exceeds its exact-integer bound")
+        _reject(
+            location=("left", "right"),
+            code="coefficient_growth_bound",
+            message="coefficient accumulation exceeds its exact-integer bound",
+        )
 
     if pair_count:
         left_height = _maximum_absolute(
@@ -123,8 +147,13 @@ def require_multiplication_budget(
             left_height + dimension * action_height * right_height + cocycle_height
         )
         if len(str(exponent_height)) > MAX_EXPONENT_DIGITS:
-            raise ValueError(
-                "predicted product exponents exceed the 64-digit carrier bound"
+            _reject(
+                location=("left", "right"),
+                code="exponent_growth_bound",
+                message=(
+                    f"predicted product exponents exceed the {MAX_EXPONENT_DIGITS}-digit "
+                    "carrier bound"
+                ),
             )
 
     # Every input pair contributes to at most one support key, so pair_count is
@@ -132,8 +161,13 @@ def require_multiplication_budget(
     # presentations and every source/product term.
     serialized_bound = _result_serialized_upper_bound(left, right, pair_count)
     if serialized_bound > MAX_SERIALIZED_RESULT_BYTES:
-        raise ValueError(
-            "predicted source-bound result exceeds the 10 MiB output bound"
+        _reject(
+            location=("left", "right"),
+            code="result_size_bound",
+            message=(
+                "predicted source-bound result exceeds the "
+                f"{MAX_SERIALIZED_RESULT_BYTES}-byte output bound"
+            ),
         )
 
 

--- a/src/jacobian/math/geometry/polygon_kernel/_operations.py
+++ b/src/jacobian/math/geometry/polygon_kernel/_operations.py
@@ -3,6 +3,7 @@
 from math import comb
 
 from jacobian._exact import canonical_rational_component_digits
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry.polygon_kernel._kernel import (
     compute_kernel_data,
     oriented_half_planes,
@@ -21,6 +22,14 @@ from jacobian.math.geometry.polygon_kernel._models import (
 )
 
 
+def _reject_visibility_kernel(message: str) -> None:
+    raise OperationDomainValidationError(
+        location=("polygon",),
+        code="geometry.visibility_kernel_not_admitted",
+        message=message,
+    )
+
+
 def _admit_visibility_kernel(
     polygon: KernelPolygon,
 ) -> tuple[OrientedEdgeHalfPlane, ...]:
@@ -32,7 +41,7 @@ def _admit_visibility_kernel(
         for component in (point.x, point.y)
     )
     if max_coordinate_digits > MAX_KERNEL_COORDINATE_DIGITS:
-        raise ValueError(
+        _reject_visibility_kernel(
             "polygon coordinates exceed the "
             f"{MAX_KERNEL_COORDINATE_DIGITS}-digit visibility-kernel bound"
         )
@@ -44,13 +53,13 @@ def _admit_visibility_kernel(
         for value in (half_plane.a, half_plane.b, half_plane.c)
     )
     if coefficient_digits > MAX_HALF_PLANE_COEFFICIENT_DIGITS:
-        raise ValueError(
+        _reject_visibility_kernel(
             "oriented half-plane coefficients exceed the "
             f"{MAX_HALF_PLANE_COEFFICIENT_DIGITS}-digit bound"
         )
     intersection_digits = 8 * coefficient_digits + 8
     if intersection_digits > MAX_INTERSECTION_COMPONENT_DIGITS:
-        raise ValueError(
+        _reject_visibility_kernel(
             "a boundary-line intersection can exceed the "
             f"{MAX_INTERSECTION_COMPONENT_DIGITS}-digit component bound"
         )
@@ -63,7 +72,7 @@ def _admit_visibility_kernel(
         intersection_digits,
     )
     if estimated_result_chars > MAX_KERNEL_RESULT_CHARS:
-        raise ValueError(
+        _reject_visibility_kernel(
             "visibility-kernel result can require "
             f"{estimated_result_chars} characters, exceeding the "
             f"{MAX_KERNEL_RESULT_CHARS}-character bound"
@@ -72,7 +81,7 @@ def _admit_visibility_kernel(
         comb(vertex_count, 2) * vertex_count * coefficient_digits * coefficient_digits
     )
     if feasibility_work > MAX_KERNEL_FEASIBILITY_WORK:
-        raise ValueError(
+        _reject_visibility_kernel(
             f"visibility-kernel feasibility work exceeds {MAX_KERNEL_FEASIBILITY_WORK}"
         )
     return half_planes

--- a/tests/dispatch/test_more_owner_admission_boundaries.py
+++ b/tests/dispatch/test_more_owner_admission_boundaries.py
@@ -96,3 +96,48 @@ def test_comultiplication_coalgebra_admission_is_typed() -> None:
 
     assert caught.value.errors()[0]["loc"] == ("coalgebra",)
     assert caught.value.errors()[0]["type"] == "coalgebra.prime_not_prime"
+
+
+def test_visibility_kernel_result_budget_is_typed_after_wire_parsing() -> None:
+    """A valid large-coordinate polygon is rejected before kernel expansion."""
+
+    scale = 10**63
+    step = scale // 16
+    points = [
+        {
+            "x": {"num": str(index * step), "den": "1"},
+            "y": {"num": "0", "den": "1"},
+        }
+        for index in range(17)
+    ]
+    points.extend(
+        {
+            "x": {"num": str(scale), "den": "1"},
+            "y": {"num": str(index * step), "den": "1"},
+        }
+        for index in range(1, 17)
+    )
+    points.extend(
+        {
+            "x": {"num": str(index * step), "den": "1"},
+            "y": {"num": str(scale), "den": "1"},
+        }
+        for index in range(15, -1, -1)
+    )
+    points.extend(
+        {
+            "x": {"num": "0", "den": "1"},
+            "y": {"num": str(index * step), "den": "1"},
+        }
+        for index in range(15, 0, -1)
+    )
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        invoke_operation(
+            "geometry.polygon.visibility_kernel.compute",
+            {"polygon": {"points": points}},
+            Catalog.open(),
+        )
+
+    assert caught.value.errors()[0]["loc"] == ("polygon",)
+    assert caught.value.errors()[0]["type"] == "geometry.visibility_kernel_not_admitted"

--- a/tests/math/crossed_products/test_crossed_products.py
+++ b/tests/math/crossed_products/test_crossed_products.py
@@ -8,6 +8,7 @@ from math import isqrt
 import pytest
 
 from jacobian.canonical import format_canonical_integer
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.crossed_products._budget import MAX_CONVOLUTION_PAIRS
 from jacobian.math.crossed_products._models import (
     CrossedProductMultiplyRequest,
@@ -413,8 +414,22 @@ def test_request_rejects_pairwise_convolution_before_expansion() -> None:
     )
 
     request = CrossedProductMultiplyRequest(left=left, right=right)
-    with pytest.raises(ValueError, match=rf"{MAX_CONVOLUTION_PAIRS}-pair"):
+    with pytest.raises(
+        OperationDomainValidationError, match=rf"{MAX_CONVOLUTION_PAIRS}-pair"
+    ):
         compute_product(request)
+
+
+def test_request_rejects_mismatched_presentations_with_a_typed_error() -> None:
+    left = _element(_c2_presentation(characteristic=3), {"e": {(0,)}})
+    right = _element(_c2_presentation(characteristic=5), {"e": {(0,)}})
+
+    with pytest.raises(OperationDomainValidationError) as exc_info:
+        compute_product(CrossedProductMultiplyRequest(left=left, right=right))
+
+    assert exc_info.value.errors()[0]["type"] == (
+        "crossed_product.presentation_mismatch"
+    )
 
 
 def test_request_rejects_scalar_work_before_expansion() -> None:
@@ -432,7 +447,7 @@ def test_request_rejects_scalar_work_before_expansion() -> None:
     right = _element(presentation, {"a": support})
 
     request = CrossedProductMultiplyRequest(left=left, right=right)
-    with pytest.raises(ValueError, match="scalar-work"):
+    with pytest.raises(OperationDomainValidationError, match="scalar-work"):
         compute_product(request)
 
 
@@ -443,7 +458,9 @@ def test_request_rejects_predicted_exponent_growth_before_expansion() -> None:
     right = _element(presentation, {"e": {(0, int("9" * 64))}})
 
     request = CrossedProductMultiplyRequest(left=left, right=right)
-    with pytest.raises(ValueError, match="predicted product exponents"):
+    with pytest.raises(
+        OperationDomainValidationError, match="predicted product exponents"
+    ):
         compute_product(request)
 
 


### PR DESCRIPTION
## Problem

Two accepted request families could escape Jacobian's typed rejection boundary. Crossed-product multiplication raised plain `ValueError` for mismatched presentations and derived work or output bounds. Visibility-kernel admission did the same when exact coordinate growth, intersection growth, result size, or feasibility work exceeded its envelope. Through `math.run`, these became generic execution failures instead of invalid-parameter responses.

## Solution

Raise owner-local `OperationDomainValidationError` directly from both admission paths. The errors retain field locations, stable domain codes, and messages derived from the existing named limits. Kernel behavior and admitted mathematical domains are unchanged.

## Testing

- `make handoff-scoped LANE=math TESTS='tests/math/crossed_products' PATHS='src/jacobian/math/crossed_products tests/math/crossed_products'` — Ruff, formatting, mypy, and 28 tests passed.
- `make handoff-scoped LANE=dispatch TESTS='tests/dispatch/test_more_owner_admission_boundaries.py tests/math/geometry/polygon_kernel' PATHS='src/jacobian/math/geometry/polygon_kernel tests/dispatch/test_more_owner_admission_boundaries.py tests/math/geometry/polygon_kernel'` — Ruff, formatting, mypy, and 27 tests passed.

## Public contract impact

Accepted requests now receive typed domain rejection for these owner admission failures. Operation IDs, request and result schemas, mathematical semantics, and accepted execution envelopes are unchanged.

## Operation boundary ownership

- Changed stage: request bounds
- Request-bounds owner and controlling quantities: crossed-product presentation equality, support-pair work, scalar work, coefficient and exponent growth, serialized result size; polygon coordinate and half-plane height, intersection height, serialized result size, and feasibility work
- Work, intermediate, memory, and exact-output bounds: existing named owner limits are unchanged
- Wall deadline, calibration workload, safety margin, and caller-selectable range: unchanged
- Backend or kernel path: unchanged; rejection occurs before kernel expansion
- Result construction: unchanged
- Independent-result verifier: none
- Native/MCP parity: both use the same owner-local typed admission path
- Serialized-result and round-trip evidence: existing catalog examples and result contracts are unchanged

## Canonical value audit

Not applicable. No mathematical value or schema changed.

## Catalog admission

Not applicable. Catalog membership and declarations are unchanged.

## Closure matrix

None.

## Checklist

- [x] Focused handoff lanes pass
- [x] Runtime-bound changes retain the same semantic path for native and MCP callers
- [x] Behavioral regressions cover mismatched crossed-product parents and visibility-kernel result growth
