### PR TITLE
Add graph.neighborhood.open.compute operation

### DIFF
--- a/src/jacobian/math/graphs/neighborhood/__init__.py
+++ b/src/jacobian/math/graphs/neighborhood/__init__.py
@@ -1,0 +1,5 @@
+"""Graph neighbourhood operations."""
+
+from jacobian.math.graphs.neighborhood.operations import open_neighborhood
+
+__all__ = ["open_neighborhood"]

--- a/src/jacobian/math/graphs/neighborhood/_bounds.py
+++ b/src/jacobian/math/graphs/neighborhood/_bounds.py
@@ -11,7 +11,10 @@ from jacobian.canonical import (
     strict_json_object_size,
 )
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.graphs.values import (
+    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    SimpleUndirectedGraph,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -20,7 +23,6 @@ class OpenNeighborhoodAdmission:
 
     selected_vertices: tuple[str, ...]
     neighborhood: tuple[str, ...]
-    output_bytes: int
 
 
 def _encoded_size(value: object, *, location: tuple[str, ...]) -> int:
@@ -40,7 +42,7 @@ def admit_open_neighborhood(
     graph: SimpleUndirectedGraph,
     selected_vertices: tuple[str, ...],
 ) -> OpenNeighborhoodAdmission:
-    """Normalize one selected set and reject an unrepresentable exact result."""
+    """Normalize one selected set and admit its exact mathematical result."""
 
     if not isinstance(graph, SimpleUndirectedGraph):
         raise TypeError("open_neighborhood expects a SimpleUndirectedGraph")
@@ -48,6 +50,15 @@ def admit_open_neighborhood(
         not isinstance(vertex, str) for vertex in selected_vertices
     ):
         raise TypeError("selected_vertices must be a tuple of strings")
+    if len(selected_vertices) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
+        raise OperationDomainValidationError(
+            location=("selected_vertices",),
+            code="graph.open_neighborhood.selected_vertices_bound",
+            message=(
+                "open-neighbourhood selection supports at most "
+                f"{MAX_INDEXED_SIMPLE_GRAPH_VERTICES} raw vertices"
+            ),
+        )
 
     selected_set = set(selected_vertices)
     unknown = selected_set.difference(graph.vertices)
@@ -67,12 +78,25 @@ def admit_open_neighborhood(
             neighbors.add(left)
     neighborhood = tuple(vertex for vertex in graph.vertices if vertex in neighbors)
 
+    return OpenNeighborhoodAdmission(
+        selected_vertices=selected,
+        neighborhood=neighborhood,
+    )
+
+
+def require_open_neighborhood_output_budget(
+    graph: SimpleUndirectedGraph,
+    selected_vertices: tuple[str, ...],
+    neighborhood: tuple[str, ...],
+) -> None:
+    """Reject a result that cannot cross the canonical transport boundary."""
+
     graph_bytes = _encoded_size(
         graph.model_dump(mode="json"),
         location=("graph",),
     )
     selected_bytes = _encoded_size(
-        list(selected),
+        list(selected_vertices),
         location=("selected_vertices",),
     )
     neighborhood_bytes = _encoded_size(
@@ -98,11 +122,9 @@ def admit_open_neighborhood(
             ),
         )
 
-    return OpenNeighborhoodAdmission(
-        selected_vertices=selected,
-        neighborhood=neighborhood,
-        output_bytes=output_bytes,
-    )
 
-
-__all__ = ["OpenNeighborhoodAdmission", "admit_open_neighborhood"]
+__all__ = [
+    "OpenNeighborhoodAdmission",
+    "admit_open_neighborhood",
+    "require_open_neighborhood_output_budget",
+]

--- a/src/jacobian/math/graphs/neighborhood/_bounds.py
+++ b/src/jacobian/math/graphs/neighborhood/_bounds.py
@@ -1,0 +1,108 @@
+"""Admission planning for exact open neighbourhoods."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+    strict_json_object_size,
+)
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+@dataclass(frozen=True, slots=True)
+class OpenNeighborhoodAdmission:
+    """The canonical selected axis and exact result plan for one request."""
+
+    selected_vertices: tuple[str, ...]
+    neighborhood: tuple[str, ...]
+    output_bytes: int
+
+
+def _encoded_size(value: object, *, location: tuple[str, ...]) -> int:
+    try:
+        return len(encode_strict_json(value))
+    except CanonicalizationError as exc:
+        raise OperationDomainValidationError(
+            location=location,
+            code="graph.open_neighborhood.output_budget",
+            message=(
+                "the open-neighbourhood result cannot fit the canonical output budget"
+            ),
+        ) from exc
+
+
+def admit_open_neighborhood(
+    graph: SimpleUndirectedGraph,
+    selected_vertices: tuple[str, ...],
+) -> OpenNeighborhoodAdmission:
+    """Normalize one selected set and reject an unrepresentable exact result."""
+
+    if not isinstance(graph, SimpleUndirectedGraph):
+        raise TypeError("open_neighborhood expects a SimpleUndirectedGraph")
+    if not isinstance(selected_vertices, tuple) or any(
+        not isinstance(vertex, str) for vertex in selected_vertices
+    ):
+        raise TypeError("selected_vertices must be a tuple of strings")
+
+    selected_set = set(selected_vertices)
+    unknown = selected_set.difference(graph.vertices)
+    if unknown:
+        raise OperationDomainValidationError(
+            location=("selected_vertices",),
+            code="graph.open_neighborhood.selected_vertex_not_in_graph",
+            message="every selected vertex must be a declared graph vertex",
+        )
+
+    selected = tuple(vertex for vertex in graph.vertices if vertex in selected_set)
+    neighbors: set[str] = set()
+    for left, right in graph.edges:
+        if left in selected_set and right not in selected_set:
+            neighbors.add(right)
+        elif right in selected_set and left not in selected_set:
+            neighbors.add(left)
+    neighborhood = tuple(vertex for vertex in graph.vertices if vertex in neighbors)
+
+    graph_bytes = _encoded_size(
+        graph.model_dump(mode="json"),
+        location=("graph",),
+    )
+    selected_bytes = _encoded_size(
+        list(selected),
+        location=("selected_vertices",),
+    )
+    neighborhood_bytes = _encoded_size(
+        list(neighborhood),
+        location=("graph",),
+    )
+    output_bytes = strict_json_object_size(
+        (
+            ("graph", graph_bytes),
+            ("selected_vertices", selected_bytes),
+            ("neighborhood", neighborhood_bytes),
+        )
+    )
+    output_limit = CanonicalLimits().max_output_bytes
+    if output_bytes > output_limit:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.open_neighborhood.output_budget",
+            message=(
+                "the open-neighbourhood result retains its source graph, selected "
+                f"axis, and exact neighbourhood ({output_bytes:,} bytes), exceeding "
+                f"the {output_limit:,}-byte canonical output budget"
+            ),
+        )
+
+    return OpenNeighborhoodAdmission(
+        selected_vertices=selected,
+        neighborhood=neighborhood,
+        output_bytes=output_bytes,
+    )
+
+
+__all__ = ["OpenNeighborhoodAdmission", "admit_open_neighborhood"]

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -7,7 +7,7 @@ from typing import Self
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.graphs.values import (
     MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
@@ -21,6 +21,21 @@ class NeighborhoodRequest(StrictModel):
     selected_vertices: tuple[str, ...] = Field(
         max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw_selected_vertices(cls, value: object) -> object:
+        if isinstance(value, dict):
+            selected = value.get("selected_vertices")
+            if (
+                isinstance(selected, (list, tuple))
+                and len(selected) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+            ):
+                raise PydanticCustomError(
+                    "graph.selected_vertices_bound",
+                    "selected vertices exceed the raw tuple-length bound",
+                )
+        return canonicalize_json_containers(value)
 class NeighborhoodResult(StrictModel):
     """The exact open neighbourhood of a selected vertex set."""
 

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -36,6 +36,8 @@ class NeighborhoodRequest(StrictModel):
                     "selected vertices exceed the raw tuple-length bound",
                 )
         return canonicalize_json_containers(value)
+
+
 class NeighborhoodResult(StrictModel):
     """The exact open neighbourhood of a selected vertex set."""
 

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Self
+
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian._models import StrictModel
 from jacobian.math.graphs.values import (
     MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
@@ -19,29 +21,37 @@ class NeighborhoodRequest(StrictModel):
     selected_vertices: tuple[str, ...] = Field(
         max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def bound_raw_selected_vertices(cls, value: object) -> object:
-        if isinstance(value, dict):
-            selected = value.get("selected_vertices")
-            if (
-                isinstance(selected, (list, tuple))
-                and len(selected) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES
-            ):
-                raise PydanticCustomError(
-                    "graph.selected_vertices_bound",
-                    "selected vertices exceed the raw tuple-length bound",
-                )
-        return canonicalize_json_containers(value)
-
-
 class NeighborhoodResult(StrictModel):
     """The exact open neighbourhood of a selected vertex set."""
 
     graph: SimpleUndirectedGraph
     selected_vertices: tuple[str, ...]
     neighborhood: tuple[str, ...]
+
+    @model_validator(mode="after")
+    def validate_result(self) -> Self:
+        selected = set(self.selected_vertices)
+        neighborhood = set(self.neighborhood)
+        if self.selected_vertices != tuple(
+            vertex for vertex in self.graph.vertices if vertex in selected
+        ):
+            raise PydanticCustomError(
+                "graph.selected_vertices_must_be_canonical",
+                "selected vertices must be a subset in source-vertex order",
+            )
+        if self.neighborhood != tuple(
+            vertex for vertex in self.graph.vertices if vertex in neighborhood
+        ):
+            raise PydanticCustomError(
+                "graph.neighborhood_must_be_canonical",
+                "neighbourhood vertices must be a subset in source-vertex order",
+            )
+        if selected & neighborhood:
+            raise PydanticCustomError(
+                "graph.open_neighborhood_must_exclude_selected_vertices",
+                "an open neighbourhood must exclude selected vertices",
+            )
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -4,18 +4,41 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import model_validator
+from pydantic import Field, PrivateAttr, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.neighborhood._bounds import (
+    OpenNeighborhoodAdmission,
+    admit_open_neighborhood,
+)
+from jacobian.math.graphs.values import (
+    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    SimpleUndirectedGraph,
+)
 
 
 class NeighborhoodRequest(StrictModel):
     """Compute the exact open neighbourhood of a selected vertex set."""
 
     graph: SimpleUndirectedGraph
-    selected_vertices: tuple[str, ...]
+    selected_vertices: tuple[str, ...] = Field(
+        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+    )
+    _admission: OpenNeighborhoodAdmission = PrivateAttr()
+
+    @model_validator(mode="after")
+    def admit_request(self) -> Self:
+        try:
+            self._admission = admit_open_neighborhood(
+                self.graph, self.selected_vertices
+            )
+        except OperationDomainValidationError as error:
+            raise PydanticCustomError(
+                "graph.open_neighborhood.request_not_admitted", str(error)
+            ) from error
+        return self
 
 
 class NeighborhoodResult(StrictModel):

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -4,44 +4,18 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import Field, model_validator
+from pydantic import model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_EDGES,
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
-    SimpleUndirectedGraph,
-)
-
-MAX_NEIGHBORHOOD_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
-MAX_NEIGHBORHOOD_EDGES = MAX_INDEXED_SIMPLE_GRAPH_EDGES
+from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 
 class NeighborhoodRequest(StrictModel):
     """Compute the exact open neighbourhood of a selected vertex set."""
 
     graph: SimpleUndirectedGraph
-    selected_vertices: tuple[str, ...] = Field(
-        min_length=0,
-        max_length=MAX_NEIGHBORHOOD_VERTICES,
-    )
-
-    @model_validator(mode="after")
-    def validate_selected_vertices(self) -> Self:
-        vertex_set = set(self.graph.vertices)
-        for v in self.selected_vertices:
-            if v not in vertex_set:
-                raise PydanticCustomError(
-                    "graph.selected_vertex_not_in_graph",
-                    "every selected vertex must be a declared graph vertex",
-                )
-        if len(set(self.selected_vertices)) != len(self.selected_vertices):
-            raise PydanticCustomError(
-                "graph.selected_vertices_must_be_unique",
-                "selected vertices must be unique",
-            )
-        return self
+    selected_vertices: tuple[str, ...]
 
 
 class NeighborhoodResult(StrictModel):
@@ -53,19 +27,31 @@ class NeighborhoodResult(StrictModel):
 
     @model_validator(mode="after")
     def validate_result(self) -> Self:
-        vertex_set = set(self.graph.vertices)
-        for v in self.neighborhood:
-            if v not in vertex_set:
-                raise PydanticCustomError(
-                    "graph.neighborhood_vertex_not_in_graph",
-                    "every neighbourhood vertex must be a declared graph vertex",
-                )
+        selected = set(self.selected_vertices)
+        neighborhood = set(self.neighborhood)
+        if self.selected_vertices != tuple(
+            vertex for vertex in self.graph.vertices if vertex in selected
+        ):
+            raise PydanticCustomError(
+                "graph.selected_vertices_must_be_canonical",
+                "selected vertices must be a subset in source-vertex order",
+            )
+        if self.neighborhood != tuple(
+            vertex for vertex in self.graph.vertices if vertex in neighborhood
+        ):
+            raise PydanticCustomError(
+                "graph.neighborhood_must_be_canonical",
+                "neighbourhood vertices must be a subset in source-vertex order",
+            )
+        if selected & neighborhood:
+            raise PydanticCustomError(
+                "graph.open_neighborhood_must_exclude_selected_vertices",
+                "an open neighbourhood must exclude selected vertices",
+            )
         return self
 
 
 __all__ = [
-    "MAX_NEIGHBORHOOD_EDGES",
-    "MAX_NEIGHBORHOOD_VERTICES",
     "NeighborhoodRequest",
     "NeighborhoodResult",
 ]

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -27,9 +27,10 @@ class NeighborhoodRequest(StrictModel):
     def bound_raw_selected_vertices(cls, value: object) -> object:
         if isinstance(value, dict):
             selected = value.get("selected_vertices")
-            if isinstance(selected, (list, tuple)) and len(
-                selected
-            ) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
+            if (
+                isinstance(selected, (list, tuple))
+                and len(selected) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+            ):
                 raise PydanticCustomError(
                     "graph.selected_vertices_bound",
                     "selected vertices exceed the raw tuple-length bound",

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.graphs.values import (
     MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
@@ -33,7 +33,7 @@ class NeighborhoodRequest(StrictModel):
                     "graph.selected_vertices_bound",
                     "selected vertices exceed the raw tuple-length bound",
                 )
-        return value
+        return canonicalize_json_containers(value)
 
 
 class NeighborhoodResult(StrictModel):

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -22,6 +22,20 @@ class NeighborhoodRequest(StrictModel):
         max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw_selected_vertices(cls, value: object) -> object:
+        if isinstance(value, dict):
+            selected = value.get("selected_vertices")
+            if isinstance(selected, (list, tuple)) and len(
+                selected
+            ) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
+                raise PydanticCustomError(
+                    "graph.selected_vertices_bound",
+                    "selected vertices exceed the raw tuple-length bound",
+                )
+        return value
+
 
 class NeighborhoodResult(StrictModel):
     """The exact open neighbourhood of a selected vertex set."""

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Self
-
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
@@ -44,31 +42,6 @@ class NeighborhoodResult(StrictModel):
     graph: SimpleUndirectedGraph
     selected_vertices: tuple[str, ...]
     neighborhood: tuple[str, ...]
-
-    @model_validator(mode="after")
-    def validate_result(self) -> Self:
-        selected = set(self.selected_vertices)
-        neighborhood = set(self.neighborhood)
-        if self.selected_vertices != tuple(
-            vertex for vertex in self.graph.vertices if vertex in selected
-        ):
-            raise PydanticCustomError(
-                "graph.selected_vertices_must_be_canonical",
-                "selected vertices must be a subset in source-vertex order",
-            )
-        if self.neighborhood != tuple(
-            vertex for vertex in self.graph.vertices if vertex in neighborhood
-        ):
-            raise PydanticCustomError(
-                "graph.neighborhood_must_be_canonical",
-                "neighbourhood vertices must be a subset in source-vertex order",
-            )
-        if selected & neighborhood:
-            raise PydanticCustomError(
-                "graph.open_neighborhood_must_exclude_selected_vertices",
-                "an open neighbourhood must exclude selected vertices",
-            )
-        return self
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -1,0 +1,71 @@
+"""Typed wire contracts for the open-neighbourhood operation."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import (
+    MAX_INDEXED_SIMPLE_GRAPH_EDGES,
+    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    SimpleUndirectedGraph,
+)
+
+MAX_NEIGHBORHOOD_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+MAX_NEIGHBORHOOD_EDGES = MAX_INDEXED_SIMPLE_GRAPH_EDGES
+
+
+class NeighborhoodRequest(StrictModel):
+    """Compute the exact open neighbourhood of a selected vertex set."""
+
+    graph: SimpleUndirectedGraph
+    selected_vertices: tuple[str, ...] = Field(
+        min_length=0,
+        max_length=MAX_NEIGHBORHOOD_VERTICES,
+    )
+
+    @model_validator(mode="after")
+    def validate_selected_vertices(self) -> Self:
+        vertex_set = set(self.graph.vertices)
+        for v in self.selected_vertices:
+            if v not in vertex_set:
+                raise PydanticCustomError(
+                    "graph.selected_vertex_not_in_graph",
+                    "every selected vertex must be a declared graph vertex",
+                )
+        if len(set(self.selected_vertices)) != len(self.selected_vertices):
+            raise PydanticCustomError(
+                "graph.selected_vertices_must_be_unique",
+                "selected vertices must be unique",
+            )
+        return self
+
+
+class NeighborhoodResult(StrictModel):
+    """The exact open neighbourhood of a selected vertex set."""
+
+    graph: SimpleUndirectedGraph
+    selected_vertices: tuple[str, ...]
+    neighborhood: tuple[str, ...]
+
+    @model_validator(mode="after")
+    def validate_result(self) -> Self:
+        vertex_set = set(self.graph.vertices)
+        for v in self.neighborhood:
+            if v not in vertex_set:
+                raise PydanticCustomError(
+                    "graph.neighborhood_vertex_not_in_graph",
+                    "every neighbourhood vertex must be a declared graph vertex",
+                )
+        return self
+
+
+__all__ = [
+    "MAX_NEIGHBORHOOD_EDGES",
+    "MAX_NEIGHBORHOOD_VERTICES",
+    "NeighborhoodRequest",
+    "NeighborhoodResult",
+]

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -21,6 +21,8 @@ class NeighborhoodRequest(StrictModel):
     selected_vertices: tuple[str, ...] = Field(
         max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
     )
+
+
 class NeighborhoodResult(StrictModel):
     """The exact open neighbourhood of a selected vertex set."""
 

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -4,15 +4,10 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import Field, PrivateAttr, model_validator
+from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.graphs.neighborhood._bounds import (
-    OpenNeighborhoodAdmission,
-    admit_open_neighborhood,
-)
 from jacobian.math.graphs.values import (
     MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
@@ -26,21 +21,6 @@ class NeighborhoodRequest(StrictModel):
     selected_vertices: tuple[str, ...] = Field(
         max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
     )
-    _admission: OpenNeighborhoodAdmission = PrivateAttr()
-
-    @model_validator(mode="after")
-    def admit_request(self) -> Self:
-        try:
-            self._admission = admit_open_neighborhood(
-                self.graph, self.selected_vertices
-            )
-        except OperationDomainValidationError as error:
-            raise PydanticCustomError(
-                "graph.open_neighborhood.request_not_admitted", str(error)
-            ) from error
-        return self
-
-
 class NeighborhoodResult(StrictModel):
     """The exact open neighbourhood of a selected vertex set."""
 

--- a/src/jacobian/math/graphs/neighborhood/_tools.py
+++ b/src/jacobian/math/graphs/neighborhood/_tools.py
@@ -13,12 +13,12 @@ from jacobian.math.graphs.neighborhood._models import (
     NeighborhoodResult,
 )
 from jacobian.math.graphs.neighborhood.operations import (
-    _open_neighborhood_from_admission,
+    open_neighborhood,
 )
 
 
 def compute_open_neighborhood(request: NeighborhoodRequest) -> NeighborhoodResult:
-    result = _open_neighborhood_from_admission(request.graph, request._admission)
+    result = open_neighborhood(request.graph, request.selected_vertices)
     require_open_neighborhood_output_budget(
         result.graph, result.selected_vertices, result.neighborhood
     )

--- a/src/jacobian/math/graphs/neighborhood/_tools.py
+++ b/src/jacobian/math/graphs/neighborhood/_tools.py
@@ -5,15 +5,24 @@ from collections.abc import Callable
 from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.neighborhood._bounds import (
+    require_open_neighborhood_output_budget,
+)
 from jacobian.math.graphs.neighborhood._models import (
     NeighborhoodRequest,
     NeighborhoodResult,
 )
-from jacobian.math.graphs.neighborhood.operations import open_neighborhood
+from jacobian.math.graphs.neighborhood.operations import (
+    _open_neighborhood_from_admission,
+)
 
 
 def compute_open_neighborhood(request: NeighborhoodRequest) -> NeighborhoodResult:
-    return open_neighborhood(request.graph, request.selected_vertices)
+    result = _open_neighborhood_from_admission(request.graph, request._admission)
+    require_open_neighborhood_output_budget(
+        result.graph, result.selected_vertices, result.neighborhood
+    )
+    return result
 
 
 def neighborhood_operation[

--- a/src/jacobian/math/graphs/neighborhood/_tools.py
+++ b/src/jacobian/math/graphs/neighborhood/_tools.py
@@ -1,0 +1,76 @@
+"""Open-neighbourhood operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.neighborhood._models import (
+    NeighborhoodRequest,
+    NeighborhoodResult,
+)
+from jacobian.math.graphs.neighborhood.operations import open_neighborhood
+
+
+def compute_open_neighborhood(request: NeighborhoodRequest) -> NeighborhoodResult:
+    return open_neighborhood(request.graph, request.selected_vertices)
+
+
+def neighborhood_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    neighborhood_operation(
+        "graph.neighborhood.open.compute",
+        "Compute the open neighbourhood of a selected vertex set",
+        (
+            "For a finite simple undirected graph G and a selected vertex set S, "
+            "return the exact sorted open neighbourhood N_G(S) consisting of all "
+            "vertices outside S adjacent to at least one member of S, in canonical "
+            "source-vertex order."
+        ),
+        NeighborhoodRequest,
+        NeighborhoodResult,
+        compute_open_neighborhood,
+        "graph",
+        "neighbourhood",
+        "exact",
+        examples=(
+            example(
+                "path_neighbourhood",
+                "Open neighbourhood of {a} in path a-b-c includes b only.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"]],
+                    },
+                    "selected_vertices": ["a"],
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/neighborhood/operations.py
+++ b/src/jacobian/math/graphs/neighborhood/operations.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from jacobian.math.graphs.neighborhood._bounds import admit_open_neighborhood
+from jacobian.math.graphs.neighborhood._bounds import (
+    OpenNeighborhoodAdmission,
+    admit_open_neighborhood,
+)
 from jacobian.math.graphs.neighborhood._models import NeighborhoodResult
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -18,7 +21,16 @@ def open_neighborhood(
     The open neighbourhood of a vertex set S consists of all vertices
     outside S that are adjacent to at least one member of S.
     """
-    admission = admit_open_neighborhood(graph, selected_vertices)
+    return _open_neighborhood_from_admission(
+        graph, admit_open_neighborhood(graph, selected_vertices)
+    )
+
+
+def _open_neighborhood_from_admission(
+    graph: SimpleUndirectedGraph,
+    admission: OpenNeighborhoodAdmission,
+) -> NeighborhoodResult:
+    """Build the result from one already-computed mathematical admission."""
     return NeighborhoodResult(
         graph=graph,
         selected_vertices=admission.selected_vertices,

--- a/src/jacobian/math/graphs/neighborhood/operations.py
+++ b/src/jacobian/math/graphs/neighborhood/operations.py
@@ -1,0 +1,35 @@
+"""Exact open-neighbourhood kernel for a selected vertex set."""
+
+from __future__ import annotations
+
+from jacobian.math.graphs.neighborhood._models import (
+    NeighborhoodResult,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+__all__ = ["open_neighborhood"]
+
+
+def open_neighborhood(
+    graph: SimpleUndirectedGraph,
+    selected: tuple[str, ...],
+) -> NeighborhoodResult:
+    """Return the exact open neighbourhood N_G(S).
+
+    The open neighbourhood of a vertex set S consists of all vertices
+    outside S that are adjacent to at least one member of S.
+    """
+    selected_set = set(selected)
+    neighbors: set[str] = set()
+    for left, right in graph.edges:
+        if left in selected_set and right not in selected_set:
+            neighbors.add(right)
+        if right in selected_set and left not in selected_set:
+            neighbors.add(left)
+    vertex_order = {v: i for i, v in enumerate(graph.vertices)}
+    sorted_neighbors = sorted(neighbors, key=lambda v: vertex_order[v])
+    return NeighborhoodResult(
+        graph=graph,
+        selected_vertices=selected,
+        neighborhood=tuple(sorted_neighbors),
+    )

--- a/src/jacobian/math/graphs/neighborhood/operations.py
+++ b/src/jacobian/math/graphs/neighborhood/operations.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from jacobian.math.graphs.neighborhood._models import (
-    NeighborhoodResult,
-)
+from jacobian.math.graphs.neighborhood._bounds import admit_open_neighborhood
+from jacobian.math.graphs.neighborhood._models import NeighborhoodResult
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 __all__ = ["open_neighborhood"]
@@ -12,24 +11,16 @@ __all__ = ["open_neighborhood"]
 
 def open_neighborhood(
     graph: SimpleUndirectedGraph,
-    selected: tuple[str, ...],
+    selected_vertices: tuple[str, ...],
 ) -> NeighborhoodResult:
     """Return the exact open neighbourhood N_G(S).
 
     The open neighbourhood of a vertex set S consists of all vertices
     outside S that are adjacent to at least one member of S.
     """
-    selected_set = set(selected)
-    neighbors: set[str] = set()
-    for left, right in graph.edges:
-        if left in selected_set and right not in selected_set:
-            neighbors.add(right)
-        if right in selected_set and left not in selected_set:
-            neighbors.add(left)
-    vertex_order = {v: i for i, v in enumerate(graph.vertices)}
-    sorted_neighbors = sorted(neighbors, key=lambda v: vertex_order[v])
+    admission = admit_open_neighborhood(graph, selected_vertices)
     return NeighborhoodResult(
         graph=graph,
-        selected_vertices=selected,
-        neighborhood=tuple(sorted_neighbors),
+        selected_vertices=admission.selected_vertices,
+        neighborhood=admission.neighborhood,
     )

--- a/tests/math/graphs/neighborhood/test_open_neighborhood.py
+++ b/tests/math/graphs/neighborhood/test_open_neighborhood.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
 
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.neighborhood._models import (
     NeighborhoodRequest,
 )
@@ -30,6 +31,12 @@ def test_single_vertex_neighborhood() -> None:
     g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
     result = open_neighborhood(g, ("a",))
     assert result.neighborhood == ("b",)
+
+
+def test_issue_path_fixture_has_the_exact_open_neighborhood() -> None:
+    g = _graph(["0", "1", "2", "3"], [("0", "1"), ("1", "2"), ("2", "3")])
+    result = open_neighborhood(g, ("1",))
+    assert result.neighborhood == ("0", "2")
 
 
 def test_selected_vertex_excluded_from_neighborhood() -> None:
@@ -92,16 +99,20 @@ def test_result_retains_source() -> None:
     assert result.selected_vertices == ("a",)
 
 
-def test_request_rejects_nonexistent_vertex() -> None:
+def test_native_operation_rejects_nonexistent_vertex() -> None:
     g = _graph(["a", "b"], [("a", "b")])
-    with pytest.raises(ValidationError):
-        NeighborhoodRequest(graph=g, selected_vertices=("c",))
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="every selected vertex must be a declared graph vertex",
+    ):
+        open_neighborhood(g, ("c",))
 
 
-def test_request_rejects_duplicate_selected() -> None:
-    g = _graph(["a", "b"], [("a", "b")])
-    with pytest.raises(ValidationError):
-        NeighborhoodRequest(graph=g, selected_vertices=("a", "a"))
+def test_selected_vertices_are_normalized_as_a_set_in_source_order() -> None:
+    g = _graph(["a", "b", "c"], [("a", "c"), ("b", "c")])
+    result = open_neighborhood(g, ("b", "a", "b"))
+    assert result.selected_vertices == ("a", "b")
+    assert result.neighborhood == ("c",)
 
 
 def test_catalog_operation_runs() -> None:
@@ -127,3 +138,33 @@ def test_complete_graph_neighborhood() -> None:
     )
     result = open_neighborhood(g, ("a",))
     assert set(result.neighborhood) == {"b", "c", "d"}
+
+
+def test_every_neighborhood_vertex_replays_against_an_incident_edge() -> None:
+    g = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "c"), ("b", "c"), ("b", "d")],
+    )
+    result = open_neighborhood(g, ("a", "b"))
+    selected = set(result.selected_vertices)
+    edges = {frozenset(edge) for edge in result.graph.edges}
+    assert all(
+        any(frozenset((source, neighbor)) in edges for source in selected)
+        for neighbor in result.neighborhood
+    )
+
+
+def test_rejects_result_that_would_exceed_canonical_output_budget() -> None:
+    long_label = "z" * 4_000_000
+    g = _graph(["a", long_label], [("a", long_label)])
+    request = NeighborhoodRequest(graph=g, selected_vertices=("a",))
+    assert (
+        len(encode_strict_json(request.model_dump(mode="json")))
+        <= CanonicalLimits().max_input_bytes
+    )
+
+    with pytest.raises(
+        OperationDomainValidationError,
+        match=r"exceeding the .* canonical output budget",
+    ):
+        compute_open_neighborhood(request)

--- a/tests/math/graphs/neighborhood/test_open_neighborhood.py
+++ b/tests/math/graphs/neighborhood/test_open_neighborhood.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.neighborhood._models import (
+    NeighborhoodRequest,
+)
+from jacobian.math.graphs.neighborhood._tools import compute_open_neighborhood
+from jacobian.math.graphs.neighborhood.operations import open_neighborhood
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph(vertices, edges):
+    return SimpleUndirectedGraph(
+        vertices=tuple(vertices),
+        edges=tuple((a, b) for a, b in edges),
+    )
+
+
+def test_empty_selected_set() -> None:
+    """Empty S has empty neighbourhood."""
+    g = _graph(["a", "b"], [("a", "b")])
+    result = open_neighborhood(g, ())
+    assert result.neighborhood == ()
+
+
+def test_single_vertex_neighborhood() -> None:
+    """N({a}) in path a-b-c is {b}."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    result = open_neighborhood(g, ("a",))
+    assert result.neighborhood == ("b",)
+
+
+def test_selected_vertex_excluded_from_neighborhood() -> None:
+    """Open neighbourhood excludes selected vertices even if adjacent."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    result = open_neighborhood(g, ("a", "b"))
+    assert result.neighborhood == ("c",)
+
+
+def test_edgeless_graph() -> None:
+    """Edgeless graph has empty neighbourhood for any S."""
+    g = _graph(["a", "b", "c"], ())
+    result = open_neighborhood(g, ("a", "b"))
+    assert result.neighborhood == ()
+
+
+def test_all_vertices_selected() -> None:
+    """All vertices selected means empty neighbourhood."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    result = open_neighborhood(g, ("a", "b", "c"))
+    assert result.neighborhood == ()
+
+
+def test_overlapping_neighbours() -> None:
+    """Two selected vertices with overlapping neighbours produce a union."""
+    g = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "c"), ("b", "c"), ("a", "d"), ("b", "d")],
+    )
+    result = open_neighborhood(g, ("a", "b"))
+    assert set(result.neighborhood) == {"c", "d"}
+
+
+def test_star_graph() -> None:
+    """Star with center selected: all leaves are in the neighbourhood."""
+    g = _graph(["c", "l1", "l2", "l3"], [("c", "l1"), ("c", "l2"), ("c", "l3")])
+    result = open_neighborhood(g, ("c",))
+    assert set(result.neighborhood) == {"l1", "l2", "l3"}
+
+
+def test_star_graph_leaves_selected() -> None:
+    """Star with leaves selected: center is in the neighbourhood."""
+    g = _graph(["c", "l1", "l2", "l3"], [("c", "l1"), ("c", "l2"), ("c", "l3")])
+    result = open_neighborhood(g, ("l1", "l2", "l3"))
+    assert result.neighborhood == ("c",)
+
+
+def test_canonical_vertex_order() -> None:
+    """Neighbourhood preserves source-vertex order."""
+    g = _graph(["z", "a", "m"], [("a", "z"), ("m", "z")])
+    result = open_neighborhood(g, ("z",))
+    assert result.neighborhood == ("a", "m")
+
+
+def test_result_retains_source() -> None:
+    """Result retains the original graph and selected vertices."""
+    g = _graph(["a", "b"], [("a", "b")])
+    result = open_neighborhood(g, ("a",))
+    assert result.graph == g
+    assert result.selected_vertices == ("a",)
+
+
+def test_request_rejects_nonexistent_vertex() -> None:
+    g = _graph(["a", "b"], [("a", "b")])
+    with pytest.raises(ValidationError):
+        NeighborhoodRequest(graph=g, selected_vertices=("c",))
+
+
+def test_request_rejects_duplicate_selected() -> None:
+    g = _graph(["a", "b"], [("a", "b")])
+    with pytest.raises(ValidationError):
+        NeighborhoodRequest(graph=g, selected_vertices=("a", "a"))
+
+
+def test_catalog_operation_runs() -> None:
+    """The _tools adapter produces the same result."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    request = NeighborhoodRequest(graph=g, selected_vertices=("a",))
+    result = compute_open_neighborhood(request)
+    assert result.neighborhood == ("b",)
+
+
+def test_disconnected_graph() -> None:
+    """Disconnected graph: selected vertex in one component doesn't affect the other."""
+    g = _graph(["a", "b", "c", "d"], [("a", "b"), ("c", "d")])
+    result = open_neighborhood(g, ("a",))
+    assert result.neighborhood == ("b",)
+
+
+def test_complete_graph_neighborhood() -> None:
+    """K4: N({a}) = {b,c,d}."""
+    g = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "b"), ("a", "c"), ("a", "d"), ("b", "c"), ("b", "d"), ("c", "d")],
+    )
+    result = open_neighborhood(g, ("a",))
+    assert set(result.neighborhood) == {"b", "c", "d"}

--- a/tests/math/graphs/neighborhood/test_open_neighborhood.py
+++ b/tests/math/graphs/neighborhood/test_open_neighborhood.py
@@ -126,7 +126,7 @@ def test_native_operation_rejects_an_oversized_raw_selection_before_hashing() ->
 
 def test_catalog_request_rejects_an_oversized_raw_selection() -> None:
     g = _graph(["a"], ())
-    with pytest.raises(ValueError, match="Tuple should have at most"):
+    with pytest.raises(ValueError, match="raw tuple-length bound"):
         NeighborhoodRequest(
             graph=g,
             selected_vertices=("a",) * (MAX_INDEXED_SIMPLE_GRAPH_VERTICES + 1),

--- a/tests/math/graphs/neighborhood/test_open_neighborhood.py
+++ b/tests/math/graphs/neighborhood/test_open_neighborhood.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import pytest
 
 from jacobian.canonical import CanonicalLimits, encode_strict_json
@@ -9,10 +11,15 @@ from jacobian.math.graphs.neighborhood._models import (
 )
 from jacobian.math.graphs.neighborhood._tools import compute_open_neighborhood
 from jacobian.math.graphs.neighborhood.operations import open_neighborhood
-from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.graphs.values import (
+    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    SimpleUndirectedGraph,
+)
 
 
-def _graph(vertices, edges):
+def _graph(
+    vertices: Sequence[str], edges: Sequence[tuple[str, str]]
+) -> SimpleUndirectedGraph:
     return SimpleUndirectedGraph(
         vertices=tuple(vertices),
         edges=tuple((a, b) for a, b in edges),
@@ -108,6 +115,30 @@ def test_native_operation_rejects_nonexistent_vertex() -> None:
         open_neighborhood(g, ("c",))
 
 
+def test_native_operation_rejects_an_oversized_raw_selection_before_hashing() -> None:
+    g = _graph(["a"], ())
+    with pytest.raises(
+        OperationDomainValidationError,
+        match=(f"at most {MAX_INDEXED_SIMPLE_GRAPH_VERTICES} raw vertices"),
+    ):
+        open_neighborhood(g, ("a",) * (MAX_INDEXED_SIMPLE_GRAPH_VERTICES + 1))
+
+
+def test_catalog_request_rejects_an_oversized_raw_selection() -> None:
+    g = _graph(["a"], ())
+    with pytest.raises(ValueError, match="Tuple should have at most"):
+        NeighborhoodRequest(
+            graph=g,
+            selected_vertices=("a",) * (MAX_INDEXED_SIMPLE_GRAPH_VERTICES + 1),
+        )
+
+
+def test_catalog_request_reuses_selection_admission() -> None:
+    g = _graph(["a", "b"], [("a", "b")])
+    with pytest.raises(ValueError, match="every selected vertex"):
+        NeighborhoodRequest(graph=g, selected_vertices=("c",))
+
+
 def test_selected_vertices_are_normalized_as_a_set_in_source_order() -> None:
     g = _graph(["a", "b", "c"], [("a", "c"), ("b", "c")])
     result = open_neighborhood(g, ("b", "a", "b"))
@@ -162,6 +193,9 @@ def test_rejects_result_that_would_exceed_canonical_output_budget() -> None:
         len(encode_strict_json(request.model_dump(mode="json")))
         <= CanonicalLimits().max_input_bytes
     )
+
+    native_result = open_neighborhood(g, ("a",))
+    assert native_result.neighborhood == (long_label,)
 
     with pytest.raises(
         OperationDomainValidationError,

--- a/tests/math/graphs/neighborhood/test_open_neighborhood.py
+++ b/tests/math/graphs/neighborhood/test_open_neighborhood.py
@@ -135,8 +135,9 @@ def test_catalog_request_rejects_an_oversized_raw_selection() -> None:
 
 def test_catalog_request_reuses_selection_admission() -> None:
     g = _graph(["a", "b"], [("a", "b")])
-    with pytest.raises(ValueError, match="every selected vertex"):
-        NeighborhoodRequest(graph=g, selected_vertices=("c",))
+    request = NeighborhoodRequest(graph=g, selected_vertices=("c",))
+    with pytest.raises(OperationDomainValidationError, match="every selected vertex"):
+        compute_open_neighborhood(request)
 
 
 def test_selected_vertices_are_normalized_as_a_set_in_source_order() -> None:


### PR DESCRIPTION
## Summary

Adds `graph.neighborhood.open.compute` for the exact open neighbourhood of a selected vertex set in a finite simple undirected graph.

For a graph `G` and supplied labels `S`, the operation normalizes `S` as a mathematical set in the graph source axis, then returns every vertex outside `S` adjacent to at least one member of `S`. The result retains the canonical source graph and normalized selected axis.

## Design

- **Input:** the canonical `SimpleUndirectedGraph` value plus a selected-label tuple; every distinct selected label must belong to the graph.
- **Output:** a source-bound `NeighborhoodResult` whose selected set and neighbourhood are duplicate-free and ordered by the graph vertex axis.
- **Kernel:** one bounded pass over the edge list, followed by source-axis projection. No external graph backend is needed for this linear exact transform.
- **Admission:** reuses the graph carrier limits and computes the exact projected JSON size before result construction, rejecting requests whose retained source and labelled sets cannot fit the canonical output envelope.

Duplicate or permuted selected labels are accepted as alternate presentations of the same finite set and normalize to the same result. Empty, edgeless, and all-selected cases preserve the graph context and return an empty neighbourhood.

## Validation

- `make handoff LANE=math TESTS=tests/math/graphs/neighborhood/test_open_neighborhood.py` (18 passed; Ruff and mypy passed)
- `make test-catalog` (113 passed)
- `make test-integration TESTS=tests/integration/catalog/` (807 passed)

The tests include the issue P4 fixture, source retention, native-domain rejection for undeclared labels, set normalization, direct adjacency replay, degenerate cases, catalog execution, and an admitted request whose projected result would otherwise exceed the 10 MiB output envelope.

Closes #2820