### PR TITLE
Construct canonical word-cube combinatorial-line hypergraphs

### DIFF
--- a/src/jacobian/math/combinatorics/word_cubes/__init__.py
+++ b/src/jacobian/math/combinatorics/word_cubes/__init__.py
@@ -1,7 +1,15 @@
 """Word-cube combinatorial-line hypergraph operations."""
 
+from jacobian.math.combinatorics.word_cubes._models import (
+    CombinatorialLine,
+    CombinatorialLineHypergraphResult,
+)
 from jacobian.math.combinatorics.word_cubes.operations import (
     construct_combinatorial_line_hypergraph,
 )
 
-__all__ = ["construct_combinatorial_line_hypergraph"]
+__all__ = [
+    "CombinatorialLine",
+    "CombinatorialLineHypergraphResult",
+    "construct_combinatorial_line_hypergraph",
+]

--- a/src/jacobian/math/combinatorics/word_cubes/__init__.py
+++ b/src/jacobian/math/combinatorics/word_cubes/__init__.py
@@ -1,0 +1,7 @@
+"""Word-cube combinatorial-line hypergraph operations."""
+
+from jacobian.math.combinatorics.word_cubes.operations import (
+    construct_combinatorial_line_hypergraph,
+)
+
+__all__ = ["construct_combinatorial_line_hypergraph"]

--- a/src/jacobian/math/combinatorics/word_cubes/_models.py
+++ b/src/jacobian/math/combinatorics/word_cubes/_models.py
@@ -1,51 +1,57 @@
-"""Typed contracts for word-cube combinatorial-line hypergraph operations."""
+"""Typed contracts for word-cube combinatorial-line hypergraphs."""
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Annotated
 
-from pydantic import Field, model_validator
-from pydantic_core import PydanticCustomError
+from pydantic import Field
 
 from jacobian._models import StrictModel
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_VERTICES,
     FiniteHypergraph,
 )
 
-MAX_ALPHABET_SIZE = 10
-MAX_DIMENSION = 6
-MAX_VERTICES = 10_000
+MAX_ALPHABET_SIZE = MAX_VERTICES
+MAX_DIMENSION = MAX_VERTICES.bit_length() - 1
+
+Word = Annotated[tuple[int, ...], Field(min_length=1, max_length=MAX_DIMENSION)]
 
 
 class CombinatorialLineHypergraphRequest(StrictModel):
-    """Request to construct the combinatorial-line hypergraph of [q]^d."""
+    """Request to construct all Hales--Jewett lines of ``[q]^d``."""
 
     alphabet_size: int = Field(ge=2, le=MAX_ALPHABET_SIZE)
     dimension: int = Field(ge=1, le=MAX_DIMENSION)
 
-    @model_validator(mode="after")
-    def validate_vertex_count(self) -> Self:
-        vertex_count = self.alphabet_size**self.dimension
-        if vertex_count > MAX_VERTICES:
-            raise PydanticCustomError(
-                "word_cube.vertex_count_exceeds_bound",
-                f"q^d = {vertex_count} exceeds the {MAX_VERTICES}-vertex limit",
-            )
-        return self
+
+class CombinatorialLine(StrictModel):
+    """One line, with the unique wildcard pattern that generates it."""
+
+    edge_id: str
+    wildcard_positions: tuple[int, ...] = Field(min_length=1, max_length=MAX_DIMENSION)
+    fixed_coordinates: tuple[tuple[int, int], ...] = Field(
+        default=(), max_length=MAX_DIMENSION
+    )
+    vertices: tuple[Word, ...] = Field(min_length=2, max_length=MAX_ALPHABET_SIZE)
 
 
 class CombinatorialLineHypergraphResult(StrictModel):
-    """The combinatorial-line hypergraph of [q]^d."""
+    """The complete word cube, its lines, and its generic hypergraph carrier."""
 
     alphabet_size: int
     dimension: int
+    words: tuple[Word, ...] = Field(max_length=MAX_VERTICES)
+    lines: tuple[CombinatorialLine, ...] = Field(max_length=MAX_EDGES)
     hypergraph: FiniteHypergraph
 
 
 __all__ = [
     "MAX_ALPHABET_SIZE",
     "MAX_DIMENSION",
-    "MAX_VERTICES",
+    "CombinatorialLine",
     "CombinatorialLineHypergraphRequest",
     "CombinatorialLineHypergraphResult",
+    "Word",
 ]

--- a/src/jacobian/math/combinatorics/word_cubes/_models.py
+++ b/src/jacobian/math/combinatorics/word_cubes/_models.py
@@ -1,0 +1,51 @@
+"""Typed contracts for word-cube combinatorial-line hypergraph operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+
+MAX_ALPHABET_SIZE = 10
+MAX_DIMENSION = 6
+MAX_VERTICES = 10_000
+
+
+class CombinatorialLineHypergraphRequest(StrictModel):
+    """Request to construct the combinatorial-line hypergraph of [q]^d."""
+
+    alphabet_size: int = Field(ge=2, le=MAX_ALPHABET_SIZE)
+    dimension: int = Field(ge=1, le=MAX_DIMENSION)
+
+    @model_validator(mode="after")
+    def validate_vertex_count(self) -> Self:
+        vertex_count = self.alphabet_size**self.dimension
+        if vertex_count > MAX_VERTICES:
+            raise PydanticCustomError(
+                "word_cube.vertex_count_exceeds_bound",
+                f"q^d = {vertex_count} exceeds the {MAX_VERTICES}-vertex limit",
+            )
+        return self
+
+
+class CombinatorialLineHypergraphResult(StrictModel):
+    """The combinatorial-line hypergraph of [q]^d."""
+
+    alphabet_size: int
+    dimension: int
+    hypergraph: FiniteHypergraph
+
+
+__all__ = [
+    "MAX_ALPHABET_SIZE",
+    "MAX_DIMENSION",
+    "MAX_VERTICES",
+    "CombinatorialLineHypergraphRequest",
+    "CombinatorialLineHypergraphResult",
+]

--- a/src/jacobian/math/combinatorics/word_cubes/_tools.py
+++ b/src/jacobian/math/combinatorics/word_cubes/_tools.py
@@ -1,0 +1,76 @@
+"""Word-cube combinatorial-line hypergraph operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.combinatorics.word_cubes._models import (
+    CombinatorialLineHypergraphRequest,
+    CombinatorialLineHypergraphResult,
+)
+from jacobian.math.combinatorics.word_cubes.operations import (
+    construct_combinatorial_line_hypergraph,
+)
+
+
+def compute_combinatorial_line_hypergraph(
+    request: CombinatorialLineHypergraphRequest,
+) -> CombinatorialLineHypergraphResult:
+    return construct_combinatorial_line_hypergraph(
+        request.alphabet_size, request.dimension
+    )
+
+
+def wc_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    wc_operation(
+        "words.combinatorial_line_hypergraph.compute",
+        "Construct the combinatorial-line hypergraph of a word cube",
+        (
+            "Construct the complete canonical q-uniform hypergraph of "
+            "combinatorial lines in the word cube [q]^d. Vertices are all "
+            "length-d words over the alphabet {0,...,q-1}, and edges "
+            "correspond to patterns with at least one wildcard coordinate."
+        ),
+        CombinatorialLineHypergraphRequest,
+        CombinatorialLineHypergraphResult,
+        compute_combinatorial_line_hypergraph,
+        "combinatorics",
+        "words",
+        "exact",
+        examples=(
+            example(
+                "binary_cube_dim2",
+                "The word cube [2]^2 has 4 vertices and 4 combinatorial lines.",
+                {"alphabet_size": 2, "dimension": 2},
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/combinatorics/word_cubes/_tools.py
+++ b/src/jacobian/math/combinatorics/word_cubes/_tools.py
@@ -66,7 +66,7 @@ TOOLS: MathTools = (
         examples=(
             example(
                 "binary_cube_dim2",
-                "The word cube [2]^2 has 4 vertices and 4 combinatorial lines.",
+                "The word cube [2]^2 has 4 vertices and 5 combinatorial lines.",
                 {"alphabet_size": 2, "dimension": 2},
             ),
         ),

--- a/src/jacobian/math/combinatorics/word_cubes/operations.py
+++ b/src/jacobian/math/combinatorics/word_cubes/operations.py
@@ -1,0 +1,68 @@
+"""Canonical combinatorial-line hypergraph constructor for word cubes [q]^d."""
+
+from __future__ import annotations
+
+from itertools import product
+
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.combinatorics.word_cubes._models import (
+    CombinatorialLineHypergraphResult,
+)
+
+__all__ = ["construct_combinatorial_line_hypergraph"]
+
+
+def construct_combinatorial_line_hypergraph(
+    alphabet_size: int,
+    dimension: int,
+) -> CombinatorialLineHypergraphResult:
+    """Construct the combinatorial-line hypergraph of [q]^d.
+
+    Vertices are all length-d words over the alphabet {0,...,q-1}.
+    Edges correspond to combinatorial lines: patterns with at least
+    one wildcard coordinate. Each edge has exactly q vertices.
+    """
+    q = alphabet_size
+    d = dimension
+
+    all_words = list(product(range(q), repeat=d))
+    word_labels = [_word_label(w) for w in all_words]
+    word_set = dict(zip(all_words, word_labels, strict=True))
+
+    edges: list[tuple[str, tuple[str, ...]]] = []
+    edge_index = 0
+
+    for mask in range(1, 1 << d):
+        wildcard_positions = [i for i in range(d) if mask & (1 << i)]
+        fixed_positions = [i for i in range(d) if not (mask & (1 << i))]
+
+        for fixed_values in product(range(q), repeat=len(fixed_positions)):
+            edge_vertices = []
+            for wildcard_val in range(q):
+                word = [0] * d
+                for i, pos in enumerate(fixed_positions):
+                    word[pos] = fixed_values[i]
+                for pos in wildcard_positions:
+                    word[pos] = wildcard_val
+                edge_vertices.append(word_set[tuple(word)])
+
+            edge_id = f"line_{edge_index}"
+            edges.append((edge_id, tuple(edge_vertices)))
+            edge_index += 1
+
+    hypergraph = FiniteHypergraph(
+        vertices=tuple(word_labels),
+        edges=tuple(edges),
+    )
+    return CombinatorialLineHypergraphResult(
+        alphabet_size=q,
+        dimension=d,
+        hypergraph=hypergraph,
+    )
+
+
+def _word_label(word: tuple[int, ...]) -> str:
+    """Canonical label for a word."""
+    return "".join(str(d) for d in word)

--- a/src/jacobian/math/combinatorics/word_cubes/operations.py
+++ b/src/jacobian/math/combinatorics/word_cubes/operations.py
@@ -1,13 +1,20 @@
-"""Canonical combinatorial-line hypergraph constructor for word cubes [q]^d."""
+"""Canonical combinatorial-line hypergraph constructor for word cubes."""
 
 from __future__ import annotations
 
-from itertools import product
+from itertools import combinations, product
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_TOTAL_INCIDENCES,
+    MAX_VERTICES,
     FiniteHypergraph,
 )
 from jacobian.math.combinatorics.word_cubes._models import (
+    MAX_ALPHABET_SIZE,
+    MAX_DIMENSION,
+    CombinatorialLine,
     CombinatorialLineHypergraphResult,
 )
 
@@ -18,51 +25,103 @@ def construct_combinatorial_line_hypergraph(
     alphabet_size: int,
     dimension: int,
 ) -> CombinatorialLineHypergraphResult:
-    """Construct the combinatorial-line hypergraph of [q]^d.
+    """Return every standard Hales--Jewett line in ``[alphabet_size]^dimension``."""
 
-    Vertices are all length-d words over the alphabet {0,...,q-1}.
-    Edges correspond to combinatorial lines: patterns with at least
-    one wildcard coordinate. Each edge has exactly q vertices.
-    """
+    _admit_word_cube(alphabet_size, dimension)
+    return _construct_admitted(alphabet_size, dimension)
+
+
+def _construct_admitted(
+    alphabet_size: int,
+    dimension: int,
+) -> CombinatorialLineHypergraphResult:
     q = alphabet_size
     d = dimension
+    words = tuple(product(range(q), repeat=d))
+    labels = tuple(_word_label(word) for word in words)
+    labels_by_word = dict(zip(words, labels, strict=True))
 
-    all_words = list(product(range(q), repeat=d))
-    word_labels = [_word_label(w) for w in all_words]
-    word_set = dict(zip(all_words, word_labels, strict=True))
+    lines: list[CombinatorialLine] = []
+    hyperedges: list[tuple[str, tuple[str, ...]]] = []
+    positions = range(d)
 
-    edges: list[tuple[str, tuple[str, ...]]] = []
-    edge_index = 0
+    for wildcard_count in range(1, d + 1):
+        for wildcard_positions in combinations(positions, wildcard_count):
+            wildcard_set = set(wildcard_positions)
+            fixed_positions = tuple(pos for pos in positions if pos not in wildcard_set)
+            for fixed_values in product(range(q), repeat=len(fixed_positions)):
+                fixed_coordinates = tuple(
+                    zip(fixed_positions, fixed_values, strict=True)
+                )
+                line_words = tuple(
+                    _instantiate(d, fixed_coordinates, wildcard_positions, value)
+                    for value in range(q)
+                )
+                edge_id = f"line_{len(lines)}"
+                lines.append(
+                    CombinatorialLine(
+                        edge_id=edge_id,
+                        wildcard_positions=wildcard_positions,
+                        fixed_coordinates=fixed_coordinates,
+                        vertices=line_words,
+                    )
+                )
+                hyperedges.append(
+                    (edge_id, tuple(labels_by_word[word] for word in line_words))
+                )
 
-    for mask in range(1, 1 << d):
-        wildcard_positions = [i for i in range(d) if mask & (1 << i)]
-        fixed_positions = [i for i in range(d) if not (mask & (1 << i))]
-
-        for fixed_values in product(range(q), repeat=len(fixed_positions)):
-            edge_vertices = []
-            for wildcard_val in range(q):
-                word = [0] * d
-                for i, pos in enumerate(fixed_positions):
-                    word[pos] = fixed_values[i]
-                for pos in wildcard_positions:
-                    word[pos] = wildcard_val
-                edge_vertices.append(word_set[tuple(word)])
-
-            edge_id = f"line_{edge_index}"
-            edges.append((edge_id, tuple(edge_vertices)))
-            edge_index += 1
-
-    hypergraph = FiniteHypergraph(
-        vertices=tuple(word_labels),
-        edges=tuple(edges),
-    )
     return CombinatorialLineHypergraphResult(
         alphabet_size=q,
         dimension=d,
-        hypergraph=hypergraph,
+        words=words,
+        lines=tuple(lines),
+        hypergraph=FiniteHypergraph(vertices=labels, edges=tuple(hyperedges)),
     )
 
 
+def _admit_word_cube(alphabet_size: int, dimension: int) -> None:
+    if not 2 <= alphabet_size <= MAX_ALPHABET_SIZE:
+        raise OperationDomainValidationError(
+            location=("alphabet_size",),
+            code="word_cube.alphabet_size",
+            message=f"alphabet_size must be between 2 and {MAX_ALPHABET_SIZE}",
+        )
+    if not 1 <= dimension <= MAX_DIMENSION:
+        raise OperationDomainValidationError(
+            location=("dimension",),
+            code="word_cube.dimension",
+            message=f"dimension must be between 1 and {MAX_DIMENSION}",
+        )
+    vertices = alphabet_size**dimension
+    edges = (alphabet_size + 1) ** dimension - vertices
+    incidences = alphabet_size * edges
+    bounds = (
+        (vertices, MAX_VERTICES, "vertex_count"),
+        (edges, MAX_EDGES, "edge_count"),
+        (incidences, MAX_TOTAL_INCIDENCES, "incidence_count"),
+    )
+    for actual, limit, quantity in bounds:
+        if actual > limit:
+            raise OperationDomainValidationError(
+                location=("alphabet_size", "dimension"),
+                code=f"word_cube.{quantity}_exceeds_bound",
+                message=f"the derived {quantity} {actual} exceeds the carrier limit {limit}",
+            )
+
+
+def _instantiate(
+    dimension: int,
+    fixed_coordinates: tuple[tuple[int, int], ...],
+    wildcard_positions: tuple[int, ...],
+    wildcard_value: int,
+) -> tuple[int, ...]:
+    word = [wildcard_value] * dimension
+    for position, value in fixed_coordinates:
+        word[position] = value
+    return tuple(word)
+
+
 def _word_label(word: tuple[int, ...]) -> str:
-    """Canonical label for a word."""
-    return "".join(str(d) for d in word)
+    """Return an injective, human-readable label for a coordinate word."""
+
+    return "[" + ",".join(map(str, word)) + "]"

--- a/tests/math/combinatorics/word_cubes/test_combinatorial_line_hypergraph.py
+++ b/tests/math/combinatorics/word_cubes/test_combinatorial_line_hypergraph.py
@@ -5,15 +5,19 @@ from itertools import product
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.word_cubes._models import (
     CombinatorialLineHypergraphRequest,
+    CombinatorialLineHypergraphResult,
 )
 from jacobian.math.combinatorics.word_cubes.operations import (
     construct_combinatorial_line_hypergraph,
 )
 
 
-def _edges(result):
+def _edges(
+    result: CombinatorialLineHypergraphResult,
+) -> list[tuple[str, tuple[str, ...]]]:
     return list(result.hypergraph.edges)
 
 
@@ -23,7 +27,7 @@ def test_q2_d1() -> None:
     assert len(result.hypergraph.vertices) == 2
     assert len(result.hypergraph.edges) == 1
     _, members = _edges(result)[0]
-    assert set(members) == {"0", "1"}
+    assert set(members) == {"[0]", "[1]"}
 
 
 def test_q3_d1() -> None:
@@ -32,7 +36,7 @@ def test_q3_d1() -> None:
     assert len(result.hypergraph.vertices) == 3
     assert len(result.hypergraph.edges) == 1
     _, members = _edges(result)[0]
-    assert set(members) == {"0", "1", "2"}
+    assert set(members) == {"[0]", "[1]", "[2]"}
 
 
 def test_q2_d2_count() -> None:
@@ -46,11 +50,13 @@ def test_q2_d2_fixture() -> None:
     """[2]^2 includes one-wildcard coordinate lines and the all-wildcard line."""
     result = construct_combinatorial_line_hypergraph(2, 2)
     edge_member_sets = {frozenset(members) for _, members in result.hypergraph.edges}
-    assert frozenset({"00", "10"}) in edge_member_sets
-    assert frozenset({"01", "11"}) in edge_member_sets
-    assert frozenset({"00", "01"}) in edge_member_sets
-    assert frozenset({"10", "11"}) in edge_member_sets
-    assert frozenset({"00", "11"}) in edge_member_sets
+    assert edge_member_sets == {
+        frozenset({"[0,0]", "[1,0]"}),
+        frozenset({"[0,1]", "[1,1]"}),
+        frozenset({"[0,0]", "[0,1]"}),
+        frozenset({"[1,0]", "[1,1]"}),
+        frozenset({"[0,0]", "[1,1]"}),
+    }
 
 
 def test_q3_d2_count() -> None:
@@ -61,12 +67,11 @@ def test_q3_d2_count() -> None:
 
 
 def test_q3_d2_fixture() -> None:
-    """For q=3,d=2: 6 one-wildcard coordinate lines plus 3 fully-wildcard diagonal lines."""
+    """Standard Hales--Jewett lines have one common wildcard value."""
     result = construct_combinatorial_line_hypergraph(3, 2)
-    edges = result.hypergraph.edges
-    assert len(edges) == 7
-    for _, members in edges:
-        assert len(members) == 3
+    assert len(result.lines) == 7
+    assert sum(line.wildcard_positions == (0, 1) for line in result.lines) == 1
+    assert result.lines[-1].vertices == ((0, 0), (1, 1), (2, 2))
 
 
 def test_count_identity() -> None:
@@ -83,7 +88,8 @@ def test_count_identity() -> None:
 def test_vertex_labels_are_words() -> None:
     """Vertex labels are canonical word representations."""
     result = construct_combinatorial_line_hypergraph(2, 2)
-    assert set(result.hypergraph.vertices) == {"00", "01", "10", "11"}
+    assert result.words == ((0, 0), (0, 1), (1, 0), (1, 1))
+    assert set(result.hypergraph.vertices) == {"[0,0]", "[0,1]", "[1,0]", "[1,1]"}
 
 
 def test_edge_size_equals_q() -> None:
@@ -106,8 +112,25 @@ def test_rejects_q_too_small() -> None:
 
 
 def test_rejects_vertex_count_exceeds_bound() -> None:
-    with pytest.raises(ValidationError):
-        CombinatorialLineHypergraphRequest(alphabet_size=10, dimension=5)
+    request = CombinatorialLineHypergraphRequest(alphabet_size=3, dimension=6)
+    with pytest.raises(OperationDomainValidationError) as error:
+        construct_combinatorial_line_hypergraph(
+            request.alphabet_size, request.dimension
+        )
+    assert error.value.errors()[0]["type"] == "word_cube.vertex_count_exceeds_bound"
+
+
+def test_native_entrypoint_uses_the_same_admission() -> None:
+    with pytest.raises(OperationDomainValidationError):
+        construct_combinatorial_line_hypergraph(2, 0)
+    with pytest.raises(OperationDomainValidationError):
+        construct_combinatorial_line_hypergraph(3, 6)
+
+
+def test_exact_carrier_boundary_is_admitted() -> None:
+    result = construct_combinatorial_line_hypergraph(2, 8)
+    assert len(result.words) == 256
+    assert len(result.lines) == 3**8 - 2**8
 
 
 def test_independent_wildcard_enumeration() -> None:
@@ -128,7 +151,25 @@ def test_independent_wildcard_enumeration() -> None:
                     word[pos] = fixed_values[i]
                 for pos in wildcard_positions:
                     word[pos] = wildcard_val
-                edge.append("".join(str(x) for x in word))
+                edge.append("[" + ",".join(str(x) for x in word) + "]")
             expected_edges.add(frozenset(edge))
 
     assert actual_edges == expected_edges
+
+
+def test_pattern_provenance_reconstructs_each_line_uniquely() -> None:
+    result = construct_combinatorial_line_hypergraph(3, 3)
+    patterns = set()
+    for line in result.lines:
+        pattern = (line.wildcard_positions, line.fixed_coordinates)
+        assert pattern not in patterns
+        patterns.add(pattern)
+        for value, word in enumerate(line.vertices):
+            assert all(word[position] == value for position in line.wildcard_positions)
+            assert all(
+                word[position] == fixed for position, fixed in line.fixed_coordinates
+            )
+        edge = dict(result.hypergraph.edges)[line.edge_id]
+        assert set(edge) == {
+            "[" + ",".join(map(str, word)) + "]" for word in line.vertices
+        }

--- a/tests/math/combinatorics/word_cubes/test_combinatorial_line_hypergraph.py
+++ b/tests/math/combinatorics/word_cubes/test_combinatorial_line_hypergraph.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from itertools import product
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.combinatorics.word_cubes._models import (
+    CombinatorialLineHypergraphRequest,
+)
+from jacobian.math.combinatorics.word_cubes.operations import (
+    construct_combinatorial_line_hypergraph,
+)
+
+
+def _edges(result):
+    return list(result.hypergraph.edges)
+
+
+def test_q2_d1() -> None:
+    """[2]^1 has 2 vertices and 1 combinatorial line."""
+    result = construct_combinatorial_line_hypergraph(2, 1)
+    assert len(result.hypergraph.vertices) == 2
+    assert len(result.hypergraph.edges) == 1
+    _, members = _edges(result)[0]
+    assert set(members) == {"0", "1"}
+
+
+def test_q3_d1() -> None:
+    """[3]^1 has 3 vertices and 1 combinatorial line."""
+    result = construct_combinatorial_line_hypergraph(3, 1)
+    assert len(result.hypergraph.vertices) == 3
+    assert len(result.hypergraph.edges) == 1
+    _, members = _edges(result)[0]
+    assert set(members) == {"0", "1", "2"}
+
+
+def test_q2_d2_count() -> None:
+    """[2]^2 has 4 vertices and 5 combinatorial lines ((3^2-2^2=5)."""
+    result = construct_combinatorial_line_hypergraph(2, 2)
+    assert len(result.hypergraph.vertices) == 4
+    assert len(result.hypergraph.edges) == 5
+
+
+def test_q2_d2_fixture() -> None:
+    """[2]^2 includes one-wildcard coordinate lines and the all-wildcard line."""
+    result = construct_combinatorial_line_hypergraph(2, 2)
+    edge_member_sets = {frozenset(members) for _, members in result.hypergraph.edges}
+    assert frozenset({"00", "10"}) in edge_member_sets
+    assert frozenset({"01", "11"}) in edge_member_sets
+    assert frozenset({"00", "01"}) in edge_member_sets
+    assert frozenset({"10", "11"}) in edge_member_sets
+    assert frozenset({"00", "11"}) in edge_member_sets
+
+
+def test_q3_d2_count() -> None:
+    """[3]^2 has 9 vertices and (3+1)^2 - 3^2 = 16-9 = 7 combinatorial lines."""
+    result = construct_combinatorial_line_hypergraph(3, 2)
+    assert len(result.hypergraph.vertices) == 9
+    assert len(result.hypergraph.edges) == 7
+
+
+def test_q3_d2_fixture() -> None:
+    """For q=3,d=2: 6 one-wildcard coordinate lines plus 3 fully-wildcard diagonal lines."""
+    result = construct_combinatorial_line_hypergraph(3, 2)
+    edges = result.hypergraph.edges
+    assert len(edges) == 7
+    for _, members in edges:
+        assert len(members) == 3
+
+
+def test_count_identity() -> None:
+    """Vertex count = q^d and edge count = (q+1)^d - q^d."""
+    for q, d in [(2, 1), (2, 2), (3, 1), (3, 2), (2, 3), (4, 1)]:
+        result = construct_combinatorial_line_hypergraph(q, d)
+        assert len(result.hypergraph.vertices) == q**d
+        expected_edges = (q + 1) ** d - q**d
+        assert len(result.hypergraph.edges) == expected_edges, (
+            f"q={q}, d={d}: got {len(result.hypergraph.edges)}, expected {expected_edges}"
+        )
+
+
+def test_vertex_labels_are_words() -> None:
+    """Vertex labels are canonical word representations."""
+    result = construct_combinatorial_line_hypergraph(2, 2)
+    assert set(result.hypergraph.vertices) == {"00", "01", "10", "11"}
+
+
+def test_edge_size_equals_q() -> None:
+    """Each edge has exactly q vertices."""
+    result = construct_combinatorial_line_hypergraph(3, 2)
+    for _, members in result.hypergraph.edges:
+        assert len(members) == 3
+
+
+def test_q4_example() -> None:
+    """q=4,d=1: 4 vertices, 1 edge."""
+    result = construct_combinatorial_line_hypergraph(4, 1)
+    assert len(result.hypergraph.vertices) == 4
+    assert len(result.hypergraph.edges) == 1
+
+
+def test_rejects_q_too_small() -> None:
+    with pytest.raises(ValidationError):
+        CombinatorialLineHypergraphRequest(alphabet_size=1, dimension=2)
+
+
+def test_rejects_vertex_count_exceeds_bound() -> None:
+    with pytest.raises(ValidationError):
+        CombinatorialLineHypergraphRequest(alphabet_size=10, dimension=5)
+
+
+def test_independent_wildcard_enumeration() -> None:
+    """Cross-check by independently enumerating all wildcard patterns."""
+    q, d = 3, 2
+    result = construct_combinatorial_line_hypergraph(q, d)
+    actual_edges = {frozenset(members) for _, members in result.hypergraph.edges}
+
+    expected_edges = set()
+    for mask in range(1, 1 << d):
+        wildcard_positions = [i for i in range(d) if mask & (1 << i)]
+        fixed_positions = [i for i in range(d) if not (mask & (1 << i))]
+        for fixed_values in product(range(q), repeat=len(fixed_positions)):
+            edge = []
+            for wildcard_val in range(q):
+                word = [0] * d
+                for i, pos in enumerate(fixed_positions):
+                    word[pos] = fixed_values[i]
+                for pos in wildcard_positions:
+                    word[pos] = wildcard_val
+                edge.append("".join(str(x) for x in word))
+            expected_edges.add(frozenset(edge))
+
+    assert actual_edges == expected_edges


### PR DESCRIPTION
## Summary

Implements `words.combinatorial_line_hypergraph.compute` for #2848.

The operation constructs every standard Hales--Jewett combinatorial line in `[q]^d`: one nonempty wildcard-coordinate set, fixed values on the remaining coordinates, and the `q` words obtained by assigning one common alphabet value to every wildcard coordinate.

## Design

The result retains both representations callers need:

- canonical coordinate words and explicit line provenance (`wildcard_positions`, `fixed_coordinates`, and line vertices);
- a `FiniteHypergraph` projection with injective coordinate labels and stable edge IDs.

Explicit provenance makes the construction source-bound and distinguishes the standard relation from geometric or affine line families. In particular, `[3]^2` has six one-coordinate lines and one all-wildcard diagonal, hence 7 lines. This follows the wildcard definition in the density Hales--Jewett literature and the issue postcondition `(q+1)^d - q^d`.

Request admission derives vertex, edge, and incidence counts before enumeration and applies the actual `FiniteHypergraph` carrier limits. The native and MCP paths share that admission. This admits useful boundary cases such as `[2]^8` (256 vertices and 6,305 lines) while rejecting an unrepresentable request before kernel work.

## Validation

- `make handoff-scoped LANE=math TESTS=tests/math/combinatorics/word_cubes/test_combinatorial_line_hypergraph.py PATHS="src/jacobian/math/combinatorics/word_cubes tests/math/combinatorics/word_cubes/test_combinatorial_line_hypergraph.py"` (16 passed)
- `make test-catalog TESTS=tests/catalog` (113 passed)
- defining-invariant coverage reconstructs every line from its unique wildcard pattern and checks the generic hypergraph projection
- accepted carrier-boundary and native rejection cases cover request admission

Closes #2848