### PR TITLE
Use FLINT for larger exact rational determinants

### DIFF
--- a/src/jacobian/math/matrices/_flint.py
+++ b/src/jacobian/math/matrices/_flint.py
@@ -1,0 +1,18 @@
+"""Private python-flint adapters for dense exact matrices."""
+
+from fractions import Fraction
+
+
+def rational_determinant(entries: tuple[tuple[Fraction, ...], ...]) -> Fraction:
+    """Return the exact determinant through FLINT's dense rational kernel."""
+
+    from flint import fmpq, fmpq_mat
+
+    backend = fmpq_mat(
+        [[fmpq(value.numerator, value.denominator) for value in row] for row in entries]
+    )
+    result = backend.det()
+    return Fraction(int(result.numerator), int(result.denominator))
+
+
+__all__ = ["rational_determinant"]

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -18,11 +18,12 @@ from jacobian.math.matrices.values import (
 )
 
 MAX_INPUT_SCALAR_DIGITS = 256
-MAX_DETERMINANT_MATRIX_DIMENSION = 64
+MAX_DETERMINANT_MATRIX_DIMENSION = 128
+MAX_DETERMINANT_SCALAR_WORK = 500_000_000
 MAX_PERMANENT_RYSER_SUBSETS = 4_096
 MAX_PERMANENT_MATRIX_ORDER = MAX_PERMANENT_RYSER_SUBSETS.bit_length() - 1
 # The canonical dense rational matrix carries determinant inputs through
-# order 64, but Kronecker admission was established only for product axes
+# order 128, but Kronecker admission was established only for product axes
 # through order 50. Pin each admitted output axis to that envelope.
 MAX_KRONECKER_PRODUCT_AXIS = 50
 
@@ -181,7 +182,7 @@ class MatrixPermanentRequest(_MatrixRequest):
 
 
 class MatrixDeterminantRequest(_MatrixRequest):
-    """One square rational matrix of order at most 64."""
+    """One square rational matrix of order at most 128."""
 
     matrix: RationalMatrix
     _raw_matrix_axis_limit: ClassVar[int] = MAX_DETERMINANT_MATRIX_DIMENSION

--- a/src/jacobian/math/matrices/_tools.py
+++ b/src/jacobian/math/matrices/_tools.py
@@ -147,7 +147,7 @@ def matrix_operation[
 MATRIX_DETERMINANT_COMPUTE = matrix_operation(
     "matrix.determinant.compute",
     "Compute an exact rational matrix determinant (det)",
-    "Compute the determinant of one square matrix over QQ through order 64 with SymPy's exact Bareiss algorithm.",
+    "Compute the determinant of one square matrix over QQ through order 128 with FLINT's exact dense rational kernel, subject to scalar-work and result-height bounds.",
     MatrixDeterminantRequest,
     MatrixDeterminantResult,
     compute_determinant,

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -9,6 +9,8 @@ lazily so importing ``jacobian.math`` does not eagerly load packaged backends.
 from __future__ import annotations
 
 from collections.abc import Callable
+from fractions import Fraction
+from math import lcm
 from typing import TYPE_CHECKING, Any, cast
 
 from pydantic_core import PydanticCustomError
@@ -19,6 +21,7 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices import _conversions as conversions
 from jacobian.math.matrices._operation_models import (
     MAX_DETERMINANT_MATRIX_DIMENSION,
+    MAX_DETERMINANT_SCALAR_WORK,
     MAX_INPUT_SCALAR_DIGITS,
     MAX_KRONECKER_PRODUCT_AXIS,
     MAX_PERMANENT_RYSER_SUBSETS,
@@ -39,7 +42,12 @@ from jacobian.math.matrices._operation_models import (
     _require_square_system_admission,
     _validation_error,
 )
-from jacobian.math.matrices.values import IntegerMatrix, RationalMatrix, SmithNormalForm
+from jacobian.math.matrices.values import (
+    MAX_MATRIX_SCALAR_DIGITS,
+    IntegerMatrix,
+    RationalMatrix,
+    SmithNormalForm,
+)
 
 if TYPE_CHECKING:
     from sympy.matrices.matrixbase import MatrixBase
@@ -229,11 +237,11 @@ def permanent(matrix: MatrixBase) -> Any:
     return Permanent(source).doit()
 
 
-def _admit(
-    check: Callable[..., None], *values: Any, location: tuple[str, ...] = ("matrix",)
-) -> None:
+def _admit[T](
+    check: Callable[..., T], *values: Any, location: tuple[str, ...] = ("matrix",)
+) -> T:
     try:
-        check(*values)
+        return check(*values)
     except PydanticCustomError as exc:
         raise OperationDomainValidationError(
             location=location, code=exc.type, message=exc.message()
@@ -329,7 +337,13 @@ def _admit_partial_trace(
         )
 
 
-def _admit_determinant(matrix: RationalMatrix) -> None:
+def _bit_bound_decimal_digits(bits: int) -> int:
+    return max(1, (bits * 30_103 + 99_999) // 100_000)
+
+
+def _admit_determinant(
+    matrix: RationalMatrix,
+) -> tuple[tuple[Fraction, ...], ...]:
     from jacobian.math.matrices.values import require_matrix_scalar_digits
 
     require_matrix_scalar_digits(
@@ -343,6 +357,44 @@ def _admit_determinant(matrix: RationalMatrix) -> None:
             "determinant matrices are limited to order "
             f"{MAX_DETERMINANT_MATRIX_DIMENSION}",
         )
+    entries = tuple(
+        tuple(value.as_fraction() for value in row) for row in matrix.entries
+    )
+    order = len(entries)
+    input_digits = max(
+        max(len(str(abs(value.numerator))), len(str(value.denominator)))
+        for row in entries
+        for value in row
+    )
+    scalar_work = order**3 * input_digits
+    if scalar_work > MAX_DETERMINANT_SCALAR_WORK:
+        raise _validation_error(
+            "budget_exceeded",
+            "determinant exceeds the "
+            f"{MAX_DETERMINANT_SCALAR_WORK:,}-unit scalar-work budget",
+        )
+    numerator_bits = 0
+    denominator_bits = 0
+    for row in entries:
+        row_denominator = lcm(*(value.denominator for value in row))
+        denominator_bits += row_denominator.bit_length()
+        squared_norm = sum(
+            (value.numerator * (row_denominator // value.denominator)) ** 2
+            for value in row
+        )
+        numerator_bits += (squared_norm.bit_length() + 1) // 2
+    if (
+        max(
+            _bit_bound_decimal_digits(numerator_bits),
+            _bit_bound_decimal_digits(denominator_bits),
+        )
+        > MAX_MATRIX_SCALAR_DIGITS
+    ):
+        raise _validation_error(
+            "budget_exceeded",
+            "determinant exceeds the canonical rational result-height bound",
+        )
+    return entries
 
 
 def _admit_linear_solve(
@@ -352,9 +404,11 @@ def _admit_linear_solve(
 
 
 def determinant_result(matrix: RationalMatrix) -> MatrixDeterminantResult:
-    _admit(_admit_determinant, matrix)
-    value = determinant(conversions.rational_matrix_to_sympy(matrix))
-    return MatrixDeterminantResult(determinant=conversions.rational_from_sympy(value))
+    entries = _admit(_admit_determinant, matrix)
+    from jacobian.math.matrices._flint import rational_determinant
+
+    value = rational_determinant(entries)
+    return MatrixDeterminantResult(determinant=CanonicalRational.from_fraction(value))
 
 
 def rank_result(matrix: RationalMatrix) -> MatrixRankResult:

--- a/src/jacobian/math/matrices/values.py
+++ b/src/jacobian/math/matrices/values.py
@@ -22,10 +22,10 @@ MAX_MATRIX_DIMENSION = 32
 # The canonical dense rational matrix retains exact sources for analysis
 # results whose operations admit them by their own work and result budgets,
 # so its structural order is not tied to the shared computation dimension.
-# The determinant operation admits square matrices through order 64.  Keep
+# The determinant operation admits square matrices through order 128. Keep
 # that complete public domain representable by the one canonical QQ matrix
 # value so a determinant consumer can accept a produced matrix unchanged.
-MAX_RATIONAL_MATRIX_ORDER = 64
+MAX_RATIONAL_MATRIX_ORDER = 128
 MAX_MATRIX_SCALAR_DIGITS = MAX_CANONICAL_RATIONAL_DIGITS
 
 

--- a/tests/math/matrices/test_result_source_binding.py
+++ b/tests/math/matrices/test_result_source_binding.py
@@ -6,10 +6,13 @@ from fractions import Fraction
 
 import pytest
 from pydantic import ValidationError
+from sympy import primerange
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices._operation_models import (
     MAX_DETERMINANT_MATRIX_DIMENSION,
+    MAX_DETERMINANT_SCALAR_WORK,
     MatrixDeterminantRequest,
     MatrixRankRequest,
     MatrixRankResult,
@@ -192,7 +195,80 @@ def test_determinant_accepts_the_canonical_matrix_boundary() -> None:
     assert MatrixDeterminantRequest(matrix=matrix).matrix is matrix
 
 
-def test_raw_preflight_keeps_32_and_64_axes_and_rejects_the_next_axis() -> None:
+def test_flint_determinant_executes_above_the_previous_order_ceiling() -> None:
+    order = 96
+    entries = tuple(
+        tuple(
+            Fraction(-2, 3)
+            if row == column == 0
+            else Fraction(1)
+            if row == column
+            else Fraction(row + column + 1, 7)
+            if column > row
+            else Fraction(0)
+            for column in range(order)
+        )
+        for row in range(order)
+    )
+    matrix = rational_matrix_from_fractions(entries)
+
+    result = compute_determinant(MatrixDeterminantRequest(matrix=matrix))
+
+    assert result.determinant == CanonicalRational(num="-2", den="3")
+
+
+def test_determinant_preserves_row_swap_and_scaling_invariants() -> None:
+    entries = (
+        (Fraction(1, 2), Fraction(2), Fraction(-1)),
+        (Fraction(3), Fraction(1, 3), Fraction(4)),
+        (Fraction(-2), Fraction(5), Fraction(7, 11)),
+    )
+    source = rational_matrix_from_fractions(entries)
+    transformed = rational_matrix_from_fractions(
+        (tuple(-3 * value for value in entries[1]), entries[0], entries[2])
+    )
+
+    source_value = compute_determinant(
+        MatrixDeterminantRequest(matrix=source)
+    ).determinant.as_fraction()
+    transformed_value = compute_determinant(
+        MatrixDeterminantRequest(matrix=transformed)
+    ).determinant.as_fraction()
+
+    assert transformed_value == 3 * source_value
+
+
+def test_determinant_rejects_requests_above_the_scalar_work_envelope() -> None:
+    order = MAX_DETERMINANT_MATRIX_DIMENSION
+    large = Fraction(int("9" * 256))
+    entries = tuple(
+        tuple(
+            large if row == column == 0 else Fraction(int(row == column))
+            for column in range(order)
+        )
+        for row in range(order)
+    )
+    matrix = rational_matrix_from_fractions(entries)
+    assert order**3 * 256 > MAX_DETERMINANT_SCALAR_WORK
+
+    with pytest.raises(OperationDomainValidationError, match="scalar-work budget"):
+        compute_determinant(MatrixDeterminantRequest(matrix=matrix))
+
+
+def test_determinant_rejects_an_unrepresentable_result_height_bound() -> None:
+    denominators = tuple(primerange(2, 730))[:MAX_DETERMINANT_MATRIX_DIMENSION]
+    row = tuple(Fraction(1, denominator) for denominator in denominators)
+    matrix = rational_matrix_from_fractions(
+        tuple(row for _ in range(MAX_DETERMINANT_MATRIX_DIMENSION))
+    )
+
+    with pytest.raises(
+        OperationDomainValidationError, match="rational result-height bound"
+    ):
+        compute_determinant(MatrixDeterminantRequest(matrix=matrix))
+
+
+def test_raw_preflight_keeps_32_and_128_axes_and_rejects_the_next_axis() -> None:
     def wire_identity(order: int) -> list[list[dict[str, str]]]:
         return [
             [{"num": str(int(row == column)), "den": "1"} for column in range(order)]


### PR DESCRIPTION
## Problem

`matrix.determinant.compute` uses SymPy's Bareiss implementation and rejects every matrix above order 64, even when a maintained exact backend can handle a materially larger bounded request. The fixed order ceiling conflates the current kernel with the mathematical domain described in #2940.

## What changed

- route exact rational determinants through python-flint's `fmpq_mat.det()` kernel;
- widen the canonical rational-matrix carrier and determinant request to order 128;
- admit each request against its scalar digits, cubic scalar-work estimate, and a pre-execution determinant-height bound derived by row-wise denominator clearing and Hadamard's inequality;
- keep FLINT values private and return the existing canonical rational result unchanged;
- update immutable catalog metadata to describe the actual backend and envelope.

The order limit remains a documented conservative backend envelope. This does not change the separate order-32 bounds for rank, RREF, nullspace, or linear-system operations.

## Evidence

The regression suite executes a dense upper-triangular 96×96 rational determinant, above the former ceiling, and checks the exact value. It also checks row-swap/scaling identities, the order-128 request boundary, raw order-129 rejection, scalar-work rejection, and result-height rejection before backend execution.

`make affected AFFECTED_BASE=origin/main` passed on commit `66655234f`:

- 503 matrix tests
- 112 catalog tests
- 800 catalog integration tests
- scoped Ruff formatting/lint and mypy

Closes #2940.
