### PR TITLE
Admit tall exact matrix reductions with FLINT

### DIFF
--- a/src/jacobian/math/lattices/_hnf.py
+++ b/src/jacobian/math/lattices/_hnf.py
@@ -9,11 +9,12 @@ from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
 from jacobian.math.lattices import hermite_normal_form
 from jacobian.math.lattices._models import (
-    _MAX_LATTICE_INPUT_SCALAR_DIGITS,
     HermiteNormalFormRequest,
     HermiteNormalFormResult,
+    _require_lattice_matrix_envelope,
+    _run_admission,
 )
-from jacobian.math.matrices.values import IntegerMatrix, require_matrix_scalar_digits
+from jacobian.math.matrices.values import IntegerMatrix
 
 
 def _matrix(value: Any) -> IntegerMatrix:
@@ -31,10 +32,11 @@ def _matrix(value: Any) -> IntegerMatrix:
 def compute_hermite_normal_form(
     request: HermiteNormalFormRequest,
 ) -> HermiteNormalFormResult:
-    require_matrix_scalar_digits(
-        request.matrix.entries,
-        maximum=_MAX_LATTICE_INPUT_SCALAR_DIGITS,
-        label="Hermite normal form input",
+    _run_admission(
+        lambda: _require_lattice_matrix_envelope(
+            request.matrix, label="Hermite normal form input"
+        ),
+        location=("matrix",),
     )
     integer_entries = [
         [parse_canonical_integer(value) for value in row]

--- a/src/jacobian/math/lattices/_lattice.py
+++ b/src/jacobian/math/lattices/_lattice.py
@@ -9,14 +9,14 @@ from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
 from jacobian.math.lattices import reduce_basis
 from jacobian.math.lattices._models import (
-    _MAX_LATTICE_INPUT_SCALAR_DIGITS,
     LatticeReductionRequest,
     LatticeReductionResult,
+    _require_lattice_matrix_envelope,
+    _run_admission,
 )
 from jacobian.math.matrices.values import (
     MAX_MATRIX_SCALAR_DIGITS,
     IntegerMatrix,
-    require_matrix_scalar_digits,
 )
 
 
@@ -40,10 +40,9 @@ def _wire(matrix: Any) -> IntegerMatrix:
 def reduce_lattice_basis(
     request: LatticeReductionRequest,
 ) -> LatticeReductionResult:
-    require_matrix_scalar_digits(
-        request.basis.entries,
-        maximum=_MAX_LATTICE_INPUT_SCALAR_DIGITS,
-        label="basis input",
+    _run_admission(
+        lambda: _require_lattice_matrix_envelope(request.basis, label="basis input"),
+        location=("basis",),
     )
     entries = [
         [parse_canonical_integer(value) for value in row]

--- a/src/jacobian/math/lattices/_models.py
+++ b/src/jacobian/math/lattices/_models.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Literal, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices.values import (
     MAX_MATRIX_DIMENSION,
     IntegerMatrix,
@@ -25,10 +27,51 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"lattice.{reason}", message)
 
 
-class HermiteNormalFormRequest(StrictModel):
-    """One bounded integer matrix for row Hermite normal form."""
+def _require_lattice_matrix_envelope(matrix: IntegerMatrix, *, label: str) -> None:
+    """Admit one integer matrix into the lattice 32-axis computation envelope."""
 
-    matrix: IntegerMatrix
+    rows = len(matrix.entries)
+    columns = len(matrix.entries[0])
+    if rows > MAX_MATRIX_DIMENSION or columns > MAX_MATRIX_DIMENSION:
+        raise _validation_error(
+            "budget_exceeded",
+            f"{label} dimensions are limited to {MAX_MATRIX_DIMENSION} rows and columns",
+        )
+    require_matrix_scalar_digits(
+        matrix.entries,
+        maximum=_MAX_LATTICE_INPUT_SCALAR_DIGITS,
+        label=label,
+    )
+
+
+def _run_admission(admission: Callable[[], None], *, location: tuple[str, ...]) -> None:
+    """Expose lattice envelope rejection through the domain API."""
+
+    try:
+        admission()
+    except PydanticCustomError as exc:
+        raise OperationDomainValidationError(
+            location=location, code=exc.type, message=exc.message()
+        ) from exc
+
+
+class HermiteNormalFormRequest(StrictModel):
+    """One bounded integer matrix for row Hermite normal form.
+
+    Row and column counts are at most ``MAX_MATRIX_DIMENSION``.
+    """
+
+    matrix: IntegerMatrix = Field(
+        description=(
+            "Integer matrix whose row and column counts are at most "
+            f"{MAX_MATRIX_DIMENSION}."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_admitted_envelope(self) -> Self:
+        _require_lattice_matrix_envelope(self.matrix, label="Hermite normal form input")
+        return self
 
 
 class HermiteNormalFormResult(StrictModel):
@@ -56,9 +99,22 @@ class HermiteNormalFormResult(StrictModel):
 
 
 class LatticeReductionRequest(StrictModel):
-    """One bounded integer row basis for exact LLL reduction."""
+    """One bounded integer row basis for exact LLL reduction.
 
-    basis: IntegerMatrix
+    Row and column counts are at most ``MAX_MATRIX_DIMENSION``.
+    """
+
+    basis: IntegerMatrix = Field(
+        description=(
+            "Integer row basis whose row and column counts are at most "
+            f"{MAX_MATRIX_DIMENSION}."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_admitted_envelope(self) -> Self:
+        _require_lattice_matrix_envelope(self.basis, label="basis input")
+        return self
 
 
 class LatticeReductionResult(StrictModel):

--- a/src/jacobian/math/matrices/_flint.py
+++ b/src/jacobian/math/matrices/_flint.py
@@ -2,6 +2,9 @@
 
 from fractions import Fraction
 
+RationalEntries = tuple[tuple[Fraction, ...], ...]
+IntegerEntries = tuple[tuple[int, ...], ...]
+
 
 def rational_determinant(entries: tuple[tuple[Fraction, ...], ...]) -> Fraction:
     """Return the exact determinant through FLINT's dense rational kernel."""
@@ -15,4 +18,40 @@ def rational_determinant(entries: tuple[tuple[Fraction, ...], ...]) -> Fraction:
     return Fraction(int(result.numerator), int(result.denominator))
 
 
-__all__ = ["rational_determinant"]
+def rational_rref(entries: RationalEntries) -> tuple[RationalEntries, int]:
+    """Return the exact rectangular RREF and rank through FLINT."""
+
+    from flint import fmpq, fmpq_mat
+
+    backend = fmpq_mat(
+        [[fmpq(value.numerator, value.denominator) for value in row] for row in entries]
+    )
+    reduced, rank = backend.rref()
+    return (
+        tuple(
+            tuple(
+                Fraction(
+                    int(reduced[row, column].numerator),
+                    int(reduced[row, column].denominator),
+                )
+                for column in range(reduced.ncols())
+            )
+            for row in range(reduced.nrows())
+        ),
+        int(rank),
+    )
+
+
+def integer_smith_normal_form(entries: IntegerEntries) -> IntegerEntries:
+    """Return the exact rectangular Smith diagonal through FLINT."""
+
+    from flint import fmpz_mat
+
+    reduced = fmpz_mat([list(row) for row in entries]).snf()
+    return tuple(
+        tuple(int(reduced[row, column]) for column in range(reduced.ncols()))
+        for row in range(reduced.nrows())
+    )
+
+
+__all__ = ["integer_smith_normal_form", "rational_determinant", "rational_rref"]

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -10,6 +10,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalInteger, CanonicalRational
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.matrices.values import (
+    MAX_EXACT_LINEAR_MATRIX_AXIS,
     MAX_MATRIX_DIMENSION,
     MAX_MATRIX_SCALAR_DIGITS,
     IntegerMatrix,
@@ -26,6 +27,7 @@ MAX_PERMANENT_MATRIX_ORDER = MAX_PERMANENT_RYSER_SUBSETS.bit_length() - 1
 # order 128, but Kronecker admission was established only for product axes
 # through order 50. Pin each admitted output axis to that envelope.
 MAX_KRONECKER_PRODUCT_AXIS = 50
+MAX_EXACT_LINEAR_MATRIX_WORK = 100_000_000
 
 
 def _require_raw_scalar_digits(value: object, *, label: str) -> None:
@@ -161,6 +163,7 @@ def _require_square_system_admission(
 
 class RationalMatrixRequest(_MatrixRequest):
     matrix: RationalMatrix
+    _raw_matrix_axis_limit: ClassVar[int] = MAX_EXACT_LINEAR_MATRIX_AXIS
 
 
 class RationalMatrixProductRequest(_MatrixRequest):
@@ -192,10 +195,12 @@ class MatrixRankRequest(_MatrixRequest):
     """One bounded rectangular matrix whose exact rank is requested."""
 
     matrix: RationalMatrix
+    _raw_matrix_axis_limit: ClassVar[int] = MAX_EXACT_LINEAR_MATRIX_AXIS
 
 
 class IntegerMatrixRequest(_MatrixRequest):
     matrix: IntegerMatrix
+    _raw_matrix_axis_limit: ClassVar[int] = MAX_EXACT_LINEAR_MATRIX_AXIS
 
 
 class NonsingularIntegerMatrixRequest(_MatrixRequest):
@@ -225,9 +230,9 @@ class RrefResult(StrictModel):
 
     matrix: RationalMatrix
     reduced_matrix: RationalMatrix
-    rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
-    pivot_columns: tuple[int, ...] = Field(max_length=MAX_MATRIX_DIMENSION)
-    free_columns: tuple[int, ...] = Field(max_length=MAX_MATRIX_DIMENSION)
+    rank: int = Field(ge=0, le=MAX_EXACT_LINEAR_MATRIX_AXIS)
+    pivot_columns: tuple[int, ...] = Field(max_length=MAX_EXACT_LINEAR_MATRIX_AXIS)
+    free_columns: tuple[int, ...] = Field(max_length=MAX_EXACT_LINEAR_MATRIX_AXIS)
     convention: Literal["UNIQUE_RREF_OVER_QQ"] = "UNIQUE_RREF_OVER_QQ"
 
     @classmethod
@@ -275,8 +280,8 @@ class MatrixRankResult(StrictModel):
     """One structurally bounded rank outcome bound to its source matrix."""
 
     matrix: RationalMatrix
-    rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
-    pivot_columns: tuple[int, ...] = Field(max_length=MAX_MATRIX_DIMENSION)
+    rank: int = Field(ge=0, le=MAX_EXACT_LINEAR_MATRIX_AXIS)
+    pivot_columns: tuple[int, ...] = Field(max_length=MAX_EXACT_LINEAR_MATRIX_AXIS)
 
     @classmethod
     def _from_kernel(cls, **values: Any) -> Self:
@@ -307,13 +312,13 @@ class NullspaceResult(StrictModel):
     """
 
     matrix: RationalMatrix
-    ambient_dimension: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
-    rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
-    nullity: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
+    ambient_dimension: int = Field(ge=1, le=MAX_EXACT_LINEAR_MATRIX_AXIS)
+    rank: int = Field(ge=0, le=MAX_EXACT_LINEAR_MATRIX_AXIS)
+    nullity: int = Field(ge=0, le=MAX_EXACT_LINEAR_MATRIX_AXIS)
     basis_vectors: tuple[tuple[CanonicalRational, ...], ...] = Field(
-        max_length=MAX_MATRIX_DIMENSION
+        max_length=MAX_EXACT_LINEAR_MATRIX_AXIS
     )
-    free_columns: tuple[int, ...] = Field(max_length=MAX_MATRIX_DIMENSION)
+    free_columns: tuple[int, ...] = Field(max_length=MAX_EXACT_LINEAR_MATRIX_AXIS)
     convention: Literal["RREF_FUNDAMENTAL_BASIS"] = "RREF_FUNDAMENTAL_BASIS"
 
     @classmethod

--- a/src/jacobian/math/matrices/_tools.py
+++ b/src/jacobian/math/matrices/_tools.py
@@ -306,7 +306,7 @@ TOOLS = (
     matrix_operation(
         "matrix.rank.compute",
         "Compute exact rational matrix rank",
-        "Compute the rank and RREF pivot columns of one rectangular matrix over QQ.",
+        "Compute the rank and RREF pivot columns of one rectangular matrix over QQ through 64 rows and columns, subject to scalar-work and result-height bounds.",
         MatrixRankRequest,
         MatrixRankResult,
         compute_rank,
@@ -431,7 +431,7 @@ TOOLS = (
     matrix_operation(
         "matrix.normal_form.rref.compute",
         "Compute exact reduced row echelon form",
-        "Compute the unique reduced row echelon form over QQ.",
+        "Compute the unique reduced row echelon form over QQ through 64 rows and columns, subject to scalar-work and result-height bounds.",
         RationalMatrixRequest,
         RrefResult,
         compute_rref,
@@ -457,7 +457,7 @@ TOOLS = (
         "matrix.nullspace.compute",
         "Compute a canonical exact nullspace or relation basis",
         (
-            "Compute the RREF fundamental basis of the right nullspace over QQ. "
+            "Compute the RREF fundamental basis of the right nullspace over QQ through 64 rows and columns, subject to scalar-work and result-height bounds. "
             "When columns are ordered vectors, the result gives their rank and "
             "every exact rational linear dependency coefficient."
         ),
@@ -547,8 +547,7 @@ TOOLS = (
         "matrix.normal_form.smith.compute",
         "Compute an exact Smith normal form",
         (
-            "Compute the canonical diagonal Smith form over ZZ without claiming "
-            "unavailable left or right transformations."
+            "Compute the canonical diagonal Smith form over ZZ through 64 rows and columns, subject to scalar-work and result-height bounds, without claiming unavailable left or right transformations."
         ),
         IntegerMatrixRequest,
         SmithNormalForm,

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -44,6 +44,7 @@ from jacobian.math.matrices._operation_models import (
     _validation_error,
 )
 from jacobian.math.matrices.values import (
+    MAX_MATRIX_DIMENSION,
     MAX_MATRIX_SCALAR_DIGITS,
     IntegerMatrix,
     RationalMatrix,
@@ -369,6 +370,12 @@ def _admit_square_integer(matrix: IntegerMatrix) -> None:
     if rows == 0 or rows != len(matrix.entries[0]):
         raise _validation_error(
             "budget_exceeded", "operation requires a square integer matrix"
+        )
+    if rows > MAX_MATRIX_DIMENSION:
+        raise _validation_error(
+            "budget_exceeded",
+            "matrix computation dimensions are limited to "
+            f"{MAX_MATRIX_DIMENSION} rows and columns",
         )
 
 

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -44,6 +44,7 @@ from jacobian.math.matrices._operation_models import (
     _validation_error,
 )
 from jacobian.math.matrices.values import (
+    MAX_EXACT_LINEAR_MATRIX_AXIS,
     MAX_MATRIX_DIMENSION,
     MAX_MATRIX_SCALAR_DIGITS,
     IntegerMatrix,
@@ -109,8 +110,15 @@ def _exact_matrix(value: MatrixBase, *, maximum_dimension: int = 32) -> MatrixBa
 
 
 def rref(matrix: MatrixBase) -> tuple[MatrixBase, tuple[int, ...]]:
-    reduced, pivots = _exact_matrix(matrix).rref()
-    return reduced, tuple(int(pivot) for pivot in pivots)
+    result = rref_result(
+        conversions.rational_matrix_from_sympy(
+            _exact_matrix(matrix, maximum_dimension=MAX_EXACT_LINEAR_MATRIX_AXIS)
+        )
+    )
+    return (
+        conversions.rational_matrix_to_sympy(result.reduced_matrix),
+        result.pivot_columns,
+    )
 
 
 def inverse(matrix: MatrixBase) -> MatrixBase:
@@ -144,22 +152,32 @@ def characteristic_polynomial(matrix: MatrixBase, variable: str) -> Any:
 
 
 def determinant(matrix: MatrixBase) -> Any:
+    import sympy
+
     source = _exact_matrix(matrix, maximum_dimension=MAX_DETERMINANT_MATRIX_DIMENSION)
     if source.rows != source.cols:
         raise ValueError("determinant requires a square matrix")
-    return source.det(method="bareiss")
+    result = determinant_result(conversions.rational_matrix_from_sympy(source))
+    value = result.determinant.as_fraction()
+    return sympy.Rational(value.numerator, value.denominator)
 
 
 def rank(matrix: MatrixBase) -> tuple[int, tuple[int, ...]]:
-    _, pivots = rref(matrix)
-    return len(pivots), pivots
+    result = rank_result(
+        conversions.rational_matrix_from_sympy(
+            _exact_matrix(matrix, maximum_dimension=MAX_EXACT_LINEAR_MATRIX_AXIS)
+        )
+    )
+    return result.rank, result.pivot_columns
 
 
 def smith_normal_form(matrix: MatrixBase) -> MatrixBase:
-    import sympy
-    from sympy.matrices.normalforms import smith_normal_form as sympy_smith_normal_form
-
-    return sympy_smith_normal_form(_exact_matrix(matrix), domain=sympy.ZZ)
+    result = smith_normal_form_result(
+        conversions.integer_matrix_from_sympy(
+            _exact_matrix(matrix, maximum_dimension=MAX_EXACT_LINEAR_MATRIX_AXIS)
+        )
+    )
+    return conversions.integer_matrix_to_sympy(result.normal_form)
 
 
 def multiply(left: MatrixBase, right: MatrixBase) -> MatrixBase:
@@ -274,6 +292,12 @@ def _admit_exact_linear_matrix(
     )
     rows = len(entries)
     columns = len(entries[0])
+    if rows > MAX_EXACT_LINEAR_MATRIX_AXIS or columns > MAX_EXACT_LINEAR_MATRIX_AXIS:
+        raise _validation_error(
+            "budget_exceeded",
+            "matrix computation dimensions are limited to "
+            f"{MAX_EXACT_LINEAR_MATRIX_AXIS} rows and columns",
+        )
     rank_bound = min(rows, columns)
     scalar_digits = max(
         len(component.lstrip("-"))

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -16,12 +16,13 @@ from typing import TYPE_CHECKING, Any, cast
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices import _conversions as conversions
 from jacobian.math.matrices._operation_models import (
     MAX_DETERMINANT_MATRIX_DIMENSION,
     MAX_DETERMINANT_SCALAR_WORK,
+    MAX_EXACT_LINEAR_MATRIX_WORK,
     MAX_INPUT_SCALAR_DIGITS,
     MAX_KRONECKER_PRODUCT_AXIS,
     MAX_PERMANENT_RYSER_SUBSETS,
@@ -47,6 +48,7 @@ from jacobian.math.matrices.values import (
     IntegerMatrix,
     RationalMatrix,
     SmithNormalForm,
+    rational_matrix_from_fractions,
 )
 
 if TYPE_CHECKING:
@@ -261,6 +263,90 @@ def _admit_rational(matrix: RationalMatrix) -> None:
     _admit_rational_matrix(matrix)
 
 
+def _admit_exact_linear_matrix(
+    entries: tuple[tuple[CanonicalRational | str, ...], ...],
+) -> None:
+    from jacobian.math.matrices.values import require_matrix_scalar_digits
+
+    require_matrix_scalar_digits(
+        entries, maximum=MAX_INPUT_SCALAR_DIGITS, label="matrix input"
+    )
+    rows = len(entries)
+    columns = len(entries[0])
+    rank_bound = min(rows, columns)
+    scalar_digits = max(
+        len(component.lstrip("-"))
+        for row in entries
+        for value in row
+        for component in (
+            (value,) if isinstance(value, str) else (value.num, value.den)
+        )
+    )
+    work = rows * columns * rank_bound * scalar_digits
+    if work > MAX_EXACT_LINEAR_MATRIX_WORK:
+        raise _validation_error(
+            "budget_exceeded",
+            "exact linear algebra exceeds the "
+            f"{MAX_EXACT_LINEAR_MATRIX_WORK:,}-unit scalar-work budget",
+        )
+
+    row_numerator_bits: list[int] = []
+    row_denominator_bits: list[int] = []
+    for row in entries:
+        if isinstance(row[0], str):
+            integer_row = cast(tuple[str, ...], row)
+            row_numerator_bits.append(
+                max(
+                    parse_canonical_integer(value).bit_length() for value in integer_row
+                )
+                + (columns.bit_length() + 1) // 2
+            )
+            row_denominator_bits.append(1)
+            continue
+        rational_row = cast(tuple[CanonicalRational, ...], row)
+        fractions = tuple(value.as_fraction() for value in rational_row)
+        denominator = lcm(*(value.denominator for value in fractions))
+        largest_cleared_numerator = max(
+            abs(value.numerator) * (denominator // value.denominator)
+            for value in fractions
+        )
+        row_numerator_bits.append(
+            largest_cleared_numerator.bit_length() + (columns.bit_length() + 1) // 2
+        )
+        row_denominator_bits.append(denominator.bit_length())
+
+    numerator_bits = sum(sorted(row_numerator_bits, reverse=True)[:rank_bound])
+    denominator_bits = sum(sorted(row_denominator_bits, reverse=True)[:rank_bound])
+    # RREF entries are ratios of minors. After clearing denominators row by
+    # row, either canonical component is bounded by one integer-minor bound
+    # plus one clearing-denominator bound. Smith factors need only the former,
+    # so this shared sum remains conservative for both domains.
+    if (
+        _bit_bound_decimal_digits(numerator_bits + denominator_bits)
+        > MAX_MATRIX_SCALAR_DIGITS
+    ):
+        raise _validation_error(
+            "budget_exceeded",
+            "exact linear algebra exceeds the canonical result-height bound",
+        )
+
+
+def _flint_rref(
+    matrix: RationalMatrix,
+) -> tuple[tuple[tuple[Fraction, ...], ...], tuple[int, ...]]:
+    from jacobian.math.matrices._flint import rational_rref
+
+    entries = tuple(
+        tuple(value.as_fraction() for value in row) for row in matrix.entries
+    )
+    reduced, rank_value = rational_rref(entries)
+    pivots = tuple(
+        next(column for column, value in enumerate(row) if value)
+        for row in reduced[:rank_value]
+    )
+    return reduced, pivots
+
+
 def _admit_square_rational(matrix: RationalMatrix) -> None:
     _admit_rational_matrix(matrix)
     if len(matrix.entries) != len(matrix.entries[0]):
@@ -412,23 +498,23 @@ def determinant_result(matrix: RationalMatrix) -> MatrixDeterminantResult:
 
 
 def rank_result(matrix: RationalMatrix) -> MatrixRankResult:
-    _admit(_admit_rational, matrix)
-    value, pivot_columns = rank(conversions.rational_matrix_to_sympy(matrix))
+    _admit(_admit_exact_linear_matrix, matrix.entries)
+    _, pivot_columns = _flint_rref(matrix)
     return MatrixRankResult._from_kernel(
         matrix=matrix,
-        rank=value,
+        rank=len(pivot_columns),
         pivot_columns=tuple(int(column) for column in pivot_columns),
     )
 
 
 def rref_result(matrix: RationalMatrix) -> RrefResult:
-    _admit(_admit_rational, matrix)
-    reduced, pivots = rref(conversions.rational_matrix_to_sympy(matrix))
-    columns = reduced.cols
+    _admit(_admit_exact_linear_matrix, matrix.entries)
+    reduced, pivots = _flint_rref(matrix)
+    columns = len(reduced[0])
     pivot_columns = tuple(int(column) for column in pivots)
     return RrefResult._from_kernel(
         matrix=matrix,
-        reduced_matrix=conversions.rational_matrix_from_sympy(reduced),
+        reduced_matrix=rational_matrix_from_fractions(reduced),
         rank=len(pivot_columns),
         pivot_columns=pivot_columns,
         free_columns=tuple(
@@ -438,28 +524,25 @@ def rref_result(matrix: RationalMatrix) -> RrefResult:
 
 
 def nullspace_result(matrix: RationalMatrix) -> NullspaceResult:
-    _admit(_admit_rational, matrix)
-    import sympy
-
-    source = conversions.rational_matrix_to_sympy(matrix)
-    reduced, pivots = rref(source)
+    _admit(_admit_exact_linear_matrix, matrix.entries)
+    reduced, pivots = _flint_rref(matrix)
     pivot_columns = tuple(int(column) for column in pivots)
     free_columns = tuple(
-        column for column in range(source.cols) if column not in pivot_columns
+        column for column in range(len(reduced[0])) if column not in pivot_columns
     )
     pivot_row_by_column = {
         pivot_column: row for row, pivot_column in enumerate(pivot_columns)
     }
     basis: list[tuple[CanonicalRational, ...]] = []
     for free_column in free_columns:
-        vector = [sympy.S.Zero] * source.cols
-        vector[free_column] = sympy.S.One
+        vector = [Fraction(0)] * len(reduced[0])
+        vector[free_column] = Fraction(1)
         for pivot_column, row in pivot_row_by_column.items():
-            vector[pivot_column] = -reduced[row, free_column]
-        basis.append(tuple(conversions.rational_from_sympy(value) for value in vector))
+            vector[pivot_column] = -reduced[row][free_column]
+        basis.append(tuple(CanonicalRational.from_fraction(value) for value in vector))
     return NullspaceResult._from_kernel(
         matrix=matrix,
-        ambient_dimension=source.cols,
+        ambient_dimension=len(reduced[0]),
         rank=len(pivot_columns),
         nullity=len(basis),
         basis_vectors=tuple(basis),
@@ -484,9 +567,36 @@ def characteristic_polynomial_result(
 
 
 def smith_normal_form_result(matrix: IntegerMatrix) -> SmithNormalForm:
-    _admit(_admit_integer, matrix)
-    raw = smith_normal_form(conversions.integer_matrix_to_sympy(matrix))
-    return conversions.smith_normal_form_from_sympy(raw)
+    _admit(_admit_exact_linear_matrix, matrix.entries)
+    from jacobian.math.matrices._flint import integer_smith_normal_form
+
+    raw = integer_smith_normal_form(
+        tuple(
+            tuple(parse_canonical_integer(value) for value in row)
+            for row in matrix.entries
+        )
+    )
+    diagonal = tuple(raw[index][index] for index in range(min(len(raw), len(raw[0]))))
+    rank_value = next(
+        (index for index, value in enumerate(diagonal) if value == 0), len(diagonal)
+    )
+    factors = tuple(abs(value) for value in diagonal[:rank_value])
+    normal_form = IntegerMatrix(
+        entries=tuple(
+            tuple(
+                format_canonical_integer(factors[row])
+                if row == column and row < rank_value
+                else "0"
+                for column in range(len(raw[0]))
+            )
+            for row in range(len(raw))
+        )
+    )
+    return SmithNormalForm(
+        normal_form=normal_form,
+        rank=rank_value,
+        invariant_factors=tuple(format_canonical_integer(value) for value in factors),
+    )
 
 
 def inverse_result(matrix: IntegerMatrix) -> MatrixInverseResult:

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -143,7 +143,7 @@ def characteristic_polynomial(matrix: MatrixBase, variable: str) -> Any:
 
 
 def determinant(matrix: MatrixBase) -> Any:
-    source = _exact_matrix(matrix, maximum_dimension=64)
+    source = _exact_matrix(matrix, maximum_dimension=MAX_DETERMINANT_MATRIX_DIMENSION)
     if source.rows != source.cols:
         raise ValueError("determinant requires a square matrix")
     return source.det(method="bareiss")

--- a/src/jacobian/math/matrices/values.py
+++ b/src/jacobian/math/matrices/values.py
@@ -227,7 +227,13 @@ class RealQuadraticMatrix(StrictModel):
 
 
 class IntegerMatrix(StrictModel):
-    """One nonempty rectangular matrix over exact canonical integers."""
+    """One nonempty rectangular matrix over exact canonical integers.
+
+    Structural axes follow ``MAX_EXACT_LINEAR_MATRIX_AXIS``. Operations whose
+    admitted computation envelope is narrower, including lattice reduction,
+    enforce that bound in owner-local admission rather than on this shared
+    value.
+    """
 
     domain: Literal["ZZ"] = "ZZ"
     entries: tuple[tuple[CanonicalInteger, ...], ...] = Field(

--- a/src/jacobian/math/matrices/values.py
+++ b/src/jacobian/math/matrices/values.py
@@ -19,6 +19,7 @@ from jacobian.canonical import parse_canonical_integer
 from jacobian.math.number_theory.algebraic_numbers.quadratic import RealQuadraticValue
 
 MAX_MATRIX_DIMENSION = 32
+MAX_EXACT_LINEAR_MATRIX_AXIS = 64
 # The canonical dense rational matrix retains exact sources for analysis
 # results whose operations admit them by their own work and result budgets,
 # so its structural order is not tied to the shared computation dimension.
@@ -231,23 +232,25 @@ class IntegerMatrix(StrictModel):
     domain: Literal["ZZ"] = "ZZ"
     entries: tuple[tuple[CanonicalInteger, ...], ...] = Field(
         min_length=1,
-        max_length=MAX_MATRIX_DIMENSION,
+        max_length=MAX_EXACT_LINEAR_MATRIX_AXIS,
     )
 
     @model_validator(mode="before")
     @classmethod
     def require_raw_matrix_envelope(cls, data: Any) -> Any:
         data = _require_raw_matrix_envelope(
-            data, maximum_axis=MAX_MATRIX_DIMENSION, label="matrix"
+            data, maximum_axis=MAX_EXACT_LINEAR_MATRIX_AXIS, label="matrix"
         )
         return canonicalize_json_containers(data)
 
     @model_validator(mode="after")
     def require_rectangular_nonempty_rows(self) -> Self:
         column_count = len(self.entries[0])
-        if column_count == 0 or column_count > MAX_MATRIX_DIMENSION:
+        if column_count == 0 or column_count > MAX_EXACT_LINEAR_MATRIX_AXIS:
             raise _validation_error(
-                "budget_exceeded", "matrix rows must contain between 1 and 32 entries"
+                "budget_exceeded",
+                "matrix rows must contain between 1 and "
+                f"{MAX_EXACT_LINEAR_MATRIX_AXIS} entries",
             )
         if any(len(row) != column_count for row in self.entries):
             raise _validation_error(
@@ -265,9 +268,9 @@ class SmithNormalForm(StrictModel):
     """A backend-independent positive divisibility diagonal and its metadata."""
 
     normal_form: IntegerMatrix
-    rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
+    rank: int = Field(ge=0, le=MAX_EXACT_LINEAR_MATRIX_AXIS)
     invariant_factors: tuple[CanonicalInteger, ...] = Field(
-        max_length=MAX_MATRIX_DIMENSION
+        max_length=MAX_EXACT_LINEAR_MATRIX_AXIS
     )
     transformation_available: Literal[False] = False
     convention: Literal["POSITIVE_DIVISIBILITY_DIAGONAL"] = (
@@ -323,6 +326,7 @@ class SmithNormalForm(StrictModel):
 
 
 __all__ = [
+    "MAX_EXACT_LINEAR_MATRIX_AXIS",
     "MAX_MATRIX_DIMENSION",
     "MAX_MATRIX_SCALAR_DIGITS",
     "MAX_RATIONAL_MATRIX_ORDER",

--- a/tests/dispatch/test_matrix_dispatch.py
+++ b/tests/dispatch/test_matrix_dispatch.py
@@ -14,6 +14,7 @@ from jacobian.math.matrices._operation_models import (
     MAX_PERMANENT_MATRIX_ORDER,
 )
 from jacobian.math.matrices.values import (
+    MAX_EXACT_LINEAR_MATRIX_AXIS,
     MAX_MATRIX_DIMENSION,
     MAX_RATIONAL_MATRIX_ORDER,
 )
@@ -76,18 +77,18 @@ def _oversized_partial_trace_payload() -> dict[str, Any]:
         ),
         (
             "matrix.rank.compute",
-            _identity_payload(MAX_MATRIX_DIMENSION + 1),
-            MAX_MATRIX_DIMENSION,
+            _identity_payload(MAX_EXACT_LINEAR_MATRIX_AXIS + 1),
+            MAX_EXACT_LINEAR_MATRIX_AXIS,
         ),
         (
             "matrix.normal_form.rref.compute",
-            _identity_payload(MAX_MATRIX_DIMENSION + 1),
-            MAX_MATRIX_DIMENSION,
+            _identity_payload(MAX_EXACT_LINEAR_MATRIX_AXIS + 1),
+            MAX_EXACT_LINEAR_MATRIX_AXIS,
         ),
         (
             "matrix.nullspace.compute",
-            _identity_payload(MAX_MATRIX_DIMENSION + 1),
-            MAX_MATRIX_DIMENSION,
+            _identity_payload(MAX_EXACT_LINEAR_MATRIX_AXIS + 1),
+            MAX_EXACT_LINEAR_MATRIX_AXIS,
         ),
         (
             "matrix.partial_trace.compute",

--- a/tests/math/lattices/test_lattice_operations.py
+++ b/tests/math/lattices/test_lattice_operations.py
@@ -5,8 +5,15 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+from jacobian.math.lattices._hnf import compute_hermite_normal_form
+from jacobian.math.lattices._lattice import reduce_lattice_basis
 from jacobian.math.lattices._models import (
+    HermiteNormalFormRequest,
     IntegerLattice,
+    LatticeReductionRequest,
     SublatticeIndexRequest,
 )
 from jacobian.math.lattices.operations import (
@@ -20,7 +27,7 @@ from jacobian.math.lattices.operations import (
     compute_saturation,
     compute_sublattice_index,
 )
-from jacobian.math.matrices.values import IntegerMatrix
+from jacobian.math.matrices.values import MAX_MATRIX_DIMENSION, IntegerMatrix
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -34,6 +41,13 @@ def _lattice(ambient: int, basis: list[list[int]]) -> IntegerLattice:
             "basis": {"entries": [[str(v) for v in row] for row in basis]},
         }
     )
+
+
+def _identity_entries(order: int) -> list[list[str]]:
+    return [
+        ["1" if row == column else "0" for column in range(order)]
+        for row in range(order)
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +340,97 @@ def test_orthogonal_sum_of_two_identity() -> None:
         ("1", "0", "0"),
         ("0", "1", "0"),
         ("0", "0", "3"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# lattice.basis.reduce and lattice.hermite_normal_form.compute
+# ---------------------------------------------------------------------------
+
+
+def test_integer_matrix_still_parses_order_33_identity() -> None:
+    """Shared IntegerMatrix is the exact-linear envelope, not the LLL bound."""
+
+    matrix = IntegerMatrix.model_validate(
+        {"entries": _identity_entries(MAX_MATRIX_DIMENSION + 1)}
+    )
+    assert len(matrix.entries) == MAX_MATRIX_DIMENSION + 1
+    assert len(matrix.entries[0]) == MAX_MATRIX_DIMENSION + 1
+
+
+def test_lattice_reduction_request_rejects_order_33_identity() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        LatticeReductionRequest.model_validate(
+            {"basis": {"entries": _identity_entries(MAX_MATRIX_DIMENSION + 1)}}
+        )
+    assert exc_info.value.errors()[0]["type"] == "lattice.budget_exceeded"
+
+
+def test_hermite_request_rejects_order_33_identity() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        HermiteNormalFormRequest.model_validate(
+            {"matrix": {"entries": _identity_entries(MAX_MATRIX_DIMENSION + 1)}}
+        )
+    assert exc_info.value.errors()[0]["type"] == "lattice.budget_exceeded"
+
+
+def test_lattice_reduction_admits_before_lll_backend() -> None:
+    """A 33-by-33 identity must not reach FLINT or fail inside the result model."""
+
+    basis = IntegerMatrix.model_validate(
+        {"entries": _identity_entries(MAX_MATRIX_DIMENSION + 1)}
+    )
+    request = LatticeReductionRequest.model_construct(basis=basis)
+    with pytest.raises(OperationDomainValidationError) as exc_info:
+        reduce_lattice_basis(request)
+    error = exc_info.value.errors()[0]
+    assert error["type"] == "lattice.budget_exceeded"
+    assert error["loc"] == ("basis",)
+    assert str(MAX_MATRIX_DIMENSION) in error["msg"]
+
+
+def test_hermite_admits_before_hnf_backend() -> None:
+    matrix = IntegerMatrix.model_validate(
+        {"entries": _identity_entries(MAX_MATRIX_DIMENSION + 1)}
+    )
+    request = HermiteNormalFormRequest.model_construct(matrix=matrix)
+    with pytest.raises(OperationDomainValidationError) as exc_info:
+        compute_hermite_normal_form(request)
+    error = exc_info.value.errors()[0]
+    assert error["type"] == "lattice.budget_exceeded"
+    assert error["loc"] == ("matrix",)
+
+
+def test_lattice_reduction_accepts_order_32_identity() -> None:
+    request = LatticeReductionRequest.model_validate(
+        {"basis": {"entries": _identity_entries(MAX_MATRIX_DIMENSION)}}
+    )
+    result = reduce_lattice_basis(request)
+    assert result.rank == MAX_MATRIX_DIMENSION
+    assert result.reduced_basis.entries == tuple(
+        tuple(row) for row in _identity_entries(MAX_MATRIX_DIMENSION)
+    )
+
+
+def test_hermite_accepts_order_32_identity() -> None:
+    request = HermiteNormalFormRequest.model_validate(
+        {"matrix": {"entries": _identity_entries(MAX_MATRIX_DIMENSION)}}
+    )
+    result = compute_hermite_normal_form(request)
+    assert result.normal_form.entries == tuple(
+        tuple(row) for row in _identity_entries(MAX_MATRIX_DIMENSION)
+    )
+
+
+def test_dispatch_rejects_lll_above_the_lattice_axis() -> None:
+    with pytest.raises(OperationRequestValidationError) as exc_info:
+        invoke_operation(
+            "lattice.basis.reduce",
+            {"basis": {"entries": _identity_entries(MAX_MATRIX_DIMENSION + 1)}},
+            Catalog.open(),
+        )
+    assert f"limited to {MAX_MATRIX_DIMENSION} rows and columns" in str(
+        exc_info.value.cause
     )
 
 

--- a/tests/math/matrices/test_inverse.py
+++ b/tests/math/matrices/test_inverse.py
@@ -14,9 +14,11 @@ from typing import Any
 
 import pytest
 
-from jacobian.catalog.models import MathTool
+from jacobian.catalog.models import MathTool, OperationDomainValidationError
 from jacobian.math.matrices._operation_models import MatrixInverseResult
 from jacobian.math.matrices._tools import TOOLS
+from jacobian.math.matrices.operations import inverse_result
+from jacobian.math.matrices.values import MAX_MATRIX_DIMENSION, IntegerMatrix
 
 
 def _operation(operation_id: str) -> MathTool[Any, Any]:
@@ -128,6 +130,25 @@ def test_inverse_operation_round_trips_random_unimodular_matrices(size: int) -> 
         )
         assert _multiply(source_fraction, inverse) == identity
         assert _multiply(inverse, source_fraction) == identity
+
+
+def test_inverse_result_rejects_order_33_integer_matrix() -> None:
+    """Widened IntegerMatrix must not skip square-integer 32-axis admission."""
+
+    matrix = IntegerMatrix(
+        entries=tuple(
+            tuple(
+                "1" if row == column else "0"
+                for column in range(MAX_MATRIX_DIMENSION + 1)
+            )
+            for row in range(MAX_MATRIX_DIMENSION + 1)
+        )
+    )
+    with pytest.raises(OperationDomainValidationError) as exc_info:
+        inverse_result(matrix)
+    error = exc_info.value.errors()[0]
+    assert error["type"] == "matrix.budget_exceeded"
+    assert str(MAX_MATRIX_DIMENSION) in error["msg"]
 
 
 def test_inverse_operation_rejects_empty_matrix() -> None:

--- a/tests/math/matrices/test_public_api.py
+++ b/tests/math/matrices/test_public_api.py
@@ -6,6 +6,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from jacobian.math import matrices
+from jacobian.math.matrices.values import MAX_EXACT_LINEAR_MATRIX_AXIS
 
 
 def test_orphan_combinatorial_matrix_models_are_not_importable() -> None:
@@ -96,7 +97,14 @@ def test_rref_rejects_non_matrix_inputs() -> None:
 
 def test_rref_rejects_oversized_matrices() -> None:
     with pytest.raises(ValueError):
-        matrices.rref(sympy.zeros(33, 1))
+        matrices.rref(sympy.zeros(MAX_EXACT_LINEAR_MATRIX_AXIS + 1, 1))
+
+
+def test_rref_admits_an_axis_above_the_square_computation_dimension() -> None:
+    reduced, pivots = matrices.rref(sympy.ones(33, 1))
+    assert pivots == (0,)
+    assert reduced[0, 0] == 1
+    assert all(reduced[row, 0] == 0 for row in range(1, 33))
 
 
 def test_matrix_input_errors_are_stable() -> None:

--- a/tests/math/matrices/test_result_source_binding.py
+++ b/tests/math/matrices/test_result_source_binding.py
@@ -6,11 +6,13 @@ from fractions import Fraction
 from itertools import islice
 
 import pytest
+import sympy
 from pydantic import ValidationError
 from sympy import primerange
 
 from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math import matrices
 from jacobian.math.matrices._operation_models import (
     MAX_DETERMINANT_MATRIX_DIMENSION,
     MAX_DETERMINANT_SCALAR_WORK,
@@ -31,7 +33,9 @@ from jacobian.math.matrices._tools import (
     compute_rref,
     compute_smith_normal_form,
 )
+from jacobian.math.matrices.operations import rank_result
 from jacobian.math.matrices.values import (
+    MAX_EXACT_LINEAR_MATRIX_AXIS,
     MAX_MATRIX_DIMENSION,
     MAX_RATIONAL_MATRIX_ORDER,
     IntegerMatrix,
@@ -51,6 +55,15 @@ def _tall_relation_rows() -> tuple[tuple[int, ...], ...]:
         values[20] = values[0] + values[1]
         rows.append(tuple(values))
     return tuple(rows)
+
+
+def _sympy_from_fractions(entries: tuple[tuple[Fraction, ...], ...]) -> sympy.Matrix:
+    return sympy.Matrix(
+        [
+            [sympy.Rational(value.numerator, value.denominator) for value in row]
+            for row in entries
+        ]
+    )
 
 
 def test_flint_exact_linear_operations_support_reported_46_by_21_shape() -> None:
@@ -89,6 +102,50 @@ def test_flint_exact_linear_operations_support_reported_46_by_21_shape() -> None
     assert smith.invariant_factors == ("1",) * 20
     assert len(smith.normal_form.entries) == 46
     assert len(smith.normal_form.entries[0]) == 21
+
+
+def test_native_exact_linear_operations_share_the_46_by_21_flint_path() -> None:
+    integer_rows = _tall_relation_rows()
+    source = sympy.Matrix([list(row) for row in integer_rows])
+    rational = rational_matrix_from_fractions(
+        tuple(tuple(Fraction(value) for value in row) for row in integer_rows)
+    )
+    integer = IntegerMatrix(
+        entries=tuple(tuple(str(value) for value in row) for row in integer_rows)
+    )
+
+    native_rank, native_pivots = matrices.rank(source)
+    wire_rank = compute_rank(MatrixRankRequest(matrix=rational))
+    native_reduced, native_rref_pivots = matrices.rref(source)
+    wire_rref = compute_rref(RationalMatrixRequest(matrix=rational))
+    native_smith = matrices.smith_normal_form(source)
+    wire_smith = compute_smith_normal_form(IntegerMatrixRequest(matrix=integer))
+
+    assert native_rank == wire_rank.rank == 20
+    assert native_pivots == wire_rank.pivot_columns
+    assert native_rref_pivots == wire_rref.pivot_columns
+    assert native_reduced == sympy.Matrix(
+        [
+            [sympy.Rational(value.as_fraction()) for value in row]
+            for row in wire_rref.reduced_matrix.entries
+        ]
+    )
+    assert native_smith == sympy.Matrix(
+        [[int(value) for value in row] for row in wire_smith.normal_form.entries]
+    )
+
+
+def test_native_exact_linear_operations_reject_an_axis_above_the_flint_envelope() -> (
+    None
+):
+    oversized = sympy.zeros(MAX_EXACT_LINEAR_MATRIX_AXIS + 1, 1)
+
+    with pytest.raises(ValueError, match="between 1 and 64"):
+        matrices.rank(oversized)
+    with pytest.raises(ValueError, match="between 1 and 64"):
+        matrices.rref(oversized)
+    with pytest.raises(ValueError, match="between 1 and 64"):
+        matrices.smith_normal_form(oversized)
 
 
 def test_exact_linear_admission_rejects_unrepresentable_rref_height() -> None:
@@ -245,9 +302,24 @@ def test_exact_linear_requests_admit_tall_matrices_above_the_square_dimension() 
     assert MatrixRankRequest(matrix=tall).matrix is tall
 
 
-def test_exact_linear_requests_reject_an_axis_above_the_operation_envelope() -> None:
-    from jacobian.math.matrices.values import MAX_EXACT_LINEAR_MATRIX_AXIS
+def test_exact_linear_admission_rejects_an_axis_above_the_operation_envelope() -> None:
+    matrix = RationalMatrix(
+        entries=tuple(
+            tuple(
+                CanonicalRational(num=str(column + 1), den="1") for column in range(2)
+            )
+            for _ in range(MAX_EXACT_LINEAR_MATRIX_AXIS + 1)
+        )
+    )
 
+    with pytest.raises(OperationDomainValidationError) as excinfo:
+        rank_result(matrix)
+
+    assert excinfo.value.errors()[0]["type"] == "matrix.budget_exceeded"
+    assert "64 rows and columns" in excinfo.value.errors()[0]["msg"]
+
+
+def test_exact_linear_requests_reject_an_axis_above_the_operation_envelope() -> None:
     tall = RationalMatrix(
         entries=tuple(
             tuple(
@@ -297,6 +369,8 @@ def test_flint_determinant_executes_above_the_previous_order_ceiling() -> None:
     result = compute_determinant(MatrixDeterminantRequest(matrix=matrix))
 
     assert result.determinant == CanonicalRational(num="-2", den="3")
+    native = matrices.determinant(_sympy_from_fractions(entries))
+    assert native == sympy.Rational(-2, 3)
 
 
 def test_determinant_preserves_row_swap_and_scaling_invariants() -> None:
@@ -335,24 +409,27 @@ def test_determinant_rejects_requests_above_the_scalar_work_envelope() -> None:
 
     with pytest.raises(OperationDomainValidationError, match="scalar-work budget"):
         compute_determinant(MatrixDeterminantRequest(matrix=matrix))
+    with pytest.raises(OperationDomainValidationError, match="scalar-work budget"):
+        matrices.determinant(_sympy_from_fractions(entries))
 
 
 def test_determinant_rejects_an_unrepresentable_result_height_bound() -> None:
     denominators = tuple(primerange(2, 730))[:MAX_DETERMINANT_MATRIX_DIMENSION]
     row = tuple(Fraction(1, denominator) for denominator in denominators)
-    matrix = rational_matrix_from_fractions(
-        tuple(row for _ in range(MAX_DETERMINANT_MATRIX_DIMENSION))
-    )
+    entries = tuple(row for _ in range(MAX_DETERMINANT_MATRIX_DIMENSION))
+    matrix = rational_matrix_from_fractions(entries)
 
     with pytest.raises(
         OperationDomainValidationError, match="rational result-height bound"
     ):
         compute_determinant(MatrixDeterminantRequest(matrix=matrix))
+    with pytest.raises(
+        OperationDomainValidationError, match="rational result-height bound"
+    ):
+        matrices.determinant(_sympy_from_fractions(entries))
 
 
 def test_raw_preflight_keeps_exact_linear_and_determinant_axis_boundaries() -> None:
-    from jacobian.math.matrices.values import MAX_EXACT_LINEAR_MATRIX_AXIS
-
     def wire_identity(order: int) -> list[list[dict[str, str]]]:
         return [
             [{"num": str(int(row == column)), "den": "1"} for column in range(order)]

--- a/tests/math/matrices/test_result_source_binding.py
+++ b/tests/math/matrices/test_result_source_binding.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from itertools import islice
 
 import pytest
 from pydantic import ValidationError
@@ -13,6 +14,7 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices._operation_models import (
     MAX_DETERMINANT_MATRIX_DIMENSION,
     MAX_DETERMINANT_SCALAR_WORK,
+    IntegerMatrixRequest,
     MatrixDeterminantRequest,
     MatrixRankRequest,
     MatrixRankResult,
@@ -27,13 +29,85 @@ from jacobian.math.matrices._tools import (
     compute_product,
     compute_rank,
     compute_rref,
+    compute_smith_normal_form,
 )
 from jacobian.math.matrices.values import (
     MAX_MATRIX_DIMENSION,
     MAX_RATIONAL_MATRIX_ORDER,
+    IntegerMatrix,
     RationalMatrix,
     rational_matrix_from_fractions,
 )
+
+
+def _tall_relation_rows() -> tuple[tuple[int, ...], ...]:
+    rows: list[tuple[int, ...]] = []
+    for row in range(46):
+        values = [0] * 21
+        if row < 20:
+            values[row] = 1
+        else:
+            values[row % 20] = 1
+        values[20] = values[0] + values[1]
+        rows.append(tuple(values))
+    return tuple(rows)
+
+
+def test_flint_exact_linear_operations_support_reported_46_by_21_shape() -> None:
+    integer_rows = _tall_relation_rows()
+    rational = rational_matrix_from_fractions(
+        tuple(tuple(Fraction(value) for value in row) for row in integer_rows)
+    )
+
+    rank = compute_rank(MatrixRankRequest(matrix=rational))
+    rref = compute_rref(RationalMatrixRequest(matrix=rational))
+    nullspace = compute_nullspace(RationalMatrixRequest(matrix=rational))
+
+    assert rank.rank == rref.rank == 20
+    assert nullspace.rank == 20
+    assert nullspace.nullity == 1
+    vector = tuple(value.as_fraction() for value in nullspace.basis_vectors[0])
+    assert all(
+        sum(
+            Fraction(entry) * coefficient
+            for entry, coefficient in zip(row, vector, strict=True)
+        )
+        == 0
+        for row in integer_rows
+    )
+
+    smith = compute_smith_normal_form(
+        IntegerMatrixRequest(
+            matrix=IntegerMatrix(
+                entries=tuple(
+                    tuple(str(value) for value in row) for row in integer_rows
+                )
+            )
+        )
+    )
+    assert smith.rank == 20
+    assert smith.invariant_factors == ("1",) * 20
+    assert len(smith.normal_form.entries) == 46
+    assert len(smith.normal_form.entries[0]) == 21
+
+
+def test_exact_linear_admission_rejects_unrepresentable_rref_height() -> None:
+    denominators = tuple(islice(primerange(1_000_000_000, 2_000_000_000), 64))
+    matrix = RationalMatrix(
+        entries=tuple(
+            tuple(
+                CanonicalRational(num="1", den=str(denominator))
+                for denominator in denominators
+            )
+            for _ in range(64)
+        )
+    )
+
+    with pytest.raises(OperationDomainValidationError) as excinfo:
+        compute_rref(RationalMatrixRequest(matrix=matrix))
+
+    assert excinfo.value.errors()[0]["type"] == "matrix.budget_exceeded"
+    assert "result-height" in excinfo.value.errors()[0]["msg"]
 
 
 def _matrix(rows: list[list[str]]) -> RationalMatrix:
@@ -157,21 +231,29 @@ def _identity_entries(size: int) -> tuple[tuple[CanonicalRational, ...], ...]:
     )
 
 
-def test_request_admission_rejects_matrices_above_the_computation_dimension() -> None:
-    oversized = RationalMatrix(entries=_identity_entries(MAX_MATRIX_DIMENSION + 1))
-    with pytest.raises(ValidationError):
-        RationalMatrixRequest(matrix=oversized)
-    with pytest.raises(ValidationError):
-        MatrixRankRequest(matrix=oversized)
+def test_exact_linear_requests_admit_tall_matrices_above_the_square_dimension() -> None:
+    tall = RationalMatrix(
+        entries=tuple(
+            tuple(
+                CanonicalRational(num=str(int(row == column)), den="1")
+                for column in range(21)
+            )
+            for row in range(46)
+        )
+    )
+    assert RationalMatrixRequest(matrix=tall).matrix is tall
+    assert MatrixRankRequest(matrix=tall).matrix is tall
 
 
-def test_request_admission_rejects_one_oversized_axis() -> None:
+def test_exact_linear_requests_reject_an_axis_above_the_operation_envelope() -> None:
+    from jacobian.math.matrices.values import MAX_EXACT_LINEAR_MATRIX_AXIS
+
     tall = RationalMatrix(
         entries=tuple(
             tuple(
                 CanonicalRational(num=str(column + 1), den="1") for column in range(2)
             )
-            for _ in range(MAX_MATRIX_DIMENSION + 1)
+            for _ in range(MAX_EXACT_LINEAR_MATRIX_AXIS + 1)
         )
     )
     with pytest.raises(ValidationError):
@@ -268,20 +350,22 @@ def test_determinant_rejects_an_unrepresentable_result_height_bound() -> None:
         compute_determinant(MatrixDeterminantRequest(matrix=matrix))
 
 
-def test_raw_preflight_keeps_32_and_128_axes_and_rejects_the_next_axis() -> None:
+def test_raw_preflight_keeps_exact_linear_and_determinant_axis_boundaries() -> None:
+    from jacobian.math.matrices.values import MAX_EXACT_LINEAR_MATRIX_AXIS
+
     def wire_identity(order: int) -> list[list[dict[str, str]]]:
         return [
             [{"num": str(int(row == column)), "den": "1"} for column in range(order)]
             for row in range(order)
         ]
 
-    rank_boundary = {"matrix": {"entries": wire_identity(MAX_MATRIX_DIMENSION)}}
+    rank_boundary = {"matrix": {"entries": wire_identity(MAX_EXACT_LINEAR_MATRIX_AXIS)}}
     assert MatrixRankRequest.model_validate(
         rank_boundary
-    ).matrix.entries == _identity_entries(MAX_MATRIX_DIMENSION)
+    ).matrix.entries == _identity_entries(MAX_EXACT_LINEAR_MATRIX_AXIS)
     with pytest.raises(ValidationError):
         MatrixRankRequest.model_validate(
-            {"matrix": {"entries": wire_identity(MAX_MATRIX_DIMENSION + 1)}}
+            {"matrix": {"entries": wire_identity(MAX_EXACT_LINEAR_MATRIX_AXIS + 1)}}
         )
 
     determinant_boundary = {


### PR DESCRIPTION
## Problem

Exact rational rank, RREF, nullspace, and integer Smith operations rejected every matrix axis above 32. This excluded the motivating 46 x 21 small-integer relation matrices even though they contain fewer entries than an admitted 32 x 32 input.

## What changed

- use python-flint's rectangular `fmpq_mat.rref()` and `fmpz_mat.snf()` kernels;
- admit these four operations through 64 rows and columns under scalar-work and conservative canonical result-height bounds;
- keep unrelated square matrix operations on their existing envelopes;
- retain canonical pivot, fundamental-nullspace, and positive Smith-diagonal conventions.

The regression fixture exercises a 46 x 21 rank-20 relation matrix, verifies the returned nullspace vector annihilates every row, and checks the Smith invariant factors. An adversarial 64 x 64 rational input proves result-height rejection occurs before backend execution.

## Validation

- `uv run pytest -q tests/math/matrices`: 515 passed
- focused matrix/source-binding tests after final changes: 23 passed
- independent exact-diff review: finding resolved; follow-up clean
- `make affected AFFECTED_BASE=origin/main`:
  - scoped Ruff and mypy passed
  - 508 selected matrix tests passed
  - 112 catalog tests passed
  - 800 catalog integration tests passed
  - dispatch: 107 passed; one test fails unchanged on `origin/main` because the native determinant wrapper still caps order 64 while the determinant contract advertises 128

Closes #2227.
