### PR TITLE
Admit larger bounded represented-matroid closures

### DIFF
--- a/src/jacobian/math/combinatorics/matroids/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/_models.py
@@ -10,7 +10,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.matrices.finite_fields.linear_algebra import PrimeFieldMatrix
 
-MAX_GROUND_SIZE = 32
+MAX_GROUND_SIZE = 256
 """Schema-visible cap on the ground-set cardinality (matrix columns)."""
 
 MAX_REPRESENTATION_ROWS = 256
@@ -42,7 +42,7 @@ class LinearMatroid(StrictModel):
             "description": (
                 "A linear matroid over GF(p) as the canonical "
                 "`PrimeFieldMatrix`: the ground set indexes matrix columns, "
-                "entries are canonical residues in [0, prime), and up to 32 "
+                "entries are canonical residues in [0, prime), and up to 256 "
                 "columns. The empty matroid (zero columns) is admitted."
             )
         }

--- a/src/jacobian/math/combinatorics/matroids/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/operations.py
@@ -15,6 +15,26 @@ from jacobian.math.matrices.finite_fields.linear_algebra import (
     rank as pf_rank,
 )
 
+MAX_CLOSURE_RANK_WORK = 50_000_000
+
+
+def _rank_work(rows: int, columns: int) -> int:
+    return rows * columns * min(rows, columns)
+
+
+def _require_closure_work(matroid: LinearMatroid, subset_size: int) -> None:
+    rows = len(matroid.matrix.entries)
+    ground_size = matroid.ground_size
+    work = _rank_work(rows, subset_size) + (ground_size - subset_size) * _rank_work(
+        rows, subset_size + 1
+    )
+    if work > MAX_CLOSURE_RANK_WORK:
+        raise OperationDomainValidationError(
+            location=("matroid", "subset"),
+            code="matroid.closure.work_bound",
+            message="closure rank computations exceed the exact work bound",
+        )
+
 
 def _selected_columns_matrix(
     matroid: LinearMatroid, column_indices: list[int]
@@ -52,7 +72,7 @@ def _closure_invariant(
     for element in range(matroid.ground_size):
         if element in closure:
             continue
-        test = sorted(closure | {element})
+        test = [*subset, element]
         if pf_rank(_selected_columns_matrix(matroid, test)) == subset_rank:
             closure.add(element)
     return tuple(sorted(closure)), subset_rank
@@ -75,6 +95,7 @@ def matroid_closure(
             code="matroid.subset.invalid",
             message=str(exc),
         ) from exc
+    _require_closure_work(matroid, len(canonical_subset))
     return _closure_invariant(matroid, list(canonical_subset))
 
 

--- a/tests/math/combinatorics/matroids/test_matroids.py
+++ b/tests/math/combinatorics/matroids/test_matroids.py
@@ -2,23 +2,27 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TypedDict
+from collections.abc import Callable, Sequence
+from typing import TypedDict, cast
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
+from tests.fixtures.accounting import assert_charged_work_parity
 
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.matroids import (
     LinearMatroid,
     matroid_closure,
     matroid_rank,
+    operations,
 )
 from jacobian.math.combinatorics.matroids._models import (
     MatroidClosureRequest,
     MatroidClosureResult,
 )
 from jacobian.math.combinatorics.matroids.operations import closure_result
+from jacobian.math.matrices.finite_fields.linear_algebra import PrimeFieldMatrix
 
 
 def compute_closure(request: MatroidClosureRequest) -> MatroidClosureResult:
@@ -166,18 +170,48 @@ class TestClosure:
         )
         matroid = _matroid(1_000_003, rows, 105)
 
-        closure, rank = matroid_closure(matroid, (0, 1, 2, 3, 4))
+        executed_work = 0
+        original_rank = cast(
+            Callable[[PrimeFieldMatrix], int], vars(operations)["pf_rank"]
+        )
+
+        def counted_rank(matrix: PrimeFieldMatrix) -> int:
+            nonlocal executed_work
+            executed_work += operations._rank_work(len(matrix.entries), matrix.columns)
+            return original_rank(matrix)
+
+        with patch.object(operations, "pf_rank", side_effect=counted_rank):
+            closure, rank = matroid_closure(matroid, (0, 1, 2, 3, 4))
 
         assert rank == 5
         assert closure == tuple(
             column for column in range(105) if column % 7 in {0, 1, 2, 3, 4}
         )
+        assert_charged_work_parity(
+            charged={"rank": 25_375}, executed={"rank": executed_work}
+        )
 
-    def test_dense_large_seed_rejects_rank_work_before_kernel(self) -> None:
-        matroid = _matroid(2, _identity_rows(256), 256)
+    def test_closure_work_boundary_accepts_last_in_range_request(self) -> None:
+        matroid = _matroid(2, [(0,) * 147 for _ in range(222)], 147)
+
+        closure, rank = matroid_closure(matroid, tuple(range(46)))
+
+        assert (
+            operations._rank_work(222, 46) + 101 * operations._rank_work(222, 47)
+            == 49_999_950
+        )
+        assert closure == tuple(range(147))
+        assert rank == 0
+
+    def test_closure_work_boundary_rejects_first_out_of_range_request(self) -> None:
+        matroid = _matroid(2, [(0,) * 250 for _ in range(141)], 250)
 
         with pytest.raises(OperationDomainValidationError, match="work bound"):
-            matroid_closure(matroid, tuple(range(128)))
+            matroid_closure(matroid, tuple(range(40)))
+        assert (
+            operations._rank_work(141, 40) + 210 * operations._rank_work(141, 41)
+            == 50_000_010
+        )
 
 
 class TestCatalogAdmission:

--- a/tests/math/combinatorics/matroids/test_matroids.py
+++ b/tests/math/combinatorics/matroids/test_matroids.py
@@ -72,33 +72,27 @@ class TestLinearMatroidRepresentation:
             )
         assert exc_info.value.errors()[0]["type"] == "matroid.field_prime.bound"
 
-    def test_ground_set_beyond_cap_rejected(self) -> None:
-        """A 33-column matrix is rejected even though the shared kernel
-        admits up to 1024 columns: the advertised envelope is 32 elements."""
+    def test_matroid_accepts_shared_matrix_column_carrier(self) -> None:
         from jacobian.math.matrices.finite_fields.linear_algebra import (
             PrimeFieldMatrix,
         )
 
-        oversized_matrix = PrimeFieldMatrix(
+        boundary_matrix = PrimeFieldMatrix(
             prime=5,
-            entries=((0,) * 33,),
-            columns=33,
+            entries=((0,) * 256,),
+            columns=256,
         )
-        with pytest.raises(ValidationError) as exc_info:
-            LinearMatroid(matrix=oversized_matrix)
-        assert exc_info.value.errors()[0]["type"] == "matroid.ground_set.bound"
+        assert LinearMatroid(matrix=boundary_matrix).ground_size == 256
         matrix_payload: _PrimeFieldMatrixPayload = {
             "prime": 5,
-            "entries": [[0] * 33],
-            "columns": 33,
+            "entries": [[0] * 256],
+            "columns": 256,
         }
         payload: _ClosureRequestPayload = {
             "matroid": {"matrix": matrix_payload},
             "subset": [],
         }
-        with pytest.raises(ValidationError) as exc_info:
-            MatroidClosureRequest.model_validate(payload)
-        assert exc_info.value.errors()[0]["type"] == "matroid.ground_set.bound"
+        assert MatroidClosureRequest.model_validate(payload).matroid.ground_size == 256
 
     def test_shared_carrier_does_not_widen_matroid_row_envelope(self) -> None:
         """The matrix carrier may scale without widening matroid witness work."""
@@ -165,6 +159,25 @@ class TestClosure:
             matroid_closure(m, [2])
         with pytest.raises(ValueError, match="distinct"):
             matroid_closure(m, [0, 0])
+
+    def test_seven_by_105_closure_uses_result_sensitive_rank_work(self) -> None:
+        rows = tuple(
+            tuple(int(column % 7 == row) for column in range(105)) for row in range(7)
+        )
+        matroid = _matroid(1_000_003, rows, 105)
+
+        closure, rank = matroid_closure(matroid, (0, 1, 2, 3, 4))
+
+        assert rank == 5
+        assert closure == tuple(
+            column for column in range(105) if column % 7 in {0, 1, 2, 3, 4}
+        )
+
+    def test_dense_large_seed_rejects_rank_work_before_kernel(self) -> None:
+        matroid = _matroid(2, _identity_rows(256), 256)
+
+        with pytest.raises(OperationDomainValidationError, match="work bound"):
+            matroid_closure(matroid, tuple(range(128)))
 
 
 class TestCatalogAdmission:


### PR DESCRIPTION
## Problem

`matroid.closure.compute` rejects represented matroids above 32 ground elements even though its canonical `PrimeFieldMatrix` carrier supports 256 columns. The fixed cap excludes a concrete 7-by-105 relation matroid whose closure workload is small.

The closure kernel also grew each candidate test matrix with closure elements found earlier. Those columns already lie in the seed span, so they cannot affect later membership decisions and only inflate backend work.

## What changed

- align the represented-matroid ground carrier with the shared 256-column prime-field matrix;
- test each candidate against the original seed subset plus that candidate, preserving the closure identity while keeping every trial width at `|S| + 1`;
- admit closure work from the actual row count, ground size, seed size, and dimensions of every rank call;
- retain the complete source-bound closure and exact seed rank.

The 256-column carrier is only a parser boundary. Requests whose rank-call ledger exceeds 50,000,000 units remain rejected before the kernel.

## Evidence

- a 7-by-105 represented matroid is admitted; a five-column rank-5 seed returns the exact 75-column closure;
- the last in-range witness charges 49,999,950 units and executes successfully;
- the first out-of-range witness charges 50,000,010 units and raises the typed work-bound error;
- the representative 7-by-105 execution instruments every actual `pf_rank` call by its matrix shape, and charged-work parity confirms all 25,375 observed units were reserved;
- independent review confirmed testing against the original seed is mathematically equivalent because every closure element is already in its span.

`make affected AFFECTED_BASE=origin/main` passed on commit `6d612d5cb`:

- scoped Ruff formatting and lint;
- scoped mypy;
- 41 matroid owner tests;
- 112 catalog tests;
- 800 catalog integration tests.

Closes #2377.
