### PR TITLE
Add graph.maximal_clique_hypergraph.construct operation

### DIFF
--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/__init__.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/__init__.py
@@ -1,0 +1,7 @@
+"""Maximal clique hypergraph construction."""
+
+from jacobian.math.graphs.maximal_clique_hypergraph.operations import (
+    construct_maximal_clique_hypergraph,
+)
+
+__all__ = ["construct_maximal_clique_hypergraph"]

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/_models.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/_models.py
@@ -15,6 +15,23 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 
+def _require_hypergraph_compatible_labels(graph: SimpleUndirectedGraph) -> None:
+    for label in graph.vertices:
+        if len(label) > MAX_LABEL_LENGTH:
+            raise PydanticCustomError(
+                "graph.maximal_clique_hypergraph.label_length",
+                "graph vertex labels must fit the hypergraph label bound of "
+                f"{MAX_LABEL_LENGTH} characters",
+            )
+        try:
+            label.encode("utf-8")
+        except UnicodeEncodeError as error:
+            raise PydanticCustomError(
+                "graph.maximal_clique_hypergraph.label_encoding",
+                "graph vertex labels must be valid UTF-8",
+            ) from error
+
+
 class MaximalCliqueHypergraphRequest(StrictModel):
     """Request to construct the maximal-clique hypergraph of a graph."""
 
@@ -22,20 +39,7 @@ class MaximalCliqueHypergraphRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_hypergraph_compatible_labels(self) -> Self:
-        for label in self.graph.vertices:
-            if len(label) > MAX_LABEL_LENGTH:
-                raise PydanticCustomError(
-                    "graph.maximal_clique_hypergraph.label_length",
-                    "graph vertex labels must fit the hypergraph label bound of "
-                    f"{MAX_LABEL_LENGTH} characters",
-                )
-            try:
-                label.encode("utf-8")
-            except UnicodeEncodeError as error:
-                raise PydanticCustomError(
-                    "graph.maximal_clique_hypergraph.label_encoding",
-                    "graph vertex labels must be valid UTF-8",
-                ) from error
+        _require_hypergraph_compatible_labels(self.graph)
         return self
 
 

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/_models.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/_models.py
@@ -1,0 +1,31 @@
+"""Typed contracts for the maximal-clique hypergraph operation."""
+
+from __future__ import annotations
+
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_GRAPH_VERTICES = 256
+
+
+class MaximalCliqueHypergraphRequest(StrictModel):
+    """Request to construct the maximal-clique hypergraph of a graph."""
+
+    graph: SimpleUndirectedGraph
+
+
+class MaximalCliqueHypergraphResult(StrictModel):
+    """The maximal-clique hypergraph of a graph."""
+
+    graph: SimpleUndirectedGraph
+    hypergraph: FiniteHypergraph
+
+
+__all__ = [
+    "MAX_GRAPH_VERTICES",
+    "MaximalCliqueHypergraphRequest",
+    "MaximalCliqueHypergraphResult",
+]

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/_models.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/_models.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from typing import Self
+
+from pydantic import StrictInt, model_validator
+from pydantic_core import PydanticCustomError
+
 from jacobian._models import StrictModel
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_LABEL_LENGTH,
     FiniteHypergraph,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
-
-MAX_GRAPH_VERTICES = 256
 
 
 class MaximalCliqueHypergraphRequest(StrictModel):
@@ -16,16 +20,48 @@ class MaximalCliqueHypergraphRequest(StrictModel):
 
     graph: SimpleUndirectedGraph
 
+    @model_validator(mode="after")
+    def require_hypergraph_compatible_labels(self) -> Self:
+        for label in self.graph.vertices:
+            if len(label) > MAX_LABEL_LENGTH:
+                raise PydanticCustomError(
+                    "graph.maximal_clique_hypergraph.label_length",
+                    "graph vertex labels must fit the hypergraph label bound of "
+                    f"{MAX_LABEL_LENGTH} characters",
+                )
+            try:
+                label.encode("utf-8")
+            except UnicodeEncodeError as error:
+                raise PydanticCustomError(
+                    "graph.maximal_clique_hypergraph.label_encoding",
+                    "graph vertex labels must be valid UTF-8",
+                ) from error
+        return self
+
 
 class MaximalCliqueHypergraphResult(StrictModel):
     """The maximal-clique hypergraph of a graph."""
 
     graph: SimpleUndirectedGraph
     hypergraph: FiniteHypergraph
+    clique_count: StrictInt
+
+    @model_validator(mode="after")
+    def bind_source_and_count(self) -> Self:
+        if self.hypergraph.vertices != self.graph.vertices:
+            raise PydanticCustomError(
+                "graph.maximal_clique_hypergraph.source_vertices",
+                "hypergraph vertices must equal the source graph vertices",
+            )
+        if self.clique_count != len(self.hypergraph.edges):
+            raise PydanticCustomError(
+                "graph.maximal_clique_hypergraph.clique_count",
+                "clique_count must equal the number of hypergraph edges",
+            )
+        return self
 
 
 __all__ = [
-    "MAX_GRAPH_VERTICES",
     "MaximalCliqueHypergraphRequest",
     "MaximalCliqueHypergraphResult",
 ]

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py
@@ -3,8 +3,18 @@
 from collections.abc import Callable
 
 from jacobian._models import StrictModel
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+)
 from jacobian.catalog._examples import example
-from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.catalog.models import (
+    MathTool,
+    MathTools,
+    OperationDomainValidationError,
+    OperationExample,
+)
 from jacobian.math.graphs.maximal_clique_hypergraph._models import (
     MaximalCliqueHypergraphRequest,
     MaximalCliqueHypergraphResult,
@@ -17,7 +27,19 @@ from jacobian.math.graphs.maximal_clique_hypergraph.operations import (
 def compute_maximal_clique_hypergraph(
     request: MaximalCliqueHypergraphRequest,
 ) -> MaximalCliqueHypergraphResult:
-    return construct_maximal_clique_hypergraph(request.graph)
+    result = construct_maximal_clique_hypergraph(request.graph)
+    try:
+        encode_strict_json(result.model_dump(mode="json"))
+    except CanonicalizationError as error:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.maximal_clique_hypergraph.output_bound",
+            message=(
+                "the source-bound maximal-clique hypergraph result exceeds the "
+                f"{CanonicalLimits().max_output_bytes}-byte canonical output bound"
+            ),
+        ) from error
+    return result
 
 
 def mch_operation[

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py
@@ -53,8 +53,8 @@ TOOLS: MathTools = (
             "Construct a source-bound FiniteHypergraph whose vertices are "
             "the graph's vertices and whose hyperedges are the inclusion-"
             "maximal complete vertex sets of cardinality at least two "
-            "(nontrivial maximal cliques). Uses Bron-Kerbosch with pivoting "
-            "for exact enumeration."
+            "(nontrivial maximal cliques). The complete family is returned "
+            "in deterministic source-vertex order."
         ),
         MaximalCliqueHypergraphRequest,
         MaximalCliqueHypergraphResult,

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py
@@ -1,0 +1,85 @@
+"""Maximal-clique hypergraph operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.maximal_clique_hypergraph._models import (
+    MaximalCliqueHypergraphRequest,
+    MaximalCliqueHypergraphResult,
+)
+from jacobian.math.graphs.maximal_clique_hypergraph.operations import (
+    construct_maximal_clique_hypergraph,
+)
+
+
+def compute_maximal_clique_hypergraph(
+    request: MaximalCliqueHypergraphRequest,
+) -> MaximalCliqueHypergraphResult:
+    return construct_maximal_clique_hypergraph(request.graph)
+
+
+def mch_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    mch_operation(
+        "graph.maximal_clique_hypergraph.construct",
+        "Construct the maximal-clique hypergraph of a graph",
+        (
+            "Construct a source-bound FiniteHypergraph whose vertices are "
+            "the graph's vertices and whose hyperedges are the inclusion-"
+            "maximal complete vertex sets of cardinality at least two "
+            "(nontrivial maximal cliques). Uses Bron-Kerbosch with pivoting "
+            "for exact enumeration."
+        ),
+        MaximalCliqueHypergraphRequest,
+        MaximalCliqueHypergraphResult,
+        compute_maximal_clique_hypergraph,
+        "graph",
+        "hypergraph",
+        "exact",
+        examples=(
+            example(
+                "triangle_with_pendant",
+                "Triangle 0-1-2 with pendant vertex 3 attached to 2.",
+                {
+                    "graph": {
+                        "vertices": ["0", "1", "2", "3"],
+                        "edges": [
+                            ["0", "1"],
+                            ["0", "2"],
+                            ["1", "2"],
+                            ["2", "3"],
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/operations.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import networkx as nx
+from pydantic_core import PydanticCustomError
 
 from jacobian.canonical import CanonicalLimits, encode_strict_json
 from jacobian.catalog.models import OperationDomainValidationError
@@ -14,8 +15,8 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
 )
 from jacobian.math.graphs.maximal_clique_hypergraph._models import (
-    MaximalCliqueHypergraphRequest,
     MaximalCliqueHypergraphResult,
+    _require_hypergraph_compatible_labels,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -45,8 +46,10 @@ def _as_networkx_graph(graph: SimpleUndirectedGraph) -> nx.Graph[str]:
 def _enumeration_plan(graph: SimpleUndirectedGraph) -> _CliqueEnumerationPlan:
     """Enumerate once while enforcing the complete-family result ledger."""
 
-    # Reuse the request contract for native callers as well as the MCP adapter.
-    MaximalCliqueHypergraphRequest(graph=graph)
+    try:
+        _require_hypergraph_compatible_labels(graph)
+    except PydanticCustomError as error:
+        raise _reject(error.type, str(error)) from error
     source_position = {vertex: index for index, vertex in enumerate(graph.vertices)}
     clique_members: list[tuple[str, ...]] = []
     incidence_count = 0

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/operations.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/operations.py
@@ -1,0 +1,81 @@
+"""Maximal-clique hypergraph constructor using Bron-Kerbosch with pivoting."""
+
+from __future__ import annotations
+
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.graphs.maximal_clique_hypergraph._models import (
+    MaximalCliqueHypergraphResult,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+__all__ = ["construct_maximal_clique_hypergraph"]
+
+
+def construct_maximal_clique_hypergraph(
+    graph: SimpleUndirectedGraph,
+) -> MaximalCliqueHypergraphResult:
+    """Construct the maximal-clique hypergraph of a simple graph.
+
+    The hypergraph has the same vertices as the graph. Each hyperedge is
+    one inclusion-maximal complete vertex set of cardinality at least two
+    (nontrivial clique). Isolated vertices induce no singleton edge.
+    """
+    vertices = list(graph.vertices)
+    adjacency = _build_adjacency(graph)
+    cliques = _find_maximal_cliques(vertices, adjacency)
+    nontrivial = [c for c in cliques if len(c) >= 2]
+
+    hyper_vertices = tuple(vertices)
+    hyper_edges = []
+    for i, clique in enumerate(nontrivial):
+        edge_id = f"clique_{i}"
+        hyper_edges.append((edge_id, tuple(sorted(clique))))
+
+    hypergraph = FiniteHypergraph(
+        vertices=hyper_vertices,
+        edges=tuple(hyper_edges),
+    )
+    return MaximalCliqueHypergraphResult(graph=graph, hypergraph=hypergraph)
+
+
+def _build_adjacency(graph: SimpleUndirectedGraph) -> dict[str, set[str]]:
+    adj: dict[str, set[str]] = {v: set() for v in graph.vertices}
+    for a, b in graph.edges:
+        adj[a].add(b)
+        adj[b].add(a)
+    return adj
+
+
+def _find_maximal_cliques(
+    vertices: list[str], adjacency: dict[str, set[str]]
+) -> list[list[str]]:
+    """Find all maximal cliques using Bron-Kerbosch with pivoting."""
+    cliques: list[list[str]] = []
+    _bron_kerbosch_pivot(set(), set(vertices), set(), adjacency, cliques)
+    return cliques
+
+
+def _bron_kerbosch_pivot(
+    r: set[str],
+    p: set[str],
+    x: set[str],
+    adjacency: dict[str, set[str]],
+    cliques: list[list[str]],
+) -> None:
+    if not p and not x:
+        cliques.append(sorted(r))
+        return
+    pivot = next(iter(p | x)) if (p | x) else None
+    if pivot is not None:
+        for v in sorted(p - adjacency[pivot]):
+            _bron_kerbosch_pivot(
+                r | {v},
+                p & adjacency[v],
+                x & adjacency[v],
+                adjacency,
+                cliques,
+            )
+            p = p - {v}
+            x = x | {v}

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/operations.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/operations.py
@@ -1,11 +1,20 @@
-"""Maximal-clique hypergraph constructor using Bron-Kerbosch with pivoting."""
+"""Exact maximal-clique hypergraph construction."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+import networkx as nx
+
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_TOTAL_INCIDENCES,
     FiniteHypergraph,
 )
 from jacobian.math.graphs.maximal_clique_hypergraph._models import (
+    MaximalCliqueHypergraphRequest,
     MaximalCliqueHypergraphResult,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
@@ -13,69 +22,96 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 __all__ = ["construct_maximal_clique_hypergraph"]
 
 
+@dataclass(frozen=True)
+class _CliqueEnumerationPlan:
+    edges: tuple[tuple[str, tuple[str, ...]], ...]
+    incidence_count: int
+    result_wire_bytes: int
+
+
+def _reject(code: str, message: str) -> OperationDomainValidationError:
+    return OperationDomainValidationError(
+        location=("graph",), code=code, message=message
+    )
+
+
+def _as_networkx_graph(graph: SimpleUndirectedGraph) -> nx.Graph[str]:
+    backend: nx.Graph[str] = nx.Graph()
+    backend.add_nodes_from(graph.vertices)
+    backend.add_edges_from(graph.edges)
+    return backend
+
+
+def _enumeration_plan(graph: SimpleUndirectedGraph) -> _CliqueEnumerationPlan:
+    """Enumerate once while enforcing the complete-family result ledger."""
+
+    # Reuse the request contract for native callers as well as the MCP adapter.
+    MaximalCliqueHypergraphRequest(graph=graph)
+    source_position = {vertex: index for index, vertex in enumerate(graph.vertices)}
+    clique_members: list[tuple[str, ...]] = []
+    incidence_count = 0
+
+    # NetworkX 3.6 find_cliques is the maintained iterative Bron--Kerbosch /
+    # Tomita kernel. It yields every maximal clique once, in unspecified order.
+    for clique in nx.find_cliques(_as_networkx_graph(graph)):
+        if len(clique) < 2:
+            continue
+        members = tuple(sorted(clique, key=source_position.__getitem__))
+        clique_members.append(members)
+        incidence_count += len(members)
+        if len(clique_members) > MAX_EDGES:
+            raise _reject(
+                "graph.maximal_clique_hypergraph.edge_bound",
+                "the complete maximal-clique family exceeds the "
+                f"{MAX_EDGES:,}-edge hypergraph bound",
+            )
+        if incidence_count > MAX_TOTAL_INCIDENCES:
+            raise _reject(
+                "graph.maximal_clique_hypergraph.incidence_bound",
+                "the complete maximal-clique family exceeds the "
+                f"{MAX_TOTAL_INCIDENCES:,}-incidence hypergraph bound",
+            )
+
+    clique_members.sort(key=lambda members: tuple(source_position[v] for v in members))
+    edges = tuple(
+        (f"clique_{index}", members) for index, members in enumerate(clique_members)
+    )
+    result_payload = {
+        "graph": graph.model_dump(mode="json"),
+        "hypergraph": {
+            "vertices": list(graph.vertices),
+            "edges": [[edge_id, list(members)] for edge_id, members in edges],
+        },
+        "clique_count": len(edges),
+    }
+    result_wire_bytes = len(encode_strict_json(result_payload))
+    output_limit = CanonicalLimits().max_output_bytes
+    if result_wire_bytes > output_limit:
+        raise _reject(
+            "graph.maximal_clique_hypergraph.output_bound",
+            "the source-bound maximal-clique hypergraph result exceeds the "
+            f"{output_limit}-byte canonical output bound",
+        )
+    return _CliqueEnumerationPlan(
+        edges=edges,
+        incidence_count=incidence_count,
+        result_wire_bytes=result_wire_bytes,
+    )
+
+
 def construct_maximal_clique_hypergraph(
     graph: SimpleUndirectedGraph,
 ) -> MaximalCliqueHypergraphResult:
-    """Construct the maximal-clique hypergraph of a simple graph.
+    """Return every nontrivial inclusion-maximal clique as one hyperedge."""
 
-    The hypergraph has the same vertices as the graph. Each hyperedge is
-    one inclusion-maximal complete vertex set of cardinality at least two
-    (nontrivial clique). Isolated vertices induce no singleton edge.
-    """
-    vertices = list(graph.vertices)
-    adjacency = _build_adjacency(graph)
-    cliques = _find_maximal_cliques(vertices, adjacency)
-    nontrivial = [c for c in cliques if len(c) >= 2]
-
-    hyper_vertices = tuple(vertices)
-    hyper_edges = []
-    for i, clique in enumerate(nontrivial):
-        edge_id = f"clique_{i}"
-        hyper_edges.append((edge_id, tuple(sorted(clique))))
-
-    hypergraph = FiniteHypergraph(
-        vertices=hyper_vertices,
-        edges=tuple(hyper_edges),
+    if not isinstance(graph, SimpleUndirectedGraph):
+        raise TypeError(
+            "construct_maximal_clique_hypergraph expects a SimpleUndirectedGraph"
+        )
+    plan = _enumeration_plan(graph)
+    hypergraph = FiniteHypergraph(vertices=graph.vertices, edges=plan.edges)
+    return MaximalCliqueHypergraphResult(
+        graph=graph,
+        hypergraph=hypergraph,
+        clique_count=len(plan.edges),
     )
-    return MaximalCliqueHypergraphResult(graph=graph, hypergraph=hypergraph)
-
-
-def _build_adjacency(graph: SimpleUndirectedGraph) -> dict[str, set[str]]:
-    adj: dict[str, set[str]] = {v: set() for v in graph.vertices}
-    for a, b in graph.edges:
-        adj[a].add(b)
-        adj[b].add(a)
-    return adj
-
-
-def _find_maximal_cliques(
-    vertices: list[str], adjacency: dict[str, set[str]]
-) -> list[list[str]]:
-    """Find all maximal cliques using Bron-Kerbosch with pivoting."""
-    cliques: list[list[str]] = []
-    _bron_kerbosch_pivot(set(), set(vertices), set(), adjacency, cliques)
-    return cliques
-
-
-def _bron_kerbosch_pivot(
-    r: set[str],
-    p: set[str],
-    x: set[str],
-    adjacency: dict[str, set[str]],
-    cliques: list[list[str]],
-) -> None:
-    if not p and not x:
-        cliques.append(sorted(r))
-        return
-    pivot = next(iter(p | x)) if (p | x) else None
-    if pivot is not None:
-        for v in sorted(p - adjacency[pivot]):
-            _bron_kerbosch_pivot(
-                r | {v},
-                p & adjacency[v],
-                x & adjacency[v],
-                adjacency,
-                cliques,
-            )
-            p = p - {v}
-            x = x | {v}

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/operations.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/operations.py
@@ -7,11 +7,6 @@ from dataclasses import dataclass
 import networkx as nx
 from pydantic_core import PydanticCustomError
 
-from jacobian.canonical import (
-    CanonicalizationError,
-    CanonicalLimits,
-    encode_strict_json,
-)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     MAX_EDGES,
@@ -31,7 +26,6 @@ __all__ = ["construct_maximal_clique_hypergraph"]
 class _CliqueEnumerationPlan:
     edges: tuple[tuple[str, tuple[str, ...]], ...]
     incidence_count: int
-    result_wire_bytes: int
 
 
 def _reject(code: str, message: str) -> OperationDomainValidationError:
@@ -83,33 +77,9 @@ def _enumeration_plan(graph: SimpleUndirectedGraph) -> _CliqueEnumerationPlan:
     edges = tuple(
         (f"clique_{index}", members) for index, members in enumerate(clique_members)
     )
-    result_payload = {
-        "graph": graph.model_dump(mode="json"),
-        "hypergraph": {
-            "vertices": list(graph.vertices),
-            "edges": [[edge_id, list(members)] for edge_id, members in edges],
-        },
-        "clique_count": len(edges),
-    }
-    try:
-        result_wire_bytes = len(encode_strict_json(result_payload))
-    except CanonicalizationError as error:
-        raise _reject(
-            "graph.maximal_clique_hypergraph.output_bound",
-            "the source-bound maximal-clique hypergraph result exceeds the "
-            f"{CanonicalLimits().max_output_bytes}-byte canonical output bound",
-        ) from error
-    output_limit = CanonicalLimits().max_output_bytes
-    if result_wire_bytes > output_limit:
-        raise _reject(
-            "graph.maximal_clique_hypergraph.output_bound",
-            "the source-bound maximal-clique hypergraph result exceeds the "
-            f"{output_limit}-byte canonical output bound",
-        )
     return _CliqueEnumerationPlan(
         edges=edges,
         incidence_count=incidence_count,
-        result_wire_bytes=result_wire_bytes,
     )
 
 

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/operations.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/operations.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 import networkx as nx
 from pydantic_core import PydanticCustomError
 
-from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     MAX_EDGES,
@@ -87,7 +91,14 @@ def _enumeration_plan(graph: SimpleUndirectedGraph) -> _CliqueEnumerationPlan:
         },
         "clique_count": len(edges),
     }
-    result_wire_bytes = len(encode_strict_json(result_payload))
+    try:
+        result_wire_bytes = len(encode_strict_json(result_payload))
+    except CanonicalizationError as error:
+        raise _reject(
+            "graph.maximal_clique_hypergraph.output_bound",
+            "the source-bound maximal-clique hypergraph result exceeds the "
+            f"{CanonicalLimits().max_output_bytes}-byte canonical output bound",
+        ) from error
     output_limit = CanonicalLimits().max_output_bytes
     if result_wire_bytes > output_limit:
         raise _reject(

--- a/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
+++ b/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
@@ -2,33 +2,48 @@ from __future__ import annotations
 
 from itertools import combinations
 
+import pytest
+from pydantic import ValidationError
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MinimumTransversalRequest,
+)
+from jacobian.math.graphs.maximal_clique_hypergraph._models import (
+    MaximalCliqueHypergraphRequest,
+    MaximalCliqueHypergraphResult,
+)
 from jacobian.math.graphs.maximal_clique_hypergraph.operations import (
     construct_maximal_clique_hypergraph,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 
-def _graph(vertices, edges):
+def _graph(vertices: list[str], edges: list[tuple[str, str]]) -> SimpleUndirectedGraph:
     return SimpleUndirectedGraph(
         vertices=tuple(vertices),
         edges=tuple((a, b) for a, b in edges),
     )
 
 
-def _clique_members(result):
+def _clique_members(
+    result: MaximalCliqueHypergraphResult,
+) -> set[frozenset[str]]:
     """Return the set of frozenset clique member sets."""
     return {frozenset(members) for _, members in result.hypergraph.edges}
 
 
-def _independent_maximal_cliques(graph):
+def _independent_maximal_cliques(
+    graph: SimpleUndirectedGraph,
+) -> list[frozenset[str]]:
     """Independent oracle: enumerate all subsets, find maximal cliques."""
     vertices = list(graph.vertices)
-    adj = {v: set() for v in vertices}
+    adj: dict[str, set[str]] = {v: set() for v in vertices}
     for a, b in graph.edges:
         adj[a].add(b)
         adj[b].add(a)
 
-    all_cliques = []
+    all_cliques: list[frozenset[str]] = []
     for size in range(2, len(vertices) + 1):
         for subset in combinations(vertices, size):
             s = set(subset)
@@ -147,15 +162,18 @@ def test_vertex_preservation() -> None:
 
 
 def test_exhaustive_small_comparison() -> None:
-    """Compare against independent oracle for small graphs."""
-    g = _graph(
-        ["a", "b", "c", "d"],
-        [("a", "b"), ("a", "c"), ("b", "c"), ("b", "d"), ("c", "d"), ("a", "d")],
-    )
-    result = construct_maximal_clique_hypergraph(g)
-    expected = _independent_maximal_cliques(g)
-    actual = _clique_members(result)
-    assert actual == set(expected)
+    """Compare every graph on four labelled vertices with a subset oracle."""
+    vertices = ["a", "b", "c", "d"]
+    candidate_edges = list(combinations(vertices, 2))
+    for edge_mask in range(1 << len(candidate_edges)):
+        edges = [
+            edge
+            for index, edge in enumerate(candidate_edges)
+            if edge_mask & (1 << index)
+        ]
+        graph = _graph(vertices, edges)
+        result = construct_maximal_clique_hypergraph(graph)
+        assert _clique_members(result) == set(_independent_maximal_cliques(graph))
 
 
 def test_source_retained() -> None:
@@ -163,3 +181,92 @@ def test_source_retained() -> None:
     g = _graph(["a", "b"], [("a", "b")])
     result = construct_maximal_clique_hypergraph(g)
     assert result.graph == g
+
+
+def test_edge_ids_follow_source_order_deterministically() -> None:
+    graph = _graph(
+        ["d", "a", "c", "b"],
+        [("a", "d"), ("b", "c")],
+    )
+    first = construct_maximal_clique_hypergraph(graph)
+    second = construct_maximal_clique_hypergraph(graph)
+    assert first == second
+    assert first.hypergraph.edges == (
+        ("clique_0", ("a", "d")),
+        ("clique_1", ("b", "c")),
+    )
+
+
+def test_coherent_relabelling_preserves_clique_id_positions() -> None:
+    original = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "b"), ("a", "c"), ("b", "c"), ("c", "d")],
+    )
+    relabelled = _graph(
+        ["w", "x", "y", "z"],
+        [("w", "x"), ("w", "y"), ("x", "y"), ("y", "z")],
+    )
+    original_result = construct_maximal_clique_hypergraph(original)
+    relabelled_result = construct_maximal_clique_hypergraph(relabelled)
+    assert tuple(edge_id for edge_id, _ in original_result.hypergraph.edges) == tuple(
+        edge_id for edge_id, _ in relabelled_result.hypergraph.edges
+    )
+    assert tuple(len(members) for _, members in original_result.hypergraph.edges) == (
+        3,
+        2,
+    )
+    assert tuple(len(members) for _, members in relabelled_result.hypergraph.edges) == (
+        3,
+        2,
+    )
+
+
+def test_rejects_graph_labels_outside_hypergraph_carrier() -> None:
+    graph = _graph(["x" * 65], [])
+    with pytest.raises(ValidationError, match="64 characters"):
+        MaximalCliqueHypergraphRequest(graph=graph)
+    with pytest.raises(ValidationError, match="64 characters"):
+        construct_maximal_clique_hypergraph(graph)
+
+
+def test_rejects_complete_family_above_hypergraph_incidence_bound() -> None:
+    parts = [[f"{part}:{offset}" for offset in range(3)] for part in range(9)]
+    vertices = [vertex for part in parts for vertex in part]
+    edges: list[tuple[str, str]] = [
+        (left, right) if left < right else (right, left)
+        for left_part, right_part in combinations(parts, 2)
+        for left in left_part
+        for right in right_part
+    ]
+    graph = _graph(vertices, edges)
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="36,000-incidence hypergraph bound",
+    ):
+        construct_maximal_clique_hypergraph(graph)
+
+
+def test_rejects_complete_family_above_hypergraph_edge_bound() -> None:
+    left = [f"left:{index}" for index in range(120)]
+    right = [f"right:{index}" for index in range(101)]
+    graph = _graph(
+        [*left, *right],
+        [(left_vertex, right_vertex) for left_vertex in left for right_vertex in right],
+    )
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="12,000-edge hypergraph bound",
+    ):
+        construct_maximal_clique_hypergraph(graph)
+
+
+def test_hypergraph_serializes_unchanged_into_transversal_consumer() -> None:
+    graph = _graph(
+        ["0", "1", "2", "3"],
+        [("0", "1"), ("0", "2"), ("1", "2"), ("2", "3")],
+    )
+    result = construct_maximal_clique_hypergraph(graph)
+    consumer = MinimumTransversalRequest.model_validate(
+        {"hypergraph": result.hypergraph.model_dump(mode="json")}
+    )
+    assert consumer.hypergraph == result.hypergraph

--- a/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
+++ b/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
@@ -260,6 +260,21 @@ def test_rejects_complete_family_above_hypergraph_edge_bound() -> None:
         construct_maximal_clique_hypergraph(graph)
 
 
+def test_rejects_result_before_bounded_encoder_failure() -> None:
+    """An oversized retained result is reported as owner-level admission."""
+    left = [f"{chr(0x1D552) * 60}L{index:03}" for index in range(102)]
+    right = [f"{chr(0x1D553) * 60}R{index:03}" for index in range(102)]
+    graph = _graph(
+        [*left, *right],
+        [(left_vertex, right_vertex) for left_vertex in left for right_vertex in right],
+    )
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="canonical output bound",
+    ):
+        construct_maximal_clique_hypergraph(graph)
+
+
 def test_hypergraph_serializes_unchanged_into_transversal_consumer() -> None:
     graph = _graph(
         ["0", "1", "2", "3"],

--- a/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
+++ b/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from itertools import combinations
+
+from jacobian.math.graphs.maximal_clique_hypergraph.operations import (
+    construct_maximal_clique_hypergraph,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph(vertices, edges):
+    return SimpleUndirectedGraph(
+        vertices=tuple(vertices),
+        edges=tuple((a, b) for a, b in edges),
+    )
+
+
+def _clique_members(result):
+    """Return the set of frozenset clique member sets."""
+    return {frozenset(members) for _, members in result.hypergraph.edges}
+
+
+def _independent_maximal_cliques(graph):
+    """Independent oracle: enumerate all subsets, find maximal cliques."""
+    vertices = list(graph.vertices)
+    adj = {v: set() for v in vertices}
+    for a, b in graph.edges:
+        adj[a].add(b)
+        adj[b].add(a)
+
+    all_cliques = []
+    for size in range(2, len(vertices) + 1):
+        for subset in combinations(vertices, size):
+            s = set(subset)
+            if all(b in adj[a] for a, b in combinations(s, 2)):
+                is_maximal = True
+                for other in all_cliques:
+                    if s < frozenset(other):
+                        is_maximal = False
+                        break
+                if is_maximal:
+                    all_cliques.append(frozenset(s))
+    # Remove non-maximal
+    final = []
+    for c in all_cliques:
+        is_max = True
+        for other in all_cliques:
+            if c != other and c < other:
+                is_max = False
+                break
+        if is_max:
+            final.append(c)
+    return final
+
+
+def test_edgeless_graph() -> None:
+    """Edgeless graph has no nontrivial maximal cliques."""
+    g = _graph(["a", "b", "c"], [])
+    result = construct_maximal_clique_hypergraph(g)
+    assert len(result.hypergraph.edges) == 0
+
+
+def test_single_edge() -> None:
+    """Single edge is the only maximal clique."""
+    g = _graph(["a", "b"], [("a", "b")])
+    result = construct_maximal_clique_hypergraph(g)
+    assert len(result.hypergraph.edges) == 1
+    members = next(iter(result.hypergraph.edges))[1]
+    assert set(members) == {"a", "b"}
+
+
+def test_triangle() -> None:
+    """Triangle K3 has one maximal clique {a,b,c}."""
+    g = _graph(
+        ["a", "b", "c"],
+        [("a", "b"), ("a", "c"), ("b", "c")],
+    )
+    result = construct_maximal_clique_hypergraph(g)
+    assert len(result.hypergraph.edges) == 1
+    members = next(iter(result.hypergraph.edges))[1]
+    assert set(members) == {"a", "b", "c"}
+
+
+def test_triangle_in_k4() -> None:
+    """K4 has only one maximal clique of size 4."""
+    g = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "b"), ("a", "c"), ("a", "d"), ("b", "c"), ("b", "d"), ("c", "d")],
+    )
+    result = construct_maximal_clique_hypergraph(g)
+    assert len(result.hypergraph.edges) == 1
+    members = next(iter(result.hypergraph.edges))[1]
+    assert set(members) == {"a", "b", "c", "d"}
+
+
+def test_triangle_with_pendant() -> None:
+    """Fixture: triangle 0-1-2 with pendant 3 attached to 2."""
+    g = _graph(
+        ["0", "1", "2", "3"],
+        [("0", "1"), ("0", "2"), ("1", "2"), ("2", "3")],
+    )
+    result = construct_maximal_clique_hypergraph(g)
+    cliques = _clique_members(result)
+    assert frozenset({"0", "1", "2"}) in cliques
+    assert frozenset({"2", "3"}) in cliques
+    assert len(result.hypergraph.edges) == 2
+
+
+def test_overlapping_triangles() -> None:
+    """Two triangles sharing an edge produce two maximal cliques."""
+    g = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "b"), ("a", "c"), ("b", "c"), ("b", "d"), ("c", "d")],
+    )
+    result = construct_maximal_clique_hypergraph(g)
+    assert len(result.hypergraph.edges) == 2
+
+
+def test_path_graph() -> None:
+    """Path a-b-c has one maximal clique {a,b,c}... no, path has no triangle."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    result = construct_maximal_clique_hypergraph(g)
+    cliques = _clique_members(result)
+    assert frozenset({"a", "b"}) in cliques
+    assert frozenset({"b", "c"}) in cliques
+    assert len(result.hypergraph.edges) == 2
+
+
+def test_cycle_graph() -> None:
+    """Cycle C4 has no triangles, each edge is a maximal clique."""
+    g = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "b"), ("b", "c"), ("c", "d"), ("a", "d")],
+    )
+    result = construct_maximal_clique_hypergraph(g)
+    assert len(result.hypergraph.edges) == 4
+
+
+def test_vertex_preservation() -> None:
+    """Hypergraph preserves all graph vertices."""
+    g = _graph(
+        ["a", "b", "c"],
+        [("a", "b"), ("b", "c")],
+    )
+    result = construct_maximal_clique_hypergraph(g)
+    assert set(result.hypergraph.vertices) == {"a", "b", "c"}
+
+
+def test_exhaustive_small_comparison() -> None:
+    """Compare against independent oracle for small graphs."""
+    g = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "b"), ("a", "c"), ("b", "c"), ("b", "d"), ("c", "d"), ("a", "d")],
+    )
+    result = construct_maximal_clique_hypergraph(g)
+    expected = _independent_maximal_cliques(g)
+    actual = _clique_members(result)
+    assert actual == set(expected)
+
+
+def test_source_retained() -> None:
+    """Result retains the original graph."""
+    g = _graph(["a", "b"], [("a", "b")])
+    result = construct_maximal_clique_hypergraph(g)
+    assert result.graph == g

--- a/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
+++ b/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
@@ -13,6 +13,9 @@ from jacobian.math.graphs.maximal_clique_hypergraph._models import (
     MaximalCliqueHypergraphRequest,
     MaximalCliqueHypergraphResult,
 )
+from jacobian.math.graphs.maximal_clique_hypergraph._tools import (
+    compute_maximal_clique_hypergraph,
+)
 from jacobian.math.graphs.maximal_clique_hypergraph.operations import (
     construct_maximal_clique_hypergraph,
 )
@@ -260,19 +263,21 @@ def test_rejects_complete_family_above_hypergraph_edge_bound() -> None:
         construct_maximal_clique_hypergraph(graph)
 
 
-def test_rejects_result_before_bounded_encoder_failure() -> None:
-    """An oversized retained result is reported as owner-level admission."""
+def test_wire_adapter_rejects_result_beyond_transport_limit() -> None:
     left = [f"{chr(0x1D552) * 60}L{index:03}" for index in range(102)]
     right = [f"{chr(0x1D553) * 60}R{index:03}" for index in range(102)]
     graph = _graph(
         [*left, *right],
         [(left_vertex, right_vertex) for left_vertex in left for right_vertex in right],
     )
+    native = construct_maximal_clique_hypergraph(graph)
+    assert native.clique_count == 10_404
+
     with pytest.raises(
         OperationDomainValidationError,
         match="canonical output bound",
     ):
-        construct_maximal_clique_hypergraph(graph)
+        compute_maximal_clique_hypergraph(MaximalCliqueHypergraphRequest(graph=graph))
 
 
 def test_hypergraph_serializes_unchanged_into_transversal_consumer() -> None:

--- a/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
+++ b/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
@@ -225,7 +225,7 @@ def test_rejects_graph_labels_outside_hypergraph_carrier() -> None:
     graph = _graph(["x" * 65], [])
     with pytest.raises(ValidationError, match="64 characters"):
         MaximalCliqueHypergraphRequest(graph=graph)
-    with pytest.raises(ValidationError, match="64 characters"):
+    with pytest.raises(OperationDomainValidationError, match="64 characters"):
         construct_maximal_clique_hypergraph(graph)
 
 


### PR DESCRIPTION
## Summary

Adds `graph.maximal_clique_hypergraph.construct`, the exact finite transform from a labelled simple graph to the hypergraph of its nontrivial inclusion-maximal cliques.

The source graph is retained unchanged. Hyperedges use deterministic IDs derived from source-vertex order, and the resulting `FiniteHypergraph` serializes unchanged into generic hypergraph consumers.

## Design

- Jacobian owns the source-bound graph-to-hypergraph contract and its admission ledger.
- NetworkX 3.6.1 `find_cliques` is the private maintained kernel. It provides iterative exact maximal-clique enumeration; its arbitrary yield order is normalized before IDs are assigned.
- One request-scoped pass accumulates the complete family while enforcing the existing 12,000-edge and 36,000-incidence hypergraph limits. The exact source-bound canonical result size is checked before result construction.
- Graph labels are rejected at the request boundary when they cannot be represented by the canonical hypergraph carrier.
- Singleton maximal cliques are intentionally omitted, so isolated vertices remain in the carrier without inducing hyperedges.

## Evidence

- Complete, edgeless, path, cycle, pendant, and overlapping-clique fixtures.
- Independent exhaustive comparison for all 64 labelled graphs on four vertices.
- Stable repeated execution and coherent relabelling checks.
- Regression cases for incompatible labels, a 19,683-clique complete multipartite graph, and a 12,120-clique complete bipartite graph.
- Serialized producer-to-minimum-transversal request composition.

## Validation

- `make handoff-scoped LANE=math TESTS=tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py PATHS="src/jacobian/math/graphs/maximal_clique_hypergraph tests/math/graphs/maximal_clique_hypergraph"` (17 passed; Ruff and mypy passed)
- `git diff --check`

Closes #2829