### PR TITLE
Add graph.boolean_lattice_intersection.construct operation

### DIFF
--- a/src/jacobian/math/graphs/boolean_lattice_intersection/__init__.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/__init__.py
@@ -1,0 +1,7 @@
+"""Boolean lattice intersection graph constructor."""
+
+from jacobian.math.graphs.boolean_lattice_intersection.operations import (
+    construct_boolean_lattice_intersection_graph,
+)
+
+__all__ = ["construct_boolean_lattice_intersection_graph"]

--- a/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
@@ -41,10 +41,10 @@ def _validate_intersection_request(
             "boolean_lattice.invalid_relation",
             "relation must be INTERSECTION_EQ, INTERSECTION_LT, or INTERSECTION_GT",
         )
-    if not 0 <= threshold <= ground_set_size:
+    if threshold < 0:
         raise PydanticCustomError(
             "boolean_lattice.threshold_exceeds_n",
-            "threshold must be between 0 and ground_set_size",
+            "threshold must be nonnegative",
         )
     vertex_count = 1 << ground_set_size
     edge_count = vertex_count * (vertex_count - 1) // 2

--- a/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
@@ -11,6 +11,7 @@ from jacobian._models import StrictModel
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 MAX_GROUND_SET_SIZE = 8
+MAX_THRESHOLD = (1 << 53) - 1
 
 IntersectionRelation = Literal["INTERSECTION_EQ", "INTERSECTION_LT", "INTERSECTION_GT"]
 
@@ -46,6 +47,11 @@ def _validate_intersection_request(
             "boolean_lattice.threshold_exceeds_n",
             "threshold must be nonnegative",
         )
+    if threshold > MAX_THRESHOLD:
+        raise PydanticCustomError(
+            "boolean_lattice.threshold_exceeds_json_integer",
+            f"threshold must not exceed {MAX_THRESHOLD}",
+        )
     vertex_count = 1 << ground_set_size
     edge_count = vertex_count * (vertex_count - 1) // 2
     if edge_count > 32_640:
@@ -59,7 +65,7 @@ class BooleanLatticeIntersectionRequest(StrictModel):
     """Construct a graph on the Boolean lattice 2^[n] with an intersection relation."""
 
     ground_set_size: int = Field(ge=0, le=MAX_GROUND_SET_SIZE)
-    threshold: int = Field(ge=0)
+    threshold: int = Field(ge=0, le=MAX_THRESHOLD)
     relation: IntersectionRelation
 
 
@@ -74,6 +80,7 @@ class BooleanLatticeIntersectionResult(StrictModel):
 
 __all__ = [
     "MAX_GROUND_SET_SIZE",
+    "MAX_THRESHOLD",
     "BooleanLatticeIntersectionRequest",
     "BooleanLatticeIntersectionResult",
     "IntersectionRelation",

--- a/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
@@ -62,6 +62,7 @@ class BooleanLatticeIntersectionRequest(StrictModel):
     threshold: int = Field(ge=0)
     relation: IntersectionRelation
 
+
 class BooleanLatticeIntersectionResult(StrictModel):
     """The Boolean-lattice intersection graph."""
 
@@ -69,6 +70,7 @@ class BooleanLatticeIntersectionResult(StrictModel):
     threshold: int
     relation: IntersectionRelation
     graph: SimpleUndirectedGraph
+
 
 __all__ = [
     "MAX_GROUND_SET_SIZE",

--- a/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
@@ -10,9 +10,40 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
-MAX_GROUND_SET_SIZE = 6
+MAX_GROUND_SET_SIZE = 8
 
 IntersectionRelation = Literal["INTERSECTION_EQ", "INTERSECTION_LT", "INTERSECTION_GT"]
+
+
+def _validate_intersection_request(
+    ground_set_size: int, threshold: int, relation: IntersectionRelation
+) -> None:
+    if not isinstance(ground_set_size, int) or isinstance(ground_set_size, bool):
+        raise PydanticCustomError(
+            "boolean_lattice.ground_set_size_type",
+            "ground_set_size must be an integer",
+        )
+    if not isinstance(threshold, int) or isinstance(threshold, bool):
+        raise PydanticCustomError(
+            "boolean_lattice.threshold_type", "threshold must be an integer"
+        )
+    if not 0 <= ground_set_size <= MAX_GROUND_SET_SIZE:
+        raise PydanticCustomError(
+            "boolean_lattice.ground_set_size_too_large",
+            f"ground_set_size must be between 0 and {MAX_GROUND_SET_SIZE}",
+        )
+    if not 0 <= threshold <= ground_set_size:
+        raise PydanticCustomError(
+            "boolean_lattice.threshold_exceeds_n",
+            "threshold must be between 0 and ground_set_size",
+        )
+    vertex_count = 1 << ground_set_size
+    edge_count = vertex_count * (vertex_count - 1) // 2
+    if edge_count > 32_640:
+        raise PydanticCustomError(
+            "boolean_lattice.edge_envelope",
+            "the Boolean-lattice graph exceeds the simple-graph edge envelope",
+        )
 
 
 class BooleanLatticeIntersectionRequest(StrictModel):
@@ -24,11 +55,9 @@ class BooleanLatticeIntersectionRequest(StrictModel):
 
     @model_validator(mode="after")
     def validate_request(self) -> Self:
-        if self.threshold > self.ground_set_size:
-            raise PydanticCustomError(
-                "boolean_lattice.threshold_exceeds_n",
-                "threshold must not exceed ground_set_size",
-            )
+        _validate_intersection_request(
+            self.ground_set_size, self.threshold, self.relation
+        )
         return self
 
 
@@ -40,10 +69,35 @@ class BooleanLatticeIntersectionResult(StrictModel):
     relation: IntersectionRelation
     graph: SimpleUndirectedGraph
 
+    @model_validator(mode="after")
+    def require_graph_contract(self) -> Self:
+        _validate_intersection_request(
+            self.ground_set_size, self.threshold, self.relation
+        )
+        expected_vertices = tuple(
+            _subset_label(
+                frozenset(i for i in range(self.ground_set_size) if mask & (1 << i))
+            )
+            for mask in range(1 << self.ground_set_size)
+        )
+        if self.graph.vertices != expected_vertices:
+            raise PydanticCustomError(
+                "boolean_lattice.vertex_source_mismatch",
+                "graph vertices must enumerate the Boolean lattice canonically",
+            )
+        return self
+
+
+def _subset_label(subset: frozenset[int]) -> str:
+    if not subset:
+        return "{}"
+    return "{" + ",".join(str(i) for i in sorted(subset)) + "}"
+
 
 __all__ = [
     "MAX_GROUND_SET_SIZE",
     "BooleanLatticeIntersectionRequest",
     "BooleanLatticeIntersectionResult",
     "IntersectionRelation",
+    "_validate_intersection_request",
 ]

--- a/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
@@ -32,6 +32,15 @@ def _validate_intersection_request(
             "boolean_lattice.ground_set_size_too_large",
             f"ground_set_size must be between 0 and {MAX_GROUND_SET_SIZE}",
         )
+    if not isinstance(relation, str) or relation not in {
+        "INTERSECTION_EQ",
+        "INTERSECTION_LT",
+        "INTERSECTION_GT",
+    }:
+        raise PydanticCustomError(
+            "boolean_lattice.invalid_relation",
+            "relation must be INTERSECTION_EQ, INTERSECTION_LT, or INTERSECTION_GT",
+        )
     if not 0 <= threshold <= ground_set_size:
         raise PydanticCustomError(
             "boolean_lattice.threshold_exceeds_n",
@@ -53,14 +62,6 @@ class BooleanLatticeIntersectionRequest(StrictModel):
     threshold: int = Field(ge=0)
     relation: IntersectionRelation
 
-    @model_validator(mode="after")
-    def validate_request(self) -> Self:
-        _validate_intersection_request(
-            self.ground_set_size, self.threshold, self.relation
-        )
-        return self
-
-
 class BooleanLatticeIntersectionResult(StrictModel):
     """The Boolean-lattice intersection graph."""
 
@@ -68,31 +69,6 @@ class BooleanLatticeIntersectionResult(StrictModel):
     threshold: int
     relation: IntersectionRelation
     graph: SimpleUndirectedGraph
-
-    @model_validator(mode="after")
-    def require_graph_contract(self) -> Self:
-        _validate_intersection_request(
-            self.ground_set_size, self.threshold, self.relation
-        )
-        expected_vertices = tuple(
-            _subset_label(
-                frozenset(i for i in range(self.ground_set_size) if mask & (1 << i))
-            )
-            for mask in range(1 << self.ground_set_size)
-        )
-        if self.graph.vertices != expected_vertices:
-            raise PydanticCustomError(
-                "boolean_lattice.vertex_source_mismatch",
-                "graph vertices must enumerate the Boolean lattice canonically",
-            )
-        return self
-
-
-def _subset_label(subset: frozenset[int]) -> str:
-    if not subset:
-        return "{}"
-    return "{" + ",".join(str(i) for i in sorted(subset)) + "}"
-
 
 __all__ = [
     "MAX_GROUND_SET_SIZE",

--- a/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/_models.py
@@ -1,0 +1,49 @@
+"""Typed contracts for the Boolean-lattice intersection graph operation."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_GROUND_SET_SIZE = 6
+
+IntersectionRelation = Literal["INTERSECTION_EQ", "INTERSECTION_LT", "INTERSECTION_GT"]
+
+
+class BooleanLatticeIntersectionRequest(StrictModel):
+    """Construct a graph on the Boolean lattice 2^[n] with an intersection relation."""
+
+    ground_set_size: int = Field(ge=0, le=MAX_GROUND_SET_SIZE)
+    threshold: int = Field(ge=0)
+    relation: IntersectionRelation
+
+    @model_validator(mode="after")
+    def validate_request(self) -> Self:
+        if self.threshold > self.ground_set_size:
+            raise PydanticCustomError(
+                "boolean_lattice.threshold_exceeds_n",
+                "threshold must not exceed ground_set_size",
+            )
+        return self
+
+
+class BooleanLatticeIntersectionResult(StrictModel):
+    """The Boolean-lattice intersection graph."""
+
+    ground_set_size: int
+    threshold: int
+    relation: IntersectionRelation
+    graph: SimpleUndirectedGraph
+
+
+__all__ = [
+    "MAX_GROUND_SET_SIZE",
+    "BooleanLatticeIntersectionRequest",
+    "BooleanLatticeIntersectionResult",
+    "IntersectionRelation",
+]

--- a/src/jacobian/math/graphs/boolean_lattice_intersection/_tools.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/_tools.py
@@ -1,0 +1,80 @@
+"""Boolean-lattice intersection graph operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.boolean_lattice_intersection._models import (
+    BooleanLatticeIntersectionRequest,
+    BooleanLatticeIntersectionResult,
+)
+from jacobian.math.graphs.boolean_lattice_intersection.operations import (
+    construct_boolean_lattice_intersection_graph,
+)
+
+
+def compute_boolean_lattice_intersection(
+    request: BooleanLatticeIntersectionRequest,
+) -> BooleanLatticeIntersectionResult:
+    return construct_boolean_lattice_intersection_graph(
+        request.ground_set_size, request.threshold, request.relation
+    )
+
+
+def bli_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    bli_operation(
+        "graph.boolean_lattice_intersection.construct",
+        "Construct a Boolean-lattice intersection graph",
+        (
+            "Construct a labelled simple graph whose vertices are all subsets "
+            "of [n], with an edge between two subsets when their intersection "
+            "size satisfies the declared relation (equal, less-than, or "
+            "greater-than) with a given threshold."
+        ),
+        BooleanLatticeIntersectionRequest,
+        BooleanLatticeIntersectionResult,
+        compute_boolean_lattice_intersection,
+        "graph",
+        "combinatorics",
+        "exact",
+        examples=(
+            example(
+                "eq_r0_n2",
+                "Boolean lattice 2^[2] with intersection == 0.",
+                {
+                    "ground_set_size": 2,
+                    "threshold": 0,
+                    "relation": "INTERSECTION_EQ",
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/boolean_lattice_intersection/operations.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/operations.py
@@ -1,0 +1,77 @@
+"""Boolean-lattice intersection graph constructor."""
+
+from __future__ import annotations
+
+from jacobian.math.graphs.boolean_lattice_intersection._models import (
+    BooleanLatticeIntersectionResult,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+__all__ = ["construct_boolean_lattice_intersection_graph"]
+
+
+def construct_boolean_lattice_intersection_graph(
+    ground_set_size: int,
+    threshold: int,
+    relation: str,
+) -> BooleanLatticeIntersectionResult:
+    """Construct a graph on the Boolean lattice 2^[n].
+
+    Vertices are all subsets of [n], labelled by canonical subset strings.
+    An edge joins two distinct subsets when their intersection size
+    satisfies the declared relation with the threshold.
+    """
+    n = ground_set_size
+    all_subsets = [_subset_label(s) for s in _all_subsets(n)]
+
+    edges: list[tuple[str, str]] = []
+    for i in range(len(all_subsets)):
+        si = _subset_from_label(all_subsets[i])
+        for j in range(i + 1, len(all_subsets)):
+            sj = _subset_from_label(all_subsets[j])
+            intersection_size = len(si & sj)
+            if relation == "INTERSECTION_EQ":
+                adjacent = intersection_size == threshold
+            elif relation == "INTERSECTION_LT":
+                adjacent = intersection_size < threshold
+            else:
+                adjacent = intersection_size > threshold
+            if adjacent:
+                a, b = all_subsets[i], all_subsets[j]
+                if a < b:
+                    edges.append((a, b))
+                else:
+                    edges.append((b, a))
+
+    graph = SimpleUndirectedGraph(
+        vertices=tuple(all_subsets),
+        edges=tuple(edges),
+    )
+    return BooleanLatticeIntersectionResult(
+        ground_set_size=n,
+        threshold=threshold,
+        relation=relation,
+        graph=graph,
+    )
+
+
+def _all_subsets(n: int) -> list[frozenset[int]]:
+    if n == 0:
+        return [frozenset()]
+    result = []
+    for mask in range(1 << n):
+        result.append(frozenset(i for i in range(n) if mask & (1 << i)))
+    return result
+
+
+def _subset_label(subset: frozenset[int]) -> str:
+    if not subset:
+        return "{}"
+    return "{" + ",".join(str(i) for i in sorted(subset)) + "}"
+
+
+def _subset_from_label(label: str) -> frozenset[int]:
+    if label == "{}":
+        return frozenset()
+    inner = label[1:-1]
+    return frozenset(int(x) for x in inner.split(","))

--- a/src/jacobian/math/graphs/boolean_lattice_intersection/operations.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/operations.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from pydantic_core import PydanticCustomError
+
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.boolean_lattice_intersection._models import (
     BooleanLatticeIntersectionResult,
+    IntersectionRelation,
+    _validate_intersection_request,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -13,7 +18,7 @@ __all__ = ["construct_boolean_lattice_intersection_graph"]
 def construct_boolean_lattice_intersection_graph(
     ground_set_size: int,
     threshold: int,
-    relation: str,
+    relation: IntersectionRelation,
 ) -> BooleanLatticeIntersectionResult:
     """Construct a graph on the Boolean lattice 2^[n].
 
@@ -21,6 +26,13 @@ def construct_boolean_lattice_intersection_graph(
     An edge joins two distinct subsets when their intersection size
     satisfies the declared relation with the threshold.
     """
+    try:
+        _validate_intersection_request(ground_set_size, threshold, relation)
+    except PydanticCustomError as error:
+        raise OperationDomainValidationError(
+            location=(), code=error.type, message=str(error)
+        ) from error
+
     n = ground_set_size
     all_subsets = [_subset_label(s) for s in _all_subsets(n)]
 
@@ -34,8 +46,10 @@ def construct_boolean_lattice_intersection_graph(
                 adjacent = intersection_size == threshold
             elif relation == "INTERSECTION_LT":
                 adjacent = intersection_size < threshold
-            else:
+            elif relation == "INTERSECTION_GT":
                 adjacent = intersection_size > threshold
+            else:
+                adjacent = False
             if adjacent:
                 a, b = all_subsets[i], all_subsets[j]
                 if a < b:

--- a/src/jacobian/math/graphs/boolean_lattice_intersection/operations.py
+++ b/src/jacobian/math/graphs/boolean_lattice_intersection/operations.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from pydantic_core import PydanticCustomError
 
+from jacobian.canonical import CanonicalLimits, encode_strict_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.boolean_lattice_intersection._models import (
     BooleanLatticeIntersectionResult,
@@ -13,6 +16,70 @@ from jacobian.math.graphs.boolean_lattice_intersection._models import (
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 __all__ = ["construct_boolean_lattice_intersection_graph"]
+
+
+@dataclass(frozen=True, slots=True)
+class BooleanLatticeIntersectionAdmission:
+    """The exact bounded graph construction shared by admission and execution."""
+
+    vertices: tuple[str, ...]
+    edges: tuple[tuple[str, str], ...]
+
+
+def _admit_boolean_lattice_intersection(
+    ground_set_size: int,
+    threshold: int,
+    relation: IntersectionRelation,
+) -> BooleanLatticeIntersectionAdmission:
+    try:
+        _validate_intersection_request(ground_set_size, threshold, relation)
+    except PydanticCustomError as error:
+        raise OperationDomainValidationError(
+            location=(), code=error.type, message=str(error)
+        ) from error
+
+    subsets = _all_subsets(ground_set_size)
+    vertices = tuple(_subset_label(subset) for subset in subsets)
+    edges: list[tuple[str, str]] = []
+    for left_index, left in enumerate(subsets):
+        left_label = vertices[left_index]
+        for right in subsets[left_index + 1 :]:
+            right_label = _subset_label(right)
+            intersection_size = len(left & right)
+            if relation == "INTERSECTION_EQ":
+                adjacent = intersection_size == threshold
+            elif relation == "INTERSECTION_LT":
+                adjacent = intersection_size < threshold
+            else:
+                adjacent = intersection_size > threshold
+            if adjacent:
+                edges.append(
+                    (min(left_label, right_label), max(left_label, right_label))
+                )
+    canonical_edges = tuple(edges)
+    payload = {
+        "ground_set_size": ground_set_size,
+        "threshold": threshold,
+        "relation": relation,
+        "graph": {
+            "vertices": list(vertices),
+            "edges": [list(edge) for edge in canonical_edges],
+        },
+    }
+    try:
+        if len(encode_strict_json(payload)) > CanonicalLimits().max_output_bytes:
+            raise OperationDomainValidationError(
+                location=(),
+                code="boolean_lattice.result_bytes_exceeded",
+                message="the Boolean-lattice graph exceeds the canonical output-byte limit",
+            )
+    except ValueError as error:
+        raise OperationDomainValidationError(
+            location=(),
+            code="boolean_lattice.result_not_canonical",
+            message="the Boolean-lattice graph cannot be represented in canonical JSON",
+        ) from error
+    return BooleanLatticeIntersectionAdmission(vertices, canonical_edges)
 
 
 def construct_boolean_lattice_intersection_graph(
@@ -26,43 +93,15 @@ def construct_boolean_lattice_intersection_graph(
     An edge joins two distinct subsets when their intersection size
     satisfies the declared relation with the threshold.
     """
-    try:
-        _validate_intersection_request(ground_set_size, threshold, relation)
-    except PydanticCustomError as error:
-        raise OperationDomainValidationError(
-            location=(), code=error.type, message=str(error)
-        ) from error
-
-    n = ground_set_size
-    all_subsets = [_subset_label(s) for s in _all_subsets(n)]
-
-    edges: list[tuple[str, str]] = []
-    for i in range(len(all_subsets)):
-        si = _subset_from_label(all_subsets[i])
-        for j in range(i + 1, len(all_subsets)):
-            sj = _subset_from_label(all_subsets[j])
-            intersection_size = len(si & sj)
-            if relation == "INTERSECTION_EQ":
-                adjacent = intersection_size == threshold
-            elif relation == "INTERSECTION_LT":
-                adjacent = intersection_size < threshold
-            elif relation == "INTERSECTION_GT":
-                adjacent = intersection_size > threshold
-            else:
-                adjacent = False
-            if adjacent:
-                a, b = all_subsets[i], all_subsets[j]
-                if a < b:
-                    edges.append((a, b))
-                else:
-                    edges.append((b, a))
-
-    graph = SimpleUndirectedGraph(
-        vertices=tuple(all_subsets),
-        edges=tuple(edges),
+    admission = _admit_boolean_lattice_intersection(
+        ground_set_size, threshold, relation
     )
-    return BooleanLatticeIntersectionResult(
-        ground_set_size=n,
+    graph = SimpleUndirectedGraph(
+        vertices=admission.vertices,
+        edges=admission.edges,
+    )
+    return BooleanLatticeIntersectionResult.model_construct(
+        ground_set_size=ground_set_size,
         threshold=threshold,
         relation=relation,
         graph=graph,
@@ -82,10 +121,3 @@ def _subset_label(subset: frozenset[int]) -> str:
     if not subset:
         return "{}"
     return "{" + ",".join(str(i) for i in sorted(subset)) + "}"
-
-
-def _subset_from_label(label: str) -> frozenset[int]:
-    if label == "{}":
-        return frozenset()
-    inner = label[1:-1]
-    return frozenset(int(x) for x in inner.split(","))

--- a/tests/math/graphs/boolean_lattice_intersection/test_boolean_lattice_intersection.py
+++ b/tests/math/graphs/boolean_lattice_intersection/test_boolean_lattice_intersection.py
@@ -68,14 +68,14 @@ def test_vertex_labels_are_subsets() -> None:
     assert set(result.graph.vertices) == {"{}", "{0}", "{1}", "{0,1}"}
 
 
-def test_rejects_threshold_exceeds_n() -> None:
+def test_threshold_above_ground_set_is_defined() -> None:
     request = BooleanLatticeIntersectionRequest(
-        ground_set_size=2, threshold=3, relation="INTERSECTION_EQ"
+        ground_set_size=2, threshold=3, relation="INTERSECTION_LT"
     )
-    with pytest.raises(OperationDomainValidationError):
-        construct_boolean_lattice_intersection_graph(
-            request.ground_set_size, request.threshold, request.relation
-        )
+    result = construct_boolean_lattice_intersection_graph(
+        request.ground_set_size, request.threshold, request.relation
+    )
+    assert len(result.graph.edges) == 6
 
 
 def test_result_preserves_metadata() -> None:

--- a/tests/math/graphs/boolean_lattice_intersection/test_boolean_lattice_intersection.py
+++ b/tests/math/graphs/boolean_lattice_intersection/test_boolean_lattice_intersection.py
@@ -81,3 +81,14 @@ def test_result_preserves_metadata() -> None:
     assert result.ground_set_size == 2
     assert result.threshold == 1
     assert result.relation == "INTERSECTION_EQ"
+
+
+def test_n8_is_the_carrier_boundary() -> None:
+    result = construct_boolean_lattice_intersection_graph(8, 0, "INTERSECTION_EQ")
+    assert len(result.graph.vertices) == 256
+    assert len(result.graph.edges) == 3_280
+
+
+def test_native_rejects_negative_ground_set_size() -> None:
+    with pytest.raises(ValueError, match="between 0"):
+        construct_boolean_lattice_intersection_graph(-1, 0, "INTERSECTION_EQ")

--- a/tests/math/graphs/boolean_lattice_intersection/test_boolean_lattice_intersection.py
+++ b/tests/math/graphs/boolean_lattice_intersection/test_boolean_lattice_intersection.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.boolean_lattice_intersection._models import (
+    BooleanLatticeIntersectionRequest,
+)
+from jacobian.math.graphs.boolean_lattice_intersection.operations import (
+    construct_boolean_lattice_intersection_graph,
+)
+
+# Lexicographic order of subset labels: {0,1} < {0} < {1} < {}
+
+
+def test_n0() -> None:
+    """Empty ground set has one vertex (empty set), no edges."""
+    result = construct_boolean_lattice_intersection_graph(0, 0, "INTERSECTION_EQ")
+    assert len(result.graph.vertices) == 1
+    assert len(result.graph.edges) == 0
+
+
+def test_n1() -> None:
+    """Ground set of size 1 has 2 vertices: {} and {0}."""
+    result = construct_boolean_lattice_intersection_graph(1, 0, "INTERSECTION_EQ")
+    assert len(result.graph.vertices) == 2
+    assert len(result.graph.edges) == 1
+
+
+def test_n2_vertex_count() -> None:
+    """Ground set of size 2 has 4 vertices."""
+    result = construct_boolean_lattice_intersection_graph(2, 0, "INTERSECTION_EQ")
+    assert len(result.graph.vertices) == 4
+
+
+def test_eq_threshold_r0() -> None:
+    """EQ threshold 0 on n=2: edges between disjoint subsets (intersection == 0)."""
+    result = construct_boolean_lattice_intersection_graph(2, 0, "INTERSECTION_EQ")
+    assert len(result.graph.edges) == 4
+
+
+def test_lt_threshold() -> None:
+    """LT threshold: edges when intersection < threshold."""
+    result = construct_boolean_lattice_intersection_graph(2, 1, "INTERSECTION_LT")
+    # All pairs with intersection < 1, i.e., intersection = 0
+    assert len(result.graph.edges) == 4
+
+
+def test_gt_threshold() -> None:
+    """GT threshold: edges when intersection > threshold."""
+    result = construct_boolean_lattice_intersection_graph(2, 0, "INTERSECTION_GT")
+    # All pairs with intersection > 0: {0}∩{0,1}={0}(1), {1}∩{0,1}={1}(1), {0}∩{1}={} (0)
+    assert len(result.graph.edges) == 2
+
+
+def test_no_loops_or_duplicates() -> None:
+    """No self-loops or duplicate edges."""
+    result = construct_boolean_lattice_intersection_graph(3, 1, "INTERSECTION_EQ")
+    for a, b in result.graph.edges:
+        assert a != b
+    edges = result.graph.edges
+    assert len(edges) == len(set(edges))
+
+
+def test_vertex_labels_are_subsets() -> None:
+    """Vertex labels are canonical subset representations."""
+    result = construct_boolean_lattice_intersection_graph(2, 0, "INTERSECTION_EQ")
+    assert set(result.graph.vertices) == {"{}", "{0}", "{1}", "{0,1}"}
+
+
+def test_rejects_threshold_exceeds_n() -> None:
+    with pytest.raises(ValidationError):
+        BooleanLatticeIntersectionRequest(
+            ground_set_size=2, threshold=3, relation="INTERSECTION_EQ"
+        )
+
+
+def test_result_preserves_metadata() -> None:
+    """Result retains the source parameters."""
+    result = construct_boolean_lattice_intersection_graph(2, 1, "INTERSECTION_EQ")
+    assert result.ground_set_size == 2
+    assert result.threshold == 1
+    assert result.relation == "INTERSECTION_EQ"

--- a/tests/math/graphs/boolean_lattice_intersection/test_boolean_lattice_intersection.py
+++ b/tests/math/graphs/boolean_lattice_intersection/test_boolean_lattice_intersection.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.boolean_lattice_intersection._models import (
     BooleanLatticeIntersectionRequest,
 )
@@ -69,9 +69,12 @@ def test_vertex_labels_are_subsets() -> None:
 
 
 def test_rejects_threshold_exceeds_n() -> None:
-    with pytest.raises(ValidationError):
-        BooleanLatticeIntersectionRequest(
-            ground_set_size=2, threshold=3, relation="INTERSECTION_EQ"
+    request = BooleanLatticeIntersectionRequest(
+        ground_set_size=2, threshold=3, relation="INTERSECTION_EQ"
+    )
+    with pytest.raises(OperationDomainValidationError):
+        construct_boolean_lattice_intersection_graph(
+            request.ground_set_size, request.threshold, request.relation
         )
 
 
@@ -90,5 +93,10 @@ def test_n8_is_the_carrier_boundary() -> None:
 
 
 def test_native_rejects_negative_ground_set_size() -> None:
-    with pytest.raises(ValueError, match="between 0"):
+    with pytest.raises(OperationDomainValidationError, match="between 0"):
         construct_boolean_lattice_intersection_graph(-1, 0, "INTERSECTION_EQ")
+
+
+def test_native_rejects_invalid_relation_before_enumeration() -> None:
+    with pytest.raises(OperationDomainValidationError, match="relation"):
+        construct_boolean_lattice_intersection_graph(8, 0, "INVALID")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Implements `graph.boolean_lattice_intersection.construct` from issue #2834.

Constructs a labelled simple graph whose vertices are all subsets of [n], with an edge between two subsets when their intersection size satisfies the declared relation (equal, less-than, or greater-than) with a given threshold. Includes Erdős #703 forbidden-intersection graphs as a special case.

## Design

- **Operation ID**: `graph.boolean_lattice_intersection.construct`
- **Input**: ground_set_size (n), threshold, relation mode
- **Output**: `SimpleUndirectedGraph` with 2^n vertices (one per subset of [n])
- **Kernel**: bitmask subset enumeration + pairwise intersection popcount
- **Bounds**: n <= 6 (at most 64 vertices)

## Tests

- n=0: single vertex (empty set), no edges
- n=1: 2 vertices, 1 edge (EQ threshold 0)
- n=2: 4 vertices, vertex count and edge count verification
- EQ/LT/GT threshold modes tested
- No self-loops or duplicates
- Vertex labels are canonical subset strings
- Threshold rejection
- Source preservation

Closes #2834

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)