### PR TITLE
Add discrepancy.homogeneous_progression_set_system.construct operation

### DIFF
--- a/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/__init__.py
+++ b/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/__init__.py
@@ -1,0 +1,7 @@
+"""Homogeneous progression set system constructor."""
+
+from jacobian.math.combinatorics.discrepancy.homogeneous_progression.operations import (
+    construct_homogeneous_progression_set_system,
+)
+
+__all__ = ["construct_homogeneous_progression_set_system"]

--- a/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/_models.py
+++ b/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/_models.py
@@ -1,0 +1,42 @@
+"""Typed contracts for homogeneous progression set system construction."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+
+MAX_N = 1000
+
+
+class HomogeneousProgressionRequest(StrictModel):
+    """Request to construct the homogeneous progression set system on [n]."""
+
+    n: int = Field(ge=0, le=MAX_N)
+
+    @model_validator(mode="after")
+    def validate_n(self) -> Self:
+        if self.n > MAX_N:
+            raise PydanticCustomError(
+                "discrepancy.n_too_large",
+                f"n must not exceed {MAX_N}",
+            )
+        return self
+
+
+class HomogeneousProgressionResult(StrictModel):
+    """The homogeneous progression set system on [n]."""
+
+    n: int
+    ground_set_size: int
+    sets: tuple[tuple[int, ...], ...]
+
+
+__all__ = [
+    "MAX_N",
+    "HomogeneousProgressionRequest",
+    "HomogeneousProgressionResult",
+]

--- a/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/_models.py
+++ b/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/_models.py
@@ -8,14 +8,18 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.math.combinatorics.discrepancy._models import (
+    MAX_GROUND_SET,
+    FiniteSetSystem,
+)
 
-MAX_N = 1000
+MAX_N = MAX_GROUND_SET
 
 
 class HomogeneousProgressionRequest(StrictModel):
     """Request to construct the homogeneous progression set system on [n]."""
 
-    n: int = Field(ge=0, le=MAX_N)
+    n: int = Field(ge=0, le=MAX_N, strict=True)
 
     @model_validator(mode="after")
     def validate_n(self) -> Self:
@@ -27,12 +31,7 @@ class HomogeneousProgressionRequest(StrictModel):
         return self
 
 
-class HomogeneousProgressionResult(StrictModel):
-    """The homogeneous progression set system on [n]."""
-
-    n: int
-    ground_set_size: int
-    sets: tuple[tuple[int, ...], ...]
+HomogeneousProgressionResult = FiniteSetSystem
 
 
 __all__ = [

--- a/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/_tools.py
+++ b/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/_tools.py
@@ -1,0 +1,75 @@
+"""Homogeneous progression set system operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.combinatorics.discrepancy.homogeneous_progression._models import (
+    HomogeneousProgressionRequest,
+    HomogeneousProgressionResult,
+)
+from jacobian.math.combinatorics.discrepancy.homogeneous_progression.operations import (
+    construct_homogeneous_progression_set_system,
+)
+
+
+def compute_homogeneous_progression(
+    request: HomogeneousProgressionRequest,
+) -> HomogeneousProgressionResult:
+    return construct_homogeneous_progression_set_system(request.n)
+
+
+def hp_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    hp_operation(
+        "discrepancy.homogeneous_progression_set_system.construct",
+        "Construct the homogeneous progression set system on [n]",
+        (
+            "Construct the canonical finite set system whose ground set is [n] "
+            "and whose sets are the homogeneous arithmetic progressions "
+            "{d, 2d, ..., kd} for every d, k >= 1 with dk <= n, with zero-based "
+            "indexing. This is the standard carrier for Erdős discrepancy "
+            "experiments."
+        ),
+        HomogeneousProgressionRequest,
+        HomogeneousProgressionResult,
+        compute_homogeneous_progression,
+        "combinatorics",
+        "discrepancy",
+        "exact",
+        examples=(
+            example(
+                "n4",
+                "The homogeneous progression set system on [4].",
+                {"n": 4},
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/_tools.py
+++ b/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/_tools.py
@@ -1,13 +1,10 @@
 """Homogeneous progression set system operation declarations."""
 
-from collections.abc import Callable
-
-from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
-from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.catalog.models import MathTool, MathTools
+from jacobian.math.combinatorics.discrepancy._models import FiniteSetSystem
 from jacobian.math.combinatorics.discrepancy.homogeneous_progression._models import (
     HomogeneousProgressionRequest,
-    HomogeneousProgressionResult,
 )
 from jacobian.math.combinatorics.discrepancy.homogeneous_progression.operations import (
     construct_homogeneous_progression_set_system,
@@ -16,37 +13,12 @@ from jacobian.math.combinatorics.discrepancy.homogeneous_progression.operations 
 
 def compute_homogeneous_progression(
     request: HomogeneousProgressionRequest,
-) -> HomogeneousProgressionResult:
+) -> FiniteSetSystem:
     return construct_homogeneous_progression_set_system(request.n)
 
 
-def hp_operation[
-    RequestT: StrictModel,
-    ResultT: StrictModel,
-](
-    operation_id: str,
-    title: str,
-    description: str,
-    request_model: type[RequestT],
-    result_model: type[ResultT],
-    operation: Callable[[RequestT], ResultT],
-    *tags: str,
-    examples: tuple[OperationExample, ...] = (),
-) -> MathTool[RequestT, ResultT]:
-    return MathTool(
-        operation_id=operation_id,
-        title=title,
-        description=description,
-        request_type=request_model,
-        result_type=result_model,
-        run=operation,
-        tags=tags,
-        examples=examples,
-    )
-
-
 TOOLS: MathTools = (
-    hp_operation(
+    MathTool(
         "discrepancy.homogeneous_progression_set_system.construct",
         "Construct the homogeneous progression set system on [n]",
         (
@@ -57,11 +29,9 @@ TOOLS: MathTools = (
             "experiments."
         ),
         HomogeneousProgressionRequest,
-        HomogeneousProgressionResult,
+        FiniteSetSystem,
         compute_homogeneous_progression,
-        "combinatorics",
-        "discrepancy",
-        "exact",
+        tags=("combinatorics", "discrepancy", "exact"),
         examples=(
             example(
                 "n4",

--- a/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/operations.py
+++ b/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/operations.py
@@ -1,0 +1,33 @@
+"""Homogeneous progression set system constructor."""
+
+from __future__ import annotations
+
+from jacobian.math.combinatorics.discrepancy.homogeneous_progression._models import (
+    HomogeneousProgressionResult,
+)
+
+__all__ = ["construct_homogeneous_progression_set_system"]
+
+
+def construct_homogeneous_progression_set_system(
+    n: int,
+) -> HomogeneousProgressionResult:
+    """Construct the homogeneous progression set system on [n].
+
+    The ground set is indexed by 0..n-1 (representing 1..n). The sets are
+    the zero-based images of homogeneous progressions {d, 2d, ..., kd}
+    for every d, k >= 1 with dk <= n, in canonical order.
+    """
+    sets: list[tuple[int, ...]] = []
+    for d in range(1, n + 1):
+        k = 1
+        while d * k <= n:
+            progression = tuple(d * i - 1 for i in range(1, k + 1))
+            sets.append(progression)
+            k += 1
+
+    return HomogeneousProgressionResult(
+        n=n,
+        ground_set_size=n,
+        sets=tuple(sets),
+    )

--- a/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/operations.py
+++ b/src/jacobian/math/combinatorics/discrepancy/homogeneous_progression/operations.py
@@ -2,22 +2,43 @@
 
 from __future__ import annotations
 
+from pydantic_core import PydanticCustomError
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics.discrepancy._models import FiniteSetSystem
 from jacobian.math.combinatorics.discrepancy.homogeneous_progression._models import (
-    HomogeneousProgressionResult,
+    MAX_N,
 )
 
 __all__ = ["construct_homogeneous_progression_set_system"]
 
 
+def _validate_n(n: int) -> None:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise PydanticCustomError("discrepancy.n_type", "n must be an integer")
+    if not 0 <= n <= MAX_N:
+        raise PydanticCustomError(
+            "discrepancy.n_too_large",
+            f"n must be between 0 and {MAX_N}",
+        )
+
+
 def construct_homogeneous_progression_set_system(
     n: int,
-) -> HomogeneousProgressionResult:
+) -> FiniteSetSystem:
     """Construct the homogeneous progression set system on [n].
 
     The ground set is indexed by 0..n-1 (representing 1..n). The sets are
     the zero-based images of homogeneous progressions {d, 2d, ..., kd}
     for every d, k >= 1 with dk <= n, in canonical order.
     """
+    try:
+        _validate_n(n)
+    except PydanticCustomError as error:
+        raise OperationDomainValidationError(
+            location=("n",), code=error.type, message=str(error)
+        ) from error
+
     sets: list[tuple[int, ...]] = []
     for d in range(1, n + 1):
         k = 1
@@ -26,8 +47,4 @@ def construct_homogeneous_progression_set_system(
             sets.append(progression)
             k += 1
 
-    return HomogeneousProgressionResult(
-        n=n,
-        ground_set_size=n,
-        sets=tuple(sets),
-    )
+    return FiniteSetSystem(ground_set_size=n, sets=tuple(sets))

--- a/tests/math/combinatorics/discrepancy/homogeneous_progression/test_homogeneous_progression.py
+++ b/tests/math/combinatorics/discrepancy/homogeneous_progression/test_homogeneous_progression.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from jacobian.math.combinatorics.discrepancy.homogeneous_progression.operations import (
+    construct_homogeneous_progression_set_system,
+)
+
+
+def test_n0() -> None:
+    """Empty ground set has no progressions."""
+    result = construct_homogeneous_progression_set_system(0)
+    assert result.ground_set_size == 0
+    assert len(result.sets) == 0
+
+
+def test_n1() -> None:
+    """n=1: one progression {0} (representing {1})."""
+    result = construct_homogeneous_progression_set_system(1)
+    assert result.ground_set_size == 1
+    assert (0,) in result.sets
+
+
+def test_n4_fixture() -> None:
+    """n=4: progressions include {0,1,2,3} for d=1 and {1,3} for d=2."""
+    result = construct_homogeneous_progression_set_system(4)
+    sets = [set(s) for s in result.sets]
+    assert {0, 1, 2, 3} in sets  # d=1, k=4: {1,2,3,4} -> {0,1,2,3}
+    assert {1, 3} in sets  # d=2, k=2: {2,4} -> {1,3}
+
+
+def test_zero_based_indexing() -> None:
+    """All indices are 0-based (representing 1..n)."""
+    result = construct_homogeneous_progression_set_system(6)
+    for s in result.sets:
+        for idx in s:
+            assert 0 <= idx < 6
+
+
+def test_replay_progressions() -> None:
+    """Replay: each row is d * initial_interval with zero-based translation."""
+    n = 8
+    result = construct_homogeneous_progression_set_system(n)
+    for s in result.sets:
+        original = tuple(idx + 1 for idx in s)
+        d = original[0]
+        for i, val in enumerate(original):
+            assert val == d * (i + 1)
+
+
+def test_count_identity() -> None:
+    """Number of sets = sum_{d=1}^{n} floor(n/d)."""
+    for n in [0, 1, 2, 4, 6, 10]:
+        result = construct_homogeneous_progression_set_system(n)
+        expected = sum(n // d for d in range(1, n + 1))
+        assert len(result.sets) == expected, (
+            f"n={n}: got {len(result.sets)}, expected {expected}"
+        )
+
+
+def test_no_duplicates() -> None:
+    """Every progression appears exactly once."""
+    result = construct_homogeneous_progression_set_system(10)
+    seen = set()
+    for s in result.sets:
+        key = tuple(s)
+        assert key not in seen
+        seen.add(key)
+
+
+def test_exhaustive_dk_enumeration() -> None:
+    """Check every valid (d,k) pair is present."""
+    n = 6
+    result = construct_homogeneous_progression_set_system(n)
+    expected_sets = set()
+    for d in range(1, n + 1):
+        k = 1
+        while d * k <= n:
+            progression = tuple(d * i - 1 for i in range(1, k + 1))
+            expected_sets.add(progression)
+            k += 1
+    actual_sets = {tuple(s) for s in result.sets}
+    assert actual_sets == expected_sets
+
+
+def test_result_preserves_n() -> None:
+    """Result retains the source n."""
+    result = construct_homogeneous_progression_set_system(5)
+    assert result.n == 5
+    assert result.ground_set_size == 5

--- a/tests/math/combinatorics/discrepancy/homogeneous_progression/test_homogeneous_progression.py
+++ b/tests/math/combinatorics/discrepancy/homogeneous_progression/test_homogeneous_progression.py
@@ -84,5 +84,11 @@ def test_exhaustive_dk_enumeration() -> None:
 def test_result_preserves_n() -> None:
     """Result retains the source n."""
     result = construct_homogeneous_progression_set_system(5)
-    assert result.n == 5
     assert result.ground_set_size == 5
+
+
+def test_native_negative_n_is_rejected() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="between 0"):
+        construct_homogeneous_progression_set_system(-1)


### PR DESCRIPTION
## Summary

Implements `discrepancy.homogeneous_progression_set_system.construct` from issue #2830.

Constructs the canonical finite set system whose ground set is [n] and whose sets are the homogeneous arithmetic progressions {d, 2d, ..., kd} for every d, k >= 1 with dk <= n, with zero-based indexing.

## Design

- **Operation ID**: `discrepancy.homogeneous_progression_set_system.construct`
- **Input**: non-negative integer  (ground set size)
- **Output**: set system with ground set [n] and one set per homogeneous progression
- **Kernel**: direct nested enumeration of (d, k) pairs — O(n log n) sets, exact and deterministic
- **Bounds**: n <= 1000

## Mathematical context

This is the standard carrier for Erdős discrepancy experiments. The returned set system composes directly with the existing  and  operations. It is not a discrepancy optimizer, SAT encoder, or Tao entropy-decrement argument.

## Tests

- n=0: empty ground set, no progressions
- n=1: one progression {0}
- n=4: fixture verification (d=1,k=4 -> {0,1,2,3}; d=2,k=2 -> {1,3})
- Zero-based indexing verification
- Progression replay: each row is d * initial interval
- Count identity: number of sets = sum_{d=1}^n floor(n/d)
- No duplicate progressions
- Exhaustive (d,k) enumeration cross-check
- Source preservation

Closes #2830

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)