### PR TITLE
Add graph.signed_induced_weight.extrema.compute operation

### DIFF
--- a/src/jacobian/math/graphs/signed_induced_weight/__init__.py
+++ b/src/jacobian/math/graphs/signed_induced_weight/__init__.py
@@ -1,0 +1,7 @@
+"""Signed induced-edge weight extrema operations."""
+
+from jacobian.math.graphs.signed_induced_weight.operations import (
+    signed_induced_weight_extrema,
+)
+
+__all__ = ["signed_induced_weight_extrema"]

--- a/src/jacobian/math/graphs/signed_induced_weight/_bounds.py
+++ b/src/jacobian/math/graphs/signed_induced_weight/_bounds.py
@@ -1,0 +1,135 @@
+"""Admission planning for signed induced-weight extrema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import lcm
+
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.optimization._models import RationalWeightedGraph
+
+MAX_SIGNED_WEIGHT_VERTICES = 20
+MAX_SIGNED_WEIGHT_EDGES = (
+    MAX_SIGNED_WEIGHT_VERTICES * (MAX_SIGNED_WEIGHT_VERTICES - 1) // 2
+)
+MAX_SUBSET_ENUMERATION = 1 << MAX_SIGNED_WEIGHT_VERTICES
+MAX_SIGNED_WEIGHT_WORK_UNITS = 25_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class SignedInducedWeightAdmission:
+    """One exact integer-scaled exhaustive-search plan."""
+
+    denominator: int
+    adjacency: tuple[tuple[tuple[int, int], ...], ...]
+    candidate_subsets: int
+    edge_updates: int
+    integer_limbs: int
+    work_units: int
+
+
+def _decimal_digit_upper_bound(value: int) -> int:
+    """Return a cheap conservative decimal-width bound for an integer."""
+
+    if value == 0:
+        return 1
+    return (abs(value).bit_length() * 30_103) // 100_000 + 1
+
+
+def admit_signed_induced_weight(
+    graph: RationalWeightedGraph,
+) -> SignedInducedWeightAdmission:
+    """Derive one bounded exact search plan shared by native and wire calls."""
+
+    if not isinstance(graph, RationalWeightedGraph):
+        raise TypeError("signed_induced_weight_extrema expects a RationalWeightedGraph")
+    order = len(graph.vertices)
+    if order > MAX_SIGNED_WEIGHT_VERTICES:
+        raise OperationDomainValidationError(
+            location=("graph", "vertices"),
+            code="graph.signed_induced_weight.vertex_bound",
+            message=(
+                "signed induced-weight extrema support at most "
+                f"{MAX_SIGNED_WEIGHT_VERTICES} vertices"
+            ),
+        )
+    if len(graph.edges) > MAX_SIGNED_WEIGHT_EDGES:
+        raise OperationDomainValidationError(
+            location=("graph", "edges"),
+            code="graph.signed_induced_weight.edge_bound",
+            message=(
+                "signed induced-weight extrema support at most "
+                f"{MAX_SIGNED_WEIGHT_EDGES} edges"
+            ),
+        )
+
+    fractions = tuple(edge.weight.as_fraction() for edge in graph.edges)
+    denominator = lcm(*(value.denominator for value in fractions)) if fractions else 1
+    if _decimal_digit_upper_bound(denominator) > MAX_CANONICAL_RATIONAL_DIGITS:
+        raise OperationDomainValidationError(
+            location=("graph", "edges"),
+            code="graph.signed_induced_weight.rational_height_bound",
+            message=(
+                "a common denominator for the induced-weight sums may exceed the "
+                f"canonical {MAX_CANONICAL_RATIONAL_DIGITS:,}-digit rational bound"
+            ),
+        )
+
+    vertex_index = {vertex: index for index, vertex in enumerate(graph.vertices)}
+    adjacency_lists: list[list[tuple[int, int]]] = [[] for _ in graph.vertices]
+    scaled_absolute_sum = 0
+    for edge, value in zip(graph.edges, fractions, strict=True):
+        scaled = value.numerator * (denominator // value.denominator)
+        left = vertex_index[edge.endpoints[0]]
+        right = vertex_index[edge.endpoints[1]]
+        adjacency_lists[left].append((right, scaled))
+        adjacency_lists[right].append((left, scaled))
+        scaled_absolute_sum += abs(scaled)
+    if _decimal_digit_upper_bound(scaled_absolute_sum) > MAX_CANONICAL_RATIONAL_DIGITS:
+        raise OperationDomainValidationError(
+            location=("graph", "edges"),
+            code="graph.signed_induced_weight.rational_height_bound",
+            message=(
+                "an induced-weight numerator may exceed the canonical "
+                f"{MAX_CANONICAL_RATIONAL_DIGITS:,}-digit rational bound"
+            ),
+        )
+
+    candidate_subsets = 1 << order
+    degrees = tuple(len(neighbors) for neighbors in adjacency_lists)
+    edge_updates = sum(
+        degree * (1 << (order - vertex - 1)) for vertex, degree in enumerate(degrees)
+    )
+    maximum_bits = max(denominator.bit_length(), scaled_absolute_sum.bit_length(), 1)
+    integer_limbs = (maximum_bits + 63) // 64
+    work_units = candidate_subsets + edge_updates * integer_limbs
+    if work_units > MAX_SIGNED_WEIGHT_WORK_UNITS:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.signed_induced_weight.work_budget",
+            message=(
+                "the exhaustive signed induced-weight search requires "
+                f"{work_units:,} candidate and integer-limb update work units, "
+                f"exceeding the {MAX_SIGNED_WEIGHT_WORK_UNITS:,}-unit bound"
+            ),
+        )
+
+    return SignedInducedWeightAdmission(
+        denominator=denominator,
+        adjacency=tuple(tuple(sorted(neighbors)) for neighbors in adjacency_lists),
+        candidate_subsets=candidate_subsets,
+        edge_updates=edge_updates,
+        integer_limbs=integer_limbs,
+        work_units=work_units,
+    )
+
+
+__all__ = [
+    "MAX_SIGNED_WEIGHT_EDGES",
+    "MAX_SIGNED_WEIGHT_VERTICES",
+    "MAX_SIGNED_WEIGHT_WORK_UNITS",
+    "MAX_SUBSET_ENUMERATION",
+    "SignedInducedWeightAdmission",
+    "admit_signed_induced_weight",
+]

--- a/src/jacobian/math/graphs/signed_induced_weight/_models.py
+++ b/src/jacobian/math/graphs/signed_induced_weight/_models.py
@@ -1,0 +1,70 @@
+"""Typed contracts for signed induced-weight extrema."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.math.graphs.optimization._models import (
+    MAX_GRAPH_WEIGHT_DIGITS,
+    RationalWeightedGraph,
+    require_bounded_rational,
+)
+
+MAX_SIGNED_WEIGHT_VERTICES = 20
+MAX_SIGNED_WEIGHT_EDGES = 496  # C(20,2)
+MAX_SUBSET_ENUMERATION = 1 << MAX_SIGNED_WEIGHT_VERTICES  # 2^20
+
+
+class SignedInducedWeightRequest(StrictModel):
+    """Request for exact signed induced-edge weight extrema."""
+
+    graph: RationalWeightedGraph
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> Self:
+        if len(self.graph.vertices) > MAX_SIGNED_WEIGHT_VERTICES:
+            raise PydanticCustomError(
+                "graph.signed_induced_weight_too_many_vertices",
+                f"at most {MAX_SIGNED_WEIGHT_VERTICES} vertices are supported",
+            )
+        if len(self.graph.edges) > MAX_SIGNED_WEIGHT_EDGES:
+            raise PydanticCustomError(
+                "graph.signed_induced_weight_too_many_edges",
+                f"at most {MAX_SIGNED_WEIGHT_EDGES} edges are supported",
+            )
+        for edge in self.graph.edges:
+            require_bounded_rational(
+                edge.weight,
+                max_digits=MAX_GRAPH_WEIGHT_DIGITS,
+                label="edge weight",
+            )
+        return self
+
+
+class WeightExtremum(StrictModel):
+    """One extremum (min or max) with a witness vertex subset."""
+
+    value: CanonicalRational
+    witness_vertices: tuple[str, ...]
+
+
+class SignedInducedWeightResult(StrictModel):
+    """Exact min and max of the signed induced-edge weight over all subsets."""
+
+    graph: RationalWeightedGraph
+    minimum: WeightExtremum
+    maximum: WeightExtremum
+
+
+__all__ = [
+    "MAX_SIGNED_WEIGHT_EDGES",
+    "MAX_SIGNED_WEIGHT_VERTICES",
+    "SignedInducedWeightRequest",
+    "SignedInducedWeightResult",
+    "WeightExtremum",
+]

--- a/src/jacobian/math/graphs/signed_induced_weight/_models.py
+++ b/src/jacobian/math/graphs/signed_induced_weight/_models.py
@@ -2,48 +2,62 @@
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Annotated, Any, Self
 
-from pydantic import model_validator
+from pydantic import GetJsonSchemaHandler, model_validator
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.math.graphs.optimization._models import (
-    MAX_GRAPH_WEIGHT_DIGITS,
     RationalWeightedGraph,
-    require_bounded_rational,
+)
+from jacobian.math.graphs.signed_induced_weight._bounds import (
+    MAX_SIGNED_WEIGHT_EDGES,
+    MAX_SIGNED_WEIGHT_VERTICES,
 )
 
-MAX_SIGNED_WEIGHT_VERTICES = 20
-MAX_SIGNED_WEIGHT_EDGES = 496  # C(20,2)
-MAX_SUBSET_ENUMERATION = 1 << MAX_SIGNED_WEIGHT_VERTICES  # 2^20
+
+class _SignedWeightGraphSchema:
+    """Project this operation's envelope onto its shared graph carrier."""
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: Any,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        schema = handler.resolve_ref_schema(handler(core_schema)).copy()
+        schema["description"] = (
+            "A canonical rational-weighted simple graph admitted for exhaustive "
+            "signed induced-weight optimization: at most "
+            f"{MAX_SIGNED_WEIGHT_VERTICES} vertices and "
+            f"{MAX_SIGNED_WEIGHT_EDGES} edges, subject to the published arithmetic "
+            "work and exact-result height budgets."
+        )
+        properties = schema["properties"]
+        properties["vertices"] = {
+            **properties["vertices"],
+            "maxItems": MAX_SIGNED_WEIGHT_VERTICES,
+        }
+        properties["edges"] = {
+            **properties["edges"],
+            "maxItems": MAX_SIGNED_WEIGHT_EDGES,
+        }
+        return schema
+
+
+SignedInducedWeightGraph = Annotated[
+    RationalWeightedGraph,
+    _SignedWeightGraphSchema,
+]
 
 
 class SignedInducedWeightRequest(StrictModel):
     """Request for exact signed induced-edge weight extrema."""
 
-    graph: RationalWeightedGraph
-
-    @model_validator(mode="after")
-    def validate_bounds(self) -> Self:
-        if len(self.graph.vertices) > MAX_SIGNED_WEIGHT_VERTICES:
-            raise PydanticCustomError(
-                "graph.signed_induced_weight_too_many_vertices",
-                f"at most {MAX_SIGNED_WEIGHT_VERTICES} vertices are supported",
-            )
-        if len(self.graph.edges) > MAX_SIGNED_WEIGHT_EDGES:
-            raise PydanticCustomError(
-                "graph.signed_induced_weight_too_many_edges",
-                f"at most {MAX_SIGNED_WEIGHT_EDGES} edges are supported",
-            )
-        for edge in self.graph.edges:
-            require_bounded_rational(
-                edge.weight,
-                max_digits=MAX_GRAPH_WEIGHT_DIGITS,
-                label="edge weight",
-            )
-        return self
+    graph: SignedInducedWeightGraph
 
 
 class WeightExtremum(StrictModel):
@@ -59,6 +73,19 @@ class SignedInducedWeightResult(StrictModel):
     graph: RationalWeightedGraph
     minimum: WeightExtremum
     maximum: WeightExtremum
+
+    @model_validator(mode="after")
+    def require_canonical_witness_axes(self) -> Self:
+        for name, extremum in (("minimum", self.minimum), ("maximum", self.maximum)):
+            witness = set(extremum.witness_vertices)
+            if extremum.witness_vertices != tuple(
+                vertex for vertex in self.graph.vertices if vertex in witness
+            ):
+                raise PydanticCustomError(
+                    "graph.signed_induced_weight.witness_axis",
+                    f"{name} witness vertices must be a subset in source-vertex order",
+                )
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/signed_induced_weight/_tools.py
+++ b/src/jacobian/math/graphs/signed_induced_weight/_tools.py
@@ -54,7 +54,9 @@ TOOLS: MathTools = (
             "return the minimum and maximum of the signed induced-edge total "
             "sum(weight(u,v) : {u,v} is an edge and both endpoints are selected) "
             "over all vertex subsets, with one deterministic witness subset for "
-            "each extremum. Empty and singleton subsets have weight zero."
+            "each extremum. Empty and singleton subsets have weight zero. The "
+            "current exhaustive envelope admits at most 20 vertices and applies "
+            "digit-sensitive arithmetic work and exact-result height bounds."
         ),
         SignedInducedWeightRequest,
         SignedInducedWeightResult,

--- a/src/jacobian/math/graphs/signed_induced_weight/_tools.py
+++ b/src/jacobian/math/graphs/signed_induced_weight/_tools.py
@@ -1,0 +1,93 @@
+"""Signed induced-weight extrema operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.signed_induced_weight._models import (
+    SignedInducedWeightRequest,
+    SignedInducedWeightResult,
+)
+from jacobian.math.graphs.signed_induced_weight.operations import (
+    signed_induced_weight_extrema,
+)
+
+
+def compute_signed_induced_weight_extrema(
+    request: SignedInducedWeightRequest,
+) -> SignedInducedWeightResult:
+    return signed_induced_weight_extrema(request.graph)
+
+
+def siw_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    siw_operation(
+        "graph.signed_induced_weight.extrema.compute",
+        "Compute exact signed induced-edge weight extrema over all vertex subsets",
+        (
+            "For a finite undirected graph with exact rational edge weights, "
+            "return the minimum and maximum of the signed induced-edge total "
+            "sum(weight(u,v) : {u,v} is an edge and both endpoints are selected) "
+            "over all vertex subsets, with one deterministic witness subset for "
+            "each extremum. Empty and singleton subsets have weight zero."
+        ),
+        SignedInducedWeightRequest,
+        SignedInducedWeightResult,
+        compute_signed_induced_weight_extrema,
+        "graph",
+        "optimization",
+        "exact",
+        examples=(
+            example(
+                "triangle_signed",
+                "Three vertices with mixed signed weights.",
+                {
+                    "graph": {
+                        "vertices": ["0", "1", "2"],
+                        "edges": [
+                            {
+                                "endpoints": ["0", "1"],
+                                "weight": {"num": "2", "den": "1"},
+                            },
+                            {
+                                "endpoints": ["0", "2"],
+                                "weight": {"num": "-1", "den": "1"},
+                            },
+                            {
+                                "endpoints": ["1", "2"],
+                                "weight": {"num": "-1", "den": "1"},
+                            },
+                        ],
+                    }
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/signed_induced_weight/_tools.py
+++ b/src/jacobian/math/graphs/signed_induced_weight/_tools.py
@@ -67,7 +67,11 @@ TOOLS: MathTools = (
         examples=(
             example(
                 "triangle_signed",
-                "Three vertices with mixed signed weights.",
+                (
+                    "Compute the minimum and maximum signed induced weights for "
+                    "this triangle. The graph must be simple and its edge weights "
+                    "must be canonical rational values."
+                ),
                 {
                     "graph": {
                         "vertices": ["0", "1", "2"],

--- a/src/jacobian/math/graphs/signed_induced_weight/operations.py
+++ b/src/jacobian/math/graphs/signed_induced_weight/operations.py
@@ -6,6 +6,9 @@ from fractions import Fraction
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.graphs.optimization._models import RationalWeightedGraph
+from jacobian.math.graphs.signed_induced_weight._bounds import (
+    admit_signed_induced_weight,
+)
 from jacobian.math.graphs.signed_induced_weight._models import (
     SignedInducedWeightResult,
     WeightExtremum,
@@ -24,47 +27,63 @@ def signed_induced_weight_extrema(
     Empty and singleton subsets have weight zero. Ties are broken by the
     lexicographically least selected vertex axis.
     """
-    vertices = list(graph.vertices)
-    n = len(vertices)
-    edge_data = [
-        (edge.endpoints[0], edge.endpoints[1], edge.weight.as_fraction())
-        for edge in graph.edges
-    ]
-
-    min_val = Fraction(0)
+    admission = admit_signed_induced_weight(graph)
+    selected = [False] * len(graph.vertices)
+    current_value = 0
+    minimum_value = 0
     min_witness: tuple[str, ...] = ()
-    max_val = Fraction(0)
+    maximum_value = 0
     max_witness: tuple[str, ...] = ()
+    previous_gray = 0
 
-    for mask in range(1 << n):
-        selected = tuple(vertices[i] for i in range(n) if mask & (1 << i))
-        selected_set = set(selected)
-        weight = Fraction(0)
-        for a, b, w in edge_data:
-            if a in selected_set and b in selected_set:
-                weight += w
-
-        if mask == 0:
-            min_val = weight
-            min_witness = selected
-            max_val = weight
-            max_witness = selected
+    for step in range(1, admission.candidate_subsets):
+        gray = step ^ (step >> 1)
+        changed = (gray ^ previous_gray).bit_length() - 1
+        if selected[changed]:
+            selected[changed] = False
+            current_value -= sum(
+                weight
+                for neighbor, weight in admission.adjacency[changed]
+                if selected[neighbor]
+            )
         else:
-            if weight < min_val or (weight == min_val and selected < min_witness):
-                min_val = weight
-                min_witness = selected
-            if weight > max_val or (weight == max_val and selected < max_witness):
-                max_val = weight
-                max_witness = selected
+            current_value += sum(
+                weight
+                for neighbor, weight in admission.adjacency[changed]
+                if selected[neighbor]
+            )
+            selected[changed] = True
+        previous_gray = gray
+
+        if current_value <= minimum_value or current_value >= maximum_value:
+            witness = tuple(
+                vertex
+                for vertex, is_selected in zip(graph.vertices, selected, strict=True)
+                if is_selected
+            )
+            if current_value < minimum_value or (
+                current_value == minimum_value and witness < min_witness
+            ):
+                minimum_value = current_value
+                min_witness = witness
+            if current_value > maximum_value or (
+                current_value == maximum_value and witness < max_witness
+            ):
+                maximum_value = current_value
+                max_witness = witness
 
     return SignedInducedWeightResult(
         graph=graph,
         minimum=WeightExtremum(
-            value=CanonicalRational.from_fraction(min_val),
+            value=CanonicalRational.from_fraction(
+                Fraction(minimum_value, admission.denominator)
+            ),
             witness_vertices=min_witness,
         ),
         maximum=WeightExtremum(
-            value=CanonicalRational.from_fraction(max_val),
+            value=CanonicalRational.from_fraction(
+                Fraction(maximum_value, admission.denominator)
+            ),
             witness_vertices=max_witness,
         ),
     )

--- a/src/jacobian/math/graphs/signed_induced_weight/operations.py
+++ b/src/jacobian/math/graphs/signed_induced_weight/operations.py
@@ -1,0 +1,70 @@
+"""Exact signed induced-edge weight extrema over all vertex subsets."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.graphs.optimization._models import RationalWeightedGraph
+from jacobian.math.graphs.signed_induced_weight._models import (
+    SignedInducedWeightResult,
+    WeightExtremum,
+)
+
+__all__ = ["signed_induced_weight_extrema"]
+
+
+def signed_induced_weight_extrema(
+    graph: RationalWeightedGraph,
+) -> SignedInducedWeightResult:
+    """Return exact min and max signed induced-edge weight over all subsets.
+
+    For a vertex subset S, the value is
+    ``sum(weight(u,v) : {u,v} is an edge and both endpoints are in S)``.
+    Empty and singleton subsets have weight zero. Ties are broken by the
+    lexicographically least selected vertex axis.
+    """
+    vertices = list(graph.vertices)
+    n = len(vertices)
+    edge_data = [
+        (edge.endpoints[0], edge.endpoints[1], edge.weight.as_fraction())
+        for edge in graph.edges
+    ]
+
+    min_val = Fraction(0)
+    min_witness: tuple[str, ...] = ()
+    max_val = Fraction(0)
+    max_witness: tuple[str, ...] = ()
+
+    for mask in range(1 << n):
+        selected = tuple(vertices[i] for i in range(n) if mask & (1 << i))
+        selected_set = set(selected)
+        weight = Fraction(0)
+        for a, b, w in edge_data:
+            if a in selected_set and b in selected_set:
+                weight += w
+
+        if mask == 0:
+            min_val = weight
+            min_witness = selected
+            max_val = weight
+            max_witness = selected
+        else:
+            if weight < min_val or (weight == min_val and selected < min_witness):
+                min_val = weight
+                min_witness = selected
+            if weight > max_val or (weight == max_val and selected < max_witness):
+                max_val = weight
+                max_witness = selected
+
+    return SignedInducedWeightResult(
+        graph=graph,
+        minimum=WeightExtremum(
+            value=CanonicalRational.from_fraction(min_val),
+            witness_vertices=min_witness,
+        ),
+        maximum=WeightExtremum(
+            value=CanonicalRational.from_fraction(max_val),
+            witness_vertices=max_witness,
+        ),
+    )

--- a/tests/math/graphs/signed_induced_weight/test_signed_induced_weight.py
+++ b/tests/math/graphs/signed_induced_weight/test_signed_induced_weight.py
@@ -1,17 +1,27 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from itertools import combinations
 
 import pytest
-from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.optimization._models import (
     RationalWeightedEdge,
     RationalWeightedGraph,
 )
+from jacobian.math.graphs.signed_induced_weight._bounds import (
+    MAX_SIGNED_WEIGHT_WORK_UNITS,
+    admit_signed_induced_weight,
+)
 from jacobian.math.graphs.signed_induced_weight._models import (
+    MAX_SIGNED_WEIGHT_EDGES,
+    MAX_SIGNED_WEIGHT_VERTICES,
     SignedInducedWeightRequest,
+)
+from jacobian.math.graphs.signed_induced_weight._tools import (
+    compute_signed_induced_weight_extrema,
 )
 from jacobian.math.graphs.signed_induced_weight.operations import (
     signed_induced_weight_extrema,
@@ -39,7 +49,7 @@ def _simple_graph(vertices, edge_specs) -> RationalWeightedGraph:
 
 def test_empty_graph() -> None:
     """Empty graph has min=max=0."""
-    g = _simple_graph(["a"], [])
+    g = _simple_graph([], [])
     result = signed_induced_weight_extrema(g)
     assert result.minimum.value.as_fraction() == Fraction(0)
     assert result.maximum.value.as_fraction() == Fraction(0)
@@ -74,6 +84,23 @@ def test_mixed_weights_fixture() -> None:
     result = signed_induced_weight_extrema(g)
     assert result.maximum.value.as_fraction() == Fraction(2)
     assert result.minimum.value.as_fraction() == Fraction(-1)
+
+    attained = []
+    for size in range(len(g.vertices) + 1):
+        for selected in combinations(g.vertices, size):
+            selected_set = set(selected)
+            attained.append(
+                sum(
+                    (
+                        edge.weight.as_fraction()
+                        for edge in g.edges
+                        if set(edge.endpoints) <= selected_set
+                    ),
+                    start=Fraction(0),
+                )
+            )
+    assert result.minimum.value.as_fraction() == min(attained)
+    assert result.maximum.value.as_fraction() == max(attained)
 
 
 def test_edgeless_graph() -> None:
@@ -113,19 +140,77 @@ def test_witness_replay() -> None:
 
 
 def test_tie_breaking_lexicographic() -> None:
-    """Ties are broken by lexicographically least witness."""
-    g = _simple_graph(
-        ["a", "b", "c"],
-        [("a", "b", 1), ("a", "c", 1), ("b", "c", 1)],
-    )
+    """Ties use tuple lexicographic order, not cardinality or search order."""
+    g = _simple_graph(["a", "b", "c"], [("b", "c", -1)])
     result = signed_induced_weight_extrema(g)
-    assert result.maximum.value.as_fraction() == Fraction(3)
-    assert set(result.maximum.witness_vertices) == {"a", "b", "c"}
+    assert result.minimum.value.as_fraction() == Fraction(-1)
+    assert result.minimum.witness_vertices == ("a", "b", "c")
 
 
 def test_rejects_too_many_vertices() -> None:
-    """Graph with >20 vertices should be rejected."""
+    """The native path enforces the exhaustive-search vertex envelope."""
     vertices = [str(i) for i in range(21)]
     g = _graph(vertices, [])
-    with pytest.raises(ValidationError):
-        SignedInducedWeightRequest(graph=g)
+    request = SignedInducedWeightRequest(graph=g)
+    with pytest.raises(
+        OperationDomainValidationError,
+        match=f"at most {MAX_SIGNED_WEIGHT_VERTICES} vertices",
+    ):
+        signed_induced_weight_extrema(g)
+    with pytest.raises(OperationDomainValidationError):
+        compute_signed_induced_weight_extrema(request)
+
+
+def test_request_schema_publishes_the_operation_specific_graph_envelope() -> None:
+    graph_schema = SignedInducedWeightRequest.model_json_schema()["properties"]["graph"]
+    assert graph_schema["properties"]["vertices"]["maxItems"] == (
+        MAX_SIGNED_WEIGHT_VERTICES
+    )
+    assert graph_schema["properties"]["edges"]["maxItems"] == MAX_SIGNED_WEIGHT_EDGES
+    assert str(MAX_SIGNED_WEIGHT_VERTICES) in graph_schema["description"]
+
+
+def test_complete_twenty_vertex_integer_graph_fits_the_derived_work_budget() -> None:
+    vertices = tuple(f"v{index:02d}" for index in range(MAX_SIGNED_WEIGHT_VERTICES))
+    graph = _simple_graph(
+        vertices,
+        [(left, right, 1) for left, right in combinations(vertices, 2)],
+    )
+    admission = admit_signed_induced_weight(graph)
+    assert admission.candidate_subsets == 1 << MAX_SIGNED_WEIGHT_VERTICES
+    assert admission.work_units <= MAX_SIGNED_WEIGHT_WORK_UNITS
+
+
+def _first_primes(count: int) -> list[int]:
+    primes: list[int] = []
+    candidate = 2
+    while len(primes) < count:
+        if all(candidate % prime for prime in primes if prime * prime <= candidate):
+            primes.append(candidate)
+        candidate += 1
+    return primes
+
+
+def test_rejects_unrepresentable_rational_height_before_search() -> None:
+    vertices = tuple(f"v{index:02d}" for index in range(17))
+    endpoint_pairs = tuple(combinations(vertices, 2))[:129]
+    edges = []
+    for (left, right), prime in zip(
+        endpoint_pairs, _first_primes(len(endpoint_pairs)), strict=True
+    ):
+        exponent = 1
+        while len(str(prime ** (exponent + 1))) <= 256:
+            exponent += 1
+        edges.append(
+            RationalWeightedEdge(
+                endpoints=(left, right),
+                weight=CanonicalRational(num="1", den=str(prime**exponent)),
+            )
+        )
+    graph = _graph(vertices, edges)
+
+    with pytest.raises(
+        OperationDomainValidationError,
+        match=r"common denominator.*32,768-digit rational bound",
+    ):
+        signed_induced_weight_extrema(graph)

--- a/tests/math/graphs/signed_induced_weight/test_signed_induced_weight.py
+++ b/tests/math/graphs/signed_induced_weight/test_signed_induced_weight.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.graphs.optimization._models import (
+    RationalWeightedEdge,
+    RationalWeightedGraph,
+)
+from jacobian.math.graphs.signed_induced_weight._models import (
+    SignedInducedWeightRequest,
+)
+from jacobian.math.graphs.signed_induced_weight.operations import (
+    signed_induced_weight_extrema,
+)
+
+
+def _edge(a: str, b: str, w: int | str) -> RationalWeightedEdge:
+    frac = Fraction(w, 1) if isinstance(w, int) else Fraction(w)
+    return RationalWeightedEdge(
+        endpoints=(a, b) if a < b else (b, a),
+        weight=CanonicalRational.from_fraction(frac),
+    )
+
+
+def _graph(vertices, edges) -> RationalWeightedGraph:
+    return RationalWeightedGraph(
+        vertices=tuple(vertices),
+        edges=tuple(edges),
+    )
+
+
+def _simple_graph(vertices, edge_specs) -> RationalWeightedGraph:
+    return _graph(vertices, [_edge(a, b, w) for a, b, w in edge_specs])
+
+
+def test_empty_graph() -> None:
+    """Empty graph has min=max=0."""
+    g = _simple_graph(["a"], [])
+    result = signed_induced_weight_extrema(g)
+    assert result.minimum.value.as_fraction() == Fraction(0)
+    assert result.maximum.value.as_fraction() == Fraction(0)
+    assert result.minimum.witness_vertices == ()
+    assert result.maximum.witness_vertices == ()
+
+
+def test_single_edge_positive() -> None:
+    """Graph with one positive edge: max picks both endpoints."""
+    g = _simple_graph(["a", "b"], [("a", "b", 3)])
+    result = signed_induced_weight_extrema(g)
+    assert result.maximum.value.as_fraction() == Fraction(3)
+    assert set(result.maximum.witness_vertices) == {"a", "b"}
+    assert result.minimum.value.as_fraction() == Fraction(0)
+
+
+def test_single_edge_negative() -> None:
+    """Graph with one negative edge: min picks both endpoints, max stays at 0."""
+    g = _simple_graph(["a", "b"], [("a", "b", -5)])
+    result = signed_induced_weight_extrema(g)
+    assert result.minimum.value.as_fraction() == Fraction(-5)
+    assert set(result.minimum.witness_vertices) == {"a", "b"}
+    assert result.maximum.value.as_fraction() == Fraction(0)
+
+
+def test_mixed_weights_fixture() -> None:
+    """Fixture from issue: w01=2, w02=-1, w12=-1 on three vertices."""
+    g = _simple_graph(
+        ["0", "1", "2"],
+        [("0", "1", 2), ("0", "2", -1), ("1", "2", -1)],
+    )
+    result = signed_induced_weight_extrema(g)
+    assert result.maximum.value.as_fraction() == Fraction(2)
+    assert result.minimum.value.as_fraction() == Fraction(-1)
+
+
+def test_edgeless_graph() -> None:
+    """Edgeless graph: min=max=0 for all subsets."""
+    g = _simple_graph(["a", "b", "c"], [])
+    result = signed_induced_weight_extrema(g)
+    assert result.minimum.value.as_fraction() == Fraction(0)
+    assert result.maximum.value.as_fraction() == Fraction(0)
+
+
+def test_rational_weights() -> None:
+    """Test with non-integer rational weights."""
+    g = _simple_graph(["a", "b"], [("a", "b", "1/2")])
+    result = signed_induced_weight_extrema(g)
+    assert result.maximum.value.as_fraction() == Fraction(1, 2)
+
+
+def test_witness_replay() -> None:
+    """Replay the witness subset to verify the weight."""
+    g = _simple_graph(
+        ["a", "b", "c", "d"],
+        [("a", "b", 1), ("b", "c", -2), ("c", "d", 3), ("a", "d", -1)],
+    )
+    result = signed_induced_weight_extrema(g)
+
+    def replay(selected):
+        total = Fraction(0)
+        sset = set(selected)
+        for edge in g.edges:
+            a, b = edge.endpoints
+            if a in sset and b in sset:
+                total += edge.weight.as_fraction()
+        return total
+
+    assert replay(result.minimum.witness_vertices) == result.minimum.value.as_fraction()
+    assert replay(result.maximum.witness_vertices) == result.maximum.value.as_fraction()
+
+
+def test_tie_breaking_lexicographic() -> None:
+    """Ties are broken by lexicographically least witness."""
+    g = _simple_graph(
+        ["a", "b", "c"],
+        [("a", "b", 1), ("a", "c", 1), ("b", "c", 1)],
+    )
+    result = signed_induced_weight_extrema(g)
+    assert result.maximum.value.as_fraction() == Fraction(3)
+    assert set(result.maximum.witness_vertices) == {"a", "b", "c"}
+
+
+def test_rejects_too_many_vertices() -> None:
+    """Graph with >20 vertices should be rejected."""
+    vertices = [str(i) for i in range(21)]
+    g = _graph(vertices, [])
+    with pytest.raises(ValidationError):
+        SignedInducedWeightRequest(graph=g)


### PR DESCRIPTION
## Summary

Adds `graph.signed_induced_weight.extrema.compute` for the exact minimum and maximum induced-edge weight over every vertex subset of a finite rational-weighted simple graph, with one deterministic witness for each extremum.

For `S ⊆ V`, the objective is the exact rational sum of weights on edges whose two endpoints lie in `S`. Empty and singleton subsets have weight zero. Ties use the lexicographically least witness tuple in the retained source-vertex axis.

## Design

- **Input:** the existing `RationalWeightedGraph` carrier; the operation-specific schema publishes the 20-vertex and 190-edge exhaustive envelope.
- **Output:** a source-bound `SignedInducedWeightResult` with exact canonical rational extrema and canonical witness subsets.
- **Kernel:** a complete Gray-code traversal updates only edges incident to the one toggled vertex. Edge weights are scaled once to a common denominator, so the search uses exact integers rather than rebuilding every subset and repeating `Fraction` addition.
- **Admission:** the native and MCP paths share one plan that bounds candidate subsets, adjacency updates, integer-limb work, and the numerator/denominator height needed by the canonical rational result.

The exhaustive kernel is deliberate. A general pseudo-Boolean solver could improve some instances, but timeout or unknown solver outcomes cannot establish an exact optimum. The bounded traversal gives deterministic completion for every admitted request and leaves room for a future exact backend change without altering the public postcondition.

## Validation

- `make handoff LANE=math TESTS=tests/math/graphs/signed_induced_weight/test_signed_induced_weight.py` (12 passed; Ruff and mypy passed)
- `make test-catalog` (113 passed)
- `make test-integration TESTS=tests/integration/catalog/` (807 passed)
- Dense 20-vertex integer complete graph: exact maximum 190 with all 20 vertices, 2.14 seconds in the local validation environment

Tests independently enumerate all subsets of the issue fixture, replay both witnesses, exercise positive, negative, mixed, rational, empty, edgeless, and tie cases, verify native/wire admission parity and the published schema, admit the dense 20-vertex boundary plan, and reject a 17-vertex rational instance whose common denominator cannot fit the canonical result type before search begins.

Closes #2822