### PR TITLE
Add hypergraph.axis_aligned_square_grid.construct operation

### DIFF
--- a/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/__init__.py
+++ b/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/__init__.py
@@ -1,0 +1,7 @@
+"""Axis-aligned square grid hypergraph constructor."""
+
+from jacobian.math.combinatorics.finite_structures.axis_aligned_square_grid.operations import (
+    construct_axis_aligned_square_grid,
+)
+
+__all__ = ["construct_axis_aligned_square_grid"]

--- a/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/_models.py
@@ -2,33 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Self
-
-from pydantic import Field, model_validator
-from pydantic_core import PydanticCustomError
+from pydantic import Field, StrictInt
 
 from jacobian._models import StrictModel
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
 )
 
-MAX_SIDE_LENGTH = 9
+MAX_SIDE_LENGTH = 16
 
 
 class AxisAlignedSquareGridRequest(StrictModel):
     """Request to construct the axis-aligned-square hypergraph of [N]^2."""
 
-    side_length: int = Field(ge=1, le=MAX_SIDE_LENGTH)
-
-    @model_validator(mode="after")
-    def validate_request(self) -> Self:
-        vertices = self.side_length**2
-        if vertices > 256:
-            raise PydanticCustomError(
-                "square_grid.too_many_vertices",
-                f"N^2 = {vertices} exceeds the 256-vertex limit",
-            )
-        return self
+    side_length: StrictInt = Field(ge=1, le=MAX_SIDE_LENGTH)
 
 
 class AxisAlignedSquareGridResult(StrictModel):

--- a/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/_models.py
@@ -1,0 +1,45 @@
+"""Typed contracts for the axis-aligned square grid hypergraph operation."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+
+MAX_SIDE_LENGTH = 9
+
+
+class AxisAlignedSquareGridRequest(StrictModel):
+    """Request to construct the axis-aligned-square hypergraph of [N]^2."""
+
+    side_length: int = Field(ge=1, le=MAX_SIDE_LENGTH)
+
+    @model_validator(mode="after")
+    def validate_request(self) -> Self:
+        vertices = self.side_length**2
+        if vertices > 256:
+            raise PydanticCustomError(
+                "square_grid.too_many_vertices",
+                f"N^2 = {vertices} exceeds the 256-vertex limit",
+            )
+        return self
+
+
+class AxisAlignedSquareGridResult(StrictModel):
+    """The axis-aligned-square hypergraph of [N]^2."""
+
+    side_length: int
+    hypergraph: FiniteHypergraph
+
+
+__all__ = [
+    "MAX_SIDE_LENGTH",
+    "AxisAlignedSquareGridRequest",
+    "AxisAlignedSquareGridResult",
+]

--- a/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/_tools.py
+++ b/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/_tools.py
@@ -63,7 +63,8 @@ TOOLS: MathTools = (
         examples=(
             example(
                 "n3",
-                "The 3x3 grid has 9 vertices and 5 axis-aligned squares.",
+                "The 3x3 grid has 9 vertices and 5 axis-aligned squares; "
+                "side_length must be an integer from 1 through 16.",
                 {"side_length": 3},
             ),
         ),

--- a/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/_tools.py
+++ b/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/_tools.py
@@ -1,0 +1,73 @@
+"""Axis-aligned square grid hypergraph operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.combinatorics.finite_structures.axis_aligned_square_grid._models import (
+    AxisAlignedSquareGridRequest,
+    AxisAlignedSquareGridResult,
+)
+from jacobian.math.combinatorics.finite_structures.axis_aligned_square_grid.operations import (
+    construct_axis_aligned_square_grid,
+)
+
+
+def compute_axis_aligned_square_grid(
+    request: AxisAlignedSquareGridRequest,
+) -> AxisAlignedSquareGridResult:
+    return construct_axis_aligned_square_grid(request.side_length)
+
+
+def asg_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    asg_operation(
+        "hypergraph.axis_aligned_square_grid.construct",
+        "Construct the axis-aligned-square hypergraph of [N]^2",
+        (
+            "Construct the 4-uniform hypergraph whose vertices are the N^2 grid "
+            "points and whose hyperedges are the axis-aligned squares "
+            "{(x,y), (x+d,y), (x,y+d), (x+d,y+d)} for every d >= 1."
+        ),
+        AxisAlignedSquareGridRequest,
+        AxisAlignedSquareGridResult,
+        compute_axis_aligned_square_grid,
+        "combinatorics",
+        "hypergraph",
+        "exact",
+        examples=(
+            example(
+                "n3",
+                "The 3x3 grid has 9 vertices and 5 axis-aligned squares.",
+                {"side_length": 3},
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/operations.py
@@ -2,14 +2,82 @@
 
 from __future__ import annotations
 
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    strict_json_object_size,
+)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.finite_structures.axis_aligned_square_grid._models import (
+    MAX_SIDE_LENGTH,
     AxisAlignedSquareGridResult,
 )
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_TOTAL_INCIDENCES,
     FiniteHypergraph,
 )
 
 __all__ = ["construct_axis_aligned_square_grid"]
+
+MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
+
+
+def _array_size(item_sizes: list[int]) -> int:
+    return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
+
+
+def _admit_side_length(side_length: int) -> int:
+    if isinstance(side_length, bool) or not isinstance(side_length, int):
+        raise OperationDomainValidationError(
+            location=("side_length",),
+            code="square_grid.invalid_side_length",
+            message="side_length must be a strict integer",
+        )
+    if not 1 <= side_length <= MAX_SIDE_LENGTH:
+        raise OperationDomainValidationError(
+            location=("side_length",),
+            code="square_grid.side_length_bound",
+            message=f"side_length must be between 1 and {MAX_SIDE_LENGTH}",
+        )
+    n = side_length
+    edge_count = n * (n - 1) * (2 * n - 1) // 6
+    incidence_count = 4 * edge_count
+    if edge_count > MAX_EDGES:
+        raise OperationDomainValidationError(
+            location=("side_length",),
+            code="square_grid.edge_bound",
+            message=f"the grid would contain {edge_count} edges, over the {MAX_EDGES}-edge bound",
+        )
+    if incidence_count > MAX_TOTAL_INCIDENCES:
+        raise OperationDomainValidationError(
+            location=("side_length",),
+            code="square_grid.incidence_bound",
+            message=(
+                f"the grid would contain {incidence_count} incidences, over the "
+                f"{MAX_TOTAL_INCIDENCES}-incidence bound"
+            ),
+        )
+
+    vertex_digit_bytes = len(encode_strict_json(f"({n - 1},{n - 1})"))
+    edge_id_bytes = len(encode_strict_json(f"square_{max(edge_count - 1, 0)}"))
+    edge_member_bytes = _array_size([vertex_digit_bytes] * 4)
+    edge_bytes = _array_size([edge_id_bytes, edge_member_bytes])
+    vertices_bytes = _array_size([vertex_digit_bytes] * (n * n))
+    edges_bytes = _array_size([edge_bytes] * edge_count)
+    hypergraph_bytes = strict_json_object_size(
+        (("vertices", vertices_bytes), ("edges", edges_bytes))
+    )
+    result_bytes = strict_json_object_size(
+        (("side_length", len(str(n))), ("hypergraph", hypergraph_bytes))
+    )
+    if result_bytes > MAX_RESULT_BYTES:
+        raise OperationDomainValidationError(
+            location=("side_length",),
+            code="square_grid.result_size_bound",
+            message=f"the grid result exceeds the {MAX_RESULT_BYTES}-byte output bound",
+        )
+    return n
 
 
 def construct_axis_aligned_square_grid(
@@ -21,7 +89,7 @@ def construct_axis_aligned_square_grid(
     Hyperedges are the sets {(x,y), (x+d,y), (x,y+d), (x+d,y+d)} for
     every d >= 1 with x+d <= N-1 and y+d <= N-1.
     """
-    n = side_length
+    n = _admit_side_length(side_length)
 
     def vertex_label(x: int, y: int) -> str:
         return f"({x},{y})"

--- a/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/operations.py
@@ -1,0 +1,53 @@
+"""Axis-aligned square grid hypergraph constructor."""
+
+from __future__ import annotations
+
+from jacobian.math.combinatorics.finite_structures.axis_aligned_square_grid._models import (
+    AxisAlignedSquareGridResult,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+
+__all__ = ["construct_axis_aligned_square_grid"]
+
+
+def construct_axis_aligned_square_grid(
+    side_length: int,
+) -> AxisAlignedSquareGridResult:
+    """Construct the 4-uniform hypergraph of axis-aligned squares in [N]^2.
+
+    Vertices are the N^2 grid points (x,y) for x,y in {0,...,N-1}.
+    Hyperedges are the sets {(x,y), (x+d,y), (x,y+d), (x+d,y+d)} for
+    every d >= 1 with x+d <= N-1 and y+d <= N-1.
+    """
+    n = side_length
+
+    def vertex_label(x: int, y: int) -> str:
+        return f"({x},{y})"
+
+    vertices = tuple(vertex_label(x, y) for y in range(n) for x in range(n))
+
+    edges: list[tuple[str, tuple[str, ...]]] = []
+    edge_index = 0
+    for y in range(n):
+        for x in range(n):
+            for d in range(1, n):
+                if x + d <= n - 1 and y + d <= n - 1:
+                    edge = (
+                        vertex_label(x, y),
+                        vertex_label(x + d, y),
+                        vertex_label(x, y + d),
+                        vertex_label(x + d, y + d),
+                    )
+                    edges.append((f"square_{edge_index}", tuple(sorted(edge))))
+                    edge_index += 1
+
+    hypergraph = FiniteHypergraph(
+        vertices=vertices,
+        edges=tuple(edges),
+    )
+    return AxisAlignedSquareGridResult(
+        side_length=n,
+        hypergraph=hypergraph,
+    )

--- a/tests/math/combinatorics/finite_structures/axis_aligned_square_grid/test_axis_aligned_square_grid.py
+++ b/tests/math/combinatorics/finite_structures/axis_aligned_square_grid/test_axis_aligned_square_grid.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from jacobian.math.combinatorics.finite_structures.axis_aligned_square_grid.operations import (
+    construct_axis_aligned_square_grid,
+)
+
+
+def test_n1() -> None:
+    """N=1: 1 vertex, 0 squares."""
+    result = construct_axis_aligned_square_grid(1)
+    assert len(result.hypergraph.vertices) == 1
+    assert len(result.hypergraph.edges) == 0
+
+
+def test_n2() -> None:
+    """N=2: 4 vertices, 1 square."""
+    result = construct_axis_aligned_square_grid(2)
+    assert len(result.hypergraph.vertices) == 4
+    assert len(result.hypergraph.edges) == 1
+
+
+def test_n3() -> None:
+    """N=3: 9 vertices, 5 squares."""
+    result = construct_axis_aligned_square_grid(3)
+    assert len(result.hypergraph.vertices) == 9
+    assert len(result.hypergraph.edges) == 5
+
+
+def test_n9_count() -> None:
+    """N=9: 81 vertices, 204 squares, 816 incidences."""
+    result = construct_axis_aligned_square_grid(9)
+    assert len(result.hypergraph.vertices) == 81
+    assert len(result.hypergraph.edges) == 204
+    total_inc = sum(len(members) for _, members in result.hypergraph.edges)
+    assert total_inc == 816
+
+
+def test_edge_size() -> None:
+    """Every edge has exactly 4 vertices."""
+    result = construct_axis_aligned_square_grid(3)
+    for _, members in result.hypergraph.edges:
+        assert len(members) == 4
+
+
+def test_replay_squares() -> None:
+    """Every edge is a valid axis-aligned square."""
+    result = construct_axis_aligned_square_grid(3)
+    for _, members in result.hypergraph.edges:
+        coords = [tuple(int(s) for s in m.strip("()").split(",")) for m in members]
+        xs = sorted({c[0] for c in coords})
+        ys = sorted({c[1] for c in coords})
+        assert len(xs) == 2
+        assert len(ys) == 2
+        dx = xs[1] - xs[0]
+        dy = ys[1] - ys[0]
+        assert dx == dy
+        assert dx >= 1
+
+
+def test_exhaustive_comparison() -> None:
+    """Compare against independent enumeration."""
+    n = 4
+    result = construct_axis_aligned_square_grid(n)
+    expected = set()
+    for y in range(n):
+        for x in range(n):
+            for d in range(1, n):
+                if x + d <= n - 1 and y + d <= n - 1:
+                    sq = frozenset(
+                        [
+                            f"({x},{y})",
+                            f"({x + d},{y})",
+                            f"({x},{y + d})",
+                            f"({x + d},{y + d})",
+                        ]
+                    )
+                    expected.add(sq)
+    actual = {frozenset(members) for _, members in result.hypergraph.edges}
+    assert actual == expected
+
+
+def test_result_preserves_n() -> None:
+    result = construct_axis_aligned_square_grid(3)
+    assert result.side_length == 3

--- a/tests/math/combinatorics/finite_structures/axis_aligned_square_grid/test_axis_aligned_square_grid.py
+++ b/tests/math/combinatorics/finite_structures/axis_aligned_square_grid/test_axis_aligned_square_grid.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.finite_structures.axis_aligned_square_grid.operations import (
     construct_axis_aligned_square_grid,
 )
@@ -82,3 +85,15 @@ def test_exhaustive_comparison() -> None:
 def test_result_preserves_n() -> None:
     result = construct_axis_aligned_square_grid(3)
     assert result.side_length == 3
+
+
+def test_n16_is_admitted_by_carrier_bounds() -> None:
+    """The largest grid has 256 vertices and remains a bounded result."""
+    result = construct_axis_aligned_square_grid(16)
+    assert len(result.hypergraph.vertices) == 256
+    assert len(result.hypergraph.edges) == 1240
+
+
+def test_native_admission_rejects_n17_before_enumeration() -> None:
+    with pytest.raises(OperationDomainValidationError, match="between 1 and 16"):
+        construct_axis_aligned_square_grid(17)


### PR DESCRIPTION
## Summary

Implements `hypergraph.axis_aligned_square_grid.construct` from issue #2915.

Constructs the 4-uniform hypergraph whose vertices are the N^2 grid points (x,y) for x,y in {0,...,N-1} and whose hyperedges are the axis-aligned squares {(x,y), (x+d,y), (x,y+d), (x+d,y+d)} for every d >= 1 with x+d and y+d within bounds.

## Design

- **Operation ID**: `hypergraph.axis_aligned_square_grid.construct`
- **Input**:  (N, at most 9)
- **Output**: `AxisAlignedSquareGridResult` containing a `FiniteHypergraph`
- **Kernel**: direct O(N^2 * N) enumeration of (x,y,d) triples
- **Bounds**: N <= 9 (at most 81 vertices, 204 edges, 816 incidences)

## Tests

- N=1: 1 vertex, 0 squares
- N=2: 4 vertices, 1 square
- N=3: 9 vertices, 5 squares
- N=9: 81 vertices, 204 squares, 816 incidences (source-table size)
- Every edge has exactly 4 vertices
- Replay: every edge is a valid axis-aligned square
- Exhaustive comparison against independent enumeration
- Source preservation

Closes #2915

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)