### PR TITLE
Add additive.cyclic_prefix_sum.residue_profile.compute operation

### DIFF
--- a/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/__init__.py
+++ b/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/__init__.py
@@ -1,0 +1,7 @@
+"""Cyclic prefix-sum residue profile operations."""
+
+from jacobian.math.combinatorics.additive.cyclic_prefix_sum.operations import (
+    compute_cyclic_prefix_sum_residue_profile,
+)
+
+__all__ = ["compute_cyclic_prefix_sum_residue_profile"]

--- a/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/_models.py
+++ b/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated, Self
 
 from pydantic import Field, StrictInt, StringConstraints, model_validator
+from pydantic.json_schema import WithJsonSchema
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
@@ -28,7 +29,7 @@ class CyclicPrefixSumResidueProfileRequest(StrictModel):
 
     sequence: Annotated[
         IndexedIntegerSequence,
-        indexed_sequence_item_ceiling(MAX_SEQUENCE_LENGTH),
+        WithJsonSchema(indexed_sequence_item_ceiling(MAX_SEQUENCE_LENGTH)),
     ]
     modulus: BoundedModulus
 

--- a/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/_models.py
+++ b/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/_models.py
@@ -1,0 +1,38 @@
+"""Typed contracts for the cyclic prefix-sum residue profile operation."""
+
+from __future__ import annotations
+
+from jacobian._models import StrictModel
+
+MAX_SEQUENCE_LENGTH = 10_000
+MAX_MODULUS_DIGITS = 100
+
+
+class CyclicPrefixSumResidueProfileRequest(StrictModel):
+    """Request for the cyclic prefix-sum residue profile."""
+
+    sequence: tuple[int, ...]
+    modulus: int
+
+
+class PrefixSumResidueRow(StrictModel):
+    """One row of the residue profile."""
+
+    residue: int
+    positions: tuple[int, ...]
+
+
+class CyclicPrefixSumResidueProfileResult(StrictModel):
+    """The complete cyclic prefix-sum residue profile."""
+
+    modulus: int
+    rows: tuple[PrefixSumResidueRow, ...]
+
+
+__all__ = [
+    "MAX_MODULUS_DIGITS",
+    "MAX_SEQUENCE_LENGTH",
+    "CyclicPrefixSumResidueProfileRequest",
+    "CyclicPrefixSumResidueProfileResult",
+    "PrefixSumResidueRow",
+]

--- a/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/_models.py
+++ b/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/_models.py
@@ -2,36 +2,70 @@
 
 from __future__ import annotations
 
+from typing import Annotated, Self
+
+from pydantic import Field, StrictInt, StringConstraints, model_validator
+
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
+from jacobian.math.combinatorics.additive.values import (
+    IndexedIntegerSequence,
+    indexed_sequence_item_ceiling,
+)
 
 MAX_SEQUENCE_LENGTH = 10_000
 MAX_MODULUS_DIGITS = 100
+MAX_RESULT_BYTES = 10 * 1024 * 1024
+
+BoundedModulus = Annotated[
+    CanonicalInteger,
+    StringConstraints(max_length=MAX_MODULUS_DIGITS, strict=True),
+]
 
 
 class CyclicPrefixSumResidueProfileRequest(StrictModel):
     """Request for the cyclic prefix-sum residue profile."""
 
-    sequence: tuple[int, ...]
-    modulus: int
+    sequence: Annotated[
+        IndexedIntegerSequence,
+        indexed_sequence_item_ceiling(MAX_SEQUENCE_LENGTH),
+    ]
+    modulus: BoundedModulus
 
 
 class PrefixSumResidueRow(StrictModel):
     """One row of the residue profile."""
 
-    residue: int
-    positions: tuple[int, ...]
+    residue: CanonicalInteger
+    positions: tuple[StrictInt, ...] = Field(min_length=1)
 
 
 class CyclicPrefixSumResidueProfileResult(StrictModel):
     """The complete cyclic prefix-sum residue profile."""
 
-    modulus: int
-    rows: tuple[PrefixSumResidueRow, ...]
+    modulus: BoundedModulus
+    rows: tuple[PrefixSumResidueRow, ...] = Field(max_length=MAX_SEQUENCE_LENGTH)
+
+    @model_validator(mode="after")
+    def require_sorted_unique_rows(self) -> Self:
+        residues = tuple(int(row.residue) for row in self.rows)
+        if residues != tuple(sorted(residues)) or len(set(residues)) != len(residues):
+            raise ValueError("residue rows must be sorted and unique")
+        positions = [position for row in self.rows for position in row.positions]
+        if len(positions) > MAX_SEQUENCE_LENGTH:
+            raise ValueError("residue rows contain too many prefix positions")
+        if any(
+            position < 1 or position > MAX_SEQUENCE_LENGTH for position in positions
+        ):
+            raise ValueError("prefix positions must be within the sequence bound")
+        return self
 
 
 __all__ = [
     "MAX_MODULUS_DIGITS",
+    "MAX_RESULT_BYTES",
     "MAX_SEQUENCE_LENGTH",
+    "BoundedModulus",
     "CyclicPrefixSumResidueProfileRequest",
     "CyclicPrefixSumResidueProfileResult",
     "PrefixSumResidueRow",

--- a/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/_tools.py
+++ b/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/_tools.py
@@ -1,0 +1,72 @@
+"""Cyclic prefix-sum residue profile operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.combinatorics.additive.cyclic_prefix_sum._models import (
+    CyclicPrefixSumResidueProfileRequest,
+    CyclicPrefixSumResidueProfileResult,
+)
+from jacobian.math.combinatorics.additive.cyclic_prefix_sum.operations import (
+    compute_cyclic_prefix_sum_residue_profile,
+)
+
+
+def compute_cyclic_prefix_sum_residue_profile_op(
+    request: CyclicPrefixSumResidueProfileRequest,
+) -> CyclicPrefixSumResidueProfileResult:
+    return compute_cyclic_prefix_sum_residue_profile(request.sequence, request.modulus)
+
+
+def cps_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    cps_operation(
+        "additive.cyclic_prefix_sum.residue_profile.compute",
+        "Compute the cyclic prefix-sum residue profile of a sequence",
+        (
+            "Given a bounded ordered integer sequence and a positive modulus, "
+            "return the complete partition of its nonempty prefix positions by "
+            "their prefix sum residue modulo that modulus."
+        ),
+        CyclicPrefixSumResidueProfileRequest,
+        CyclicPrefixSumResidueProfileResult,
+        compute_cyclic_prefix_sum_residue_profile_op,
+        "additive-combinatorics",
+        "exact",
+        examples=(
+            example(
+                "z5_sequence_113",
+                "In Z/5Z, the sequence (1,1,3) has prefix residues 1,2,0.",
+                {"sequence": [1, 1, 3], "modulus": 5},
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/_tools.py
+++ b/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/_tools.py
@@ -63,7 +63,10 @@ TOOLS: MathTools = (
             example(
                 "z5_sequence_113",
                 "In Z/5Z, the sequence (1,1,3) has prefix residues 1,2,0.",
-                {"sequence": [1, 1, 3], "modulus": 5},
+                {
+                    "sequence": {"items": ["1", "1", "3"]},
+                    "modulus": "5",
+                },
             ),
         ),
     ),

--- a/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/operations.py
@@ -1,0 +1,37 @@
+"""Cyclic prefix-sum residue profile kernel."""
+
+from __future__ import annotations
+
+from jacobian.math.combinatorics.additive.cyclic_prefix_sum._models import (
+    CyclicPrefixSumResidueProfileResult,
+    PrefixSumResidueRow,
+)
+
+__all__ = ["compute_cyclic_prefix_sum_residue_profile"]
+
+
+def compute_cyclic_prefix_sum_residue_profile(
+    sequence: tuple[int, ...],
+    modulus: int,
+) -> CyclicPrefixSumResidueProfileResult:
+    """Return the complete partition of prefix positions by residue.
+
+    For each prefix position k (1-indexed), compute the prefix sum
+    S_k = a_1 + ... + a_k mod m and group positions by their residue.
+    """
+    residue_to_positions: dict[int, list[int]] = {}
+    running = 0
+    for k, value in enumerate(sequence, start=1):
+        running = (running + value) % modulus
+        if running not in residue_to_positions:
+            residue_to_positions[running] = []
+        residue_to_positions[running].append(k)
+
+    rows = [
+        PrefixSumResidueRow(residue=res, positions=tuple(positions))
+        for res, positions in sorted(residue_to_positions.items())
+    ]
+    return CyclicPrefixSumResidueProfileResult(
+        modulus=modulus,
+        rows=tuple(rows),
+    )

--- a/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/cyclic_prefix_sum/operations.py
@@ -2,36 +2,139 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from jacobian._exact import CanonicalInteger
+from jacobian.canonical import (
+    CanonicalizationError,
+    format_canonical_integer,
+    parse_canonical_integer,
+)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.additive.cyclic_prefix_sum._models import (
+    MAX_MODULUS_DIGITS,
+    MAX_RESULT_BYTES,
+    MAX_SEQUENCE_LENGTH,
     CyclicPrefixSumResidueProfileResult,
     PrefixSumResidueRow,
 )
+from jacobian.math.combinatorics.additive.values import IndexedIntegerSequence
 
 __all__ = ["compute_cyclic_prefix_sum_residue_profile"]
 
+MAX_WORK_UNITS = 50_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class _AdmissionPlan:
+    sequence: tuple[int, ...]
+    modulus: int
+
+
+def _reject(location: tuple[str | int, ...], code: str, message: str) -> None:
+    raise OperationDomainValidationError(location=location, code=code, message=message)
+
+
+def _admit(
+    sequence: IndexedIntegerSequence,
+    modulus: CanonicalInteger,
+) -> _AdmissionPlan:
+    """Validate the complete native and MCP execution envelope once."""
+    if not isinstance(sequence, IndexedIntegerSequence):
+        _reject(
+            ("sequence",),
+            "cyclic_prefix_sum.sequence_type",
+            "sequence must be an indexed integer sequence",
+        )
+    if type(modulus) is not str:
+        _reject(
+            ("modulus",),
+            "cyclic_prefix_sum.modulus_type",
+            "modulus must be a canonical integer string",
+        )
+    modulus_digits = len(modulus.lstrip("-"))
+    if modulus_digits > MAX_MODULUS_DIGITS:
+        _reject(
+            ("modulus",),
+            "cyclic_prefix_sum.modulus_digits",
+            f"modulus may contain at most {MAX_MODULUS_DIGITS} digits",
+        )
+    try:
+        modulus_value = parse_canonical_integer(modulus)
+    except CanonicalizationError:
+        _reject(
+            ("modulus",),
+            "cyclic_prefix_sum.modulus_format",
+            "modulus must be a canonical integer string",
+        )
+    if modulus_value <= 0:
+        _reject(
+            ("modulus",),
+            "cyclic_prefix_sum.modulus_domain",
+            "modulus must be positive",
+        )
+
+    item_count = len(sequence.items)
+    if item_count > MAX_SEQUENCE_LENGTH:
+        _reject(
+            ("sequence",),
+            "cyclic_prefix_sum.sequence_length",
+            f"sequence may contain at most {MAX_SEQUENCE_LENGTH:,} items",
+        )
+    maximum_item_digits = max(
+        (len(item.lstrip("-")) for item in sequence.items),
+        default=1,
+    )
+    work = item_count * max(maximum_item_digits, modulus_digits)
+    if work > MAX_WORK_UNITS:
+        _reject(
+            ("sequence",),
+            "cyclic_prefix_sum.work_bound",
+            "prefix-sum modular arithmetic exceeds the admitted work bound",
+        )
+
+    row_count = min(item_count, modulus_value)
+    position_digits = len(str(max(item_count, 1)))
+    result_bytes = (
+        256
+        + modulus_digits
+        + row_count * (modulus_digits + 32)
+        + item_count * (position_digits + 2)
+    )
+    if result_bytes > MAX_RESULT_BYTES:
+        _reject(
+            ("sequence",),
+            "cyclic_prefix_sum.result_bound",
+            "the exact residue profile exceeds the canonical output bound",
+        )
+    return _AdmissionPlan(sequence=sequence.as_int_tuple(), modulus=modulus_value)
+
 
 def compute_cyclic_prefix_sum_residue_profile(
-    sequence: tuple[int, ...],
-    modulus: int,
+    sequence: IndexedIntegerSequence,
+    modulus: CanonicalInteger,
 ) -> CyclicPrefixSumResidueProfileResult:
     """Return the complete partition of prefix positions by residue.
 
     For each prefix position k (1-indexed), compute the prefix sum
     S_k = a_1 + ... + a_k mod m and group positions by their residue.
     """
+    plan = _admit(sequence, modulus)
     residue_to_positions: dict[int, list[int]] = {}
     running = 0
-    for k, value in enumerate(sequence, start=1):
-        running = (running + value) % modulus
+    for k, value in enumerate(plan.sequence, start=1):
+        running = (running + value) % plan.modulus
         if running not in residue_to_positions:
             residue_to_positions[running] = []
         residue_to_positions[running].append(k)
 
     rows = [
-        PrefixSumResidueRow(residue=res, positions=tuple(positions))
+        PrefixSumResidueRow(
+            residue=format_canonical_integer(res), positions=tuple(positions)
+        )
         for res, positions in sorted(residue_to_positions.items())
     ]
     return CyclicPrefixSumResidueProfileResult(
-        modulus=modulus,
+        modulus=format_canonical_integer(plan.modulus),
         rows=tuple(rows),
     )

--- a/tests/math/combinatorics/additive/cyclic_prefix_sum/test_cyclic_prefix_sum.py
+++ b/tests/math/combinatorics/additive/cyclic_prefix_sum/test_cyclic_prefix_sum.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from jacobian.math.combinatorics.additive.cyclic_prefix_sum.operations import (
+    compute_cyclic_prefix_sum_residue_profile,
+)
+
+
+def test_fixture_z5_113() -> None:
+    """In Z/5Z, sequence (1,1,3) has prefix residues 1,2,0."""
+    result = compute_cyclic_prefix_sum_residue_profile((1, 1, 3), 5)
+    residue_map = {r.residue: r.positions for r in result.rows}
+    assert residue_map[1] == (1,)
+    assert residue_map[2] == (2,)
+    assert residue_map[0] == (3,)
+
+
+def test_replay_residues() -> None:
+    """Replay: each position's prefix sum matches its residue."""
+    seq = (3, 7, 2, 5, 1)
+    m = 4
+    result = compute_cyclic_prefix_sum_residue_profile(seq, m)
+    for row in result.rows:
+        for pos in row.positions:
+            prefix_sum = sum(seq[:pos]) % m
+            assert prefix_sum == row.residue
+
+
+def test_collision_classes() -> None:
+    """Positions with equal prefix residues are grouped."""
+    result = compute_cyclic_prefix_sum_residue_profile((1, 2, 3), 6)
+    for row in result.rows:
+        positions = list(row.positions)
+        for i in range(len(positions)):
+            for j in range(i + 1, len(positions)):
+                assert positions[i] < positions[j]
+
+
+def test_empty_sequence() -> None:
+    """Empty sequence has no rows."""
+    result = compute_cyclic_prefix_sum_residue_profile((), 5)
+    assert len(result.rows) == 0
+
+
+def test_single_element() -> None:
+    """Single element has one row."""
+    result = compute_cyclic_prefix_sum_residue_profile((2,), 5)
+    assert len(result.rows) == 1
+    assert result.rows[0].residue == 2
+    assert result.rows[0].positions == (1,)
+
+
+def test_total_positions() -> None:
+    """Total positions across all rows equals sequence length."""
+    seq = (1, 2, 3, 4, 5)
+    result = compute_cyclic_prefix_sum_residue_profile(seq, 7)
+    total = sum(len(r.positions) for r in result.rows)
+    assert total == len(seq)
+
+
+def test_large_modulus() -> None:
+    """Large modulus with small sequence: only few occupied residues."""
+    result = compute_cyclic_prefix_sum_residue_profile((1, 2, 3), 1000)
+    assert len(result.rows) == 3  # all distinct residues
+    residues = {r.residue for r in result.rows}
+    assert residues == {1, 3, 6}
+
+
+def test_zero_modulus_not_applicable() -> None:
+    """Modulus 1 collapses everything to residue 0."""
+    result = compute_cyclic_prefix_sum_residue_profile((5, 7, 3), 1)
+    assert len(result.rows) == 1
+    assert result.rows[0].residue == 0
+    assert result.rows[0].positions == (1, 2, 3)
+
+
+def test_result_preserves_modulus() -> None:
+    """Result retains the modulus."""
+    result = compute_cyclic_prefix_sum_residue_profile((1, 2, 3), 7)
+    assert result.modulus == 7

--- a/tests/math/combinatorics/additive/cyclic_prefix_sum/test_cyclic_prefix_sum.py
+++ b/tests/math/combinatorics/additive/cyclic_prefix_sum/test_cyclic_prefix_sum.py
@@ -3,31 +3,36 @@ from __future__ import annotations
 from jacobian.math.combinatorics.additive.cyclic_prefix_sum.operations import (
     compute_cyclic_prefix_sum_residue_profile,
 )
+from jacobian.math.combinatorics.additive.values import IndexedIntegerSequence
+
+
+def _sequence(*values: int) -> IndexedIntegerSequence:
+    return IndexedIntegerSequence(items=tuple(str(value) for value in values))
 
 
 def test_fixture_z5_113() -> None:
     """In Z/5Z, sequence (1,1,3) has prefix residues 1,2,0."""
-    result = compute_cyclic_prefix_sum_residue_profile((1, 1, 3), 5)
+    result = compute_cyclic_prefix_sum_residue_profile(_sequence(1, 1, 3), "5")
     residue_map = {r.residue: r.positions for r in result.rows}
-    assert residue_map[1] == (1,)
-    assert residue_map[2] == (2,)
-    assert residue_map[0] == (3,)
+    assert residue_map["1"] == (1,)
+    assert residue_map["2"] == (2,)
+    assert residue_map["0"] == (3,)
 
 
 def test_replay_residues() -> None:
     """Replay: each position's prefix sum matches its residue."""
     seq = (3, 7, 2, 5, 1)
     m = 4
-    result = compute_cyclic_prefix_sum_residue_profile(seq, m)
+    result = compute_cyclic_prefix_sum_residue_profile(_sequence(*seq), str(m))
     for row in result.rows:
         for pos in row.positions:
             prefix_sum = sum(seq[:pos]) % m
-            assert prefix_sum == row.residue
+            assert str(prefix_sum) == row.residue
 
 
 def test_collision_classes() -> None:
     """Positions with equal prefix residues are grouped."""
-    result = compute_cyclic_prefix_sum_residue_profile((1, 2, 3), 6)
+    result = compute_cyclic_prefix_sum_residue_profile(_sequence(1, 2, 3), "6")
     for row in result.rows:
         positions = list(row.positions)
         for i in range(len(positions)):
@@ -37,43 +42,59 @@ def test_collision_classes() -> None:
 
 def test_empty_sequence() -> None:
     """Empty sequence has no rows."""
-    result = compute_cyclic_prefix_sum_residue_profile((), 5)
+    result = compute_cyclic_prefix_sum_residue_profile(_sequence(), "5")
     assert len(result.rows) == 0
 
 
 def test_single_element() -> None:
     """Single element has one row."""
-    result = compute_cyclic_prefix_sum_residue_profile((2,), 5)
+    result = compute_cyclic_prefix_sum_residue_profile(_sequence(2), "5")
     assert len(result.rows) == 1
-    assert result.rows[0].residue == 2
+    assert result.rows[0].residue == "2"
     assert result.rows[0].positions == (1,)
 
 
 def test_total_positions() -> None:
     """Total positions across all rows equals sequence length."""
     seq = (1, 2, 3, 4, 5)
-    result = compute_cyclic_prefix_sum_residue_profile(seq, 7)
+    result = compute_cyclic_prefix_sum_residue_profile(_sequence(*seq), "7")
     total = sum(len(r.positions) for r in result.rows)
     assert total == len(seq)
 
 
 def test_large_modulus() -> None:
     """Large modulus with small sequence: only few occupied residues."""
-    result = compute_cyclic_prefix_sum_residue_profile((1, 2, 3), 1000)
+    result = compute_cyclic_prefix_sum_residue_profile(_sequence(1, 2, 3), "1000")
     assert len(result.rows) == 3  # all distinct residues
     residues = {r.residue for r in result.rows}
-    assert residues == {1, 3, 6}
+    assert residues == {"1", "3", "6"}
 
 
 def test_zero_modulus_not_applicable() -> None:
     """Modulus 1 collapses everything to residue 0."""
-    result = compute_cyclic_prefix_sum_residue_profile((5, 7, 3), 1)
+    result = compute_cyclic_prefix_sum_residue_profile(_sequence(5, 7, 3), "1")
     assert len(result.rows) == 1
-    assert result.rows[0].residue == 0
+    assert result.rows[0].residue == "0"
     assert result.rows[0].positions == (1, 2, 3)
 
 
 def test_result_preserves_modulus() -> None:
     """Result retains the modulus."""
-    result = compute_cyclic_prefix_sum_residue_profile((1, 2, 3), 7)
-    assert result.modulus == 7
+    result = compute_cyclic_prefix_sum_residue_profile(_sequence(1, 2, 3), "7")
+    assert result.modulus == "7"
+
+
+def test_native_admission_rejects_nonpositive_modulus() -> None:
+    """Native execution rejects modulus zero through the domain channel."""
+    import pytest
+
+    with pytest.raises(ValueError, match="modulus must be positive"):
+        compute_cyclic_prefix_sum_residue_profile(_sequence(1), "0")
+
+
+def test_native_admission_rejects_noncanonical_sequence() -> None:
+    """Native execution uses the shared canonical indexed sequence value."""
+    import pytest
+
+    with pytest.raises(ValueError, match="indexed integer sequence"):
+        compute_cyclic_prefix_sum_residue_profile((1, 2), "5")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Implements `additive.cyclic_prefix_sum.residue_profile.compute` from issue #2795.

Given a bounded ordered integer sequence and a positive modulus, returns the complete partition of its nonempty prefix positions by their prefix sum residue modulo that modulus. This is the standard carrier for Graham's valid-ordering problem (Erdős #475), zero-sum block searches, and finite cyclic walk analysis.

## Design

- **Operation ID**: `additive.cyclic_prefix_sum.residue_profile.compute`
- **Input**: integer sequence + positive modulus
- **Output**: `CyclicPrefixSumResidueProfileResult` with rows (residue, positions)
- **Kernel**: O(n) modular accumulation with dictionary grouping

## Tests

- Fixture: Z/5Z sequence (1,1,3) with prefix residues 1,2,0
- Replay: each position's prefix sum matches its residue
- Collision classes: positions with equal residues are grouped
- Empty sequence: no rows
- Single element: one row
- Total positions: sum equals sequence length
- Large modulus: only occupied residues appear
- Modulus 1: everything collapses to 0
- Modulus preservation

Closes #2795

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)