### PR TITLE
Scale periodic-point profiles with FLINT traces

### DIFF
--- a/src/jacobian/math/dynamics/symbolic/_flint.py
+++ b/src/jacobian/math/dynamics/symbolic/_flint.py
@@ -1,0 +1,22 @@
+"""Private FLINT adapters for exact symbolic-dynamics matrices."""
+
+
+def matrix_power_traces(
+    matrix: tuple[tuple[int, ...], ...], max_period: int
+) -> tuple[int, ...]:
+    """Return ``trace(A^n)`` for every ``1 <= n <= max_period``."""
+
+    from flint import fmpz_mat
+
+    adjacency = fmpz_mat(matrix)
+    power = adjacency
+    size = len(matrix)
+    traces: list[int] = []
+    for period in range(1, max_period + 1):
+        traces.append(sum(int(power[index, index]) for index in range(size)))
+        if period < max_period:
+            power *= adjacency
+    return tuple(traces)
+
+
+__all__ = ["matrix_power_traces"]

--- a/src/jacobian/math/dynamics/symbolic/operations.py
+++ b/src/jacobian/math/dynamics/symbolic/operations.py
@@ -247,37 +247,21 @@ def adjacency_shift(
     return AdjacencyShift(matrix=matrix, two_sided=two_sided)
 
 
-def _matrix_product(
-    left: tuple[tuple[int, ...], ...], right: tuple[tuple[int, ...], ...]
-) -> tuple[tuple[int, ...], ...]:
-    size = len(left)
-    return tuple(
-        tuple(
-            sum(left[row][inner] * right[inner][column] for inner in range(size))
-            for column in range(size)
-        )
-        for row in range(size)
-    )
+def _mobius_sieve(limit: int) -> tuple[int, ...]:
+    """Return mu(0)..mu(limit) by a bounded Eratosthenes sieve."""
 
-
-def _mobius(value: int) -> int:
-    remaining = value
-    prime = 2
-    distinct_factors = 0
-    while prime * prime <= remaining:
-        if remaining % prime:
-            prime += 1
+    values = [1] * (limit + 1)
+    is_prime = [True] * (limit + 1)
+    for prime in range(2, limit + 1):
+        if not is_prime[prime]:
             continue
-        remaining //= prime
-        distinct_factors += 1
-        if remaining % prime == 0:
-            return 0
-        while remaining % prime == 0:
-            remaining //= prime
-        prime += 1
-    if remaining > 1:
-        distinct_factors += 1
-    return -1 if distinct_factors % 2 else 1
+        for multiple in range(prime, limit + 1, prime):
+            is_prime[multiple] = False
+            values[multiple] *= -1
+        square = prime * prime
+        for multiple in range(square, limit + 1, square):
+            values[multiple] = 0
+    return tuple(values)
 
 
 def periodic_point_profile(
@@ -291,35 +275,37 @@ def periodic_point_profile(
         )
     matrix = shift.matrix
     states = len(matrix)
-    if states**3 * max_period > MAX_PERIODIC_PROFILE_WORK:
+    matrix_work = states**3 * max_period
+    divisor_work = 3 * max_period * (max_period.bit_length() + 1)
+    if matrix_work + divisor_work > MAX_PERIODIC_PROFILE_WORK:
         raise OperationDomainValidationError(
             location=("shift", "max_period"),
             code="symbolic_dynamics.periodic_profile_work_bound",
             message="periodic-point matrix powering exceeds the work bound",
         )
     maximum_row_sum = max(sum(row) for row in matrix)
-    count_bound = states * max(1, maximum_row_sum) ** max_period
-    aggregate_digits = 3 * max_period * len(str(count_bound))
+    count_bits = (
+        states.bit_length() + max_period * (max(1, maximum_row_sum) - 1).bit_length()
+    )
+    count_digits = max(1, (count_bits * 30_103 + 99_999) // 100_000)
+    aggregate_digits = 3 * max_period * count_digits
     if aggregate_digits > MAX_PERIODIC_PROFILE_DIGITS:
         raise OperationDomainValidationError(
             location=("shift", "max_period"),
             code="symbolic_dynamics.periodic_profile_output_bound",
             message="periodic-point profile exceeds the output digit bound",
         )
-    power = matrix
-    fixed: list[int] = []
-    for period in range(1, max_period + 1):
-        fixed.append(sum(power[index][index] for index in range(len(matrix))))
-        if period < max_period:
-            power = _matrix_product(power, matrix)
-    exact = tuple(
-        sum(
-            _mobius(divisor) * fixed[period // divisor - 1]
-            for divisor in range(1, period + 1)
-            if period % divisor == 0
-        )
-        for period in range(1, max_period + 1)
-    )
+    from jacobian.math.dynamics.symbolic._flint import matrix_power_traces
+
+    fixed = matrix_power_traces(matrix, max_period)
+    mobius = _mobius_sieve(max_period)
+    exact_values = [0] * max_period
+    for divisor in range(1, max_period + 1):
+        multiplier = mobius[divisor]
+        if multiplier:
+            for period in range(divisor, max_period + 1, divisor):
+                exact_values[period - 1] += multiplier * fixed[period // divisor - 1]
+    exact = tuple(exact_values)
     if any(count < 0 or count % period for period, count in enumerate(exact, 1)):
         raise RuntimeError("periodic-point inversion violated orbit integrality")
     orbits = tuple(count // period for period, count in enumerate(exact, 1))

--- a/src/jacobian/math/dynamics/symbolic/values.py
+++ b/src/jacobian/math/dynamics/symbolic/values.py
@@ -17,7 +17,9 @@ MAX_ADJACENCY_STATES = 50
 MAX_ADJACENCY_ENTRY = 1_000_000
 MAX_ENUMERATED_BLOCKS = 100_000
 MAX_PRESENTATION_CELLS = MAX_ENUMERATED_BLOCKS
-MAX_PERIOD = 50
+# Three complete integer vectors are returned. Even one-digit counts consume
+# three digits per period under the aggregate profile budget.
+MAX_PERIOD = 100_000 // 3
 
 Symbol = Annotated[str, Field(min_length=1, max_length=MAX_SYMBOL_LENGTH)]
 

--- a/tests/math/dynamics/symbolic/test_symbolic_dynamics.py
+++ b/tests/math/dynamics/symbolic/test_symbolic_dynamics.py
@@ -348,6 +348,35 @@ def test_periodic_profile_handles_square_mobius_factor() -> None:
     assert result.complete_through_period == 4
 
 
+def test_periodic_profile_executes_above_the_previous_period_ceiling() -> None:
+    max_period = 128
+    fixed, exact, orbits = periodic_point_profile(
+        AdjacencyShift(matrix=((2,),)), max_period
+    )
+
+    assert fixed[-1] == 2**max_period
+    for period in range(1, max_period + 1):
+        assert fixed[period - 1] == sum(
+            exact[divisor - 1]
+            for divisor in range(1, period + 1)
+            if period % divisor == 0
+        )
+        assert exact[period - 1] == period * orbits[period - 1]
+
+
+def test_periodic_profile_rejects_matrix_work_before_powering() -> None:
+    size = 50
+    shift = AdjacencyShift(matrix=tuple((0,) * size for _ in range(size)))
+
+    with pytest.raises(OperationDomainValidationError, match="matrix powering"):
+        periodic_point_profile(shift, 81)
+
+
+def test_periodic_profile_rejects_projected_output_digits() -> None:
+    with pytest.raises(OperationDomainValidationError, match="output digit bound"):
+        periodic_point_profile(AdjacencyShift(matrix=((1_000_000,),)), 100)
+
+
 def test_value_models_reject_ambiguous_and_invalid_carriers() -> None:
     with pytest.raises(ValidationError) as exc_info:
         ForbiddenBlockShift(alphabet=("0", "0"), forbidden_blocks=())


### PR DESCRIPTION
## Problem

`symbolic_dynamics.periodic_point_profile.compute` rejects every period above 50 and computes both dense matrix powers and Möbius inversion with Python loops. The result is a complete profile, so useful scale depends on state count, requested period, projected count digits, and the work for both phases—not a uniform period cap.

## What changed

- compute `trace(A^n)` through the requested period with python-flint's exact `fmpz_mat` multiplication;
- replace the quadratic divisor scan with an Eratosthenes Möbius sieve and divisor convolution;
- charge dense matrix products and the complete Möbius/profile pass together before backend execution;
- derive a conservative fixed-count digit bound from state count and maximum row sum without constructing the potentially huge bound integer;
- raise the structural period carrier to the maximum possible for three one-digit result vectors under the existing 100,000-digit aggregate budget.

The public postcondition is unchanged: all fixed-point counts, least-period counts, and primitive-orbit counts are returned through the declared period.

## Evidence

The regression suite executes the one-state two-loop shift through period 128, above the old ceiling. For every period it independently checks

`fixed(n) = sum(exact(d) for d | n)`

and `exact(n) = n * primitive_orbits(n)`. Existing closed-walk oracles continue to cover several small matrices, including square Möbius factors. New boundary tests reject a dense 50-state request on combined work and a high-growth one-state request on projected output digits before FLINT runs.

`make affected AFFECTED_BASE=origin/main` passed on commit `bbc62825a`:

- 21 symbolic-dynamics tests
- 112 catalog tests
- 800 catalog integration tests
- scoped Ruff formatting/lint and mypy

Closes #2958.
