### PR TITLE
Construct bounded rooted-tree fine partitions

### DIFF
--- a/src/jacobian/math/graphs/rooted_trees/__init__.py
+++ b/src/jacobian/math/graphs/rooted_trees/__init__.py
@@ -1,0 +1,17 @@
+"""Native operations and values for rooted trees."""
+
+from jacobian.math.graphs.rooted_trees.operations import construct_fine_partition
+from jacobian.math.graphs.rooted_trees.values import (
+    RootedTreeFinePartition,
+    RootedTreeFinePartitionConstructed,
+    RootedTreeNotATree,
+    RootedTreeShrub,
+)
+
+__all__ = [
+    "RootedTreeFinePartition",
+    "RootedTreeFinePartitionConstructed",
+    "RootedTreeNotATree",
+    "RootedTreeShrub",
+    "construct_fine_partition",
+]

--- a/src/jacobian/math/graphs/rooted_trees/_models.py
+++ b/src/jacobian/math/graphs/rooted_trees/_models.py
@@ -1,0 +1,33 @@
+"""Private request models for rooted-tree operations."""
+
+from pydantic import Field, StrictInt
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import GraphVertexLabel, SimpleUndirectedGraph
+
+
+class RootedTreeFinePartitionRequest(StrictModel):
+    """One graph, declared root, and requested maximum shrub order."""
+
+    graph: SimpleUndirectedGraph = Field(
+        description=(
+            "The retained canonical finite simple undirected graph. The graph "
+            "must be nonempty; every vertex label must be nonempty and use at "
+            "most 64 UTF-8 bytes. A well-formed non-tree returns a typed "
+            "NOT_A_TREE outcome."
+        )
+    )
+    root: GraphVertexLabel = Field(
+        description="A declared graph vertex used as the root of the tree."
+    )
+    component_size_limit: StrictInt = Field(
+        ge=1,
+        le=255,
+        description=(
+            "The inclusive maximum number of vertices in each returned shrub; "
+            "it must be strictly smaller than the graph order."
+        ),
+    )
+
+
+__all__ = ["RootedTreeFinePartitionRequest"]

--- a/src/jacobian/math/graphs/rooted_trees/_tools.py
+++ b/src/jacobian/math/graphs/rooted_trees/_tools.py
@@ -1,0 +1,66 @@
+"""Rooted-tree operation declarations."""
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools
+from jacobian.math.graphs.rooted_trees._models import (
+    RootedTreeFinePartitionRequest,
+)
+from jacobian.math.graphs.rooted_trees.operations import construct_fine_partition
+from jacobian.math.graphs.rooted_trees.values import RootedTreeFinePartition
+
+
+def _run_fine_partition(
+    request: RootedTreeFinePartitionRequest,
+) -> RootedTreeFinePartition:
+    return construct_fine_partition(
+        request.graph, request.root, request.component_size_limit
+    )
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="graph.rooted_tree.fine_partition.construct",
+        title="Construct a rooted-tree fine partition",
+        description=(
+            "Construct a deterministic fine partition of a rooted finite simple "
+            "tree into even- and odd-distance seed classes and bounded connected "
+            "shrubs. Every shrub has a nonempty boundary wholly in one seed "
+            "class, and each seed class has size at most "
+            "12 * (n - 1) / component_size_limit. The result retains and exactly "
+            "reconstructs the source graph; a non-tree returns a typed diagnostic. "
+            "Rows are lexically ordered and shrubs are indexed rootward-first, "
+            "with no label-independent canonicity claim."
+        ),
+        request_type=RootedTreeFinePartitionRequest,
+        result_type=RootedTreeFinePartition,
+        run=_run_fine_partition,
+        tags=("graph", "rooted-tree", "fine-partition", "decomposition", "exact"),
+        discovery_terms=(
+            "fine partition",
+            "rooted tree partition",
+            "parity refined tree separator",
+            "bounded shrubs",
+        ),
+        examples=(
+            example(
+                "path_fine_partition",
+                (
+                    "Construct a 2-fine partition of a five-vertex rooted path; "
+                    "the supplied graph must be a tree, and "
+                    "component_size_limit=2 bounds every returned shrub."
+                ),
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c", "d", "e"],
+                        "edges": [["a", "b"], ["b", "c"], ["c", "d"], ["d", "e"]],
+                    },
+                    "root": "a",
+                    "component_size_limit": 2,
+                },
+            ),
+        ),
+    ),
+)
+
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/rooted_trees/operations.py
+++ b/src/jacobian/math/graphs/rooted_trees/operations.py
@@ -1,0 +1,486 @@
+"""Constructive bounded operations for rooted trees."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+import networkx as nx
+
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs._networkx import graph_from_value
+from jacobian.math.graphs.rooted_trees.values import (
+    RootedTreeFinePartition,
+    RootedTreeFinePartitionConstructed,
+    RootedTreeNotATree,
+    RootedTreeShrub,
+)
+from jacobian.math.graphs.values import MAX_GRAPH_LABEL_BYTES, SimpleUndirectedGraph
+
+type _Adjacency = dict[str, tuple[str, ...]]
+
+_SOURCE_MEASUREMENT_LIMIT_MULTIPLIER = 4
+_RESULT_STRUCTURE_RESERVE_PER_VERTEX = 1024
+
+
+@dataclass(frozen=True, slots=True)
+class _FinePartitionPlan:
+    connected: bool
+    has_cycle: bool
+    component_count: int
+
+
+def _plan_request(
+    graph: SimpleUndirectedGraph, root: str, component_size_limit: int
+) -> _FinePartitionPlan:
+    if not graph.vertices:
+        raise OperationDomainValidationError(
+            location=("graph", "vertices"),
+            code="graph.rooted_tree.fine_partition.nonempty_graph",
+            message="fine-partition construction requires a nonempty graph",
+        )
+    if root not in graph.vertices:
+        raise OperationDomainValidationError(
+            location=("root",),
+            code="graph.rooted_tree.fine_partition.root_membership",
+            message="root must be a declared graph vertex",
+        )
+    if component_size_limit < 1 or component_size_limit >= len(graph.vertices):
+        raise OperationDomainValidationError(
+            location=("component_size_limit",),
+            code="graph.rooted_tree.fine_partition.component_size_limit",
+            message=(
+                "component_size_limit must be at least 1 and strictly smaller "
+                "than the graph order"
+            ),
+        )
+    if any(not vertex for vertex in graph.vertices):
+        raise OperationDomainValidationError(
+            location=("graph", "vertices"),
+            code="graph.rooted_tree.fine_partition.empty_label",
+            message="graph vertex labels must not be empty",
+        )
+    for vertex in graph.vertices:
+        try:
+            label_bytes = len(vertex.encode("utf-8"))
+        except UnicodeEncodeError as exc:
+            raise OperationDomainValidationError(
+                location=("graph", "vertices"),
+                code="graph.rooted_tree.fine_partition.label_utf8",
+                message="every graph vertex label must be valid UTF-8 text",
+            ) from exc
+        if label_bytes > MAX_GRAPH_LABEL_BYTES:
+            raise OperationDomainValidationError(
+                location=("graph", "vertices"),
+                code="graph.rooted_tree.fine_partition.label_bytes",
+                message=(
+                    f"every graph vertex label must use at most "
+                    f"{MAX_GRAPH_LABEL_BYTES} UTF-8 bytes"
+                ),
+            )
+
+    # The canonical graph owner bounds n by 256 and m by n-choose-2. A tree
+    # result has m=n-1, at most n-1 shrubs, exactly n seed-or-shrub vertex rows,
+    # exactly m classified edge rows, and at most m boundary-seed incidences.
+    # Graph scans and materialized intermediates are O(n+m); lexical canonical
+    # ordering is the only superlinear work.
+    backend = graph_from_value(graph)
+    components = tuple(nx.connected_components(backend))
+    component_count = len(components)
+    connected = component_count == 1
+    has_cycle = len(graph.edges) > len(graph.vertices) - component_count
+
+    output_limit = CanonicalLimits().max_output_bytes
+    # At the graph owner's maxima, there are at most 65,536 serialized label
+    # occurrences. A 64-byte label needs at most 386 JSON bytes when every byte
+    # is escaped, so four output envelopes safely measure every admitted source.
+    measurement_limits = CanonicalLimits(
+        max_output_bytes=_SOURCE_MEASUREMENT_LIMIT_MULTIPLIER * output_limit
+    )
+    source_bytes = len(
+        encode_strict_json(graph.model_dump(mode="json"), limits=measurement_limits)
+    )
+    if connected and not has_cycle:
+        max_label_wire_bytes = max(
+            len(encode_strict_json(vertex)) for vertex in graph.vertices
+        )
+        order = len(graph.vertices)
+        # Besides the retained graph, a constructed tree repeats at most 6n-4
+        # labels: the root, seed/shrub vertex partition, classified edges,
+        # boundary seeds, upper seeds, and shrub roots. One KiB per source
+        # vertex conservatively covers all remaining JSON structure.
+        predicted_result_bytes = (
+            source_bytes
+            + (6 * order - 4) * max_label_wire_bytes
+            + _RESULT_STRUCTURE_RESERVE_PER_VERTEX * (order + 1)
+        )
+    else:
+        diagnostic_payload = {
+            "graph": graph.model_dump(mode="json"),
+            "root": root,
+            "component_size_limit": component_size_limit,
+            "outcome": {
+                "status": "NOT_A_TREE",
+                "connected": connected,
+                "has_cycle": has_cycle,
+                "component_count": component_count,
+            },
+        }
+        predicted_result_bytes = len(
+            encode_strict_json(diagnostic_payload, limits=measurement_limits)
+        )
+    if predicted_result_bytes > output_limit:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.rooted_tree.fine_partition.output_budget",
+            message=(
+                "the retained source graph and complete fine-partition rows "
+                f"would exceed the {output_limit}-byte canonical output limit"
+            ),
+        )
+    return _FinePartitionPlan(
+        connected=connected,
+        has_cycle=has_cycle,
+        component_count=component_count,
+    )
+
+
+def _tree_orientation(
+    adjacency: _Adjacency, root: str
+) -> tuple[
+    dict[str, str | None], dict[str, int], dict[str, tuple[str, ...]], tuple[str, ...]
+]:
+    parent: dict[str, str | None] = {root: None}
+    depth = {root: 0}
+    children: dict[str, list[str]] = {vertex: [] for vertex in adjacency}
+    order: list[str] = []
+    stack = [root]
+    while stack:
+        vertex = stack.pop()
+        order.append(vertex)
+        for neighbor in reversed(adjacency[vertex]):
+            if neighbor in parent:
+                continue
+            parent[neighbor] = vertex
+            depth[neighbor] = depth[vertex] + 1
+            children[vertex].append(neighbor)
+            stack.append(neighbor)
+    return (
+        parent,
+        depth,
+        {vertex: tuple(sorted(row)) for vertex, row in children.items()},
+        tuple(order),
+    )
+
+
+def _components_after_deleting(
+    adjacency: _Adjacency, deleted: set[str]
+) -> tuple[frozenset[str], ...]:
+    seen = set(deleted)
+    components: list[frozenset[str]] = []
+    for start in sorted(adjacency):
+        if start in seen:
+            continue
+        seen.add(start)
+        component = {start}
+        stack = [start]
+        while stack:
+            vertex = stack.pop()
+            for neighbor in reversed(adjacency[vertex]):
+                if neighbor not in seen:
+                    seen.add(neighbor)
+                    component.add(neighbor)
+                    stack.append(neighbor)
+        components.append(frozenset(component))
+    return tuple(components)
+
+
+def _initial_seeds(
+    *,
+    root: str,
+    component_size_limit: int,
+    children: dict[str, tuple[str, ...]],
+    order: tuple[str, ...],
+) -> set[str]:
+    """Build W1 by the repeated deepest-heavy-component rule."""
+
+    seeds: set[str] = set()
+    residual_size: dict[str, int] = {}
+    for vertex in reversed(order):
+        size = 1 + sum(residual_size[child] for child in children[vertex])
+        if vertex != root and size > component_size_limit:
+            # Resetting at a cut makes these charged residual blocks disjoint;
+            # every non-root W1 seed therefore consumes at least k+1 vertices.
+            seeds.add(vertex)
+            residual_size[vertex] = 0
+        else:
+            residual_size[vertex] = size
+    seeds.add(root)
+    return seeds
+
+
+def _branch_vertices(
+    component: frozenset[str], attachments: set[str], adjacency: _Adjacency
+) -> set[str]:
+    """Return branch vertices of the minimal subtree spanning attachments."""
+
+    if len(attachments) < 3:
+        return set()
+    active = set(component)
+    degree = {
+        vertex: sum(neighbor in active for neighbor in adjacency[vertex])
+        for vertex in active
+    }
+    leaves = deque(
+        sorted(
+            vertex
+            for vertex in active
+            if vertex not in attachments and degree[vertex] <= 1
+        )
+    )
+    while leaves:
+        vertex = leaves.popleft()
+        if vertex not in active or vertex in attachments or degree[vertex] > 1:
+            continue
+        active.remove(vertex)
+        for neighbor in adjacency[vertex]:
+            if neighbor not in active:
+                continue
+            degree[neighbor] -= 1
+            if neighbor not in attachments and degree[neighbor] <= 1:
+                leaves.append(neighbor)
+    return {
+        vertex
+        for vertex in active
+        if sum(neighbor in active for neighbor in adjacency[vertex]) >= 3
+    }
+
+
+def _add_branch_seeds(adjacency: _Adjacency, initial_seeds: set[str]) -> set[str]:
+    """Build W2 from branch vertices of each attachment-spanning subtree."""
+
+    seeds = set(initial_seeds)
+    for component in _components_after_deleting(adjacency, initial_seeds):
+        attachments = {
+            vertex
+            for vertex in component
+            if any(neighbor in initial_seeds for neighbor in adjacency[vertex])
+        }
+        # Leaf-pruning computes the unique attachment-spanning subtree. Its
+        # degree-at-least-three vertices are bounded by attachments minus two,
+        # which is the W2 charge used in the theorem.
+        seeds.update(_branch_vertices(component, attachments, adjacency))
+    return seeds
+
+
+def _add_parity_seeds(
+    *,
+    adjacency: _Adjacency,
+    branch_seeds: set[str],
+    parent: dict[str, str | None],
+    depth: dict[str, int],
+) -> set[str]:
+    """Build W3 using the two parity cuts from the fine-partition proof.
+
+    This is the constructive W3 step of Hladký--Piguet, Lemma 5.3: cut the
+    rootward vertex of every internal component whose upper seed is odd, and
+    cut the parent of every odd lower seed. Both new cut types are even.
+    """
+
+    seeds = set(branch_seeds)
+    lower_seeds_by_parent: dict[str, list[str]] = {}
+    for seed in branch_seeds:
+        seed_parent = parent[seed]
+        if seed_parent is not None:
+            lower_seeds_by_parent.setdefault(seed_parent, []).append(seed)
+    for component in _components_after_deleting(adjacency, branch_seeds):
+        lower_seeds = tuple(
+            seed
+            for vertex in component
+            for seed in lower_seeds_by_parent.get(vertex, ())
+        )
+        if not lower_seeds:
+            continue
+
+        top = min(component, key=lambda vertex: (depth[vertex], vertex))
+        upper_seed = parent[top]
+        # Internal components inject into lower W2 seeds, and each odd lower
+        # seed has one parent. Thus these two additions contribute at most two
+        # new vertices per W2 seed, yielding |W3| <= 3|W2|.
+        if upper_seed is not None and depth[upper_seed] % 2 == 1:
+            seeds.add(top)
+        for lower_seed in lower_seeds:
+            lower_parent = parent[lower_seed]
+            if depth[lower_seed] % 2 == 1 and lower_parent is not None:
+                seeds.add(lower_parent)
+    return seeds
+
+
+def _constructed_outcome(
+    *,
+    graph: SimpleUndirectedGraph,
+    adjacency: _Adjacency,
+    seeds: set[str],
+    parent: dict[str, str | None],
+    depth: dict[str, int],
+) -> RootedTreeFinePartitionConstructed:
+    seeds_x = tuple(sorted(seed for seed in seeds if depth[seed] % 2 == 0))
+    seeds_y = tuple(sorted(seeds - set(seeds_x)))
+    components = tuple(
+        sorted(
+            _components_after_deleting(adjacency, seeds),
+            key=lambda component: (
+                min(depth[vertex] for vertex in component),
+                tuple(sorted(component)),
+            ),
+        )
+    )
+    owner = {
+        vertex: index
+        for index, component in enumerate(components)
+        for vertex in component
+    }
+    seed_edges: list[tuple[str, str]] = []
+    shrub_edges: list[list[tuple[str, str]]] = [[] for _ in components]
+    boundary_edges: list[list[tuple[str, str]]] = [[] for _ in components]
+    for edge in graph.edges:
+        left, right = edge
+        left_seed = left in seeds
+        right_seed = right in seeds
+        if left_seed and right_seed:
+            seed_edges.append(edge)
+        elif left_seed:
+            boundary_edges[owner[right]].append(edge)
+        elif right_seed:
+            boundary_edges[owner[left]].append(edge)
+        else:
+            shrub_edges[owner[left]].append(edge)
+
+    shrubs: list[RootedTreeShrub] = []
+    for component_index, component in enumerate(components):
+        vertices = tuple(sorted(component))
+        edges = tuple(sorted(shrub_edges[component_index]))
+        component_boundary_edges = tuple(sorted(boundary_edges[component_index]))
+        boundary_seeds = tuple(
+            sorted(
+                {
+                    right if left in component else left
+                    for left, right in component_boundary_edges
+                }
+            )
+        )
+        top = min(component, key=lambda vertex: (depth[vertex], vertex))
+        upper_seed = parent[top]
+        if upper_seed is None:
+            raise RuntimeError("a non-seed shrub must have an upper seed")
+        route_side = "X" if depth[boundary_seeds[0]] % 2 == 0 else "Y"
+        if any(
+            depth[seed] % 2 != depth[boundary_seeds[0]] % 2 for seed in boundary_seeds
+        ):
+            raise RuntimeError(
+                "fine-partition parity construction produced a mixed boundary"
+            )
+        shrubs.append(
+            RootedTreeShrub.model_construct(
+                index=component_index,
+                vertices=vertices,
+                edges=edges,
+                boundary_seeds=boundary_seeds,
+                boundary_edges=component_boundary_edges,
+                upper_seed=upper_seed,
+                root_vertex=top,
+                route_side=route_side,
+            )
+        )
+    return RootedTreeFinePartitionConstructed.model_construct(
+        status="CONSTRUCTED",
+        seeds_x=seeds_x,
+        seeds_y=seeds_y,
+        seed_edges=tuple(sorted(seed_edges)),
+        shrubs=tuple(shrubs),
+    )
+
+
+def construct_fine_partition(
+    graph: SimpleUndirectedGraph,
+    root: str,
+    component_size_limit: int,
+) -> RootedTreeFinePartition:
+    """Construct a deterministic bounded fine partition of a rooted tree.
+
+    A well-formed graph that is disconnected or contains a cycle returns a
+    typed ``NOT_A_TREE`` diagnostic. For a tree, the result reconstructs the
+    complete source from seed, shrub, and boundary edge rows; each shrub has at
+    most ``component_size_limit`` vertices, each shrub boundary belongs to one
+    seed parity class, and each seed class has size at most
+    ``12 * (n - 1) / component_size_limit``.
+
+    The constructed partition is deterministic for the supplied labels and
+    root, but is not claimed to be invariant under relabelling. Public vertex
+    and edge axes are lexically sorted; shrubs are indexed by increasing root
+    distance of ``root_vertex``, with their vertex tuple as the tie-breaker.
+    """
+
+    if not isinstance(graph, SimpleUndirectedGraph):
+        raise TypeError("graph must be a SimpleUndirectedGraph")
+    if not isinstance(root, str):
+        raise TypeError("root must be a string")
+    if isinstance(component_size_limit, bool) or not isinstance(
+        component_size_limit, int
+    ):
+        raise TypeError("component_size_limit must be an integer")
+    plan = _plan_request(graph, root, component_size_limit)
+
+    if not plan.connected or plan.has_cycle:
+        non_tree_outcome = RootedTreeNotATree.model_construct(
+            status="NOT_A_TREE",
+            connected=plan.connected,
+            has_cycle=plan.has_cycle,
+            component_count=plan.component_count,
+        )
+        return RootedTreeFinePartition._from_kernel(
+            graph=graph,
+            root=root,
+            component_size_limit=component_size_limit,
+            outcome=non_tree_outcome,
+        )
+
+    mutable_adjacency: dict[str, list[str]] = {vertex: [] for vertex in graph.vertices}
+    for left, right in graph.edges:
+        mutable_adjacency[left].append(right)
+        mutable_adjacency[right].append(left)
+    adjacency = {
+        vertex: tuple(sorted(neighbors))
+        for vertex, neighbors in mutable_adjacency.items()
+    }
+    parent, depth, children, order = _tree_orientation(adjacency, root)
+    initial_seeds = _initial_seeds(
+        root=root,
+        component_size_limit=component_size_limit,
+        children=children,
+        order=order,
+    )
+    branch_seeds = _add_branch_seeds(adjacency, initial_seeds)
+    seeds = _add_parity_seeds(
+        adjacency=adjacency,
+        branch_seeds=branch_seeds,
+        parent=parent,
+        depth=depth,
+    )
+    constructed_outcome = _constructed_outcome(
+        graph=graph,
+        adjacency=adjacency,
+        seeds=seeds,
+        parent=parent,
+        depth=depth,
+    )
+    return RootedTreeFinePartition._from_kernel(
+        graph=graph,
+        root=root,
+        component_size_limit=component_size_limit,
+        outcome=constructed_outcome,
+    )
+
+
+__all__ = ["construct_fine_partition"]

--- a/src/jacobian/math/graphs/rooted_trees/values.py
+++ b/src/jacobian/math/graphs/rooted_trees/values.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from typing import Annotated, Literal, Self
 
 from pydantic import Field, StrictBool, StrictInt, model_validator
@@ -37,6 +38,35 @@ def _require_sorted_unique_edges(values: tuple[_Edge, ...], *, field: str) -> No
             f"canonical_{field.replace(' ', '_')}",
             f"{field} must be unique and lexically sorted",
         )
+
+
+def _graph_topology(
+    graph: SimpleUndirectedGraph,
+    root: str,
+) -> tuple[bool, bool, int, dict[str, int]]:
+    adjacency = {vertex: set[str]() for vertex in graph.vertices}
+    for left, right in graph.edges:
+        adjacency[left].add(right)
+        adjacency[right].add(left)
+
+    component_count = 0
+    depths: dict[str, int] = {}
+    for start in (root, *graph.vertices):
+        if start in depths:
+            continue
+        component_count += 1
+        depths[start] = 0
+        queue = deque([start])
+        while queue:
+            vertex = queue.popleft()
+            for neighbor in adjacency[vertex]:
+                if neighbor not in depths:
+                    depths[neighbor] = depths[vertex] + 1
+                    queue.append(neighbor)
+
+    connected = component_count == 1
+    has_cycle = len(graph.edges) > len(graph.vertices) - component_count
+    return connected, has_cycle, component_count, depths
 
 
 class RootedTreeShrub(StrictModel):
@@ -169,7 +199,7 @@ class RootedTreeFinePartition(StrictModel):
         )
 
     @model_validator(mode="after")
-    def require_source_representation(self) -> Self:
+    def require_source_representation(self) -> Self:  # noqa: C901
         graph_vertices = set(self.graph.vertices)
         if self.root not in graph_vertices:
             raise _fine_partition_error(
@@ -197,6 +227,207 @@ class RootedTreeFinePartition(StrictModel):
                     "graph vertex labels must use at most "
                     f"{MAX_GRAPH_LABEL_BYTES} UTF-8 bytes",
                 )
+
+        connected, has_cycle, component_count, depths = _graph_topology(
+            self.graph, self.root
+        )
+        outcome = self.outcome
+        if isinstance(outcome, RootedTreeNotATree):
+            if (
+                outcome.connected != connected
+                or outcome.has_cycle != has_cycle
+                or outcome.component_count != component_count
+            ):
+                raise _fine_partition_error(
+                    "non_tree_diagnostic",
+                    "the NOT_A_TREE diagnostic must match the retained graph",
+                )
+            return self
+
+        if not connected or has_cycle:
+            raise _fine_partition_error(
+                "constructed_graph_topology",
+                "a CONSTRUCTED outcome requires a connected acyclic graph",
+            )
+
+        seeds_x = set(outcome.seeds_x)
+        seeds_y = set(outcome.seeds_y)
+        seeds = seeds_x | seeds_y
+        if not seeds <= graph_vertices:
+            raise _fine_partition_error(
+                "seed_source_membership",
+                "every seed must be a retained graph vertex",
+            )
+        if self.root not in seeds_x:
+            raise _fine_partition_error(
+                "root_seed", "the retained root must be an X seed"
+            )
+        if any(depths[seed] % 2 for seed in seeds_x) or any(
+            depths[seed] % 2 == 0 for seed in seeds_y
+        ):
+            raise _fine_partition_error(
+                "seed_parity",
+                "X and Y seeds must match their rooted graph depth parity",
+            )
+        if len(seeds_x) * self.component_size_limit > 12 * (
+            len(graph_vertices) - 1
+        ) or len(seeds_y) * self.component_size_limit > 12 * (len(graph_vertices) - 1):
+            raise _fine_partition_error(
+                "seed_bound",
+                "each seed side must satisfy the fine-partition size bound",
+            )
+
+        reported_vertices: set[str] = set()
+        reported_edges: set[_Edge] = set()
+
+        def report_edge(edge: _Edge, *, field: str) -> None:
+            if edge not in self.graph.edges:
+                raise _fine_partition_error(
+                    f"{field}_source_membership",
+                    f"every {field.replace('_', ' ')} must belong to the graph",
+                )
+            if edge in reported_edges:
+                raise _fine_partition_error(
+                    "edge_partition",
+                    "each source edge must occur in exactly one outcome row",
+                )
+            reported_edges.add(edge)
+
+        for edge in outcome.seed_edges:
+            report_edge(edge, field="seed_edge")
+            if not set(edge) <= seeds:
+                raise _fine_partition_error(
+                    "seed_edge_membership",
+                    "seed edges must have both endpoints in the seed set",
+                )
+
+        for shrub in outcome.shrubs:
+            vertices = set(shrub.vertices)
+            if not vertices <= graph_vertices:
+                raise _fine_partition_error(
+                    "shrub_source_membership",
+                    "every shrub vertex must be a retained graph vertex",
+                )
+            if vertices & seeds:
+                raise _fine_partition_error(
+                    "shrub_seed_disjoint",
+                    "shrub vertices must be disjoint from all seeds",
+                )
+            if reported_vertices & vertices:
+                raise _fine_partition_error(
+                    "shrub_vertex_partition",
+                    "shrub vertices must be pairwise disjoint",
+                )
+            reported_vertices.update(vertices)
+            if len(vertices) > self.component_size_limit:
+                raise _fine_partition_error(
+                    "shrub_size",
+                    "a shrub must not exceed component_size_limit",
+                )
+            shrub_adjacency = {vertex: set[str]() for vertex in vertices}
+            for left, right in shrub.edges:
+                if left in vertices and right in vertices:
+                    shrub_adjacency[left].add(right)
+                    shrub_adjacency[right].add(left)
+            reached = {shrub.root_vertex}
+            queue = deque([shrub.root_vertex])
+            while queue:
+                vertex = queue.popleft()
+                for neighbor in shrub_adjacency[vertex]:
+                    if neighbor not in reached:
+                        reached.add(neighbor)
+                        queue.append(neighbor)
+            if reached != vertices:
+                raise _fine_partition_error(
+                    "shrub_connected",
+                    "each shrub must be one connected source component",
+                )
+            if shrub.root_vertex != min(
+                vertices, key=lambda vertex: (depths[vertex], vertex)
+            ):
+                raise _fine_partition_error(
+                    "shrub_root_vertex",
+                    "a shrub root_vertex must be its rootward vertex",
+                )
+            if depths[shrub.upper_seed] != depths[shrub.root_vertex] - 1:
+                raise _fine_partition_error(
+                    "shrub_upper_seed",
+                    "a shrub upper_seed must be the parent of root_vertex",
+                )
+
+            for edge in shrub.edges:
+                report_edge(edge, field="shrub_edge")
+                if not set(edge) <= vertices:
+                    raise _fine_partition_error(
+                        "shrub_edge_membership",
+                        "shrub edges must have both endpoints in that shrub",
+                    )
+
+            boundary_seed_values: set[str] = set()
+            for edge in shrub.boundary_edges:
+                report_edge(edge, field="boundary_edge")
+                endpoints = set(edge)
+                if (
+                    len(endpoints & vertices) != 1
+                    or len(endpoints - vertices) != 1
+                    or not (endpoints - vertices) <= seeds
+                ):
+                    raise _fine_partition_error(
+                        "boundary_edge_membership",
+                        "boundary edges must join one shrub vertex to one seed",
+                    )
+                boundary_seed_values.update(endpoints - vertices)
+            if set(shrub.boundary_seeds) != boundary_seed_values:
+                raise _fine_partition_error(
+                    "boundary_seed_coverage",
+                    "boundary_seeds must be exactly the seed endpoints of boundary_edges",
+                )
+            expected_route_side = (
+                "X" if all(seed in seeds_x for seed in boundary_seed_values) else "Y"
+            )
+            if (
+                not boundary_seed_values
+                or (
+                    not boundary_seed_values <= seeds_x
+                    and not boundary_seed_values <= seeds_y
+                )
+                or shrub.route_side != expected_route_side
+            ):
+                raise _fine_partition_error(
+                    "boundary_seed_side",
+                    "a shrub boundary must be nonempty and lie in one seed side",
+                )
+            if shrub.upper_seed not in boundary_seed_values:
+                raise _fine_partition_error(
+                    "upper_seed_boundary",
+                    "a shrub upper_seed must be incident to its boundary",
+                )
+            root_boundary_edge = tuple(sorted((shrub.upper_seed, shrub.root_vertex)))
+            if root_boundary_edge not in shrub.boundary_edges:
+                raise _fine_partition_error(
+                    "upper_seed_parent",
+                    "a shrub upper_seed must be the parent of root_vertex",
+                )
+
+        shrub_order = tuple(
+            (depths[shrub.root_vertex], shrub.vertices) for shrub in outcome.shrubs
+        )
+        if shrub_order != tuple(sorted(shrub_order)):
+            raise _fine_partition_error(
+                "shrub_order",
+                "shrubs must be ordered by root distance and vertex tuple",
+            )
+
+        if reported_vertices != graph_vertices - seeds:
+            raise _fine_partition_error(
+                "vertex_partition",
+                "seeds and shrubs must partition all graph vertices",
+            )
+        if reported_edges != set(self.graph.edges):
+            raise _fine_partition_error(
+                "edge_partition",
+                "seed, shrub, and boundary rows must partition all graph edges",
+            )
         return self
 
 

--- a/src/jacobian/math/graphs/rooted_trees/values.py
+++ b/src/jacobian/math/graphs/rooted_trees/values.py
@@ -1,0 +1,208 @@
+"""Canonical source-bound values for rooted-tree fine partitions."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictBool, StrictInt, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import (
+    MAX_GRAPH_LABEL_BYTES,
+    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    GraphVertexLabel,
+    SimpleUndirectedGraph,
+)
+
+_MAX_TREE_EDGES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1
+type _Edge = tuple[str, str]
+
+
+def _fine_partition_error(code: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"graph.rooted_tree.fine_partition.{code}", message)
+
+
+def _require_sorted_unique(values: tuple[str, ...], *, field: str) -> None:
+    if values != tuple(sorted(set(values))):
+        raise _fine_partition_error(
+            f"canonical_{field.replace(' ', '_')}",
+            f"{field} must be unique and lexically sorted",
+        )
+
+
+def _require_sorted_unique_edges(values: tuple[_Edge, ...], *, field: str) -> None:
+    if values != tuple(sorted(set(values))):
+        raise _fine_partition_error(
+            f"canonical_{field.replace(' ', '_')}",
+            f"{field} must be unique and lexically sorted",
+        )
+
+
+class RootedTreeShrub(StrictModel):
+    """One rooted component left after deleting all fine-partition seeds.
+
+    ``root_vertex`` is the unique shrub vertex closest to the retained root,
+    and ``upper_seed`` is its parent. ``route_side`` is the common bipartition
+    side of every boundary seed.
+    """
+
+    index: StrictInt = Field(ge=0, le=MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1)
+    vertices: tuple[GraphVertexLabel, ...] = Field(
+        min_length=1, max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1
+    )
+    edges: tuple[_Edge, ...] = Field(max_length=_MAX_TREE_EDGES)
+    boundary_seeds: tuple[GraphVertexLabel, ...] = Field(
+        min_length=1, max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+    )
+    boundary_edges: tuple[_Edge, ...] = Field(min_length=1, max_length=_MAX_TREE_EDGES)
+    upper_seed: GraphVertexLabel
+    root_vertex: GraphVertexLabel
+    route_side: Literal["X", "Y"]
+
+    @model_validator(mode="after")
+    def require_canonical_rows(self) -> Self:
+        _require_sorted_unique(self.vertices, field="shrub vertices")
+        _require_sorted_unique_edges(self.edges, field="shrub edges")
+        _require_sorted_unique(self.boundary_seeds, field="boundary seeds")
+        _require_sorted_unique_edges(self.boundary_edges, field="boundary edges")
+        if self.root_vertex not in self.vertices:
+            raise _fine_partition_error(
+                "root_vertex_membership",
+                "a shrub root_vertex must belong to that shrub",
+            )
+        if self.upper_seed not in self.boundary_seeds:
+            raise _fine_partition_error(
+                "upper_seed_membership",
+                "a shrub upper_seed must belong to its boundary",
+            )
+        return self
+
+
+class RootedTreeFinePartitionConstructed(StrictModel):
+    """The constructed seed sides and all source-bound shrubs."""
+
+    status: Literal["CONSTRUCTED"] = "CONSTRUCTED"
+    seeds_x: tuple[GraphVertexLabel, ...] = Field(
+        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+    )
+    seeds_y: tuple[GraphVertexLabel, ...] = Field(
+        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+    )
+    seed_edges: tuple[_Edge, ...] = Field(max_length=_MAX_TREE_EDGES)
+    shrubs: tuple[RootedTreeShrub, ...] = Field(
+        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_rows(self) -> Self:
+        _require_sorted_unique(self.seeds_x, field="X seeds")
+        _require_sorted_unique(self.seeds_y, field="Y seeds")
+        _require_sorted_unique_edges(self.seed_edges, field="seed edges")
+        if set(self.seeds_x) & set(self.seeds_y):
+            raise _fine_partition_error(
+                "disjoint_seed_sides", "the X and Y seed sides must be disjoint"
+            )
+        if tuple(shrub.index for shrub in self.shrubs) != tuple(
+            range(len(self.shrubs))
+        ):
+            raise _fine_partition_error(
+                "shrub_indexes", "shrub indexes must be consecutive from zero"
+            )
+        return self
+
+
+class RootedTreeNotATree(StrictModel):
+    """A total diagnostic for a well-formed graph that is not a tree."""
+
+    status: Literal["NOT_A_TREE"] = "NOT_A_TREE"
+    connected: StrictBool
+    has_cycle: StrictBool
+    component_count: StrictInt = Field(ge=1, le=MAX_INDEXED_SIMPLE_GRAPH_VERTICES)
+
+
+RootedTreeFinePartitionOutcome = Annotated[
+    RootedTreeFinePartitionConstructed | RootedTreeNotATree,
+    Field(discriminator="status"),
+]
+
+
+class RootedTreeFinePartition(StrictModel):
+    """A source-bound fine partition or an exact non-tree diagnostic.
+
+    In a constructed result the seeds contain the declared root, every shrub
+    is a nonempty component of the source tree after seed deletion, and every
+    source edge occurs exactly once as a seed edge, shrub edge, or boundary
+    edge. Each shrub has at most ``component_size_limit`` vertices. Its
+    boundary is nonempty and lies wholly in the reported route side. The X and
+    Y seed sides are the even- and odd-depth seed classes, respectively, and
+    each contains at most ``12 * (n - 1) / component_size_limit`` vertices.
+    Seed and edge axes are lexically sorted. Shrubs are indexed by increasing
+    root distance of ``root_vertex``, then by their complete vertex tuple. This
+    is deterministic for the retained labels, not label-independent canonical
+    graph structure.
+    """
+
+    graph: SimpleUndirectedGraph
+    root: GraphVertexLabel
+    component_size_limit: StrictInt = Field(
+        ge=1, le=MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1
+    )
+    outcome: RootedTreeFinePartitionOutcome
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        graph: SimpleUndirectedGraph,
+        root: str,
+        component_size_limit: int,
+        outcome: RootedTreeFinePartitionConstructed | RootedTreeNotATree,
+    ) -> Self:
+        """Build an owner-produced value without replaying source binding."""
+
+        return cls.model_construct(
+            graph=graph,
+            root=root,
+            component_size_limit=component_size_limit,
+            outcome=outcome,
+        )
+
+    @model_validator(mode="after")
+    def require_source_representation(self) -> Self:
+        graph_vertices = set(self.graph.vertices)
+        if self.root not in graph_vertices:
+            raise _fine_partition_error(
+                "root_membership", "root must be a declared graph vertex"
+            )
+        if self.component_size_limit >= len(graph_vertices):
+            raise _fine_partition_error(
+                "component_size_limit",
+                "component_size_limit must be strictly smaller than graph order",
+            )
+        if any(not vertex for vertex in self.graph.vertices):
+            raise _fine_partition_error(
+                "empty_label", "graph vertex labels must not be empty"
+            )
+        for vertex in self.graph.vertices:
+            try:
+                label_bytes = len(vertex.encode("utf-8"))
+            except UnicodeEncodeError as exc:
+                raise _fine_partition_error(
+                    "label_utf8", "graph vertex labels must be valid UTF-8 text"
+                ) from exc
+            if label_bytes > MAX_GRAPH_LABEL_BYTES:
+                raise _fine_partition_error(
+                    "label_bytes",
+                    "graph vertex labels must use at most "
+                    f"{MAX_GRAPH_LABEL_BYTES} UTF-8 bytes",
+                )
+        return self
+
+
+__all__ = [
+    "RootedTreeFinePartition",
+    "RootedTreeFinePartitionConstructed",
+    "RootedTreeNotATree",
+    "RootedTreeShrub",
+]

--- a/src/jacobian/math/graphs/rooted_trees/values.py
+++ b/src/jacobian/math/graphs/rooted_trees/values.py
@@ -242,6 +242,11 @@ class RootedTreeFinePartition(StrictModel):
                     "non_tree_diagnostic",
                     "the NOT_A_TREE diagnostic must match the retained graph",
                 )
+            if connected and not has_cycle:
+                raise _fine_partition_error(
+                    "non_tree_status",
+                    "a NOT_A_TREE outcome requires a disconnected or cyclic graph",
+                )
             return self
 
         if not connected or has_cycle:
@@ -348,6 +353,11 @@ class RootedTreeFinePartition(StrictModel):
                 raise _fine_partition_error(
                     "shrub_root_vertex",
                     "a shrub root_vertex must be its rootward vertex",
+                )
+            if shrub.upper_seed not in seeds:
+                raise _fine_partition_error(
+                    "shrub_upper_seed_membership",
+                    "a shrub upper_seed must be a retained seed",
                 )
             if depths[shrub.upper_seed] != depths[shrub.root_vertex] - 1:
                 raise _fine_partition_error(

--- a/tests/math/graphs/rooted_trees/test_fine_partition.py
+++ b/tests/math/graphs/rooted_trees/test_fine_partition.py
@@ -243,6 +243,41 @@ def test_non_tree_inputs_return_source_bound_diagnostics(
     )
 
 
+def test_result_parsing_rejects_constructed_rows_not_bound_to_source() -> None:
+    payload = {
+        "graph": {"vertices": ["a", "b"], "edges": [["a", "b"]]},
+        "root": "a",
+        "component_size_limit": 1,
+        "outcome": {
+            "status": "CONSTRUCTED",
+            "seeds_x": ["a"],
+            "seeds_y": [],
+            "seed_edges": [],
+            "shrubs": [],
+        },
+    }
+
+    with pytest.raises(ValidationError, match="partition all graph vertices"):
+        RootedTreeFinePartition.model_validate(payload)
+
+
+def test_result_parsing_rejects_contradictory_non_tree_diagnostic() -> None:
+    payload = {
+        "graph": {"vertices": ["a", "b"], "edges": [["a", "b"]]},
+        "root": "a",
+        "component_size_limit": 1,
+        "outcome": {
+            "status": "NOT_A_TREE",
+            "connected": False,
+            "has_cycle": True,
+            "component_count": 2,
+        },
+    }
+
+    with pytest.raises(ValidationError, match="diagnostic must match"):
+        RootedTreeFinePartition.model_validate(payload)
+
+
 @pytest.mark.parametrize(
     ("root", "size_limit", "code"),
     [

--- a/tests/math/graphs/rooted_trees/test_fine_partition.py
+++ b/tests/math/graphs/rooted_trees/test_fine_partition.py
@@ -278,6 +278,34 @@ def test_result_parsing_rejects_contradictory_non_tree_diagnostic() -> None:
         RootedTreeFinePartition.model_validate(payload)
 
 
+def test_result_parsing_rejects_non_tree_status_for_a_tree() -> None:
+    payload = {
+        "graph": {"vertices": ["a", "b"], "edges": [["a", "b"]]},
+        "root": "a",
+        "component_size_limit": 1,
+        "outcome": {
+            "status": "NOT_A_TREE",
+            "connected": True,
+            "has_cycle": False,
+            "component_count": 1,
+        },
+    }
+
+    with pytest.raises(ValidationError, match="disconnected or cyclic"):
+        RootedTreeFinePartition.model_validate(payload)
+
+
+def test_result_parsing_rejects_undeclared_upper_seed_without_key_error(
+    path_five: SimpleUndirectedGraph,
+) -> None:
+    payload = construct_fine_partition(path_five, "a", 2).model_dump(mode="json")
+    payload["outcome"]["shrubs"][0]["upper_seed"] = "missing"
+    payload["outcome"]["shrubs"][0]["boundary_seeds"] = ["c", "missing"]
+
+    with pytest.raises(ValidationError, match="upper_seed must be a retained seed"):
+        RootedTreeFinePartition.model_validate(payload)
+
+
 @pytest.mark.parametrize(
     ("root", "size_limit", "code"),
     [

--- a/tests/math/graphs/rooted_trees/test_fine_partition.py
+++ b/tests/math/graphs/rooted_trees/test_fine_partition.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+from typing import cast
+
+import networkx as nx
+import pytest
+from pydantic import ValidationError
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.rooted_trees import (
+    RootedTreeFinePartition,
+    RootedTreeFinePartitionConstructed,
+    RootedTreeNotATree,
+    construct_fine_partition,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph_value(graph: nx.Graph[int]) -> SimpleUndirectedGraph:
+    labels = {vertex: f"v{vertex:02d}" for vertex in graph.nodes}
+    return SimpleUndirectedGraph(
+        vertices=tuple(sorted(labels.values())),
+        edges=tuple(
+            sorted(
+                (labels[left], labels[right])
+                if labels[left] < labels[right]
+                else (labels[right], labels[left])
+                for left, right in graph.edges
+            )
+        ),
+    )
+
+
+def _backend(graph: SimpleUndirectedGraph) -> nx.Graph[str]:
+    backend: nx.Graph[str] = nx.Graph()
+    backend.add_nodes_from(graph.vertices)
+    backend.add_edges_from(graph.edges)
+    return backend
+
+
+def _assert_fine_partition(result: RootedTreeFinePartition) -> None:
+    outcome = result.outcome
+    assert isinstance(outcome, RootedTreeFinePartitionConstructed)
+    graph = _backend(result.graph)
+    depths = nx.single_source_shortest_path_length(graph, result.root)
+    seeds_x = set(outcome.seeds_x)
+    seeds_y = set(outcome.seeds_y)
+    seeds = seeds_x | seeds_y
+
+    assert result.root in seeds_x
+    assert all(depths[seed] % 2 == 0 for seed in seeds_x)
+    assert all(depths[seed] % 2 == 1 for seed in seeds_y)
+    assert len(seeds_x) * result.component_size_limit <= 12 * (len(graph) - 1)
+    assert len(seeds_y) * result.component_size_limit <= 12 * (len(graph) - 1)
+
+    expected_components = {
+        frozenset(component)
+        for component in nx.connected_components(graph.subgraph(set(graph) - seeds))
+    }
+    assert {
+        frozenset(shrub.vertices) for shrub in outcome.shrubs
+    } == expected_components
+
+    reported_edges = set(outcome.seed_edges)
+    row_count = len(outcome.seed_edges)
+    for shrub in outcome.shrubs:
+        vertices = set(shrub.vertices)
+        boundary = set(shrub.boundary_seeds)
+        assert 1 <= len(vertices) <= result.component_size_limit
+        assert boundary
+        assert boundary <= seeds_x or boundary <= seeds_y
+        assert shrub.route_side == ("X" if boundary <= seeds_x else "Y")
+        assert set(shrub.edges) == {
+            tuple(sorted(edge)) for edge in graph.subgraph(vertices).edges
+        }
+        assert set(shrub.boundary_edges) == {
+            tuple(sorted((vertex, neighbor)))
+            for vertex in vertices
+            for neighbor in graph.neighbors(vertex)
+            if neighbor in seeds
+        }
+        route = nx.shortest_path(graph, shrub.root_vertex, result.root)
+        assert route[1] == shrub.upper_seed
+        reported_edges.update(shrub.edges)
+        reported_edges.update(shrub.boundary_edges)
+        row_count += len(shrub.edges) + len(shrub.boundary_edges)
+
+    assert reported_edges == set(result.graph.edges)
+    assert row_count == len(result.graph.edges)
+    assert (
+        RootedTreeFinePartition.model_validate_json(result.model_dump_json()) == result
+    )
+
+
+@pytest.fixture
+def path_five() -> SimpleUndirectedGraph:
+    return SimpleUndirectedGraph(
+        vertices=("a", "b", "c", "d", "e"),
+        edges=(("a", "b"), ("b", "c"), ("c", "d"), ("d", "e")),
+    )
+
+
+def test_path_partition_has_deterministic_source_bound_rows(
+    path_five: SimpleUndirectedGraph,
+) -> None:
+    result = construct_fine_partition(path_five, "a", 2)
+
+    assert isinstance(result.outcome, RootedTreeFinePartitionConstructed)
+    assert result.outcome.seeds_x == ("a", "c")
+    assert result.outcome.seeds_y == ()
+    assert result.outcome.seed_edges == ()
+    assert tuple(shrub.vertices for shrub in result.outcome.shrubs) == (
+        ("b",),
+        ("d", "e"),
+    )
+    assert result.outcome.shrubs[0].boundary_seeds == ("a", "c")
+    assert result.outcome.shrubs[0].upper_seed == "a"
+    assert result.outcome.shrubs[1].upper_seed == "c"
+    _assert_fine_partition(result)
+
+
+@pytest.mark.parametrize(("root", "size_limit"), [("c", 1), ("e", 2)])
+def test_path_partition_supports_different_roots_and_limits(
+    path_five: SimpleUndirectedGraph, root: str, size_limit: int
+) -> None:
+    _assert_fine_partition(construct_fine_partition(path_five, root, size_limit))
+
+
+def test_full_parity_repair_cuts_both_sides_of_an_internal_component() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("v00", "v01", "v02", "v03", "v04"),
+        edges=(
+            ("v00", "v01"),
+            ("v00", "v03"),
+            ("v01", "v02"),
+            ("v03", "v04"),
+        ),
+    )
+
+    result = construct_fine_partition(graph, "v02", 1)
+
+    assert isinstance(result.outcome, RootedTreeFinePartitionConstructed)
+    # v00 is the W3 repair seed: omitting it leaves opposite-parity boundary seeds.
+    assert result.outcome.seeds_x == ("v00", "v02")
+    assert result.outcome.seeds_y == ("v01", "v03")
+    assert tuple(shrub.boundary_seeds for shrub in result.outcome.shrubs) == (("v03",),)
+    _assert_fine_partition(result)
+
+
+@pytest.mark.parametrize("root", ["center", "leaf-a"])
+def test_star_partition_is_valid_for_different_declared_roots(root: str) -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("center", "leaf-a", "leaf-b", "leaf-c", "leaf-d"),
+        edges=(
+            ("center", "leaf-a"),
+            ("center", "leaf-b"),
+            ("center", "leaf-c"),
+            ("center", "leaf-d"),
+        ),
+    )
+
+    _assert_fine_partition(construct_fine_partition(graph, root, 1))
+
+
+def test_largest_component_limit_leaves_one_root_seed(
+    path_five: SimpleUndirectedGraph,
+) -> None:
+    result = construct_fine_partition(path_five, "a", len(path_five.vertices) - 1)
+
+    assert isinstance(result.outcome, RootedTreeFinePartitionConstructed)
+    assert result.outcome.seeds_x == ("a",)
+    assert result.outcome.seeds_y == ()
+    assert tuple(shrub.vertices for shrub in result.outcome.shrubs) == (
+        ("b", "c", "d", "e"),
+    )
+    _assert_fine_partition(result)
+
+
+def test_representation_order_does_not_change_the_constructed_outcome() -> None:
+    ordered = SimpleUndirectedGraph(
+        vertices=("a", "b", "c", "d", "e"),
+        edges=(("a", "b"), ("b", "c"), ("c", "d"), ("d", "e")),
+    )
+    permuted = SimpleUndirectedGraph(
+        vertices=("e", "c", "a", "d", "b"),
+        edges=(("d", "e"), ("b", "c"), ("a", "b"), ("c", "d")),
+    )
+
+    left = construct_fine_partition(ordered, "a", 2)
+    right = construct_fine_partition(permuted, "a", 2)
+
+    assert left.outcome == right.outcome
+
+
+def test_relabelling_preserves_the_contract_without_promising_the_same_cut() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("ant", "bee", "cat", "dog", "elk"),
+        edges=(("ant", "dog"), ("bee", "elk"), ("cat", "dog"), ("cat", "elk")),
+    )
+
+    _assert_fine_partition(construct_fine_partition(graph, "bee", 2))
+
+
+@pytest.mark.parametrize(
+    ("graph", "connected", "has_cycle", "component_count"),
+    [
+        (
+            SimpleUndirectedGraph(
+                vertices=("a", "b", "c"),
+                edges=(("a", "b"), ("a", "c"), ("b", "c")),
+            ),
+            True,
+            True,
+            1,
+        ),
+        (
+            SimpleUndirectedGraph(
+                vertices=("a", "b", "c", "d"),
+                edges=(("a", "b"), ("c", "d")),
+            ),
+            False,
+            False,
+            2,
+        ),
+    ],
+)
+def test_non_tree_inputs_return_source_bound_diagnostics(
+    graph: SimpleUndirectedGraph,
+    connected: bool,
+    has_cycle: bool,
+    component_count: int,
+) -> None:
+    result = construct_fine_partition(graph, graph.vertices[0], 1)
+
+    assert result.outcome == RootedTreeNotATree(
+        connected=connected,
+        has_cycle=has_cycle,
+        component_count=component_count,
+    )
+    assert (
+        RootedTreeFinePartition.model_validate_json(result.model_dump_json()) == result
+    )
+
+
+@pytest.mark.parametrize(
+    ("root", "size_limit", "code"),
+    [
+        ("missing", 1, "root_membership"),
+        ("a", 0, "component_size_limit"),
+        ("a", 5, "component_size_limit"),
+    ],
+)
+def test_semantic_admission_rejects_invalid_root_or_limit(
+    path_five: SimpleUndirectedGraph,
+    root: str,
+    size_limit: int,
+    code: str,
+) -> None:
+    with pytest.raises(OperationDomainValidationError) as caught:
+        construct_fine_partition(path_five, root, size_limit)
+
+    assert (
+        caught.value.errors()[0]["type"] == f"graph.rooted_tree.fine_partition.{code}"
+    )
+
+
+def test_empty_graph_is_rejected_before_backend_execution() -> None:
+    graph = SimpleUndirectedGraph(vertices=(), edges=())
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        construct_fine_partition(graph, "root", 1)
+
+    assert caught.value.errors()[0]["type"].endswith("nonempty_graph")
+
+
+def test_utf8_label_byte_boundary_is_admitted_before_construction() -> None:
+    accepted_label = "é" * 32
+    accepted = SimpleUndirectedGraph(
+        vertices=("root", accepted_label), edges=(("root", accepted_label),)
+    )
+    rejected_label = "é" * 33
+    rejected = SimpleUndirectedGraph(
+        vertices=("root", rejected_label), edges=(("root", rejected_label),)
+    )
+
+    _assert_fine_partition(construct_fine_partition(accepted, "root", 1))
+    with pytest.raises(OperationDomainValidationError) as caught:
+        construct_fine_partition(rejected, "root", 1)
+    assert caught.value.errors()[0]["type"].endswith("label_bytes")
+
+
+def test_unencodable_label_is_rejected_by_native_admission() -> None:
+    surrogate = "\ud800"
+    graph = SimpleUndirectedGraph(
+        vertices=("root", surrogate),
+        edges=(("root", surrogate),),
+    )
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        construct_fine_partition(graph, "root", 1)
+
+    assert caught.value.errors()[0]["type"].endswith("label_utf8")
+
+
+def test_empty_source_label_is_rejected_before_result_construction() -> None:
+    graph = SimpleUndirectedGraph(vertices=("", "root"), edges=(("", "root"),))
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        construct_fine_partition(graph, "root", 1)
+
+    assert caught.value.errors()[0]["type"].endswith("empty_label")
+
+
+def test_structural_result_parsing_rejects_an_empty_retained_source_label() -> None:
+    payload = {
+        "graph": {
+            "vertices": ["", "a", "b"],
+            "edges": [["", "a"], ["", "b"], ["a", "b"]],
+        },
+        "root": "a",
+        "component_size_limit": 1,
+        "outcome": {
+            "status": "NOT_A_TREE",
+            "connected": True,
+            "has_cycle": True,
+            "component_count": 1,
+        },
+    }
+
+    with pytest.raises(ValidationError, match="graph vertex labels must not be empty"):
+        RootedTreeFinePartition.model_validate(payload)
+
+
+def test_shared_maximum_order_path_is_admitted() -> None:
+    vertices = tuple(f"v{index:03d}" for index in range(256))
+    graph = SimpleUndirectedGraph(
+        vertices=vertices,
+        edges=tuple((vertices[index], vertices[index + 1]) for index in range(255)),
+    )
+
+    result = construct_fine_partition(graph, vertices[0], 255)
+
+    assert isinstance(result.outcome, RootedTreeFinePartitionConstructed)
+    assert result.outcome.seeds_x == (vertices[0],)
+    assert len(result.outcome.shrubs) == 1
+    assert len(result.outcome.shrubs[0].vertices) == 255
+    _assert_fine_partition(result)
+
+
+def test_retained_non_tree_must_fit_the_canonical_output_budget() -> None:
+    # NUL consumes one UTF-8 byte but six canonical JSON bytes, exercising the
+    # distinction between label-byte admission and the retained wire bound.
+    vertices = tuple(f"{index:03d}" + "\x00" * 61 for index in range(180))
+    graph = SimpleUndirectedGraph(
+        vertices=vertices,
+        edges=tuple(
+            (vertices[left], vertices[right])
+            for left in range(len(vertices))
+            for right in range(left + 1, len(vertices))
+        ),
+    )
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        construct_fine_partition(graph, vertices[0], 1)
+
+    assert caught.value.errors()[0]["type"].endswith("output_budget")
+
+
+def test_every_nonisomorphic_tree_through_order_seven_satisfies_contract() -> None:
+    checked = 0
+    for order in range(2, 8):
+        for backend in nx.generators.nonisomorphic_trees(order):
+            graph = _graph_value(cast("nx.Graph[int]", backend))
+            for root in graph.vertices:
+                for size_limit in range(1, order):
+                    _assert_fine_partition(
+                        construct_fine_partition(graph, root, size_limit)
+                    )
+                    checked += 1
+
+    assert checked == 734
+
+
+def test_catalog_example_executes_and_round_trips() -> None:
+    operation = Catalog.open().operation("graph.rooted_tree.fine_partition.construct")
+    assert operation is not None
+    assert len(operation.examples) == 1
+    request = operation.request_type.model_validate(operation.examples[0].input)
+
+    result = operation.run(request)
+
+    assert isinstance(result.outcome, RootedTreeFinePartitionConstructed)
+    assert operation.result_type.model_validate_json(result.model_dump_json()) == result

--- a/tests/math/graphs/rooted_trees/test_public_api.py
+++ b/tests/math/graphs/rooted_trees/test_public_api.py
@@ -1,0 +1,16 @@
+from jacobian.math.graphs import rooted_trees
+
+
+def test_exact_rooted_tree_public_api() -> None:
+    expected = (
+        "RootedTreeFinePartition",
+        "RootedTreeFinePartitionConstructed",
+        "RootedTreeNotATree",
+        "RootedTreeShrub",
+        "construct_fine_partition",
+    )
+
+    assert tuple(rooted_trees.__all__) == expected
+    assert len(rooted_trees.__all__) == len(set(rooted_trees.__all__))
+    assert all(hasattr(rooted_trees, name) for name in rooted_trees.__all__)
+    assert not hasattr(rooted_trees, "RootedTreeFinePartitionRequest")


### PR DESCRIPTION
## Problem

Jacobian can represent caller-supplied graph and tree-decomposition data, but it cannot construct the bounded seed-and-shrub decomposition used by rooted-tree embedding arguments. A caller would have to reproduce the tree cut, parity repair, boundary classification, and source reconstruction outside the typed operation boundary.

Closes #2912.

## Solution

Add `graph.rooted_tree.fine_partition.construct` for a nonempty `SimpleUndirectedGraph`, declared root, and `1 <= k < |V(T)|`.

For a tree, the kernel implements the constructive W1/W2/W3 cut from Hladký–Piguet, Lemma 5.3:

- postorder heavy-component cuts bound each residual shrub by `k`;
- branch vertices of attachment-spanning subtrees make the contracted structure path-like; and
- two even-depth parity cuts make every shrub boundary lie in one seed side.

The result retains the source graph, root, and `k`; both seed classes; every shrub's vertices, induced edges, boundary incidences, upper seed, rootward vertex, and routing side; and every seed-induced edge. Disconnected or cyclic inputs return a source-bound `NOT_A_TREE` diagnostic. The construction is deterministic for the supplied labels and root, without claiming relabelling-invariant canonicity.

NetworkX is used only for maintained connected-component recognition. The theorem-specific cut is a bounded, stateless owner kernel. Ordinary result parsing enforces cheap structural/canonical-row rules; the producer and mathematical tests, rather than an implicit Pydantic verifier, own the defining relation.

The focused diff adds seven files with 1,220 lines, including the operation, complete typed value, catalog declaration, and its owning tests.

Suggested review order:

1. `operations.py` for admission and the W1/W2/W3 construction.
2. `values.py` for the source-bound result and structural trust boundary.
3. `test_fine_partition.py` for reconstruction, theorem bounds, boundary cases, and exhaustive small-tree evidence.
4. `_tools.py` for the catalog declaration and example.

## Testing

Final commit `bdbfaa6c84f4456d1c6b4389fa0096d74dd151ad`:

```sh
make handoff LANE=math TESTS='tests/math/graphs/rooted_trees/test_fine_partition.py tests/math/graphs/rooted_trees/test_public_api.py'
make test-catalog PYTEST_DIAGNOSTIC_ARGS='--durations=0'
make test-integration TESTS=tests/integration/catalog/ PYTEST_DIAGNOSTIC_ARGS='--durations=0'
```

- repository Ruff, format, and MyPy checks passed;
- 24 focused rooted-tree tests passed;
- 113 catalog tests passed;
- 807 catalog integration/example tests passed.

The committed exhaustive test checks all 734 combinations of every nonisomorphic tree through order 7, every root, and every admissible `k`. Independent review extended that sweep through order 11 (40,796 combinations) without finding a counterexample. The UTF-8 regression was first reproduced as an uncaught `UnicodeEncodeError` and now returns the owner-specific `label_utf8` domain error.

- Specialist validation run: catalog and catalog-integration lanes above.

## Public contract impact

Adds one catalog operation, its strict request schema, the native `construct_fine_partition` function, and typed source-bound rooted-tree partition values under `jacobian.math.graphs.rooted_trees`.

## Operation boundary ownership

- Changed stage: request bounds, owner kernel, result construction, native API, and catalog publication.
- Request-bounds owner and controlling quantities: graphs; graph order/size, UTF-8 label bytes, retained source bytes, seed/shrub rows, classified edge rows, and boundary incidences.
- Work, intermediate, memory, and exact-output bounds: the shared graph carrier bounds `n <= 256`; graph scans are `O(n+m)`, lexical ordering adds sorting, and a constructed result is preflighted by `source_bytes + (6n-4) * max_encoded_label_bytes + 1024(n+1)` against the canonical output limit.
- Wall deadline, calibration workload, safety margin, and caller-selectable range: no additional wall deadline is needed for the bounded in-process tree traversal; `k` ranges from 1 through `n-1`.
- Backend or kernel path: NetworkX connected-component recognition plus the direct W1/W2/W3 tree-cut kernel.
- Result construction: trusted owner construction after one semantic admission pass; no independently supplied mathematical claim is accepted.
- Independent-result verifier: none. Tests replay the complete defining invariant; Pydantic parsing is structural.
- Native/MCP parity: the catalog adapter calls the exported native function with the same request values and result type.
- Serialized-result and round-trip evidence: constructed and `NOT_A_TREE` results round-trip through strict JSON; the advertised example executes through catalog integration.

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Advertised codomain is closed under the result types, including required parent, embedding, branch, orientation, basis, or coordinate data
- [x] Producer→consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: a nonempty finite simple tree, declared member root, and `1 <= k < n`; well-formed non-trees use the typed diagnostic branch.
- Structurally valid but mathematically invalid fixture and outcome: a triangle and a disconnected forest return exact `NOT_A_TREE` connectedness/cycle data; missing roots and invalid `k` reject before execution.
- Serialized-subtype trust boundary: trusted owner construction plus cheap structural parsing; serialized partitions are values, not independently verified claims.
- Exact-success defining invariant: seeds and shrub vertices partition `V(T)`; shrubs are exactly the components after seed deletion, have order at most `k`, and have one-side boundaries; the classified rows reconstruct every source edge exactly once; each seed class satisfies `|S|k <= 12(n-1)`.
- Discriminated result schema and impossible combinations: `CONSTRUCTED` and `NOT_A_TREE` are a strict status-discriminated union with branch-specific required fields.

## Catalog admission

- Concrete gap: no operation constructs a complete bounded rooted-tree seed/shrub partition.
- Why existing operations or typed values are insufficient: generic components and caller-supplied tree decompositions neither choose the simultaneous bounded/parity cut nor retain its rooted scheduling relations.
- Stable mathematical result: one complete source-bound fine partition, or an exact non-tree diagnostic.
- Semantic domain and admitted execution envelope: canonical finite simple graphs within the shared 256-vertex carrier, with tree-specific `k` and exact-output admission.
- Controlling work, intermediate, memory, and output quantities: `n`, `m`, label wire bytes, shrubs, boundary incidences, classified edge rows, and retained-source bytes.
- Exact representation, algorithm regimes, and maintained backend: explicit graph-labelled rows; NetworkX recognition; direct constructive theorem kernel.
- Remaining fixed caps and their classification: the existing 256-vertex and 64-byte-label representation caps; `k <= 255` follows from graph order.
- Motivating source request exercised through the public boundary: the small rooted-path example exercises the fine-partition move cited in #2912.
- Final-tree outcome for that request: a complete two-shrub partition with reconstructing boundary data.
- Effect of private normalization or presolve on admission: none; lexical ordering changes only deterministic presentation, not the retained source.
- Admission decision: admit the single operation.

## Closure matrix

None; #2912 requests one operation and defers Ramsey, regularity, and embedding workflows.

## Checklist

- [x] `make handoff LANE=... TESTS=...` passes
- [x] Explicitly relevant specialist validation is listed above
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (not applicable)
- [x] Catalog changes have an explicit owner-local `_tools.py` publication outcome
- [x] No compatibility aliases, forwarding modules, or generic `_operations.py` shadow paths were introduced
- [x] Runtime-bound changes name the request-bounds owner and execute the same semantic path for native and MCP callers
- [x] Result semantics distinguish exact and non-tree outcomes; no incomplete or operational condition is represented as a partition
- [x] Public operation changes include behavioral fixtures from the motivating request
- [x] New bounds include boundary and source-sized evidence
- [ ] New shared abstractions replace duplication in at least two surviving production paths (not applicable)
