### PR TITLE
Make rational generating-function admission degree-sensitive

### DIFF
--- a/src/jacobian/math/combinatorics/_recurrence_admission.py
+++ b/src/jacobian/math/combinatorics/_recurrence_admission.py
@@ -16,6 +16,7 @@ from jacobian.math.combinatorics._recurrence_models import (
     MAX_COMBINATORICS_RESULT_ARTIFACT_BYTES,
     MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS,
     MAX_P_RECURSIVE_POLYNOMIAL_DEGREE,
+    MAX_RATIONAL_SERIES_WORK_UNITS,
     _require_bounded_rational,
     _require_canonical_polynomial,
     _validate_result_inline_size,
@@ -318,6 +319,29 @@ def _admit_series(
         )
     numerator_values = tuple(value.as_fraction() for value in numerator)
     denominator_values = tuple(value.as_fraction() for value in denominator)
+    denominator_degree = len(denominator_values) - 1
+    ramp = min(max(0, truncation_order - 1), denominator_degree)
+    recurrence_products = ramp * (ramp + 1) // 2
+    recurrence_products += (
+        max(0, truncation_order - denominator_degree - 1) * denominator_degree
+    )
+    work_units = truncation_order + recurrence_products
+    if work_units > MAX_RATIONAL_SERIES_WORK_UNITS:
+        raise OperationDomainValidationError(
+            location=("truncation_order",),
+            code="combinatorics.work_bound",
+            message="rational-series recurrence exceeds the exact work bound",
+        )
+    minimum_result_size = (
+        2 * truncation_order * _minimum_fraction_wire_bytes(Fraction())
+        + _RESULT_WIRE_FIXED_BYTES
+    )
+    if minimum_result_size > MAX_COMBINATORICS_RESULT_ARTIFACT_BYTES:
+        raise OperationDomainValidationError(
+            location=("truncation_order",),
+            code="combinatorics.result_bound",
+            message="the exact combinatorics result exceeds the bounded result limit",
+        )
     coefficients: list[Fraction] = []
     for degree in range(truncation_order):
         numerator_coefficient = (

--- a/src/jacobian/math/combinatorics/_recurrence_models.py
+++ b/src/jacobian/math/combinatorics/_recurrence_models.py
@@ -25,7 +25,12 @@ MAX_LINEAR_RECURRENCE_INDEX = 512
 MAX_LINEAR_RECURRENCE_REQUESTED_INDICES = 256
 MAX_P_RECURSIVE_POLYNOMIAL_DEGREE = 16
 MAX_RATIONAL_GENERATING_FUNCTION_DEGREE = 32
-MAX_RATIONAL_SERIES_TRUNCATION_ORDER = 512
+# The rational-series recurrence charges one coefficient construction plus
+# every nonconstant denominator product. Its 250,000-unit work ledger therefore
+# permits this many terms only for a constant denominator; higher-degree
+# denominators admit proportionally shorter prefixes.
+MAX_RATIONAL_SERIES_TRUNCATION_ORDER = 250_000
+MAX_RATIONAL_SERIES_WORK_UNITS = 250_000
 MAX_COMBINATORICS_INPUT_RATIONAL_DIGITS = 64
 MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS = 32_768
 MAX_COMBINATORICS_RESULT_ARTIFACT_BYTES = 10 * 1024 * 1024

--- a/src/jacobian/math/combinatorics/operations.py
+++ b/src/jacobian/math/combinatorics/operations.py
@@ -19,6 +19,7 @@ from jacobian.math.combinatorics._recurrence_admission import (
     _admit_series,
 )
 from jacobian.math.combinatorics._recurrence_models import (
+    MAX_RATIONAL_SERIES_TRUNCATION_ORDER,
     IndexedRationalValue,
     LinearRecurrenceEvaluationResult,
     PolynomialCoefficientRecurrenceEvaluationResult,
@@ -512,7 +513,10 @@ def rational_generating_function_coefficients(
             code="combinatorics.polynomial_invariant",
             message="polynomial degree is outside the bound",
         )
-    if type(truncation_order) is not int or not 1 <= truncation_order <= 512:
+    if (
+        type(truncation_order) is not int
+        or not 1 <= truncation_order <= MAX_RATIONAL_SERIES_TRUNCATION_ORDER
+    ):
         raise OperationDomainValidationError(
             location=("truncation_order",),
             code="combinatorics.result_bound",

--- a/tests/math/combinatorics/test_rational_generating_functions.py
+++ b/tests/math/combinatorics/test_rational_generating_functions.py
@@ -1,0 +1,68 @@
+"""Result-sensitive exact rational generating-function expansions."""
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics._recurrence_models import (
+    RationalGeneratingFunctionCoefficientsRequest,
+    RationalGeneratingFunctionCoefficientsResult,
+)
+from jacobian.math.combinatorics.operations import (
+    rational_generating_function_coefficients,
+)
+
+ONE = CanonicalRational(num="1", den="1")
+MINUS_ONE = CanonicalRational(num="-1", den="1")
+
+
+def _expand(
+    denominator: tuple[CanonicalRational, ...], order: int
+) -> RationalGeneratingFunctionCoefficientsResult:
+    return rational_generating_function_coefficients(
+        (ONE,), denominator, "ASCENDING_POWERS_OF_X", "0", order
+    )
+
+
+def test_degree_32_recurrence_admits_a_prefix_above_the_old_ceiling() -> None:
+    order = 4_096
+    denominator = (ONE, *((MINUS_ONE,) * 32))
+    request = RationalGeneratingFunctionCoefficientsRequest(
+        numerator=(ONE,),
+        denominator=denominator,
+        coefficient_convention="ASCENDING_POWERS_OF_X",
+        expansion_point="0",
+        truncation_order=order,
+    )
+
+    result = _expand(request.denominator, request.truncation_order)
+    values = tuple(value.as_fraction() for value in result.coefficients)
+    denominator_values = tuple(value.as_fraction() for value in denominator)
+
+    assert len(values) == order
+    assert values[-1] == sum(values[-33:-1])
+    assert all(
+        sum(
+            denominator_values[offset] * values[degree - offset]
+            for offset in range(min(degree, len(denominator_values) - 1) + 1)
+        )
+        == (1 if degree == 0 else 0)
+        for degree in range(order)
+    )
+    assert all(value.num == "0" for value in result.residual_coefficients)
+    assert (
+        RationalGeneratingFunctionCoefficientsResult.model_validate(result.model_dump())
+        == result
+    )
+
+
+def test_denominator_degree_controls_the_recurrence_work_envelope() -> None:
+    denominator = (ONE, *((MINUS_ONE,) * 32))
+
+    with pytest.raises(OperationDomainValidationError, match="exact work bound"):
+        _expand(denominator, 8_000)
+
+
+def test_minimum_result_size_rejects_before_materializing_a_large_prefix() -> None:
+    with pytest.raises(OperationDomainValidationError, match="bounded result limit"):
+        _expand((ONE,), 250_000)


### PR DESCRIPTION
## Problem

`combinatorics.generating_function.coefficients.compute` rejects every precision above 512 before its existing coefficient-height and 10 MiB artifact checks run. Current main already computes `N(x)/D(x)` with the exact order-`deg(D)` recurrence rather than the SymPy kernel described in #2948, so the fixed precision field—not the backend—is the remaining scale constraint.

Using `fmpq_series` here would be a regression in isolation: python-flint 0.9.0 series arithmetic consults process-global `ctx.cap`. The existing recurrence is stateless, exact, and performs only the denominator products mathematically required for each coefficient.

## What changed

- replace the order-512 execution cap with a 250,000-unit ledger that charges one coefficient construction per output term and every nonconstant denominator product;
- derive recurrence work from the requested precision and the actual denominator degree, so low-degree rational functions admit longer prefixes;
- preflight the minimum size of both complete output vectors against the existing 10 MiB artifact boundary before allocating coefficient storage;
- retain the existing per-coefficient rational-height checks and exact final canonical serialization check.

The 250,000-term schema ceiling is the maximum allowed by the work ledger for a constant denominator. Higher-degree denominators reach the work boundary earlier, and the artifact or exact-height envelope may reject earlier still.

## Evidence

A degree-32 denominator `1-x-...-x^32` now succeeds at precision 4,096. The regression proof reconstructs every coefficient of `D(x)S(x)-1` independently and checks the complete returned zero-residual ledger and serialized round trip. Precision 8,000 for the same denominator rejects at preflight on exact work, while a 250,000-term constant-denominator request rejects from its minimum output size before materialization.

`make affected AFFECTED_BASE=origin/main` passed on commit `9f11577a8`:

- 900 combinatorics tests
- 112 catalog tests
- 800 catalog integration tests
- scoped Ruff formatting/lint and mypy

Closes #2948.
