### PR TITLE
Scale graph characteristic polynomials with FLINT

### DIFF
--- a/src/jacobian/math/graphs/spectra/_models.py
+++ b/src/jacobian/math/graphs/spectra/_models.py
@@ -10,7 +10,9 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
-from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+from jacobian.math.graphs.values import (
+    IndexedSimpleUndirectedGraph,
+)
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
     RationalPolynomialTerm,
@@ -19,12 +21,36 @@ from jacobian.math.polynomials.values import (
 )
 
 _VARIABLE = "x"
-_MAX_CHARPOLY_TERMS = 33
-_MAX_CHARPOLY_EXPONENT = 32
-_MAX_CHARPOLY_COEFFICIENT_DIGITS = 128
+# Every order-k Laplacian principal minor is at most n**k by Hadamard, and
+# each coefficient sums at most binomial(n, k) such minors. The uniform
+# (2n)**n bound therefore covers every coefficient for n <= 256.
+_MAX_CHARPOLY_VERTICES = 256
+_MAX_CHARPOLY_MATRIX_CELLS = _MAX_CHARPOLY_VERTICES**2
+_MAX_CHARPOLY_WORK = _MAX_CHARPOLY_VERTICES**4
+_MAX_CHARPOLY_EDGES = _MAX_CHARPOLY_VERTICES * (_MAX_CHARPOLY_VERTICES - 1) // 2
 
 
 _MAX_SPECTRAL_VERTICES = 32
+
+
+def _charpoly_coefficient_digit_bound(order: int) -> int:
+    return 1 if order == 0 else len(str((2 * order) ** order))
+
+
+def _require_characteristic_polynomial_graph(
+    graph: IndexedSimpleUndirectedGraph,
+) -> None:
+    order = graph.vertex_count
+    if order > _MAX_CHARPOLY_VERTICES:
+        raise PydanticCustomError(
+            "graph.characteristic_polynomial_vertex_count_exceeds_operation_bound",
+            "characteristic-polynomial operations support at most 256 vertices",
+        )
+    if order**2 > _MAX_CHARPOLY_MATRIX_CELLS or order**4 > _MAX_CHARPOLY_WORK:
+        raise PydanticCustomError(
+            "graph.characteristic_polynomial_work_exceeds_operation_bound",
+            "characteristic-polynomial matrix work exceeds the operation bound",
+        )
 
 
 def _require_spectral_graph(graph: IndexedSimpleUndirectedGraph) -> None:
@@ -54,8 +80,32 @@ SpectralGraph = Annotated[
 ]
 
 
+def _characteristic_polynomial_graph_schema() -> JsonSchemaValue:
+    schema = IndexedSimpleUndirectedGraph.model_json_schema()
+    schema["description"] = (
+        "An integer-indexed simple undirected graph accepted by exact "
+        "characteristic-polynomial operations: at most 256 vertices and "
+        "at most 32640 canonical edges."
+    )
+    schema["properties"]["vertex_count"].update(maximum=_MAX_CHARPOLY_VERTICES)
+    schema["properties"]["edges"].update(maxItems=_MAX_CHARPOLY_EDGES)
+    return schema
+
+
+CharacteristicPolynomialGraph = Annotated[
+    IndexedSimpleUndirectedGraph,
+    WithJsonSchema(_characteristic_polynomial_graph_schema()),
+]
+
+
 class GraphSpectrumRequest(StrictModel):
     graph: SpectralGraph
+
+
+class GraphCharacteristicPolynomialRequest(StrictModel):
+    """A graph whose dense integer matrix and exact polynomial are bounded."""
+
+    graph: CharacteristicPolynomialGraph
 
 
 class GraphSpectrumResult(StrictModel):
@@ -144,13 +194,13 @@ class GraphCharacteristicPolynomialResult(StrictModel):
     source graph and convention.
     """
 
-    graph: SpectralGraph
+    graph: CharacteristicPolynomialGraph
     convention: Literal["ADJACENCY", "LAPLACIAN"]
     polynomial: RationalPolynomial
 
     @model_validator(mode="after")
     def require_structural_shape(self) -> Self:
-        _require_spectral_graph(self.graph)
+        _require_characteristic_polynomial_graph(self.graph)
         if self.polynomial.variables != (_VARIABLE,):
             raise PydanticCustomError(
                 "graph.characteristic_polynomial_must_be_univariate_in_",
@@ -158,9 +208,11 @@ class GraphCharacteristicPolynomialResult(StrictModel):
             )
         require_polynomial_budget(
             self.polynomial,
-            maximum_terms=_MAX_CHARPOLY_TERMS,
-            maximum_exponent=_MAX_CHARPOLY_EXPONENT,
-            maximum_coefficient_digits=_MAX_CHARPOLY_COEFFICIENT_DIGITS,
+            maximum_terms=self.graph.vertex_count + 1,
+            maximum_exponent=self.graph.vertex_count,
+            maximum_coefficient_digits=_charpoly_coefficient_digit_bound(
+                self.graph.vertex_count
+            ),
             label="characteristic polynomial",
         )
         return self
@@ -181,6 +233,7 @@ class GraphCharacteristicPolynomialResult(StrictModel):
 
 
 __all__ = [
+    "GraphCharacteristicPolynomialRequest",
     "GraphCharacteristicPolynomialResult",
     "GraphSpectrumRequest",
     "GraphSpectrumResult",

--- a/src/jacobian/math/graphs/spectra/_tools.py
+++ b/src/jacobian/math/graphs/spectra/_tools.py
@@ -13,6 +13,7 @@ from jacobian.math.graphs.spectra import (
     laplacian_spectrum,
 )
 from jacobian.math.graphs.spectra._models import (
+    GraphCharacteristicPolynomialRequest,
     GraphCharacteristicPolynomialResult,
     GraphSpectrumRequest,
     GraphSpectrumResult,
@@ -40,7 +41,7 @@ def compute_laplacian_spectrum(request: GraphSpectrumRequest) -> GraphSpectrumRe
 
 
 def compute_adjacency_characteristic_polynomial(
-    request: GraphSpectrumRequest,
+    request: GraphCharacteristicPolynomialRequest,
 ) -> GraphCharacteristicPolynomialResult:
     return GraphCharacteristicPolynomialResult._from_kernel(
         graph=request.graph,
@@ -50,7 +51,7 @@ def compute_adjacency_characteristic_polynomial(
 
 
 def compute_laplacian_characteristic_polynomial(
-    request: GraphSpectrumRequest,
+    request: GraphCharacteristicPolynomialRequest,
 ) -> GraphCharacteristicPolynomialResult:
     return GraphCharacteristicPolynomialResult._from_kernel(
         graph=request.graph,
@@ -143,8 +144,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "Compute the exact monic characteristic polynomial det(xI - A) of the "
         "adjacency matrix of a simple undirected graph over QQ, returned as "
         "the canonical sparse RationalPolynomial in x with nonzero terms "
-        "serialized in descending exponent order, using SymPy.",
-        GraphSpectrumRequest,
+        "serialized in descending exponent order, using FLINT.",
+        GraphCharacteristicPolynomialRequest,
         GraphCharacteristicPolynomialResult,
         compute_adjacency_characteristic_polynomial,
         "graph",
@@ -157,7 +158,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 "path_adjacency_charpoly",
                 (
                     "Characteristic polynomial of the adjacency matrix of P3; "
-                    "the graph must be simple with at most 32 vertices."
+                    "the graph must be simple with at most 256 vertices."
                 ),
                 PATH_P3,
             ),
@@ -169,8 +170,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "Compute the exact monic characteristic polynomial det(xI - L) of the "
         "Laplacian matrix of a simple undirected graph over QQ, returned as "
         "the canonical sparse RationalPolynomial in x with nonzero terms "
-        "serialized in descending exponent order, using SymPy.",
-        GraphSpectrumRequest,
+        "serialized in descending exponent order, using FLINT.",
+        GraphCharacteristicPolynomialRequest,
         GraphCharacteristicPolynomialResult,
         compute_laplacian_characteristic_polynomial,
         "graph",
@@ -183,7 +184,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 "path_laplacian_charpoly",
                 (
                     "Characteristic polynomial of the Laplacian matrix of P3; "
-                    "the graph must be simple with at most 32 vertices."
+                    "the graph must be simple with at most 256 vertices."
                 ),
                 PATH_P3,
             ),

--- a/src/jacobian/math/graphs/spectra/operations.py
+++ b/src/jacobian/math/graphs/spectra/operations.py
@@ -15,7 +15,10 @@ __all__ = [
 
 from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.graphs.spectra._models import _require_spectral_graph
+from jacobian.math.graphs.spectra._models import (
+    _require_characteristic_polynomial_graph,
+    _require_spectral_graph,
+)
 from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 from jacobian.math.polynomials.values import RationalPolynomial
 
@@ -33,17 +36,29 @@ def _require_admitted_spectral_graph(
         ) from error
 
 
+def _require_admitted_characteristic_polynomial_graph(
+    graph: IndexedSimpleUndirectedGraph,
+) -> None:
+    try:
+        _require_characteristic_polynomial_graph(graph)
+    except PydanticCustomError as error:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code=error.type,
+            message=error.message(),
+        ) from error
+
+
 def _characteristic_polynomial_coeffs(
-    matrix: Any,
+    entries: list[int], order: int
 ) -> tuple[CanonicalRational, ...]:
     """Return monic charpoly coefficients (increasing degree) as canonical values."""
-    from fractions import Fraction
+    from flint import fmpz_mat
 
-    coeffs = matrix.charpoly().all_coeffs()
-    increasing = list(reversed(coeffs))
+    coefficients = fmpz_mat(order, order, entries).charpoly().coeffs()
     return tuple(
-        CanonicalRational.from_fraction(Fraction(int(c.p), int(c.q)))
-        for c in increasing
+        CanonicalRational(num=str(int(coefficient)), den="1")
+        for coefficient in coefficients
     )
 
 
@@ -74,6 +89,29 @@ def _laplacian_matrix(graph: IndexedSimpleUndirectedGraph) -> Any:
     return degree - adj
 
 
+def _adjacency_matrix_entries(graph: IndexedSimpleUndirectedGraph) -> list[int]:
+    order = graph.vertex_count
+    entries = [0] * (order * order)
+    for left, right in graph.edges:
+        entries[left * order + right] = 1
+        entries[right * order + left] = 1
+    return entries
+
+
+def _laplacian_matrix_entries(graph: IndexedSimpleUndirectedGraph) -> list[int]:
+    order = graph.vertex_count
+    entries = [0] * (order * order)
+    degrees = [0] * order
+    for left, right in graph.edges:
+        entries[left * order + right] = -1
+        entries[right * order + left] = -1
+        degrees[left] += 1
+        degrees[right] += 1
+    for vertex, degree in enumerate(degrees):
+        entries[vertex * order + vertex] = degree
+    return entries
+
+
 def adjacency_spectrum(graph: IndexedSimpleUndirectedGraph) -> list[tuple[str, int]]:
     mat = _adjacency_matrix(graph)
     eigenvals = mat.eigenvals()
@@ -90,9 +128,10 @@ def adjacency_characteristic_polynomial(
 ) -> RationalPolynomial:
     """Return det(xI - A) as the canonical sparse rational polynomial."""
 
-    _require_spectral_graph(graph)
+    _require_admitted_characteristic_polynomial_graph(graph)
+    order = graph.vertex_count
     return _dense_to_canonical_polynomial(
-        _characteristic_polynomial_coeffs(_adjacency_matrix(graph))
+        _characteristic_polynomial_coeffs(_adjacency_matrix_entries(graph), order)
     )
 
 
@@ -101,7 +140,8 @@ def laplacian_characteristic_polynomial(
 ) -> RationalPolynomial:
     """Return det(xI - L) as the canonical sparse rational polynomial."""
 
-    _require_spectral_graph(graph)
+    _require_admitted_characteristic_polynomial_graph(graph)
+    order = graph.vertex_count
     return _dense_to_canonical_polynomial(
-        _characteristic_polynomial_coeffs(_laplacian_matrix(graph))
+        _characteristic_polynomial_coeffs(_laplacian_matrix_entries(graph), order)
     )

--- a/tests/math/graphs/spectra/test_graph_characteristic_polynomial.py
+++ b/tests/math/graphs/spectra/test_graph_characteristic_polynomial.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from fractions import Fraction
+from math import comb
 from typing import Any
 
 import pytest
@@ -14,8 +15,10 @@ from jacobian.math.graphs.spectra import (
     laplacian_characteristic_polynomial,
 )
 from jacobian.math.graphs.spectra._models import (
+    GraphCharacteristicPolynomialRequest,
     GraphCharacteristicPolynomialResult,
     GraphSpectrumRequest,
+    _charpoly_coefficient_digit_bound,
 )
 from jacobian.math.graphs.spectra._tools import (
     TOOLS,
@@ -40,8 +43,8 @@ def _graph(edges: list[list[int]], vc: int) -> IndexedSimpleUndirectedGraph:
     )
 
 
-def _request(edges: list[list[int]], vc: int) -> GraphSpectrumRequest:
-    return GraphSpectrumRequest(graph=_graph(edges, vc))
+def _request(edges: list[list[int]], vc: int) -> GraphCharacteristicPolynomialRequest:
+    return GraphCharacteristicPolynomialRequest(graph=_graph(edges, vc))
 
 
 def _coeffs(polynomial: RationalPolynomial) -> list[Fraction]:
@@ -86,6 +89,21 @@ def _charpoly_payload(polynomial: RationalPolynomial) -> dict[str, Any]:
 
 
 class TestAdjacencyCharacteristicPolynomial:
+    def test_complete_graph_above_previous_limit(self) -> None:
+        order = 64
+        edges = [
+            [left, right] for left in range(order) for right in range(left + 1, order)
+        ]
+        result = compute_adjacency_characteristic_polynomial(_request(edges, order))
+        expected = [
+            Fraction(
+                (comb(order - 1, degree - 1) if degree else 0)
+                - (order - 1) * (comb(order - 1, degree) if degree < order else 0)
+            )
+            for degree in range(order + 1)
+        ]
+        assert _coeffs(result.polynomial) == expected
+
     def test_path_p3(self) -> None:
         # P3 adjacency eigenvalues: 0, sqrt(2), -sqrt(2) -> charpoly x(x^2-2) = x^3 - 2x.
         result = compute_adjacency_characteristic_polynomial(
@@ -135,6 +153,18 @@ class TestAdjacencyCharacteristicPolynomial:
 
 
 class TestLaplacianCharacteristicPolynomial:
+    def test_complete_graph_above_previous_limit(self) -> None:
+        order = 64
+        edges = [
+            [left, right] for left in range(order) for right in range(left + 1, order)
+        ]
+        result = compute_laplacian_characteristic_polynomial(_request(edges, order))
+        expected = [Fraction(0)] + [
+            Fraction(comb(order - 1, degree - 1) * (-order) ** (order - degree))
+            for degree in range(1, order + 1)
+        ]
+        assert _coeffs(result.polynomial) == expected
+
     def test_path_p3(self) -> None:
         # P3 Laplacian eigenvalues 0,1,3 -> charpoly x(x-1)(x-3) = x^3 - 4x^2 + 3x.
         result = compute_laplacian_characteristic_polynomial(
@@ -189,7 +219,9 @@ class TestLaplacianCharacteristicPolynomial:
 )
 def test_trusted_characteristic_polynomial_producers_run_the_kernel_once(
     monkeypatch: pytest.MonkeyPatch,
-    operation: Callable[[GraphSpectrumRequest], GraphCharacteristicPolynomialResult],
+    operation: Callable[
+        [GraphCharacteristicPolynomialRequest], GraphCharacteristicPolynomialResult
+    ],
     kernel_name: str,
 ) -> None:
     original = getattr(spectral_operations, kernel_name)
@@ -209,29 +241,27 @@ def test_trusted_characteristic_polynomial_producers_run_the_kernel_once(
 
 
 def test_replay_rejects_more_terms_than_any_admitted_charpoly_has() -> None:
-    # A degree-32 univariate characteristic polynomial has at most 33 nonzero
-    # terms, so a 34-term value is rejected before any backend conversion.
-    oversized = _univariate_polynomial(dict.fromkeys(range(34), "2"))
+    oversized = _univariate_polynomial(dict.fromkeys(range(5), "2"))
     with pytest.raises(ValidationError):
         GraphCharacteristicPolynomialResult.model_validate(_charpoly_payload(oversized))
 
 
-def test_replay_rejects_exponents_beyond_the_32_vertex_degree_bound() -> None:
-    beyond = _univariate_polynomial({32: "1", 40: "1"})
+def test_replay_rejects_exponents_beyond_the_graph_order_bound() -> None:
+    beyond = _univariate_polynomial({3: "1", 4: "1"})
     with pytest.raises(ValidationError):
         GraphCharacteristicPolynomialResult.model_validate(_charpoly_payload(beyond))
 
 
 def test_replay_rejects_coefficients_beyond_the_charpoly_digit_budget() -> None:
-    huge = _univariate_polynomial({3: "9" * 129})
+    huge = _univariate_polynomial({3: "9" * (_charpoly_coefficient_digit_bound(3) + 1)})
     with pytest.raises(ValidationError):
         GraphCharacteristicPolynomialResult.model_validate(_charpoly_payload(huge))
 
 
 def test_maximal_path_round_trips_through_serialization() -> None:
-    # Degree exactly 32 exercises the replay degree bound from above.
+    # Degree exactly 256 exercises the full graph carrier and result bounds.
     graph = IndexedSimpleUndirectedGraph(
-        vertex_count=32, edges=tuple((i, i + 1) for i in range(31))
+        vertex_count=256, edges=tuple((i, i + 1) for i in range(255))
     )
     polynomial = adjacency_characteristic_polynomial(graph)
     restored = GraphCharacteristicPolynomialResult.model_validate(
@@ -242,7 +272,14 @@ def test_maximal_path_round_trips_through_serialization() -> None:
         ).model_dump(mode="json")
     )
     assert restored.polynomial == polynomial
-    assert max(_exponents(restored.polynomial)) == 32
+    assert max(_exponents(restored.polynomial)) == 256
+
+
+def test_characteristic_polynomial_request_rejects_above_graph_carrier() -> None:
+    with pytest.raises(ValidationError):
+        GraphCharacteristicPolynomialRequest.model_validate(
+            {"graph": {"vertex_count": 257, "edges": []}}
+        )
 
 
 def test_native_adjacency_returns_canonical_polynomial() -> None:
@@ -315,3 +352,22 @@ def test_discovery_names_canonical_sparse_polynomial() -> None:
         assert "increasing-degree" not in description
         assert "canonical sparse RationalPolynomial" in description
         assert "descending exponent order" in description
+
+
+def test_characteristic_polynomial_schema_is_independent_of_exact_spectrum() -> None:
+    spectrum_graph_schema = GraphSpectrumRequest.model_json_schema()["properties"][
+        "graph"
+    ]
+    polynomial_graph_schema = GraphCharacteristicPolynomialRequest.model_json_schema()[
+        "properties"
+    ]["graph"]
+    assert spectrum_graph_schema["properties"]["vertex_count"]["maximum"] == 32
+    assert polynomial_graph_schema["properties"]["vertex_count"]["maximum"] == 256
+    characteristic_tools = [
+        tool for tool in TOOLS if "characteristic_polynomial" in tool.operation_id
+    ]
+    assert characteristic_tools
+    assert all(
+        tool.request_type is GraphCharacteristicPolynomialRequest
+        for tool in characteristic_tools
+    )

--- a/tests/math/graphs/test_graph_spectrum_binding.py
+++ b/tests/math/graphs/test_graph_spectrum_binding.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.spectra._models import (
+    GraphCharacteristicPolynomialRequest,
     GraphSpectrumRequest,
     GraphSpectrumResult,
 )
@@ -182,7 +183,9 @@ def test_spectrum_reconstructs_the_characteristic_polynomial() -> None:
     path = _graph(4, ((0, 1), (1, 2), (2, 3)))
     request = GraphSpectrumRequest(graph=path)
     spectrum = compute_adjacency_spectrum(request)
-    charpoly_result = compute_adjacency_characteristic_polynomial(request)
+    charpoly_result = compute_adjacency_characteristic_polynomial(
+        GraphCharacteristicPolynomialRequest(graph=path)
+    )
     expected = Poly(
         rational_polynomial_to_sympy(charpoly_result.polynomial).as_expr(), x
     )


### PR DESCRIPTION
Closes #2951.

## Problem

The adjacency and Laplacian characteristic-polynomial operations shared the 32-vertex request/result envelope used by exact algebraic spectra. Their actual result is a canonical integer polynomial, so that coupling rejected graphs whose dense integer matrices, FLINT work, and complete coefficient output remain tractable.

## Change

- give characteristic-polynomial tools their own request and graph schema, admitting the full 256-vertex canonical graph carrier
- retain the existing 32-vertex request/result/runtime gate for exact eigenvalue operations
- construct adjacency and Laplacian integer matrices directly and delegate exact characteristic polynomials to python-flint `fmpz_mat.charpoly()`
- convert FLINT's increasing-degree integer coefficients directly to the existing canonical `RationalPolynomial`
- derive source-sensitive result bounds: at most `n + 1` terms, degree `n`, and `digits((2n)^n)` coefficient digits (694 at `n = 256`)
- bound dense materialization at `256^2` cells and conservatively ledger characteristic-polynomial work at `256^4` scalar steps

The null graph still returns the constant polynomial 1, and downstream polynomial consumers receive the same canonical value unchanged.

## Evidence

- exact closed-form adjacency and Laplacian characteristic polynomials for `K_64`, beyond the former cap
- exact order-256 path computation and serialization round trip
- 520 deterministic FLINT/SymPy comparisons across graph orders 0 through 12
- maximum-order review probes, including a complete-graph Laplacian with 615-digit coefficients under the 694-digit bound

## Validation

- `make affected AFFECTED_BASE=origin/main`
  - 36 graph-owner tests passed
  - 112 catalog tests passed
  - 800 catalog integration examples passed
  - scoped Ruff and mypy checks passed

## Suggested review order

1. independent request/result bounds in `_models.py`
2. FLINT matrix conversion in `operations.py`
3. declarations and boundary/defining-invariant tests