### PR TITLE
Add exact embeddings for bounded simple number fields

### DIFF
--- a/docs/reference/operations/geometry/index.md
+++ b/docs/reference/operations/geometry/index.md
@@ -3,3 +3,4 @@
 [Documentation home](../../../index.md) · [Tool surface](../../tools.md)
 
 - [Exact planar geometry](exact-planar-geometry.md)
+- [Projective plane-curve singularity profiles](projective-plane-curve-singularities.md)

--- a/docs/reference/operations/geometry/projective-plane-curve-singularities.md
+++ b/docs/reference/operations/geometry/projective-plane-curve-singularities.md
@@ -1,0 +1,99 @@
+# Projective plane-curve singularity profiles
+
+[Documentation home](../../../index.md) · [Tool surface](../../tools.md)
+
+`algebraic_geometry.projective_plane_curve.singularity_profile.compute`
+computes the complete projective singular locus of one bounded homogeneous
+polynomial `F` in `QQ[X,Y,Z]`. The geometric scope is the algebraic closure of
+`QQ`; this is not a search for rational singular points.
+
+The returned profile retains the primitive positive-leading integer scalar
+representative of `F`, the ordered projective axis, all three exact partial
+derivatives, and the saturated homogeneous Jacobian ideal
+
+```text
+<F, F_X, F_Y, F_Z> : <X,Y,Z>^infinity.
+```
+
+It then has one mathematical outcome:
+
+- `SMOOTH_OVER_ALGEBRAIC_CLOSURE` retains the unit ideal `<1>`, whose
+  projective zero locus is empty.
+- `SINGULAR_ZERO_DIMENSIONAL` returns every geometric point in a disjoint
+  three-chart cover. Each point has a canonical first-nonzero-coordinate
+  normalization, one exact presented number field, one indexed real or complex
+  embedding, and an exact zero first jet.
+- `SINGULAR_POSITIVE_DIMENSIONAL` retains the exact saturated ideal,
+  projective dimension one, and its complete family of rational minimal
+  components. The saturated ideal remains the authoritative geometric-locus
+  evidence; the rational components are not advertised as an absolute
+  decomposition.
+
+Backend unavailability, cancellation, timeout, malformed output, and output
+limit exhaustion are separate typed operational outcomes. None implies
+smoothness or absence of a singular point.
+
+## Exact finite-point construction
+
+The finite branch uses the disjoint charts `X=1`, then `X=0,Y=1`, then
+`X=Y=0,Z=1`. Singular 4.4 computes the projective saturation and the rational
+minimal primes of each retained chart. A zero-dimensional rational prime is a
+number-field residue algebra. A deterministic separating form gives a
+univariate irreducible presentation and reduced power-basis expressions for
+the remaining coordinates. Enumerating that presentation's exact embeddings
+then enumerates every geometric point in the prime's Galois orbit.
+
+For example, the curve
+
+```text
+Z (X^2 + Y^2 + Z^2) = 0
+```
+
+returns two distinct points with the shared presentation
+`QQ(alpha)=QQ[x]/(x^2+1)`: `[1:alpha:0]` under root indexes zero and one. Thus
+`[1:-i:0]` and `[1:i:0]` survive strict JSON serialization as different
+embedded points.
+
+Before returning a point, the kernel substitutes its reduced coordinates into
+`F` and every partial and reduces exactly modulo the defining polynomial. The
+four remainders must all vanish. Numerical matching and backend root objects do
+not cross the public boundary.
+
+## Execution envelope
+
+The first envelope admits nonzero homogeneous ternary polynomials of degree one
+through three, at most ten sparse terms, at most sixteen digits per raw rational
+coefficient component, and at most eight digits after primitive integer scalar
+normalization. The degree bound is tied to the complete finite-result
+obligation: Bézout bounds the zero-dimensional Jacobian locus by
+`(degree-1)^2 <= 4`, matching the degree-four residue-field and four-point
+carriers.
+
+Admission derives one execution plan before launching Singular. In the largest
+cubic case it charges four Jacobian generators, at most forty source/partial
+terms, a fifteen-monomial homogeneous Macaulay layer, coefficient growth from a
+Hadamard minor bound followed by Landau–Mignotte factor growth, quotient degree
+four, at most seven separating-form attempts, and the retained exact result.
+The derived coordinate components remain below the number-field carrier's
+256-digit limit. Every decoded ideal is checked against the same plan before it
+can enter point construction or a result: at most 64 generators and 1,024
+aggregate terms, generator degree at most four, and rational coefficient
+components no wider than the derived Macaulay-minor bound. Admission prices the
+largest retained saturation and component family from those limits, plus four
+embedded-point records and fixed JSON framing. A maximal-shape canonical
+serialization remains below the 10-MiB transport boundary; an output that
+contradicts the plan becomes a stage-specific `LIMIT_EXCEEDED` outcome.
+
+All Singular calls and exact point construction share one request-scoped
+deadline. Singular and the one-shot SymPy point worker are killable and have
+fixed diagnostic, address-space, file-size, and exact-output limits. Singular
+is the private exact ideal engine; the isolated SymPy transaction supplies
+factorization, Gröbner shape conversion, and residue-field replay. Public
+identities use only Jacobian's canonical polynomials, ideals, number fields,
+field elements, and embeddings.
+
+The equation is never silently square-free reduced. In characteristic zero a
+projective plane curve has a positive-dimensional singular locus exactly when
+its defining polynomial has a repeated irreducible component; a reduced plane
+curve has only finitely many singular points. This dichotomy selects the result
+branch while the exact saturated ideal remains the defining invariant.

--- a/docs/reference/operations/number-theory/index.md
+++ b/docs/reference/operations/number-theory/index.md
@@ -10,3 +10,4 @@ and finite abelian-group decompositions are separate catalog entries.
 
 - [Powerful-number decision](integer-powerful-number-decision.md)
 - [Integer prime factorization](integer-prime-factorization-verification.md)
+- [Simple number-field embeddings](number-field-embeddings.md)

--- a/docs/reference/operations/number-theory/number-field-embeddings.md
+++ b/docs/reference/operations/number-theory/number-field-embeddings.md
@@ -48,9 +48,6 @@ a raw backend isolator happens to place a root on its boundary.
 
 `SimpleNumberFieldElement` stores exactly degree-many reduced rational
 coordinates in the ascending basis `1, alpha, ..., alpha^(n-1)`.
-`EmbeddedSimpleNumberFieldElement` retains that abstract element together with
-the complete field presentation and one selected exact embedding. It does not
-use an isolating rectangle as embedding identity.
 
 The same serialized `SimpleNumberFieldPresentation` is the `field` input to
 `number_field.discriminant.compute`; no caller-selected polynomial variable or

--- a/docs/reference/operations/number-theory/number-field-embeddings.md
+++ b/docs/reference/operations/number-theory/number-field-embeddings.md
@@ -16,6 +16,11 @@ the complex-conjugate grouping, and the discriminant of `f`. This last value is
 the defining-polynomial discriminant; it is not a claim about the maximal order
 or the field discriminant.
 
+Parsing the carrier establishes only its bounded primitive, positive-leading
+canonical shape. The operation recognizes irreducibility inside its isolated
+worker; ordinary request or result deserialization never factors the polynomial
+or isolates its roots.
+
 **Scope:** Part of #1689; unblocks #2870. This operation and its field/element
 carriers provide separate serializable embedding identities for `i` and `-i`.
 They deliberately do not add the umbrella issue's element-conjugate profile,
@@ -47,36 +52,51 @@ coordinates in the ascending basis `1, alpha, ..., alpha^(n-1)`.
 the complete field presentation and one selected exact embedding. It does not
 use an isolating rectangle as embedding identity.
 
+The same serialized `SimpleNumberFieldPresentation` is the `field` input to
+`number_field.discriminant.compute`; no caller-selected polynomial variable or
+shape conversion is needed. The native `discriminant(field)` and
+`ring_of_integers(field)` functions accept that value directly. Their private
+symbol is always `alpha`. For a nonmonic defining polynomial with leading
+coefficient `a`, maximal-order computation uses the integral generator
+`beta = a*alpha` and substitutes the resulting basis back into the defining
+`alpha` power basis.
+
 ## Execution envelope
 
-The canonical field carrier admits degree at most 8 and at most 256 decimal
-digits per defining coefficient. Before enumerating roots, admission derives:
+The canonical field carrier admits degree at most 31, preserving the existing
+field-discriminant envelope, and at most 256 decimal digits per defining
+coefficient. This complete-profile operation separately admits degree at most
+8. Before enumerating roots, admission derives:
 
-- Mignotte separation bounds for distinct roots and for distinct real
-  coordinates of nonreal roots;
+- a Mignotte separation bound for distinct roots;
 - the size and coefficient-height envelope of the exact real-coordinate
   elimination resultant;
 - rational isolation precision and intermediate component digits;
 - a Hadamard bound for the defining-polynomial discriminant;
-- exact root-ordering and isolation work; and
 - the retained-source JSON result against the 10,485,760-byte canonical
-  transport envelope.
+  transport envelope; and
+- a separate byte bound for the worker's compact root-evidence projection.
 
 The elimination resultant is admitted from a `2n`-square Sylvester determinant
 and at most `2n^2 + 1` integer coefficients before it is expanded; its storage
 envelope is 2,097,152 bits. Exact root refinement is limited to 32,768 bits per
 call. An exact Sturm count supplies the signature after the Sylvester
-intermediate is admitted; inputs whose pair-order precision is too large are
-rejected at that point. Accepted inputs then receive one exact all-root
-isolation pass for deterministic rational evidence candidates. The kernel makes
-`3r2` rational refinements: two per conjugate pair for sign and pair order, and
-one to bind the pair to its admitted evidence rectangle. The complete JSON byte
-estimate counts every repeated presentation, indexed polynomial, and four
-rational components per record (the larger record shape) before embedding
-construction.
+intermediate is admitted. One request-scoped, disposable worker then recognizes
+irreducibility, obtains the exact signature by a Sturm count, and expands the
+real-coordinate resultant only when more than one conjugate pair needs ordering.
+That resultant gives the additional separation bound for distinct real
+coordinates. Inputs whose resulting pair-order precision is too large are
+rejected before root isolation. Accepted inputs receive exactly one exact
+all-root isolation pass at a precision that simultaneously separates roots and
+orders positive representatives. The worker coarsens those fine boxes onto the
+admitted public evidence grid, so high internal pair-order precision cannot
+enlarge a result beyond the component estimate. The complete-result estimate
+counts every repeated presentation, indexed polynomial, and four rational
+components per record (the larger record shape) before embedding construction;
+the worker stdout limit uses the smaller projection estimate instead.
 
-The public pair order is mapped to private backend indexes by exact rational
-refinement at the admitted separation precision. SymPy 1.14 supplies maintained
-exact polynomial irreducibility, resultants, root isolation, `CRootOf`
-refinement, and discriminants. No SymPy expression or floating approximation
-appears in a public value.
+The worker shares the operation's request deadline, is killed on deadline or
+client cancellation, and exits after its one response; SymPy root caches cannot
+survive into a later request. SymPy 1.14 supplies maintained exact polynomial
+irreducibility, resultants, Sturm counts, root isolation, and discriminants. No
+SymPy expression or floating approximation appears in a public value.

--- a/docs/reference/operations/number-theory/number-field-embeddings.md
+++ b/docs/reference/operations/number-theory/number-field-embeddings.md
@@ -1,0 +1,82 @@
+# Simple number-field embeddings
+
+[Documentation home](../../../index.md) · [Tool surface](../../tools.md)
+
+`number_field.embeddings.compute` returns every Archimedean embedding of one
+bounded presentation
+
+```text
+QQ(alpha) = QQ[x] / (f)
+```
+
+where `f` is primitive, irreducible in `ZZ[x]`, and has positive leading
+coefficient. Degree one is the presentation of `QQ`. The operation returns the
+field signature, every exact selected root with rational isolation evidence,
+the complex-conjugate grouping, and the discriminant of `f`. This last value is
+the defining-polynomial discriminant; it is not a claim about the maximal order
+or the field discriminant.
+
+**Scope:** Part of #1689; unblocks #2870. This operation and its field/element
+carriers provide separate serializable embedding identities for `i` and `-i`.
+They deliberately do not add the umbrella issue's element-conjugate profile,
+Minkowski embedding, order recognition, order-ideal construction or arithmetic,
+maximal-order computation, or rational-prime splitting operations.
+
+## Exact identity and order
+
+A real root is identified by its primitive minimal polynomial and its index
+among the increasing real roots. A nonreal root is identified by the same
+polynomial and one global index under this order:
+
+1. all real roots increasingly;
+2. conjugate pairs ordered lexicographically by the positive-imaginary
+   representative `(Re(z), Im(z))`; and
+3. within each pair, the negative-imaginary root followed by the
+   positive-imaginary root.
+
+Rational intervals and closed rectangles certify those identities, but they do
+not define new algebraic values: many valid isolators can describe the same
+indexed root. The operation derives each evidence cell from a certified error
+box strictly inside the public interval or closed rectangle. Mignotte separation
+then proves that the cell contains exactly one root. This avoids ambiguity when
+a raw backend isolator happens to place a root on its boundary.
+
+`SimpleNumberFieldElement` stores exactly degree-many reduced rational
+coordinates in the ascending basis `1, alpha, ..., alpha^(n-1)`.
+`EmbeddedSimpleNumberFieldElement` retains that abstract element together with
+the complete field presentation and one selected exact embedding. It does not
+use an isolating rectangle as embedding identity.
+
+## Execution envelope
+
+The canonical field carrier admits degree at most 8 and at most 256 decimal
+digits per defining coefficient. Before enumerating roots, admission derives:
+
+- Mignotte separation bounds for distinct roots and for distinct real
+  coordinates of nonreal roots;
+- the size and coefficient-height envelope of the exact real-coordinate
+  elimination resultant;
+- rational isolation precision and intermediate component digits;
+- a Hadamard bound for the defining-polynomial discriminant;
+- exact root-ordering and isolation work; and
+- the retained-source JSON result against the 10,485,760-byte canonical
+  transport envelope.
+
+The elimination resultant is admitted from a `2n`-square Sylvester determinant
+and at most `2n^2 + 1` integer coefficients before it is expanded; its storage
+envelope is 2,097,152 bits. Exact root refinement is limited to 32,768 bits per
+call. An exact Sturm count supplies the signature after the Sylvester
+intermediate is admitted; inputs whose pair-order precision is too large are
+rejected at that point. Accepted inputs then receive one exact all-root
+isolation pass for deterministic rational evidence candidates. The kernel makes
+`3r2` rational refinements: two per conjugate pair for sign and pair order, and
+one to bind the pair to its admitted evidence rectangle. The complete JSON byte
+estimate counts every repeated presentation, indexed polynomial, and four
+rational components per record (the larger record shape) before embedding
+construction.
+
+The public pair order is mapped to private backend indexes by exact rational
+refinement at the admitted separation precision. SymPy 1.14 supplies maintained
+exact polynomial irreducibility, resultants, root isolation, `CRootOf`
+refinement, and discriminants. No SymPy expression or floating approximation
+appears in a public value.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,7 @@ ignore_imports = [
     "jacobian.math.combinatorics._counting_process -> jacobian.process",
     "jacobian.math.number_theory.number_fields._discriminant_process -> jacobian.process",
     "jacobian.math.number_theory.number_fields._embeddings_process -> jacobian.process",
+    "jacobian.math.geometry.algebraic_curves._singularity_point_process -> jacobian.process",
     "jacobian.math.number_theory._factorization_kernels -> jacobian.process",
     # Private exact-algebra adapters share one bounded Singular process owner.
     "jacobian.math._singular -> jacobian.process",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,7 @@ ignore_imports = [
     "jacobian.math.combinatorics.discrepancy._optimum_process -> jacobian.process",
     "jacobian.math.combinatorics._counting_process -> jacobian.process",
     "jacobian.math.number_theory.number_fields._discriminant_process -> jacobian.process",
+    "jacobian.math.number_theory.number_fields._embeddings_process -> jacobian.process",
     "jacobian.math.number_theory._factorization_kernels -> jacobian.process",
     # Private exact-algebra adapters share one bounded Singular process owner.
     "jacobian.math._singular -> jacobian.process",

--- a/src/jacobian/math/_singular.py
+++ b/src/jacobian/math/_singular.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import shutil
 import tempfile
 from dataclasses import dataclass
@@ -106,7 +107,7 @@ def format_singular_version(version: int) -> str:
 def run_bounded_singular(
     source: bytes,
     *,
-    wall_seconds: int,
+    wall_seconds: float,
 ) -> BoundedProcessResult | None:
     """Run one request-scoped Singular program, or return ``None`` if unavailable."""
 
@@ -127,7 +128,7 @@ def run_bounded_singular(
                 stdout_limit=_STDOUT_LIMIT,
                 stderr_limit=_STDERR_LIMIT,
                 resource_limits=ProcessResourceLimits(
-                    cpu_seconds=wall_seconds,
+                    cpu_seconds=max(1, math.ceil(wall_seconds)),
                     address_space_bytes=_ADDRESS_SPACE_LIMIT,
                     file_size_bytes=_FILE_SIZE_LIMIT,
                 ),

--- a/src/jacobian/math/geometry/algebraic_curves/__init__.py
+++ b/src/jacobian/math/geometry/algebraic_curves/__init__.py
@@ -1,15 +1,23 @@
 """Plane algebraic curve operations."""
 
+from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    ProjectivePlaneCurveSingularityBudget,
+    ProjectivePlaneCurveSingularityProfile,
+)
 from jacobian.math.geometry.algebraic_curves.operations import (
     affine_chart,
     affine_curve_check,
     projective_closure,
     rational_conic_parametrization,
+    singularity_profile,
 )
 
 __all__ = [
+    "ProjectivePlaneCurveSingularityBudget",
+    "ProjectivePlaneCurveSingularityProfile",
     "affine_chart",
     "affine_curve_check",
     "projective_closure",
     "rational_conic_parametrization",
+    "singularity_profile",
 ]

--- a/src/jacobian/math/geometry/algebraic_curves/_models.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_models.py
@@ -9,6 +9,17 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    IncompleteProjectivePlaneCurveSingularityComputation,
+    PositiveDimensionalProjectivePlaneCurveSingularLocus,
+    ProjectivePlaneCurveFirstJet,
+    ProjectivePlaneCurveSingularityBudget,
+    ProjectivePlaneCurveSingularityProfile,
+    ProjectivePlaneCurveSingularityRequest,
+    ProjectivePlaneCurveSingularPointRecord,
+    SmoothProjectivePlaneCurve,
+    ZeroDimensionalProjectivePlaneCurveSingularLocus,
+)
 from jacobian.math.polynomials.maps._models import VariablePoint
 from jacobian.math.polynomials.values import (
     PolynomialVariable,
@@ -288,8 +299,17 @@ __all__ = [
     "AffineChartResult",
     "AffineCurveRequest",
     "AffineCurveResult",
+    "IncompleteProjectivePlaneCurveSingularityComputation",
+    "PositiveDimensionalProjectivePlaneCurveSingularLocus",
     "ProjectiveClosureRequest",
     "ProjectiveClosureResult",
+    "ProjectivePlaneCurveFirstJet",
+    "ProjectivePlaneCurveSingularPointRecord",
+    "ProjectivePlaneCurveSingularityBudget",
+    "ProjectivePlaneCurveSingularityProfile",
+    "ProjectivePlaneCurveSingularityRequest",
     "RationalConicParametrizationRequest",
     "RationalConicParametrizationResult",
+    "SmoothProjectivePlaneCurve",
+    "ZeroDimensionalProjectivePlaneCurveSingularLocus",
 ]

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity.py
@@ -1,0 +1,803 @@
+"""Exact bounded singular-locus kernel for projective plane curves."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from math import comb
+from time import monotonic
+from typing import Literal
+
+import sympy
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_execution,
+)
+from jacobian.canonical import CanonicalizationError, encode_strict_json
+from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    MAX_PROJECTIVE_SINGULAR_COMPONENTS,
+    MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE,
+    MAX_PROJECTIVE_SINGULAR_POINTS,
+    IncompleteProjectivePlaneCurveSingularityComputation,
+    PositiveDimensionalProjectivePlaneCurveSingularLocus,
+    ProjectivePlaneCurveFirstJet,
+    ProjectivePlaneCurveSingularityBudget,
+    ProjectivePlaneCurveSingularityOutcome,
+    ProjectivePlaneCurveSingularityProfile,
+    ProjectivePlaneCurveSingularityRequest,
+    ProjectivePlaneCurveSingularPointRecord,
+    SmoothProjectivePlaneCurve,
+    ZeroDimensionalProjectivePlaneCurveSingularLocus,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_process import (
+    PointConstructionLimitError,
+    run_point_construction_worker,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_worker import (
+    ProjectiveSingularityPointSeed,
+    ProjectiveSingularityPointWorkerRequest,
+)
+from jacobian.math.geometry.projective.values import AlgebraicProjectivePlanePoint
+from jacobian.math.number_theory.number_fields.operations import embeddings
+from jacobian.math.number_theory.number_fields.values import (
+    NumberFieldEmbeddingProfile,
+    SimpleNumberFieldElement,
+)
+from jacobian.math.polynomials._conversions import (
+    rational_polynomial_from_sympy,
+    rational_polynomial_to_sympy,
+)
+from jacobian.math.polynomials.ideals._models import IdealComputationBudget
+from jacobian.math.polynomials.ideals._singular import (
+    SingularIdealResult,
+    SingularMinimalPrimesResult,
+    run_singular_ideal_operation,
+    run_singular_minimal_primes,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+_MAX_NORMALIZED_SOURCE_COEFFICIENT_DIGITS = 8
+_MAX_BACKEND_GENERATORS = 64
+_MAX_BACKEND_TERMS = 1_024
+_MAX_IDEAL_GENERATOR_DEGREE = 4
+_MAX_POINT_COORDINATE_DIGITS = 256
+_MAX_SHAPE_ATTEMPTS = comb(MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE, 2) + 1
+_PROFILE_FIXED_BYTES = 64 * 1_024
+_IDEAL_TERM_FRAMING_BYTES = 192
+_IDEAL_GENERATOR_FRAMING_BYTES = 512
+_IDEAL_COMPONENT_FRAMING_BYTES = 256
+_IDEAL_FAMILY_FIXED_BYTES = 4_096
+_CANONICAL_RESULT_BYTES = 10 * 1_024 * 1_024
+
+FailureStage = Literal[
+    "SATURATION",
+    "PROJECTIVE_COMPONENTS",
+    "CHART_ZERO_COMPONENTS",
+    "CHART_ONE_COMPONENTS",
+    "POINT_CONSTRUCTION",
+    "RESULT_CONSTRUCTION",
+]
+FailureStatus = Literal[
+    "BACKEND_UNAVAILABLE",
+    "TIMEOUT",
+    "CANCELLED",
+    "LIMIT_EXCEEDED",
+    "BACKEND_ERROR",
+]
+
+
+class _SingularityAdmissionError(ValueError):
+    """The normalized request exceeds the derived execution envelope."""
+
+
+@dataclass(frozen=True, slots=True)
+class _SingularityAdmission:
+    """One derived execution proof reused by every kernel phase."""
+
+    degree: int
+    source_terms: int
+    normalized_coefficient_digits: int
+    jacobian_generator_bound: int
+    jacobian_term_bound: int
+    macaulay_matrix_dimension_bound: int
+    macaulay_minor_component_digits: int
+    ideal_generator_degree_bound: int
+    quotient_degree_bound: int
+    geometric_point_bound: int
+    shape_attempt_bound: int
+    predicted_result_bytes: int
+    has_repeated_component: bool
+
+
+def _remaining(deadline: float) -> float:
+    return deadline - monotonic()
+
+
+def _deadline_for(request: ProjectivePlaneCurveSingularityRequest) -> float:
+    execution = current_request_execution()
+    started = execution.started_at if execution is not None else monotonic()
+    owner_deadline = started + request.resource_budget.wall_seconds
+    deadline = (
+        min(owner_deadline, execution.deadline)
+        if execution is not None and execution.deadline is not None
+        else owner_deadline
+    )
+    bind_request_deadline(deadline)
+    return deadline
+
+
+def _normalized_source(polynomial: RationalPolynomial) -> sympy.Poly:
+    source = rational_polynomial_to_sympy(polynomial)
+    _denominator, integer_source = source.clear_denoms(convert=True)
+    _content, primitive = integer_source.primitive()
+    if primitive.LC() < 0:
+        primitive = -primitive
+    return sympy.Poly(primitive, *source.gens, domain=sympy.QQ)
+
+
+def _predicted_point_record_bytes() -> int:
+    degree = MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE
+    integer_bytes = _MAX_POINT_COORDINATE_DIGITS + 3
+    rational_bytes = 2 * _MAX_POINT_COORDINATE_DIGITS + 32
+    presentation_bytes = (degree + 1) * integer_bytes + 256
+    element_bytes = presentation_bytes + degree * rational_bytes + 256
+    # The point has three coordinates and its first jet has four values.  An
+    # embedding repeats the presentation once in its indexed root identity.
+    embedding_bytes = 2 * presentation_bytes + 512
+    return embedding_bytes + 7 * element_bytes + 2_048
+
+
+def _predicted_profile_bytes(component_digits: int) -> int:
+    """Bound the largest retained positive- or zero-dimensional profile."""
+
+    term_bytes = 2 * component_digits + _IDEAL_TERM_FRAMING_BYTES
+    ideal_family_bytes = (
+        _IDEAL_FAMILY_FIXED_BYTES
+        + MAX_PROJECTIVE_SINGULAR_COMPONENTS * _IDEAL_COMPONENT_FRAMING_BYTES
+        + _MAX_BACKEND_GENERATORS * _IDEAL_GENERATOR_FRAMING_BYTES
+        + _MAX_BACKEND_TERMS * term_bytes
+    )
+    # The positive branch is the larger ideal shape: one saturation plus one
+    # complete minimal-prime family.  The alternate finite branch replaces the
+    # latter with at most four embedded point records.
+    return (
+        2 * ideal_family_bytes
+        + MAX_PROJECTIVE_SINGULAR_POINTS * _predicted_point_record_bytes()
+        + _PROFILE_FIXED_BYTES
+    )
+
+
+def _admit_singularity(source: sympy.Poly) -> _SingularityAdmission:
+    """Derive intermediate, quotient, point, and exact-result bounds once."""
+
+    degree = int(source.total_degree())
+    source_terms = len(source.terms())
+    coefficient_height = max(abs(int(coefficient)) for coefficient in source.coeffs())
+    coefficient_digits = len(str(coefficient_height))
+    if coefficient_digits > _MAX_NORMALIZED_SOURCE_COEFFICIENT_DIGITS:
+        raise _SingularityAdmissionError(
+            "primitive source coefficients exceed the derived 8-digit elimination envelope"
+        )
+
+    # For ternary cubics, the relevant homogeneous Macaulay layer through
+    # degree four has C(4+2,2)=15 monomials.  Hadamard bounds a 15-square
+    # minor by (3H)^15 * 15^8; Landau-Mignotte factor growth for a degree-four
+    # eliminant contributes at most (n+1)2^n.  This bounds both numerator and
+    # denominator components used by the residue-field coordinates.
+    macaulay_dimension = 15
+    minor_bound = (3 * max(coefficient_height, 1)) ** macaulay_dimension * (
+        macaulay_dimension**8
+    )
+    factor_bound = (
+        (MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE + 1)
+        * 2**MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE
+        * minor_bound
+    )
+    minor_digits = len(str(factor_bound))
+    if minor_digits > _MAX_POINT_COORDINATE_DIGITS:
+        raise _SingularityAdmissionError(
+            "the derived elimination minors exceed the 256-digit point-carrier bound"
+        )
+
+    predicted_result_bytes = _predicted_profile_bytes(minor_digits)
+
+    quotient_degree = (degree - 1) ** 2
+    admission = _SingularityAdmission(
+        degree=degree,
+        source_terms=source_terms,
+        normalized_coefficient_digits=coefficient_digits,
+        jacobian_generator_bound=4,
+        jacobian_term_bound=4 * source_terms,
+        macaulay_matrix_dimension_bound=macaulay_dimension,
+        macaulay_minor_component_digits=minor_digits,
+        ideal_generator_degree_bound=_MAX_IDEAL_GENERATOR_DEGREE,
+        quotient_degree_bound=quotient_degree,
+        geometric_point_bound=quotient_degree,
+        shape_attempt_bound=comb(quotient_degree, 2) + 1,
+        predicted_result_bytes=predicted_result_bytes,
+        has_repeated_component=not source.is_sqf,
+    )
+    if (
+        admission.quotient_degree_bound > MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE
+        or admission.geometric_point_bound > MAX_PROJECTIVE_SINGULAR_POINTS
+        or admission.shape_attempt_bound > _MAX_SHAPE_ATTEMPTS
+        or admission.predicted_result_bytes >= _CANONICAL_RESULT_BYTES
+    ):
+        raise _SingularityAdmissionError(
+            "the derived quotient, point, shape, or exact-result envelope is exceeded"
+        )
+    return admission
+
+
+def _to_public_polynomial(
+    polynomial: sympy.Poly,
+    variables: tuple[str, ...],
+) -> RationalPolynomial:
+    return rational_polynomial_from_sympy(
+        polynomial,
+        variables,
+        maximum_terms=_MAX_BACKEND_TERMS,
+    )
+
+
+def _variable_polynomial(
+    variables: tuple[str, str, str], index: int
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(num="1", den="1"),
+                    exponents=tuple(1 if slot == index else 0 for slot in range(3)),
+                ),
+            )
+        ),
+    )
+
+
+def _ideal_budget(
+    request: ProjectivePlaneCurveSingularityRequest,
+) -> IdealComputationBudget:
+    return IdealComputationBudget(
+        wall_seconds=request.resource_budget.wall_seconds,
+        maximum_output_generators=_MAX_BACKEND_GENERATORS,
+        maximum_output_terms=_MAX_BACKEND_TERMS,
+    )
+
+
+def _is_unit_ideal(ideal: RationalPolynomialIdeal) -> bool:
+    if len(ideal.generators) != 1:
+        return False
+    terms = ideal.generators[0].polynomial.terms
+    return (
+        len(terms) == 1
+        and not any(terms[0].exponents)
+        and terms[0].coefficient.as_fraction() != 0
+    )
+
+
+def _ideal_projection_limit_failure(
+    stage: FailureStage,
+    ideals: tuple[RationalPolynomialIdeal, ...],
+    admission: _SingularityAdmission,
+    *,
+    maximum_ideals: int,
+) -> IncompleteProjectivePlaneCurveSingularityComputation | None:
+    """Reject a decoded ideal family that contradicts the admitted plan."""
+
+    if len(ideals) > maximum_ideals:
+        return _limit_failure(
+            stage,
+            "the exact ideal family exceeds the admitted component bound",
+        )
+    generator_count = sum(len(ideal.generators) for ideal in ideals)
+    term_count = sum(
+        len(generator.polynomial.terms)
+        for ideal in ideals
+        for generator in ideal.generators
+    )
+    if generator_count > _MAX_BACKEND_GENERATORS:
+        return _limit_failure(
+            stage,
+            "the exact ideal family exceeds the admitted generator bound",
+        )
+    if term_count > _MAX_BACKEND_TERMS:
+        return _limit_failure(
+            stage,
+            "the exact ideal family exceeds the admitted term bound",
+        )
+    for ideal in ideals:
+        for generator in ideal.generators:
+            for term in generator.polynomial.terms:
+                if sum(term.exponents) > admission.ideal_generator_degree_bound:
+                    return _limit_failure(
+                        stage,
+                        "an exact ideal generator exceeds the admitted degree bound",
+                    )
+                if (
+                    len(term.coefficient.num.lstrip("-"))
+                    > admission.macaulay_minor_component_digits
+                    or len(term.coefficient.den)
+                    > admission.macaulay_minor_component_digits
+                ):
+                    return _limit_failure(
+                        stage,
+                        "an exact ideal coefficient exceeds the admitted Macaulay bound",
+                    )
+    return None
+
+
+def _failure(
+    stage: FailureStage,
+    backend: SingularIdealResult | SingularMinimalPrimesResult,
+) -> IncompleteProjectivePlaneCurveSingularityComputation:
+    status: FailureStatus
+    if backend.outcome == "UNAVAILABLE":
+        status = "BACKEND_UNAVAILABLE"
+    elif backend.outcome == "TIMEOUT":
+        status = "TIMEOUT"
+    elif backend.outcome == "CANCELLED":
+        status = "CANCELLED"
+    elif backend.outcome == "LIMIT_EXCEEDED":
+        status = "LIMIT_EXCEEDED"
+    else:
+        status = "BACKEND_ERROR"
+    return IncompleteProjectivePlaneCurveSingularityComputation(
+        status=status,
+        stage=stage,
+        detail=backend.detail or "the exact backend did not produce a complete result",
+    )
+
+
+def _local_failure(
+    detail: str,
+) -> IncompleteProjectivePlaneCurveSingularityComputation:
+    return IncompleteProjectivePlaneCurveSingularityComputation(
+        status="BACKEND_ERROR",
+        stage="POINT_CONSTRUCTION",
+        detail=detail[:256],
+    )
+
+
+def _limit_failure(
+    stage: FailureStage,
+    detail: str,
+) -> IncompleteProjectivePlaneCurveSingularityComputation:
+    return IncompleteProjectivePlaneCurveSingularityComputation(
+        status="LIMIT_EXCEEDED",
+        stage=stage,
+        detail=detail[:256],
+    )
+
+
+def _timeout_failure(
+    stage: FailureStage,
+) -> IncompleteProjectivePlaneCurveSingularityComputation:
+    return IncompleteProjectivePlaneCurveSingularityComputation(
+        status="TIMEOUT",
+        stage=stage,
+        detail="the shared projective singularity deadline expired",
+    )
+
+
+def _cancelled_failure(
+    stage: FailureStage,
+) -> IncompleteProjectivePlaneCurveSingularityComputation:
+    return IncompleteProjectivePlaneCurveSingularityComputation(
+        status="CANCELLED",
+        stage=stage,
+        detail="the projective singularity request was cancelled",
+    )
+
+
+def _specialize_ideal(
+    ideal: RationalPolynomialIdeal,
+    *,
+    substitutions: dict[int, int],
+    remaining_indices: tuple[int, ...],
+) -> RationalPolynomialIdeal:
+    remaining_variables = tuple(ideal.variables[index] for index in remaining_indices)
+    generators: list[RationalPolynomial] = []
+    for generator in ideal.generators:
+        coefficients: dict[tuple[int, ...], Fraction] = {}
+        for term in generator.polynomial.terms:
+            if any(
+                value == 0 and term.exponents[index] > 0
+                for index, value in substitutions.items()
+            ):
+                continue
+            exponents = tuple(term.exponents[index] for index in remaining_indices)
+            coefficients[exponents] = (
+                coefficients.get(exponents, Fraction(0))
+                + term.coefficient.as_fraction()
+            )
+        terms = tuple(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational.from_fraction(coefficient),
+                exponents=exponents,
+            )
+            for exponents, coefficient in sorted(coefficients.items(), reverse=True)
+            if coefficient
+        )
+        generators.append(
+            RationalPolynomial(
+                variables=remaining_variables,
+                polynomial=SparseRationalPolynomial(terms=terms),
+            )
+        )
+    return RationalPolynomialIdeal(
+        variables=remaining_variables,
+        generators=tuple(generators),
+    )
+
+
+def _chart_two_is_present(ideal: RationalPolynomialIdeal) -> bool:
+    return all(
+        sum(
+            (
+                term.coefficient.as_fraction()
+                for term in generator.polynomial.terms
+                if term.exponents[0] == 0 and term.exponents[1] == 0
+            ),
+            Fraction(0),
+        )
+        == 0
+        for generator in ideal.generators
+    )
+
+
+def _records_from_worker_seeds(
+    seeds: tuple[ProjectiveSingularityPointSeed, ...],
+    *,
+    axis: tuple[str, str, str],
+    maximum_points: int,
+) -> tuple[ProjectivePlaneCurveSingularPointRecord, ...]:
+    if sum(seed.presentation.degree for seed in seeds) > maximum_points:
+        raise RuntimeError("point worker exceeded the admitted geometric point bound")
+    records: list[ProjectivePlaneCurveSingularPointRecord] = []
+    profiles_by_presentation: dict[str, NumberFieldEmbeddingProfile] = {}
+    for seed in seeds:
+        zero = SimpleNumberFieldElement(
+            presentation=seed.presentation,
+            coefficients_ascending=tuple(
+                CanonicalRational(num="0", den="1")
+                for _ in range(seed.presentation.degree)
+            ),
+        )
+        presentation_key = seed.presentation.model_dump_json()
+        profile = profiles_by_presentation.get(presentation_key)
+        if profile is None:
+            profile = embeddings(seed.presentation)
+            profiles_by_presentation[presentation_key] = profile
+        records.extend(
+            ProjectivePlaneCurveSingularPointRecord(
+                point=AlgebraicProjectivePlanePoint(
+                    axis=axis,
+                    embedding=record.embedding,
+                    coordinates=seed.coordinates,
+                    chart_index=seed.chart_index,
+                ),
+                first_jet=ProjectivePlaneCurveFirstJet._from_kernel(
+                    value=zero,
+                    gradient=(zero, zero, zero),
+                ),
+            )
+            for record in profile.records
+        )
+    return tuple(sorted(records, key=lambda record: record.point.model_dump_json()))
+
+
+def _complete_zero_dimensional_points(
+    saturation: RationalPolynomialIdeal,
+    *,
+    admission: _SingularityAdmission,
+    source: RationalPolynomial,
+    partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
+    axis: tuple[str, str, str],
+    budget: IdealComputationBudget,
+    deadline: float,
+    maximum_points: int,
+) -> (
+    tuple[ProjectivePlaneCurveSingularPointRecord, ...]
+    | IncompleteProjectivePlaneCurveSingularityComputation
+):
+    chart_zero = _specialize_ideal(
+        saturation,
+        substitutions={0: 1},
+        remaining_indices=(1, 2),
+    )
+    chart_zero_primes = run_singular_minimal_primes(
+        chart_zero,
+        budget,
+        wall_seconds=_remaining(deadline),
+    )
+    if chart_zero_primes.outcome != "COMPUTED":
+        return _failure("CHART_ZERO_COMPONENTS", chart_zero_primes)
+    chart_zero_components = chart_zero_primes.components or ()
+    projection_failure = _ideal_projection_limit_failure(
+        "CHART_ZERO_COMPONENTS",
+        chart_zero_components,
+        admission,
+        maximum_ideals=MAX_PROJECTIVE_SINGULAR_POINTS,
+    )
+    if projection_failure is not None:
+        return projection_failure
+
+    chart_one = _specialize_ideal(
+        saturation,
+        substitutions={0: 0, 1: 1},
+        remaining_indices=(2,),
+    )
+    chart_one_primes = run_singular_minimal_primes(
+        chart_one,
+        budget,
+        wall_seconds=_remaining(deadline),
+    )
+    if chart_one_primes.outcome != "COMPUTED":
+        return _failure("CHART_ONE_COMPONENTS", chart_one_primes)
+    chart_one_components = chart_one_primes.components or ()
+    projection_failure = _ideal_projection_limit_failure(
+        "CHART_ONE_COMPONENTS",
+        chart_one_components,
+        admission,
+        maximum_ideals=MAX_PROJECTIVE_SINGULAR_POINTS,
+    )
+    if projection_failure is not None:
+        return projection_failure
+
+    worker_request = ProjectiveSingularityPointWorkerRequest(
+        source=source,
+        partials=partials,
+        chart_zero_components=chart_zero_components,
+        chart_one_components=chart_one_components,
+        chart_two_present=_chart_two_is_present(saturation),
+    )
+    worker_response = run_point_construction_worker(
+        worker_request,
+        deadline=deadline,
+    )
+    return _records_from_worker_seeds(
+        worker_response.seeds,
+        axis=axis,
+        maximum_points=maximum_points,
+    )
+
+
+def _profile(
+    *,
+    source: RationalPolynomial,
+    partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
+    outcome: ProjectivePlaneCurveSingularityOutcome,
+) -> ProjectivePlaneCurveSingularityProfile:
+    return ProjectivePlaneCurveSingularityProfile._from_kernel(
+        source=source,
+        axis=(source.variables[0], source.variables[1], source.variables[2]),
+        partials=partials,
+        outcome=outcome,
+    )
+
+
+def _positive_dimensional_outcome(
+    saturation: RationalPolynomialIdeal,
+    *,
+    admission: _SingularityAdmission,
+    budget: IdealComputationBudget,
+    deadline: float,
+) -> ProjectivePlaneCurveSingularityOutcome:
+    components_backend = run_singular_minimal_primes(
+        saturation,
+        budget,
+        wall_seconds=_remaining(deadline),
+    )
+    if components_backend.outcome != "COMPUTED":
+        return _failure("PROJECTIVE_COMPONENTS", components_backend)
+    components = components_backend.components or ()
+    projection_failure = _ideal_projection_limit_failure(
+        "PROJECTIVE_COMPONENTS",
+        components,
+        admission,
+        maximum_ideals=MAX_PROJECTIVE_SINGULAR_COMPONENTS,
+    )
+    if projection_failure is not None:
+        return projection_failure
+    if not components:
+        return _local_failure(
+            "a repeated component produced no rational minimal component"
+        )
+    return PositiveDimensionalProjectivePlaneCurveSingularLocus._from_kernel(
+        ideal=saturation,
+        components=components,
+    )
+
+
+def _bounded_result_profile(
+    *,
+    source: RationalPolynomial,
+    partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
+    outcome: ProjectivePlaneCurveSingularityOutcome,
+    admission: _SingularityAdmission,
+    deadline: float,
+) -> ProjectivePlaneCurveSingularityProfile:
+    if _remaining(deadline) <= 0:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_timeout_failure("RESULT_CONSTRUCTION"),
+        )
+    profile = _profile(source=source, partials=partials, outcome=outcome)
+    try:
+        encoded_bytes = len(encode_strict_json(profile.model_dump(mode="json")))
+    except CanonicalizationError:
+        encoded_bytes = _CANONICAL_RESULT_BYTES + 1
+    if encoded_bytes > admission.predicted_result_bytes:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_limit_failure(
+                "RESULT_CONSTRUCTION",
+                "the exact singularity profile exceeds its admitted byte bound",
+            ),
+        )
+    if _remaining(deadline) <= 0:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_timeout_failure("RESULT_CONSTRUCTION"),
+        )
+    return profile
+
+
+def _singularity_profile_request(
+    request: ProjectivePlaneCurveSingularityRequest,
+) -> ProjectivePlaneCurveSingularityProfile:
+    deadline = _deadline_for(request)
+
+    try:
+        source_backend = _normalized_source(request.polynomial)
+        admission = _admit_singularity(source_backend)
+    except _SingularityAdmissionError as exc:
+        # This is deterministic semantic admission, not a backend failure.
+        from jacobian.catalog.models import OperationDomainValidationError
+
+        raise OperationDomainValidationError(
+            location=("polynomial",),
+            code="projective_plane_curve.normalized_height_bound",
+            message=str(exc),
+        ) from exc
+
+    axis = (
+        request.polynomial.variables[0],
+        request.polynomial.variables[1],
+        request.polynomial.variables[2],
+    )
+    source = _to_public_polynomial(source_backend, axis)
+    partials_backend = (
+        source_backend.diff(source_backend.gens[0]),
+        source_backend.diff(source_backend.gens[1]),
+        source_backend.diff(source_backend.gens[2]),
+    )
+    partials = (
+        _to_public_polynomial(partials_backend[0], axis),
+        _to_public_polynomial(partials_backend[1], axis),
+        _to_public_polynomial(partials_backend[2], axis),
+    )
+    if _remaining(deadline) <= 0:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_timeout_failure("SATURATION"),
+        )
+    budget = _ideal_budget(request)
+    jacobian_ideal = RationalPolynomialIdeal(
+        variables=axis,
+        generators=(source, *partials),
+    )
+    irrelevant_ideal = RationalPolynomialIdeal(
+        variables=axis,
+        generators=tuple(_variable_polynomial(axis, index) for index in range(3)),
+    )
+    saturation_backend = run_singular_ideal_operation(
+        "saturation",
+        jacobian_ideal,
+        irrelevant_ideal,
+        budget,
+        wall_seconds=_remaining(deadline),
+    )
+    if saturation_backend.outcome != "COMPUTED" or saturation_backend.ideal is None:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_failure("SATURATION", saturation_backend),
+        )
+    saturation = saturation_backend.ideal
+    projection_failure = _ideal_projection_limit_failure(
+        "SATURATION",
+        (saturation,),
+        admission,
+        maximum_ideals=1,
+    )
+    if projection_failure is not None:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=projection_failure,
+        )
+
+    if admission.has_repeated_component:
+        outcome: ProjectivePlaneCurveSingularityOutcome = _positive_dimensional_outcome(
+            saturation,
+            admission=admission,
+            budget=budget,
+            deadline=deadline,
+        )
+    elif _is_unit_ideal(saturation):
+        outcome = SmoothProjectivePlaneCurve._from_kernel(saturation)
+    else:
+        try:
+            points = _complete_zero_dimensional_points(
+                saturation,
+                admission=admission,
+                source=source,
+                partials=partials,
+                axis=axis,
+                budget=budget,
+                deadline=deadline,
+                maximum_points=admission.geometric_point_bound,
+            )
+        except OperationExecutionTimeoutError:
+            outcome = _timeout_failure("POINT_CONSTRUCTION")
+        except OperationExecutionCancelledError:
+            outcome = _cancelled_failure("POINT_CONSTRUCTION")
+        except PointConstructionLimitError as exc:
+            outcome = _limit_failure("POINT_CONSTRUCTION", str(exc))
+        except (ValueError, TypeError, ArithmeticError, RuntimeError):
+            outcome = _local_failure(
+                "exact point construction rejected malformed backend algebra"
+            )
+        else:
+            if isinstance(points, IncompleteProjectivePlaneCurveSingularityComputation):
+                outcome = points
+            else:
+                outcome = ZeroDimensionalProjectivePlaneCurveSingularLocus._from_kernel(
+                    ideal=saturation,
+                    points=points,
+                )
+
+    return _bounded_result_profile(
+        source=source,
+        partials=partials,
+        outcome=outcome,
+        admission=admission,
+        deadline=deadline,
+    )
+
+
+def singularity_profile(
+    polynomial: RationalPolynomial,
+    resource_budget: ProjectivePlaneCurveSingularityBudget | None = None,
+) -> ProjectivePlaneCurveSingularityProfile:
+    """Compute the complete geometric singular locus of one admitted curve."""
+
+    started = monotonic()
+    request = ProjectivePlaneCurveSingularityRequest(
+        polynomial=polynomial,
+        resource_budget=resource_budget or ProjectivePlaneCurveSingularityBudget(),
+    )
+    if current_request_execution() is not None:
+        return _singularity_profile_request(request)
+    with request_execution(started):
+        return _singularity_profile_request(request)
+
+
+__all__ = ["singularity_profile"]

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity_models.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity_models.py
@@ -1,0 +1,400 @@
+"""Typed contracts for exact projective plane-curve singular loci."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import Field, StrictInt, StringConstraints, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.geometry.projective.values import AlgebraicProjectivePlanePoint
+from jacobian.math.number_theory.number_fields.values import SimpleNumberFieldElement
+from jacobian.math.polynomials.values import (
+    PolynomialVariable,
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+    require_polynomial_budget,
+)
+
+MAX_PROJECTIVE_PLANE_CURVE_DEGREE = 3
+MAX_PROJECTIVE_PLANE_CURVE_TERMS = 10
+MAX_PROJECTIVE_PLANE_CURVE_COEFFICIENT_DIGITS = 16
+MAX_PROJECTIVE_SINGULAR_POINTS = 4
+MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE = 4
+MAX_PROJECTIVE_SINGULAR_COMPONENTS = 16
+MAX_PROJECTIVE_SINGULARITY_WALL_SECONDS = 60
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"projective_plane_curve.{reason}", message)
+
+
+class ProjectivePlaneCurveSingularityBudget(StrictModel):
+    """The one request-scoped wall deadline for all exact backend phases."""
+
+    wall_seconds: StrictInt = Field(
+        default=30,
+        ge=1,
+        le=MAX_PROJECTIVE_SINGULARITY_WALL_SECONDS,
+        description=(
+            "One shared deadline, in seconds, covering saturation, prime "
+            "decomposition, exact point construction, and serialization."
+        ),
+    )
+
+
+class ProjectivePlaneCurveSingularityRequest(StrictModel):
+    """One bounded nonzero homogeneous ternary polynomial over ``QQ``."""
+
+    polynomial: RationalPolynomial = Field(
+        description=(
+            "A nonzero homogeneous polynomial in exactly three ordered variables. "
+            "The first envelope admits total degree 1 through 3, at most 10 terms, "
+            "and at most 16 digits in each rational coefficient component."
+        )
+    )
+    resource_budget: ProjectivePlaneCurveSingularityBudget = Field(
+        default_factory=ProjectivePlaneCurveSingularityBudget
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_term_bound(cls, data: Any) -> Any:
+        if not isinstance(data, Mapping):
+            return data
+        polynomial = data.get("polynomial")
+        if isinstance(polynomial, Mapping):
+            sparse = polynomial.get("polynomial")
+            if isinstance(sparse, Mapping):
+                terms = sparse.get("terms")
+                if isinstance(terms, (list, tuple)) and len(terms) > (
+                    MAX_PROJECTIVE_PLANE_CURVE_TERMS
+                ):
+                    raise _validation_error(
+                        "term_bound",
+                        "projective plane-curve source exceeds the 10-term envelope",
+                    )
+        return canonicalize_json_containers(data)
+
+    @model_validator(mode="after")
+    def require_backend_domain(self) -> Self:
+        try:
+            require_polynomial_budget(
+                self.polynomial,
+                maximum_terms=MAX_PROJECTIVE_PLANE_CURVE_TERMS,
+                maximum_exponent=MAX_PROJECTIVE_PLANE_CURVE_DEGREE,
+                maximum_coefficient_digits=(
+                    MAX_PROJECTIVE_PLANE_CURVE_COEFFICIENT_DIGITS
+                ),
+                label="projective plane-curve source",
+            )
+        except ValueError as exc:
+            raise _validation_error("source_bound", str(exc)) from exc
+        if len(self.polynomial.variables) != 3:
+            raise _validation_error(
+                "axis",
+                "a projective plane curve requires exactly three ordered variables",
+            )
+        terms = self.polynomial.polynomial.terms
+        if not terms:
+            raise _validation_error(
+                "zero_source", "the zero polynomial does not define a plane curve"
+            )
+        total_degrees = {sum(term.exponents) for term in terms}
+        if len(total_degrees) != 1:
+            raise _validation_error(
+                "homogeneity", "the projective plane-curve source must be homogeneous"
+            )
+        degree = next(iter(total_degrees))
+        if not 1 <= degree <= MAX_PROJECTIVE_PLANE_CURVE_DEGREE:
+            raise _validation_error(
+                "degree_bound",
+                "the first projective singularity envelope admits degree 1 through 3",
+            )
+        return self
+
+
+class ProjectivePlaneCurveFirstJet(StrictModel):
+    """The exact value and ordered first partials at one algebraic point."""
+
+    value: SimpleNumberFieldElement
+    gradient: tuple[
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+    ]
+
+    @model_validator(mode="after")
+    def require_one_field(self) -> Self:
+        presentation = self.value.presentation
+        entries = (self.value, *self.gradient)
+        if any(entry.presentation != presentation for entry in entries):
+            raise _validation_error(
+                "first_jet_field",
+                "a projective first jet must use one number-field presentation",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        value: SimpleNumberFieldElement,
+        gradient: tuple[
+            SimpleNumberFieldElement,
+            SimpleNumberFieldElement,
+            SimpleNumberFieldElement,
+        ],
+    ) -> Self:
+        """Construct the exact zero jet after owner-local replay established it."""
+
+        return cls.model_construct(value=value, gradient=gradient)
+
+
+class ProjectivePlaneCurveSingularPointRecord(StrictModel):
+    """One normalized geometric singular point and its exact zero first jet."""
+
+    point: AlgebraicProjectivePlanePoint
+    first_jet: ProjectivePlaneCurveFirstJet
+
+    @model_validator(mode="after")
+    def bind_point_and_jet(self) -> Self:
+        if self.first_jet.value.presentation != self.point.embedding.presentation:
+            raise _validation_error(
+                "point_jet_field",
+                "a singular point and its first jet must share one field presentation",
+            )
+        return self
+
+
+class SmoothProjectivePlaneCurve(StrictModel):
+    status: Literal["SMOOTH_OVER_ALGEBRAIC_CLOSURE"]
+    saturated_jacobian_ideal: RationalPolynomialIdeal
+
+    @classmethod
+    def _from_kernel(cls, ideal: RationalPolynomialIdeal) -> Self:
+        """Construct the smooth branch after the kernel established ``<1>``."""
+
+        return cls.model_construct(
+            status="SMOOTH_OVER_ALGEBRAIC_CLOSURE",
+            saturated_jacobian_ideal=ideal,
+        )
+
+
+class ZeroDimensionalProjectivePlaneCurveSingularLocus(StrictModel):
+    status: Literal["SINGULAR_ZERO_DIMENSIONAL"]
+    saturated_jacobian_ideal: RationalPolynomialIdeal
+    projective_dimension: Literal[0] = 0
+    points: tuple[ProjectivePlaneCurveSingularPointRecord, ...] = Field(
+        min_length=1, max_length=MAX_PROJECTIVE_SINGULAR_POINTS
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_complete_point_family(self) -> Self:
+        keys = tuple(record.point.model_dump_json() for record in self.points)
+        if keys != tuple(sorted(keys)) or len(set(keys)) != len(keys):
+            raise _validation_error(
+                "point_order",
+                "singular points must be unique and canonically ordered",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        ideal: RationalPolynomialIdeal,
+        points: tuple[ProjectivePlaneCurveSingularPointRecord, ...],
+    ) -> Self:
+        """Construct the finite branch after exact chart enumeration."""
+
+        return cls.model_construct(
+            status="SINGULAR_ZERO_DIMENSIONAL",
+            saturated_jacobian_ideal=ideal,
+            projective_dimension=0,
+            points=points,
+        )
+
+
+class PositiveDimensionalProjectivePlaneCurveSingularLocus(StrictModel):
+    status: Literal["SINGULAR_POSITIVE_DIMENSIONAL"]
+    saturated_jacobian_ideal: RationalPolynomialIdeal
+    affine_cone_dimension: Literal[2] = 2
+    projective_dimension: Literal[1] = 1
+    rational_minimal_components: tuple[RationalPolynomialIdeal, ...] = Field(
+        min_length=1, max_length=MAX_PROJECTIVE_SINGULAR_COMPONENTS
+    )
+
+    @model_validator(mode="after")
+    def bind_component_ring(self) -> Self:
+        if any(
+            component.variables != self.saturated_jacobian_ideal.variables
+            for component in self.rational_minimal_components
+        ):
+            raise _validation_error(
+                "component_axis",
+                "all rational minimal components must use the projective axis",
+            )
+        keys = tuple(
+            component.model_dump_json()
+            for component in self.rational_minimal_components
+        )
+        if keys != tuple(sorted(keys)) or len(set(keys)) != len(keys):
+            raise _validation_error(
+                "component_order",
+                "rational minimal components must be unique and canonically ordered",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        ideal: RationalPolynomialIdeal,
+        components: tuple[RationalPolynomialIdeal, ...],
+    ) -> Self:
+        """Construct the positive-dimensional branch after exact decomposition."""
+
+        return cls.model_construct(
+            status="SINGULAR_POSITIVE_DIMENSIONAL",
+            saturated_jacobian_ideal=ideal,
+            affine_cone_dimension=2,
+            projective_dimension=1,
+            rational_minimal_components=components,
+        )
+
+
+SafeExecutionDetail = Annotated[
+    str,
+    StringConstraints(min_length=1, max_length=256, strict=True),
+]
+
+
+class IncompleteProjectivePlaneCurveSingularityComputation(StrictModel):
+    status: Literal[
+        "BACKEND_UNAVAILABLE",
+        "TIMEOUT",
+        "CANCELLED",
+        "LIMIT_EXCEEDED",
+        "BACKEND_ERROR",
+    ]
+    stage: Literal[
+        "SATURATION",
+        "PROJECTIVE_COMPONENTS",
+        "CHART_ZERO_COMPONENTS",
+        "CHART_ONE_COMPONENTS",
+        "POINT_CONSTRUCTION",
+        "RESULT_CONSTRUCTION",
+    ]
+    detail: SafeExecutionDetail
+
+
+ProjectivePlaneCurveSingularityOutcome = Annotated[
+    SmoothProjectivePlaneCurve
+    | ZeroDimensionalProjectivePlaneCurveSingularLocus
+    | PositiveDimensionalProjectivePlaneCurveSingularLocus
+    | IncompleteProjectivePlaneCurveSingularityComputation,
+    Field(discriminator="status"),
+]
+
+
+class ProjectivePlaneCurveSingularityProfile(StrictModel):
+    """A source-bound exact global singular-locus computation over ``QQbar``."""
+
+    source_polynomial: RationalPolynomial
+    axis: tuple[
+        PolynomialVariable,
+        PolynomialVariable,
+        PolynomialVariable,
+    ]
+    partial_derivatives: tuple[
+        RationalPolynomial,
+        RationalPolynomial,
+        RationalPolynomial,
+    ]
+    base_field: Literal["QQ"] = "QQ"
+    geometric_scope: Literal["ALGEBRAIC_CLOSURE"] = "ALGEBRAIC_CLOSURE"
+    outcome: ProjectivePlaneCurveSingularityOutcome
+
+    @model_validator(mode="after")
+    def bind_profile_axis(self) -> Self:
+        if self.source_polynomial.variables != self.axis:
+            raise _validation_error(
+                "source_axis", "the normalized source must use the declared axis"
+            )
+        if any(
+            derivative.variables != self.axis for derivative in self.partial_derivatives
+        ):
+            raise _validation_error(
+                "partial_axis", "all partial derivatives must use the source axis"
+            )
+        mathematical = (
+            SmoothProjectivePlaneCurve,
+            ZeroDimensionalProjectivePlaneCurveSingularLocus,
+            PositiveDimensionalProjectivePlaneCurveSingularLocus,
+        )
+        if (
+            isinstance(self.outcome, mathematical)
+            and self.outcome.saturated_jacobian_ideal.variables != self.axis
+        ):
+            raise _validation_error(
+                "saturation_axis",
+                "the saturated Jacobian ideal must use the source axis",
+            )
+        if isinstance(
+            self.outcome, ZeroDimensionalProjectivePlaneCurveSingularLocus
+        ) and any(record.point.axis != self.axis for record in self.outcome.points):
+            raise _validation_error(
+                "point_axis", "every singular point must use the source axis"
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source: RationalPolynomial,
+        axis: tuple[
+            PolynomialVariable,
+            PolynomialVariable,
+            PolynomialVariable,
+        ],
+        partials: tuple[
+            RationalPolynomial,
+            RationalPolynomial,
+            RationalPolynomial,
+        ],
+        outcome: ProjectivePlaneCurveSingularityOutcome,
+    ) -> Self:
+        """Construct one trusted profile after its exact kernel transaction."""
+
+        return cls.model_construct(
+            source_polynomial=source,
+            axis=axis,
+            partial_derivatives=partials,
+            base_field="QQ",
+            geometric_scope="ALGEBRAIC_CLOSURE",
+            outcome=outcome,
+        )
+
+
+__all__ = [
+    "MAX_PROJECTIVE_PLANE_CURVE_COEFFICIENT_DIGITS",
+    "MAX_PROJECTIVE_PLANE_CURVE_DEGREE",
+    "MAX_PROJECTIVE_PLANE_CURVE_TERMS",
+    "MAX_PROJECTIVE_SINGULAR_COMPONENTS",
+    "MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE",
+    "MAX_PROJECTIVE_SINGULAR_POINTS",
+    "IncompleteProjectivePlaneCurveSingularityComputation",
+    "PositiveDimensionalProjectivePlaneCurveSingularLocus",
+    "ProjectivePlaneCurveFirstJet",
+    "ProjectivePlaneCurveSingularPointRecord",
+    "ProjectivePlaneCurveSingularityBudget",
+    "ProjectivePlaneCurveSingularityOutcome",
+    "ProjectivePlaneCurveSingularityProfile",
+    "ProjectivePlaneCurveSingularityRequest",
+    "SmoothProjectivePlaneCurve",
+    "ZeroDimensionalProjectivePlaneCurveSingularLocus",
+]

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity_point_process.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity_point_process.py
@@ -1,0 +1,104 @@
+"""Killable process boundary for exact projective singular-point construction."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from time import monotonic
+
+from pydantic import ValidationError
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_worker import (
+    ProjectiveSingularityPointWorkerComplete,
+    ProjectiveSingularityPointWorkerRequest,
+)
+
+_POINT_WORKER = Path(__file__).resolve().with_name("_singularity_point_worker.py")
+_POINT_WORKER_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_POINT_WORKER_FILE_SIZE_BYTES = 1024 * 1024
+_POINT_WORKER_STDOUT_BYTES = 256 * 1024
+_POINT_WORKER_STDERR_BYTES = 64 * 1024
+
+
+class PointConstructionLimitError(RuntimeError):
+    """The isolated point result exceeded its proved exact-output envelope."""
+
+
+def run_point_construction_worker(
+    request: ProjectiveSingularityPointWorkerRequest,
+    *,
+    deadline: float,
+) -> ProjectiveSingularityPointWorkerComplete:
+    """Run one deadline-bound exact chart-to-residue-field transaction."""
+
+    from jacobian.process import (
+        ProcessResourceLimits,
+        run_bounded_process,
+        worker_environment,
+    )
+
+    payload = request.model_dump_json().encode("utf-8")
+    try:
+        with TemporaryDirectory(
+            prefix="jacobian-projective-singular-points-"
+        ) as worker_directory:
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                raise OperationExecutionTimeoutError(
+                    "request deadline expired before projective point construction"
+                )
+            completed = run_bounded_process(
+                [sys.executable, str(_POINT_WORKER)],
+                input_bytes=payload,
+                timeout_seconds=remaining,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_POINT_WORKER_STDOUT_BYTES,
+                stderr_limit=_POINT_WORKER_STDERR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(remaining)),
+                    address_space_bytes=_POINT_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_POINT_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OperationExecutionTimeoutError:
+        raise
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded projective singular-point worker could not be started"
+        ) from exc
+
+    if completed.cancelled:
+        raise OperationExecutionCancelledError(
+            "request cancelled during projective singular-point construction"
+        )
+    if completed.timed_out:
+        raise OperationExecutionTimeoutError(
+            "request deadline expired during projective singular-point construction"
+        )
+    if completed.stdout_exceeded:
+        raise PointConstructionLimitError(
+            "projective singular-point result exceeded its exact-output bound"
+        )
+    if completed.stderr_exceeded or completed.returncode != 0:
+        raise RuntimeError(
+            "bounded projective singular-point worker did not establish a complete result"
+        )
+    try:
+        return ProjectiveSingularityPointWorkerComplete.model_validate_json(
+            completed.stdout,
+            strict=True,
+        )
+    except ValidationError as exc:
+        raise RuntimeError(
+            "bounded projective singular-point worker returned malformed output"
+        ) from exc
+
+
+__all__ = ["PointConstructionLimitError", "run_point_construction_worker"]

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity_point_worker.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity_point_worker.py
@@ -1,0 +1,466 @@
+"""One-shot exact point-construction kernel for projective singular loci."""
+
+from __future__ import annotations
+
+import sys
+from fractions import Fraction
+from math import comb
+from typing import Any, Literal, Self
+
+import sympy
+from pydantic import Field, StrictBool, StrictInt, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE,
+    MAX_PROJECTIVE_SINGULAR_POINTS,
+)
+from jacobian.math.number_theory.number_fields.values import (
+    SimpleNumberFieldElement,
+    SimpleNumberFieldPresentation,
+)
+from jacobian.math.polynomials._conversions import (
+    rational_polynomial_to_sympy,
+    symbols_for_variables,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+)
+
+_MAX_POINT_COORDINATE_DIGITS = 256
+_MAX_SHAPE_ATTEMPTS = comb(MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE, 2) + 1
+
+
+class ProjectiveSingularityPointSeed(StrictModel):
+    """One residue-field point before its exact embeddings are enumerated."""
+
+    presentation: SimpleNumberFieldPresentation
+    coordinates: tuple[
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+    ]
+    chart_index: StrictInt = Field(ge=0, le=2)
+
+    @model_validator(mode="after")
+    def bind_field_and_chart(self) -> Self:
+        if any(
+            coordinate.presentation != self.presentation
+            for coordinate in self.coordinates
+        ):
+            raise ValueError("point-seed coordinates do not share one presentation")
+        coordinate_is_zero = tuple(
+            all(
+                coefficient.as_fraction() == 0
+                for coefficient in coordinate.coefficients_ascending
+            )
+            for coordinate in self.coordinates
+        )
+        coordinate_is_one = tuple(
+            coordinate.coefficients_ascending[0].as_fraction() == 1
+            and all(
+                coefficient.as_fraction() == 0
+                for coefficient in coordinate.coefficients_ascending[1:]
+            )
+            for coordinate in self.coordinates
+        )
+        if (
+            any(not coordinate_is_zero[index] for index in range(self.chart_index))
+            or not coordinate_is_one[self.chart_index]
+        ):
+            raise ValueError("point seed is not normalized in its declared chart")
+        return self
+
+
+class ProjectiveSingularityPointWorkerRequest(StrictModel):
+    """Canonical exact input for one complete point-construction transaction."""
+
+    source: RationalPolynomial
+    partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial]
+    chart_zero_components: tuple[RationalPolynomialIdeal, ...] = Field(
+        max_length=MAX_PROJECTIVE_SINGULAR_POINTS
+    )
+    chart_one_components: tuple[RationalPolynomialIdeal, ...] = Field(
+        max_length=MAX_PROJECTIVE_SINGULAR_POINTS
+    )
+    chart_two_present: StrictBool
+
+    @model_validator(mode="after")
+    def bind_component_axes(self) -> Self:
+        axis = self.source.variables
+        if len(axis) != 3 or any(
+            partial.variables != axis for partial in self.partials
+        ):
+            raise ValueError("point worker source and partial axes do not agree")
+        if any(
+            component.variables != axis[1:] for component in self.chart_zero_components
+        ):
+            raise ValueError("first-chart component has the wrong axis")
+        if any(
+            component.variables != axis[2:] for component in self.chart_one_components
+        ):
+            raise ValueError("second-chart component has the wrong axis")
+        if (
+            len(self.chart_zero_components) + len(self.chart_one_components)
+            > MAX_PROJECTIVE_SINGULAR_POINTS
+        ):
+            raise ValueError("chart components exceed the geometric point bound")
+        return self
+
+
+class ProjectiveSingularityPointWorkerComplete(StrictModel):
+    """Complete residue-field seeds for the disjoint projective chart cover."""
+
+    kind: Literal["complete"]
+    seeds: tuple[ProjectiveSingularityPointSeed, ...] = Field(
+        min_length=1,
+        max_length=MAX_PROJECTIVE_SINGULAR_POINTS,
+    )
+
+    @model_validator(mode="after")
+    def require_complete_canonical_family(self) -> Self:
+        if sum(seed.presentation.degree for seed in self.seeds) > (
+            MAX_PROJECTIVE_SINGULAR_POINTS
+        ):
+            raise ValueError("embedded point count exceeds the geometric point bound")
+        keys = tuple(seed.model_dump_json() for seed in self.seeds)
+        if keys != tuple(sorted(keys)) or len(keys) != len(set(keys)):
+            raise ValueError("point seeds are not unique and canonically ordered")
+        return self
+
+
+def _shape_data(
+    component: RationalPolynomialIdeal,
+) -> tuple[sympy.Symbol, sympy.Poly, tuple[sympy.Poly, sympy.Poly]]:
+    """Return a deterministic rational univariate representation of a chart prime."""
+
+    coordinate_symbols = symbols_for_variables(component.variables)
+    if len(coordinate_symbols) != 2:
+        raise ValueError("shape construction requires a two-axis chart")
+    parameter = sympy.Symbol("__jacobian_shape_parameter")
+    expressions = [
+        rational_polynomial_to_sympy(generator).as_expr()
+        for generator in component.generators
+    ]
+
+    for coefficient in range(_MAX_SHAPE_ATTEMPTS):
+        basis = sympy.groebner(
+            [
+                *expressions,
+                parameter - coordinate_symbols[0] - coefficient * coordinate_symbols[1],
+            ],
+            *coordinate_symbols,
+            parameter,
+            order="lex",
+            domain=sympy.QQ,
+        )
+        univariate = [
+            polynomial
+            for polynomial in basis.polys
+            if polynomial.as_expr().free_symbols <= {parameter}
+            and polynomial.degree(parameter) > 0
+        ]
+        if len(univariate) != 1:
+            continue
+        eliminant = sympy.Poly(
+            univariate[0].monic().as_expr(), parameter, domain=sympy.QQ
+        )
+        if not 1 <= int(eliminant.degree()) <= MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE:
+            raise ValueError("a chart residue field exceeds the degree-four bound")
+
+        coordinate_polynomials: list[sympy.Poly] = []
+        for coordinate_index, coordinate in enumerate(coordinate_symbols):
+            other = coordinate_symbols[1 - coordinate_index]
+            selected: sympy.Poly | None = None
+            for polynomial in basis.polys:
+                expression = polynomial.as_expr()
+                if polynomial.degree(coordinate) != 1 or polynomial.degree(other) != 0:
+                    continue
+                as_coordinate = sympy.Poly(expression, coordinate)
+                leading = as_coordinate.coeff_monomial(coordinate)
+                remainder = sympy.expand(expression - leading * coordinate)
+                if leading.free_symbols or remainder.free_symbols - {parameter}:
+                    continue
+                selected = sympy.Poly(
+                    sympy.expand(-remainder / leading), parameter, domain=sympy.QQ
+                )
+                break
+            if selected is None:
+                break
+            coordinate_polynomials.append(selected)
+        if len(coordinate_polynomials) == 2:
+            return (
+                parameter,
+                eliminant,
+                (coordinate_polynomials[0], coordinate_polynomials[1]),
+            )
+    raise ValueError("no separating chart coordinate fit the seven-attempt bound")
+
+
+def _univariate_component_polynomial(
+    component: RationalPolynomialIdeal,
+) -> tuple[sympy.Symbol, sympy.Poly]:
+    (variable,) = symbols_for_variables(component.variables)
+    nonzero: list[sympy.Poly] = []
+    for generator in component.generators:
+        converted = rational_polynomial_to_sympy(generator)
+        if not converted.is_zero:
+            nonzero.append(converted)
+    if not nonzero:
+        raise ValueError("a finite chart component returned the zero ideal")
+    polynomial = nonzero[0]
+    for generator in nonzero[1:]:
+        polynomial = sympy.gcd(polynomial, generator)
+    polynomial = sympy.Poly(polynomial.monic().as_expr(), variable, domain=sympy.QQ)
+    if not 1 <= int(polynomial.degree()) <= MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE:
+        raise ValueError("a chart residue field exceeds the degree-four bound")
+    return variable, polynomial
+
+
+def _primitive_integer_factor(polynomial: sympy.Poly) -> tuple[str, ...]:
+    _denominator, integer_polynomial = polynomial.clear_denoms(convert=True)
+    _content, primitive = integer_polynomial.primitive()
+    if primitive.LC() < 0:
+        primitive = -primitive
+    coefficients = tuple(int(coefficient) for coefficient in primitive.all_coeffs())
+    if any(
+        len(str(abs(coefficient))) > _MAX_POINT_COORDINATE_DIGITS
+        for coefficient in coefficients
+    ):
+        raise ValueError("a residue-field polynomial exceeds the carrier digit bound")
+    return tuple(format_canonical_integer(coefficient) for coefficient in coefficients)
+
+
+def _canonical_rational(value: Any) -> CanonicalRational:
+    rational = sympy.Rational(value)
+    numerator = int(rational.p)
+    denominator = int(rational.q)
+    if (
+        len(str(abs(numerator))) > _MAX_POINT_COORDINATE_DIGITS
+        or len(str(denominator)) > _MAX_POINT_COORDINATE_DIGITS
+    ):
+        raise ValueError("a point coordinate exceeds the carrier digit bound")
+    return CanonicalRational.from_fraction(Fraction(numerator, denominator))
+
+
+def _field_element(
+    presentation: SimpleNumberFieldPresentation,
+    polynomial: sympy.Poly,
+) -> SimpleNumberFieldElement:
+    parameter = polynomial.gens[0]
+    if polynomial.degree(parameter) >= presentation.degree:
+        raise ValueError("a point coordinate is not reduced in its residue field")
+    return SimpleNumberFieldElement(
+        presentation=presentation,
+        coefficients_ascending=tuple(
+            _canonical_rational(polynomial.nth(degree))
+            for degree in range(presentation.degree)
+        ),
+    )
+
+
+def _rational_field_element(
+    presentation: SimpleNumberFieldPresentation,
+    value: Any,
+) -> SimpleNumberFieldElement:
+    return SimpleNumberFieldElement(
+        presentation=presentation,
+        coefficients_ascending=(_canonical_rational(value),),
+    )
+
+
+def _seed_for_factor(
+    *,
+    factor: sympy.Poly,
+    parameter: sympy.Symbol,
+    coordinate_polynomials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+    chart_index: int,
+    source: sympy.Poly,
+    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+) -> ProjectiveSingularityPointSeed:
+    if int(factor.degree()) == 1:
+        presentation = SimpleNumberFieldPresentation(coefficients_descending=("1", "0"))
+        root = -factor.nth(0) / factor.nth(1)
+        coordinate_values = tuple(
+            _rational_field_element(presentation, polynomial.eval(root))
+            for polynomial in coordinate_polynomials
+        )
+    else:
+        presentation = SimpleNumberFieldPresentation(
+            coefficients_descending=_primitive_integer_factor(factor)
+        )
+        coordinate_values = tuple(
+            _field_element(
+                presentation,
+                sympy.Poly(
+                    polynomial.rem(factor).as_expr(), parameter, domain=sympy.QQ
+                ),
+            )
+            for polynomial in coordinate_polynomials
+        )
+    coordinates = (
+        coordinate_values[0],
+        coordinate_values[1],
+        coordinate_values[2],
+    )
+
+    modulus = sympy.Poly(
+        sum(
+            int(coefficient) * parameter ** (presentation.degree - index)
+            for index, coefficient in enumerate(presentation.coefficients_descending)
+        ),
+        parameter,
+        domain=sympy.QQ,
+    )
+    coordinate_expressions = tuple(
+        sum(
+            sympy.Rational(*coefficient.as_integer_ratio()) * parameter**index
+            for index, coefficient in enumerate(coordinate.coefficients_ascending)
+        )
+        for coordinate in coordinates
+    )
+    substitutions = dict(zip(source.gens, coordinate_expressions, strict=True))
+    evaluated = tuple(
+        sympy.Poly(
+            sympy.expand(polynomial.as_expr().subs(substitutions)),
+            parameter,
+            domain=sympy.QQ,
+        ).rem(modulus)
+        for polynomial in (source, *partials)
+    )
+    if any(not value.is_zero for value in evaluated):
+        raise ValueError("exact point replay did not annihilate the first jet")
+    return ProjectiveSingularityPointSeed(
+        presentation=presentation,
+        coordinates=coordinates,
+        chart_index=chart_index,
+    )
+
+
+def _factor_seeds(
+    *,
+    eliminant: sympy.Poly,
+    parameter: sympy.Symbol,
+    coordinate_polynomials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+    chart_index: int,
+    source: sympy.Poly,
+    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+) -> tuple[ProjectiveSingularityPointSeed, ...]:
+    _coefficient, factors = eliminant.factor_list()
+    if any(multiplicity != 1 for _factor, multiplicity in factors):
+        raise ValueError("a minimal-prime eliminant retained multiplicity")
+    return tuple(
+        _seed_for_factor(
+            factor=sympy.Poly(factor.monic().as_expr(), parameter, domain=sympy.QQ),
+            parameter=parameter,
+            coordinate_polynomials=coordinate_polynomials,
+            chart_index=chart_index,
+            source=source,
+            partials=partials,
+        )
+        for factor, _multiplicity in factors
+    )
+
+
+def _two_axis_seeds(
+    component: RationalPolynomialIdeal,
+    *,
+    source: sympy.Poly,
+    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+) -> tuple[ProjectiveSingularityPointSeed, ...]:
+    parameter, eliminant, (first, second) = _shape_data(component)
+    one = sympy.Poly(1, parameter, domain=sympy.QQ)
+    return _factor_seeds(
+        eliminant=eliminant,
+        parameter=parameter,
+        coordinate_polynomials=(one, first, second),
+        chart_index=0,
+        source=source,
+        partials=partials,
+    )
+
+
+def _one_axis_seeds(
+    component: RationalPolynomialIdeal,
+    *,
+    source: sympy.Poly,
+    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+) -> tuple[ProjectiveSingularityPointSeed, ...]:
+    parameter, eliminant = _univariate_component_polynomial(component)
+    zero = sympy.Poly(0, parameter, domain=sympy.QQ)
+    one = sympy.Poly(1, parameter, domain=sympy.QQ)
+    coordinate = sympy.Poly(parameter, parameter, domain=sympy.QQ)
+    return _factor_seeds(
+        eliminant=eliminant,
+        parameter=parameter,
+        coordinate_polynomials=(zero, one, coordinate),
+        chart_index=1,
+        source=source,
+        partials=partials,
+    )
+
+
+def _chart_two_seed(
+    *,
+    source: sympy.Poly,
+    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+) -> ProjectiveSingularityPointSeed:
+    parameter = sympy.Symbol("__jacobian_rational_parameter")
+    factor = sympy.Poly(parameter, parameter, domain=sympy.QQ)
+    zero = sympy.Poly(0, parameter, domain=sympy.QQ)
+    one = sympy.Poly(1, parameter, domain=sympy.QQ)
+    return _seed_for_factor(
+        factor=factor,
+        parameter=parameter,
+        coordinate_polynomials=(zero, zero, one),
+        chart_index=2,
+        source=source,
+        partials=partials,
+    )
+
+
+def compute_point_worker_response(
+    request: ProjectiveSingularityPointWorkerRequest,
+) -> ProjectiveSingularityPointWorkerComplete:
+    """Construct every residue-field seed in one isolated exact transaction."""
+
+    source = rational_polynomial_to_sympy(request.source)
+    partials = (
+        rational_polynomial_to_sympy(request.partials[0]),
+        rational_polynomial_to_sympy(request.partials[1]),
+        rational_polynomial_to_sympy(request.partials[2]),
+    )
+    seeds: list[ProjectiveSingularityPointSeed] = []
+    for component in request.chart_zero_components:
+        seeds.extend(_two_axis_seeds(component, source=source, partials=partials))
+    for component in request.chart_one_components:
+        seeds.extend(_one_axis_seeds(component, source=source, partials=partials))
+    if request.chart_two_present:
+        seeds.append(_chart_two_seed(source=source, partials=partials))
+    ordered = tuple(sorted(seeds, key=lambda seed: seed.model_dump_json()))
+    return ProjectiveSingularityPointWorkerComplete(kind="complete", seeds=ordered)
+
+
+def main() -> int:
+    request = ProjectiveSingularityPointWorkerRequest.model_validate_json(
+        sys.stdin.buffer.read(),
+        strict=True,
+    )
+    response = compute_point_worker_response(request)
+    sys.stdout.write(response.model_dump_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ProjectiveSingularityPointSeed",
+    "ProjectiveSingularityPointWorkerComplete",
+    "ProjectiveSingularityPointWorkerRequest",
+    "compute_point_worker_response",
+]

--- a/src/jacobian/math/geometry/algebraic_curves/_tools.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_tools.py
@@ -13,6 +13,8 @@ from jacobian.math.geometry.algebraic_curves._models import (
     AffineCurveResult,
     ProjectiveClosureRequest,
     ProjectiveClosureResult,
+    ProjectivePlaneCurveSingularityProfile,
+    ProjectivePlaneCurveSingularityRequest,
     RationalConicParametrizationRequest,
     RationalConicParametrizationResult,
 )
@@ -21,6 +23,7 @@ from jacobian.math.geometry.algebraic_curves.operations import (
     affine_curve_check,
     projective_closure,
     rational_conic_parametrization,
+    singularity_profile,
 )
 
 
@@ -61,6 +64,14 @@ def compute_rational_conic_parametrization(
         inverse_parameter=data.inverse_parameter,
         finite_parameter_denominator=data.finite_parameter_denominator,
     )
+
+
+def compute_projective_plane_curve_singularity_profile(
+    request: ProjectivePlaneCurveSingularityRequest,
+) -> ProjectivePlaneCurveSingularityProfile:
+    """Compute one exact source-bound global projective singular locus."""
+
+    return singularity_profile(request.polynomial, request.resource_budget)
 
 
 def _polynomial(
@@ -105,6 +116,37 @@ def _op[RequestT: StrictModel, ResultT: StrictModel](
 
 
 TOOLS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "algebraic_geometry.projective_plane_curve.singularity_profile.compute",
+        "Compute a projective plane-curve singularity profile",
+        "Compute the complete saturated projective Jacobian locus over the "
+        "algebraic closure of QQ for one bounded homogeneous ternary polynomial. "
+        "The result distinguishes the unit-ideal smooth case, a complete finite "
+        "family of exact embedded number-field points, a positive-dimensional "
+        "locus, and operational noncompletion.",
+        ProjectivePlaneCurveSingularityRequest,
+        ProjectivePlaneCurveSingularityProfile,
+        compute_projective_plane_curve_singularity_profile,
+        "algebraic-geometry",
+        "projective-curve",
+        "singular-locus",
+        "exact",
+        examples=(
+            example(
+                "conjugate_singularities",
+                "Find both non-rational singular points [1:i:0] and [1:-i:0] "
+                "of Z*(X^2+Y^2+Z^2), retaining their distinct exact embeddings.",
+                {
+                    "polynomial": _polynomial(
+                        ("X", "Y", "Z"),
+                        (1, (2, 0, 1)),
+                        (1, (0, 2, 1)),
+                        (1, (0, 0, 3)),
+                    )
+                },
+            ),
+        ),
+    ),
     _op(
         "algebraic_geometry.affine_plane_curve.check",
         "Check an affine plane curve",

--- a/src/jacobian/math/geometry/algebraic_curves/operations.py
+++ b/src/jacobian/math/geometry/algebraic_curves/operations.py
@@ -17,6 +17,7 @@ from jacobian.math.geometry.algebraic_curves._models import (
     _validation_error,
     _validation_error_from,
 )
+from jacobian.math.geometry.algebraic_curves._singularity import singularity_profile
 from jacobian.math.polynomials._conversions import (
     rational_polynomial_from_sympy,
     rational_polynomial_to_sympy,
@@ -164,4 +165,5 @@ __all__ = [
     "affine_curve_check",
     "projective_closure",
     "rational_conic_parametrization",
+    "singularity_profile",
 ]

--- a/src/jacobian/math/geometry/projective/__init__.py
+++ b/src/jacobian/math/geometry/projective/__init__.py
@@ -1,3 +1,5 @@
 """Projective-geometry operation ownership."""
 
-__all__: list[str] = []
+from jacobian.math.geometry.projective.values import AlgebraicProjectivePlanePoint
+
+__all__ = ["AlgebraicProjectivePlanePoint"]

--- a/src/jacobian/math/geometry/projective/values.py
+++ b/src/jacobian/math/geometry/projective/values.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 from math import gcd, lcm
 from typing import Annotated, Self
 
-from pydantic import StringConstraints, model_validator
+from pydantic import Field, StrictInt, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.math.number_theory.number_fields.values import (
+    NumberFieldEmbedding,
+    SimpleNumberFieldElement,
+)
+from jacobian.math.polynomials.values import PolynomialVariable
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -105,4 +110,75 @@ class PrimitiveProjectiveTriple(StrictModel):
         return self
 
 
-__all__ = ["PrimitiveProjectiveTriple", "RationalProjectiveLine"]
+class AlgebraicProjectivePlanePoint(StrictModel):
+    """A canonical projective-plane point in one exact embedded number field.
+
+    Coordinates use the field presentation's reduced power basis.  The selected
+    embedding supplies the geometric point over ``QQbar``.  Normalization uses
+    the first nonzero projective coordinate, which is exactly one; this makes
+    chart membership and equality independent of a backend's root objects.
+    """
+
+    axis: tuple[
+        PolynomialVariable,
+        PolynomialVariable,
+        PolynomialVariable,
+    ]
+    embedding: NumberFieldEmbedding
+    coordinates: tuple[
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+    ]
+    chart_index: StrictInt = Field(ge=0, le=2)
+
+    @model_validator(mode="after")
+    def bind_parent_and_normalization(self) -> Self:
+        if len(set(self.axis)) != 3:
+            raise _validation_error(
+                "projective_plane_axis",
+                "an algebraic projective-plane point needs three distinct axes",
+            )
+        presentation = self.embedding.presentation
+        if any(
+            coordinate.presentation != presentation for coordinate in self.coordinates
+        ):
+            raise _validation_error(
+                "projective_point_field",
+                "all projective coordinates and the selected embedding must share one field presentation",
+            )
+        zero = tuple(
+            coefficient.as_fraction() == 0
+            for coordinate in self.coordinates
+            for coefficient in coordinate.coefficients_ascending
+        )
+        degree = presentation.degree
+        coordinate_is_zero = tuple(
+            all(zero[index * degree : (index + 1) * degree]) for index in range(3)
+        )
+        coordinate_is_one = tuple(
+            coordinate.coefficients_ascending[0].as_fraction() == 1
+            and all(
+                coefficient.as_fraction() == 0
+                for coefficient in coordinate.coefficients_ascending[1:]
+            )
+            for coordinate in self.coordinates
+        )
+        if any(not coordinate_is_zero[index] for index in range(self.chart_index)):
+            raise _validation_error(
+                "projective_point_chart",
+                "coordinates before the declared projective chart must be zero",
+            )
+        if not coordinate_is_one[self.chart_index]:
+            raise _validation_error(
+                "projective_point_normalization",
+                "the declared projective chart coordinate must be exactly one",
+            )
+        return self
+
+
+__all__ = [
+    "AlgebraicProjectivePlanePoint",
+    "PrimitiveProjectiveTriple",
+    "RationalProjectiveLine",
+]

--- a/src/jacobian/math/number_theory/algebraic_numbers/__init__.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/__init__.py
@@ -1,7 +1,6 @@
 """Algebraic number arithmetic operations."""
 
 from jacobian.math.number_theory.algebraic_numbers.complex import (
-    ComplexAlgebraicValue,
     RationalComplexIsolatingRectangle,
 )
 from jacobian.math.number_theory.algebraic_numbers.operations import (
@@ -10,7 +9,6 @@ from jacobian.math.number_theory.algebraic_numbers.operations import (
 )
 
 __all__ = [
-    "ComplexAlgebraicValue",
     "RationalComplexIsolatingRectangle",
     "add_quadratic",
     "multiply_quadratic",

--- a/src/jacobian/math/number_theory/algebraic_numbers/__init__.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/__init__.py
@@ -1,8 +1,17 @@
 """Algebraic number arithmetic operations."""
 
+from jacobian.math.number_theory.algebraic_numbers.complex import (
+    ComplexAlgebraicValue,
+    RationalComplexIsolatingRectangle,
+)
 from jacobian.math.number_theory.algebraic_numbers.operations import (
     add_quadratic,
     multiply_quadratic,
 )
 
-__all__ = ["add_quadratic", "multiply_quadratic"]
+__all__ = [
+    "ComplexAlgebraicValue",
+    "RationalComplexIsolatingRectangle",
+    "add_quadratic",
+    "multiply_quadratic",
+]

--- a/src/jacobian/math/number_theory/algebraic_numbers/complex.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/complex.py
@@ -1,0 +1,529 @@
+"""Canonical exact nonreal algebraic values and rational isolation evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from fractions import Fraction
+from functools import cmp_to_key, lru_cache
+from math import gcd
+from typing import Any, Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalInteger, CanonicalRational
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS,
+    MAX_REAL_ALGEBRAIC_DEGREE,
+    _real_polynomial_validation,
+    _sympy_polynomial_from_coefficients,
+)
+
+MAX_COMPLEX_ISOLATOR_COMPONENT_DIGITS = 4_096
+MAX_COMPLEX_ORDERING_INTERMEDIATE_DIGITS = 32_768
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"complex_algebraic.{reason}", message)
+
+
+def _integer_coefficients(
+    coefficients: Sequence[CanonicalInteger],
+) -> tuple[int, ...]:
+    return tuple(parse_canonical_integer(coefficient) for coefficient in coefficients)
+
+
+def _sympy_polynomial(coefficients: tuple[CanonicalInteger, ...]) -> Any:
+    return _sympy_polynomial_from_coefficients(coefficients)
+
+
+def algebraic_root_separation_denominator_bound(
+    coefficients: Sequence[CanonicalInteger],
+) -> int:
+    """Return ``B`` such that distinct roots have distance greater than ``1/B``.
+
+    For a square-free integer polynomial of degree ``n``, Mignotte's bound is
+
+    ``sep(f) > sqrt(3) / (n^((n+2)/2) * ||f||_2^(n-1))``.
+
+    With coefficient height ``H``, ``||f||_2 <= sqrt(n+1) H``.  Replacing both
+    square roots by larger integer factors gives the deliberately conservative
+    denominator below.  The public carriers independently require
+    irreducibility, hence square-freeness in characteristic zero.
+    """
+
+    integers = _integer_coefficients(coefficients)
+    degree = len(integers) - 1
+    if degree <= 1:
+        return 1
+    height: int = max(abs(coefficient) for coefficient in integers)
+    degree_factor: int = degree ** ((degree + 3) // 2)
+    norm_factor: int = ((degree + 1) * height) ** (degree - 1)
+    return int(degree_factor * norm_factor)
+
+
+@lru_cache(maxsize=128)
+def _real_part_elimination_polynomial(
+    coefficients: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Eliminate the imaginary coordinate from ``f(u + i*v) = 0`` exactly."""
+
+    import sympy
+
+    real_coordinate, imaginary_coordinate = sympy.symbols("u v", real=True)
+    degree = len(coefficients) - 1
+    argument = real_coordinate + sympy.I * imaginary_coordinate
+    expression = sum(
+        coefficient * argument ** (degree - index)
+        for index, coefficient in enumerate(coefficients)
+    )
+    real_part, imaginary_part = map(sympy.expand, expression.as_real_imag())
+    resultant = sympy.resultant(real_part, imaginary_part, imaginary_coordinate)
+    polynomial = sympy.Poly(resultant, real_coordinate, domain=sympy.ZZ)
+    _content, primitive = polynomial.primitive()
+    square_free = primitive.sqf_part()
+    if square_free.LC() < 0:
+        square_free = -square_free
+    return tuple(int(coefficient) for coefficient in square_free.all_coeffs())
+
+
+def algebraic_real_part_separation_denominator_bound(
+    coefficients: Sequence[CanonicalInteger],
+) -> int:
+    """Bound separation between distinct real coordinates of roots of ``f``."""
+
+    integer_coefficients = _integer_coefficients(coefficients)
+    elimination = _real_part_elimination_polynomial(integer_coefficients)
+    degree = len(elimination) - 1
+    if degree <= 1:
+        return 1
+    height: int = max(abs(coefficient) for coefficient in elimination)
+    bound: int = degree ** ((degree + 3) // 2) * ((degree + 1) * height) ** (degree - 1)
+    return int(bound)
+
+
+def algebraic_root_magnitude_numerator_bound(
+    coefficients: Sequence[CanonicalInteger],
+) -> int:
+    """Return an integer strictly above every root magnitude (Cauchy's bound)."""
+
+    integers = _integer_coefficients(coefficients)
+    leading = abs(integers[0])
+    tail_height = max((abs(coefficient) for coefficient in integers[1:]), default=0)
+    return 2 + tail_height // leading
+
+
+def complex_isolator_component_digit_bound(
+    coefficients: Sequence[CanonicalInteger],
+) -> int:
+    """Bound decimal component digits of the dyadic evidence constructed here."""
+
+    separation_denominator = algebraic_root_separation_denominator_bound(coefficients)
+    grid_bits = separation_denominator.bit_length() + 4
+    magnitude_bits = algebraic_root_magnitude_numerator_bound(coefficients).bit_length()
+    component_bits = grid_bits + magnitude_bits + 3
+    # 0.30103 is a strict decimal upper bound for log10(2).
+    return (component_bits * 30_103) // 100_000 + 2
+
+
+def _sympy_fraction(value: Any) -> Fraction:
+    return Fraction(int(value.p), int(value.q))
+
+
+def _indexed_root_approximation(
+    polynomial: Any,
+    root_index: int,
+    error: Fraction,
+) -> tuple[Fraction, Fraction]:
+    import sympy
+
+    root = sympy.CRootOf(polynomial.as_expr(), root_index, radicals=False)
+    tolerance = sympy.Rational(error.numerator, error.denominator)
+    approximation = root.eval_rational(dx=tolerance, dy=tolerance)
+    real_part, imaginary_part = approximation.as_real_imag()
+    return _sympy_fraction(real_part), _sympy_fraction(imaginary_part)
+
+
+def _root_evidence_parameters(
+    coefficients: Sequence[CanonicalInteger],
+) -> tuple[int, Fraction]:
+    separation_denominator = algebraic_root_separation_denominator_bound(coefficients)
+    grid_denominator = 1 << (separation_denominator.bit_length() + 4)
+    return grid_denominator, Fraction(1, 16 * grid_denominator)
+
+
+@lru_cache(maxsize=128)
+def _public_to_backend_root_indices_from_count(
+    coefficients: tuple[CanonicalInteger, ...],
+    real_count: int,
+) -> tuple[int, ...]:
+    """Map pair-ordered public indexes to SymPy indexes using exact bounds."""
+
+    import sympy
+
+    polynomial = _sympy_polynomial(coefficients)
+    degree = polynomial.degree()
+    if real_count == degree:
+        return tuple(range(degree))
+
+    root_separation = algebraic_root_separation_denominator_bound(coefficients)
+    pair_count = (degree - real_count) // 2
+    real_part_separation = (
+        algebraic_real_part_separation_denominator_bound(coefficients)
+        if pair_count > 1
+        else 1
+    )
+    real_part_digits = (real_part_separation.bit_length() * 30_103) // 100_000 + 1
+    if real_part_digits > MAX_COMPLEX_ORDERING_INTERMEDIATE_DIGITS:
+        raise _validation_error(
+            "ordering_intermediate_bound",
+            "exact conjugate-pair ordering exceeds the "
+            f"{MAX_COMPLEX_ORDERING_INTERMEDIATE_DIGITS:,}-digit "
+            "real-coordinate separation bound",
+        )
+    root_error = Fraction(1, 16 * root_separation)
+    real_part_error = Fraction(1, 16 * real_part_separation)
+    ordering_error = min(root_error, real_part_error)
+    backend_roots = [
+        sympy.CRootOf(polynomial.as_expr(), index, radicals=False)
+        for index in range(degree)
+    ]
+    unused = set(range(real_count, degree))
+    positive_representatives: list[tuple[int, Fraction, Fraction]] = []
+    negative_for_positive: dict[int, int] = {}
+    while unused:
+        backend_index = min(unused)
+        root = backend_roots[backend_index]
+        conjugate = sympy.conjugate(root)
+        # Real coefficients make the nonreal roots disjoint conjugate pairs.
+        # SymPy's exact CRootOf equality therefore guarantees this lookup.
+        partner = next(
+            candidate
+            for candidate in unused
+            if candidate != backend_index and backend_roots[candidate] == conjugate
+        )
+
+        _left_real, left_imaginary = _indexed_root_approximation(
+            polynomial, backend_index, root_error
+        )
+        positive_index = backend_index if left_imaginary > 0 else partner
+        negative_index = partner if positive_index == backend_index else backend_index
+        positive_real, positive_imaginary = _indexed_root_approximation(
+            polynomial, positive_index, ordering_error
+        )
+        positive_representatives.append(
+            (positive_index, positive_real, positive_imaginary)
+        )
+        negative_for_positive[positive_index] = negative_index
+        unused.remove(backend_index)
+        unused.remove(partner)
+
+    def compare(
+        left: tuple[int, Fraction, Fraction],
+        right: tuple[int, Fraction, Fraction],
+    ) -> int:
+        _left_index, left_real, left_imaginary = left
+        _right_index, right_real, right_imaginary = right
+        if left_real + real_part_error < right_real - real_part_error:
+            return -1
+        if right_real + real_part_error < left_real - real_part_error:
+            return 1
+        # Mignotte separation for the real-coordinate elimination polynomial
+        # proves that overlapping error intervals represent the same real
+        # coordinate.  Original-root separation then orders their positive
+        # imaginary coordinates.
+        if left_imaginary + root_error < right_imaginary - root_error:
+            return -1
+        if right_imaginary + root_error < left_imaginary - root_error:
+            return 1
+        return -1 if left_imaginary < right_imaginary else 1
+
+    positive_representatives.sort(key=cmp_to_key(compare))
+    public_to_backend = list(range(real_count))
+    for positive_index, _real_part, _imaginary_part in positive_representatives:
+        public_to_backend.extend(
+            (negative_for_positive[positive_index], positive_index)
+        )
+    return tuple(public_to_backend)
+
+
+def _public_to_backend_root_indices(
+    coefficients: tuple[CanonicalInteger, ...],
+) -> tuple[int, ...]:
+    _is_irreducible, real_count = _real_polynomial_validation(coefficients)
+    return _public_to_backend_root_indices_from_count(coefficients, real_count)
+
+
+class RationalComplexIsolatingRectangle(StrictModel):
+    """A closed rational rectangle carrying one certified nonreal root.
+
+    All four boundary segments are included.  Embedding records additionally
+    prove that a rational error box for their selected exact root lies strictly
+    inside this rectangle, so boundary-root ambiguities in backend root counts
+    cannot affect the public identity.
+    """
+
+    real_lower: CanonicalRational
+    real_upper: CanonicalRational
+    imaginary_lower: CanonicalRational
+    imaginary_upper: CanonicalRational
+    boundary: Literal["CLOSED"] = "CLOSED"
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_component_bound(cls, data: Any) -> Any:
+        if not isinstance(data, Mapping):
+            return data
+        for name in (
+            "real_lower",
+            "real_upper",
+            "imaginary_lower",
+            "imaginary_upper",
+        ):
+            component = data.get(name)
+            if not isinstance(component, Mapping):
+                continue
+            for part in ("num", "den"):
+                raw = component.get(part)
+                if isinstance(raw, str) and len(raw.lstrip("-")) > (
+                    MAX_COMPLEX_ISOLATOR_COMPONENT_DIGITS
+                ):
+                    raise _validation_error(
+                        "isolator_component_bound",
+                        "complex isolator components exceed the "
+                        f"{MAX_COMPLEX_ISOLATOR_COMPONENT_DIGITS:,}-digit bound",
+                    )
+        return canonicalize_json_containers(data)
+
+    @model_validator(mode="after")
+    def require_nonempty_rectangle(self) -> Self:
+        if any(
+            len(component.num.lstrip("-")) > MAX_COMPLEX_ISOLATOR_COMPONENT_DIGITS
+            or len(component.den) > MAX_COMPLEX_ISOLATOR_COMPONENT_DIGITS
+            for component in (
+                self.real_lower,
+                self.real_upper,
+                self.imaginary_lower,
+                self.imaginary_upper,
+            )
+        ):
+            raise _validation_error(
+                "isolator_component_bound",
+                "complex isolator components exceed the "
+                f"{MAX_COMPLEX_ISOLATOR_COMPONENT_DIGITS:,}-digit bound",
+            )
+        if self.real_lower.as_fraction() >= self.real_upper.as_fraction():
+            raise _validation_error(
+                "real_axis_order",
+                "complex isolator real bounds must be strictly increasing",
+            )
+        if self.imaginary_lower.as_fraction() >= self.imaginary_upper.as_fraction():
+            raise _validation_error(
+                "imaginary_axis_order",
+                "complex isolator imaginary bounds must be strictly increasing",
+            )
+        return self
+
+    def conjugate(self) -> RationalComplexIsolatingRectangle:
+        """Reflect this rectangle exactly across the real axis."""
+
+        return RationalComplexIsolatingRectangle(
+            real_lower=self.real_lower,
+            real_upper=self.real_upper,
+            imaginary_lower=CanonicalRational.from_fraction(
+                -self.imaginary_upper.as_fraction()
+            ),
+            imaginary_upper=CanonicalRational.from_fraction(
+                -self.imaginary_lower.as_fraction()
+            ),
+        )
+
+
+class ComplexAlgebraicValue(StrictModel):
+    """One nonreal algebraic number in canonical indexed-root form.
+
+    ``polynomial`` is primitive irreducible in ``ZZ[x]`` with positive leading
+    coefficient.  ``root_index`` uses the mathematical global order: all real
+    roots increasingly first; then conjugate pairs ordered lexicographically
+    by their positive-imaginary representative ``(Re(z), Im(z))``; and within
+    each pair the negative root precedes the positive root.  Thus the
+    polynomial and index, rather than any one of infinitely many valid
+    isolating rectangles, are the value's identity.
+    """
+
+    polynomial: tuple[CanonicalInteger, ...] = Field(
+        min_length=2,
+        max_length=MAX_REAL_ALGEBRAIC_DEGREE + 1,
+        description=(
+            "Primitive irreducible ZZ[x] coefficients in descending degree, "
+            "with positive leading coefficient."
+        ),
+    )
+    root_index: StrictInt = Field(
+        ge=0,
+        le=MAX_REAL_ALGEBRAIC_DEGREE - 1,
+        description=(
+            "Index in the real-first, positive-representative conjugate-pair "
+            "order declared by ComplexAlgebraicValue."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_polynomial_bound(cls, data: Any) -> Any:
+        if not isinstance(data, Mapping):
+            return data
+        polynomial = data.get("polynomial")
+        if isinstance(polynomial, (list, tuple)):
+            if len(polynomial) > MAX_REAL_ALGEBRAIC_DEGREE + 1:
+                raise _validation_error(
+                    "degree_bound",
+                    "complex algebraic degree exceeds the bounded root envelope",
+                )
+            if any(
+                isinstance(value, str)
+                and len(value.lstrip("-")) > MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS
+                for value in polynomial
+            ):
+                raise _validation_error(
+                    "coefficient_bound",
+                    "complex algebraic polynomial coefficients exceed the "
+                    f"{MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS}-digit bound",
+                )
+        return canonicalize_json_containers(data)
+
+    @model_validator(mode="after")
+    def require_canonical_nonreal_root(self) -> Self:
+        coefficients = _integer_coefficients(self.polynomial)
+        if coefficients[0] <= 0:
+            raise _validation_error(
+                "leading_sign",
+                "complex algebraic minimal polynomial must have positive leading coefficient",
+            )
+        content = 0
+        for coefficient in coefficients:
+            content = gcd(content, abs(coefficient))
+        if content != 1:
+            raise _validation_error(
+                "not_primitive",
+                "complex algebraic minimal polynomial must be primitive over ZZ",
+            )
+
+        is_irreducible, real_root_count = _real_polynomial_validation(self.polynomial)
+        if not is_irreducible:
+            raise _validation_error(
+                "not_irreducible",
+                "complex algebraic minimal polynomial must be irreducible over QQ",
+            )
+        if not real_root_count <= self.root_index < len(self.polynomial) - 1:
+            raise _validation_error(
+                "root_index",
+                "root_index must select a nonreal root in the declared global order",
+            )
+        return self
+
+    @classmethod
+    def _from_admitted_polynomial(
+        cls,
+        *,
+        polynomial: tuple[CanonicalInteger, ...],
+        root_index: int,
+    ) -> ComplexAlgebraicValue:
+        """Construct after an owner has admitted the canonical polynomial/root."""
+
+        return cls.model_construct(polynomial=polynomial, root_index=root_index)
+
+
+def _isolate_complex_algebraic(
+    value: ComplexAlgebraicValue,
+    *,
+    backend_root_index: int,
+    candidates: tuple[RationalComplexIsolatingRectangle, ...],
+) -> RationalComplexIsolatingRectangle:
+    """Select one deterministic admitted rectangle for an indexed root."""
+
+    polynomial = _sympy_polynomial(value.polynomial)
+    _grid_denominator, error = _root_evidence_parameters(value.polynomial)
+    real_part, imaginary_part = _indexed_root_approximation(
+        polynomial, backend_root_index, error
+    )
+    return next(
+        rectangle
+        for rectangle in candidates
+        if rectangle.real_lower.as_fraction() < real_part - error
+        and real_part + error < rectangle.real_upper.as_fraction()
+        and rectangle.imaginary_lower.as_fraction() < imaginary_part - error
+        and imaginary_part + error < rectangle.imaginary_upper.as_fraction()
+    )
+
+
+def _require_rectangle_selects_root(
+    value: ComplexAlgebraicValue,
+    rectangle: RationalComplexIsolatingRectangle,
+) -> Literal["NEGATIVE_IMAGINARY", "POSITIVE_IMAGINARY"]:
+    """Replay exact root count and indexed-root containment for one rectangle."""
+
+    import sympy
+
+    polynomial = _sympy_polynomial(value.polynomial)
+    _grid_denominator, error = _root_evidence_parameters(value.polynomial)
+    backend_root_index = _public_to_backend_root_indices(value.polynomial)[
+        value.root_index
+    ]
+    real_part, imaginary_part = _indexed_root_approximation(
+        polynomial, backend_root_index, error
+    )
+    if not (
+        rectangle.real_lower.as_fraction() < real_part - error
+        and real_part + error < rectangle.real_upper.as_fraction()
+        and rectangle.imaginary_lower.as_fraction() < imaginary_part - error
+        and imaginary_part + error < rectangle.imaginary_upper.as_fraction()
+    ):
+        raise _validation_error(
+            "root_identity",
+            "complex isolator does not certify the selected indexed root",
+        )
+
+    lower = sympy.Rational(*rectangle.real_lower.as_integer_ratio()) + sympy.I * (
+        sympy.Rational(*rectangle.imaginary_lower.as_integer_ratio())
+    )
+    upper = sympy.Rational(*rectangle.real_upper.as_integer_ratio()) + sympy.I * (
+        sympy.Rational(*rectangle.imaginary_upper.as_integer_ratio())
+    )
+    try:
+        root_count = int(polynomial.count_roots(lower, upper))
+    except NotImplementedError as exc:
+        raise _validation_error(
+            "boundary_root",
+            "complex isolator boundaries must contain no additional polynomial root",
+        ) from exc
+    if root_count != 1:
+        raise _validation_error(
+            "root_count",
+            "a complex algebraic isolator must contain exactly one root",
+        )
+
+    imaginary_lower = rectangle.imaginary_lower.as_fraction()
+    imaginary_upper = rectangle.imaginary_upper.as_fraction()
+    if imaginary_upper < 0:
+        return "NEGATIVE_IMAGINARY"
+    if imaginary_lower > 0:
+        return "POSITIVE_IMAGINARY"
+    raise _validation_error(
+        "half_plane",
+        "a nonreal root isolator must lie wholly in one open half-plane",
+    )
+
+
+__all__ = [
+    "MAX_COMPLEX_ISOLATOR_COMPONENT_DIGITS",
+    "MAX_COMPLEX_ORDERING_INTERMEDIATE_DIGITS",
+    "ComplexAlgebraicValue",
+    "RationalComplexIsolatingRectangle",
+    "algebraic_real_part_separation_denominator_bound",
+    "algebraic_root_magnitude_numerator_bound",
+    "algebraic_root_separation_denominator_bound",
+    "complex_isolator_component_digit_bound",
+]

--- a/src/jacobian/math/number_theory/algebraic_numbers/complex.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/complex.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from fractions import Fraction
-from functools import cmp_to_key, lru_cache
+from functools import lru_cache
 from math import gcd
 from typing import Any, Literal, Self
 
@@ -17,12 +16,9 @@ from jacobian.canonical import parse_canonical_integer
 from jacobian.math.number_theory.algebraic_numbers.real import (
     MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS,
     MAX_REAL_ALGEBRAIC_DEGREE,
-    _real_polynomial_validation,
-    _sympy_polynomial_from_coefficients,
 )
 
 MAX_COMPLEX_ISOLATOR_COMPONENT_DIGITS = 4_096
-MAX_COMPLEX_ORDERING_INTERMEDIATE_DIGITS = 32_768
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -33,10 +29,6 @@ def _integer_coefficients(
     coefficients: Sequence[CanonicalInteger],
 ) -> tuple[int, ...]:
     return tuple(parse_canonical_integer(coefficient) for coefficient in coefficients)
-
-
-def _sympy_polynomial(coefficients: tuple[CanonicalInteger, ...]) -> Any:
-    return _sympy_polynomial_from_coefficients(coefficients)
 
 
 def algebraic_root_separation_denominator_bound(
@@ -126,134 +118,6 @@ def complex_isolator_component_digit_bound(
     component_bits = grid_bits + magnitude_bits + 3
     # 0.30103 is a strict decimal upper bound for log10(2).
     return (component_bits * 30_103) // 100_000 + 2
-
-
-def _sympy_fraction(value: Any) -> Fraction:
-    return Fraction(int(value.p), int(value.q))
-
-
-def _indexed_root_approximation(
-    polynomial: Any,
-    root_index: int,
-    error: Fraction,
-) -> tuple[Fraction, Fraction]:
-    import sympy
-
-    root = sympy.CRootOf(polynomial.as_expr(), root_index, radicals=False)
-    tolerance = sympy.Rational(error.numerator, error.denominator)
-    approximation = root.eval_rational(dx=tolerance, dy=tolerance)
-    real_part, imaginary_part = approximation.as_real_imag()
-    return _sympy_fraction(real_part), _sympy_fraction(imaginary_part)
-
-
-def _root_evidence_parameters(
-    coefficients: Sequence[CanonicalInteger],
-) -> tuple[int, Fraction]:
-    separation_denominator = algebraic_root_separation_denominator_bound(coefficients)
-    grid_denominator = 1 << (separation_denominator.bit_length() + 4)
-    return grid_denominator, Fraction(1, 16 * grid_denominator)
-
-
-@lru_cache(maxsize=128)
-def _public_to_backend_root_indices_from_count(
-    coefficients: tuple[CanonicalInteger, ...],
-    real_count: int,
-) -> tuple[int, ...]:
-    """Map pair-ordered public indexes to SymPy indexes using exact bounds."""
-
-    import sympy
-
-    polynomial = _sympy_polynomial(coefficients)
-    degree = polynomial.degree()
-    if real_count == degree:
-        return tuple(range(degree))
-
-    root_separation = algebraic_root_separation_denominator_bound(coefficients)
-    pair_count = (degree - real_count) // 2
-    real_part_separation = (
-        algebraic_real_part_separation_denominator_bound(coefficients)
-        if pair_count > 1
-        else 1
-    )
-    real_part_digits = (real_part_separation.bit_length() * 30_103) // 100_000 + 1
-    if real_part_digits > MAX_COMPLEX_ORDERING_INTERMEDIATE_DIGITS:
-        raise _validation_error(
-            "ordering_intermediate_bound",
-            "exact conjugate-pair ordering exceeds the "
-            f"{MAX_COMPLEX_ORDERING_INTERMEDIATE_DIGITS:,}-digit "
-            "real-coordinate separation bound",
-        )
-    root_error = Fraction(1, 16 * root_separation)
-    real_part_error = Fraction(1, 16 * real_part_separation)
-    ordering_error = min(root_error, real_part_error)
-    backend_roots = [
-        sympy.CRootOf(polynomial.as_expr(), index, radicals=False)
-        for index in range(degree)
-    ]
-    unused = set(range(real_count, degree))
-    positive_representatives: list[tuple[int, Fraction, Fraction]] = []
-    negative_for_positive: dict[int, int] = {}
-    while unused:
-        backend_index = min(unused)
-        root = backend_roots[backend_index]
-        conjugate = sympy.conjugate(root)
-        # Real coefficients make the nonreal roots disjoint conjugate pairs.
-        # SymPy's exact CRootOf equality therefore guarantees this lookup.
-        partner = next(
-            candidate
-            for candidate in unused
-            if candidate != backend_index and backend_roots[candidate] == conjugate
-        )
-
-        _left_real, left_imaginary = _indexed_root_approximation(
-            polynomial, backend_index, root_error
-        )
-        positive_index = backend_index if left_imaginary > 0 else partner
-        negative_index = partner if positive_index == backend_index else backend_index
-        positive_real, positive_imaginary = _indexed_root_approximation(
-            polynomial, positive_index, ordering_error
-        )
-        positive_representatives.append(
-            (positive_index, positive_real, positive_imaginary)
-        )
-        negative_for_positive[positive_index] = negative_index
-        unused.remove(backend_index)
-        unused.remove(partner)
-
-    def compare(
-        left: tuple[int, Fraction, Fraction],
-        right: tuple[int, Fraction, Fraction],
-    ) -> int:
-        _left_index, left_real, left_imaginary = left
-        _right_index, right_real, right_imaginary = right
-        if left_real + real_part_error < right_real - real_part_error:
-            return -1
-        if right_real + real_part_error < left_real - real_part_error:
-            return 1
-        # Mignotte separation for the real-coordinate elimination polynomial
-        # proves that overlapping error intervals represent the same real
-        # coordinate.  Original-root separation then orders their positive
-        # imaginary coordinates.
-        if left_imaginary + root_error < right_imaginary - root_error:
-            return -1
-        if right_imaginary + root_error < left_imaginary - root_error:
-            return 1
-        return -1 if left_imaginary < right_imaginary else 1
-
-    positive_representatives.sort(key=cmp_to_key(compare))
-    public_to_backend = list(range(real_count))
-    for positive_index, _real_part, _imaginary_part in positive_representatives:
-        public_to_backend.extend(
-            (negative_for_positive[positive_index], positive_index)
-        )
-    return tuple(public_to_backend)
-
-
-def _public_to_backend_root_indices(
-    coefficients: tuple[CanonicalInteger, ...],
-) -> tuple[int, ...]:
-    _is_irreducible, real_count = _real_polynomial_validation(coefficients)
-    return _public_to_backend_root_indices_from_count(coefficients, real_count)
 
 
 class RationalComplexIsolatingRectangle(StrictModel):
@@ -351,6 +215,10 @@ class ComplexAlgebraicValue(StrictModel):
     each pair the negative root precedes the positive root.  Thus the
     polynomial and index, rather than any one of infinitely many valid
     isolating rectangles, are the value's identity.
+
+    Ordinary parsing establishes this canonical bounded representation. The
+    producer or a mathematical consumer recognizes irreducibility and the
+    selected nonreal root; deserialization does not repeat that work.
     """
 
     polynomial: tuple[CanonicalInteger, ...] = Field(
@@ -395,7 +263,7 @@ class ComplexAlgebraicValue(StrictModel):
         return canonicalize_json_containers(data)
 
     @model_validator(mode="after")
-    def require_canonical_nonreal_root(self) -> Self:
+    def require_canonical_indexed_root_shape(self) -> Self:
         coefficients = _integer_coefficients(self.polynomial)
         if coefficients[0] <= 0:
             raise _validation_error(
@@ -411,16 +279,10 @@ class ComplexAlgebraicValue(StrictModel):
                 "complex algebraic minimal polynomial must be primitive over ZZ",
             )
 
-        is_irreducible, real_root_count = _real_polynomial_validation(self.polynomial)
-        if not is_irreducible:
-            raise _validation_error(
-                "not_irreducible",
-                "complex algebraic minimal polynomial must be irreducible over QQ",
-            )
-        if not real_root_count <= self.root_index < len(self.polynomial) - 1:
+        if self.root_index >= len(self.polynomial) - 1:
             raise _validation_error(
                 "root_index",
-                "root_index must select a nonreal root in the declared global order",
+                "root_index must be smaller than the polynomial degree",
             )
         return self
 
@@ -436,90 +298,8 @@ class ComplexAlgebraicValue(StrictModel):
         return cls.model_construct(polynomial=polynomial, root_index=root_index)
 
 
-def _isolate_complex_algebraic(
-    value: ComplexAlgebraicValue,
-    *,
-    backend_root_index: int,
-    candidates: tuple[RationalComplexIsolatingRectangle, ...],
-) -> RationalComplexIsolatingRectangle:
-    """Select one deterministic admitted rectangle for an indexed root."""
-
-    polynomial = _sympy_polynomial(value.polynomial)
-    _grid_denominator, error = _root_evidence_parameters(value.polynomial)
-    real_part, imaginary_part = _indexed_root_approximation(
-        polynomial, backend_root_index, error
-    )
-    return next(
-        rectangle
-        for rectangle in candidates
-        if rectangle.real_lower.as_fraction() < real_part - error
-        and real_part + error < rectangle.real_upper.as_fraction()
-        and rectangle.imaginary_lower.as_fraction() < imaginary_part - error
-        and imaginary_part + error < rectangle.imaginary_upper.as_fraction()
-    )
-
-
-def _require_rectangle_selects_root(
-    value: ComplexAlgebraicValue,
-    rectangle: RationalComplexIsolatingRectangle,
-) -> Literal["NEGATIVE_IMAGINARY", "POSITIVE_IMAGINARY"]:
-    """Replay exact root count and indexed-root containment for one rectangle."""
-
-    import sympy
-
-    polynomial = _sympy_polynomial(value.polynomial)
-    _grid_denominator, error = _root_evidence_parameters(value.polynomial)
-    backend_root_index = _public_to_backend_root_indices(value.polynomial)[
-        value.root_index
-    ]
-    real_part, imaginary_part = _indexed_root_approximation(
-        polynomial, backend_root_index, error
-    )
-    if not (
-        rectangle.real_lower.as_fraction() < real_part - error
-        and real_part + error < rectangle.real_upper.as_fraction()
-        and rectangle.imaginary_lower.as_fraction() < imaginary_part - error
-        and imaginary_part + error < rectangle.imaginary_upper.as_fraction()
-    ):
-        raise _validation_error(
-            "root_identity",
-            "complex isolator does not certify the selected indexed root",
-        )
-
-    lower = sympy.Rational(*rectangle.real_lower.as_integer_ratio()) + sympy.I * (
-        sympy.Rational(*rectangle.imaginary_lower.as_integer_ratio())
-    )
-    upper = sympy.Rational(*rectangle.real_upper.as_integer_ratio()) + sympy.I * (
-        sympy.Rational(*rectangle.imaginary_upper.as_integer_ratio())
-    )
-    try:
-        root_count = int(polynomial.count_roots(lower, upper))
-    except NotImplementedError as exc:
-        raise _validation_error(
-            "boundary_root",
-            "complex isolator boundaries must contain no additional polynomial root",
-        ) from exc
-    if root_count != 1:
-        raise _validation_error(
-            "root_count",
-            "a complex algebraic isolator must contain exactly one root",
-        )
-
-    imaginary_lower = rectangle.imaginary_lower.as_fraction()
-    imaginary_upper = rectangle.imaginary_upper.as_fraction()
-    if imaginary_upper < 0:
-        return "NEGATIVE_IMAGINARY"
-    if imaginary_lower > 0:
-        return "POSITIVE_IMAGINARY"
-    raise _validation_error(
-        "half_plane",
-        "a nonreal root isolator must lie wholly in one open half-plane",
-    )
-
-
 __all__ = [
     "MAX_COMPLEX_ISOLATOR_COMPONENT_DIGITS",
-    "MAX_COMPLEX_ORDERING_INTERMEDIATE_DIGITS",
     "ComplexAlgebraicValue",
     "RationalComplexIsolatingRectangle",
     "algebraic_real_part_separation_denominator_bound",

--- a/src/jacobian/math/number_theory/algebraic_numbers/complex.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/complex.py
@@ -288,28 +288,12 @@ class _ComplexAlgebraicValueShape(StrictModel):
 
 
 class ComplexAlgebraicValue(_ComplexAlgebraicValueShape):
-    """One recognized nonreal algebraic number in canonical indexed-root form."""
+    """Structural indexed-root value established by an admitted result owner.
 
-    @model_validator(mode="after")
-    def require_canonical_nonreal_root(self) -> Self:
-        import sympy
-
-        variable = sympy.Symbol("x")
-        polynomial = sympy.Poly.from_list(
-            _integer_coefficients(self.polynomial), gens=variable, domain=sympy.ZZ
-        )
-        if polynomial.is_irreducible is not True:
-            raise _validation_error(
-                "not_irreducible",
-                "complex algebraic minimal polynomial must be irreducible over QQ",
-            )
-        real_root_count = int(polynomial.count_roots(-sympy.oo, sympy.oo))
-        if self.root_index < real_root_count:
-            raise _validation_error(
-                "root_index",
-                "root_index must select a nonreal root of the minimal polynomial",
-            )
-        return self
+    Parsing checks only its bounded canonical shape. Mathematical consumers
+    must recognize irreducibility and the selected nonreal root within their
+    own admitted execution path; model validation never replays that work.
+    """
 
     @classmethod
     def _from_admitted_polynomial(

--- a/src/jacobian/math/number_theory/algebraic_numbers/complex.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/complex.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from functools import lru_cache
 from math import gcd
-from typing import Any, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
-from pydantic import Field, StrictInt, model_validator
+from pydantic import Field, StrictInt, ValidateAs, WithJsonSchema, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger, CanonicalRational
@@ -205,8 +205,8 @@ class RationalComplexIsolatingRectangle(StrictModel):
         )
 
 
-class ComplexAlgebraicValue(StrictModel):
-    """One nonreal algebraic number in canonical indexed-root form.
+class _ComplexAlgebraicValueShape(StrictModel):
+    """Canonical structural representation of an indexed nonreal root.
 
     ``polynomial`` is primitive irreducible in ``ZZ[x]`` with positive leading
     coefficient.  ``root_index`` uses the mathematical global order: all real
@@ -216,9 +216,9 @@ class ComplexAlgebraicValue(StrictModel):
     polynomial and index, rather than any one of infinitely many valid
     isolating rectangles, are the value's identity.
 
-    Ordinary parsing establishes this canonical bounded representation. The
-    producer or a mathematical consumer recognizes irreducibility and the
-    selected nonreal root; deserialization does not repeat that work.
+    This structural view checks the bounded canonical representation. A public
+    value constructor or mathematical consumer must additionally recognize
+    irreducibility and that the index selects a nonreal root.
     """
 
     polynomial: tuple[CanonicalInteger, ...] = Field(
@@ -286,6 +286,31 @@ class ComplexAlgebraicValue(StrictModel):
             )
         return self
 
+
+class ComplexAlgebraicValue(_ComplexAlgebraicValueShape):
+    """One recognized nonreal algebraic number in canonical indexed-root form."""
+
+    @model_validator(mode="after")
+    def require_canonical_nonreal_root(self) -> Self:
+        import sympy
+
+        variable = sympy.Symbol("x")
+        polynomial = sympy.Poly.from_list(
+            _integer_coefficients(self.polynomial), gens=variable, domain=sympy.ZZ
+        )
+        if polynomial.is_irreducible is not True:
+            raise _validation_error(
+                "not_irreducible",
+                "complex algebraic minimal polynomial must be irreducible over QQ",
+            )
+        real_root_count = int(polynomial.count_roots(-sympy.oo, sympy.oo))
+        if self.root_index < real_root_count:
+            raise _validation_error(
+                "root_index",
+                "root_index must select a nonreal root of the minimal polynomial",
+            )
+        return self
+
     @classmethod
     def _from_admitted_polynomial(
         cls,
@@ -298,10 +323,29 @@ class ComplexAlgebraicValue(StrictModel):
         return cls.model_construct(polynomial=polynomial, root_index=root_index)
 
 
+def _unrecognized_complex_value_from_shape(
+    shape: _ComplexAlgebraicValueShape,
+) -> ComplexAlgebraicValue:
+    if isinstance(shape, ComplexAlgebraicValue):
+        return shape
+    return ComplexAlgebraicValue.model_construct(
+        polynomial=shape.polynomial,
+        root_index=shape.root_index,
+    )
+
+
+_UnrecognizedComplexAlgebraicValue = Annotated[
+    ComplexAlgebraicValue,
+    ValidateAs(_ComplexAlgebraicValueShape, _unrecognized_complex_value_from_shape),
+    WithJsonSchema(ComplexAlgebraicValue.model_json_schema()),
+]
+
+
 __all__ = [
     "MAX_COMPLEX_ISOLATOR_COMPONENT_DIGITS",
     "ComplexAlgebraicValue",
     "RationalComplexIsolatingRectangle",
+    "_UnrecognizedComplexAlgebraicValue",
     "algebraic_real_part_separation_denominator_bound",
     "algebraic_root_magnitude_numerator_bound",
     "algebraic_root_separation_denominator_bound",

--- a/src/jacobian/math/number_theory/algebraic_numbers/real.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/real.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
 from math import gcd
-from typing import TYPE_CHECKING, Literal, Self
+from typing import TYPE_CHECKING, Annotated, Literal, Self
 
-from pydantic import Field, StrictInt, model_validator
+from pydantic import Field, StrictInt, ValidateAs, WithJsonSchema, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger, CanonicalRational
@@ -36,42 +35,15 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 RealAlgebraicOrder = Literal["LT", "EQ", "GT"]
 
 
-@lru_cache(maxsize=128)
-def _sympy_polynomial_from_coefficients(
-    coefficients: tuple[CanonicalInteger, ...],
-) -> Poly:
+def _sympy_polynomial(value: RealAlgebraicValue) -> Poly:
     import sympy
 
     x = sympy.Symbol("x")
     return sympy.Poly.from_list(
-        [parse_canonical_integer(coefficient) for coefficient in coefficients],
+        [parse_canonical_integer(coefficient) for coefficient in value.polynomial],
         gens=x,
         domain=sympy.ZZ,
     )
-
-
-def _sympy_polynomial(value: RealAlgebraicValue) -> Poly:
-    return _sympy_polynomial_from_coefficients(value.polynomial)
-
-
-@lru_cache(maxsize=128)
-def _polynomial_is_irreducible(
-    coefficients: tuple[CanonicalInteger, ...],
-) -> bool:
-    return _sympy_polynomial_from_coefficients(coefficients).is_irreducible is True
-
-
-@lru_cache(maxsize=128)
-def _real_root_count(
-    coefficients: tuple[CanonicalInteger, ...],
-) -> int:
-    return len(_sympy_polynomial_from_coefficients(coefficients).intervals())
-
-
-def _real_polynomial_validation(
-    coefficients: tuple[CanonicalInteger, ...],
-) -> tuple[bool, int]:
-    return _polynomial_is_irreducible(coefficients), _real_root_count(coefficients)
 
 
 def _rational(value: SympyRational) -> CanonicalRational:
@@ -84,8 +56,8 @@ def _rational(value: SympyRational) -> CanonicalRational:
     )
 
 
-class RealAlgebraicValue(StrictModel):
-    """One real algebraic number in canonical minimal-polynomial form.
+class _RealAlgebraicValueShape(StrictModel):
+    """Canonical structural representation of an indexed real root.
 
     ``polynomial`` is the primitive irreducible polynomial in ``ZZ[x]`` with
     positive leading coefficient, listed in descending degree.  The
@@ -112,7 +84,7 @@ class RealAlgebraicValue(StrictModel):
     )
 
     @model_validator(mode="after")
-    def require_canonical_real_root(self) -> Self:
+    def require_canonical_polynomial_shape(self) -> Self:
         if any(
             len(coefficient.lstrip("-")) > MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS
             for coefficient in self.polynomial
@@ -139,12 +111,31 @@ class RealAlgebraicValue(StrictModel):
                 "real algebraic minimal polynomial must be primitive over ZZ",
             )
 
-        is_irreducible, real_root_count = _real_polynomial_validation(self.polynomial)
-        if not is_irreducible:
+        if self.real_root_index >= len(self.polynomial) - 1:
+            raise _validation_error(
+                "root_index",
+                "real_root_index must be smaller than the polynomial degree",
+            )
+        return self
+
+
+class RealAlgebraicValue(_RealAlgebraicValueShape):
+    """One real algebraic number in canonical minimal-polynomial form.
+
+    Direct construction recognizes irreducibility and the selected real root.
+    Result owners may instead use the structural request view after their
+    admitted kernel has established those mathematical invariants.
+    """
+
+    @model_validator(mode="after")
+    def require_canonical_real_root(self) -> Self:
+        polynomial = _sympy_polynomial(self)
+        if polynomial.is_irreducible is not True:
             raise _validation_error(
                 "not_irreducible",
                 "real algebraic minimal polynomial must be irreducible over QQ",
             )
+        real_root_count = len(polynomial.intervals())
         if self.real_root_index >= real_root_count:
             raise _validation_error(
                 "root_index",
@@ -165,6 +156,24 @@ class RealAlgebraicValue(StrictModel):
             polynomial=polynomial,
             real_root_index=real_root_index,
         )
+
+
+def _unrecognized_real_value_from_shape(
+    shape: _RealAlgebraicValueShape,
+) -> RealAlgebraicValue:
+    if isinstance(shape, RealAlgebraicValue):
+        return shape
+    return RealAlgebraicValue.model_construct(
+        polynomial=shape.polynomial,
+        real_root_index=shape.real_root_index,
+    )
+
+
+_UnrecognizedRealAlgebraicValue = Annotated[
+    RealAlgebraicValue,
+    ValidateAs(_RealAlgebraicValueShape, _unrecognized_real_value_from_shape),
+    WithJsonSchema(RealAlgebraicValue.model_json_schema()),
+]
 
 
 class RationalIsolatingInterval(StrictModel):

--- a/src/jacobian/math/number_theory/algebraic_numbers/real.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/real.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 from math import gcd
 from typing import TYPE_CHECKING, Literal, Self
 
@@ -35,15 +36,42 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 RealAlgebraicOrder = Literal["LT", "EQ", "GT"]
 
 
-def _sympy_polynomial(value: RealAlgebraicValue) -> Poly:
+@lru_cache(maxsize=128)
+def _sympy_polynomial_from_coefficients(
+    coefficients: tuple[CanonicalInteger, ...],
+) -> Poly:
     import sympy
 
     x = sympy.Symbol("x")
     return sympy.Poly.from_list(
-        [parse_canonical_integer(coefficient) for coefficient in value.polynomial],
+        [parse_canonical_integer(coefficient) for coefficient in coefficients],
         gens=x,
         domain=sympy.ZZ,
     )
+
+
+def _sympy_polynomial(value: RealAlgebraicValue) -> Poly:
+    return _sympy_polynomial_from_coefficients(value.polynomial)
+
+
+@lru_cache(maxsize=128)
+def _polynomial_is_irreducible(
+    coefficients: tuple[CanonicalInteger, ...],
+) -> bool:
+    return _sympy_polynomial_from_coefficients(coefficients).is_irreducible is True
+
+
+@lru_cache(maxsize=128)
+def _real_root_count(
+    coefficients: tuple[CanonicalInteger, ...],
+) -> int:
+    return len(_sympy_polynomial_from_coefficients(coefficients).intervals())
+
+
+def _real_polynomial_validation(
+    coefficients: tuple[CanonicalInteger, ...],
+) -> tuple[bool, int]:
+    return _polynomial_is_irreducible(coefficients), _real_root_count(coefficients)
 
 
 def _rational(value: SympyRational) -> CanonicalRational:
@@ -111,19 +139,32 @@ class RealAlgebraicValue(StrictModel):
                 "real algebraic minimal polynomial must be primitive over ZZ",
             )
 
-        polynomial = _sympy_polynomial(self)
-        if polynomial.is_irreducible is not True:
+        is_irreducible, real_root_count = _real_polynomial_validation(self.polynomial)
+        if not is_irreducible:
             raise _validation_error(
                 "not_irreducible",
                 "real algebraic minimal polynomial must be irreducible over QQ",
             )
-        real_root_count = len(polynomial.intervals())
         if self.real_root_index >= real_root_count:
             raise _validation_error(
                 "root_index",
                 "real_root_index must select an existing real root of the minimal polynomial",
             )
         return self
+
+    @classmethod
+    def _from_admitted_polynomial(
+        cls,
+        *,
+        polynomial: tuple[CanonicalInteger, ...],
+        real_root_index: int,
+    ) -> RealAlgebraicValue:
+        """Construct after an owner has admitted the canonical polynomial/root."""
+
+        return cls.model_construct(
+            polynomial=polynomial,
+            real_root_index=real_root_index,
+        )
 
 
 class RationalIsolatingInterval(StrictModel):

--- a/src/jacobian/math/number_theory/number_fields/__init__.py
+++ b/src/jacobian/math/number_theory/number_fields/__init__.py
@@ -2,7 +2,26 @@
 
 from jacobian.math.number_theory.number_fields.operations import (
     discriminant,
+    embeddings,
     ring_of_integers,
 )
+from jacobian.math.number_theory.number_fields.values import (
+    ComplexNumberFieldEmbedding,
+    EmbeddedSimpleNumberFieldElement,
+    NumberFieldEmbeddingProfile,
+    RealNumberFieldEmbedding,
+    SimpleNumberFieldElement,
+    SimpleNumberFieldPresentation,
+)
 
-__all__ = ["discriminant", "ring_of_integers"]
+__all__ = [
+    "ComplexNumberFieldEmbedding",
+    "EmbeddedSimpleNumberFieldElement",
+    "NumberFieldEmbeddingProfile",
+    "RealNumberFieldEmbedding",
+    "SimpleNumberFieldElement",
+    "SimpleNumberFieldPresentation",
+    "discriminant",
+    "embeddings",
+    "ring_of_integers",
+]

--- a/src/jacobian/math/number_theory/number_fields/__init__.py
+++ b/src/jacobian/math/number_theory/number_fields/__init__.py
@@ -6,19 +6,13 @@ from jacobian.math.number_theory.number_fields.operations import (
     ring_of_integers,
 )
 from jacobian.math.number_theory.number_fields.values import (
-    ComplexNumberFieldEmbedding,
-    EmbeddedSimpleNumberFieldElement,
     NumberFieldEmbeddingProfile,
-    RealNumberFieldEmbedding,
     SimpleNumberFieldElement,
     SimpleNumberFieldPresentation,
 )
 
 __all__ = [
-    "ComplexNumberFieldEmbedding",
-    "EmbeddedSimpleNumberFieldElement",
     "NumberFieldEmbeddingProfile",
-    "RealNumberFieldEmbedding",
     "SimpleNumberFieldElement",
     "SimpleNumberFieldPresentation",
     "discriminant",

--- a/src/jacobian/math/number_theory/number_fields/_discriminant_process.py
+++ b/src/jacobian/math/number_theory/number_fields/_discriminant_process.py
@@ -80,7 +80,7 @@ def compute_nf_discriminant(
         response = None
     if isinstance(response, dict) and response.get("kind") == "invalid":
         raise OperationDomainValidationError(
-            location=("coefficients_descending",),
+            location=("field",),
             code="number_field.not_irreducible",
             message="number-field polynomial must be irreducible over QQ",
         )

--- a/src/jacobian/math/number_theory/number_fields/_embedding_limits.py
+++ b/src/jacobian/math/number_theory/number_fields/_embedding_limits.py
@@ -1,0 +1,16 @@
+"""Shared resource bounds for exact number-field embedding profiles."""
+
+from __future__ import annotations
+
+from jacobian.canonical import CanonicalLimits
+
+MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES = CanonicalLimits().max_output_bytes
+MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS = 2_097_152
+MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS = 32_768
+
+
+__all__ = [
+    "MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES",
+    "MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS",
+    "MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS",
+]

--- a/src/jacobian/math/number_theory/number_fields/_embedding_protocol.py
+++ b/src/jacobian/math/number_theory/number_fields/_embedding_protocol.py
@@ -1,0 +1,100 @@
+"""Strict private protocol for the one-shot embedding worker."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictInt, TypeAdapter, model_validator
+
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel
+from jacobian.math.number_theory.algebraic_numbers.complex import (
+    RationalComplexIsolatingRectangle,
+)
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+)
+from jacobian.math.number_theory.number_fields._embedding_limits import (
+    MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS,
+)
+from jacobian.math.number_theory.number_fields.values import (
+    MAX_NUMBER_FIELD_EMBEDDING_DEGREE,
+    SimpleNumberFieldPresentation,
+)
+
+
+class NumberFieldEmbeddingWorkerRequest(StrictModel):
+    """Retained source plus the owner-admitted static isolation plan."""
+
+    field: SimpleNumberFieldPresentation
+    root_isolation_bits: StrictInt = Field(
+        ge=5,
+        le=MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS,
+    )
+    evidence_grid_bits: StrictInt = Field(
+        ge=1,
+        le=MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS - 4,
+    )
+
+    @model_validator(mode="after")
+    def bind_admitted_grids(self) -> Self:
+        if self.root_isolation_bits != self.evidence_grid_bits + 4:
+            raise ValueError(
+                "worker isolation grid must refine the public evidence grid by 4 bits"
+            )
+        return self
+
+
+class NumberFieldEmbeddingWorkerComplete(StrictModel):
+    kind: Literal["complete"]
+    real_intervals: tuple[RationalIsolatingInterval, ...] = Field(
+        max_length=MAX_NUMBER_FIELD_EMBEDDING_DEGREE
+    )
+    negative_complex_rectangles: tuple[RationalComplexIsolatingRectangle, ...] = Field(
+        max_length=MAX_NUMBER_FIELD_EMBEDDING_DEGREE // 2
+    )
+    defining_polynomial_discriminant: CanonicalInteger
+
+    @model_validator(mode="after")
+    def bind_degree_and_half_plane(self) -> Self:
+        degree = len(self.real_intervals) + 2 * len(self.negative_complex_rectangles)
+        if not 1 <= degree <= MAX_NUMBER_FIELD_EMBEDDING_DEGREE:
+            raise ValueError("worker root evidence must describe a bounded degree")
+        if any(
+            rectangle.imaginary_upper.as_fraction() >= 0
+            for rectangle in self.negative_complex_rectangles
+        ):
+            raise ValueError("worker complex evidence must select negative roots")
+        return self
+
+
+class NumberFieldEmbeddingWorkerInvalid(StrictModel):
+    kind: Literal["invalid"]
+    reason: Literal["not_irreducible"]
+
+
+class NumberFieldEmbeddingWorkerRejected(StrictModel):
+    kind: Literal["rejected"]
+    reason: Literal["pair_ordering_precision_bound"]
+
+
+NumberFieldEmbeddingWorkerResponse = Annotated[
+    NumberFieldEmbeddingWorkerComplete
+    | NumberFieldEmbeddingWorkerInvalid
+    | NumberFieldEmbeddingWorkerRejected,
+    Field(discriminator="kind"),
+]
+
+NUMBER_FIELD_EMBEDDING_WORKER_RESPONSE_ADAPTER: TypeAdapter[
+    NumberFieldEmbeddingWorkerResponse
+] = TypeAdapter(NumberFieldEmbeddingWorkerResponse)
+
+
+__all__ = [
+    "NUMBER_FIELD_EMBEDDING_WORKER_RESPONSE_ADAPTER",
+    "NumberFieldEmbeddingWorkerComplete",
+    "NumberFieldEmbeddingWorkerInvalid",
+    "NumberFieldEmbeddingWorkerRejected",
+    "NumberFieldEmbeddingWorkerRequest",
+    "NumberFieldEmbeddingWorkerResponse",
+]

--- a/src/jacobian/math/number_theory/number_fields/_embeddings_process.py
+++ b/src/jacobian/math/number_theory/number_fields/_embeddings_process.py
@@ -1,0 +1,106 @@
+"""Killable one-shot process boundary for exact field embeddings."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from pydantic import ValidationError
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.math.number_theory.number_fields._embedding_protocol import (
+    NUMBER_FIELD_EMBEDDING_WORKER_RESPONSE_ADAPTER,
+    NumberFieldEmbeddingWorkerRequest,
+    NumberFieldEmbeddingWorkerResponse,
+)
+
+_EMBEDDINGS_WORKER = Path(__file__).resolve().with_name("_embeddings_worker.py")
+EMBEDDINGS_WORKER_WALL_SECONDS = 120.0
+_EMBEDDINGS_WORKER_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_EMBEDDINGS_WORKER_FILE_SIZE_BYTES = 1024 * 1024
+_EMBEDDINGS_WORKER_STDERR_BYTES = 64 * 1024
+
+
+def run_embeddings_worker(
+    request: NumberFieldEmbeddingWorkerRequest,
+    *,
+    timeout_seconds: float,
+    stdout_limit: int,
+) -> NumberFieldEmbeddingWorkerResponse:
+    """Run one isolated recognition, ordering, and isolation computation."""
+
+    from jacobian.process import (
+        ProcessResourceLimits,
+        run_bounded_process,
+        worker_environment,
+    )
+
+    try:
+        with TemporaryDirectory(
+            prefix="jacobian-number-field-embeddings-"
+        ) as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_EMBEDDINGS_WORKER)],
+                input_bytes=request.model_dump_json().encode("utf-8"),
+                timeout_seconds=timeout_seconds,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=stdout_limit,
+                stderr_limit=_EMBEDDINGS_WORKER_STDERR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(EMBEDDINGS_WORKER_WALL_SECONDS)),
+                    address_space_bytes=_EMBEDDINGS_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_EMBEDDINGS_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded number-field embedding worker could not be started"
+        ) from exc
+
+    if completed.cancelled:
+        raise OperationExecutionCancelledError(
+            "request cancelled during number-field embedding computation"
+        )
+    if completed.timed_out:
+        raise OperationExecutionTimeoutError(
+            "request deadline expired during number-field embedding computation"
+        )
+    if (
+        completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        raise RuntimeError(
+            "bounded number-field embedding worker did not establish a profile"
+        )
+
+    try:
+        return NUMBER_FIELD_EMBEDDING_WORKER_RESPONSE_ADAPTER.validate_json(
+            completed.stdout,
+            strict=True,
+        )
+    except ValidationError as exc:
+        raise RuntimeError(
+            "bounded number-field embedding worker returned malformed output"
+        ) from exc
+
+
+def embeddings_worker_cancelled() -> bool:
+    """Report cancellation through the shared bounded-process context."""
+
+    from jacobian.process import bounded_process_cancelled
+
+    return bounded_process_cancelled()
+
+
+__all__ = [
+    "EMBEDDINGS_WORKER_WALL_SECONDS",
+    "embeddings_worker_cancelled",
+    "run_embeddings_worker",
+]

--- a/src/jacobian/math/number_theory/number_fields/_embeddings_process.py
+++ b/src/jacobian/math/number_theory/number_fields/_embeddings_process.py
@@ -19,6 +19,9 @@ from jacobian.math.number_theory.number_fields._embedding_protocol import (
     NumberFieldEmbeddingWorkerRequest,
     NumberFieldEmbeddingWorkerResponse,
 )
+from jacobian.math.number_theory.number_fields.values import (
+    SimpleNumberFieldPresentation,
+)
 
 _EMBEDDINGS_WORKER = Path(__file__).resolve().with_name("_embeddings_worker.py")
 EMBEDDINGS_WORKER_WALL_SECONDS = 120.0
@@ -28,8 +31,10 @@ _EMBEDDINGS_WORKER_STDERR_BYTES = 64 * 1024
 
 
 def run_embeddings_worker(
-    request: NumberFieldEmbeddingWorkerRequest,
+    field: SimpleNumberFieldPresentation,
     *,
+    root_isolation_bits: int,
+    evidence_grid_bits: int,
     deadline: float,
     stdout_limit: int,
 ) -> NumberFieldEmbeddingWorkerResponse:
@@ -41,6 +46,11 @@ def run_embeddings_worker(
         worker_environment,
     )
 
+    request = NumberFieldEmbeddingWorkerRequest(
+        field=field,
+        root_isolation_bits=root_isolation_bits,
+        evidence_grid_bits=evidence_grid_bits,
+    )
     timeout_seconds = deadline - time.monotonic()
     if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
         raise OperationExecutionTimeoutError(

--- a/src/jacobian/math/number_theory/number_fields/_embeddings_process.py
+++ b/src/jacobian/math/number_theory/number_fields/_embeddings_process.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import sys
+import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -29,7 +30,7 @@ _EMBEDDINGS_WORKER_STDERR_BYTES = 64 * 1024
 def run_embeddings_worker(
     request: NumberFieldEmbeddingWorkerRequest,
     *,
-    timeout_seconds: float,
+    deadline: float,
     stdout_limit: int,
 ) -> NumberFieldEmbeddingWorkerResponse:
     """Run one isolated recognition, ordering, and isolation computation."""
@@ -39,6 +40,12 @@ def run_embeddings_worker(
         run_bounded_process,
         worker_environment,
     )
+
+    timeout_seconds = deadline - time.monotonic()
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise OperationExecutionTimeoutError(
+            "request deadline expired before number-field embedding worker launch"
+        )
 
     try:
         with TemporaryDirectory(

--- a/src/jacobian/math/number_theory/number_fields/_embeddings_worker.py
+++ b/src/jacobian/math/number_theory/number_fields/_embeddings_worker.py
@@ -1,0 +1,269 @@
+"""One-shot SymPy kernel for exact number-field embedding profiles."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from fractions import Fraction
+from functools import cmp_to_key
+from typing import Any
+
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.math.number_theory.algebraic_numbers.complex import (
+    RationalComplexIsolatingRectangle,
+    algebraic_real_part_separation_denominator_bound,
+)
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+)
+from jacobian.math.number_theory.number_fields._embedding_limits import (
+    MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS,
+)
+from jacobian.math.number_theory.number_fields._embedding_protocol import (
+    NumberFieldEmbeddingWorkerComplete,
+    NumberFieldEmbeddingWorkerInvalid,
+    NumberFieldEmbeddingWorkerRejected,
+    NumberFieldEmbeddingWorkerRequest,
+    NumberFieldEmbeddingWorkerResponse,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _RationalRectangle:
+    real_lower: Fraction
+    real_upper: Fraction
+    imaginary_lower: Fraction
+    imaginary_upper: Fraction
+
+    def conjugate(self) -> _RationalRectangle:
+        return _RationalRectangle(
+            real_lower=self.real_lower,
+            real_upper=self.real_upper,
+            imaginary_lower=-self.imaginary_upper,
+            imaginary_upper=-self.imaginary_lower,
+        )
+
+
+def _backend_fraction(value: Any) -> Fraction:
+    return Fraction(int(value.p), int(value.q))
+
+
+def _dyadic_floor(value: Fraction, denominator: int) -> int:
+    return (value.numerator * denominator) // value.denominator
+
+
+def _dyadic_ceiling(value: Fraction, denominator: int) -> int:
+    return -((-value.numerator * denominator) // value.denominator)
+
+
+def _normalize_real_isolator(
+    lower: Fraction,
+    upper: Fraction,
+    *,
+    grid_denominator: int,
+) -> RationalIsolatingInterval:
+    if lower == upper:
+        endpoint = CanonicalRational.from_fraction(lower)
+        return RationalIsolatingInterval(
+            lower=endpoint,
+            upper=endpoint,
+            interval_type="SINGLETON",
+        )
+    lower_cell = _dyadic_floor(lower, grid_denominator)
+    upper_cell = _dyadic_ceiling(upper, grid_denominator)
+    return RationalIsolatingInterval(
+        lower=CanonicalRational.from_fraction(
+            Fraction(lower_cell - 1, grid_denominator)
+        ),
+        upper=CanonicalRational.from_fraction(
+            Fraction(upper_cell + 1, grid_denominator)
+        ),
+        interval_type="OPEN",
+    )
+
+
+def _normalize_complex_isolator(
+    rectangle: _RationalRectangle,
+    *,
+    grid_denominator: int,
+) -> RationalComplexIsolatingRectangle:
+    real_lower_cell = _dyadic_floor(rectangle.real_lower, grid_denominator)
+    real_upper_cell = _dyadic_ceiling(rectangle.real_upper, grid_denominator)
+    imaginary_lower_cell = _dyadic_floor(rectangle.imaginary_lower, grid_denominator)
+    imaginary_upper_cell = _dyadic_ceiling(rectangle.imaginary_upper, grid_denominator)
+    return RationalComplexIsolatingRectangle(
+        real_lower=CanonicalRational.from_fraction(
+            Fraction(real_lower_cell - 1, grid_denominator)
+        ),
+        real_upper=CanonicalRational.from_fraction(
+            Fraction(real_upper_cell + 1, grid_denominator)
+        ),
+        imaginary_lower=CanonicalRational.from_fraction(
+            Fraction(imaginary_lower_cell - 1, grid_denominator)
+        ),
+        imaginary_upper=CanonicalRational.from_fraction(
+            Fraction(imaginary_upper_cell + 1, grid_denominator)
+        ),
+    )
+
+
+def _rational_rectangle(lower: Any, upper: Any) -> _RationalRectangle:
+    lower_real, lower_imaginary = lower.as_real_imag()
+    upper_real, upper_imaginary = upper.as_real_imag()
+    return _RationalRectangle(
+        real_lower=_backend_fraction(lower_real),
+        real_upper=_backend_fraction(upper_real),
+        imaginary_lower=_backend_fraction(lower_imaginary),
+        imaginary_upper=_backend_fraction(upper_imaginary),
+    )
+
+
+def _ordered_negative_representatives(
+    rectangles: tuple[_RationalRectangle, ...],
+) -> tuple[_RationalRectangle, ...]:
+    negative = tuple(
+        rectangle for rectangle in rectangles if rectangle.imaginary_upper < 0
+    )
+    positive = {
+        rectangle: rectangle
+        for rectangle in rectangles
+        if rectangle.imaginary_lower > 0
+    }
+    if len(negative) * 2 != len(rectangles) or len(positive) != len(negative):
+        raise RuntimeError("complex root isolators do not lie in open half-planes")
+
+    pairs: list[tuple[_RationalRectangle, _RationalRectangle]] = []
+    for negative_rectangle in negative:
+        positive_rectangle = positive.pop(negative_rectangle.conjugate(), None)
+        if positive_rectangle is None:
+            raise RuntimeError("complex root isolators are not exact conjugate pairs")
+        pairs.append((negative_rectangle, positive_rectangle))
+    if positive:
+        raise RuntimeError("complex root isolators have unmatched conjugates")
+
+    def compare(
+        left: tuple[_RationalRectangle, _RationalRectangle],
+        right: tuple[_RationalRectangle, _RationalRectangle],
+    ) -> int:
+        if left is right:
+            return 0
+        left_positive = left[1]
+        right_positive = right[1]
+        if left_positive.real_upper < right_positive.real_lower:
+            return -1
+        if right_positive.real_upper < left_positive.real_lower:
+            return 1
+        if left_positive.imaginary_upper < right_positive.imaginary_lower:
+            return -1
+        if right_positive.imaginary_upper < left_positive.imaginary_lower:
+            return 1
+        raise RuntimeError("refined complex root isolators do not establish order")
+
+    pairs.sort(key=cmp_to_key(compare))
+    return tuple(negative_rectangle for negative_rectangle, _positive in pairs)
+
+
+def compute_embeddings_worker_response(
+    request: NumberFieldEmbeddingWorkerRequest,
+) -> NumberFieldEmbeddingWorkerResponse:
+    """Recognize and compute one profile with exactly one all-root isolation."""
+
+    import sympy
+
+    field = request.field
+    variable = sympy.Symbol("x")
+    polynomial = sympy.Poly.from_list(
+        [
+            parse_canonical_integer(coefficient)
+            for coefficient in field.coefficients_descending
+        ],
+        gens=variable,
+        domain=sympy.ZZ,
+    )
+    if polynomial.is_irreducible is not True:
+        return NumberFieldEmbeddingWorkerInvalid(
+            kind="invalid",
+            reason="not_irreducible",
+        )
+
+    real_count = int(polynomial.count_roots(-sympy.oo, sympy.oo))
+    pair_count = (field.degree - real_count) // 2
+    # The exact Sturm signature count determines whether pair ordering needs
+    # the elimination polynomial.  It does not construct complex isolators;
+    # the call below remains the sole all-root isolation pass.
+    real_part_separation = (
+        algebraic_real_part_separation_denominator_bound(field.coefficients_descending)
+        if pair_count > 1
+        else 1
+    )
+    refinement_bits = max(
+        request.root_isolation_bits,
+        real_part_separation.bit_length() + 4,
+    )
+    if refinement_bits > MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS:
+        return NumberFieldEmbeddingWorkerRejected(
+            kind="rejected",
+            reason="pair_ordering_precision_bound",
+        )
+
+    fine_grid_denominator = 1 << refinement_bits
+    backend_real_intervals, backend_complex_rectangles = polynomial.intervals(
+        all=True,
+        eps=sympy.Rational(1, fine_grid_denominator),
+    )
+    if any(multiplicity != 1 for _interval, multiplicity in backend_real_intervals):
+        raise RuntimeError("irreducible polynomial returned repeated real roots")
+    if any(
+        multiplicity != 1 for _rectangle, multiplicity in backend_complex_rectangles
+    ):
+        raise RuntimeError("irreducible polynomial returned repeated complex roots")
+
+    evidence_grid_denominator = 1 << request.evidence_grid_bits
+    real_intervals = tuple(
+        _normalize_real_isolator(
+            _backend_fraction(lower),
+            _backend_fraction(upper),
+            grid_denominator=evidence_grid_denominator,
+        )
+        for (lower, upper), _multiplicity in backend_real_intervals
+    )
+    raw_complex_rectangles = tuple(
+        _rational_rectangle(lower, upper)
+        for (lower, upper), _multiplicity in backend_complex_rectangles
+    )
+    ordered_negative = _ordered_negative_representatives(raw_complex_rectangles)
+    negative_rectangles = tuple(
+        _normalize_complex_isolator(
+            rectangle,
+            grid_denominator=evidence_grid_denominator,
+        )
+        for rectangle in ordered_negative
+    )
+    if len(real_intervals) + 2 * len(negative_rectangles) != field.degree:
+        raise RuntimeError("root isolation did not return a complete field signature")
+    if len(real_intervals) != real_count or len(negative_rectangles) != pair_count:
+        raise RuntimeError("root isolation disagrees with the exact field signature")
+
+    return NumberFieldEmbeddingWorkerComplete(
+        kind="complete",
+        real_intervals=real_intervals,
+        negative_complex_rectangles=negative_rectangles,
+        defining_polynomial_discriminant=format_canonical_integer(
+            int(polynomial.discriminant())
+        ),
+    )
+
+
+def main() -> int:
+    request = NumberFieldEmbeddingWorkerRequest.model_validate_json(
+        sys.stdin.buffer.read(),
+        strict=True,
+    )
+    response = compute_embeddings_worker_response(request)
+    sys.stdout.write(response.model_dump_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/number_theory/number_fields/_integral_basis.py
+++ b/src/jacobian/math/number_theory/number_fields/_integral_basis.py
@@ -1,0 +1,50 @@
+"""Private SymPy kernel for canonical simple-field presentations."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math.number_theory.number_fields.values import (
+    SimpleNumberFieldPresentation,
+)
+
+
+def recognized_integral_basis(
+    field: SimpleNumberFieldPresentation,
+) -> tuple[Any, Any, Any, int] | None:
+    """Recognize the presentation and compute its integral basis once."""
+
+    import sympy
+    from sympy.polys.numberfields import round_two
+
+    alpha = sympy.Symbol("alpha")
+    coefficients = tuple(
+        parse_canonical_integer(coefficient)
+        for coefficient in field.coefficients_descending
+    )
+    leading = coefficients[0]
+    # beta = leading * alpha has the monic integral polynomial
+    # leading^(n-1) f(beta / leading). This preserves QQ(alpha) while
+    # allowing the canonical presentation itself to remain nonmonic.
+    monic_coefficients = (
+        1,
+        *(
+            coefficient * leading ** (index - 1)
+            for index, coefficient in enumerate(coefficients[1:], start=1)
+        ),
+    )
+    polynomial = sympy.Poly.from_list(
+        monic_coefficients,
+        gens=alpha,
+        domain=sympy.ZZ,
+    )
+    if polynomial.is_irreducible is not True:
+        return None
+    ring, field_discriminant = cast(tuple[Any, Any], round_two(polynomial))
+    return ring, field_discriminant, alpha, leading
+
+
+__all__ = [
+    "recognized_integral_basis",
+]

--- a/src/jacobian/math/number_theory/number_fields/_models.py
+++ b/src/jacobian/math/number_theory/number_fields/_models.py
@@ -9,6 +9,9 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.canonical import parse_canonical_integer
+from jacobian.math.number_theory.number_fields.values import (
+    SimpleNumberFieldPresentation,
+)
 from jacobian.math.polynomials.values import PolynomialVariable
 
 MAX_NUMBER_FIELD_COEFFICIENT_DIGITS = 256
@@ -74,3 +77,17 @@ class NumberFieldDiscriminantResult(StrictModel):
                 "an unknown number-field computation requires detail and no value",
             )
         return self
+
+
+class NumberFieldEmbeddingsRequest(StrictModel):
+    """Request every Archimedean embedding of one bounded presented field."""
+
+    field: SimpleNumberFieldPresentation
+
+
+__all__ = [
+    "MAX_NUMBER_FIELD_COEFFICIENT_DIGITS",
+    "NumberFieldDiscriminantResult",
+    "NumberFieldEmbeddingsRequest",
+    "NumberFieldRequest",
+]

--- a/src/jacobian/math/number_theory/number_fields/_models.py
+++ b/src/jacobian/math/number_theory/number_fields/_models.py
@@ -8,13 +8,9 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.canonical import parse_canonical_integer
 from jacobian.math.number_theory.number_fields.values import (
     SimpleNumberFieldPresentation,
 )
-from jacobian.math.polynomials.values import PolynomialVariable
-
-MAX_NUMBER_FIELD_COEFFICIENT_DIGITS = 256
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -24,37 +20,7 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 class NumberFieldRequest(StrictModel):
     """A number field Q(alpha) defined by a minimal polynomial."""
 
-    coefficients_descending: tuple[str, ...] = Field(min_length=2, max_length=32)
-    variable: PolynomialVariable
-
-    @model_validator(mode="after")
-    def require_bounded_monic_integer_polynomial(self) -> Self:
-        # Bound digit conversion before SymPy sees an arbitrary decimal
-        # spelling.  Degree and coefficient height jointly bound the parser
-        # input and every polynomial construction that follows.
-        if any(
-            len(coefficient.lstrip("-")) > MAX_NUMBER_FIELD_COEFFICIENT_DIGITS
-            for coefficient in self.coefficients_descending
-        ):
-            raise _validation_error(
-                "coefficient_digits",
-                "number-field coefficients may contain at most "
-                f"{MAX_NUMBER_FIELD_COEFFICIENT_DIGITS} decimal digits",
-            )
-        try:
-            coefficients = tuple(
-                parse_canonical_integer(value) for value in self.coefficients_descending
-            )
-        except ValueError as exc:
-            raise _validation_error(
-                "coefficient_syntax",
-                "number-field coefficients must be canonical integers",
-            ) from exc
-        if coefficients[0] != 1:
-            raise _validation_error(
-                "not_monic", "number-field polynomial must be monic"
-            )
-        return self
+    field: SimpleNumberFieldPresentation
 
 
 class NumberFieldDiscriminantResult(StrictModel):
@@ -86,7 +52,6 @@ class NumberFieldEmbeddingsRequest(StrictModel):
 
 
 __all__ = [
-    "MAX_NUMBER_FIELD_COEFFICIENT_DIGITS",
     "NumberFieldDiscriminantResult",
     "NumberFieldEmbeddingsRequest",
     "NumberFieldRequest",

--- a/src/jacobian/math/number_theory/number_fields/_tools.py
+++ b/src/jacobian/math/number_theory/number_fields/_tools.py
@@ -5,13 +5,25 @@ from typing import Any
 
 from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
-from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.catalog.models import (
+    MathTool,
+    OperationDomainValidationError,
+    OperationExample,
+)
 from jacobian.math.number_theory.number_fields._discriminant_process import (
     compute_nf_discriminant,
 )
 from jacobian.math.number_theory.number_fields._models import (
     NumberFieldDiscriminantResult,
+    NumberFieldEmbeddingsRequest,
     NumberFieldRequest,
+)
+from jacobian.math.number_theory.number_fields.operations import (
+    NumberFieldEmbeddingAdmissionError,
+    embeddings,
+)
+from jacobian.math.number_theory.number_fields.values import (
+    NumberFieldEmbeddingProfile,
 )
 
 
@@ -37,6 +49,19 @@ def nf_operation[RequestT: StrictModel, ResultT: StrictModel](
     )
 
 
+def _compute_embeddings(
+    request: NumberFieldEmbeddingsRequest,
+) -> NumberFieldEmbeddingProfile:
+    try:
+        return embeddings(request.field)
+    except NumberFieldEmbeddingAdmissionError as exc:
+        raise OperationDomainValidationError(
+            location=("field",),
+            code=f"number_field.embeddings.{exc.reason}",
+            message=str(exc),
+        ) from exc
+
+
 TOOLS: tuple[MathTool[Any, Any], ...] = (
     nf_operation(
         "number_field.discriminant.compute",
@@ -53,6 +78,30 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 "quadratic_disc",
                 "Discriminant of x^2-2.",
                 {"coefficients_descending": ["1", "0", "-2"], "variable": "x"},
+            ),
+        ),
+    ),
+    nf_operation(
+        "number_field.embeddings.compute",
+        "Compute every exact embedding of a simple number field",
+        "Return all real and complex embeddings of one bounded primitive irreducible ZZ presentation of QQ(alpha), ordered by exact roots, with certified rational isolation, signature, conjugate-pair grouping, and defining-polynomial discriminant. Degree is at most 8, coefficients have at most 256 digits, and staged preflight bounds root separation, an exact signature count, one all-root isolation pass, at most 32,768 refinement bits, the elimination resultant, and the complete result against the 10,485,760-byte canonical transport envelope before embedding construction.",
+        NumberFieldEmbeddingsRequest,
+        NumberFieldEmbeddingProfile,
+        _compute_embeddings,
+        "number-field",
+        "embedding",
+        "algebraic-number",
+        "exact",
+        examples=(
+            example(
+                "gaussian_field",
+                "Both embeddings of QQ(i), grouped as one conjugate pair.",
+                {
+                    "field": {
+                        "domain": "QQ",
+                        "coefficients_descending": ["1", "0", "1"],
+                    }
+                },
             ),
         ),
     ),

--- a/src/jacobian/math/number_theory/number_fields/_tools.py
+++ b/src/jacobian/math/number_theory/number_fields/_tools.py
@@ -66,7 +66,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
     nf_operation(
         "number_field.discriminant.compute",
         "Compute the discriminant of a number field",
-        "Compute the discriminant of a number field defined by one irreducible polynomial in an isolated SymPy worker, or return UNKNOWN if its bounded execution cannot establish a result.",
+        "Compute the field discriminant of one canonical SimpleNumberFieldPresentation in an isolated SymPy worker, or return UNKNOWN if its bounded execution cannot establish a result.",
         NumberFieldRequest,
         NumberFieldDiscriminantResult,
         compute_nf_discriminant,
@@ -77,14 +77,19 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
             example(
                 "quadratic_disc",
                 "Discriminant of x^2-2.",
-                {"coefficients_descending": ["1", "0", "-2"], "variable": "x"},
+                {
+                    "field": {
+                        "domain": "QQ",
+                        "coefficients_descending": ["1", "0", "-2"],
+                    }
+                },
             ),
         ),
     ),
     nf_operation(
         "number_field.embeddings.compute",
         "Compute every exact embedding of a simple number field",
-        "Return all real and complex embeddings of one bounded primitive irreducible ZZ presentation of QQ(alpha), ordered by exact roots, with certified rational isolation, signature, conjugate-pair grouping, and defining-polynomial discriminant. Degree is at most 8, coefficients have at most 256 digits, and staged preflight bounds root separation, an exact signature count, one all-root isolation pass, at most 32,768 refinement bits, the elimination resultant, and the complete result against the 10,485,760-byte canonical transport envelope before embedding construction.",
+        "Return all real and complex embeddings of one bounded primitive irreducible ZZ presentation of QQ(alpha), ordered by exact roots, with certified rational isolation, signature, conjugate-pair grouping, and defining-polynomial discriminant. Degree is at most 8, coefficients have at most 256 digits, and a request-deadline-bound one-shot worker performs recognition, exact signature, conditional elimination, and one all-root isolation pass within the admitted 32,768-bit refinement, 2,097,152-bit resultant-storage, and 10,485,760-byte result envelopes.",
         NumberFieldEmbeddingsRequest,
         NumberFieldEmbeddingProfile,
         _compute_embeddings,

--- a/src/jacobian/math/number_theory/number_fields/_worker.py
+++ b/src/jacobian/math/number_theory/number_fields/_worker.py
@@ -5,28 +5,25 @@ from __future__ import annotations
 import json
 import sys
 
-from jacobian.math.number_theory.number_fields import discriminant
+from jacobian.math.number_theory.number_fields._integral_basis import (
+    recognized_integral_basis,
+)
 from jacobian.math.number_theory.number_fields._models import NumberFieldRequest
 
 
 def main() -> int:
-    request = NumberFieldRequest.model_validate(json.load(sys.stdin))
-    import sympy
-
-    variable = sympy.Symbol(request.variable)
-    polynomial = sympy.Poly.from_list(
-        [int(value) for value in request.coefficients_descending],
-        gens=variable,
-        domain=sympy.ZZ,
+    request = NumberFieldRequest.model_validate_json(
+        sys.stdin.buffer.read(),
+        strict=True,
     )
-    if not polynomial.is_irreducible:
+    integral_basis = recognized_integral_basis(request.field)
+    if integral_basis is None:
         response: dict[str, object] = {"kind": "invalid"}
     else:
+        _ring, field_discriminant, _alpha, _leading = integral_basis
         response = {
             "kind": "complete",
-            "discriminant": discriminant(
-                request.coefficients_descending, request.variable
-            ),
+            "discriminant": str(field_discriminant),
         }
     json.dump(response, sys.stdout, separators=(",", ":"))
     return 0

--- a/src/jacobian/math/number_theory/number_fields/operations.py
+++ b/src/jacobian/math/number_theory/number_fields/operations.py
@@ -237,14 +237,13 @@ def embeddings(
     _require_embedding_execution_active(deadline, "before embedding admission")
     admission = _admit_number_field_embeddings(field)
     _require_embedding_execution_active(deadline, "after embedding admission")
-    remaining = deadline - time.monotonic()
     worker_response = run_embeddings_worker(
         NumberFieldEmbeddingWorkerRequest(
             field=field,
             root_isolation_bits=admission.root_isolation_bits,
             evidence_grid_bits=admission.evidence_grid_bits,
         ),
-        timeout_seconds=remaining,
+        deadline=deadline,
         stdout_limit=admission.predicted_worker_output_bytes,
     )
     _require_embedding_execution_active(deadline, "after embedding worker execution")

--- a/src/jacobian/math/number_theory/number_fields/operations.py
+++ b/src/jacobian/math/number_theory/number_fields/operations.py
@@ -2,34 +2,46 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import time
 from dataclasses import dataclass
-from fractions import Fraction
 from math import factorial
-from typing import Any, cast
+from typing import Any
 
-from jacobian._exact import CanonicalRational
-from jacobian.canonical import (
-    CanonicalLimits,
-    format_canonical_integer,
-    parse_canonical_integer,
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
 )
+from jacobian.canonical import parse_canonical_integer
 from jacobian.math.number_theory.algebraic_numbers.complex import (
     ComplexAlgebraicValue,
-    RationalComplexIsolatingRectangle,
-    _isolate_complex_algebraic,
-    _public_to_backend_root_indices_from_count,
-    _root_evidence_parameters,
-    algebraic_real_part_separation_denominator_bound,
     algebraic_root_separation_denominator_bound,
     complex_isolator_component_digit_bound,
 )
 from jacobian.math.number_theory.algebraic_numbers.real import (
-    RationalIsolatingInterval,
     RealAlgebraicValue,
-    _sympy_polynomial_from_coefficients,
+)
+from jacobian.math.number_theory.number_fields._embedding_limits import (
+    MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES,
+    MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS,
+    MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS,
+)
+from jacobian.math.number_theory.number_fields._embedding_protocol import (
+    NumberFieldEmbeddingWorkerInvalid,
+    NumberFieldEmbeddingWorkerRejected,
+    NumberFieldEmbeddingWorkerRequest,
+)
+from jacobian.math.number_theory.number_fields._embeddings_process import (
+    EMBEDDINGS_WORKER_WALL_SECONDS,
+    embeddings_worker_cancelled,
+    run_embeddings_worker,
+)
+from jacobian.math.number_theory.number_fields._integral_basis import (
+    recognized_integral_basis,
 )
 from jacobian.math.number_theory.number_fields.values import (
+    MAX_NUMBER_FIELD_EMBEDDING_DEGREE,
     ComplexNumberFieldEmbedding,
     ComplexNumberFieldEmbeddingRecord,
     NumberFieldConjugatePair,
@@ -40,10 +52,6 @@ from jacobian.math.number_theory.number_fields.values import (
     SimpleNumberFieldPresentation,
 )
 
-MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES = CanonicalLimits().max_output_bytes
-MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS = 2_097_152
-MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS = 32_768
-
 
 class NumberFieldEmbeddingAdmissionError(ValueError):
     """A proved owner-local resource rejection for embedding enumeration."""
@@ -53,101 +61,23 @@ class NumberFieldEmbeddingAdmissionError(ValueError):
         super().__init__(message)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class NumberFieldEmbeddingAdmission:
-    degree: int
-    real_embedding_count: int
-    complex_conjugate_pair_count: int
-    coefficient_height_bits: int
-    root_separation_denominator_bits: int
-    real_part_separation_denominator_bits: int
     root_isolation_bits: int
-    real_part_resultant_coefficient_bits: int
-    real_part_resultant_storage_bits: int
-    isolator_component_digits: int
-    polynomial_discriminant_digits: int
+    evidence_grid_bits: int
+    predicted_worker_output_bytes: int
     predicted_result_bytes: int
-    root_refinement_calls: int
-    root_refinement_precision_bits: int
-    root_refinement_bit_work: int
-    real_isolating_intervals: tuple[RationalIsolatingInterval, ...]
-    complex_isolating_rectangles: tuple[RationalComplexIsolatingRectangle, ...]
 
 
 def _decimal_digits_from_bits(bits: int) -> int:
     return (max(bits, 1) * 30_103) // 100_000 + 1
 
 
-def _backend_fraction(value: Any) -> Fraction:
-    return Fraction(int(value.p), int(value.q))
-
-
-def _dyadic_floor(value: Fraction, denominator: int) -> int:
-    return (value.numerator * denominator) // value.denominator
-
-
-def _dyadic_ceiling(value: Fraction, denominator: int) -> int:
-    return -((-value.numerator * denominator) // value.denominator)
-
-
-def _normalize_real_isolator(
-    lower: Any,
-    upper: Any,
-    *,
-    grid_denominator: int,
-) -> RationalIsolatingInterval:
-    lower_fraction = _backend_fraction(lower)
-    upper_fraction = _backend_fraction(upper)
-    if lower_fraction == upper_fraction:
-        endpoint = CanonicalRational.from_fraction(lower_fraction)
-        return RationalIsolatingInterval(
-            lower=endpoint,
-            upper=endpoint,
-            interval_type="SINGLETON",
-        )
-    lower_cell = _dyadic_floor(lower_fraction, grid_denominator)
-    upper_cell = _dyadic_ceiling(upper_fraction, grid_denominator)
-    return RationalIsolatingInterval(
-        lower=CanonicalRational.from_fraction(
-            Fraction(lower_cell - 1, grid_denominator)
-        ),
-        upper=CanonicalRational.from_fraction(
-            Fraction(upper_cell + 1, grid_denominator)
-        ),
-        interval_type="OPEN",
-    )
-
-
-def _normalize_complex_isolator(
-    lower: Any,
-    upper: Any,
-    *,
-    grid_denominator: int,
-) -> RationalComplexIsolatingRectangle:
-    lower_real, lower_imaginary = lower.as_real_imag()
-    upper_real, upper_imaginary = upper.as_real_imag()
-    real_lower_cell = _dyadic_floor(_backend_fraction(lower_real), grid_denominator)
-    real_upper_cell = _dyadic_ceiling(_backend_fraction(upper_real), grid_denominator)
-    imaginary_lower_cell = _dyadic_floor(
-        _backend_fraction(lower_imaginary), grid_denominator
-    )
-    imaginary_upper_cell = _dyadic_ceiling(
-        _backend_fraction(upper_imaginary), grid_denominator
-    )
-    return RationalComplexIsolatingRectangle(
-        real_lower=CanonicalRational.from_fraction(
-            Fraction(real_lower_cell - 1, grid_denominator)
-        ),
-        real_upper=CanonicalRational.from_fraction(
-            Fraction(real_upper_cell + 1, grid_denominator)
-        ),
-        imaginary_lower=CanonicalRational.from_fraction(
-            Fraction(imaginary_lower_cell - 1, grid_denominator)
-        ),
-        imaginary_upper=CanonicalRational.from_fraction(
-            Fraction(imaginary_upper_cell + 1, grid_denominator)
-        ),
-    )
+def _require_embedding_execution_active(deadline: float, phase: str) -> None:
+    if embeddings_worker_cancelled():
+        raise OperationExecutionCancelledError(f"request cancelled {phase}")
+    if deadline <= time.monotonic():
+        raise OperationExecutionTimeoutError(f"request deadline expired {phase}")
 
 
 def _admit_number_field_embeddings(
@@ -160,16 +90,21 @@ def _admit_number_field_embeddings(
         for coefficient in field.coefficients_descending
     )
     degree = field.degree
+    if degree > MAX_NUMBER_FIELD_EMBEDDING_DEGREE:
+        raise NumberFieldEmbeddingAdmissionError(
+            "degree_bound",
+            "number-field embeddings are limited to degree "
+            f"{MAX_NUMBER_FIELD_EMBEDDING_DEGREE}",
+        )
     height = max(abs(coefficient) for coefficient in coefficients)
-    height_bits = max(height.bit_length(), 1)
     separation_denominator = algebraic_root_separation_denominator_bound(
         field.coefficients_descending
     )
     separation_bits = separation_denominator.bit_length()
-    # Evidence uses a dyadic grid more than 2^4 finer than Mignotte separation
-    # and indexed-root matching another 2^4 finer than that grid.  A backend
-    # isolator is first refined to one grid cell; outward normalization spans
-    # at most four cells, whose diagonal remains below the separation bound.
+    # Public evidence uses a dyadic grid more than 2^4 finer than Mignotte
+    # separation.  The worker isolates on a grid another 2^4 finer before
+    # outward normalization; the public rectangle spans at most four evidence
+    # cells, whose diagonal remains below the separation bound.
     isolation_bits = separation_bits + 8
     isolator_digits = complex_isolator_component_digit_bound(
         field.coefficients_descending
@@ -251,6 +186,13 @@ def _admit_number_field_embeddings(
         + 64
     )
     rational_bytes = 2 * isolator_digits + 32
+    # The worker projection carries either one two-rational interval per real
+    # root or one four-rational rectangle per conjugate pair.  Both cases use
+    # at most two bounded rationals per degree unit.  It does not echo the
+    # retained presentation or construct public embedding records.
+    predicted_worker_output_bytes = (
+        degree * (2 * rational_bytes + 256) + discriminant_digits + 1_024
+    )
     embedding_bytes = source_bytes + polynomial_bytes + 256
     record_bytes = embedding_bytes + 4 * rational_bytes + 512
     predicted_result_bytes = (
@@ -263,79 +205,11 @@ def _admit_number_field_embeddings(
             f"{MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES:,}-byte result bound",
         )
 
-    # The raw carrier has already bounded degree and coefficient digits, and
-    # the formulas above have now admitted exact real-root isolation plus the
-    # largest possible elimination resultant.  It is therefore safe to ask
-    # the maintained backend for the exact signature before deciding whether
-    # pair ordering needs that resultant at all.
-    import sympy
-
-    polynomial = _sympy_polynomial_from_coefficients(field.coefficients_descending)
-    real_count = int(polynomial.count_roots(-sympy.oo, sympy.oo))
-    pair_count = (degree - real_count) // 2
-    real_part_separation_denominator = (
-        algebraic_real_part_separation_denominator_bound(field.coefficients_descending)
-        if pair_count > 1
-        else 1
-    )
-    real_part_separation_bits = real_part_separation_denominator.bit_length()
-    refinement_precision_bits = max(isolation_bits, real_part_separation_bits + 4)
-    if refinement_precision_bits > MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS:
-        raise NumberFieldEmbeddingAdmissionError(
-            "pair_ordering_precision_bound",
-            "exact conjugate-pair ordering exceeds the "
-            f"{MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS:,}-bit refinement bound",
-        )
-
-    grid_denominator, _matching_error = _root_evidence_parameters(
-        field.coefficients_descending
-    )
-    backend_real_intervals, backend_complex_rectangles = polynomial.intervals(
-        all=True,
-        eps=sympy.Rational(1, grid_denominator),
-    )
-    real_isolating_intervals = tuple(
-        _normalize_real_isolator(
-            lower,
-            upper,
-            grid_denominator=grid_denominator,
-        )
-        for (lower, upper), _multiplicity in backend_real_intervals
-    )
-    complex_isolating_rectangles = tuple(
-        _normalize_complex_isolator(
-            lower,
-            upper,
-            grid_denominator=grid_denominator,
-        )
-        for (lower, upper), _multiplicity in backend_complex_rectangles
-    )
-
-    # The kernel makes two exact rational approximations per conjugate pair to
-    # establish sign/order and one more to select its deterministic admitted
-    # rectangle.  Real evidence is reused directly from the signature/root-
-    # isolation pass.  This is a precision-and-call bound on the actual root
-    # refinement plan, rather than an unrelated combinatorial proxy.
-    root_refinement_calls = 3 * pair_count
-    root_refinement_bit_work = root_refinement_calls * refinement_precision_bits
     return NumberFieldEmbeddingAdmission(
-        degree=degree,
-        real_embedding_count=real_count,
-        complex_conjugate_pair_count=pair_count,
-        coefficient_height_bits=height_bits,
-        root_separation_denominator_bits=separation_bits,
-        real_part_separation_denominator_bits=real_part_separation_bits,
         root_isolation_bits=isolation_bits,
-        real_part_resultant_coefficient_bits=resultant_coefficient_bits,
-        real_part_resultant_storage_bits=resultant_storage_bits,
-        isolator_component_digits=isolator_digits,
-        polynomial_discriminant_digits=discriminant_digits,
+        evidence_grid_bits=separation_bits + 4,
+        predicted_worker_output_bytes=predicted_worker_output_bytes,
         predicted_result_bytes=predicted_result_bytes,
-        root_refinement_calls=root_refinement_calls,
-        root_refinement_precision_bits=refinement_precision_bits,
-        root_refinement_bit_work=root_refinement_bit_work,
-        real_isolating_intervals=real_isolating_intervals,
-        complex_isolating_rectangles=complex_isolating_rectangles,
     )
 
 
@@ -346,21 +220,51 @@ def embeddings(
 
     Root identity uses increasing real roots followed by conjugate pairs sorted
     by the positive representative's exact ``(Re, Im)`` coordinates, with the
-    negative root first in each pair.  An exact real-coordinate elimination and
-    Mignotte separation map this public order to SymPy's private root indexes.
-    Only indexed canonical roots and rational isolation evidence cross the
-    boundary.
+    negative root first in each pair.  Exact real-coordinate elimination and
+    Mignotte separation establish this order inside one killable worker.  Only
+    indexed canonical roots and rational isolation evidence cross the boundary.
     """
 
-    admission = _admit_number_field_embeddings(field)
-
-    polynomial = _sympy_polynomial_from_coefficients(field.coefficients_descending)
-    real_count = admission.real_embedding_count
-    pair_count = admission.complex_conjugate_pair_count
-    backend_root_indices = _public_to_backend_root_indices_from_count(
-        field.coefficients_descending,
-        real_count,
+    execution = current_request_execution()
+    started = execution.started_at if execution is not None else time.monotonic()
+    owner_deadline = started + EMBEDDINGS_WORKER_WALL_SECONDS
+    deadline = (
+        min(execution.deadline, owner_deadline)
+        if execution is not None and execution.deadline is not None
+        else owner_deadline
     )
+    bind_request_deadline(deadline)
+    _require_embedding_execution_active(deadline, "before embedding admission")
+    admission = _admit_number_field_embeddings(field)
+    _require_embedding_execution_active(deadline, "after embedding admission")
+    remaining = deadline - time.monotonic()
+    worker_response = run_embeddings_worker(
+        NumberFieldEmbeddingWorkerRequest(
+            field=field,
+            root_isolation_bits=admission.root_isolation_bits,
+            evidence_grid_bits=admission.evidence_grid_bits,
+        ),
+        timeout_seconds=remaining,
+        stdout_limit=admission.predicted_worker_output_bytes,
+    )
+    _require_embedding_execution_active(deadline, "after embedding worker execution")
+    if isinstance(worker_response, NumberFieldEmbeddingWorkerInvalid):
+        raise NumberFieldEmbeddingAdmissionError(
+            "not_irreducible",
+            "simple number-field polynomial must be irreducible over QQ",
+        )
+    if isinstance(worker_response, NumberFieldEmbeddingWorkerRejected):
+        raise NumberFieldEmbeddingAdmissionError(
+            worker_response.reason,
+            "exact conjugate-pair ordering exceeds the "
+            f"{MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS:,}-bit refinement bound",
+        )
+    real_count = len(worker_response.real_intervals)
+    pair_count = len(worker_response.negative_complex_rectangles)
+    if real_count + 2 * pair_count != field.degree:
+        raise RuntimeError(
+            "number-field embedding worker returned an inconsistent root count"
+        )
 
     records: list[
         RealNumberFieldEmbeddingRecord | ComplexNumberFieldEmbeddingRecord
@@ -370,11 +274,15 @@ def embeddings(
             polynomial=field.coefficients_descending,
             real_root_index=root_index,
         )
-        real_embedding = RealNumberFieldEmbedding(presentation=field, root=real_root)
+        real_embedding = RealNumberFieldEmbedding(
+            kind="REAL",
+            presentation=field,
+            root=real_root,
+        )
         records.append(
             RealNumberFieldEmbeddingRecord._from_kernel(
                 embedding=real_embedding,
-                isolating_interval=admission.real_isolating_intervals[root_index],
+                isolating_interval=worker_response.real_intervals[root_index],
             )
         )
 
@@ -391,16 +299,16 @@ def embeddings(
             root_index=positive_index,
         )
         negative_embedding = ComplexNumberFieldEmbedding(
-            presentation=field, root=negative_root
+            kind="COMPLEX",
+            presentation=field,
+            root=negative_root,
         )
         positive_embedding = ComplexNumberFieldEmbedding(
-            presentation=field, root=positive_root
+            kind="COMPLEX",
+            presentation=field,
+            root=positive_root,
         )
-        negative_rectangle = _isolate_complex_algebraic(
-            negative_root,
-            backend_root_index=backend_root_indices[negative_index],
-            candidates=admission.complex_isolating_rectangles,
-        )
+        negative_rectangle = worker_response.negative_complex_rectangles[pair_offset]
         positive_rectangle = negative_rectangle.conjugate()
         records.extend(
             (
@@ -431,11 +339,35 @@ def embeddings(
             complex_conjugate_pair_count=pair_count,
         ),
         complex_conjugate_pairs=tuple(conjugate_pairs),
-        defining_polynomial_discriminant=format_canonical_integer(
-            int(polynomial.discriminant())
+        defining_polynomial_discriminant=(
+            worker_response.defining_polynomial_discriminant
         ),
     )
+    _require_embedding_execution_active(deadline, "after embedding result construction")
     return result
+
+
+def _integral_basis(
+    field: SimpleNumberFieldPresentation,
+) -> tuple[Any, Any, Any, int]:
+    integral_basis = recognized_integral_basis(field)
+    if integral_basis is None:
+        raise ValueError("simple number-field polynomial must be irreducible over QQ")
+    return integral_basis
+
+
+def discriminant(field: SimpleNumberFieldPresentation) -> str:
+    _ring_of_integers, field_discriminant, _alpha, _leading = _integral_basis(field)
+    return str(field_discriminant)
+
+
+def ring_of_integers(field: SimpleNumberFieldPresentation) -> list[str]:
+    """Return the exact integral basis expressed in the defining power basis."""
+    ring, _field_discriminant, alpha, leading = _integral_basis(field)
+    return [
+        str(element.as_expr().subs(alpha, leading * alpha).expand())
+        for element in ring.basis_element_pullbacks()
+    ]
 
 
 __all__ = [
@@ -443,33 +375,3 @@ __all__ = [
     "embeddings",
     "ring_of_integers",
 ]
-
-
-def _integral_basis(
-    coefficients_descending: Sequence[str], variable: str
-) -> tuple[Any, Any]:
-    import sympy
-    from sympy.polys.numberfields import round_two
-
-    x = sympy.Symbol(variable)
-    polynomial = sum(
-        sympy.Rational(parse_canonical_integer(coefficient))
-        * x ** (len(coefficients_descending) - 1 - index)
-        for index, coefficient in enumerate(coefficients_descending)
-    )
-    return cast(tuple[Any, Any], round_two(sympy.Poly(polynomial, x)))
-
-
-def discriminant(coefficients_descending: Sequence[str], variable: str) -> str:
-    _ring_of_integers, field_discriminant = _integral_basis(
-        coefficients_descending, variable
-    )
-    return str(field_discriminant)
-
-
-def ring_of_integers(
-    coefficients_descending: Sequence[str], variable: str
-) -> list[str]:
-    """Return the exact integral basis expressed in the defining power basis."""
-    ring, _field_discriminant = _integral_basis(coefficients_descending, variable)
-    return [str(element.as_expr()) for element in ring.basis_element_pullbacks()]

--- a/src/jacobian/math/number_theory/number_fields/operations.py
+++ b/src/jacobian/math/number_theory/number_fields/operations.py
@@ -30,7 +30,6 @@ from jacobian.math.number_theory.number_fields._embedding_limits import (
 from jacobian.math.number_theory.number_fields._embedding_protocol import (
     NumberFieldEmbeddingWorkerInvalid,
     NumberFieldEmbeddingWorkerRejected,
-    NumberFieldEmbeddingWorkerRequest,
 )
 from jacobian.math.number_theory.number_fields._embeddings_process import (
     EMBEDDINGS_WORKER_WALL_SECONDS,
@@ -238,11 +237,9 @@ def embeddings(
     admission = _admit_number_field_embeddings(field)
     _require_embedding_execution_active(deadline, "after embedding admission")
     worker_response = run_embeddings_worker(
-        NumberFieldEmbeddingWorkerRequest(
-            field=field,
-            root_isolation_bits=admission.root_isolation_bits,
-            evidence_grid_bits=admission.evidence_grid_bits,
-        ),
+        field,
+        root_isolation_bits=admission.root_isolation_bits,
+        evidence_grid_bits=admission.evidence_grid_bits,
         deadline=deadline,
         stdout_limit=admission.predicted_worker_output_bytes,
     )

--- a/src/jacobian/math/number_theory/number_fields/operations.py
+++ b/src/jacobian/math/number_theory/number_fields/operations.py
@@ -3,11 +3,446 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
+from fractions import Fraction
+from math import factorial
 from typing import Any, cast
 
-from jacobian.canonical import parse_canonical_integer
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import (
+    CanonicalLimits,
+    format_canonical_integer,
+    parse_canonical_integer,
+)
+from jacobian.math.number_theory.algebraic_numbers.complex import (
+    ComplexAlgebraicValue,
+    RationalComplexIsolatingRectangle,
+    _isolate_complex_algebraic,
+    _public_to_backend_root_indices_from_count,
+    _root_evidence_parameters,
+    algebraic_real_part_separation_denominator_bound,
+    algebraic_root_separation_denominator_bound,
+    complex_isolator_component_digit_bound,
+)
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+    RealAlgebraicValue,
+    _sympy_polynomial_from_coefficients,
+)
+from jacobian.math.number_theory.number_fields.values import (
+    ComplexNumberFieldEmbedding,
+    ComplexNumberFieldEmbeddingRecord,
+    NumberFieldConjugatePair,
+    NumberFieldEmbeddingProfile,
+    NumberFieldSignature,
+    RealNumberFieldEmbedding,
+    RealNumberFieldEmbeddingRecord,
+    SimpleNumberFieldPresentation,
+)
 
-__all__ = ["discriminant", "ring_of_integers"]
+MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES = CanonicalLimits().max_output_bytes
+MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS = 2_097_152
+MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS = 32_768
+
+
+class NumberFieldEmbeddingAdmissionError(ValueError):
+    """A proved owner-local resource rejection for embedding enumeration."""
+
+    def __init__(self, reason: str, message: str) -> None:
+        self.reason = reason
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class NumberFieldEmbeddingAdmission:
+    degree: int
+    real_embedding_count: int
+    complex_conjugate_pair_count: int
+    coefficient_height_bits: int
+    root_separation_denominator_bits: int
+    real_part_separation_denominator_bits: int
+    root_isolation_bits: int
+    real_part_resultant_coefficient_bits: int
+    real_part_resultant_storage_bits: int
+    isolator_component_digits: int
+    polynomial_discriminant_digits: int
+    predicted_result_bytes: int
+    root_refinement_calls: int
+    root_refinement_precision_bits: int
+    root_refinement_bit_work: int
+    real_isolating_intervals: tuple[RationalIsolatingInterval, ...]
+    complex_isolating_rectangles: tuple[RationalComplexIsolatingRectangle, ...]
+
+
+def _decimal_digits_from_bits(bits: int) -> int:
+    return (max(bits, 1) * 30_103) // 100_000 + 1
+
+
+def _backend_fraction(value: Any) -> Fraction:
+    return Fraction(int(value.p), int(value.q))
+
+
+def _dyadic_floor(value: Fraction, denominator: int) -> int:
+    return (value.numerator * denominator) // value.denominator
+
+
+def _dyadic_ceiling(value: Fraction, denominator: int) -> int:
+    return -((-value.numerator * denominator) // value.denominator)
+
+
+def _normalize_real_isolator(
+    lower: Any,
+    upper: Any,
+    *,
+    grid_denominator: int,
+) -> RationalIsolatingInterval:
+    lower_fraction = _backend_fraction(lower)
+    upper_fraction = _backend_fraction(upper)
+    if lower_fraction == upper_fraction:
+        endpoint = CanonicalRational.from_fraction(lower_fraction)
+        return RationalIsolatingInterval(
+            lower=endpoint,
+            upper=endpoint,
+            interval_type="SINGLETON",
+        )
+    lower_cell = _dyadic_floor(lower_fraction, grid_denominator)
+    upper_cell = _dyadic_ceiling(upper_fraction, grid_denominator)
+    return RationalIsolatingInterval(
+        lower=CanonicalRational.from_fraction(
+            Fraction(lower_cell - 1, grid_denominator)
+        ),
+        upper=CanonicalRational.from_fraction(
+            Fraction(upper_cell + 1, grid_denominator)
+        ),
+        interval_type="OPEN",
+    )
+
+
+def _normalize_complex_isolator(
+    lower: Any,
+    upper: Any,
+    *,
+    grid_denominator: int,
+) -> RationalComplexIsolatingRectangle:
+    lower_real, lower_imaginary = lower.as_real_imag()
+    upper_real, upper_imaginary = upper.as_real_imag()
+    real_lower_cell = _dyadic_floor(_backend_fraction(lower_real), grid_denominator)
+    real_upper_cell = _dyadic_ceiling(_backend_fraction(upper_real), grid_denominator)
+    imaginary_lower_cell = _dyadic_floor(
+        _backend_fraction(lower_imaginary), grid_denominator
+    )
+    imaginary_upper_cell = _dyadic_ceiling(
+        _backend_fraction(upper_imaginary), grid_denominator
+    )
+    return RationalComplexIsolatingRectangle(
+        real_lower=CanonicalRational.from_fraction(
+            Fraction(real_lower_cell - 1, grid_denominator)
+        ),
+        real_upper=CanonicalRational.from_fraction(
+            Fraction(real_upper_cell + 1, grid_denominator)
+        ),
+        imaginary_lower=CanonicalRational.from_fraction(
+            Fraction(imaginary_lower_cell - 1, grid_denominator)
+        ),
+        imaginary_upper=CanonicalRational.from_fraction(
+            Fraction(imaginary_upper_cell + 1, grid_denominator)
+        ),
+    )
+
+
+def _admit_number_field_embeddings(
+    field: SimpleNumberFieldPresentation,
+) -> NumberFieldEmbeddingAdmission:
+    """Preflight root work, intermediates, exact output, and serialization."""
+
+    coefficients = tuple(
+        parse_canonical_integer(coefficient)
+        for coefficient in field.coefficients_descending
+    )
+    degree = field.degree
+    height = max(abs(coefficient) for coefficient in coefficients)
+    height_bits = max(height.bit_length(), 1)
+    separation_denominator = algebraic_root_separation_denominator_bound(
+        field.coefficients_descending
+    )
+    separation_bits = separation_denominator.bit_length()
+    # Evidence uses a dyadic grid more than 2^4 finer than Mignotte separation
+    # and indexed-root matching another 2^4 finer than that grid.  A backend
+    # isolator is first refined to one grid cell; outward normalization spans
+    # at most four cells, whose diagonal remains below the separation bound.
+    isolation_bits = separation_bits + 8
+    isolator_digits = complex_isolator_component_digit_bound(
+        field.coefficients_descending
+    )
+    if degree == 1:
+        # The exact singleton root -b/a retains a reduced divisor of the
+        # source coefficients rather than a dyadic denominator.
+        isolator_digits = max(
+            isolator_digits,
+            *(
+                len(coefficient.lstrip("-"))
+                for coefficient in field.coefficients_descending
+            ),
+        )
+
+    if isolator_digits > 4_096:
+        raise NumberFieldEmbeddingAdmissionError(
+            "isolation_intermediate_bound",
+            "the Mignotte-derived root-isolation envelope exceeds the "
+            "4,096-digit rational component bound",
+        )
+    if isolation_bits > MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS:
+        raise NumberFieldEmbeddingAdmissionError(
+            "root_isolation_precision_bound",
+            "exact root isolation exceeds the "
+            f"{MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS:,}-bit refinement bound",
+        )
+
+    # Hadamard on the (2n-1)-square Sylvester matrix gives
+    # |disc(f)| <= |Res(f,f')|
+    # <= n^n (n+1)^((2n-1)/2) H^(2n-1).
+    # Replacing the half power by (n+1)^(2n-1) is an integer upper bound.
+    discriminant_bound = (
+        1
+        if degree == 1
+        else degree**degree
+        * (degree + 1) ** (2 * degree - 1)
+        * height ** (2 * degree - 1)
+    )
+    discriminant_digits = _decimal_digits_from_bits(discriminant_bound.bit_length())
+
+    # In f(u + i*v), every coefficient of Re(f) and Im(f) has magnitude at
+    # most C = (n+1) 2^n H.  A Leibniz expansion of the at-most-2n Sylvester
+    # determinant therefore bounds every resultant coefficient by
+    # (2n)! (n+1)^(2n-1) C^(2n).  Its u-degree is at most 2n^2.  The final
+    # Landau-Mignotte factor covers coefficient growth when taking the
+    # primitive square-free part used for real-coordinate separation.
+    sylvester_size = 2 * degree
+    resultant_degree = 2 * degree * degree
+    expanded_coefficient_bound = (degree + 1) * 2**degree * height
+    expanded_resultant_coefficient_bound = (
+        factorial(sylvester_size)
+        * (degree + 1) ** max(sylvester_size - 1, 0)
+        * expanded_coefficient_bound**sylvester_size
+    )
+    resultant_coefficient_bound = (
+        (resultant_degree + 1)
+        * 2**resultant_degree
+        * expanded_resultant_coefficient_bound
+    )
+    resultant_coefficient_bits = max(resultant_coefficient_bound.bit_length(), 1)
+    resultant_storage_bits = (resultant_degree + 1) * resultant_coefficient_bits
+    if resultant_storage_bits > MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS:
+        raise NumberFieldEmbeddingAdmissionError(
+            "pair_ordering_resultant_bound",
+            "the exact real-coordinate resultant exceeds the "
+            f"{MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS:,}-bit "
+            "intermediate storage bound",
+        )
+
+    # Every record repeats one field presentation and one indexed polynomial;
+    # complex evidence is the larger case at four bounded rationals.  The
+    # fixed allowance covers all field names, enum literals, tuple delimiters,
+    # signature/pair records, and canonical JSON punctuation at degree <= 8.
+    source_bytes = len(field.model_dump_json().encode("utf-8"))
+    polynomial_bytes = (
+        sum(len(coefficient) for coefficient in field.coefficients_descending)
+        + 3 * (degree + 1)
+        + 64
+    )
+    rational_bytes = 2 * isolator_digits + 32
+    embedding_bytes = source_bytes + polynomial_bytes + 256
+    record_bytes = embedding_bytes + 4 * rational_bytes + 512
+    predicted_result_bytes = (
+        source_bytes + degree * record_bytes + discriminant_digits + 4_096
+    )
+    if predicted_result_bytes > MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES:
+        raise NumberFieldEmbeddingAdmissionError(
+            "result_byte_bound",
+            "the complete retained-source embedding profile exceeds the "
+            f"{MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES:,}-byte result bound",
+        )
+
+    # The raw carrier has already bounded degree and coefficient digits, and
+    # the formulas above have now admitted exact real-root isolation plus the
+    # largest possible elimination resultant.  It is therefore safe to ask
+    # the maintained backend for the exact signature before deciding whether
+    # pair ordering needs that resultant at all.
+    import sympy
+
+    polynomial = _sympy_polynomial_from_coefficients(field.coefficients_descending)
+    real_count = int(polynomial.count_roots(-sympy.oo, sympy.oo))
+    pair_count = (degree - real_count) // 2
+    real_part_separation_denominator = (
+        algebraic_real_part_separation_denominator_bound(field.coefficients_descending)
+        if pair_count > 1
+        else 1
+    )
+    real_part_separation_bits = real_part_separation_denominator.bit_length()
+    refinement_precision_bits = max(isolation_bits, real_part_separation_bits + 4)
+    if refinement_precision_bits > MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS:
+        raise NumberFieldEmbeddingAdmissionError(
+            "pair_ordering_precision_bound",
+            "exact conjugate-pair ordering exceeds the "
+            f"{MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS:,}-bit refinement bound",
+        )
+
+    grid_denominator, _matching_error = _root_evidence_parameters(
+        field.coefficients_descending
+    )
+    backend_real_intervals, backend_complex_rectangles = polynomial.intervals(
+        all=True,
+        eps=sympy.Rational(1, grid_denominator),
+    )
+    real_isolating_intervals = tuple(
+        _normalize_real_isolator(
+            lower,
+            upper,
+            grid_denominator=grid_denominator,
+        )
+        for (lower, upper), _multiplicity in backend_real_intervals
+    )
+    complex_isolating_rectangles = tuple(
+        _normalize_complex_isolator(
+            lower,
+            upper,
+            grid_denominator=grid_denominator,
+        )
+        for (lower, upper), _multiplicity in backend_complex_rectangles
+    )
+
+    # The kernel makes two exact rational approximations per conjugate pair to
+    # establish sign/order and one more to select its deterministic admitted
+    # rectangle.  Real evidence is reused directly from the signature/root-
+    # isolation pass.  This is a precision-and-call bound on the actual root
+    # refinement plan, rather than an unrelated combinatorial proxy.
+    root_refinement_calls = 3 * pair_count
+    root_refinement_bit_work = root_refinement_calls * refinement_precision_bits
+    return NumberFieldEmbeddingAdmission(
+        degree=degree,
+        real_embedding_count=real_count,
+        complex_conjugate_pair_count=pair_count,
+        coefficient_height_bits=height_bits,
+        root_separation_denominator_bits=separation_bits,
+        real_part_separation_denominator_bits=real_part_separation_bits,
+        root_isolation_bits=isolation_bits,
+        real_part_resultant_coefficient_bits=resultant_coefficient_bits,
+        real_part_resultant_storage_bits=resultant_storage_bits,
+        isolator_component_digits=isolator_digits,
+        polynomial_discriminant_digits=discriminant_digits,
+        predicted_result_bytes=predicted_result_bytes,
+        root_refinement_calls=root_refinement_calls,
+        root_refinement_precision_bits=refinement_precision_bits,
+        root_refinement_bit_work=root_refinement_bit_work,
+        real_isolating_intervals=real_isolating_intervals,
+        complex_isolating_rectangles=complex_isolating_rectangles,
+    )
+
+
+def embeddings(
+    field: SimpleNumberFieldPresentation,
+) -> NumberFieldEmbeddingProfile:
+    """Return every exact embedding of one bounded presented field.
+
+    Root identity uses increasing real roots followed by conjugate pairs sorted
+    by the positive representative's exact ``(Re, Im)`` coordinates, with the
+    negative root first in each pair.  An exact real-coordinate elimination and
+    Mignotte separation map this public order to SymPy's private root indexes.
+    Only indexed canonical roots and rational isolation evidence cross the
+    boundary.
+    """
+
+    admission = _admit_number_field_embeddings(field)
+
+    polynomial = _sympy_polynomial_from_coefficients(field.coefficients_descending)
+    real_count = admission.real_embedding_count
+    pair_count = admission.complex_conjugate_pair_count
+    backend_root_indices = _public_to_backend_root_indices_from_count(
+        field.coefficients_descending,
+        real_count,
+    )
+
+    records: list[
+        RealNumberFieldEmbeddingRecord | ComplexNumberFieldEmbeddingRecord
+    ] = []
+    for root_index in range(real_count):
+        real_root = RealAlgebraicValue._from_admitted_polynomial(
+            polynomial=field.coefficients_descending,
+            real_root_index=root_index,
+        )
+        real_embedding = RealNumberFieldEmbedding(presentation=field, root=real_root)
+        records.append(
+            RealNumberFieldEmbeddingRecord._from_kernel(
+                embedding=real_embedding,
+                isolating_interval=admission.real_isolating_intervals[root_index],
+            )
+        )
+
+    conjugate_pairs: list[NumberFieldConjugatePair] = []
+    for pair_offset in range(pair_count):
+        negative_index = real_count + 2 * pair_offset
+        positive_index = negative_index + 1
+        negative_root = ComplexAlgebraicValue._from_admitted_polynomial(
+            polynomial=field.coefficients_descending,
+            root_index=negative_index,
+        )
+        positive_root = ComplexAlgebraicValue._from_admitted_polynomial(
+            polynomial=field.coefficients_descending,
+            root_index=positive_index,
+        )
+        negative_embedding = ComplexNumberFieldEmbedding(
+            presentation=field, root=negative_root
+        )
+        positive_embedding = ComplexNumberFieldEmbedding(
+            presentation=field, root=positive_root
+        )
+        negative_rectangle = _isolate_complex_algebraic(
+            negative_root,
+            backend_root_index=backend_root_indices[negative_index],
+            candidates=admission.complex_isolating_rectangles,
+        )
+        positive_rectangle = negative_rectangle.conjugate()
+        records.extend(
+            (
+                ComplexNumberFieldEmbeddingRecord._from_kernel(
+                    embedding=negative_embedding,
+                    isolating_rectangle=negative_rectangle,
+                    half_plane="NEGATIVE_IMAGINARY",
+                ),
+                ComplexNumberFieldEmbeddingRecord._from_kernel(
+                    embedding=positive_embedding,
+                    isolating_rectangle=positive_rectangle,
+                    half_plane="POSITIVE_IMAGINARY",
+                ),
+            )
+        )
+        conjugate_pairs.append(
+            NumberFieldConjugatePair(
+                negative_embedding_index=negative_index,
+                positive_embedding_index=positive_index,
+            )
+        )
+
+    result = NumberFieldEmbeddingProfile._from_kernel(
+        field=field,
+        records=tuple(records),
+        signature=NumberFieldSignature(
+            real_embedding_count=real_count,
+            complex_conjugate_pair_count=pair_count,
+        ),
+        complex_conjugate_pairs=tuple(conjugate_pairs),
+        defining_polynomial_discriminant=format_canonical_integer(
+            int(polynomial.discriminant())
+        ),
+    )
+    return result
+
+
+__all__ = [
+    "discriminant",
+    "embeddings",
+    "ring_of_integers",
+]
 
 
 def _integral_basis(

--- a/src/jacobian/math/number_theory/number_fields/values.py
+++ b/src/jacobian/math/number_theory/number_fields/values.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from math import gcd
 from typing import Annotated, Any, Literal, Self
 
-from pydantic import Field, StrictInt, model_validator
+from pydantic import Field, StrictInt, ValidateAs, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger, CanonicalRational
@@ -15,6 +15,7 @@ from jacobian.canonical import parse_canonical_integer
 from jacobian.math.number_theory.algebraic_numbers.complex import (
     ComplexAlgebraicValue,
     RationalComplexIsolatingRectangle,
+    _UnrecognizedComplexAlgebraicValue,
 )
 from jacobian.math.number_theory.algebraic_numbers.real import (
     RationalIsolatingInterval,
@@ -185,12 +186,12 @@ class RealNumberFieldEmbedding(StrictModel):
         return self
 
 
-class ComplexNumberFieldEmbedding(StrictModel):
-    """A field homomorphism selected by one exact nonreal indexed root."""
+class _ComplexNumberFieldEmbeddingShape(StrictModel):
+    """Structural view of a complex embedding recognized by its result owner."""
 
     kind: Literal["COMPLEX"]
     presentation: SimpleNumberFieldPresentation
-    root: ComplexAlgebraicValue
+    root: _UnrecognizedComplexAlgebraicValue
 
     @model_validator(mode="after")
     def bind_root_to_presentation(self) -> Self:
@@ -200,6 +201,33 @@ class ComplexNumberFieldEmbedding(StrictModel):
                 "embedding root must use the presentation's defining polynomial",
             )
         return self
+
+
+class ComplexNumberFieldEmbedding(_ComplexNumberFieldEmbeddingShape):
+    """A field homomorphism selected by one recognized exact nonreal root."""
+
+    root: ComplexAlgebraicValue
+
+
+def _unrecognized_complex_embedding_from_shape(
+    shape: _ComplexNumberFieldEmbeddingShape,
+) -> ComplexNumberFieldEmbedding:
+    if isinstance(shape, ComplexNumberFieldEmbedding):
+        return shape
+    return ComplexNumberFieldEmbedding.model_construct(
+        kind=shape.kind,
+        presentation=shape.presentation,
+        root=shape.root,
+    )
+
+
+_UnrecognizedComplexNumberFieldEmbedding = Annotated[
+    ComplexNumberFieldEmbedding,
+    ValidateAs(
+        _ComplexNumberFieldEmbeddingShape,
+        _unrecognized_complex_embedding_from_shape,
+    ),
+]
 
 
 NumberFieldEmbedding = Annotated[
@@ -273,7 +301,7 @@ class ComplexNumberFieldEmbeddingRecord(StrictModel):
     """A nonreal embedding together with exact rational isolation evidence."""
 
     kind: Literal["COMPLEX"]
-    embedding: ComplexNumberFieldEmbedding
+    embedding: _UnrecognizedComplexNumberFieldEmbedding
     isolating_rectangle: RationalComplexIsolatingRectangle
     half_plane: Literal["NEGATIVE_IMAGINARY", "POSITIVE_IMAGINARY"]
 

--- a/src/jacobian/math/number_theory/number_fields/values.py
+++ b/src/jacobian/math/number_theory/number_fields/values.py
@@ -483,43 +483,18 @@ class NumberFieldEmbeddingProfile(StrictModel):
         )
 
 
-class EmbeddedSimpleNumberFieldElement(StrictModel):
-    """An exact power-basis element evaluated at one selected embedding.
-
-    The value denotes ``sum(c_j * sigma(alpha)^j)``.  Both the reduced abstract
-    element and the exact embedding identity are retained; an incidental
-    isolating rectangle is neither required nor part of this canonical value.
-    """
-
-    element: SimpleNumberFieldElement
-    embedding: NumberFieldEmbedding
-    evaluation: Literal["POWER_BASIS_AT_SELECTED_ROOT"] = "POWER_BASIS_AT_SELECTED_ROOT"
-
-    @model_validator(mode="after")
-    def bind_element_and_embedding(self) -> Self:
-        if self.element.presentation != self.embedding.presentation:
-            raise _validation_error(
-                "embedded_element_field",
-                "embedded element and selected embedding must share one presentation",
-            )
-        return self
-
-
 __all__ = [
     "MAX_NUMBER_FIELD_EMBEDDING_DEGREE",
     "MAX_NUMBER_FIELD_ISOLATOR_COMPONENT_DIGITS",
     "MAX_SIMPLE_NUMBER_FIELD_COEFFICIENT_DIGITS",
     "MAX_SIMPLE_NUMBER_FIELD_DEGREE",
     "MAX_SIMPLE_NUMBER_FIELD_ELEMENT_DIGITS",
-    "ComplexNumberFieldEmbedding",
     "ComplexNumberFieldEmbeddingRecord",
-    "EmbeddedSimpleNumberFieldElement",
     "NumberFieldConjugatePair",
     "NumberFieldEmbedding",
     "NumberFieldEmbeddingProfile",
     "NumberFieldEmbeddingRecord",
     "NumberFieldSignature",
-    "RealNumberFieldEmbedding",
     "RealNumberFieldEmbeddingRecord",
     "SimpleNumberFieldElement",
     "SimpleNumberFieldPresentation",

--- a/src/jacobian/math/number_theory/number_fields/values.py
+++ b/src/jacobian/math/number_theory/number_fields/values.py
@@ -12,19 +12,17 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalInteger, CanonicalRational
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import parse_canonical_integer
-from jacobian.math._root_isolation import strict_root_count
 from jacobian.math.number_theory.algebraic_numbers.complex import (
     ComplexAlgebraicValue,
     RationalComplexIsolatingRectangle,
 )
 from jacobian.math.number_theory.algebraic_numbers.real import (
     RationalIsolatingInterval,
-    RealAlgebraicValue,
-    _polynomial_is_irreducible,
-    _sympy_polynomial_from_coefficients,
+    _UnrecognizedRealAlgebraicValue,
 )
 
-MAX_SIMPLE_NUMBER_FIELD_DEGREE = 8
+MAX_SIMPLE_NUMBER_FIELD_DEGREE = 31
+MAX_NUMBER_FIELD_EMBEDDING_DEGREE = 8
 MAX_SIMPLE_NUMBER_FIELD_COEFFICIENT_DIGITS = 256
 MAX_SIMPLE_NUMBER_FIELD_ELEMENT_DIGITS = 256
 MAX_NUMBER_FIELD_ISOLATOR_COMPONENT_DIGITS = 4_096
@@ -54,18 +52,15 @@ def _raw_rational_component_bound(
                 )
 
 
-def _presentation_polynomial(presentation: SimpleNumberFieldPresentation) -> Any:
-    return _sympy_polynomial_from_coefficients(presentation.coefficients_descending)
-
-
 class SimpleNumberFieldPresentation(StrictModel):
-    """The bounded presented field ``QQ(alpha) = QQ[x]/(f)``.
+    """The canonical bounded presentation ``QQ(alpha) = QQ[x]/(f)``.
 
     The defining polynomial is the unique primitive positive-leading integer
-    representative of its rational scalar class.  It is irreducible, so the
-    presentation is a field.  ``alpha`` always denotes the residue class of
-    the fixed indeterminate; a caller-chosen symbol is not part of field
-    identity.  Degree one is the presentation of ``QQ``.
+    representative of its rational scalar class. Mathematical consumers
+    recognize irreducibility before treating the presented quotient as a
+    field; ordinary construction and deserialization establish only this
+    bounded canonical representation. ``alpha`` is the fixed indeterminate,
+    not caller-selected syntax. Degree one presents ``QQ``.
     """
 
     domain: Literal["QQ"] = "QQ"
@@ -105,7 +100,7 @@ class SimpleNumberFieldPresentation(StrictModel):
         return canonicalize_json_containers(data)
 
     @model_validator(mode="after")
-    def require_canonical_irreducible_polynomial(self) -> Self:
+    def require_canonical_polynomial(self) -> Self:
         coefficients = tuple(
             parse_canonical_integer(coefficient)
             for coefficient in self.coefficients_descending
@@ -122,11 +117,6 @@ class SimpleNumberFieldPresentation(StrictModel):
             raise _validation_error(
                 "not_primitive",
                 "simple number-field polynomial must be primitive over ZZ",
-            )
-        if not _polynomial_is_irreducible(self.coefficients_descending):
-            raise _validation_error(
-                "not_irreducible",
-                "simple number-field polynomial must be irreducible over QQ",
             )
         return self
 
@@ -181,9 +171,9 @@ class SimpleNumberFieldElement(StrictModel):
 class RealNumberFieldEmbedding(StrictModel):
     """A field homomorphism selected by one exact real root of its presentation."""
 
-    kind: Literal["REAL"] = "REAL"
+    kind: Literal["REAL"]
     presentation: SimpleNumberFieldPresentation
-    root: RealAlgebraicValue
+    root: _UnrecognizedRealAlgebraicValue
 
     @model_validator(mode="after")
     def bind_root_to_presentation(self) -> Self:
@@ -198,7 +188,7 @@ class RealNumberFieldEmbedding(StrictModel):
 class ComplexNumberFieldEmbedding(StrictModel):
     """A field homomorphism selected by one exact nonreal indexed root."""
 
-    kind: Literal["COMPLEX"] = "COMPLEX"
+    kind: Literal["COMPLEX"]
     presentation: SimpleNumberFieldPresentation
     root: ComplexAlgebraicValue
 
@@ -218,34 +208,10 @@ NumberFieldEmbedding = Annotated[
 ]
 
 
-def _require_real_interval_selects_root(
-    embedding: RealNumberFieldEmbedding,
-    interval: RationalIsolatingInterval,
-) -> None:
-    import sympy
-
-    polynomial = _presentation_polynomial(embedding.presentation)
-    lower = sympy.Rational(*interval.lower.as_integer_ratio())
-    upper = sympy.Rational(*interval.upper.as_integer_ratio())
-    if strict_root_count(polynomial, lower, upper) != 1:
-        raise _validation_error(
-            "real_root_count",
-            "a real embedding interval must isolate exactly one root",
-        )
-    roots_below = int(polynomial.count_roots(-sympy.oo, lower))
-    if polynomial.eval(lower) == 0:
-        roots_below -= 1
-    if roots_below != embedding.root.real_root_index:
-        raise _validation_error(
-            "real_root_identity",
-            "real isolating interval does not select the embedding's indexed root",
-        )
-
-
 class RealNumberFieldEmbeddingRecord(StrictModel):
     """A real embedding together with exact rational isolation evidence."""
 
-    kind: Literal["REAL"] = "REAL"
+    kind: Literal["REAL"]
     embedding: RealNumberFieldEmbedding
     isolating_interval: RationalIsolatingInterval
 
@@ -306,7 +272,7 @@ class RealNumberFieldEmbeddingRecord(StrictModel):
 class ComplexNumberFieldEmbeddingRecord(StrictModel):
     """A nonreal embedding together with exact rational isolation evidence."""
 
-    kind: Literal["COMPLEX"] = "COMPLEX"
+    kind: Literal["COMPLEX"]
     embedding: ComplexNumberFieldEmbedding
     isolating_rectangle: RationalComplexIsolatingRectangle
     half_plane: Literal["NEGATIVE_IMAGINARY", "POSITIVE_IMAGINARY"]
@@ -355,18 +321,18 @@ NumberFieldEmbeddingRecord = Annotated[
 
 
 class NumberFieldSignature(StrictModel):
-    real_embedding_count: StrictInt = Field(ge=0, le=MAX_SIMPLE_NUMBER_FIELD_DEGREE)
+    real_embedding_count: StrictInt = Field(ge=0, le=MAX_NUMBER_FIELD_EMBEDDING_DEGREE)
     complex_conjugate_pair_count: StrictInt = Field(
-        ge=0, le=MAX_SIMPLE_NUMBER_FIELD_DEGREE // 2
+        ge=0, le=MAX_NUMBER_FIELD_EMBEDDING_DEGREE // 2
     )
 
 
 class NumberFieldConjugatePair(StrictModel):
     negative_embedding_index: StrictInt = Field(
-        ge=0, le=MAX_SIMPLE_NUMBER_FIELD_DEGREE - 1
+        ge=0, le=MAX_NUMBER_FIELD_EMBEDDING_DEGREE - 1
     )
     positive_embedding_index: StrictInt = Field(
-        ge=0, le=MAX_SIMPLE_NUMBER_FIELD_DEGREE - 1
+        ge=0, le=MAX_NUMBER_FIELD_EMBEDDING_DEGREE - 1
     )
 
 
@@ -380,11 +346,11 @@ class NumberFieldEmbeddingProfile(StrictModel):
 
     field: SimpleNumberFieldPresentation
     records: tuple[NumberFieldEmbeddingRecord, ...] = Field(
-        min_length=1, max_length=MAX_SIMPLE_NUMBER_FIELD_DEGREE
+        min_length=1, max_length=MAX_NUMBER_FIELD_EMBEDDING_DEGREE
     )
     signature: NumberFieldSignature
     complex_conjugate_pairs: tuple[NumberFieldConjugatePair, ...] = Field(
-        max_length=MAX_SIMPLE_NUMBER_FIELD_DEGREE // 2
+        max_length=MAX_NUMBER_FIELD_EMBEDDING_DEGREE // 2
     )
     defining_polynomial_discriminant: CanonicalInteger
     ordering: Literal["REAL_INCREASING_THEN_POSITIVE_REPRESENTATIVE_PAIRS_V1"] = (
@@ -512,6 +478,7 @@ class EmbeddedSimpleNumberFieldElement(StrictModel):
 
 
 __all__ = [
+    "MAX_NUMBER_FIELD_EMBEDDING_DEGREE",
     "MAX_NUMBER_FIELD_ISOLATOR_COMPONENT_DIGITS",
     "MAX_SIMPLE_NUMBER_FIELD_COEFFICIENT_DIGITS",
     "MAX_SIMPLE_NUMBER_FIELD_DEGREE",

--- a/src/jacobian/math/number_theory/number_fields/values.py
+++ b/src/jacobian/math/number_theory/number_fields/values.py
@@ -1,0 +1,531 @@
+"""Canonical bounded values for simple number fields and their embeddings."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import gcd
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalInteger, CanonicalRational
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math._root_isolation import strict_root_count
+from jacobian.math.number_theory.algebraic_numbers.complex import (
+    ComplexAlgebraicValue,
+    RationalComplexIsolatingRectangle,
+)
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+    RealAlgebraicValue,
+    _polynomial_is_irreducible,
+    _sympy_polynomial_from_coefficients,
+)
+
+MAX_SIMPLE_NUMBER_FIELD_DEGREE = 8
+MAX_SIMPLE_NUMBER_FIELD_COEFFICIENT_DIGITS = 256
+MAX_SIMPLE_NUMBER_FIELD_ELEMENT_DIGITS = 256
+MAX_NUMBER_FIELD_ISOLATOR_COMPONENT_DIGITS = 4_096
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"simple_number_field.{reason}", message)
+
+
+def _raw_rational_component_bound(
+    components: object,
+    *,
+    max_digits: int,
+    label: str,
+) -> None:
+    if not isinstance(components, (list, tuple)):
+        return
+    for component in components:
+        if not isinstance(component, Mapping):
+            continue
+        for part in ("num", "den"):
+            raw = component.get(part)
+            if isinstance(raw, str) and len(raw.lstrip("-")) > max_digits:
+                raise _validation_error(
+                    "rational_component_bound",
+                    f"{label} components may contain at most {max_digits} digits",
+                )
+
+
+def _presentation_polynomial(presentation: SimpleNumberFieldPresentation) -> Any:
+    return _sympy_polynomial_from_coefficients(presentation.coefficients_descending)
+
+
+class SimpleNumberFieldPresentation(StrictModel):
+    """The bounded presented field ``QQ(alpha) = QQ[x]/(f)``.
+
+    The defining polynomial is the unique primitive positive-leading integer
+    representative of its rational scalar class.  It is irreducible, so the
+    presentation is a field.  ``alpha`` always denotes the residue class of
+    the fixed indeterminate; a caller-chosen symbol is not part of field
+    identity.  Degree one is the presentation of ``QQ``.
+    """
+
+    domain: Literal["QQ"] = "QQ"
+    coefficients_descending: tuple[CanonicalInteger, ...] = Field(
+        min_length=2,
+        max_length=MAX_SIMPLE_NUMBER_FIELD_DEGREE + 1,
+        description=(
+            "Primitive irreducible ZZ[x] coefficients in descending degree "
+            "with positive leading coefficient."
+        ),
+        examples=[["1", "0", "-2"]],
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_polynomial_bound(cls, data: Any) -> Any:
+        if not isinstance(data, Mapping):
+            return data
+        coefficients = data.get("coefficients_descending")
+        if isinstance(coefficients, (list, tuple)):
+            if len(coefficients) > MAX_SIMPLE_NUMBER_FIELD_DEGREE + 1:
+                raise _validation_error(
+                    "degree_bound",
+                    "simple number-field degree exceeds the bounded envelope",
+                )
+            if any(
+                isinstance(coefficient, str)
+                and len(coefficient.lstrip("-"))
+                > MAX_SIMPLE_NUMBER_FIELD_COEFFICIENT_DIGITS
+                for coefficient in coefficients
+            ):
+                raise _validation_error(
+                    "coefficient_bound",
+                    "simple number-field coefficients may contain at most "
+                    f"{MAX_SIMPLE_NUMBER_FIELD_COEFFICIENT_DIGITS} digits",
+                )
+        return canonicalize_json_containers(data)
+
+    @model_validator(mode="after")
+    def require_canonical_irreducible_polynomial(self) -> Self:
+        coefficients = tuple(
+            parse_canonical_integer(coefficient)
+            for coefficient in self.coefficients_descending
+        )
+        if coefficients[0] <= 0:
+            raise _validation_error(
+                "leading_sign",
+                "simple number-field polynomial must have positive leading coefficient",
+            )
+        content = 0
+        for coefficient in coefficients:
+            content = gcd(content, abs(coefficient))
+        if content != 1:
+            raise _validation_error(
+                "not_primitive",
+                "simple number-field polynomial must be primitive over ZZ",
+            )
+        if not _polynomial_is_irreducible(self.coefficients_descending):
+            raise _validation_error(
+                "not_irreducible",
+                "simple number-field polynomial must be irreducible over QQ",
+            )
+        return self
+
+    @property
+    def degree(self) -> int:
+        return len(self.coefficients_descending) - 1
+
+
+class SimpleNumberFieldElement(StrictModel):
+    """One reduced exact element in the presentation's ascending power basis."""
+
+    presentation: SimpleNumberFieldPresentation
+    coefficients_ascending: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_SIMPLE_NUMBER_FIELD_DEGREE,
+        description=("Exactly degree-many coefficients of 1, alpha, ..., alpha^(n-1)."),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_coordinate_bound(cls, data: Any) -> Any:
+        if not isinstance(data, Mapping):
+            return data
+        _raw_rational_component_bound(
+            data.get("coefficients_ascending"),
+            max_digits=MAX_SIMPLE_NUMBER_FIELD_ELEMENT_DIGITS,
+            label="simple number-field element",
+        )
+        return canonicalize_json_containers(data)
+
+    @model_validator(mode="after")
+    def require_reduced_power_basis_coordinates(self) -> Self:
+        if len(self.coefficients_ascending) != self.presentation.degree:
+            raise _validation_error(
+                "element_coordinate_count",
+                "a reduced field element needs exactly one coefficient per power-basis vector",
+            )
+        for coefficient in self.coefficients_ascending:
+            if (
+                len(coefficient.num.lstrip("-"))
+                > MAX_SIMPLE_NUMBER_FIELD_ELEMENT_DIGITS
+                or len(coefficient.den) > MAX_SIMPLE_NUMBER_FIELD_ELEMENT_DIGITS
+            ):
+                raise _validation_error(
+                    "element_coordinate_bound",
+                    "simple number-field element coefficients exceed the "
+                    f"{MAX_SIMPLE_NUMBER_FIELD_ELEMENT_DIGITS}-digit bound",
+                )
+        return self
+
+
+class RealNumberFieldEmbedding(StrictModel):
+    """A field homomorphism selected by one exact real root of its presentation."""
+
+    kind: Literal["REAL"] = "REAL"
+    presentation: SimpleNumberFieldPresentation
+    root: RealAlgebraicValue
+
+    @model_validator(mode="after")
+    def bind_root_to_presentation(self) -> Self:
+        if self.root.polynomial != self.presentation.coefficients_descending:
+            raise _validation_error(
+                "embedding_polynomial",
+                "embedding root must use the presentation's defining polynomial",
+            )
+        return self
+
+
+class ComplexNumberFieldEmbedding(StrictModel):
+    """A field homomorphism selected by one exact nonreal indexed root."""
+
+    kind: Literal["COMPLEX"] = "COMPLEX"
+    presentation: SimpleNumberFieldPresentation
+    root: ComplexAlgebraicValue
+
+    @model_validator(mode="after")
+    def bind_root_to_presentation(self) -> Self:
+        if self.root.polynomial != self.presentation.coefficients_descending:
+            raise _validation_error(
+                "embedding_polynomial",
+                "embedding root must use the presentation's defining polynomial",
+            )
+        return self
+
+
+NumberFieldEmbedding = Annotated[
+    RealNumberFieldEmbedding | ComplexNumberFieldEmbedding,
+    Field(discriminator="kind"),
+]
+
+
+def _require_real_interval_selects_root(
+    embedding: RealNumberFieldEmbedding,
+    interval: RationalIsolatingInterval,
+) -> None:
+    import sympy
+
+    polynomial = _presentation_polynomial(embedding.presentation)
+    lower = sympy.Rational(*interval.lower.as_integer_ratio())
+    upper = sympy.Rational(*interval.upper.as_integer_ratio())
+    if strict_root_count(polynomial, lower, upper) != 1:
+        raise _validation_error(
+            "real_root_count",
+            "a real embedding interval must isolate exactly one root",
+        )
+    roots_below = int(polynomial.count_roots(-sympy.oo, lower))
+    if polynomial.eval(lower) == 0:
+        roots_below -= 1
+    if roots_below != embedding.root.real_root_index:
+        raise _validation_error(
+            "real_root_identity",
+            "real isolating interval does not select the embedding's indexed root",
+        )
+
+
+class RealNumberFieldEmbeddingRecord(StrictModel):
+    """A real embedding together with exact rational isolation evidence."""
+
+    kind: Literal["REAL"] = "REAL"
+    embedding: RealNumberFieldEmbedding
+    isolating_interval: RationalIsolatingInterval
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_isolator_bound(cls, data: Any) -> Any:
+        if not isinstance(data, Mapping):
+            return data
+        interval = data.get("isolating_interval")
+        if isinstance(interval, Mapping):
+            for endpoint_name in ("lower", "upper"):
+                endpoint = interval.get(endpoint_name)
+                if not isinstance(endpoint, Mapping):
+                    continue
+                for part in ("num", "den"):
+                    raw = endpoint.get(part)
+                    if isinstance(raw, str) and len(raw.lstrip("-")) > (
+                        MAX_NUMBER_FIELD_ISOLATOR_COMPONENT_DIGITS
+                    ):
+                        raise _validation_error(
+                            "isolator_component_bound",
+                            "real isolator components exceed the "
+                            f"{MAX_NUMBER_FIELD_ISOLATOR_COMPONENT_DIGITS:,}-digit bound",
+                        )
+        return canonicalize_json_containers(data)
+
+    @model_validator(mode="after")
+    def require_canonical_isolator_bound(self) -> Self:
+        if any(
+            len(endpoint.num.lstrip("-")) > MAX_NUMBER_FIELD_ISOLATOR_COMPONENT_DIGITS
+            or len(endpoint.den) > MAX_NUMBER_FIELD_ISOLATOR_COMPONENT_DIGITS
+            for endpoint in (
+                self.isolating_interval.lower,
+                self.isolating_interval.upper,
+            )
+        ):
+            raise _validation_error(
+                "isolator_component_bound",
+                "real isolator components exceed the "
+                f"{MAX_NUMBER_FIELD_ISOLATOR_COMPONENT_DIGITS:,}-digit bound",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        embedding: RealNumberFieldEmbedding,
+        isolating_interval: RationalIsolatingInterval,
+    ) -> Self:
+        return cls.model_construct(
+            kind="REAL",
+            embedding=embedding,
+            isolating_interval=isolating_interval,
+        )
+
+
+class ComplexNumberFieldEmbeddingRecord(StrictModel):
+    """A nonreal embedding together with exact rational isolation evidence."""
+
+    kind: Literal["COMPLEX"] = "COMPLEX"
+    embedding: ComplexNumberFieldEmbedding
+    isolating_rectangle: RationalComplexIsolatingRectangle
+    half_plane: Literal["NEGATIVE_IMAGINARY", "POSITIVE_IMAGINARY"]
+
+    @model_validator(mode="after")
+    def bind_declared_half_plane(self) -> Self:
+        imaginary_lower = self.isolating_rectangle.imaginary_lower.as_fraction()
+        imaginary_upper = self.isolating_rectangle.imaginary_upper.as_fraction()
+        expected_half_plane: Literal["NEGATIVE_IMAGINARY", "POSITIVE_IMAGINARY"]
+        if imaginary_upper < 0:
+            expected_half_plane = "NEGATIVE_IMAGINARY"
+        elif imaginary_lower > 0:
+            expected_half_plane = "POSITIVE_IMAGINARY"
+        else:
+            raise _validation_error(
+                "complex_half_plane",
+                "a nonreal embedding isolator must lie wholly in one open half-plane",
+            )
+        if self.half_plane != expected_half_plane:
+            raise _validation_error(
+                "complex_half_plane",
+                "complex embedding half-plane must agree with its exact isolator",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        embedding: ComplexNumberFieldEmbedding,
+        isolating_rectangle: RationalComplexIsolatingRectangle,
+        half_plane: Literal["NEGATIVE_IMAGINARY", "POSITIVE_IMAGINARY"],
+    ) -> Self:
+        return cls.model_construct(
+            kind="COMPLEX",
+            embedding=embedding,
+            isolating_rectangle=isolating_rectangle,
+            half_plane=half_plane,
+        )
+
+
+NumberFieldEmbeddingRecord = Annotated[
+    RealNumberFieldEmbeddingRecord | ComplexNumberFieldEmbeddingRecord,
+    Field(discriminator="kind"),
+]
+
+
+class NumberFieldSignature(StrictModel):
+    real_embedding_count: StrictInt = Field(ge=0, le=MAX_SIMPLE_NUMBER_FIELD_DEGREE)
+    complex_conjugate_pair_count: StrictInt = Field(
+        ge=0, le=MAX_SIMPLE_NUMBER_FIELD_DEGREE // 2
+    )
+
+
+class NumberFieldConjugatePair(StrictModel):
+    negative_embedding_index: StrictInt = Field(
+        ge=0, le=MAX_SIMPLE_NUMBER_FIELD_DEGREE - 1
+    )
+    positive_embedding_index: StrictInt = Field(
+        ge=0, le=MAX_SIMPLE_NUMBER_FIELD_DEGREE - 1
+    )
+
+
+class NumberFieldEmbeddingProfile(StrictModel):
+    """Every Archimedean embedding of one presented simple number field.
+
+    Exact embedding identity is carried by ``presentation + indexed root``.
+    Isolation data is evidence for that identity and is deliberately kept in
+    records rather than in the canonical embedding value itself.
+    """
+
+    field: SimpleNumberFieldPresentation
+    records: tuple[NumberFieldEmbeddingRecord, ...] = Field(
+        min_length=1, max_length=MAX_SIMPLE_NUMBER_FIELD_DEGREE
+    )
+    signature: NumberFieldSignature
+    complex_conjugate_pairs: tuple[NumberFieldConjugatePair, ...] = Field(
+        max_length=MAX_SIMPLE_NUMBER_FIELD_DEGREE // 2
+    )
+    defining_polynomial_discriminant: CanonicalInteger
+    ordering: Literal["REAL_INCREASING_THEN_POSITIVE_REPRESENTATIVE_PAIRS_V1"] = (
+        "REAL_INCREASING_THEN_POSITIVE_REPRESENTATIVE_PAIRS_V1"
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_profile(self) -> Self:
+        if len(self.records) != self.field.degree:
+            raise _validation_error(
+                "embedding_count",
+                "a complete profile needs exactly degree-many embedding records",
+            )
+        if any(record.embedding.presentation != self.field for record in self.records):
+            raise _validation_error(
+                "embedding_field",
+                "every embedding record must belong to the profile field",
+            )
+
+        real_count = self.signature.real_embedding_count
+        pair_count = self.signature.complex_conjugate_pair_count
+        if real_count + 2 * pair_count != self.field.degree:
+            raise _validation_error(
+                "signature_degree",
+                "signature must satisfy r1 + 2*r2 = field degree",
+            )
+        for index, record in enumerate(self.records[:real_count]):
+            if not isinstance(record, RealNumberFieldEmbeddingRecord):
+                raise _validation_error(
+                    "real_embedding_prefix",
+                    "all real embeddings must precede nonreal embeddings",
+                )
+            if record.embedding.root.real_root_index != index:
+                raise _validation_error(
+                    "real_root_order",
+                    "real embedding records must follow increasing root order",
+                )
+
+        expected_pairs: list[NumberFieldConjugatePair] = []
+        for pair_offset in range(pair_count):
+            negative_index = real_count + 2 * pair_offset
+            positive_index = negative_index + 1
+            negative_record = self.records[negative_index]
+            positive_record = self.records[positive_index]
+            if not isinstance(
+                negative_record, ComplexNumberFieldEmbeddingRecord
+            ) or not isinstance(positive_record, ComplexNumberFieldEmbeddingRecord):
+                raise _validation_error(
+                    "complex_embedding_suffix",
+                    "the nonreal suffix must consist of complex embedding pairs",
+                )
+            if (
+                negative_record.embedding.root.root_index != negative_index
+                or positive_record.embedding.root.root_index != positive_index
+                or negative_record.half_plane != "NEGATIVE_IMAGINARY"
+                or positive_record.half_plane != "POSITIVE_IMAGINARY"
+            ):
+                raise _validation_error(
+                    "complex_root_order",
+                    "each complex pair must list its negative then positive root",
+                )
+            negative_rectangle = negative_record.isolating_rectangle
+            positive_rectangle = positive_record.isolating_rectangle
+            if negative_rectangle.conjugate() != positive_rectangle:
+                raise _validation_error(
+                    "complex_conjugacy",
+                    "each grouped pair must contain exact conjugate roots and evidence",
+                )
+            expected_pairs.append(
+                NumberFieldConjugatePair(
+                    negative_embedding_index=negative_index,
+                    positive_embedding_index=positive_index,
+                )
+            )
+        if self.complex_conjugate_pairs != tuple(expected_pairs):
+            raise _validation_error(
+                "complex_pair_grouping",
+                "complex conjugate-pair grouping must cover the ordered nonreal suffix",
+            )
+
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        field: SimpleNumberFieldPresentation,
+        records: tuple[
+            RealNumberFieldEmbeddingRecord | ComplexNumberFieldEmbeddingRecord, ...
+        ],
+        signature: NumberFieldSignature,
+        complex_conjugate_pairs: tuple[NumberFieldConjugatePair, ...],
+        defining_polynomial_discriminant: CanonicalInteger,
+    ) -> Self:
+        return cls.model_construct(
+            field=field,
+            records=records,
+            signature=signature,
+            complex_conjugate_pairs=complex_conjugate_pairs,
+            defining_polynomial_discriminant=defining_polynomial_discriminant,
+            ordering="REAL_INCREASING_THEN_POSITIVE_REPRESENTATIVE_PAIRS_V1",
+        )
+
+
+class EmbeddedSimpleNumberFieldElement(StrictModel):
+    """An exact power-basis element evaluated at one selected embedding.
+
+    The value denotes ``sum(c_j * sigma(alpha)^j)``.  Both the reduced abstract
+    element and the exact embedding identity are retained; an incidental
+    isolating rectangle is neither required nor part of this canonical value.
+    """
+
+    element: SimpleNumberFieldElement
+    embedding: NumberFieldEmbedding
+    evaluation: Literal["POWER_BASIS_AT_SELECTED_ROOT"] = "POWER_BASIS_AT_SELECTED_ROOT"
+
+    @model_validator(mode="after")
+    def bind_element_and_embedding(self) -> Self:
+        if self.element.presentation != self.embedding.presentation:
+            raise _validation_error(
+                "embedded_element_field",
+                "embedded element and selected embedding must share one presentation",
+            )
+        return self
+
+
+__all__ = [
+    "MAX_NUMBER_FIELD_ISOLATOR_COMPONENT_DIGITS",
+    "MAX_SIMPLE_NUMBER_FIELD_COEFFICIENT_DIGITS",
+    "MAX_SIMPLE_NUMBER_FIELD_DEGREE",
+    "MAX_SIMPLE_NUMBER_FIELD_ELEMENT_DIGITS",
+    "ComplexNumberFieldEmbedding",
+    "ComplexNumberFieldEmbeddingRecord",
+    "EmbeddedSimpleNumberFieldElement",
+    "NumberFieldConjugatePair",
+    "NumberFieldEmbedding",
+    "NumberFieldEmbeddingProfile",
+    "NumberFieldEmbeddingRecord",
+    "NumberFieldSignature",
+    "RealNumberFieldEmbedding",
+    "RealNumberFieldEmbeddingRecord",
+    "SimpleNumberFieldElement",
+    "SimpleNumberFieldPresentation",
+]

--- a/src/jacobian/math/polynomials/ideals/_singular.py
+++ b/src/jacobian/math/polynomials/ideals/_singular.py
@@ -482,12 +482,28 @@ def run_singular_ideal_operation(
     left: RationalPolynomialIdeal,
     right: RationalPolynomialIdeal | None,
     budget: IdealComputationBudget,
+    *,
+    wall_seconds: float | None = None,
 ) -> SingularIdealResult:
-    """Run one exact ideal operation in a bounded, request-scoped process."""
+    """Run one exact ideal operation in a bounded, request-scoped process.
+
+    ``wall_seconds`` lets an owner charge this call to a shared absolute
+    deadline without widening the declared ideal-computation budget.
+    """
+
+    allowance = min(
+        float(budget.wall_seconds),
+        float(budget.wall_seconds if wall_seconds is None else wall_seconds),
+    )
+    if not math.isfinite(allowance) or allowance <= 0:
+        return SingularIdealResult(
+            outcome="TIMEOUT",
+            detail="Singular exceeded the declared wall-time limit.",
+        )
 
     completed = run_bounded_singular(
         _script(operation, left, right),
-        wall_seconds=budget.wall_seconds,
+        wall_seconds=allowance,
     )
     if completed is None:
         return SingularIdealResult(

--- a/tests/integration/algebra/test_exact_operations.py
+++ b/tests/integration/algebra/test_exact_operations.py
@@ -17,7 +17,12 @@ from jacobian.math.number_theory.algebraic_numbers.root_isolation._sympy import 
     compute_algebraic_compare,
     compute_root_isolation,
 )
-from jacobian.math.number_theory.number_fields import ring_of_integers
+from jacobian.math.number_theory.number_fields import (
+    SimpleNumberFieldPresentation,
+    discriminant,
+    embeddings,
+    ring_of_integers,
+)
 from jacobian.math.number_theory.number_fields._discriminant_process import (
     compute_nf_discriminant,
 )
@@ -247,38 +252,72 @@ def test_algebraic_comparison_contract_rejects_a_missing_real_root() -> None:
 
 
 def test_number_field_discriminant_is_not_power_basis_discriminant() -> None:
-    result = compute_nf_discriminant(
-        NumberFieldRequest(coefficients_descending=("1", "0", "-5"), variable="x")
-    )
+    field = SimpleNumberFieldPresentation(coefficients_descending=("1", "0", "-5"))
+    result = compute_nf_discriminant(NumberFieldRequest(field=field))
 
     assert result.discriminant == "5"
 
 
-@pytest.mark.parametrize(
-    "variable",
-    ["", " ", "x y", "x; y", "x\n", "x\x00", "1x", "x" * 33],
-)
-def test_number_field_variable_uses_polynomial_identifier_grammar(
-    variable: str,
-) -> None:
-    with pytest.raises(ValidationError):
-        NumberFieldRequest(
-            coefficients_descending=("1", "0", "-2"),
-            variable=variable,
-        )
+def test_embedding_field_composes_unchanged_with_field_invariant_consumers() -> None:
+    produced = embeddings(
+        SimpleNumberFieldPresentation(coefficients_descending=("1", "0", "1"))
+    ).field
+    request = NumberFieldRequest.model_validate(
+        {"field": produced.model_dump(mode="json")}
+    )
+
+    assert request.field == produced
+    assert compute_nf_discriminant(request).discriminant == "-4"
+    assert discriminant(request.field) == "-4"
+    assert ring_of_integers(request.field) == ["1", "alpha"]
+
+
+def test_field_discriminant_request_schema_uses_the_canonical_presentation() -> None:
+    request_schema = NumberFieldRequest.model_json_schema()
+    field_reference = request_schema["properties"]["field"]["$ref"]
+    field_schema = request_schema["$defs"][field_reference.rsplit("/", 1)[-1]]
+
+    assert field_schema["title"] == "SimpleNumberFieldPresentation"
+    assert set(field_schema["properties"]) == {
+        "domain",
+        "coefficients_descending",
+    }
+    assert field_schema["properties"]["coefficients_descending"]["maxItems"] == 32
+
+
+def test_field_carrier_preserves_the_prior_discriminant_degree_envelope() -> None:
+    field = SimpleNumberFieldPresentation(
+        coefficients_descending=("1", *("0",) * 30, "1")
+    )
+
+    assert field.degree == 31
+    assert NumberFieldRequest(field=field).field is field
 
 
 def test_integral_basis_is_computed_in_the_defining_power_basis() -> None:
-    assert ring_of_integers(["1", "0", "-5"], "x") == ["1", "x/2 + 1/2"]
+    field = SimpleNumberFieldPresentation(coefficients_descending=("1", "0", "-5"))
+
+    assert ring_of_integers(field) == ["1", "alpha/2 + 1/2"]
+    assert discriminant(field) == "5"
 
 
-def test_number_field_requires_a_monic_irreducible_integer_polynomial() -> None:
-    with algebra_validation_error():
-        NumberFieldRequest(coefficients_descending=("2", "0", "-10"), variable="x")
+def test_number_field_consumers_accept_a_nonmonic_canonical_presentation() -> None:
+    field = SimpleNumberFieldPresentation(coefficients_descending=("2", "0", "1"))
+
+    assert compute_nf_discriminant(NumberFieldRequest(field=field)).discriminant == "-8"
+    assert discriminant(field) == "-8"
+    assert ring_of_integers(field) == ["1", "2*alpha"]
 
 
 def test_number_field_reducibility_is_an_owner_declared_invalid_request() -> None:
-    request = NumberFieldRequest(coefficients_descending=("1", "0", "-1"), variable="x")
+    request = NumberFieldRequest.model_validate(
+        {
+            "field": {
+                "domain": "QQ",
+                "coefficients_descending": ["1", "0", "-1"],
+            }
+        }
+    )
 
     with pytest.raises(OperationDomainValidationError) as caught:
         compute_nf_discriminant(request)
@@ -288,12 +327,16 @@ def test_number_field_reducibility_is_an_owner_declared_invalid_request() -> Non
 
 def test_number_field_rejects_oversized_coefficients_before_sympy() -> None:
     with pytest.raises(ValidationError) as caught:
-        NumberFieldRequest(
-            coefficients_descending=("1" + "0" * 256, "0", "-2"),
-            variable="x",
+        NumberFieldRequest.model_validate(
+            {
+                "field": {
+                    "domain": "QQ",
+                    "coefficients_descending": ["1" + "0" * 256, "0", "-2"],
+                }
+            }
         )
 
-    assert caught.value.errors()[0]["type"] == "number_field.coefficient_digits"
+    assert caught.value.errors()[0]["type"] == "simple_number_field.coefficient_bound"
 
 
 def test_recurrence_finder_solves_for_coefficients() -> None:

--- a/tests/math/geometry/algebraic_curves/test_plane_algebraic_curves.py
+++ b/tests/math/geometry/algebraic_curves/test_plane_algebraic_curves.py
@@ -118,6 +118,7 @@ def test_catalog_contains_only_audited_operations() -> None:
         "algebraic_geometry.affine_plane_curve.check",
         "algebraic_geometry.conic.rational_parametrization.compute",
         "algebraic_geometry.plane_curve.projective_closure.compute",
+        "algebraic_geometry.projective_plane_curve.singularity_profile.compute",
         "algebraic_geometry.projective_curve.affine_chart.compute",
     }
 

--- a/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
+++ b/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
@@ -1,0 +1,611 @@
+"""Exact global projective plane-curve singular-locus evidence."""
+
+from __future__ import annotations
+
+import shutil
+import threading
+from fractions import Fraction
+from itertools import product
+from typing import cast
+
+import pytest
+import sympy
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import encode_strict_json
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.algebraic_curves._singularity import (
+    _admit_singularity,
+    _ideal_projection_limit_failure,
+    _normalized_source,
+    _profile,
+    _to_public_polynomial,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    MAX_PROJECTIVE_SINGULAR_COMPONENTS,
+    PositiveDimensionalProjectivePlaneCurveSingularLocus,
+    ProjectivePlaneCurveSingularityProfile,
+    ProjectivePlaneCurveSingularityRequest,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_worker import (
+    _shape_data,
+)
+from jacobian.math.geometry.algebraic_curves._tools import (
+    TOOLS,
+    compute_projective_plane_curve_singularity_profile,
+)
+from jacobian.math.geometry.algebraic_curves.operations import singularity_profile
+from jacobian.math.number_theory.number_fields.values import (
+    ComplexNumberFieldEmbedding,
+    RealNumberFieldEmbedding,
+)
+from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+from jacobian.process import bounded_process_cancellation
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("Singular") is None,
+    reason="the exact projective singular-locus backend is unavailable",
+)
+
+_AXIS = ("X", "Y", "Z")
+
+
+def _rational(value: int | Fraction) -> CanonicalRational:
+    fraction = Fraction(value)
+    return CanonicalRational.from_fraction(fraction)
+
+
+def _polynomial(
+    *terms: tuple[int | Fraction, tuple[int, int, int]],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=_AXIS,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=_rational(coefficient),
+                    exponents=exponents,
+                )
+                for coefficient, exponents in terms
+            )
+        ),
+    )
+
+
+def _chart_polynomial(
+    *terms: tuple[int, tuple[int, int]],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=("u", "v"),
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=_rational(coefficient),
+                    exponents=exponents,
+                )
+                for coefficient, exponents in terms
+            )
+        ),
+    )
+
+
+def _compute(source: RationalPolynomial) -> ProjectivePlaneCurveSingularityProfile:
+    return compute_projective_plane_curve_singularity_profile(
+        ProjectivePlaneCurveSingularityRequest(polynomial=source)
+    )
+
+
+def _ideal_with_shape(
+    *,
+    coefficient: CanonicalRational,
+    generator_count: int,
+    terms_per_generator: int,
+    axis: tuple[str, str, str] = _AXIS,
+) -> RationalPolynomialIdeal:
+    exponents = tuple(
+        sorted(
+            (
+                exponent
+                for exponent in product(range(5), repeat=3)
+                if sum(exponent) <= 4
+            ),
+            reverse=True,
+        )[:terms_per_generator]
+    )
+    generator = RationalPolynomial(
+        variables=axis,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=coefficient,
+                    exponents=exponent,
+                )
+                for exponent in exponents
+            )
+        ),
+    )
+    return RationalPolynomialIdeal(
+        variables=axis,
+        generators=(generator,) * generator_count,
+    )
+
+
+def test_conjugate_nonrational_singularities_keep_distinct_embedding_identity() -> None:
+    result = _compute(
+        _polynomial(
+            (1, (2, 0, 1)),
+            (1, (0, 2, 1)),
+            (1, (0, 0, 3)),
+        )
+    )
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert len(result.outcome.points) == 2
+    roots: list[int] = []
+    for record in result.outcome.points:
+        point = record.point
+        assert isinstance(point.embedding, ComplexNumberFieldEmbedding)
+        assert point.embedding.presentation.coefficients_descending == ("1", "0", "1")
+        roots.append(point.embedding.root.root_index)
+        assert tuple(
+            tuple(
+                coefficient.as_fraction()
+                for coefficient in coordinate.coefficients_ascending
+            )
+            for coordinate in point.coordinates
+        ) == (
+            (Fraction(1), Fraction(0)),
+            (Fraction(0), Fraction(1)),
+            (Fraction(0), Fraction(0)),
+        )
+        assert point.chart_index == 0
+    assert roots == [0, 1]
+
+    payload = result.model_dump(mode="json")
+    assert ProjectivePlaneCurveSingularityProfile.model_validate(payload) == result
+
+
+def test_geometrically_split_cubic_keeps_its_complete_galois_orbit() -> None:
+    # This is Norm_{QQ(cuberoot(2))/QQ}(X + alpha*Y + alpha^2*Z).
+    # Its three conjugate lines meet in one degree-three closed-point orbit.
+    result = _compute(
+        _polynomial(
+            (1, (3, 0, 0)),
+            (-6, (1, 1, 1)),
+            (2, (0, 3, 0)),
+            (4, (0, 0, 3)),
+        )
+    )
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert len(result.outcome.points) == 3
+    presentations = {
+        record.point.embedding.presentation for record in result.outcome.points
+    }
+    assert len(presentations) == 1
+    (presentation,) = presentations
+    assert presentation.degree == 3
+    assert presentation.coefficients_descending[0] != "1"
+
+    real_embeddings = [
+        record.point.embedding
+        for record in result.outcome.points
+        if isinstance(record.point.embedding, RealNumberFieldEmbedding)
+    ]
+    complex_embeddings = [
+        record.point.embedding
+        for record in result.outcome.points
+        if isinstance(record.point.embedding, ComplexNumberFieldEmbedding)
+    ]
+    assert len(real_embeddings) == 1
+    assert len(complex_embeddings) == 2
+    assert real_embeddings[0].root.real_root_index == 0
+    assert sorted(embedding.root.root_index for embedding in complex_embeddings) == [
+        1,
+        2,
+    ]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        _polynomial((1, (2, 0, 0)), (1, (0, 2, 0)), (1, (0, 0, 2))),
+        _polynomial((1, (3, 0, 0)), (1, (0, 3, 0)), (1, (0, 0, 3))),
+    ],
+)
+def test_smooth_curve_retains_the_saturated_unit_ideal(
+    source: RationalPolynomial,
+) -> None:
+    result = _compute(source)
+
+    assert result.outcome.status == "SMOOTH_OVER_ALGEBRAIC_CLOSURE"
+    saturation = result.outcome.saturated_jacobian_ideal
+    assert len(saturation.generators) == 1
+    assert rational_polynomial_to_sympy(saturation.generators[0]).as_expr() == 1
+
+
+@pytest.mark.parametrize(
+    ("source", "chart_index", "coordinates"),
+    [
+        (
+            _polynomial((1, (3, 0, 0)), (-1, (0, 2, 1))),
+            2,
+            (Fraction(0), Fraction(0), Fraction(1)),
+        ),
+        (
+            _polynomial((1, (2, 1, 0)), (-1, (0, 0, 3))),
+            1,
+            (Fraction(0), Fraction(1), Fraction(0)),
+        ),
+    ],
+)
+def test_disjoint_chart_cover_finds_singularities_at_infinity(
+    source: RationalPolynomial,
+    chart_index: int,
+    coordinates: tuple[Fraction, Fraction, Fraction],
+) -> None:
+    result = _compute(source)
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert len(result.outcome.points) == 1
+    point = result.outcome.points[0].point
+    assert point.chart_index == chart_index
+    assert (
+        tuple(
+            coordinate.coefficients_ascending[0].as_fraction()
+            for coordinate in point.coordinates
+        )
+        == coordinates
+    )
+
+
+def test_nodal_cubic_returns_an_exact_zero_first_jet() -> None:
+    result = _compute(
+        _polynomial(
+            (-1, (3, 0, 0)),
+            (-1, (2, 0, 1)),
+            (1, (0, 2, 1)),
+        )
+    )
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    (record,) = result.outcome.points
+    assert all(
+        coefficient.as_fraction() == 0
+        for value in (record.first_jet.value, *record.first_jet.gradient)
+        for coefficient in value.coefficients_ascending
+    )
+
+
+def test_result_deserialization_does_not_replay_the_zero_jet() -> None:
+    result = _compute(
+        _polynomial(
+            (-1, (3, 0, 0)),
+            (-1, (2, 0, 1)),
+            (1, (0, 2, 1)),
+        )
+    )
+    payload = result.model_dump(mode="json")
+    payload["outcome"]["points"][0]["first_jet"]["value"]["coefficients_ascending"][0][
+        "num"
+    ] = "1"
+
+    parsed = ProjectivePlaneCurveSingularityProfile.model_validate(payload)
+
+    assert parsed.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert (
+        parsed.outcome.points[0].first_jet.value.coefficients_ascending[0].as_fraction()
+        == 1
+    )
+
+
+def test_three_coordinate_lines_return_one_point_in_each_disjoint_chart() -> None:
+    result = _compute(_polynomial((1, (1, 1, 1))))
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert len(result.outcome.points) == 3
+    assert {record.point.chart_index for record in result.outcome.points} == {0, 1, 2}
+
+
+def test_concurrent_lines_reduce_a_nonreduced_local_scheme_to_one_point() -> None:
+    result = _compute(
+        _polynomial(
+            (1, (2, 1, 0)),
+            (-1, (1, 2, 0)),
+        )
+    )
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert len(result.outcome.points) == 1
+    assert result.outcome.points[0].point.chart_index == 2
+
+
+def test_second_chart_keeps_a_complete_quadratic_galois_orbit() -> None:
+    result = _compute(
+        _polynomial(
+            (1, (1, 2, 0)),
+            (1, (1, 0, 2)),
+        )
+    )
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    second_chart = [
+        record for record in result.outcome.points if record.point.chart_index == 1
+    ]
+    assert len(second_chart) == 2
+    assert [
+        cast(ComplexNumberFieldEmbedding, record.point.embedding).root.root_index
+        for record in second_chart
+    ] == [0, 1]
+
+
+def test_repeated_line_is_positive_dimensional_without_squarefree_replacement() -> None:
+    source = _polynomial((1, (2, 0, 1)))
+    result = _compute(source)
+
+    assert result.outcome.status == "SINGULAR_POSITIVE_DIMENSIONAL"
+    assert result.outcome.projective_dimension == 1
+    assert result.outcome.affine_cone_dimension == 2
+    assert result.source_polynomial == source
+    assert result.outcome.rational_minimal_components
+    assert any(
+        rational_polynomial_to_sympy(generator).as_expr() == sympy.Symbol("X")
+        for component in result.outcome.rational_minimal_components
+        for generator in component.generators
+    )
+
+
+def test_nonzero_rational_scalar_associates_have_the_same_profile() -> None:
+    primitive = _polynomial(
+        (1, (3, 0, 0)),
+        (-1, (0, 2, 1)),
+    )
+    scaled = _polynomial(
+        (Fraction(-2, 3), (3, 0, 0)),
+        (Fraction(2, 3), (0, 2, 1)),
+    )
+
+    assert _compute(primitive) == _compute(scaled)
+
+
+def test_shape_search_passes_two_colliding_integer_forms_before_separating() -> None:
+    four_points = RationalPolynomialIdeal(
+        variables=("u", "v"),
+        generators=(
+            _chart_polynomial((1, (2, 0)), (-1, (1, 0))),
+            _chart_polynomial((1, (0, 2)), (-1, (0, 1))),
+        ),
+    )
+
+    parameter, eliminant, coordinates = _shape_data(four_points)
+
+    assert eliminant.degree() == 4
+    assert (
+        sympy.expand(coordinates[0].as_expr() + 2 * coordinates[1].as_expr())
+        == parameter
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "code"),
+    [
+        (
+            RationalPolynomial(
+                variables=_AXIS,
+                polynomial=SparseRationalPolynomial(terms=()),
+            ),
+            "projective_plane_curve.zero_source",
+        ),
+        (
+            _polynomial((1, (2, 0, 0)), (1, (0, 1, 0))),
+            "projective_plane_curve.homogeneity",
+        ),
+        (
+            _polynomial((1, (4, 0, 0)), (1, (0, 4, 0))),
+            "projective_plane_curve.source_bound",
+        ),
+    ],
+)
+def test_request_rejects_sources_outside_the_exact_projective_domain(
+    source: RationalPolynomial,
+    code: str,
+) -> None:
+    with pytest.raises(ValidationError) as caught:
+        ProjectivePlaneCurveSingularityRequest(polynomial=source)
+    assert caught.value.errors()[0]["type"] == code
+
+
+def test_normalized_height_is_rejected_before_singular_launch() -> None:
+    accepted = _polynomial(
+        (99_999_999, (3, 0, 0)),
+        (1, (0, 2, 1)),
+    )
+    assert _compute(accepted).outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+
+    source = _polynomial(
+        (100_000_000, (3, 0, 0)),
+        (1, (0, 2, 1)),
+    )
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        singularity_profile(source)
+    assert caught.value.errors()[0]["type"] == (
+        "projective_plane_curve.normalized_height_bound"
+    )
+
+
+def test_decoded_ideal_cannot_exceed_the_admitted_coefficient_bound() -> None:
+    source = _normalized_source(
+        _polynomial(
+            (99_999_999, (3, 0, 0)),
+            (1, (2, 1, 0)),
+        )
+    )
+    admission = _admit_singularity(source)
+    over_bound = CanonicalRational(
+        num="1" + "0" * admission.macaulay_minor_component_digits,
+        den="1",
+    )
+    ideal = _ideal_with_shape(
+        coefficient=over_bound,
+        generator_count=1,
+        terms_per_generator=1,
+    )
+
+    failure = _ideal_projection_limit_failure(
+        "SATURATION",
+        (ideal,),
+        admission,
+        maximum_ideals=1,
+    )
+
+    assert failure is not None
+    assert failure.status == "LIMIT_EXCEEDED"
+    assert failure.stage == "SATURATION"
+
+
+def test_derived_result_bound_covers_the_maximal_admitted_ideal_shape() -> None:
+    maximal_axis = ("X" * 32, "Y" * 32, "Z" * 32)
+    cubic_exponents = tuple(
+        sorted(
+            exponent for exponent in product(range(4), repeat=3) if sum(exponent) == 3
+        )
+    )
+    source_backend = _normalized_source(
+        RationalPolynomial(
+            variables=maximal_axis,
+            polynomial=SparseRationalPolynomial(
+                terms=tuple(
+                    RationalPolynomialTerm(
+                        coefficient=_rational(99_999_999 if index == 1 else index),
+                        exponents=exponents,
+                    )
+                    for index, exponents in enumerate(
+                        reversed(cubic_exponents), start=1
+                    )
+                )
+            ),
+        )
+    )
+    admission = _admit_singularity(source_backend)
+    assert admission.macaulay_minor_component_digits == 139
+    numerator = 10 ** (admission.macaulay_minor_component_digits - 1)
+    denominator_base = 10**admission.macaulay_minor_component_digits
+
+    saturation = _ideal_with_shape(
+        coefficient=CanonicalRational(
+            num=str(numerator),
+            den=str(denominator_base - 1),
+        ),
+        generator_count=64,
+        terms_per_generator=16,
+        axis=maximal_axis,
+    )
+    components = tuple(
+        _ideal_with_shape(
+            coefficient=CanonicalRational(
+                num=str(numerator),
+                den=str(denominator_base - (10 * index + 1)),
+            ),
+            generator_count=4,
+            terms_per_generator=16,
+            axis=maximal_axis,
+        )
+        for index in range(MAX_PROJECTIVE_SINGULAR_COMPONENTS)
+    )
+    components = tuple(sorted(components, key=lambda ideal: ideal.model_dump_json()))
+
+    assert (
+        _ideal_projection_limit_failure(
+            "SATURATION",
+            (saturation,),
+            admission,
+            maximum_ideals=1,
+        )
+        is None
+    )
+    assert (
+        _ideal_projection_limit_failure(
+            "PROJECTIVE_COMPONENTS",
+            components,
+            admission,
+            maximum_ideals=MAX_PROJECTIVE_SINGULAR_COMPONENTS,
+        )
+        is None
+    )
+
+    axis = cast(
+        tuple[str, str, str], tuple(str(symbol) for symbol in source_backend.gens)
+    )
+    source = _to_public_polynomial(source_backend, axis)
+    partials = cast(
+        tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
+        tuple(
+            _to_public_polynomial(source_backend.diff(symbol), axis)
+            for symbol in source_backend.gens
+        ),
+    )
+    profile = _profile(
+        source=source,
+        partials=partials,
+        outcome=PositiveDimensionalProjectivePlaneCurveSingularLocus._from_kernel(
+            ideal=saturation,
+            components=components,
+        ),
+    )
+
+    encoded_size = len(encode_strict_json(profile.model_dump(mode="json")))
+    assert encoded_size <= admission.predicted_result_bytes
+    assert admission.predicted_result_bytes < 10 * 1_024 * 1_024
+
+
+def test_every_outcome_discriminator_is_required_by_schema_and_runtime() -> None:
+    schema = ProjectivePlaneCurveSingularityProfile.model_json_schema()
+    for definition in (
+        "SmoothProjectivePlaneCurve",
+        "ZeroDimensionalProjectivePlaneCurveSingularLocus",
+        "PositiveDimensionalProjectivePlaneCurveSingularLocus",
+        "IncompleteProjectivePlaneCurveSingularityComputation",
+    ):
+        assert "status" in schema["$defs"][definition]["required"]
+
+
+def test_catalog_contract_and_example_round_trip() -> None:
+    tool = next(
+        tool
+        for tool in TOOLS
+        if tool.operation_id
+        == "algebraic_geometry.projective_plane_curve.singularity_profile.compute"
+    )
+
+    request = tool.request_type.model_validate(tool.examples[0].input)
+    result = tool.run(request)
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert tool.result_type.model_validate(result.model_dump(mode="json")) == result
+
+
+def test_cancelled_saturation_is_not_a_mathematical_outcome() -> None:
+    cancellation = threading.Event()
+    cancellation.set()
+    source = _polynomial((1, (2, 0, 0)), (1, (0, 2, 0)), (1, (0, 0, 2)))
+
+    with bounded_process_cancellation(cancellation):
+        result = _compute(source)
+
+    assert result.outcome.status == "CANCELLED"
+    assert result.outcome.stage == "SATURATION"
+
+
+def test_native_operation_accepts_the_canonical_polynomial_value() -> None:
+    source = _polynomial((1, (2, 0, 0)), (1, (0, 2, 0)), (1, (0, 0, 2)))
+
+    assert singularity_profile(source).outcome.status == (
+        "SMOOTH_OVER_ALGEBRAIC_CLOSURE"
+    )

--- a/tests/math/number_theory/number_fields/__init__.py
+++ b/tests/math/number_theory/number_fields/__init__.py
@@ -1,0 +1,1 @@
+"""Number-field operation tests."""

--- a/tests/math/number_theory/number_fields/_embedding_replay.py
+++ b/tests/math/number_theory/number_fields/_embedding_replay.py
@@ -1,0 +1,205 @@
+"""Independent defining-invariant replay for embedding-profile tests."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from functools import cmp_to_key
+from typing import Any, Literal
+
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math._root_isolation import strict_root_count
+from jacobian.math.number_theory.algebraic_numbers.complex import (
+    ComplexAlgebraicValue,
+    RationalComplexIsolatingRectangle,
+    algebraic_real_part_separation_denominator_bound,
+    algebraic_root_separation_denominator_bound,
+)
+from jacobian.math.number_theory.algebraic_numbers.real import RationalIsolatingInterval
+from jacobian.math.number_theory.number_fields.values import (
+    RealNumberFieldEmbedding,
+)
+
+
+def _backend_fraction(value: Any) -> Fraction:
+    return Fraction(int(value.p), int(value.q))
+
+
+def _sympy_polynomial(coefficients: tuple[str, ...]) -> Any:
+    import sympy
+
+    variable = sympy.Symbol("x")
+    return sympy.Poly.from_list(
+        [parse_canonical_integer(coefficient) for coefficient in coefficients],
+        gens=variable,
+        domain=sympy.ZZ,
+    )
+
+
+def _indexed_root_approximation(
+    polynomial: Any,
+    root_index: int,
+    error: Fraction,
+) -> tuple[Fraction, Fraction]:
+    import sympy
+
+    root = sympy.CRootOf(polynomial.as_expr(), root_index, radicals=False)
+    tolerance = sympy.Rational(error.numerator, error.denominator)
+    approximation = root.eval_rational(dx=tolerance, dy=tolerance)
+    real_part, imaginary_part = approximation.as_real_imag()
+    return _backend_fraction(real_part), _backend_fraction(imaginary_part)
+
+
+def _public_to_backend_root_indices(
+    value: ComplexAlgebraicValue,
+) -> tuple[int, ...]:
+    import sympy
+
+    polynomial = _sympy_polynomial(value.polynomial)
+    degree = polynomial.degree()
+    real_count = int(polynomial.count_roots(-sympy.oo, sympy.oo))
+    if real_count == degree:
+        return tuple(range(degree))
+
+    root_separation = algebraic_root_separation_denominator_bound(value.polynomial)
+    pair_count = (degree - real_count) // 2
+    real_part_separation = (
+        algebraic_real_part_separation_denominator_bound(value.polynomial)
+        if pair_count > 1
+        else 1
+    )
+    root_error = Fraction(1, 16 * root_separation)
+    real_part_error = Fraction(1, 16 * real_part_separation)
+    ordering_error = min(root_error, real_part_error)
+    backend_roots = tuple(
+        sympy.CRootOf(polynomial.as_expr(), index, radicals=False)
+        for index in range(degree)
+    )
+    unused = set(range(real_count, degree))
+    positive_representatives: list[tuple[int, Fraction, Fraction]] = []
+    negative_for_positive: dict[int, int] = {}
+    while unused:
+        backend_index = min(unused)
+        conjugate = sympy.conjugate(backend_roots[backend_index])
+        partner = next(
+            candidate
+            for candidate in unused
+            if candidate != backend_index and backend_roots[candidate] == conjugate
+        )
+        _real_part, imaginary_part = _indexed_root_approximation(
+            polynomial,
+            backend_index,
+            root_error,
+        )
+        positive_index = backend_index if imaginary_part > 0 else partner
+        negative_index = partner if positive_index == backend_index else backend_index
+        positive_real, positive_imaginary = _indexed_root_approximation(
+            polynomial,
+            positive_index,
+            ordering_error,
+        )
+        positive_representatives.append(
+            (positive_index, positive_real, positive_imaginary)
+        )
+        negative_for_positive[positive_index] = negative_index
+        unused.remove(backend_index)
+        unused.remove(partner)
+
+    def compare(
+        left: tuple[int, Fraction, Fraction],
+        right: tuple[int, Fraction, Fraction],
+    ) -> int:
+        _left_index, left_real, left_imaginary = left
+        _right_index, right_real, right_imaginary = right
+        if left_real + real_part_error < right_real - real_part_error:
+            return -1
+        if right_real + real_part_error < left_real - real_part_error:
+            return 1
+        if left_imaginary + root_error < right_imaginary - root_error:
+            return -1
+        if right_imaginary + root_error < left_imaginary - root_error:
+            return 1
+        return -1 if left_imaginary < right_imaginary else 1
+
+    positive_representatives.sort(key=cmp_to_key(compare))
+    public_to_backend = list(range(real_count))
+    for positive_index, _real_part, _imaginary_part in positive_representatives:
+        public_to_backend.extend(
+            (negative_for_positive[positive_index], positive_index)
+        )
+    return tuple(public_to_backend)
+
+
+def require_rectangle_selects_root(
+    value: ComplexAlgebraicValue,
+    rectangle: RationalComplexIsolatingRectangle,
+) -> Literal["NEGATIVE_IMAGINARY", "POSITIVE_IMAGINARY"]:
+    """Replay root identity, count, and half-plane for test evidence."""
+
+    import sympy
+
+    polynomial = _sympy_polynomial(value.polynomial)
+    root_separation = algebraic_root_separation_denominator_bound(value.polynomial)
+    evidence_grid_denominator = 1 << (root_separation.bit_length() + 4)
+    error = Fraction(1, 16 * evidence_grid_denominator)
+    backend_root_index = _public_to_backend_root_indices(value)[value.root_index]
+    real_part, imaginary_part = _indexed_root_approximation(
+        polynomial,
+        backend_root_index,
+        error,
+    )
+    if not (
+        rectangle.real_lower.as_fraction() < real_part - error
+        and real_part + error < rectangle.real_upper.as_fraction()
+        and rectangle.imaginary_lower.as_fraction() < imaginary_part - error
+        and imaginary_part + error < rectangle.imaginary_upper.as_fraction()
+    ):
+        raise ValueError("complex isolator does not certify the selected indexed root")
+
+    lower = sympy.Rational(*rectangle.real_lower.as_integer_ratio()) + sympy.I * (
+        sympy.Rational(*rectangle.imaginary_lower.as_integer_ratio())
+    )
+    upper = sympy.Rational(*rectangle.real_upper.as_integer_ratio()) + sympy.I * (
+        sympy.Rational(*rectangle.imaginary_upper.as_integer_ratio())
+    )
+    try:
+        root_count = int(polynomial.count_roots(lower, upper))
+    except NotImplementedError as exc:
+        raise ValueError(
+            "complex isolator boundaries must contain no additional polynomial root"
+        ) from exc
+    if root_count != 1:
+        raise ValueError("a complex algebraic isolator must contain exactly one root")
+
+    if rectangle.imaginary_upper.as_fraction() < 0:
+        return "NEGATIVE_IMAGINARY"
+    if rectangle.imaginary_lower.as_fraction() > 0:
+        return "POSITIVE_IMAGINARY"
+    raise ValueError("a nonreal root isolator must lie wholly in one open half-plane")
+
+
+def require_real_interval_selects_root(
+    embedding: RealNumberFieldEmbedding,
+    interval: RationalIsolatingInterval,
+) -> None:
+    """Replay real root identity and count for test evidence."""
+
+    import sympy
+
+    polynomial = _sympy_polynomial(embedding.presentation.coefficients_descending)
+    lower = sympy.Rational(*interval.lower.as_integer_ratio())
+    upper = sympy.Rational(*interval.upper.as_integer_ratio())
+    if strict_root_count(polynomial, lower, upper) != 1:
+        raise ValueError("a real embedding interval must isolate exactly one root")
+    roots_below = int(polynomial.count_roots(-sympy.oo, lower))
+    if polynomial.eval(lower) == 0:
+        roots_below -= 1
+    if roots_below != embedding.root.real_root_index:
+        raise ValueError(
+            "real isolating interval does not select the embedding's indexed root"
+        )
+
+
+__all__ = [
+    "require_real_interval_selects_root",
+    "require_rectangle_selects_root",
+]

--- a/tests/math/number_theory/number_fields/test_embeddings.py
+++ b/tests/math/number_theory/number_fields/test_embeddings.py
@@ -24,6 +24,7 @@ from jacobian._execution import (
 from jacobian.canonical import encode_strict_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.algebraic_numbers.complex import (
+    ComplexAlgebraicValue,
     RationalComplexIsolatingRectangle,
 )
 from jacobian.math.number_theory.algebraic_numbers.real import (
@@ -655,6 +656,20 @@ def test_embedding_discriminator_is_required_at_runtime() -> None:
 
     with pytest.raises(ValidationError, match="Field required"):
         ComplexNumberFieldEmbedding.model_validate(embedding)
+
+
+@pytest.mark.parametrize(
+    ("polynomial", "root_index", "message"),
+    [
+        (("1", "0", "-1"), 0, "irreducible"),
+        (("1", "0", "-2"), 0, "nonreal root"),
+    ],
+)
+def test_complex_algebraic_value_recognizes_its_selected_root(
+    polynomial: tuple[str, ...], root_index: int, message: str
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        ComplexAlgebraicValue(polynomial=polynomial, root_index=root_index)
 
 
 def test_catalog_operation_projects_owner_local_admission_rejection() -> None:

--- a/tests/math/number_theory/number_fields/test_embeddings.py
+++ b/tests/math/number_theory/number_fields/test_embeddings.py
@@ -22,7 +22,6 @@ from jacobian._execution import (
     request_execution,
 )
 from jacobian.canonical import encode_strict_json
-from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.algebraic_numbers.complex import (
     RationalComplexIsolatingRectangle,
@@ -49,6 +48,7 @@ from jacobian.math.number_theory.number_fields._embeddings_worker import (
 from jacobian.math.number_theory.number_fields._models import (
     NumberFieldEmbeddingsRequest,
 )
+from jacobian.math.number_theory.number_fields._tools import TOOLS
 from jacobian.math.number_theory.number_fields.operations import (
     MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES,
     NumberFieldEmbeddingAdmissionError,
@@ -581,8 +581,9 @@ def test_every_kernel_isolator_replays_and_result_stays_below_preflight_bound(
 
 
 def test_catalog_operation_exposes_and_runs_the_advertised_gaussian_example() -> None:
-    operation = Catalog.open().operation("number_field.embeddings.compute")
-    assert operation is not None
+    operation = next(
+        tool for tool in TOOLS if tool.operation_id == "number_field.embeddings.compute"
+    )
     example = operation.examples[0]
     request = NumberFieldEmbeddingsRequest.model_validate(example.input)
 
@@ -594,8 +595,9 @@ def test_catalog_operation_exposes_and_runs_the_advertised_gaussian_example() ->
 
 
 def test_reducible_presentation_is_recognized_inside_the_operation() -> None:
-    operation = Catalog.open().operation("number_field.embeddings.compute")
-    assert operation is not None
+    operation = next(
+        tool for tool in TOOLS if tool.operation_id == "number_field.embeddings.compute"
+    )
     request = NumberFieldEmbeddingsRequest.model_validate(
         {
             "field": {
@@ -656,8 +658,9 @@ def test_embedding_discriminator_is_required_at_runtime() -> None:
 
 
 def test_catalog_operation_projects_owner_local_admission_rejection() -> None:
-    operation = Catalog.open().operation("number_field.embeddings.compute")
-    assert operation is not None
+    operation = next(
+        tool for tool in TOOLS if tool.operation_id == "number_field.embeddings.compute"
+    )
     field = _field("1", *("0",) * 7, str(10**255 + 2))
     request = NumberFieldEmbeddingsRequest(field=field)
 

--- a/tests/math/number_theory/number_fields/test_embeddings.py
+++ b/tests/math/number_theory/number_fields/test_embeddings.py
@@ -2,18 +2,30 @@
 
 from __future__ import annotations
 
+import cProfile
+import time
 from fractions import Fraction
+from threading import Event
+from types import CodeType
 
 import pytest
 from pydantic import TypeAdapter, ValidationError
+from tests.math.number_theory.number_fields._embedding_replay import (
+    require_real_interval_selects_root,
+    require_rectangle_selects_root,
+)
 
 from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    request_execution,
+)
 from jacobian.canonical import encode_strict_json
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.algebraic_numbers.complex import (
     RationalComplexIsolatingRectangle,
-    _require_rectangle_selects_root,
 )
 from jacobian.math.number_theory.algebraic_numbers.real import (
     RationalIsolatingInterval,
@@ -22,25 +34,31 @@ from jacobian.math.number_theory.number_fields import (
     ComplexNumberFieldEmbedding,
     EmbeddedSimpleNumberFieldElement,
     NumberFieldEmbeddingProfile,
+    RealNumberFieldEmbedding,
     SimpleNumberFieldElement,
     SimpleNumberFieldPresentation,
     embeddings,
+)
+from jacobian.math.number_theory.number_fields._embedding_protocol import (
+    NumberFieldEmbeddingWorkerComplete,
+    NumberFieldEmbeddingWorkerRequest,
+)
+from jacobian.math.number_theory.number_fields._embeddings_worker import (
+    compute_embeddings_worker_response,
 )
 from jacobian.math.number_theory.number_fields._models import (
     NumberFieldEmbeddingsRequest,
 )
 from jacobian.math.number_theory.number_fields.operations import (
     MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES,
-    MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS,
-    MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS,
     NumberFieldEmbeddingAdmissionError,
     _admit_number_field_embeddings,
 )
 from jacobian.math.number_theory.number_fields.values import (
     ComplexNumberFieldEmbeddingRecord,
     RealNumberFieldEmbeddingRecord,
-    _require_real_interval_selects_root,
 )
+from jacobian.process import bounded_process_cancellation
 
 
 def _field(*coefficients: str) -> SimpleNumberFieldPresentation:
@@ -51,6 +69,17 @@ def _field(*coefficients: str) -> SimpleNumberFieldPresentation:
 
 def _rational(value: int | Fraction) -> CanonicalRational:
     return CanonicalRational.from_fraction(Fraction(value))
+
+
+def _worker_request(
+    field: SimpleNumberFieldPresentation,
+) -> NumberFieldEmbeddingWorkerRequest:
+    admission = _admit_number_field_embeddings(field)
+    return NumberFieldEmbeddingWorkerRequest(
+        field=field,
+        root_isolation_bits=admission.root_isolation_bits,
+        evidence_grid_bits=admission.evidence_grid_bits,
+    )
 
 
 def test_rational_field_degree_one_is_the_cheapest_complete_profile() -> None:
@@ -152,11 +181,12 @@ def test_embedding_identity_is_independent_of_valid_isolation_evidence() -> None
         imaginary_upper=_rational(Fraction(-1, 2)),
     )
     assert (
-        _require_rectangle_selects_root(original.embedding.root, wider_evidence)
+        require_rectangle_selects_root(original.embedding.root, wider_evidence)
         == "NEGATIVE_IMAGINARY"
     )
 
     alternate_record = ComplexNumberFieldEmbeddingRecord(
+        kind="COMPLEX",
         embedding=original.embedding,
         isolating_rectangle=wider_evidence,
         half_plane="NEGATIVE_IMAGINARY",
@@ -185,6 +215,7 @@ def test_reduced_elements_compose_with_selected_embedding_without_backend_values
     )
 
     assert image.evaluation == "POWER_BASIS_AT_SELECTED_ROOT"
+    assert isinstance(image.embedding, ComplexNumberFieldEmbedding)
     assert image.embedding.root.root_index == 1
     assert (
         EmbeddedSimpleNumberFieldElement.model_validate_json(image.model_dump_json())
@@ -228,13 +259,14 @@ def test_projective_curve_2870_prerequisite_preserves_gaussian_coordinate_triple
         EmbeddedSimpleNumberFieldElement,
         EmbeddedSimpleNumberFieldElement,
     ]:
-        return tuple(
+        embedded = tuple(
             EmbeddedSimpleNumberFieldElement(
                 element=coordinate,
                 embedding=record.embedding,
             )
             for coordinate in (one, alpha, zero)
         )
+        return embedded[0], embedded[1], embedded[2]
 
     negative_coordinates = embedded_coordinates(negative_record)
     positive_coordinates = embedded_coordinates(positive_record)
@@ -253,6 +285,8 @@ def test_projective_curve_2870_prerequisite_preserves_gaussian_coordinate_triple
 
     assert restored_negative == negative_coordinates
     assert restored_positive == positive_coordinates
+    assert isinstance(restored_negative[1].embedding, ComplexNumberFieldEmbedding)
+    assert isinstance(restored_positive[1].embedding, ComplexNumberFieldEmbedding)
     assert restored_negative[1].embedding.root.root_index == 0
     assert restored_positive[1].embedding.root.root_index == 1
     assert restored_negative[1].embedding != restored_positive[1].embedding
@@ -277,9 +311,7 @@ def test_embedded_element_rejects_a_different_field_presentation() -> None:
         )
 
 
-def test_reducible_nonprimitive_and_malformed_elements_are_rejected() -> None:
-    with pytest.raises(ValidationError, match="irreducible"):
-        _field("1", "0", "-1")
+def test_nonprimitive_presentations_and_malformed_elements_are_rejected() -> None:
     with pytest.raises(ValidationError, match="primitive"):
         _field("2", "0", "2")
     with pytest.raises(ValidationError, match="positive leading"):
@@ -300,7 +332,7 @@ def test_malformed_overlapping_wrong_root_and_wrong_sign_evidence_are_rejected()
     assert isinstance(positive, ComplexNumberFieldEmbeddingRecord)
 
     with pytest.raises(ValueError, match="selected indexed root"):
-        _require_rectangle_selects_root(
+        require_rectangle_selects_root(
             negative.embedding.root,
             positive.isolating_rectangle,
         )
@@ -312,7 +344,7 @@ def test_malformed_overlapping_wrong_root_and_wrong_sign_evidence_are_rejected()
         imaginary_upper=_rational(2),
     )
     with pytest.raises(ValueError, match="exactly one root"):
-        _require_rectangle_selects_root(negative.embedding.root, overlapping)
+        require_rectangle_selects_root(negative.embedding.root, overlapping)
 
     wrong_sign = negative.model_dump(mode="json")
     wrong_sign["half_plane"] = "POSITIVE_IMAGINARY"
@@ -326,7 +358,7 @@ def test_malformed_overlapping_wrong_root_and_wrong_sign_evidence_are_rejected()
         imaginary_upper=_rational(Fraction(-1, 2)),
     )
     with pytest.raises(ValueError, match="selected indexed root"):
-        _require_rectangle_selects_root(negative.embedding.root, boundary_root)
+        require_rectangle_selects_root(negative.embedding.root, boundary_root)
 
     oversized = negative.model_dump(mode="json")
     oversized["isolating_rectangle"]["real_lower"]["num"] = "1" * 4_097
@@ -349,7 +381,7 @@ def test_real_interval_is_bound_to_the_selected_real_root() -> None:
     assert isinstance(negative, RealNumberFieldEmbeddingRecord)
     assert isinstance(positive, RealNumberFieldEmbeddingRecord)
     with pytest.raises(ValueError, match="indexed root"):
-        _require_real_interval_selects_root(
+        require_real_interval_selects_root(
             negative.embedding,
             positive.isolating_interval,
         )
@@ -362,6 +394,7 @@ def test_real_interval_is_bound_to_the_selected_real_root() -> None:
     oversized_component = CanonicalRational(num="-1", den="9" * 4_097)
     with pytest.raises(ValidationError, match="4,096-digit bound"):
         RealNumberFieldEmbeddingRecord(
+            kind="REAL",
             embedding=negative.embedding,
             isolating_interval=RationalIsolatingInterval(
                 lower=oversized_component,
@@ -397,16 +430,47 @@ def test_profiles_are_deterministic_across_backend_cache_refinement(
     assert embeddings(field).model_dump_json() == first
 
 
+def test_worker_executes_one_all_root_isolation_pass() -> None:
+    profiler = cProfile.Profile()
+    field = _field("1", "0", "5", "0", "5")
+
+    profiler.runcall(compute_embeddings_worker_response, _worker_request(field))
+    poly_intervals_calls = sum(
+        entry.callcount
+        for entry in profiler.getstats()
+        if isinstance(entry.code, CodeType)
+        and entry.code.co_filename.endswith("sympy/polys/polytools.py")
+        and entry.code.co_name == "intervals"
+    )
+    complex_isolation_calls = sum(
+        entry.callcount
+        for entry in profiler.getstats()
+        if isinstance(entry.code, CodeType)
+        and entry.code.co_name == "dup_isolate_complex_roots_sqf"
+    )
+
+    assert poly_intervals_calls == 1
+    assert complex_isolation_calls == 1
+
+
 def test_profile_and_canonical_values_round_trip_without_backend_objects() -> None:
     profile = embeddings(_field("1", "0", "-1", "1"))
     encoded = encode_strict_json(profile.model_dump(mode="json"))
+    profiler = cProfile.Profile()
 
-    restored = NumberFieldEmbeddingProfile.model_validate_json(
-        encoded,
-        strict=True,
+    restored = profiler.runcall(
+        lambda: NumberFieldEmbeddingProfile.model_validate_json(
+            encoded,
+            strict=True,
+        )
     )
 
     assert restored == profile
+    assert not any(
+        isinstance(entry.code, CodeType)
+        and "/sympy/" in entry.code.co_filename.replace("\\", "/")
+        for entry in profiler.getstats()
+    )
     assert "CRootOf" not in profile.model_dump_json()
     assert "sympy" not in profile.model_dump_json().lower()
 
@@ -426,17 +490,6 @@ def test_degree_coefficient_isolation_work_and_result_bounds_are_preflighted() -
     degree_eight = _field("1", "1", "-7", "-5", "15", "6", "-10", "-1", "1")
     admission = _admit_number_field_embeddings(degree_eight)
 
-    assert admission.degree == 8
-    assert admission.isolator_component_digits <= 4_096
-    assert admission.real_part_resultant_storage_bits <= (
-        MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS
-    )
-    assert admission.root_refinement_precision_bits <= (
-        MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS
-    )
-    assert admission.root_refinement_bit_work == (
-        admission.root_refinement_calls * admission.root_refinement_precision_bits
-    )
     assert admission.predicted_result_bytes <= MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES
     degree_eight_result = embeddings(degree_eight)
     assert (
@@ -444,8 +497,10 @@ def test_degree_coefficient_isolation_work_and_result_bounds_are_preflighted() -
         <= admission.predicted_result_bytes
     )
 
-    with pytest.raises(ValidationError):
-        _field("1", *("0",) * 8, "2")
+    degree_nine = _field("1", *("0",) * 8, "2")
+    with pytest.raises(NumberFieldEmbeddingAdmissionError) as caught:
+        embeddings(degree_nine)
+    assert caught.value.reason == "degree_bound"
     with pytest.raises(ValidationError, match="256 digits"):
         _field("1", "0", "1" + "0" * 256)
     with pytest.raises(ValidationError, match="256 digits"):
@@ -457,11 +512,11 @@ def test_degree_coefficient_isolation_work_and_result_bounds_are_preflighted() -
         )
 
     # Eisenstein at 2: this is a valid 256-digit defining polynomial, but its
-    # exact all-root ordering plan is immediately rejected before expansion by
-    # the separately derived work/intermediate envelope.
+    # exact pair-ordering precision is rejected inside the bounded worker after
+    # the static resultant-storage envelope has admitted the presolve.
     large_eisenstein = _field("1", *("0",) * 7, str(10**255 + 2))
     with pytest.raises(NumberFieldEmbeddingAdmissionError) as caught:
-        _admit_number_field_embeddings(large_eisenstein)
+        embeddings(large_eisenstein)
     assert caught.value.reason == "pair_ordering_precision_bound"
 
 
@@ -471,6 +526,7 @@ def test_degree_coefficient_isolation_work_and_result_bounds_are_preflighted() -
         ("1", "0"),
         ("9" * 256, "1"),
         ("1", "0", "-2"),
+        ("2", "0", "1"),
         ("1", "0", "1"),
         ("1", "0", "-1", "1"),
         ("1", "0", "5", "0", "5"),
@@ -484,20 +540,39 @@ def test_every_kernel_isolator_replays_and_result_stays_below_preflight_bound(
     admission = _admit_number_field_embeddings(field)
     result = embeddings(field)
     encoded = encode_strict_json(result.model_dump(mode="json"))
+    worker_projection = NumberFieldEmbeddingWorkerComplete(
+        kind="complete",
+        real_intervals=tuple(
+            record.isolating_interval
+            for record in result.records
+            if isinstance(record, RealNumberFieldEmbeddingRecord)
+        ),
+        negative_complex_rectangles=tuple(
+            record.isolating_rectangle
+            for record in result.records
+            if isinstance(record, ComplexNumberFieldEmbeddingRecord)
+            and record.half_plane == "NEGATIVE_IMAGINARY"
+        ),
+        defining_polynomial_discriminant=result.defining_polynomial_discriminant,
+    )
 
     assert len(encoded) <= admission.predicted_result_bytes
+    assert (
+        len(worker_projection.model_dump_json().encode("utf-8"))
+        <= admission.predicted_worker_output_bytes
+    )
     assert (
         NumberFieldEmbeddingProfile.model_validate_json(encoded, strict=True) == result
     )
     for record in result.records:
         if isinstance(record, RealNumberFieldEmbeddingRecord):
-            _require_real_interval_selects_root(
+            require_real_interval_selects_root(
                 record.embedding,
                 record.isolating_interval,
             )
         else:
             assert (
-                _require_rectangle_selects_root(
+                require_rectangle_selects_root(
                     record.embedding.root,
                     record.isolating_rectangle,
                 )
@@ -516,6 +591,68 @@ def test_catalog_operation_exposes_and_runs_the_advertised_gaussian_example() ->
     assert isinstance(result, NumberFieldEmbeddingProfile)
     assert result.signature.complex_conjugate_pair_count == 1
     assert result.defining_polynomial_discriminant == "-4"
+
+
+def test_reducible_presentation_is_recognized_inside_the_operation() -> None:
+    operation = Catalog.open().operation("number_field.embeddings.compute")
+    assert operation is not None
+    request = NumberFieldEmbeddingsRequest.model_validate(
+        {
+            "field": {
+                "domain": "QQ",
+                "coefficients_descending": ["1", "0", "-1"],
+            }
+        }
+    )
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        operation.run(request)
+
+    assert caught.value.errors()[0]["type"] == "number_field.embeddings.not_irreducible"
+
+
+def test_embedding_worker_honors_an_already_expired_request_deadline() -> None:
+    field = _field("1", "0", "1")
+
+    with (
+        request_execution(started_at=time.monotonic() - 121),
+        pytest.raises(OperationExecutionTimeoutError, match="before"),
+    ):
+        embeddings(field)
+
+
+def test_embedding_worker_honors_request_cancellation_before_launch() -> None:
+    field = _field("1", "0", "1")
+    cancellation = Event()
+    cancellation.set()
+
+    with (
+        bounded_process_cancellation(cancellation),
+        pytest.raises(OperationExecutionCancelledError, match="cancelled"),
+    ):
+        embeddings(field)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        RealNumberFieldEmbedding,
+        ComplexNumberFieldEmbedding,
+        RealNumberFieldEmbeddingRecord,
+        ComplexNumberFieldEmbeddingRecord,
+    ],
+)
+def test_embedding_discriminator_is_required_in_schema(model: type[object]) -> None:
+    assert "kind" in model.model_json_schema()["required"]  # type: ignore[attr-defined]
+
+
+def test_embedding_discriminator_is_required_at_runtime() -> None:
+    profile = embeddings(_field("1", "0", "1"))
+    embedding = profile.records[0].embedding.model_dump(mode="json")
+    embedding.pop("kind")
+
+    with pytest.raises(ValidationError, match="Field required"):
+        ComplexNumberFieldEmbedding.model_validate(embedding)
 
 
 def test_catalog_operation_projects_owner_local_admission_rejection() -> None:

--- a/tests/math/number_theory/number_fields/test_embeddings.py
+++ b/tests/math/number_theory/number_fields/test_embeddings.py
@@ -9,7 +9,7 @@ from threading import Event
 from types import CodeType
 
 import pytest
-from pydantic import TypeAdapter, ValidationError
+from pydantic import ValidationError
 from tests.math.number_theory.number_fields._embedding_replay import (
     require_real_interval_selects_root,
     require_rectangle_selects_root,
@@ -23,6 +23,7 @@ from jacobian._execution import (
 )
 from jacobian.canonical import encode_strict_json
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.number_theory import number_fields
 from jacobian.math.number_theory.algebraic_numbers.complex import (
     ComplexAlgebraicValue,
     RationalComplexIsolatingRectangle,
@@ -31,10 +32,7 @@ from jacobian.math.number_theory.algebraic_numbers.real import (
     RationalIsolatingInterval,
 )
 from jacobian.math.number_theory.number_fields import (
-    ComplexNumberFieldEmbedding,
-    EmbeddedSimpleNumberFieldElement,
     NumberFieldEmbeddingProfile,
-    RealNumberFieldEmbedding,
     SimpleNumberFieldElement,
     SimpleNumberFieldPresentation,
     embeddings,
@@ -196,120 +194,6 @@ def test_embedding_identity_is_independent_of_valid_isolation_evidence() -> None
     assert alternate_record.embedding == original.embedding
     assert alternate_record.isolating_rectangle != original.isolating_rectangle
     assert "isolating_rectangle" not in original.embedding.model_dump()
-
-
-def test_reduced_elements_compose_with_selected_embedding_without_backend_values() -> (
-    None
-):
-    field = _field("1", "0", "1")
-    profile = embeddings(field)
-    positive = profile.records[1]
-    assert isinstance(positive, ComplexNumberFieldEmbeddingRecord)
-    element = SimpleNumberFieldElement(
-        presentation=field,
-        coefficients_ascending=(_rational(Fraction(1, 2)), _rational(1)),
-    )
-
-    image = EmbeddedSimpleNumberFieldElement(
-        element=element,
-        embedding=positive.embedding,
-    )
-
-    assert image.evaluation == "POWER_BASIS_AT_SELECTED_ROOT"
-    assert isinstance(image.embedding, ComplexNumberFieldEmbedding)
-    assert image.embedding.root.root_index == 1
-    assert (
-        EmbeddedSimpleNumberFieldElement.model_validate_json(image.model_dump_json())
-        == image
-    )
-    assert "isolating_rectangle" not in image.model_dump_json()
-
-
-def test_projective_curve_2870_prerequisite_preserves_gaussian_coordinate_triples() -> (
-    None
-):
-    field = _field("1", "0", "1")
-    negative_record, positive_record = embeddings(field).records
-    assert isinstance(negative_record, ComplexNumberFieldEmbeddingRecord)
-    assert isinstance(positive_record, ComplexNumberFieldEmbeddingRecord)
-    one = SimpleNumberFieldElement(
-        presentation=field,
-        coefficients_ascending=(_rational(1), _rational(0)),
-    )
-    alpha = SimpleNumberFieldElement(
-        presentation=field,
-        coefficients_ascending=(_rational(0), _rational(1)),
-    )
-    zero = SimpleNumberFieldElement(
-        presentation=field,
-        coefficients_ascending=(_rational(0), _rational(0)),
-    )
-
-    coordinate_adapter = TypeAdapter(
-        tuple[
-            EmbeddedSimpleNumberFieldElement,
-            EmbeddedSimpleNumberFieldElement,
-            EmbeddedSimpleNumberFieldElement,
-        ]
-    )
-
-    def embedded_coordinates(
-        record: ComplexNumberFieldEmbeddingRecord,
-    ) -> tuple[
-        EmbeddedSimpleNumberFieldElement,
-        EmbeddedSimpleNumberFieldElement,
-        EmbeddedSimpleNumberFieldElement,
-    ]:
-        embedded = tuple(
-            EmbeddedSimpleNumberFieldElement(
-                element=coordinate,
-                embedding=record.embedding,
-            )
-            for coordinate in (one, alpha, zero)
-        )
-        return embedded[0], embedded[1], embedded[2]
-
-    negative_coordinates = embedded_coordinates(negative_record)
-    positive_coordinates = embedded_coordinates(positive_record)
-    restored_negative = coordinate_adapter.validate_json(
-        encode_strict_json(
-            coordinate_adapter.dump_python(negative_coordinates, mode="json")
-        ),
-        strict=True,
-    )
-    restored_positive = coordinate_adapter.validate_json(
-        encode_strict_json(
-            coordinate_adapter.dump_python(positive_coordinates, mode="json")
-        ),
-        strict=True,
-    )
-
-    assert restored_negative == negative_coordinates
-    assert restored_positive == positive_coordinates
-    assert isinstance(restored_negative[1].embedding, ComplexNumberFieldEmbedding)
-    assert isinstance(restored_positive[1].embedding, ComplexNumberFieldEmbedding)
-    assert restored_negative[1].embedding.root.root_index == 0
-    assert restored_positive[1].embedding.root.root_index == 1
-    assert restored_negative[1].embedding != restored_positive[1].embedding
-    for coordinate in (*restored_negative, *restored_positive):
-        assert coordinate.element.presentation == field
-        assert coordinate.embedding.presentation == field
-
-
-def test_embedded_element_rejects_a_different_field_presentation() -> None:
-    gaussian = _field("1", "0", "1")
-    positive = embeddings(gaussian).records[1]
-    assert isinstance(positive, ComplexNumberFieldEmbeddingRecord)
-    rational_element = SimpleNumberFieldElement(
-        presentation=_field("1", "0"),
-        coefficients_ascending=(_rational(1),),
-    )
-
-    with pytest.raises(ValidationError, match="share one presentation"):
-        EmbeddedSimpleNumberFieldElement(
-            element=rational_element,
-            embedding=positive.embedding,
-        )
 
 
 def test_nonprimitive_presentations_and_malformed_elements_are_rejected() -> None:
@@ -476,6 +360,26 @@ def test_profile_and_canonical_values_round_trip_without_backend_objects() -> No
     assert "sympy" not in profile.model_dump_json().lower()
 
 
+def test_structural_complex_root_parsing_does_not_replay_sympy() -> None:
+    profiler = cProfile.Profile()
+    value = profiler.runcall(
+        lambda: ComplexAlgebraicValue(polynomial=("1", "0", "-1"), root_index=0)
+    )
+
+    assert value.root_index == 0
+    assert not any(
+        isinstance(entry.code, CodeType)
+        and "/sympy/" in entry.code.co_filename.replace("\\", "/")
+        for entry in profiler.getstats()
+    )
+
+
+def test_unrecognized_embedding_carriers_are_not_native_api() -> None:
+    assert "ComplexNumberFieldEmbedding" not in number_fields.__all__
+    assert "RealNumberFieldEmbedding" not in number_fields.__all__
+    assert "EmbeddedSimpleNumberFieldElement" not in number_fields.__all__
+
+
 def test_profile_structural_validation_rejects_an_incomplete_result() -> None:
     profile = embeddings(_field("1", "0", "1"))
     incomplete = profile.model_dump(mode="json")
@@ -639,37 +543,12 @@ def test_embedding_worker_honors_request_cancellation_before_launch() -> None:
 @pytest.mark.parametrize(
     "model",
     [
-        RealNumberFieldEmbedding,
-        ComplexNumberFieldEmbedding,
         RealNumberFieldEmbeddingRecord,
         ComplexNumberFieldEmbeddingRecord,
     ],
 )
 def test_embedding_discriminator_is_required_in_schema(model: type[object]) -> None:
     assert "kind" in model.model_json_schema()["required"]  # type: ignore[attr-defined]
-
-
-def test_embedding_discriminator_is_required_at_runtime() -> None:
-    profile = embeddings(_field("1", "0", "1"))
-    embedding = profile.records[0].embedding.model_dump(mode="json")
-    embedding.pop("kind")
-
-    with pytest.raises(ValidationError, match="Field required"):
-        ComplexNumberFieldEmbedding.model_validate(embedding)
-
-
-@pytest.mark.parametrize(
-    ("polynomial", "root_index", "message"),
-    [
-        (("1", "0", "-1"), 0, "irreducible"),
-        (("1", "0", "-2"), 0, "nonreal root"),
-    ],
-)
-def test_complex_algebraic_value_recognizes_its_selected_root(
-    polynomial: tuple[str, ...], root_index: int, message: str
-) -> None:
-    with pytest.raises(ValidationError, match=message):
-        ComplexAlgebraicValue(polynomial=polynomial, root_index=root_index)
 
 
 def test_catalog_operation_projects_owner_local_admission_rejection() -> None:
@@ -691,9 +570,5 @@ def test_embedding_union_keeps_the_selected_parent_context() -> None:
     record = profile.records[1]
     assert isinstance(record, ComplexNumberFieldEmbeddingRecord)
 
-    embedding = ComplexNumberFieldEmbedding.model_validate_json(
-        record.embedding.model_dump_json()
-    )
-
-    assert embedding.presentation == profile.field
-    assert embedding.root.polynomial == profile.field.coefficients_descending
+    assert record.embedding.presentation == profile.field
+    assert record.embedding.root.polynomial == profile.field.coefficients_descending

--- a/tests/math/number_theory/number_fields/test_embeddings.py
+++ b/tests/math/number_theory/number_fields/test_embeddings.py
@@ -1,0 +1,544 @@
+"""Exact simple number fields and complete Archimedean embedding profiles."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import encode_strict_json
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.number_theory.algebraic_numbers.complex import (
+    RationalComplexIsolatingRectangle,
+    _require_rectangle_selects_root,
+)
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+)
+from jacobian.math.number_theory.number_fields import (
+    ComplexNumberFieldEmbedding,
+    EmbeddedSimpleNumberFieldElement,
+    NumberFieldEmbeddingProfile,
+    SimpleNumberFieldElement,
+    SimpleNumberFieldPresentation,
+    embeddings,
+)
+from jacobian.math.number_theory.number_fields._models import (
+    NumberFieldEmbeddingsRequest,
+)
+from jacobian.math.number_theory.number_fields.operations import (
+    MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES,
+    MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS,
+    MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS,
+    NumberFieldEmbeddingAdmissionError,
+    _admit_number_field_embeddings,
+)
+from jacobian.math.number_theory.number_fields.values import (
+    ComplexNumberFieldEmbeddingRecord,
+    RealNumberFieldEmbeddingRecord,
+    _require_real_interval_selects_root,
+)
+
+
+def _field(*coefficients: str) -> SimpleNumberFieldPresentation:
+    return SimpleNumberFieldPresentation(
+        coefficients_descending=coefficients,
+    )
+
+
+def _rational(value: int | Fraction) -> CanonicalRational:
+    return CanonicalRational.from_fraction(Fraction(value))
+
+
+def test_rational_field_degree_one_is_the_cheapest_complete_profile() -> None:
+    field = _field("1", "0")
+
+    result = embeddings(field)
+
+    assert field.degree == 1
+    assert result.signature.real_embedding_count == 1
+    assert result.signature.complex_conjugate_pair_count == 0
+    assert result.defining_polynomial_discriminant == "1"
+    assert result.complex_conjugate_pairs == ()
+    assert isinstance(result.records[0], RealNumberFieldEmbeddingRecord)
+    assert result.records[0].isolating_interval.lower.as_fraction() == 0
+    assert result.records[0].isolating_interval.interval_type == "SINGLETON"
+
+
+def test_sqrt_two_has_two_ordered_real_embeddings_and_polynomial_discriminant() -> None:
+    result = embeddings(_field("1", "0", "-2"))
+
+    assert result.signature.real_embedding_count == 2
+    assert result.signature.complex_conjugate_pair_count == 0
+    assert result.defining_polynomial_discriminant == "8"
+    assert all(
+        isinstance(record, RealNumberFieldEmbeddingRecord) for record in result.records
+    )
+    left, right = result.records
+    assert isinstance(left, RealNumberFieldEmbeddingRecord)
+    assert isinstance(right, RealNumberFieldEmbeddingRecord)
+    assert (
+        left.isolating_interval.upper.as_fraction()
+        <= right.isolating_interval.lower.as_fraction()
+    )
+
+
+def test_gaussian_field_distinguishes_i_from_negative_i_exactly() -> None:
+    result = embeddings(_field("1", "0", "1"))
+
+    assert result.signature.real_embedding_count == 0
+    assert result.signature.complex_conjugate_pair_count == 1
+    assert result.defining_polynomial_discriminant == "-4"
+    assert len(result.complex_conjugate_pairs) == 1
+    pair = result.complex_conjugate_pairs[0]
+    assert (pair.negative_embedding_index, pair.positive_embedding_index) == (0, 1)
+    negative, positive = result.records
+    assert isinstance(negative, ComplexNumberFieldEmbeddingRecord)
+    assert isinstance(positive, ComplexNumberFieldEmbeddingRecord)
+    assert negative.embedding.root.root_index == 0
+    assert positive.embedding.root.root_index == 1
+    assert negative.half_plane == "NEGATIVE_IMAGINARY"
+    assert positive.half_plane == "POSITIVE_IMAGINARY"
+    assert negative.isolating_rectangle.conjugate() == positive.isolating_rectangle
+
+
+def test_signature_one_one_cubic_is_complete() -> None:
+    result = embeddings(_field("1", "0", "-1", "1"))
+
+    assert result.signature.real_embedding_count == 1
+    assert result.signature.complex_conjugate_pair_count == 1
+    assert result.defining_polynomial_discriminant == "-23"
+    assert [record.kind for record in result.records] == [
+        "REAL",
+        "COMPLEX",
+        "COMPLEX",
+    ]
+    assert result.complex_conjugate_pairs[0].positive_embedding_index == 2
+
+
+def test_pair_order_uses_positive_representatives_not_full_root_lexicography() -> None:
+    # The full lexicographic order of the four roots of this irreducible
+    # polynomial is not conjugate-pair adjacent.  The public convention orders
+    # the positive representatives by imaginary part, then emits each pair as
+    # negative followed by positive.
+    result = embeddings(_field("1", "0", "5", "0", "5"))
+
+    assert result.signature.complex_conjugate_pair_count == 2
+    first_positive = result.records[1]
+    second_positive = result.records[3]
+    assert isinstance(first_positive, ComplexNumberFieldEmbeddingRecord)
+    assert isinstance(second_positive, ComplexNumberFieldEmbeddingRecord)
+    assert (
+        first_positive.isolating_rectangle.imaginary_upper.as_fraction()
+        < second_positive.isolating_rectangle.imaginary_lower.as_fraction()
+    )
+    assert tuple(
+        (pair.negative_embedding_index, pair.positive_embedding_index)
+        for pair in result.complex_conjugate_pairs
+    ) == ((0, 1), (2, 3))
+
+
+def test_embedding_identity_is_independent_of_valid_isolation_evidence() -> None:
+    result = embeddings(_field("1", "0", "1"))
+    original = result.records[0]
+    assert isinstance(original, ComplexNumberFieldEmbeddingRecord)
+    wider_evidence = RationalComplexIsolatingRectangle(
+        real_lower=_rational(Fraction(-1, 2)),
+        real_upper=_rational(Fraction(1, 2)),
+        imaginary_lower=_rational(Fraction(-3, 2)),
+        imaginary_upper=_rational(Fraction(-1, 2)),
+    )
+    assert (
+        _require_rectangle_selects_root(original.embedding.root, wider_evidence)
+        == "NEGATIVE_IMAGINARY"
+    )
+
+    alternate_record = ComplexNumberFieldEmbeddingRecord(
+        embedding=original.embedding,
+        isolating_rectangle=wider_evidence,
+        half_plane="NEGATIVE_IMAGINARY",
+    )
+
+    assert alternate_record.embedding == original.embedding
+    assert alternate_record.isolating_rectangle != original.isolating_rectangle
+    assert "isolating_rectangle" not in original.embedding.model_dump()
+
+
+def test_reduced_elements_compose_with_selected_embedding_without_backend_values() -> (
+    None
+):
+    field = _field("1", "0", "1")
+    profile = embeddings(field)
+    positive = profile.records[1]
+    assert isinstance(positive, ComplexNumberFieldEmbeddingRecord)
+    element = SimpleNumberFieldElement(
+        presentation=field,
+        coefficients_ascending=(_rational(Fraction(1, 2)), _rational(1)),
+    )
+
+    image = EmbeddedSimpleNumberFieldElement(
+        element=element,
+        embedding=positive.embedding,
+    )
+
+    assert image.evaluation == "POWER_BASIS_AT_SELECTED_ROOT"
+    assert image.embedding.root.root_index == 1
+    assert (
+        EmbeddedSimpleNumberFieldElement.model_validate_json(image.model_dump_json())
+        == image
+    )
+    assert "isolating_rectangle" not in image.model_dump_json()
+
+
+def test_projective_curve_2870_prerequisite_preserves_gaussian_coordinate_triples() -> (
+    None
+):
+    field = _field("1", "0", "1")
+    negative_record, positive_record = embeddings(field).records
+    assert isinstance(negative_record, ComplexNumberFieldEmbeddingRecord)
+    assert isinstance(positive_record, ComplexNumberFieldEmbeddingRecord)
+    one = SimpleNumberFieldElement(
+        presentation=field,
+        coefficients_ascending=(_rational(1), _rational(0)),
+    )
+    alpha = SimpleNumberFieldElement(
+        presentation=field,
+        coefficients_ascending=(_rational(0), _rational(1)),
+    )
+    zero = SimpleNumberFieldElement(
+        presentation=field,
+        coefficients_ascending=(_rational(0), _rational(0)),
+    )
+
+    coordinate_adapter = TypeAdapter(
+        tuple[
+            EmbeddedSimpleNumberFieldElement,
+            EmbeddedSimpleNumberFieldElement,
+            EmbeddedSimpleNumberFieldElement,
+        ]
+    )
+
+    def embedded_coordinates(
+        record: ComplexNumberFieldEmbeddingRecord,
+    ) -> tuple[
+        EmbeddedSimpleNumberFieldElement,
+        EmbeddedSimpleNumberFieldElement,
+        EmbeddedSimpleNumberFieldElement,
+    ]:
+        return tuple(
+            EmbeddedSimpleNumberFieldElement(
+                element=coordinate,
+                embedding=record.embedding,
+            )
+            for coordinate in (one, alpha, zero)
+        )
+
+    negative_coordinates = embedded_coordinates(negative_record)
+    positive_coordinates = embedded_coordinates(positive_record)
+    restored_negative = coordinate_adapter.validate_json(
+        encode_strict_json(
+            coordinate_adapter.dump_python(negative_coordinates, mode="json")
+        ),
+        strict=True,
+    )
+    restored_positive = coordinate_adapter.validate_json(
+        encode_strict_json(
+            coordinate_adapter.dump_python(positive_coordinates, mode="json")
+        ),
+        strict=True,
+    )
+
+    assert restored_negative == negative_coordinates
+    assert restored_positive == positive_coordinates
+    assert restored_negative[1].embedding.root.root_index == 0
+    assert restored_positive[1].embedding.root.root_index == 1
+    assert restored_negative[1].embedding != restored_positive[1].embedding
+    for coordinate in (*restored_negative, *restored_positive):
+        assert coordinate.element.presentation == field
+        assert coordinate.embedding.presentation == field
+
+
+def test_embedded_element_rejects_a_different_field_presentation() -> None:
+    gaussian = _field("1", "0", "1")
+    positive = embeddings(gaussian).records[1]
+    assert isinstance(positive, ComplexNumberFieldEmbeddingRecord)
+    rational_element = SimpleNumberFieldElement(
+        presentation=_field("1", "0"),
+        coefficients_ascending=(_rational(1),),
+    )
+
+    with pytest.raises(ValidationError, match="share one presentation"):
+        EmbeddedSimpleNumberFieldElement(
+            element=rational_element,
+            embedding=positive.embedding,
+        )
+
+
+def test_reducible_nonprimitive_and_malformed_elements_are_rejected() -> None:
+    with pytest.raises(ValidationError, match="irreducible"):
+        _field("1", "0", "-1")
+    with pytest.raises(ValidationError, match="primitive"):
+        _field("2", "0", "2")
+    with pytest.raises(ValidationError, match="positive leading"):
+        _field("-1", "0", "-1")
+    with pytest.raises(ValidationError, match="exactly one coefficient"):
+        SimpleNumberFieldElement(
+            presentation=_field("1", "0", "1"),
+            coefficients_ascending=(_rational(1),),
+        )
+
+
+def test_malformed_overlapping_wrong_root_and_wrong_sign_evidence_are_rejected() -> (
+    None
+):
+    result = embeddings(_field("1", "0", "1"))
+    negative, positive = result.records
+    assert isinstance(negative, ComplexNumberFieldEmbeddingRecord)
+    assert isinstance(positive, ComplexNumberFieldEmbeddingRecord)
+
+    with pytest.raises(ValueError, match="selected indexed root"):
+        _require_rectangle_selects_root(
+            negative.embedding.root,
+            positive.isolating_rectangle,
+        )
+
+    overlapping = RationalComplexIsolatingRectangle(
+        real_lower=_rational(-1),
+        real_upper=_rational(1),
+        imaginary_lower=_rational(-2),
+        imaginary_upper=_rational(2),
+    )
+    with pytest.raises(ValueError, match="exactly one root"):
+        _require_rectangle_selects_root(negative.embedding.root, overlapping)
+
+    wrong_sign = negative.model_dump(mode="json")
+    wrong_sign["half_plane"] = "POSITIVE_IMAGINARY"
+    with pytest.raises(ValidationError, match="half-plane"):
+        ComplexNumberFieldEmbeddingRecord.model_validate(wrong_sign)
+
+    boundary_root = RationalComplexIsolatingRectangle(
+        real_lower=_rational(0),
+        real_upper=_rational(Fraction(1, 2)),
+        imaginary_lower=_rational(-1),
+        imaginary_upper=_rational(Fraction(-1, 2)),
+    )
+    with pytest.raises(ValueError, match="selected indexed root"):
+        _require_rectangle_selects_root(negative.embedding.root, boundary_root)
+
+    oversized = negative.model_dump(mode="json")
+    oversized["isolating_rectangle"]["real_lower"]["num"] = "1" * 4_097
+    with pytest.raises(ValidationError, match="4,096-digit bound"):
+        ComplexNumberFieldEmbeddingRecord.model_validate(oversized)
+
+    oversized_component = CanonicalRational(num="-1", den="9" * 4_097)
+    with pytest.raises(ValidationError, match="4,096-digit bound"):
+        RationalComplexIsolatingRectangle(
+            real_lower=oversized_component,
+            real_upper=_rational(1),
+            imaginary_lower=_rational(-2),
+            imaginary_upper=_rational(-1),
+        )
+
+
+def test_real_interval_is_bound_to_the_selected_real_root() -> None:
+    result = embeddings(_field("1", "0", "-2"))
+    negative, positive = result.records
+    assert isinstance(negative, RealNumberFieldEmbeddingRecord)
+    assert isinstance(positive, RealNumberFieldEmbeddingRecord)
+    with pytest.raises(ValueError, match="indexed root"):
+        _require_real_interval_selects_root(
+            negative.embedding,
+            positive.isolating_interval,
+        )
+
+    oversized = negative.model_dump(mode="json")
+    oversized["isolating_interval"]["lower"]["num"] = "1" * 4_097
+    with pytest.raises(ValidationError, match="4,096-digit bound"):
+        RealNumberFieldEmbeddingRecord.model_validate(oversized)
+
+    oversized_component = CanonicalRational(num="-1", den="9" * 4_097)
+    with pytest.raises(ValidationError, match="4,096-digit bound"):
+        RealNumberFieldEmbeddingRecord(
+            embedding=negative.embedding,
+            isolating_interval=RationalIsolatingInterval(
+                lower=oversized_component,
+                upper=_rational(0),
+                interval_type="OPEN",
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "coefficients",
+    [
+        ("1", "0", "5", "0", "5"),
+        ("1", "0", "0", "-1", "1"),
+    ],
+)
+def test_profiles_are_deterministic_across_backend_cache_refinement(
+    coefficients: tuple[str, ...],
+) -> None:
+    field = _field(*coefficients)
+    first = embeddings(field).model_dump_json()
+
+    import sympy
+
+    variable = sympy.Symbol("a")
+    polynomial = sympy.Poly.from_list(
+        [int(coefficient) for coefficient in coefficients],
+        variable,
+    )
+    for root in polynomial.all_roots(radicals=False):
+        root.eval_rational(n=40)
+
+    assert embeddings(field).model_dump_json() == first
+
+
+def test_profile_and_canonical_values_round_trip_without_backend_objects() -> None:
+    profile = embeddings(_field("1", "0", "-1", "1"))
+    encoded = encode_strict_json(profile.model_dump(mode="json"))
+
+    restored = NumberFieldEmbeddingProfile.model_validate_json(
+        encoded,
+        strict=True,
+    )
+
+    assert restored == profile
+    assert "CRootOf" not in profile.model_dump_json()
+    assert "sympy" not in profile.model_dump_json().lower()
+
+
+def test_profile_structural_validation_rejects_an_incomplete_result() -> None:
+    profile = embeddings(_field("1", "0", "1"))
+    incomplete = profile.model_dump(mode="json")
+    incomplete["records"].pop()
+    with pytest.raises(ValidationError, match="degree-many"):
+        NumberFieldEmbeddingProfile.model_validate(incomplete)
+
+
+def test_degree_coefficient_isolation_work_and_result_bounds_are_preflighted() -> None:
+    # The minimal polynomial of zeta_17 + zeta_17^-1 is irreducible of degree
+    # eight and totally real, so it exercises the closed degree boundary
+    # without making this unit test duplicate the complex-order stress case.
+    degree_eight = _field("1", "1", "-7", "-5", "15", "6", "-10", "-1", "1")
+    admission = _admit_number_field_embeddings(degree_eight)
+
+    assert admission.degree == 8
+    assert admission.isolator_component_digits <= 4_096
+    assert admission.real_part_resultant_storage_bits <= (
+        MAX_NUMBER_FIELD_REAL_PART_RESULTANT_STORAGE_BITS
+    )
+    assert admission.root_refinement_precision_bits <= (
+        MAX_NUMBER_FIELD_ROOT_REFINEMENT_BITS
+    )
+    assert admission.root_refinement_bit_work == (
+        admission.root_refinement_calls * admission.root_refinement_precision_bits
+    )
+    assert admission.predicted_result_bytes <= MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES
+    degree_eight_result = embeddings(degree_eight)
+    assert (
+        len(encode_strict_json(degree_eight_result.model_dump(mode="json")))
+        <= admission.predicted_result_bytes
+    )
+
+    with pytest.raises(ValidationError):
+        _field("1", *("0",) * 8, "2")
+    with pytest.raises(ValidationError, match="256 digits"):
+        _field("1", "0", "1" + "0" * 256)
+    with pytest.raises(ValidationError, match="256 digits"):
+        SimpleNumberFieldElement.model_validate(
+            {
+                "presentation": _field("1", "0").model_dump(mode="json"),
+                "coefficients_ascending": [{"num": "1" * 257, "den": "1"}],
+            }
+        )
+
+    # Eisenstein at 2: this is a valid 256-digit defining polynomial, but its
+    # exact all-root ordering plan is immediately rejected before expansion by
+    # the separately derived work/intermediate envelope.
+    large_eisenstein = _field("1", *("0",) * 7, str(10**255 + 2))
+    with pytest.raises(NumberFieldEmbeddingAdmissionError) as caught:
+        _admit_number_field_embeddings(large_eisenstein)
+    assert caught.value.reason == "pair_ordering_precision_bound"
+
+
+@pytest.mark.parametrize(
+    "coefficients",
+    [
+        ("1", "0"),
+        ("9" * 256, "1"),
+        ("1", "0", "-2"),
+        ("1", "0", "1"),
+        ("1", "0", "-1", "1"),
+        ("1", "0", "5", "0", "5"),
+        ("1", "1", "-7", "-5", "15", "6", "-10", "-1", "1"),
+    ],
+)
+def test_every_kernel_isolator_replays_and_result_stays_below_preflight_bound(
+    coefficients: tuple[str, ...],
+) -> None:
+    field = _field(*coefficients)
+    admission = _admit_number_field_embeddings(field)
+    result = embeddings(field)
+    encoded = encode_strict_json(result.model_dump(mode="json"))
+
+    assert len(encoded) <= admission.predicted_result_bytes
+    assert (
+        NumberFieldEmbeddingProfile.model_validate_json(encoded, strict=True) == result
+    )
+    for record in result.records:
+        if isinstance(record, RealNumberFieldEmbeddingRecord):
+            _require_real_interval_selects_root(
+                record.embedding,
+                record.isolating_interval,
+            )
+        else:
+            assert (
+                _require_rectangle_selects_root(
+                    record.embedding.root,
+                    record.isolating_rectangle,
+                )
+                == record.half_plane
+            )
+
+
+def test_catalog_operation_exposes_and_runs_the_advertised_gaussian_example() -> None:
+    operation = Catalog.open().operation("number_field.embeddings.compute")
+    assert operation is not None
+    example = operation.examples[0]
+    request = NumberFieldEmbeddingsRequest.model_validate(example.input)
+
+    result = operation.run(request)
+
+    assert isinstance(result, NumberFieldEmbeddingProfile)
+    assert result.signature.complex_conjugate_pair_count == 1
+    assert result.defining_polynomial_discriminant == "-4"
+
+
+def test_catalog_operation_projects_owner_local_admission_rejection() -> None:
+    operation = Catalog.open().operation("number_field.embeddings.compute")
+    assert operation is not None
+    field = _field("1", *("0",) * 7, str(10**255 + 2))
+    request = NumberFieldEmbeddingsRequest(field=field)
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        operation.run(request)
+
+    assert caught.value.errors()[0]["loc"] == ("field",)
+    assert str(caught.value.errors()[0]["type"]).startswith("number_field.embeddings.")
+
+
+def test_embedding_union_keeps_the_selected_parent_context() -> None:
+    profile = embeddings(_field("1", "0", "1"))
+    record = profile.records[1]
+    assert isinstance(record, ComplexNumberFieldEmbeddingRecord)
+
+    embedding = ComplexNumberFieldEmbedding.model_validate_json(
+        record.embedding.model_dump_json()
+    )
+
+    assert embedding.presentation == profile.field
+    assert embedding.root.polynomial == profile.field.coefficients_descending

--- a/tests/process/geometry/test_projective_singularity_point_worker.py
+++ b/tests/process/geometry/test_projective_singularity_point_worker.py
@@ -1,0 +1,125 @@
+"""Process-boundary tests for exact projective singular-point construction."""
+
+from __future__ import annotations
+
+import threading
+from fractions import Fraction
+from time import monotonic
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_process import (
+    run_point_construction_worker,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_worker import (
+    ProjectiveSingularityPointWorkerRequest,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+from jacobian.process import bounded_process_cancellation
+
+
+def _polynomial(
+    variables: tuple[str, ...],
+    *terms: tuple[int, tuple[int, ...]],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(num=str(coefficient), den="1"),
+                    exponents=exponents,
+                )
+                for coefficient, exponents in terms
+            )
+        ),
+    )
+
+
+def _conjugate_point_request() -> ProjectiveSingularityPointWorkerRequest:
+    axis = ("X", "Y", "Z")
+    source = _polynomial(
+        axis,
+        (1, (2, 0, 1)),
+        (1, (0, 2, 1)),
+        (1, (0, 0, 3)),
+    )
+    partials = (
+        _polynomial(axis, (2, (1, 0, 1))),
+        _polynomial(axis, (2, (0, 1, 1))),
+        _polynomial(
+            axis,
+            (1, (2, 0, 0)),
+            (1, (0, 2, 0)),
+            (3, (0, 0, 2)),
+        ),
+    )
+    component = RationalPolynomialIdeal(
+        variables=("Y", "Z"),
+        generators=(
+            _polynomial(("Y", "Z"), (1, (2, 0)), (1, (0, 0))),
+            _polynomial(("Y", "Z"), (1, (0, 1))),
+        ),
+    )
+    return ProjectiveSingularityPointWorkerRequest(
+        source=source,
+        partials=partials,
+        chart_zero_components=(component,),
+        chart_one_components=(),
+        chart_two_present=False,
+    )
+
+
+def test_point_worker_returns_one_exact_quadratic_residue_field_seed() -> None:
+    result = run_point_construction_worker(
+        _conjugate_point_request(),
+        deadline=monotonic() + 30,
+    )
+
+    assert result.kind == "complete"
+    assert len(result.seeds) == 1
+    seed = result.seeds[0]
+    assert seed.presentation.coefficients_descending == ("1", "0", "1")
+    assert tuple(
+        tuple(
+            coefficient.as_fraction()
+            for coefficient in coordinate.coefficients_ascending
+        )
+        for coordinate in seed.coordinates
+    ) == (
+        (Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(1)),
+        (Fraction(0), Fraction(0)),
+    )
+
+
+def test_expired_point_worker_deadline_fails_before_launch() -> None:
+    with pytest.raises(OperationExecutionTimeoutError):
+        run_point_construction_worker(
+            _conjugate_point_request(),
+            deadline=monotonic() - 1,
+        )
+
+
+def test_point_worker_preserves_request_cancellation() -> None:
+    cancellation = threading.Event()
+    cancellation.set()
+
+    with (
+        bounded_process_cancellation(cancellation),
+        pytest.raises(OperationExecutionCancelledError),
+    ):
+        run_point_construction_worker(
+            _conjugate_point_request(),
+            deadline=monotonic() + 30,
+        )

--- a/tests/process/polynomials/ideals/test_singular_process.py
+++ b/tests/process/polynomials/ideals/test_singular_process.py
@@ -111,6 +111,19 @@ def test_timeout_is_not_reported_as_a_mathematical_result(
     assert result.ideal is None
 
 
+def test_exhausted_shared_deadline_does_not_launch_singular() -> None:
+    result = run_singular_ideal_operation(
+        "radical",
+        _ideal(),
+        None,
+        IdealComputationBudget(wall_seconds=60),
+        wall_seconds=0.0,
+    )
+
+    assert result.outcome == "TIMEOUT"
+    assert result.ideal is None
+
+
 def test_cancellation_is_preserved_as_its_own_outcome(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/process/test_graph_isomorphism_worker.py
+++ b/tests/process/test_graph_isomorphism_worker.py
@@ -21,6 +21,9 @@ from jacobian.math.number_theory._factorization_kernels import (
     factorize_primes,
 )
 from jacobian.math.number_theory.number_fields import (
+    SimpleNumberFieldPresentation,
+)
+from jacobian.math.number_theory.number_fields import (
     _discriminant_process as number_field_operations,
 )
 from jacobian.math.number_theory.number_fields._discriminant_process import (
@@ -28,6 +31,10 @@ from jacobian.math.number_theory.number_fields._discriminant_process import (
 )
 from jacobian.math.number_theory.number_fields._models import NumberFieldRequest
 from jacobian.process import BoundedProcessResult, ProcessResourceLimits
+
+
+def _number_field(*coefficients: str) -> SimpleNumberFieldPresentation:
+    return SimpleNumberFieldPresentation(coefficients_descending=coefficients)
 
 
 def test_vf2_worker_obtains_a_positive_witness_in_one_search_traversal() -> None:
@@ -212,7 +219,7 @@ def test_timed_out_number_field_worker_is_an_unknown_non_conclusion(
     )
 
     result = compute_nf_discriminant(
-        NumberFieldRequest(coefficients_descending=("1", "0", "-2"), variable="x")
+        NumberFieldRequest(field=_number_field("1", "0", "-2"))
     )
 
     assert result.status == "UNKNOWN"
@@ -238,7 +245,7 @@ def test_number_field_worker_has_private_cwd_and_os_resource_limits(
     monkeypatch.setattr(process, "run_bounded_process", complete_worker)
 
     result = compute_nf_discriminant(
-        NumberFieldRequest(coefficients_descending=("1", "0", "-2"), variable="x")
+        NumberFieldRequest(field=_number_field("1", "0", "-2"))
     )
 
     assert result.discriminant == "8"
@@ -259,7 +266,7 @@ def test_number_field_worker_start_failure_is_an_unknown_non_conclusion(
     monkeypatch.setattr(process, "run_bounded_process", unavailable)
 
     result = compute_nf_discriminant(
-        NumberFieldRequest(coefficients_descending=("1", "0", "-2"), variable="x")
+        NumberFieldRequest(field=_number_field("1", "0", "-2"))
     )
 
     assert result.status == "UNKNOWN"

--- a/tests/process/test_number_field_embeddings_worker.py
+++ b/tests/process/test_number_field_embeddings_worker.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import time
+
 import pytest
 
 import jacobian.process as process
-from jacobian._execution import OperationExecutionTimeoutError
+from jacobian._execution import OperationExecutionTimeoutError, request_execution
 from jacobian.math.number_theory.number_fields import (
     SimpleNumberFieldPresentation,
     embeddings,
@@ -34,6 +36,19 @@ def test_embedding_worker_timeout_is_an_operational_failure(
     )
 
     with pytest.raises(OperationExecutionTimeoutError, match="during"):
+        embeddings(_gaussian_field())
+
+
+def test_deadline_expiry_immediately_before_worker_launch_is_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = iter((119.0, 119.5, 120.5))
+    monkeypatch.setattr(time, "monotonic", lambda: next(clock))
+
+    with (
+        request_execution(started_at=0.0),
+        pytest.raises(OperationExecutionTimeoutError, match=r"before.*launch"),
+    ):
         embeddings(_gaussian_field())
 
 

--- a/tests/process/test_number_field_embeddings_worker.py
+++ b/tests/process/test_number_field_embeddings_worker.py
@@ -1,0 +1,69 @@
+"""Failure semantics for the one-shot number-field embedding worker."""
+
+from __future__ import annotations
+
+import pytest
+
+import jacobian.process as process
+from jacobian._execution import OperationExecutionTimeoutError
+from jacobian.math.number_theory.number_fields import (
+    SimpleNumberFieldPresentation,
+    embeddings,
+)
+from jacobian.process import BoundedProcessResult
+
+
+def _gaussian_field() -> SimpleNumberFieldPresentation:
+    return SimpleNumberFieldPresentation(coefficients_descending=("1", "0", "1"))
+
+
+def test_embedding_worker_timeout_is_an_operational_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        process,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    with pytest.raises(OperationExecutionTimeoutError, match="during"):
+        embeddings(_gaussian_field())
+
+
+def test_embedding_worker_start_failure_does_not_escape_as_os_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        raise OSError("worker unavailable")
+
+    monkeypatch.setattr(process, "run_bounded_process", unavailable)
+
+    with pytest.raises(RuntimeError, match="could not be started"):
+        embeddings(_gaussian_field())
+
+
+def test_embedding_worker_rejects_malformed_protocol_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        process,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=0,
+            stdout=b'\x7b"kind":"complete"\x7d',
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="malformed output"):
+        embeddings(_gaussian_field())


### PR DESCRIPTION
## Problem

Part of #1689. Jacobian has exact arithmetic for presented number fields, but it cannot identify a selected nonreal embedding in a canonical public value. That blocks consumers which must retain algebraic-closure points rather than silently restrict to rational points. In particular, #2870 needs to distinguish and serialize the two singular points `[1:-i:0]` and `[1:i:0]` of a rational projective cubic.

The existing number-field discriminant request also owns a separate flat polynomial shape and caller-selected variable, so its result cannot compose directly with a future embedding carrier.

## Solution

Add `number_field.embeddings.compute` for primitive irreducible presentations of `QQ(alpha)` of degree at most 8. It returns every Archimedean embedding, the exact signature and conjugate-pair grouping, certified rational intervals or rectangles, and the defining-polynomial discriminant.

Embedding identity is independent of its isolator. A real embedding uses the increasing real-root index. A nonreal embedding uses a global root index: real roots first, then conjugate pairs ordered by the exact `(Re, Im)` coordinates of their positive-imaginary representative, with the negative root first in each pair. The public `EmbeddedSimpleNumberFieldElement` combines reduced power-basis coordinates with one selected embedding, so downstream values retain the complete parent and branch choice.

One disposable worker uses SymPy 1.14 for irreducibility, an exact Sturm signature, conditional real-coordinate elimination, one all-root isolation pass, and the defining-polynomial discriminant. Only a compact strict projection crosses the process boundary. Public result parsing is structural and does not rerun SymPy. The adapter receives the absolute request deadline and recomputes its remaining budget immediately before launch; an expiry in that transition is a typed timeout rather than a host `ValueError`.

The shared `SimpleNumberFieldPresentation` also becomes the input to the existing discriminant and native integral-basis functions. This intentionally changes the pre-stable discriminant request from flat `coefficients_descending` plus `variable` to `{field: {domain, coefficients_descending}}`; the fixed internal symbol is `alpha`. Nonmonic primitive presentations are supported through the integral generator `beta = a*alpha` rather than being excluded by the carrier.

This PR does not close #1689. Conjugate-value profiles, Minkowski coordinates, order recognition, order-ideal arithmetic, and rational-prime splitting remain deferred there.

Suggested review order:

1. `values.py` and `algebraic_numbers/complex.py` for canonical identity and structural parsing.
2. `_embeddings_worker.py`, `_embeddings_process.py`, and `operations.py` for exact ordering, admission, and deadline ownership.
3. `_models.py` and `_tools.py` for the public request and catalog contract.
4. `test_embeddings.py` for defining invariants, bounds, serialization, and the #2870 regression.

## Testing

```sh
make handoff LANE=math TESTS='tests/math/number_theory/number_fields/test_embeddings.py tests/integration/algebra/test_exact_operations.py'
make test-process TESTS=tests/process/test_number_field_embeddings_worker.py
make import-contracts
```

The final tree passed Ruff, format checking, mypy over 980 source files, 62 focused mathematical/integration tests, 4 process tests, and all 4 import contracts. Fixtures cover `QQ`, `QQ(sqrt(2))`, `QQ(i)`, a mixed-signature cubic, deterministic ordering of multiple complex pairs, a degree-8 boundary field, reducible and over-bound inputs, nonmonic composition, compact worker output, structural round trips without SymPy, and typed cancellation/deadline failures.

- Specialist validation run: the process lane above exercises the killable worker and the deadline-transition regression.

## Public contract impact

- Adds the native `embeddings(field)` function and `number_field.embeddings.compute`.
- Adds canonical simple-field, field-element, real/complex embedding, embedding-profile, isolator, and embedded-element values.
- Changes `number_field.discriminant.compute` and the native discriminant/integral-basis functions to consume `SimpleNumberFieldPresentation` directly.
- Native and direct-MCP calls use the same admission, kernel, and exact result.

## Operation boundary ownership

- Changed stage: canonical request values, request bounds, kernel adapter, result construction, catalog publication, and native API.
- Request-bounds owner and controlling quantities: `number_fields`; degree, coefficient digits, root-separation precision, real-coordinate resultant size, exact isolator size, worker projection bytes, and retained-source result bytes.
- Work, intermediate, memory, and exact-output bounds: degree 8 and 256 coefficient digits for complete embeddings; 32,768-bit refinement, 2,097,152-bit resultant storage, a 1 GiB worker address-space limit, bounded stdout/stderr/files, and a 10,485,760-byte canonical result envelope.
- Wall deadline, calibration workload, safety margin, and caller-selectable range: one request-scoped 120-second owner deadline, shared by admission and the disposable worker; there is no caller-selected wall-time field.
- Backend or kernel path: maintained SymPy exact polynomial algorithms inside a one-shot bounded Python process.
- Result construction: the worker returns only strict rational root evidence and a discriminant; the owner constructs canonical indexed roots, bindings, and pair records through trusted factories and rejects malformed projections.
- Independent-result verifier: none; no independently supplied mathematical result is accepted.
- Native/MCP parity: identical semantic admission and results; MCP only performs strict request/result projection.
- Serialized-result and round-trip evidence: complete profiles and embedded Gaussian coordinate triples round-trip through strict JSON while preserving distinct root indices; every retained result is checked against its preflight byte bound.

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Advertised codomain is closed under the result types, including required parent, embedding, branch, orientation, basis, or coordinate data
- [x] Producer→consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: primitive positive-leading bounded `ZZ[x]` shape is structural; the worker recognizes irreducibility before treating `QQ[x]/(f)` as a field.
- Structurally valid but mathematically invalid fixture and outcome: a reducible primitive presentation is rejected as `number_field.embeddings.not_irreducible`, not parsed by result validators and not turned into a partial profile.
- Serialized-subtype trust boundary: ordinary values validate bounded canonical structure only; the source-bound producer establishes irreducibility, signature, ordering, isolation, and completeness inside its admitted worker.
- Exact-success defining invariant: there are exactly `degree(f)` records, `r1 + 2*r2 = degree(f)`, each root identity uses `f` and its canonical index, and every declared conjugate pair carries reflected exact rectangles in the required half-planes.
- Discriminated result schema and impossible combinations: real and complex embeddings/records require explicit `kind` discriminators; profile validators reject wrong parents, incomplete degree, mixed ordering, inconsistent signature, unmatched conjugates, wrong half-planes, and contradictory pair indices.

## Catalog admission

- Concrete gap: no public value or operation can identify a selected nonreal embedding or return every embedding of a presented field.
- Why existing operations or typed values are insufficient: real algebraic roots do not encode nonreal branches, the discriminant operation returns one scalar, and floating complex approximations cannot be canonical algebraic identity.
- Stable mathematical result: the complete ordered Archimedean embedding profile of one bounded simple-field presentation.
- Semantic domain and admitted execution envelope: primitive irreducible simple presentations over `QQ`; complete profiles currently admit degree at most 8 under the explicit work and output budgets above.
- Controlling work, intermediate, memory, and output quantities: separation/refinement bits, elimination-resultant degree and coefficient height, worker limits, degree-many retained presentations and isolators, and strict serialized bytes.
- Exact representation, algorithm regimes, and maintained backend: indexed primitive-polynomial roots plus rational isolation evidence; SymPy exact Sturm, resultant, isolation, irreducibility, and discriminant kernels.
- Remaining fixed caps and their classification: degree 8, 32,768 refinement bits, and 2,097,152 resultant bits are documented conservative execution-envelope caps, not restrictions on the mathematical definition.
- Motivating source request exercised through the public boundary: #2870's Gaussian-field singular coordinates.
- Final-tree outcome for that request: `[1:-i:0]` and `[1:i:0]` survive strict serialization with different exact embedding indices and the same canonical field parent.
- Effect of private normalization or presolve on admission: the presentation fixes the primitive positive-leading scalar representative; static bounds are computed before the worker, and worker recognition/order refinement cannot broaden the admitted envelope.
- Admission decision: publish one atomic complete-embedding operation; leave the rest of #1689 open.

## Closure matrix

This is a partial delivery and does not close the broad parent issue.

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Complete exact embedding profile | delivered | `number_field.embeddings.compute` |
| Element conjugates and Minkowski coordinates | deferred | #1689 |
| Order recognition and order-ideal arithmetic | deferred | #1689 |
| Rational-prime splitting | deferred | #1689 |

## Checklist

- [x] `make handoff LANE=... TESTS=...` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Catalog changes have an explicit owner-local `_tools.py` publication outcome
- [x] No compatibility aliases, forwarding modules, or generic `_operations.py` shadow paths were introduced
- [x] Runtime-bound changes name the request-bounds owner and execute the same semantic path for native and MCP callers
- [x] Result semantics distinguish mathematical rejection from timeout, cancellation, malformed-worker, and unavailable outcomes
- [x] The public operation includes the motivating #2870 Gaussian-embedding regression
- [x] New bounds include boundary, deterministic ordering, and realistic source-backed evidence
- [x] The shared field presentation replaces duplicate request shapes across embeddings, discriminant, and integral-basis consumers
