### PR TITLE
Count congruence boxes by exact residue classes

### DIFF
--- a/src/jacobian/math/number_theory/counting/_models.py
+++ b/src/jacobian/math/number_theory/counting/_models.py
@@ -18,7 +18,7 @@ from jacobian._models import StrictModel
 _MAX_FLOOR_SUM_N = 10**15
 _MAX_FLOOR_SUM_PARAM = 1_000_000
 _MAX_BOX_COORD = 10_000
-_MAX_BOX_AREA = 250_000
+_MAX_BOX_LINEAR_COEFFICIENT = 10**15
 _MAX_BOX_MODULUS = 10_000
 
 
@@ -60,9 +60,18 @@ class CongruenceBoxCountRequest(StrictModel):
     x_hi: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
     y_lo: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
     y_hi: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
-    u: int
-    v: int
-    c: int
+    u: int = Field(
+        ge=-_MAX_BOX_LINEAR_COEFFICIENT,
+        le=_MAX_BOX_LINEAR_COEFFICIENT,
+    )
+    v: int = Field(
+        ge=-_MAX_BOX_LINEAR_COEFFICIENT,
+        le=_MAX_BOX_LINEAR_COEFFICIENT,
+    )
+    c: int = Field(
+        ge=-_MAX_BOX_LINEAR_COEFFICIENT,
+        le=_MAX_BOX_LINEAR_COEFFICIENT,
+    )
     modulus: int = Field(ge=1, le=_MAX_BOX_MODULUS)
 
     @model_validator(mode="after")

--- a/src/jacobian/math/number_theory/counting/operations.py
+++ b/src/jacobian/math/number_theory/counting/operations.py
@@ -1,9 +1,11 @@
 """Exact arithmetic counting operations."""
 
+from math import gcd
+
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.counting._models import (
-    _MAX_BOX_AREA,
     _MAX_BOX_COORD,
+    _MAX_BOX_LINEAR_COEFFICIENT,
     _MAX_BOX_MODULUS,
     _MAX_FLOOR_SUM_N,
     _MAX_FLOOR_SUM_PARAM,
@@ -84,18 +86,33 @@ def congruence_box_count(
             "modulus_out_of_range",
             "modulus is outside the admitted range",
         )
-    area = (x_hi - x_lo + 1) * (y_hi - y_lo + 1)
-    if area > _MAX_BOX_AREA:
-        _reject(
-            ("x_lo", "x_hi", "y_lo", "y_hi"),
-            "box_area_exceeds_budget",
-            "box area exceeds the computational budget",
-        )
-    return sum(
-        (u * x + v * y - c) % modulus == 0
-        for x in range(x_lo, x_hi + 1)
-        for y in range(y_lo, y_hi + 1)
-    )
+    for name, value in (("u", u), ("v", v), ("c", c)):
+        if not -_MAX_BOX_LINEAR_COEFFICIENT <= value <= _MAX_BOX_LINEAR_COEFFICIENT:
+            _reject(
+                (name,),
+                f"{name}_out_of_range",
+                f"{name} is outside the admitted range",
+            )
+
+    x_length = x_hi - x_lo + 1
+    y_length = y_hi - y_lo + 1
+    if y_length < x_length:
+        x_lo, x_hi, y_lo, y_hi = y_lo, y_hi, x_lo, x_hi
+        u, v = v, u
+
+    divisor = gcd(v, modulus)
+    reduced_modulus = modulus // divisor
+    inverse = 0 if reduced_modulus == 1 else pow(v // divisor, -1, reduced_modulus)
+
+    count = 0
+    for x in range(x_lo, x_hi + 1):
+        right_hand_side = c - u * x
+        if right_hand_side % divisor:
+            continue
+        residue = (right_hand_side // divisor * inverse) % reduced_modulus
+        count += (y_hi - residue) // reduced_modulus
+        count -= (y_lo - 1 - residue) // reduced_modulus
+    return count
 
 
 __all__ = ["congruence_box_count", "floor_sum"]

--- a/tests/math/number_theory/counting/test_arithmetic_counting.py
+++ b/tests/math/number_theory/counting/test_arithmetic_counting.py
@@ -1,9 +1,11 @@
 """Tests for arithmetic counting operations."""
 
+from itertools import product
 from typing import TypedDict
 
 from jacobian.math.number_theory.counting import congruence_box_count, floor_sum
 from jacobian.math.number_theory.counting._models import (
+    _MAX_BOX_LINEAR_COEFFICIENT,
     CongruenceBoxCountRequest,
     FloorSumRequest,
 )
@@ -127,26 +129,132 @@ class TestCongruenceBoxCount:
             == 12
         )
 
-    def test_rejects_oversized_box(self) -> None:
-        import pytest
-
-        from jacobian.catalog.models import OperationDomainValidationError
-
+    def test_admits_full_coordinate_box(self) -> None:
         request = CongruenceBoxCountRequest.model_validate(
             CongruenceBoxCountPayload(
                 x_lo=-10_000,
                 x_hi=10_000,
                 y_lo=-10_000,
                 y_hi=10_000,
-                u=1,
-                v=1,
-                c=0,
-                modulus=3,
+                u=7331,
+                v=4096,
+                c=17,
+                modulus=9991,
             )
         )
-        with pytest.raises(OperationDomainValidationError) as error:
-            compute_congruence_box_count(request)
-        assert (
-            error.value.errors()[0]["type"]
-            == "arithmetic_counting.box_area_exceeds_budget"
+        assert compute_congruence_box_count(request).count == 40_040
+
+    def test_matches_exhaustive_small_boxes(self) -> None:
+        intervals = ((-2, 2), (-1, -1), (0, 2))
+        for (x_lo, x_hi), (y_lo, y_hi), u, v, c, modulus in product(
+            intervals,
+            intervals,
+            range(-2, 3),
+            range(-2, 3),
+            range(-2, 3),
+            range(1, 6),
+        ):
+            expected = sum(
+                (u * x + v * y - c) % modulus == 0
+                for x in range(x_lo, x_hi + 1)
+                for y in range(y_lo, y_hi + 1)
+            )
+            assert (
+                congruence_box_count(
+                    x_lo=x_lo,
+                    x_hi=x_hi,
+                    y_lo=y_lo,
+                    y_hi=y_hi,
+                    u=u,
+                    v=v,
+                    c=c,
+                    modulus=modulus,
+                )
+                == expected
+            )
+
+    def test_axis_swap_preserves_count(self) -> None:
+        request = CongruenceBoxCountPayload(
+            x_lo=-20,
+            x_hi=19,
+            y_lo=-30,
+            y_hi=31,
+            u=6,
+            v=10,
+            c=4,
+            modulus=14,
         )
+        expected = congruence_box_count(**request)
+        assert expected == 354
+        assert (
+            congruence_box_count(
+                x_lo=request["y_lo"],
+                x_hi=request["y_hi"],
+                y_lo=request["x_lo"],
+                y_hi=request["x_hi"],
+                u=request["v"],
+                v=request["u"],
+                c=request["c"],
+                modulus=request["modulus"],
+            )
+            == expected
+        )
+
+    def test_degenerate_boxes(self) -> None:
+        assert (
+            congruence_box_count(
+                x_lo=0,
+                x_hi=0,
+                y_lo=-3,
+                y_hi=3,
+                u=2,
+                v=4,
+                c=1,
+                modulus=6,
+            )
+            == 0
+        )
+        assert (
+            congruence_box_count(
+                x_lo=-3,
+                x_hi=3,
+                y_lo=0,
+                y_hi=0,
+                u=2,
+                v=4,
+                c=2,
+                modulus=6,
+            )
+            == 2
+        )
+        assert (
+            congruence_box_count(
+                x_lo=1,
+                x_hi=1,
+                y_lo=1,
+                y_hi=1,
+                u=2,
+                v=4,
+                c=0,
+                modulus=6,
+            )
+            == 1
+        )
+
+    def test_rejects_linear_coefficient_above_digit_budget(self) -> None:
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            CongruenceBoxCountRequest.model_validate(
+                CongruenceBoxCountPayload(
+                    x_lo=0,
+                    x_hi=0,
+                    y_lo=0,
+                    y_hi=0,
+                    u=_MAX_BOX_LINEAR_COEFFICIENT + 1,
+                    v=0,
+                    c=0,
+                    modulus=1,
+                )
+            )


### PR DESCRIPTION
Closes #2947.

## Problem

`integer.counting.congruence_box.compute` visited every lattice point and rejected boxes above 250,000 cells. The full supported coordinate box contains 400,040,001 points even though, after fixing one coordinate, the congruence admits either no solution or one residue class for the other coordinate.

## Solution

Count the shorter axis directly. For each outer coordinate, reduce the remaining linear congruence by `gcd(coefficient, modulus)`, solve its unique reduced residue with a modular inverse, and count that residue in the inclusive inner interval by exact floor differences.

This removes box area from admission. Existing coordinate and modulus bounds limit work to at most 20,001 outer iterations and the exact scalar result to the supported box area. The request schema now explicitly bounds `u`, `v`, and `c` to magnitude `10^15`, so integer parsing and reduction work are also admitted before execution.

## Testing

- `make handoff-scoped LANE=math TESTS="tests/math/number_theory/counting" PATHS="src/jacobian/math/number_theory/counting/_models.py src/jacobian/math/number_theory/counting/operations.py tests/math/number_theory/counting/test_arithmetic_counting.py"` — lint, formatting, mypy, and 12 owner tests passed.
- `make test-catalog` — 112 passed.
- `make test-integration TESTS=tests/integration/catalog/` — 800 passed.

The owner tests compare 28,125 small parameter combinations with exhaustive enumeration, check the symmetric axis swap and degenerate boxes, reject a coefficient immediately above the new request bound, and admit the issue workload on `[-10,000,10,000]^2` with exact count 40,040.

## Public contract impact

The operation ID, scalar result, inclusive interval semantics, and native/MCP mathematical behavior are unchanged. The request envelope removes the 250,000-cell area rejection and adds schema-visible bounds for the three linear coefficients.

## Operation boundary ownership

- Changed stage: request bounds and owner-local exact kernel.
- Request-bounds owner and controlling quantities: number-theory counting; coordinate spans, coefficient magnitude, and modulus.
- Work, intermediate, memory, and exact-output bounds: at most 20,001 residue iterations, constant auxiliary memory, modular intermediates bounded by the admitted coefficients and coordinates, and one nonnegative count bounded by 400,040,001.
- Wall deadline, calibration workload, safety margin, and caller-selectable range: no wall deadline or caller range is needed for the fixed 20,001-iteration envelope; the maximum-span motivating request completed in 0.01 seconds in the owner test run.
- Backend or kernel path: owner-local integer `gcd`, modular inverse, and floor-difference arithmetic; no external backend.
- Result construction: unchanged `CongruenceBoxCountResult`.
- Independent-result verifier: none; callers cannot supply an independent result.
- Native/MCP parity: both use `congruence_box_count`; MCP adds only request parsing and result projection.
- Serialized-result and round-trip evidence: existing catalog and advertised-example integration suites passed unchanged.

## Canonical value audit

- [x] Existing canonical values searched
- [x] Existing owner retained; no new value introduced
- [x] Producer serialization remains covered by catalog integration
- Theorem-dependent preconditions and validated input subtype: not applicable; this is an exact scalar count over a validated request.
- Structurally valid but mathematically invalid fixture and outcome: invalid interval ordering is rejected by the existing request contract.
- Serialized-subtype trust boundary: not applicable.
- Exact-success defining invariant: each admitted outer coordinate contributes exactly the number of integers in the unique reduced residue class, or zero when the gcd divisibility condition fails; exhaustive enumeration checks this identity.
- Discriminated result schema and impossible combinations: not applicable; the operation has one exact-success result.

## Catalog admission

Not applicable. Catalog membership and the stable mathematical postcondition are unchanged.

## Closure matrix

None; this issue concerns one existing operation.

## Checklist

- [x] Focused handoff passes
- [x] No specialist backend lane applies
- [x] No compatibility aliases or shadow paths introduced
- [x] Native and MCP callers share the same semantic admission and kernel
- [x] The motivating source request is a public-boundary regression
- [x] Boundary, symmetric-regime, degenerate, and source-scale evidence is included