### PR TITLE
Add graph.path_decomposition.minimum.compute operation

### DIFF
--- a/src/jacobian/math/graphs/path_decomposition/__init__.py
+++ b/src/jacobian/math/graphs/path_decomposition/__init__.py
@@ -1,0 +1,7 @@
+"""Path decomposition operations."""
+
+from jacobian.math.graphs.path_decomposition.operations import (
+    compute_minimum_path_decomposition,
+)
+
+__all__ = ["compute_minimum_path_decomposition"]

--- a/src/jacobian/math/graphs/path_decomposition/_models.py
+++ b/src/jacobian/math/graphs/path_decomposition/_models.py
@@ -11,7 +11,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
-MAX_VERTICES = 12
+MAX_VERTICES = 256
 
 
 class PathDecompositionRequest(StrictModel):
@@ -20,7 +20,7 @@ class PathDecompositionRequest(StrictModel):
     graph: SimpleUndirectedGraph = Field(
         description=(
             "Simple undirected graph with at most "
-            f"{MAX_VERTICES} vertices; this operation's exhaustive path search "
+            f"{MAX_VERTICES} vertices; this operation's graph-sensitive path search "
             "also applies a graph-sensitive work bound."
         )
     )

--- a/src/jacobian/math/graphs/path_decomposition/_models.py
+++ b/src/jacobian/math/graphs/path_decomposition/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
@@ -16,7 +16,13 @@ MAX_VERTICES = 12
 class PathDecompositionRequest(StrictModel):
     """Request for the minimum path decomposition of a graph."""
 
-    graph: SimpleUndirectedGraph
+    graph: SimpleUndirectedGraph = Field(
+        description=(
+            "Simple undirected graph with at most "
+            f"{MAX_VERTICES} vertices; this operation's exhaustive path search "
+            "also applies a graph-sensitive work bound."
+        )
+    )
 
     @model_validator(mode="after")
     def validate_graph(self) -> Self:

--- a/src/jacobian/math/graphs/path_decomposition/_models.py
+++ b/src/jacobian/math/graphs/path_decomposition/_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from itertools import pairwise
 from typing import Self
 
 from pydantic import Field, model_validator
@@ -38,8 +39,44 @@ class PathDecompositionResult(StrictModel):
     """The minimum path decomposition of a graph."""
 
     graph: SimpleUndirectedGraph
-    path_count: int
+    path_count: int = Field(ge=0)
     paths: tuple[tuple[str, ...], ...]
+
+    @model_validator(mode="after")
+    def require_source_edge_partition(self) -> Self:
+        if self.path_count != len(self.paths):
+            raise PydanticCustomError(
+                "path_decomposition.path_count",
+                "path_count must equal the number of returned paths",
+            )
+        source_edges = set(self.graph.edges)
+        used_edges: set[tuple[str, str]] = set()
+        source_vertices = set(self.graph.vertices)
+        for path in self.paths:
+            if len(path) < 2 or len(path) != len(set(path)):
+                raise PydanticCustomError(
+                    "path_decomposition.simple_path",
+                    "each returned path must contain distinct vertices and at least one edge",
+                )
+            if any(vertex not in source_vertices for vertex in path):
+                raise PydanticCustomError(
+                    "path_decomposition.unknown_vertex",
+                    "returned paths must use vertices from the source graph",
+                )
+            for left, right in pairwise(path):
+                edge = (left, right) if left < right else (right, left)
+                if edge not in source_edges or edge in used_edges:
+                    raise PydanticCustomError(
+                        "path_decomposition.edge_partition",
+                        "returned paths must partition the source edges exactly once",
+                    )
+                used_edges.add(edge)
+        if used_edges != source_edges:
+            raise PydanticCustomError(
+                "path_decomposition.edge_partition",
+                "returned paths must partition the source edges exactly once",
+            )
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/path_decomposition/_models.py
+++ b/src/jacobian/math/graphs/path_decomposition/_models.py
@@ -1,0 +1,43 @@
+"""Typed contracts for the path decomposition operation."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_VERTICES = 12
+
+
+class PathDecompositionRequest(StrictModel):
+    """Request for the minimum path decomposition of a graph."""
+
+    graph: SimpleUndirectedGraph
+
+    @model_validator(mode="after")
+    def validate_graph(self) -> Self:
+        if len(self.graph.vertices) > MAX_VERTICES:
+            raise PydanticCustomError(
+                "path_decomposition.too_many_vertices",
+                f"at most {MAX_VERTICES} vertices are supported",
+            )
+        return self
+
+
+class PathDecompositionResult(StrictModel):
+    """The minimum path decomposition of a graph."""
+
+    graph: SimpleUndirectedGraph
+    path_count: int
+    paths: tuple[tuple[str, ...], ...]
+
+
+__all__ = [
+    "MAX_VERTICES",
+    "PathDecompositionRequest",
+    "PathDecompositionResult",
+]

--- a/src/jacobian/math/graphs/path_decomposition/_tools.py
+++ b/src/jacobian/math/graphs/path_decomposition/_tools.py
@@ -1,0 +1,78 @@
+"""Path decomposition operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.path_decomposition._models import (
+    PathDecompositionRequest,
+    PathDecompositionResult,
+)
+from jacobian.math.graphs.path_decomposition.operations import (
+    compute_minimum_path_decomposition,
+)
+
+
+def compute_minimum_path_decomposition_op(
+    request: PathDecompositionRequest,
+) -> PathDecompositionResult:
+    return compute_minimum_path_decomposition(request.graph)
+
+
+def pd_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    pd_operation(
+        "graph.path_decomposition.minimum.compute",
+        "Compute the exact minimum path decomposition of a graph",
+        (
+            "Given a bounded finite simple graph, return its exact path number "
+            "(minimum number of edge-disjoint simple paths covering all edges) "
+            "together with a realizing partition."
+        ),
+        PathDecompositionRequest,
+        PathDecompositionResult,
+        compute_minimum_path_decomposition_op,
+        "graph",
+        "optimization",
+        "exact",
+        examples=(
+            example(
+                "p3",
+                "P3 has path number 1 (one path covers all edges).",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"]],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -54,9 +54,6 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
         adjacency[left].add(right)
         adjacency[right].add(left)
 
-    candidate_sets, candidate_incidences = _find_all_simple_paths(
-        adjacency, candidate_limit=MAX_SEARCH_STATES
-    )
     try:
         source_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
         active_vertices = {vertex for edge in graph.edges for vertex in edge}

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -2,12 +2,83 @@
 
 from __future__ import annotations
 
+import math
+from typing import NoReturn
+
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    strict_json_object_size,
+)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.path_decomposition._models import (
+    MAX_VERTICES,
     PathDecompositionResult,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 __all__ = ["compute_minimum_path_decomposition"]
+
+MAX_SEARCH_STATES = 1_000_000
+MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
+
+
+def _array_size(item_sizes: list[int]) -> int:
+    return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
+
+
+def _reject(code: str, message: str) -> NoReturn:
+    raise OperationDomainValidationError(
+        location=("graph",), code=f"path_decomposition.{code}", message=message
+    )
+
+
+def _admit_graph(graph: SimpleUndirectedGraph) -> None:
+    if not isinstance(graph, SimpleUndirectedGraph):
+        _reject("invalid_graph", "graph must be a simple undirected graph")
+    vertex_count = len(graph.vertices)
+    if vertex_count > MAX_VERTICES:
+        _reject("too_many_vertices", f"at most {MAX_VERTICES} vertices are supported")
+    edge_count = len(graph.edges)
+    if not edge_count:
+        return
+
+    # A simple path on k vertices has at most P(n,k)/2 distinct undirected
+    # orientations.  Raising this candidate bound once per edge gives a
+    # conservative upper bound for the cover recursion, before it is entered.
+    candidate_bound = sum(
+        math.perm(vertex_count, length) // 2 for length in range(2, vertex_count + 1)
+    )
+    search_bound = 1
+    for _ in range(edge_count):
+        search_bound *= max(candidate_bound, 1)
+        if search_bound > MAX_SEARCH_STATES:
+            _reject(
+                "search_work_bound",
+                "the exact path-partition search exceeds its bounded work envelope",
+            )
+
+    try:
+        source_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
+        max_label_bytes = max(
+            (len(encode_strict_json(vertex)) for vertex in graph.vertices), default=2
+        )
+    except ValueError as exc:
+        _reject("source_representation", str(exc))
+    path_bytes = _array_size([max_label_bytes] * vertex_count)
+    paths_bytes = _array_size([path_bytes] * edge_count)
+    result_bytes = strict_json_object_size(
+        (
+            ("graph", source_bytes),
+            ("path_count", 3),
+            ("paths", paths_bytes),
+        )
+    )
+    if result_bytes > MAX_RESULT_BYTES:
+        _reject(
+            "result_size_bound",
+            f"the path decomposition result exceeds the {MAX_RESULT_BYTES}-byte output bound",
+        )
 
 
 def compute_minimum_path_decomposition(
@@ -18,6 +89,7 @@ def compute_minimum_path_decomposition(
     The path number p(G) is the minimum number of edge-disjoint simple
     paths whose union is E(G). Uses exhaustive search over edge partitions.
     """
+    _admit_graph(graph)
     edges = list(graph.edges)
     if not edges:
         return PathDecompositionResult(graph=graph, path_count=0, paths=())

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -57,14 +57,6 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
     candidate_sets, candidate_incidences = _find_all_simple_paths(
         adjacency, candidate_limit=MAX_SEARCH_STATES
     )
-    candidates = tuple(
-        sorted(
-            candidate_sets,
-            key=lambda path: (-len(path), tuple(sorted(path))),
-        )
-    )
-    candidate_checks_bound = MAX_SEARCH_STATES
-
     try:
         source_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
         active_vertices = {vertex for edge in graph.edges for vertex in edge}
@@ -88,6 +80,17 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
             "result_size_bound",
             f"the path decomposition result exceeds the {MAX_RESULT_BYTES}-byte output bound",
         )
+
+    candidate_sets, candidate_incidences = _find_all_simple_paths(
+        adjacency, candidate_limit=MAX_SEARCH_STATES
+    )
+    candidates = tuple(
+        sorted(
+            candidate_sets,
+            key=lambda path: (-len(path), tuple(sorted(path))),
+        )
+    )
+    candidate_checks_bound = MAX_SEARCH_STATES
     return _PathSearchPlan(
         candidates=candidates,
         candidate_incidences=candidate_incidences,

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -21,6 +21,7 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 __all__ = ["compute_minimum_path_decomposition"]
 
 MAX_SEARCH_STATES = 1_000_000
+MAX_CANDIDATE_EDGE_INCIDENCES = 1_000_000
 MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
 
 
@@ -132,6 +133,7 @@ def _find_all_simple_paths(
     """Find all simple paths as sets of edges."""
     paths: set[frozenset[tuple[str, str]]] = set()
     enumeration_steps = [0]
+    candidate_incidences = [0]
     for start in adjacency:
         _dfs_paths(
             start,
@@ -141,6 +143,7 @@ def _find_all_simple_paths(
             paths,
             candidate_limit=candidate_limit,
             enumeration_steps=enumeration_steps,
+            candidate_incidences=candidate_incidences,
         )
     return paths
 
@@ -154,6 +157,7 @@ def _dfs_paths(
     *,
     candidate_limit: int,
     enumeration_steps: list[int],
+    candidate_incidences: list[int],
 ) -> None:
     enumeration_steps[0] += 1
     if enumeration_steps[0] > MAX_SEARCH_STATES:
@@ -162,7 +166,14 @@ def _dfs_paths(
             "simple-path enumeration exceeds its bounded work envelope",
         )
     if edges_used:
-        paths.add(edges_used)
+        if edges_used not in paths:
+            candidate_incidences[0] += len(edges_used)
+            if candidate_incidences[0] > MAX_CANDIDATE_EDGE_INCIDENCES:
+                _reject(
+                    "candidate_materialization_bound",
+                    "simple-path candidate materialization exceeds its bounded incidence envelope",
+                )
+            paths.add(edges_used)
         if len(paths) > candidate_limit:
             _reject(
                 "search_work_bound",
@@ -182,6 +193,7 @@ def _dfs_paths(
             paths,
             candidate_limit=candidate_limit,
             enumeration_steps=enumeration_steps,
+            candidate_incidences=candidate_incidences,
         )
 
 

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -1,0 +1,128 @@
+"""Minimum path decomposition kernel using exhaustive search."""
+
+from __future__ import annotations
+
+from jacobian.math.graphs.path_decomposition._models import (
+    PathDecompositionResult,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+__all__ = ["compute_minimum_path_decomposition"]
+
+
+def compute_minimum_path_decomposition(
+    graph: SimpleUndirectedGraph,
+) -> PathDecompositionResult:
+    """Return the exact minimum path number and a realizing partition.
+
+    The path number p(G) is the minimum number of edge-disjoint simple
+    paths whose union is E(G). Uses exhaustive search over edge partitions.
+    """
+    edges = list(graph.edges)
+    if not edges:
+        return PathDecompositionResult(graph=graph, path_count=0, paths=())
+
+    adjacency: dict[str, set[str]] = {v: set() for v in graph.vertices}
+    for a, b in edges:
+        adjacency[a].add(b)
+        adjacency[b].add(a)
+
+    all_paths = _find_all_simple_paths(adjacency)
+    all_paths = [p for p in all_paths if p]
+
+    edge_set = frozenset(edges)
+    best = _minimum_cover(edge_set, all_paths)
+
+    if best is None:
+        return PathDecompositionResult(graph=graph, path_count=len(edges), paths=())
+
+    path_vertices = []
+    for path_edges in best:
+        vertices = _path_to_vertices(path_edges)
+        if vertices:
+            path_vertices.append(tuple(vertices))
+    return PathDecompositionResult(
+        graph=graph,
+        path_count=len(best),
+        paths=tuple(path_vertices),
+    )
+
+
+def _find_all_simple_paths(
+    adjacency: dict[str, set[str]],
+) -> list[frozenset[tuple[str, str]]]:
+    """Find all simple paths as sets of edges."""
+    paths: set[frozenset[tuple[str, str]]] = set()
+    for start in adjacency:
+        _dfs_paths(start, frozenset(), frozenset({start}), adjacency, paths)
+    paths.add(frozenset())
+    return list(paths)
+
+
+def _dfs_paths(
+    current: str,
+    edges_used: frozenset[tuple[str, str]],
+    vertices_visited: frozenset[str],
+    adjacency: dict[str, set[str]],
+    paths: set[frozenset[tuple[str, str]]],
+) -> None:
+    if edges_used:
+        paths.add(edges_used)
+    for neighbor in sorted(adjacency[current]):
+        if neighbor in vertices_visited:
+            continue
+        edge = (min(current, neighbor), max(current, neighbor))
+        if edge in edges_used:
+            continue
+        _dfs_paths(
+            neighbor,
+            edges_used | {edge},
+            vertices_visited | {neighbor},
+            adjacency,
+            paths,
+        )
+
+
+def _minimum_cover(
+    edge_set: frozenset[tuple[str, str]],
+    candidates: list[frozenset[tuple[str, str]]],
+) -> list[frozenset[tuple[str, str]]] | None:
+    """Find the minimum number of paths that partition all edges."""
+    if not edge_set:
+        return []
+    best: list[frozenset[tuple[str, str]]] | None = None
+    for path in candidates:
+        if path <= edge_set:
+            remaining = edge_set - path
+            result = _minimum_cover(remaining, candidates)
+            if result is not None and (best is None or len(result) + 1 < len(best)):
+                best = [path, *result]
+    return best
+
+
+def _path_to_vertices(path_edges: frozenset[tuple[str, str]]) -> list[str]:
+    if not path_edges:
+        return []
+    adj: dict[str, list[str]] = {}
+    for a, b in path_edges:
+        adj.setdefault(a, []).append(b)
+        adj.setdefault(b, []).append(a)
+    start = None
+    for v, neighbors in adj.items():
+        if len(neighbors) == 1:
+            start = v
+            break
+    if start is None:
+        start = next(iter(adj))
+    vertices = [start]
+    current = start
+    used_edges: set[tuple[str, str]] = set()
+    while len(vertices) < len(path_edges) + 1:
+        for neighbor in adj[current]:
+            edge = (min(current, neighbor), max(current, neighbor))
+            if edge not in used_edges:
+                used_edges.add(edge)
+                vertices.append(neighbor)
+                current = neighbor
+                break
+    return vertices

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -28,6 +28,7 @@ MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
 @dataclass(frozen=True, slots=True)
 class _PathSearchPlan:
     candidates: tuple[frozenset[tuple[str, str]], ...]
+    candidate_incidences: int
     candidate_checks_bound: int
 
 
@@ -53,9 +54,12 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
         adjacency[left].add(right)
         adjacency[right].add(left)
 
+    candidate_sets, candidate_incidences = _find_all_simple_paths(
+        adjacency, candidate_limit=MAX_SEARCH_STATES
+    )
     candidates = tuple(
         sorted(
-            _find_all_simple_paths(adjacency, candidate_limit=MAX_SEARCH_STATES),
+            candidate_sets,
             key=lambda path: (-len(path), tuple(sorted(path))),
         )
     )
@@ -86,6 +90,7 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
         )
     return _PathSearchPlan(
         candidates=candidates,
+        candidate_incidences=candidate_incidences,
         candidate_checks_bound=candidate_checks_bound,
     )
 
@@ -107,6 +112,7 @@ def compute_minimum_path_decomposition(
     best = _minimum_cover(
         edge_set,
         plan.candidates,
+        candidate_incidences=plan.candidate_incidences,
         candidate_checks_bound=plan.candidate_checks_bound,
     )
 
@@ -129,7 +135,7 @@ def _find_all_simple_paths(
     adjacency: dict[str, set[str]],
     *,
     candidate_limit: int,
-) -> set[frozenset[tuple[str, str]]]:
+) -> tuple[set[frozenset[tuple[str, str]]], int]:
     """Find all simple paths as sets of edges."""
     paths: set[frozenset[tuple[str, str]]] = set()
     enumeration_steps = [0]
@@ -145,7 +151,7 @@ def _find_all_simple_paths(
             enumeration_steps=enumeration_steps,
             candidate_incidences=candidate_incidences,
         )
-    return paths
+    return paths, candidate_incidences[0]
 
 
 def _dfs_paths(
@@ -201,13 +207,24 @@ def _minimum_cover(
     edge_set: frozenset[tuple[str, str]],
     candidates: tuple[frozenset[tuple[str, str]], ...],
     *,
+    candidate_incidences: int,
     candidate_checks_bound: int,
 ) -> list[frozenset[tuple[str, str]]] | None:
     """Find the minimum partition while solving each residual edge set once."""
 
-    by_edge: dict[tuple[str, str], tuple[frozenset[tuple[str, str]], ...]] = {
-        edge: tuple(path for path in candidates if edge in path) for edge in edge_set
+    by_edge_lists: dict[tuple[str, str], list[frozenset[tuple[str, str]]]] = {
+        edge: [] for edge in edge_set
     }
+    for path in candidates:
+        for edge in path:
+            candidate_incidences += 1
+            if candidate_incidences > MAX_CANDIDATE_EDGE_INCIDENCES:
+                _reject(
+                    "candidate_materialization_bound",
+                    "simple-path candidate indexing exceeds its bounded incidence envelope",
+                )
+            by_edge_lists[edge].append(path)
+    by_edge = {edge: tuple(paths) for edge, paths in by_edge_lists.items()}
     candidate_checks = 0
 
     @cache

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from typing import NoReturn
 
 from jacobian.canonical import (
@@ -40,23 +39,27 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> None:
     if vertex_count > MAX_VERTICES:
         _reject("too_many_vertices", f"at most {MAX_VERTICES} vertices are supported")
     edge_count = len(graph.edges)
-    if not edge_count:
-        return
+    adjacency: dict[str, set[str]] = {v: set() for v in graph.vertices}
+    for left, right in graph.edges:
+        adjacency[left].add(right)
+        adjacency[right].add(left)
 
-    # A simple path on k vertices has at most P(n,k)/2 distinct undirected
-    # orientations.  Raising this candidate bound once per edge gives a
-    # conservative upper bound for the cover recursion, before it is entered.
-    candidate_bound = sum(
-        math.perm(vertex_count, length) // 2 for length in range(2, vertex_count + 1)
-    )
-    search_bound = 1
-    for _ in range(edge_count):
-        search_bound *= max(candidate_bound, 1)
-        if search_bound > MAX_SEARCH_STATES:
-            _reject(
-                "search_work_bound",
-                "the exact path-partition search exceeds its bounded work envelope",
-            )
+    if edge_count:
+        # Count paths in the actual graph, stopping once the work budget is
+        # already impossible. This preserves sparse graphs that the complete
+        # graph envelope rejected.
+        candidate_bound = max(
+            _count_simple_paths(adjacency, MAX_SEARCH_STATES * 2) // 2,
+            1,
+        )
+        search_bound = 1
+        for _ in range(edge_count):
+            search_bound *= max(candidate_bound, 1)
+            if search_bound > MAX_SEARCH_STATES:
+                _reject(
+                    "search_work_bound",
+                    "the exact path-partition search exceeds its bounded work envelope",
+                )
 
     try:
         source_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
@@ -66,7 +69,7 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> None:
     except ValueError as exc:
         _reject("source_representation", str(exc))
     path_bytes = _array_size([max_label_bytes] * vertex_count)
-    paths_bytes = _array_size([path_bytes] * edge_count)
+    paths_bytes = _array_size([path_bytes] * edge_count) if edge_count else 2
     result_bytes = strict_json_object_size(
         (
             ("graph", source_bytes),
@@ -79,6 +82,31 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> None:
             "result_size_bound",
             f"the path decomposition result exceeds the {MAX_RESULT_BYTES}-byte output bound",
         )
+
+
+def _count_simple_paths(
+    adjacency: dict[str, set[str]],
+    limit: int,
+) -> int:
+    count = 0
+
+    def visit(current: str, visited: frozenset[str]) -> None:
+        nonlocal count
+        for neighbor in adjacency[current]:
+            if neighbor in visited:
+                continue
+            count += 1
+            if count > limit:
+                return
+            visit(neighbor, visited | {neighbor})
+            if count > limit:
+                return
+
+    for start in adjacency:
+        visit(start, frozenset({start}))
+        if count > limit:
+            return limit + 1
+    return count
 
 
 def compute_minimum_path_decomposition(

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from functools import cache
 from typing import NoReturn
 
 from jacobian.canonical import (
@@ -22,6 +24,12 @@ MAX_SEARCH_STATES = 1_000_000
 MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
 
 
+@dataclass(frozen=True, slots=True)
+class _PathSearchPlan:
+    candidates: tuple[frozenset[tuple[str, str]], ...]
+    candidate_checks_bound: int
+
+
 def _array_size(item_sizes: list[int]) -> int:
     return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
 
@@ -32,7 +40,7 @@ def _reject(code: str, message: str) -> NoReturn:
     )
 
 
-def _admit_graph(graph: SimpleUndirectedGraph) -> None:
+def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
     if not isinstance(graph, SimpleUndirectedGraph):
         _reject("invalid_graph", "graph must be a simple undirected graph")
     vertex_count = len(graph.vertices)
@@ -44,22 +52,18 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> None:
         adjacency[left].add(right)
         adjacency[right].add(left)
 
-    if edge_count:
-        # Count paths in the actual graph, stopping once the work budget is
-        # already impossible. This preserves sparse graphs that the complete
-        # graph envelope rejected.
-        candidate_bound = max(
-            _count_simple_paths(adjacency, MAX_SEARCH_STATES * 2) // 2,
-            1,
+    candidates = tuple(
+        sorted(
+            _find_all_simple_paths(adjacency),
+            key=lambda path: (-len(path), tuple(sorted(path))),
         )
-        search_bound = 1
-        for _ in range(edge_count):
-            search_bound *= max(candidate_bound, 1)
-            if search_bound > MAX_SEARCH_STATES:
-                _reject(
-                    "search_work_bound",
-                    "the exact path-partition search exceeds its bounded work envelope",
-                )
+    )
+    candidate_checks_bound = (1 << edge_count) * max(len(candidates), 1)
+    if candidate_checks_bound > MAX_SEARCH_STATES:
+        _reject(
+            "search_work_bound",
+            "the exact memoized residual-edge search exceeds its bounded work envelope",
+        )
 
     try:
         source_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
@@ -82,31 +86,10 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> None:
             "result_size_bound",
             f"the path decomposition result exceeds the {MAX_RESULT_BYTES}-byte output bound",
         )
-
-
-def _count_simple_paths(
-    adjacency: dict[str, set[str]],
-    limit: int,
-) -> int:
-    count = 0
-
-    def visit(current: str, visited: frozenset[str]) -> None:
-        nonlocal count
-        for neighbor in adjacency[current]:
-            if neighbor in visited:
-                continue
-            count += 1
-            if count > limit:
-                return
-            visit(neighbor, visited | {neighbor})
-            if count > limit:
-                return
-
-    for start in adjacency:
-        visit(start, frozenset({start}))
-        if count > limit:
-            return limit + 1
-    return count
+    return _PathSearchPlan(
+        candidates=candidates,
+        candidate_checks_bound=candidate_checks_bound,
+    )
 
 
 def compute_minimum_path_decomposition(
@@ -117,24 +100,20 @@ def compute_minimum_path_decomposition(
     The path number p(G) is the minimum number of edge-disjoint simple
     paths whose union is E(G). Uses exhaustive search over edge partitions.
     """
-    _admit_graph(graph)
+    plan = _admit_graph(graph)
     edges = list(graph.edges)
     if not edges:
         return PathDecompositionResult(graph=graph, path_count=0, paths=())
 
-    adjacency: dict[str, set[str]] = {v: set() for v in graph.vertices}
-    for a, b in edges:
-        adjacency[a].add(b)
-        adjacency[b].add(a)
-
-    all_paths = _find_all_simple_paths(adjacency)
-    all_paths = [p for p in all_paths if p]
-
     edge_set = frozenset(edges)
-    best = _minimum_cover(edge_set, all_paths)
+    best = _minimum_cover(
+        edge_set,
+        plan.candidates,
+        candidate_checks_bound=plan.candidate_checks_bound,
+    )
 
     if best is None:
-        return PathDecompositionResult(graph=graph, path_count=len(edges), paths=())
+        raise AssertionError("single-edge paths must realize every admitted graph")
 
     path_vertices = []
     for path_edges in best:
@@ -150,13 +129,12 @@ def compute_minimum_path_decomposition(
 
 def _find_all_simple_paths(
     adjacency: dict[str, set[str]],
-) -> list[frozenset[tuple[str, str]]]:
+) -> set[frozenset[tuple[str, str]]]:
     """Find all simple paths as sets of edges."""
     paths: set[frozenset[tuple[str, str]]] = set()
     for start in adjacency:
         _dfs_paths(start, frozenset(), frozenset({start}), adjacency, paths)
-    paths.add(frozenset())
-    return list(paths)
+    return paths
 
 
 def _dfs_paths(
@@ -185,19 +163,41 @@ def _dfs_paths(
 
 def _minimum_cover(
     edge_set: frozenset[tuple[str, str]],
-    candidates: list[frozenset[tuple[str, str]]],
+    candidates: tuple[frozenset[tuple[str, str]], ...],
+    *,
+    candidate_checks_bound: int,
 ) -> list[frozenset[tuple[str, str]]] | None:
-    """Find the minimum number of paths that partition all edges."""
-    if not edge_set:
-        return []
-    best: list[frozenset[tuple[str, str]]] | None = None
-    for path in candidates:
-        if path <= edge_set:
-            remaining = edge_set - path
-            result = _minimum_cover(remaining, candidates)
-            if result is not None and (best is None or len(result) + 1 < len(best)):
-                best = [path, *result]
-    return best
+    """Find the minimum partition while solving each residual edge set once."""
+
+    by_edge: dict[tuple[str, str], tuple[frozenset[tuple[str, str]], ...]] = {
+        edge: tuple(path for path in candidates if edge in path) for edge in edge_set
+    }
+    candidate_checks = 0
+
+    @cache
+    def solve(
+        remaining: frozenset[tuple[str, str]],
+    ) -> tuple[frozenset[tuple[str, str]], ...] | None:
+        nonlocal candidate_checks
+        if not remaining:
+            return ()
+        pivot = min(remaining)
+        best: tuple[frozenset[tuple[str, str]], ...] | None = None
+        for path in by_edge[pivot]:
+            candidate_checks += 1
+            if candidate_checks > candidate_checks_bound:
+                raise AssertionError(
+                    "path-decomposition admission undercounted search work"
+                )
+            if not path <= remaining:
+                continue
+            suffix = solve(remaining - path)
+            if suffix is not None and (best is None or len(suffix) + 1 < len(best)):
+                best = (path, *suffix)
+        return best
+
+    result = solve(edge_set)
+    return list(result) if result is not None else None
 
 
 def _path_to_vertices(path_edges: frozenset[tuple[str, str]]) -> list[str]:

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -52,13 +52,20 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
         adjacency[left].add(right)
         adjacency[right].add(left)
 
+    if edge_count >= MAX_SEARCH_STATES.bit_length():
+        _reject(
+            "search_work_bound",
+            "the exact memoized residual-edge search exceeds its bounded work envelope",
+        )
+    residual_state_bound = 1 << edge_count
+    candidate_limit = MAX_SEARCH_STATES // residual_state_bound
     candidates = tuple(
         sorted(
-            _find_all_simple_paths(adjacency),
+            _find_all_simple_paths(adjacency, candidate_limit=candidate_limit),
             key=lambda path: (-len(path), tuple(sorted(path))),
         )
     )
-    candidate_checks_bound = (1 << edge_count) * max(len(candidates), 1)
+    candidate_checks_bound = residual_state_bound * max(len(candidates), 1)
     if candidate_checks_bound > MAX_SEARCH_STATES:
         _reject(
             "search_work_bound",
@@ -129,11 +136,22 @@ def compute_minimum_path_decomposition(
 
 def _find_all_simple_paths(
     adjacency: dict[str, set[str]],
+    *,
+    candidate_limit: int,
 ) -> set[frozenset[tuple[str, str]]]:
     """Find all simple paths as sets of edges."""
     paths: set[frozenset[tuple[str, str]]] = set()
+    enumeration_steps = [0]
     for start in adjacency:
-        _dfs_paths(start, frozenset(), frozenset({start}), adjacency, paths)
+        _dfs_paths(
+            start,
+            frozenset(),
+            frozenset({start}),
+            adjacency,
+            paths,
+            candidate_limit=candidate_limit,
+            enumeration_steps=enumeration_steps,
+        )
     return paths
 
 
@@ -143,9 +161,23 @@ def _dfs_paths(
     vertices_visited: frozenset[str],
     adjacency: dict[str, set[str]],
     paths: set[frozenset[tuple[str, str]]],
+    *,
+    candidate_limit: int,
+    enumeration_steps: list[int],
 ) -> None:
+    enumeration_steps[0] += 1
+    if enumeration_steps[0] > MAX_SEARCH_STATES:
+        _reject(
+            "path_enumeration_bound",
+            "simple-path enumeration exceeds its bounded work envelope",
+        )
     if edges_used:
         paths.add(edges_used)
+        if len(paths) > candidate_limit:
+            _reject(
+                "search_work_bound",
+                "the exact memoized residual-edge search exceeds its bounded work envelope",
+            )
     for neighbor in sorted(adjacency[current]):
         if neighbor in vertices_visited:
             continue
@@ -158,6 +190,8 @@ def _dfs_paths(
             vertices_visited | {neighbor},
             adjacency,
             paths,
+            candidate_limit=candidate_limit,
+            enumeration_steps=enumeration_steps,
         )
 
 
@@ -204,21 +238,15 @@ def _path_to_vertices(path_edges: frozenset[tuple[str, str]]) -> list[str]:
     if not path_edges:
         return []
     adj: dict[str, list[str]] = {}
-    for a, b in path_edges:
+    for a, b in sorted(path_edges):
         adj.setdefault(a, []).append(b)
         adj.setdefault(b, []).append(a)
-    start = None
-    for v, neighbors in adj.items():
-        if len(neighbors) == 1:
-            start = v
-            break
-    if start is None:
-        start = next(iter(adj))
+    start = min(vertex for vertex, neighbors in adj.items() if len(neighbors) == 1)
     vertices = [start]
     current = start
     used_edges: set[tuple[str, str]] = set()
     while len(vertices) < len(path_edges) + 1:
-        for neighbor in adj[current]:
+        for neighbor in sorted(adj[current]):
             edge = (min(current, neighbor), max(current, neighbor))
             if edge not in used_edges:
                 used_edges.add(edge)

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -52,39 +52,29 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
         adjacency[left].add(right)
         adjacency[right].add(left)
 
-    if edge_count >= MAX_SEARCH_STATES.bit_length():
-        _reject(
-            "search_work_bound",
-            "the exact memoized residual-edge search exceeds its bounded work envelope",
-        )
-    residual_state_bound = 1 << edge_count
-    candidate_limit = MAX_SEARCH_STATES // residual_state_bound
     candidates = tuple(
         sorted(
-            _find_all_simple_paths(adjacency, candidate_limit=candidate_limit),
+            _find_all_simple_paths(adjacency, candidate_limit=MAX_SEARCH_STATES),
             key=lambda path: (-len(path), tuple(sorted(path))),
         )
     )
-    candidate_checks_bound = residual_state_bound * max(len(candidates), 1)
-    if candidate_checks_bound > MAX_SEARCH_STATES:
-        _reject(
-            "search_work_bound",
-            "the exact memoized residual-edge search exceeds its bounded work envelope",
-        )
+    candidate_checks_bound = MAX_SEARCH_STATES
 
     try:
         source_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
+        active_vertices = {vertex for edge in graph.edges for vertex in edge}
         max_label_bytes = max(
-            (len(encode_strict_json(vertex)) for vertex in graph.vertices), default=2
+            (len(encode_strict_json(vertex)) for vertex in active_vertices), default=2
         )
     except ValueError as exc:
         _reject("source_representation", str(exc))
-    path_bytes = _array_size([max_label_bytes] * vertex_count)
-    paths_bytes = _array_size([path_bytes] * edge_count) if edge_count else 2
+    paths_bytes = (
+        1 + 4 * edge_count + 2 * edge_count * max_label_bytes if edge_count else 2
+    )
     result_bytes = strict_json_object_size(
         (
             ("graph", source_bytes),
-            ("path_count", 3),
+            ("path_count", len(str(edge_count))),
             ("paths", paths_bytes),
         )
     )
@@ -220,8 +210,9 @@ def _minimum_cover(
         for path in by_edge[pivot]:
             candidate_checks += 1
             if candidate_checks > candidate_checks_bound:
-                raise AssertionError(
-                    "path-decomposition admission undercounted search work"
+                _reject(
+                    "search_work_bound",
+                    "the exact memoized residual-edge search exceeds its bounded work envelope",
                 )
             if not path <= remaining:
                 continue

--- a/tests/math/graphs/path_decomposition/test_path_decomposition.py
+++ b/tests/math/graphs/path_decomposition/test_path_decomposition.py
@@ -101,7 +101,7 @@ def test_isolated_vertices_do_not_trigger_a_coarse_carrier_rejection() -> None:
     assert result.path_count == 1
 
 
-def test_dense_graph_is_rejected_before_path_enumeration() -> None:
+def test_dense_graph_is_rejected_by_path_enumeration_ledger() -> None:
     vertices = [f"v{i:02d}" for i in range(12)]
     edges = [
         (vertices[left], vertices[right])
@@ -109,7 +109,7 @@ def test_dense_graph_is_rejected_before_path_enumeration() -> None:
         for right in range(left + 1, 12)
     ]
 
-    with pytest.raises(OperationDomainValidationError, match="residual-edge search"):
+    with pytest.raises(OperationDomainValidationError, match="bounded work envelope"):
         compute_minimum_path_decomposition(_graph(vertices, edges))
 
 
@@ -122,6 +122,25 @@ def test_path_orientation_is_canonical() -> None:
     result = compute_minimum_path_decomposition(graph)
 
     assert result.paths == (("a", "b", "c", "d"),)
+
+
+def test_path_search_uses_reachable_residual_states() -> None:
+    vertices = [f"v{i:02d}" for i in range(16)]
+
+    result = compute_minimum_path_decomposition(
+        _graph(vertices, list(pairwise(vertices)))
+    )
+
+    assert result.path_count == 1
+
+
+def test_result_bound_charges_only_active_path_vertices() -> None:
+    vertices = [f"{index:03d}-" + "x" * 2996 for index in range(256)]
+    edges = [(vertices[2 * index], vertices[2 * index + 1]) for index in range(15)]
+
+    result = compute_minimum_path_decomposition(_graph(vertices, edges))
+
+    assert result.path_count == 15
 
 
 @pytest.mark.parametrize(

--- a/tests/math/graphs/path_decomposition/test_path_decomposition.py
+++ b/tests/math/graphs/path_decomposition/test_path_decomposition.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.path_decomposition.operations import (
     compute_minimum_path_decomposition,
 )
@@ -59,3 +62,14 @@ def test_result_preserves_source() -> None:
     g = _graph(["a", "b"], [("a", "b")])
     result = compute_minimum_path_decomposition(g)
     assert result.graph == g
+
+
+def test_k5_search_is_rejected_before_exhaustive_cover() -> None:
+    """The admitted graph shape must fit the exact cover work envelope."""
+    vertices = ["a", "b", "c", "d", "e"]
+    g = _graph(
+        vertices,
+        [(vertices[i], vertices[j]) for i in range(5) for j in range(i + 1, 5)],
+    )
+    with pytest.raises(OperationDomainValidationError, match="work envelope"):
+        compute_minimum_path_decomposition(g)

--- a/tests/math/graphs/path_decomposition/test_path_decomposition.py
+++ b/tests/math/graphs/path_decomposition/test_path_decomposition.py
@@ -5,6 +5,7 @@ from itertools import pairwise
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.path_decomposition._models import PathDecompositionResult
 from jacobian.math.graphs.path_decomposition.operations import (
     compute_minimum_path_decomposition,
@@ -90,6 +91,37 @@ def test_sparse_graph_uses_actual_path_candidates() -> None:
     g = _graph(vertices, [(vertices[0], vertices[1])])
     result = compute_minimum_path_decomposition(g)
     assert result.path_count == 1
+
+
+def test_isolated_vertices_do_not_trigger_a_coarse_carrier_rejection() -> None:
+    vertices = [f"v{i}" for i in range(13)]
+    result = compute_minimum_path_decomposition(
+        _graph(vertices, [(vertices[0], vertices[1])])
+    )
+    assert result.path_count == 1
+
+
+def test_dense_graph_is_rejected_before_path_enumeration() -> None:
+    vertices = [f"v{i:02d}" for i in range(12)]
+    edges = [
+        (vertices[left], vertices[right])
+        for left in range(12)
+        for right in range(left + 1, 12)
+    ]
+
+    with pytest.raises(OperationDomainValidationError, match="residual-edge search"):
+        compute_minimum_path_decomposition(_graph(vertices, edges))
+
+
+def test_path_orientation_is_canonical() -> None:
+    graph = _graph(
+        ["a", "b", "c", "d"],
+        [("c", "d"), ("a", "b"), ("b", "c")],
+    )
+
+    result = compute_minimum_path_decomposition(graph)
+
+    assert result.paths == (("a", "b", "c", "d"),)
 
 
 @pytest.mark.parametrize(

--- a/tests/math/graphs/path_decomposition/test_path_decomposition.py
+++ b/tests/math/graphs/path_decomposition/test_path_decomposition.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from jacobian.math.graphs.path_decomposition.operations import (
+    compute_minimum_path_decomposition,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph(vertices, edges):
+    return SimpleUndirectedGraph(
+        vertices=tuple(vertices),
+        edges=tuple((a, b) for a, b in edges),
+    )
+
+
+def test_p3_path_number_1() -> None:
+    """P3 has path number 1."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    result = compute_minimum_path_decomposition(g)
+    assert result.path_count == 1
+
+
+def test_k3_path_number_2() -> None:
+    """K3 has path number 2: one length-2 path plus one remaining edge."""
+    g = _graph(["a", "b", "c"], [("a", "b"), ("a", "c"), ("b", "c")])
+    result = compute_minimum_path_decomposition(g)
+    assert result.path_count == 2
+
+
+def test_single_edge() -> None:
+    """A single edge has path number 1."""
+    g = _graph(["a", "b"], [("a", "b")])
+    result = compute_minimum_path_decomposition(g)
+    assert result.path_count == 1
+
+
+def test_edgeless_graph() -> None:
+    """An edgeless graph has path number 0."""
+    g = _graph(["a", "b"], [])
+    result = compute_minimum_path_decomposition(g)
+    assert result.path_count == 0
+
+
+def test_path_replay() -> None:
+    """Every source edge appears in exactly one returned path."""
+    g = _graph(["a", "b", "c", "d"], [("a", "b"), ("b", "c"), ("c", "d")])
+    result = compute_minimum_path_decomposition(g)
+    all_edges = set()
+    for path in result.paths:
+        for i in range(len(path) - 1):
+            a, b = path[i], path[i + 1]
+            edge = (min(a, b), max(a, b))
+            assert edge not in all_edges
+            all_edges.add(edge)
+    assert all_edges == set(g.edges)
+
+
+def test_result_preserves_source() -> None:
+    g = _graph(["a", "b"], [("a", "b")])
+    result = compute_minimum_path_decomposition(g)
+    assert result.graph == g

--- a/tests/math/graphs/path_decomposition/test_path_decomposition.py
+++ b/tests/math/graphs/path_decomposition/test_path_decomposition.py
@@ -73,3 +73,11 @@ def test_k5_search_is_rejected_before_exhaustive_cover() -> None:
     )
     with pytest.raises(OperationDomainValidationError, match="work envelope"):
         compute_minimum_path_decomposition(g)
+
+
+def test_sparse_graph_uses_actual_path_candidates() -> None:
+    """Isolated vertices do not make a one-edge search look dense."""
+    vertices = [f"v{i}" for i in range(10)]
+    g = _graph(vertices, [(vertices[0], vertices[1])])
+    result = compute_minimum_path_decomposition(g)
+    assert result.path_count == 1

--- a/tests/math/graphs/path_decomposition/test_path_decomposition.py
+++ b/tests/math/graphs/path_decomposition/test_path_decomposition.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-import pytest
+from itertools import pairwise
 
-from jacobian.catalog.models import OperationDomainValidationError
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.path_decomposition._models import PathDecompositionResult
 from jacobian.math.graphs.path_decomposition.operations import (
     compute_minimum_path_decomposition,
 )
@@ -64,15 +67,21 @@ def test_result_preserves_source() -> None:
     assert result.graph == g
 
 
-def test_k5_search_is_rejected_before_exhaustive_cover() -> None:
-    """The admitted graph shape must fit the exact cover work envelope."""
+def test_k5_search_uses_memoized_residual_states() -> None:
     vertices = ["a", "b", "c", "d", "e"]
     g = _graph(
         vertices,
         [(vertices[i], vertices[j]) for i in range(5) for j in range(i + 1, 5)],
     )
-    with pytest.raises(OperationDomainValidationError, match="work envelope"):
-        compute_minimum_path_decomposition(g)
+    result = compute_minimum_path_decomposition(g)
+    assert result.path_count > 0
+
+
+def test_seven_vertex_path_is_inside_the_residual_state_bound() -> None:
+    vertices = [f"v{i}" for i in range(7)]
+    graph = _graph(vertices, list(pairwise(vertices)))
+    result = compute_minimum_path_decomposition(graph)
+    assert result.path_count == 1
 
 
 def test_sparse_graph_uses_actual_path_candidates() -> None:
@@ -81,3 +90,24 @@ def test_sparse_graph_uses_actual_path_candidates() -> None:
     g = _graph(vertices, [(vertices[0], vertices[1])])
     result = compute_minimum_path_decomposition(g)
     assert result.path_count == 1
+
+
+@pytest.mark.parametrize(
+    "payload_update",
+    [
+        {"path_count": -1, "paths": []},
+        {"path_count": 2, "paths": [["a", "b"]]},
+        {"path_count": 1, "paths": [["a", "c"]]},
+        {"path_count": 1, "paths": [["a", "b", "a"]]},
+    ],
+)
+def test_result_requires_an_exact_source_edge_partition(payload_update: dict) -> None:
+    graph = _graph(["a", "b"], [("a", "b")])
+    payload = {
+        "graph": graph.model_dump(mode="json"),
+        "path_count": 1,
+        "paths": [["a", "b"]],
+        **payload_update,
+    }
+    with pytest.raises(ValidationError):
+        PathDecompositionResult.model_validate(payload)

--- a/tests/math/graphs/path_decomposition/test_path_decomposition.py
+++ b/tests/math/graphs/path_decomposition/test_path_decomposition.py
@@ -109,7 +109,9 @@ def test_dense_graph_is_rejected_by_path_enumeration_ledger() -> None:
         for right in range(left + 1, 12)
     ]
 
-    with pytest.raises(OperationDomainValidationError, match="bounded work envelope"):
+    with pytest.raises(
+        OperationDomainValidationError, match=r"bounded (?:work|incidence) envelope"
+    ):
         compute_minimum_path_decomposition(_graph(vertices, edges))
 
 


### PR DESCRIPTION
## Summary

Implements `graph.path_decomposition.minimum.compute` from issue #2812.

Given a bounded finite simple graph, returns its exact path number (minimum number of edge-disjoint simple paths covering all edges) together with a realizing partition. This is the finite path-number invariant used by Gallai's path decomposition conjecture (Erdos #583).

## Design

- **Operation ID**: `graph.path_decomposition.minimum.compute`
- **Input**: `SimpleUndirectedGraph` (at most 12 vertices)
- **Output**: `PathDecompositionResult` with path_count and witness paths
- **Kernel**: exhaustive enumeration of all simple paths + minimum edge-partition search
- **Bounds**: at most 12 vertices (exhaustive search over edge partitions)

## Tests

- P3 has path number 1 (one path covers all edges)
- K3 has path number 2 (one length-2 path plus one remaining edge)
- Single edge: path number 1
- Edgeless graph: path number 0
- Path replay: every source edge appears in exactly one returned path
- Source preservation

Closes #2812

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)