### PR TITLE
Add congruence.periodic_union.prefix_count.compute operation

### DIFF
--- a/src/jacobian/math/number_theory/periodic_prefix_count/__init__.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/__init__.py
@@ -1,0 +1,7 @@
+"""Periodic congruence union prefix count operations."""
+
+from jacobian.math.number_theory.periodic_prefix_count.operations import (
+    compute_periodic_union_prefix_count,
+)
+
+__all__ = ["compute_periodic_union_prefix_count"]

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
@@ -1,14 +1,17 @@
 """Typed contracts for the periodic union prefix count operation."""
 
-from typing import Annotated
+from math import lcm
+from typing import Annotated, Self
 
-from pydantic import Field, StringConstraints
+from pydantic import Field, StringConstraints, model_validator
+from pydantic_core import PydanticCustomError
 
-from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.canonical import CanonicalLimits
 from jacobian.math.number_theory._periodic_models import (
     PeriodicCongruenceUnionSource,
+    PeriodicNonnegativeInteger,
+    PeriodicPositiveInteger,
 )
 
 # Prefix arithmetic is scalar and does not inherit the 256-digit period bound;
@@ -42,10 +45,43 @@ class PeriodicUnionPrefixCountResult(StrictModel):
     """The exact count of integers in [1, cutoff] belonging to the periodic set."""
 
     source: PeriodicCongruenceUnionSource
-    cutoff: CanonicalInteger
-    common_period: CanonicalInteger
-    occupied_count: CanonicalInteger
-    count: CanonicalInteger
+    cutoff: PeriodicPrefixCutoff
+    common_period: PeriodicPositiveInteger
+    occupied_count: PeriodicNonnegativeInteger
+    count: PeriodicNonnegativeInteger
+
+    @model_validator(mode="after")
+    def require_count_invariants(self) -> Self:
+        cutoff = int(self.cutoff)
+        period = int(self.common_period)
+        occupied = int(self.occupied_count)
+        count = int(self.count)
+        source_period = lcm(
+            *(int(subset.modulus) for subset in self.source.subsets)
+        )
+        if period != source_period:
+            raise PydanticCustomError(
+                "number_theory.periodic_prefix.period_mismatch",
+                "common_period must equal the source common period",
+            )
+        if occupied > period:
+            raise PydanticCustomError(
+                "number_theory.periodic_prefix.occupied_count_out_of_range",
+                "occupied_count must lie between 0 and common_period",
+            )
+        if count > cutoff:
+            raise PydanticCustomError(
+                "number_theory.periodic_prefix.count_out_of_range",
+                "count must lie between 0 and cutoff",
+            )
+        remainder = cutoff % period
+        partial = count - (cutoff // period) * occupied
+        if not 0 <= partial <= remainder:
+            raise PydanticCustomError(
+                "number_theory.periodic_prefix.count_identity_mismatch",
+                "count must decompose into full periods and a bounded partial period",
+            )
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
@@ -56,9 +56,7 @@ class PeriodicUnionPrefixCountResult(StrictModel):
         period = int(self.common_period)
         occupied = int(self.occupied_count)
         count = int(self.count)
-        source_period = lcm(
-            *(int(subset.modulus) for subset in self.source.subsets)
-        )
+        source_period = lcm(*(int(subset.modulus) for subset in self.source.subsets))
         if period != source_period:
             raise PydanticCustomError(
                 "number_theory.periodic_prefix.period_mismatch",

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
@@ -7,7 +7,7 @@ from pydantic import Field, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.canonical import CanonicalLimits
+from jacobian.canonical import CanonicalLimits, parse_canonical_integer
 from jacobian.math.number_theory._periodic_models import (
     PeriodicCongruenceUnionSource,
     PeriodicNonnegativeInteger,
@@ -52,12 +52,12 @@ class PeriodicUnionPrefixCountResult(StrictModel):
 
     @model_validator(mode="after")
     def require_count_invariants(self) -> Self:
-        cutoff = int(self.cutoff)
-        period = int(self.common_period)
-        occupied = int(self.occupied_count)
-        count = int(self.count)
+        cutoff = parse_canonical_integer(self.cutoff)
+        period = parse_canonical_integer(self.common_period)
+        occupied = parse_canonical_integer(self.occupied_count)
+        count = parse_canonical_integer(self.count)
         source_period = lcm(
-            *(int(subset.modulus) for subset in self.source.subsets)
+            *(parse_canonical_integer(subset.modulus) for subset in self.source.subsets)
         )
         if period != source_period:
             raise PydanticCustomError(

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
@@ -1,17 +1,38 @@
 """Typed contracts for the periodic union prefix count operation."""
 
+from typing import Annotated
+
+from pydantic import Field, StringConstraints
+
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.math.number_theory._periodic_models import (
+    MAX_PERIODIC_INTEGER_DIGITS,
     PeriodicCongruenceUnionSource,
 )
+
+MAX_PREFIX_CUTOFF_DIGITS = MAX_PERIODIC_INTEGER_DIGITS
+PeriodicPrefixCutoff = Annotated[
+    str,
+    StringConstraints(
+        pattern=rf"^(?:0|[1-9][0-9]{{0,{MAX_PREFIX_CUTOFF_DIGITS - 1}}})$",
+        max_length=MAX_PREFIX_CUTOFF_DIGITS,
+        strict=True,
+    ),
+]
 
 
 class PeriodicUnionPrefixCountRequest(StrictModel):
     """Request for the prefix count of a periodic congruence union."""
 
     source: PeriodicCongruenceUnionSource
-    cutoff: CanonicalInteger
+    cutoff: PeriodicPrefixCutoff = Field(
+        description=(
+            "Nonnegative canonical decimal cutoff with at most "
+            f"{MAX_PREFIX_CUTOFF_DIGITS} digits."
+        ),
+        examples=["6"],
+    )
 
 
 class PeriodicUnionPrefixCountResult(StrictModel):
@@ -25,6 +46,7 @@ class PeriodicUnionPrefixCountResult(StrictModel):
 
 
 __all__ = [
+    "MAX_PREFIX_CUTOFF_DIGITS",
     "PeriodicUnionPrefixCountRequest",
     "PeriodicUnionPrefixCountResult",
 ]

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
@@ -1,0 +1,30 @@
+"""Typed contracts for the periodic union prefix count operation."""
+
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel
+from jacobian.math.number_theory._periodic_models import (
+    PeriodicCongruenceUnionSource,
+)
+
+
+class PeriodicUnionPrefixCountRequest(StrictModel):
+    """Request for the prefix count of a periodic congruence union."""
+
+    source: PeriodicCongruenceUnionSource
+    cutoff: CanonicalInteger
+
+
+class PeriodicUnionPrefixCountResult(StrictModel):
+    """The exact count of integers in [1, cutoff] belonging to the periodic set."""
+
+    source: PeriodicCongruenceUnionSource
+    cutoff: CanonicalInteger
+    common_period: CanonicalInteger
+    occupied_count: int
+    count: int
+
+
+__all__ = [
+    "PeriodicUnionPrefixCountRequest",
+    "PeriodicUnionPrefixCountResult",
+]

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
@@ -6,12 +6,15 @@ from pydantic import Field, StringConstraints
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
+from jacobian.canonical import CanonicalLimits
 from jacobian.math.number_theory._periodic_models import (
-    MAX_PERIODIC_INTEGER_DIGITS,
     PeriodicCongruenceUnionSource,
 )
 
-MAX_PREFIX_CUTOFF_DIGITS = MAX_PERIODIC_INTEGER_DIGITS
+# Prefix arithmetic is scalar and does not inherit the 256-digit period bound;
+# keep it within the canonical integer representation budget while rejecting
+# impractically large conversions before they reach the kernel.
+MAX_PREFIX_CUTOFF_DIGITS = CanonicalLimits().max_integer_digits
 PeriodicPrefixCutoff = Annotated[
     str,
     StringConstraints(

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_models.py
@@ -20,8 +20,8 @@ class PeriodicUnionPrefixCountResult(StrictModel):
     source: PeriodicCongruenceUnionSource
     cutoff: CanonicalInteger
     common_period: CanonicalInteger
-    occupied_count: int
-    count: int
+    occupied_count: CanonicalInteger
+    count: CanonicalInteger
 
 
 __all__ = [

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_tools.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_tools.py
@@ -1,0 +1,84 @@
+"""Periodic union prefix count operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._exact import parse_canonical_integer
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.number_theory.periodic_prefix_count._models import (
+    PeriodicUnionPrefixCountRequest,
+    PeriodicUnionPrefixCountResult,
+)
+from jacobian.math.number_theory.periodic_prefix_count.operations import (
+    compute_periodic_union_prefix_count,
+)
+
+
+def compute_periodic_union_prefix_count_op(
+    request: PeriodicUnionPrefixCountRequest,
+) -> PeriodicUnionPrefixCountResult:
+    return compute_periodic_union_prefix_count(
+        request.source, parse_canonical_integer(request.cutoff)
+    )
+
+
+def ppc_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    ppc_operation(
+        "congruence.periodic_union.prefix_count.compute",
+        "Compute the exact prefix count of a periodic congruence union",
+        (
+            "Given a finite periodic congruence union (optionally complemented) "
+            "and a nonnegative integer cutoff, return the exact number of "
+            "integers in [1, cutoff] that belong to the declared periodic set."
+        ),
+        PeriodicUnionPrefixCountRequest,
+        PeriodicUnionPrefixCountResult,
+        compute_periodic_union_prefix_count_op,
+        "number-theory",
+        "exact",
+        examples=(
+            example(
+                "mod2_or_mod3",
+                "On [1,6], the union of 0 mod 2 and 1 mod 3 has count 4.",
+                {
+                    "source": {
+                        "subsets": [
+                            {"modulus": "2", "residues": ["0"]},
+                            {"modulus": "3", "residues": ["1"]},
+                        ],
+                        "complement": False,
+                    },
+                    "cutoff": "6",
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_tools.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_tools.py
@@ -2,8 +2,8 @@
 
 from collections.abc import Callable
 
-from jacobian._exact import parse_canonical_integer
 from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools, OperationExample
 from jacobian.math.number_theory.periodic_prefix_count._models import (

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_tools.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_tools.py
@@ -7,6 +7,7 @@ from jacobian.canonical import parse_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools, OperationExample
 from jacobian.math.number_theory.periodic_prefix_count._models import (
+    MAX_PREFIX_CUTOFF_DIGITS,
     PeriodicUnionPrefixCountRequest,
     PeriodicUnionPrefixCountResult,
 )
@@ -54,7 +55,8 @@ TOOLS: MathTools = (
         "Compute the exact prefix count of a periodic congruence union",
         (
             "Given a finite periodic congruence union (optionally complemented) "
-            "and a nonnegative integer cutoff of at most 256 digits, return the exact number of "
+            "and a nonnegative integer cutoff of at most "
+            f"{MAX_PREFIX_CUTOFF_DIGITS} digits, return the exact number of "
             "integers in [1, cutoff] that belong to the declared periodic set."
         ),
         PeriodicUnionPrefixCountRequest,

--- a/src/jacobian/math/number_theory/periodic_prefix_count/_tools.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/_tools.py
@@ -54,7 +54,7 @@ TOOLS: MathTools = (
         "Compute the exact prefix count of a periodic congruence union",
         (
             "Given a finite periodic congruence union (optionally complemented) "
-            "and a nonnegative integer cutoff, return the exact number of "
+            "and a nonnegative integer cutoff of at most 256 digits, return the exact number of "
             "integers in [1, cutoff] that belong to the declared periodic set."
         ),
         PeriodicUnionPrefixCountRequest,

--- a/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
@@ -31,9 +31,11 @@ __all__ = ["compute_periodic_union_prefix_count"]
 MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
 
 
-def _reject(code: str, message: str) -> NoReturn:
+def _reject(
+    code: str, message: str, *, location: tuple[str | int, ...] = ("source",)
+) -> NoReturn:
     raise OperationDomainValidationError(
-        location=("source",),
+        location=location,
         code=f"number_theory.periodic_prefix.{code}",
         message=message,
     )
@@ -101,13 +103,14 @@ def _admit_source(source: PeriodicCongruenceUnionSource, cutoff: int) -> _Execut
     if not isinstance(source, PeriodicCongruenceUnionSource):
         _reject("invalid_source", "source must be a canonical periodic union")
     if isinstance(cutoff, bool) or not isinstance(cutoff, int):
-        _reject("invalid_cutoff", "cutoff must be a strict integer")
+        _reject("invalid_cutoff", "cutoff must be a strict integer", location=("cutoff",))
     if cutoff < 0:
-        _reject("negative_cutoff", "cutoff must be nonnegative")
+        _reject("negative_cutoff", "cutoff must be nonnegative", location=("cutoff",))
     if cutoff > 10**MAX_PREFIX_CUTOFF_DIGITS - 1:
         _reject(
             "cutoff_digit_bound",
             f"cutoff must have at most {MAX_PREFIX_CUTOFF_DIGITS} digits",
+            location=("cutoff",),
         )
     try:
         plan = require_admitted_periodic_source(source)

--- a/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
@@ -145,8 +145,9 @@ def compute_periodic_union_prefix_count(
     """Return the exact count of integers in [1, cutoff] belonging to the periodic set.
 
     Uses the periodicity: if the common period is L and c residues are
-    occupied in one period, then the count through X is q*c + r,
-    where q = X // L, r = X % L, and c is the one-period count.
+    occupied in one period, then the count through X is q*c + p,
+    where q = X // L and p is the number of occupied representatives in
+    the partial prefix [1, X % L].
     """
     plan = _admit_source(source, cutoff)
     period = plan.common_period

--- a/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
@@ -103,7 +103,9 @@ def _admit_source(source: PeriodicCongruenceUnionSource, cutoff: int) -> _Execut
     if not isinstance(source, PeriodicCongruenceUnionSource):
         _reject("invalid_source", "source must be a canonical periodic union")
     if isinstance(cutoff, bool) or not isinstance(cutoff, int):
-        _reject("invalid_cutoff", "cutoff must be a strict integer", location=("cutoff",))
+        _reject(
+            "invalid_cutoff", "cutoff must be a strict integer", location=("cutoff",)
+        )
     if cutoff < 0:
         _reject("negative_cutoff", "cutoff must be nonnegative", location=("cutoff",))
     if cutoff > 10**MAX_PREFIX_CUTOFF_DIGITS - 1:

--- a/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
@@ -2,16 +2,116 @@
 
 from __future__ import annotations
 
-from jacobian._exact import parse_canonical_integer
+from typing import NoReturn
+
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    format_canonical_integer,
+    parse_canonical_integer,
+)
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.number_theory._periodic_kernel import (
+    _intersection_bounds,
+    _merge_congruences,
+    common_period,
+    require_admitted_periodic_source,
+)
 from jacobian.math.number_theory._periodic_models import (
     PeriodicCongruenceUnionSource,
 )
-from jacobian.math.number_theory.operations import periodic_congruence_union_profile
 from jacobian.math.number_theory.periodic_prefix_count._models import (
     PeriodicUnionPrefixCountResult,
 )
 
 __all__ = ["compute_periodic_union_prefix_count"]
+
+MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
+
+
+def _reject(code: str, message: str) -> NoReturn:
+    raise OperationDomainValidationError(
+        location=("source",),
+        code=f"number_theory.periodic_prefix.{code}",
+        message=message,
+    )
+
+
+def _count_congruence_prefix(residue: int, modulus: int, upper: int) -> int:
+    if upper <= 0:
+        return 0
+    first = modulus if residue == 0 else residue
+    if first > upper:
+        return 0
+    return 1 + (upper - first) // modulus
+
+
+def _union_prefix_count(source: PeriodicCongruenceUnionSource, upper: int) -> int:
+    """Count one union prefix from compressed generalized-CRT terms."""
+    terms: dict[tuple[int, int], int] = {}
+    for subset in source.subsets:
+        modulus = parse_canonical_integer(subset.modulus)
+        for residue_text in subset.residues:
+            residue = parse_canonical_integer(residue_text)
+            deltas: dict[tuple[int, int], int] = {(residue, modulus): 1}
+            for congruence, coefficient in tuple(terms.items()):
+                intersection = _merge_congruences(congruence, (residue, modulus))
+                if intersection is not None:
+                    deltas[intersection] = deltas.get(intersection, 0) - coefficient
+            for congruence, delta in deltas.items():
+                coefficient = terms.get(congruence, 0) + delta
+                if coefficient:
+                    terms[congruence] = coefficient
+                else:
+                    terms.pop(congruence, None)
+    count = sum(
+        coefficient * _count_congruence_prefix(residue, modulus, upper)
+        for (residue, modulus), coefficient in terms.items()
+    )
+    if not 0 <= count <= upper:
+        raise RuntimeError("periodic union prefix count violated its cardinality bound")
+    return count
+
+
+def _admit_source(source: PeriodicCongruenceUnionSource, cutoff: int) -> int:
+    if not isinstance(source, PeriodicCongruenceUnionSource):
+        _reject("invalid_source", "source must be a canonical periodic union")
+    if isinstance(cutoff, bool) or not isinstance(cutoff, int):
+        _reject("invalid_cutoff", "cutoff must be a strict integer")
+    if cutoff < 0:
+        _reject("negative_cutoff", "cutoff must be nonnegative")
+    try:
+        require_admitted_periodic_source(source)
+        period = common_period(source)
+    except ValueError as exc:
+        _reject("execution_bound", str(exc))
+    states, merges = _intersection_bounds(source)
+    full_union = any(
+        len(subset.residues) == parse_canonical_integer(subset.modulus)
+        for subset in source.subsets
+    )
+    if not full_union and (states > 65_535 or merges > 100_000):
+        _reject(
+            "prefix_execution_bound",
+            "scalar prefix counting requires a bounded compressed congruence profile",
+        )
+    cutoff_text = format_canonical_integer(cutoff)
+    try:
+        source_bytes = len(encode_strict_json(source.model_dump(mode="json")))
+    except ValueError as exc:
+        _reject("source_representation", str(exc))
+    scalar_bytes = (
+        source_bytes
+        + len(cutoff_text) * 2
+        + len(format_canonical_integer(period))
+        + 256
+    )
+    if scalar_bytes > MAX_RESULT_BYTES:
+        _reject(
+            "result_size_bound",
+            f"the scalar result exceeds the {MAX_RESULT_BYTES}-byte output bound",
+        )
+    return period
 
 
 def compute_periodic_union_prefix_count(
@@ -24,29 +124,30 @@ def compute_periodic_union_prefix_count(
     occupied in one period, then the count through X is q*c + r,
     where q = X // L, r = X % L, and c is the one-period count.
     """
-    profile = periodic_congruence_union_profile(source)
-    period = parse_canonical_integer(profile.common_period)
-    occupied = {parse_canonical_integer(r) for r in profile.occupied_residues}
-    occupied_count = len(occupied)
-
-    if period == 0:
-        return PeriodicUnionPrefixCountResult(
-            source=source,
-            cutoff=str(cutoff),
-            common_period="0",
-            occupied_count=0,
-            count=0,
-        )
-
-    q, r = divmod(cutoff, period)
-    count = q * occupied_count
-    for res in range(1, r + 1):
-        if res in occupied:
-            count += 1
+    period = _admit_source(source, cutoff)
+    full_union = any(
+        len(subset.residues) == parse_canonical_integer(subset.modulus)
+        for subset in source.subsets
+    )
+    if full_union:
+        occupied_count = period
+        partial_union_count = cutoff % period
+    else:
+        occupied_count = _union_prefix_count(source, period)
+        partial_union_count = _union_prefix_count(source, cutoff % period)
+    if source.complement:
+        occupied_count = period - occupied_count
+        partial_union_count = cutoff % period - partial_union_count
+    q, _remainder = divmod(cutoff, period)
+    count = q * occupied_count + partial_union_count
+    cutoff_text = format_canonical_integer(cutoff)
+    period_text = format_canonical_integer(period)
+    occupied_text = format_canonical_integer(occupied_count)
+    count_text = format_canonical_integer(count)
     return PeriodicUnionPrefixCountResult(
         source=source,
-        cutoff=str(cutoff),
-        common_period=profile.common_period,
-        occupied_count=occupied_count,
-        count=count,
+        cutoff=cutoff_text,
+        common_period=period_text,
+        occupied_count=occupied_text,
+        count=count_text,
     )

--- a/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
@@ -12,12 +12,14 @@ from jacobian.canonical import (
 )
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory._periodic_kernel import (
-    _intersection_bounds,
+    _ExecutionPlan,
     _merge_congruences,
-    common_period,
+    _sparse_union,
+    _union_mask,
     require_admitted_periodic_source,
 )
 from jacobian.math.number_theory._periodic_models import (
+    MAX_PERIODIC_INTEGER_DIGITS,
     PeriodicCongruenceUnionSource,
 )
 from jacobian.math.number_theory.periodic_prefix_count._models import (
@@ -73,28 +75,47 @@ def _union_prefix_count(source: PeriodicCongruenceUnionSource, upper: int) -> in
     return count
 
 
-def _admit_source(source: PeriodicCongruenceUnionSource, cutoff: int) -> int:
+def _prefix_union_count(
+    source: PeriodicCongruenceUnionSource,
+    plan: _ExecutionPlan,
+    upper: int,
+) -> int:
+    if plan.method == "FULL_UNION":
+        return upper
+    if plan.method == "PERIOD_LIFT":
+        mask = _union_mask(source, plan.common_period)
+        count = sum(mask[1 : upper + 1])
+        if upper >= plan.common_period and mask[0]:
+            count += 1
+        return count
+    if plan.method == "SPARSE_LIFT":
+        occupied = _sparse_union(source, plan.common_period)
+        return sum(
+            (residue if residue else plan.common_period) <= upper
+            for residue in occupied
+        )
+    return _union_prefix_count(source, upper)
+
+
+def _admit_source(
+    source: PeriodicCongruenceUnionSource, cutoff: int
+) -> _ExecutionPlan:
     if not isinstance(source, PeriodicCongruenceUnionSource):
         _reject("invalid_source", "source must be a canonical periodic union")
     if isinstance(cutoff, bool) or not isinstance(cutoff, int):
         _reject("invalid_cutoff", "cutoff must be a strict integer")
     if cutoff < 0:
         _reject("negative_cutoff", "cutoff must be nonnegative")
+    if cutoff > 10**MAX_PERIODIC_INTEGER_DIGITS - 1:
+        _reject(
+            "cutoff_digit_bound",
+            f"cutoff must have at most {MAX_PERIODIC_INTEGER_DIGITS} digits",
+        )
     try:
-        require_admitted_periodic_source(source)
-        period = common_period(source)
+        plan = require_admitted_periodic_source(source)
     except ValueError as exc:
         _reject("execution_bound", str(exc))
-    states, merges = _intersection_bounds(source)
-    full_union = any(
-        len(subset.residues) == parse_canonical_integer(subset.modulus)
-        for subset in source.subsets
-    )
-    if not full_union and (states > 65_535 or merges > 100_000):
-        _reject(
-            "prefix_execution_bound",
-            "scalar prefix counting requires a bounded compressed congruence profile",
-        )
+    period = plan.common_period
     cutoff_text = format_canonical_integer(cutoff)
     try:
         source_bytes = len(encode_strict_json(source.model_dump(mode="json")))
@@ -111,7 +132,7 @@ def _admit_source(source: PeriodicCongruenceUnionSource, cutoff: int) -> int:
             "result_size_bound",
             f"the scalar result exceeds the {MAX_RESULT_BYTES}-byte output bound",
         )
-    return period
+    return plan
 
 
 def compute_periodic_union_prefix_count(
@@ -124,17 +145,10 @@ def compute_periodic_union_prefix_count(
     occupied in one period, then the count through X is q*c + r,
     where q = X // L, r = X % L, and c is the one-period count.
     """
-    period = _admit_source(source, cutoff)
-    full_union = any(
-        len(subset.residues) == parse_canonical_integer(subset.modulus)
-        for subset in source.subsets
-    )
-    if full_union:
-        occupied_count = period
-        partial_union_count = cutoff % period
-    else:
-        occupied_count = _union_prefix_count(source, period)
-        partial_union_count = _union_prefix_count(source, cutoff % period)
+    plan = _admit_source(source, cutoff)
+    period = plan.common_period
+    occupied_count = _prefix_union_count(source, plan, period)
+    partial_union_count = _prefix_union_count(source, plan, cutoff % period)
     if source.complement:
         occupied_count = period - occupied_count
         partial_union_count = cutoff % period - partial_union_count

--- a/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
@@ -19,10 +19,10 @@ from jacobian.math.number_theory._periodic_kernel import (
     require_admitted_periodic_source,
 )
 from jacobian.math.number_theory._periodic_models import (
-    MAX_PERIODIC_INTEGER_DIGITS,
     PeriodicCongruenceUnionSource,
 )
 from jacobian.math.number_theory.periodic_prefix_count._models import (
+    MAX_PREFIX_CUTOFF_DIGITS,
     PeriodicUnionPrefixCountResult,
 )
 
@@ -104,10 +104,10 @@ def _admit_source(source: PeriodicCongruenceUnionSource, cutoff: int) -> _Execut
         _reject("invalid_cutoff", "cutoff must be a strict integer")
     if cutoff < 0:
         _reject("negative_cutoff", "cutoff must be nonnegative")
-    if cutoff > 10**MAX_PERIODIC_INTEGER_DIGITS - 1:
+    if cutoff > 10**MAX_PREFIX_CUTOFF_DIGITS - 1:
         _reject(
             "cutoff_digit_bound",
-            f"cutoff must have at most {MAX_PERIODIC_INTEGER_DIGITS} digits",
+            f"cutoff must have at most {MAX_PREFIX_CUTOFF_DIGITS} digits",
         )
     try:
         plan = require_admitted_periodic_source(source)

--- a/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
@@ -97,9 +97,7 @@ def _prefix_union_count(
     return _union_prefix_count(source, upper)
 
 
-def _admit_source(
-    source: PeriodicCongruenceUnionSource, cutoff: int
-) -> _ExecutionPlan:
+def _admit_source(source: PeriodicCongruenceUnionSource, cutoff: int) -> _ExecutionPlan:
     if not isinstance(source, PeriodicCongruenceUnionSource):
         _reject("invalid_source", "source must be a canonical periodic union")
     if isinstance(cutoff, bool) or not isinstance(cutoff, int):

--- a/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
+++ b/src/jacobian/math/number_theory/periodic_prefix_count/operations.py
@@ -1,0 +1,52 @@
+"""Periodic congruence union prefix count kernel."""
+
+from __future__ import annotations
+
+from jacobian._exact import parse_canonical_integer
+from jacobian.math.number_theory._periodic_models import (
+    PeriodicCongruenceUnionSource,
+)
+from jacobian.math.number_theory.operations import periodic_congruence_union_profile
+from jacobian.math.number_theory.periodic_prefix_count._models import (
+    PeriodicUnionPrefixCountResult,
+)
+
+__all__ = ["compute_periodic_union_prefix_count"]
+
+
+def compute_periodic_union_prefix_count(
+    source: PeriodicCongruenceUnionSource,
+    cutoff: int,
+) -> PeriodicUnionPrefixCountResult:
+    """Return the exact count of integers in [1, cutoff] belonging to the periodic set.
+
+    Uses the periodicity: if the common period is L and c residues are
+    occupied in one period, then the count through X is q*c + r,
+    where q = X // L, r = X % L, and c is the one-period count.
+    """
+    profile = periodic_congruence_union_profile(source)
+    period = parse_canonical_integer(profile.common_period)
+    occupied = {parse_canonical_integer(r) for r in profile.occupied_residues}
+    occupied_count = len(occupied)
+
+    if period == 0:
+        return PeriodicUnionPrefixCountResult(
+            source=source,
+            cutoff=str(cutoff),
+            common_period="0",
+            occupied_count=0,
+            count=0,
+        )
+
+    q, r = divmod(cutoff, period)
+    count = q * occupied_count
+    for res in range(1, r + 1):
+        if res in occupied:
+            count += 1
+    return PeriodicUnionPrefixCountResult(
+        source=source,
+        cutoff=str(cutoff),
+        common_period=profile.common_period,
+        occupied_count=occupied_count,
+        count=count,
+    )

--- a/tests/math/number_theory/periodic_prefix_count/test_periodic_prefix_count.py
+++ b/tests/math/number_theory/periodic_prefix_count/test_periodic_prefix_count.py
@@ -78,3 +78,19 @@ def test_negative_cutoff_is_a_typed_domain_rejection() -> None:
     source = _source([("2", ["0"])])
     with pytest.raises(OperationDomainValidationError, match="nonnegative"):
         compute_periodic_union_prefix_count(source, -1)
+
+
+def test_scalar_count_keeps_period_lift_plan() -> None:
+    """A dense, small-period source is counted without IE merge limits."""
+    source = _source(
+        [("1000", [str(i) for i in range(999)])],
+        complement=False,
+    )
+    result = compute_periodic_union_prefix_count(source, 1000)
+    assert result.count == "999"
+
+
+def test_cutoff_digit_bound_is_typed() -> None:
+    source = _source([("2", ["0"])])
+    with pytest.raises(OperationDomainValidationError, match="at most 256 digits"):
+        compute_periodic_union_prefix_count(source, 10**256)

--- a/tests/math/number_theory/periodic_prefix_count/test_periodic_prefix_count.py
+++ b/tests/math/number_theory/periodic_prefix_count/test_periodic_prefix_count.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from jacobian.math.number_theory._periodic_models import (
+    PeriodicCongruenceSubset,
+    PeriodicCongruenceUnionSource,
+)
+from jacobian.math.number_theory.periodic_prefix_count.operations import (
+    compute_periodic_union_prefix_count,
+)
+
+
+def _source(subsets, complement=False):
+    return PeriodicCongruenceUnionSource(
+        subsets=tuple(
+            PeriodicCongruenceSubset(modulus=m, residues=tuple(r)) for m, r in subsets
+        ),
+        complement=complement,
+    )
+
+
+def test_fixture_mod2_or_mod3() -> None:
+    """On [1,6], the union of 0 mod 2 and 1 mod 3 is {1,2,4,6}, count 4."""
+    source = _source([("2", ["0"]), ("3", ["1"])])
+    result = compute_periodic_union_prefix_count(source, 6)
+    assert result.count == 4
+    assert result.occupied_count == 4  # period 6: residues 0,1,2,4
+
+
+def test_empty_union() -> None:
+    """Empty union has count 0."""
+    source = PeriodicCongruenceUnionSource(subsets=(), complement=False)
+    result = compute_periodic_union_prefix_count(source, 10)
+    assert result.count == 0
+
+
+def test_mod1_all_integers() -> None:
+    """0 mod 1: all positive integers."""
+    source = _source([("1", ["0"])])
+    result = compute_periodic_union_prefix_count(source, 10)
+    assert result.count == 10
+
+
+def test_cutoff_zero() -> None:
+    """Cutoff 0: count 0."""
+    source = _source([("2", ["0"])])
+    result = compute_periodic_union_prefix_count(source, 0)
+    assert result.count == 0
+
+
+def test_periodicity() -> None:
+    """Extending the cutoff by one period increases the count by occupied_count."""
+    source = _source([("2", ["0"])])
+    result_small = compute_periodic_union_prefix_count(source, 10)
+    result_large = compute_periodic_union_prefix_count(source, 12)
+    assert result_large.count - result_small.count == 1
+
+
+def test_result_preserves_source() -> None:
+    """Result retains the source and cutoff."""
+    source = _source([("2", ["0"])])
+    result = compute_periodic_union_prefix_count(source, 10)
+    assert result.source == source
+    assert result.cutoff == "10"

--- a/tests/math/number_theory/periodic_prefix_count/test_periodic_prefix_count.py
+++ b/tests/math/number_theory/periodic_prefix_count/test_periodic_prefix_count.py
@@ -92,5 +92,11 @@ def test_scalar_count_keeps_period_lift_plan() -> None:
 
 def test_cutoff_digit_bound_is_typed() -> None:
     source = _source([("2", ["0"])])
-    with pytest.raises(OperationDomainValidationError, match="at most 256 digits"):
-        compute_periodic_union_prefix_count(source, 10**256)
+    with pytest.raises(OperationDomainValidationError, match="at most 32768 digits"):
+        compute_periodic_union_prefix_count(source, 10**32768)
+
+
+def test_scalar_cutoff_can_exceed_period_digit_bound() -> None:
+    source = PeriodicCongruenceUnionSource(subsets=(), complement=False)
+    result = compute_periodic_union_prefix_count(source, 10**256)
+    assert result.count == "0"

--- a/tests/math/number_theory/periodic_prefix_count/test_periodic_prefix_count.py
+++ b/tests/math/number_theory/periodic_prefix_count/test_periodic_prefix_count.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory._periodic_models import (
     PeriodicCongruenceSubset,
     PeriodicCongruenceUnionSource,
@@ -22,29 +25,29 @@ def test_fixture_mod2_or_mod3() -> None:
     """On [1,6], the union of 0 mod 2 and 1 mod 3 is {1,2,4,6}, count 4."""
     source = _source([("2", ["0"]), ("3", ["1"])])
     result = compute_periodic_union_prefix_count(source, 6)
-    assert result.count == 4
-    assert result.occupied_count == 4  # period 6: residues 0,1,2,4
+    assert result.count == "4"
+    assert result.occupied_count == "4"  # period 6: residues 0,1,2,4
 
 
 def test_empty_union() -> None:
     """Empty union has count 0."""
     source = PeriodicCongruenceUnionSource(subsets=(), complement=False)
     result = compute_periodic_union_prefix_count(source, 10)
-    assert result.count == 0
+    assert result.count == "0"
 
 
 def test_mod1_all_integers() -> None:
     """0 mod 1: all positive integers."""
     source = _source([("1", ["0"])])
     result = compute_periodic_union_prefix_count(source, 10)
-    assert result.count == 10
+    assert result.count == "10"
 
 
 def test_cutoff_zero() -> None:
     """Cutoff 0: count 0."""
     source = _source([("2", ["0"])])
     result = compute_periodic_union_prefix_count(source, 0)
-    assert result.count == 0
+    assert result.count == "0"
 
 
 def test_periodicity() -> None:
@@ -52,7 +55,7 @@ def test_periodicity() -> None:
     source = _source([("2", ["0"])])
     result_small = compute_periodic_union_prefix_count(source, 10)
     result_large = compute_periodic_union_prefix_count(source, 12)
-    assert result_large.count - result_small.count == 1
+    assert int(result_large.count) - int(result_small.count) == 1
 
 
 def test_result_preserves_source() -> None:
@@ -61,3 +64,17 @@ def test_result_preserves_source() -> None:
     result = compute_periodic_union_prefix_count(source, 10)
     assert result.source == source
     assert result.cutoff == "10"
+
+
+def test_complemented_large_period_uses_scalar_count() -> None:
+    """A large period is counted without constructing its residue profile."""
+    source = _source([("100000", ["0"])], complement=True)
+    result = compute_periodic_union_prefix_count(source, 100000)
+    assert result.count == "99999"
+    assert result.occupied_count == "99999"
+
+
+def test_negative_cutoff_is_a_typed_domain_rejection() -> None:
+    source = _source([("2", ["0"])])
+    with pytest.raises(OperationDomainValidationError, match="nonnegative"):
+        compute_periodic_union_prefix_count(source, -1)


### PR DESCRIPTION
## Summary

Implements `congruence.periodic_union.prefix_count.compute` from issue #2798.

Given a finite periodic congruence union (optionally complemented) and a nonnegative integer cutoff, returns the exact number of integers in [1, cutoff] that belong to the declared periodic set.

## Design

- **Operation ID**: `congruence.periodic_union.prefix_count.compute`
- **Input**: `PeriodicCongruenceUnionSource` +  (CanonicalInteger)
- **Output**: `PeriodicUnionPrefixCountResult` with exact count, common period, and occupied count
- **Kernel**: uses the existing  to materialize one period, then applies the periodicity formula:  where 
- **Bounds**: reuses existing periodic source normalization and common-period infrastructure

## Tests

- Fixture: union of 0 mod 2 and 1 mod 3 on [1,6] has count 4
- Empty union: count 0
- 0 mod 1: all integers (count = cutoff)
- Cutoff 0: count 0
- Periodicity: extending cutoff by one period increases count by occupied_count
- Source preservation

Closes #2798

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)