### PR TITLE
Add number_theory.integer_set.non_coprimality_graph.compute operation

### DIFF
--- a/src/jacobian/math/number_theory/non_coprimality_graph/__init__.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/__init__.py
@@ -1,0 +1,7 @@
+"""Non-coprimality graph constructor."""
+
+from jacobian.math.number_theory.non_coprimality_graph.operations import (
+    construct_non_coprimality_graph,
+)
+
+__all__ = ["construct_non_coprimality_graph"]

--- a/src/jacobian/math/number_theory/non_coprimality_graph/_models.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/_models.py
@@ -2,58 +2,14 @@
 
 from __future__ import annotations
 
-from math import gcd
-from typing import Self
-
-from pydantic import Field, model_validator
-from pydantic_core import PydanticCustomError
+from pydantic import Field
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.canonical import CanonicalLimits, encode_strict_json
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 MAX_INTEGERS = 256
 MAX_INTEGER_DIGITS = 256
-
-
-def _validate_integer_source(integers: tuple[str, ...]) -> None:
-    if not 1 <= len(integers) <= MAX_INTEGERS:
-        raise PydanticCustomError(
-            "non_coprimality.size",
-            f"integers must contain between 1 and {MAX_INTEGERS} values",
-        )
-    values: list[int] = []
-    for index, value in enumerate(integers):
-        if len(value.lstrip("-")) > MAX_INTEGER_DIGITS:
-            raise PydanticCustomError(
-                "non_coprimality.digits",
-                f"integer {index} exceeds the {MAX_INTEGER_DIGITS}-digit bound",
-            )
-        parsed = int(value)
-        if parsed <= 0:
-            raise PydanticCustomError(
-                "non_coprimality.must_be_positive",
-                "all integers must be positive",
-            )
-        values.append(parsed)
-    if len(set(values)) != len(values):
-        raise PydanticCustomError(
-            "non_coprimality.must_be_distinct",
-            "integers must be distinct",
-        )
-
-    labels = tuple(sorted(integers, key=int))
-    all_edges = [[left, right] for left in labels for right in labels if left < right]
-    payload = {
-        "integers": list(labels),
-        "graph": {"vertices": list(labels), "edges": all_edges},
-    }
-    if len(encode_strict_json(payload)) > CanonicalLimits().max_output_bytes:
-        raise PydanticCustomError(
-            "non_coprimality.result_too_large",
-            "the graph result exceeds the canonical output limit",
-        )
 
 
 class NonCoprimalityGraphRequest(StrictModel):
@@ -64,46 +20,15 @@ class NonCoprimalityGraphRequest(StrictModel):
         max_length=MAX_INTEGERS,
     )
 
-    @model_validator(mode="after")
-    def validate_integers(self) -> Self:
-        _validate_integer_source(self.integers)
-        return self
-
-
 class NonCoprimalityGraphResult(StrictModel):
     """The non-coprimality graph of a set of integers."""
 
     integers: tuple[CanonicalInteger, ...]
     graph: SimpleUndirectedGraph
 
-    @model_validator(mode="after")
-    def require_source_graph_contract(self) -> Self:
-        _validate_integer_source(self.integers)
-        expected_vertices = tuple(sorted(self.integers, key=int))
-        if self.graph.vertices != expected_vertices:
-            raise PydanticCustomError(
-                "non_coprimality.graph_source_mismatch",
-                "graph vertices must be the source integers in numeric order",
-            )
-        values = {label: int(label) for label in self.integers}
-        expected_edges = {
-            tuple(sorted((left, right)))
-            for left in self.integers
-            for right in self.integers
-            if left < right and gcd(values[left], values[right]) > 1
-        }
-        if set(self.graph.edges) != expected_edges:
-            raise PydanticCustomError(
-                "non_coprimality.graph_edges_mismatch",
-                "graph edges must be exactly the non-coprime source pairs",
-            )
-        return self
-
-
 __all__ = [
     "MAX_INTEGERS",
     "MAX_INTEGER_DIGITS",
     "NonCoprimalityGraphRequest",
     "NonCoprimalityGraphResult",
-    "_validate_integer_source",
 ]

--- a/src/jacobian/math/number_theory/non_coprimality_graph/_models.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/_models.py
@@ -1,0 +1,51 @@
+"""Typed contracts for the non-coprimality graph operation."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_INTEGERS = 256
+
+
+class NonCoprimalityGraphRequest(StrictModel):
+    """Request to construct the non-coprimality graph of a set of integers."""
+
+    integers: tuple[int, ...] = Field(
+        min_length=1,
+        max_length=MAX_INTEGERS,
+    )
+
+    @model_validator(mode="after")
+    def validate_integers(self) -> Self:
+        for v in self.integers:
+            if v <= 0:
+                raise PydanticCustomError(
+                    "non_coprimality.must_be_positive",
+                    "all integers must be positive",
+                )
+        if len(set(self.integers)) != len(self.integers):
+            raise PydanticCustomError(
+                "non_coprimality.must_be_distinct",
+                "integers must be distinct",
+            )
+        return self
+
+
+class NonCoprimalityGraphResult(StrictModel):
+    """The non-coprimality graph of a set of integers."""
+
+    integers: tuple[int, ...]
+    graph: SimpleUndirectedGraph
+
+
+__all__ = [
+    "MAX_INTEGERS",
+    "NonCoprimalityGraphRequest",
+    "NonCoprimalityGraphResult",
+]

--- a/src/jacobian/math/number_theory/non_coprimality_graph/_models.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/_models.py
@@ -2,20 +2,31 @@
 
 from __future__ import annotations
 
-from pydantic import Field
+from typing import Annotated
+
+from pydantic import Field, StringConstraints
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.graphs.values import MAX_GRAPH_LABEL_BYTES, SimpleUndirectedGraph
 
 MAX_INTEGERS = 256
-MAX_INTEGER_DIGITS = 256
+MAX_INTEGER_DIGITS = MAX_GRAPH_LABEL_BYTES
+
+NonCoprimeInteger = Annotated[
+    str,
+    StringConstraints(
+        pattern=rf"^[1-9][0-9]{{0,{MAX_INTEGER_DIGITS - 1}}}$",
+        max_length=MAX_INTEGER_DIGITS,
+        strict=True,
+    ),
+]
 
 
 class NonCoprimalityGraphRequest(StrictModel):
     """Request to construct the non-coprimality graph of a set of integers."""
 
-    integers: tuple[CanonicalInteger, ...] = Field(
+    integers: tuple[NonCoprimeInteger, ...] = Field(
         min_length=1,
         max_length=MAX_INTEGERS,
     )

--- a/src/jacobian/math/number_theory/non_coprimality_graph/_models.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/_models.py
@@ -20,11 +20,13 @@ class NonCoprimalityGraphRequest(StrictModel):
         max_length=MAX_INTEGERS,
     )
 
+
 class NonCoprimalityGraphResult(StrictModel):
     """The non-coprimality graph of a set of integers."""
 
     integers: tuple[CanonicalInteger, ...]
     graph: SimpleUndirectedGraph
+
 
 __all__ = [
     "MAX_INTEGERS",

--- a/src/jacobian/math/number_theory/non_coprimality_graph/_models.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/_models.py
@@ -2,50 +2,108 @@
 
 from __future__ import annotations
 
+from math import gcd
 from typing import Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
+from jacobian.canonical import CanonicalLimits, encode_strict_json
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 MAX_INTEGERS = 256
+MAX_INTEGER_DIGITS = 256
+
+
+def _validate_integer_source(integers: tuple[str, ...]) -> None:
+    if not 1 <= len(integers) <= MAX_INTEGERS:
+        raise PydanticCustomError(
+            "non_coprimality.size",
+            f"integers must contain between 1 and {MAX_INTEGERS} values",
+        )
+    values: list[int] = []
+    for index, value in enumerate(integers):
+        if len(value.lstrip("-")) > MAX_INTEGER_DIGITS:
+            raise PydanticCustomError(
+                "non_coprimality.digits",
+                f"integer {index} exceeds the {MAX_INTEGER_DIGITS}-digit bound",
+            )
+        parsed = int(value)
+        if parsed <= 0:
+            raise PydanticCustomError(
+                "non_coprimality.must_be_positive",
+                "all integers must be positive",
+            )
+        values.append(parsed)
+    if len(set(values)) != len(values):
+        raise PydanticCustomError(
+            "non_coprimality.must_be_distinct",
+            "integers must be distinct",
+        )
+
+    labels = tuple(sorted(integers, key=int))
+    all_edges = [[left, right] for left in labels for right in labels if left < right]
+    payload = {
+        "integers": list(labels),
+        "graph": {"vertices": list(labels), "edges": all_edges},
+    }
+    if len(encode_strict_json(payload)) > CanonicalLimits().max_output_bytes:
+        raise PydanticCustomError(
+            "non_coprimality.result_too_large",
+            "the graph result exceeds the canonical output limit",
+        )
 
 
 class NonCoprimalityGraphRequest(StrictModel):
     """Request to construct the non-coprimality graph of a set of integers."""
 
-    integers: tuple[int, ...] = Field(
+    integers: tuple[CanonicalInteger, ...] = Field(
         min_length=1,
         max_length=MAX_INTEGERS,
     )
 
     @model_validator(mode="after")
     def validate_integers(self) -> Self:
-        for v in self.integers:
-            if v <= 0:
-                raise PydanticCustomError(
-                    "non_coprimality.must_be_positive",
-                    "all integers must be positive",
-                )
-        if len(set(self.integers)) != len(self.integers):
-            raise PydanticCustomError(
-                "non_coprimality.must_be_distinct",
-                "integers must be distinct",
-            )
+        _validate_integer_source(self.integers)
         return self
 
 
 class NonCoprimalityGraphResult(StrictModel):
     """The non-coprimality graph of a set of integers."""
 
-    integers: tuple[int, ...]
+    integers: tuple[CanonicalInteger, ...]
     graph: SimpleUndirectedGraph
+
+    @model_validator(mode="after")
+    def require_source_graph_contract(self) -> Self:
+        _validate_integer_source(self.integers)
+        expected_vertices = tuple(sorted(self.integers, key=int))
+        if self.graph.vertices != expected_vertices:
+            raise PydanticCustomError(
+                "non_coprimality.graph_source_mismatch",
+                "graph vertices must be the source integers in numeric order",
+            )
+        values = {label: int(label) for label in self.integers}
+        expected_edges = {
+            tuple(sorted((left, right)))
+            for left in self.integers
+            for right in self.integers
+            if left < right and gcd(values[left], values[right]) > 1
+        }
+        if set(self.graph.edges) != expected_edges:
+            raise PydanticCustomError(
+                "non_coprimality.graph_edges_mismatch",
+                "graph edges must be exactly the non-coprime source pairs",
+            )
+        return self
 
 
 __all__ = [
     "MAX_INTEGERS",
+    "MAX_INTEGER_DIGITS",
     "NonCoprimalityGraphRequest",
     "NonCoprimalityGraphResult",
+    "_validate_integer_source",
 ]

--- a/src/jacobian/math/number_theory/non_coprimality_graph/_tools.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/_tools.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 
 from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools, OperationExample
 from jacobian.math.number_theory.non_coprimality_graph._models import (
@@ -17,7 +18,9 @@ from jacobian.math.number_theory.non_coprimality_graph.operations import (
 def compute_non_coprimality_graph(
     request: NonCoprimalityGraphRequest,
 ) -> NonCoprimalityGraphResult:
-    return construct_non_coprimality_graph(request.integers)
+    return construct_non_coprimality_graph(
+        tuple(parse_canonical_integer(value) for value in request.integers)
+    )
 
 
 def ncg_operation[

--- a/src/jacobian/math/number_theory/non_coprimality_graph/_tools.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/_tools.py
@@ -67,8 +67,8 @@ TOOLS: MathTools = (
         examples=(
             example(
                 "basic_fixture",
-                "Non-coprimality graph of {2, 3, 4, 6}.",
-                {"integers": [2, 3, 4, 6]},
+                "Non-coprimality graph of {2, 3, 4, 6}; integers are canonical decimal strings.",
+                {"integers": ["2", "3", "4", "6"]},
             ),
         ),
     ),

--- a/src/jacobian/math/number_theory/non_coprimality_graph/_tools.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/_tools.py
@@ -1,0 +1,74 @@
+"""Non-coprimality graph operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.number_theory.non_coprimality_graph._models import (
+    NonCoprimalityGraphRequest,
+    NonCoprimalityGraphResult,
+)
+from jacobian.math.number_theory.non_coprimality_graph.operations import (
+    construct_non_coprimality_graph,
+)
+
+
+def compute_non_coprimality_graph(
+    request: NonCoprimalityGraphRequest,
+) -> NonCoprimalityGraphResult:
+    return construct_non_coprimality_graph(request.integers)
+
+
+def ncg_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    ncg_operation(
+        "number_theory.integer_set.non_coprimality_graph.compute",
+        "Construct the non-coprimality graph of a set of positive integers",
+        (
+            "Given a bounded finite set of distinct positive integers, construct "
+            "the canonical simple conflict graph whose vertices are the supplied "
+            "integers and whose edges join exactly the distinct pairs with gcd "
+            "greater than one."
+        ),
+        NonCoprimalityGraphRequest,
+        NonCoprimalityGraphResult,
+        compute_non_coprimality_graph,
+        "number-theory",
+        "graph",
+        "exact",
+        examples=(
+            example(
+                "basic_fixture",
+                "Non-coprimality graph of {2, 3, 4, 6}.",
+                {"integers": [2, 3, 4, 6]},
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/number_theory/non_coprimality_graph/operations.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/operations.py
@@ -66,8 +66,7 @@ def _admit_non_coprimality_graph(
                 location=("integers", index),
                 code="non_coprimality.digits",
                 message=(
-                    f"integer {index} exceeds the "
-                    f"{MAX_INTEGER_DIGITS}-digit bound"
+                    f"integer {index} exceeds the {MAX_INTEGER_DIGITS}-digit bound"
                 ),
             )
         label = format_canonical_integer(value)
@@ -76,8 +75,7 @@ def _admit_non_coprimality_graph(
                 location=("integers", index),
                 code="non_coprimality.digits",
                 message=(
-                    f"integer {index} exceeds the "
-                    f"{MAX_INTEGER_DIGITS}-digit bound"
+                    f"integer {index} exceeds the {MAX_INTEGER_DIGITS}-digit bound"
                 ),
             )
         source.append(label)

--- a/src/jacobian/math/number_theory/non_coprimality_graph/operations.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/operations.py
@@ -2,19 +2,121 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from math import gcd
 
-from pydantic_core import PydanticCustomError
-
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    format_canonical_integer,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 from jacobian.math.number_theory.non_coprimality_graph._models import (
+    MAX_INTEGER_DIGITS,
+    MAX_INTEGERS,
     NonCoprimalityGraphResult,
-    _validate_integer_source,
 )
 
 __all__ = ["construct_non_coprimality_graph"]
+
+
+@dataclass(frozen=True, slots=True)
+class NonCoprimalityGraphAdmission:
+    """Canonical source and exact conflict edges computed during admission."""
+
+    source: tuple[str, ...]
+    vertices: tuple[str, ...]
+    edges: tuple[tuple[str, str], ...]
+
+
+def _admit_non_coprimality_graph(
+    integers: tuple[int, ...],
+) -> NonCoprimalityGraphAdmission:
+    if not isinstance(integers, tuple):
+        raise OperationDomainValidationError(
+            location=("integers",),
+            code="non_coprimality.integer_type",
+            message="integers must be a tuple of integers",
+        )
+    if not 1 <= len(integers) <= MAX_INTEGERS:
+        raise OperationDomainValidationError(
+            location=("integers",),
+            code="non_coprimality.size",
+            message=f"integers must contain between 1 and {MAX_INTEGERS} values",
+        )
+
+    source: list[str] = []
+    values: list[int] = []
+    for index, value in enumerate(integers):
+        if type(value) is not int:
+            raise OperationDomainValidationError(
+                location=("integers", index),
+                code="non_coprimality.integer_type",
+                message="integers must contain only integers",
+            )
+        if value <= 0:
+            raise OperationDomainValidationError(
+                location=("integers", index),
+                code="non_coprimality.must_be_positive",
+                message="all integers must be positive",
+            )
+        if value.bit_length() > 850:
+            raise OperationDomainValidationError(
+                location=("integers", index),
+                code="non_coprimality.digits",
+                message=(
+                    f"integer {index} exceeds the "
+                    f"{MAX_INTEGER_DIGITS}-digit bound"
+                ),
+            )
+        label = format_canonical_integer(value)
+        if len(label) > MAX_INTEGER_DIGITS:
+            raise OperationDomainValidationError(
+                location=("integers", index),
+                code="non_coprimality.digits",
+                message=(
+                    f"integer {index} exceeds the "
+                    f"{MAX_INTEGER_DIGITS}-digit bound"
+                ),
+            )
+        source.append(label)
+        values.append(value)
+    if len(set(values)) != len(values):
+        raise OperationDomainValidationError(
+            location=("integers",),
+            code="non_coprimality.must_be_distinct",
+            message="integers must be distinct",
+        )
+
+    sorted_pairs = sorted(zip(source, values, strict=True), key=lambda pair: pair[1])
+    vertices = tuple(label for label, _ in sorted_pairs)
+    edges: list[tuple[str, str]] = []
+    for left_index, (left_label, left_value) in enumerate(sorted_pairs):
+        for right_label, right_value in sorted_pairs[left_index + 1 :]:
+            if gcd(left_value, right_value) > 1:
+                edges.append(
+                    (min(left_label, right_label), max(left_label, right_label))
+                )
+    canonical_edges = tuple(edges)
+    payload = {
+        "integers": list(source),
+        "graph": {"vertices": list(vertices), "edges": [list(edge) for edge in edges]},
+    }
+    try:
+        if len(encode_strict_json(payload)) > CanonicalLimits().max_output_bytes:
+            raise OperationDomainValidationError(
+                location=("integers",),
+                code="non_coprimality.result_too_large",
+                message="the graph result exceeds the canonical output limit",
+            )
+    except ValueError as error:
+        raise OperationDomainValidationError(
+            location=("integers",),
+            code="non_coprimality.result_not_canonical",
+            message="the graph result cannot be represented in canonical JSON",
+        ) from error
+    return NonCoprimalityGraphAdmission(tuple(source), vertices, canonical_edges)
 
 
 def construct_non_coprimality_graph(
@@ -25,37 +127,12 @@ def construct_non_coprimality_graph(
     The graph has one vertex per integer (labelled by the integer's
     canonical string) and an edge between two vertices iff their gcd > 1.
     """
-    if not isinstance(integers, tuple) or any(
-        not isinstance(value, int) or isinstance(value, bool) for value in integers
-    ):
-        raise OperationDomainValidationError(
-            location=("integers",),
-            code="non_coprimality.integer_type",
-            message="integers must be a tuple of integers",
-        )
-    vertices = tuple(format_canonical_integer(i) for i in integers)
-    try:
-        _validate_integer_source(vertices)
-    except PydanticCustomError as error:
-        raise OperationDomainValidationError(
-            location=("integers",), code=error.type, message=str(error)
-        ) from error
-    sorted_pairs = sorted(
-        zip(vertices, integers, strict=True), key=lambda pair: pair[1]
-    )
-    sorted_vertices = tuple(label for label, _ in sorted_pairs)
-    edges: list[tuple[str, str]] = []
-    for i in range(len(sorted_pairs)):
-        for j in range(i + 1, len(sorted_pairs)):
-            if gcd(sorted_pairs[i][1], sorted_pairs[j][1]) > 1:
-                a, b = sorted_pairs[i][0], sorted_pairs[j][0]
-                if a < b:
-                    edges.append((a, b))
-                else:
-                    edges.append((b, a))
-
+    admission = _admit_non_coprimality_graph(integers)
     graph = SimpleUndirectedGraph(
-        vertices=sorted_vertices,
-        edges=tuple(edges),
+        vertices=admission.vertices,
+        edges=admission.edges,
     )
-    return NonCoprimalityGraphResult(integers=vertices, graph=graph)
+    return NonCoprimalityGraphResult.model_construct(
+        integers=admission.source,
+        graph=graph,
+    )

--- a/src/jacobian/math/number_theory/non_coprimality_graph/operations.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/operations.py
@@ -61,7 +61,10 @@ def _admit_non_coprimality_graph(
                 code="non_coprimality.must_be_positive",
                 message="all integers must be positive",
             )
-        if value.bit_length() > 850:
+        # Avoid decimal conversion of huge native integers.  The generous
+        # bit-length threshold cannot exclude any value within the exact
+        # decimal label bound; the precise check below remains authoritative.
+        if value.bit_length() > (MAX_INTEGER_DIGITS + 1) * 4:
             raise OperationDomainValidationError(
                 location=("integers", index),
                 code="non_coprimality.digits",

--- a/src/jacobian/math/number_theory/non_coprimality_graph/operations.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/operations.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 from math import gcd
 
+from pydantic_core import PydanticCustomError
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 from jacobian.math.number_theory.non_coprimality_graph._models import (
     NonCoprimalityGraphResult,
+    _validate_integer_source,
 )
 
 __all__ = ["construct_non_coprimality_graph"]
@@ -20,19 +25,37 @@ def construct_non_coprimality_graph(
     The graph has one vertex per integer (labelled by the integer's
     canonical string) and an edge between two vertices iff their gcd > 1.
     """
-    vertices = tuple(str(i) for i in integers)
+    if not isinstance(integers, tuple) or any(
+        not isinstance(value, int) or isinstance(value, bool) for value in integers
+    ):
+        raise OperationDomainValidationError(
+            location=("integers",),
+            code="non_coprimality.integer_type",
+            message="integers must be a tuple of integers",
+        )
+    vertices = tuple(format_canonical_integer(i) for i in integers)
+    try:
+        _validate_integer_source(vertices)
+    except PydanticCustomError as error:
+        raise OperationDomainValidationError(
+            location=("integers",), code=error.type, message=str(error)
+        ) from error
+    sorted_pairs = sorted(
+        zip(vertices, integers, strict=True), key=lambda pair: pair[1]
+    )
+    sorted_vertices = tuple(label for label, _ in sorted_pairs)
     edges: list[tuple[str, str]] = []
-    for i in range(len(integers)):
-        for j in range(i + 1, len(integers)):
-            if gcd(integers[i], integers[j]) > 1:
-                a, b = str(integers[i]), str(integers[j])
+    for i in range(len(sorted_pairs)):
+        for j in range(i + 1, len(sorted_pairs)):
+            if gcd(sorted_pairs[i][1], sorted_pairs[j][1]) > 1:
+                a, b = sorted_pairs[i][0], sorted_pairs[j][0]
                 if a < b:
                     edges.append((a, b))
                 else:
                     edges.append((b, a))
 
     graph = SimpleUndirectedGraph(
-        vertices=vertices,
+        vertices=sorted_vertices,
         edges=tuple(edges),
     )
-    return NonCoprimalityGraphResult(integers=integers, graph=graph)
+    return NonCoprimalityGraphResult(integers=vertices, graph=graph)

--- a/src/jacobian/math/number_theory/non_coprimality_graph/operations.py
+++ b/src/jacobian/math/number_theory/non_coprimality_graph/operations.py
@@ -1,0 +1,38 @@
+"""Non-coprimality graph constructor."""
+
+from __future__ import annotations
+
+from math import gcd
+
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.number_theory.non_coprimality_graph._models import (
+    NonCoprimalityGraphResult,
+)
+
+__all__ = ["construct_non_coprimality_graph"]
+
+
+def construct_non_coprimality_graph(
+    integers: tuple[int, ...],
+) -> NonCoprimalityGraphResult:
+    """Construct the non-coprimality graph of a set of positive integers.
+
+    The graph has one vertex per integer (labelled by the integer's
+    canonical string) and an edge between two vertices iff their gcd > 1.
+    """
+    vertices = tuple(str(i) for i in integers)
+    edges: list[tuple[str, str]] = []
+    for i in range(len(integers)):
+        for j in range(i + 1, len(integers)):
+            if gcd(integers[i], integers[j]) > 1:
+                a, b = str(integers[i]), str(integers[j])
+                if a < b:
+                    edges.append((a, b))
+                else:
+                    edges.append((b, a))
+
+    graph = SimpleUndirectedGraph(
+        vertices=vertices,
+        edges=tuple(edges),
+    )
+    return NonCoprimalityGraphResult(integers=integers, graph=graph)

--- a/tests/math/number_theory/non_coprimality_graph/test_non_coprimality_graph.py
+++ b/tests/math/number_theory/non_coprimality_graph/test_non_coprimality_graph.py
@@ -70,4 +70,14 @@ def test_result_preserves_source() -> None:
     """Result retains the source integers."""
     ints = (3, 5, 7)
     result = construct_non_coprimality_graph(ints)
-    assert result.integers == ints
+    assert result.integers == tuple(str(value) for value in ints)
+
+
+def test_canonical_integer_strings_preserve_large_values() -> None:
+    result = construct_non_coprimality_graph((2**53 + 1, 2**53 + 3))
+    assert result.integers == (str(2**53 + 1), str(2**53 + 3))
+
+
+def test_native_rejects_oversized_integer_before_gcd() -> None:
+    with pytest.raises(ValueError, match="digit bound"):
+        construct_non_coprimality_graph((10**256,))

--- a/tests/math/number_theory/non_coprimality_graph/test_non_coprimality_graph.py
+++ b/tests/math/number_theory/non_coprimality_graph/test_non_coprimality_graph.py
@@ -51,9 +51,8 @@ def test_replay_gcd() -> None:
 
 
 def test_rejects_non_positive() -> None:
-    request = NonCoprimalityGraphRequest(integers=("0", "2"))
     with pytest.raises(OperationDomainValidationError):
-        construct_non_coprimality_graph(tuple(map(int, request.integers)))
+        construct_non_coprimality_graph((0, 2))
 
 
 def test_rejects_duplicates() -> None:

--- a/tests/math/number_theory/non_coprimality_graph/test_non_coprimality_graph.py
+++ b/tests/math/number_theory/non_coprimality_graph/test_non_coprimality_graph.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from math import gcd
 
 import pytest
-from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.non_coprimality_graph._models import (
     NonCoprimalityGraphRequest,
 )
@@ -51,13 +51,20 @@ def test_replay_gcd() -> None:
 
 
 def test_rejects_non_positive() -> None:
-    with pytest.raises(ValidationError):
-        NonCoprimalityGraphRequest(integers=(0, 2))
+    request = NonCoprimalityGraphRequest(integers=("0", "2"))
+    with pytest.raises(OperationDomainValidationError):
+        construct_non_coprimality_graph(tuple(map(int, request.integers)))
 
 
 def test_rejects_duplicates() -> None:
-    with pytest.raises(ValidationError):
-        NonCoprimalityGraphRequest(integers=(2, 2))
+    request = NonCoprimalityGraphRequest(integers=("2", "2"))
+    with pytest.raises(OperationDomainValidationError):
+        construct_non_coprimality_graph(tuple(map(int, request.integers)))
+
+
+def test_request_uses_canonical_integer_strings() -> None:
+    request = NonCoprimalityGraphRequest(integers=("2", "3", "4", "6"))
+    assert request.integers == ("2", "3", "4", "6")
 
 
 def test_vertex_labels_preserve_integers() -> None:

--- a/tests/math/number_theory/non_coprimality_graph/test_non_coprimality_graph.py
+++ b/tests/math/number_theory/non_coprimality_graph/test_non_coprimality_graph.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from math import gcd
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.number_theory.non_coprimality_graph._models import (
+    NonCoprimalityGraphRequest,
+)
+from jacobian.math.number_theory.non_coprimality_graph.operations import (
+    construct_non_coprimality_graph,
+)
+
+
+def test_fixture() -> None:
+    """For {2,3,4,6}, edges are 2-4, 2-6, 3-6, 4-6."""
+    result = construct_non_coprimality_graph((2, 3, 4, 6))
+    edges = set(result.graph.edges)
+    assert ("2", "4") in edges
+    assert ("2", "6") in edges
+    assert ("3", "6") in edges
+    assert ("4", "6") in edges
+    assert len(result.graph.edges) == 4
+
+
+def test_all_coprime() -> None:
+    """Set of pairwise coprime integers has no edges."""
+    result = construct_non_coprimality_graph((2, 3, 5, 7))
+    assert len(result.graph.edges) == 0
+
+
+def test_single_vertex() -> None:
+    """Single integer has no edges."""
+    result = construct_non_coprimality_graph((7,))
+    assert len(result.graph.vertices) == 1
+    assert len(result.graph.edges) == 0
+
+
+def test_replay_gcd() -> None:
+    """Every edge satisfies gcd > 1, every non-edge has gcd = 1."""
+    ints = (6, 10, 15, 7, 35)
+    result = construct_non_coprimality_graph(ints)
+    edge_set = set(result.graph.edges)
+    for i in range(len(ints)):
+        for j in range(i + 1, len(ints)):
+            a, b = str(ints[i]), str(ints[j])
+            expected = (min(a, b), max(a, b))
+            should_have = gcd(ints[i], ints[j]) > 1
+            assert (expected in edge_set) == should_have
+
+
+def test_rejects_non_positive() -> None:
+    with pytest.raises(ValidationError):
+        NonCoprimalityGraphRequest(integers=(0, 2))
+
+
+def test_rejects_duplicates() -> None:
+    with pytest.raises(ValidationError):
+        NonCoprimalityGraphRequest(integers=(2, 2))
+
+
+def test_vertex_labels_preserve_integers() -> None:
+    """Vertex labels are the canonical integer strings."""
+    result = construct_non_coprimality_graph((11, 13, 17))
+    assert set(result.graph.vertices) == {"11", "13", "17"}
+
+
+def test_result_preserves_source() -> None:
+    """Result retains the source integers."""
+    ints = (3, 5, 7)
+    result = construct_non_coprimality_graph(ints)
+    assert result.integers == ints


### PR DESCRIPTION
## Summary

Implements `number_theory.integer_set.non_coprimality_graph.compute` from issue #2794.

Given a bounded finite set of distinct positive integers, constructs the canonical simple conflict graph whose vertices are the supplied integers and whose edges join exactly the distinct pairs with gcd greater than one. Vertex labels preserve the source integers.

## Design

- **Operation ID**: `number_theory.integer_set.non_coprimality_graph.compute`
- **Input**: tuple of distinct positive integers (at most 256)
- **Output**: `SimpleUndirectedGraph` with one vertex per integer
- **Kernel**: all-pairs GCD pass — O(C(m,2)) GCD computations

## Tests

- Fixture {2,3,4,6} with edges 2-4, 2-6, 3-6, 4-6
- All-coprime set (no edges)
- Single vertex
- GCD replay (every edge has gcd>1, every non-edge has gcd=1)
- Rejects non-positive and duplicate integers
- Vertex label preservation
- Source preservation

Closes #2794

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)