### PR TITLE
Use FLINT for larger exact Delta q-expansions

### DIFF
--- a/src/jacobian/math/number_theory/modular_forms/_flint.py
+++ b/src/jacobian/math/number_theory/modular_forms/_flint.py
@@ -1,0 +1,31 @@
+"""Private FLINT adapters for exact finite modular-form series."""
+
+from fractions import Fraction
+
+
+def delta_coefficients(
+    e4: tuple[Fraction, ...], e6: tuple[Fraction, ...]
+) -> tuple[Fraction, ...]:
+    """Return ``(E4^3 - E6^2) / 1728`` through the input precision.
+
+    ``fmpq_series`` multiplication consults FLINT's process-global ``ctx.cap``
+    even when its operands carry explicit precision.  Exact polynomial
+    multiplication followed by explicit truncation computes the same finite
+    prefix without mutating or depending on that ambient context.
+    """
+
+    from flint import fmpq, fmpq_poly
+
+    precision = len(e4)
+    e4_poly = fmpq_poly([fmpq(value.numerator, value.denominator) for value in e4])
+    e6_poly = fmpq_poly([fmpq(value.numerator, value.denominator) for value in e6])
+    e4_cubed = ((e4_poly * e4_poly).truncate(precision) * e4_poly).truncate(precision)
+    e6_squared = (e6_poly * e6_poly).truncate(precision)
+    delta = (e4_cubed - e6_squared) / 1728
+    return tuple(
+        Fraction(int(delta[index].numerator), int(delta[index].denominator))
+        for index in range(precision)
+    )
+
+
+__all__ = ["delta_coefficients"]

--- a/src/jacobian/math/number_theory/modular_forms/kernel.py
+++ b/src/jacobian/math/number_theory/modular_forms/kernel.py
@@ -17,7 +17,9 @@ NamedLevelOneModularForm = Literal["E4", "E6", "DELTA"]
 
 NAMED_LEVEL_ONE_FORMS = frozenset(("E4", "E6", "DELTA"))
 
-# Delta needs five finite convolutions to construct its defining identity.
+# This ceiling charges all coefficient products in three schoolbook truncated
+# products. FLINT selects faster kernels where applicable, so the estimate is
+# conservative without depending on one private multiplication algorithm.
 MAX_LEVEL_ONE_WORK_TERMS = 4_000_000
 MAX_LEVEL_ONE_SERIALIZED_CHARACTERS = 65_536
 
@@ -56,20 +58,6 @@ def eisenstein_coefficients(
     )
 
 
-def _convolve(
-    left: tuple[Fraction, ...], right: tuple[Fraction, ...]
-) -> tuple[Fraction, ...]:
-    """Cauchy product through the common finite precision."""
-    order = len(left)
-    return tuple(
-        sum(
-            (left[index] * right[degree - index] for index in range(degree + 1)),
-            start=Fraction(0),
-        )
-        for degree in range(order)
-    )
-
-
 def expected_coefficients(
     form: NamedLevelOneModularForm, truncation_order: int
 ) -> tuple[Fraction, ...]:
@@ -80,11 +68,9 @@ def expected_coefficients(
         return eisenstein_coefficients("E6", truncation_order)
     e4 = eisenstein_coefficients("E4", truncation_order)
     e6 = eisenstein_coefficients("E6", truncation_order)
-    e4_cubed = _convolve(_convolve(e4, e4), e4)
-    e6_squared = _convolve(e6, e6)
-    return tuple(
-        (left - right) / 1728 for left, right in zip(e4_cubed, e6_squared, strict=True)
-    )
+    from jacobian.math.number_theory.modular_forms._flint import delta_coefficients
+
+    return delta_coefficients(e4, e6)
 
 
 def metadata(
@@ -103,9 +89,10 @@ def coefficient_digit_bound(
 ) -> int:
     """Conservative decimal bound for every integral output coefficient.
 
-    For n < P, ``sigma_r(n) <= n^(r+1) <= P^(r+1)``.  Delta is formed
-    from at most P^2 triple and P double Cauchy terms.  The bound deliberately
-    exceeds the exact coefficient size so admission occurs before any scan.
+    For n < P, ``sigma_r(n) <= n^(r+1) <= P^(r+1)``. For Delta, Deligne's
+    bound ``|tau(n)| <= d(n)n^(11/2)`` and ``d(n) <= 2sqrt(n)`` give the
+    integral bound ``|tau(n)| <= 2P^6``. Admission therefore tracks the
+    canonical result rather than unreduced intermediates in its identity.
     """
     p = truncation_order
     e4_bound = 240 * p**4
@@ -115,7 +102,7 @@ def coefficient_digit_bound(
     elif form == "E6":
         bound = e6_bound
     else:
-        bound = p**2 * e4_bound**3 + p * e6_bound**2
+        bound = 2 * p**6
     return len(str(bound))
 
 
@@ -145,7 +132,7 @@ def require_level_one_admission(
     p = truncation_order
     divisor_scans = p * isqrt(p)
     formula_scans = divisor_scans if form in {"E4", "E6"} else 2 * divisor_scans
-    series_terms = 0 if form in {"E4", "E6"} else 5 * p * p
+    series_terms = 0 if form in {"E4", "E6"} else 3 * p * (p + 1) // 2
     if formula_scans + series_terms > MAX_LEVEL_ONE_WORK_TERMS:
         raise OperationDomainValidationError(
             location=("truncation_order",),

--- a/tests/math/number_theory/modular_forms/test_level_one_q_expansions.py
+++ b/tests/math/number_theory/modular_forms/test_level_one_q_expansions.py
@@ -76,13 +76,35 @@ def test_delta_known_prefix_and_defining_e4_e6_identity() -> None:
 
 
 def test_full_public_precision_is_complete_and_carries_parent_metadata() -> None:
-    result = level_one_named_q_expansion("DELTA", 844)
-    assert result.q_expansion.truncation_order == 844
-    assert len(result.q_expansion.coefficients) == 844
+    result = level_one_named_q_expansion("DELTA", 1024)
+    assert result.q_expansion.truncation_order == 1024
+    assert len(result.q_expansion.coefficients) == 1024
     assert result.congruence_subgroup == "SL2Z"
     assert result.level == 1
     assert result.weight == 12
     assert result.space_kind == "CUSP"
+
+
+def test_delta_precision_1024_satisfies_its_defining_identity_coefficientwise() -> None:
+    from flint import fmpq, fmpq_poly
+
+    precision = 1024
+    delta = level_one_named_q_expansion("DELTA", precision).q_expansion
+    e4 = level_one_named_q_expansion("E4", precision).q_expansion
+    e6 = level_one_named_q_expansion("E6", precision).q_expansion
+
+    def polynomial(coefficients: tuple[CanonicalRational, ...]) -> fmpq_poly:
+        return fmpq_poly(
+            [fmpq(int(value.num), int(value.den)) for value in coefficients]
+        )
+
+    delta_poly = polynomial(delta.coefficients)
+    e4_poly = polynomial(e4.coefficients)
+    e6_poly = polynomial(e6.coefficients)
+    assert 1728 * delta_poly == (
+        ((e4_poly * e4_poly).truncate(precision) * e4_poly).truncate(precision)
+        - (e6_poly * e6_poly).truncate(precision)
+    )
 
 
 def test_e4_and_e6_report_the_standard_holomorphic_space_kind() -> None:
@@ -124,11 +146,24 @@ def test_requests_above_the_serialized_budget_name_the_controlling_quantity() ->
 
 
 def test_delta_above_the_serialized_budget_names_the_controlling_quantity() -> None:
-    request = LevelOneNamedQExpansionRequest(form="DELTA", truncation_order=845)
+    request = LevelOneNamedQExpansionRequest(form="DELTA", truncation_order=1355)
     with pytest.raises(OperationDomainValidationError, match="serialized result bound"):
         level_one_named_q_expansion(request.form, request.truncation_order)
     with pytest.raises(OperationDomainValidationError, match="serialized result bound"):
-        require_level_one_admission("DELTA", 845)
+        require_level_one_admission("DELTA", 1355)
+
+
+def test_delta_backend_does_not_read_or_mutate_global_series_precision() -> None:
+    from flint import ctx
+
+    original_cap = ctx.cap
+    try:
+        ctx.cap = 2
+        result = level_one_named_q_expansion("DELTA", 1024)
+        assert len(result.q_expansion.coefficients) == 1024
+        assert ctx.cap == 2
+    finally:
+        ctx.cap = original_cap
 
 
 def test_wire_request_rejects_boolean_truncation_orders() -> None:


### PR DESCRIPTION
## Problem

`modular_form.level_one.named_q_expansion.compute` constructs Ramanujan Delta with three quadratic Python `Fraction` convolutions. Its admission also charges five full quadratic products and bounds the serialized result from the much larger unreduced `E4^3 - E6^2` intermediates. Consequently, precision 1024 is rejected although the canonical coefficient prefix is small and FLINT can compute it exactly.

## What changed

- compute the finite identity `(E4^3 - E6^2) / 1728` with python-flint exact rational polynomial products and explicit truncation;
- charge the three actual truncated products by their conservative schoolbook-equivalent coefficient count while retaining the existing 4,000,000-unit work ceiling;
- bound Delta's canonical coefficients using `|tau(n)| <= d(n)n^(11/2) <= 2n^6`, so serialized-result admission tracks the returned coefficients instead of unreduced identity intermediates;
- widen the admitted Delta precision from 844 through 1354; precision 1355 remains rejected by the existing 65,536-character result envelope.

I used `fmpq_poly` rather than `fmpq_series` deliberately. In python-flint 0.9.0, series multiplication consults process-global `ctx.cap` even when operands were constructed with explicit precision. Polynomial multiplication followed by `truncate(P)` computes the same finite prefix without mutating or depending on process-global precision.

The public result type, form metadata, normalization, and E4/E6 paths are unchanged.

## Evidence

At precision 1024, the regression proof checks all delivered coefficients against

`1728 * Delta = E4^3 - E6^2`.

It also verifies the 1,024-coefficient canonical result, known prefixes, the new precision-1355 serialized boundary, and independence from `flint.ctx.cap`.

`make affected AFFECTED_BASE=origin/main` passed on commit `7d7c7ada3`:

- 24 modular-form tests
- scoped Ruff formatting/lint and mypy

Closes #2945.
