### PR TITLE
Add graph.edge_colored.monochromatic_clique_hypergraph.construct operation

### DIFF
--- a/src/jacobian/math/graphs/monochromatic_clique/__init__.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/__init__.py
@@ -1,0 +1,7 @@
+"""Monochromatic clique hypergraph constructor."""
+
+from jacobian.math.graphs.monochromatic_clique.operations import (
+    construct_monochromatic_clique_hypergraph,
+)
+
+__all__ = ["construct_monochromatic_clique_hypergraph"]

--- a/src/jacobian/math/graphs/monochromatic_clique/_models.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/_models.py
@@ -14,7 +14,7 @@ from jacobian.math.graphs.values import (
 )
 
 MAX_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
-MAX_CLIQUE_ORDER = 8
+MAX_CLIQUE_ORDER = MAX_VERTICES
 
 
 class MonochromaticCliqueHypergraphRequest(StrictModel):

--- a/src/jacobian/math/graphs/monochromatic_clique/_models.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/_models.py
@@ -8,9 +8,12 @@ from jacobian._models import StrictModel
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
 )
-from jacobian.math.graphs.values import ColoredUndirectedGraph
+from jacobian.math.graphs.values import (
+    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    ColoredUndirectedGraph,
+)
 
-MAX_VERTICES = 20
+MAX_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
 MAX_CLIQUE_ORDER = 8
 
 

--- a/src/jacobian/math/graphs/monochromatic_clique/_models.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/_models.py
@@ -1,0 +1,69 @@
+"""Typed contracts for the monochromatic clique hypergraph operation."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.graphs.values import ColoredUndirectedGraph
+
+MAX_VERTICES = 20
+MAX_CLIQUE_ORDER = 8
+
+
+class MonochromaticCliqueHypergraphRequest(StrictModel):
+    """Request to construct the monochromatic clique hypergraph."""
+
+    colored_graph: ColoredUndirectedGraph
+    clique_order: int = Field(ge=2, le=MAX_CLIQUE_ORDER)
+
+    @model_validator(mode="after")
+    def validate_request(self) -> Self:
+        if not self.colored_graph.edge_colors:
+            raise PydanticCustomError(
+                "monochromatic_clique.no_edge_colors",
+                "edge_colors must be provided (total colouring required)",
+            )
+        if len(self.colored_graph.graph.vertices) > MAX_VERTICES:
+            raise PydanticCustomError(
+                "monochromatic_clique.too_many_vertices",
+                f"at most {MAX_VERTICES} vertices are supported",
+            )
+        vertices = self.colored_graph.graph.vertices
+        n = len(vertices)
+        for i in range(n):
+            for j in range(i + 1, n):
+                if (
+                    vertices[i],
+                    vertices[j],
+                ) not in self.colored_graph.graph.edges and (
+                    vertices[j],
+                    vertices[i],
+                ) not in self.colored_graph.graph.edges:
+                    raise PydanticCustomError(
+                        "monochromatic_clique.graph_not_complete",
+                        "the underlying graph must be complete",
+                    )
+        return self
+
+
+class MonochromaticCliqueHypergraphResult(StrictModel):
+    """The monochromatic clique hypergraph of a coloured complete graph."""
+
+    colored_graph: ColoredUndirectedGraph
+    clique_order: int
+    hypergraph: FiniteHypergraph
+
+
+__all__ = [
+    "MAX_CLIQUE_ORDER",
+    "MAX_VERTICES",
+    "MonochromaticCliqueHypergraphRequest",
+    "MonochromaticCliqueHypergraphResult",
+]

--- a/src/jacobian/math/graphs/monochromatic_clique/_models.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/_models.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Self
-
-from pydantic import Field, model_validator
-from pydantic_core import PydanticCustomError
+from pydantic import Field, StrictInt
 
 from jacobian._models import StrictModel
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
@@ -21,43 +18,14 @@ class MonochromaticCliqueHypergraphRequest(StrictModel):
     """Request to construct the monochromatic clique hypergraph."""
 
     colored_graph: ColoredUndirectedGraph
-    clique_order: int = Field(ge=2, le=MAX_CLIQUE_ORDER)
-
-    @model_validator(mode="after")
-    def validate_request(self) -> Self:
-        if not self.colored_graph.edge_colors:
-            raise PydanticCustomError(
-                "monochromatic_clique.no_edge_colors",
-                "edge_colors must be provided (total colouring required)",
-            )
-        if len(self.colored_graph.graph.vertices) > MAX_VERTICES:
-            raise PydanticCustomError(
-                "monochromatic_clique.too_many_vertices",
-                f"at most {MAX_VERTICES} vertices are supported",
-            )
-        vertices = self.colored_graph.graph.vertices
-        n = len(vertices)
-        for i in range(n):
-            for j in range(i + 1, n):
-                if (
-                    vertices[i],
-                    vertices[j],
-                ) not in self.colored_graph.graph.edges and (
-                    vertices[j],
-                    vertices[i],
-                ) not in self.colored_graph.graph.edges:
-                    raise PydanticCustomError(
-                        "monochromatic_clique.graph_not_complete",
-                        "the underlying graph must be complete",
-                    )
-        return self
+    clique_order: StrictInt = Field(ge=2, le=MAX_CLIQUE_ORDER)
 
 
 class MonochromaticCliqueHypergraphResult(StrictModel):
     """The monochromatic clique hypergraph of a coloured complete graph."""
 
     colored_graph: ColoredUndirectedGraph
-    clique_order: int
+    clique_order: StrictInt = Field(ge=2, le=MAX_CLIQUE_ORDER)
     hypergraph: FiniteHypergraph
 
 

--- a/src/jacobian/math/graphs/monochromatic_clique/_tools.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/_tools.py
@@ -1,0 +1,92 @@
+"""Monochromatic clique hypergraph operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.monochromatic_clique._models import (
+    MonochromaticCliqueHypergraphRequest,
+    MonochromaticCliqueHypergraphResult,
+)
+from jacobian.math.graphs.monochromatic_clique.operations import (
+    construct_monochromatic_clique_hypergraph,
+)
+
+
+def compute_monochromatic_clique_hypergraph(
+    request: MonochromaticCliqueHypergraphRequest,
+) -> MonochromaticCliqueHypergraphResult:
+    return construct_monochromatic_clique_hypergraph(
+        request.colored_graph, request.clique_order
+    )
+
+
+def mc_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    mc_operation(
+        "graph.edge_colored.monochromatic_clique_hypergraph.construct",
+        "Construct the monochromatic-clique hypergraph of an edge-coloured graph",
+        (
+            "Given a bounded complete edge-coloured simple graph and an integer "
+            "t >= 2, return the canonical t-uniform FiniteHypergraph whose "
+            "hyperedges are exactly the t-element vertex sets inducing a "
+            "monochromatic clique in the source."
+        ),
+        MonochromaticCliqueHypergraphRequest,
+        MonochromaticCliqueHypergraphResult,
+        compute_monochromatic_clique_hypergraph,
+        "graph",
+        "ramsey",
+        "exact",
+        examples=(
+            example(
+                "all_red_k4_t3",
+                "All-red K4 with target clique order 3.",
+                {
+                    "colored_graph": {
+                        "graph": {
+                            "vertices": ["0", "1", "2", "3"],
+                            "edges": [
+                                ["0", "1"],
+                                ["0", "2"],
+                                ["0", "3"],
+                                ["1", "2"],
+                                ["1", "3"],
+                                ["2", "3"],
+                            ],
+                        },
+                        "edge_colors": ["red", "red", "red", "red", "red", "red"],
+                    },
+                    "clique_order": 3,
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/monochromatic_clique/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/operations.py
@@ -102,9 +102,7 @@ def _admit_monochromatic_clique_hypergraph(
             code="monochromatic_clique.work_bound_exceeded",
             message="monochromatic clique enumeration exceeds the work bound",
         )
-    edge_to_color = dict(
-        zip(graph.edges, colored_graph.edge_colors, strict=True)
-    )
+    edge_to_color = dict(zip(graph.edges, colored_graph.edge_colors, strict=True))
     cliques = tuple(
         tuple(sorted(subset))
         for subset in combinations(vertices, clique_order)

--- a/src/jacobian/math/graphs/monochromatic_clique/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/operations.py
@@ -73,7 +73,7 @@ def _admit_monochromatic_clique_hypergraph(
             code="monochromatic_clique.too_many_vertices",
             message=f"at most {MAX_VERTICES} vertices are supported",
         )
-    if not colored_graph.edge_colors:
+    if graph.edges and not colored_graph.edge_colors:
         raise OperationDomainValidationError(
             location=("colored_graph", "edge_colors"),
             code="monochromatic_clique.no_edge_colors",

--- a/src/jacobian/math/graphs/monochromatic_clique/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/operations.py
@@ -45,7 +45,7 @@ def _int_size(value: int) -> int:
     return len(encode_strict_json(value))
 
 
-def _admit_monochromatic_clique_hypergraph(
+def _admit_monochromatic_clique_hypergraph(  # noqa: C901
     colored_graph: ColoredUndirectedGraph, clique_order: int
 ) -> MonochromaticCliqueAdmission:
     """Admit the complete finite construction before enumerating subsets."""
@@ -103,17 +103,32 @@ def _admit_monochromatic_clique_hypergraph(
             message="monochromatic clique enumeration exceeds the work bound",
         )
     edge_to_color = dict(zip(graph.edges, colored_graph.edge_colors, strict=True))
-    cliques = tuple(
-        tuple(sorted(subset))
-        for subset in combinations(vertices, clique_order)
+    cliques_list: list[tuple[str, ...]] = []
+    for subset in combinations(vertices, clique_order):
         if len(
             {
                 edge_to_color.get((left, right), edge_to_color.get((right, left)))
                 for left, right in combinations(subset, 2)
             }
-        )
-        == 1
-    )
+        ) != 1:
+            continue
+        cliques_list.append(tuple(sorted(subset)))
+        if len(cliques_list) > MAX_EDGES:
+            raise OperationDomainValidationError(
+                location=("clique_order",),
+                code="monochromatic_clique.edge_bound_exceeded",
+                message=f"the construction exceeds the {MAX_EDGES}-edge hypergraph bound",
+            )
+        if len(cliques_list) * clique_order > MAX_TOTAL_INCIDENCES:
+            raise OperationDomainValidationError(
+                location=("clique_order",),
+                code="monochromatic_clique.incidence_bound_exceeded",
+                message=(
+                    "the construction exceeds the "
+                    f"{MAX_TOTAL_INCIDENCES}-incidence hypergraph bound"
+                ),
+            )
+    cliques = tuple(cliques_list)
     clique_count = len(cliques)
     incidence_count = clique_count * clique_order
     if clique_count > MAX_EDGES:
@@ -137,15 +152,21 @@ def _admit_monochromatic_clique_hypergraph(
         )
         label_sizes = tuple(len(encode_strict_json(label)) for label in vertices)
         vertex_bytes = _array_size(label_sizes)
-        member_bytes = _array_size(
-            tuple(sorted(label_sizes, reverse=True)[:clique_order])
+        edge_bytes = tuple(
+            _array_size(
+                (
+                    len(encode_strict_json(f"clique_{index}")),
+                    _array_size(
+                        tuple(len(encode_strict_json(vertex)) for vertex in clique)
+                    ),
+                )
+            )
+            for index, clique in enumerate(cliques)
         )
-        edge_id_bytes = len(encode_strict_json(f"clique_{clique_count - 1}"))
-        edge_bytes = _array_size((edge_id_bytes, member_bytes))
         hypergraph_bytes = strict_json_object_size(
             (
                 ("vertices", vertex_bytes),
-                ("edges", _array_size((edge_bytes,) * clique_count)),
+                ("edges", _array_size(edge_bytes)),
             )
         )
         result_bytes = strict_json_object_size(

--- a/src/jacobian/math/graphs/monochromatic_clique/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/operations.py
@@ -34,6 +34,7 @@ class MonochromaticCliqueAdmission:
     clique_count: int
     incidence_count: int
     result_bytes: int
+    cliques: tuple[tuple[str, ...], ...]
 
 
 def _array_size(value_sizes: tuple[int, ...]) -> int:
@@ -93,7 +94,29 @@ def _admit_monochromatic_clique_hypergraph(
                     code="monochromatic_clique.graph_not_complete",
                     message="the underlying graph must be complete",
                 )
-    clique_count = comb(vertex_count, clique_order)
+    candidate_count = comb(vertex_count, clique_order)
+    work = candidate_count * (clique_order * (clique_order - 1) // 2)
+    if work > 2_000_000:
+        raise OperationDomainValidationError(
+            location=("clique_order",),
+            code="monochromatic_clique.work_bound_exceeded",
+            message="monochromatic clique enumeration exceeds the work bound",
+        )
+    edge_to_color = dict(
+        zip(graph.edges, colored_graph.edge_colors, strict=True)
+    )
+    cliques = tuple(
+        tuple(sorted(subset))
+        for subset in combinations(vertices, clique_order)
+        if len(
+            {
+                edge_to_color.get((left, right), edge_to_color.get((right, left)))
+                for left, right in combinations(subset, 2)
+            }
+        )
+        == 1
+    )
+    clique_count = len(cliques)
     incidence_count = clique_count * clique_order
     if clique_count > MAX_EDGES:
         raise OperationDomainValidationError(
@@ -146,7 +169,9 @@ def _admit_monochromatic_clique_hypergraph(
             code="monochromatic_clique.result_bytes_exceeded",
             message="monochromatic clique hypergraph exceeds the canonical output-byte limit",
         )
-    return MonochromaticCliqueAdmission(clique_count, incidence_count, result_bytes)
+    return MonochromaticCliqueAdmission(
+        clique_count, incidence_count, result_bytes, cliques
+    )
 
 
 __all__ = ["construct_monochromatic_clique_hypergraph"]
@@ -163,42 +188,15 @@ def construct_monochromatic_clique_hypergraph(
     and becomes a hyperedge.
     """
     admission = _admit_monochromatic_clique_hypergraph(colored_graph, clique_order)
-    graph = colored_graph.graph
-    vertices = list(graph.vertices)
-    edges = list(graph.edges)
-    edge_colors = colored_graph.edge_colors
+    hyper_edges = tuple(
+        (f"clique_{index}", clique) for index, clique in enumerate(admission.cliques)
+    )
 
-    edge_to_color: dict[tuple[str, str], str] = {}
-    for i, (a, b) in enumerate(edges):
-        edge_to_color[(a, b)] = edge_colors[i]
-
-    hyper_edges: list[tuple[str, tuple[str, ...]]] = []
-    edge_index = 0
-
-    for subset in combinations(vertices, clique_order):
-        colors = set()
-        is_mono = True
-        for i in range(clique_order):
-            for j in range(i + 1, clique_order):
-                a, b = subset[i], subset[j]
-                if (a, b) in edge_to_color:
-                    colors.add(edge_to_color[(a, b)])
-                elif (b, a) in edge_to_color:
-                    colors.add(edge_to_color[(b, a)])
-                else:
-                    is_mono = False
-                    break
-            if not is_mono:
-                break
-        if is_mono and len(colors) == 1:
-            hyper_edges.append((f"clique_{edge_index}", tuple(sorted(subset))))
-            edge_index += 1
-
-    if len(hyper_edges) > admission.clique_count:
+    if len(hyper_edges) != admission.clique_count:
         raise AssertionError("kernel produced more clique edges than admitted")
     hypergraph = FiniteHypergraph(
-        vertices=tuple(vertices),
-        edges=tuple(hyper_edges),
+        vertices=colored_graph.graph.vertices,
+        edges=hyper_edges,
     )
     return MonochromaticCliqueHypergraphResult(
         colored_graph=colored_graph,

--- a/src/jacobian/math/graphs/monochromatic_clique/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/operations.py
@@ -105,12 +105,15 @@ def _admit_monochromatic_clique_hypergraph(  # noqa: C901
     edge_to_color = dict(zip(graph.edges, colored_graph.edge_colors, strict=True))
     cliques_list: list[tuple[str, ...]] = []
     for subset in combinations(vertices, clique_order):
-        if len(
-            {
-                edge_to_color.get((left, right), edge_to_color.get((right, left)))
-                for left, right in combinations(subset, 2)
-            }
-        ) != 1:
+        if (
+            len(
+                {
+                    edge_to_color.get((left, right), edge_to_color.get((right, left)))
+                    for left, right in combinations(subset, 2)
+                }
+            )
+            != 1
+        ):
             continue
         cliques_list.append(tuple(sorted(subset)))
         if len(cliques_list) > MAX_EDGES:

--- a/src/jacobian/math/graphs/monochromatic_clique/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/operations.py
@@ -60,8 +60,7 @@ def _admit_monochromatic_clique_hypergraph(
             location=("clique_order",),
             code="monochromatic_clique.invalid_clique_order",
             message=(
-                "clique_order must be an integer between 2 and "
-                f"{MAX_CLIQUE_ORDER}"
+                f"clique_order must be an integer between 2 and {MAX_CLIQUE_ORDER}"
             ),
         )
     graph = colored_graph.graph
@@ -117,7 +116,9 @@ def _admit_monochromatic_clique_hypergraph(
         )
         label_sizes = tuple(len(encode_strict_json(label)) for label in vertices)
         vertex_bytes = _array_size(label_sizes)
-        member_bytes = _array_size(tuple(sorted(label_sizes, reverse=True)[:clique_order]))
+        member_bytes = _array_size(
+            tuple(sorted(label_sizes, reverse=True)[:clique_order])
+        )
         edge_id_bytes = len(encode_strict_json(f"clique_{clique_count - 1}"))
         edge_bytes = _array_size((edge_id_bytes, member_bytes))
         hypergraph_bytes = strict_json_object_size(
@@ -146,6 +147,7 @@ def _admit_monochromatic_clique_hypergraph(
             message="monochromatic clique hypergraph exceeds the canonical output-byte limit",
         )
     return MonochromaticCliqueAdmission(clique_count, incidence_count, result_bytes)
+
 
 __all__ = ["construct_monochromatic_clique_hypergraph"]
 

--- a/src/jacobian/math/graphs/monochromatic_clique/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/operations.py
@@ -2,15 +2,150 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from itertools import combinations
+from math import comb
 
+from pydantic_core import PydanticCustomError
+
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    strict_json_object_size,
+)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_TOTAL_INCIDENCES,
     FiniteHypergraph,
 )
 from jacobian.math.graphs.monochromatic_clique._models import (
+    MAX_CLIQUE_ORDER,
+    MAX_VERTICES,
     MonochromaticCliqueHypergraphResult,
 )
 from jacobian.math.graphs.values import ColoredUndirectedGraph
+
+
+@dataclass(frozen=True, slots=True)
+class MonochromaticCliqueAdmission:
+    """Derived bounds shared by native and catalog execution."""
+
+    clique_count: int
+    incidence_count: int
+    result_bytes: int
+
+
+def _array_size(value_sizes: tuple[int, ...]) -> int:
+    return 2 + max(len(value_sizes) - 1, 0) + sum(value_sizes)
+
+
+def _int_size(value: int) -> int:
+    return len(encode_strict_json(value))
+
+
+def _admit_monochromatic_clique_hypergraph(
+    colored_graph: ColoredUndirectedGraph, clique_order: int
+) -> MonochromaticCliqueAdmission:
+    """Admit the complete finite construction before enumerating subsets."""
+
+    if not isinstance(colored_graph, ColoredUndirectedGraph):
+        raise OperationDomainValidationError(
+            location=("colored_graph",),
+            code="monochromatic_clique.invalid_graph",
+            message="colored_graph must be a ColoredUndirectedGraph",
+        )
+    if type(clique_order) is not int or not 2 <= clique_order <= MAX_CLIQUE_ORDER:
+        raise OperationDomainValidationError(
+            location=("clique_order",),
+            code="monochromatic_clique.invalid_clique_order",
+            message=(
+                "clique_order must be an integer between 2 and "
+                f"{MAX_CLIQUE_ORDER}"
+            ),
+        )
+    graph = colored_graph.graph
+    vertices = graph.vertices
+    vertex_count = len(vertices)
+    if vertex_count > MAX_VERTICES:
+        raise OperationDomainValidationError(
+            location=("colored_graph", "graph", "vertices"),
+            code="monochromatic_clique.too_many_vertices",
+            message=f"at most {MAX_VERTICES} vertices are supported",
+        )
+    if not colored_graph.edge_colors:
+        raise OperationDomainValidationError(
+            location=("colored_graph", "edge_colors"),
+            code="monochromatic_clique.no_edge_colors",
+            message="edge_colors must be provided (total colouring required)",
+        )
+    if len(colored_graph.edge_colors) != len(graph.edges):
+        raise OperationDomainValidationError(
+            location=("colored_graph", "edge_colors"),
+            code="monochromatic_clique.edge_colors_not_aligned",
+            message="edge_colors must align with every graph edge",
+        )
+    edge_set = set(graph.edges)
+    for left_index, left in enumerate(vertices):
+        for right in vertices[left_index + 1 :]:
+            if (left, right) not in edge_set and (right, left) not in edge_set:
+                raise OperationDomainValidationError(
+                    location=("colored_graph", "graph", "edges"),
+                    code="monochromatic_clique.graph_not_complete",
+                    message="the underlying graph must be complete",
+                )
+    clique_count = comb(vertex_count, clique_order)
+    incidence_count = clique_count * clique_order
+    if clique_count > MAX_EDGES:
+        raise OperationDomainValidationError(
+            location=("clique_order",),
+            code="monochromatic_clique.edge_bound_exceeded",
+            message=f"the construction exceeds the {MAX_EDGES}-edge hypergraph bound",
+        )
+    if incidence_count > MAX_TOTAL_INCIDENCES:
+        raise OperationDomainValidationError(
+            location=("clique_order",),
+            code="monochromatic_clique.incidence_bound_exceeded",
+            message=(
+                "the construction exceeds the "
+                f"{MAX_TOTAL_INCIDENCES}-incidence hypergraph bound"
+            ),
+        )
+    try:
+        colored_graph_bytes = len(
+            encode_strict_json(colored_graph.model_dump(mode="json"))
+        )
+        label_sizes = tuple(len(encode_strict_json(label)) for label in vertices)
+        vertex_bytes = _array_size(label_sizes)
+        member_bytes = _array_size(tuple(sorted(label_sizes, reverse=True)[:clique_order]))
+        edge_id_bytes = len(encode_strict_json(f"clique_{clique_count - 1}"))
+        edge_bytes = _array_size((edge_id_bytes, member_bytes))
+        hypergraph_bytes = strict_json_object_size(
+            (
+                ("vertices", vertex_bytes),
+                ("edges", _array_size((edge_bytes,) * clique_count)),
+            )
+        )
+        result_bytes = strict_json_object_size(
+            (
+                ("colored_graph", colored_graph_bytes),
+                ("clique_order", _int_size(clique_order)),
+                ("hypergraph", hypergraph_bytes),
+            )
+        )
+    except (ValueError, TypeError, PydanticCustomError) as error:
+        raise OperationDomainValidationError(
+            location=("colored_graph",),
+            code="monochromatic_clique.source_not_canonical",
+            message="colored_graph cannot be represented in canonical JSON",
+        ) from error
+    if result_bytes > CanonicalLimits().max_output_bytes:
+        raise OperationDomainValidationError(
+            location=("colored_graph",),
+            code="monochromatic_clique.result_bytes_exceeded",
+            message="monochromatic clique hypergraph exceeds the canonical output-byte limit",
+        )
+    return MonochromaticCliqueAdmission(clique_count, incidence_count, result_bytes)
 
 __all__ = ["construct_monochromatic_clique_hypergraph"]
 
@@ -25,6 +160,7 @@ def construct_monochromatic_clique_hypergraph(
     share the same colour. If so, the subset is a monochromatic t-clique
     and becomes a hyperedge.
     """
+    admission = _admit_monochromatic_clique_hypergraph(colored_graph, clique_order)
     graph = colored_graph.graph
     vertices = list(graph.vertices)
     edges = list(graph.edges)
@@ -56,6 +192,8 @@ def construct_monochromatic_clique_hypergraph(
             hyper_edges.append((f"clique_{edge_index}", tuple(sorted(subset))))
             edge_index += 1
 
+    if len(hyper_edges) > admission.clique_count:
+        raise AssertionError("kernel produced more clique edges than admitted")
     hypergraph = FiniteHypergraph(
         vertices=tuple(vertices),
         edges=tuple(hyper_edges),

--- a/src/jacobian/math/graphs/monochromatic_clique/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/operations.py
@@ -1,0 +1,67 @@
+"""Monochromatic clique hypergraph constructor."""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.graphs.monochromatic_clique._models import (
+    MonochromaticCliqueHypergraphResult,
+)
+from jacobian.math.graphs.values import ColoredUndirectedGraph
+
+__all__ = ["construct_monochromatic_clique_hypergraph"]
+
+
+def construct_monochromatic_clique_hypergraph(
+    colored_graph: ColoredUndirectedGraph,
+    clique_order: int,
+) -> MonochromaticCliqueHypergraphResult:
+    """Construct the t-uniform monochromatic-clique hypergraph.
+
+    For each t-element vertex subset, check whether all C(t,2) edges
+    share the same colour. If so, the subset is a monochromatic t-clique
+    and becomes a hyperedge.
+    """
+    graph = colored_graph.graph
+    vertices = list(graph.vertices)
+    edges = list(graph.edges)
+    edge_colors = colored_graph.edge_colors
+
+    edge_to_color: dict[tuple[str, str], str] = {}
+    for i, (a, b) in enumerate(edges):
+        edge_to_color[(a, b)] = edge_colors[i]
+
+    hyper_edges: list[tuple[str, tuple[str, ...]]] = []
+    edge_index = 0
+
+    for subset in combinations(vertices, clique_order):
+        colors = set()
+        is_mono = True
+        for i in range(clique_order):
+            for j in range(i + 1, clique_order):
+                a, b = subset[i], subset[j]
+                if (a, b) in edge_to_color:
+                    colors.add(edge_to_color[(a, b)])
+                elif (b, a) in edge_to_color:
+                    colors.add(edge_to_color[(b, a)])
+                else:
+                    is_mono = False
+                    break
+            if not is_mono:
+                break
+        if is_mono and len(colors) == 1:
+            hyper_edges.append((f"clique_{edge_index}", tuple(sorted(subset))))
+            edge_index += 1
+
+    hypergraph = FiniteHypergraph(
+        vertices=tuple(vertices),
+        edges=tuple(hyper_edges),
+    )
+    return MonochromaticCliqueHypergraphResult(
+        colored_graph=colored_graph,
+        clique_order=clique_order,
+        hypergraph=hypergraph,
+    )

--- a/tests/math/graphs/monochromatic_clique/test_monochromatic_clique.py
+++ b/tests/math/graphs/monochromatic_clique/test_monochromatic_clique.py
@@ -69,6 +69,27 @@ def test_t2() -> None:
     assert len(result.hypergraph.edges) == 6  # C(4,2) = 6
 
 
+def test_all_red_k9_is_admitted_when_only_one_clique_is_materialized() -> None:
+    vertices = tuple(str(index) for index in range(9))
+    graph = SimpleUndirectedGraph(
+        vertices=vertices,
+        edges=tuple(combinations(vertices, 2)),
+    )
+    result = construct_monochromatic_clique_hypergraph(
+        ColoredUndirectedGraph(graph=graph, edge_colors=("red",) * len(graph.edges)),
+        9,
+    )
+    assert len(result.hypergraph.edges) == 1
+
+
+def test_edgeless_graph_accepts_empty_edge_coloring() -> None:
+    graph = SimpleUndirectedGraph(vertices=("0",), edges=())
+    result = construct_monochromatic_clique_hypergraph(
+        ColoredUndirectedGraph(graph=graph), 2
+    )
+    assert result.hypergraph.edges == ()
+
+
 def test_replay_monochromatic() -> None:
     """Every hyperedge induces a monochromatic clique."""
     result = construct_monochromatic_clique_hypergraph(_k4_mixed(), 3)

--- a/tests/math/graphs/monochromatic_clique/test_monochromatic_clique.py
+++ b/tests/math/graphs/monochromatic_clique/test_monochromatic_clique.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from itertools import combinations
+
+from jacobian.math.graphs.monochromatic_clique.operations import (
+    construct_monochromatic_clique_hypergraph,
+)
+from jacobian.math.graphs.values import ColoredUndirectedGraph, SimpleUndirectedGraph
+
+
+def _k4_red():
+    return ColoredUndirectedGraph(
+        graph=SimpleUndirectedGraph(
+            vertices=("0", "1", "2", "3"),
+            edges=(
+                ("0", "1"),
+                ("0", "2"),
+                ("0", "3"),
+                ("1", "2"),
+                ("1", "3"),
+                ("2", "3"),
+            ),
+        ),
+        edge_colors=("red", "red", "red", "red", "red", "red"),
+    )
+
+
+def _k4_mixed():
+    return ColoredUndirectedGraph(
+        graph=SimpleUndirectedGraph(
+            vertices=("0", "1", "2", "3"),
+            edges=(
+                ("0", "1"),
+                ("0", "2"),
+                ("0", "3"),
+                ("1", "2"),
+                ("1", "3"),
+                ("2", "3"),
+            ),
+        ),
+        edge_colors=("red", "red", "red", "blue", "blue", "blue"),
+    )
+
+
+def test_all_red_k4_t3() -> None:
+    """All-red K4 with t=3: four monochromatic 3-cliques."""
+    result = construct_monochromatic_clique_hypergraph(_k4_red(), 3)
+    assert len(result.hypergraph.edges) == 4
+
+
+def test_mixed_k4_t3() -> None:
+    """Mixed K4 with edges 0-1-2 red, 1-2-3 blue: check clique counts."""
+    result = construct_monochromatic_clique_hypergraph(_k4_mixed(), 3)
+    # Only {0,1,2} is a monochromatic triangle (all red)
+    edges = [frozenset(members) for _, members in result.hypergraph.edges]
+    assert frozenset({"1", "2", "3"}) in edges
+    assert len(edges) == 1
+
+
+def test_t2() -> None:
+    """t=2: every edge is a monochromatic 2-clique."""
+    result = construct_monochromatic_clique_hypergraph(_k4_red(), 2)
+    assert len(result.hypergraph.edges) == 6  # C(4,2) = 6
+
+
+def test_replay_monochromatic() -> None:
+    """Every hyperedge induces a monochromatic clique."""
+    result = construct_monochromatic_clique_hypergraph(_k4_mixed(), 3)
+    graph = _k4_mixed()
+    edge_colors = {}
+    for (a, b), c in zip(graph.graph.edges, graph.edge_colors, strict=True):
+        edge_colors[(a, b)] = c
+    for _, members in result.hypergraph.edges:
+        colors = set()
+        for a, b in combinations(members, 2):
+            colors.add(edge_colors.get((a, b), edge_colors.get((b, a))))
+        assert len(colors) == 1
+
+
+def test_exhaustive_comparison() -> None:
+    """Compare against independent enumeration."""
+    result = construct_monochromatic_clique_hypergraph(_k4_red(), 3)
+    graph = _k4_red()
+    edge_colors = {}
+    for (a, b), c in zip(graph.graph.edges, graph.edge_colors, strict=True):
+        edge_colors[(a, b)] = c
+    expected = set()
+    for subset in combinations(["0", "1", "2", "3"], 3):
+        colors = set()
+        is_clique = True
+        for a, b in combinations(subset, 2):
+            color = edge_colors.get((a, b), edge_colors.get((b, a)))
+            if color is None:
+                is_clique = False
+                break
+            colors.add(color)
+        if is_clique and len(colors) == 1:
+            expected.add(frozenset(subset))
+    actual = {frozenset(members) for _, members in result.hypergraph.edges}
+    assert actual == expected
+
+
+def test_vertex_preservation() -> None:
+    """Hypergraph preserves all source vertices."""
+    result = construct_monochromatic_clique_hypergraph(_k4_red(), 3)
+    assert set(result.hypergraph.vertices) == {"0", "1", "2", "3"}
+
+
+def test_result_preserves_source() -> None:
+    """Result retains the source graph and clique order."""
+    cg = _k4_red()
+    result = construct_monochromatic_clique_hypergraph(cg, 2)
+    assert result.colored_graph == cg
+    assert result.clique_order == 2

--- a/tests/math/graphs/monochromatic_clique/test_monochromatic_clique.py
+++ b/tests/math/graphs/monochromatic_clique/test_monochromatic_clique.py
@@ -139,7 +139,9 @@ def test_native_admission_rejects_hypergraph_edge_and_incidence_overflow() -> No
 
 def test_native_admission_rejects_missing_total_coloring() -> None:
     with pytest.raises(OperationDomainValidationError, match="edge_colors"):
-        construct_monochromatic_clique_hypergraph(_k4_red().model_copy(update={"edge_colors": ()}), 3)
+        construct_monochromatic_clique_hypergraph(
+            _k4_red().model_copy(update={"edge_colors": ()}), 3
+        )
 
 
 def test_native_admission_rejects_untransportable_result() -> None:

--- a/tests/math/graphs/monochromatic_clique/test_monochromatic_clique.py
+++ b/tests/math/graphs/monochromatic_clique/test_monochromatic_clique.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 from itertools import combinations
 
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.monochromatic_clique._models import (
+    MonochromaticCliqueHypergraphRequest,
+)
 from jacobian.math.graphs.monochromatic_clique.operations import (
     construct_monochromatic_clique_hypergraph,
 )
 from jacobian.math.graphs.values import ColoredUndirectedGraph, SimpleUndirectedGraph
 
 
-def _k4_red():
+def _k4_red() -> ColoredUndirectedGraph:
     return ColoredUndirectedGraph(
         graph=SimpleUndirectedGraph(
             vertices=("0", "1", "2", "3"),
@@ -25,7 +31,7 @@ def _k4_red():
     )
 
 
-def _k4_mixed():
+def _k4_mixed() -> ColoredUndirectedGraph:
     return ColoredUndirectedGraph(
         graph=SimpleUndirectedGraph(
             vertices=("0", "1", "2", "3"),
@@ -112,3 +118,49 @@ def test_result_preserves_source() -> None:
     result = construct_monochromatic_clique_hypergraph(cg, 2)
     assert result.colored_graph == cg
     assert result.clique_order == 2
+
+
+def test_native_admission_rejects_hypergraph_edge_and_incidence_overflow() -> None:
+    vertices = tuple(f"{index:02}" for index in range(20))
+    graph = SimpleUndirectedGraph(
+        vertices=vertices,
+        edges=tuple(
+            (vertices[left], vertices[right])
+            for left in range(20)
+            for right in range(left + 1, 20)
+        ),
+    )
+    colored_graph = ColoredUndirectedGraph(
+        graph=graph, edge_colors=("red",) * len(graph.edges)
+    )
+    with pytest.raises(OperationDomainValidationError, match="hypergraph bound"):
+        construct_monochromatic_clique_hypergraph(colored_graph, 5)
+
+
+def test_native_admission_rejects_missing_total_coloring() -> None:
+    with pytest.raises(OperationDomainValidationError, match="edge_colors"):
+        construct_monochromatic_clique_hypergraph(_k4_red().model_copy(update={"edge_colors": ()}), 3)
+
+
+def test_native_admission_rejects_untransportable_result() -> None:
+    vertices = tuple("x" * 400_000 + str(index) for index in range(4))
+    graph = SimpleUndirectedGraph(
+        vertices=vertices,
+        edges=tuple(
+            (vertices[left], vertices[right])
+            for left in range(4)
+            for right in range(left + 1, 4)
+        ),
+    )
+    colored_graph = ColoredUndirectedGraph.model_construct(
+        graph=graph, edge_colors=("red",) * len(graph.edges)
+    )
+    with pytest.raises(OperationDomainValidationError, match="output-byte limit"):
+        construct_monochromatic_clique_hypergraph(colored_graph, 2)
+
+
+def test_request_keeps_structural_validation_separate_from_domain_admission() -> None:
+    request = MonochromaticCliqueHypergraphRequest(
+        colored_graph=_k4_red(), clique_order=3
+    )
+    assert request.clique_order == 3


### PR DESCRIPTION
## Summary

Implements `graph.edge_colored.monochromatic_clique_hypergraph.construct` from issue #2849.

Given a bounded complete edge-coloured simple graph and an integer t >= 2, returns the canonical t-uniform FiniteHypergraph whose hyperedges are exactly the t-element vertex sets inducing a monochromatic clique in the source.

## Design

- **Operation ID**: `graph.edge_colored.monochromatic_clique_hypergraph.construct`
- **Input**: `ColoredUndirectedGraph` (must be complete with total edge colours) +  (t)
- **Output**: `FiniteHypergraph` with one t-edge per monochromatic clique
- **Kernel**: O(C(n,t) * C(t,2)) — enumerate t-subsets, check all edge colours match
- **Bounds**: at most 20 vertices, clique order <= 8

## Tests

- All-red K4 with t=3: 4 monochromatic triangles
- Mixed red/blue K4 with t=3: 1 monochromatic triangle
- t=2: every edge is a 2-clique (6 for K4)
- Monochromatic replay: every hyperedge induces a monochromatic clique
- Exhaustive comparison against independent enumeration
- Vertex preservation
- Source preservation

Closes #2849

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)