### PR TITLE
Serialize python-flint precision contexts across requests

### DIFF
--- a/src/jacobian/_execution.py
+++ b/src/jacobian/_execution.py
@@ -6,6 +6,13 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, replace
+from typing import Protocol
+
+
+class RequestCancellationSignal(Protocol):
+    """Minimal cooperative cancellation signal bound to one request."""
+
+    def is_set(self) -> bool: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,6 +25,9 @@ class RequestExecution:
 
 _REQUEST_EXECUTION: ContextVar[RequestExecution | None] = ContextVar(
     "jacobian_request_execution", default=None
+)
+_REQUEST_CANCELLATION: ContextVar[RequestCancellationSignal | None] = ContextVar(
+    "jacobian_request_cancellation", default=None
 )
 
 
@@ -39,6 +49,30 @@ def current_request_execution() -> RequestExecution | None:
     return _REQUEST_EXECUTION.get()
 
 
+@contextmanager
+def request_cancellation(event: RequestCancellationSignal) -> Iterator[None]:
+    """Bind cooperative cancellation to the current request context."""
+
+    token = _REQUEST_CANCELLATION.set(event)
+    try:
+        yield
+    finally:
+        _REQUEST_CANCELLATION.reset(token)
+
+
+def current_request_cancellation() -> RequestCancellationSignal | None:
+    """Return the current request cancellation signal, if one is bound."""
+
+    return _REQUEST_CANCELLATION.get()
+
+
+def request_cancelled() -> bool:
+    """Report whether the current request has been cancelled."""
+
+    event = current_request_cancellation()
+    return event is not None and event.is_set()
+
+
 class OperationExecutionTimeoutError(TimeoutError):
     """The request-scoped owner envelope expired."""
 
@@ -58,8 +92,12 @@ def bind_request_deadline(deadline: float) -> None:
 __all__ = [
     "OperationExecutionCancelledError",
     "OperationExecutionTimeoutError",
+    "RequestCancellationSignal",
     "RequestExecution",
     "bind_request_deadline",
+    "current_request_cancellation",
     "current_request_execution",
+    "request_cancellation",
+    "request_cancelled",
     "request_execution",
 ]

--- a/src/jacobian/_flint.py
+++ b/src/jacobian/_flint.py
@@ -1,0 +1,59 @@
+"""Process-wide ownership of python-flint's mutable global context."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from threading import RLock
+from time import monotonic
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    current_request_execution,
+)
+
+_DEFAULT_CONTEXT_WAIT_SECONDS = 120.0
+_CONTEXT_LOCK = RLock()
+
+
+@contextmanager
+def flint_workprec(
+    precision_bits: int, *, deadline: float | None = None
+) -> Iterator[None]:
+    """Own python-flint's global precision context for one bounded scope.
+
+    ``deadline`` is an absolute ``time.monotonic`` instant. The earliest caller
+    or request deadline bounds lock acquisition. Callers without either get a
+    120-second lock-wait ceiling, matching existing bounded backend adapters.
+    """
+
+    execution = current_request_execution()
+    request_deadline = execution.deadline if execution is not None else None
+    if deadline is not None and request_deadline is not None:
+        wait_deadline = min(deadline, request_deadline)
+    elif deadline is not None:
+        wait_deadline = deadline
+    elif request_deadline is not None:
+        wait_deadline = request_deadline
+    else:
+        wait_deadline = monotonic() + _DEFAULT_CONTEXT_WAIT_SECONDS
+
+    remaining = wait_deadline - monotonic()
+    if remaining <= 0.0 or not _CONTEXT_LOCK.acquire(timeout=remaining):
+        raise OperationExecutionTimeoutError(
+            "execution deadline expired waiting for the python-flint precision context"
+        )
+    try:
+        from flint import ctx
+
+        if monotonic() >= wait_deadline:
+            raise OperationExecutionTimeoutError(
+                "execution deadline expired waiting for the python-flint precision context"
+            )
+        with ctx.workprec(precision_bits):
+            yield
+    finally:
+        _CONTEXT_LOCK.release()
+
+
+__all__ = ["flint_workprec"]

--- a/src/jacobian/_flint.py
+++ b/src/jacobian/_flint.py
@@ -14,7 +14,6 @@ from jacobian._execution import (
     request_cancelled,
 )
 
-_DEFAULT_CONTEXT_WAIT_SECONDS = 120.0
 _CONTEXT_LOCK_POLL_SECONDS = 0.1
 _CONTEXT_LOCK = RLock()
 
@@ -26,9 +25,9 @@ def flint_workprec(
     """Own python-flint's global precision context for one bounded scope.
 
     ``deadline`` is an absolute ``time.monotonic`` instant. The earliest caller
-    or request deadline bounds lock acquisition. Callers without either get a
-    120-second lock-wait ceiling, matching existing bounded backend adapters.
-    A bound request cancellation interrupts a queued acquisition.
+    or request deadline bounds lock acquisition. A bound request cancellation
+    interrupts a queued acquisition; callers without a deadline wait until the
+    context is available while continuing to poll cancellation.
     """
 
     execution = current_request_execution()
@@ -40,19 +39,24 @@ def flint_workprec(
     elif request_deadline is not None:
         wait_deadline = request_deadline
     else:
-        wait_deadline = monotonic() + _DEFAULT_CONTEXT_WAIT_SECONDS
+        wait_deadline = None
 
     while True:
         if request_cancelled():
             raise OperationExecutionCancelledError(
                 "operation cancelled waiting for the python-flint precision context"
             )
-        remaining = wait_deadline - monotonic()
-        if remaining <= 0.0:
+        remaining = wait_deadline - monotonic() if wait_deadline is not None else None
+        if remaining is not None and remaining <= 0.0:
             raise OperationExecutionTimeoutError(
                 "execution deadline expired waiting for the python-flint precision context"
             )
-        if _CONTEXT_LOCK.acquire(timeout=min(_CONTEXT_LOCK_POLL_SECONDS, remaining)):
+        poll_seconds = (
+            min(_CONTEXT_LOCK_POLL_SECONDS, remaining)
+            if remaining is not None
+            else _CONTEXT_LOCK_POLL_SECONDS
+        )
+        if _CONTEXT_LOCK.acquire(timeout=poll_seconds):
             break
     try:
         if request_cancelled():
@@ -61,7 +65,7 @@ def flint_workprec(
             )
         from flint import ctx
 
-        if monotonic() >= wait_deadline:
+        if wait_deadline is not None and monotonic() >= wait_deadline:
             raise OperationExecutionTimeoutError(
                 "execution deadline expired waiting for the python-flint precision context"
             )

--- a/src/jacobian/_flint.py
+++ b/src/jacobian/_flint.py
@@ -8,11 +8,13 @@ from threading import RLock
 from time import monotonic
 
 from jacobian._execution import (
+    OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
     current_request_execution,
 )
 
 _DEFAULT_CONTEXT_WAIT_SECONDS = 120.0
+_CONTEXT_LOCK_POLL_SECONDS = 0.1
 _CONTEXT_LOCK = RLock()
 
 
@@ -25,7 +27,10 @@ def flint_workprec(
     ``deadline`` is an absolute ``time.monotonic`` instant. The earliest caller
     or request deadline bounds lock acquisition. Callers without either get a
     120-second lock-wait ceiling, matching existing bounded backend adapters.
+    A bound request cancellation interrupts a queued acquisition.
     """
+
+    from jacobian.process import bounded_process_cancelled
 
     execution = current_request_execution()
     request_deadline = execution.deadline if execution is not None else None
@@ -38,12 +43,23 @@ def flint_workprec(
     else:
         wait_deadline = monotonic() + _DEFAULT_CONTEXT_WAIT_SECONDS
 
-    remaining = wait_deadline - monotonic()
-    if remaining <= 0.0 or not _CONTEXT_LOCK.acquire(timeout=remaining):
-        raise OperationExecutionTimeoutError(
-            "execution deadline expired waiting for the python-flint precision context"
-        )
+    while True:
+        if bounded_process_cancelled():
+            raise OperationExecutionCancelledError(
+                "operation cancelled waiting for the python-flint precision context"
+            )
+        remaining = wait_deadline - monotonic()
+        if remaining <= 0.0:
+            raise OperationExecutionTimeoutError(
+                "execution deadline expired waiting for the python-flint precision context"
+            )
+        if _CONTEXT_LOCK.acquire(timeout=min(_CONTEXT_LOCK_POLL_SECONDS, remaining)):
+            break
     try:
+        if bounded_process_cancelled():
+            raise OperationExecutionCancelledError(
+                "operation cancelled waiting for the python-flint precision context"
+            )
         from flint import ctx
 
         if monotonic() >= wait_deadline:

--- a/src/jacobian/_flint.py
+++ b/src/jacobian/_flint.py
@@ -11,6 +11,7 @@ from jacobian._execution import (
     OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
     current_request_execution,
+    request_cancelled,
 )
 
 _DEFAULT_CONTEXT_WAIT_SECONDS = 120.0
@@ -30,8 +31,6 @@ def flint_workprec(
     A bound request cancellation interrupts a queued acquisition.
     """
 
-    from jacobian.process import bounded_process_cancelled
-
     execution = current_request_execution()
     request_deadline = execution.deadline if execution is not None else None
     if deadline is not None and request_deadline is not None:
@@ -44,7 +43,7 @@ def flint_workprec(
         wait_deadline = monotonic() + _DEFAULT_CONTEXT_WAIT_SECONDS
 
     while True:
-        if bounded_process_cancelled():
+        if request_cancelled():
             raise OperationExecutionCancelledError(
                 "operation cancelled waiting for the python-flint precision context"
             )
@@ -56,7 +55,7 @@ def flint_workprec(
         if _CONTEXT_LOCK.acquire(timeout=min(_CONTEXT_LOCK_POLL_SECONDS, remaining)):
             break
     try:
-        if bounded_process_cancelled():
+        if request_cancelled():
             raise OperationExecutionCancelledError(
                 "operation cancelled waiting for the python-flint precision context"
             )

--- a/src/jacobian/math/analysis/_box_enclosure.py
+++ b/src/jacobian/math/analysis/_box_enclosure.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, Self
 
 from pydantic import Field, model_validator
 
+from jacobian._flint import flint_workprec
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationDomainValidationError
 from jacobian.math.analysis._arb import arb_source_interval, dyadic_endpoints
@@ -264,10 +265,8 @@ def _box_expression_enclosure(
             ),
         )
 
-    from flint import ctx
-
     try:
-        with ctx.workprec(request.precision_bits):
+        with flint_workprec(request.precision_bits):
             variables = {
                 variable: arb_source_interval(interval)
                 for variable, interval in zip(

--- a/src/jacobian/math/analysis/_definite_integral_enclosure.py
+++ b/src/jacobian/math/analysis/_definite_integral_enclosure.py
@@ -1,0 +1,1180 @@
+"""Rigorous definite-integral enclosures over exact rational partitions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from fractions import Fraction
+from itertools import pairwise
+from time import monotonic
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictInt, field_validator, model_validator
+
+from jacobian._exact import (
+    CanonicalRational,
+    canonical_rational_component_digits,
+)
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_cancelled,
+)
+from jacobian._flint import flint_workprec
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.canonical import (
+    CanonicalLimits,
+    canonicalize_json,
+    format_canonical_integer,
+)
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationDomainValidationError
+from jacobian.math.analysis._arb import arb_source_interval, dyadic_endpoints
+from jacobian.math.analysis._box_enclosure import (
+    _BoxEvaluationFailure,
+    _evaluate_box_expression,
+    _preflight_box_expression,
+)
+from jacobian.math.analysis._models import (
+    MAX_BOX_INTERMEDIATE_BITS,
+    MAX_DYADIC_MANTISSA_DIGITS,
+    MAX_EXPRESSION_NODES,
+    MAX_RATIONAL_DIGITS,
+    DyadicClosedInterval,
+    ExactDyadic,
+    IntervalExpressionDomainFailure,
+    IntervalExpressionNode,
+    RationalIntervalBox,
+    _bounded_expression_nodes,
+    _BoxPreflight,
+    _IntervalExpressionBoxRequest,
+    _rational_box_bounds,
+    _RationalBounds,
+    _validation_error,
+)
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+
+MAX_DEFINITE_INTEGRAL_LEAVES = 1_024
+MAX_DEFINITE_INTEGRAL_DEPTH = MAX_DEFINITE_INTEGRAL_LEAVES - 1
+MAX_DEFINITE_INTEGRAL_SUBPROBLEMS = 2 * MAX_DEFINITE_INTEGRAL_LEAVES - 1
+MAX_DEFINITE_INTEGRAL_NODE_WORK = (
+    2 * MAX_EXPRESSION_NODES * MAX_DEFINITE_INTEGRAL_SUBPROBLEMS
+)
+# This conservative node-bit ceiling admits a full 64-node/1,024-leaf request
+# through 2,048 bits, or a 32-node request through the 4,096-bit backend limit.
+MAX_DEFINITE_INTEGRAL_PRECISION_WORK = 268_435_456
+MAX_DEFINITE_INTEGRAL_SELECTION_COMPARISONS = (
+    MAX_DEFINITE_INTEGRAL_LEAVES * (MAX_DEFINITE_INTEGRAL_LEAVES - 1) // 2
+)
+MAX_DEFINITE_INTEGRAL_SUMMATION_UNITS = MAX_DEFINITE_INTEGRAL_LEAVES * (
+    MAX_DEFINITE_INTEGRAL_LEAVES + 1
+)
+MAX_DEFINITE_INTEGRAL_WALL_SECONDS = 120
+MAX_DEFINITE_INTEGRAL_RESULT_BYTES = CanonicalLimits().max_output_bytes
+
+# A retained rational preflight bound has at most 8,192 component bits. A source
+# endpoint has at most 128 decimal digits (< 4 * 128 bits), a midpoint path adds
+# at most 1,023 denominator bits, and a normalized 4,096-bit endpoint may shift
+# by its precision. The final sum adds at most ceil(log2(1,024)) magnitude bits.
+# This owner-local ceiling is therefore strictly below the ambient ExactDyadic
+# wire exponent and bounds every Fraction shift performed by result validation.
+MAX_DEFINITE_INTEGRAL_DYADIC_EXPONENT = (
+    MAX_BOX_INTERMEDIATE_BITS
+    + 4 * MAX_RATIONAL_DIGITS
+    + MAX_DEFINITE_INTEGRAL_DEPTH
+    + 4_096
+    + (MAX_DEFINITE_INTEGRAL_LEAVES - 1).bit_length()
+    + 4
+)
+MAX_DEFINITE_INTEGRAL_ACCUMULATOR_BITS = (
+    4_096
+    + 2 * MAX_DEFINITE_INTEGRAL_DYADIC_EXPONENT
+    + (MAX_DEFINITE_INTEGRAL_LEAVES - 1).bit_length()
+)
+
+
+class DefiniteIntegralEnclosureRequest(_IntervalExpressionBoxRequest):
+    """Enclose one definite integral over an exact one-dimensional box."""
+
+    target_width: ExactDyadic = Field(
+        description=(
+            "A nonnegative exact dyadic target for integral upper-lower; zero "
+            "requests an exact singleton enclosure."
+        )
+    )
+    max_leaves: StrictInt = Field(
+        default=32,
+        ge=1,
+        le=MAX_DEFINITE_INTEGRAL_LEAVES,
+        description=(
+            "Maximum leaves in the exact binary midpoint partition. This is the "
+            "only caller-selected partition budget."
+        ),
+    )
+    wall_seconds: StrictInt = Field(
+        default=30,
+        ge=1,
+        le=MAX_DEFINITE_INTEGRAL_WALL_SECONDS,
+        description=(
+            "Shared owner deadline in seconds, measured from dispatch start through "
+            "result construction."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def preserve_raw_request_limits(cls, value: object) -> object:
+        return canonicalize_json_containers(value)
+
+    @model_validator(mode="after")
+    def require_complete_named_source_axis(self) -> Self:
+        if len(self.box.variables) != 1:
+            raise _validation_error(
+                "definite integration requires exactly one named source variable"
+            )
+        used_variables: set[str] = set()
+        for node in _bounded_expression_nodes(self.expression):
+            if node.op != "var":
+                continue
+            if node.variable is None:
+                raise _validation_error(
+                    "definite-integral variable nodes must be named"
+                )
+            used_variables.add(node.variable)
+        if used_variables and used_variables != set(self.box.variables):
+            raise _validation_error(
+                "the expression's named variable must match the integration axis"
+            )
+        if int(self.target_width.mantissa) < 0:
+            raise _validation_error(
+                "definite-integral target width must be nonnegative"
+            )
+        return self
+
+
+class _IntegralLeafPath(StrictModel):
+    """One canonical address in the exact midpoint partition."""
+
+    path: tuple[StrictInt, ...] = Field(
+        max_length=MAX_DEFINITE_INTEGRAL_DEPTH,
+        description=(
+            "Binary child choices from the source interval; 0 is the lower and 1 "
+            "the upper exact-midpoint child."
+        ),
+    )
+
+    @field_validator("path", mode="before")
+    @classmethod
+    def preserve_bounded_path(cls, value: object) -> object:
+        if (
+            isinstance(value, (list, tuple))
+            and len(value) > MAX_DEFINITE_INTEGRAL_DEPTH
+        ):
+            raise _validation_error(
+                "definite-integral leaf path exceeds the partition-depth bound"
+            )
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def require_binary_path(self) -> Self:
+        if any(bit not in (0, 1) for bit in self.path):
+            raise _validation_error("definite-integral leaf paths contain only 0 and 1")
+        return self
+
+
+class DefiniteIntegralEnclosedLeaf(_IntegralLeafPath):
+    """One positive-measure leaf with a sound range and integral contribution."""
+
+    status: Literal["ENCLOSED"] = "ENCLOSED"
+    range_enclosure: DyadicClosedInterval
+    contribution: DyadicClosedInterval
+
+
+class DefiniteIntegralDomainUnprovenLeaf(_IntegralLeafPath):
+    """One leaf where bounded interval evaluation did not prove the real domain."""
+
+    status: Literal["DOMAIN_UNPROVEN"] = "DOMAIN_UNPROVEN"
+    domain_failure: IntervalExpressionDomainFailure
+
+
+class DefiniteIntegralZeroMeasureLeaf(_IntegralLeafPath):
+    """The unique degenerate source interval, whose integral is exactly zero."""
+
+    status: Literal["ZERO_MEASURE"] = "ZERO_MEASURE"
+    contribution: DyadicClosedInterval
+
+
+type DefiniteIntegralLeaf = Annotated[
+    DefiniteIntegralEnclosedLeaf
+    | DefiniteIntegralDomainUnprovenLeaf
+    | DefiniteIntegralZeroMeasureLeaf,
+    Field(discriminator="status"),
+]
+
+type DefiniteIntegralConcludedLeaf = Annotated[
+    DefiniteIntegralEnclosedLeaf | DefiniteIntegralZeroMeasureLeaf,
+    Field(discriminator="status"),
+]
+
+
+def _preserve_bounded_leaf_payload(value: object) -> object:
+    if isinstance(value, (list, tuple)):
+        if len(value) > MAX_DEFINITE_INTEGRAL_LEAVES:
+            raise _validation_error("definite-integral result exceeds its leaf bound")
+        for raw_leaf in value:
+            if isinstance(raw_leaf, Mapping):
+                path = raw_leaf.get("path")
+                if (
+                    isinstance(path, (list, tuple))
+                    and len(path) > MAX_DEFINITE_INTEGRAL_DEPTH
+                ):
+                    raise _validation_error(
+                        "definite-integral leaf path exceeds the partition-depth bound"
+                    )
+    return tuple(value) if isinstance(value, list) else value
+
+
+class DefiniteIntegralTargetMet(StrictModel):
+    """A sound final integral enclosure no wider than the requested target."""
+
+    status: Literal["TARGET_MET"] = "TARGET_MET"
+    enclosure: DyadicClosedInterval
+    leaves: tuple[DefiniteIntegralConcludedLeaf, ...] = Field(
+        min_length=1,
+        max_length=MAX_DEFINITE_INTEGRAL_LEAVES,
+        description=(
+            "Canonical path-ordered complete midpoint cover. Every retained leaf "
+            "carries its exact outward dyadic integral contribution."
+        ),
+    )
+
+    @field_validator("leaves", mode="before")
+    @classmethod
+    def preserve_bounded_leaves(cls, value: object) -> object:
+        return _preserve_bounded_leaf_payload(value)
+
+
+class DefiniteIntegralBudgetExhausted(StrictModel):
+    """A sound complete cover whose leaf budget did not meet the target."""
+
+    status: Literal["BUDGET_EXHAUSTED"] = "BUDGET_EXHAUSTED"
+    enclosure: DyadicClosedInterval
+    leaves: tuple[DefiniteIntegralConcludedLeaf, ...] = Field(
+        min_length=1,
+        max_length=MAX_DEFINITE_INTEGRAL_LEAVES,
+        description=(
+            "Canonical path-ordered complete midpoint cover. Every retained leaf "
+            "carries its exact outward dyadic integral contribution."
+        ),
+    )
+
+    @field_validator("leaves", mode="before")
+    @classmethod
+    def preserve_bounded_leaves(cls, value: object) -> object:
+        return _preserve_bounded_leaf_payload(value)
+
+
+class DefiniteIntegralDomainUnproven(StrictModel):
+    """A complete cover with no global conclusion because a leaf is unproven."""
+
+    status: Literal["DOMAIN_UNPROVEN"] = "DOMAIN_UNPROVEN"
+    leaves: tuple[DefiniteIntegralLeaf, ...] = Field(
+        min_length=1,
+        max_length=MAX_DEFINITE_INTEGRAL_LEAVES,
+        description=(
+            "Canonical path-ordered complete midpoint cover retaining every sound "
+            "contribution and every local domain-failure diagnostic."
+        ),
+    )
+
+    @field_validator("leaves", mode="before")
+    @classmethod
+    def preserve_bounded_leaves(cls, value: object) -> object:
+        return _preserve_bounded_leaf_payload(value)
+
+
+type DefiniteIntegralOutcome = Annotated[
+    DefiniteIntegralTargetMet
+    | DefiniteIntegralBudgetExhausted
+    | DefiniteIntegralDomainUnproven,
+    Field(discriminator="status"),
+]
+
+
+def _normalize_dyadic_pair(mantissa: int, exponent: int) -> tuple[int, int]:
+    if mantissa == 0:
+        return 0, 0
+    while mantissa % 2 == 0:
+        mantissa //= 2
+        exponent += 1
+    return mantissa, exponent
+
+
+def _exact_dyadic(mantissa: int, exponent: int) -> ExactDyadic:
+    mantissa, exponent = _normalize_dyadic_pair(mantissa, exponent)
+    if abs(exponent) > MAX_DEFINITE_INTEGRAL_DYADIC_EXPONENT:
+        raise _validation_error(
+            "definite-integral dyadic exponent exceeds the admitted source bound"
+        )
+    return ExactDyadic(mantissa=format_canonical_integer(mantissa), exponent=exponent)
+
+
+def _dyadic_fraction(value: ExactDyadic) -> Fraction:
+    if abs(value.exponent) > MAX_DEFINITE_INTEGRAL_DYADIC_EXPONENT:
+        raise _validation_error(
+            "definite-integral dyadic exponent exceeds the admitted source bound"
+        )
+    return value.as_fraction()
+
+
+def _floor_log2_abs(value: Fraction) -> int:
+    """Return floor(log2(abs(value))) without floating-point conversion."""
+
+    if value == 0:
+        raise ValueError("zero has no binary magnitude")
+    numerator = abs(value.numerator)
+    denominator = value.denominator
+    exponent = numerator.bit_length() - denominator.bit_length()
+    if exponent >= 0:
+        if numerator < denominator << exponent:
+            exponent -= 1
+    elif numerator << (-exponent) < denominator:
+        exponent -= 1
+    return exponent
+
+
+def _round_fraction_outward(
+    value: Fraction, precision_bits: int, *, toward_positive: bool
+) -> ExactDyadic:
+    """Round one rational outward to a deterministic significant-bit dyadic."""
+
+    if value == 0:
+        return ExactDyadic(mantissa="0", exponent=0)
+    exponent = _floor_log2_abs(value) - (precision_bits - 1)
+    if exponent >= 0:
+        scaled_numerator = value.numerator
+        scaled_denominator = value.denominator << exponent
+    else:
+        scaled_numerator = value.numerator << (-exponent)
+        scaled_denominator = value.denominator
+    if toward_positive:
+        mantissa = -((-scaled_numerator) // scaled_denominator)
+    else:
+        mantissa = scaled_numerator // scaled_denominator
+    return _exact_dyadic(mantissa, exponent)
+
+
+def _interval_width(interval: ClosedRationalInterval) -> Fraction:
+    return interval.upper.as_fraction() - interval.lower.as_fraction()
+
+
+def _enclosure_width(enclosure: DyadicClosedInterval) -> Fraction:
+    return _dyadic_fraction(enclosure.upper) - _dyadic_fraction(enclosure.lower)
+
+
+def _leaf_contribution(
+    interval: ClosedRationalInterval,
+    range_enclosure: DyadicClosedInterval,
+    precision_bits: int,
+) -> DyadicClosedInterval:
+    width = _interval_width(interval)
+    lower = width * _dyadic_fraction(range_enclosure.lower)
+    upper = width * _dyadic_fraction(range_enclosure.upper)
+    return DyadicClosedInterval(
+        lower=_round_fraction_outward(lower, precision_bits, toward_positive=False),
+        upper=_round_fraction_outward(upper, precision_bits, toward_positive=True),
+    )
+
+
+def _summed_enclosure(
+    contributions: tuple[DyadicClosedInterval, ...], precision_bits: int
+) -> DyadicClosedInterval:
+    lower = sum((_dyadic_fraction(value.lower) for value in contributions), Fraction())
+    upper = sum((_dyadic_fraction(value.upper) for value in contributions), Fraction())
+    return DyadicClosedInterval(
+        lower=_round_fraction_outward(lower, precision_bits, toward_positive=False),
+        upper=_round_fraction_outward(upper, precision_bits, toward_positive=True),
+    )
+
+
+def _compare_nonnegative_fraction_to_dyadic(
+    value: Fraction, dyadic: ExactDyadic
+) -> int:
+    """Compare a bounded nonnegative Fraction with a nonnegative dyadic safely."""
+
+    if value < 0 or int(dyadic.mantissa) < 0:
+        raise AssertionError("comparison operands must be nonnegative")
+    mantissa = int(dyadic.mantissa)
+    if value == 0 or mantissa == 0:
+        return (value > 0) - (mantissa > 0)
+    value_top = _floor_log2_abs(value)
+    dyadic_top = mantissa.bit_length() - 1 + dyadic.exponent
+    if value_top != dyadic_top:
+        return (value_top > dyadic_top) - (value_top < dyadic_top)
+    if dyadic.exponent >= 0:
+        right = value.denominator * (mantissa << dyadic.exponent)
+        left = value.numerator
+    else:
+        left = value.numerator << (-dyadic.exponent)
+        right = value.denominator * mantissa
+    return (left > right) - (left < right)
+
+
+def _target_met(enclosure: DyadicClosedInterval, target_width: ExactDyadic) -> bool:
+    return (
+        _compare_nonnegative_fraction_to_dyadic(
+            _enclosure_width(enclosure), target_width
+        )
+        <= 0
+    )
+
+
+def _split_interval(
+    interval: ClosedRationalInterval,
+) -> tuple[ClosedRationalInterval, ClosedRationalInterval]:
+    midpoint = CanonicalRational.from_fraction(
+        (interval.lower.as_fraction() + interval.upper.as_fraction()) / 2
+    )
+    return (
+        ClosedRationalInterval(lower=interval.lower, upper=midpoint),
+        ClosedRationalInterval(lower=midpoint, upper=interval.upper),
+    )
+
+
+def _interval_at_path(
+    source: ClosedRationalInterval, path: tuple[int, ...]
+) -> ClosedRationalInterval:
+    interval = source
+    for bit in path:
+        if _interval_width(interval) <= 0:
+            raise _validation_error(
+                "a positive-depth leaf cannot descend from a degenerate interval"
+            )
+        interval = _split_interval(interval)[bit]
+    return interval
+
+
+def _paths_are_complete(paths: tuple[tuple[int, ...], ...]) -> bool:
+    if not paths:
+        return False
+    for left, right in pairwise(paths):
+        if right[: len(left)] == left:
+            return False
+    depth = max(map(len, paths))
+    return sum(1 << (depth - len(path)) for path in paths) == 1 << depth
+
+
+def _bind_domain_failure_to_expression(
+    expression: IntervalExpressionNode,
+    failure: IntervalExpressionDomainFailure,
+) -> None:
+    node = expression
+    for child_index in failure.node_path:
+        if child_index >= len(node.children):
+            raise _validation_error(
+                "domain-failure node path does not exist in the source expression"
+            )
+        node = node.children[child_index]
+    if node.op != failure.operation:
+        raise _validation_error(
+            "domain-failure operation does not match the source expression node"
+        )
+    if failure.operation == "pow" and (node.exponent is None or node.exponent >= 0):
+        raise _validation_error(
+            "negative-power domain failure requires a negative source exponent"
+        )
+    if failure.reason == "SQRT_ARGUMENT_NOT_STRICTLY_POSITIVE_FOR_SECOND_JET":
+        raise _validation_error(
+            "second-jet differentiability evidence is not an integral-domain failure"
+        )
+
+
+def _bind_partition(
+    result: DefiniteIntegralEnclosureResult,
+    leaves: tuple[DefiniteIntegralLeaf, ...]
+    | tuple[DefiniteIntegralConcludedLeaf, ...],
+) -> None:
+    if len(leaves) > result.max_leaves:
+        raise _validation_error(
+            "definite-integral result exceeds the requested leaf budget"
+        )
+    paths = tuple(leaf.path for leaf in leaves)
+    if paths != tuple(sorted(paths)) or len(set(paths)) != len(paths):
+        raise _validation_error(
+            "definite-integral leaves must have unique lexicographically ordered paths"
+        )
+    if any(len(path) > result.max_leaves - 1 for path in paths):
+        raise _validation_error(
+            "definite-integral leaf exceeds the requested partition-depth bound"
+        )
+    if not _paths_are_complete(paths):
+        raise _validation_error(
+            "definite-integral leaf paths must be a complete prefix-free cover"
+        )
+
+    source = result.box.intervals[0]
+    source_is_degenerate = source.lower == source.upper
+    zero_leaves = tuple(
+        leaf for leaf in leaves if isinstance(leaf, DefiniteIntegralZeroMeasureLeaf)
+    )
+    if zero_leaves:
+        if not source_is_degenerate or len(leaves) != 1 or paths != ((),):
+            raise _validation_error(
+                "ZERO_MEASURE is reserved for the unique degenerate source leaf"
+            )
+        zero = zero_leaves[0].contribution
+        if int(zero.lower.mantissa) != 0 or int(zero.upper.mantissa) != 0:
+            raise _validation_error(
+                "the zero-measure contribution must be exactly zero"
+            )
+    elif source_is_degenerate:
+        raise _validation_error(
+            "a degenerate source interval requires its exact zero-measure leaf"
+        )
+    for leaf in leaves:
+        if isinstance(leaf, DefiniteIntegralDomainUnprovenLeaf):
+            _bind_domain_failure_to_expression(result.expression, leaf.domain_failure)
+
+
+class DefiniteIntegralEnclosureResult(DefiniteIntegralEnclosureRequest):
+    """A source-bound integral enclosure or a complete domain-unproven cover."""
+
+    outcome: DefiniteIntegralOutcome
+
+    @model_validator(mode="after")
+    def bind_partition_and_outcome_state(self) -> Self:
+        leaves = self.outcome.leaves
+        _bind_partition(self, leaves)
+        unproven = tuple(
+            leaf
+            for leaf in leaves
+            if isinstance(leaf, DefiniteIntegralDomainUnprovenLeaf)
+        )
+        if isinstance(self.outcome, DefiniteIntegralDomainUnproven):
+            if not unproven:
+                raise _validation_error(
+                    "DOMAIN_UNPROVEN requires at least one unproven final leaf"
+                )
+            if len(leaves) != self.max_leaves:
+                raise _validation_error(
+                    "DOMAIN_UNPROVEN requires exhausting the requested leaf cover"
+                )
+            return self
+
+        if unproven:
+            raise _validation_error(
+                "a domain-unproven leaf requires DOMAIN_UNPROVEN outcome"
+            )
+        if (
+            isinstance(self.outcome, DefiniteIntegralBudgetExhausted)
+            and len(leaves) != self.max_leaves
+        ):
+            raise _validation_error(
+                "BUDGET_EXHAUSTED requires filling the requested leaf budget"
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: DefiniteIntegralEnclosureRequest,
+        *,
+        outcome: DefiniteIntegralOutcome,
+    ) -> DefiniteIntegralEnclosureResult:
+        """Construct a result after the admitted kernel established every claim."""
+
+        return cls.model_construct(
+            expression=request.expression,
+            box=request.box,
+            precision_bits=request.precision_bits,
+            target_width=request.target_width,
+            max_leaves=request.max_leaves,
+            wall_seconds=request.wall_seconds,
+            outcome=outcome,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _DefiniteIntegralAdmission:
+    deadline: float
+    root_preflight: _BoxPreflight | None
+
+
+@dataclass(frozen=True, slots=True)
+class _EvaluatedIntegralLeaf:
+    path: tuple[int, ...]
+    interval: ClosedRationalInterval
+    domain_proven: bool
+    range_enclosure: DyadicClosedInterval | None = None
+    contribution: DyadicClosedInterval | None = None
+    domain_failure: IntervalExpressionDomainFailure | None = None
+    selection_width: Fraction = field(init=False)
+
+    def __post_init__(self) -> None:
+        enclosed = self.range_enclosure is not None and self.contribution is not None
+        unproven = self.domain_failure is not None
+        if enclosed == unproven or (self.range_enclosure is None) != (
+            self.contribution is None
+        ):
+            raise AssertionError("one evaluated leaf must carry exactly one outcome")
+        if enclosed and not self.domain_proven:
+            raise AssertionError(
+                "an enclosed leaf requires inherited exact domain proof"
+            )
+        source_width = _interval_width(self.interval)
+        if source_width <= 0:
+            raise AssertionError(
+                "an evaluated integral leaf must have positive measure"
+            )
+        selection_width = source_width
+        if enclosed:
+            assert self.range_enclosure is not None
+            selection_width *= _enclosure_width(self.range_enclosure)
+        object.__setattr__(self, "selection_width", selection_width)
+
+
+def _midpoint_component_digits(box: RationalIntervalBox, depth: int) -> int:
+    source_digits = max(
+        (
+            canonical_rational_component_digits(endpoint)
+            for interval in box.intervals
+            for endpoint in (interval.lower, interval.upper)
+        ),
+        default=1,
+    )
+    return 2 * source_digits + depth + 2
+
+
+def _estimated_result_bytes(request: DefiniteIntegralEnclosureRequest) -> int:
+    source_bytes = len(canonicalize_json(request.model_dump(mode="json")))
+    dyadic_interval_bytes = 2 * (MAX_DYADIC_MANTISSA_DIGITS + 64) + 64
+    path_bytes = 2 * (request.max_leaves - 1) + 32
+    enclosed_leaf_bytes = path_bytes + 2 * dyadic_interval_bytes + 256
+    return (
+        source_bytes
+        + request.max_leaves * enclosed_leaf_bytes
+        + dyadic_interval_bytes
+        + 8_192
+    )
+
+
+def _require_deadline(deadline: float, stage: str) -> None:
+    if request_cancelled():
+        raise OperationExecutionCancelledError(
+            f"definite-integral enclosure cancelled {stage}"
+        )
+    if monotonic() >= deadline:
+        raise OperationExecutionTimeoutError(
+            f"definite-integral enclosure deadline expired {stage}"
+        )
+
+
+def _admit_definite_integral(
+    request: DefiniteIntegralEnclosureRequest, *, started_at: float
+) -> _DefiniteIntegralAdmission:
+    deadline = started_at + request.wall_seconds
+    bind_request_deadline(deadline)
+    _require_deadline(deadline, "before semantic preflight")
+
+    nodes = _bounded_expression_nodes(request.expression)
+    maximum_subproblems = 2 * request.max_leaves - 1
+    node_work = 2 * len(nodes) * maximum_subproblems
+    if node_work > MAX_DEFINITE_INTEGRAL_NODE_WORK:
+        raise OperationDomainValidationError(
+            location=("max_leaves", "expression"),
+            code="analysis.definite_integral.node_work",
+            message=(
+                f"definite-integral work of {node_work} exact-and-Arb node units "
+                f"exceeds the {MAX_DEFINITE_INTEGRAL_NODE_WORK}-unit bound"
+            ),
+        )
+    precision_work = len(nodes) * maximum_subproblems * request.precision_bits
+    if precision_work > MAX_DEFINITE_INTEGRAL_PRECISION_WORK:
+        raise OperationDomainValidationError(
+            location=("precision_bits", "max_leaves", "expression"),
+            code="analysis.definite_integral.precision_work",
+            message=(
+                f"definite-integral precision work of {precision_work} node-bit "
+                f"units exceeds the {MAX_DEFINITE_INTEGRAL_PRECISION_WORK}-unit bound"
+            ),
+        )
+    selection_comparisons = request.max_leaves * (request.max_leaves - 1) // 2
+    if selection_comparisons > MAX_DEFINITE_INTEGRAL_SELECTION_COMPARISONS:
+        raise AssertionError("definite-integral selection accounting is inconsistent")
+    summation_units = request.max_leaves * (request.max_leaves + 1)
+    if summation_units > MAX_DEFINITE_INTEGRAL_SUMMATION_UNITS:
+        raise AssertionError("definite-integral summation accounting is inconsistent")
+    accumulator_bits = (
+        request.precision_bits
+        + 2 * MAX_DEFINITE_INTEGRAL_DYADIC_EXPONENT
+        + (request.max_leaves - 1).bit_length()
+    )
+    if accumulator_bits > MAX_DEFINITE_INTEGRAL_ACCUMULATOR_BITS:
+        raise OperationDomainValidationError(
+            location=("precision_bits", "max_leaves"),
+            code="analysis.definite_integral.accumulator_bits",
+            message=(
+                f"definite-integral exact-sum work of {accumulator_bits} bits "
+                f"exceeds the {MAX_DEFINITE_INTEGRAL_ACCUMULATOR_BITS}-bit bound"
+            ),
+        )
+    midpoint_digits = _midpoint_component_digits(request.box, request.max_leaves - 1)
+    if midpoint_digits > 2 * MAX_RATIONAL_DIGITS + MAX_DEFINITE_INTEGRAL_DEPTH + 2:
+        raise AssertionError("definite-integral midpoint accounting is inconsistent")
+    estimated_result_bytes = _estimated_result_bytes(request)
+    if estimated_result_bytes > MAX_DEFINITE_INTEGRAL_RESULT_BYTES:
+        raise OperationDomainValidationError(
+            location=("max_leaves",),
+            code="analysis.definite_integral.result_bytes",
+            message=(
+                f"definite-integral result estimate of {estimated_result_bytes} bytes "
+                f"exceeds the {MAX_DEFINITE_INTEGRAL_RESULT_BYTES}-byte canonical "
+                "output bound"
+            ),
+        )
+
+    source = request.box.intervals[0]
+    root_preflight: _BoxPreflight | None = None
+    if _interval_width(source) > 0:
+        try:
+            root_preflight = _preflight_box_expression(
+                request.expression, _rational_box_bounds(request.box)
+            )
+        except ValueError as exc:
+            raise OperationDomainValidationError(
+                location=("expression",),
+                code="analysis.definite_integral.intermediate_bound",
+                message=str(exc),
+            ) from exc
+    _require_deadline(deadline, "after semantic preflight")
+    return _DefiniteIntegralAdmission(
+        deadline=deadline,
+        root_preflight=root_preflight,
+    )
+
+
+def _leaf_box(
+    source: RationalIntervalBox, interval: ClosedRationalInterval
+) -> RationalIntervalBox:
+    return RationalIntervalBox(variables=source.variables, intervals=(interval,))
+
+
+def _evaluate_integral_leaf(
+    request: DefiniteIntegralEnclosureRequest,
+    path: tuple[int, ...],
+    interval: ClosedRationalInterval,
+    *,
+    deadline: float,
+    domain_proven: bool,
+    domain_failure: IntervalExpressionDomainFailure | None = None,
+) -> _EvaluatedIntegralLeaf:
+    if not domain_proven:
+        if domain_failure is None:
+            raise AssertionError("an unproved leaf requires domain-failure evidence")
+        return _EvaluatedIntegralLeaf(
+            path=path,
+            interval=interval,
+            domain_proven=False,
+            domain_failure=domain_failure,
+        )
+    if domain_failure is not None:
+        raise AssertionError("proved-domain input cannot carry failure evidence")
+
+    _require_deadline(deadline, "before an Arb leaf evaluation")
+    try:
+        with flint_workprec(request.precision_bits, deadline=deadline):
+            variables = {
+                request.box.variables[0]: arb_source_interval(interval),
+            }
+            result = _evaluate_box_expression(request.expression, variables)
+            if isinstance(result, IntervalExpressionDomainFailure):
+                return _EvaluatedIntegralLeaf(
+                    path=path,
+                    interval=interval,
+                    domain_proven=True,
+                    domain_failure=result,
+                )
+            if isinstance(result, _BoxEvaluationFailure) or not result.is_finite():
+                raise RuntimeError(
+                    "pinned Arb returned no finite integral-leaf enclosure"
+                )
+            lower_mantissa, lower_exponent = result.lower().man_exp()
+            upper_mantissa, upper_exponent = result.upper().man_exp()
+            endpoints = dyadic_endpoints(
+                lower_mantissa,
+                lower_exponent,
+                upper_mantissa,
+                upper_exponent,
+            )
+    except (OverflowError, ValueError, ZeroDivisionError) as exc:
+        raise RuntimeError(
+            "pinned Arb rejected an admitted integral-leaf evaluation"
+        ) from exc
+    _require_deadline(deadline, "after an Arb leaf evaluation")
+    if endpoints is None or any(
+        abs(endpoint.exponent) > MAX_DEFINITE_INTEGRAL_DYADIC_EXPONENT
+        for endpoint in endpoints
+    ):
+        raise RuntimeError(
+            "pinned Arb produced an integral endpoint outside the admitted dyadic "
+            "source envelope"
+        )
+    range_enclosure = DyadicClosedInterval(lower=endpoints[0], upper=endpoints[1])
+    leaf = _EvaluatedIntegralLeaf(
+        path=path,
+        interval=interval,
+        domain_proven=True,
+        range_enclosure=range_enclosure,
+        contribution=_leaf_contribution(
+            interval, range_enclosure, request.precision_bits
+        ),
+    )
+    _require_deadline(deadline, "after leaf contribution construction")
+    return leaf
+
+
+def _refine_unproven_integral_leaf(
+    request: DefiniteIntegralEnclosureRequest,
+    path: tuple[int, ...],
+    interval: ClosedRationalInterval,
+    *,
+    inherited_failure: IntervalExpressionDomainFailure,
+    deadline: float,
+) -> _EvaluatedIntegralLeaf:
+    """Try to discharge an exact domain obstruction without reopening admission."""
+
+    _require_deadline(deadline, "before a leaf domain refinement")
+    try:
+        preflight = _preflight_box_expression(
+            request.expression,
+            _rational_box_bounds(_leaf_box(request.box, interval)),
+        )
+    except ValueError:
+        # Admission already charged this bounded probe. If its retained exact
+        # interval reaches the intermediate ceiling, the inherited obligation
+        # remains unproved rather than becoming a late request rejection.
+        preflight = inherited_failure
+    _require_deadline(deadline, "after a leaf domain refinement")
+    if isinstance(preflight, IntervalExpressionDomainFailure):
+        return _evaluate_integral_leaf(
+            request,
+            path,
+            interval,
+            deadline=deadline,
+            domain_proven=False,
+            domain_failure=preflight,
+        )
+    assert isinstance(preflight, _RationalBounds)
+    return _evaluate_integral_leaf(
+        request,
+        path,
+        interval,
+        deadline=deadline,
+        domain_proven=True,
+    )
+
+
+def _public_leaves(
+    leaves: tuple[_EvaluatedIntegralLeaf, ...],
+) -> tuple[DefiniteIntegralLeaf, ...]:
+    if any(left.path >= right.path for left, right in pairwise(leaves)):
+        raise AssertionError("the kernel must retain lexicographic leaf order")
+    public: list[DefiniteIntegralLeaf] = []
+    for leaf in leaves:
+        if leaf.domain_failure is not None:
+            public.append(
+                DefiniteIntegralDomainUnprovenLeaf(
+                    path=leaf.path, domain_failure=leaf.domain_failure
+                )
+            )
+            continue
+        assert leaf.range_enclosure is not None and leaf.contribution is not None
+        public.append(
+            DefiniteIntegralEnclosedLeaf(
+                path=leaf.path,
+                range_enclosure=leaf.range_enclosure,
+                contribution=leaf.contribution,
+            )
+        )
+    return tuple(public)
+
+
+def _finish_result(
+    request: DefiniteIntegralEnclosureRequest,
+    public_leaves: tuple[DefiniteIntegralLeaf, ...],
+    *,
+    enclosure: DyadicClosedInterval | None,
+    deadline: float,
+) -> DefiniteIntegralEnclosureResult:
+    if any(
+        isinstance(leaf, DefiniteIntegralDomainUnprovenLeaf) for leaf in public_leaves
+    ):
+        assert enclosure is None
+        result = DefiniteIntegralEnclosureResult._from_kernel(
+            request,
+            outcome=DefiniteIntegralDomainUnproven(leaves=public_leaves),
+        )
+    else:
+        assert enclosure is not None
+        concluded_leaves = tuple(
+            leaf
+            for leaf in public_leaves
+            if isinstance(
+                leaf,
+                (DefiniteIntegralEnclosedLeaf, DefiniteIntegralZeroMeasureLeaf),
+            )
+        )
+        assert len(concluded_leaves) == len(public_leaves)
+        outcome: DefiniteIntegralTargetMet | DefiniteIntegralBudgetExhausted
+        if _target_met(enclosure, request.target_width):
+            outcome = DefiniteIntegralTargetMet(
+                enclosure=enclosure, leaves=concluded_leaves
+            )
+        else:
+            outcome = DefiniteIntegralBudgetExhausted(
+                enclosure=enclosure, leaves=concluded_leaves
+            )
+        result = DefiniteIntegralEnclosureResult._from_kernel(
+            request,
+            outcome=outcome,
+        )
+    _require_deadline(deadline, "after result construction")
+    return result
+
+
+def _finish_zero_measure_result(
+    request: DefiniteIntegralEnclosureRequest, *, deadline: float
+) -> DefiniteIntegralEnclosureResult:
+    zero = DyadicClosedInterval(
+        lower=ExactDyadic(mantissa="0", exponent=0),
+        upper=ExactDyadic(mantissa="0", exponent=0),
+    )
+    result = DefiniteIntegralEnclosureResult._from_kernel(
+        request,
+        outcome=DefiniteIntegralTargetMet(
+            enclosure=zero,
+            leaves=(DefiniteIntegralZeroMeasureLeaf(path=(), contribution=zero),),
+        ),
+    )
+    _require_deadline(deadline, "after result construction")
+    return result
+
+
+def _select_leaf(leaves: tuple[_EvaluatedIntegralLeaf, ...]) -> int:
+    """Return the deterministic highest-priority leaf index in one linear scan."""
+
+    if not leaves:
+        raise AssertionError("leaf selection requires a nonempty partition")
+    selected_index = 0
+    for candidate_index in range(1, len(leaves)):
+        candidate = leaves[candidate_index]
+        selected = leaves[selected_index]
+        candidate_unproven = candidate.domain_failure is not None
+        selected_unproven = selected.domain_failure is not None
+        if candidate_unproven != selected_unproven:
+            if candidate_unproven:
+                selected_index = candidate_index
+            continue
+        if candidate.selection_width > selected.selection_width or (
+            candidate.selection_width == selected.selection_width
+            and candidate.path < selected.path
+        ):
+            selected_index = candidate_index
+    return selected_index
+
+
+def _compute_definite_integral_enclosure(
+    request: DefiniteIntegralEnclosureRequest,
+) -> DefiniteIntegralEnclosureResult:
+    execution = current_request_execution()
+    started_at = execution.started_at if execution is not None else monotonic()
+    admission = _admit_definite_integral(request, started_at=started_at)
+    source = request.box.intervals[0]
+    if _interval_width(source) == 0:
+        return _finish_zero_measure_result(request, deadline=admission.deadline)
+
+    root_preflight = admission.root_preflight
+    assert root_preflight is not None
+    leaves: tuple[_EvaluatedIntegralLeaf, ...] = (
+        _evaluate_integral_leaf(
+            request,
+            (),
+            source,
+            deadline=admission.deadline,
+            domain_proven=isinstance(root_preflight, _RationalBounds),
+            domain_failure=(
+                root_preflight
+                if isinstance(root_preflight, IntervalExpressionDomainFailure)
+                else None
+            ),
+        ),
+    )
+    while True:
+        _require_deadline(admission.deadline, "before partition refinement")
+        has_unproven = any(leaf.domain_failure is not None for leaf in leaves)
+        enclosure: DyadicClosedInterval | None = None
+        if not has_unproven:
+            contributions = tuple(
+                leaf.contribution for leaf in leaves if leaf.contribution is not None
+            )
+            assert len(contributions) == len(leaves)
+            enclosure = _summed_enclosure(contributions, request.precision_bits)
+            _require_deadline(admission.deadline, "after exact leaf summation")
+            if _target_met(enclosure, request.target_width):
+                public = _public_leaves(leaves)
+                _require_deadline(admission.deadline, "after leaf result construction")
+                return _finish_result(
+                    request,
+                    public,
+                    enclosure=enclosure,
+                    deadline=admission.deadline,
+                )
+        if len(leaves) >= request.max_leaves:
+            public = _public_leaves(leaves)
+            _require_deadline(admission.deadline, "after leaf result construction")
+            return _finish_result(
+                request,
+                public,
+                enclosure=enclosure,
+                deadline=admission.deadline,
+            )
+
+        selected_index = _select_leaf(leaves)
+        selected = leaves[selected_index]
+        child_intervals = _split_interval(selected.interval)
+        if selected.domain_proven:
+            lower = _evaluate_integral_leaf(
+                request,
+                (*selected.path, 0),
+                child_intervals[0],
+                deadline=admission.deadline,
+                domain_proven=True,
+            )
+        else:
+            assert selected.domain_failure is not None
+            lower = _refine_unproven_integral_leaf(
+                request,
+                (*selected.path, 0),
+                child_intervals[0],
+                inherited_failure=selected.domain_failure,
+                deadline=admission.deadline,
+            )
+        _require_deadline(admission.deadline, "between child evaluations")
+        if selected.domain_proven:
+            upper = _evaluate_integral_leaf(
+                request,
+                (*selected.path, 1),
+                child_intervals[1],
+                deadline=admission.deadline,
+                domain_proven=True,
+            )
+        else:
+            assert selected.domain_failure is not None
+            upper = _refine_unproven_integral_leaf(
+                request,
+                (*selected.path, 1),
+                child_intervals[1],
+                inherited_failure=selected.domain_failure,
+                deadline=admission.deadline,
+            )
+        leaves = (
+            *leaves[:selected_index],
+            lower,
+            upper,
+            *leaves[selected_index + 1 :],
+        )
+
+
+DEFINITE_INTEGRAL_ENCLOSURE_OPERATIONS = (
+    MathTool(
+        operation_id="interval.expression.definite_integral_enclosure.compute",
+        title="Enclose the definite integral of an elementary expression",
+        description=(
+            "Return an outward-rounded dyadic enclosure of one definite integral "
+            "over an exact rational interval. Each leaf uses pinned Arb natural "
+            "interval arithmetic; exact rational leaf width times its range is "
+            "rounded outward and all contributions are summed exactly before one "
+            "final outward conversion. Binary midpoint paths identify the complete "
+            "deterministic cover. DOMAIN_UNPROVEN means bounded interval evaluation "
+            "left at least one real-domain obligation unproved and carries no integral "
+            "conclusion. BUDGET_EXHAUSTED retains a sound enclosure after filling "
+            "the requested leaf budget. The envelope admits at most "
+            f"{MAX_DEFINITE_INTEGRAL_LEAVES:,} leaves, "
+            f"{MAX_DEFINITE_INTEGRAL_SUBPROBLEMS:,} subproblems, "
+            f"{MAX_DEFINITE_INTEGRAL_NODE_WORK:,} exact-and-Arb node units, "
+            f"{MAX_DEFINITE_INTEGRAL_PRECISION_WORK:,} precision-weighted node-bit "
+            "units, "
+            f"{MAX_DEFINITE_INTEGRAL_SELECTION_COMPARISONS:,} deterministic "
+            "leaf-selection comparisons, "
+            f"{MAX_DEFINITE_INTEGRAL_SUMMATION_UNITS:,} exact dyadic endpoint-add "
+            "units, 4,096 Arb precision bits, and one complete result within the "
+            "10 MiB canonical output bound."
+        ),
+        request_type=DefiniteIntegralEnclosureRequest,
+        result_type=DefiniteIntegralEnclosureResult,
+        run=_compute_definite_integral_enclosure,
+        tags=(
+            "analysis",
+            "interval",
+            "expression",
+            "integral",
+            "definite-integral",
+            "adaptive",
+            "partition",
+            "arb",
+            "validated",
+            "bounded",
+        ),
+        examples=(
+            example(
+                "linear_unit_interval",
+                (
+                    "Enclose the integral of t over 0 <= t <= 1 until width 1/4; "
+                    "the expression and one-axis box must name the same variable."
+                ),
+                {
+                    "expression": {"op": "var", "variable": "t"},
+                    "box": {
+                        "variables": ["t"],
+                        "intervals": [
+                            {
+                                "lower": {"num": "0", "den": "1"},
+                                "upper": {"num": "1", "den": "1"},
+                            }
+                        ],
+                    },
+                    "precision_bits": 128,
+                    "target_width": {"mantissa": "1", "exponent": -2},
+                    "max_leaves": 8,
+                    "wall_seconds": 30,
+                },
+            ),
+        ),
+    ),
+)
+
+
+__all__ = [
+    "DEFINITE_INTEGRAL_ENCLOSURE_OPERATIONS",
+    "MAX_DEFINITE_INTEGRAL_ACCUMULATOR_BITS",
+    "MAX_DEFINITE_INTEGRAL_DEPTH",
+    "MAX_DEFINITE_INTEGRAL_DYADIC_EXPONENT",
+    "MAX_DEFINITE_INTEGRAL_LEAVES",
+    "MAX_DEFINITE_INTEGRAL_NODE_WORK",
+    "MAX_DEFINITE_INTEGRAL_PRECISION_WORK",
+    "MAX_DEFINITE_INTEGRAL_RESULT_BYTES",
+    "MAX_DEFINITE_INTEGRAL_SELECTION_COMPARISONS",
+    "MAX_DEFINITE_INTEGRAL_SUBPROBLEMS",
+    "MAX_DEFINITE_INTEGRAL_SUMMATION_UNITS",
+    "MAX_DEFINITE_INTEGRAL_WALL_SECONDS",
+    "DefiniteIntegralBudgetExhausted",
+    "DefiniteIntegralDomainUnproven",
+    "DefiniteIntegralDomainUnprovenLeaf",
+    "DefiniteIntegralEnclosedLeaf",
+    "DefiniteIntegralEnclosureRequest",
+    "DefiniteIntegralEnclosureResult",
+    "DefiniteIntegralTargetMet",
+    "DefiniteIntegralZeroMeasureLeaf",
+]

--- a/src/jacobian/math/analysis/_point_enclosure.py
+++ b/src/jacobian/math/analysis/_point_enclosure.py
@@ -8,6 +8,7 @@ from typing import Literal, Self
 from pydantic import ConfigDict, Field, StrictInt, model_validator
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._flint import flint_workprec
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.analysis._arb import dyadic_endpoints
@@ -304,10 +305,10 @@ def _point_enclosure(request: ArbPointEnclosureRequest) -> ArbPointEnclosureResu
             message=str(exc),
         ) from exc
 
-    from flint import arb, ctx, fmpq
+    from flint import arb, fmpq
 
     numerator, denominator = request.argument.as_integer_ratio()
-    with ctx.workprec(request.precision_bits):
+    with flint_workprec(request.precision_bits):
         value = arb(fmpq(numerator, denominator))
         result = getattr(value, request.function.value.lower())()
         if not result.is_finite():
@@ -321,6 +322,7 @@ def _point_enclosure(request: ArbPointEnclosureRequest) -> ArbPointEnclosureResu
         lower_mantissa, lower_exponent = result.lower().man_exp()
         upper_mantissa, upper_exponent = result.upper().man_exp()
         exact = bool(result.is_exact())
+        relative_accuracy_bits = None if exact else int(result.rel_accuracy_bits())
         endpoints = dyadic_endpoints(
             lower_mantissa, lower_exponent, upper_mantissa, upper_exponent
         )
@@ -344,7 +346,7 @@ def _point_enclosure(request: ArbPointEnclosureRequest) -> ArbPointEnclosureResu
             lower=endpoints[0],
             upper=endpoints[1],
         ),
-        relative_accuracy_bits=None if exact else int(result.rel_accuracy_bits()),
+        relative_accuracy_bits=relative_accuracy_bits,
         exact=exact,
         detail="Pinned Arb ball arithmetic returned an outward-rounded enclosure with exact dyadic endpoints.",
     )

--- a/src/jacobian/math/analysis/_tools.py
+++ b/src/jacobian/math/analysis/_tools.py
@@ -3,6 +3,9 @@
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools
 from jacobian.math.analysis._box_enclosure import BOX_EXPRESSION_ENCLOSURE_OPERATIONS
+from jacobian.math.analysis._definite_integral_enclosure import (
+    DEFINITE_INTEGRAL_ENCLOSURE_OPERATIONS,
+)
 from jacobian.math.analysis._expression_enclosure import (
     IntervalExpressionEnclosureRequest,
     IntervalExpressionEnclosureResult,
@@ -217,6 +220,7 @@ TOOLS: MathTools = (
     *POINT_ENCLOSURE_OPERATIONS,
     *EXPRESSION_ENCLOSURE_OPERATIONS,
     *BOX_EXPRESSION_ENCLOSURE_OPERATIONS,
+    *DEFINITE_INTEGRAL_ENCLOSURE_OPERATIONS,
     *SECOND_JET_ENCLOSURE_OPERATIONS,
 )
 

--- a/src/jacobian/math/analysis/operations.py
+++ b/src/jacobian/math/analysis/operations.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from typing import Any
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._flint import flint_workprec
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.analysis._arb import arb_source_interval, dyadic_endpoints
 from jacobian.math.analysis._expression_enclosure import (
@@ -133,10 +134,10 @@ def expression_enclosure(
             code="analysis.expression.named_variable",
             message="point-enclosure variable nodes must remain anonymous",
         )
-    from flint import arb, ctx, fmpq
+    from flint import arb, fmpq
 
     numerator, denominator = argument.as_integer_ratio()
-    with ctx.workprec(precision_bits):
+    with flint_workprec(precision_bits):
         result = _evaluate_expression(expression, arb(fmpq(numerator, denominator)))
         if isinstance(result, _EvaluationFailure):
             return IntervalExpressionEnclosureResult(
@@ -161,6 +162,7 @@ def expression_enclosure(
         lower_mantissa, lower_exponent = result.lower().man_exp()
         upper_mantissa, upper_exponent = result.upper().man_exp()
         exact = bool(result.is_exact())
+        relative_accuracy_bits = None if exact else int(result.rel_accuracy_bits())
         endpoints = dyadic_endpoints(
             lower_mantissa, lower_exponent, upper_mantissa, upper_exponent
         )
@@ -175,7 +177,7 @@ def expression_enclosure(
         precision_bits=precision_bits,
         lower=endpoints[0],
         upper=endpoints[1],
-        relative_accuracy_bits=None if exact else int(result.rel_accuracy_bits()),
+        relative_accuracy_bits=relative_accuracy_bits,
         exact=exact,
         detail="Arb returned an outward-rounded enclosure with exact dyadic endpoints.",
     )
@@ -466,9 +468,7 @@ def second_jet_enclosure(
         )
 
     try:
-        from flint import ctx
-
-        with ctx.workprec(precision_bits):
+        with flint_workprec(precision_bits):
             variables = {
                 variable: arb_source_interval(interval)
                 for variable, interval in zip(box.variables, box.intervals, strict=True)

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -15,6 +15,7 @@ from jacobian._exact import (
     CanonicalRational,
     require_bounded_rational,
 )
+from jacobian._flint import flint_workprec
 from jacobian._models import StrictModel
 from jacobian.canonical import encode_strict_json, format_canonical_integer
 
@@ -1162,9 +1163,9 @@ def _compare_euclidean_root_sums(
 
     if left == right:
         return 0
-    from flint import arb, ctx, fmpq
+    from flint import arb, fmpq
 
-    with ctx.workprec(EUCLIDEAN_TRIANGULATION_COMPARISON_PRECISION_BITS):
+    with flint_workprec(EUCLIDEAN_TRIANGULATION_COMPARISON_PRECISION_BITS):
         difference = arb(0)
         for value in left:
             difference += arb(fmpq(value.numerator, value.denominator)).sqrt()

--- a/src/jacobian/math/matrices/quadratic_spectral/operations.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/operations.py
@@ -7,6 +7,7 @@ from fractions import Fraction
 from math import gcd
 from typing import TYPE_CHECKING, Literal
 
+from jacobian._flint import flint_workprec
 from jacobian.canonical import format_canonical_integer
 from jacobian.math._root_isolation import strict_root_count
 from jacobian.math.matrices.quadratic_spectral._bounds import (
@@ -290,37 +291,33 @@ def _branch_balls(
     determinant: Quadratic,
     spectrum_kind: SpectrumKind,
     radicand: int,
-    precision: int,
     repeated: bool,
 ) -> dict[Branch, arb] | None:
-    from flint import ctx
-
-    with ctx.workprec(precision):
-        trace_ball = _arb_quadratic(trace, radicand)
-        if repeated:
-            repeated_ball = trace_ball / 2
-            if spectrum_kind == "SINGULAR_VALUES":
-                if not repeated_ball > 0:
-                    return None
-                repeated_ball = repeated_ball.sqrt()
-            return {"REPEATED": repeated_ball}
-        determinant_ball = _arb_quadratic(determinant, radicand)
-        discriminant_ball = trace_ball * trace_ball - 4 * determinant_ball
-        if not discriminant_ball > 0:
-            return None
-        root = discriminant_ball.sqrt()
-        upper = (trace_ball + root) / 2
-        lower_candidate = (trace_ball - root) / 2
-        lower_ball: arb | None = lower_candidate
+    trace_ball = _arb_quadratic(trace, radicand)
+    if repeated:
+        repeated_ball = trace_ball / 2
         if spectrum_kind == "SINGULAR_VALUES":
-            if not upper > 0:
+            if not repeated_ball > 0:
                 return None
-            upper = upper.sqrt()
-            lower_ball = lower_candidate.sqrt() if lower_candidate > 0 else None
-        result: dict[Branch, arb] = {"UPPER": upper}
-        if lower_ball is not None:
-            result["LOWER"] = lower_ball
-        return result
+            repeated_ball = repeated_ball.sqrt()
+        return {"REPEATED": repeated_ball}
+    determinant_ball = _arb_quadratic(determinant, radicand)
+    discriminant_ball = trace_ball * trace_ball - 4 * determinant_ball
+    if not discriminant_ball > 0:
+        return None
+    root = discriminant_ball.sqrt()
+    upper = (trace_ball + root) / 2
+    lower_candidate = (trace_ball - root) / 2
+    lower_ball: arb | None = lower_candidate
+    if spectrum_kind == "SINGULAR_VALUES":
+        if not upper > 0:
+            return None
+        upper = upper.sqrt()
+        lower_ball = lower_candidate.sqrt() if lower_candidate > 0 else None
+    result: dict[Branch, arb] = {"UPPER": upper}
+    if lower_ball is not None:
+        result["LOWER"] = lower_ball
+    return result
 
 
 def _select_nonrational_branches(
@@ -333,27 +330,27 @@ def _select_nonrational_branches(
 ) -> dict[Branch, _RootData]:
     precision = 128
     while precision <= _MAX_ARB_PRECISION_BITS:
-        balls = _branch_balls(
-            trace,
-            determinant,
-            spectrum_kind,
-            radicand,
-            precision,
-            repeated=missing == ("REPEATED",),
-        )
-        if balls is not None:
-            selected: dict[Branch, _RootData] = {}
-            for branch in missing:
-                ball = balls.get(branch)
-                if ball is None:
-                    break
-                matches = [root for root in roots if _strictly_inside(ball, root)]
-                if len(matches) != 1:
-                    break
-                selected[branch] = matches[0]
-            else:
-                if len({row.value for row in selected.values()}) == len(selected):
-                    return selected
+        with flint_workprec(precision):
+            balls = _branch_balls(
+                trace,
+                determinant,
+                spectrum_kind,
+                radicand,
+                repeated=missing == ("REPEATED",),
+            )
+            if balls is not None:
+                selected: dict[Branch, _RootData] = {}
+                for branch in missing:
+                    ball = balls.get(branch)
+                    if ball is None:
+                        break
+                    matches = [root for root in roots if _strictly_inside(ball, root)]
+                    if len(matches) != 1:
+                        break
+                    selected[branch] = matches[0]
+                else:
+                    if len({row.value for row in selected.values()}) == len(selected):
+                        return selected
         precision *= 2
     raise RuntimeError("rigorous algebraic-root selection exceeded its precision proof")
 

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -20,10 +20,16 @@ import threading
 import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager, suppress
-from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO, Protocol, cast
+from typing import BinaryIO, cast
+
+from jacobian._execution import (
+    RequestCancellationSignal,
+    current_request_cancellation,
+    request_cancellation,
+    request_cancelled,
+)
 
 __all__ = [
     "BoundedProcessResult",
@@ -36,16 +42,6 @@ __all__ = [
 ]
 
 
-class _CancellationSignal(Protocol):
-    """Minimal cooperative signal accepted by the process monitor."""
-
-    def is_set(self) -> bool: ...
-
-
-_CANCELLATION_EVENT: ContextVar[_CancellationSignal | None] = ContextVar(
-    "jacobian_bounded_process_cancellation_event",
-    default=None,
-)
 _PIPE_DRAIN_GRACE_SECONDS = 0.5
 _DEFAULT_LOCALE = "C.UTF-8"
 
@@ -63,22 +59,18 @@ class BoundedProcessResult:
 
 @contextmanager
 def bounded_process_cancellation(
-    event: _CancellationSignal,
+    event: RequestCancellationSignal,
 ) -> Iterator[None]:
     """Bind cooperative subprocess cancellation to the current worker context."""
 
-    token = _CANCELLATION_EVENT.set(event)
-    try:
+    with request_cancellation(event):
         yield
-    finally:
-        _CANCELLATION_EVENT.reset(token)
 
 
 def bounded_process_cancelled() -> bool:
     """Report whether the current operation worker has lost its client."""
 
-    event = _CANCELLATION_EVENT.get()
-    return event is not None and event.is_set()
+    return request_cancelled()
 
 
 @dataclass(frozen=True, slots=True)
@@ -270,7 +262,7 @@ def _monitor_bounded_process(
     process: subprocess.Popen[bytes],
     *,
     deadline: float,
-    cancellation_event: _CancellationSignal | None,
+    cancellation_event: RequestCancellationSignal | None,
     platform_tools: ProcessPlatformTools | None,
 ) -> tuple[bool, bool]:
     """Poll the child until exit, timeout, or cancellation.
@@ -332,7 +324,7 @@ def run_bounded_process(
     resource_limits: ProcessResourceLimits | None = None,
     cwd: str | None = None,
     platform_tools: ProcessPlatformTools | None = None,
-    cancellation_event: _CancellationSignal | None = None,
+    cancellation_event: RequestCancellationSignal | None = None,
 ) -> BoundedProcessResult:
     """Run a child with bounded output, time, lifetime, and supported resources.
 
@@ -369,7 +361,7 @@ def run_bounded_process(
     stdout_exceeded = threading.Event()
     stderr_exceeded = threading.Event()
     if cancellation_event is None:
-        cancellation_event = _CANCELLATION_EVENT.get()
+        cancellation_event = current_request_cancellation()
 
     prlimit_executable = (
         platform_tools.prlimit_executable if platform_tools is not None else None

--- a/tests/catalog/test_validated_analysis_declarations.py
+++ b/tests/catalog/test_validated_analysis_declarations.py
@@ -19,6 +19,7 @@ def test_subject_operation_groups_preserve_wire_contracts() -> None:
             "analysis.real_function.point_enclosure.check",
             "interval.compute.enclosure",
             "interval.expression.box_enclosure.compute",
+            "interval.expression.definite_integral_enclosure.compute",
             "interval.expression.second_jet_enclosure.compute",
         ),
         (

--- a/tests/math/analysis/test_analysis_definite_integral_enclosure.py
+++ b/tests/math/analysis/test_analysis_definite_integral_enclosure.py
@@ -1,0 +1,902 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+from fractions import Fraction
+from itertools import pairwise
+from threading import Event
+from time import monotonic
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from tests.fixtures.accounting import assert_charged_work_parity
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    request_execution,
+)
+from jacobian._flint import flint_workprec
+from jacobian.canonical import canonicalize_json
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math import analysis
+from jacobian.math.analysis._box_enclosure import (
+    _evaluate_box_expression,
+    _preflight_box_expression,
+)
+from jacobian.math.analysis._definite_integral_enclosure import (
+    MAX_DEFINITE_INTEGRAL_LEAVES,
+    MAX_DEFINITE_INTEGRAL_PRECISION_WORK,
+    MAX_DEFINITE_INTEGRAL_RESULT_BYTES,
+    MAX_DEFINITE_INTEGRAL_WALL_SECONDS,
+    DefiniteIntegralBudgetExhausted,
+    DefiniteIntegralDomainUnproven,
+    DefiniteIntegralDomainUnprovenLeaf,
+    DefiniteIntegralEnclosedLeaf,
+    DefiniteIntegralEnclosureRequest,
+    DefiniteIntegralEnclosureResult,
+    DefiniteIntegralTargetMet,
+    DefiniteIntegralZeroMeasureLeaf,
+    _admit_definite_integral,
+    _compute_definite_integral_enclosure,
+    _enclosure_width,
+    _estimated_result_bytes,
+    _interval_at_path,
+)
+from jacobian.math.analysis._models import (
+    DyadicClosedInterval,
+    ExactDyadic,
+    IntervalExpressionNode,
+    RationalIntervalBox,
+    _bounded_expression_nodes,
+)
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.process import bounded_process_cancellation
+
+
+def _q(value: Fraction | int, denominator: int = 1) -> dict[str, str]:
+    fraction = value if isinstance(value, Fraction) else Fraction(value, denominator)
+    return {"num": str(fraction.numerator), "den": str(fraction.denominator)}
+
+
+def _var(name: str = "t") -> dict[str, Any]:
+    return {"op": "var", "variable": name}
+
+
+def _const(value: Fraction | int) -> dict[str, Any]:
+    return {"op": "const", "value": _q(value)}
+
+
+def _request(
+    expression: dict[str, Any],
+    *,
+    lower: Fraction = Fraction(0),
+    upper: Fraction = Fraction(1),
+    target_mantissa: str = "1",
+    target_exponent: int = -2,
+    precision_bits: int = 128,
+    max_leaves: int = 8,
+    wall_seconds: int = 30,
+    variable: str = "t",
+) -> DefiniteIntegralEnclosureRequest:
+    return DefiniteIntegralEnclosureRequest.model_validate(
+        {
+            "expression": expression,
+            "box": {
+                "variables": [variable],
+                "intervals": [
+                    {"lower": _q(lower), "upper": _q(upper)},
+                ],
+            },
+            "precision_bits": precision_bits,
+            "target_width": {
+                "mantissa": target_mantissa,
+                "exponent": target_exponent,
+            },
+            "max_leaves": max_leaves,
+            "wall_seconds": wall_seconds,
+        }
+    )
+
+
+def _run(expression: dict[str, Any], **kwargs: Any) -> DefiniteIntegralEnclosureResult:
+    return _compute_definite_integral_enclosure(_request(expression, **kwargs))
+
+
+def _contains(enclosure: DyadicClosedInterval, value: Fraction) -> bool:
+    return enclosure.lower.as_fraction() <= value <= enclosure.upper.as_fraction()
+
+
+def _linear_integral(lower: Fraction, upper: Fraction) -> Fraction:
+    return (upper * upper - lower * lower) / 2
+
+
+def _quadratic_integral(lower: Fraction, upper: Fraction) -> Fraction:
+    def antiderivative(value: Fraction) -> Fraction:
+        return value * value / 2 - value * value * value / 3
+
+    return antiderivative(upper) - antiderivative(lower)
+
+
+def _balanced_sum_expression(depth: int) -> dict[str, Any]:
+    if depth == 0:
+        return _var()
+    child = _balanced_sum_expression(depth - 1)
+    return {"op": "add", "children": [child, deepcopy(child)]}
+
+
+def test_constant_one_has_the_exact_integral_singleton() -> None:
+    result = _run(_const(1), target_mantissa="0", target_exponent=0, max_leaves=1)
+
+    assert isinstance(result.outcome, DefiniteIntegralTargetMet)
+    assert result.outcome.enclosure.lower.as_fraction() == 1
+    assert result.outcome.enclosure.upper.as_fraction() == 1
+    assert len(result.outcome.leaves) == 1
+    leaf = result.outcome.leaves[0]
+    assert isinstance(leaf, DefiniteIntegralEnclosedLeaf)
+    assert leaf.contribution == result.outcome.enclosure
+
+
+def test_degenerate_interval_uses_the_explicit_zero_integral_convention() -> None:
+    expression = {
+        "op": "div",
+        "children": [_const(1), _const(0)],
+    }
+    result = _run(
+        expression,
+        lower=Fraction(7, 3),
+        upper=Fraction(7, 3),
+        target_mantissa="0",
+        target_exponent=0,
+        max_leaves=1,
+    )
+
+    assert isinstance(result.outcome, DefiniteIntegralTargetMet)
+    assert result.outcome.enclosure.lower.as_fraction() == 0
+    assert result.outcome.enclosure.upper.as_fraction() == 0
+    assert len(result.outcome.leaves) == 1
+    assert isinstance(result.outcome.leaves[0], DefiniteIntegralZeroMeasureLeaf)
+
+
+def test_linear_integral_contains_one_half_and_reconstructs_each_leaf() -> None:
+    result = _run(_var(), target_mantissa="1", target_exponent=-2, max_leaves=8)
+
+    assert isinstance(result.outcome, DefiniteIntegralTargetMet)
+    assert _contains(result.outcome.enclosure, Fraction(1, 2))
+    assert tuple(leaf.path for leaf in result.outcome.leaves) == (
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+    )
+    source = result.box.intervals[0]
+    intervals = tuple(
+        _interval_at_path(source, leaf.path) for leaf in result.outcome.leaves
+    )
+    assert intervals[0].lower == source.lower
+    assert intervals[-1].upper == source.upper
+    assert all(left.upper == right.lower for left, right in pairwise(intervals))
+    assert sum((_interval_width(interval) for interval in intervals), Fraction()) == 1
+    for leaf, interval in zip(result.outcome.leaves, intervals, strict=True):
+        assert isinstance(leaf, DefiniteIntegralEnclosedLeaf)
+        assert _contains(
+            leaf.contribution,
+            _linear_integral(
+                interval.lower.as_fraction(), interval.upper.as_fraction()
+            ),
+        )
+    summed_lower = sum(
+        (leaf.contribution.lower.as_fraction() for leaf in result.outcome.leaves),
+        Fraction(),
+    )
+    summed_upper = sum(
+        (leaf.contribution.upper.as_fraction() for leaf in result.outcome.leaves),
+        Fraction(),
+    )
+    assert result.outcome.enclosure.lower.as_fraction() <= summed_lower
+    assert result.outcome.enclosure.upper.as_fraction() >= summed_upper
+
+
+def _interval_width(interval: ClosedRationalInterval) -> Fraction:
+    return interval.upper.as_fraction() - interval.lower.as_fraction()
+
+
+def test_quadratic_refinement_contains_one_six_and_tightens_the_sum() -> None:
+    expression = {
+        "op": "mul",
+        "children": [
+            _var(),
+            {
+                "op": "sub",
+                "children": [_const(1), _var()],
+            },
+        ],
+    }
+    coarse = _run(expression, target_mantissa="0", target_exponent=0, max_leaves=1)
+    refined = _run(expression, target_mantissa="1", target_exponent=-2, max_leaves=8)
+
+    assert isinstance(coarse.outcome, DefiniteIntegralBudgetExhausted)
+    assert isinstance(refined.outcome, DefiniteIntegralTargetMet)
+    assert _contains(refined.outcome.enclosure, Fraction(1, 6))
+    assert _enclosure_width(refined.outcome.enclosure) < _enclosure_width(
+        coarse.outcome.enclosure
+    )
+    source = refined.box.intervals[0]
+    for leaf in refined.outcome.leaves:
+        assert isinstance(leaf, DefiniteIntegralEnclosedLeaf)
+        interval = _interval_at_path(source, leaf.path)
+        assert _contains(
+            leaf.contribution,
+            _quadratic_integral(
+                interval.lower.as_fraction(), interval.upper.as_fraction()
+            ),
+        )
+
+
+def test_sendov_shaped_polynomial_contains_its_exact_integral() -> None:
+    expression = {
+        "op": "mul",
+        "children": [
+            {"op": "pow", "exponent": 3, "children": [_var()]},
+            {
+                "op": "add",
+                "children": [
+                    {"op": "sub", "children": [_const(1), _var()]},
+                    {
+                        "op": "mul",
+                        "children": [
+                            _const(Fraction(9, 16)),
+                            {
+                                "op": "pow",
+                                "exponent": 2,
+                                "children": [_var()],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    result = _run(expression, target_mantissa="1", target_exponent=-5, max_leaves=32)
+
+    assert isinstance(result.outcome, DefiniteIntegralTargetMet)
+    assert _contains(result.outcome.enclosure, Fraction(23, 160))
+    assert 1 < len(result.outcome.leaves) <= 32
+
+
+def test_sine_integral_matches_an_independent_endpoint_antiderivative() -> None:
+    from flint import arb
+
+    expression = {"op": "sin", "children": [_var()]}
+    coarse = _run(expression, target_mantissa="0", target_exponent=0, max_leaves=1)
+    refined = _run(expression, target_mantissa="1", target_exponent=-4, max_leaves=16)
+
+    assert isinstance(coarse.outcome, DefiniteIntegralBudgetExhausted)
+    assert isinstance(refined.outcome, DefiniteIntegralTargetMet)
+    with flint_workprec(512):
+        antiderivative = arb(1) - arb(1).cos()
+        exact_lower = antiderivative.lower().man_exp()
+        exact_upper = antiderivative.upper().man_exp()
+    lower = Fraction(int(exact_lower[0])) * Fraction(2) ** int(exact_lower[1])
+    upper = Fraction(int(exact_upper[0])) * Fraction(2) ** int(exact_upper[1])
+    assert refined.outcome.enclosure.lower.as_fraction() <= lower
+    assert refined.outcome.enclosure.upper.as_fraction() >= upper
+    assert _enclosure_width(refined.outcome.enclosure) < _enclosure_width(
+        coarse.outcome.enclosure
+    )
+
+
+def test_negative_linear_integral_preserves_orientation_and_sign() -> None:
+    result = _run(
+        _var(),
+        lower=Fraction(-1),
+        upper=Fraction(0),
+        target_mantissa="1",
+        target_exponent=-2,
+        max_leaves=8,
+    )
+
+    assert not isinstance(result.outcome, DefiniteIntegralDomainUnproven)
+    assert _contains(result.outcome.enclosure, Fraction(-1, 2))
+
+
+def test_equal_contribution_widths_use_lexicographic_path_ties() -> None:
+    result = _run(_var(), target_mantissa="0", target_exponent=0, max_leaves=3)
+
+    assert isinstance(result.outcome, DefiniteIntegralBudgetExhausted)
+    assert tuple(leaf.path for leaf in result.outcome.leaves) == (
+        (0, 0),
+        (0, 1),
+        (1,),
+    )
+
+
+def test_budget_exhaustion_retains_a_sound_complete_enclosure() -> None:
+    result = _run(_var(), target_mantissa="1", target_exponent=-4, max_leaves=2)
+
+    assert isinstance(result.outcome, DefiniteIntegralBudgetExhausted)
+    assert _contains(result.outcome.enclosure, Fraction(1, 2))
+    assert len(result.outcome.leaves) == result.max_leaves
+    assert all(
+        isinstance(leaf, DefiniteIntegralEnclosedLeaf) for leaf in result.outcome.leaves
+    )
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        {"op": "div", "children": [_const(1), _var()]},
+        {"op": "log", "children": [_var()]},
+        {"op": "sqrt", "children": [_var()]},
+    ],
+)
+def test_unproved_real_domain_never_returns_an_integral_conclusion(
+    expression: dict[str, Any],
+) -> None:
+    lower = Fraction(-1) if expression["op"] != "log" else Fraction(0)
+    result = _run(
+        expression,
+        lower=lower,
+        upper=Fraction(1),
+        target_mantissa="1",
+        target_exponent=8,
+        max_leaves=8,
+    )
+
+    assert isinstance(result.outcome, DefiniteIntegralDomainUnproven)
+    assert len(result.outcome.leaves) == result.max_leaves
+    assert any(
+        isinstance(leaf, DefiniteIntegralDomainUnprovenLeaf)
+        for leaf in result.outcome.leaves
+    )
+
+
+def test_arb_domain_uncertainty_is_a_typed_leaf_nonconclusion() -> None:
+    expression = {
+        "op": "log",
+        "children": [
+            {
+                "op": "add",
+                "children": [_var(), _const(Fraction(1, 10**127))],
+            }
+        ],
+    }
+
+    result = _run(
+        expression,
+        precision_bits=32,
+        target_mantissa="1",
+        target_exponent=8,
+        max_leaves=1,
+    )
+
+    assert isinstance(result.outcome, DefiniteIntegralDomainUnproven)
+    assert len(result.outcome.leaves) == 1
+    leaf = result.outcome.leaves[0]
+    assert isinstance(leaf, DefiniteIntegralDomainUnprovenLeaf)
+    assert leaf.path == ()
+    assert leaf.domain_failure.operation == "log"
+    assert leaf.domain_failure.reason == "LOG_ARGUMENT_NOT_STRICTLY_POSITIVE"
+
+
+def test_arb_domain_uncertainty_can_resolve_under_midpoint_refinement() -> None:
+    expression = {
+        "op": "log",
+        "children": [
+            {
+                "op": "add",
+                "children": [_var(), _const(Fraction(1, 2**40))],
+            }
+        ],
+    }
+
+    result = _run(
+        expression,
+        precision_bits=32,
+        target_mantissa="1",
+        target_exponent=8,
+        max_leaves=16,
+    )
+
+    assert isinstance(result.outcome, DefiniteIntegralTargetMet)
+    assert len(result.outcome.leaves) == 9
+    assert all(
+        isinstance(leaf, DefiniteIntegralEnclosedLeaf) for leaf in result.outcome.leaves
+    )
+
+
+def test_admitted_domain_proof_is_inherited_without_late_readmission() -> None:
+    pole = Fraction(1) + Fraction(1, 2**200)
+    expression = {
+        "op": "add",
+        "children": [
+            {
+                "op": "div",
+                "children": [
+                    _const(1),
+                    {"op": "sub", "children": [_const(pole), _var()]},
+                ],
+            },
+            {"op": "pow", "exponent": 64, "children": [_var()]},
+        ],
+    }
+
+    result = _run(
+        expression,
+        precision_bits=256,
+        target_mantissa="0",
+        target_exponent=0,
+        max_leaves=200,
+        wall_seconds=120,
+    )
+
+    assert isinstance(result.outcome, DefiniteIntegralBudgetExhausted)
+    assert len(result.outcome.leaves) == 200
+    assert all(
+        isinstance(leaf, DefiniteIntegralEnclosedLeaf) for leaf in result.outcome.leaves
+    )
+
+
+def test_dependency_domain_obstruction_can_be_resolved_by_subdivision() -> None:
+    expression = {
+        "op": "log",
+        "children": [
+            {
+                "op": "add",
+                "children": [
+                    _const(1),
+                    {"op": "sub", "children": [_var(), _var()]},
+                ],
+            }
+        ],
+    }
+    result = _run(
+        expression,
+        target_mantissa="1",
+        target_exponent=4,
+        max_leaves=2,
+    )
+
+    assert isinstance(result.outcome, DefiniteIntegralTargetMet)
+    assert _contains(result.outcome.enclosure, Fraction(0))
+    assert tuple(leaf.path for leaf in result.outcome.leaves) == ((0,), (1,))
+    assert all(
+        isinstance(leaf, DefiniteIntegralEnclosedLeaf) for leaf in result.outcome.leaves
+    )
+
+
+def test_target_boundary_is_inclusive() -> None:
+    met = _run(_var(), target_mantissa="1", target_exponent=-2, max_leaves=4)
+    missed = _run(_var(), target_mantissa="1", target_exponent=-3, max_leaves=4)
+
+    assert isinstance(met.outcome, DefiniteIntegralTargetMet)
+    assert isinstance(missed.outcome, DefiniteIntegralBudgetExhausted)
+    assert _enclosure_width(met.outcome.enclosure) == Fraction(1, 4)
+
+
+def test_zero_target_is_admitted_but_negative_target_is_not() -> None:
+    zero = _request(_const(1), target_mantissa="0", target_exponent=0, max_leaves=1)
+    assert zero.target_width == ExactDyadic(mantissa="0", exponent=0)
+
+    with pytest.raises(ValidationError, match="must be nonnegative"):
+        _request(_const(1), target_mantissa="-1", target_exponent=0)
+
+
+@pytest.mark.parametrize(
+    ("box_variables", "expression", "message"),
+    [
+        ([], _const(1), "exactly one"),
+        (["t", "u"], _var(), "exactly one"),
+        (["t"], {"op": "var"}, "must be named"),
+        (["t"], _var("u"), "must match"),
+    ],
+)
+def test_request_requires_one_explicit_integration_axis(
+    box_variables: list[str], expression: dict[str, Any], message: str
+) -> None:
+    intervals = [{"lower": _q(0), "upper": _q(1)} for _ in box_variables]
+    with pytest.raises(ValidationError, match=message):
+        DefiniteIntegralEnclosureRequest.model_validate(
+            {
+                "expression": expression,
+                "box": {"variables": box_variables, "intervals": intervals},
+                "target_width": {"mantissa": "1", "exponent": -2},
+                "max_leaves": 4,
+                "wall_seconds": 30,
+            }
+        )
+
+
+def test_constant_expression_retains_an_otherwise_unused_integration_axis() -> None:
+    request = _request(_const(3), variable="x")
+    assert request.box.variables == ("x",)
+
+
+def test_request_precision_overrides_the_ambient_arb_context() -> None:
+    request = _request(_var(), max_leaves=4)
+    with flint_workprec(64):
+        low_ambient = _compute_definite_integral_enclosure(request)
+    with flint_workprec(512):
+        high_ambient = _compute_definite_integral_enclosure(request)
+    assert low_ambient == high_ambient
+
+
+def test_concurrent_precision_requests_do_not_overlap_the_arb_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from flint import ctx
+
+    import jacobian.math.analysis._definite_integral_enclosure as integral
+
+    ambient_precision = ctx.prec
+    expression = {"op": "exp", "children": [_var()]}
+    low_request = _request(
+        expression,
+        precision_bits=32,
+        target_mantissa="0",
+        target_exponent=0,
+        max_leaves=1,
+    )
+    high_request = _request(
+        expression,
+        precision_bits=512,
+        target_mantissa="0",
+        target_exponent=0,
+        max_leaves=1,
+    )
+    expected_low = _compute_definite_integral_enclosure(low_request)
+    expected_high = _compute_definite_integral_enclosure(high_request)
+    assert expected_low != expected_high
+
+    low_evaluating = Event()
+    high_attempting = Event()
+    high_evaluating = Event()
+    low_checked_context = Event()
+    high_finished = Event()
+    observations: dict[str, int | bool] = {}
+    original_evaluate = _evaluate_box_expression
+
+    def observe_real_evaluation(*args: Any, **kwargs: Any) -> Any:
+        if not low_evaluating.is_set():
+            observations["low_entered_precision"] = ctx.prec
+            low_evaluating.set()
+            assert high_attempting.wait(timeout=1)
+            observations["contexts_overlapped"] = high_evaluating.wait(timeout=0.25)
+            observations["low_precision_during_high_attempt"] = ctx.prec
+            low_checked_context.set()
+            if observations["contexts_overlapped"]:
+                assert high_finished.wait(timeout=1)
+        else:
+            observations["high_entered_precision"] = ctx.prec
+            high_evaluating.set()
+            assert low_checked_context.wait(timeout=1)
+        return original_evaluate(*args, **kwargs)
+
+    monkeypatch.setattr(integral, "_evaluate_box_expression", observe_real_evaluation)
+
+    def run_high_precision() -> DefiniteIntegralEnclosureResult:
+        assert low_evaluating.wait(timeout=1)
+        high_attempting.set()
+        try:
+            return _compute_definite_integral_enclosure(high_request)
+        finally:
+            high_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        low_future = workers.submit(
+            _compute_definite_integral_enclosure,
+            low_request,
+        )
+        high_future = workers.submit(run_high_precision)
+        low_result = low_future.result(timeout=3)
+        high_result = high_future.result(timeout=3)
+
+    assert low_result == expected_low
+    assert high_result == expected_high
+    assert ctx.prec == ambient_precision
+    assert observations == {
+        "low_entered_precision": 32,
+        "contexts_overlapped": False,
+        "low_precision_during_high_attempt": 32,
+        "high_entered_precision": 512,
+    }
+
+
+def test_result_round_trips_through_public_json() -> None:
+    result = _run(_var(), max_leaves=4)
+    assert (
+        DefiniteIntegralEnclosureResult.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+def test_structural_validation_rejects_an_invalid_partition_path() -> None:
+    result = _run(_var(), max_leaves=4)
+    payload = deepcopy(result.model_dump(mode="json"))
+    payload["outcome"]["leaves"][0]["path"] = []
+
+    with pytest.raises(ValidationError):
+        DefiniteIntegralEnclosureResult.model_validate(payload)
+
+
+def test_result_deserialization_does_not_replay_computed_math(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jacobian.math.analysis._definite_integral_enclosure as integral
+
+    result = _run(_var(), max_leaves=4)
+
+    def replayed(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("computed mathematics was replayed during deserialization")
+
+    for name in (
+        "_interval_at_path",
+        "_leaf_contribution",
+        "_summed_enclosure",
+        "_target_met",
+    ):
+        monkeypatch.setattr(integral, name, replayed)
+
+    parsed = DefiniteIntegralEnclosureResult.model_validate(
+        result.model_dump(mode="json")
+    )
+    assert parsed == result
+
+
+def test_result_rejects_a_leaf_deeper_than_the_requested_budget() -> None:
+    result = _run(_var(), target_mantissa="0", target_exponent=0, max_leaves=3)
+    payload = deepcopy(result.model_dump(mode="json"))
+    payload["outcome"]["leaves"][0]["path"] = [0, 0, 0]
+
+    with pytest.raises(ValidationError, match="requested partition-depth"):
+        DefiniteIntegralEnclosureResult.model_validate(payload)
+
+
+def test_domain_unproven_result_cannot_smuggle_a_global_enclosure() -> None:
+    result = _run(
+        {"op": "div", "children": [_const(1), _var()]},
+        lower=Fraction(-1),
+        max_leaves=2,
+    )
+    payload = deepcopy(result.model_dump(mode="json"))
+    payload["outcome"]["enclosure"] = {
+        "lower": {"mantissa": "0", "exponent": 0},
+        "upper": {"mantissa": "0", "exponent": 0},
+    }
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        DefiniteIntegralEnclosureResult.model_validate(payload)
+
+
+def test_domain_failure_evidence_is_bound_to_the_expression_node() -> None:
+    result = _run(
+        {"op": "div", "children": [_const(1), _var()]},
+        lower=Fraction(-1),
+        max_leaves=1,
+    )
+    payload = deepcopy(result.model_dump(mode="json"))
+    leaf = payload["outcome"]["leaves"][0]
+    leaf["domain_failure"] = {
+        "node_path": [],
+        "operation": "log",
+        "reason": "LOG_ARGUMENT_NOT_STRICTLY_POSITIVE",
+    }
+
+    with pytest.raises(ValidationError, match="does not match"):
+        DefiniteIntegralEnclosureResult.model_validate(payload)
+
+
+def test_result_schema_exposes_both_discriminated_branch_families() -> None:
+    schema = DefiniteIntegralEnclosureResult.model_json_schema()
+    outcome = schema["$defs"]["DefiniteIntegralOutcome"]
+    assert outcome["discriminator"]["propertyName"] == "status"
+    assert set(outcome["discriminator"]["mapping"]) == {
+        "TARGET_MET",
+        "BUDGET_EXHAUSTED",
+        "DOMAIN_UNPROVEN",
+    }
+    domain_properties = schema["$defs"]["DefiniteIntegralDomainUnproven"]["properties"]
+    assert "enclosure" not in domain_properties
+    budget_properties = schema["$defs"]["DefiniteIntegralBudgetExhausted"]["properties"]
+    assert "reason" not in budget_properties
+    concluded_leaf_mapping = schema["$defs"]["DefiniteIntegralConcludedLeaf"][
+        "discriminator"
+    ]["mapping"]
+    assert set(concluded_leaf_mapping) == {"ENCLOSED", "ZERO_MEASURE"}
+
+
+def test_wire_only_integral_contract_is_not_published_as_a_native_api() -> None:
+    assert "definite_integral_enclosure" not in analysis.__all__
+    assert not hasattr(analysis, "definite_integral_enclosure")
+
+
+def test_dispatch_start_time_is_part_of_the_owner_deadline() -> None:
+    request = _request(_var(), wall_seconds=1)
+    with (
+        request_execution(monotonic() - 2),
+        pytest.raises(OperationExecutionTimeoutError, match="semantic preflight"),
+    ):
+        _compute_definite_integral_enclosure(request)
+
+
+def test_owner_checkpoints_observe_request_cancellation() -> None:
+    cancellation = Event()
+    cancellation.set()
+    request = _request(_var())
+
+    with (
+        bounded_process_cancellation(cancellation),
+        pytest.raises(OperationExecutionCancelledError, match="cancelled"),
+    ):
+        _compute_definite_integral_enclosure(request)
+
+
+def test_precision_work_boundary_is_derived_from_actual_subproblems() -> None:
+    expression = _balanced_sum_expression(5)  # 63 nodes
+    node_count = 63
+    subproblems = 2 * MAX_DEFINITE_INTEGRAL_LEAVES - 1
+    accepted_precision = MAX_DEFINITE_INTEGRAL_PRECISION_WORK // (
+        node_count * subproblems
+    )
+    accepted = _request(
+        expression,
+        precision_bits=accepted_precision,
+        max_leaves=MAX_DEFINITE_INTEGRAL_LEAVES,
+    )
+    _admit_definite_integral(accepted, started_at=monotonic())
+    assert (
+        node_count * subproblems * accepted_precision
+        <= MAX_DEFINITE_INTEGRAL_PRECISION_WORK
+    )
+
+    rejected = _request(
+        expression,
+        precision_bits=accepted_precision + 1,
+        max_leaves=MAX_DEFINITE_INTEGRAL_LEAVES,
+    )
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="precision work",
+    ):
+        _admit_definite_integral(rejected, started_at=monotonic())
+
+
+def test_leaf_and_wall_field_bounds_reject_one_beyond() -> None:
+    payload = _request(_var()).model_dump(mode="json")
+    payload["max_leaves"] = MAX_DEFINITE_INTEGRAL_LEAVES + 1
+    with pytest.raises(ValidationError):
+        DefiniteIntegralEnclosureRequest.model_validate(payload)
+
+    payload = _request(_var()).model_dump(mode="json")
+    payload["wall_seconds"] = MAX_DEFINITE_INTEGRAL_WALL_SECONDS + 1
+    with pytest.raises(ValidationError):
+        DefiniteIntegralEnclosureRequest.model_validate(payload)
+
+
+def test_result_size_estimator_dominates_the_actual_canonical_result() -> None:
+    request = _request(_var(), max_leaves=16, target_mantissa="0", target_exponent=0)
+    result = _compute_definite_integral_enclosure(request)
+    actual = len(canonicalize_json(result.model_dump(mode="json")))
+    assert actual <= _estimated_result_bytes(request)
+
+
+def test_maximum_result_reservation_fits_the_real_transport_limit() -> None:
+    request = _request(
+        _const(1),
+        target_mantissa="0",
+        target_exponent=0,
+        max_leaves=MAX_DEFINITE_INTEGRAL_LEAVES,
+    )
+    assert _estimated_result_bytes(request) <= MAX_DEFINITE_INTEGRAL_RESULT_BYTES
+
+
+def test_admission_charges_every_executed_partition_primitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jacobian.math.analysis._definite_integral_enclosure as integral
+
+    executed = {
+        "arb_node_bit": 0,
+        "expression_node": 0,
+        "midpoint_split": 0,
+        "output_leaf": 0,
+        "selection_candidate": 0,
+        "subproblem": 0,
+        "summation_endpoint": 0,
+    }
+    admissions = 0
+    expression = {
+        "op": "mul",
+        "children": [
+            _var(),
+            {"op": "sub", "children": [_const(1), _var()]},
+        ],
+    }
+    request = _request(expression, target_mantissa="0", target_exponent=0, max_leaves=8)
+    node_count = len(_bounded_expression_nodes(request.expression))
+
+    original_admit = integral._admit_definite_integral
+    original_evaluate = integral._evaluate_integral_leaf
+    original_preflight = _preflight_box_expression
+    original_arb = _evaluate_box_expression
+    original_select = integral._select_leaf
+    original_split = integral._split_interval
+    original_sum = integral._summed_enclosure
+
+    def admitting(*args: Any, **kwargs: Any) -> Any:
+        nonlocal admissions
+        admissions += 1
+        return original_admit(*args, **kwargs)
+
+    def evaluating(*args: Any, **kwargs: Any) -> Any:
+        executed["subproblem"] += 1
+        return original_evaluate(*args, **kwargs)
+
+    def preflighting(*args: Any, **kwargs: Any) -> Any:
+        executed["expression_node"] += node_count
+        return original_preflight(*args, **kwargs)
+
+    def evaluating_arb(*args: Any, **kwargs: Any) -> Any:
+        executed["expression_node"] += node_count
+        executed["arb_node_bit"] += node_count * request.precision_bits
+        return original_arb(*args, **kwargs)
+
+    def selecting(leaves: tuple[Any, ...]) -> Any:
+        executed["selection_candidate"] += len(leaves)
+        return original_select(leaves)
+
+    def splitting(*args: Any, **kwargs: Any) -> Any:
+        executed["midpoint_split"] += 1
+        return original_split(*args, **kwargs)
+
+    def summing(contributions: tuple[Any, ...], precision_bits: int) -> Any:
+        executed["summation_endpoint"] += 2 * len(contributions)
+        return original_sum(contributions, precision_bits)
+
+    monkeypatch.setattr(integral, "_admit_definite_integral", admitting)
+    monkeypatch.setattr(integral, "_evaluate_integral_leaf", evaluating)
+    monkeypatch.setattr(integral, "_preflight_box_expression", preflighting)
+    monkeypatch.setattr(integral, "_evaluate_box_expression", evaluating_arb)
+    monkeypatch.setattr(integral, "_select_leaf", selecting)
+    monkeypatch.setattr(integral, "_split_interval", splitting)
+    monkeypatch.setattr(integral, "_summed_enclosure", summing)
+
+    result = _compute_definite_integral_enclosure(request)
+    assert admissions == 1
+    executed["output_leaf"] = len(result.outcome.leaves)
+    maximum_subproblems = 2 * request.max_leaves - 1
+    assert_charged_work_parity(
+        charged={
+            "arb_node_bit": (node_count * maximum_subproblems * request.precision_bits),
+            "expression_node": 2 * node_count * maximum_subproblems,
+            "midpoint_split": request.max_leaves - 1,
+            "output_leaf": request.max_leaves,
+            "selection_candidate": (request.max_leaves * (request.max_leaves - 1) // 2),
+            "subproblem": maximum_subproblems,
+            "summation_endpoint": (request.max_leaves * (request.max_leaves + 1)),
+        },
+        executed=executed,
+    )
+    assert executed == {
+        "arb_node_bit": 15 * node_count * request.precision_bits,
+        "expression_node": 16 * node_count,
+        "midpoint_split": 7,
+        "output_leaf": 8,
+        "selection_candidate": 28,
+        "subproblem": 15,
+        "summation_endpoint": 72,
+    }
+
+
+def test_public_source_envelope_is_retained_without_backend_objects() -> None:
+    request = _request(_var(), max_leaves=4)
+    result = _compute_definite_integral_enclosure(request)
+    assert result.expression == request.expression
+    assert result.box == request.box
+    assert result.precision_bits == request.precision_bits
+    assert result.target_width == request.target_width
+    assert result.max_leaves == request.max_leaves
+    assert result.wall_seconds == request.wall_seconds
+    assert isinstance(result.expression, IntervalExpressionNode)
+    assert isinstance(result.box, RationalIntervalBox)

--- a/tests/math/analysis/test_analysis_expression_box_enclosure.py
+++ b/tests/math/analysis/test_analysis_expression_box_enclosure.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import ValidationError
 from tests.math.analysis._analysis_support import analysis_validation_error
 
+from jacobian._flint import flint_workprec
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.analysis._box_enclosure import (
     IntervalExpressionBoxEnclosureRequest,
@@ -152,16 +153,14 @@ def test_degenerate_point_box_agrees_with_point_expression_operation() -> None:
 
 
 def test_request_precision_overrides_the_ambient_arb_context() -> None:
-    from flint import ctx
-
     request = _request(
         {"op": "exp", "children": [_var("x")]},
         (("x", Fraction(0), Fraction(1)),),
         precision_bits=128,
     )
-    with ctx.workprec(64):
+    with flint_workprec(64):
         low_ambient_precision = _box_expression_enclosure(request)
-    with ctx.workprec(512):
+    with flint_workprec(512):
         high_ambient_precision = _box_expression_enclosure(request)
 
     assert low_ambient_precision == high_ambient_precision

--- a/tests/math/test_flint_context.py
+++ b/tests/math/test_flint_context.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from time import monotonic
+
+import pytest
+from flint import arb, ctx
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
+from jacobian._flint import flint_workprec
+
+
+def _exp_one_interval() -> tuple[tuple[int, int], tuple[int, int]]:
+    value = arb(1).exp()
+    lower_mantissa, lower_exponent = value.lower().man_exp()
+    upper_mantissa, upper_exponent = value.upper().man_exp()
+    return (
+        (int(lower_mantissa), int(lower_exponent)),
+        (int(upper_mantissa), int(upper_exponent)),
+    )
+
+
+def test_flint_workprec_serializes_real_arb_precision_and_restores_context() -> None:
+    original_precision = ctx.prec
+    with flint_workprec(32):
+        expected_low_precision = _exp_one_interval()
+    with flint_workprec(512):
+        expected_high_precision = _exp_one_interval()
+
+    first_entered = Event()
+    second_attempting = Event()
+    second_entered = Event()
+
+    def low_precision_worker() -> tuple[tuple[int, int], tuple[int, int]]:
+        with flint_workprec(32):
+            first_entered.set()
+            assert second_attempting.wait(timeout=1)
+            assert not second_entered.wait(timeout=0.25)
+            assert ctx.prec == 32
+            return _exp_one_interval()
+
+    def high_precision_worker() -> tuple[tuple[int, int], tuple[int, int]]:
+        assert first_entered.wait(timeout=1)
+        second_attempting.set()
+        with flint_workprec(512):
+            second_entered.set()
+            assert ctx.prec == 512
+            return _exp_one_interval()
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        low_future = workers.submit(low_precision_worker)
+        high_future = workers.submit(high_precision_worker)
+        low_precision = low_future.result(timeout=2)
+        high_precision = high_future.result(timeout=2)
+
+    assert low_precision == expected_low_precision
+    assert high_precision == expected_high_precision
+    assert ctx.prec == original_precision
+
+
+def test_flint_workprec_is_reentrant_and_restores_nested_precision() -> None:
+    original_precision = ctx.prec
+
+    with flint_workprec(64):
+        outer_interval = _exp_one_interval()
+        assert ctx.prec == 64
+        with flint_workprec(256, deadline=monotonic() + 0.25):
+            inner_interval = _exp_one_interval()
+            assert ctx.prec == 256
+        assert ctx.prec == 64
+
+    assert outer_interval != inner_interval
+    assert ctx.prec == original_precision
+
+
+def test_flint_workprec_rejects_an_expired_native_deadline() -> None:
+    original_precision = ctx.prec
+
+    with flint_workprec(64):
+        with (
+            pytest.raises(
+                OperationExecutionTimeoutError,
+                match="python-flint precision context",
+            ),
+            flint_workprec(256, deadline=monotonic() - 1.0),
+        ):
+            raise AssertionError("expired native deadline entered the context")
+        assert ctx.prec == 64
+
+    assert ctx.prec == original_precision
+
+
+def test_flint_workprec_restores_precision_after_body_failure() -> None:
+    original_precision = ctx.prec
+
+    with pytest.raises(RuntimeError, match="test body failed"), flint_workprec(80):
+        assert ctx.prec == 80
+        _exp_one_interval()
+        raise RuntimeError("test body failed")
+
+    assert ctx.prec == original_precision
+
+
+def test_flint_workprec_lock_wait_uses_the_request_deadline() -> None:
+    original_precision = ctx.prec
+    holder_entered = Event()
+    release_holder = Event()
+
+    def hold_context() -> tuple[tuple[int, int], tuple[int, int]]:
+        with flint_workprec(96):
+            interval = _exp_one_interval()
+            holder_entered.set()
+            release_holder.wait(timeout=0.4)
+            return interval
+
+    with ThreadPoolExecutor(max_workers=1) as workers:
+        holder = workers.submit(hold_context)
+        assert holder_entered.wait(timeout=1)
+        wait_started = monotonic()
+        try:
+            with request_execution(wait_started):
+                bind_request_deadline(wait_started + 0.05)
+                with (
+                    pytest.raises(
+                        OperationExecutionTimeoutError,
+                        match="python-flint precision context",
+                    ),
+                    flint_workprec(128),
+                ):
+                    raise AssertionError("expired lock wait entered the context")
+        finally:
+            release_holder.set()
+        holder.result(timeout=1)
+
+    assert ctx.prec == original_precision

--- a/tests/math/test_flint_context.py
+++ b/tests/math/test_flint_context.py
@@ -8,11 +8,13 @@ import pytest
 from flint import arb, ctx
 
 from jacobian._execution import (
+    OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
     bind_request_deadline,
     request_execution,
 )
 from jacobian._flint import flint_workprec
+from jacobian.process import bounded_process_cancellation
 
 
 def _exp_one_interval() -> tuple[tuple[int, int], tuple[int, int]]:
@@ -136,5 +138,116 @@ def test_flint_workprec_lock_wait_uses_the_request_deadline() -> None:
         finally:
             release_holder.set()
         holder.result(timeout=1)
+
+    assert ctx.prec == original_precision
+
+
+def test_flint_workprec_queued_wait_observes_request_cancellation() -> None:
+    original_precision = ctx.prec
+    holder_entered = Event()
+    release_holder = Event()
+    waiter_attempting = Event()
+    waiter_entered = Event()
+    cancellation = Event()
+
+    def hold_context() -> tuple[tuple[int, int], tuple[int, int]]:
+        with flint_workprec(96):
+            interval = _exp_one_interval()
+            holder_entered.set()
+            assert release_holder.wait(timeout=2)
+            return interval
+
+    def wait_for_context() -> tuple[tuple[int, int], tuple[int, int]]:
+        assert holder_entered.wait(timeout=1)
+        with bounded_process_cancellation(cancellation):
+            waiter_attempting.set()
+            with flint_workprec(256, deadline=monotonic() + 2.0):
+                waiter_entered.set()
+                return _exp_one_interval()
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        holder = workers.submit(hold_context)
+        assert holder_entered.wait(timeout=1)
+        waiter = workers.submit(wait_for_context)
+        assert waiter_attempting.wait(timeout=1)
+        assert not waiter.done()
+        cancellation.set()
+        try:
+            with pytest.raises(
+                OperationExecutionCancelledError,
+                match="python-flint precision context",
+            ):
+                waiter.result(timeout=1)
+            assert not waiter_entered.is_set()
+        finally:
+            release_holder.set()
+        holder.result(timeout=1)
+        assert not waiter_entered.is_set()
+
+    assert ctx.prec == original_precision
+
+
+def test_flint_workprec_rechecks_cancellation_after_lock_acquisition() -> None:
+    class GatedCancellation:
+        def __init__(self) -> None:
+            self._cancelled = Event()
+            self._allow_first_return = Event()
+            self.first_check_read = Event()
+            self._is_first_check = True
+
+        def is_set(self) -> bool:
+            observed = self._cancelled.is_set()
+            if self._is_first_check:
+                self._is_first_check = False
+                self.first_check_read.set()
+                assert self._allow_first_return.wait(timeout=1)
+            return observed
+
+        def set(self) -> None:
+            self._cancelled.set()
+
+        def allow_first_return(self) -> None:
+            self._allow_first_return.set()
+
+    original_precision = ctx.prec
+    holder_entered = Event()
+    release_holder = Event()
+    waiter_entered = Event()
+    cancellation = GatedCancellation()
+
+    def hold_context() -> tuple[tuple[int, int], tuple[int, int]]:
+        with flint_workprec(96):
+            interval = _exp_one_interval()
+            holder_entered.set()
+            assert release_holder.wait(timeout=2)
+            return interval
+
+    def wait_for_context() -> tuple[tuple[int, int], tuple[int, int]]:
+        with (
+            bounded_process_cancellation(cancellation),
+            flint_workprec(256, deadline=monotonic() + 2.0),
+        ):
+            waiter_entered.set()
+            return _exp_one_interval()
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        holder = workers.submit(hold_context)
+        assert holder_entered.wait(timeout=1)
+        waiter = workers.submit(wait_for_context)
+        try:
+            assert cancellation.first_check_read.wait(timeout=1)
+            cancellation.set()
+            release_holder.set()
+            cancellation.allow_first_return()
+            with pytest.raises(
+                OperationExecutionCancelledError,
+                match="python-flint precision context",
+            ):
+                waiter.result(timeout=1)
+        finally:
+            cancellation.allow_first_return()
+            release_holder.set()
+        holder.result(timeout=1)
+        assert not waiter_entered.is_set()
 
     assert ctx.prec == original_precision

--- a/tests/math/test_flint_context.py
+++ b/tests/math/test_flint_context.py
@@ -142,6 +142,30 @@ def test_flint_workprec_lock_wait_uses_the_request_deadline() -> None:
     assert ctx.prec == original_precision
 
 
+def test_flint_workprec_without_deadline_waits_for_the_context() -> None:
+    holder_entered = Event()
+    release_holder = Event()
+
+    def hold_context() -> None:
+        with flint_workprec(96):
+            holder_entered.set()
+            assert release_holder.wait(timeout=1)
+
+    def wait_for_context() -> int:
+        assert holder_entered.wait(timeout=1)
+        with flint_workprec(128):
+            return ctx.prec
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        holder = workers.submit(hold_context)
+        waiter = workers.submit(wait_for_context)
+        assert holder_entered.wait(timeout=1)
+        assert not waiter.done()
+        release_holder.set()
+        holder.result(timeout=1)
+        assert waiter.result(timeout=1) == 128
+
+
 def test_flint_workprec_queued_wait_observes_request_cancellation() -> None:
     original_precision = ctx.prec
     holder_entered = Event()


### PR DESCRIPTION
## Problem

python-flint exposes Arb working precision through a mutable process-global context. Six surviving math paths entered `ctx.workprec(...)` independently, so concurrent requests at different precisions could overlap. A real 32-bit/512-bit two-thread reproduction observed the 32-bit request execute at 512 bits and leave the global context at 32 bits after both scopes exited.

This is a shared prerequisite for the adaptive range and integration operations: their per-request precision choices are not trustworthy until precision ownership is serialized.

## Solution

Add one reentrant owner for python-flint working precision and migrate every production `ctx.workprec(...)` scope to it. The owner serializes construction, comparison, endpoint extraction, and accuracy reads under the selected precision, while retaining lazy python-flint imports.

Lock acquisition uses the earliest explicit or request-scoped monotonic deadline, with the existing 120-second native fallback when neither is present. Queued callers poll request cancellation, including the acquire-versus-cancel edge, and release the lock before raising the typed cancellation or timeout error.

The migrated paths are point, expression-box, and second-jet enclosures; Euclidean root-sum comparison; and real-quadratic spectral branch selection.

## Testing

```sh
make handoff LANE=math TESTS='tests/math/test_flint_context.py tests/mcp/test_direct_operations.py::test_direct_calls_preserve_owner_cancellation_diagnosis'
make import-contracts
```

The import-contract lane also passes after keeping the generic cancellation context in the execution layer and leaving process-specific wrappers at the process boundary.

The regression suite uses real Arb scopes to prove cross-thread serialization, exact precision restoration, reentrancy, deadline behavior, queued cancellation, the cancel-versus-acquire race, and direct MCP cancellation projection.

- Specialist validation run (if any): focused direct-MCP cancellation regression included above

## Public contract impact

None. Operation IDs, request/result schemas, and mathematical semantics are unchanged. Existing typed execution timeout and cancellation diagnoses now also cover waiting for the shared python-flint context.

## Operation boundary ownership

- Changed stage: shared kernel adapter ownership
- Request-bounds owner and controlling quantities: each existing operation retains its precision and request deadline; the shared adapter uses the earliest bound deadline
- Work, intermediate, memory, and exact-output bounds: unchanged from each owning operation
- Wall deadline, calibration workload, safety margin, and caller-selectable range: existing request deadline, or the established 120-second native fallback when no request scope exists
- Backend or kernel path: direct python-flint binding under one process-wide reentrant precision scope
- Result construction: unchanged; construction and precision-dependent reads now remain inside the owned scope
- Independent-result verifier (only if the public contract accepts independently supplied result data): not applicable
- Native/MCP parity: both paths enter the same adapter; MCP retains typed timeout and cancellation projection
- Serialized-result and round-trip evidence: existing operation suites plus the direct-MCP regression; no result schema changes

## Canonical value audit

Not applicable: no mathematical value, request, result, producer codomain, or consumer domain changes.

## Catalog admission

Not applicable: catalog membership is unchanged.

## Closure matrix

None.

## Checklist

- [x] `make handoff LANE=math TESTS=...` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] No compatibility aliases, forwarding modules, or generic `_operations.py` shadow paths were introduced
- [x] Runtime-bound changes name the request-bounds owner and execute the same semantic path for native and MCP callers
- [x] Result semantics distinguish exact mathematical results from timeout, cancellation, and backend outcomes
- [x] The shared owner replaces six surviving production precision scopes
