### PR TITLE
Add graph.invariant.common_neighbor_profile.compute operation

### DIFF
--- a/src/jacobian/math/graphs/common_neighbor_profile/__init__.py
+++ b/src/jacobian/math/graphs/common_neighbor_profile/__init__.py
@@ -1,0 +1,7 @@
+"""Common-neighbour profile operations."""
+
+from jacobian.math.graphs.common_neighbor_profile.operations import (
+    compute_common_neighbor_profile,
+)
+
+__all__ = ["compute_common_neighbor_profile"]

--- a/src/jacobian/math/graphs/common_neighbor_profile/_models.py
+++ b/src/jacobian/math/graphs/common_neighbor_profile/_models.py
@@ -1,0 +1,52 @@
+"""Typed contracts for the common-neighbour profile operation."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_VERTICES = 256
+
+
+class CommonNeighborProfileRequest(StrictModel):
+    """Request for the common-neighbour profile of a graph."""
+
+    graph: SimpleUndirectedGraph
+
+    @model_validator(mode="after")
+    def validate_graph(self) -> Self:
+        if len(self.graph.vertices) > MAX_VERTICES:
+            raise PydanticCustomError(
+                "common_neighbor.too_many_vertices",
+                f"at most {MAX_VERTICES} vertices are supported",
+            )
+        return self
+
+
+class CommonNeighborRow(StrictModel):
+    """One unordered vertex pair with its common-neighbour set."""
+
+    vertex_u: str
+    vertex_v: str
+    common_neighbors: tuple[str, ...]
+    codegree: int
+
+
+class CommonNeighborProfileResult(StrictModel):
+    """The complete common-neighbour profile of a graph."""
+
+    graph: SimpleUndirectedGraph
+    rows: tuple[CommonNeighborRow, ...]
+
+
+__all__ = [
+    "MAX_VERTICES",
+    "CommonNeighborProfileRequest",
+    "CommonNeighborProfileResult",
+    "CommonNeighborRow",
+]

--- a/src/jacobian/math/graphs/common_neighbor_profile/_tools.py
+++ b/src/jacobian/math/graphs/common_neighbor_profile/_tools.py
@@ -1,0 +1,78 @@
+"""Common-neighbour profile operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.common_neighbor_profile._models import (
+    CommonNeighborProfileRequest,
+    CommonNeighborProfileResult,
+)
+from jacobian.math.graphs.common_neighbor_profile.operations import (
+    compute_common_neighbor_profile,
+)
+
+
+def compute_common_neighbor_profile_op(
+    request: CommonNeighborProfileRequest,
+) -> CommonNeighborProfileResult:
+    return compute_common_neighbor_profile(request.graph)
+
+
+def cnp_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    cnp_operation(
+        "graph.invariant.common_neighbor_profile.compute",
+        "Compute the common-neighbour profile of a graph",
+        (
+            "For a bounded finite simple graph G, return for every unordered pair "
+            "of distinct vertices the canonical sorted set of common neighbours "
+            "(N(u) ∩ N(v)) and its cardinality (codegree)."
+        ),
+        CommonNeighborProfileRequest,
+        CommonNeighborProfileResult,
+        compute_common_neighbor_profile_op,
+        "graph",
+        "invariant",
+        "exact",
+        examples=(
+            example(
+                "c4",
+                "The 4-cycle C4 has opposite pairs with codegree 2 and adjacent pairs with codegree 0.",
+                {
+                    "graph": {
+                        "vertices": ["0", "1", "2", "3"],
+                        "edges": [["0", "1"], ["1", "2"], ["2", "3"], ["0", "3"]],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/common_neighbor_profile/operations.py
+++ b/src/jacobian/math/graphs/common_neighbor_profile/operations.py
@@ -1,0 +1,42 @@
+"""Common-neighbour profile kernel."""
+
+from __future__ import annotations
+
+from jacobian.math.graphs.common_neighbor_profile._models import (
+    CommonNeighborProfileResult,
+    CommonNeighborRow,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+__all__ = ["compute_common_neighbor_profile"]
+
+
+def compute_common_neighbor_profile(
+    graph: SimpleUndirectedGraph,
+) -> CommonNeighborProfileResult:
+    """Return the complete common-neighbour profile of a simple graph.
+
+    For every unordered pair of distinct vertices, return the sorted
+    set of common neighbours, its cardinality (codegree), in canonical
+    source-vertex order.
+    """
+    vertices = list(graph.vertices)
+    adjacency: dict[str, set[str]] = {v: set() for v in vertices}
+    for a, b in graph.edges:
+        adjacency[a].add(b)
+        adjacency[b].add(a)
+
+    rows: list[CommonNeighborRow] = []
+    for i in range(len(vertices)):
+        for j in range(i + 1, len(vertices)):
+            u, v = vertices[i], vertices[j]
+            common = sorted(adjacency[u] & adjacency[v])
+            rows.append(
+                CommonNeighborRow(
+                    vertex_u=u,
+                    vertex_v=v,
+                    common_neighbors=tuple(common),
+                    codegree=len(common),
+                )
+            )
+    return CommonNeighborProfileResult(graph=graph, rows=tuple(rows))

--- a/src/jacobian/math/graphs/common_neighbor_profile/operations.py
+++ b/src/jacobian/math/graphs/common_neighbor_profile/operations.py
@@ -52,28 +52,30 @@ def _admit_graph(
         adjacency[left].add(right)
         adjacency[right].add(left)
 
+    rows: list[tuple[str, str, tuple[str, ...]]] = []
+    for index, left in enumerate(vertices):
+        for right in vertices[index + 1 :]:
+            common = tuple(sorted(adjacency[left] & adjacency[right]))
+            rows.append((left, right, common))
+
     try:
         source_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
-        max_label_bytes = max(
-            (len(encode_strict_json(vertex)) for vertex in vertices), default=2
-        )
-        row_sizes: list[int] = []
-        for index, left in enumerate(vertices):
-            for right in vertices[index + 1 :]:
-                possible_common = min(len(adjacency[left]), len(adjacency[right]))
-                row_sizes.append(
-                    strict_json_object_size(
-                        (
-                            ("vertex_u", len(encode_strict_json(left))),
-                            ("vertex_v", len(encode_strict_json(right))),
-                            (
-                                "common_neighbors",
-                                _array_size([max_label_bytes] * possible_common),
-                            ),
-                            ("codegree", 3),
-                        )
-                    )
+        row_sizes = [
+            strict_json_object_size(
+                (
+                    ("vertex_u", len(encode_strict_json(left))),
+                    ("vertex_v", len(encode_strict_json(right))),
+                    (
+                        "common_neighbors",
+                        _array_size(
+                            [len(encode_strict_json(vertex)) for vertex in common]
+                        ),
+                    ),
+                    ("codegree", 3),
                 )
+            )
+            for left, right, common in rows
+        ]
         upper_bound = strict_json_object_size(
             (
                 ("graph", source_bytes),
@@ -88,11 +90,6 @@ def _admit_graph(
             f"the complete profile exceeds the {MAX_RESULT_BYTES}-byte output bound",
         )
 
-    rows: list[tuple[str, str, tuple[str, ...]]] = []
-    for index, left in enumerate(vertices):
-        for right in vertices[index + 1 :]:
-            common = tuple(sorted(adjacency[left] & adjacency[right]))
-            rows.append((left, right, common))
     return adjacency, _ProfilePlan(rows=tuple(rows))
 
 

--- a/src/jacobian/math/graphs/common_neighbor_profile/operations.py
+++ b/src/jacobian/math/graphs/common_neighbor_profile/operations.py
@@ -71,7 +71,7 @@ def _admit_graph(
                             [len(encode_strict_json(vertex)) for vertex in common]
                         ),
                     ),
-                    ("codegree", 3),
+                    ("codegree", len(encode_strict_json(len(common)))),
                 )
             )
             for left, right, common in rows

--- a/src/jacobian/math/graphs/common_neighbor_profile/operations.py
+++ b/src/jacobian/math/graphs/common_neighbor_profile/operations.py
@@ -2,13 +2,98 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import NoReturn
+
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    strict_json_object_size,
+)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.common_neighbor_profile._models import (
+    MAX_VERTICES,
     CommonNeighborProfileResult,
     CommonNeighborRow,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 __all__ = ["compute_common_neighbor_profile"]
+
+MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _ProfilePlan:
+    rows: tuple[tuple[str, str, tuple[str, ...]], ...]
+
+
+def _array_size(item_sizes: list[int]) -> int:
+    return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
+
+
+def _reject(code: str, message: str) -> NoReturn:
+    raise OperationDomainValidationError(
+        location=("graph",), code=f"common_neighbor.{code}", message=message
+    )
+
+
+def _admit_graph(
+    graph: SimpleUndirectedGraph,
+) -> tuple[dict[str, set[str]], _ProfilePlan]:
+    if not isinstance(graph, SimpleUndirectedGraph):
+        _reject("invalid_graph", "graph must be a simple undirected graph")
+    vertices = list(graph.vertices)
+    if len(vertices) > MAX_VERTICES:
+        _reject("too_many_vertices", f"at most {MAX_VERTICES} vertices are supported")
+
+    adjacency: dict[str, set[str]] = {vertex: set() for vertex in vertices}
+    for left, right in graph.edges:
+        adjacency[left].add(right)
+        adjacency[right].add(left)
+
+    try:
+        source_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
+        max_label_bytes = max(
+            (len(encode_strict_json(vertex)) for vertex in vertices), default=2
+        )
+        row_sizes: list[int] = []
+        for index, left in enumerate(vertices):
+            for right in vertices[index + 1 :]:
+                possible_common = min(len(adjacency[left]), len(adjacency[right]))
+                row_sizes.append(
+                    strict_json_object_size(
+                        (
+                            ("vertex_u", len(encode_strict_json(left))),
+                            ("vertex_v", len(encode_strict_json(right))),
+                            (
+                                "common_neighbors",
+                                _array_size([max_label_bytes] * possible_common),
+                            ),
+                            ("codegree", 3),
+                        )
+                    )
+                )
+        upper_bound = strict_json_object_size(
+            (
+                ("graph", source_bytes),
+                ("rows", _array_size(row_sizes)),
+            )
+        )
+    except ValueError as exc:
+        _reject("source_representation", str(exc))
+    if upper_bound > MAX_RESULT_BYTES:
+        _reject(
+            "result_size_bound",
+            f"the complete profile exceeds the {MAX_RESULT_BYTES}-byte output bound",
+        )
+
+    rows: list[tuple[str, str, tuple[str, ...]]] = []
+    for index, left in enumerate(vertices):
+        for right in vertices[index + 1 :]:
+            common = tuple(sorted(adjacency[left] & adjacency[right]))
+            rows.append((left, right, common))
+    return adjacency, _ProfilePlan(rows=tuple(rows))
 
 
 def compute_common_neighbor_profile(
@@ -20,23 +105,14 @@ def compute_common_neighbor_profile(
     set of common neighbours, its cardinality (codegree), in canonical
     source-vertex order.
     """
-    vertices = list(graph.vertices)
-    adjacency: dict[str, set[str]] = {v: set() for v in vertices}
-    for a, b in graph.edges:
-        adjacency[a].add(b)
-        adjacency[b].add(a)
-
-    rows: list[CommonNeighborRow] = []
-    for i in range(len(vertices)):
-        for j in range(i + 1, len(vertices)):
-            u, v = vertices[i], vertices[j]
-            common = sorted(adjacency[u] & adjacency[v])
-            rows.append(
-                CommonNeighborRow(
-                    vertex_u=u,
-                    vertex_v=v,
-                    common_neighbors=tuple(common),
-                    codegree=len(common),
-                )
-            )
+    _adjacency, plan = _admit_graph(graph)
+    rows = [
+        CommonNeighborRow(
+            vertex_u=left,
+            vertex_v=right,
+            common_neighbors=common,
+            codegree=len(common),
+        )
+        for left, right, common in plan.rows
+    ]
     return CommonNeighborProfileResult(graph=graph, rows=tuple(rows))

--- a/src/jacobian/math/graphs/common_neighbor_profile/operations.py
+++ b/src/jacobian/math/graphs/common_neighbor_profile/operations.py
@@ -52,30 +52,37 @@ def _admit_graph(
         adjacency[left].add(right)
         adjacency[right].add(left)
 
-    rows: list[tuple[str, str, tuple[str, ...]]] = []
-    for index, left in enumerate(vertices):
-        for right in vertices[index + 1 :]:
-            common = tuple(sorted(adjacency[left] & adjacency[right]))
-            rows.append((left, right, common))
-
     try:
+        encoded_vertex_sizes = {
+            vertex: len(encode_strict_json(vertex)) for vertex in vertices
+        }
         source_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
-        row_sizes = [
-            strict_json_object_size(
-                (
-                    ("vertex_u", len(encode_strict_json(left))),
-                    ("vertex_v", len(encode_strict_json(right))),
-                    (
-                        "common_neighbors",
-                        _array_size(
-                            [len(encode_strict_json(vertex)) for vertex in common]
-                        ),
-                    ),
-                    ("codegree", len(encode_strict_json(len(common)))),
+        row_sizes: list[int] = []
+        for index, left in enumerate(vertices):
+            for right in vertices[index + 1 :]:
+                common_count = 0
+                common_bytes = 0
+                smaller, larger = sorted((adjacency[left], adjacency[right]), key=len)
+                for vertex in smaller:
+                    if vertex in larger:
+                        common_count += 1
+                        common_bytes += encoded_vertex_sizes[vertex]
+                row_sizes.append(
+                    strict_json_object_size(
+                        (
+                            ("vertex_u", encoded_vertex_sizes[left]),
+                            ("vertex_v", encoded_vertex_sizes[right]),
+                            (
+                                "common_neighbors",
+                                2 + max(common_count - 1, 0) + common_bytes,
+                            ),
+                            (
+                                "codegree",
+                                len(encode_strict_json(common_count)),
+                            ),
+                        )
+                    )
                 )
-            )
-            for left, right, common in rows
-        ]
         upper_bound = strict_json_object_size(
             (
                 ("graph", source_bytes),
@@ -90,7 +97,16 @@ def _admit_graph(
             f"the complete profile exceeds the {MAX_RESULT_BYTES}-byte output bound",
         )
 
-    return adjacency, _ProfilePlan(rows=tuple(rows))
+    rows = tuple(
+        (
+            left,
+            right,
+            tuple(sorted(adjacency[left] & adjacency[right])),
+        )
+        for index, left in enumerate(vertices)
+        for right in vertices[index + 1 :]
+    )
+    return adjacency, _ProfilePlan(rows=rows)
 
 
 def compute_common_neighbor_profile(

--- a/tests/math/graphs/common_neighbor_profile/test_common_neighbor_profile.py
+++ b/tests/math/graphs/common_neighbor_profile/test_common_neighbor_profile.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.common_neighbor_profile.operations import (
     compute_common_neighbor_profile,
 )
@@ -86,3 +89,12 @@ def test_result_preserves_source() -> None:
     g = _graph(["a", "b"], [("a", "b")])
     result = compute_common_neighbor_profile(g)
     assert result.graph == g
+
+
+def test_native_admission_rejects_complete_profile_over_output_bound() -> None:
+    """A dense large graph is rejected before retaining millions of labels."""
+    vertices = sorted(str(i) for i in range(256))
+    edges = [(vertices[i], vertices[j]) for i in range(256) for j in range(i + 1, 256)]
+    g = _graph(vertices, edges)
+    with pytest.raises(OperationDomainValidationError, match="output bound"):
+        compute_common_neighbor_profile(g)

--- a/tests/math/graphs/common_neighbor_profile/test_common_neighbor_profile.py
+++ b/tests/math/graphs/common_neighbor_profile/test_common_neighbor_profile.py
@@ -98,3 +98,13 @@ def test_native_admission_rejects_complete_profile_over_output_bound() -> None:
     g = _graph(vertices, edges)
     with pytest.raises(OperationDomainValidationError, match="output bound"):
         compute_common_neighbor_profile(g)
+
+
+def test_result_bound_uses_actual_common_neighbor_labels() -> None:
+    """A long isolated label does not inflate unrelated common-neighbor rows."""
+    short = [f"{i:03d}" for i in range(99)]
+    isolated = "x" * 64
+    vertices = [*short, isolated]
+    edges = [(left, right) for i, left in enumerate(short) for right in short[i + 1 :]]
+    result = compute_common_neighbor_profile(_graph(vertices, edges))
+    assert len(result.rows) == len(vertices) * (len(vertices) - 1) // 2

--- a/tests/math/graphs/common_neighbor_profile/test_common_neighbor_profile.py
+++ b/tests/math/graphs/common_neighbor_profile/test_common_neighbor_profile.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from jacobian.canonical import CanonicalLimits, encode_strict_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.common_neighbor_profile.operations import (
     compute_common_neighbor_profile,
@@ -108,3 +109,17 @@ def test_result_bound_uses_actual_common_neighbor_labels() -> None:
     edges = [(left, right) for i, left in enumerate(short) for right in short[i + 1 :]]
     result = compute_common_neighbor_profile(_graph(vertices, edges))
     assert len(result.rows) == len(vertices) * (len(vertices) - 1) // 2
+
+
+def test_result_bound_uses_actual_codegree_digit_width() -> None:
+    left = ["a" * 60 + suffix for suffix in ("0", "1")]
+    right = ["b" * 60 + f"{index:04x}" for index in range(254)]
+    graph = _graph(
+        [*left, *right],
+        [(left_vertex, right_vertex) for left_vertex in left for right_vertex in right],
+    )
+
+    result = compute_common_neighbor_profile(graph)
+    assert len(encode_strict_json(result.model_dump(mode="json"))) <= (
+        CanonicalLimits().max_output_bytes
+    )

--- a/tests/math/graphs/common_neighbor_profile/test_common_neighbor_profile.py
+++ b/tests/math/graphs/common_neighbor_profile/test_common_neighbor_profile.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from jacobian.math.graphs.common_neighbor_profile.operations import (
+    compute_common_neighbor_profile,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph(vertices, edges):
+    return SimpleUndirectedGraph(
+        vertices=tuple(vertices),
+        edges=tuple((a, b) for a, b in edges),
+    )
+
+
+def test_c4_fixture() -> None:
+    """C4: opposite pairs have codegree 2, adjacent pairs have codegree 0."""
+    g = _graph(["0", "1", "2", "3"], [("0", "1"), ("1", "2"), ("2", "3"), ("0", "3")])
+    result = compute_common_neighbor_profile(g)
+    row_map = {(r.vertex_u, r.vertex_v): r for r in result.rows}
+    assert row_map[("0", "2")].codegree == 2
+    assert set(row_map[("0", "2")].common_neighbors) == {"1", "3"}
+    assert row_map[("0", "1")].codegree == 0
+    assert row_map[("1", "3")].codegree == 2
+    assert set(row_map[("1", "3")].common_neighbors) == {"0", "2"}
+
+
+def test_k3() -> None:
+    """K3: every pair has one common neighbour (codegree 1)."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("a", "c"), ("b", "c")])
+    result = compute_common_neighbor_profile(g)
+    for row in result.rows:
+        assert row.codegree == 1
+
+
+def test_edgeless_graph() -> None:
+    """Edgeless graph has all codegrees 0."""
+    g = _graph(["a", "b", "c"], [])
+    result = compute_common_neighbor_profile(g)
+    for row in result.rows:
+        assert row.codegree == 0
+
+
+def test_row_count() -> None:
+    """Number of rows = C(n, 2)."""
+    g = _graph(["a", "b", "c", "d"], [("a", "b"), ("b", "c"), ("c", "d")])
+    result = compute_common_neighbor_profile(g)
+    assert len(result.rows) == 6  # C(4,2)
+
+
+def test_replay_intersection() -> None:
+    """Each row equals the intersection of the two source neighbourhoods."""
+    g = _graph(["a", "b", "c", "d"], [("a", "b"), ("a", "c"), ("b", "c"), ("b", "d")])
+    adjacency: dict[str, set[str]] = {v: set() for v in g.vertices}
+    for a, b in g.edges:
+        adjacency[a].add(b)
+        adjacency[b].add(a)
+    result = compute_common_neighbor_profile(g)
+    for row in result.rows:
+        expected = sorted(adjacency[row.vertex_u] & adjacency[row.vertex_v])
+        assert list(row.common_neighbors) == expected
+        assert row.codegree == len(expected)
+
+
+def test_c4_free_condition() -> None:
+    """A graph is C4-free iff every pair has codegree at most 1."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("a", "c"), ("b", "c")])
+    result = compute_common_neighbor_profile(g)
+    is_c4_free = all(r.codegree <= 1 for r in result.rows)
+    assert is_c4_free
+
+
+def test_complete_pair_coverage() -> None:
+    """Every unordered distinct pair appears exactly once."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    result = compute_common_neighbor_profile(g)
+    seen = set()
+    for row in result.rows:
+        pair = (row.vertex_u, row.vertex_v)
+        assert pair not in seen
+        seen.add(pair)
+    assert len(seen) == 3  # C(3,2)
+
+
+def test_result_preserves_source() -> None:
+    g = _graph(["a", "b"], [("a", "b")])
+    result = compute_common_neighbor_profile(g)
+    assert result.graph == g


### PR DESCRIPTION
## Summary

Implements `graph.invariant.common_neighbor_profile.compute` from issue #2766.

For a bounded finite simple graph, returns for every unordered pair of distinct vertices the canonical sorted set of common neighbours (N(u) ∩ N(v)) and its cardinality (codegree). This is the complete pairwise intersection data needed for Ramsey certificate verification, C4-freeness checks, and codegree hypotheses.

## Design

- **Operation ID**: `graph.invariant.common_neighbor_profile.compute`
- **Input**: `SimpleUndirectedGraph` (at most 256 vertices)
- **Output**: `CommonNeighborProfileResult` with one row per unordered pair
- **Kernel**: O(n^2) pairwise neighbourhood intersection

## Tests

- C4 fixture: opposite pairs have codegree 2, adjacent pairs have codegree 0
- K3: every pair has codegree 1
- Edgeless graph: all codegrees 0
- Row count: C(n,2)
- Replay: each row equals neighbourhood intersection
- C4-free condition: max codegree <= 1
- Complete pair coverage
- Source preservation

Closes #2766

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)