### PR TITLE
Admit larger bounded integer Sidon profiles

### DIFF
--- a/src/jacobian/math/combinatorics/_difference_set_models.py
+++ b/src/jacobian/math/combinatorics/_difference_set_models.py
@@ -9,8 +9,8 @@ from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_vali
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.canonical import CanonicalLimits
 
-MAX_SIDON_SET_SIZE = 256
 MAX_CYCLIC_DIFFERENCE_SET_MODULUS = 4_096
 MAX_DIFFERENCE_SET_EXTENSION_CANDIDATES = 50_000
 MAX_DIFFERENCE_SET_ADDITIONAL_ELEMENTS = 3
@@ -41,6 +41,68 @@ AdditiveDifferenceInteger = Annotated[
         strict=True,
     ),
 ]
+
+# Empty arrays plus the longer ``false`` Sidon decision occupy 68 bytes
+# before contents are inserted. Each ordered-difference object contributes
+# 46 bytes of field spelling around the three integer wires.
+_SIDON_RESULT_ENVELOPE_BYTES = 68
+_SIDON_DIFFERENCE_ROW_OVERHEAD_BYTES = 46
+MAX_SIDON_RESULT_BYTES = CanonicalLimits().max_output_bytes
+
+
+def _integer_sidon_canonical_result_bytes(elements: tuple[int, ...]) -> int:
+    """Return the compact JSON size of one complete ordered-difference ledger.
+
+    The estimate is exact for ``is_sidon=false`` and overcounts a true
+    decision by one byte, so admission remains conservative.
+    """
+
+    normalized = tuple(str(value) for value in elements)
+    normalized_bytes = sum(len(value) + 2 for value in normalized) + max(
+        len(normalized) - 1, 0
+    )
+    difference_bytes = 0
+    pair_count = 0
+    for left in elements:
+        left_wire = str(left)
+        for right in elements:
+            if left == right:
+                continue
+            pair_count += 1
+            difference_bytes += (
+                _SIDON_DIFFERENCE_ROW_OVERHEAD_BYTES
+                + len(left_wire)
+                + len(str(right))
+                + len(str(left - right))
+            )
+    difference_bytes += max(pair_count - 1, 0)
+    return _SIDON_RESULT_ENVELOPE_BYTES + normalized_bytes + difference_bytes
+
+
+def _max_sidon_set_size_for_output_budget(budget: int) -> int:
+    """Largest ``n`` whose unique set ``0..n-1`` still fits ``budget`` bytes.
+
+    Pair work is ``n(n-1)`` ordered rows. The shortest unique AdditiveInteger
+    n-set is ``0..n-1``, so this ceiling is the largest cardinality whose
+    work and output can still fit; wider integers are rejected later by the
+    same byte reservation.
+    """
+
+    low = 0
+    high = math.isqrt(max(budget, 0) // _SIDON_DIFFERENCE_ROW_OVERHEAD_BYTES) + 2
+    while low < high:
+        mid = (low + high + 1) // 2
+        if _integer_sidon_canonical_result_bytes(tuple(range(mid))) <= budget:
+            low = mid
+        else:
+            high = mid - 1
+    return low
+
+
+# Cheap parser bound derived from the canonical output budget. Result-sensitive
+# admission still reserves the actual payload from source and difference widths.
+MAX_SIDON_SET_SIZE = _max_sidon_set_size_for_output_budget(MAX_SIDON_RESULT_BYTES)
+MAX_SIDON_ORDERED_DIFFERENCES = MAX_SIDON_SET_SIZE * max(MAX_SIDON_SET_SIZE - 1, 0)
 
 
 def _difference_set_validation_error(code: str, message: str) -> PydanticCustomError:
@@ -76,7 +138,7 @@ class IntegerSidonResult(StrictModel):
         max_length=MAX_SIDON_SET_SIZE
     )
     ordered_differences: tuple[OrderedIntegerDifference, ...] = Field(
-        max_length=MAX_SIDON_SET_SIZE * (MAX_SIDON_SET_SIZE - 1)
+        max_length=MAX_SIDON_ORDERED_DIFFERENCES
     )
     is_sidon: StrictBool
 

--- a/src/jacobian/math/combinatorics/_difference_set_models.py
+++ b/src/jacobian/math/combinatorics/_difference_set_models.py
@@ -10,7 +10,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 
-MAX_SIDON_SET_SIZE = 32
+MAX_SIDON_SET_SIZE = 256
 MAX_CYCLIC_DIFFERENCE_SET_MODULUS = 4_096
 MAX_DIFFERENCE_SET_EXTENSION_CANDIDATES = 50_000
 MAX_DIFFERENCE_SET_ADDITIONAL_ELEMENTS = 3
@@ -92,6 +92,28 @@ class IntegerSidonResult(StrictModel):
             raise _difference_set_validation_error(
                 "combinatorics.sidon_invariant",
                 "ordered-difference profile has the wrong cardinality",
+            )
+        seen_differences: set[int] = set()
+        for record, (left, right) in zip(
+            self.ordered_differences,
+            ((left, right) for left in values for right in values if left != right),
+            strict=True,
+        ):
+            difference = left - right
+            if (
+                int(record.minuend) != left
+                or int(record.subtrahend) != right
+                or int(record.difference) != difference
+            ):
+                raise _difference_set_validation_error(
+                    "combinatorics.sidon_invariant",
+                    "ordered-difference rows must be the canonical source pairs",
+                )
+            seen_differences.add(difference)
+        if self.is_sidon != (len(seen_differences) == len(self.ordered_differences)):
+            raise _difference_set_validation_error(
+                "combinatorics.sidon_invariant",
+                "is_sidon must match the ordered-difference multiplicities",
             )
         return self
 

--- a/src/jacobian/math/combinatorics/_difference_set_models.py
+++ b/src/jacobian/math/combinatorics/_difference_set_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from typing import Annotated, Literal, Self
 
 from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
@@ -50,6 +51,50 @@ _SIDON_DIFFERENCE_ROW_OVERHEAD_BYTES = 46
 MAX_SIDON_RESULT_BYTES = CanonicalLimits().max_output_bytes
 
 
+@dataclass(frozen=True, slots=True)
+class _IntegerSidonAdmissionPlan:
+    """Request-scoped Sidon wires reused by trusted result construction."""
+
+    normalized_wires: tuple[str, ...]
+    difference_wires: tuple[tuple[str, str, str], ...]
+    result_bytes: int
+    is_sidon: bool
+
+
+def _integer_sidon_profile(elements: tuple[int, ...]) -> _IntegerSidonAdmissionPlan:
+    """Traverse one ordered-difference ledger and retain its canonical wires."""
+
+    normalized_wires = tuple(str(value) for value in elements)
+    normalized_bytes = sum(len(wire) + 2 for wire in normalized_wires) + max(
+        len(normalized_wires) - 1, 0
+    )
+    difference_wires: list[tuple[str, str, str]] = []
+    seen_differences: set[int] = set()
+    difference_bytes = 0
+    for left, left_wire in zip(elements, normalized_wires, strict=True):
+        for right, right_wire in zip(elements, normalized_wires, strict=True):
+            if left == right:
+                continue
+            difference = left - right
+            difference_wire = str(difference)
+            difference_wires.append((left_wire, right_wire, difference_wire))
+            difference_bytes += (
+                _SIDON_DIFFERENCE_ROW_OVERHEAD_BYTES
+                + len(left_wire)
+                + len(right_wire)
+                + len(difference_wire)
+            )
+            seen_differences.add(difference)
+    pair_count = len(difference_wires)
+    difference_bytes += max(pair_count - 1, 0)
+    return _IntegerSidonAdmissionPlan(
+        normalized_wires=normalized_wires,
+        difference_wires=tuple(difference_wires),
+        result_bytes=_SIDON_RESULT_ENVELOPE_BYTES + normalized_bytes + difference_bytes,
+        is_sidon=len(seen_differences) == pair_count,
+    )
+
+
 def _integer_sidon_canonical_result_bytes(elements: tuple[int, ...]) -> int:
     """Return the compact JSON size of one complete ordered-difference ledger.
 
@@ -57,42 +102,79 @@ def _integer_sidon_canonical_result_bytes(elements: tuple[int, ...]) -> int:
     decision by one byte, so admission remains conservative.
     """
 
-    normalized = tuple(str(value) for value in elements)
-    normalized_bytes = sum(len(value) + 2 for value in normalized) + max(
-        len(normalized) - 1, 0
+    return _integer_sidon_profile(elements).result_bytes
+
+
+def _minimum_payload_sidon_start(cardinality: int) -> int:
+    """Return the start of a consecutive n-set with minimum source-wire length.
+
+    Consecutive integers minimize ordered-difference magnitudes. Shifting that
+    interval toward the shortest AdditiveInteger spellings then minimizes the
+    source wires that appear in every row; several starts can tie.
+    """
+
+    if cardinality <= 0:
+        return 0
+    current = sum(len(str(value)) for value in range(cardinality))
+    best = current
+    best_start = 0
+    start = 0
+    while start > -cardinality:
+        start -= 1
+        current += len(str(start)) - len(str(start + cardinality))
+        if current < best:
+            best = current
+            best_start = start
+        elif current > best:
+            break
+    return best_start
+
+
+def _minimum_payload_sidon_elements(cardinality: int) -> tuple[int, ...]:
+    """Return one unique AdditiveInteger n-set with the lightest ledger."""
+
+    if cardinality <= 0:
+        return ()
+    start = _minimum_payload_sidon_start(cardinality)
+    return tuple(range(start, start + cardinality))
+
+
+def _minimum_integer_sidon_result_bytes(cardinality: int) -> int:
+    """Compact JSON size of the lightest unique AdditiveInteger n-set ledger."""
+
+    if cardinality <= 0:
+        return _SIDON_RESULT_ENVELOPE_BYTES
+    start = _minimum_payload_sidon_start(cardinality)
+    length_sum = sum(len(str(value)) for value in range(start, start + cardinality))
+    pair_count = cardinality * (cardinality - 1)
+    normalized_bytes = length_sum + 2 * cardinality + (cardinality - 1)
+    difference_value_bytes = 0
+    for gap in range(1, cardinality):
+        multiplicity = cardinality - gap
+        positive_length = len(str(gap))
+        difference_value_bytes += multiplicity * (2 * positive_length + 1)
+    difference_bytes = (
+        pair_count * _SIDON_DIFFERENCE_ROW_OVERHEAD_BYTES
+        + 2 * (cardinality - 1) * length_sum
+        + difference_value_bytes
+        + max(pair_count - 1, 0)
     )
-    difference_bytes = 0
-    pair_count = 0
-    for left in elements:
-        left_wire = str(left)
-        for right in elements:
-            if left == right:
-                continue
-            pair_count += 1
-            difference_bytes += (
-                _SIDON_DIFFERENCE_ROW_OVERHEAD_BYTES
-                + len(left_wire)
-                + len(str(right))
-                + len(str(left - right))
-            )
-    difference_bytes += max(pair_count - 1, 0)
     return _SIDON_RESULT_ENVELOPE_BYTES + normalized_bytes + difference_bytes
 
 
 def _max_sidon_set_size_for_output_budget(budget: int) -> int:
-    """Largest ``n`` whose unique set ``0..n-1`` still fits ``budget`` bytes.
+    """Largest ``n`` whose lightest unique AdditiveInteger n-set fits ``budget``.
 
-    Pair work is ``n(n-1)`` ordered rows. The shortest unique AdditiveInteger
-    n-set is ``0..n-1``, so this ceiling is the largest cardinality whose
-    work and output can still fit; wider integers are rejected later by the
-    same byte reservation.
+    Pair work is ``n(n-1)`` ordered rows. The parser ceiling is the largest
+    cardinality whose minimum payload can still fit; actual source and
+    difference widths are reserved later by result-sensitive admission.
     """
 
     low = 0
     high = math.isqrt(max(budget, 0) // _SIDON_DIFFERENCE_ROW_OVERHEAD_BYTES) + 2
     while low < high:
         mid = (low + high + 1) // 2
-        if _integer_sidon_canonical_result_bytes(tuple(range(mid))) <= budget:
+        if _minimum_integer_sidon_result_bytes(mid) <= budget:
             low = mid
         else:
             high = mid - 1
@@ -129,6 +211,14 @@ class OrderedIntegerDifference(StrictModel):
     minuend: AdditiveInteger
     subtrahend: AdditiveInteger
     difference: AdditiveDifferenceInteger
+
+    @classmethod
+    def _from_kernel(cls, minuend: str, subtrahend: str, difference: str) -> Self:
+        return cls.model_construct(
+            minuend=minuend,
+            subtrahend=subtrahend,
+            difference=difference,
+        )
 
 
 class IntegerSidonResult(StrictModel):

--- a/src/jacobian/math/combinatorics/_difference_sets.py
+++ b/src/jacobian/math/combinatorics/_difference_sets.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import math
 from collections import Counter
 
-from jacobian.canonical import CanonicalLimits
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics._difference_set_models import (
     MAX_CYCLIC_DIFFERENCE_SET_MODULUS,
     MAX_DIFFERENCE_SET_ADDITIONAL_ELEMENTS,
     MAX_DIFFERENCE_SET_EXTENSION_CANDIDATES,
+    MAX_SIDON_RESULT_BYTES,
     CyclicDifferenceMultiplicity,
     CyclicDifferenceSetExtensionRequest,
     CyclicDifferenceSetExtensionResult,
@@ -20,6 +20,7 @@ from jacobian.math.combinatorics._difference_set_models import (
     IntegerSidonRequest,
     IntegerSidonResult,
     OrderedIntegerDifference,
+    _integer_sidon_canonical_result_bytes,
 )
 from jacobian.math.combinatorics._support import (
     combinatorics_operation,
@@ -50,26 +51,7 @@ def decide_integer_sidon(request: IntegerSidonRequest) -> IntegerSidonResult:
 def _require_integer_sidon_result_admission(elements: tuple[int, ...]) -> None:
     """Reserve the complete canonical result before constructing profile rows."""
 
-    normalized = tuple(str(value) for value in elements)
-    normalized_bytes = sum(len(value) + 2 for value in normalized) + max(
-        len(normalized) - 1, 0
-    )
-    difference_bytes = 0
-    pair_count = 0
-    for left in elements:
-        left_wire = str(left)
-        for right in elements:
-            if left == right:
-                continue
-            pair_count += 1
-            difference_bytes += (
-                46 + len(left_wire) + len(str(right)) + len(str(left - right))
-            )
-    difference_bytes += max(pair_count - 1, 0)
-    # Empty arrays and the longer ``false`` decision occupy 68 bytes before
-    # their contents are inserted.
-    result_bytes = 68 + normalized_bytes + difference_bytes
-    if result_bytes > CanonicalLimits().max_output_bytes:
+    if _integer_sidon_canonical_result_bytes(elements) > MAX_SIDON_RESULT_BYTES:
         raise OperationDomainValidationError(
             location=("elements",),
             code="combinatorics.sidon_result_bound",

--- a/src/jacobian/math/combinatorics/_difference_sets.py
+++ b/src/jacobian/math/combinatorics/_difference_sets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 from collections import Counter
 
+from jacobian.canonical import CanonicalLimits
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics._difference_set_models import (
@@ -27,6 +28,7 @@ from jacobian.math.combinatorics._support import (
 
 def decide_integer_sidon(request: IntegerSidonRequest) -> IntegerSidonResult:
     elements = tuple(sorted(int(value) for value in request.elements))
+    _require_integer_sidon_result_admission(elements)
     differences = tuple(
         OrderedIntegerDifference(
             minuend=str(left),
@@ -38,11 +40,43 @@ def decide_integer_sidon(request: IntegerSidonRequest) -> IntegerSidonResult:
         if left != right
     )
     values = tuple(int(record.difference) for record in differences)
-    return IntegerSidonResult(
+    return IntegerSidonResult._from_kernel(
         normalized_elements=tuple(str(value) for value in elements),
         ordered_differences=differences,
         is_sidon=len(set(values)) == len(values),
     )
+
+
+def _require_integer_sidon_result_admission(elements: tuple[int, ...]) -> None:
+    """Reserve the complete canonical result before constructing profile rows."""
+
+    normalized = tuple(str(value) for value in elements)
+    normalized_bytes = sum(len(value) + 2 for value in normalized) + max(
+        len(normalized) - 1, 0
+    )
+    difference_bytes = 0
+    pair_count = 0
+    for left in elements:
+        left_wire = str(left)
+        for right in elements:
+            if left == right:
+                continue
+            pair_count += 1
+            difference_bytes += (
+                46 + len(left_wire) + len(str(right)) + len(str(left - right))
+            )
+    difference_bytes += max(pair_count - 1, 0)
+    # Empty arrays and the longer ``false`` decision occupy 68 bytes before
+    # their contents are inserted.
+    result_bytes = 68 + normalized_bytes + difference_bytes
+    if result_bytes > CanonicalLimits().max_output_bytes:
+        raise OperationDomainValidationError(
+            location=("elements",),
+            code="combinatorics.sidon_result_bound",
+            message=(
+                "complete ordered-difference profile exceeds the canonical output bound"
+            ),
+        )
 
 
 def _difference_counts(residues: tuple[int, ...], modulus: int) -> Counter[int]:

--- a/src/jacobian/math/combinatorics/_difference_sets.py
+++ b/src/jacobian/math/combinatorics/_difference_sets.py
@@ -20,7 +20,8 @@ from jacobian.math.combinatorics._difference_set_models import (
     IntegerSidonRequest,
     IntegerSidonResult,
     OrderedIntegerDifference,
-    _integer_sidon_canonical_result_bytes,
+    _integer_sidon_profile,
+    _IntegerSidonAdmissionPlan,
 )
 from jacobian.math.combinatorics._support import (
     combinatorics_operation,
@@ -29,29 +30,28 @@ from jacobian.math.combinatorics._support import (
 
 def decide_integer_sidon(request: IntegerSidonRequest) -> IntegerSidonResult:
     elements = tuple(sorted(int(value) for value in request.elements))
-    _require_integer_sidon_result_admission(elements)
-    differences = tuple(
-        OrderedIntegerDifference(
-            minuend=str(left),
-            subtrahend=str(right),
-            difference=str(left - right),
-        )
-        for left in elements
-        for right in elements
-        if left != right
-    )
-    values = tuple(int(record.difference) for record in differences)
+    plan = _require_integer_sidon_result_admission(elements)
     return IntegerSidonResult._from_kernel(
-        normalized_elements=tuple(str(value) for value in elements),
-        ordered_differences=differences,
-        is_sidon=len(set(values)) == len(values),
+        normalized_elements=plan.normalized_wires,
+        ordered_differences=tuple(
+            OrderedIntegerDifference._from_kernel(
+                minuend=minuend,
+                subtrahend=subtrahend,
+                difference=difference,
+            )
+            for minuend, subtrahend, difference in plan.difference_wires
+        ),
+        is_sidon=plan.is_sidon,
     )
 
 
-def _require_integer_sidon_result_admission(elements: tuple[int, ...]) -> None:
-    """Reserve the complete canonical result before constructing profile rows."""
+def _require_integer_sidon_result_admission(
+    elements: tuple[int, ...],
+) -> _IntegerSidonAdmissionPlan:
+    """Reserve the complete canonical result and retain its difference wires."""
 
-    if _integer_sidon_canonical_result_bytes(elements) > MAX_SIDON_RESULT_BYTES:
+    plan = _integer_sidon_profile(elements)
+    if plan.result_bytes > MAX_SIDON_RESULT_BYTES:
         raise OperationDomainValidationError(
             location=("elements",),
             code="combinatorics.sidon_result_bound",
@@ -59,6 +59,7 @@ def _require_integer_sidon_result_admission(elements: tuple[int, ...]) -> None:
                 "complete ordered-difference profile exceeds the canonical output bound"
             ),
         )
+    return plan
 
 
 def _difference_counts(residues: tuple[int, ...], modulus: int) -> Counter[int]:

--- a/tests/math/combinatorics/test_difference_set_models.py
+++ b/tests/math/combinatorics/test_difference_set_models.py
@@ -9,6 +9,9 @@ from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics._difference_set_models import (
+    MAX_SIDON_ORDERED_DIFFERENCES,
+    MAX_SIDON_RESULT_BYTES,
+    MAX_SIDON_SET_SIZE,
     CyclicDifferenceMultiplicity,
     CyclicDifferenceSetExtensionRequest,
     CyclicDifferenceSetExtensionResult,
@@ -16,8 +19,10 @@ from jacobian.math.combinatorics._difference_set_models import (
     CyclicPerfectDifferenceSetResult,
     IntegerSidonRequest,
     IntegerSidonResult,
+    _integer_sidon_canonical_result_bytes,
 )
 from jacobian.math.combinatorics._difference_sets import (
+    _require_integer_sidon_result_admission,
     decide_cyclic_difference_set_extension,
     decide_cyclic_perfect_difference_set,
     decide_integer_sidon,
@@ -79,12 +84,46 @@ def test_sidon_admits_complete_profile_for_first_69_squares() -> None:
 
     assert len(result.normalized_elements) == 69
     assert len(result.ordered_differences) == 69 * 68
-    assert len(result.model_dump_json().encode()) < 10 * 1024 * 1024
+    assert len(result.model_dump_json().encode()) < MAX_SIDON_RESULT_BYTES
+
+
+def test_sidon_byte_formula_matches_compact_json_for_a_false_decision() -> None:
+    result = decide_integer_sidon(IntegerSidonRequest(elements=("0", "1", "2")))
+
+    assert result.is_sidon is False
+    assert _integer_sidon_canonical_result_bytes((0, 1, 2)) == len(
+        result.model_dump_json().encode()
+    )
+
+
+def test_sidon_parser_ceiling_is_derived_from_shortest_output_budget() -> None:
+    admitted = tuple(range(MAX_SIDON_SET_SIZE))
+    rejected = tuple(range(MAX_SIDON_SET_SIZE + 1))
+
+    assert _integer_sidon_canonical_result_bytes(admitted) <= MAX_SIDON_RESULT_BYTES
+    assert _integer_sidon_canonical_result_bytes(rejected) > MAX_SIDON_RESULT_BYTES
+    assert MAX_SIDON_ORDERED_DIFFERENCES == MAX_SIDON_SET_SIZE * (
+        MAX_SIDON_SET_SIZE - 1
+    )
+    IntegerSidonRequest(elements=tuple(str(value) for value in admitted))
+    _require_integer_sidon_result_admission(admitted)
+    with pytest.raises(ValidationError) as exc_info:
+        IntegerSidonRequest(elements=tuple(str(value) for value in rejected))
+    assert exc_info.value.errors()[0]["type"] == "too_long"
+
+
+def test_sidon_zero_through_256_reaches_result_sensitive_admission() -> None:
+    elements = tuple(range(257))
+    request = IntegerSidonRequest(elements=tuple(str(value) for value in elements))
+
+    assert len(request.elements) == 257
+    assert _integer_sidon_canonical_result_bytes(elements) == 3_616_904
+    _require_integer_sidon_result_admission(elements)
 
 
 def test_sidon_rejects_profile_exceeding_canonical_output_bound() -> None:
     prefix = "9" * 125
-    elements = tuple(f"{prefix}{value:03d}" for value in range(256))
+    elements = tuple(f"{prefix}{value:03d}" for value in range(MAX_SIDON_SET_SIZE))
 
     with pytest.raises(OperationDomainValidationError, match="canonical output bound"):
         decide_integer_sidon(IntegerSidonRequest(elements=elements))

--- a/tests/math/combinatorics/test_difference_set_models.py
+++ b/tests/math/combinatorics/test_difference_set_models.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics import _difference_set_models as sidon_models
+from jacobian.math.combinatorics import _difference_sets as sidon_kernel
 from jacobian.math.combinatorics._difference_set_models import (
     MAX_SIDON_ORDERED_DIFFERENCES,
     MAX_SIDON_RESULT_BYTES,
@@ -20,6 +23,8 @@ from jacobian.math.combinatorics._difference_set_models import (
     IntegerSidonRequest,
     IntegerSidonResult,
     _integer_sidon_canonical_result_bytes,
+    _minimum_integer_sidon_result_bytes,
+    _minimum_payload_sidon_elements,
 )
 from jacobian.math.combinatorics._difference_sets import (
     _require_integer_sidon_result_admission,
@@ -96,20 +101,49 @@ def test_sidon_byte_formula_matches_compact_json_for_a_false_decision() -> None:
     )
 
 
-def test_sidon_parser_ceiling_is_derived_from_shortest_output_budget() -> None:
-    admitted = tuple(range(MAX_SIDON_SET_SIZE))
-    rejected = tuple(range(MAX_SIDON_SET_SIZE + 1))
+def test_sidon_parser_ceiling_is_derived_from_minimum_payload_per_cardinality() -> None:
+    admitted = _minimum_payload_sidon_elements(MAX_SIDON_SET_SIZE)
+    rejected = tuple(str(value) for value in range(MAX_SIDON_SET_SIZE + 1))
 
-    assert _integer_sidon_canonical_result_bytes(admitted) <= MAX_SIDON_RESULT_BYTES
-    assert _integer_sidon_canonical_result_bytes(rejected) > MAX_SIDON_RESULT_BYTES
+    assert (
+        _minimum_integer_sidon_result_bytes(MAX_SIDON_SET_SIZE)
+        <= MAX_SIDON_RESULT_BYTES
+    )
+    assert (
+        _minimum_integer_sidon_result_bytes(MAX_SIDON_SET_SIZE + 1)
+        > MAX_SIDON_RESULT_BYTES
+    )
+    assert _integer_sidon_canonical_result_bytes(
+        admitted
+    ) == _minimum_integer_sidon_result_bytes(MAX_SIDON_SET_SIZE)
     assert MAX_SIDON_ORDERED_DIFFERENCES == MAX_SIDON_SET_SIZE * (
         MAX_SIDON_SET_SIZE - 1
     )
     IntegerSidonRequest(elements=tuple(str(value) for value in admitted))
     _require_integer_sidon_result_admission(admitted)
     with pytest.raises(ValidationError) as exc_info:
-        IntegerSidonRequest(elements=tuple(str(value) for value in rejected))
+        IntegerSidonRequest(elements=rejected)
     assert exc_info.value.errors()[0]["type"] == "too_long"
+
+
+def test_sidon_translated_interval_reaches_result_sensitive_admission() -> None:
+    elements = tuple(range(-9, 426))
+    request = IntegerSidonRequest(elements=tuple(str(value) for value in elements))
+    plan = _require_integer_sidon_result_admission(elements)
+
+    assert len(request.elements) == 435
+    assert MAX_SIDON_SET_SIZE == 435
+    assert plan.result_bytes == 10_481_930
+    assert plan.result_bytes <= MAX_SIDON_RESULT_BYTES
+
+
+def test_sidon_nonnegative_interval_at_the_ceiling_is_rejected_by_bytes() -> None:
+    elements = tuple(range(MAX_SIDON_SET_SIZE))
+    IntegerSidonRequest(elements=tuple(str(value) for value in elements))
+
+    assert _integer_sidon_canonical_result_bytes(elements) > MAX_SIDON_RESULT_BYTES
+    with pytest.raises(OperationDomainValidationError, match="canonical output bound"):
+        _require_integer_sidon_result_admission(elements)
 
 
 def test_sidon_zero_through_256_reaches_result_sensitive_admission() -> None:
@@ -121,9 +155,40 @@ def test_sidon_zero_through_256_reaches_result_sensitive_admission() -> None:
     _require_integer_sidon_result_admission(elements)
 
 
+def test_sidon_kernel_reuses_admitted_difference_wires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+    captured: list[Any] = []
+    real_profile = sidon_models._integer_sidon_profile
+
+    def counted_profile(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        plan = real_profile(*args, **kwargs)
+        captured.append(plan)
+        return plan
+
+    monkeypatch.setattr(sidon_models, "_integer_sidon_profile", counted_profile)
+    monkeypatch.setattr(sidon_kernel, "_integer_sidon_profile", counted_profile)
+    result = decide_integer_sidon(IntegerSidonRequest(elements=("0", "1", "3")))
+
+    assert calls == 1
+    plan = captured[0]
+    assert result.normalized_elements == plan.normalized_wires
+    assert result.is_sidon == plan.is_sidon
+    assert (
+        tuple(
+            (item.minuend, item.subtrahend, item.difference)
+            for item in result.ordered_differences
+        )
+        == plan.difference_wires
+    )
+
+
 def test_sidon_rejects_profile_exceeding_canonical_output_bound() -> None:
     prefix = "9" * 125
-    elements = tuple(f"{prefix}{value:03d}" for value in range(MAX_SIDON_SET_SIZE))
+    elements = tuple(f"{prefix}{value:03d}" for value in range(256))
 
     with pytest.raises(OperationDomainValidationError, match="canonical output bound"):
         decide_integer_sidon(IntegerSidonRequest(elements=elements))

--- a/tests/math/combinatorics/test_difference_set_models.py
+++ b/tests/math/combinatorics/test_difference_set_models.py
@@ -65,6 +65,41 @@ def test_sidon_kernel_decision_matches_its_complete_profile() -> None:
     assert result.is_sidon == (len(set(differences)) == len(differences))
 
 
+def test_singleton_sidon_has_empty_complete_ledger() -> None:
+    result = decide_integer_sidon(IntegerSidonRequest(elements=("7",)))
+
+    assert result.normalized_elements == ("7",)
+    assert result.ordered_differences == ()
+    assert result.is_sidon is True
+
+
+def test_sidon_admits_complete_profile_for_first_69_squares() -> None:
+    elements = tuple(str(value * value) for value in range(1, 70))
+    result = decide_integer_sidon(IntegerSidonRequest(elements=elements))
+
+    assert len(result.normalized_elements) == 69
+    assert len(result.ordered_differences) == 69 * 68
+    assert len(result.model_dump_json().encode()) < 10 * 1024 * 1024
+
+
+def test_sidon_rejects_profile_exceeding_canonical_output_bound() -> None:
+    prefix = "9" * 125
+    elements = tuple(f"{prefix}{value:03d}" for value in range(256))
+
+    with pytest.raises(OperationDomainValidationError, match="canonical output bound"):
+        decide_integer_sidon(IntegerSidonRequest(elements=elements))
+
+
+def test_sidon_result_rejects_forged_difference_and_decision() -> None:
+    result = decide_integer_sidon(IntegerSidonRequest(elements=("0", "1", "3")))
+    payload = result.model_dump(mode="json")
+    payload["ordered_differences"][0]["difference"] = "0"
+    payload["is_sidon"] = not result.is_sidon
+
+    with raises_code("combinatorics.sidon_invariant"):
+        IntegerSidonResult.model_validate(payload)
+
+
 def test_extension_request_rejects_an_unbounded_candidate_space() -> None:
     request = CyclicDifferenceSetExtensionRequest(
         base_elements=("0", "1", "2", "3", "4", "5", "6"),


### PR DESCRIPTION
## Problem

`combinatorics.integer_set.sidon.decide` returns a complete ordered nonzero-difference ledger, but both request and result contracts reject every source above 32 elements. Its actual work and output are determined by `n(n-1)` rows and the source/difference wire widths, so the fixed cap excludes tractable profiles such as the first 69 squares.

## What changed

- widen the parser-level source carrier from 32 to 256 elements;
- reserve the complete canonical JSON result from the actual normalized values and all ordered differences before constructing row models;
- reject requests whose full ledger would exceed the real 10 MiB canonical output boundary;
- construct kernel-produced results through the trusted factory;
- make independent result validation replay every canonical ordered pair, subtraction, and the Sidon multiplicity decision.

The public postcondition is unchanged: the result contains each ordered pair of distinct normalized source elements exactly once. This does not introduce a decision-only shortcut or an incomplete profile.

## Evidence

- the first 69 squares are admitted and return all 4,692 rows;
- 256 small integers are admitted with a roughly 3.59 MB canonical payload;
- 256 maximum-width positive integers are rejected before result materialization;
- singleton input returns an empty ledger and `is_sidon=true`; duplicate input remains rejected;
- forged differences and decisions fail closed on `IntegerSidonResult.model_validate`;
- independent review checked the byte formula against canonical JSON: it is exact for `is_sidon=false` and conservatively overcounts true results by one byte.

`make affected AFFECTED_BASE=origin/main` passed on commit `3c25ea02f`:

- scoped Ruff formatting and lint;
- scoped mypy;
- 912 combinatorics owner tests.

Closes #2884.
