### PR TITLE
Add additive.rational_subset_sum.profile.compute operation

### DIFF
--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/__init__.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/__init__.py
@@ -1,0 +1,7 @@
+"""Rational subset-sum profile operations."""
+
+from jacobian.math.combinatorics.additive.rational_subset_sum.operations import (
+    compute_rational_subset_sum_profile,
+)
+
+__all__ = ["compute_rational_subset_sum_profile"]

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/_models.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/_models.py
@@ -1,0 +1,34 @@
+"""Typed contracts for the rational subset-sum profile operation."""
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+
+MAX_SEQUENCE_LENGTH = 20
+
+
+class RationalSubsetSumRequest(StrictModel):
+    """Request for the rational subset-sum profile."""
+
+    values: tuple[CanonicalRational, ...]
+
+
+class SubsetSumRow(StrictModel):
+    """One attained rational sum with its multiplicity."""
+
+    sum_value: CanonicalRational
+    multiplicity: int
+
+
+class RationalSubsetSumResult(StrictModel):
+    """The complete rational subset-sum profile."""
+
+    values: tuple[CanonicalRational, ...]
+    rows: tuple[SubsetSumRow, ...]
+
+
+__all__ = [
+    "MAX_SEQUENCE_LENGTH",
+    "RationalSubsetSumRequest",
+    "RationalSubsetSumResult",
+    "SubsetSumRow",
+]

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/_models.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/_models.py
@@ -1,5 +1,7 @@
 """Typed contracts for the rational subset-sum profile operation."""
 
+from pydantic import Field
+
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 
@@ -9,7 +11,7 @@ MAX_SEQUENCE_LENGTH = 20
 class RationalSubsetSumRequest(StrictModel):
     """Request for the rational subset-sum profile."""
 
-    values: tuple[CanonicalRational, ...]
+    values: tuple[CanonicalRational, ...] = Field(max_length=MAX_SEQUENCE_LENGTH)
 
 
 class SubsetSumRow(StrictModel):

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/_tools.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/_tools.py
@@ -1,0 +1,78 @@
+"""Rational subset-sum profile operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.combinatorics.additive.rational_subset_sum._models import (
+    RationalSubsetSumRequest,
+    RationalSubsetSumResult,
+)
+from jacobian.math.combinatorics.additive.rational_subset_sum.operations import (
+    compute_rational_subset_sum_profile,
+)
+
+
+def compute_rational_subset_sum_profile_op(
+    request: RationalSubsetSumRequest,
+) -> RationalSubsetSumResult:
+    return compute_rational_subset_sum_profile(request.values)
+
+
+def rss_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    rss_operation(
+        "additive.rational_subset_sum.profile.compute",
+        "Compute the rational subset-sum profile",
+        (
+            "Given an ordered indexed sequence of canonical rationals, return "
+            "every attainable subset sum and its number of realizing selection "
+            "vectors, including the empty subset at zero."
+        ),
+        RationalSubsetSumRequest,
+        RationalSubsetSumResult,
+        compute_rational_subset_sum_profile_op,
+        "additive-combinatorics",
+        "exact",
+        examples=(
+            example(
+                "fixture",
+                "Complete profile of (1/2, 1/2, -1).",
+                {
+                    "values": [
+                        {"num": "1", "den": "2"},
+                        {"num": "1", "den": "2"},
+                        {"num": "-1", "den": "1"},
+                    ],
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -130,8 +130,10 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
                 max(_decimal_digits(value.numerator), _decimal_digits(value.denominator))
                 for value in exact_sums
             )
+    # Values are canonical JSON strings: include both quotes and a possible
+    # minus sign in the numerator component before sizing the object.
     rational_bytes = strict_json_object_size(
-        (("num", growth_digits), ("den", growth_digits))
+        (("num", growth_digits + 2), ("den", growth_digits + 2))
     )
     row_bytes = strict_json_object_size(
         (("sum_value", rational_bytes), ("multiplicity", len(str(1 << n))))

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fractions import Fraction
 from itertools import combinations
+from math import gcd
 from typing import NoReturn
 
 from jacobian._exact import (
@@ -33,6 +34,18 @@ def _reject(code: str, message: str) -> NoReturn:
     )
 
 
+def _decimal_digits(value: int) -> int:
+    magnitude = abs(value)
+    if magnitude == 0:
+        return 1
+    estimate = magnitude.bit_length() * 30_103 // 100_000 + 1
+    while estimate > 1 and magnitude < 10 ** (estimate - 1):
+        estimate -= 1
+    while magnitude >= 10**estimate:
+        estimate += 1
+    return estimate
+
+
 def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
     if not isinstance(values, tuple) or any(
         not isinstance(value, CanonicalRational) for value in values
@@ -49,15 +62,26 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
 
     nonzero = [value for value in values if value.as_fraction()]
     if nonzero:
-        denominator_digits = sum(len(value.den) for value in nonzero)
-        numerator_digits = max(
-            len(value.num.lstrip("-"))
-            + denominator_digits
-            - len(value.den)
-            for value in nonzero
-        )
-        if len(nonzero) > 1:
-            numerator_digits += len(str(len(nonzero)))
+        fractions = [value.as_fraction() for value in nonzero]
+        common_denominator = 1
+        for value in fractions:
+            common_denominator = common_denominator // gcd(
+                common_denominator, value.denominator
+            ) * value.denominator
+            if _decimal_digits(common_denominator) > MAX_CANONICAL_RATIONAL_DIGITS:
+                _reject(
+                    "rational_growth_bound",
+                    "subset-sum intermediates exceed the canonical rational digit bound",
+                )
+        scaled = [
+            value.numerator * (common_denominator // value.denominator)
+            for value in fractions
+        ]
+        positive_span = sum(value for value in scaled if value > 0)
+        negative_span = sum(value for value in scaled if value < 0)
+        numerator_bound = max(abs(positive_span), abs(negative_span))
+        denominator_digits = _decimal_digits(common_denominator)
+        numerator_digits = _decimal_digits(numerator_bound)
         growth_digits = max(denominator_digits, numerator_digits)
     else:
         growth_digits = 1
@@ -80,6 +104,9 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
     support_upper_bound = 1
     for multiplicity in multiplicities.values():
         support_upper_bound *= multiplicity + 1
+    if nonzero:
+        support_span = positive_span - negative_span
+        support_upper_bound = min(support_upper_bound, support_span + 1)
     rational_bytes = strict_json_object_size(
         (("num", growth_digits), ("den", growth_digits))
     )

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -105,7 +105,7 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
             lattice_step = gcd(lattice_step, abs(value))
         support_span = (positive_span - negative_span) // max(lattice_step, 1)
         support_upper_bound = min(support_upper_bound, support_span + 1)
-        if common_denominator_overflow:
+        if common_denominator_overflow or numerator_digits > MAX_CANONICAL_RATIONAL_DIGITS:
             if len(nonzero) > 2:
                 _reject(
                     "rational_growth_bound",
@@ -137,7 +137,8 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
     # Values are canonical JSON strings: include both quotes and a possible
     # minus sign in the numerator component before sizing the object.
     rational_bytes = strict_json_object_size(
-        (("num", growth_digits + 2), ("den", growth_digits + 2))
+        # Numerators may be negative; reserve quotes plus an optional sign.
+        (("num", growth_digits + 3), ("den", growth_digits + 2))
     )
     row_bytes = strict_json_object_size(
         (("sum_value", rational_bytes), ("multiplicity", len(str(1 << n))))

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -86,12 +86,6 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
         growth_digits = max(denominator_digits, numerator_digits)
     else:
         growth_digits = 1
-    if growth_digits > MAX_CANONICAL_RATIONAL_DIGITS:
-        _reject(
-            "rational_growth_bound",
-            "subset-sum intermediates exceed the canonical rational digit bound",
-        )
-
     source_bytes = len(
         encode_strict_json({"values": [v.model_dump(mode="json") for v in values]})
     )
@@ -135,6 +129,11 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
                 )
                 for value in exact_sums
             )
+    if growth_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        _reject(
+            "rational_growth_bound",
+            "subset-sum intermediates exceed the canonical rational digit bound",
+        )
     # Values are canonical JSON strings: include both quotes and a possible
     # minus sign in the numerator component before sizing the object.
     rational_bytes = strict_json_object_size(

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -66,12 +66,13 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
         fractions = [value.as_fraction() for value in nonzero]
         common_denominator = 1
         for value in fractions:
-            common_denominator = common_denominator // gcd(
-                common_denominator, value.denominator
-            ) * value.denominator
+            common_denominator = (
+                common_denominator
+                // gcd(common_denominator, value.denominator)
+                * value.denominator
+            )
             common_denominator_overflow |= (
-                _decimal_digits(common_denominator)
-                > MAX_CANONICAL_RATIONAL_DIGITS
+                _decimal_digits(common_denominator) > MAX_CANONICAL_RATIONAL_DIGITS
             )
         scaled = [
             value.numerator * (common_denominator // value.denominator)
@@ -118,7 +119,9 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
                 )
             exact_sums = {Fraction(0), *fractions, sum(fractions, Fraction(0))}
             if any(
-                max(_decimal_digits(value.numerator), _decimal_digits(value.denominator))
+                max(
+                    _decimal_digits(value.numerator), _decimal_digits(value.denominator)
+                )
                 > MAX_CANONICAL_RATIONAL_DIGITS
                 for value in exact_sums
             ):
@@ -127,7 +130,9 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
                     "subset-sum intermediates exceed the canonical rational digit bound",
                 )
             growth_digits = max(
-                max(_decimal_digits(value.numerator), _decimal_digits(value.denominator))
+                max(
+                    _decimal_digits(value.numerator), _decimal_digits(value.denominator)
+                )
                 for value in exact_sums
             )
     rational_bytes = strict_json_object_size(

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -105,7 +105,10 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
             lattice_step = gcd(lattice_step, abs(value))
         support_span = (positive_span - negative_span) // max(lattice_step, 1)
         support_upper_bound = min(support_upper_bound, support_span + 1)
-        if common_denominator_overflow or numerator_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        if (
+            common_denominator_overflow
+            or numerator_digits > MAX_CANONICAL_RATIONAL_DIGITS
+        ):
             if len(nonzero) > 2:
                 _reject(
                     "rational_growth_bound",

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -65,9 +65,11 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
         fractions = [value.as_fraction() for value in nonzero]
         common_denominator = 1
         for value in fractions:
-            common_denominator = common_denominator // gcd(
-                common_denominator, value.denominator
-            ) * value.denominator
+            common_denominator = (
+                common_denominator
+                // gcd(common_denominator, value.denominator)
+                * value.denominator
+            )
             if _decimal_digits(common_denominator) > MAX_CANONICAL_RATIONAL_DIGITS:
                 _reject(
                     "rational_growth_bound",

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -61,6 +61,7 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
         return
 
     nonzero = [value for value in values if value.as_fraction()]
+    common_denominator_overflow = False
     if nonzero:
         fractions = [value.as_fraction() for value in nonzero]
         common_denominator = 1
@@ -68,11 +69,10 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
             common_denominator = common_denominator // gcd(
                 common_denominator, value.denominator
             ) * value.denominator
-            if _decimal_digits(common_denominator) > MAX_CANONICAL_RATIONAL_DIGITS:
-                _reject(
-                    "rational_growth_bound",
-                    "subset-sum intermediates exceed the canonical rational digit bound",
-                )
+            common_denominator_overflow |= (
+                _decimal_digits(common_denominator)
+                > MAX_CANONICAL_RATIONAL_DIGITS
+            )
         scaled = [
             value.numerator * (common_denominator // value.denominator)
             for value in fractions
@@ -105,8 +105,31 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
     for multiplicity in multiplicities.values():
         support_upper_bound *= multiplicity + 1
     if nonzero:
-        support_span = positive_span - negative_span
+        lattice_step = 0
+        for value in scaled:
+            lattice_step = gcd(lattice_step, abs(value))
+        support_span = (positive_span - negative_span) // max(lattice_step, 1)
         support_upper_bound = min(support_upper_bound, support_span + 1)
+        if common_denominator_overflow:
+            if len(nonzero) > 2:
+                _reject(
+                    "rational_growth_bound",
+                    "subset-sum intermediates exceed the canonical rational digit bound",
+                )
+            exact_sums = {Fraction(0), *fractions, sum(fractions, Fraction(0))}
+            if any(
+                max(_decimal_digits(value.numerator), _decimal_digits(value.denominator))
+                > MAX_CANONICAL_RATIONAL_DIGITS
+                for value in exact_sums
+            ):
+                _reject(
+                    "rational_growth_bound",
+                    "subset-sum intermediates exceed the canonical rational digit bound",
+                )
+            growth_digits = max(
+                max(_decimal_digits(value.numerator), _decimal_digits(value.denominator))
+                for value in exact_sums
+            )
     rational_bytes = strict_json_object_size(
         (("num", growth_digits), ("den", growth_digits))
     )

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -51,8 +51,13 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
     if nonzero:
         denominator_digits = sum(len(value.den) for value in nonzero)
         numerator_digits = max(
-            len(value.num) + denominator_digits - len(value.den) for value in nonzero
-        ) + len(str(len(nonzero)))
+            len(value.num.lstrip("-"))
+            + denominator_digits
+            - len(value.den)
+            for value in nonzero
+        )
+        if len(nonzero) > 1:
+            numerator_digits += len(str(len(nonzero)))
         growth_digits = max(denominator_digits, numerator_digits)
     else:
         growth_digits = 1

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -51,9 +51,7 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
     if nonzero:
         denominator_digits = sum(len(value.den) for value in nonzero)
         numerator_digits = max(
-            len(value.num.lstrip("-"))
-            + denominator_digits
-            - len(value.den)
+            len(value.num.lstrip("-")) + denominator_digits - len(value.den)
             for value in nonzero
         )
         if len(nonzero) > 1:

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -4,14 +4,68 @@ from __future__ import annotations
 
 from fractions import Fraction
 from itertools import combinations
+from typing import NoReturn
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import (
+    MAX_CANONICAL_RATIONAL_DIGITS,
+    CanonicalRational,
+    canonical_rational_component_digits,
+)
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.additive.rational_subset_sum._models import (
+    MAX_SEQUENCE_LENGTH,
     RationalSubsetSumResult,
     SubsetSumRow,
 )
 
 __all__ = ["compute_rational_subset_sum_profile"]
+
+MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
+
+
+def _reject(code: str, message: str) -> NoReturn:
+    raise OperationDomainValidationError(
+        location=("values",), code=f"rational_subset_sum.{code}", message=message
+    )
+
+
+def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
+    if not isinstance(values, tuple) or any(
+        not isinstance(value, CanonicalRational) for value in values
+    ):
+        _reject("invalid_values", "values must be a tuple of canonical rationals")
+    n = len(values)
+    if n > MAX_SEQUENCE_LENGTH:
+        _reject(
+            "sequence_length_bound",
+            f"at most {MAX_SEQUENCE_LENGTH} values are supported",
+        )
+    if not n:
+        return
+
+    max_digits = max(canonical_rational_component_digits(value) for value in values)
+    # Adding n fractions can multiply denominators and numerators by every
+    # other input denominator.  This is a conservative bound for every
+    # intermediate subset sum, including the complete sum.
+    growth_digits = n * max_digits + len(str(n)) + 1
+    if growth_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        _reject(
+            "rational_growth_bound",
+            "subset-sum intermediates exceed the canonical rational digit bound",
+        )
+
+    source_bytes = len(
+        encode_strict_json({"values": [v.model_dump(mode="json") for v in values]})
+    )
+    row_bytes = 2 * growth_digits + 96
+    predicted_rows = 1 << n
+    predicted_bytes = source_bytes + 128 + predicted_rows * (row_bytes + 1)
+    if predicted_bytes > MAX_RESULT_BYTES:
+        _reject(
+            "result_size_bound",
+            f"the complete subset-sum profile exceeds the {MAX_RESULT_BYTES}-byte output bound",
+        )
 
 
 def compute_rational_subset_sum_profile(
@@ -23,13 +77,14 @@ def compute_rational_subset_sum_profile(
     corresponding rational values. Group by canonical rational value
     and count multiplicities.
     """
+    _admit_values(values)
     fractions = [v.as_fraction() for v in values]
     n = len(fractions)
     sum_to_count: dict[Fraction, int] = {}
 
     for r in range(n + 1):
         for indices in combinations(range(n), r):
-            s = sum(fractions[i] for i in indices)
+            s = sum((fractions[i] for i in indices), Fraction(0))
             sum_to_count[s] = sum_to_count.get(s, 0) + 1
 
     rows = [

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -9,9 +9,12 @@ from typing import NoReturn
 from jacobian._exact import (
     MAX_CANONICAL_RATIONAL_DIGITS,
     CanonicalRational,
-    canonical_rational_component_digits,
 )
-from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    strict_json_object_size,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.additive.rational_subset_sum._models import (
     MAX_SEQUENCE_LENGTH,
@@ -44,11 +47,15 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
     if not n:
         return
 
-    max_digits = max(canonical_rational_component_digits(value) for value in values)
-    # Adding n fractions can multiply denominators and numerators by every
-    # other input denominator.  This is a conservative bound for every
-    # intermediate subset sum, including the complete sum.
-    growth_digits = n * max_digits + len(str(n)) + 1
+    nonzero = [value for value in values if value.as_fraction()]
+    if nonzero:
+        denominator_digits = sum(len(value.den) for value in nonzero)
+        numerator_digits = max(
+            len(value.num) + denominator_digits - len(value.den) for value in nonzero
+        ) + len(str(len(nonzero)))
+        growth_digits = max(denominator_digits, numerator_digits)
+    else:
+        growth_digits = 1
     if growth_digits > MAX_CANONICAL_RATIONAL_DIGITS:
         _reject(
             "rational_growth_bound",
@@ -63,12 +70,17 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
     # bounds the number of distinct sums while retaining the actual
     # exponential work bound below.
     multiplicities: dict[Fraction, int] = {}
-    for value in (item.as_fraction() for item in values):
+    for value in (item.as_fraction() for item in nonzero):
         multiplicities[value] = multiplicities.get(value, 0) + 1
     support_upper_bound = 1
     for multiplicity in multiplicities.values():
         support_upper_bound *= multiplicity + 1
-    row_bytes = 2 * growth_digits + 96
+    rational_bytes = strict_json_object_size(
+        (("num", growth_digits), ("den", growth_digits))
+    )
+    row_bytes = strict_json_object_size(
+        (("sum_value", rational_bytes), ("multiplicity", len(str(1 << n))))
+    )
     predicted_rows = support_upper_bound
     predicted_bytes = source_bytes + 128 + predicted_rows * (row_bytes + 1)
     if predicted_bytes > MAX_RESULT_BYTES:

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -1,0 +1,45 @@
+"""Rational subset-sum profile kernel."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import combinations
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.combinatorics.additive.rational_subset_sum._models import (
+    RationalSubsetSumResult,
+    SubsetSumRow,
+)
+
+__all__ = ["compute_rational_subset_sum_profile"]
+
+
+def compute_rational_subset_sum_profile(
+    values: tuple[CanonicalRational, ...],
+) -> RationalSubsetSumResult:
+    """Return the complete profile of all subset sums of the given rationals.
+
+    For every subset I of the source indices, compute the sum of the
+    corresponding rational values. Group by canonical rational value
+    and count multiplicities.
+    """
+    fractions = [v.as_fraction() for v in values]
+    n = len(fractions)
+    sum_to_count: dict[Fraction, int] = {}
+
+    for r in range(n + 1):
+        for indices in combinations(range(n), r):
+            s = sum(fractions[i] for i in indices)
+            sum_to_count[s] = sum_to_count.get(s, 0) + 1
+
+    rows = [
+        SubsetSumRow(
+            sum_value=CanonicalRational.from_fraction(s),
+            multiplicity=count,
+        )
+        for s, count in sorted(sum_to_count.items())
+    ]
+    return RationalSubsetSumResult(
+        values=values,
+        rows=tuple(rows),
+    )

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -58,8 +58,18 @@ def _admit_values(values: tuple[CanonicalRational, ...]) -> None:
     source_bytes = len(
         encode_strict_json({"values": [v.model_dump(mode="json") for v in values]})
     )
+    # Equal source values can collapse many subset vectors to one row. Group
+    # them before estimating the support; the product of (multiplicity + 1)
+    # bounds the number of distinct sums while retaining the actual
+    # exponential work bound below.
+    multiplicities: dict[Fraction, int] = {}
+    for value in (item.as_fraction() for item in values):
+        multiplicities[value] = multiplicities.get(value, 0) + 1
+    support_upper_bound = 1
+    for multiplicity in multiplicities.values():
+        support_upper_bound *= multiplicity + 1
     row_bytes = 2 * growth_digits + 96
-    predicted_rows = 1 << n
+    predicted_rows = support_upper_bound
     predicted_bytes = source_bytes + 128 + predicted_rows * (row_bytes + 1)
     if predicted_bytes > MAX_RESULT_BYTES:
         _reject(

--- a/tests/math/combinatorics/additive/rational_subset_sum/test_rational_subset_sum.py
+++ b/tests/math/combinatorics/additive/rational_subset_sum/test_rational_subset_sum.py
@@ -82,3 +82,11 @@ def test_native_admission_rejects_oversized_profile() -> None:
     values = tuple(_cr(1, 2**i) for i in range(20))
     with pytest.raises(OperationDomainValidationError, match="output bound"):
         compute_rational_subset_sum_profile(values)
+
+
+def test_repeated_zero_values_use_their_small_support_bound() -> None:
+    """Twenty equal zeroes have one result row, not 2**20 rows."""
+    values = tuple(_cr(0) for _ in range(20))
+    result = compute_rational_subset_sum_profile(values)
+    assert len(result.rows) == 1
+    assert result.rows[0].multiplicity == 2**20

--- a/tests/math/combinatorics/additive/rational_subset_sum/test_rational_subset_sum.py
+++ b/tests/math/combinatorics/additive/rational_subset_sum/test_rational_subset_sum.py
@@ -100,6 +100,14 @@ def test_single_max_height_value_is_admitted() -> None:
     assert len(result.rows) == 2
 
 
+def test_single_max_height_negative_numerator_is_admitted() -> None:
+    value = _cr(-(10**32768 - 1))
+
+    result = compute_rational_subset_sum_profile((value,))
+
+    assert len(result.rows) == 2
+
+
 def test_uncancellable_rational_growth_is_rejected_before_enumeration() -> None:
     values = (
         _cr(1, 10**20000 + 1),

--- a/tests/math/combinatorics/additive/rational_subset_sum/test_rational_subset_sum.py
+++ b/tests/math/combinatorics/additive/rational_subset_sum/test_rational_subset_sum.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import combinations
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.combinatorics.additive.rational_subset_sum.operations import (
+    compute_rational_subset_sum_profile,
+)
+
+
+def _cr(num, den=None):
+    if den is None:
+        return CanonicalRational.from_fraction(Fraction(num))
+    return CanonicalRational.from_fraction(Fraction(num, den))
+
+
+def test_fixture() -> None:
+    """Complete profile of (1/2, 1/2, -1)."""
+    values = (_cr(1, 2), _cr(1, 2), _cr(-1))
+    result = compute_rational_subset_sum_profile(values)
+    sum_map = {r.sum_value.as_fraction(): r.multiplicity for r in result.rows}
+    assert sum_map[Fraction(-1)] == 1
+    assert sum_map[Fraction(-1, 2)] == 2
+    assert sum_map[Fraction(0)] == 2
+    assert sum_map[Fraction(1, 2)] == 2
+    assert sum_map[Fraction(1)] == 1
+
+
+def test_empty_subset() -> None:
+    """The empty subset contributes sum 0 with multiplicity 1."""
+    values = (_cr(1, 2),)
+    result = compute_rational_subset_sum_profile(values)
+    sum_map = {r.sum_value.as_fraction(): r.multiplicity for r in result.rows}
+    assert sum_map[Fraction(0)] == 1
+    assert sum_map[Fraction(1, 2)] == 1
+
+
+def test_multiplicity_sum() -> None:
+    """Total multiplicity equals 2^n."""
+    values = (_cr(1, 3), _cr(2, 3), _cr(1))
+    result = compute_rational_subset_sum_profile(values)
+    total = sum(r.multiplicity for r in result.rows)
+    assert total == 2**3
+
+
+def test_replay() -> None:
+    """Replay: independently compute all subset sums."""
+    values = (_cr(1, 2), _cr(1, 3), _cr(-1, 4))
+    result = compute_rational_subset_sum_profile(values)
+    fracs = [v.as_fraction() for v in values]
+    n = len(fracs)
+    expected: dict[Fraction, int] = {}
+    for r in range(n + 1):
+        for indices in combinations(range(n), r):
+            s = sum(fracs[i] for i in indices)
+            expected[s] = expected.get(s, 0) + 1
+    actual = {r.sum_value.as_fraction(): r.multiplicity for r in result.rows}
+    assert actual == expected
+
+
+def test_sorted_output() -> None:
+    """Rows are sorted by rational value."""
+    values = (_cr(3, 2), _cr(-1, 4), _cr(1, 2))
+    result = compute_rational_subset_sum_profile(values)
+    sums = [r.sum_value.as_fraction() for r in result.rows]
+    assert sums == sorted(sums)
+
+
+def test_result_preserves_source() -> None:
+    """Result retains the source values."""
+    values = (_cr(1, 2), _cr(1, 3))
+    result = compute_rational_subset_sum_profile(values)
+    assert result.values == values

--- a/tests/math/combinatorics/additive/rational_subset_sum/test_rational_subset_sum.py
+++ b/tests/math/combinatorics/additive/rational_subset_sum/test_rational_subset_sum.py
@@ -90,3 +90,21 @@ def test_repeated_zero_values_use_their_small_support_bound() -> None:
     result = compute_rational_subset_sum_profile(values)
     assert len(result.rows) == 1
     assert result.rows[0].multiplicity == 2**20
+
+
+def test_single_max_height_value_is_admitted() -> None:
+    value = _cr(1, 10**32767 + 1)
+
+    result = compute_rational_subset_sum_profile((value,))
+
+    assert len(result.rows) == 2
+
+
+def test_uncancellable_rational_growth_is_rejected_before_enumeration() -> None:
+    values = (
+        _cr(1, 10**20000 + 1),
+        _cr(1, 10**20000 + 3),
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="rational"):
+        compute_rational_subset_sum_profile(values)

--- a/tests/math/combinatorics/additive/rational_subset_sum/test_rational_subset_sum.py
+++ b/tests/math/combinatorics/additive/rational_subset_sum/test_rational_subset_sum.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from fractions import Fraction
 from itertools import combinations
 
+import pytest
+
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.additive.rational_subset_sum.operations import (
     compute_rational_subset_sum_profile,
 )
@@ -72,3 +75,10 @@ def test_result_preserves_source() -> None:
     values = (_cr(1, 2), _cr(1, 3))
     result = compute_rational_subset_sum_profile(values)
     assert result.values == values
+
+
+def test_native_admission_rejects_oversized_profile() -> None:
+    """Native calls reject the exhaustive profile before enumeration."""
+    values = tuple(_cr(1, 2**i) for i in range(20))
+    with pytest.raises(OperationDomainValidationError, match="output bound"):
+        compute_rational_subset_sum_profile(values)


### PR DESCRIPTION
## Summary

Implements `additive.rational_subset_sum.profile.compute` from issue #2783.

Given an ordered indexed sequence of canonical rationals, returns every attainable subset sum and its number of realizing selection vectors, including the empty subset at zero.

## Design

- **Operation ID**: `additive.rational_subset_sum.profile.compute`
- **Input**: tuple of  values
- **Output**: `RationalSubsetSumResult` with rows (sum, multiplicity) sorted by rational value
- **Kernel**: exhaustive 2^n subset enumeration with exact rational accumulation
- **Bounds**: sequence length <= 20 (at most 2^20 = 1,048,576 subsets)

## Tests

- Fixture: (1/2, 1/2, -1) with expected profile (-1:1, -1/2:2, 0:2, 1/2:2, 1:1)
- Empty subset: contributes sum 0 with multiplicity 1
- Multiplicity sum: total = 2^n
- Replay: independent computation matches
- Sorted output by rational value
- Source preservation

Closes #2783

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)