### PR TITLE
Add graph.uniform_subset_intersection.construct operation

### DIFF
--- a/src/jacobian/math/graphs/uniform_subset_intersection/__init__.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/__init__.py
@@ -1,0 +1,7 @@
+"""Uniform-subset intersection graph construction."""
+
+from jacobian.math.graphs.uniform_subset_intersection.operations import (
+    construct_uniform_subset_intersection_graph,
+)
+
+__all__ = ["construct_uniform_subset_intersection_graph"]

--- a/src/jacobian/math/graphs/uniform_subset_intersection/_models.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/_models.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import comb
-from typing import Literal, Self
+from typing import Literal
 
-from pydantic import Field, PrivateAttr, StrictInt, model_validator
-from pydantic_core import PydanticCustomError
+from pydantic import Field, StrictInt
 
 from jacobian._models import StrictModel
 from jacobian.canonical import CanonicalLimits
@@ -159,23 +158,6 @@ class UniformSubsetIntersectionRequest(StrictModel):
     subset_cardinality: StrictInt = Field(ge=0, le=MAX_SAFE_GROUND_SET_SIZE)
     threshold: StrictInt = Field(ge=0, le=MAX_SAFE_GROUND_SET_SIZE)
     relation: IntersectionRelation
-    _admission_plan: _UniformSubsetIntersectionPlan = PrivateAttr()
-
-    @model_validator(mode="after")
-    def validate_request(self) -> Self:
-        try:
-            self._admission_plan = _admit_uniform_subset_intersection(
-                self.ground_set_size,
-                self.subset_cardinality,
-                self.threshold,
-                self.relation,
-            )
-        except ValueError as error:
-            raise PydanticCustomError(
-                "graph.uniform_subset_intersection.request_not_admitted",
-                str(error),
-            ) from error
-        return self
 
 
 class UniformSubsetIntersectionResult(StrictModel):

--- a/src/jacobian/math/graphs/uniform_subset_intersection/_models.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/_models.py
@@ -2,56 +2,170 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from math import comb
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.canonical import CanonicalLimits
+from jacobian.math.graphs.values import (
+    MAX_GRAPH_LABEL_BYTES,
+    MAX_INDEXED_SIMPLE_GRAPH_EDGES,
+    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    SimpleUndirectedGraph,
+)
 
-MAX_GROUND_SET_SIZE = 12
-MAX_VERTEX_COUNT = 256  # C(12,6) = 924 > 256, but the graph vertex cap limits this
-MAX_EDGE_COUNT = 256 * 255 // 2
+MAX_SAFE_GROUND_SET_SIZE = (1 << 53) - 1
 
 IntersectionRelation = Literal["INTERSECTION_LT_THRESHOLD", "INTERSECTION_EQ_THRESHOLD"]
+
+
+@dataclass(frozen=True)
+class _UniformSubsetIntersectionPlan:
+    """Request-scoped exact size quantities used by the constructor."""
+
+    vertex_count: int
+    edge_count: int
+    result_wire_upper_bound: int
+
+
+def _intersection_pair_count(n: int, k: int, t: int, relation: str) -> int:
+    qualifying = (
+        (size for size in range(k + 1) if size < t)
+        if relation == "INTERSECTION_LT_THRESHOLD"
+        else (size for size in range(k + 1) if size == t)
+    )
+    neighbors_per_vertex = sum(
+        comb(k, size) * comb(n - k, k - size)
+        for size in qualifying
+        if k - size <= n - k
+    )
+    if relation == "INTERSECTION_EQ_THRESHOLD" and t == k:
+        neighbors_per_vertex -= 1
+    return comb(n, k) * neighbors_per_vertex // 2
+
+
+def _largest_subset_label_bytes(n: int, k: int) -> int:
+    if k == 0:
+        return 2
+    if 2 * k + 1 > MAX_GRAPH_LABEL_BYTES:
+        return 2 * k + 1
+    return 2 + (k - 1) + sum(len(str(value)) for value in range(n - k, n))
+
+
+def _admit_uniform_subset_intersection(
+    ground_set_size: int,
+    subset_cardinality: int,
+    threshold: int,
+    relation: IntersectionRelation,
+) -> _UniformSubsetIntersectionPlan:
+    """Validate one request and derive its exact materialization sizes."""
+
+    for name, value in (
+        ("ground_set_size", ground_set_size),
+        ("subset_cardinality", subset_cardinality),
+        ("threshold", threshold),
+    ):
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"{name} must be an integer")
+        if value < 0:
+            raise ValueError(f"{name} must be nonnegative")
+    if ground_set_size > MAX_SAFE_GROUND_SET_SIZE:
+        raise ValueError(f"ground_set_size must not exceed {MAX_SAFE_GROUND_SET_SIZE}")
+    if subset_cardinality > ground_set_size:
+        raise ValueError("subset_cardinality must not exceed ground_set_size")
+    if threshold > subset_cardinality:
+        raise ValueError("threshold must not exceed subset_cardinality")
+    if relation not in (
+        "INTERSECTION_LT_THRESHOLD",
+        "INTERSECTION_EQ_THRESHOLD",
+    ):
+        raise ValueError("relation must name a supported intersection predicate")
+
+    vertex_count = comb(ground_set_size, subset_cardinality)
+    if vertex_count > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
+        raise ValueError(
+            "the uniform subset family exceeds the "
+            f"{MAX_INDEXED_SIMPLE_GRAPH_VERTICES}-vertex graph bound"
+        )
+    if (
+        _largest_subset_label_bytes(ground_set_size, subset_cardinality)
+        > MAX_GRAPH_LABEL_BYTES
+    ):
+        raise ValueError(
+            "a canonical subset label exceeds the "
+            f"{MAX_GRAPH_LABEL_BYTES}-byte graph-label bound"
+        )
+    edge_count = _intersection_pair_count(
+        ground_set_size, subset_cardinality, threshold, relation
+    )
+    if edge_count > MAX_INDEXED_SIMPLE_GRAPH_EDGES:
+        raise ValueError(
+            "the selected intersection relation exceeds the "
+            f"{MAX_INDEXED_SIMPLE_GRAPH_EDGES}-edge graph bound"
+        )
+    largest_label_bytes = _largest_subset_label_bytes(
+        ground_set_size, subset_cardinality
+    )
+    # This counts every occurrence of a label in the vertex and edge arrays,
+    # plus delimiters and a conservative fixed envelope for result field names
+    # and scalar metadata. JSON escaping cannot expand these ASCII labels.
+    result_wire_upper_bound = (vertex_count + 2 * edge_count) * (
+        largest_label_bytes + 4
+    ) + 512
+    output_limit = CanonicalLimits().max_output_bytes
+    if result_wire_upper_bound > output_limit:
+        raise ValueError(
+            "the materialized graph result exceeds the "
+            f"{output_limit}-byte canonical output bound"
+        )
+    return _UniformSubsetIntersectionPlan(
+        vertex_count=vertex_count,
+        edge_count=edge_count,
+        result_wire_upper_bound=result_wire_upper_bound,
+    )
 
 
 class UniformSubsetIntersectionRequest(StrictModel):
     """Construct a graph from k-subsets of [n] with a threshold relation."""
 
-    ground_set_size: int = Field(ge=0, le=MAX_GROUND_SET_SIZE)
-    subset_cardinality: int = Field(ge=0, le=MAX_GROUND_SET_SIZE)
-    threshold: int = Field(ge=0)
+    ground_set_size: StrictInt = Field(ge=0, le=MAX_SAFE_GROUND_SET_SIZE)
+    subset_cardinality: StrictInt = Field(ge=0, le=MAX_SAFE_GROUND_SET_SIZE)
+    threshold: StrictInt = Field(ge=0, le=MAX_SAFE_GROUND_SET_SIZE)
     relation: IntersectionRelation
 
     @model_validator(mode="after")
     def validate_request(self) -> Self:
-        if self.subset_cardinality > self.ground_set_size:
-            raise PydanticCustomError(
-                "graph.subset_cardinality_exceeds_ground_set",
-                "subset_cardinality must not exceed ground_set_size",
+        try:
+            _admit_uniform_subset_intersection(
+                self.ground_set_size,
+                self.subset_cardinality,
+                self.threshold,
+                self.relation,
             )
-        if self.threshold > self.subset_cardinality:
+        except ValueError as error:
             raise PydanticCustomError(
-                "graph.threshold_exceeds_subset_cardinality",
-                "threshold must not exceed subset_cardinality",
-            )
+                "graph.uniform_subset_intersection.request_not_admitted",
+                str(error),
+            ) from error
         return self
 
 
 class UniformSubsetIntersectionResult(StrictModel):
     """The constructed uniform-subset intersection graph."""
 
-    ground_set_size: int
-    subset_cardinality: int
-    threshold: int
+    ground_set_size: StrictInt
+    subset_cardinality: StrictInt
+    threshold: StrictInt
     relation: IntersectionRelation
     graph: SimpleUndirectedGraph
 
 
 __all__ = [
-    "MAX_GROUND_SET_SIZE",
+    "MAX_SAFE_GROUND_SET_SIZE",
     "IntersectionRelation",
     "UniformSubsetIntersectionRequest",
     "UniformSubsetIntersectionResult",

--- a/src/jacobian/math/graphs/uniform_subset_intersection/_models.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/_models.py
@@ -1,0 +1,58 @@
+"""Typed contracts for uniform-subset intersection graph construction."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_GROUND_SET_SIZE = 12
+MAX_VERTEX_COUNT = 256  # C(12,6) = 924 > 256, but the graph vertex cap limits this
+MAX_EDGE_COUNT = 256 * 255 // 2
+
+IntersectionRelation = Literal["INTERSECTION_LT_THRESHOLD", "INTERSECTION_EQ_THRESHOLD"]
+
+
+class UniformSubsetIntersectionRequest(StrictModel):
+    """Construct a graph from k-subsets of [n] with a threshold relation."""
+
+    ground_set_size: int = Field(ge=0, le=MAX_GROUND_SET_SIZE)
+    subset_cardinality: int = Field(ge=0, le=MAX_GROUND_SET_SIZE)
+    threshold: int = Field(ge=0)
+    relation: IntersectionRelation
+
+    @model_validator(mode="after")
+    def validate_request(self) -> Self:
+        if self.subset_cardinality > self.ground_set_size:
+            raise PydanticCustomError(
+                "graph.subset_cardinality_exceeds_ground_set",
+                "subset_cardinality must not exceed ground_set_size",
+            )
+        if self.threshold > self.subset_cardinality:
+            raise PydanticCustomError(
+                "graph.threshold_exceeds_subset_cardinality",
+                "threshold must not exceed subset_cardinality",
+            )
+        return self
+
+
+class UniformSubsetIntersectionResult(StrictModel):
+    """The constructed uniform-subset intersection graph."""
+
+    ground_set_size: int
+    subset_cardinality: int
+    threshold: int
+    relation: IntersectionRelation
+    graph: SimpleUndirectedGraph
+
+
+__all__ = [
+    "MAX_GROUND_SET_SIZE",
+    "IntersectionRelation",
+    "UniformSubsetIntersectionRequest",
+    "UniformSubsetIntersectionResult",
+]

--- a/src/jacobian/math/graphs/uniform_subset_intersection/_models.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/_models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from math import comb
 from typing import Literal, Self
 
-from pydantic import Field, StrictInt, model_validator
+from pydantic import Field, PrivateAttr, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
@@ -30,6 +30,25 @@ class _UniformSubsetIntersectionPlan:
     vertex_count: int
     edge_count: int
     result_wire_upper_bound: int
+
+
+def _combination_at_most(n: int, k: int, limit: int) -> int:
+    """Return ``C(n, k)`` exactly up to ``limit``, then return ``limit + 1``.
+
+    The recurrence is checked before each multiplication, so a rejected
+    family never constructs an unrestricted large binomial coefficient.
+    """
+
+    if k < 0 or k > n:
+        return 0
+    k = min(k, n - k)
+    value = 1
+    for index in range(1, k + 1):
+        numerator = n - k + index
+        if value * numerator > limit * index:
+            return limit + 1
+        value = value * numerator // index
+    return value
 
 
 def _intersection_pair_count(n: int, k: int, t: int, relation: str) -> int:
@@ -85,7 +104,11 @@ def _admit_uniform_subset_intersection(
     ):
         raise ValueError("relation must name a supported intersection predicate")
 
-    vertex_count = comb(ground_set_size, subset_cardinality)
+    vertex_count = _combination_at_most(
+        ground_set_size,
+        subset_cardinality,
+        MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    )
     if vertex_count > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
         raise ValueError(
             "the uniform subset family exceeds the "
@@ -136,11 +159,12 @@ class UniformSubsetIntersectionRequest(StrictModel):
     subset_cardinality: StrictInt = Field(ge=0, le=MAX_SAFE_GROUND_SET_SIZE)
     threshold: StrictInt = Field(ge=0, le=MAX_SAFE_GROUND_SET_SIZE)
     relation: IntersectionRelation
+    _admission_plan: _UniformSubsetIntersectionPlan = PrivateAttr()
 
     @model_validator(mode="after")
     def validate_request(self) -> Self:
         try:
-            _admit_uniform_subset_intersection(
+            self._admission_plan = _admit_uniform_subset_intersection(
                 self.ground_set_size,
                 self.subset_cardinality,
                 self.threshold,

--- a/src/jacobian/math/graphs/uniform_subset_intersection/_tools.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/_tools.py
@@ -10,18 +10,19 @@ from jacobian.math.graphs.uniform_subset_intersection._models import (
     UniformSubsetIntersectionResult,
 )
 from jacobian.math.graphs.uniform_subset_intersection.operations import (
-    construct_uniform_subset_intersection_graph,
+    _construct_uniform_subset_intersection_graph_from_plan,
 )
 
 
 def compute_uniform_subset_intersection_graph(
     request: UniformSubsetIntersectionRequest,
 ) -> UniformSubsetIntersectionResult:
-    return construct_uniform_subset_intersection_graph(
+    return _construct_uniform_subset_intersection_graph_from_plan(
         request.ground_set_size,
         request.subset_cardinality,
         request.threshold,
         request.relation,
+        request._admission_plan,
     )
 
 

--- a/src/jacobian/math/graphs/uniform_subset_intersection/_tools.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/_tools.py
@@ -17,7 +17,12 @@ from jacobian.math.graphs.uniform_subset_intersection.operations import (
 def compute_uniform_subset_intersection_graph(
     request: UniformSubsetIntersectionRequest,
 ) -> UniformSubsetIntersectionResult:
-    return construct_uniform_subset_intersection_graph(request)
+    return construct_uniform_subset_intersection_graph(
+        request.ground_set_size,
+        request.subset_cardinality,
+        request.threshold,
+        request.relation,
+    )
 
 
 def usi_operation[
@@ -52,8 +57,8 @@ TOOLS: MathTools = (
         (
             "Construct a labelled simple graph whose vertices are all k-subsets "
             "of [n], with an edge between two subsets when their intersection size "
-            "satisfies the declared relation (less-than or equal-to) with a given "
-            "threshold. Includes Kneser graphs and Johnson-scheme threshold graphs "
+            "satisfies the declared less-than-threshold or equality relation. "
+            "Includes Kneser graphs and Johnson-scheme threshold graphs "
             "as special cases."
         ),
         UniformSubsetIntersectionRequest,

--- a/src/jacobian/math/graphs/uniform_subset_intersection/_tools.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/_tools.py
@@ -56,7 +56,8 @@ TOOLS: MathTools = (
         "Construct a uniform-subset intersection graph",
         (
             "Construct a labelled simple graph whose vertices are all k-subsets "
-            "of [n], with an edge between two subsets when their intersection size "
+            "of the zero-based ground set {0,...,n-1}, with an edge between two "
+            "subsets when their intersection size "
             "satisfies the declared less-than-threshold or equality relation. "
             "Includes Kneser graphs and Johnson-scheme threshold graphs "
             "as special cases."
@@ -70,7 +71,7 @@ TOOLS: MathTools = (
         examples=(
             example(
                 "kneser_kg42",
-                "Kneser graph KG(4,2): 2-subsets of [4] with intersection < 1.",
+                "Kneser graph KG(4,2): 2-subsets of {0,1,2,3} with intersection < 1.",
                 {
                     "ground_set_size": 4,
                     "subset_cardinality": 2,

--- a/src/jacobian/math/graphs/uniform_subset_intersection/_tools.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/_tools.py
@@ -10,19 +10,18 @@ from jacobian.math.graphs.uniform_subset_intersection._models import (
     UniformSubsetIntersectionResult,
 )
 from jacobian.math.graphs.uniform_subset_intersection.operations import (
-    _construct_uniform_subset_intersection_graph_from_plan,
+    construct_uniform_subset_intersection_graph,
 )
 
 
 def compute_uniform_subset_intersection_graph(
     request: UniformSubsetIntersectionRequest,
 ) -> UniformSubsetIntersectionResult:
-    return _construct_uniform_subset_intersection_graph_from_plan(
+    return construct_uniform_subset_intersection_graph(
         request.ground_set_size,
         request.subset_cardinality,
         request.threshold,
         request.relation,
-        request._admission_plan,
     )
 
 

--- a/src/jacobian/math/graphs/uniform_subset_intersection/_tools.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/_tools.py
@@ -1,0 +1,80 @@
+"""Uniform-subset intersection graph operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.uniform_subset_intersection._models import (
+    UniformSubsetIntersectionRequest,
+    UniformSubsetIntersectionResult,
+)
+from jacobian.math.graphs.uniform_subset_intersection.operations import (
+    construct_uniform_subset_intersection_graph,
+)
+
+
+def compute_uniform_subset_intersection_graph(
+    request: UniformSubsetIntersectionRequest,
+) -> UniformSubsetIntersectionResult:
+    return construct_uniform_subset_intersection_graph(request)
+
+
+def usi_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    usi_operation(
+        "graph.uniform_subset_intersection.construct",
+        "Construct a uniform-subset intersection graph",
+        (
+            "Construct a labelled simple graph whose vertices are all k-subsets "
+            "of [n], with an edge between two subsets when their intersection size "
+            "satisfies the declared relation (less-than or equal-to) with a given "
+            "threshold. Includes Kneser graphs and Johnson-scheme threshold graphs "
+            "as special cases."
+        ),
+        UniformSubsetIntersectionRequest,
+        UniformSubsetIntersectionResult,
+        compute_uniform_subset_intersection_graph,
+        "graph",
+        "combinatorics",
+        "exact",
+        examples=(
+            example(
+                "kneser_kg42",
+                "Kneser graph KG(4,2): 2-subsets of [4] with intersection < 1.",
+                {
+                    "ground_set_size": 4,
+                    "subset_cardinality": 2,
+                    "threshold": 1,
+                    "relation": "INTERSECTION_LT_THRESHOLD",
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/uniform_subset_intersection/operations.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/operations.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from itertools import combinations
 
 from jacobian.math.graphs.uniform_subset_intersection._models import (
-    UniformSubsetIntersectionRequest,
+    IntersectionRelation,
     UniformSubsetIntersectionResult,
+    _admit_uniform_subset_intersection,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -14,7 +15,10 @@ __all__ = ["construct_uniform_subset_intersection_graph"]
 
 
 def construct_uniform_subset_intersection_graph(
-    request: UniformSubsetIntersectionRequest,
+    ground_set_size: int,
+    subset_cardinality: int,
+    threshold: int,
+    relation: IntersectionRelation,
 ) -> UniformSubsetIntersectionResult:
     """Construct a graph on k-subsets of [n] with a threshold relation.
 
@@ -22,23 +26,11 @@ def construct_uniform_subset_intersection_graph(
     comma-separated subset. An edge joins two subsets when their
     intersection size satisfies the declared relation with the threshold.
     """
-    n = request.ground_set_size
-    k = request.subset_cardinality
-    t = request.threshold
-    relation = request.relation
-
-    if k == 0 or k > n:
-        graph = SimpleUndirectedGraph(vertices=(), edges=())
-        return UniformSubsetIntersectionResult(
-            ground_set_size=n,
-            subset_cardinality=k,
-            threshold=t,
-            relation=relation,
-            graph=graph,
-        )
-
-    ground = list(range(n))
-    subsets = list(combinations(ground, k))
+    plan = _admit_uniform_subset_intersection(
+        ground_set_size, subset_cardinality, threshold, relation
+    )
+    subsets = tuple(combinations(range(ground_set_size), subset_cardinality))
+    assert len(subsets) == plan.vertex_count
 
     if len(subsets) == 1:
         graph = SimpleUndirectedGraph(
@@ -46,9 +38,9 @@ def construct_uniform_subset_intersection_graph(
             edges=(),
         )
         return UniformSubsetIntersectionResult(
-            ground_set_size=n,
-            subset_cardinality=k,
-            threshold=t,
+            ground_set_size=ground_set_size,
+            subset_cardinality=subset_cardinality,
+            threshold=threshold,
             relation=relation,
             graph=graph,
         )
@@ -59,11 +51,11 @@ def construct_uniform_subset_intersection_graph(
     for i in range(len(subsets)):
         si = set(subsets[i])
         for j in range(i + 1, len(subsets)):
-            intersection_size = len(si & set(subsets[j]))
+            intersection_size = len(si.intersection(subsets[j]))
             if relation == "INTERSECTION_LT_THRESHOLD":
-                adjacent = intersection_size < t
+                adjacent = intersection_size < threshold
             else:
-                adjacent = intersection_size == t
+                adjacent = intersection_size == threshold
             if adjacent:
                 a, b = vertices_labels[i], vertices_labels[j]
                 if a < b:
@@ -75,10 +67,11 @@ def construct_uniform_subset_intersection_graph(
         vertices=tuple(vertices_labels),
         edges=tuple(edges),
     )
+    assert len(graph.edges) == plan.edge_count
     return UniformSubsetIntersectionResult(
-        ground_set_size=n,
-        subset_cardinality=k,
-        threshold=t,
+        ground_set_size=ground_set_size,
+        subset_cardinality=subset_cardinality,
+        threshold=threshold,
         relation=relation,
         graph=graph,
     )

--- a/src/jacobian/math/graphs/uniform_subset_intersection/operations.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/operations.py
@@ -1,0 +1,89 @@
+"""Canonical uniform-subset intersection graph constructor."""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+from jacobian.math.graphs.uniform_subset_intersection._models import (
+    UniformSubsetIntersectionRequest,
+    UniformSubsetIntersectionResult,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+__all__ = ["construct_uniform_subset_intersection_graph"]
+
+
+def construct_uniform_subset_intersection_graph(
+    request: UniformSubsetIntersectionRequest,
+) -> UniformSubsetIntersectionResult:
+    """Construct a graph on k-subsets of [n] with a threshold relation.
+
+    Vertices are all k-subsets of {0,...,n-1}, labelled by the sorted
+    comma-separated subset. An edge joins two subsets when their
+    intersection size satisfies the declared relation with the threshold.
+    """
+    n = request.ground_set_size
+    k = request.subset_cardinality
+    t = request.threshold
+    relation = request.relation
+
+    if k == 0 or k > n:
+        graph = SimpleUndirectedGraph(vertices=(), edges=())
+        return UniformSubsetIntersectionResult(
+            ground_set_size=n,
+            subset_cardinality=k,
+            threshold=t,
+            relation=relation,
+            graph=graph,
+        )
+
+    ground = list(range(n))
+    subsets = list(combinations(ground, k))
+
+    if len(subsets) == 1:
+        graph = SimpleUndirectedGraph(
+            vertices=(_subset_label(subsets[0]),),
+            edges=(),
+        )
+        return UniformSubsetIntersectionResult(
+            ground_set_size=n,
+            subset_cardinality=k,
+            threshold=t,
+            relation=relation,
+            graph=graph,
+        )
+
+    vertices_labels = [_subset_label(s) for s in subsets]
+    edges: list[tuple[str, str]] = []
+
+    for i in range(len(subsets)):
+        si = set(subsets[i])
+        for j in range(i + 1, len(subsets)):
+            intersection_size = len(si & set(subsets[j]))
+            if relation == "INTERSECTION_LT_THRESHOLD":
+                adjacent = intersection_size < t
+            else:
+                adjacent = intersection_size == t
+            if adjacent:
+                a, b = vertices_labels[i], vertices_labels[j]
+                if a < b:
+                    edges.append((a, b))
+                else:
+                    edges.append((b, a))
+
+    graph = SimpleUndirectedGraph(
+        vertices=tuple(vertices_labels),
+        edges=tuple(edges),
+    )
+    return UniformSubsetIntersectionResult(
+        ground_set_size=n,
+        subset_cardinality=k,
+        threshold=t,
+        relation=relation,
+        graph=graph,
+    )
+
+
+def _subset_label(subset: tuple[int, ...]) -> str:
+    """Canonical label for a k-subset."""
+    return "{" + ",".join(str(x) for x in subset) + "}"

--- a/src/jacobian/math/graphs/uniform_subset_intersection/operations.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/operations.py
@@ -52,7 +52,11 @@ def _construct_uniform_subset_intersection_graph_from_plan(
 ) -> UniformSubsetIntersectionResult:
     """Construct a graph from one already-computed request admission."""
 
-    subsets = tuple(combinations(range(ground_set_size), subset_cardinality))
+    subsets = (
+        ((),)
+        if subset_cardinality == 0
+        else tuple(combinations(range(ground_set_size), subset_cardinality))
+    )
     assert len(subsets) == plan.vertex_count
 
     if len(subsets) == 1:

--- a/src/jacobian/math/graphs/uniform_subset_intersection/operations.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/operations.py
@@ -8,6 +8,7 @@ from jacobian.math.graphs.uniform_subset_intersection._models import (
     IntersectionRelation,
     UniformSubsetIntersectionResult,
     _admit_uniform_subset_intersection,
+    _UniformSubsetIntersectionPlan,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -29,6 +30,20 @@ def construct_uniform_subset_intersection_graph(
     plan = _admit_uniform_subset_intersection(
         ground_set_size, subset_cardinality, threshold, relation
     )
+    return _construct_uniform_subset_intersection_graph_from_plan(
+        ground_set_size, subset_cardinality, threshold, relation, plan
+    )
+
+
+def _construct_uniform_subset_intersection_graph_from_plan(
+    ground_set_size: int,
+    subset_cardinality: int,
+    threshold: int,
+    relation: IntersectionRelation,
+    plan: _UniformSubsetIntersectionPlan,
+) -> UniformSubsetIntersectionResult:
+    """Construct a graph from one already-computed request admission."""
+
     subsets = tuple(combinations(range(ground_set_size), subset_cardinality))
     assert len(subsets) == plan.vertex_count
 

--- a/src/jacobian/math/graphs/uniform_subset_intersection/operations.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/operations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from itertools import combinations
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.uniform_subset_intersection._models import (
     IntersectionRelation,
     UniformSubsetIntersectionResult,
@@ -27,9 +28,16 @@ def construct_uniform_subset_intersection_graph(
     comma-separated subset. An edge joins two subsets when their
     intersection size satisfies the declared relation with the threshold.
     """
-    plan = _admit_uniform_subset_intersection(
-        ground_set_size, subset_cardinality, threshold, relation
-    )
+    try:
+        plan = _admit_uniform_subset_intersection(
+            ground_set_size, subset_cardinality, threshold, relation
+        )
+    except (TypeError, ValueError) as error:
+        raise OperationDomainValidationError(
+            location=(),
+            code="graph.uniform_subset_intersection.request_not_admitted",
+            message=str(error),
+        ) from error
     return _construct_uniform_subset_intersection_graph_from_plan(
         ground_set_size, subset_cardinality, threshold, relation, plan
     )

--- a/tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py
+++ b/tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py
@@ -4,8 +4,8 @@ from itertools import combinations
 from typing import Literal
 
 import pytest
-from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.chip_firing._models import LaplacianRequest
 from jacobian.math.graphs.chip_firing.operations import laplacian
 from jacobian.math.graphs.uniform_subset_intersection._models import (
@@ -164,56 +164,58 @@ def test_no_loops_or_duplicates() -> None:
 
 
 def test_rejects_k_exceeds_n() -> None:
-    with pytest.raises(ValidationError):
-        UniformSubsetIntersectionRequest(
-            ground_set_size=3,
-            subset_cardinality=5,
-            threshold=1,
-            relation="INTERSECTION_LT_THRESHOLD",
-        )
+    request = UniformSubsetIntersectionRequest(
+        ground_set_size=3,
+        subset_cardinality=5,
+        threshold=1,
+        relation="INTERSECTION_LT_THRESHOLD",
+    )
+    with pytest.raises(OperationDomainValidationError):
+        _construct(request)
 
 
 def test_rejects_threshold_exceeds_k() -> None:
-    with pytest.raises(ValidationError):
-        UniformSubsetIntersectionRequest(
-            ground_set_size=4,
-            subset_cardinality=2,
-            threshold=3,
-            relation="INTERSECTION_LT_THRESHOLD",
-        )
+    request = UniformSubsetIntersectionRequest(
+        ground_set_size=4,
+        subset_cardinality=2,
+        threshold=3,
+        relation="INTERSECTION_LT_THRESHOLD",
+    )
+    with pytest.raises(OperationDomainValidationError):
+        _construct(request)
 
 
 def test_rejects_family_beyond_graph_vertex_bound_before_enumeration() -> None:
-    with pytest.raises(ValidationError, match="256-vertex graph bound"):
-        UniformSubsetIntersectionRequest(
-            ground_set_size=11,
-            subset_cardinality=5,
-            threshold=1,
-            relation="INTERSECTION_LT_THRESHOLD",
-        )
+    request = UniformSubsetIntersectionRequest(
+        ground_set_size=11,
+        subset_cardinality=5,
+        threshold=1,
+        relation="INTERSECTION_LT_THRESHOLD",
+    )
+    with pytest.raises(OperationDomainValidationError, match="256-vertex graph bound"):
+        _construct(request)
 
 
 def test_rejects_huge_binomial_family_without_constructing_it() -> None:
-    with pytest.raises(ValidationError, match="256-vertex graph bound"):
-        UniformSubsetIntersectionRequest(
-            ground_set_size=(1 << 53) - 1,
-            subset_cardinality=2,
-            threshold=1,
-            relation="INTERSECTION_LT_THRESHOLD",
-        )
+    request = UniformSubsetIntersectionRequest(
+        ground_set_size=(1 << 53) - 1,
+        subset_cardinality=2,
+        threshold=1,
+        relation="INTERSECTION_LT_THRESHOLD",
+    )
+    with pytest.raises(OperationDomainValidationError, match="256-vertex graph bound"):
+        _construct(request)
 
 
-def test_request_retains_one_admission_plan_for_the_constructor() -> None:
+def test_catalog_adapter_uses_the_native_admission() -> None:
     request = UniformSubsetIntersectionRequest(
         ground_set_size=4,
         subset_cardinality=2,
         threshold=1,
         relation="INTERSECTION_LT_THRESHOLD",
     )
-    assert request._admission_plan.vertex_count == 6
-    assert request._admission_plan.edge_count == 3
     result = compute_uniform_subset_intersection_graph(request)
-    assert len(result.graph.vertices) == request._admission_plan.vertex_count
+    assert len(result.graph.vertices) == 6
 
 
 def test_native_api_accepts_domain_arguments() -> None:

--- a/tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py
+++ b/tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from itertools import combinations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.uniform_subset_intersection._models import (
+    UniformSubsetIntersectionRequest,
+)
+from jacobian.math.graphs.uniform_subset_intersection.operations import (
+    construct_uniform_subset_intersection_graph,
+)
+
+
+def _subset_label(subset):
+    return "{" + ",".join(str(x) for x in subset) + "}"
+
+
+def test_kneser_kg42() -> None:
+    """KG(4,2): 2-subsets of [4] with intersection < 1."""
+    req = UniformSubsetIntersectionRequest(
+        ground_set_size=4,
+        subset_cardinality=2,
+        threshold=1,
+        relation="INTERSECTION_LT_THRESHOLD",
+    )
+    result = construct_uniform_subset_intersection_graph(req)
+    graph = result.graph
+    assert len(graph.vertices) == 6  # C(4,2) = 6
+    # KG(4,2) is the Petersen graph minus... actually KG(4,2) has 6 vertices
+    # and is 3 disjoint edges (perfect matching)
+    assert len(graph.edges) == 3
+
+
+def test_johnson_eq_threshold() -> None:
+    """Johnson-scheme equality: edges when intersection == threshold."""
+    req = UniformSubsetIntersectionRequest(
+        ground_set_size=5,
+        subset_cardinality=2,
+        threshold=1,
+        relation="INTERSECTION_EQ_THRESHOLD",
+    )
+    result = construct_uniform_subset_intersection_graph(req)
+    graph = result.graph
+    assert len(graph.vertices) == 10  # C(5,2) = 10
+    # Two 2-subsets of [5] share exactly 1 element when they are not disjoint
+    # Pairs sharing exactly 1 element: total - disjoint pairs
+    # Disjoint pairs: for each pair {a,b}, {c,d} with no overlap, that's C(5,2)*C(3,2)/2 = 15
+    # Total pairs: C(10,2) = 45
+    # So 45 - 15 = 30 edges with intersection == 1
+    assert len(graph.edges) == 30
+
+
+def test_empty_k_zero() -> None:
+    """k=0 means one empty subset vertex, no edges."""
+    req = UniformSubsetIntersectionRequest(
+        ground_set_size=4,
+        subset_cardinality=0,
+        threshold=0,
+        relation="INTERSECTION_EQ_THRESHOLD",
+    )
+    result = construct_uniform_subset_intersection_graph(req)
+    graph = result.graph
+    assert len(graph.vertices) == 0  # k=0 yields empty graph by convention
+
+
+def test_single_subset() -> None:
+    """k=n yields one subset, no edges."""
+    req = UniformSubsetIntersectionRequest(
+        ground_set_size=3,
+        subset_cardinality=3,
+        threshold=0,
+        relation="INTERSECTION_LT_THRESHOLD",
+    )
+    result = construct_uniform_subset_intersection_graph(req)
+    graph = result.graph
+    assert len(graph.vertices) == 1
+    assert len(graph.edges) == 0
+
+
+def test_vertex_labels_retain_source() -> None:
+    """Each vertex label is the canonical subset representation."""
+    req = UniformSubsetIntersectionRequest(
+        ground_set_size=4,
+        subset_cardinality=2,
+        threshold=1,
+        relation="INTERSECTION_LT_THRESHOLD",
+    )
+    result = construct_uniform_subset_intersection_graph(req)
+    expected_labels = {_subset_label(s) for s in combinations(range(4), 2)}
+    assert set(result.graph.vertices) == expected_labels
+
+
+def test_exhaustive_small_comparison() -> None:
+    """Compare against independent enumeration for small n,k,t."""
+    for n in range(2, 6):
+        for k in range(1, n + 1):
+            subsets = list(combinations(range(n), k))
+            for t in range(k + 1):
+                for relation in [
+                    "INTERSECTION_LT_THRESHOLD",
+                    "INTERSECTION_EQ_THRESHOLD",
+                ]:
+                    req = UniformSubsetIntersectionRequest(
+                        ground_set_size=n,
+                        subset_cardinality=k,
+                        threshold=t,
+                        relation=relation,
+                    )
+                    result = construct_uniform_subset_intersection_graph(req)
+                    edges = set()
+                    for i, a in enumerate(subsets):
+                        for j, b in enumerate(subsets):
+                            if i >= j:
+                                continue
+                            isect = len(set(a) & set(b))
+                            if relation == "INTERSECTION_LT_THRESHOLD":
+                                adj = isect < t
+                            else:
+                                adj = isect == t
+                            if adj:
+                                la, lb = _subset_label(a), _subset_label(b)
+                                edges.add((min(la, lb), max(la, lb)))
+                    assert set(result.graph.edges) == edges
+
+
+def test_no_loops_or_duplicates() -> None:
+    """No self-loops or duplicate edges."""
+    req = UniformSubsetIntersectionRequest(
+        ground_set_size=5,
+        subset_cardinality=2,
+        threshold=1,
+        relation="INTERSECTION_LT_THRESHOLD",
+    )
+    result = construct_uniform_subset_intersection_graph(req)
+    for a, b in result.graph.edges:
+        assert a != b, "self-loop found"
+    edges = result.graph.edges
+    assert len(edges) == len(set(edges)), "duplicate edges found"
+
+
+def test_rejects_k_exceeds_n() -> None:
+    with pytest.raises(ValidationError):
+        UniformSubsetIntersectionRequest(
+            ground_set_size=3,
+            subset_cardinality=5,
+            threshold=1,
+            relation="INTERSECTION_LT_THRESHOLD",
+        )
+
+
+def test_rejects_threshold_exceeds_k() -> None:
+    with pytest.raises(ValidationError):
+        UniformSubsetIntersectionRequest(
+            ground_set_size=4,
+            subset_cardinality=2,
+            threshold=3,
+            relation="INTERSECTION_LT_THRESHOLD",
+        )
+
+
+def test_result_retains_metadata() -> None:
+    """Result retains the source parameters."""
+    req = UniformSubsetIntersectionRequest(
+        ground_set_size=4,
+        subset_cardinality=2,
+        threshold=1,
+        relation="INTERSECTION_LT_THRESHOLD",
+    )
+    result = construct_uniform_subset_intersection_graph(req)
+    assert result.ground_set_size == 4
+    assert result.subset_cardinality == 2
+    assert result.threshold == 1
+    assert result.relation == "INTERSECTION_LT_THRESHOLD"

--- a/tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py
+++ b/tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py
@@ -1,20 +1,35 @@
 from __future__ import annotations
 
 from itertools import combinations
+from typing import Literal
 
 import pytest
 from pydantic import ValidationError
 
+from jacobian.math.graphs.chip_firing._models import LaplacianRequest
+from jacobian.math.graphs.chip_firing.operations import laplacian
 from jacobian.math.graphs.uniform_subset_intersection._models import (
     UniformSubsetIntersectionRequest,
+    UniformSubsetIntersectionResult,
 )
 from jacobian.math.graphs.uniform_subset_intersection.operations import (
     construct_uniform_subset_intersection_graph,
 )
 
 
-def _subset_label(subset):
+def _subset_label(subset: tuple[int, ...]) -> str:
     return "{" + ",".join(str(x) for x in subset) + "}"
+
+
+def _construct(
+    request: UniformSubsetIntersectionRequest,
+) -> UniformSubsetIntersectionResult:
+    return construct_uniform_subset_intersection_graph(
+        request.ground_set_size,
+        request.subset_cardinality,
+        request.threshold,
+        request.relation,
+    )
 
 
 def test_kneser_kg42() -> None:
@@ -25,7 +40,7 @@ def test_kneser_kg42() -> None:
         threshold=1,
         relation="INTERSECTION_LT_THRESHOLD",
     )
-    result = construct_uniform_subset_intersection_graph(req)
+    result = _construct(req)
     graph = result.graph
     assert len(graph.vertices) == 6  # C(4,2) = 6
     # KG(4,2) is the Petersen graph minus... actually KG(4,2) has 6 vertices
@@ -41,7 +56,7 @@ def test_johnson_eq_threshold() -> None:
         threshold=1,
         relation="INTERSECTION_EQ_THRESHOLD",
     )
-    result = construct_uniform_subset_intersection_graph(req)
+    result = _construct(req)
     graph = result.graph
     assert len(graph.vertices) == 10  # C(5,2) = 10
     # Two 2-subsets of [5] share exactly 1 element when they are not disjoint
@@ -60,9 +75,10 @@ def test_empty_k_zero() -> None:
         threshold=0,
         relation="INTERSECTION_EQ_THRESHOLD",
     )
-    result = construct_uniform_subset_intersection_graph(req)
+    result = _construct(req)
     graph = result.graph
-    assert len(graph.vertices) == 0  # k=0 yields empty graph by convention
+    assert graph.vertices == ("{}",)
+    assert graph.edges == ()
 
 
 def test_single_subset() -> None:
@@ -73,7 +89,7 @@ def test_single_subset() -> None:
         threshold=0,
         relation="INTERSECTION_LT_THRESHOLD",
     )
-    result = construct_uniform_subset_intersection_graph(req)
+    result = _construct(req)
     graph = result.graph
     assert len(graph.vertices) == 1
     assert len(graph.edges) == 0
@@ -87,7 +103,7 @@ def test_vertex_labels_retain_source() -> None:
         threshold=1,
         relation="INTERSECTION_LT_THRESHOLD",
     )
-    result = construct_uniform_subset_intersection_graph(req)
+    result = _construct(req)
     expected_labels = {_subset_label(s) for s in combinations(range(4), 2)}
     assert set(result.graph.vertices) == expected_labels
 
@@ -98,17 +114,21 @@ def test_exhaustive_small_comparison() -> None:
         for k in range(1, n + 1):
             subsets = list(combinations(range(n), k))
             for t in range(k + 1):
-                for relation in [
+                relations: tuple[
+                    Literal["INTERSECTION_LT_THRESHOLD", "INTERSECTION_EQ_THRESHOLD"],
+                    ...,
+                ] = (
                     "INTERSECTION_LT_THRESHOLD",
                     "INTERSECTION_EQ_THRESHOLD",
-                ]:
+                )
+                for relation in relations:
                     req = UniformSubsetIntersectionRequest(
                         ground_set_size=n,
                         subset_cardinality=k,
                         threshold=t,
                         relation=relation,
                     )
-                    result = construct_uniform_subset_intersection_graph(req)
+                    result = _construct(req)
                     edges = set()
                     for i, a in enumerate(subsets):
                         for j, b in enumerate(subsets):
@@ -133,7 +153,7 @@ def test_no_loops_or_duplicates() -> None:
         threshold=1,
         relation="INTERSECTION_LT_THRESHOLD",
     )
-    result = construct_uniform_subset_intersection_graph(req)
+    result = _construct(req)
     for a, b in result.graph.edges:
         assert a != b, "self-loop found"
     edges = result.graph.edges
@@ -160,6 +180,36 @@ def test_rejects_threshold_exceeds_k() -> None:
         )
 
 
+def test_rejects_family_beyond_graph_vertex_bound_before_enumeration() -> None:
+    with pytest.raises(ValidationError, match="256-vertex graph bound"):
+        UniformSubsetIntersectionRequest(
+            ground_set_size=11,
+            subset_cardinality=5,
+            threshold=1,
+            relation="INTERSECTION_LT_THRESHOLD",
+        )
+
+
+def test_native_api_accepts_domain_arguments() -> None:
+    result = construct_uniform_subset_intersection_graph(
+        4, 2, 1, "INTERSECTION_LT_THRESHOLD"
+    )
+    assert len(result.graph.vertices) == 6
+    assert len(result.graph.edges) == 3
+
+
+def test_graph_serializes_unchanged_into_graph_consumer() -> None:
+    result = construct_uniform_subset_intersection_graph(
+        3, 2, 1, "INTERSECTION_EQ_THRESHOLD"
+    )
+    consumer_request = LaplacianRequest.model_validate(
+        {"graph": result.graph.model_dump(mode="json")}
+    )
+    consumed = laplacian(consumer_request.graph)
+    assert consumed.vertices == result.graph.vertices
+    assert consumed.degrees == (2, 2, 2)
+
+
 def test_result_retains_metadata() -> None:
     """Result retains the source parameters."""
     req = UniformSubsetIntersectionRequest(
@@ -168,7 +218,7 @@ def test_result_retains_metadata() -> None:
         threshold=1,
         relation="INTERSECTION_LT_THRESHOLD",
     )
-    result = construct_uniform_subset_intersection_graph(req)
+    result = _construct(req)
     assert result.ground_set_size == 4
     assert result.subset_cardinality == 2
     assert result.threshold == 1

--- a/tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py
+++ b/tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py
@@ -84,6 +84,17 @@ def test_empty_k_zero() -> None:
     assert graph.edges == ()
 
 
+def test_empty_subset_does_not_materialize_the_ground_axis() -> None:
+    result = construct_uniform_subset_intersection_graph(
+        (1 << 53) - 1,
+        0,
+        0,
+        "INTERSECTION_EQ_THRESHOLD",
+    )
+    assert result.graph.vertices == ("{}",)
+    assert result.graph.edges == ()
+
+
 def test_single_subset() -> None:
     """k=n yields one subset, no edges."""
     req = UniformSubsetIntersectionRequest(

--- a/tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py
+++ b/tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py
@@ -12,6 +12,9 @@ from jacobian.math.graphs.uniform_subset_intersection._models import (
     UniformSubsetIntersectionRequest,
     UniformSubsetIntersectionResult,
 )
+from jacobian.math.graphs.uniform_subset_intersection._tools import (
+    compute_uniform_subset_intersection_graph,
+)
 from jacobian.math.graphs.uniform_subset_intersection.operations import (
     construct_uniform_subset_intersection_graph,
 )
@@ -188,6 +191,29 @@ def test_rejects_family_beyond_graph_vertex_bound_before_enumeration() -> None:
             threshold=1,
             relation="INTERSECTION_LT_THRESHOLD",
         )
+
+
+def test_rejects_huge_binomial_family_without_constructing_it() -> None:
+    with pytest.raises(ValidationError, match="256-vertex graph bound"):
+        UniformSubsetIntersectionRequest(
+            ground_set_size=(1 << 53) - 1,
+            subset_cardinality=2,
+            threshold=1,
+            relation="INTERSECTION_LT_THRESHOLD",
+        )
+
+
+def test_request_retains_one_admission_plan_for_the_constructor() -> None:
+    request = UniformSubsetIntersectionRequest(
+        ground_set_size=4,
+        subset_cardinality=2,
+        threshold=1,
+        relation="INTERSECTION_LT_THRESHOLD",
+    )
+    assert request._admission_plan.vertex_count == 6
+    assert request._admission_plan.edge_count == 3
+    result = compute_uniform_subset_intersection_graph(request)
+    assert len(result.graph.vertices) == request._admission_plan.vertex_count
 
 
 def test_native_api_accepts_domain_arguments() -> None:


### PR DESCRIPTION
## Summary

Adds `graph.uniform_subset_intersection.construct`, a deterministic producer for the labelled graph on all `k`-subsets of `[n]` under either an intersection-less-than-threshold or exact-intersection relation.

The operation preserves each source subset as a canonical ordered label, including the unique empty subset `{}`. Its graph value serializes unchanged into existing graph consumers.

## Design

- The native API accepts the four mathematical arguments directly; the MCP adapter owns request-envelope unpacking.
- Request admission derives `C(n,k)`, the exact emitted-edge count, the largest subset-label size, and a conservative canonical-result byte bound before combination enumeration.
- The kernel uses lexicographic `itertools.combinations` and exact pairwise intersection counts. No graph optimizer or theorem-specific search is involved.
- The returned value is the existing domain-owned `SimpleUndirectedGraph`, with source parameters retained by the result.

## Evidence

- Kneser `KG(4,2)` and Johnson equality fixtures.
- Empty-subset and singleton-family degeneracies.
- Exhaustive small comparison of every vertex and edge for both relation modes.
- Rejection before enumeration when `C(n,k)` exceeds the graph carrier.
- Serialized producer-to-Laplacian-consumer composition.

## Validation

- `make handoff-scoped LANE=math TESTS=tests/math/graphs/uniform_subset_intersection/test_uniform_subset_intersection.py PATHS="src/jacobian/math/graphs/uniform_subset_intersection tests/math/graphs/uniform_subset_intersection"` (13 passed; Ruff and mypy passed)
- `git diff --check`

Closes #2832