### PR TITLE
fix(arrangements): combined chamber ledger and 2^m-2 prefixes

### DIFF
--- a/src/jacobian/math/geometry/arrangements/operations.py
+++ b/src/jacobian/math/geometry/arrangements/operations.py
@@ -158,7 +158,7 @@ def characteristic_polynomial(
         nonzero_coefficients * _canonical_integer_conversion_work(coefficient_digits)
         + zero_coefficients
     )
-    if conversion_work > MAX_GENERIC_FORMULA_WORK:
+    if n + conversion_work > MAX_GENERIC_FORMULA_WORK:
         _reject(
             ("ambient_dimension", "hyperplane_count"),
             "characteristic_formatting_work_exceeded",
@@ -205,12 +205,33 @@ def chamber_count(ambient_dimension: int, hyperplane_count: int) -> ChamberCount
                 "chamber count exceeds the canonical integer-conversion work budget",
             )
         count = 1 << m
+    elif n == m - 1:
+        result_bit_bound = m + 1
+        result_digits = _bit_bound_to_decimal_digits(result_bit_bound)
+        if (
+            result_digits + _FORMULA_RESULT_RESERVE_BYTES
+            > CanonicalLimits().max_output_bytes
+        ):
+            _reject(
+                ("hyperplane_count",),
+                "chamber_result_bytes_exceeded",
+                "chamber count exceeds the canonical output-byte limit",
+            )
+        conversion_work = _canonical_integer_conversion_work(result_digits)
+        if conversion_work > MAX_GENERIC_FORMULA_WORK:
+            _reject(
+                ("hyperplane_count",),
+                "chamber_formatting_work_exceeded",
+                "chamber count exceeds the canonical integer-conversion work budget",
+            )
+        count = (1 << m) - 2
     else:
         prefix_bit_bound = _binomial_prefix_bit_bound(m - 1, n)
         result_bit_bound = prefix_bit_bound + n.bit_length() + 1
         result_digits = _bit_bound_to_decimal_digits(result_bit_bound)
         recurrence_work = _chamber_recurrence_limb_work(m - 1, n)
-        if n + recurrence_work > MAX_GENERIC_FORMULA_WORK:
+        conversion_work = _canonical_integer_conversion_work(result_digits)
+        if n + recurrence_work + conversion_work > MAX_GENERIC_FORMULA_WORK:
             _reject(
                 ("ambient_dimension", "hyperplane_count"),
                 "chamber_summation_work_exceeded",
@@ -224,13 +245,6 @@ def chamber_count(ambient_dimension: int, hyperplane_count: int) -> ChamberCount
                 ("ambient_dimension", "hyperplane_count"),
                 "chamber_result_bytes_exceeded",
                 "chamber count exceeds the canonical output-byte limit",
-            )
-        conversion_work = _canonical_integer_conversion_work(result_digits)
-        if n + conversion_work > MAX_GENERIC_FORMULA_WORK:
-            _reject(
-                ("ambient_dimension", "hyperplane_count"),
-                "chamber_formatting_work_exceeded",
-                "chamber count exceeds the canonical integer-conversion work budget",
             )
         count = _chamber_recurrence(m - 1, n)
     return ChamberCountResult(chamber_count=format_canonical_integer(count))

--- a/tests/math/geometry/arrangements/test_hyperplane_arrangements.py
+++ b/tests/math/geometry/arrangements/test_hyperplane_arrangements.py
@@ -316,8 +316,8 @@ def test_chamber_count_rejects_closed_form_integer_conversion_work() -> None:
 
 def test_chamber_count_rejects_long_partial_sum() -> None:
     request = ChamberCountRequest(
-        ambient_dimension=MAX_GENERIC_FORMULA_WORK + 1,
-        hyperplane_count=MAX_GENERIC_FORMULA_WORK + 2,
+        ambient_dimension=5_000,
+        hyperplane_count=100_000,
     )
     with pytest.raises(OperationDomainValidationError) as error:
         compute_chamber_count(request)
@@ -327,20 +327,26 @@ def test_chamber_count_rejects_long_partial_sum() -> None:
     )
 
 
-def test_chamber_count_rejects_recurrence_limb_work() -> None:
-    # n = 8500, m = 8501 passes the digit and conversion guards (~90,010
-    # units) but the binomial recurrence walks C(8500, 4250). Max-width
-    # mul/div limb visits are about 4.8 million, over the 100,000 ledger.
+def test_chamber_count_uses_complementary_power_near_the_full_prefix() -> None:
     request = ChamberCountRequest(
         ambient_dimension=8_500,
         hyperplane_count=8_501,
     )
+    result = compute_chamber_count(request)
+    assert result.chamber_count == format_canonical_integer((1 << 8_501) - 2)
+
+
+def test_chamber_count_rejects_combined_recurrence_and_formatting_work() -> None:
+    request = ChamberCountRequest(
+        ambient_dimension=173,
+        hyperplane_count=10**15,
+    )
     with pytest.raises(OperationDomainValidationError) as error:
         compute_chamber_count(request)
-    assert (
-        error.value.errors()[0]["type"]
-        == "hyperplane_arrangement.chamber_summation_work_exceeded"
-    )
+    assert error.value.errors()[0]["type"] in {
+        "hyperplane_arrangement.chamber_summation_work_exceeded",
+        "hyperplane_arrangement.chamber_formatting_work_exceeded",
+    }
 
 
 def test_result_models_reject_contradictory_exact_values() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

#2988 merged with remaining Codex notes: near-full prefixes (`n = m-1`) should use `2^m - 2` instead of a central-binomial recurrence, and chamber/characteristic phases must share one 100,000-unit ledger.

## Solution

When `ambient_dimension = hyperplane_count - 1`, return `2^m - 2` on the closed-form conversion envelope. Otherwise charge `n + recurrence limbs + conversion` together. Characteristic polynomials charge coefficient index work with formatting.

## Testing

```sh
uv run --locked pytest tests/math/geometry/arrangements/test_hyperplane_arrangements.py
```

32 passed.

## Public contract impact

none

## Operation boundary ownership

- Changed stage: request bounds
- Request-bounds owner: `chamber_count` / `characteristic_polynomial` formula work ledger
- Native/MCP parity: same native kernel used by tools

## Canonical value audit

not applicable

## Catalog admission

not applicable

## Closure matrix

none

## Checklist

- [x] Arrangement tests passed
- [x] No new public operations
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5038921b-26ec-4d17-abfa-852e02903ac7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5038921b-26ec-4d17-abfa-852e02903ac7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

