### PR TITLE
Use FLINT for larger exact homology ranks

### DIFF
--- a/src/jacobian/math/topology/chain_complexes/_models.py
+++ b/src/jacobian/math/topology/chain_complexes/_models.py
@@ -9,6 +9,8 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.topology.chain_complexes.values import (
+    MAX_MATRIX_CELLS,
+    MAX_OPERATION_MATRIX_CELLS,
     ChainComplexValue,
     CoefficientField,
 )
@@ -16,6 +18,25 @@ from jacobian.math.topology.chain_complexes.values import (
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"chain_complex.{reason}", message)
+
+
+def _matrix_cells(complex_value: ChainComplexValue) -> int:
+    return sum(
+        complex_value.basis_sizes[index] * complex_value.basis_sizes[index + 1]
+        for index in range(len(complex_value.basis_sizes) - 1)
+    )
+
+
+def _require_complex_cell_budget(
+    complex_value: ChainComplexValue, *, maximum: int, label: str
+) -> None:
+    cells = _matrix_cells(complex_value)
+    if cells > maximum:
+        raise _validation_error(
+            "operation_matrix_cell_budget_exceeded",
+            f"{label} has {cells} differential cells, exceeding the "
+            f"{maximum}-cell operation budget",
+        )
 
 
 class ConstructChainComplexRequest(StrictModel):
@@ -57,6 +78,15 @@ class VerifyDifferentialRequest(StrictModel):
     """Verify that d^2 = 0 for a chain complex."""
 
     complex: ChainComplexValue
+
+    @model_validator(mode="after")
+    def require_operation_budget(self) -> Self:
+        _require_complex_cell_budget(
+            self.complex,
+            maximum=MAX_OPERATION_MATRIX_CELLS,
+            label="differential verification input",
+        )
+        return self
 
 
 def _require_component_entry_grammar(
@@ -177,6 +207,12 @@ class VerifyChainMapRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_admissible_map_components(self) -> Self:
+        for label, complex_value in (("source", self.source), ("target", self.target)):
+            _require_complex_cell_budget(
+                complex_value,
+                maximum=MAX_OPERATION_MATRIX_CELLS,
+                label=f"chain-map {label}",
+            )
         _require_chain_map_components(
             self.source,
             self.target,
@@ -190,6 +226,15 @@ class ComputeHomologyRequest(StrictModel):
     """Compute homology of a chain complex."""
 
     complex: ChainComplexValue
+
+    @model_validator(mode="after")
+    def require_homology_budget(self) -> Self:
+        _require_complex_cell_budget(
+            self.complex,
+            maximum=MAX_MATRIX_CELLS,
+            label="homology input",
+        )
+        return self
 
 
 class MappingConeRequest(StrictModel):
@@ -207,12 +252,32 @@ class MappingConeRequest(StrictModel):
         )
     )
 
+    @model_validator(mode="after")
+    def require_input_budgets(self) -> Self:
+        for label, complex_value in (("source", self.source), ("target", self.target)):
+            _require_complex_cell_budget(
+                complex_value,
+                maximum=MAX_OPERATION_MATRIX_CELLS,
+                label=f"mapping-cone {label}",
+            )
+        return self
+
 
 class TensorProductRequest(StrictModel):
     """Compute the tensor product of two chain complexes."""
 
     left: ChainComplexValue
     right: ChainComplexValue
+
+    @model_validator(mode="after")
+    def require_input_budgets(self) -> Self:
+        for label, complex_value in (("left", self.left), ("right", self.right)):
+            _require_complex_cell_budget(
+                complex_value,
+                maximum=MAX_OPERATION_MATRIX_CELLS,
+                label=f"tensor-product {label}",
+            )
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/topology/chain_complexes/operations.py
+++ b/src/jacobian/math/topology/chain_complexes/operations.py
@@ -7,9 +7,12 @@ from fractions import Fraction
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.topology.chain_complexes._models import (
     _require_chain_map_components,
+    _require_complex_cell_budget,
 )
 from jacobian.math.topology.chain_complexes.values import (
+    MAX_MATRIX_CELLS,
     MAX_MATRIX_ENTRY_CHARS,
+    MAX_OPERATION_MATRIX_CELLS,
     MAX_TENSOR_COEFFICIENT_DIGITS,
     MAX_TENSOR_GROUP_DIMENSION,
     MAX_TENSOR_TOTAL_CELLS,
@@ -210,59 +213,23 @@ def _matrix_to_fractions(
 
 
 def _rank_over_prime_field(mat: list[list[Fraction]], prime: int) -> int:
-    """Gauss-Jordan elimination inside GF(p) using modular inverses."""
+    """Return exact rank over GF(p) through FLINT modular elimination."""
     rows = len(mat)
     cols = len(mat[0])
-    work = [[int(v) % prime for v in row] for row in mat]
-    rank = 0
-    for col in range(cols):
-        pivot = next(
-            (row for row in range(rank, rows) if work[row][col] % prime != 0),
-            None,
-        )
-        if pivot is None:
-            continue
-        work[rank], work[pivot] = work[pivot], work[rank]
-        inverse = pow(work[rank][col], -1, prime)
-        for j in range(cols):
-            work[rank][j] = (work[rank][j] * inverse) % prime
-        for row in range(rows):
-            if row == rank:
-                continue
-            factor = work[row][col] % prime
-            if factor != 0:
-                for j in range(cols):
-                    work[row][j] = (work[row][j] - factor * work[rank][j]) % prime
-        rank += 1
-        if rank == rows:
-            break
-    return rank
+    from flint import nmod_mat
+
+    entries = [int(value) % prime for row in mat for value in row]
+    return int(nmod_mat(rows, cols, entries, prime).rank())
 
 
 def _rank_over_rationals(mat: list[list[Fraction]]) -> int:
-    """Gauss-Jordan elimination over QQ."""
+    """Return exact rank over QQ through FLINT fraction-free elimination."""
     rows = len(mat)
     cols = len(mat[0])
-    work = [row[:] for row in mat]
-    rank = 0
-    for col in range(cols):
-        pivot = next(
-            (row for row in range(rank, rows) if work[row][col] != 0),
-            None,
-        )
-        if pivot is None:
-            continue
-        work[rank], work[pivot] = work[pivot], work[rank]
-        for row in range(rows):
-            if row == rank or work[row][col] == 0:
-                continue
-            factor = work[row][col] / work[rank][col]
-            for j in range(cols):
-                work[row][j] -= factor * work[rank][j]
-        rank += 1
-        if rank == rows:
-            break
-    return rank
+    from flint import fmpq, fmpq_mat
+
+    entries = [fmpq(value.numerator, value.denominator) for row in mat for value in row]
+    return int(fmpq_mat(rows, cols, entries).rank())
 
 
 def _matrix_rank(matrix: list[list[Fraction]], prime: int | None = None) -> int:
@@ -1010,6 +977,11 @@ def construct_chain_complex(
         basis_sizes=basis_sizes,
         differential_matrices=differential_matrices,
     )
+    _require_complex_cell_budget(
+        value,
+        maximum=MAX_OPERATION_MATRIX_CELLS,
+        label="chain-complex construction",
+    )
     _require_square_zero(
         _parsed_differentials(value, value.prime),
         value.prime,
@@ -1022,6 +994,11 @@ def construct_chain_complex(
 
 def homology_groups(complex_value: ChainComplexValue) -> HomologyResult:
     """Return exact homology groups for a canonical chain complex value."""
+    _require_complex_cell_budget(
+        complex_value,
+        maximum=MAX_MATRIX_CELLS,
+        label="homology input",
+    )
     groups = _compute_homology_groups(complex_value)
     return HomologyResult._from_kernel(
         homology_groups=tuple(groups),
@@ -1033,6 +1010,11 @@ def differential_squares_to_zero(
     complex_value: ChainComplexValue,
 ) -> VerificationResult:
     """Verify d^2 = 0 for one canonical chain-complex value."""
+    _require_complex_cell_budget(
+        complex_value,
+        maximum=MAX_OPERATION_MATRIX_CELLS,
+        label="differential verification input",
+    )
     is_valid, detail = _differential_verdict(complex_value)
     return VerificationResult(is_valid=is_valid, detail=detail, complex=complex_value)
 
@@ -1043,6 +1025,12 @@ def chain_map_commutes(
     map_matrices: MapMatrices,
 ) -> VerificationResult:
     """Verify that a component-wise chain map commutes with differentials."""
+    for label, complex_value in (("source", source), ("target", target)):
+        _require_complex_cell_budget(
+            complex_value,
+            maximum=MAX_OPERATION_MATRIX_CELLS,
+            label=f"chain-map {label}",
+        )
     _require_chain_map_components(
         source, target, map_matrices, label="chain-map verification"
     )
@@ -1062,6 +1050,12 @@ def mapping_cone(
     map_matrices: MapMatrices,
 ) -> MappingConeResult:
     """Compute the mapping cone of a chain-map value."""
+    for label, complex_value in (("source", source), ("target", target)):
+        _require_complex_cell_budget(
+            complex_value,
+            maximum=MAX_OPERATION_MATRIX_CELLS,
+            label=f"mapping-cone {label}",
+        )
     _require_chain_map_components(source, target, map_matrices, label="mapping cone")
     _require_cone_admission(source, target, map_matrices)
     cone_basis_sizes, cone_diffs = _compute_mapping_cone(source, target, map_matrices)
@@ -1088,6 +1082,12 @@ def tensor_product_complex(
     right: ChainComplexValue,
 ) -> TensorProductResult:
     """Compute the tensor product of two canonical chain-complex values."""
+    for label, complex_value in (("left", left), ("right", right)):
+        _require_complex_cell_budget(
+            complex_value,
+            maximum=MAX_OPERATION_MATRIX_CELLS,
+            label=f"tensor-product {label}",
+        )
     _require_tensor_admission(left, right)
     tensor_basis_sizes, tensor_diffs = _compute_tensor_product(left, right)
     group_count = len(tensor_basis_sizes)

--- a/src/jacobian/math/topology/chain_complexes/values.py
+++ b/src/jacobian/math/topology/chain_complexes/values.py
@@ -12,7 +12,10 @@ from jacobian._models import StrictModel
 
 MAX_CHAIN_DEGREE = 32
 MAX_BASIS_SIZE = 64
-MAX_MATRIX_CELLS = 4096
+# Canonical values may retain the larger homology input envelope. Operations
+# that construct or expand complexes keep the smaller owner-local limit.
+MAX_OPERATION_MATRIX_CELLS = 4096
+MAX_MATRIX_CELLS = 16384
 # Derived tensor-product work bounds: each tensor group dimension and the
 # total tensor cell count stay within these conservative limits so no
 # accepted request can allocate an unbounded dense intermediate.
@@ -521,6 +524,7 @@ __all__ = [
     "MAX_BASIS_SIZE",
     "MAX_CHAIN_DEGREE",
     "MAX_MATRIX_CELLS",
+    "MAX_OPERATION_MATRIX_CELLS",
     "MAX_TENSOR_COEFFICIENT_DIGITS",
     "MAX_TENSOR_GROUP_DIMENSION",
     "MAX_TENSOR_TOTAL_CELLS",

--- a/tests/math/topology/chain_complexes/test_chain_complexes.py
+++ b/tests/math/topology/chain_complexes/test_chain_complexes.py
@@ -138,6 +138,54 @@ class TestComputeHomology:
         assert result.homology_groups[0].betti_number == 1
         assert result.homology_groups[1].betti_number == 1
 
+    @pytest.mark.parametrize(
+        ("coefficient_field", "prime"),
+        [
+            (CoefficientField.RATIONAL, None),
+            (CoefficientField.PRIME_FIELD, 101),
+        ],
+    )
+    def test_flint_rank_admits_retained_complex_above_shared_ceiling(
+        self, coefficient_field: CoefficientField, prime: int | None
+    ) -> None:
+        size = 64
+        identity = tuple(
+            tuple("1" if row == column else "0" for column in range(size))
+            for row in range(size)
+        )
+        zero = tuple(tuple("0" for _ in range(size)) for _ in range(size))
+        complex_value = ChainComplexValue(
+            coefficient_field=coefficient_field,
+            prime=prime,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(size, size, size),
+            differential_matrices=(identity, zero),
+        )
+
+        result = compute_homology(ComputeHomologyRequest(complex=complex_value))
+
+        assert tuple(group.betti_number for group in result.homology_groups) == (
+            0,
+            0,
+            size,
+        )
+        assert result.complex is complex_value
+
+    def test_non_homology_request_retains_smaller_cell_envelope(self) -> None:
+        size = 64
+        zero = tuple(tuple("0" for _ in range(size)) for _ in range(size))
+        complex_value = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(size, size, size),
+            differential_matrices=(zero, zero),
+        )
+
+        with pytest.raises(ValidationError, match="4096-cell operation budget"):
+            VerifyDifferentialRequest(complex=complex_value)
+
     def test_point_homology(self) -> None:
         result = compute_homology(ComputeHomologyRequest(complex=_point_complex()))
         assert result.homology_groups[0].betti_number == 1


### PR DESCRIPTION
## Problem

chain_complex.homology.compute inherited the canonical carrier 4,096-cell cap and used handwritten dense elimination, even though its result is only a retained source plus an exact rank ledger. Raising the shared limit without separating consumers would also widen construction, verification, mapping-cone, and tensor-product work without proof.

Closes #2938.

## Solution

Use python-flint fmpq_mat.rank() over QQ and nmod_mat.rank() over GF(p). Widen the canonical retained ChainComplexValue representation to 16,384 differential cells, then preserve an explicit 4,096-cell input boundary for construction, differential and chain-map verification, mapping cones, and tensor products. Homology alone admits the larger retained-source envelope.

Square-zero validation remains mandatory before rank computation. With basis dimensions capped at 64, the 16,384-cell envelope bounds parsing, adjacent differential products, FLINT rank work, retained serialization, and the one-record-per-degree result.

## Testing

- make affected AFFECTED_BASE=origin/main
  - 83 chain-complex tests passed
  - 112 catalog tests passed
  - 800 catalog integration examples passed
  - scoped lint and typing passed

The public-boundary regression runs both QQ and GF(101) homology on an 8,192-cell three-term complex. It checks the exact Betti profile (0, 0, 64), retained-source identity, and rejection of the same source by the unchanged 4,096-cell differential-verification envelope.

## Public contract impact

ChainComplexValue can retain up to 16,384 differential cells. ComputeHomologyRequest admits that full representation envelope. Other chain-complex operation requests and native functions retain a 4,096-cell input boundary. Operation IDs and result schemas are unchanged.

## Operation boundary ownership

- Changed stage: canonical representation bound, operation-specific request admission, and rank kernel
- Request-bounds owner and controlling quantities: topology/chain complexes; aggregate differential cells, aggregate entry characters, basis dimensions, degree count, and coefficient field
- Work, intermediate, memory, and exact-output bounds: homology has at most 16,384 dense input cells, 65 groups of dimension at most 64, 65 rank records, and the existing 65,536 aggregate coefficient-character cap; adjacent square-zero and rank matrices stay at dimension 64
- Wall deadline, calibration workload, safety margin, and caller-selectable range: no new wall deadline or caller-selected budget; deterministic shape and character bounds own admission
- Backend or kernel path: python-flint fmpq_mat.rank() and nmod_mat.rank(); existing exact square-zero kernel remains the defining precondition check
- Result construction: existing HomologyResult kernel constructor retains the exact canonical source and Betti ledger
- Independent-result verifier: none; no independently supplied result data
- Native/MCP parity: request validators and native functions enforce the same operation-specific envelopes
- Serialized-result and round-trip evidence: the widened test invokes ComputeHomologyRequest and the published adapter and verifies the retained canonical source

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Producer→consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: finite based chain complex over QQ or validated GF(p), with adjacent differentials composing to zero
- Structurally valid but mathematically invalid fixture and outcome: existing nonsquare-zero fixtures are rejected before homology ranks are returned
- Serialized-subtype trust boundary: ChainComplexValue grammar/shape validation, operation-specific cell admission, then exact square-zero validation
- Exact-success defining invariant: betti = dim(C_n) - rank(d_n) - rank(d_(n+1)); the scale regression checks the complete known ledger
- Discriminated result schema and impossible combinations: coefficient field and prime remain bound to the retained source

## Catalog admission

No catalog membership changes.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| QQ homology ranks | delivered with FLINT and 16,384-cell retained-source admission | chain_complex.homology.compute |
| GF(p) homology ranks | delivered with FLINT and the same envelope | chain_complex.homology.compute |
| Construction, verification, cone, and tensor input envelopes | intentionally retained at 4,096 cells | existing operations |

## Checklist

- [x] Relevant affected validation passes
- [x] No duplicate canonical chain-complex type introduced
- [x] Runtime-bound change names its owner and preserves native/MCP semantics
- [x] Exact defining identity and neighboring-operation rejection are tested
