### PR TITLE
Add graph.induced_edge_count_profile.compute operation

### DIFF
--- a/src/jacobian/math/graphs/induced_edge_count/__init__.py
+++ b/src/jacobian/math/graphs/induced_edge_count/__init__.py
@@ -1,0 +1,7 @@
+"""Induced edge count profile operations."""
+
+from jacobian.math.graphs.induced_edge_count.operations import (
+    compute_induced_edge_count_profile,
+)
+
+__all__ = ["compute_induced_edge_count_profile"]

--- a/src/jacobian/math/graphs/induced_edge_count/_models.py
+++ b/src/jacobian/math/graphs/induced_edge_count/_models.py
@@ -2,43 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Self
-
-from pydantic import Field, model_validator
-from pydantic_core import PydanticCustomError
+from pydantic import Field, StrictInt
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
-MAX_VERTICES = 20
+MAX_VERTICES = 256
 
 
 class InducedEdgeCountProfileRequest(StrictModel):
     """Request for the induced-edge-count distribution at a fixed cardinality."""
 
     graph: SimpleUndirectedGraph
-    cardinality: int = Field(ge=0)
-
-    @model_validator(mode="after")
-    def validate_cardinality(self) -> Self:
-        if self.cardinality > len(self.graph.vertices):
-            raise PydanticCustomError(
-                "graph.induced_edge_count.cardinality_too_large",
-                "cardinality must not exceed the number of graph vertices",
-            )
-        if len(self.graph.vertices) > MAX_VERTICES:
-            raise PydanticCustomError(
-                "graph.induced_edge_count.too_many_vertices",
-                f"at most {MAX_VERTICES} vertices are supported",
-            )
-        return self
+    cardinality: StrictInt = Field(ge=0, le=MAX_VERTICES)
 
 
 class InducedEdgeCountRow(StrictModel):
     """One row of the induced-edge-count distribution."""
 
-    edge_count: int
-    subset_count: int
+    edge_count: StrictInt = Field(ge=0)
+    subset_count: StrictInt = Field(ge=1)
     witness: tuple[str, ...]
 
 
@@ -46,7 +29,7 @@ class InducedEdgeCountProfileResult(StrictModel):
     """The complete distribution of induced-edge counts over k-subsets."""
 
     graph: SimpleUndirectedGraph
-    cardinality: int
+    cardinality: StrictInt = Field(ge=0, le=MAX_VERTICES)
     rows: tuple[InducedEdgeCountRow, ...]
 
 

--- a/src/jacobian/math/graphs/induced_edge_count/_models.py
+++ b/src/jacobian/math/graphs/induced_edge_count/_models.py
@@ -1,0 +1,58 @@
+"""Typed contracts for the induced-edge-count profile operation."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_VERTICES = 20
+
+
+class InducedEdgeCountProfileRequest(StrictModel):
+    """Request for the induced-edge-count distribution at a fixed cardinality."""
+
+    graph: SimpleUndirectedGraph
+    cardinality: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_cardinality(self) -> Self:
+        if self.cardinality > len(self.graph.vertices):
+            raise PydanticCustomError(
+                "graph.induced_edge_count.cardinality_too_large",
+                "cardinality must not exceed the number of graph vertices",
+            )
+        if len(self.graph.vertices) > MAX_VERTICES:
+            raise PydanticCustomError(
+                "graph.induced_edge_count.too_many_vertices",
+                f"at most {MAX_VERTICES} vertices are supported",
+            )
+        return self
+
+
+class InducedEdgeCountRow(StrictModel):
+    """One row of the induced-edge-count distribution."""
+
+    edge_count: int
+    subset_count: int
+    witness: tuple[str, ...]
+
+
+class InducedEdgeCountProfileResult(StrictModel):
+    """The complete distribution of induced-edge counts over k-subsets."""
+
+    graph: SimpleUndirectedGraph
+    cardinality: int
+    rows: tuple[InducedEdgeCountRow, ...]
+
+
+__all__ = [
+    "MAX_VERTICES",
+    "InducedEdgeCountProfileRequest",
+    "InducedEdgeCountProfileResult",
+    "InducedEdgeCountRow",
+]

--- a/src/jacobian/math/graphs/induced_edge_count/_tools.py
+++ b/src/jacobian/math/graphs/induced_edge_count/_tools.py
@@ -1,0 +1,80 @@
+"""Induced-edge-count profile operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.induced_edge_count._models import (
+    InducedEdgeCountProfileRequest,
+    InducedEdgeCountProfileResult,
+)
+from jacobian.math.graphs.induced_edge_count.operations import (
+    compute_induced_edge_count_profile,
+)
+
+
+def compute_induced_edge_count_profile_op(
+    request: InducedEdgeCountProfileRequest,
+) -> InducedEdgeCountProfileResult:
+    return compute_induced_edge_count_profile(request.graph, request.cardinality)
+
+
+def iec_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    iec_operation(
+        "graph.induced_edge_count_profile.compute",
+        "Profile induced-edge counts over fixed-cardinality vertex subsets",
+        (
+            "For a finite simple graph and a selected cardinality k, return the "
+            "complete exact distribution of induced-edge counts over all "
+            "k-element vertex subsets, with one canonical witness subset for "
+            "each attained count."
+        ),
+        InducedEdgeCountProfileRequest,
+        InducedEdgeCountProfileResult,
+        compute_induced_edge_count_profile_op,
+        "graph",
+        "profile",
+        "exact",
+        examples=(
+            example(
+                "path3_k2",
+                "P3 at cardinality 2: subsets have edge counts 1,1,0.",
+                {
+                    "graph": {
+                        "vertices": ["0", "1", "2"],
+                        "edges": [["0", "1"], ["1", "2"]],
+                    },
+                    "cardinality": 2,
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/induced_edge_count/operations.py
+++ b/src/jacobian/math/graphs/induced_edge_count/operations.py
@@ -137,7 +137,10 @@ def compute_induced_edge_count_profile(
     vertices = list(graph.vertices)
     edges = list(graph.edges)
 
-    count_to_subsets: dict[int, list[tuple[str, ...]]] = {}
+    # Keep one witness and a multiplicity per attained edge count rather than
+    # retaining every subset (large edgeless graphs can have nearly a million
+    # subsets but only one histogram row).
+    count_to_stats: dict[int, tuple[int, tuple[str, ...]]] = {}
 
     for subset in combinations(vertices, cardinality):
         subset_set = set(subset)
@@ -145,18 +148,21 @@ def compute_induced_edge_count_profile(
         for a, b in edges:
             if a in subset_set and b in subset_set:
                 edge_count += 1
-        if edge_count not in count_to_subsets:
-            count_to_subsets[edge_count] = []
-        count_to_subsets[edge_count].append(tuple(sorted(subset)))
+        witness = tuple(sorted(subset))
+        previous = count_to_stats.get(edge_count)
+        if previous is None:
+            count_to_stats[edge_count] = (1, witness)
+        else:
+            count, prior_witness = previous
+            count_to_stats[edge_count] = (count + 1, min(prior_witness, witness))
 
     rows: list[InducedEdgeCountRow] = []
-    for edge_count in sorted(count_to_subsets):
-        subsets = count_to_subsets[edge_count]
-        witness = min(subsets)
+    for edge_count in sorted(count_to_stats):
+        subset_count, witness = count_to_stats[edge_count]
         rows.append(
             InducedEdgeCountRow(
                 edge_count=edge_count,
-                subset_count=len(subsets),
+                subset_count=subset_count,
                 witness=witness,
             )
         )

--- a/src/jacobian/math/graphs/induced_edge_count/operations.py
+++ b/src/jacobian/math/graphs/induced_edge_count/operations.py
@@ -1,0 +1,57 @@
+"""Induced-edge-count profile kernel."""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+from jacobian.math.graphs.induced_edge_count._models import (
+    InducedEdgeCountProfileResult,
+    InducedEdgeCountRow,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+__all__ = ["compute_induced_edge_count_profile"]
+
+
+def compute_induced_edge_count_profile(
+    graph: SimpleUndirectedGraph,
+    cardinality: int,
+) -> InducedEdgeCountProfileResult:
+    """Return the distribution of induced-edge counts over all k-subsets.
+
+    For each k-element vertex subset, count the edges with both endpoints
+    in the subset. The result is a histogram: for each attained count,
+    the number of k-subsets having that count, and one canonical witness.
+    """
+    vertices = list(graph.vertices)
+    edges = list(graph.edges)
+
+    count_to_subsets: dict[int, list[tuple[str, ...]]] = {}
+
+    for subset in combinations(vertices, cardinality):
+        subset_set = set(subset)
+        edge_count = 0
+        for a, b in edges:
+            if a in subset_set and b in subset_set:
+                edge_count += 1
+        if edge_count not in count_to_subsets:
+            count_to_subsets[edge_count] = []
+        count_to_subsets[edge_count].append(tuple(sorted(subset)))
+
+    rows: list[InducedEdgeCountRow] = []
+    for edge_count in sorted(count_to_subsets):
+        subsets = count_to_subsets[edge_count]
+        witness = min(subsets)
+        rows.append(
+            InducedEdgeCountRow(
+                edge_count=edge_count,
+                subset_count=len(subsets),
+                witness=witness,
+            )
+        )
+
+    return InducedEdgeCountProfileResult(
+        graph=graph,
+        cardinality=cardinality,
+        rows=tuple(rows),
+    )

--- a/src/jacobian/math/graphs/induced_edge_count/operations.py
+++ b/src/jacobian/math/graphs/induced_edge_count/operations.py
@@ -119,6 +119,7 @@ def _admit_induced_edge_count_profile(
         result_bytes=result_bytes,
     )
 
+
 __all__ = ["compute_induced_edge_count_profile"]
 
 

--- a/src/jacobian/math/graphs/induced_edge_count/operations.py
+++ b/src/jacobian/math/graphs/induced_edge_count/operations.py
@@ -2,13 +2,122 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from itertools import combinations
+from math import comb
 
+from pydantic_core import PydanticCustomError
+
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    strict_json_object_size,
+)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.induced_edge_count._models import (
     InducedEdgeCountProfileResult,
     InducedEdgeCountRow,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_SUBSET_ENUMERATION = 1_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class InducedEdgeCountAdmission:
+    """Derived facts shared by native and catalog execution."""
+
+    subset_count: int
+    edge_count: int
+    result_rows: int
+    result_bytes: int
+
+
+def _array_size(value_sizes: tuple[int, ...]) -> int:
+    return 2 + max(len(value_sizes) - 1, 0) + sum(value_sizes)
+
+
+def _int_size(value: int) -> int:
+    return len(encode_strict_json(value))
+
+
+def _admit_induced_edge_count_profile(
+    graph: SimpleUndirectedGraph, cardinality: int
+) -> InducedEdgeCountAdmission:
+    """Admit one exact profile before combinations or edge scans begin."""
+
+    if not isinstance(graph, SimpleUndirectedGraph):
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.induced_edge_count.invalid_graph",
+            message="graph must be a SimpleUndirectedGraph",
+        )
+    if type(cardinality) is not int or cardinality < 0:
+        raise OperationDomainValidationError(
+            location=("cardinality",),
+            code="graph.induced_edge_count.invalid_cardinality",
+            message="cardinality must be a nonnegative integer",
+        )
+    vertex_count = len(graph.vertices)
+    edge_count = len(graph.edges)
+    if cardinality > vertex_count:
+        raise OperationDomainValidationError(
+            location=("cardinality",),
+            code="graph.induced_edge_count.cardinality_too_large",
+            message="cardinality must not exceed the number of graph vertices",
+        )
+    subset_count = comb(vertex_count, cardinality)
+    work = subset_count * max(edge_count, 1)
+    if work > MAX_SUBSET_ENUMERATION:
+        raise OperationDomainValidationError(
+            location=("cardinality",),
+            code="graph.induced_edge_count.enumeration_work_exceeded",
+            message=(
+                "induced-edge profile exceeds the "
+                f"{MAX_SUBSET_ENUMERATION}-iteration subset/edge work bound"
+            ),
+        )
+
+    try:
+        graph_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
+        label_sizes = tuple(len(encode_strict_json(label)) for label in graph.vertices)
+        witness_bytes = _array_size(
+            tuple(sorted(label_sizes, reverse=True)[:cardinality])
+        )
+        max_rows = min(edge_count + 1, subset_count)
+        row_bytes = strict_json_object_size(
+            (
+                ("edge_count", _int_size(edge_count)),
+                ("subset_count", _int_size(subset_count)),
+                ("witness", witness_bytes),
+            )
+        )
+        rows_bytes = _array_size((row_bytes,) * max_rows)
+        result_bytes = strict_json_object_size(
+            (
+                ("graph", graph_bytes),
+                ("cardinality", _int_size(cardinality)),
+                ("rows", rows_bytes),
+            )
+        )
+    except (ValueError, TypeError, PydanticCustomError) as error:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.induced_edge_count.source_not_canonical",
+            message="graph cannot be represented in canonical JSON",
+        ) from error
+    if result_bytes > CanonicalLimits().max_output_bytes:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.induced_edge_count.result_bytes_exceeded",
+            message="induced-edge profile exceeds the canonical output-byte limit",
+        )
+    return InducedEdgeCountAdmission(
+        subset_count=subset_count,
+        edge_count=edge_count,
+        result_rows=max_rows,
+        result_bytes=result_bytes,
+    )
 
 __all__ = ["compute_induced_edge_count_profile"]
 
@@ -23,6 +132,7 @@ def compute_induced_edge_count_profile(
     in the subset. The result is a histogram: for each attained count,
     the number of k-subsets having that count, and one canonical witness.
     """
+    _admit_induced_edge_count_profile(graph, cardinality)
     vertices = list(graph.vertices)
     edges = list(graph.edges)
 

--- a/tests/math/graphs/induced_edge_count/test_induced_edge_count.py
+++ b/tests/math/graphs/induced_edge_count/test_induced_edge_count.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from itertools import combinations
 
 import pytest
-from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.induced_edge_count._models import (
     InducedEdgeCountProfileRequest,
 )
@@ -14,7 +15,9 @@ from jacobian.math.graphs.induced_edge_count.operations import (
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 
-def _graph(vertices, edges):
+def _graph(
+    vertices: Sequence[str], edges: Sequence[tuple[str, str]]
+) -> SimpleUndirectedGraph:
     return SimpleUndirectedGraph(
         vertices=tuple(vertices),
         edges=tuple((a, b) for a, b in edges),
@@ -88,8 +91,32 @@ def test_exhaustive_comparison() -> None:
 
 def test_rejects_cardinality_too_large() -> None:
     g = _graph(["a", "b"], [("a", "b")])
-    with pytest.raises(ValidationError):
-        InducedEdgeCountProfileRequest(graph=g, cardinality=3)
+    request = InducedEdgeCountProfileRequest(graph=g, cardinality=3)
+    with pytest.raises(OperationDomainValidationError):
+        compute_induced_edge_count_profile(request.graph, request.cardinality)
+
+
+def test_native_admission_rejects_excessive_subset_edge_work() -> None:
+    g = _graph(
+        [f"{index:02}" for index in range(20)],
+        [
+            (f"{left:02}", f"{right:02}")
+            for left in range(20)
+            for right in range(left + 1, 20)
+        ],
+    )
+    with pytest.raises(OperationDomainValidationError, match="work bound"):
+        compute_induced_edge_count_profile(g, 10)
+
+
+def test_native_admission_rejects_untransportable_retained_result() -> None:
+    labels = tuple("x" * 240_000 + str(index) for index in range(20))
+    g = _graph(
+        labels,
+        [(labels[0], labels[1]), (labels[1], labels[2]), (labels[2], labels[3])],
+    )
+    with pytest.raises(OperationDomainValidationError, match="output-byte limit"):
+        compute_induced_edge_count_profile(g, 10)
 
 
 def test_result_preserves_source() -> None:

--- a/tests/math/graphs/induced_edge_count/test_induced_edge_count.py
+++ b/tests/math/graphs/induced_edge_count/test_induced_edge_count.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from itertools import combinations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.induced_edge_count._models import (
+    InducedEdgeCountProfileRequest,
+)
+from jacobian.math.graphs.induced_edge_count.operations import (
+    compute_induced_edge_count_profile,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph(vertices, edges):
+    return SimpleUndirectedGraph(
+        vertices=tuple(vertices),
+        edges=tuple((a, b) for a, b in edges),
+    )
+
+
+def test_path3_k2_fixture() -> None:
+    """P3 at k=2: subsets {0,1} and {1,2} have 1 edge, {0,2} has 0."""
+    g = _graph(["0", "1", "2"], [("0", "1"), ("1", "2")])
+    result = compute_induced_edge_count_profile(g, 2)
+    assert len(result.rows) == 2
+    row0 = next(r for r in result.rows if r.edge_count == 0)
+    row1 = next(r for r in result.rows if r.edge_count == 1)
+    assert row0.subset_count == 1
+    assert row1.subset_count == 2
+
+
+def test_empty_cardinality() -> None:
+    """k=0: one empty subset with 0 edges."""
+    g = _graph(["a", "b"], [("a", "b")])
+    result = compute_induced_edge_count_profile(g, 0)
+    assert len(result.rows) == 1
+    assert result.rows[0].edge_count == 0
+    assert result.rows[0].subset_count == 1
+
+
+def test_full_cardinality() -> None:
+    """k=|V|: one subset (all vertices) with all edges."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    result = compute_induced_edge_count_profile(g, 3)
+    assert len(result.rows) == 1
+    assert result.rows[0].edge_count == 2
+    assert result.rows[0].subset_count == 1
+
+
+def test_histogram_aggregation() -> None:
+    """The histogram is the aggregation of all retained rows."""
+    g = _graph(["a", "b", "c", "d"], [("a", "b"), ("b", "c"), ("c", "d"), ("a", "d")])
+    result = compute_induced_edge_count_profile(g, 2)
+    total = sum(r.subset_count for r in result.rows)
+    from math import comb
+
+    assert total == comb(4, 2)
+
+
+def test_witness_replay() -> None:
+    """Replay: verify the witness subset actually has the claimed edge count."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    result = compute_induced_edge_count_profile(g, 2)
+    edges = set(g.edges)
+    for row in result.rows:
+        subset_set = set(row.witness)
+        count = sum(1 for a, b in edges if a in subset_set and b in subset_set)
+        assert count == row.edge_count
+
+
+def test_exhaustive_comparison() -> None:
+    """Compare against independent enumeration."""
+    g = _graph(["a", "b", "c", "d"], [("a", "b"), ("a", "c"), ("b", "c"), ("c", "d")])
+    k = 2
+    result = compute_induced_edge_count_profile(g, k)
+    expected: dict[int, int] = {}
+    edges = set(g.edges)
+    for subset in combinations(g.vertices, k):
+        subset_set = set(subset)
+        count = sum(1 for a, b in edges if a in subset_set and b in subset_set)
+        expected[count] = expected.get(count, 0) + 1
+    actual = {r.edge_count: r.subset_count for r in result.rows}
+    assert actual == expected
+
+
+def test_rejects_cardinality_too_large() -> None:
+    g = _graph(["a", "b"], [("a", "b")])
+    with pytest.raises(ValidationError):
+        InducedEdgeCountProfileRequest(graph=g, cardinality=3)
+
+
+def test_result_preserves_source() -> None:
+    """Result retains the source graph and cardinality."""
+    g = _graph(["a", "b"], [("a", "b")])
+    result = compute_induced_edge_count_profile(g, 1)
+    assert result.graph == g
+    assert result.cardinality == 1


### PR DESCRIPTION
## Summary

Implements `graph.induced_edge_count_profile.compute` from issue #2787.

For a finite simple graph and a selected cardinality k, returns the complete exact distribution of induced-edge counts over all k-element vertex subsets, with one canonical witness subset for each attained count.

## Design

- **Operation ID**: `graph.induced_edge_count_profile.compute`
- **Input**: `SimpleUndirectedGraph` +  (k)
- **Output**: `InducedEdgeCountProfileResult` with histogram rows (edge_count, subset_count, witness)
- **Kernel**: O(C(n,k)) combination enumeration with per-subset induced-edge counting
- **Bounds**: at most 20 vertices (C(20,10) = 184,756 subsets)

## Tests

- P3 at k=2: fixture (2 subsets with 1 edge, 1 with 0 edges)
- k=0: single empty subset with 0 edges
- k=|V|: one full subset with all edges
- Histogram aggregation: sum of counts = C(n,k)
- Witness replay: each witness actually has the claimed edge count
- Exhaustive comparison against independent enumeration
- Cardinality rejection (> n)
- Source preservation

Closes #2787

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)