### PR TITLE
Add graph.edge_coloring_arrowing.decide operation

### DIFF
--- a/src/jacobian/math/graphs/edge_coloring_arrowing/__init__.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/__init__.py
@@ -1,0 +1,7 @@
+"""Edge-colouring Ramsey arrowing decision."""
+
+from jacobian.math.graphs.edge_coloring_arrowing.operations import (
+    decide_edge_coloring_arrowing,
+)
+
+__all__ = ["decide_edge_coloring_arrowing"]

--- a/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
@@ -10,6 +10,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel
 from jacobian.math.graphs.coloring._models import EdgeColoringAssignment
 from jacobian.math.graphs.values import (
+    MAX_INDEXED_SIMPLE_GRAPH_EDGES,
     MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
@@ -17,8 +18,8 @@ from jacobian.math.graphs.values import (
 # The graph value already bounds the carrier at 256 vertices.  Arrowing
 # admission is otherwise controlled by the derived coloring/embedding work.
 MAX_HOST_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
-MAX_HOST_EDGES = 45
-MAX_TARGET_VERTICES = 8
+MAX_HOST_EDGES = MAX_INDEXED_SIMPLE_GRAPH_EDGES
+MAX_TARGET_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
 MAX_TARGET_COUNT = 8
 MAX_ARROWING_WORK = 20_000_000
 
@@ -76,6 +77,8 @@ def _validate_arrowing_envelope(
 
 
 def _permutation_upper_bound(n: int, k: int) -> int:
+    if k > n:
+        return 0
     result = 1
     for value in range(n - k + 1, n + 1):
         result *= value

--- a/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import Literal, Self
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.math.graphs.coloring._models import EdgeColoringAssignment
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 MAX_HOST_VERTICES = 10
@@ -80,12 +81,7 @@ class EdgeColoringArrowingRequest(StrictModel):
     """Decide whether a host graph arrows a tuple of target graphs."""
 
     host_graph: SimpleUndirectedGraph
-    targets: tuple[SimpleUndirectedGraph, ...]
-
-    @model_validator(mode="after")
-    def validate_request(self) -> Self:
-        _validate_arrowing_envelope(self.host_graph, self.targets)
-        return self
+    targets: tuple[SimpleUndirectedGraph, ...] = Field(max_length=MAX_TARGET_COUNT)
 
 
 class EdgeColoringArrowingResult(StrictModel):
@@ -94,9 +90,7 @@ class EdgeColoringArrowingResult(StrictModel):
     host_graph: SimpleUndirectedGraph
     targets: tuple[SimpleUndirectedGraph, ...]
     outcome: Literal["ARROWS", "DOES_NOT_ARROW"]
-    avoiding_coloring: tuple[tuple[int, int], ...] | None = (
-        None  # (edge_index, color) pairs
-    )
+    avoiding_coloring: EdgeColoringAssignment | None = None
 
     @model_validator(mode="after")
     def require_outcome_certificate_shape(self) -> Self:
@@ -111,14 +105,19 @@ class EdgeColoringArrowingResult(StrictModel):
                     "graph.arrowing.missing_avoiding_coloring",
                     "DOES_NOT_ARROW results must carry an avoiding colouring",
                 )
-            if len(self.avoiding_coloring) != len(self.host_graph.edges):
+            if self.avoiding_coloring.graph != self.host_graph:
+                raise PydanticCustomError(
+                    "graph.arrowing.mismatched_avoiding_coloring",
+                    "avoiding colouring must be bound to the host graph",
+                )
+            if len(self.avoiding_coloring.coloring) != len(self.host_graph.edges):
                 raise PydanticCustomError(
                     "graph.arrowing.incomplete_avoiding_coloring",
                     "avoiding colouring must cover every host edge",
                 )
             if any(
-                edge_index != index or not 0 <= color < len(self.targets)
-                for index, (edge_index, color) in enumerate(self.avoiding_coloring)
+                not 0 <= color < len(self.targets)
+                for color in self.avoiding_coloring.coloring
             ):
                 raise PydanticCustomError(
                     "graph.arrowing.invalid_avoiding_coloring",

--- a/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
@@ -9,9 +9,14 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.coloring._models import EdgeColoringAssignment
-from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.graphs.values import (
+    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    SimpleUndirectedGraph,
+)
 
-MAX_HOST_VERTICES = 10
+# The graph value already bounds the carrier at 256 vertices.  Arrowing
+# admission is otherwise controlled by the derived coloring/embedding work.
+MAX_HOST_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
 MAX_HOST_EDGES = 45
 MAX_TARGET_VERTICES = 8
 MAX_TARGET_COUNT = 8
@@ -114,6 +119,11 @@ class EdgeColoringArrowingResult(StrictModel):
                 raise PydanticCustomError(
                     "graph.arrowing.incomplete_avoiding_coloring",
                     "avoiding colouring must cover every host edge",
+                )
+            if self.avoiding_coloring.colors != len(self.targets):
+                raise PydanticCustomError(
+                    "graph.arrowing.mismatched_avoiding_palette",
+                    "avoiding colouring palette must match the target count",
                 )
             if any(
                 not 0 <= color < len(self.targets)

--- a/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import model_validator
 from pydantic_core import PydanticCustomError
@@ -13,6 +13,67 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 MAX_HOST_VERTICES = 10
 MAX_HOST_EDGES = 45
 MAX_TARGET_VERTICES = 8
+MAX_TARGET_COUNT = 8
+MAX_ARROWING_WORK = 20_000_000
+
+
+def _validate_arrowing_envelope(
+    host_graph: SimpleUndirectedGraph,
+    targets: tuple[SimpleUndirectedGraph, ...],
+) -> None:
+    """Validate source structure and the complete finite-search envelope."""
+    if not targets:
+        raise PydanticCustomError(
+            "graph.arrowing.no_targets", "at least one target graph is required"
+        )
+    if len(targets) > MAX_TARGET_COUNT:
+        raise PydanticCustomError(
+            "graph.arrowing.too_many_targets",
+            f"at most {MAX_TARGET_COUNT} target graphs are supported",
+        )
+    if len(host_graph.vertices) > MAX_HOST_VERTICES:
+        raise PydanticCustomError(
+            "graph.arrowing.host_too_large",
+            f"host graph has at most {MAX_HOST_VERTICES} vertices",
+        )
+    if len(host_graph.edges) > MAX_HOST_EDGES:
+        raise PydanticCustomError(
+            "graph.arrowing.host_too_many_edges",
+            f"host graph has at most {MAX_HOST_EDGES} edges",
+        )
+    for i, target in enumerate(targets):
+        if len(target.vertices) > MAX_TARGET_VERTICES:
+            raise PydanticCustomError(
+                "graph.arrowing.target_too_large",
+                f"target {i} has at most {MAX_TARGET_VERTICES} vertices",
+            )
+        if not target.vertices:
+            raise PydanticCustomError(
+                "graph.arrowing.target_empty",
+                f"target {i} must not be empty",
+            )
+
+    # Each colouring is checked against every target embedding.  The count is
+    # deliberately conservative; permutations(n, t) bounds the embedding
+    # checks for target t and includes sparse targets safely.
+    host_vertices = len(host_graph.vertices)
+    embedding_checks = sum(
+        _permutation_upper_bound(host_vertices, len(target.vertices))
+        for target in targets
+    )
+    work = len(targets) ** len(host_graph.edges) * embedding_checks
+    if work > MAX_ARROWING_WORK:
+        raise PydanticCustomError(
+            "graph.arrowing.work_too_large",
+            f"arrowing search requires at most {MAX_ARROWING_WORK} embedding checks",
+        )
+
+
+def _permutation_upper_bound(n: int, k: int) -> int:
+    result = 1
+    for value in range(n - k + 1, n + 1):
+        result *= value
+    return result
 
 
 class EdgeColoringArrowingRequest(StrictModel):
@@ -23,27 +84,7 @@ class EdgeColoringArrowingRequest(StrictModel):
 
     @model_validator(mode="after")
     def validate_request(self) -> Self:
-        if len(self.host_graph.vertices) > MAX_HOST_VERTICES:
-            raise PydanticCustomError(
-                "graph.arrowing.host_too_large",
-                f"host graph has at most {MAX_HOST_VERTICES} vertices",
-            )
-        if len(self.host_graph.edges) > MAX_HOST_EDGES:
-            raise PydanticCustomError(
-                "graph.arrowing.host_too_many_edges",
-                f"host graph has at most {MAX_HOST_EDGES} edges",
-            )
-        for i, target in enumerate(self.targets):
-            if len(target.vertices) > MAX_TARGET_VERTICES:
-                raise PydanticCustomError(
-                    "graph.arrowing.target_too_large",
-                    f"target {i} has at most {MAX_TARGET_VERTICES} vertices",
-                )
-            if not target.vertices:
-                raise PydanticCustomError(
-                    "graph.arrowing.target_empty",
-                    f"target {i} must not be empty",
-                )
+        _validate_arrowing_envelope(self.host_graph, self.targets)
         return self
 
 
@@ -52,16 +93,47 @@ class EdgeColoringArrowingResult(StrictModel):
 
     host_graph: SimpleUndirectedGraph
     targets: tuple[SimpleUndirectedGraph, ...]
-    outcome: str  # "ARROWS" or "DOES_NOT_ARROW"
+    outcome: Literal["ARROWS", "DOES_NOT_ARROW"]
     avoiding_coloring: tuple[tuple[int, int], ...] | None = (
         None  # (edge_index, color) pairs
     )
 
+    @model_validator(mode="after")
+    def require_outcome_certificate_shape(self) -> Self:
+        if self.outcome == "ARROWS" and self.avoiding_coloring is not None:
+            raise PydanticCustomError(
+                "graph.arrowing.arrows_has_avoiding_coloring",
+                "ARROWS results must not carry an avoiding colouring",
+            )
+        if self.outcome == "DOES_NOT_ARROW":
+            if self.avoiding_coloring is None:
+                raise PydanticCustomError(
+                    "graph.arrowing.missing_avoiding_coloring",
+                    "DOES_NOT_ARROW results must carry an avoiding colouring",
+                )
+            if len(self.avoiding_coloring) != len(self.host_graph.edges):
+                raise PydanticCustomError(
+                    "graph.arrowing.incomplete_avoiding_coloring",
+                    "avoiding colouring must cover every host edge",
+                )
+            if any(
+                edge_index != index or not 0 <= color < len(self.targets)
+                for index, (edge_index, color) in enumerate(self.avoiding_coloring)
+            ):
+                raise PydanticCustomError(
+                    "graph.arrowing.invalid_avoiding_coloring",
+                    "avoiding colouring must use ordered edge indices and valid colours",
+                )
+        return self
+
 
 __all__ = [
+    "MAX_ARROWING_WORK",
     "MAX_HOST_EDGES",
     "MAX_HOST_VERTICES",
+    "MAX_TARGET_COUNT",
     "MAX_TARGET_VERTICES",
     "EdgeColoringArrowingRequest",
     "EdgeColoringArrowingResult",
+    "_validate_arrowing_envelope",
 ]

--- a/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
@@ -1,0 +1,67 @@
+"""Typed contracts for edge-colouring Ramsey arrowing decision."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_HOST_VERTICES = 10
+MAX_HOST_EDGES = 45
+MAX_TARGET_VERTICES = 8
+
+
+class EdgeColoringArrowingRequest(StrictModel):
+    """Decide whether a host graph arrows a tuple of target graphs."""
+
+    host_graph: SimpleUndirectedGraph
+    targets: tuple[SimpleUndirectedGraph, ...]
+
+    @model_validator(mode="after")
+    def validate_request(self) -> Self:
+        if len(self.host_graph.vertices) > MAX_HOST_VERTICES:
+            raise PydanticCustomError(
+                "graph.arrowing.host_too_large",
+                f"host graph has at most {MAX_HOST_VERTICES} vertices",
+            )
+        if len(self.host_graph.edges) > MAX_HOST_EDGES:
+            raise PydanticCustomError(
+                "graph.arrowing.host_too_many_edges",
+                f"host graph has at most {MAX_HOST_EDGES} edges",
+            )
+        for i, target in enumerate(self.targets):
+            if len(target.vertices) > MAX_TARGET_VERTICES:
+                raise PydanticCustomError(
+                    "graph.arrowing.target_too_large",
+                    f"target {i} has at most {MAX_TARGET_VERTICES} vertices",
+                )
+            if not target.vertices:
+                raise PydanticCustomError(
+                    "graph.arrowing.target_empty",
+                    f"target {i} must not be empty",
+                )
+        return self
+
+
+class EdgeColoringArrowingResult(StrictModel):
+    """Result of an edge-colouring Ramsey arrowing decision."""
+
+    host_graph: SimpleUndirectedGraph
+    targets: tuple[SimpleUndirectedGraph, ...]
+    outcome: str  # "ARROWS" or "DOES_NOT_ARROW"
+    avoiding_coloring: tuple[tuple[int, int], ...] | None = (
+        None  # (edge_index, color) pairs
+    )
+
+
+__all__ = [
+    "MAX_HOST_EDGES",
+    "MAX_HOST_VERTICES",
+    "MAX_TARGET_VERTICES",
+    "EdgeColoringArrowingRequest",
+    "EdgeColoringArrowingResult",
+]

--- a/src/jacobian/math/graphs/edge_coloring_arrowing/_tools.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/_tools.py
@@ -1,0 +1,106 @@
+"""Edge-colouring Ramsey arrowing operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.edge_coloring_arrowing._models import (
+    EdgeColoringArrowingRequest,
+    EdgeColoringArrowingResult,
+)
+from jacobian.math.graphs.edge_coloring_arrowing.operations import (
+    decide_edge_coloring_arrowing,
+)
+
+
+def compute_edge_coloring_arrowing(
+    request: EdgeColoringArrowingRequest,
+) -> EdgeColoringArrowingResult:
+    return decide_edge_coloring_arrowing(request.host_graph, request.targets)
+
+
+def eca_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    eca_operation(
+        "graph.edge_coloring_arrowing.decide",
+        "Decide bounded edge-colouring Ramsey arrowing",
+        (
+            "Given a bounded host graph and an ordered tuple of target graphs "
+            "(one per edge colour), decide whether every edge-colouring of the "
+            "host contains a monochromatic copy of the corresponding target in "
+            "some colour. Returns ARROWS or DOES_NOT_ARROW with one avoiding "
+            "colouring."
+        ),
+        EdgeColoringArrowingRequest,
+        EdgeColoringArrowingResult,
+        compute_edge_coloring_arrowing,
+        "graph",
+        "ramsey",
+        "exact",
+        examples=(
+            example(
+                "k6_arrows_k3_k3",
+                "K6 arrows (K3,K3) under red/blue edge colourings.",
+                {
+                    "host_graph": {
+                        "vertices": ["0", "1", "2", "3", "4", "5"],
+                        "edges": [
+                            ["0", "1"],
+                            ["0", "2"],
+                            ["0", "3"],
+                            ["0", "4"],
+                            ["0", "5"],
+                            ["1", "2"],
+                            ["1", "3"],
+                            ["1", "4"],
+                            ["1", "5"],
+                            ["2", "3"],
+                            ["2", "4"],
+                            ["2", "5"],
+                            ["3", "4"],
+                            ["3", "5"],
+                            ["4", "5"],
+                        ],
+                    },
+                    "targets": [
+                        {
+                            "vertices": ["0", "1", "2"],
+                            "edges": [["0", "1"], ["1", "2"], ["0", "2"]],
+                        },
+                        {
+                            "vertices": ["0", "1", "2"],
+                            "edges": [["0", "1"], ["1", "2"], ["0", "2"]],
+                        },
+                    ],
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/edge_coloring_arrowing/operations.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/operations.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from itertools import permutations, product
 
+from pydantic_core import PydanticCustomError
+
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.edge_coloring_arrowing._models import (
     EdgeColoringArrowingResult,
+    _validate_arrowing_envelope,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -24,6 +28,13 @@ def decide_edge_coloring_arrowing(
     Returns ARROWS if every colouring contains a monochromatic target copy,
     or DOES_NOT_ARROW with one avoiding colouring otherwise.
     """
+    try:
+        _validate_arrowing_envelope(host_graph, targets)
+    except PydanticCustomError as error:
+        raise OperationDomainValidationError(
+            location=(), code=error.type, message=str(error)
+        ) from error
+
     edges = list(host_graph.edges)
     num_colors = len(targets)
     edge_count = len(edges)

--- a/src/jacobian/math/graphs/edge_coloring_arrowing/operations.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/operations.py
@@ -1,0 +1,86 @@
+"""Edge-colouring Ramsey arrowing decision for finite graphs."""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+
+from jacobian.math.graphs.edge_coloring_arrowing._models import (
+    EdgeColoringArrowingResult,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+__all__ = ["decide_edge_coloring_arrowing"]
+
+
+def decide_edge_coloring_arrowing(
+    host_graph: SimpleUndirectedGraph,
+    targets: tuple[SimpleUndirectedGraph, ...],
+) -> EdgeColoringArrowingResult:
+    """Decide whether host_graph arrows (T_1, ..., T_q) under edge colouring.
+
+    The host graph H arrows (T_1,...,T_q) if every q-edge-colouring of H
+    contains a monochromatic copy of T_i in colour i for some i.
+
+    Returns ARROWS if every colouring contains a monochromatic target copy,
+    or DOES_NOT_ARROW with one avoiding colouring otherwise.
+    """
+    edges = list(host_graph.edges)
+    num_colors = len(targets)
+    edge_count = len(edges)
+
+    for coloring in product(range(num_colors), repeat=edge_count):
+        if _is_avoiding_coloring(coloring, edges, targets, host_graph):
+            avoiding = tuple((i, coloring[i]) for i in range(edge_count))
+            return EdgeColoringArrowingResult(
+                host_graph=host_graph,
+                targets=targets,
+                outcome="DOES_NOT_ARROW",
+                avoiding_coloring=avoiding,
+            )
+
+    return EdgeColoringArrowingResult(
+        host_graph=host_graph,
+        targets=targets,
+        outcome="ARROWS",
+    )
+
+
+def _is_avoiding_coloring(
+    coloring: tuple[int, ...],
+    edges: list[tuple[str, str]],
+    targets: tuple[SimpleUndirectedGraph, ...],
+    host: SimpleUndirectedGraph,
+) -> bool:
+    """Check if a colouring avoids all monochromatic target copies."""
+    for color, target in enumerate(targets):
+        color_edges = [edges[i] for i in range(len(edges)) if coloring[i] == color]
+        if _contains_target(host.vertices, color_edges, target):
+            return False
+    return True
+
+
+def _contains_target(
+    host_vertices: tuple[str, ...],
+    colored_edges: list[tuple[str, str]],
+    target: SimpleUndirectedGraph,
+) -> bool:
+    """Check if the target graph appears as a subgraph using only colored_edges."""
+    colored_edge_set = set(colored_edges)
+    host_vertex_list = list(host_vertices)
+    target_vertices = list(target.vertices)
+
+    if len(target_vertices) > len(host_vertex_list):
+        return False
+
+    for vertex_assignment in permutations(host_vertex_list, len(target_vertices)):
+        vmap = dict(zip(target_vertices, vertex_assignment, strict=True))
+        found = True
+        for a, _b in target.edges:
+            ha, hb = vmap[a], vmap[_b]
+            edge = (min(ha, hb), max(ha, hb))
+            if edge not in colored_edge_set:
+                found = False
+                break
+        if found:
+            return True
+    return False

--- a/src/jacobian/math/graphs/edge_coloring_arrowing/operations.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/operations.py
@@ -7,6 +7,7 @@ from itertools import permutations, product
 from pydantic_core import PydanticCustomError
 
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.coloring._models import EdgeColoringAssignment
 from jacobian.math.graphs.edge_coloring_arrowing._models import (
     EdgeColoringArrowingResult,
     _validate_arrowing_envelope,
@@ -41,7 +42,11 @@ def decide_edge_coloring_arrowing(
 
     for coloring in product(range(num_colors), repeat=edge_count):
         if _is_avoiding_coloring(coloring, edges, targets, host_graph):
-            avoiding = tuple((i, coloring[i]) for i in range(edge_count))
+            avoiding = EdgeColoringAssignment(
+                graph=host_graph,
+                colors=num_colors,
+                coloring=coloring,
+            )
             return EdgeColoringArrowingResult(
                 host_graph=host_graph,
                 targets=targets,

--- a/tests/math/graphs/edge_coloring_arrowing/test_edge_coloring_arrowing.py
+++ b/tests/math/graphs/edge_coloring_arrowing/test_edge_coloring_arrowing.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from jacobian.math.graphs.edge_coloring_arrowing.operations import (
+    decide_edge_coloring_arrowing,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph(vertices, edges):
+    return SimpleUndirectedGraph(
+        vertices=tuple(vertices),
+        edges=tuple((a, b) for a, b in edges),
+    )
+
+
+def _k3():
+    return _graph(["a", "b", "c"], [("a", "b"), ("a", "c"), ("b", "c")])
+
+
+def _k6():
+    vs = [str(i) for i in range(6)]
+    edges = []
+    for i in range(6):
+        for j in range(i + 1, 6):
+            edges.append((str(i), str(j)))
+    return _graph(vs, edges)
+
+
+def _k5():
+    vs = [str(i) for i in range(5)]
+    edges = []
+    for i in range(5):
+        for j in range(i + 1, 5):
+            edges.append((str(i), str(j)))
+    return _graph(vs, edges)
+
+
+def test_k6_arrows_k3_k3() -> None:
+    """K6 arrows (K3,K3) under red/blue edge colourings."""
+    result = decide_edge_coloring_arrowing(_k6(), (_k3(), _k3()))
+    assert result.outcome == "ARROWS"
+
+
+def test_k5_does_not_arrow_k3_k3() -> None:
+    """K5 does not arrow (K3,K3): the 5-cycle colouring avoids triangles."""
+    result = decide_edge_coloring_arrowing(_k5(), (_k3(), _k3()))
+    assert result.outcome == "DOES_NOT_ARROW"
+    assert result.avoiding_coloring is not None
+
+
+def test_k2_arrows_k1_k1() -> None:
+    """K2 arrows (K1,K1): any single-edge graph must be one colour."""
+    k1_a = _graph(["x"], [])
+    k1_b = _graph(["y"], [])
+    k2 = _graph(["0", "1"], [("0", "1")])
+    result = decide_edge_coloring_arrowing(k2, (k1_a, k1_b))
+    assert result.outcome == "ARROWS"
+
+
+def test_empty_host_does_not_arrow() -> None:
+    """Empty host cannot force any target."""
+    empty = _graph([], [])
+    result = decide_edge_coloring_arrowing(empty, (_k3(), _k3()))
+    assert result.outcome == "DOES_NOT_ARROW"
+
+
+def test_avoiding_coloring_replay() -> None:
+    """Replay the avoiding colouring to verify it avoids all targets."""
+    result = decide_edge_coloring_arrowing(_k5(), (_k3(), _k3()))
+    assert result.outcome == "DOES_NOT_ARROW"
+    coloring = dict(result.avoiding_coloring)
+    edges = list(result.host_graph.edges)
+    for color, target in enumerate(result.targets):
+        color_edges = [edges[i] for i in range(len(edges)) if coloring[i] == color]
+        host_v = result.host_graph.vertices
+        from itertools import permutations
+
+        for va in permutations(host_v, len(target.vertices)):
+            vmap = dict(zip(target.vertices, va, strict=True))
+            found = True
+            for a, b in target.edges:
+                ha, hb = vmap[a], vmap[b]
+                edge = (min(ha, hb), max(ha, hb))
+                if edge not in set(color_edges):
+                    found = False
+                    break
+            assert not found
+
+
+def test_result_preserves_inputs() -> None:
+    """Result retains the original host and targets."""
+    k6 = _k6()
+    k3 = _k3()
+    result = decide_edge_coloring_arrowing(k6, (k3, k3))
+    assert result.host_graph == k6
+    assert result.targets == (k3, k3)

--- a/tests/math/graphs/edge_coloring_arrowing/test_edge_coloring_arrowing.py
+++ b/tests/math/graphs/edge_coloring_arrowing/test_edge_coloring_arrowing.py
@@ -68,6 +68,15 @@ def test_empty_host_does_not_arrow() -> None:
     assert result.outcome == "DOES_NOT_ARROW"
 
 
+def test_sparse_large_host_uses_derived_work_bound() -> None:
+    host = _graph([f"v{i}" for i in range(100)], [("v0", "v1")])
+    target = _k3()
+
+    result = decide_edge_coloring_arrowing(host, (target, target))
+
+    assert result.outcome == "DOES_NOT_ARROW"
+
+
 def test_avoiding_coloring_replay() -> None:
     """Replay the avoiding colouring to verify it avoids all targets."""
     result = decide_edge_coloring_arrowing(_k5(), (_k3(), _k3()))

--- a/tests/math/graphs/edge_coloring_arrowing/test_edge_coloring_arrowing.py
+++ b/tests/math/graphs/edge_coloring_arrowing/test_edge_coloring_arrowing.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.edge_coloring_arrowing._models import (
+    EdgeColoringArrowingRequest,
+)
 from jacobian.math.graphs.edge_coloring_arrowing.operations import (
     decide_edge_coloring_arrowing,
 )
@@ -94,3 +100,14 @@ def test_result_preserves_inputs() -> None:
     result = decide_edge_coloring_arrowing(k6, (k3, k3))
     assert result.host_graph == k6
     assert result.targets == (k3, k3)
+
+
+def test_rejects_empty_target_and_unbounded_search() -> None:
+    host = _k6()
+    empty = _graph([], [])
+    with pytest.raises(ValidationError):
+        EdgeColoringArrowingRequest(host_graph=host, targets=(empty,))
+    with pytest.raises(ValueError, match="embedding checks"):
+        decide_edge_coloring_arrowing(
+            _graph([str(i) for i in range(10)], _k6().edges), (_k3(),) * 6
+        )

--- a/tests/math/graphs/edge_coloring_arrowing/test_edge_coloring_arrowing.py
+++ b/tests/math/graphs/edge_coloring_arrowing/test_edge_coloring_arrowing.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
 
-from jacobian.math.graphs.edge_coloring_arrowing._models import (
-    EdgeColoringArrowingRequest,
-)
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.coloring._models import EdgeColoringAssignment
 from jacobian.math.graphs.edge_coloring_arrowing.operations import (
     decide_edge_coloring_arrowing,
 )
@@ -74,7 +72,8 @@ def test_avoiding_coloring_replay() -> None:
     """Replay the avoiding colouring to verify it avoids all targets."""
     result = decide_edge_coloring_arrowing(_k5(), (_k3(), _k3()))
     assert result.outcome == "DOES_NOT_ARROW"
-    coloring = dict(result.avoiding_coloring)
+    assert isinstance(result.avoiding_coloring, EdgeColoringAssignment)
+    coloring = dict(enumerate(result.avoiding_coloring.coloring))
     edges = list(result.host_graph.edges)
     for color, target in enumerate(result.targets):
         color_edges = [edges[i] for i in range(len(edges)) if coloring[i] == color]
@@ -105,9 +104,9 @@ def test_result_preserves_inputs() -> None:
 def test_rejects_empty_target_and_unbounded_search() -> None:
     host = _k6()
     empty = _graph([], [])
-    with pytest.raises(ValidationError):
-        EdgeColoringArrowingRequest(host_graph=host, targets=(empty,))
-    with pytest.raises(ValueError, match="embedding checks"):
+    with pytest.raises(OperationDomainValidationError, match="target 0"):
+        decide_edge_coloring_arrowing(host, (empty,))
+    with pytest.raises(OperationDomainValidationError, match="embedding checks"):
         decide_edge_coloring_arrowing(
             _graph([str(i) for i in range(10)], _k6().edges), (_k3(),) * 6
         )


### PR DESCRIPTION
## Summary

Implements `graph.edge_coloring_arrowing.decide` from issue #2835.

Given a bounded host graph and an ordered tuple of target graphs (one per edge colour), decides whether every edge-colouring of the host contains a monochromatic copy of the corresponding target in some colour. Returns ARROWS or DOES_NOT_ARROW with one avoiding colouring.

## Design

- **Operation ID**: `graph.edge_coloring_arrowing.decide`
- **Input**: `SimpleUndirectedGraph` (host) + tuple of `SimpleUndirectedGraph` (targets, one per colour)
- **Output**: `EdgeColoringArrowingResult` with outcome ARROWS/DOES_NOT_ARROW and optional avoiding colouring
- **Kernel**: Exhaustive q^m edge-colouring enumeration with subgraph embedding check per colour
- **Bounds**: host <= 10 vertices, <= 45 edges; targets <= 8 vertices each

## Mathematical context

This is the finite Ramsey arrowing decision: H -> (T_1,...,T_q) iff every q-edge-colouring of H contains a monochromatic copy of T_i in colour i for some i. It is not a Ramsey number calculator, host graph optimizer, or Folkman theorem solver.

## Tests

- K6 arrows (K3,K3): the classical Ramsey result R(3,3) = 6
- K5 does not arrow (K3,K3): the 5-cycle avoiding colouring
- K2 arrows (K1,K1): any single edge must be one colour
- Empty host does not arrow
- Avoiding colouring replay: verify the colouring avoids all target embeddings
- Source preservation

Closes #2835

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)