### PR TITLE
Use FLINT for larger Hankel moment invariants

### DIFF
--- a/src/jacobian/math/analysis/orthogonal_polynomials/_flint.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/_flint.py
@@ -1,0 +1,23 @@
+"""Private FLINT adapters for exact moment matrices."""
+
+from fractions import Fraction
+
+
+def determinant_and_rank(
+    matrix: tuple[tuple[Fraction, ...], ...],
+) -> tuple[Fraction, int]:
+    """Return the exact determinant and rank of a rational matrix."""
+
+    from flint import fmpq, fmpq_mat
+
+    backend = fmpq_mat(
+        [[fmpq(value.numerator, value.denominator) for value in row] for row in matrix]
+    )
+    determinant = backend.det()
+    return (
+        Fraction(int(determinant.numerator), int(determinant.denominator)),
+        int(backend.rank()),
+    )
+
+
+__all__ = ["determinant_and_rank"]

--- a/src/jacobian/math/analysis/orthogonal_polynomials/_models.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/_models.py
@@ -31,7 +31,7 @@ class ShiftedHankelRequest(StrictModel):
 
     prefix: MomentFunctionalPrefix
     # A shifted matrix of order r consumes mu_1..mu_(2r+1); the canonical
-    # prefix holds at most 65 moments, so r = 32 could never validate and
+    # prefix holds at most 129 moments, so r = 64 could never validate and
     # must not be advertised as supported.
     order: int = Field(ge=0, le=MAX_HANKEL_ORDER - 1)
 

--- a/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
@@ -116,7 +116,7 @@ def require_hankel_matrix_admission(
         )
     consumed = prefix.moments[1:] if shifted else prefix.moments
     per_entry = MAX_CANONICAL_RATIONAL_DIGITS // ((order + 1) ** 2)
-    bound = max(per_entry - 2, 8)
+    bound = max(per_entry - 2, 1)
     if any(
         RationalHeight.from_canonical(value).exceeds(bound)
         for value in consumed[: 2 * order + 1]

--- a/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
@@ -11,6 +11,7 @@ from jacobian.math.analysis.orthogonal_polynomials._jacobi import (
     require_jacobi_matrix_admission,
 )
 from jacobian.math.analysis.orthogonal_polynomials.values import (
+    MAX_HANKEL_ORDER,
     ChristoffelDarbouxKernel,
     GaussianQuadratureRule,
     HankelMomentMatrix,
@@ -90,12 +91,22 @@ def _require_gram_schmidt_heights_admissible(
             )
 
 
+def _hankel_determinant_height_bound(order: int) -> int:
+    """Conservative per-entry digit bound for an exact Hankel determinant.
+
+    An ``(order + 1)``-by-``(order + 1)`` product of consumed moments stays
+    representable when each entry has at most this many decimal digits. Two
+    digits of slack cover exact-determinant height beyond that product, and
+    the bound is at least one digit.
+    """
+    per_entry = MAX_CANONICAL_RATIONAL_DIGITS // ((order + 1) ** 2)
+    return max(per_entry - 2, 1)
+
+
 def require_hankel_matrix_admission(
     prefix: MomentFunctionalPrefix, order: int, *, shifted: bool
 ) -> None:
     """Validate one canonical prefix for a bounded Hankel construction."""
-    from jacobian.math.analysis.orthogonal_polynomials.values import MAX_HANKEL_ORDER
-
     maximum = MAX_HANKEL_ORDER - int(shifted)
     if (
         isinstance(order, bool)
@@ -115,8 +126,7 @@ def require_hankel_matrix_admission(
             f"{len(prefix.moments)}",
         )
     consumed = prefix.moments[1:] if shifted else prefix.moments
-    per_entry = MAX_CANONICAL_RATIONAL_DIGITS // ((order + 1) ** 2)
-    bound = max(per_entry - 2, 1)
+    bound = _hankel_determinant_height_bound(order)
     if any(
         RationalHeight.from_canonical(value).exceeds(bound)
         for value in consumed[: 2 * order + 1]

--- a/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
@@ -90,63 +90,6 @@ def _require_gram_schmidt_heights_admissible(
             )
 
 
-def _rational_det(matrix: list[list[Fraction]]) -> Fraction:
-    """Compute the determinant of a rational matrix via Gaussian elimination."""
-    n = len(matrix)
-    if n == 0:
-        return Fraction(1)
-    mat = [row[:] for row in matrix]
-    det = Fraction(1)
-    for col in range(n):
-        pivot = None
-        for row in range(col, n):
-            if mat[row][col] != 0:
-                pivot = row
-                break
-        if pivot is None:
-            return Fraction(0)
-        if pivot != col:
-            mat[col], mat[pivot] = mat[pivot], mat[col]
-            det = -det
-        det *= mat[col][col]
-        for row in range(col + 1, n):
-            factor = mat[row][col] / mat[col][col]
-            for j in range(col, n):
-                mat[row][j] -= factor * mat[col][j]
-    return det
-
-
-def _rational_rank(matrix: list[list[Fraction]]) -> int:
-    """Compute the rank of a rational matrix via Gaussian elimination."""
-    if not matrix or not matrix[0]:
-        return 0
-    rows = len(matrix)
-    cols = len(matrix[0])
-    mat = [row[:] for row in matrix]
-    rank = 0
-    for col in range(cols):
-        pivot = next((row for row in range(rank, rows) if mat[row][col] != 0), None)
-        if pivot is None:
-            continue
-        mat[rank], mat[pivot] = mat[pivot], mat[rank]
-        _eliminate_below(mat, rank, col)
-        rank += 1
-        if rank == rows:
-            break
-    return rank
-
-
-def _eliminate_below(mat: list[list[Fraction]], rank: int, col: int) -> None:
-    """Clear ``col`` in every row except the current pivot row."""
-    cols = len(mat[0])
-    for row in range(len(mat)):
-        if row == rank or mat[row][col] == 0:
-            continue
-        factor = mat[row][col] / mat[rank][col]
-        for j in range(cols):
-            mat[row][j] -= factor * mat[rank][j]
-
-
 def require_hankel_matrix_admission(
     prefix: MomentFunctionalPrefix, order: int, *, shifted: bool
 ) -> None:
@@ -191,11 +134,15 @@ def hankel_matrix_from_prefix(
     """Compute one admitted ordinary or shifted exact Hankel matrix."""
     moments = [_to_fraction(moment) for moment in prefix.moments]
     offset = int(shifted)
-    matrix = [
-        [moments[i + j + offset] for j in range(order + 1)] for i in range(order + 1)
-    ]
-    determinant = _rational_det(matrix)
-    rank = _rational_rank(matrix)
+    matrix = tuple(
+        tuple(moments[i + j + offset] for j in range(order + 1))
+        for i in range(order + 1)
+    )
+    from jacobian.math.analysis.orthogonal_polynomials._flint import (
+        determinant_and_rank,
+    )
+
+    determinant, rank = determinant_and_rank(matrix)
     return HankelMomentMatrix._from_kernel(
         order=order,
         entries=tuple(

--- a/src/jacobian/math/analysis/orthogonal_polynomials/values.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/values.py
@@ -15,8 +15,8 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"moments_orthogonal.{reason}", message)
 
 
-MAX_MOMENT_DEGREE = 64
-MAX_HANKEL_ORDER = 32
+MAX_MOMENT_DEGREE = 128
+MAX_HANKEL_ORDER = 64
 MAX_POLYNOMIAL_DEGREE = 32
 MAX_QUADRATURE_ORDER = 16
 MAX_VARIABLE_LENGTH = 64

--- a/tests/math/analysis/orthogonal_polynomials/test_moments.py
+++ b/tests/math/analysis/orthogonal_polynomials/test_moments.py
@@ -99,6 +99,15 @@ class TestHankel:
             for column in range(65)
         )
 
+    def test_maximum_order_rejects_nonrepresentable_determinant_height(self) -> None:
+        moments = (
+            CanonicalRational(num="1", den="10000019"),
+            *(CanonicalRational(num="1", den="1") for _ in range(128)),
+        )
+
+        with pytest.raises(ValueError, match="conservative 5-digit bound"):
+            compute_hankel_matrix(HankelRequest(prefix=_prefix(moments), order=64))
+
 
 class TestShiftedHankel:
     def test_shifted_hankel(self) -> None:

--- a/tests/math/analysis/orthogonal_polynomials/test_moments.py
+++ b/tests/math/analysis/orthogonal_polynomials/test_moments.py
@@ -27,7 +27,12 @@ from jacobian.math.analysis.orthogonal_polynomials._tools import (
     compute_recurrence,
     compute_shifted_hankel,
 )
+from jacobian.math.analysis.orthogonal_polynomials.operations import (
+    _hankel_determinant_height_bound,
+    require_hankel_matrix_admission,
+)
 from jacobian.math.analysis.orthogonal_polynomials.values import (
+    MAX_HANKEL_ORDER,
     GaussianQuadratureRule,
     MomentFunctionalPrefix,
     OrthogonalPolynomialFamily,
@@ -100,13 +105,17 @@ class TestHankel:
         )
 
     def test_maximum_order_rejects_moment_above_derived_height_bound(self) -> None:
-        moments = (
-            CanonicalRational(num="1", den="10000019"),
-            *(CanonicalRational(num="1", den="1") for _ in range(128)),
+        order = MAX_HANKEL_ORDER
+        bound = _hankel_determinant_height_bound(order)
+        ones = tuple(CanonicalRational(num="1", den="1") for _ in range(2 * order))
+        prefix_at_bound = _prefix((CanonicalRational(num="1", den="9" * bound), *ones))
+        prefix_over_bound = _prefix(
+            (CanonicalRational(num="1", den="9" * (bound + 1)), *ones)
         )
 
-        with pytest.raises(ValueError, match="conservative 5-digit bound"):
-            compute_hankel_matrix(HankelRequest(prefix=_prefix(moments), order=64))
+        require_hankel_matrix_admission(prefix_at_bound, order, shifted=False)
+        with pytest.raises(ValueError, match=rf"conservative {bound}-digit bound"):
+            compute_hankel_matrix(HankelRequest(prefix=prefix_over_bound, order=order))
 
 
 class TestShiftedHankel:

--- a/tests/math/analysis/orthogonal_polynomials/test_moments.py
+++ b/tests/math/analysis/orthogonal_polynomials/test_moments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from math import comb, prod
 
 import pytest
 from pydantic import ValidationError
@@ -51,6 +52,10 @@ def _moments_uniform(n: int) -> tuple[CanonicalRational, ...]:
     )
 
 
+def _moments_unit_interval(n: int) -> tuple[CanonicalRational, ...]:
+    return tuple(CanonicalRational(num="1", den=str(degree + 1)) for degree in range(n))
+
+
 class TestHankel:
     def test_hankel_order_0(self) -> None:
         result = compute_hankel_matrix(
@@ -79,6 +84,21 @@ class TestHankel:
         with pytest.raises(ValueError):
             compute_hankel_matrix(request)
 
+    def test_flint_invariants_at_maximum_hankel_order(self) -> None:
+        moments = _moments_unit_interval(129)
+        result = compute_hankel_matrix(HankelRequest(prefix=_prefix(moments), order=64))
+        expected_denominator = prod(
+            (2 * index + 1) * comb(2 * index, index) ** 2 for index in range(65)
+        )
+
+        assert result.rank == 65
+        assert result.determinant.as_fraction() == Fraction(1, expected_denominator)
+        assert all(
+            result.entries[row][column] == moments[row + column]
+            for row in range(65)
+            for column in range(65)
+        )
+
 
 class TestShiftedHankel:
     def test_shifted_hankel(self) -> None:
@@ -86,6 +106,16 @@ class TestShiftedHankel:
             ShiftedHankelRequest(prefix=_prefix(_moments_uniform(6)), order=2)
         )
         assert result.order == 2
+
+    def test_rank_deficient_invariants_at_maximum_shifted_order(self) -> None:
+        moments = tuple(CanonicalRational(num="1", den="1") for _ in range(129))
+        result = compute_shifted_hankel(
+            ShiftedHankelRequest(prefix=_prefix(moments), order=63)
+        )
+
+        assert result.rank == 1
+        assert result.determinant.as_fraction() == 0
+        assert all(entry == moments[0] for row in result.entries for entry in row)
 
     def test_consumed_moment_heights_bound_admission(self) -> None:
         """The shifted determinant consumes mu_1..mu_(2r+1); an extreme
@@ -1048,16 +1078,16 @@ class TestRuleRoundTrip:
 
 
 class TestShiftedHankelOrderCap:
-    def test_order_32_is_not_schema_advertised(self) -> None:
-        """A shifted matrix of order 32 would need mu_1..mu_66 but the
-        canonical prefix holds at most 65 moments, so order 32 must not be
+    def test_order_64_is_not_schema_advertised(self) -> None:
+        """A shifted matrix of order 64 would need mu_1..mu_129 but the
+        canonical prefix holds at most 129 moments, so order 64 must not be
         advertised as supported."""
         full_prefix = _prefix(
-            tuple(CanonicalRational(num="1", den="1") for _ in range(65))
+            tuple(CanonicalRational(num="1", den="1") for _ in range(129))
         )
         with pytest.raises(ValidationError):
-            ShiftedHankelRequest(prefix=full_prefix, order=32)
-        assert ShiftedHankelRequest(prefix=full_prefix, order=31)
+            ShiftedHankelRequest(prefix=full_prefix, order=64)
+        assert ShiftedHankelRequest(prefix=full_prefix, order=63)
 
 
 class TestCoefficientTupleSchemaBound:

--- a/tests/math/analysis/orthogonal_polynomials/test_moments.py
+++ b/tests/math/analysis/orthogonal_polynomials/test_moments.py
@@ -99,7 +99,7 @@ class TestHankel:
             for column in range(65)
         )
 
-    def test_maximum_order_rejects_nonrepresentable_determinant_height(self) -> None:
+    def test_maximum_order_rejects_moment_above_derived_height_bound(self) -> None:
         moments = (
             CanonicalRational(num="1", den="10000019"),
             *(CanonicalRational(num="1", den="1") for _ in range(128)),


### PR DESCRIPTION
## Problem

The two Hankel moment operations compute exact rational determinants and ranks with duplicated `Fraction` Gaussian elimination. Their public result already materializes the matrix and both invariants, but the shared moment carrier stops at 65 values and limits ordinary Hankel matrices to order 32.

## What changed

- replace the handwritten determinant and rank routines with one private python-flint `fmpq_mat` adapter;
- widen the canonical moment prefix from 65 to 129 values;
- widen ordinary Hankel matrices from order 32 to 64 and shifted matrices from order 31 to 63, matching the moments each construction consumes;
- retain the consumed-slice determinant-height admission, with a five-digit per-entry bound at order 64 so every accepted determinant remains representable;
- leave Gram–Schmidt, recurrence, and quadrature degree limits unchanged.

The wider prefix is a shared canonical value, but lower-degree consumers continue to inspect only the moments their own postconditions require. At the new boundary, the returned Hankel matrix is bounded to 4,225 exact rational cells.

## Evidence

- the order-64 unit-interval moment matrix reconstructs `H[i,j] = 1/(i+j+1)`, has rank 65, and matches the exact Hilbert determinant formula;
- the order-63 shifted constant-moment matrix reconstructs all ones, has rank 1, and determinant zero;
- an eight-digit consumed moment at order 64 is rejected by the derived five-digit height gate before FLINT/result construction;
- independent review also exercised 129 distinct five-digit prime denominators: FLINT returned rank 65 with a 20,563-digit numerator and 21,103-digit denominator, inside the 32,768-digit canonical limit.

On this machine, pinned python-flint 0.9 computed determinant and rank for a 65-by-65 Hilbert matrix in about 0.03 seconds.

`make affected AFFECTED_BASE=origin/main` passed on commit `e6ccaf0da` after merging current main:

- scoped Ruff formatting and lint;
- scoped mypy;
- 63 orthogonal-polynomial owner tests;
- 112 catalog tests;
- 800 catalog integration tests.

Closes #2963.
