### PR TITLE
Add graph.edge_colored.monochromatic_path_hypergraphs.construct operation

### DIFF
--- a/src/jacobian/math/graphs/monochromatic_path/__init__.py
+++ b/src/jacobian/math/graphs/monochromatic_path/__init__.py
@@ -1,0 +1,7 @@
+"""Monochromatic path hypergraph operations."""
+
+from jacobian.math.graphs.monochromatic_path.operations import (
+    construct_monochromatic_path_hypergraphs,
+)
+
+__all__ = ["construct_monochromatic_path_hypergraphs"]

--- a/src/jacobian/math/graphs/monochromatic_path/_models.py
+++ b/src/jacobian/math/graphs/monochromatic_path/_models.py
@@ -1,5 +1,10 @@
 """Typed contracts for the monochromatic path hypergraph operation."""
 
+from typing import Annotated
+
+from pydantic import WithJsonSchema
+from pydantic.json_schema import JsonSchemaValue
+
 from jacobian._models import StrictModel
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
@@ -9,10 +14,36 @@ from jacobian.math.graphs.values import ColoredUndirectedGraph
 MAX_VERTICES = 12
 
 
+def _monochromatic_graph_schema() -> JsonSchemaValue:
+    schema = ColoredUndirectedGraph.model_json_schema()
+    schema["description"] = (
+        "A coloured simple graph with at most "
+        f"{MAX_VERTICES} vertices; the operation bounds its exact subset "
+        "search and complete hypergraph result."
+    )
+    definition = schema.get("$defs", {}).get("SimpleUndirectedGraph")
+    if definition is None:
+        raise AssertionError("colored graph schema lost its simple-graph definition")
+    definition["properties"]["vertices"]["maxItems"] = MAX_VERTICES
+    definition["properties"]["edges"]["maxItems"] = MAX_VERTICES * (MAX_VERTICES - 1) // 2
+    schema["properties"]["graph"] = definition
+    del schema["$defs"]
+    schema["properties"]["edge_colors"]["maxItems"] = (
+        MAX_VERTICES * (MAX_VERTICES - 1) // 2
+    )
+    return schema
+
+
+MonochromaticPathGraph = Annotated[
+    ColoredUndirectedGraph,
+    WithJsonSchema(_monochromatic_graph_schema()),
+]
+
+
 class MonochromaticPathRequest(StrictModel):
     """Request for the monochromatic path hypergraphs of a coloured graph."""
 
-    graph: ColoredUndirectedGraph
+    graph: MonochromaticPathGraph
 
 
 class MonochromaticPathResult(StrictModel):
@@ -24,6 +55,7 @@ class MonochromaticPathResult(StrictModel):
 
 __all__ = [
     "MAX_VERTICES",
+    "MonochromaticPathGraph",
     "MonochromaticPathRequest",
     "MonochromaticPathResult",
 ]

--- a/src/jacobian/math/graphs/monochromatic_path/_models.py
+++ b/src/jacobian/math/graphs/monochromatic_path/_models.py
@@ -25,7 +25,9 @@ def _monochromatic_graph_schema() -> JsonSchemaValue:
     if definition is None:
         raise AssertionError("colored graph schema lost its simple-graph definition")
     definition["properties"]["vertices"]["maxItems"] = MAX_VERTICES
-    definition["properties"]["edges"]["maxItems"] = MAX_VERTICES * (MAX_VERTICES - 1) // 2
+    definition["properties"]["edges"]["maxItems"] = (
+        MAX_VERTICES * (MAX_VERTICES - 1) // 2
+    )
     schema["properties"]["graph"] = definition
     del schema["$defs"]
     schema["properties"]["edge_colors"]["maxItems"] = (

--- a/src/jacobian/math/graphs/monochromatic_path/_models.py
+++ b/src/jacobian/math/graphs/monochromatic_path/_models.py
@@ -1,0 +1,29 @@
+"""Typed contracts for the monochromatic path hypergraph operation."""
+
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.graphs.values import ColoredUndirectedGraph
+
+MAX_VERTICES = 12
+
+
+class MonochromaticPathRequest(StrictModel):
+    """Request for the monochromatic path hypergraphs of a coloured graph."""
+
+    graph: ColoredUndirectedGraph
+
+
+class MonochromaticPathResult(StrictModel):
+    """The monochromatic path hypergraphs of a coloured graph."""
+
+    graph: ColoredUndirectedGraph
+    colour_to_hypergraph: dict[str, FiniteHypergraph]
+
+
+__all__ = [
+    "MAX_VERTICES",
+    "MonochromaticPathRequest",
+    "MonochromaticPathResult",
+]

--- a/src/jacobian/math/graphs/monochromatic_path/_tools.py
+++ b/src/jacobian/math/graphs/monochromatic_path/_tools.py
@@ -1,0 +1,77 @@
+"""Monochromatic path hypergraph operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.monochromatic_path._models import (
+    MonochromaticPathRequest,
+    MonochromaticPathResult,
+)
+from jacobian.math.graphs.monochromatic_path.operations import (
+    construct_monochromatic_path_hypergraphs,
+)
+
+
+def compute_monochromatic_path_op(
+    request: MonochromaticPathRequest,
+) -> MonochromaticPathResult:
+    return construct_monochromatic_path_hypergraphs(request.graph)
+
+
+def mph_action(
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type,
+    result_model: type,
+    operation: Callable,
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool:
+    return MathTool(
+        operation_id=operation_id,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    mph_action(
+        "graph.edge_colored.monochromatic_path_hypergraphs.construct",
+        "Construct monochromatic path hypergraphs from a coloured graph",
+        (
+            "For each colour in an edge-coloured graph, return one canonical "
+            "FiniteHypergraph whose hyperedges are the nonempty source-vertex "
+            "sets that admit a simple path using only edges of that colour."
+        ),
+        MonochromaticPathRequest,
+        MonochromaticPathResult,
+        compute_monochromatic_path_op,
+        "graph",
+        "ramsey",
+        "exact",
+        examples=(
+            example(
+                "all_red_k3",
+                "All-red K3: red path on every nonempty vertex subset.",
+                {
+                    "graph": {
+                        "graph": {
+                            "vertices": ["0", "1", "2"],
+                            "edges": [["0", "1"], ["0", "2"], ["1", "2"]],
+                        },
+                        "edge_colors": ["red", "red", "red"],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/monochromatic_path/_tools.py
+++ b/src/jacobian/math/graphs/monochromatic_path/_tools.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 
+from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools, OperationExample
 from jacobian.math.graphs.monochromatic_path._models import (
@@ -19,16 +20,16 @@ def compute_monochromatic_path_op(
     return construct_monochromatic_path_hypergraphs(request.graph)
 
 
-def mph_action(
+def mph_action[RequestT: StrictModel, ResultT: StrictModel](
     operation_id: str,
     title: str,
     description: str,
-    request_model: type,
-    result_model: type,
-    operation: Callable,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
     *tags: str,
     examples: tuple[OperationExample, ...] = (),
-) -> MathTool:
+) -> MathTool[RequestT, ResultT]:
     return MathTool(
         operation_id=operation_id,
         title=title,

--- a/src/jacobian/math/graphs/monochromatic_path/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_path/operations.py
@@ -59,14 +59,16 @@ def _admit_monochromatic_path_graph(graph: ColoredUndirectedGraph) -> tuple[str,
             code="graph.monochromatic_path.work_exceeds_bound",
             message="monochromatic path search exceeds its exact work bound",
         )
-    edge_upper_bound = len(colours) * subset_count
+    # Each colour produces its own hypergraph.  The finite-hypergraph edge
+    # bound applies per result, while the aggregate output is bounded below.
+    edge_upper_bound = subset_count
     if edge_upper_bound > MAX_EDGES:
         raise OperationDomainValidationError(
             location=("graph",),
             code="graph.monochromatic_path.edge_count_exceeds_bound",
             message="complete monochromatic path hypergraphs exceed the edge bound",
         )
-    incidence_upper_bound = len(colours) * vertex_count * (1 << (vertex_count - 1))
+    incidence_upper_bound = vertex_count * (1 << (vertex_count - 1))
     if incidence_upper_bound > MAX_TOTAL_INCIDENCES:
         raise OperationDomainValidationError(
             location=("graph",),

--- a/src/jacobian/math/graphs/monochromatic_path/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_path/operations.py
@@ -2,17 +2,103 @@
 
 from __future__ import annotations
 
-from itertools import combinations
-
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    strict_json_object_size,
+)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_TOTAL_INCIDENCES,
     FiniteHypergraph,
 )
 from jacobian.math.graphs.monochromatic_path._models import (
+    MAX_VERTICES,
     MonochromaticPathResult,
 )
 from jacobian.math.graphs.values import ColoredUndirectedGraph
 
 __all__ = ["construct_monochromatic_path_hypergraphs"]
+
+MAX_MONOCHROMATIC_PATH_WORK = 100_000_000
+
+
+def _json_array_size(item_sizes: list[int]) -> int:
+    return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
+
+
+def _admit_monochromatic_path_graph(graph: ColoredUndirectedGraph) -> tuple[str, ...]:
+    vertex_count = len(graph.graph.vertices)
+    edge_count = len(graph.graph.edges)
+    if vertex_count > MAX_VERTICES:
+        raise OperationDomainValidationError(
+            location=("graph", "vertices"),
+            code="graph.monochromatic_path.vertex_count_exceeds_bound",
+            message=f"monochromatic path search supports at most {MAX_VERTICES} vertices",
+        )
+    if edge_count and not graph.edge_colors:
+        raise OperationDomainValidationError(
+            location=("graph", "edge_colors"),
+            code="graph.monochromatic_path.edge_colors_must_cover_edges",
+            message="edge_colors must assign one color to every graph edge",
+        )
+    if len(graph.edge_colors) not in (0, edge_count):
+        raise OperationDomainValidationError(
+            location=("graph", "edge_colors"),
+            code="graph.monochromatic_path.edge_colors_must_cover_edges",
+            message="edge_colors must be empty or align with every graph edge",
+        )
+
+    colours = tuple(sorted(set(graph.edge_colors))) or ("uncolored",)
+    subset_count = (1 << vertex_count) - 1
+    work = len(colours) * max(1, vertex_count * vertex_count * (1 << vertex_count))
+    if work > MAX_MONOCHROMATIC_PATH_WORK:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.monochromatic_path.work_exceeds_bound",
+            message="monochromatic path search exceeds its exact work bound",
+        )
+    edge_upper_bound = len(colours) * subset_count
+    if edge_upper_bound > MAX_EDGES:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.monochromatic_path.edge_count_exceeds_bound",
+            message="complete monochromatic path hypergraphs exceed the edge bound",
+        )
+    if edge_upper_bound * vertex_count > MAX_TOTAL_INCIDENCES:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.monochromatic_path.incidence_count_exceeds_bound",
+            message="complete monochromatic path hypergraphs exceed the incidence bound",
+        )
+
+    graph_bytes = len(encode_strict_json(graph.model_dump(mode="json")))
+    vertex_sizes = [len(encode_strict_json(vertex)) for vertex in graph.graph.vertices]
+    vertices_bytes = _json_array_size(vertex_sizes)
+    edge_id_size = len(encode_strict_json(f"path_{max(0, subset_count - 1)}"))
+    edge_entry_size = _json_array_size(
+        [edge_id_size, _json_array_size(vertex_sizes)]
+    )
+    hypergraph_bytes = strict_json_object_size(
+        (
+            ("vertices", vertices_bytes),
+            ("edges", _json_array_size([edge_entry_size] * subset_count)),
+        )
+    )
+    map_bytes = 2 + max(len(colours) - 1, 0) + sum(
+        len(encode_strict_json(colour)) + 1 + hypergraph_bytes for colour in colours
+    )
+    result_bytes = strict_json_object_size(
+        (("graph", graph_bytes), ("colour_to_hypergraph", map_bytes))
+    )
+    if result_bytes > CanonicalLimits().max_output_bytes:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.monochromatic_path.result_exceeds_output_bound",
+            message="monochromatic path result exceeds the canonical output bound",
+        )
+    return colours
 
 
 def construct_monochromatic_path_hypergraphs(
@@ -23,13 +109,10 @@ def construct_monochromatic_path_hypergraphs(
 
     Singletons are included (length-0 path convention).
     """
+    colours = _admit_monochromatic_path_graph(graph)
     vertices = list(graph.graph.vertices)
     edges = list(graph.graph.edges)
     edge_colors = list(graph.edge_colors)
-
-    colours = sorted(set(edge_colors))
-    if not colours:
-        colours = ["uncolored"]
 
     colour_to_adjacency: dict[str, dict[str, set[str]]] = {
         c: {v: set() for v in vertices} for c in colours
@@ -42,16 +125,11 @@ def construct_monochromatic_path_hypergraphs(
 
     for colour in colours:
         adj = colour_to_adjacency[colour]
-        supports: list[tuple[str, ...]] = []
-
-        for size in range(1, len(vertices) + 1):
-            for subset in combinations(vertices, size):
-                if _has_hamiltonian_path(subset, adj):
-                    supports.append(tuple(sorted(subset)))
+        supports = _hamiltonian_supports(tuple(vertices), adj)
 
         hyper_edges: list[tuple[str, tuple[str, ...]]] = []
         for i, support in enumerate(sorted(supports)):
-            hyper_edges.append((f"path_{colour}_{i}", support))
+            hyper_edges.append((f"path_{i}", support))
 
         result[colour] = FiniteHypergraph(
             vertices=tuple(vertices),
@@ -69,37 +147,35 @@ def _has_hamiltonian_path(
     adjacency: dict[str, set[str]],
 ) -> bool:
     """Check if the subgraph induced on `vertices` has a Hamiltonian path."""
+    return tuple(vertices) in _hamiltonian_supports(vertices, adjacency)
+
+
+def _hamiltonian_supports(
+    vertices: tuple[str, ...], adjacency: dict[str, set[str]]
+) -> tuple[tuple[str, ...], ...]:
+    """Return all supports admitting a simple path using subset DP."""
     n = len(vertices)
-    if n == 1:
-        return True
-
-    v_set = set(vertices)
-
-    for start in vertices:
-        visited: set[str] = {start}
-        path = [start]
-        if _dfs_path(start, path, visited, n, vertices, adjacency, v_set):
-            return True
-    return False
-
-
-def _dfs_path(
-    current: str,
-    path: list[str],
-    visited: set[str],
-    n: int,
-    vertices: tuple[str, ...],
-    adjacency: dict[str, set[str]],
-    v_set: set[str],
-) -> bool:
-    if len(path) == n:
-        return True
-    for neighbor in sorted(adjacency[current]):
-        if neighbor in v_set and neighbor not in visited:
-            visited.add(neighbor)
-            path.append(neighbor)
-            if _dfs_path(neighbor, path, visited, n, vertices, adjacency, v_set):
-                return True
-            path.pop()
-            visited.discard(neighbor)
-    return False
+    index = {vertex: position for position, vertex in enumerate(vertices)}
+    neighbor_masks = [
+        sum(1 << index[neighbor] for neighbor in adjacency[vertex])
+        for vertex in vertices
+    ]
+    endpoint_masks = [0] * (1 << n)
+    for vertex in range(n):
+        endpoint_masks[1 << vertex] = 1 << vertex
+    for mask in range(1, 1 << n):
+        endpoints = endpoint_masks[mask]
+        while endpoints:
+            endpoint_bit = endpoints & -endpoints
+            endpoints -= endpoint_bit
+            endpoint = endpoint_bit.bit_length() - 1
+            additions = neighbor_masks[endpoint] & ~mask
+            while additions:
+                addition = additions & -additions
+                additions -= addition
+                endpoint_masks[mask | addition] |= addition
+    return tuple(
+        tuple(vertices[position] for position in range(n) if mask & (1 << position))
+        for mask in range(1, 1 << n)
+        if endpoint_masks[mask]
+    )

--- a/src/jacobian/math/graphs/monochromatic_path/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_path/operations.py
@@ -66,7 +66,8 @@ def _admit_monochromatic_path_graph(graph: ColoredUndirectedGraph) -> tuple[str,
             code="graph.monochromatic_path.edge_count_exceeds_bound",
             message="complete monochromatic path hypergraphs exceed the edge bound",
         )
-    if edge_upper_bound * vertex_count > MAX_TOTAL_INCIDENCES:
+    incidence_upper_bound = len(colours) * vertex_count * (1 << (vertex_count - 1))
+    if incidence_upper_bound > MAX_TOTAL_INCIDENCES:
         raise OperationDomainValidationError(
             location=("graph",),
             code="graph.monochromatic_path.incidence_count_exceeds_bound",

--- a/src/jacobian/math/graphs/monochromatic_path/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_path/operations.py
@@ -1,0 +1,105 @@
+"""Monochromatic path hypergraph constructor."""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.graphs.monochromatic_path._models import (
+    MonochromaticPathResult,
+)
+from jacobian.math.graphs.values import ColoredUndirectedGraph
+
+__all__ = ["construct_monochromatic_path_hypergraphs"]
+
+
+def construct_monochromatic_path_hypergraphs(
+    graph: ColoredUndirectedGraph,
+) -> MonochromaticPathResult:
+    """For each colour, return the hypergraph whose edges are vertex sets
+    that admit a monochromatic simple path using only edges of that colour.
+
+    Singletons are included (length-0 path convention).
+    """
+    vertices = list(graph.graph.vertices)
+    edges = list(graph.graph.edges)
+    edge_colors = list(graph.edge_colors)
+
+    colours = sorted(set(edge_colors))
+    if not colours:
+        colours = ["uncolored"]
+
+    colour_to_adjacency: dict[str, dict[str, set[str]]] = {
+        c: {v: set() for v in vertices} for c in colours
+    }
+    for (a, b), c in zip(edges, edge_colors, strict=True):
+        colour_to_adjacency[c][a].add(b)
+        colour_to_adjacency[c][b].add(a)
+
+    result: dict[str, FiniteHypergraph] = {}
+
+    for colour in colours:
+        adj = colour_to_adjacency[colour]
+        supports: list[tuple[str, ...]] = []
+
+        for size in range(1, len(vertices) + 1):
+            for subset in combinations(vertices, size):
+                if _has_hamiltonian_path(subset, adj):
+                    supports.append(tuple(sorted(subset)))
+
+        hyper_edges: list[tuple[str, tuple[str, ...]]] = []
+        for i, support in enumerate(sorted(supports)):
+            hyper_edges.append((f"path_{colour}_{i}", support))
+
+        result[colour] = FiniteHypergraph(
+            vertices=tuple(vertices),
+            edges=tuple(hyper_edges),
+        )
+
+    return MonochromaticPathResult(
+        graph=graph,
+        colour_to_hypergraph=result,
+    )
+
+
+def _has_hamiltonian_path(
+    vertices: tuple[str, ...],
+    adjacency: dict[str, set[str]],
+) -> bool:
+    """Check if the subgraph induced on `vertices` has a Hamiltonian path."""
+    n = len(vertices)
+    if n == 1:
+        return True
+
+    v_set = set(vertices)
+
+    for start in vertices:
+        visited: set[str] = {start}
+        path = [start]
+        if _dfs_path(start, path, visited, n, vertices, adjacency, v_set):
+            return True
+    return False
+
+
+def _dfs_path(
+    current: str,
+    path: list[str],
+    visited: set[str],
+    n: int,
+    vertices: tuple[str, ...],
+    adjacency: dict[str, set[str]],
+    v_set: set[str],
+) -> bool:
+    if len(path) == n:
+        return True
+    for neighbor in sorted(adjacency[current]):
+        if neighbor in v_set and neighbor not in visited:
+            visited.add(neighbor)
+            path.append(neighbor)
+            if _dfs_path(neighbor, path, visited, n, vertices, adjacency, v_set):
+                return True
+            path.pop()
+            visited.discard(neighbor)
+    return False

--- a/src/jacobian/math/graphs/monochromatic_path/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_path/operations.py
@@ -77,17 +77,19 @@ def _admit_monochromatic_path_graph(graph: ColoredUndirectedGraph) -> tuple[str,
     vertex_sizes = [len(encode_strict_json(vertex)) for vertex in graph.graph.vertices]
     vertices_bytes = _json_array_size(vertex_sizes)
     edge_id_size = len(encode_strict_json(f"path_{max(0, subset_count - 1)}"))
-    edge_entry_size = _json_array_size(
-        [edge_id_size, _json_array_size(vertex_sizes)]
-    )
+    edge_entry_size = _json_array_size([edge_id_size, _json_array_size(vertex_sizes)])
     hypergraph_bytes = strict_json_object_size(
         (
             ("vertices", vertices_bytes),
             ("edges", _json_array_size([edge_entry_size] * subset_count)),
         )
     )
-    map_bytes = 2 + max(len(colours) - 1, 0) + sum(
-        len(encode_strict_json(colour)) + 1 + hypergraph_bytes for colour in colours
+    map_bytes = (
+        2
+        + max(len(colours) - 1, 0)
+        + sum(
+            len(encode_strict_json(colour)) + 1 + hypergraph_bytes for colour in colours
+        )
     )
     result_bytes = strict_json_object_size(
         (("graph", graph_bytes), ("colour_to_hypergraph", map_bytes))

--- a/tests/math/graphs/monochromatic_path/test_monochromatic_path.py
+++ b/tests/math/graphs/monochromatic_path/test_monochromatic_path.py
@@ -87,7 +87,7 @@ def test_result_preserves_source() -> None:
 
 
 def test_twelve_vertex_complete_graph_fits_tight_incidence_bound() -> None:
-    vertices = tuple(str(index) for index in range(12))
+    vertices = tuple(sorted(str(index) for index in range(12)))
     edges = tuple(
         (vertices[left], vertices[right])
         for left in range(12)

--- a/tests/math/graphs/monochromatic_path/test_monochromatic_path.py
+++ b/tests/math/graphs/monochromatic_path/test_monochromatic_path.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from jacobian.math.graphs.monochromatic_path.operations import (
+    construct_monochromatic_path_hypergraphs,
+)
+from jacobian.math.graphs.values import ColoredUndirectedGraph, SimpleUndirectedGraph
+
+
+def _k3_red():
+    return ColoredUndirectedGraph(
+        graph=SimpleUndirectedGraph(
+            vertices=("0", "1", "2"),
+            edges=(("0", "1"), ("0", "2"), ("1", "2")),
+        ),
+        edge_colors=("red", "red", "red"),
+    )
+
+
+def test_all_red_k3() -> None:
+    """All-red K3: red path on every 2-vertex support and the full 3-vertex support."""
+    result = construct_monochromatic_path_hypergraphs(_k3_red())
+    red_hg = result.colour_to_hypergraph["red"]
+    edges = {frozenset(m) for _, m in red_hg.edges}
+    assert frozenset({"0", "1"}) in edges
+    assert frozenset({"0", "2"}) in edges
+    assert frozenset({"1", "2"}) in edges
+    assert frozenset({"0", "1", "2"}) in edges
+
+
+def test_blue_class_no_edges() -> None:
+    """A blue class with no edges: only singletons."""
+    g = ColoredUndirectedGraph(
+        graph=SimpleUndirectedGraph(
+            vertices=("0", "1", "2"),
+            edges=(("0", "1"),),
+        ),
+        edge_colors=("red",),
+    )
+    result = construct_monochromatic_path_hypergraphs(g)
+    red_hg = result.colour_to_hypergraph["red"]
+    red_edges = {frozenset(m) for _, m in red_hg.edges}
+    assert frozenset({"0", "1"}) in red_edges
+    assert frozenset({"0", "1", "2"}) not in red_edges
+
+
+def test_singletons_included() -> None:
+    """Singletons are included (length-0 path convention)."""
+    result = construct_monochromatic_path_hypergraphs(_k3_red())
+    red_hg = result.colour_to_hypergraph["red"]
+    edges = {frozenset(m) for _, m in red_hg.edges}
+    assert frozenset({"0"}) in edges
+    assert frozenset({"1"}) in edges
+    assert frozenset({"2"}) in edges
+
+
+def test_replay_hamiltonian_path() -> None:
+    """Each support has an actual spanning simple path in the colour subgraph."""
+    result = construct_monochromatic_path_hypergraphs(_k3_red())
+    red_hg = result.colour_to_hypergraph["red"]
+    adjacency = {"0": {"1", "2"}, "1": {"0", "2"}, "2": {"0", "1"}}
+    for _, members in red_hg.edges:
+        members_list = list(members)
+        if len(members_list) == 1:
+            continue
+        assert _has_spanning_path(members_list, adjacency)
+
+
+def _has_spanning_path(vertices, adj):
+    from itertools import permutations
+
+    n = len(vertices)
+    for perm in permutations(vertices):
+        valid = True
+        for i in range(n - 1):
+            if perm[i + 1] not in adj[perm[i]]:
+                valid = False
+                break
+        if valid:
+            return True
+    return False
+
+
+def test_result_preserves_source() -> None:
+    g = _k3_red()
+    result = construct_monochromatic_path_hypergraphs(g)
+    assert result.graph == g

--- a/tests/math/graphs/monochromatic_path/test_monochromatic_path.py
+++ b/tests/math/graphs/monochromatic_path/test_monochromatic_path.py
@@ -84,3 +84,20 @@ def test_result_preserves_source() -> None:
     g = _k3_red()
     result = construct_monochromatic_path_hypergraphs(g)
     assert result.graph == g
+
+
+def test_twelve_vertex_complete_graph_fits_tight_incidence_bound() -> None:
+    vertices = tuple(str(index) for index in range(12))
+    edges = tuple(
+        (vertices[left], vertices[right])
+        for left in range(12)
+        for right in range(left + 1, 12)
+    )
+    graph = ColoredUndirectedGraph(
+        graph=SimpleUndirectedGraph(vertices=vertices, edges=edges),
+        edge_colors=("red",) * len(edges),
+    )
+
+    result = construct_monochromatic_path_hypergraphs(graph)
+
+    assert len(result.colour_to_hypergraph["red"].edges) == 2**12 - 1


### PR DESCRIPTION
## Summary

Implements `graph.edge_colored.monochromatic_path_hypergraphs.construct` from issue #2851.

For each colour in an edge-coloured graph, returns one canonical `FiniteHypergraph` whose hyperedges are the nonempty source-vertex sets that admit a simple path using only edges of that colour. Singletons are included (length-0 path convention).

## Design

- **Operation ID**: `graph.edge_colored.monochromatic_path_hypergraphs.construct`
- **Input**: `ColoredUndirectedGraph` (with total edge-colour axis)
- **Output**: `MonochromaticPathResult` mapping each colour to its `FiniteHypergraph`
- **Kernel**: for each vertex subset and colour, check if the induced subgraph (using only edges of that colour) has a Hamiltonian path via DFS backtracking
- **Bounds**: at most 12 vertices (exhaustive search over 2^n subsets)

## Tests

- All-red K3: red path on every 2-vertex and 3-vertex support
- Blue class with no edges: only singletons
- Singletons included (length-0 path convention)
- Replay: each support has an actual spanning simple path
- Source preservation

Closes #2851

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/75e7770a-f231-4c70-a9d6-4f60aa64c75a)