### PR TITLE
Construct source-bound binary-union relation hypergraphs

### DIFF
--- a/src/jacobian/math/combinatorics/codes/nonlinear/_models.py
+++ b/src/jacobian/math/combinatorics/codes/nonlinear/_models.py
@@ -355,6 +355,11 @@ class ToSetSystemResult(StrictModel):
                 "nonlinear_code.coordinate_axis_length",
                 "coordinate_axis must have one coordinate per source position",
             )
+        if self.coordinate_axis != tuple(range(self.length)):
+            raise _validation_error(
+                "nonlinear_code.coordinate_axis_mismatch",
+                "coordinate_axis must equal the source's zero-based coordinate axis",
+            )
         if len(self.supports) != self.cardinality:
             raise _validation_error(
                 "nonlinear_code.support_count_mismatch",

--- a/src/jacobian/math/combinatorics/extremal_sets/__init__.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/__init__.py
@@ -1,0 +1,7 @@
+"""Extremal set theory operations."""
+
+from jacobian.math.combinatorics.extremal_sets.operations import (
+    construct_binary_union_relation,
+)
+
+__all__ = ["construct_binary_union_relation"]

--- a/src/jacobian/math/combinatorics/extremal_sets/__init__.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/__init__.py
@@ -3,5 +3,6 @@
 from jacobian.math.combinatorics.extremal_sets.operations import (
     construct_binary_union_relation,
 )
+from jacobian.math.combinatorics.extremal_sets.values import IndexedFiniteSetFamily
 
-__all__ = ["construct_binary_union_relation"]
+__all__ = ["IndexedFiniteSetFamily", "construct_binary_union_relation"]

--- a/src/jacobian/math/combinatorics/extremal_sets/_models.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/_models.py
@@ -1,90 +1,44 @@
-"""Typed contracts for binary-union relation hypergraph operations."""
+"""Typed contracts for binary-union relation hypergraphs."""
 
 from __future__ import annotations
 
-from typing import Self
-
-from pydantic import Field, model_validator
-from pydantic_core import PydanticCustomError
+from pydantic import Field
 
 from jacobian._models import StrictModel
+from jacobian.math.combinatorics.extremal_sets.values import (
+    MAX_FAMILY_SIZE,
+    IndexedFiniteSetFamily,
+)
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
     FiniteHypergraph,
 )
 
-MAX_FAMILY_SIZE = 200
-MAX_SET_SIZE = 100
-MAX_GROUND_SET_SIZE = 200
-
 
 class BinaryUnionRelationRequest(StrictModel):
-    """Request to compute the binary-union relation of a set family.
+    """Request to compute the binary-union relation of an indexed family."""
 
-    The family is a tuple of sets, each represented as a sorted tuple of
-    non-negative integers.
-    """
-
-    family: tuple[tuple[int, ...], ...] = Field(
-        min_length=1,
-        max_length=MAX_FAMILY_SIZE,
-    )
-
-    @model_validator(mode="after")
-    def validate_family(self) -> Self:
-        seen_sets: set[frozenset[int]] = set()
-        for i, s in enumerate(self.family):
-            if len(s) > MAX_SET_SIZE:
-                raise PydanticCustomError(
-                    "set_system.set_too_large",
-                    f"set {i} exceeds the {MAX_SET_SIZE}-element limit",
-                )
-            if len(set(s)) != len(s):
-                raise PydanticCustomError(
-                    "set_system.duplicate_elements",
-                    f"set {i} contains duplicate elements",
-                )
-            if list(s) != sorted(s):
-                raise PydanticCustomError(
-                    "set_system.elements_not_sorted",
-                    f"set {i} elements must be sorted",
-                )
-            seen_sets.add(frozenset(s))
-        if len(seen_sets) != len(self.family):
-            raise PydanticCustomError(
-                "set_system.duplicate_members",
-                "family members must be pairwise distinct",
-            )
-        flat: set[int] = set()
-        for s in self.family:
-            flat.update(s)
-        if len(flat) > MAX_GROUND_SET_SIZE:
-            raise PydanticCustomError(
-                "set_system.ground_set_too_large",
-                f"ground set exceeds the {MAX_GROUND_SET_SIZE}-element limit",
-            )
-        return self
+    source: IndexedFiniteSetFamily
 
 
 class UnionRelationRow(StrictModel):
-    """One row of the binary-union relation."""
+    """One oriented equation ``source[i] union source[j] = source[k]``."""
 
-    operand_i: int
-    operand_j: int
-    result_k: int
+    edge_id: str
+    operand_i: int = Field(ge=0, le=MAX_FAMILY_SIZE - 1)
+    operand_j: int = Field(ge=0, le=MAX_FAMILY_SIZE - 1)
+    result_k: int = Field(ge=0, le=MAX_FAMILY_SIZE - 1)
 
 
 class BinaryUnionRelationResult(StrictModel):
-    """The complete binary-union relation of a set family."""
+    """The complete source-bound binary-union relation."""
 
-    family: tuple[tuple[int, ...], ...]
-    rows: tuple[UnionRelationRow, ...]
+    source: IndexedFiniteSetFamily
+    rows: tuple[UnionRelationRow, ...] = Field(max_length=MAX_EDGES)
     hypergraph: FiniteHypergraph
 
 
 __all__ = [
-    "MAX_FAMILY_SIZE",
-    "MAX_GROUND_SET_SIZE",
-    "MAX_SET_SIZE",
     "BinaryUnionRelationRequest",
     "BinaryUnionRelationResult",
     "UnionRelationRow",

--- a/src/jacobian/math/combinatorics/extremal_sets/_models.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pydantic import Field
 
 from jacobian._models import StrictModel
+from jacobian.math.combinatorics.codes.nonlinear._models import ToSetSystemResult
 from jacobian.math.combinatorics.extremal_sets.values import (
     MAX_FAMILY_SIZE,
     IndexedFiniteSetFamily,
@@ -18,7 +19,7 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 class BinaryUnionRelationRequest(StrictModel):
     """Request to compute the binary-union relation of an indexed family."""
 
-    source: IndexedFiniteSetFamily
+    source: IndexedFiniteSetFamily | ToSetSystemResult
 
 
 class UnionRelationRow(StrictModel):

--- a/src/jacobian/math/combinatorics/extremal_sets/_models.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/_models.py
@@ -1,0 +1,91 @@
+"""Typed contracts for binary-union relation hypergraph operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+
+MAX_FAMILY_SIZE = 200
+MAX_SET_SIZE = 100
+MAX_GROUND_SET_SIZE = 200
+
+
+class BinaryUnionRelationRequest(StrictModel):
+    """Request to compute the binary-union relation of a set family.
+
+    The family is a tuple of sets, each represented as a sorted tuple of
+    non-negative integers.
+    """
+
+    family: tuple[tuple[int, ...], ...] = Field(
+        min_length=1,
+        max_length=MAX_FAMILY_SIZE,
+    )
+
+    @model_validator(mode="after")
+    def validate_family(self) -> Self:
+        seen_sets: set[frozenset[int]] = set()
+        for i, s in enumerate(self.family):
+            if len(s) > MAX_SET_SIZE:
+                raise PydanticCustomError(
+                    "set_system.set_too_large",
+                    f"set {i} exceeds the {MAX_SET_SIZE}-element limit",
+                )
+            if len(set(s)) != len(s):
+                raise PydanticCustomError(
+                    "set_system.duplicate_elements",
+                    f"set {i} contains duplicate elements",
+                )
+            if list(s) != sorted(s):
+                raise PydanticCustomError(
+                    "set_system.elements_not_sorted",
+                    f"set {i} elements must be sorted",
+                )
+            seen_sets.add(frozenset(s))
+        if len(seen_sets) != len(self.family):
+            raise PydanticCustomError(
+                "set_system.duplicate_members",
+                "family members must be pairwise distinct",
+            )
+        flat: set[int] = set()
+        for s in self.family:
+            flat.update(s)
+        if len(flat) > MAX_GROUND_SET_SIZE:
+            raise PydanticCustomError(
+                "set_system.ground_set_too_large",
+                f"ground set exceeds the {MAX_GROUND_SET_SIZE}-element limit",
+            )
+        return self
+
+
+class UnionRelationRow(StrictModel):
+    """One row of the binary-union relation."""
+
+    operand_i: int
+    operand_j: int
+    result_k: int
+
+
+class BinaryUnionRelationResult(StrictModel):
+    """The complete binary-union relation of a set family."""
+
+    family: tuple[tuple[int, ...], ...]
+    rows: tuple[UnionRelationRow, ...]
+    hypergraph: FiniteHypergraph
+
+
+__all__ = [
+    "MAX_FAMILY_SIZE",
+    "MAX_GROUND_SET_SIZE",
+    "MAX_SET_SIZE",
+    "BinaryUnionRelationRequest",
+    "BinaryUnionRelationResult",
+    "UnionRelationRow",
+]

--- a/src/jacobian/math/combinatorics/extremal_sets/_tools.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/_tools.py
@@ -17,7 +17,7 @@ from jacobian.math.combinatorics.extremal_sets.operations import (
 def compute_binary_union_relation(
     request: BinaryUnionRelationRequest,
 ) -> BinaryUnionRelationResult:
-    return construct_binary_union_relation(request.family)
+    return construct_binary_union_relation(request.source)
 
 
 def es_operation[
@@ -50,9 +50,10 @@ TOOLS: MathTools = (
         "set_system.binary_union_relation_hypergraph.compute",
         "Compute the binary-union relation hypergraph of a set family",
         (
-            "Given a finite indexed family of distinct finite sets, return the "
-            "complete 3-uniform relation hypergraph whose edges record triples "
-            "(i,j,k) where S_i union S_j = S_k, with i < j and k distinct from both."
+            "Given a declared finite ground-set axis and an indexed family of "
+            "distinct subsets, return every distinct-index equation S_i union "
+            "S_j = S_k. Rows retain the operand/result orientation, and each "
+            "row is bound by ID to its edge in the 3-uniform hypergraph projection."
         ),
         BinaryUnionRelationRequest,
         BinaryUnionRelationResult,
@@ -65,12 +66,10 @@ TOOLS: MathTools = (
                 "boolean_lattice_2",
                 "Family {empty, {a}, {b}, {a,b}} has one union relation.",
                 {
-                    "family": [
-                        [],
-                        [0],
-                        [1],
-                        [0, 1],
-                    ],
+                    "source": {
+                        "ground_set_size": 2,
+                        "members": [[], [0], [1], [0, 1]],
+                    },
                 },
             ),
         ),

--- a/src/jacobian/math/combinatorics/extremal_sets/_tools.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/_tools.py
@@ -1,0 +1,80 @@
+"""Binary-union relation hypergraph operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.combinatorics.extremal_sets._models import (
+    BinaryUnionRelationRequest,
+    BinaryUnionRelationResult,
+)
+from jacobian.math.combinatorics.extremal_sets.operations import (
+    construct_binary_union_relation,
+)
+
+
+def compute_binary_union_relation(
+    request: BinaryUnionRelationRequest,
+) -> BinaryUnionRelationResult:
+    return construct_binary_union_relation(request.family)
+
+
+def es_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    es_operation(
+        "set_system.binary_union_relation_hypergraph.compute",
+        "Compute the binary-union relation hypergraph of a set family",
+        (
+            "Given a finite indexed family of distinct finite sets, return the "
+            "complete 3-uniform relation hypergraph whose edges record triples "
+            "(i,j,k) where S_i union S_j = S_k, with i < j and k distinct from both."
+        ),
+        BinaryUnionRelationRequest,
+        BinaryUnionRelationResult,
+        compute_binary_union_relation,
+        "combinatorics",
+        "extremal-set-theory",
+        "exact",
+        examples=(
+            example(
+                "boolean_lattice_2",
+                "Family {empty, {a}, {b}, {a,b}} has one union relation.",
+                {
+                    "family": [
+                        [],
+                        [0],
+                        [1],
+                        [0, 1],
+                    ],
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -170,9 +170,14 @@ def _canonical_source(
 
 
 def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
-    membership_work = (len(source.members) + 1) * sum(
-        len(member) for member in source.members
+    member_sizes = tuple(len(member) for member in source.members)
+    membership_work = (len(source.members) + 1) * sum(member_sizes)
+    generated_union_work = sum(
+        member_sizes[i] + member_sizes[j]
+        for i in range(len(member_sizes))
+        for j in range(i + 1, len(member_sizes))
     )
+    membership_work += generated_union_work
     if membership_work > MAX_BINARY_UNION_MEMBERSHIP_WORK:
         raise OperationDomainValidationError(
             location=("source",),

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -2,55 +2,80 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.extremal_sets._models import (
     BinaryUnionRelationResult,
     UnionRelationRow,
 )
+from jacobian.math.combinatorics.extremal_sets.values import IndexedFiniteSetFamily
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_TOTAL_INCIDENCES,
     FiniteHypergraph,
 )
 
 __all__ = ["construct_binary_union_relation"]
 
 
+@dataclass(frozen=True)
+class _UnionRelationPlan:
+    rows: tuple[tuple[int, int, int], ...]
+
+
 def construct_binary_union_relation(
-    family: tuple[tuple[int, ...], ...],
+    source: IndexedFiniteSetFamily,
 ) -> BinaryUnionRelationResult:
-    """Compute the complete binary-union relation of a set family.
+    """Return every distinct-member equation ``S_i union S_j = S_k``."""
 
-    For every pair of distinct source indices (i, j) with i < j, compute
-    S_i union S_j and check whether the result equals any source member S_k
-    with k distinct from both i and j. If so, record the triple (i, j, k).
-    """
-    m = len(family)
-    sets = [frozenset(s) for s in family]
-    union_to_index: dict[frozenset[int], int] = {}
-    for i, s in enumerate(sets):
-        union_to_index.setdefault(s, i)
-
-    rows: list[UnionRelationRow] = []
-    for i in range(m):
-        for j in range(i + 1, m):
-            union = sets[i] | sets[j]
-            k = union_to_index.get(union)
-            if k is not None and k != i and k != j:
-                rows.append(UnionRelationRow(operand_i=i, operand_j=j, result_k=k))
-
-    vertices = tuple(str(i) for i in range(m))
-    hyper_edges: list[tuple[str, tuple[str, ...]]] = []
-    for idx, row in enumerate(rows):
-        edge_id = f"edge_{idx}"
-        members = tuple(
-            sorted([str(row.operand_i), str(row.operand_j), str(row.result_k)])
+    plan = _admit_union_relation(source)
+    rows = tuple(
+        UnionRelationRow(
+            edge_id=_edge_id(i, j, k),
+            operand_i=i,
+            operand_j=j,
+            result_k=k,
         )
-        hyper_edges.append((edge_id, members))
-
-    hypergraph = FiniteHypergraph(
-        vertices=vertices,
-        edges=tuple(hyper_edges),
+        for i, j, k in plan.rows
+    )
+    vertices = tuple(str(index) for index in range(len(source.members)))
+    edges = tuple(
+        (
+            row.edge_id,
+            tuple(sorted((str(row.operand_i), str(row.operand_j), str(row.result_k)))),
+        )
+        for row in rows
     )
     return BinaryUnionRelationResult(
-        family=family,
-        rows=tuple(rows),
-        hypergraph=hypergraph,
+        source=source,
+        rows=rows,
+        hypergraph=FiniteHypergraph(vertices=vertices, edges=edges),
     )
+
+
+def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
+    sets = tuple(frozenset(member) for member in source.members)
+    source_index = {member: index for index, member in enumerate(sets)}
+    rows: list[tuple[int, int, int]] = []
+    for i, left in enumerate(sets):
+        for j in range(i + 1, len(sets)):
+            result = source_index.get(left | sets[j])
+            if result is not None and result not in (i, j):
+                rows.append((i, j, result))
+
+    row_count = len(rows)
+    if row_count > MAX_EDGES or 3 * row_count > MAX_TOTAL_INCIDENCES:
+        raise OperationDomainValidationError(
+            location=("source",),
+            code="set_system.binary_union_relation.result_exceeds_carrier",
+            message=(
+                f"the exact relation has {row_count} rows, exceeding the "
+                f"{MAX_EDGES}-edge or {MAX_TOTAL_INCIDENCES}-incidence carrier limit"
+            ),
+        )
+    return _UnionRelationPlan(rows=tuple(rows))
+
+
+def _edge_id(operand_i: int, operand_j: int, result_k: int) -> str:
+    return f"union_{operand_i}_{operand_j}_to_{result_k}"

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics.codes.nonlinear._models import ToSetSystemResult
 from jacobian.math.combinatorics.extremal_sets._models import (
     BinaryUnionRelationResult,
     UnionRelationRow,
@@ -25,10 +26,11 @@ class _UnionRelationPlan:
 
 
 def construct_binary_union_relation(
-    source: IndexedFiniteSetFamily,
+    source: IndexedFiniteSetFamily | ToSetSystemResult,
 ) -> BinaryUnionRelationResult:
     """Return every distinct-member equation ``S_i union S_j = S_k``."""
 
+    source = _canonical_source(source)
     plan = _admit_union_relation(source)
     rows = tuple(
         UnionRelationRow(
@@ -52,6 +54,18 @@ def construct_binary_union_relation(
         rows=rows,
         hypergraph=FiniteHypergraph(vertices=vertices, edges=edges),
     )
+
+
+def _canonical_source(
+    source: IndexedFiniteSetFamily | ToSetSystemResult,
+) -> IndexedFiniteSetFamily:
+    """Convert the code-support producer's value to the shared family type."""
+    if isinstance(source, ToSetSystemResult):
+        return IndexedFiniteSetFamily(
+            ground_set_size=source.length,
+            members=source.supports,
+        )
+    return source
 
 
 def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -177,7 +177,10 @@ def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
         for i in range(len(member_sizes))
         for j in range(i + 1, len(member_sizes))
     )
-    membership_work += generated_union_work
+    # Source sizing and the final canonical serialization each inspect every
+    # retained coordinate; charge both traversals before any pair work begins.
+    source_delivery_work = 2 * sum(member_sizes)
+    membership_work += generated_union_work + source_delivery_work
     if membership_work > MAX_BINARY_UNION_MEMBERSHIP_WORK:
         raise OperationDomainValidationError(
             location=("source",),

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -89,9 +89,19 @@ def _canonical_source(
                     "within the declared axis"
                 ),
             )
+        expected_supports = tuple(
+            tuple(index for index, bit in enumerate(word) if bit == 1)
+            for word in source.source.codewords
+        )
+        if source.supports != expected_supports:
+            raise OperationDomainValidationError(
+                location=("source", "supports"),
+                code="set_system.binary_union_relation.support_source_mismatch",
+                message="code supports must equal the retained codeword supports",
+            )
         return IndexedFiniteSetFamily(
             ground_set_size=source.length,
-            members=source.supports,
+            members=expected_supports,
         )
     return source
 

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -107,7 +107,7 @@ def _canonical_source(
 
 
 def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
-    membership_work = max(1, len(source.members) - 1) * sum(
+    membership_work = (len(source.members) + 1) * sum(
         len(member) for member in source.members
     )
     if membership_work > MAX_BINARY_UNION_MEMBERSHIP_WORK:

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from jacobian.canonical import CanonicalLimits, canonicalize_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.codes.nonlinear._models import ToSetSystemResult
 from jacobian.math.combinatorics.extremal_sets._models import (
     BinaryUnionRelationResult,
     UnionRelationRow,
 )
-from jacobian.math.combinatorics.extremal_sets.values import IndexedFiniteSetFamily
+from jacobian.math.combinatorics.extremal_sets.values import (
+    MAX_FAMILY_SIZE,
+    IndexedFiniteSetFamily,
+)
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     MAX_EDGES,
     MAX_TOTAL_INCIDENCES,
@@ -18,6 +22,8 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 )
 
 __all__ = ["construct_binary_union_relation"]
+
+MAX_BINARY_UNION_MEMBERSHIP_WORK = 20_000_000
 
 
 @dataclass(frozen=True)
@@ -61,6 +67,15 @@ def _canonical_source(
 ) -> IndexedFiniteSetFamily:
     """Convert the code-support producer's value to the shared family type."""
     if isinstance(source, ToSetSystemResult):
+        if len(source.supports) > MAX_FAMILY_SIZE:
+            raise OperationDomainValidationError(
+                location=("source",),
+                code="set_system.binary_union_relation.family_exceeds_carrier",
+                message=(
+                    f"the source family exceeds the {MAX_FAMILY_SIZE}-vertex "
+                    "relation carrier"
+                ),
+            )
         return IndexedFiniteSetFamily(
             ground_set_size=source.length,
             members=source.supports,
@@ -69,6 +84,18 @@ def _canonical_source(
 
 
 def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
+    membership_work = max(0, len(source.members) - 1) * sum(
+        len(member) for member in source.members
+    )
+    if membership_work > MAX_BINARY_UNION_MEMBERSHIP_WORK:
+        raise OperationDomainValidationError(
+            location=("source",),
+            code="set_system.binary_union_relation.work_exceeded",
+            message=(
+                f"binary-union membership work of {membership_work} exceeds the "
+                f"{MAX_BINARY_UNION_MEMBERSHIP_WORK}-unit bound"
+            ),
+        )
     sets = tuple(frozenset(member) for member in source.members)
     source_index = {member: index for index, member in enumerate(sets)}
     rows: list[tuple[int, int, int]] = []
@@ -87,6 +114,40 @@ def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
                 f"the exact relation has {row_count} rows, exceeding the "
                 f"{MAX_EDGES}-edge or {MAX_TOTAL_INCIDENCES}-incidence carrier limit"
             ),
+        )
+    vertices = tuple(str(index) for index in range(len(source.members)))
+    raw_rows = [
+        {
+            "edge_id": _edge_id(i, j, k),
+            "operand_i": i,
+            "operand_j": j,
+            "result_k": k,
+        }
+        for i, j, k in rows
+    ]
+    raw_edges = [
+        [
+            row["edge_id"],
+            sorted(
+                (str(row["operand_i"]), str(row["operand_j"]), str(row["result_k"]))
+            ),
+        ]
+        for row in raw_rows
+    ]
+    result_bytes = len(
+        canonicalize_json(
+            {
+                "source": source.model_dump(mode="json"),
+                "rows": raw_rows,
+                "hypergraph": {"vertices": list(vertices), "edges": raw_edges},
+            }
+        )
+    )
+    if result_bytes > CanonicalLimits().max_output_bytes:
+        raise OperationDomainValidationError(
+            location=("source",),
+            code="set_system.binary_union_relation.output_exceeded",
+            message="the complete retained-source relation exceeds the output budget",
         )
     return _UnionRelationPlan(rows=tuple(rows))
 

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -1,0 +1,56 @@
+"""Binary-union relation hypergraph constructor."""
+
+from __future__ import annotations
+
+from jacobian.math.combinatorics.extremal_sets._models import (
+    BinaryUnionRelationResult,
+    UnionRelationRow,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+
+__all__ = ["construct_binary_union_relation"]
+
+
+def construct_binary_union_relation(
+    family: tuple[tuple[int, ...], ...],
+) -> BinaryUnionRelationResult:
+    """Compute the complete binary-union relation of a set family.
+
+    For every pair of distinct source indices (i, j) with i < j, compute
+    S_i union S_j and check whether the result equals any source member S_k
+    with k distinct from both i and j. If so, record the triple (i, j, k).
+    """
+    m = len(family)
+    sets = [frozenset(s) for s in family]
+    union_to_index: dict[frozenset[int], int] = {}
+    for i, s in enumerate(sets):
+        union_to_index.setdefault(s, i)
+
+    rows: list[UnionRelationRow] = []
+    for i in range(m):
+        for j in range(i + 1, m):
+            union = sets[i] | sets[j]
+            k = union_to_index.get(union)
+            if k is not None and k != i and k != j:
+                rows.append(UnionRelationRow(operand_i=i, operand_j=j, result_k=k))
+
+    vertices = tuple(str(i) for i in range(m))
+    hyper_edges: list[tuple[str, tuple[str, ...]]] = []
+    for idx, row in enumerate(rows):
+        edge_id = f"edge_{idx}"
+        members = tuple(
+            sorted([str(row.operand_i), str(row.operand_j), str(row.result_k)])
+        )
+        hyper_edges.append((edge_id, members))
+
+    hypergraph = FiniteHypergraph(
+        vertices=vertices,
+        edges=tuple(hyper_edges),
+    )
+    return BinaryUnionRelationResult(
+        family=family,
+        rows=tuple(rows),
+        hypergraph=hypergraph,
+    )

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from jacobian.canonical import CanonicalizationError, CanonicalLimits, canonicalize_json
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    strict_json_object_size,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.codes.nonlinear._models import ToSetSystemResult
 from jacobian.math.combinatorics.extremal_sets._models import (
@@ -24,11 +28,70 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 __all__ = ["construct_binary_union_relation"]
 
 MAX_BINARY_UNION_MEMBERSHIP_WORK = 20_000_000
+MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
 
 
 @dataclass(frozen=True)
 class _UnionRelationPlan:
     rows: tuple[tuple[int, int, int], ...]
+
+
+def _array_size(item_sizes: list[int]) -> int:
+    return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
+
+
+def _source_size(source: IndexedFiniteSetFamily) -> int:
+    member_sizes: list[int] = []
+    for member in source.members:
+        member_size = 2 + max(len(member) - 1, 0)
+        for coordinate in member:
+            member_size += len(str(coordinate))
+            if member_size > MAX_RESULT_BYTES:
+                return MAX_RESULT_BYTES + 1
+        member_sizes.append(member_size)
+    return strict_json_object_size(
+        (
+            ("ground_set_size", len(str(source.ground_set_size))),
+            ("members", _array_size(member_sizes)),
+        )
+    )
+
+
+def _result_size(
+    source_size: int,
+    rows: list[tuple[int, int, int]],
+    vertices: tuple[str, ...],
+) -> int:
+    row_sizes: list[int] = []
+    edge_sizes: list[int] = []
+    for i, j, k in rows:
+        edge_id_size = len(encode_strict_json(_edge_id(i, j, k)))
+        row_sizes.append(
+            strict_json_object_size(
+                (
+                    ("edge_id", edge_id_size),
+                    ("operand_i", len(str(i))),
+                    ("operand_j", len(str(j))),
+                    ("result_k", len(str(k))),
+                )
+            )
+        )
+        incident_sizes = [len(encode_strict_json(str(value))) for value in (i, j, k)]
+        edge_sizes.append(_array_size([edge_id_size, _array_size(incident_sizes)]))
+    vertex_sizes = [len(encode_strict_json(vertex)) for vertex in vertices]
+    hypergraph_size = strict_json_object_size(
+        (
+            ("vertices", _array_size(vertex_sizes)),
+            ("edges", _array_size(edge_sizes)),
+        )
+    )
+    return strict_json_object_size(
+        (
+            ("source", source_size),
+            ("rows", _array_size(row_sizes)),
+            ("hypergraph", hypergraph_size),
+        )
+    )
 
 
 def construct_binary_union_relation(
@@ -119,6 +182,13 @@ def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
                 f"{MAX_BINARY_UNION_MEMBERSHIP_WORK}-unit bound"
             ),
         )
+    source_size = _source_size(source)
+    if source_size > MAX_RESULT_BYTES:
+        raise OperationDomainValidationError(
+            location=("source",),
+            code="set_system.binary_union_relation.output_exceeded",
+            message="the complete retained-source relation exceeds the output budget",
+        )
     sets = tuple(frozenset(member) for member in source.members)
     source_index = {member: index for index, member in enumerate(sets)}
     rows: list[tuple[int, int, int]] = []
@@ -139,41 +209,7 @@ def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
             ),
         )
     vertices = tuple(str(index) for index in range(len(source.members)))
-    raw_rows = [
-        {
-            "edge_id": _edge_id(i, j, k),
-            "operand_i": i,
-            "operand_j": j,
-            "result_k": k,
-        }
-        for i, j, k in rows
-    ]
-    raw_edges = [
-        [
-            row["edge_id"],
-            sorted(
-                (str(row["operand_i"]), str(row["operand_j"]), str(row["result_k"]))
-            ),
-        ]
-        for row in raw_rows
-    ]
-    try:
-        result_bytes = len(
-            canonicalize_json(
-                {
-                    "source": source.model_dump(mode="json"),
-                    "rows": raw_rows,
-                    "hypergraph": {"vertices": list(vertices), "edges": raw_edges},
-                }
-            )
-        )
-    except CanonicalizationError as exc:
-        raise OperationDomainValidationError(
-            location=("source",),
-            code="set_system.binary_union_relation.output_exceeded",
-            message="the complete retained-source relation exceeds the output budget",
-        ) from exc
-    if result_bytes > CanonicalLimits().max_output_bytes:
+    if _result_size(source_size, rows, vertices) > MAX_RESULT_BYTES:
         raise OperationDomainValidationError(
             location=("source",),
             code="set_system.binary_union_relation.output_exceeded",

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from jacobian.canonical import CanonicalLimits, canonicalize_json
+from jacobian.canonical import CanonicalizationError, CanonicalLimits, canonicalize_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.codes.nonlinear._models import ToSetSystemResult
 from jacobian.math.combinatorics.extremal_sets._models import (
@@ -76,6 +76,19 @@ def _canonical_source(
                     "relation carrier"
                 ),
             )
+        if any(
+            support != tuple(sorted(set(support)))
+            or any(not 0 <= element < source.length for element in support)
+            for support in source.supports
+        ):
+            raise OperationDomainValidationError(
+                location=("source", "supports"),
+                code="set_system.binary_union_relation.noncanonical_supports",
+                message=(
+                    "code supports must be strictly increasing distinct coordinates "
+                    "within the declared axis"
+                ),
+            )
         return IndexedFiniteSetFamily(
             ground_set_size=source.length,
             members=source.supports,
@@ -84,7 +97,7 @@ def _canonical_source(
 
 
 def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
-    membership_work = max(0, len(source.members) - 1) * sum(
+    membership_work = max(1, len(source.members) - 1) * sum(
         len(member) for member in source.members
     )
     if membership_work > MAX_BINARY_UNION_MEMBERSHIP_WORK:
@@ -134,15 +147,22 @@ def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
         ]
         for row in raw_rows
     ]
-    result_bytes = len(
-        canonicalize_json(
-            {
-                "source": source.model_dump(mode="json"),
-                "rows": raw_rows,
-                "hypergraph": {"vertices": list(vertices), "edges": raw_edges},
-            }
+    try:
+        result_bytes = len(
+            canonicalize_json(
+                {
+                    "source": source.model_dump(mode="json"),
+                    "rows": raw_rows,
+                    "hypergraph": {"vertices": list(vertices), "edges": raw_edges},
+                }
+            )
         )
-    )
+    except CanonicalizationError as exc:
+        raise OperationDomainValidationError(
+            location=("source",),
+            code="set_system.binary_union_relation.output_exceeded",
+            message="the complete retained-source relation exceeds the output budget",
+        ) from exc
     if result_bytes > CanonicalLimits().max_output_bytes:
         raise OperationDomainValidationError(
             location=("source",),

--- a/src/jacobian/math/combinatorics/extremal_sets/values.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/values.py
@@ -1,0 +1,59 @@
+"""Canonical values for finite indexed set families."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_VERTICES,
+)
+
+MAX_GROUND_SET_SIZE = MAX_VERTICES
+MAX_FAMILY_SIZE = MAX_VERTICES
+
+
+def _value_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"set_system.{reason}", message)
+
+
+class IndexedFiniteSetFamily(StrictModel):
+    """A distinct indexed family of subsets of the declared axis ``[n]``.
+
+    Member order is source identity. Each member is a strictly increasing tuple
+    of indices in ``0,...,ground_set_size-1``. The family may be empty.
+    """
+
+    ground_set_size: int = Field(ge=0, le=MAX_GROUND_SET_SIZE)
+    members: tuple[tuple[int, ...], ...] = Field(max_length=MAX_FAMILY_SIZE)
+
+    @model_validator(mode="after")
+    def require_canonical_family(self) -> Self:
+        seen: set[tuple[int, ...]] = set()
+        for member in self.members:
+            if any(not 0 <= element < self.ground_set_size for element in member):
+                raise _value_error(
+                    "element_out_of_range",
+                    "member elements must lie in 0..ground_set_size-1",
+                )
+            if tuple(sorted(member)) != member:
+                raise _value_error(
+                    "elements_not_sorted",
+                    "each member must be a strictly increasing index tuple",
+                )
+            if len(set(member)) != len(member):
+                raise _value_error(
+                    "duplicate_elements", "a member must not repeat an element"
+                )
+            if member in seen:
+                raise _value_error(
+                    "duplicate_members", "family members must be pairwise distinct"
+                )
+            seen.add(member)
+        return self
+
+
+__all__ = ["MAX_FAMILY_SIZE", "MAX_GROUND_SET_SIZE", "IndexedFiniteSetFamily"]

--- a/src/jacobian/math/combinatorics/extremal_sets/values.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/values.py
@@ -12,7 +12,7 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     MAX_VERTICES,
 )
 
-MAX_GROUND_SET_SIZE = MAX_VERTICES
+MAX_GROUND_SET_SIZE = (1 << 53) - 1
 MAX_FAMILY_SIZE = MAX_VERTICES
 
 

--- a/src/jacobian/math/combinatorics/extremal_sets/values.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/values.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
@@ -27,8 +27,8 @@ class IndexedFiniteSetFamily(StrictModel):
     of indices in ``0,...,ground_set_size-1``. The family may be empty.
     """
 
-    ground_set_size: int = Field(ge=0, le=MAX_GROUND_SET_SIZE)
-    members: tuple[tuple[int, ...], ...] = Field(max_length=MAX_FAMILY_SIZE)
+    ground_set_size: StrictInt = Field(ge=0, le=MAX_GROUND_SET_SIZE)
+    members: tuple[tuple[StrictInt, ...], ...] = Field(max_length=MAX_FAMILY_SIZE)
 
     @model_validator(mode="after")
     def require_canonical_family(self) -> Self:

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -170,12 +170,35 @@ def test_oversized_code_support_family_is_a_domain_rejection() -> None:
         construct_binary_union_relation(to_set_system(code))
 
 
+def test_noncanonical_code_support_is_a_domain_rejection() -> None:
+    code = ExplicitBinaryCode(length=2, codewords=((1, 1),))
+    payload = to_set_system(code).model_dump(mode="json")
+    payload["supports"] = [[1, 0]]
+    malformed = type(to_set_system(code)).model_validate(payload)
+
+    with pytest.raises(OperationDomainValidationError, match="strictly increasing"):
+        construct_binary_union_relation(malformed)
+
+
 def test_total_membership_work_is_bounded_before_pair_scanning() -> None:
     common_size = MAX_BINARY_UNION_MEMBERSHIP_WORK // (255 * 256) + 1
     common = tuple(range(common_size))
     source = IndexedFiniteSetFamily(
         ground_set_size=common_size + 256,
         members=tuple((*common, common_size + index) for index in range(256)),
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="membership work"):
+        construct_binary_union_relation(source)
+
+
+def test_single_member_normalization_is_charged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source((tuple(range(32)),), ground_set_size=32)
+    monkeypatch.setattr(
+        "jacobian.math.combinatorics.extremal_sets.operations.MAX_BINARY_UNION_MEMBERSHIP_WORK",
+        31,
     )
 
     with pytest.raises(OperationDomainValidationError, match="membership work"):

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -6,6 +6,8 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics.codes.nonlinear._models import ExplicitBinaryCode
+from jacobian.math.combinatorics.codes.nonlinear.operations import to_set_system
 from jacobian.math.combinatorics.extremal_sets.operations import (
     construct_binary_union_relation,
 )
@@ -125,3 +127,25 @@ def test_large_sparse_family_remains_admitted() -> None:
     result = construct_binary_union_relation(source)
     assert result.rows == ()
     assert len(result.hypergraph.vertices) == 200
+
+
+def test_code_support_producer_composes_without_reconstruction() -> None:
+    code = ExplicitBinaryCode(
+        length=2,
+        codewords=((0, 0), (1, 0), (0, 1), (1, 1)),
+    )
+    result = construct_binary_union_relation(to_set_system(code))
+    assert result.source.ground_set_size == 2
+    assert result.rows[0].model_dump(exclude={"edge_id"}) == {
+        "operand_i": 1,
+        "operand_j": 2,
+        "result_k": 3,
+    }
+
+
+def test_ground_axis_is_independent_of_relation_vertex_count() -> None:
+    result = construct_binary_union_relation(
+        _source(((256,),), ground_set_size=257)
+    )
+    assert result.source.ground_set_size == 257
+    assert result.rows == ()

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.combinatorics.extremal_sets._models import (
+    BinaryUnionRelationRequest,
+)
+from jacobian.math.combinatorics.extremal_sets.operations import (
+    construct_binary_union_relation,
+)
+
+
+def test_fixture_boolean_lattice() -> None:
+    """Fixture: {empty, {a}, {b}, {a,b}} has one union: {a} U {b} = {a,b}."""
+    family = ((), (0,), (1,), (0, 1))
+    result = construct_binary_union_relation(family)
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.operand_i == 1
+    assert row.operand_j == 2
+    assert row.result_k == 3
+
+
+def test_empty_family_rejected() -> None:
+    with pytest.raises(ValidationError):
+        BinaryUnionRelationRequest(family=())
+
+
+def test_single_member() -> None:
+    """A singleton family has no union relations."""
+    result = construct_binary_union_relation(((),))
+    assert len(result.rows) == 0
+
+
+def test_two_members_no_relation() -> None:
+    """Two distinct sets with no third member: no union relation."""
+    result = construct_binary_union_relation(((0,), (1,)))
+    assert len(result.rows) == 0
+
+
+def test_positive_relation() -> None:
+    """{0} U {1} = {0,1}."""
+    family = ((0,), (1,), (0, 1))
+    result = construct_binary_union_relation(family)
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.operand_i == 0
+    assert row.operand_j == 1
+    assert row.result_k == 2
+
+
+def test_no_relation_chains() -> None:
+    """Family with no union triples."""
+    family = ((0,), (1,), (2,))
+    result = construct_binary_union_relation(family)
+    assert len(result.rows) == 0
+
+
+def test_rejects_duplicate_members() -> None:
+    with pytest.raises(ValidationError):
+        BinaryUnionRelationRequest(family=((0,), (0,)))
+
+
+def test_rejects_unsorted_elements() -> None:
+    with pytest.raises(ValidationError):
+        BinaryUnionRelationRequest(family=((1, 0),))
+
+
+def test_rejects_duplicate_elements() -> None:
+    with pytest.raises(ValidationError):
+        BinaryUnionRelationRequest(family=((0, 0),))
+
+
+def test_row_replay() -> None:
+    """Replay: S_i union S_j = S_k for every row."""
+    family = ((), (0,), (1,), (0, 1), (0, 1, 2))
+    result = construct_binary_union_relation(family)
+    sets = [frozenset(s) for s in family]
+    for row in result.rows:
+        assert sets[row.operand_i] | sets[row.operand_j] == sets[row.result_k]
+        assert row.operand_i < row.operand_j
+        assert row.result_k != row.operand_i
+        assert row.result_k != row.operand_j
+
+
+def test_exhaustive_comparison() -> None:
+    """Compare against independent nested pair loop."""
+    family = ((), (0,), (1,), (0, 1))
+    result = construct_binary_union_relation(family)
+    sets = [frozenset(s) for s in family]
+    expected = []
+    for i in range(len(family)):
+        for j in range(i + 1, len(family)):
+            union = sets[i] | sets[j]
+            for k in range(len(family)):
+                if k != i and k != j and sets[k] == union:
+                    expected.append((i, j, k))
+    assert len(result.rows) == len(expected)
+    for row, exp in zip(result.rows, expected, strict=True):
+        assert (row.operand_i, row.operand_j, row.result_k) == exp
+
+
+def test_hypergraph_edges() -> None:
+    """The hypergraph has one 3-edge per union row."""
+    family = ((), (0,), (1,), (0, 1))
+    result = construct_binary_union_relation(family)
+    assert len(result.hypergraph.edges) == 1
+    _, members = next(iter(result.hypergraph.edges))
+    assert set(members) == {"1", "2", "3"}
+
+
+def test_source_preserved() -> None:
+    """Result retains the original family."""
+    family = ((0,), (1,))
+    result = construct_binary_union_relation(family)
+    assert result.family == family

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -144,8 +144,6 @@ def test_code_support_producer_composes_without_reconstruction() -> None:
 
 
 def test_ground_axis_is_independent_of_relation_vertex_count() -> None:
-    result = construct_binary_union_relation(
-        _source(((256,),), ground_set_size=257)
-    )
+    result = construct_binary_union_relation(_source(((256,),), ground_set_size=257))
     assert result.source.ground_set_size == 257
     assert result.rows == ()

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -247,3 +247,15 @@ def test_ground_axis_is_independent_of_relation_vertex_count() -> None:
     result = construct_binary_union_relation(_source(((256,),), ground_set_size=257))
     assert result.source.ground_set_size == 257
     assert result.rows == ()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"ground_set_size": True, "members": [[0]]},
+        {"ground_set_size": 1, "members": [[False]]},
+    ],
+)
+def test_canonical_family_rejects_boolean_coordinates(payload: dict) -> None:
+    with pytest.raises(ValidationError):
+        IndexedFiniteSetFamily.model_validate(payload)

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
 from itertools import combinations
+from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
 
+from jacobian.canonical import canonicalize_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.codes.nonlinear._models import ExplicitBinaryCode
 from jacobian.math.combinatorics.codes.nonlinear.operations import to_set_system
+from jacobian.math.combinatorics.extremal_sets._models import (
+    BinaryUnionRelationRequest,
+)
 from jacobian.math.combinatorics.extremal_sets.operations import (
+    MAX_BINARY_UNION_MEMBERSHIP_WORK,
     construct_binary_union_relation,
 )
 from jacobian.math.combinatorics.extremal_sets.values import IndexedFiniteSetFamily
@@ -141,6 +147,53 @@ def test_code_support_producer_composes_without_reconstruction() -> None:
         "operand_j": 2,
         "result_k": 3,
     }
+
+    serialized_request = BinaryUnionRelationRequest.model_validate(
+        {"source": to_set_system(code).model_dump(mode="json")}
+    )
+    assert (
+        construct_binary_union_relation(serialized_request.source).rows == result.rows
+    )
+
+
+def test_oversized_code_support_family_is_a_domain_rejection() -> None:
+    length = 512
+    code = ExplicitBinaryCode(
+        length=length,
+        codewords=tuple(
+            tuple(1 if coordinate == word else 0 for coordinate in range(length))
+            for word in range(length)
+        ),
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="relation carrier"):
+        construct_binary_union_relation(to_set_system(code))
+
+
+def test_total_membership_work_is_bounded_before_pair_scanning() -> None:
+    common_size = MAX_BINARY_UNION_MEMBERSHIP_WORK // (255 * 256) + 1
+    common = tuple(range(common_size))
+    source = IndexedFiniteSetFamily(
+        ground_set_size=common_size + 256,
+        members=tuple((*common, common_size + index) for index in range(256)),
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="membership work"):
+        construct_binary_union_relation(source)
+
+
+def test_output_admission_includes_the_retained_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(((0,), (1,), (0, 1)), ground_set_size=2)
+    source_bytes = len(canonicalize_json(source.model_dump(mode="json")))
+    monkeypatch.setattr(
+        "jacobian.math.combinatorics.extremal_sets.operations.CanonicalLimits",
+        lambda: SimpleNamespace(max_output_bytes=source_bytes + 16),
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="retained-source"):
+        construct_binary_union_relation(source)
 
 
 def test_ground_axis_is_independent_of_relation_vertex_count() -> None:

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from itertools import combinations
-from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
@@ -218,15 +217,18 @@ def test_single_member_normalization_is_charged(
         construct_binary_union_relation(source)
 
 
-def test_output_admission_includes_the_retained_source(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    source = _source(((0,), (1,), (0, 1)), ground_set_size=2)
-    source_bytes = len(canonicalize_json(source.model_dump(mode="json")))
-    monkeypatch.setattr(
-        "jacobian.math.combinatorics.extremal_sets.operations.CanonicalLimits",
-        lambda: SimpleNamespace(max_output_bytes=source_bytes + 16),
+def test_real_serializer_overflow_is_a_domain_rejection() -> None:
+    member_size = 154_200
+    base = 10**15
+    left = tuple(base + 2 * index for index in range(member_size))
+    right = tuple(base + 2 * index + 1 for index in range(member_size))
+    union = tuple(range(base, base + 2 * member_size))
+    source = IndexedFiniteSetFamily(
+        ground_set_size=base + 2 * member_size + 1,
+        members=(left, right, union),
     )
+    source_bytes = len(canonicalize_json(source.model_dump(mode="json")))
+    assert source_bytes < 10 * 1024 * 1024
 
     with pytest.raises(OperationDomainValidationError, match="retained-source"):
         construct_binary_union_relation(source)

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -192,6 +192,15 @@ def test_code_supports_are_bound_to_the_retained_code() -> None:
         construct_binary_union_relation(forged)
 
 
+def test_serialized_code_support_axis_is_bound_to_source_coordinates() -> None:
+    code = ExplicitBinaryCode(length=2, codewords=((0, 0), (1, 0)))
+    payload = to_set_system(code).model_dump(mode="json")
+    payload["coordinate_axis"] = [1, 0]
+
+    with pytest.raises(ValidationError, match="zero-based coordinate axis"):
+        type(to_set_system(code)).model_validate(payload)
+
+
 def test_total_membership_work_is_bounded_before_pair_scanning() -> None:
     common_size = MAX_BINARY_UNION_MEMBERSHIP_WORK // (255 * 256) + 1
     common = tuple(range(common_size))

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -180,6 +180,19 @@ def test_noncanonical_code_support_is_a_domain_rejection() -> None:
         construct_binary_union_relation(malformed)
 
 
+def test_code_supports_are_bound_to_the_retained_code() -> None:
+    code = ExplicitBinaryCode(
+        length=2,
+        codewords=((0, 0), (0, 1), (1, 0), (1, 1)),
+    )
+    payload = to_set_system(code).model_dump(mode="json")
+    payload["supports"] = [[], [0], [0, 1], [1]]
+    forged = type(to_set_system(code)).model_validate(payload)
+
+    with pytest.raises(OperationDomainValidationError, match="retained codeword"):
+        construct_binary_union_relation(forged)
+
+
 def test_total_membership_work_is_bounded_before_pair_scanning() -> None:
     common_size = MAX_BINARY_UNION_MEMBERSHIP_WORK // (255 * 256) + 1
     common = tuple(range(common_size))

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -1,117 +1,127 @@
 from __future__ import annotations
 
+from itertools import combinations
+
 import pytest
 from pydantic import ValidationError
 
-from jacobian.math.combinatorics.extremal_sets._models import (
-    BinaryUnionRelationRequest,
-)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.extremal_sets.operations import (
     construct_binary_union_relation,
 )
+from jacobian.math.combinatorics.extremal_sets.values import IndexedFiniteSetFamily
 
 
-def test_fixture_boolean_lattice() -> None:
-    """Fixture: {empty, {a}, {b}, {a,b}} has one union: {a} U {b} = {a,b}."""
-    family = ((), (0,), (1,), (0, 1))
-    result = construct_binary_union_relation(family)
-    assert len(result.rows) == 1
-    row = result.rows[0]
-    assert row.operand_i == 1
-    assert row.operand_j == 2
-    assert row.result_k == 3
+def _source(
+    members: tuple[tuple[int, ...], ...], ground_set_size: int = 3
+) -> IndexedFiniteSetFamily:
+    return IndexedFiniteSetFamily(
+        ground_set_size=ground_set_size,
+        members=members,
+    )
 
 
-def test_empty_family_rejected() -> None:
+def test_boolean_lattice_fixture_preserves_orientation() -> None:
+    source = _source(((), (0,), (1,), (0, 1)), ground_set_size=2)
+    result = construct_binary_union_relation(source)
+    assert result.source == source
+    assert result.rows[0].model_dump() == {
+        "edge_id": "union_1_2_to_3",
+        "operand_i": 1,
+        "operand_j": 2,
+        "result_k": 3,
+    }
+    assert result.hypergraph.edges == (("union_1_2_to_3", ("1", "2", "3")),)
+
+
+def test_empty_family_is_an_exact_empty_relation() -> None:
+    source = _source((), ground_set_size=2)
+    result = construct_binary_union_relation(source)
+    assert result.source == source
+    assert result.rows == ()
+    assert result.hypergraph.vertices == ()
+    assert result.hypergraph.edges == ()
+
+
+def test_unused_ground_axis_is_retained() -> None:
+    source = _source(((0,), (1,)), ground_set_size=3)
+    result = construct_binary_union_relation(source)
+    assert result.source.ground_set_size == 3
+    assert result.rows == ()
+
+
+@pytest.mark.parametrize(
+    "members",
+    [
+        ((0,), (0,)),
+        ((1, 0),),
+        ((0, 0),),
+        ((3,),),
+    ],
+)
+def test_source_rejects_noncanonical_members(
+    members: tuple[tuple[int, ...], ...],
+) -> None:
     with pytest.raises(ValidationError):
-        BinaryUnionRelationRequest(family=())
+        _source(members)
 
 
-def test_single_member() -> None:
-    """A singleton family has no union relations."""
-    result = construct_binary_union_relation(((),))
-    assert len(result.rows) == 0
+def test_every_row_replays_and_the_relation_is_complete() -> None:
+    source = _source(((), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)))
+    result = construct_binary_union_relation(source)
+    sets = tuple(frozenset(member) for member in source.members)
+    expected = tuple(
+        (i, j, k)
+        for i, j in combinations(range(len(sets)), 2)
+        for k in range(len(sets))
+        if k not in (i, j) and sets[i] | sets[j] == sets[k]
+    )
+    actual = tuple((row.operand_i, row.operand_j, row.result_k) for row in result.rows)
+    assert actual == expected
+    assert len({row.edge_id for row in result.rows}) == len(result.rows)
+    assert {edge_id for edge_id, _ in result.hypergraph.edges} == {
+        row.edge_id for row in result.rows
+    }
 
 
-def test_two_members_no_relation() -> None:
-    """Two distinct sets with no third member: no union relation."""
-    result = construct_binary_union_relation(((0,), (1,)))
-    assert len(result.rows) == 0
+def test_input_permutation_covariance() -> None:
+    first = _source(((0,), (1,), (0, 1)), ground_set_size=2)
+    second = _source(((0, 1), (1,), (0,)), ground_set_size=2)
+    first_result = construct_binary_union_relation(first)
+    second_result = construct_binary_union_relation(second)
+    assert first_result.rows[0].model_dump(exclude={"edge_id"}) == {
+        "operand_i": 0,
+        "operand_j": 1,
+        "result_k": 2,
+    }
+    assert second_result.rows[0].model_dump(exclude={"edge_id"}) == {
+        "operand_i": 1,
+        "operand_j": 2,
+        "result_k": 0,
+    }
 
 
-def test_positive_relation() -> None:
-    """{0} U {1} = {0,1}."""
-    family = ((0,), (1,), (0, 1))
-    result = construct_binary_union_relation(family)
-    assert len(result.rows) == 1
-    row = result.rows[0]
-    assert row.operand_i == 0
-    assert row.operand_j == 1
-    assert row.result_k == 2
+def test_dense_relation_exceeding_hypergraph_carrier_rejects_before_result() -> None:
+    members = tuple(
+        combination
+        for size in range(9)
+        if size != 3
+        for combination in combinations(range(8), size)
+    )
+    source = IndexedFiniteSetFamily(ground_set_size=8, members=members)
+    assert len(source.members) == 200
+    with pytest.raises(OperationDomainValidationError) as error:
+        construct_binary_union_relation(source)
+    assert error.value.errors()[0]["type"] == (
+        "set_system.binary_union_relation.result_exceeds_carrier"
+    )
 
 
-def test_no_relation_chains() -> None:
-    """Family with no union triples."""
-    family = ((0,), (1,), (2,))
-    result = construct_binary_union_relation(family)
-    assert len(result.rows) == 0
-
-
-def test_rejects_duplicate_members() -> None:
-    with pytest.raises(ValidationError):
-        BinaryUnionRelationRequest(family=((0,), (0,)))
-
-
-def test_rejects_unsorted_elements() -> None:
-    with pytest.raises(ValidationError):
-        BinaryUnionRelationRequest(family=((1, 0),))
-
-
-def test_rejects_duplicate_elements() -> None:
-    with pytest.raises(ValidationError):
-        BinaryUnionRelationRequest(family=((0, 0),))
-
-
-def test_row_replay() -> None:
-    """Replay: S_i union S_j = S_k for every row."""
-    family = ((), (0,), (1,), (0, 1), (0, 1, 2))
-    result = construct_binary_union_relation(family)
-    sets = [frozenset(s) for s in family]
-    for row in result.rows:
-        assert sets[row.operand_i] | sets[row.operand_j] == sets[row.result_k]
-        assert row.operand_i < row.operand_j
-        assert row.result_k != row.operand_i
-        assert row.result_k != row.operand_j
-
-
-def test_exhaustive_comparison() -> None:
-    """Compare against independent nested pair loop."""
-    family = ((), (0,), (1,), (0, 1))
-    result = construct_binary_union_relation(family)
-    sets = [frozenset(s) for s in family]
-    expected = []
-    for i in range(len(family)):
-        for j in range(i + 1, len(family)):
-            union = sets[i] | sets[j]
-            for k in range(len(family)):
-                if k != i and k != j and sets[k] == union:
-                    expected.append((i, j, k))
-    assert len(result.rows) == len(expected)
-    for row, exp in zip(result.rows, expected, strict=True):
-        assert (row.operand_i, row.operand_j, row.result_k) == exp
-
-
-def test_hypergraph_edges() -> None:
-    """The hypergraph has one 3-edge per union row."""
-    family = ((), (0,), (1,), (0, 1))
-    result = construct_binary_union_relation(family)
-    assert len(result.hypergraph.edges) == 1
-    _, members = next(iter(result.hypergraph.edges))
-    assert set(members) == {"1", "2", "3"}
-
-
-def test_source_preserved() -> None:
-    """Result retains the original family."""
-    family = ((0,), (1,))
-    result = construct_binary_union_relation(family)
-    assert result.family == family
+def test_large_sparse_family_remains_admitted() -> None:
+    source = IndexedFiniteSetFamily(
+        ground_set_size=200,
+        members=tuple((index,) for index in range(200)),
+    )
+    result = construct_binary_union_relation(source)
+    assert result.rows == ()
+    assert len(result.hypergraph.vertices) == 200

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -213,6 +213,18 @@ def test_total_membership_work_is_bounded_before_pair_scanning() -> None:
         construct_binary_union_relation(source)
 
 
+def test_generated_union_hashing_is_charged_to_membership_work() -> None:
+    source = _source(
+        tuple(
+            tuple(index * 200 + offset for offset in range(200)) for index in range(256)
+        ),
+        ground_set_size=51_200,
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="membership work"):
+        construct_binary_union_relation(source)
+
+
 def test_single_member_normalization_is_charged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Implements `set_system.binary_union_relation_hypergraph.compute` for #2847.

Given a declared finite ground-set axis and an indexed family of pairwise distinct subsets, the operation returns every distinct-index equation `S_i union S_j = S_k` with `i < j`, together with an ordinary 3-uniform hypergraph projection.

## Design

`IndexedFiniteSetFamily` is the canonical source value. It retains the ground-set size, including unused ground elements, and preserves member order as source identity. Members are strictly increasing index tuples; duplicate members and out-of-axis elements reject. An empty family is valid and produces an exact empty relation.

Each result row carries sorted operand indices, the result index, and a stable edge ID such as `union_1_2_to_3`. The hypergraph uses that same ID, so projecting the oriented equation to an unordered 3-edge does not erase which member is the union result.

Admission enumerates the bounded pair relation once and reuses those rows for result construction. It checks the actual edge and incidence counts against the `FiniteHypergraph` carrier. Consequently, a dense 200-member fixture with 15,387 rows rejects before result construction, while a sparse 200-member family remains admitted.

The kernel uses Python immutable sets and a canonical-member hash index. This is a deterministic finite relation with no solver or specialist backend requirement.

## Validation

- `make handoff-scoped LANE=math TESTS=tests/math/combinatorics/extremal_sets/test_binary_union_relation.py PATHS="src/jacobian/math/combinatorics/extremal_sets tests/math/combinatorics/extremal_sets/test_binary_union_relation.py"` (11 passed)
- `make test-catalog TESTS=tests/catalog` (113 passed)
- exhaustive small-family reconstruction checks completeness and equation replay
- tests cover empty families, unused ground-axis elements, permutation covariance, malformed sources, dense rejection, sparse admission, and edge-role provenance

Closes #2847