### PR TITLE
Support sparse exact rational linear systems

### DIFF
--- a/docs/reference/operations/linear-algebra/linear-rational-solutions.md
+++ b/docs/reference/operations/linear-algebra/linear-rational-solutions.md
@@ -10,9 +10,11 @@ Both operations take the entire typed system in their request and return their
 candidate or witness inline. They do not consume producer IDs, create evidence
 records, or require a checker-installation decision.
 
-The system stores its coefficient matrix canonically as row-major nonzero
-coordinates. `row_count`, the ordered variable axis, and the right-hand side
-retain implicit zero rows and columns without materializing a dense matrix.
+The system uses the domain-owned `SparseRationalMatrix`, whose canonical
+row-major nonzero coordinates retain both axes without materializing a dense
+matrix. Explicit conversions connect it to the canonical dense
+`RationalMatrix`; no operation-specific matrix representation is introduced.
+The ordered variable axis and the right-hand side bind those matrix axes.
 Duplicate coordinates, stored zeros, and coordinates outside those axes are
 rejected. Admission separately bounds axes, stored nonzeros, rational digits,
 the conservative dense fill-in work envelope, and the exact output-height

--- a/docs/reference/operations/linear-algebra/linear-rational-solutions.md
+++ b/docs/reference/operations/linear-algebra/linear-rational-solutions.md
@@ -9,3 +9,11 @@ one normalized left witness when the supplied system is inconsistent.
 Both operations take the entire typed system in their request and return their
 candidate or witness inline. They do not consume producer IDs, create evidence
 records, or require a checker-installation decision.
+
+The system stores its coefficient matrix canonically as row-major nonzero
+coordinates. `row_count`, the ordered variable axis, and the right-hand side
+retain implicit zero rows and columns without materializing a dense matrix.
+Duplicate coordinates, stored zeros, and coordinates outside those axes are
+rejected. Admission separately bounds axes, stored nonzeros, rational digits,
+the conservative dense fill-in work envelope, and the exact output-height
+estimate before SymPy's maintained sparse `DomainMatrix` RREF kernel runs.

--- a/docs/reference/operations/linear-algebra/linear-rational-solutions.md
+++ b/docs/reference/operations/linear-algebra/linear-rational-solutions.md
@@ -16,6 +16,8 @@ matrix. Explicit conversions connect it to the canonical dense
 `RationalMatrix`; no operation-specific matrix representation is introduced.
 The ordered variable axis and the right-hand side bind those matrix axes.
 Duplicate coordinates, stored zeros, and coordinates outside those axes are
-rejected. Admission separately bounds axes, stored nonzeros, rational digits,
-the conservative dense fill-in work envelope, and the exact output-height
-estimate before SymPy's maintained sparse `DomainMatrix` RREF kernel runs.
+rejected. Shared structural limits bound axes, stored nonzeros, and input
+rational digits. Each operation then admits only its own postcondition: a
+solution call bounds primal fill-in work and solution-coordinate height, while
+an inconsistency call bounds the dual witness envelope. The maintained sparse
+`DomainMatrix` RREF kernel runs only after that outcome-specific admission.

--- a/src/jacobian/math/matrices/rational_linear/_models.py
+++ b/src/jacobian/math/matrices/rational_linear/_models.py
@@ -2,25 +2,21 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
-from math import gcd
 from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._exact import (
-    MAX_CANONICAL_RATIONAL_DIGITS,
-    CanonicalRational,
-    require_bounded_rational,
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.matrices.values import (
+    MAX_SPARSE_RATIONAL_MATRIX_AXIS,
+    MAX_SPARSE_RATIONAL_MATRIX_NONZEROS,
+    SparseRationalMatrix,
 )
-from jacobian._models import StrictModel
-from jacobian.canonical import CanonicalLimits
 
-MAX_LINEAR_DIMENSION = 8_192
-MAX_LINEAR_NONZERO_COUNT = 32_768
-MAX_LINEAR_SCALAR_WORK = 100_000_000
-MAX_LINEAR_RESULT_BYTES = CanonicalLimits().max_output_bytes
+MAX_LINEAR_DIMENSION = MAX_SPARSE_RATIONAL_MATRIX_AXIS
+MAX_LINEAR_NONZERO_COUNT = MAX_SPARSE_RATIONAL_MATRIX_NONZEROS
 MAX_RATIONAL_DIGITS = 256
 
 LinearVariableName = Annotated[
@@ -44,14 +40,6 @@ def _require_bounded_rationals(values: tuple[CanonicalRational, ...]) -> None:
             raise _validation_error("rational_bound", str(error)) from error
 
 
-class LinearRationalCoefficient(StrictModel):
-    """One nonzero coefficient at a stable zero-based row and column."""
-
-    row: int = Field(ge=0, le=MAX_LINEAR_DIMENSION - 1)
-    column: int = Field(ge=0, le=MAX_LINEAR_DIMENSION - 1)
-    value: CanonicalRational
-
-
 class LinearRationalSystem(StrictModel):
     """One declared finite system ``A x = b`` over exact rationals."""
 
@@ -61,10 +49,7 @@ class LinearRationalSystem(StrictModel):
         min_length=1,
         max_length=MAX_LINEAR_DIMENSION,
     )
-    row_count: int = Field(ge=1, le=MAX_LINEAR_DIMENSION)
-    coefficients: tuple[LinearRationalCoefficient, ...] = Field(
-        default=(), max_length=MAX_LINEAR_NONZERO_COUNT
-    )
+    coefficients: SparseRationalMatrix
     rhs: tuple[CanonicalRational, ...] = Field(
         min_length=1,
         max_length=MAX_LINEAR_DIMENSION,
@@ -86,8 +71,12 @@ class LinearRationalSystem(StrictModel):
                 "budget_exceeded",
                 f"linear systems have at most {MAX_LINEAR_DIMENSION} variables",
             )
-        if isinstance(coefficients, (list, tuple)) and len(coefficients) > (
-            MAX_LINEAR_NONZERO_COUNT
+        coefficient_entries = (
+            coefficients.get("entries") if isinstance(coefficients, dict) else None
+        )
+        if (
+            isinstance(coefficient_entries, (list, tuple))
+            and len(coefficient_entries) > MAX_LINEAR_NONZERO_COUNT
         ):
             raise _validation_error(
                 "budget_exceeded",
@@ -99,9 +88,11 @@ class LinearRationalSystem(StrictModel):
                 f"linear systems have at most {MAX_LINEAR_DIMENSION} rows",
             )
         raw_values: list[object] = list(rhs) if isinstance(rhs, (list, tuple)) else []
-        if isinstance(coefficients, (list, tuple)):
+        if isinstance(coefficient_entries, (list, tuple)):
             raw_values.extend(
-                item.get("value") for item in coefficients if isinstance(item, dict)
+                item.get("value")
+                for item in coefficient_entries
+                if isinstance(item, dict)
             )
         for value in raw_values:
             components = (
@@ -118,7 +109,7 @@ class LinearRationalSystem(StrictModel):
                     "rational_bound",
                     f"linear-system rationals are limited to {MAX_RATIONAL_DIGITS} decimal digits",
                 )
-        return data
+        return canonicalize_json_containers(data)
 
     @model_validator(mode="after")
     def require_matching_canonical_dimensions(self) -> Self:
@@ -126,133 +117,20 @@ class LinearRationalSystem(StrictModel):
             raise _validation_error(
                 "budget_exceeded", "linear-system variable names must be unique"
             )
-        if self.row_count != len(self.rhs):
+        if self.coefficients.row_count != len(self.rhs):
             raise _validation_error(
                 "budget_exceeded",
                 "the right-hand side length must equal the coefficient row count",
             )
-        coordinates = tuple((item.row, item.column) for item in self.coefficients)
-        if coordinates != tuple(sorted(set(coordinates))):
+        if self.coefficients.column_count != len(self.variables):
             raise _validation_error(
-                "shape_mismatch",
-                "sparse coefficient coordinates must be unique and row-major sorted",
-            )
-        if any(
-            item.row >= self.row_count or item.column >= len(self.variables)
-            for item in self.coefficients
-        ):
-            raise _validation_error(
-                "shape_mismatch", "sparse coefficient coordinates exceed system axes"
-            )
-        if any(item.value.as_fraction() == 0 for item in self.coefficients):
-            raise _validation_error(
-                "shape_mismatch", "sparse coefficients must not store explicit zeros"
+                "budget_exceeded",
+                "the coefficient column count must equal the declared variable count",
             )
         _require_bounded_rationals(
-            tuple(item.value for item in self.coefficients) + self.rhs
+            tuple(item.value for item in self.coefficients.entries) + self.rhs
         )
-        _require_execution_envelope(self)
         return self
-
-
-def _decimal_digits_from_bits(bits: int) -> int:
-    return max(1, (bits * 30_103 + 99_999) // 100_000)
-
-
-def _minor_component_bits(
-    rows: tuple[tuple[Fraction, ...], ...], *, column_count: int
-) -> int:
-    rank_bound = min(len(rows), column_count)
-    numerator_bits: list[int] = []
-    denominator_bits: list[int] = []
-    for row in rows:
-        denominator = 1
-        for value in row:
-            factor = value.denominator // gcd(denominator, value.denominator)
-            denominator *= factor
-            if _decimal_digits_from_bits(denominator.bit_length()) > (
-                MAX_CANONICAL_RATIONAL_DIGITS
-            ):
-                return MAX_CANONICAL_RATIONAL_DIGITS * 4
-        largest = max(
-            (
-                abs(value.numerator) * (denominator // value.denominator)
-                for value in row
-            ),
-            default=0,
-        )
-        numerator_bits.append(
-            largest.bit_length() + (column_count.bit_length() + 1) // 2
-        )
-        denominator_bits.append(denominator.bit_length())
-    return sum(sorted(numerator_bits, reverse=True)[:rank_bound]) + sum(
-        sorted(denominator_bits, reverse=True)[:rank_bound]
-    )
-
-
-def _require_execution_envelope(system: LinearRationalSystem) -> None:
-    rows = system.row_count
-    columns = len(system.variables)
-    scalar_digits = max(
-        len(component.lstrip("-"))
-        for value in tuple(item.value for item in system.coefficients) + system.rhs
-        for component in (value.num, value.den)
-    )
-    solution_work = rows * (columns + 1) * min(rows, columns + 1)
-    witness_work = (columns + 1) * (rows + 1) * min(columns + 1, rows + 1)
-    if max(solution_work, witness_work) * scalar_digits > MAX_LINEAR_SCALAR_WORK:
-        raise _validation_error(
-            "budget_exceeded",
-            "sparse exact linear algebra exceeds the "
-            f"{MAX_LINEAR_SCALAR_WORK:,}-unit scalar-work budget",
-        )
-
-    solution_values: dict[int, list[Fraction]] = {row: [] for row in range(rows)}
-    witness_values: dict[int, list[Fraction]] = {
-        column: [] for column in range(columns)
-    }
-    for item in system.coefficients:
-        fraction = item.value.as_fraction()
-        solution_values[item.row].append(fraction)
-        witness_values[item.column].append(fraction)
-    for row, bound in enumerate(system.rhs):
-        if bound.as_fraction():
-            solution_values[row].append(bound.as_fraction())
-    solution_rows = tuple(tuple(solution_values[row]) for row in range(rows))
-    witness_rows = (
-        *(tuple(witness_values[column]) for column in range(columns)),
-        tuple(value.as_fraction() for value in system.rhs if value.as_fraction()),
-    )
-    result_digits = max(
-        _decimal_digits_from_bits(
-            _minor_component_bits(solution_rows, column_count=columns + 1)
-        ),
-        _decimal_digits_from_bits(
-            _minor_component_bits(witness_rows, column_count=rows + 1)
-        ),
-    )
-    if result_digits > MAX_CANONICAL_RATIONAL_DIGITS:
-        raise _validation_error(
-            "budget_exceeded",
-            "sparse exact linear algebra exceeds the canonical result-height bound",
-        )
-    source_bytes = sum(len(name) + 3 for name in system.variables)
-    source_bytes += sum(
-        len(item.value.num)
-        + len(item.value.den)
-        + len(str(item.row))
-        + len(str(item.column))
-        + 64
-        for item in system.coefficients
-    )
-    source_bytes += sum(len(value.num) + len(value.den) + 24 for value in system.rhs)
-    result_bytes = source_bytes + max(rows, columns) * (2 * result_digits + 32) + 4_096
-    if result_bytes > MAX_LINEAR_RESULT_BYTES:
-        raise _validation_error(
-            "budget_exceeded",
-            "sparse exact linear algebra exceeds the "
-            f"{MAX_LINEAR_RESULT_BYTES:,}-byte transport result bound",
-        )
 
 
 class LinearRationalSolutionFindRequest(StrictModel):

--- a/src/jacobian/math/matrices/rational_linear/_models.py
+++ b/src/jacobian/math/matrices/rational_linear/_models.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from fractions import Fraction
+from math import gcd
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._exact import (
+    MAX_CANONICAL_RATIONAL_DIGITS,
+    CanonicalRational,
+    require_bounded_rational,
+)
 from jacobian._models import StrictModel
-from jacobian.math.matrices.values import RationalMatrix
+from jacobian.canonical import CanonicalLimits
 
-MAX_LINEAR_DIMENSION = 32
+MAX_LINEAR_DIMENSION = 8_192
+MAX_LINEAR_NONZERO_COUNT = 32_768
+MAX_LINEAR_SCALAR_WORK = 100_000_000
+MAX_LINEAR_RESULT_BYTES = CanonicalLimits().max_output_bytes
 MAX_RATIONAL_DIGITS = 256
 
 LinearVariableName = Annotated[
@@ -35,6 +44,14 @@ def _require_bounded_rationals(values: tuple[CanonicalRational, ...]) -> None:
             raise _validation_error("rational_bound", str(error)) from error
 
 
+class LinearRationalCoefficient(StrictModel):
+    """One nonzero coefficient at a stable zero-based row and column."""
+
+    row: int = Field(ge=0, le=MAX_LINEAR_DIMENSION - 1)
+    column: int = Field(ge=0, le=MAX_LINEAR_DIMENSION - 1)
+    value: CanonicalRational
+
+
 class LinearRationalSystem(StrictModel):
     """One declared finite system ``A x = b`` over exact rationals."""
 
@@ -44,11 +61,64 @@ class LinearRationalSystem(StrictModel):
         min_length=1,
         max_length=MAX_LINEAR_DIMENSION,
     )
-    coefficients: RationalMatrix
+    row_count: int = Field(ge=1, le=MAX_LINEAR_DIMENSION)
+    coefficients: tuple[LinearRationalCoefficient, ...] = Field(
+        default=(), max_length=MAX_LINEAR_NONZERO_COUNT
+    )
     rhs: tuple[CanonicalRational, ...] = Field(
         min_length=1,
         max_length=MAX_LINEAR_DIMENSION,
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_sparse_envelope(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        variables = data.get("variables")
+        coefficients = data.get("coefficients")
+        rhs = data.get("rhs")
+        if (
+            isinstance(variables, (list, tuple))
+            and len(variables) > MAX_LINEAR_DIMENSION
+        ):
+            raise _validation_error(
+                "budget_exceeded",
+                f"linear systems have at most {MAX_LINEAR_DIMENSION} variables",
+            )
+        if isinstance(coefficients, (list, tuple)) and len(coefficients) > (
+            MAX_LINEAR_NONZERO_COUNT
+        ):
+            raise _validation_error(
+                "budget_exceeded",
+                f"linear systems store at most {MAX_LINEAR_NONZERO_COUNT} nonzeros",
+            )
+        if isinstance(rhs, (list, tuple)) and len(rhs) > MAX_LINEAR_DIMENSION:
+            raise _validation_error(
+                "budget_exceeded",
+                f"linear systems have at most {MAX_LINEAR_DIMENSION} rows",
+            )
+        raw_values: list[object] = list(rhs) if isinstance(rhs, (list, tuple)) else []
+        if isinstance(coefficients, (list, tuple)):
+            raw_values.extend(
+                item.get("value") for item in coefficients if isinstance(item, dict)
+            )
+        for value in raw_values:
+            components = (
+                (value.get("num"), value.get("den"))
+                if isinstance(value, dict)
+                else (value,)
+            )
+            if any(
+                isinstance(component, (str, int))
+                and len(str(component).lstrip("-")) > MAX_RATIONAL_DIGITS
+                for component in components
+            ):
+                raise _validation_error(
+                    "rational_bound",
+                    f"linear-system rationals are limited to {MAX_RATIONAL_DIGITS} decimal digits",
+                )
+        return data
 
     @model_validator(mode="after")
     def require_matching_canonical_dimensions(self) -> Self:
@@ -56,21 +126,133 @@ class LinearRationalSystem(StrictModel):
             raise _validation_error(
                 "budget_exceeded", "linear-system variable names must be unique"
             )
-        if len(self.coefficients.entries[0]) != len(self.variables):
-            raise _validation_error(
-                "budget_exceeded",
-                "the coefficient column count must equal the declared variable count",
-            )
-        if len(self.coefficients.entries) != len(self.rhs):
+        if self.row_count != len(self.rhs):
             raise _validation_error(
                 "budget_exceeded",
                 "the right-hand side length must equal the coefficient row count",
             )
+        coordinates = tuple((item.row, item.column) for item in self.coefficients)
+        if coordinates != tuple(sorted(set(coordinates))):
+            raise _validation_error(
+                "shape_mismatch",
+                "sparse coefficient coordinates must be unique and row-major sorted",
+            )
+        if any(
+            item.row >= self.row_count or item.column >= len(self.variables)
+            for item in self.coefficients
+        ):
+            raise _validation_error(
+                "shape_mismatch", "sparse coefficient coordinates exceed system axes"
+            )
+        if any(item.value.as_fraction() == 0 for item in self.coefficients):
+            raise _validation_error(
+                "shape_mismatch", "sparse coefficients must not store explicit zeros"
+            )
         _require_bounded_rationals(
-            tuple(value for row in self.coefficients.entries for value in row)
-            + self.rhs
+            tuple(item.value for item in self.coefficients) + self.rhs
         )
+        _require_execution_envelope(self)
         return self
+
+
+def _decimal_digits_from_bits(bits: int) -> int:
+    return max(1, (bits * 30_103 + 99_999) // 100_000)
+
+
+def _minor_component_bits(
+    rows: tuple[tuple[Fraction, ...], ...], *, column_count: int
+) -> int:
+    rank_bound = min(len(rows), column_count)
+    numerator_bits: list[int] = []
+    denominator_bits: list[int] = []
+    for row in rows:
+        denominator = 1
+        for value in row:
+            factor = value.denominator // gcd(denominator, value.denominator)
+            denominator *= factor
+            if _decimal_digits_from_bits(denominator.bit_length()) > (
+                MAX_CANONICAL_RATIONAL_DIGITS
+            ):
+                return MAX_CANONICAL_RATIONAL_DIGITS * 4
+        largest = max(
+            (
+                abs(value.numerator) * (denominator // value.denominator)
+                for value in row
+            ),
+            default=0,
+        )
+        numerator_bits.append(
+            largest.bit_length() + (column_count.bit_length() + 1) // 2
+        )
+        denominator_bits.append(denominator.bit_length())
+    return sum(sorted(numerator_bits, reverse=True)[:rank_bound]) + sum(
+        sorted(denominator_bits, reverse=True)[:rank_bound]
+    )
+
+
+def _require_execution_envelope(system: LinearRationalSystem) -> None:
+    rows = system.row_count
+    columns = len(system.variables)
+    scalar_digits = max(
+        len(component.lstrip("-"))
+        for value in tuple(item.value for item in system.coefficients) + system.rhs
+        for component in (value.num, value.den)
+    )
+    solution_work = rows * (columns + 1) * min(rows, columns + 1)
+    witness_work = (columns + 1) * (rows + 1) * min(columns + 1, rows + 1)
+    if max(solution_work, witness_work) * scalar_digits > MAX_LINEAR_SCALAR_WORK:
+        raise _validation_error(
+            "budget_exceeded",
+            "sparse exact linear algebra exceeds the "
+            f"{MAX_LINEAR_SCALAR_WORK:,}-unit scalar-work budget",
+        )
+
+    solution_values: dict[int, list[Fraction]] = {row: [] for row in range(rows)}
+    witness_values: dict[int, list[Fraction]] = {
+        column: [] for column in range(columns)
+    }
+    for item in system.coefficients:
+        fraction = item.value.as_fraction()
+        solution_values[item.row].append(fraction)
+        witness_values[item.column].append(fraction)
+    for row, bound in enumerate(system.rhs):
+        if bound.as_fraction():
+            solution_values[row].append(bound.as_fraction())
+    solution_rows = tuple(tuple(solution_values[row]) for row in range(rows))
+    witness_rows = (
+        *(tuple(witness_values[column]) for column in range(columns)),
+        tuple(value.as_fraction() for value in system.rhs if value.as_fraction()),
+    )
+    result_digits = max(
+        _decimal_digits_from_bits(
+            _minor_component_bits(solution_rows, column_count=columns + 1)
+        ),
+        _decimal_digits_from_bits(
+            _minor_component_bits(witness_rows, column_count=rows + 1)
+        ),
+    )
+    if result_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        raise _validation_error(
+            "budget_exceeded",
+            "sparse exact linear algebra exceeds the canonical result-height bound",
+        )
+    source_bytes = sum(len(name) + 3 for name in system.variables)
+    source_bytes += sum(
+        len(item.value.num)
+        + len(item.value.den)
+        + len(str(item.row))
+        + len(str(item.column))
+        + 64
+        for item in system.coefficients
+    )
+    source_bytes += sum(len(value.num) + len(value.den) + 24 for value in system.rhs)
+    result_bytes = source_bytes + max(rows, columns) * (2 * result_digits + 32) + 4_096
+    if result_bytes > MAX_LINEAR_RESULT_BYTES:
+        raise _validation_error(
+            "budget_exceeded",
+            "sparse exact linear algebra exceeds the "
+            f"{MAX_LINEAR_RESULT_BYTES:,}-byte transport result bound",
+        )
 
 
 class LinearRationalSolutionFindRequest(StrictModel):

--- a/src/jacobian/math/matrices/rational_linear/_tools.py
+++ b/src/jacobian/math/matrices/rational_linear/_tools.py
@@ -91,10 +91,17 @@ TOOLS: MathTools = (
                 {
                     "system": {
                         "variables": ["x"],
-                        "row_count": 1,
-                        "coefficients": [
-                            {"row": 0, "column": 0, "value": {"num": "1", "den": "1"}}
-                        ],
+                        "coefficients": {
+                            "row_count": 1,
+                            "column_count": 1,
+                            "entries": [
+                                {
+                                    "row": 0,
+                                    "column": 0,
+                                    "value": {"num": "1", "den": "1"},
+                                }
+                            ],
+                        },
                         "rhs": [{"num": "2", "den": "1"}],
                     }
                 },
@@ -119,11 +126,22 @@ TOOLS: MathTools = (
                 {
                     "system": {
                         "variables": ["x"],
-                        "row_count": 2,
-                        "coefficients": [
-                            {"row": 0, "column": 0, "value": {"num": "1", "den": "1"}},
-                            {"row": 1, "column": 0, "value": {"num": "1", "den": "1"}},
-                        ],
+                        "coefficients": {
+                            "row_count": 2,
+                            "column_count": 1,
+                            "entries": [
+                                {
+                                    "row": 0,
+                                    "column": 0,
+                                    "value": {"num": "1", "den": "1"},
+                                },
+                                {
+                                    "row": 1,
+                                    "column": 0,
+                                    "value": {"num": "1", "den": "1"},
+                                },
+                            ],
+                        },
                         "rhs": [
                             {"num": "0", "den": "1"},
                             {"num": "1", "den": "1"},

--- a/src/jacobian/math/matrices/rational_linear/_tools.py
+++ b/src/jacobian/math/matrices/rational_linear/_tools.py
@@ -76,7 +76,7 @@ TOOLS: MathTools = (
     _op(
         "linear.rational_solution.compute",
         "Compute an exact rational solution",
-        "Return an exact rational solution or an inconsistent outcome.",
+        "Return an exact rational solution or an inconsistent outcome for one canonical coordinate-sparse system, subject to nonzero, scalar-work, and result-height bounds.",
         LinearRationalSolutionFindRequest,
         LinearRationalSolutionResult,
         compute_rational_solution,
@@ -91,7 +91,10 @@ TOOLS: MathTools = (
                 {
                     "system": {
                         "variables": ["x"],
-                        "coefficients": {"entries": [[{"num": "1", "den": "1"}]]},
+                        "row_count": 1,
+                        "coefficients": [
+                            {"row": 0, "column": 0, "value": {"num": "1", "den": "1"}}
+                        ],
                         "rhs": [{"num": "2", "den": "1"}],
                     }
                 },
@@ -101,7 +104,7 @@ TOOLS: MathTools = (
     _op(
         "linear.rational_inconsistency.compute",
         "Compute an exact rational inconsistency witness",
-        "Return an inconsistency witness or a consistent outcome.",
+        "Return an exact left inconsistency witness or a consistent outcome for one canonical coordinate-sparse system, subject to nonzero, scalar-work, and result-height bounds.",
         LinearRationalInconsistencyFindRequest,
         LinearRationalInconsistencyResult,
         compute_rational_inconsistency,
@@ -116,12 +119,11 @@ TOOLS: MathTools = (
                 {
                     "system": {
                         "variables": ["x"],
-                        "coefficients": {
-                            "entries": [
-                                [{"num": "1", "den": "1"}],
-                                [{"num": "1", "den": "1"}],
-                            ]
-                        },
+                        "row_count": 2,
+                        "coefficients": [
+                            {"row": 0, "column": 0, "value": {"num": "1", "den": "1"}},
+                            {"row": 1, "column": 0, "value": {"num": "1", "den": "1"}},
+                        ],
                         "rhs": [
                             {"num": "0", "den": "1"},
                             {"num": "1", "den": "1"},

--- a/src/jacobian/math/matrices/rational_linear/operations.py
+++ b/src/jacobian/math/matrices/rational_linear/operations.py
@@ -1,13 +1,139 @@
 """Native exact operations for sparse rational linear systems."""
 
+from dataclasses import dataclass
 from fractions import Fraction
+from math import gcd
 from typing import Any
 
-from jacobian._exact import CanonicalRational
-from jacobian.canonical import format_canonical_integer
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
+from jacobian.canonical import CanonicalLimits, format_canonical_integer
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices.rational_linear._models import LinearRationalSystem
 
 __all__ = ["inconsistency_witness", "solve"]
+
+MAX_LINEAR_SCALAR_WORK = 100_000_000
+MAX_LINEAR_RESULT_BYTES = CanonicalLimits().max_output_bytes
+
+
+@dataclass(frozen=True)
+class _LinearPlan:
+    entries: dict[tuple[int, int], Fraction]
+    bounds: tuple[Fraction, ...]
+    row_count: int
+    column_count: int
+
+
+def _decimal_digits_from_bits(bits: int) -> int:
+    return max(1, (bits * 30_103 + 99_999) // 100_000)
+
+
+def _minor_component_bits(
+    rows: tuple[tuple[Fraction, ...], ...], *, column_count: int
+) -> int:
+    rank_bound = min(len(rows), column_count)
+    numerator_bits: list[int] = []
+    denominator_bits: list[int] = []
+    for row in rows:
+        denominator = 1
+        for value in row:
+            denominator *= value.denominator // gcd(denominator, value.denominator)
+            if _decimal_digits_from_bits(denominator.bit_length()) > (
+                MAX_CANONICAL_RATIONAL_DIGITS
+            ):
+                return MAX_CANONICAL_RATIONAL_DIGITS * 4
+        largest = max(
+            (
+                abs(value.numerator) * (denominator // value.denominator)
+                for value in row
+            ),
+            default=0,
+        )
+        numerator_bits.append(
+            largest.bit_length() + (column_count.bit_length() + 1) // 2
+        )
+        denominator_bits.append(denominator.bit_length())
+    return sum(sorted(numerator_bits, reverse=True)[:rank_bound]) + sum(
+        sorted(denominator_bits, reverse=True)[:rank_bound]
+    )
+
+
+def _reject(message: str) -> None:
+    raise OperationDomainValidationError(
+        location=("system",), code="matrix.budget_exceeded", message=message
+    )
+
+
+def _admit_system(system: LinearRationalSystem) -> _LinearPlan:
+    rows = system.coefficients.row_count
+    columns = system.coefficients.column_count
+    entries = {
+        (item.row, item.column): item.value.as_fraction()
+        for item in system.coefficients.entries
+    }
+    bounds = tuple(value.as_fraction() for value in system.rhs)
+    scalar_digits = max(
+        len(component.lstrip("-"))
+        for value in tuple(item.value for item in system.coefficients.entries)
+        + system.rhs
+        for component in (value.num, value.den)
+    )
+    solution_work = rows * (columns + 1) * min(rows, columns + 1)
+    witness_work = (columns + 1) * (rows + 1) * min(columns + 1, rows + 1)
+    if max(solution_work, witness_work) * scalar_digits > MAX_LINEAR_SCALAR_WORK:
+        _reject(
+            "sparse exact linear algebra exceeds the "
+            f"{MAX_LINEAR_SCALAR_WORK:,}-unit scalar-work budget"
+        )
+
+    solution_values: dict[int, list[Fraction]] = {row: [] for row in range(rows)}
+    witness_values: dict[int, list[Fraction]] = {
+        column: [] for column in range(columns)
+    }
+    for (row, column), fraction in entries.items():
+        solution_values[row].append(fraction)
+        witness_values[column].append(fraction)
+    for row, bound in enumerate(bounds):
+        if bound:
+            solution_values[row].append(bound)
+    solution_rows = tuple(tuple(solution_values[row]) for row in range(rows))
+    witness_rows = (
+        *(tuple(witness_values[column]) for column in range(columns)),
+        tuple(bound for bound in bounds if bound),
+    )
+    result_digits = max(
+        _decimal_digits_from_bits(
+            _minor_component_bits(solution_rows, column_count=columns + 1)
+        ),
+        _decimal_digits_from_bits(
+            _minor_component_bits(witness_rows, column_count=rows + 1)
+        ),
+    )
+    if result_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        _reject("sparse exact linear algebra exceeds the canonical result-height bound")
+
+    source_bytes = sum(len(name) + 3 for name in system.variables)
+    source_bytes += sum(
+        len(item.value.num)
+        + len(item.value.den)
+        + len(str(item.row))
+        + len(str(item.column))
+        + 64
+        for item in system.coefficients.entries
+    )
+    source_bytes += sum(len(value.num) + len(value.den) + 24 for value in system.rhs)
+    result_bytes = source_bytes + max(rows, columns) * (2 * result_digits + 32) + 4_096
+    if result_bytes > MAX_LINEAR_RESULT_BYTES:
+        _reject(
+            "sparse exact linear algebra exceeds the "
+            f"{MAX_LINEAR_RESULT_BYTES:,}-byte transport result bound"
+        )
+    return _LinearPlan(
+        entries=entries,
+        bounds=bounds,
+        row_count=rows,
+        column_count=columns,
+    )
 
 
 def _canonical_rational(value: Any) -> CanonicalRational:
@@ -48,25 +174,15 @@ def _solve_sparse(
     return tuple(values)
 
 
-def _fractions(
-    system: LinearRationalSystem,
-) -> tuple[dict[tuple[int, int], Fraction], tuple[Fraction, ...]]:
-    coefficients = {
-        (item.row, item.column): item.value.as_fraction()
-        for item in system.coefficients
-    }
-    return coefficients, tuple(value.as_fraction() for value in system.rhs)
-
-
 def solve(system: LinearRationalSystem) -> tuple[CanonicalRational, ...] | None:
     """Return one exact solution, or ``None`` when the system is inconsistent."""
 
-    coefficients, bounds = _fractions(system)
+    plan = _admit_system(system)
     values = _solve_sparse(
-        coefficients,
-        row_count=system.row_count,
-        column_count=len(system.variables),
-        rhs=bounds,
+        plan.entries,
+        row_count=plan.row_count,
+        column_count=plan.column_count,
+        rhs=plan.bounds,
     )
     if values is None:
         return None
@@ -78,19 +194,19 @@ def inconsistency_witness(
 ) -> tuple[tuple[CanonicalRational, ...], CanonicalRational] | None:
     """Return a separating left witness and nonzero RHS pairing, if any."""
 
-    coefficients, bounds = _fractions(system)
-    dual = {(column, row): value for (row, column), value in coefficients.items()}
+    plan = _admit_system(system)
+    dual = {(column, row): value for (row, column), value in plan.entries.items()}
     dual.update(
         {
             (len(system.variables), row): value
-            for row, value in enumerate(bounds)
+            for row, value in enumerate(plan.bounds)
             if value
         }
     )
     values = _solve_sparse(
         dual,
         row_count=len(system.variables) + 1,
-        column_count=system.row_count,
+        column_count=plan.row_count,
         rhs=(Fraction(0),) * len(system.variables) + (Fraction(1),),
     )
     if values is None:
@@ -99,7 +215,7 @@ def inconsistency_witness(
     pairing = sum(
         (
             bound * coordinate.as_fraction()
-            for bound, coordinate in zip(bounds, witness, strict=True)
+            for bound, coordinate in zip(plan.bounds, witness, strict=True)
         ),
         Fraction(0),
     )

--- a/src/jacobian/math/matrices/rational_linear/operations.py
+++ b/src/jacobian/math/matrices/rational_linear/operations.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from fractions import Fraction
 from math import gcd
-from typing import Any
+from typing import Any, Literal
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import CanonicalLimits, format_canonical_integer
@@ -64,7 +64,9 @@ def _reject(message: str) -> None:
     )
 
 
-def _admit_system(system: LinearRationalSystem) -> _LinearPlan:
+def _admit_system(
+    system: LinearRationalSystem, *, outcome: Literal["solution", "witness"]
+) -> _LinearPlan:
     rows = system.coefficients.row_count
     columns = system.coefficients.column_count
     entries = {
@@ -78,36 +80,36 @@ def _admit_system(system: LinearRationalSystem) -> _LinearPlan:
         + system.rhs
         for component in (value.num, value.den)
     )
-    solution_work = rows * (columns + 1) * min(rows, columns + 1)
-    witness_work = (columns + 1) * (rows + 1) * min(columns + 1, rows + 1)
-    if max(solution_work, witness_work) * scalar_digits > MAX_LINEAR_SCALAR_WORK:
+    if outcome == "solution":
+        work = rows * (columns + 1) * min(rows, columns + 1)
+        grouped: dict[int, list[Fraction]] = {row: [] for row in range(rows)}
+        for (row, _column), fraction in entries.items():
+            grouped[row].append(fraction)
+        for row, bound in enumerate(bounds):
+            if bound:
+                grouped[row].append(bound)
+        minor_rows = tuple(tuple(grouped[row]) for row in range(rows))
+        minor_columns = columns + 1
+        output_count = columns
+    else:
+        work = (columns + 1) * (rows + 1) * min(columns + 1, rows + 1)
+        grouped = {column: [] for column in range(columns)}
+        for (_row, column), fraction in entries.items():
+            grouped[column].append(fraction)
+        minor_rows = (
+            *(tuple(grouped[column]) for column in range(columns)),
+            tuple(bound for bound in bounds if bound),
+        )
+        minor_columns = rows + 1
+        output_count = rows + 1
+    if work * scalar_digits > MAX_LINEAR_SCALAR_WORK:
         _reject(
             "sparse exact linear algebra exceeds the "
             f"{MAX_LINEAR_SCALAR_WORK:,}-unit scalar-work budget"
         )
 
-    solution_values: dict[int, list[Fraction]] = {row: [] for row in range(rows)}
-    witness_values: dict[int, list[Fraction]] = {
-        column: [] for column in range(columns)
-    }
-    for (row, column), fraction in entries.items():
-        solution_values[row].append(fraction)
-        witness_values[column].append(fraction)
-    for row, bound in enumerate(bounds):
-        if bound:
-            solution_values[row].append(bound)
-    solution_rows = tuple(tuple(solution_values[row]) for row in range(rows))
-    witness_rows = (
-        *(tuple(witness_values[column]) for column in range(columns)),
-        tuple(bound for bound in bounds if bound),
-    )
-    result_digits = max(
-        _decimal_digits_from_bits(
-            _minor_component_bits(solution_rows, column_count=columns + 1)
-        ),
-        _decimal_digits_from_bits(
-            _minor_component_bits(witness_rows, column_count=rows + 1)
-        ),
+    result_digits = _decimal_digits_from_bits(
+        _minor_component_bits(minor_rows, column_count=minor_columns)
     )
     if result_digits > MAX_CANONICAL_RATIONAL_DIGITS:
         _reject("sparse exact linear algebra exceeds the canonical result-height bound")
@@ -122,7 +124,7 @@ def _admit_system(system: LinearRationalSystem) -> _LinearPlan:
         for item in system.coefficients.entries
     )
     source_bytes += sum(len(value.num) + len(value.den) + 24 for value in system.rhs)
-    result_bytes = source_bytes + max(rows, columns) * (2 * result_digits + 32) + 4_096
+    result_bytes = source_bytes + output_count * (2 * result_digits + 32) + 4_096
     if result_bytes > MAX_LINEAR_RESULT_BYTES:
         _reject(
             "sparse exact linear algebra exceeds the "
@@ -177,7 +179,7 @@ def _solve_sparse(
 def solve(system: LinearRationalSystem) -> tuple[CanonicalRational, ...] | None:
     """Return one exact solution, or ``None`` when the system is inconsistent."""
 
-    plan = _admit_system(system)
+    plan = _admit_system(system, outcome="solution")
     values = _solve_sparse(
         plan.entries,
         row_count=plan.row_count,
@@ -194,7 +196,7 @@ def inconsistency_witness(
 ) -> tuple[tuple[CanonicalRational, ...], CanonicalRational] | None:
     """Return a separating left witness and nonzero RHS pairing, if any."""
 
-    plan = _admit_system(system)
+    plan = _admit_system(system, outcome="witness")
     dual = {(column, row): value for (row, column), value in plan.entries.items()}
     dual.update(
         {

--- a/src/jacobian/math/matrices/rational_linear/operations.py
+++ b/src/jacobian/math/matrices/rational_linear/operations.py
@@ -1,4 +1,4 @@
-"""Native exact operations for rational linear systems."""
+"""Native exact operations for sparse rational linear systems."""
 
 from fractions import Fraction
 from typing import Any
@@ -10,10 +10,6 @@ from jacobian.math.matrices.rational_linear._models import LinearRationalSystem
 __all__ = ["inconsistency_witness", "solve"]
 
 
-def _fmpq(value: Fraction, flint: Any) -> Any:
-    return flint.fmpq(value.numerator, value.denominator)
-
-
 def _canonical_rational(value: Any) -> CanonicalRational:
     return CanonicalRational(
         num=format_canonical_integer(int(value.numerator)),
@@ -21,48 +17,57 @@ def _canonical_rational(value: Any) -> CanonicalRational:
     )
 
 
-def _solve(
-    coefficients: list[list[Fraction]], rhs: list[Fraction], flint: Any
-) -> list[Any] | None:
-    augmented = flint.fmpq_mat(
-        [
-            [_fmpq(value, flint) for value in row] + [_fmpq(bound, flint)]
-            for row, bound in zip(coefficients, rhs, strict=True)
-        ]
-    )
-    reduced, _ = augmented.rref()
-    columns = len(coefficients[0])
-    values = [flint.fmpq(0) for _ in range(columns)]
-    for row in range(reduced.nrows()):
-        pivot = next(
-            (column for column in range(columns) if reduced[row, column] != 0),
-            None,
-        )
-        if pivot is None:
-            if reduced[row, columns] != 0:
-                return None
-            continue
-        values[pivot] = reduced[row, columns]
-    return values
+def _solve_sparse(
+    entries: dict[tuple[int, int], Fraction],
+    *,
+    row_count: int,
+    column_count: int,
+    rhs: tuple[Fraction, ...],
+) -> tuple[Any, ...] | None:
+    """Return one zero-free-variable solution using SymPy's sparse QQ RREF."""
+
+    from sympy import QQ
+    from sympy.polys.matrices import DomainMatrix
+
+    rows: dict[int, dict[int, Any]] = {}
+    for (row, column), value in entries.items():
+        rows.setdefault(row, {})[column] = QQ(value.numerator, value.denominator)
+    for row, value in enumerate(rhs):
+        if value:
+            rows.setdefault(row, {})[column_count] = QQ(
+                value.numerator, value.denominator
+            )
+
+    augmented = DomainMatrix(rows, (row_count, column_count + 1), QQ)
+    reduced, pivots = augmented.rref()
+    if column_count in pivots:
+        return None
+    values = [QQ.zero] * column_count
+    for row, pivot in enumerate(pivots):
+        values[pivot] = reduced[row, column_count].element
+    return tuple(values)
 
 
 def _fractions(
     system: LinearRationalSystem,
-) -> tuple[list[list[Fraction]], list[Fraction]]:
-    coefficients = [
-        [value.as_fraction() for value in row] for row in system.coefficients.entries
-    ]
-    bounds = [value.as_fraction() for value in system.rhs]
-    return coefficients, bounds
+) -> tuple[dict[tuple[int, int], Fraction], tuple[Fraction, ...]]:
+    coefficients = {
+        (item.row, item.column): item.value.as_fraction()
+        for item in system.coefficients
+    }
+    return coefficients, tuple(value.as_fraction() for value in system.rhs)
 
 
 def solve(system: LinearRationalSystem) -> tuple[CanonicalRational, ...] | None:
     """Return one exact solution, or ``None`` when the system is inconsistent."""
 
     coefficients, bounds = _fractions(system)
-    import flint
-
-    values = _solve(coefficients, bounds, flint)
+    values = _solve_sparse(
+        coefficients,
+        row_count=system.row_count,
+        column_count=len(system.variables),
+        rhs=bounds,
+    )
     if values is None:
         return None
     return tuple(_canonical_rational(value) for value in values)
@@ -74,27 +79,28 @@ def inconsistency_witness(
     """Return a separating left witness and nonzero RHS pairing, if any."""
 
     coefficients, bounds = _fractions(system)
-    import flint
-
-    row_count = len(coefficients)
-    column_count = len(coefficients[0])
-    dual = [
-        [coefficients[row][column] for row in range(row_count)]
-        for column in range(column_count)
-    ]
-    dual.append(bounds)
-    values = _solve(dual, [Fraction(0)] * column_count + [Fraction(1)], flint)
+    dual = {(column, row): value for (row, column), value in coefficients.items()}
+    dual.update(
+        {
+            (len(system.variables), row): value
+            for row, value in enumerate(bounds)
+            if value
+        }
+    )
+    values = _solve_sparse(
+        dual,
+        row_count=len(system.variables) + 1,
+        column_count=system.row_count,
+        rhs=(Fraction(0),) * len(system.variables) + (Fraction(1),),
+    )
     if values is None:
         return None
     witness = tuple(_canonical_rational(value) for value in values)
-    pairing: Fraction = sum(
+    pairing = sum(
         (
             bound * coordinate.as_fraction()
             for bound, coordinate in zip(bounds, witness, strict=True)
         ),
         Fraction(0),
     )
-    return witness, CanonicalRational(
-        num=format_canonical_integer(pairing.numerator),
-        den=format_canonical_integer(pairing.denominator),
-    )
+    return witness, CanonicalRational.from_fraction(pairing)

--- a/src/jacobian/math/matrices/values.py
+++ b/src/jacobian/math/matrices/values.py
@@ -26,6 +26,8 @@ MAX_MATRIX_DIMENSION = 32
 # that complete public domain representable by the one canonical QQ matrix
 # value so a determinant consumer can accept a produced matrix unchanged.
 MAX_RATIONAL_MATRIX_ORDER = 128
+MAX_SPARSE_RATIONAL_MATRIX_AXIS = 8_192
+MAX_SPARSE_RATIONAL_MATRIX_NONZEROS = 32_768
 MAX_MATRIX_SCALAR_DIGITS = MAX_CANONICAL_RATIONAL_DIGITS
 
 
@@ -144,6 +146,110 @@ def rational_matrix_from_fractions(
         entries=tuple(
             tuple(CanonicalRational.from_fraction(value) for value in row)
             for row in entries
+        )
+    )
+
+
+class SparseRationalMatrixEntry(StrictModel):
+    """One nonzero entry at a stable zero-based matrix coordinate."""
+
+    row: int = Field(ge=0, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS - 1)
+    column: int = Field(ge=0, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS - 1)
+    value: CanonicalRational
+
+
+class SparseRationalMatrix(StrictModel):
+    """A dimension-retaining coordinate-sparse matrix over QQ."""
+
+    domain: Literal["QQ"] = "QQ"
+    row_count: int = Field(ge=1, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
+    column_count: int = Field(ge=1, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
+    entries: tuple[SparseRationalMatrixEntry, ...] = Field(
+        default=(), max_length=MAX_SPARSE_RATIONAL_MATRIX_NONZEROS
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_sparse_envelope(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        if set(data).difference({"domain", "row_count", "column_count", "entries"}):
+            raise _validation_error(
+                "shape_mismatch", "sparse matrix contains unknown fields"
+            )
+        entries = data.get("entries")
+        if (
+            isinstance(entries, (list, tuple))
+            and len(entries) > MAX_SPARSE_RATIONAL_MATRIX_NONZEROS
+        ):
+            raise _validation_error(
+                "budget_exceeded",
+                "sparse matrix stores at most "
+                f"{MAX_SPARSE_RATIONAL_MATRIX_NONZEROS} nonzeros",
+            )
+        return canonicalize_json_containers(data)
+
+    @model_validator(mode="after")
+    def require_canonical_coordinates(self) -> Self:
+        coordinates = tuple((entry.row, entry.column) for entry in self.entries)
+        if coordinates != tuple(sorted(set(coordinates))):
+            raise _validation_error(
+                "shape_mismatch",
+                "sparse matrix coordinates must be unique and row-major sorted",
+            )
+        if any(
+            entry.row >= self.row_count or entry.column >= self.column_count
+            for entry in self.entries
+        ):
+            raise _validation_error(
+                "shape_mismatch", "sparse matrix coordinates exceed declared axes"
+            )
+        if any(entry.value.as_fraction() == 0 for entry in self.entries):
+            raise _validation_error(
+                "shape_mismatch", "sparse matrices must not store explicit zeros"
+            )
+        require_matrix_scalar_digits(
+            tuple((entry.value,) for entry in self.entries),
+            maximum=MAX_MATRIX_SCALAR_DIGITS,
+            label="sparse matrix",
+        )
+        return self
+
+
+def sparse_rational_matrix_from_dense(matrix: RationalMatrix) -> SparseRationalMatrix:
+    """Convert the canonical dense QQ matrix to dimension-retaining coordinates."""
+
+    return SparseRationalMatrix(
+        row_count=len(matrix.entries),
+        column_count=len(matrix.entries[0]),
+        entries=tuple(
+            SparseRationalMatrixEntry(row=row, column=column, value=value)
+            for row, values in enumerate(matrix.entries)
+            for column, value in enumerate(values)
+            if value.as_fraction()
+        ),
+    )
+
+
+def dense_rational_matrix_from_sparse(matrix: SparseRationalMatrix) -> RationalMatrix:
+    """Convert bounded sparse coordinates to the canonical dense QQ matrix."""
+
+    if (
+        matrix.row_count > MAX_RATIONAL_MATRIX_ORDER
+        or matrix.column_count > MAX_RATIONAL_MATRIX_ORDER
+    ):
+        raise ValueError(
+            "sparse matrix axes exceed the canonical dense matrix representation"
+        )
+    zero = CanonicalRational(num="0", den="1")
+    coordinates = {(entry.row, entry.column): entry.value for entry in matrix.entries}
+    return RationalMatrix(
+        entries=tuple(
+            tuple(
+                coordinates.get((row, column), zero)
+                for column in range(matrix.column_count)
+            )
+            for row in range(matrix.row_count)
         )
     )
 
@@ -326,14 +432,20 @@ __all__ = [
     "MAX_MATRIX_DIMENSION",
     "MAX_MATRIX_SCALAR_DIGITS",
     "MAX_RATIONAL_MATRIX_ORDER",
+    "MAX_SPARSE_RATIONAL_MATRIX_AXIS",
+    "MAX_SPARSE_RATIONAL_MATRIX_NONZEROS",
     "IntegerMatrix",
     "RationalMatrix",
     "RationalVectorSpaceBasis",
     "RealQuadraticMatrix",
     "SmithNormalForm",
+    "SparseRationalMatrix",
+    "SparseRationalMatrixEntry",
+    "dense_rational_matrix_from_sparse",
     "rational_matrix_from_fractions",
     "rational_vector_space_basis_from_fractions",
     "require_matrix_scalar_digits",
+    "sparse_rational_matrix_from_dense",
 ]
 
 

--- a/tests/integration/linear/test_direct_linear_outcomes.py
+++ b/tests/integration/linear/test_direct_linear_outcomes.py
@@ -119,6 +119,12 @@ def test_rational_linear_program_returns_a_source_bound_optimum() -> None:
             }
         ).program
     )
+    assert result.primal_candidate is not None
+    assert result.dual_candidate is not None
+    assert result.primal_objective is not None
+    assert result.dual_objective is not None
+    assert result.primal_residuals is not None
+    assert result.dual_slacks is not None
     assert [v.model_dump(mode="json") for v in result.primal_candidate] == [q(1)]
     assert [v.model_dump(mode="json") for v in result.dual_candidate] == [q(1)]
     assert result.primal_objective.model_dump(mode="json") == q(1)
@@ -141,6 +147,8 @@ def test_rational_linear_program_handles_multiple_equalities() -> None:
     result = linear_program(request.program)
 
     assert result.status == "OPTIMAL"
+    assert result.primal_candidate is not None
+    assert result.primal_residuals is not None
     assert [v.model_dump(mode="json") for v in result.primal_candidate] == [q(1), q(2)]
     assert [v.model_dump(mode="json") for v in result.primal_residuals] == [q(0), q(0)]
 

--- a/tests/integration/linear/test_direct_linear_outcomes.py
+++ b/tests/integration/linear/test_direct_linear_outcomes.py
@@ -29,7 +29,10 @@ pytestmark = pytest.mark.requires_backend("flint")
 def _system(rhs: list[dict[str, str]]) -> dict[str, object]:
     return {
         "variables": ["x"],
-        "coefficients": {"entries": [[q(1)] for _ in rhs]},
+        "row_count": len(rhs),
+        "coefficients": [
+            {"row": row, "column": 0, "value": q(1)} for row in range(len(rhs))
+        ],
         "rhs": rhs,
     }
 

--- a/tests/integration/linear/test_direct_linear_outcomes.py
+++ b/tests/integration/linear/test_direct_linear_outcomes.py
@@ -23,16 +23,17 @@ from jacobian.math.optimization._models import (
 )
 from jacobian.math.optimization.operations import linear_program
 
-pytestmark = pytest.mark.requires_backend("flint")
-
 
 def _system(rhs: list[dict[str, str]]) -> dict[str, object]:
     return {
         "variables": ["x"],
-        "row_count": len(rhs),
-        "coefficients": [
-            {"row": row, "column": 0, "value": q(1)} for row in range(len(rhs))
-        ],
+        "coefficients": {
+            "row_count": len(rhs),
+            "column_count": 1,
+            "entries": [
+                {"row": row, "column": 0, "value": q(1)} for row in range(len(rhs))
+            ],
+        },
         "rhs": rhs,
     }
 

--- a/tests/integration/linear/test_models.py
+++ b/tests/integration/linear/test_models.py
@@ -24,7 +24,13 @@ def _canonical(numerator: int, denominator: int = 1) -> CanonicalRational:
 def _system() -> dict[str, object]:
     return {
         "variables": ["x", "y"],
-        "coefficients": {"entries": [[_q(2), _q(1)], [_q(1), _q(-1)]]},
+        "row_count": 2,
+        "coefficients": [
+            {"row": 0, "column": 0, "value": _q(2)},
+            {"row": 0, "column": 1, "value": _q(1)},
+            {"row": 1, "column": 0, "value": _q(1)},
+            {"row": 1, "column": 1, "value": _q(-1)},
+        ],
         "rhs": [_q(5), _q(1)],
     }
 
@@ -32,7 +38,7 @@ def _system() -> dict[str, object]:
 def test_linear_system_requires_exact_matching_dimensions() -> None:
     system = LinearRationalSystem.model_validate(_system())
     assert system.variables == ("x", "y")
-    assert len(system.coefficients.entries) == len(system.rhs) == 2
+    assert system.row_count == len(system.rhs) == 2
 
     malformed = _system()
     malformed["rhs"] = [_q(5)]
@@ -66,7 +72,12 @@ def test_inline_results_keep_only_mathematical_values() -> None:
     dependent = LinearRationalSystem.model_validate(
         {
             "variables": ["x", "y"],
-            "coefficients": {"entries": [[_q(1), _q(1)], [_q(1), _q(1)]]},
+            "row_count": 2,
+            "coefficients": [
+                {"row": row, "column": column, "value": _q(1)}
+                for row in range(2)
+                for column in range(2)
+            ],
             "rhs": [_q(0), _q(1)],
         }
     )
@@ -88,7 +99,12 @@ def test_inline_results_preserve_completed_no_candidate_outcomes() -> None:
     dependent = LinearRationalSystem.model_validate(
         {
             "variables": ["x", "y"],
-            "coefficients": {"entries": [[_q(1), _q(1)], [_q(1), _q(1)]]},
+            "row_count": 2,
+            "coefficients": [
+                {"row": row, "column": column, "value": _q(1)}
+                for row in range(2)
+                for column in range(2)
+            ],
             "rhs": [_q(0), _q(1)],
         }
     )
@@ -96,7 +112,10 @@ def test_inline_results_preserve_completed_no_candidate_outcomes() -> None:
     free = LinearRationalSystem.model_validate(
         {
             "variables": ["x", "y"],
-            "coefficients": {"entries": [[_q(1), _q(1)]]},
+            "row_count": 1,
+            "coefficients": [
+                {"row": 0, "column": column, "value": _q(1)} for column in range(2)
+            ],
             "rhs": [_q(1)],
         }
     )

--- a/tests/integration/linear/test_models.py
+++ b/tests/integration/linear/test_models.py
@@ -24,13 +24,16 @@ def _canonical(numerator: int, denominator: int = 1) -> CanonicalRational:
 def _system() -> dict[str, object]:
     return {
         "variables": ["x", "y"],
-        "row_count": 2,
-        "coefficients": [
-            {"row": 0, "column": 0, "value": _q(2)},
-            {"row": 0, "column": 1, "value": _q(1)},
-            {"row": 1, "column": 0, "value": _q(1)},
-            {"row": 1, "column": 1, "value": _q(-1)},
-        ],
+        "coefficients": {
+            "row_count": 2,
+            "column_count": 2,
+            "entries": [
+                {"row": 0, "column": 0, "value": _q(2)},
+                {"row": 0, "column": 1, "value": _q(1)},
+                {"row": 1, "column": 0, "value": _q(1)},
+                {"row": 1, "column": 1, "value": _q(-1)},
+            ],
+        },
         "rhs": [_q(5), _q(1)],
     }
 
@@ -38,7 +41,7 @@ def _system() -> dict[str, object]:
 def test_linear_system_requires_exact_matching_dimensions() -> None:
     system = LinearRationalSystem.model_validate(_system())
     assert system.variables == ("x", "y")
-    assert system.row_count == len(system.rhs) == 2
+    assert system.coefficients.row_count == len(system.rhs) == 2
 
     malformed = _system()
     malformed["rhs"] = [_q(5)]
@@ -72,12 +75,15 @@ def test_inline_results_keep_only_mathematical_values() -> None:
     dependent = LinearRationalSystem.model_validate(
         {
             "variables": ["x", "y"],
-            "row_count": 2,
-            "coefficients": [
-                {"row": row, "column": column, "value": _q(1)}
-                for row in range(2)
-                for column in range(2)
-            ],
+            "coefficients": {
+                "row_count": 2,
+                "column_count": 2,
+                "entries": [
+                    {"row": row, "column": column, "value": _q(1)}
+                    for row in range(2)
+                    for column in range(2)
+                ],
+            },
             "rhs": [_q(0), _q(1)],
         }
     )
@@ -99,12 +105,15 @@ def test_inline_results_preserve_completed_no_candidate_outcomes() -> None:
     dependent = LinearRationalSystem.model_validate(
         {
             "variables": ["x", "y"],
-            "row_count": 2,
-            "coefficients": [
-                {"row": row, "column": column, "value": _q(1)}
-                for row in range(2)
-                for column in range(2)
-            ],
+            "coefficients": {
+                "row_count": 2,
+                "column_count": 2,
+                "entries": [
+                    {"row": row, "column": column, "value": _q(1)}
+                    for row in range(2)
+                    for column in range(2)
+                ],
+            },
             "rhs": [_q(0), _q(1)],
         }
     )
@@ -112,10 +121,13 @@ def test_inline_results_preserve_completed_no_candidate_outcomes() -> None:
     free = LinearRationalSystem.model_validate(
         {
             "variables": ["x", "y"],
-            "row_count": 1,
-            "coefficients": [
-                {"row": 0, "column": column, "value": _q(1)} for column in range(2)
-            ],
+            "coefficients": {
+                "row_count": 1,
+                "column_count": 2,
+                "entries": [
+                    {"row": 0, "column": column, "value": _q(1)} for column in range(2)
+                ],
+            },
             "rhs": [_q(1)],
         }
     )

--- a/tests/math/matrices/test_rational_linear_source_binding.py
+++ b/tests/math/matrices/test_rational_linear_source_binding.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import copy
 import json
 from fractions import Fraction
+from itertools import islice
 from typing import Any, cast
 
 import pytest
 from pydantic import ValidationError
+from sympy import primerange
 from tests.support.rationals import rational_payload as q
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.matrices.rational_linear._models import (
     LinearRationalInconsistencyFindRequest,
     LinearRationalInconsistencyResult,
@@ -22,8 +25,6 @@ from jacobian.math.matrices.rational_linear._tools import (
     compute_rational_inconsistency,
     compute_rational_solution,
 )
-
-pytestmark = pytest.mark.requires_backend("flint")
 
 
 def _q(value: Fraction) -> dict[str, str]:
@@ -37,7 +38,13 @@ def _system(
 ) -> dict[str, object]:
     return {
         "variables": variables,
-        "coefficients": {"entries": [[_q(value) for value in row] for row in entries]},
+        "row_count": len(entries),
+        "coefficients": [
+            {"row": row, "column": column, "value": _q(value)}
+            for row, values in enumerate(entries)
+            for column, value in enumerate(values)
+            if value
+        ],
         "rhs": [_q(value) for value in rhs],
     }
 
@@ -101,14 +108,18 @@ def test_solution_result_replays_against_the_source() -> None:
     assert result.values is not None
     assert len(result.values) == len(system.variables)
     components = [value.as_fraction() for value in result.values]
+    coefficient_map = {
+        (item.row, item.column): item.value.as_fraction()
+        for item in system.coefficients
+    }
     for row, bound in zip(
-        system.coefficients.entries,
+        range(system.row_count),
         (value.as_fraction() for value in system.rhs),
         strict=True,
     ):
         residual = sum(
-            coefficient.as_fraction() * component
-            for coefficient, component in zip(row, components, strict=True)
+            coefficient_map.get((row, column), Fraction(0)) * component
+            for column, component in enumerate(components)
         )
         assert residual == bound
 
@@ -126,15 +137,15 @@ def test_inconsistent_result_replays_witness_relations() -> None:
     assert result.rhs_pairing is not None
     assert len(result.left_witness) == len(system.rhs)
     coordinates = [value.as_fraction() for value in result.left_witness]
-    for column in range(len(system.coefficients.entries[0])):
+    coefficient_map = {
+        (item.row, item.column): item.value.as_fraction()
+        for item in system.coefficients
+    }
+    for column in range(len(system.variables)):
         assert (
             sum(
-                row[column].as_fraction() * coordinate
-                for row, coordinate in zip(
-                    system.coefficients.entries,
-                    coordinates,
-                    strict=True,
-                )
+                coefficient_map.get((row, column), Fraction(0)) * coordinate
+                for row, coordinate in enumerate(coordinates)
             )
             == 0
         )
@@ -361,3 +372,116 @@ def test_separating_functional_annihilates_generators_but_not_the_target() -> No
     for generator in generators:
         assert sum(y * g for y, g in zip(coordinates, generator, strict=True)) == 0
     assert sum(y * t for y, t in zip(coordinates, target, strict=True)) != 0
+
+
+def test_sparse_diagonal_system_scales_beyond_the_dense_32_axis() -> None:
+    dimension = 128
+    payload = {
+        "variables": [f"x_{index}" for index in range(dimension)],
+        "row_count": dimension,
+        "coefficients": [
+            {"row": index, "column": index, "value": _q(Fraction(index + 1))}
+            for index in range(dimension)
+        ],
+        "rhs": [_q(Fraction(index + 1)) for index in range(dimension)],
+    }
+    result = compute_rational_solution(
+        LinearRationalSolutionFindRequest.model_validate({"system": payload})
+    )
+    assert result.status == "SOLUTION"
+    assert result.values == tuple(
+        CanonicalRational(num="1", den="1") for _ in range(dimension)
+    )
+
+
+def test_sparse_kernel_agrees_with_dense_sympy_on_the_overlap() -> None:
+    from sympy import Matrix, Rational
+
+    payload = _unique_system()
+    result = compute_rational_solution(
+        LinearRationalSolutionFindRequest.model_validate({"system": payload})
+    )
+    dense_solution, parameters = Matrix([[2, 1], [1, -1]]).gauss_jordan_solve(
+        Matrix([5, 1])
+    )
+    assert parameters.rows == 0
+    assert result.values is not None
+    assert all(isinstance(value, Rational) for value in dense_solution)
+    assert tuple(value.as_fraction() for value in result.values) == tuple(
+        Fraction(int(value.p), int(value.q)) for value in dense_solution
+    )
+
+
+def test_result_sensitive_admission_keeps_a_wide_one_row_system() -> None:
+    dimension = 1_024
+    payload = {
+        "variables": [f"x_{index}" for index in range(dimension)],
+        "row_count": 1,
+        "coefficients": [{"row": 0, "column": dimension - 1, "value": _q(Fraction(1))}],
+        "rhs": [_q(Fraction(7))],
+    }
+    result = compute_rational_solution(
+        LinearRationalSolutionFindRequest.model_validate({"system": payload})
+    )
+    assert result.values is not None
+    assert len(result.values) == dimension
+    assert result.values[-1] == CanonicalRational(num="7", den="1")
+    assert all(value.num == "0" for value in result.values[:-1])
+
+
+@pytest.mark.parametrize(
+    "coefficients",
+    (
+        [
+            {"row": 0, "column": 0, "value": _q(Fraction(1))},
+            {"row": 0, "column": 0, "value": _q(Fraction(2))},
+        ],
+        [{"row": 0, "column": 0, "value": _q(Fraction(0))}],
+    ),
+)
+def test_sparse_coefficients_reject_noncanonical_storage(
+    coefficients: list[dict[str, object]],
+) -> None:
+    with pytest.raises(ValidationError):
+        LinearRationalSystem.model_validate(
+            {
+                "variables": ["x"],
+                "row_count": 1,
+                "coefficients": coefficients,
+                "rhs": [_q(Fraction(0))],
+            }
+        )
+
+
+def test_sparse_work_budget_rejects_large_fill_envelope() -> None:
+    dimension = 500
+    with pytest.raises(ValidationError, match="scalar-work budget"):
+        LinearRationalSystem.model_validate(
+            {
+                "variables": [f"x_{index}" for index in range(dimension)],
+                "row_count": dimension,
+                "coefficients": [],
+                "rhs": [_q(Fraction(0)) for _ in range(dimension)],
+            }
+        )
+
+
+def test_sparse_result_height_rejects_before_backend_expansion() -> None:
+    denominators = tuple(islice(primerange(1_000_000_000, 2_000_000_000), 64))
+    with pytest.raises(ValidationError, match="result-height bound"):
+        LinearRationalSystem.model_validate(
+            {
+                "variables": [f"x_{index}" for index in range(64)],
+                "row_count": 64,
+                "coefficients": [
+                    {
+                        "row": row,
+                        "column": column,
+                        "value": _q(Fraction(1, denominators[column])),
+                    }
+                    for row in range(64)
+                    for column in range(64)
+                ],
+                "rhs": [_q(Fraction(0)) for _ in range(64)],
+            }
+        )

--- a/tests/math/matrices/test_rational_linear_source_binding.py
+++ b/tests/math/matrices/test_rational_linear_source_binding.py
@@ -6,6 +6,7 @@ import copy
 import json
 from fractions import Fraction
 from itertools import islice
+from math import log10
 from typing import Any, cast
 
 import pytest
@@ -13,9 +14,10 @@ from pydantic import ValidationError
 from sympy import primerange
 from tests.support.rationals import rational_payload as q
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices.rational_linear._models import (
+    MAX_LINEAR_DIMENSION,
     LinearRationalInconsistencyFindRequest,
     LinearRationalInconsistencyResult,
     LinearRationalSolutionFindRequest,
@@ -547,5 +549,85 @@ def test_sparse_result_height_rejects_before_backend_expansion() -> None:
             "rhs": [_q(Fraction(0)) for _ in range(64)],
         }
     )
+    with pytest.raises(OperationDomainValidationError, match="result-height bound"):
+        compute_rational_solution(LinearRationalSolutionFindRequest(system=system))
+
+
+def _primes_whose_product_exceeds_result_height() -> tuple[int, ...]:
+    """Distinct small primes whose primorial exceeds the canonical height cap."""
+
+    primes: list[int] = []
+    log10_product = 0.0
+    for prime in primerange(2, 200_000):
+        primes.append(int(prime))
+        log10_product += log10(prime)
+        if (
+            log10_product > MAX_CANONICAL_RATIONAL_DIGITS
+            and len(primes) <= MAX_LINEAR_DIMENSION
+        ):
+            return tuple(primes)
+    raise AssertionError("could not assemble a dual-height-exceeding prime list")
+
+
+def _tall_reciprocal_prime_system() -> dict[str, object]:
+    """One-variable system ``(1/p_i) x = 1/p_i``; the exact solution is ``x = 1``."""
+
+    primes = _primes_whose_product_exceeds_result_height()
+    return {
+        "variables": ["x"],
+        "coefficients": {
+            "row_count": len(primes),
+            "column_count": 1,
+            "entries": [
+                {"row": index, "column": 0, "value": _q(Fraction(1, prime))}
+                for index, prime in enumerate(primes)
+            ],
+        },
+        "rhs": [_q(Fraction(1, prime)) for prime in primes],
+    }
+
+
+def test_solution_admission_excludes_dual_witness_height() -> None:
+    """A tall reciprocal-prime identity is admitted for the solution postcondition."""
+
+    system = LinearRationalSystem.model_validate(_tall_reciprocal_prime_system())
+    result = compute_rational_solution(LinearRationalSolutionFindRequest(system=system))
+
+    assert result.status == "SOLUTION"
+    assert result.values == (CanonicalRational(num="1", den="1"),)
+
+
+def test_inconsistency_admission_still_enforces_witness_height() -> None:
+    """The same dual primorial still rejects the left-witness postcondition."""
+
+    system = LinearRationalSystem.model_validate(_tall_reciprocal_prime_system())
+    with pytest.raises(OperationDomainValidationError, match="result-height bound"):
+        compute_rational_inconsistency(
+            LinearRationalInconsistencyFindRequest(system=system)
+        )
+
+
+def test_witness_admission_excludes_primal_solution_height() -> None:
+    """A wide reciprocal-prime row is admitted for the inconsistency postcondition."""
+
+    primes = _primes_whose_product_exceeds_result_height()
+    payload = {
+        "variables": [f"x_{index}" for index in range(len(primes))],
+        "coefficients": {
+            "row_count": 1,
+            "column_count": len(primes),
+            "entries": [
+                {"row": 0, "column": index, "value": _q(Fraction(1, prime))}
+                for index, prime in enumerate(primes)
+            ],
+        },
+        "rhs": [_q(Fraction(1, primes[0]))],
+    }
+    system = LinearRationalSystem.model_validate(payload)
+    result = compute_rational_inconsistency(
+        LinearRationalInconsistencyFindRequest(system=system)
+    )
+
+    assert result.status == "CONSISTENT"
     with pytest.raises(OperationDomainValidationError, match="result-height bound"):
         compute_rational_solution(LinearRationalSolutionFindRequest(system=system))

--- a/tests/math/matrices/test_rational_linear_source_binding.py
+++ b/tests/math/matrices/test_rational_linear_source_binding.py
@@ -14,6 +14,7 @@ from sympy import primerange
 from tests.support.rationals import rational_payload as q
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices.rational_linear._models import (
     LinearRationalInconsistencyFindRequest,
     LinearRationalInconsistencyResult,
@@ -24,6 +25,12 @@ from jacobian.math.matrices.rational_linear._models import (
 from jacobian.math.matrices.rational_linear._tools import (
     compute_rational_inconsistency,
     compute_rational_solution,
+)
+from jacobian.math.matrices.values import (
+    RationalMatrix,
+    SparseRationalMatrix,
+    dense_rational_matrix_from_sparse,
+    sparse_rational_matrix_from_dense,
 )
 
 
@@ -38,13 +45,16 @@ def _system(
 ) -> dict[str, object]:
     return {
         "variables": variables,
-        "row_count": len(entries),
-        "coefficients": [
-            {"row": row, "column": column, "value": _q(value)}
-            for row, values in enumerate(entries)
-            for column, value in enumerate(values)
-            if value
-        ],
+        "coefficients": {
+            "row_count": len(entries),
+            "column_count": len(variables),
+            "entries": [
+                {"row": row, "column": column, "value": _q(value)}
+                for row, values in enumerate(entries)
+                for column, value in enumerate(values)
+                if value
+            ],
+        },
         "rhs": [_q(value) for value in rhs],
     }
 
@@ -63,6 +73,24 @@ def _inconsistent_system() -> dict[str, object]:
         [[Fraction(1), Fraction(1)], [Fraction(1), Fraction(1)]],
         [Fraction(0), Fraction(1)],
     )
+
+
+def test_sparse_rational_matrix_round_trips_through_its_dense_owner() -> None:
+    dense = RationalMatrix.model_validate(
+        {
+            "entries": [
+                [_q(Fraction(0)), _q(Fraction(2)), _q(Fraction(0))],
+                [_q(Fraction(0)), _q(Fraction(0)), _q(Fraction(0))],
+            ]
+        }
+    )
+    sparse = sparse_rational_matrix_from_dense(dense)
+    restored = SparseRationalMatrix.model_validate(sparse.model_dump(mode="json"))
+
+    assert restored.row_count == 2
+    assert restored.column_count == 3
+    assert tuple((entry.row, entry.column) for entry in restored.entries) == ((0, 1),)
+    assert dense_rational_matrix_from_sparse(restored) == dense
 
 
 def _underdetermined_system() -> dict[str, object]:
@@ -110,10 +138,10 @@ def test_solution_result_replays_against_the_source() -> None:
     components = [value.as_fraction() for value in result.values]
     coefficient_map = {
         (item.row, item.column): item.value.as_fraction()
-        for item in system.coefficients
+        for item in system.coefficients.entries
     }
     for row, bound in zip(
-        range(system.row_count),
+        range(system.coefficients.row_count),
         (value.as_fraction() for value in system.rhs),
         strict=True,
     ):
@@ -139,7 +167,7 @@ def test_inconsistent_result_replays_witness_relations() -> None:
     coordinates = [value.as_fraction() for value in result.left_witness]
     coefficient_map = {
         (item.row, item.column): item.value.as_fraction()
-        for item in system.coefficients
+        for item in system.coefficients.entries
     }
     for column in range(len(system.variables)):
         assert (
@@ -378,11 +406,14 @@ def test_sparse_diagonal_system_scales_beyond_the_dense_32_axis() -> None:
     dimension = 128
     payload = {
         "variables": [f"x_{index}" for index in range(dimension)],
-        "row_count": dimension,
-        "coefficients": [
-            {"row": index, "column": index, "value": _q(Fraction(index + 1))}
-            for index in range(dimension)
-        ],
+        "coefficients": {
+            "row_count": dimension,
+            "column_count": dimension,
+            "entries": [
+                {"row": index, "column": index, "value": _q(Fraction(index + 1))}
+                for index in range(dimension)
+            ],
+        },
         "rhs": [_q(Fraction(index + 1)) for index in range(dimension)],
     }
     result = compute_rational_solution(
@@ -416,8 +447,11 @@ def test_result_sensitive_admission_keeps_a_wide_one_row_system() -> None:
     dimension = 1_024
     payload = {
         "variables": [f"x_{index}" for index in range(dimension)],
-        "row_count": 1,
-        "coefficients": [{"row": 0, "column": dimension - 1, "value": _q(Fraction(1))}],
+        "coefficients": {
+            "row_count": 1,
+            "column_count": dimension,
+            "entries": [{"row": 0, "column": dimension - 1, "value": _q(Fraction(1))}],
+        },
         "rhs": [_q(Fraction(7))],
     }
     result = compute_rational_solution(
@@ -446,8 +480,11 @@ def test_sparse_coefficients_reject_noncanonical_storage(
         LinearRationalSystem.model_validate(
             {
                 "variables": ["x"],
-                "row_count": 1,
-                "coefficients": coefficients,
+                "coefficients": {
+                    "row_count": 1,
+                    "column_count": 1,
+                    "entries": coefficients,
+                },
                 "rhs": [_q(Fraction(0))],
             }
         )
@@ -455,25 +492,49 @@ def test_sparse_coefficients_reject_noncanonical_storage(
 
 def test_sparse_work_budget_rejects_large_fill_envelope() -> None:
     dimension = 500
-    with pytest.raises(ValidationError, match="scalar-work budget"):
-        LinearRationalSystem.model_validate(
-            {
-                "variables": [f"x_{index}" for index in range(dimension)],
+    system = LinearRationalSystem.model_validate(
+        {
+            "variables": [f"x_{index}" for index in range(dimension)],
+            "coefficients": {
                 "row_count": dimension,
-                "coefficients": [],
-                "rhs": [_q(Fraction(0)) for _ in range(dimension)],
-            }
-        )
+                "column_count": dimension,
+                "entries": [],
+            },
+            "rhs": [_q(Fraction(0)) for _ in range(dimension)],
+        }
+    )
+    with pytest.raises(OperationDomainValidationError, match="scalar-work budget"):
+        compute_rational_solution(LinearRationalSolutionFindRequest(system=system))
+
+
+def test_result_deserialization_does_not_repeat_semantic_admission() -> None:
+    dimension = 500
+    system = LinearRationalSystem.model_validate(
+        {
+            "variables": [f"x_{index}" for index in range(dimension)],
+            "coefficients": {
+                "row_count": dimension,
+                "column_count": dimension,
+                "entries": [],
+            },
+            "rhs": [_q(Fraction(0)) for _ in range(dimension)],
+        }
+    )
+    restored = LinearRationalSolutionResult.model_validate(
+        {"system": system.model_dump(mode="json"), "status": "INCONSISTENT"}
+    )
+    assert restored.system == system
 
 
 def test_sparse_result_height_rejects_before_backend_expansion() -> None:
     denominators = tuple(islice(primerange(1_000_000_000, 2_000_000_000), 64))
-    with pytest.raises(ValidationError, match="result-height bound"):
-        LinearRationalSystem.model_validate(
-            {
-                "variables": [f"x_{index}" for index in range(64)],
+    system = LinearRationalSystem.model_validate(
+        {
+            "variables": [f"x_{index}" for index in range(64)],
+            "coefficients": {
                 "row_count": 64,
-                "coefficients": [
+                "column_count": 64,
+                "entries": [
                     {
                         "row": row,
                         "column": column,
@@ -482,6 +543,9 @@ def test_sparse_result_height_rejects_before_backend_expansion() -> None:
                     for row in range(64)
                     for column in range(64)
                 ],
-                "rhs": [_q(Fraction(0)) for _ in range(64)],
-            }
-        )
+            },
+            "rhs": [_q(Fraction(0)) for _ in range(64)],
+        }
+    )
+    with pytest.raises(OperationDomainValidationError, match="result-height bound"):
+        compute_rational_solution(LinearRationalSolutionFindRequest(system=system))


### PR DESCRIPTION
Closes #2302

## Problem

The rational solution and inconsistency operations used a coordinate list but admitted only 32 rows or variables. That fixed dense-style ceiling rejected sparse exact systems whose actual input, work, and output remain bounded.

## What changed

- add a domain-owned `SparseRationalMatrix` value with canonical row-major nonzero coordinates, retained axes, and explicit dense conversions
- use SymPy 1.14 `DomainMatrix` over `QQ` as the maintained sparse RREF backend
- replace the fixed 32-axis restriction with separate axis, nonzero, scalar-work, exact result-height, and transport-result bounds
- perform semantic admission once at operation invocation; result deserialization performs structural/source validation only
- remove the stale module-wide FLINT test marker now that rational-system outcomes use SymPy

This intentionally replaces the pre-stable inline coefficient-list contract. It does not claim that every matrix fitting the structural 8,192-axis/32,768-nonzero carrier is executable: operation admission rejects requests whose conservative fill-in work or exact result bounds exceed the envelope. In particular, this supports tractable sparse Atlas-style shapes without claiming the full 1,598 by 8,367 candidate-search matrix is safe in one call.

## Evidence

- 128 by 128 sparse diagonal solution
- 1 by 1,024 result-sensitive wide solution
- agreement with dense SymPy on the overlapping domain
- exact inconsistency-witness invariants
- duplicate/stored-zero, work-budget, and adversarial result-height rejection
- dense/sparse serialized round trip preserving implicit zero axes
- result deserialization regression proving semantic admission is not repeated

## Validation

`make affected AFFECTED_BASE=origin/main`

Selected lanes passed: scoped Ruff and mypy; 515 matrix tests; 112 catalog tests; 800 catalog-integration tests; and 907 integration tests.

An independent exact-diff review found no remaining correctness, contract, or boundedness issues.