### PR TITLE
Use FLINT to scale prime-field matrix operations

### DIFF
--- a/src/jacobian/math/combinatorics/matroids/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/_models.py
@@ -13,6 +13,9 @@ from jacobian.math.matrices.finite_fields.linear_algebra import PrimeFieldMatrix
 MAX_GROUND_SIZE = 32
 """Schema-visible cap on the ground-set cardinality (matrix columns)."""
 
+MAX_REPRESENTATION_ROWS = 256
+"""Preserved row envelope for matroid representation and witness work."""
+
 MAX_PRIME = 2_147_483_647
 """Explicit conservative bound on the field prime before primality testing."""
 
@@ -69,6 +72,12 @@ class LinearMatroid(StrictModel):
 
     @model_validator(mode="after")
     def require_bounded_ground_set(self) -> Self:
+        if len(self.matrix.entries) > MAX_REPRESENTATION_ROWS:
+            raise _validation_error(
+                "representation_rows.bound",
+                "matroid representation must have at most "
+                f"{MAX_REPRESENTATION_ROWS} rows",
+            )
         if self.matrix.columns > MAX_GROUND_SIZE:
             raise _validation_error(
                 "ground_set.bound",

--- a/src/jacobian/math/matrices/finite_fields/_bounds.py
+++ b/src/jacobian/math/matrices/finite_fields/_bounds.py
@@ -1,0 +1,23 @@
+"""Representation and execution bounds for canonical prime-field matrices."""
+
+# A dense 1024-square matrix carries 1,048,576 canonical residues. RREF returns
+# the same number of residues; a complete right-nullspace basis carries at most
+# columns**2 entries. FLINT's measured dense 1024-square rank and RREF stay well
+# inside the owning test lane, while this explicit cubic ledger conservatively
+# accounts for elimination work independently of wall time.
+MAX_PRIME_FIELD_MATRIX_AXIS = 1_024
+MAX_PRIME_FIELD_MATRIX_CELLS = 1_048_576
+MAX_PRIME_FIELD_ELIMINATION_WORK = 1_073_741_824
+
+# Catalog requests use a cross-platform word-safe modulus. Native canonical
+# values retain their broader exact-prime domain through the SymPy fallback.
+MAX_PRIME_FIELD_FLINT_PRIME = 2_147_483_647
+MAX_PRIME_FIELD_FALLBACK_AXIS = 256
+
+__all__ = [
+    "MAX_PRIME_FIELD_ELIMINATION_WORK",
+    "MAX_PRIME_FIELD_FALLBACK_AXIS",
+    "MAX_PRIME_FIELD_FLINT_PRIME",
+    "MAX_PRIME_FIELD_MATRIX_AXIS",
+    "MAX_PRIME_FIELD_MATRIX_CELLS",
+]

--- a/src/jacobian/math/matrices/finite_fields/_models.py
+++ b/src/jacobian/math/matrices/finite_fields/_models.py
@@ -8,11 +8,19 @@ from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel, canonicalize_json_containers
-from jacobian.math.matrices.finite_fields.linear_algebra import PrimeFieldMatrix
+from jacobian.math.matrices.finite_fields._bounds import (
+    MAX_PRIME_FIELD_ELIMINATION_WORK,
+    MAX_PRIME_FIELD_FLINT_PRIME,
+    MAX_PRIME_FIELD_MATRIX_AXIS,
+    MAX_PRIME_FIELD_MATRIX_CELLS,
+)
+from jacobian.math.matrices.finite_fields.linear_algebra import (
+    PrimeFieldMatrix,
+)
 
-MAX_ROWS = 256
-MAX_COLUMNS = 256
-MAX_PRIME = 2_147_483_647
+MAX_ROWS = MAX_PRIME_FIELD_MATRIX_AXIS
+MAX_COLUMNS = MAX_PRIME_FIELD_MATRIX_AXIS
+MAX_PRIME = MAX_PRIME_FIELD_FLINT_PRIME
 """Explicit conservative bound on the field prime before primality testing."""
 
 
@@ -27,7 +35,7 @@ class PrimeFieldMatrixRequest(StrictModel):
 
     The matrix is carried as the domain-owned ``PrimeFieldMatrix`` canonical
     value so it composes unchanged with the other GF(p) producers and
-    consumers. Shape rules (schema-visible): 0..256 rows, 1..256 columns,
+    consumers. Shape rules (schema-visible): 0..1024 rows, 1..1024 columns,
     rectangular rows, and every entry a canonical residue in ``[0, prime)``.
     Zero rows carry an explicit column axis, matching the canonical empty
     matrix that full-rank nullspace producers return. The characteristic is
@@ -41,10 +49,11 @@ class PrimeFieldMatrixRequest(StrictModel):
                 "A bounded integer matrix over an explicit prime field GF(p), "
                 "as the canonical `PrimeFieldMatrix` value: `prime` must be a "
                 "prime integer in [2, 2147483647], `entries` must have at "
-                "most 256 rows, each row 1..256 columns, all rows the same "
+                "most 1024 rows, each row 1..1024 columns, all rows the same "
                 "length matching the declared `columns`, and every entry a "
-                "canonical residue in [0, prime). Zero rows are permitted "
-                "and carry the explicit `columns` axis."
+                "canonical residue in [0, prime). The dense matrix carries "
+                "at most 1048576 cells. Zero rows are permitted and carry "
+                "the explicit `columns` axis."
             )
         }
     )
@@ -83,6 +92,24 @@ class PrimeFieldMatrixRequest(StrictModel):
         if not 1 <= self.matrix.columns <= MAX_COLUMNS:
             raise _validation_error(
                 "request.columns_bound", f"matrix has at most {MAX_COLUMNS} columns"
+            )
+        if (
+            len(self.matrix.entries) * self.matrix.columns
+            > MAX_PRIME_FIELD_MATRIX_CELLS
+        ):
+            raise _validation_error(
+                "request.cells_bound",
+                f"matrix has at most {MAX_PRIME_FIELD_MATRIX_CELLS} dense cells",
+            )
+        elimination_work = (
+            len(self.matrix.entries)
+            * self.matrix.columns
+            * min(len(self.matrix.entries), self.matrix.columns)
+        )
+        if elimination_work > MAX_PRIME_FIELD_ELIMINATION_WORK:
+            raise _validation_error(
+                "request.elimination_work_bound",
+                "matrix exceeds the exact modular-elimination work budget",
             )
         return self
 

--- a/src/jacobian/math/matrices/finite_fields/linear_algebra.py
+++ b/src/jacobian/math/matrices/finite_fields/linear_algebra.py
@@ -8,7 +8,12 @@ from typing import Any
 from pydantic import ConfigDict, StrictInt
 from pydantic.dataclasses import dataclass
 
-_MAX_DIMENSION = 256
+from jacobian.math.matrices.finite_fields._bounds import (
+    MAX_PRIME_FIELD_FALLBACK_AXIS,
+    MAX_PRIME_FIELD_FLINT_PRIME,
+    MAX_PRIME_FIELD_MATRIX_AXIS,
+    MAX_PRIME_FIELD_MATRIX_CELLS,
+)
 
 __all__ = [
     "PrimeFieldMatrix",
@@ -33,8 +38,18 @@ class PrimeFieldMatrix:
             raise ValueError("prime must be a prime integer")
         if type(self.columns) is not int or self.columns < 0:
             raise ValueError("columns must be a nonnegative integer")
-        if self.columns > _MAX_DIMENSION or len(self.entries) > _MAX_DIMENSION:
-            raise ValueError("matrix exceeds the supported dimension bound")
+        if (
+            self.columns > MAX_PRIME_FIELD_MATRIX_AXIS
+            or len(self.entries) > MAX_PRIME_FIELD_MATRIX_AXIS
+        ):
+            raise ValueError("matrix exceeds the supported axis bound")
+        if self.prime > MAX_PRIME_FIELD_FLINT_PRIME and (
+            self.columns > MAX_PRIME_FIELD_FALLBACK_AXIS
+            or len(self.entries) > MAX_PRIME_FIELD_FALLBACK_AXIS
+        ):
+            raise ValueError("matrix exceeds the exact fallback axis bound")
+        if len(self.entries) * self.columns > MAX_PRIME_FIELD_MATRIX_CELLS:
+            raise ValueError("matrix exceeds the supported cell bound")
         if any(len(row) != self.columns for row in self.entries):
             raise ValueError("every matrix row must match the declared column count")
         if any(
@@ -49,13 +64,23 @@ class PrimeFieldMatrix:
             raise ValueError("prime must be a prime integer")
 
 
+def _backend_matrix(matrix: PrimeFieldMatrix) -> Any:
+    from flint import nmod_mat
+
+    return nmod_mat(
+        len(matrix.entries),
+        matrix.columns,
+        [value for row in matrix.entries for value in row],
+        matrix.prime,
+    )
+
+
 def _domain_matrix(matrix: PrimeFieldMatrix) -> Any:
     import sympy
     from sympy.polys.matrices import DomainMatrix
 
-    entries = [list(row) for row in matrix.entries]
     return DomainMatrix(
-        entries,
+        [list(row) for row in matrix.entries],
         (len(matrix.entries), matrix.columns),
         sympy.GF(matrix.prime),
     )
@@ -69,17 +94,31 @@ def rref(
     row_count = len(matrix.entries)
     if row_count == 0 or matrix.columns == 0:
         return tuple((0,) * matrix.columns for _ in matrix.entries), ()
-    reduced_domain, pivot_columns = _domain_matrix(matrix).rref()
-    reduced = reduced_domain.to_Matrix()
-    return (
-        tuple(
+    if matrix.prime > MAX_PRIME_FIELD_FLINT_PRIME:
+        reduced_domain, pivot_columns = _domain_matrix(matrix).rref()
+        reduced = reduced_domain.to_Matrix()
+        return (
             tuple(
-                int(reduced[row, column]) % matrix.prime
-                for column in range(matrix.columns)
-            )
-            for row in range(row_count)
-        ),
-        tuple(int(pivot) for pivot in pivot_columns),
+                tuple(
+                    int(reduced[row, column]) % matrix.prime
+                    for column in range(matrix.columns)
+                )
+                for row in range(row_count)
+            ),
+            tuple(int(pivot) for pivot in pivot_columns),
+        )
+    reduced, rank_value = _backend_matrix(matrix).rref()
+    reduced_rows = tuple(
+        tuple(int(reduced[row, column]) for column in range(matrix.columns))
+        for row in range(row_count)
+    )
+    pivot_columns = tuple(
+        next(column for column, value in enumerate(row) if value)
+        for row in reduced_rows[: int(rank_value)]
+    )
+    return (
+        reduced_rows,
+        pivot_columns,
     )
 
 
@@ -88,7 +127,9 @@ def rank(matrix: PrimeFieldMatrix) -> int:
 
     if not matrix.entries or matrix.columns == 0:
         return 0
-    return int(_domain_matrix(matrix).rank())
+    if matrix.prime > MAX_PRIME_FIELD_FLINT_PRIME:
+        return int(_domain_matrix(matrix).rank())
+    return int(_backend_matrix(matrix).rank())
 
 
 def nullspace(matrix: PrimeFieldMatrix) -> tuple[tuple[int, ...], ...]:
@@ -96,9 +137,21 @@ def nullspace(matrix: PrimeFieldMatrix) -> tuple[tuple[int, ...], ...]:
 
     if matrix.columns == 0:
         return ()
-    domain = _domain_matrix(matrix).nullspace(divide_last=True)
+    if not matrix.entries:
+        return tuple(
+            tuple(int(row == column) for column in range(matrix.columns))
+            for row in range(matrix.columns)
+        )
+    if matrix.prime > MAX_PRIME_FIELD_FLINT_PRIME:
+        domain = _domain_matrix(matrix).nullspace(divide_last=True)
+        return tuple(
+            tuple(int(value) % matrix.prime for value in row)
+            for row in domain.to_list()
+        )
+    vectors, nullity = _backend_matrix(matrix).nullspace()
     return tuple(
-        tuple(int(value) % matrix.prime for value in row) for row in domain.to_list()
+        tuple(int(vectors[coordinate, basis]) for coordinate in range(matrix.columns))
+        for basis in range(int(nullity))
     )
 
 

--- a/tests/math/combinatorics/matroids/test_matroids.py
+++ b/tests/math/combinatorics/matroids/test_matroids.py
@@ -14,11 +14,14 @@ from jacobian.math.combinatorics.matroids import (
     matroid_closure,
     matroid_rank,
 )
-from jacobian.math.combinatorics.matroids._models import MatroidClosureRequest
+from jacobian.math.combinatorics.matroids._models import (
+    MatroidClosureRequest,
+    MatroidClosureResult,
+)
 from jacobian.math.combinatorics.matroids.operations import closure_result
 
 
-def compute_closure(request: MatroidClosureRequest):
+def compute_closure(request: MatroidClosureRequest) -> MatroidClosureResult:
     return closure_result(request.matroid, request.subset)
 
 
@@ -71,7 +74,7 @@ class TestLinearMatroidRepresentation:
 
     def test_ground_set_beyond_cap_rejected(self) -> None:
         """A 33-column matrix is rejected even though the shared kernel
-        admits up to 256 columns: the advertised envelope is 32 elements."""
+        admits up to 1024 columns: the advertised envelope is 32 elements."""
         from jacobian.math.matrices.finite_fields.linear_algebra import (
             PrimeFieldMatrix,
         )
@@ -96,6 +99,21 @@ class TestLinearMatroidRepresentation:
         with pytest.raises(ValidationError) as exc_info:
             MatroidClosureRequest.model_validate(payload)
         assert exc_info.value.errors()[0]["type"] == "matroid.ground_set.bound"
+
+    def test_shared_carrier_does_not_widen_matroid_row_envelope(self) -> None:
+        """The matrix carrier may scale without widening matroid witness work."""
+        from jacobian.math.matrices.finite_fields.linear_algebra import (
+            PrimeFieldMatrix,
+        )
+
+        matrix = PrimeFieldMatrix(
+            prime=2,
+            entries=((0,),) * 257,
+            columns=1,
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            LinearMatroid(matrix=matrix)
+        assert exc_info.value.errors()[0]["type"] == "matroid.representation_rows.bound"
 
     def test_empty_matroid_admitted(self) -> None:
         """The empty ground set with a preserved row axis is representable."""

--- a/tests/math/matrices/finite_fields/test_linear_algebra.py
+++ b/tests/math/matrices/finite_fields/test_linear_algebra.py
@@ -93,11 +93,21 @@ def test_matrix_accepts_canonical_residues_at_the_boundary() -> None:
     assert rank(matrix) == 2
 
 
+def test_large_native_prime_uses_exact_fallback() -> None:
+    prime = 2**127 - 1
+    matrix = PrimeFieldMatrix(prime=prime, entries=((1, 1),), columns=2)
+    assert rank(matrix) == 1
+    assert rref(matrix) == (((1, 1),), (0,))
+    assert nullspace(matrix) == ((prime - 1, 1),)
+    with pytest.raises(ValueError, match="fallback axis bound"):
+        PrimeFieldMatrix(prime=prime, entries=(), columns=257)
+
+
 def test_matrix_rejects_oversized_dimensions_before_primality() -> None:
-    with pytest.raises(ValueError, match="dimension bound"):
-        PrimeFieldMatrix(prime=2, entries=(), columns=257)
-    with pytest.raises(ValueError, match="dimension bound"):
-        PrimeFieldMatrix(prime=2, entries=((),) * 257, columns=0)
+    with pytest.raises(ValueError, match="axis bound"):
+        PrimeFieldMatrix(prime=2, entries=(), columns=1025)
+    with pytest.raises(ValueError, match="axis bound"):
+        PrimeFieldMatrix(prime=2, entries=((),) * 1025, columns=0)
 
 
 def test_exact_public_api_symbols() -> None:

--- a/tests/math/matrices/finite_fields/test_prime_field_matrix.py
+++ b/tests/math/matrices/finite_fields/test_prime_field_matrix.py
@@ -39,6 +39,46 @@ def assert_error_type(
 
 
 class TestRank:
+    def test_flint_operations_execute_above_previous_axis_limit(self) -> None:
+        """All three FLINT kernels execute beyond the former 256-axis cap."""
+        prime = 65_537
+        rows = 256
+        columns = 257
+        entries = tuple(
+            tuple(
+                int(column == row or column == columns - 1) for column in range(columns)
+            )
+            for row in range(rows)
+        )
+        request = pfm(prime=prime, entries=entries)
+
+        assert compute_rank(request).rank == rows
+        rref_result = compute_rref(request)
+        assert rref_result.rref_matrix.entries == entries
+        assert rref_result.pivot_columns == tuple(range(rows))
+        nullspace_result = compute_nullspace(request)
+        expected_vector = (prime - 1,) * rows + (1,)
+        assert nullspace_result.nullspace_matrix.entries == (expected_vector,)
+
+    def test_maximum_dense_rref_and_nullspace_output_are_exact(self) -> None:
+        dimension = 1_024
+        zero_row = (0,) * dimension
+        dense_zero = (zero_row,) * dimension
+        request = pfm(prime=2, entries=dense_zero)
+        rref_result = compute_rref(request)
+        assert rref_result.rref_matrix.entries == dense_zero
+        assert rref_result.pivot_columns == ()
+
+        empty_request = PrimeFieldMatrixRequest(
+            matrix=PrimeFieldMatrix(prime=2, entries=(), columns=dimension)
+        )
+        nullspace_result = compute_nullspace(empty_request)
+        assert nullspace_result.nullity == dimension
+        assert all(
+            sum(vector) == 1 and vector[index] == 1
+            for index, vector in enumerate(nullspace_result.nullspace_matrix.entries)
+        )
+
     def test_full_rank_gf2(self) -> None:
         """Identity 3x3 over GF(2) has rank 3."""
         req = pfm(prime=2, entries=((1, 0, 0), (0, 1, 0), (0, 0, 1)))


### PR DESCRIPTION
Closes #2950.

## Problem

`prime_field.matrix.rank.compute`, `.rref.compute`, and `.nullspace.compute` used SymPy `DomainMatrix` elimination and inherited a shared 256-axis carrier ceiling. This rejected larger dense modular systems even though python-flint is already pinned and provides exact `nmod_mat` kernels for the catalog's prime range.

## Change

- route catalog-range rank, RREF, and right-nullspace computations through `nmod_mat`
- preserve the existing canonical RREF pivots and row-oriented nullspace basis
- raise the dense carrier and request axes from 256 to 1024 under explicit 1,048,576-cell and 1,073,741,824-step elimination ledgers
- retain the prior exact SymPy path for native matrices whose primes exceed FLINT's word-safe catalog range, including the former 256-axis fallback envelope
- preserve the unrelated matroid representation envelope with an owner-local 256-row bound

The public prime range and canonical empty-matrix behavior are unchanged. Dense 1024-square RREF output and the maximum 1024-vector nullspace basis are exercised directly; a 256-by-257 system proves all three FLINT operations execute beyond the former ceiling.

## Validation

- `make affected AFFECTED_BASE=origin/main`
  - 85 owning mathematical tests passed
  - 112 catalog tests passed
  - 800 catalog integration examples passed
  - scoped Ruff and mypy checks passed

## Suggested review order

1. bound derivation in `_bounds.py` and request admission in `_models.py`
2. FLINT selection and exact large-prime fallback in `linear_algebra.py`
3. maximum-envelope and shared-consumer regression tests