### PR TITLE
Use FLINT for larger exact stationary distributions

### DIFF
--- a/src/jacobian/math/probability/markov_chains/_flint.py
+++ b/src/jacobian/math/probability/markov_chains/_flint.py
@@ -1,0 +1,40 @@
+"""Private FLINT adapters for exact finite Markov chains."""
+
+from fractions import Fraction
+
+from jacobian.math.probability.markov_chains.values import TransitionMatrix
+
+
+def solve_stationary_class(
+    matrix: TransitionMatrix, closed_class: tuple[int, ...]
+) -> tuple[Fraction, ...]:
+    """Solve the normalized stationary system on one closed class."""
+
+    from flint import fmpq, fmpq_mat
+
+    size = len(closed_class)
+    equations = [
+        [
+            fmpq(
+                matrix[closed_class[column]][closed_class[row]].numerator,
+                matrix[closed_class[column]][closed_class[row]].denominator,
+            )
+            - int(row == column)
+            for column in range(size)
+        ]
+        for row in range(size)
+    ]
+    equations[-1] = [fmpq(1) for _ in range(size)]
+    rhs = fmpq_mat([[0] for _ in range(size)])
+    rhs[size - 1, 0] = 1
+    solution = fmpq_mat(equations).solve(rhs)
+    return tuple(
+        Fraction(
+            int(solution[index, 0].numerator),
+            int(solution[index, 0].denominator),
+        )
+        for index in range(size)
+    )
+
+
+__all__ = ["solve_stationary_class"]

--- a/src/jacobian/math/probability/markov_chains/_models.py
+++ b/src/jacobian/math/probability/markov_chains/_models.py
@@ -11,6 +11,7 @@ from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 
 MAX_MARKOV_STATES = 32
+MAX_STATIONARY_STATES = 128
 MAX_MIXING_STEPS = 256
 DEFAULT_MIXING_STEPS = 64
 
@@ -41,6 +42,10 @@ class TransitionMatrixRequest(StrictModel):
 class StationaryDistributionRequest(TransitionMatrixRequest):
     """A transition matrix whose exact stationary solutions fit the wire contract."""
 
+    matrix: tuple[tuple[CanonicalRational, ...], ...] = Field(
+        min_length=1, max_length=MAX_STATIONARY_STATES
+    )
+
 
 class ExtremeStationaryDistribution(StrictModel):
     """One canonical extreme point supported on a closed class."""
@@ -53,7 +58,7 @@ class StationaryDistributionResult(StrictModel):
     """Extreme points of the finite chain's stationary-distribution simplex."""
 
     transition_matrix: tuple[tuple[CanonicalRational, ...], ...] = Field(
-        min_length=1, max_length=MAX_MARKOV_STATES
+        min_length=1, max_length=MAX_STATIONARY_STATES
     )
     """The source transition matrix whose stationary simplex was computed."""
 

--- a/src/jacobian/math/probability/markov_chains/operations.py
+++ b/src/jacobian/math/probability/markov_chains/operations.py
@@ -85,18 +85,8 @@ def _stationary_distribution_extremes(
     """Return one normalized stationary vector for every closed class."""
 
     import networkx as nx
-    import sympy
 
     n = len(matrix)
-    p = sympy.Matrix(
-        [
-            [
-                sympy.Rational(matrix[i][j].numerator, matrix[i][j].denominator)
-                for j in range(n)
-            ]
-            for i in range(n)
-        ]
-    )
     graph: nx.DiGraph[int] = nx.DiGraph()
     graph.add_nodes_from(range(n))
     graph.add_edges_from(
@@ -118,20 +108,17 @@ def _stationary_distribution_extremes(
         key=lambda component: component,
     )
     extremes: list[tuple[tuple[int, ...], tuple[Fraction, ...]]] = []
+    from jacobian.math.probability.markov_chains._flint import solve_stationary_class
+
     for closed_class in closed_classes:
-        submatrix = p.extract(closed_class, closed_class)
-        equations = submatrix.T - sympy.eye(len(closed_class))
-        equations[len(closed_class) - 1, :] = sympy.ones(1, len(closed_class))
-        rhs = sympy.zeros(len(closed_class), 1)
-        rhs[len(closed_class) - 1, 0] = 1
-        local = equations.inv() * rhs
-        distribution = [sympy.S.Zero] * n
+        local = solve_stationary_class(matrix, closed_class)
+        distribution = [Fraction(0)] * n
         for index, state in enumerate(closed_class):
             distribution[state] = local[index]
         extremes.append(
             (
                 closed_class,
-                tuple(Fraction(int(value.p), int(value.q)) for value in distribution),
+                tuple(distribution),
             )
         )
     return extremes

--- a/src/jacobian/math/probability/markov_chains/values.py
+++ b/src/jacobian/math/probability/markov_chains/values.py
@@ -8,6 +8,8 @@ from math import factorial
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 
 MAX_TRANSITION_STATES = 32
+MAX_STATIONARY_STATES = 128
+MAX_STATIONARY_SOLVE_WORK = 1_000_000
 
 type TransitionMatrix = tuple[tuple[Fraction, ...], ...]
 
@@ -44,14 +46,16 @@ def as_canonical_transition_matrix(
     )
 
 
-def require_transition_matrix(matrix: TransitionMatrix) -> None:
+def require_transition_matrix(
+    matrix: TransitionMatrix, *, maximum_states: int = MAX_TRANSITION_STATES
+) -> None:
     """Admit one finite exact stochastic matrix before a native kernel runs."""
 
     dimension = len(matrix)
-    if not 1 <= dimension <= MAX_TRANSITION_STATES:
+    if not 1 <= dimension <= maximum_states:
         raise TransitionMatrixAdmissionError(
             "transition_matrix_dimension",
-            f"transition matrix dimension must be between 1 and {MAX_TRANSITION_STATES}",
+            f"transition matrix dimension must be between 1 and {maximum_states}",
         )
     if any(len(row) != dimension for row in matrix):
         raise TransitionMatrixAdmissionError(
@@ -88,8 +92,13 @@ def _decimal_digits(value: int) -> int:
 def require_stationary_distribution_admission(matrix: TransitionMatrix) -> None:
     """Bound exact stationary coordinates for a native transition matrix."""
 
-    require_transition_matrix(matrix)
+    require_transition_matrix(matrix, maximum_states=MAX_STATIONARY_STATES)
     dimension = len(matrix)
+    if dimension**3 > MAX_STATIONARY_SOLVE_WORK:
+        raise TransitionMatrixAdmissionError(
+            "stationary_solve_work_exceeds_bound",
+            "stationary closed-class systems exceed the exact solve-work bound",
+        )
     row_bounds: list[int] = []
     for column in range(dimension - 1):
         entries = tuple(matrix[row][column] for row in range(dimension))

--- a/tests/math/probability/markov_chains/test_regressions.py
+++ b/tests/math/probability/markov_chains/test_regressions.py
@@ -150,6 +150,58 @@ def test_native_markov_api_accepts_canonical_fraction_matrices() -> None:
     assert ergodic_properties(matrix) == (True, True)
 
 
+def _lazy_cycle_request(size: int) -> dict[str, object]:
+    return {
+        "matrix": [
+            [
+                {
+                    "num": "1" if column in {row, (row + 1) % size} else "0",
+                    "den": "2" if column in {row, (row + 1) % size} else "1",
+                }
+                for column in range(size)
+            ]
+            for row in range(size)
+        ]
+    }
+
+
+def test_flint_stationary_solve_exceeds_the_previous_state_ceiling() -> None:
+    size = 64
+    request = StationaryDistributionRequest.model_validate(_lazy_cycle_request(size))
+
+    result = compute_stationary_distribution(request)
+
+    assert result.unique is True
+    distribution = tuple(
+        value.as_fraction() for value in result.extreme_distributions[0].distribution
+    )
+    matrix = tuple(
+        tuple(value.as_fraction() for value in row) for row in request.matrix
+    )
+    assert distribution == (Fraction(1, size),) * size
+    assert sum(distribution) == 1
+    assert all(value >= 0 for value in distribution)
+    assert (
+        tuple(
+            sum(distribution[row] * matrix[row][column] for row in range(size))
+            for column in range(size)
+        )
+        == distribution
+    )
+
+
+def test_stationary_solve_work_rejects_before_flint() -> None:
+    request = StationaryDistributionRequest.model_validate(_lazy_cycle_request(101))
+
+    with pytest.raises(OperationDomainValidationError, match="solve-work bound"):
+        compute_stationary_distribution(request)
+
+
+def test_generic_markov_requests_keep_the_32_state_carrier() -> None:
+    with pytest.raises(ValidationError):
+        TransitionMatrixRequest.model_validate(_lazy_cycle_request(33))
+
+
 def test_stationary_family_solves_each_nonsingleton_closed_class_exactly() -> None:
     request = StationaryDistributionRequest.model_validate(
         {


### PR DESCRIPTION
## Problem

`probability.markov_chain.stationary_distribution.compute` solves one normalized rational system per closed communicating class with SymPy and inherits the generic 32-state Markov request carrier. The stationary simplex has a bounded exact solve/output obligation distinct from mixing-time search.

## What changed

- solve each closed-class system `(P^T-I)pi=0`, `sum(pi)=1` with python-flint's exact `fmpq_mat.solve()`;
- give stationary requests and results a separate 128-state structural carrier while retaining 32 states for generic, communicating-class, ergodic, and mixing-time requests;
- admit stationary work with a conservative whole-matrix cubic bound before SCC decomposition and FLINT allocation;
- retain the determinant-height proof for every canonical rational coordinate;
- preserve canonical closed-class ordering and zero extension outside each class.

## Evidence

A 64-state cyclic lazy chain now returns its exact unique stationary distribution above the old ceiling. The regression test independently verifies that every coordinate is `1/64`, the distribution is normalized and nonnegative, and every coordinate of `pi P = pi` holds. A 101-state stationary request rejects on solve work before FLINT; the generic transition request still rejects a 33-state matrix.

Existing reducible-chain tests continue to verify one extreme distribution per closed class, canonical support, and unique/non-unique behavior.

`make affected AFFECTED_BASE=origin/main` passed on commit `213ce47ac`:

- 32 Markov-chain tests
- 112 catalog tests
- 800 catalog integration tests
- scoped Ruff formatting/lint and mypy

Closes #2961.
