### PR TITLE
Compute exact projective plane-curve singular loci

### DIFF
--- a/docs/reference/operations/geometry/index.md
+++ b/docs/reference/operations/geometry/index.md
@@ -3,3 +3,4 @@
 [Documentation home](../../../index.md) · [Tool surface](../../tools.md)
 
 - [Exact planar geometry](exact-planar-geometry.md)
+- [Projective plane-curve singularity profiles](projective-plane-curve-singularities.md)

--- a/docs/reference/operations/geometry/projective-plane-curve-singularities.md
+++ b/docs/reference/operations/geometry/projective-plane-curve-singularities.md
@@ -75,9 +75,14 @@ terms, a fifteen-monomial homogeneous Macaulay layer, coefficient growth from a
 Hadamard minor bound followed by Landau–Mignotte factor growth, quotient degree
 four, at most seven separating-form attempts, and the retained exact result.
 The derived coordinate components remain below the number-field carrier's
-256-digit limit. Two retained 512-KiB Singular protocol projections plus JSON
-expansion and four embedded-point records remain below the canonical 10-MiB
-transport boundary.
+256-digit limit. Every decoded ideal is checked against the same plan before it
+can enter point construction or a result: at most 64 generators and 1,024
+aggregate terms, generator degree at most four, and rational coefficient
+components no wider than the derived Macaulay-minor bound. Admission prices the
+largest retained saturation and component family from those limits, plus four
+embedded-point records and fixed JSON framing. A maximal-shape canonical
+serialization remains below the 10-MiB transport boundary; an output that
+contradicts the plan becomes a stage-specific `LIMIT_EXCEEDED` outcome.
 
 All Singular calls and exact point construction share one request-scoped
 deadline. Singular and the one-shot SymPy point worker are killable and have

--- a/docs/reference/operations/geometry/projective-plane-curve-singularities.md
+++ b/docs/reference/operations/geometry/projective-plane-curve-singularities.md
@@ -1,0 +1,94 @@
+# Projective plane-curve singularity profiles
+
+[Documentation home](../../../index.md) · [Tool surface](../../tools.md)
+
+`algebraic_geometry.projective_plane_curve.singularity_profile.compute`
+computes the complete projective singular locus of one bounded homogeneous
+polynomial `F` in `QQ[X,Y,Z]`. The geometric scope is the algebraic closure of
+`QQ`; this is not a search for rational singular points.
+
+The returned profile retains the primitive positive-leading integer scalar
+representative of `F`, the ordered projective axis, all three exact partial
+derivatives, and the saturated homogeneous Jacobian ideal
+
+```text
+<F, F_X, F_Y, F_Z> : <X,Y,Z>^infinity.
+```
+
+It then has one mathematical outcome:
+
+- `SMOOTH_OVER_ALGEBRAIC_CLOSURE` retains the unit ideal `<1>`, whose
+  projective zero locus is empty.
+- `SINGULAR_ZERO_DIMENSIONAL` returns every geometric point in a disjoint
+  three-chart cover. Each point has a canonical first-nonzero-coordinate
+  normalization, one exact presented number field, one indexed real or complex
+  embedding, and an exact zero first jet.
+- `SINGULAR_POSITIVE_DIMENSIONAL` retains the exact saturated ideal,
+  projective dimension one, and its complete family of rational minimal
+  components. The saturated ideal remains the authoritative geometric-locus
+  evidence; the rational components are not advertised as an absolute
+  decomposition.
+
+Backend unavailability, cancellation, timeout, malformed output, and output
+limit exhaustion are separate typed operational outcomes. None implies
+smoothness or absence of a singular point.
+
+## Exact finite-point construction
+
+The finite branch uses the disjoint charts `X=1`, then `X=0,Y=1`, then
+`X=Y=0,Z=1`. Singular 4.4 computes the projective saturation and the rational
+minimal primes of each retained chart. A zero-dimensional rational prime is a
+number-field residue algebra. A deterministic separating form gives a
+univariate irreducible presentation and reduced power-basis expressions for
+the remaining coordinates. Enumerating that presentation's exact embeddings
+then enumerates every geometric point in the prime's Galois orbit.
+
+For example, the curve
+
+```text
+Z (X^2 + Y^2 + Z^2) = 0
+```
+
+returns two distinct points with the shared presentation
+`QQ(alpha)=QQ[x]/(x^2+1)`: `[1:alpha:0]` under root indexes zero and one. Thus
+`[1:-i:0]` and `[1:i:0]` survive strict JSON serialization as different
+embedded points.
+
+Before returning a point, the kernel substitutes its reduced coordinates into
+`F` and every partial and reduces exactly modulo the defining polynomial. The
+four remainders must all vanish. Numerical matching and backend root objects do
+not cross the public boundary.
+
+## Execution envelope
+
+The first envelope admits nonzero homogeneous ternary polynomials of degree one
+through three, at most ten sparse terms, at most sixteen digits per raw rational
+coefficient component, and at most eight digits after primitive integer scalar
+normalization. The degree bound is tied to the complete finite-result
+obligation: Bézout bounds the zero-dimensional Jacobian locus by
+`(degree-1)^2 <= 4`, matching the degree-four residue-field and four-point
+carriers.
+
+Admission derives one execution plan before launching Singular. In the largest
+cubic case it charges four Jacobian generators, at most forty source/partial
+terms, a fifteen-monomial homogeneous Macaulay layer, coefficient growth from a
+Hadamard minor bound followed by Landau–Mignotte factor growth, quotient degree
+four, at most seven separating-form attempts, and the retained exact result.
+The derived coordinate components remain below the number-field carrier's
+256-digit limit. Two retained 512-KiB Singular protocol projections plus JSON
+expansion and four embedded-point records remain below the canonical 10-MiB
+transport boundary.
+
+All Singular calls and exact point construction share one request-scoped
+deadline. Singular and the one-shot SymPy point worker are killable and have
+fixed diagnostic, address-space, file-size, and exact-output limits. Singular
+is the private exact ideal engine; the isolated SymPy transaction supplies
+factorization, Gröbner shape conversion, and residue-field replay. Public
+identities use only Jacobian's canonical polynomials, ideals, number fields,
+field elements, and embeddings.
+
+The equation is never silently square-free reduced. In characteristic zero a
+projective plane curve has a positive-dimensional singular locus exactly when
+its defining polynomial has a repeated irreducible component; a reduced plane
+curve has only finitely many singular points. This dichotomy selects the result
+branch while the exact saturated ideal remains the defining invariant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,7 @@ ignore_imports = [
     "jacobian.math.combinatorics._counting_process -> jacobian.process",
     "jacobian.math.number_theory.number_fields._discriminant_process -> jacobian.process",
     "jacobian.math.number_theory.number_fields._embeddings_process -> jacobian.process",
+    "jacobian.math.geometry.algebraic_curves._singularity_point_process -> jacobian.process",
     "jacobian.math.number_theory._factorization_kernels -> jacobian.process",
     # Private exact-algebra adapters share one bounded Singular process owner.
     "jacobian.math._singular -> jacobian.process",

--- a/src/jacobian/math/_singular.py
+++ b/src/jacobian/math/_singular.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import shutil
 import tempfile
 from dataclasses import dataclass
@@ -106,7 +107,7 @@ def format_singular_version(version: int) -> str:
 def run_bounded_singular(
     source: bytes,
     *,
-    wall_seconds: int,
+    wall_seconds: float,
 ) -> BoundedProcessResult | None:
     """Run one request-scoped Singular program, or return ``None`` if unavailable."""
 
@@ -127,7 +128,7 @@ def run_bounded_singular(
                 stdout_limit=_STDOUT_LIMIT,
                 stderr_limit=_STDERR_LIMIT,
                 resource_limits=ProcessResourceLimits(
-                    cpu_seconds=wall_seconds,
+                    cpu_seconds=max(1, math.ceil(wall_seconds)),
                     address_space_bytes=_ADDRESS_SPACE_LIMIT,
                     file_size_bytes=_FILE_SIZE_LIMIT,
                 ),

--- a/src/jacobian/math/geometry/algebraic_curves/__init__.py
+++ b/src/jacobian/math/geometry/algebraic_curves/__init__.py
@@ -1,15 +1,23 @@
 """Plane algebraic curve operations."""
 
+from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    ProjectivePlaneCurveSingularityBudget,
+    ProjectivePlaneCurveSingularityProfile,
+)
 from jacobian.math.geometry.algebraic_curves.operations import (
     affine_chart,
     affine_curve_check,
     projective_closure,
     rational_conic_parametrization,
+    singularity_profile,
 )
 
 __all__ = [
+    "ProjectivePlaneCurveSingularityBudget",
+    "ProjectivePlaneCurveSingularityProfile",
     "affine_chart",
     "affine_curve_check",
     "projective_closure",
     "rational_conic_parametrization",
+    "singularity_profile",
 ]

--- a/src/jacobian/math/geometry/algebraic_curves/_models.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_models.py
@@ -9,6 +9,17 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    IncompleteProjectivePlaneCurveSingularityComputation,
+    PositiveDimensionalProjectivePlaneCurveSingularLocus,
+    ProjectivePlaneCurveFirstJet,
+    ProjectivePlaneCurveSingularityBudget,
+    ProjectivePlaneCurveSingularityProfile,
+    ProjectivePlaneCurveSingularityRequest,
+    ProjectivePlaneCurveSingularPointRecord,
+    SmoothProjectivePlaneCurve,
+    ZeroDimensionalProjectivePlaneCurveSingularLocus,
+)
 from jacobian.math.polynomials.maps._models import VariablePoint
 from jacobian.math.polynomials.values import (
     PolynomialVariable,
@@ -288,8 +299,17 @@ __all__ = [
     "AffineChartResult",
     "AffineCurveRequest",
     "AffineCurveResult",
+    "IncompleteProjectivePlaneCurveSingularityComputation",
+    "PositiveDimensionalProjectivePlaneCurveSingularLocus",
     "ProjectiveClosureRequest",
     "ProjectiveClosureResult",
+    "ProjectivePlaneCurveFirstJet",
+    "ProjectivePlaneCurveSingularPointRecord",
+    "ProjectivePlaneCurveSingularityBudget",
+    "ProjectivePlaneCurveSingularityProfile",
+    "ProjectivePlaneCurveSingularityRequest",
     "RationalConicParametrizationRequest",
     "RationalConicParametrizationResult",
+    "SmoothProjectivePlaneCurve",
+    "ZeroDimensionalProjectivePlaneCurveSingularLocus",
 ]

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity.py
@@ -18,7 +18,9 @@ from jacobian._execution import (
     current_request_execution,
     request_execution,
 )
+from jacobian.canonical import CanonicalizationError, encode_strict_json
 from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    MAX_PROJECTIVE_SINGULAR_COMPONENTS,
     MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE,
     MAX_PROJECTIVE_SINGULAR_POINTS,
     IncompleteProjectivePlaneCurveSingularityComputation,
@@ -67,13 +69,15 @@ from jacobian.math.polynomials.values import (
 _MAX_NORMALIZED_SOURCE_COEFFICIENT_DIGITS = 8
 _MAX_BACKEND_GENERATORS = 64
 _MAX_BACKEND_TERMS = 1_024
+_MAX_IDEAL_GENERATOR_DEGREE = 4
 _MAX_POINT_COORDINATE_DIGITS = 256
 _MAX_SHAPE_ATTEMPTS = comb(MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE, 2) + 1
-# Two retained Singular projections can each reach the adapter's concrete
-# 512-KiB capture boundary.  Even after conservative JSON expansion, four
-# degree-four embedded points with 256-digit coordinates, and fixed framing,
-# the profile remains below the canonical 10-MiB transport envelope.
-_PREDICTED_RESULT_BYTES = 3 * 512 * 1_024 + 4 * 128 * 1_024
+_PROFILE_FIXED_BYTES = 64 * 1_024
+_IDEAL_TERM_FRAMING_BYTES = 192
+_IDEAL_GENERATOR_FRAMING_BYTES = 512
+_IDEAL_COMPONENT_FRAMING_BYTES = 256
+_IDEAL_FAMILY_FIXED_BYTES = 4_096
+_CANONICAL_RESULT_BYTES = 10 * 1_024 * 1_024
 
 FailureStage = Literal[
     "SATURATION",
@@ -107,6 +111,7 @@ class _SingularityAdmission:
     jacobian_term_bound: int
     macaulay_matrix_dimension_bound: int
     macaulay_minor_component_digits: int
+    ideal_generator_degree_bound: int
     quotient_degree_bound: int
     geometric_point_bound: int
     shape_attempt_bound: int
@@ -138,6 +143,38 @@ def _normalized_source(polynomial: RationalPolynomial) -> sympy.Poly:
     if primitive.LC() < 0:
         primitive = -primitive
     return sympy.Poly(primitive, *source.gens, domain=sympy.QQ)
+
+
+def _predicted_point_record_bytes() -> int:
+    degree = MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE
+    integer_bytes = _MAX_POINT_COORDINATE_DIGITS + 3
+    rational_bytes = 2 * _MAX_POINT_COORDINATE_DIGITS + 32
+    presentation_bytes = (degree + 1) * integer_bytes + 256
+    element_bytes = presentation_bytes + degree * rational_bytes + 256
+    # The point has three coordinates and its first jet has four values.  An
+    # embedding repeats the presentation once in its indexed root identity.
+    embedding_bytes = 2 * presentation_bytes + 512
+    return embedding_bytes + 7 * element_bytes + 2_048
+
+
+def _predicted_profile_bytes(component_digits: int) -> int:
+    """Bound the largest retained positive- or zero-dimensional profile."""
+
+    term_bytes = 2 * component_digits + _IDEAL_TERM_FRAMING_BYTES
+    ideal_family_bytes = (
+        _IDEAL_FAMILY_FIXED_BYTES
+        + MAX_PROJECTIVE_SINGULAR_COMPONENTS * _IDEAL_COMPONENT_FRAMING_BYTES
+        + _MAX_BACKEND_GENERATORS * _IDEAL_GENERATOR_FRAMING_BYTES
+        + _MAX_BACKEND_TERMS * term_bytes
+    )
+    # The positive branch is the larger ideal shape: one saturation plus one
+    # complete minimal-prime family.  The alternate finite branch replaces the
+    # latter with at most four embedded point records.
+    return (
+        2 * ideal_family_bytes
+        + MAX_PROJECTIVE_SINGULAR_POINTS * _predicted_point_record_bytes()
+        + _PROFILE_FIXED_BYTES
+    )
 
 
 def _admit_singularity(source: sympy.Poly) -> _SingularityAdmission:
@@ -172,6 +209,8 @@ def _admit_singularity(source: sympy.Poly) -> _SingularityAdmission:
             "the derived elimination minors exceed the 256-digit point-carrier bound"
         )
 
+    predicted_result_bytes = _predicted_profile_bytes(minor_digits)
+
     quotient_degree = (degree - 1) ** 2
     admission = _SingularityAdmission(
         degree=degree,
@@ -181,17 +220,18 @@ def _admit_singularity(source: sympy.Poly) -> _SingularityAdmission:
         jacobian_term_bound=4 * source_terms,
         macaulay_matrix_dimension_bound=macaulay_dimension,
         macaulay_minor_component_digits=minor_digits,
+        ideal_generator_degree_bound=_MAX_IDEAL_GENERATOR_DEGREE,
         quotient_degree_bound=quotient_degree,
         geometric_point_bound=quotient_degree,
         shape_attempt_bound=comb(quotient_degree, 2) + 1,
-        predicted_result_bytes=_PREDICTED_RESULT_BYTES,
+        predicted_result_bytes=predicted_result_bytes,
         has_repeated_component=not source.is_sqf,
     )
     if (
         admission.quotient_degree_bound > MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE
         or admission.geometric_point_bound > MAX_PROJECTIVE_SINGULAR_POINTS
         or admission.shape_attempt_bound > _MAX_SHAPE_ATTEMPTS
-        or admission.predicted_result_bytes >= 10 * 1_024 * 1_024
+        or admission.predicted_result_bytes >= _CANONICAL_RESULT_BYTES
     ):
         raise _SingularityAdmissionError(
             "the derived quotient, point, shape, or exact-result envelope is exceeded"
@@ -247,6 +287,57 @@ def _is_unit_ideal(ideal: RationalPolynomialIdeal) -> bool:
     )
 
 
+def _ideal_projection_limit_failure(
+    stage: FailureStage,
+    ideals: tuple[RationalPolynomialIdeal, ...],
+    admission: _SingularityAdmission,
+    *,
+    maximum_ideals: int,
+) -> IncompleteProjectivePlaneCurveSingularityComputation | None:
+    """Reject a decoded ideal family that contradicts the admitted plan."""
+
+    if len(ideals) > maximum_ideals:
+        return _limit_failure(
+            stage,
+            "the exact ideal family exceeds the admitted component bound",
+        )
+    generator_count = sum(len(ideal.generators) for ideal in ideals)
+    term_count = sum(
+        len(generator.polynomial.terms)
+        for ideal in ideals
+        for generator in ideal.generators
+    )
+    if generator_count > _MAX_BACKEND_GENERATORS:
+        return _limit_failure(
+            stage,
+            "the exact ideal family exceeds the admitted generator bound",
+        )
+    if term_count > _MAX_BACKEND_TERMS:
+        return _limit_failure(
+            stage,
+            "the exact ideal family exceeds the admitted term bound",
+        )
+    for ideal in ideals:
+        for generator in ideal.generators:
+            for term in generator.polynomial.terms:
+                if sum(term.exponents) > admission.ideal_generator_degree_bound:
+                    return _limit_failure(
+                        stage,
+                        "an exact ideal generator exceeds the admitted degree bound",
+                    )
+                if (
+                    len(term.coefficient.num.lstrip("-"))
+                    > admission.macaulay_minor_component_digits
+                    or len(term.coefficient.den)
+                    > admission.macaulay_minor_component_digits
+                ):
+                    return _limit_failure(
+                        stage,
+                        "an exact ideal coefficient exceeds the admitted Macaulay bound",
+                    )
+    return None
+
+
 def _failure(
     stage: FailureStage,
     backend: SingularIdealResult | SingularMinimalPrimesResult,
@@ -279,12 +370,13 @@ def _local_failure(
     )
 
 
-def _local_limit_failure(
+def _limit_failure(
+    stage: FailureStage,
     detail: str,
 ) -> IncompleteProjectivePlaneCurveSingularityComputation:
     return IncompleteProjectivePlaneCurveSingularityComputation(
         status="LIMIT_EXCEEDED",
-        stage="POINT_CONSTRUCTION",
+        stage=stage,
         detail=detail[:256],
     )
 
@@ -409,6 +501,7 @@ def _records_from_worker_seeds(
 def _complete_zero_dimensional_points(
     saturation: RationalPolynomialIdeal,
     *,
+    admission: _SingularityAdmission,
     source: RationalPolynomial,
     partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
     axis: tuple[str, str, str],
@@ -431,6 +524,15 @@ def _complete_zero_dimensional_points(
     )
     if chart_zero_primes.outcome != "COMPUTED":
         return _failure("CHART_ZERO_COMPONENTS", chart_zero_primes)
+    chart_zero_components = chart_zero_primes.components or ()
+    projection_failure = _ideal_projection_limit_failure(
+        "CHART_ZERO_COMPONENTS",
+        chart_zero_components,
+        admission,
+        maximum_ideals=MAX_PROJECTIVE_SINGULAR_POINTS,
+    )
+    if projection_failure is not None:
+        return projection_failure
 
     chart_one = _specialize_ideal(
         saturation,
@@ -444,12 +546,21 @@ def _complete_zero_dimensional_points(
     )
     if chart_one_primes.outcome != "COMPUTED":
         return _failure("CHART_ONE_COMPONENTS", chart_one_primes)
+    chart_one_components = chart_one_primes.components or ()
+    projection_failure = _ideal_projection_limit_failure(
+        "CHART_ONE_COMPONENTS",
+        chart_one_components,
+        admission,
+        maximum_ideals=MAX_PROJECTIVE_SINGULAR_POINTS,
+    )
+    if projection_failure is not None:
+        return projection_failure
 
     worker_request = ProjectiveSingularityPointWorkerRequest(
         source=source,
         partials=partials,
-        chart_zero_components=chart_zero_primes.components or (),
-        chart_one_components=chart_one_primes.components or (),
+        chart_zero_components=chart_zero_components,
+        chart_one_components=chart_one_components,
         chart_two_present=_chart_two_is_present(saturation),
     )
     worker_response = run_point_construction_worker(
@@ -475,6 +586,76 @@ def _profile(
         partials=partials,
         outcome=outcome,
     )
+
+
+def _positive_dimensional_outcome(
+    saturation: RationalPolynomialIdeal,
+    *,
+    admission: _SingularityAdmission,
+    budget: IdealComputationBudget,
+    deadline: float,
+) -> ProjectivePlaneCurveSingularityOutcome:
+    components_backend = run_singular_minimal_primes(
+        saturation,
+        budget,
+        wall_seconds=_remaining(deadline),
+    )
+    if components_backend.outcome != "COMPUTED":
+        return _failure("PROJECTIVE_COMPONENTS", components_backend)
+    components = components_backend.components or ()
+    projection_failure = _ideal_projection_limit_failure(
+        "PROJECTIVE_COMPONENTS",
+        components,
+        admission,
+        maximum_ideals=MAX_PROJECTIVE_SINGULAR_COMPONENTS,
+    )
+    if projection_failure is not None:
+        return projection_failure
+    if not components:
+        return _local_failure(
+            "a repeated component produced no rational minimal component"
+        )
+    return PositiveDimensionalProjectivePlaneCurveSingularLocus._from_kernel(
+        ideal=saturation,
+        components=components,
+    )
+
+
+def _bounded_result_profile(
+    *,
+    source: RationalPolynomial,
+    partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
+    outcome: ProjectivePlaneCurveSingularityOutcome,
+    admission: _SingularityAdmission,
+    deadline: float,
+) -> ProjectivePlaneCurveSingularityProfile:
+    if _remaining(deadline) <= 0:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_timeout_failure("RESULT_CONSTRUCTION"),
+        )
+    profile = _profile(source=source, partials=partials, outcome=outcome)
+    try:
+        encoded_bytes = len(encode_strict_json(profile.model_dump(mode="json")))
+    except CanonicalizationError:
+        encoded_bytes = _CANONICAL_RESULT_BYTES + 1
+    if encoded_bytes > admission.predicted_result_bytes:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_limit_failure(
+                "RESULT_CONSTRUCTION",
+                "the exact singularity profile exceeds its admitted byte bound",
+            ),
+        )
+    if _remaining(deadline) <= 0:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_timeout_failure("RESULT_CONSTRUCTION"),
+        )
+    return profile
 
 
 def _singularity_profile_request(
@@ -540,33 +721,25 @@ def _singularity_profile_request(
             outcome=_failure("SATURATION", saturation_backend),
         )
     saturation = saturation_backend.ideal
+    projection_failure = _ideal_projection_limit_failure(
+        "SATURATION",
+        (saturation,),
+        admission,
+        maximum_ideals=1,
+    )
+    if projection_failure is not None:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=projection_failure,
+        )
 
     if admission.has_repeated_component:
-        components_backend = run_singular_minimal_primes(
+        outcome: ProjectivePlaneCurveSingularityOutcome = _positive_dimensional_outcome(
             saturation,
-            budget,
-            wall_seconds=_remaining(deadline),
-        )
-        if components_backend.outcome != "COMPUTED":
-            return _profile(
-                source=source,
-                partials=partials,
-                outcome=_failure("PROJECTIVE_COMPONENTS", components_backend),
-            )
-        components = components_backend.components or ()
-        if not components:
-            return _profile(
-                source=source,
-                partials=partials,
-                outcome=_local_failure(
-                    "a repeated component produced no rational minimal component"
-                ),
-            )
-        outcome: ProjectivePlaneCurveSingularityOutcome = (
-            PositiveDimensionalProjectivePlaneCurveSingularLocus._from_kernel(
-                ideal=saturation,
-                components=components,
-            )
+            admission=admission,
+            budget=budget,
+            deadline=deadline,
         )
     elif _is_unit_ideal(saturation):
         outcome = SmoothProjectivePlaneCurve._from_kernel(saturation)
@@ -574,6 +747,7 @@ def _singularity_profile_request(
         try:
             points = _complete_zero_dimensional_points(
                 saturation,
+                admission=admission,
                 source=source,
                 partials=partials,
                 axis=axis,
@@ -586,7 +760,7 @@ def _singularity_profile_request(
         except OperationExecutionCancelledError:
             outcome = _cancelled_failure("POINT_CONSTRUCTION")
         except PointConstructionLimitError as exc:
-            outcome = _local_limit_failure(str(exc))
+            outcome = _limit_failure("POINT_CONSTRUCTION", str(exc))
         except (ValueError, TypeError, ArithmeticError, RuntimeError):
             outcome = _local_failure(
                 "exact point construction rejected malformed backend algebra"
@@ -600,13 +774,13 @@ def _singularity_profile_request(
                     points=points,
                 )
 
-    if _remaining(deadline) <= 0:
-        return _profile(
-            source=source,
-            partials=partials,
-            outcome=_timeout_failure("RESULT_CONSTRUCTION"),
-        )
-    return _profile(source=source, partials=partials, outcome=outcome)
+    return _bounded_result_profile(
+        source=source,
+        partials=partials,
+        outcome=outcome,
+        admission=admission,
+        deadline=deadline,
+    )
 
 
 def singularity_profile(

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity.py
@@ -1,0 +1,629 @@
+"""Exact bounded singular-locus kernel for projective plane curves."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from math import comb
+from time import monotonic
+from typing import Literal
+
+import sympy
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_execution,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE,
+    MAX_PROJECTIVE_SINGULAR_POINTS,
+    IncompleteProjectivePlaneCurveSingularityComputation,
+    PositiveDimensionalProjectivePlaneCurveSingularLocus,
+    ProjectivePlaneCurveFirstJet,
+    ProjectivePlaneCurveSingularityBudget,
+    ProjectivePlaneCurveSingularityOutcome,
+    ProjectivePlaneCurveSingularityProfile,
+    ProjectivePlaneCurveSingularityRequest,
+    ProjectivePlaneCurveSingularPointRecord,
+    SmoothProjectivePlaneCurve,
+    ZeroDimensionalProjectivePlaneCurveSingularLocus,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_process import (
+    PointConstructionLimitError,
+    run_point_construction_worker,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_worker import (
+    ProjectiveSingularityPointSeed,
+    ProjectiveSingularityPointWorkerRequest,
+)
+from jacobian.math.geometry.projective.values import AlgebraicProjectivePlanePoint
+from jacobian.math.number_theory.number_fields.operations import embeddings
+from jacobian.math.number_theory.number_fields.values import (
+    NumberFieldEmbeddingProfile,
+    SimpleNumberFieldElement,
+)
+from jacobian.math.polynomials._conversions import (
+    rational_polynomial_from_sympy,
+    rational_polynomial_to_sympy,
+)
+from jacobian.math.polynomials.ideals._models import IdealComputationBudget
+from jacobian.math.polynomials.ideals._singular import (
+    SingularIdealResult,
+    SingularMinimalPrimesResult,
+    run_singular_ideal_operation,
+    run_singular_minimal_primes,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+_MAX_NORMALIZED_SOURCE_COEFFICIENT_DIGITS = 8
+_MAX_BACKEND_GENERATORS = 64
+_MAX_BACKEND_TERMS = 1_024
+_MAX_POINT_COORDINATE_DIGITS = 256
+_MAX_SHAPE_ATTEMPTS = comb(MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE, 2) + 1
+# Two retained Singular projections can each reach the adapter's concrete
+# 512-KiB capture boundary.  Even after conservative JSON expansion, four
+# degree-four embedded points with 256-digit coordinates, and fixed framing,
+# the profile remains below the canonical 10-MiB transport envelope.
+_PREDICTED_RESULT_BYTES = 3 * 512 * 1_024 + 4 * 128 * 1_024
+
+FailureStage = Literal[
+    "SATURATION",
+    "PROJECTIVE_COMPONENTS",
+    "CHART_ZERO_COMPONENTS",
+    "CHART_ONE_COMPONENTS",
+    "POINT_CONSTRUCTION",
+    "RESULT_CONSTRUCTION",
+]
+FailureStatus = Literal[
+    "BACKEND_UNAVAILABLE",
+    "TIMEOUT",
+    "CANCELLED",
+    "LIMIT_EXCEEDED",
+    "BACKEND_ERROR",
+]
+
+
+class _SingularityAdmissionError(ValueError):
+    """The normalized request exceeds the derived execution envelope."""
+
+
+@dataclass(frozen=True, slots=True)
+class _SingularityAdmission:
+    """One derived execution proof reused by every kernel phase."""
+
+    degree: int
+    source_terms: int
+    normalized_coefficient_digits: int
+    jacobian_generator_bound: int
+    jacobian_term_bound: int
+    macaulay_matrix_dimension_bound: int
+    macaulay_minor_component_digits: int
+    quotient_degree_bound: int
+    geometric_point_bound: int
+    shape_attempt_bound: int
+    predicted_result_bytes: int
+    has_repeated_component: bool
+
+
+def _remaining(deadline: float) -> float:
+    return deadline - monotonic()
+
+
+def _deadline_for(request: ProjectivePlaneCurveSingularityRequest) -> float:
+    execution = current_request_execution()
+    started = execution.started_at if execution is not None else monotonic()
+    owner_deadline = started + request.resource_budget.wall_seconds
+    deadline = (
+        min(owner_deadline, execution.deadline)
+        if execution is not None and execution.deadline is not None
+        else owner_deadline
+    )
+    bind_request_deadline(deadline)
+    return deadline
+
+
+def _normalized_source(polynomial: RationalPolynomial) -> sympy.Poly:
+    source = rational_polynomial_to_sympy(polynomial)
+    _denominator, integer_source = source.clear_denoms(convert=True)
+    _content, primitive = integer_source.primitive()
+    if primitive.LC() < 0:
+        primitive = -primitive
+    return sympy.Poly(primitive, *source.gens, domain=sympy.QQ)
+
+
+def _admit_singularity(source: sympy.Poly) -> _SingularityAdmission:
+    """Derive intermediate, quotient, point, and exact-result bounds once."""
+
+    degree = int(source.total_degree())
+    source_terms = len(source.terms())
+    coefficient_height = max(abs(int(coefficient)) for coefficient in source.coeffs())
+    coefficient_digits = len(str(coefficient_height))
+    if coefficient_digits > _MAX_NORMALIZED_SOURCE_COEFFICIENT_DIGITS:
+        raise _SingularityAdmissionError(
+            "primitive source coefficients exceed the derived 8-digit elimination envelope"
+        )
+
+    # For ternary cubics, the relevant homogeneous Macaulay layer through
+    # degree four has C(4+2,2)=15 monomials.  Hadamard bounds a 15-square
+    # minor by (3H)^15 * 15^8; Landau-Mignotte factor growth for a degree-four
+    # eliminant contributes at most (n+1)2^n.  This bounds both numerator and
+    # denominator components used by the residue-field coordinates.
+    macaulay_dimension = 15
+    minor_bound = (3 * max(coefficient_height, 1)) ** macaulay_dimension * (
+        macaulay_dimension**8
+    )
+    factor_bound = (
+        (MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE + 1)
+        * 2**MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE
+        * minor_bound
+    )
+    minor_digits = len(str(factor_bound))
+    if minor_digits > _MAX_POINT_COORDINATE_DIGITS:
+        raise _SingularityAdmissionError(
+            "the derived elimination minors exceed the 256-digit point-carrier bound"
+        )
+
+    quotient_degree = (degree - 1) ** 2
+    admission = _SingularityAdmission(
+        degree=degree,
+        source_terms=source_terms,
+        normalized_coefficient_digits=coefficient_digits,
+        jacobian_generator_bound=4,
+        jacobian_term_bound=4 * source_terms,
+        macaulay_matrix_dimension_bound=macaulay_dimension,
+        macaulay_minor_component_digits=minor_digits,
+        quotient_degree_bound=quotient_degree,
+        geometric_point_bound=quotient_degree,
+        shape_attempt_bound=comb(quotient_degree, 2) + 1,
+        predicted_result_bytes=_PREDICTED_RESULT_BYTES,
+        has_repeated_component=not source.is_sqf,
+    )
+    if (
+        admission.quotient_degree_bound > MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE
+        or admission.geometric_point_bound > MAX_PROJECTIVE_SINGULAR_POINTS
+        or admission.shape_attempt_bound > _MAX_SHAPE_ATTEMPTS
+        or admission.predicted_result_bytes >= 10 * 1_024 * 1_024
+    ):
+        raise _SingularityAdmissionError(
+            "the derived quotient, point, shape, or exact-result envelope is exceeded"
+        )
+    return admission
+
+
+def _to_public_polynomial(
+    polynomial: sympy.Poly,
+    variables: tuple[str, ...],
+) -> RationalPolynomial:
+    return rational_polynomial_from_sympy(
+        polynomial,
+        variables,
+        maximum_terms=_MAX_BACKEND_TERMS,
+    )
+
+
+def _variable_polynomial(
+    variables: tuple[str, str, str], index: int
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(num="1", den="1"),
+                    exponents=tuple(1 if slot == index else 0 for slot in range(3)),
+                ),
+            )
+        ),
+    )
+
+
+def _ideal_budget(
+    request: ProjectivePlaneCurveSingularityRequest,
+) -> IdealComputationBudget:
+    return IdealComputationBudget(
+        wall_seconds=request.resource_budget.wall_seconds,
+        maximum_output_generators=_MAX_BACKEND_GENERATORS,
+        maximum_output_terms=_MAX_BACKEND_TERMS,
+    )
+
+
+def _is_unit_ideal(ideal: RationalPolynomialIdeal) -> bool:
+    if len(ideal.generators) != 1:
+        return False
+    terms = ideal.generators[0].polynomial.terms
+    return (
+        len(terms) == 1
+        and not any(terms[0].exponents)
+        and terms[0].coefficient.as_fraction() != 0
+    )
+
+
+def _failure(
+    stage: FailureStage,
+    backend: SingularIdealResult | SingularMinimalPrimesResult,
+) -> IncompleteProjectivePlaneCurveSingularityComputation:
+    status: FailureStatus
+    if backend.outcome == "UNAVAILABLE":
+        status = "BACKEND_UNAVAILABLE"
+    elif backend.outcome == "TIMEOUT":
+        status = "TIMEOUT"
+    elif backend.outcome == "CANCELLED":
+        status = "CANCELLED"
+    elif backend.outcome == "LIMIT_EXCEEDED":
+        status = "LIMIT_EXCEEDED"
+    else:
+        status = "BACKEND_ERROR"
+    return IncompleteProjectivePlaneCurveSingularityComputation(
+        status=status,
+        stage=stage,
+        detail=backend.detail or "the exact backend did not produce a complete result",
+    )
+
+
+def _local_failure(
+    detail: str,
+) -> IncompleteProjectivePlaneCurveSingularityComputation:
+    return IncompleteProjectivePlaneCurveSingularityComputation(
+        status="BACKEND_ERROR",
+        stage="POINT_CONSTRUCTION",
+        detail=detail[:256],
+    )
+
+
+def _local_limit_failure(
+    detail: str,
+) -> IncompleteProjectivePlaneCurveSingularityComputation:
+    return IncompleteProjectivePlaneCurveSingularityComputation(
+        status="LIMIT_EXCEEDED",
+        stage="POINT_CONSTRUCTION",
+        detail=detail[:256],
+    )
+
+
+def _timeout_failure(
+    stage: FailureStage,
+) -> IncompleteProjectivePlaneCurveSingularityComputation:
+    return IncompleteProjectivePlaneCurveSingularityComputation(
+        status="TIMEOUT",
+        stage=stage,
+        detail="the shared projective singularity deadline expired",
+    )
+
+
+def _cancelled_failure(
+    stage: FailureStage,
+) -> IncompleteProjectivePlaneCurveSingularityComputation:
+    return IncompleteProjectivePlaneCurveSingularityComputation(
+        status="CANCELLED",
+        stage=stage,
+        detail="the projective singularity request was cancelled",
+    )
+
+
+def _specialize_ideal(
+    ideal: RationalPolynomialIdeal,
+    *,
+    substitutions: dict[int, int],
+    remaining_indices: tuple[int, ...],
+) -> RationalPolynomialIdeal:
+    remaining_variables = tuple(ideal.variables[index] for index in remaining_indices)
+    generators: list[RationalPolynomial] = []
+    for generator in ideal.generators:
+        coefficients: dict[tuple[int, ...], Fraction] = {}
+        for term in generator.polynomial.terms:
+            if any(
+                value == 0 and term.exponents[index] > 0
+                for index, value in substitutions.items()
+            ):
+                continue
+            exponents = tuple(term.exponents[index] for index in remaining_indices)
+            coefficients[exponents] = (
+                coefficients.get(exponents, Fraction(0))
+                + term.coefficient.as_fraction()
+            )
+        terms = tuple(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational.from_fraction(coefficient),
+                exponents=exponents,
+            )
+            for exponents, coefficient in sorted(coefficients.items(), reverse=True)
+            if coefficient
+        )
+        generators.append(
+            RationalPolynomial(
+                variables=remaining_variables,
+                polynomial=SparseRationalPolynomial(terms=terms),
+            )
+        )
+    return RationalPolynomialIdeal(
+        variables=remaining_variables,
+        generators=tuple(generators),
+    )
+
+
+def _chart_two_is_present(ideal: RationalPolynomialIdeal) -> bool:
+    return all(
+        sum(
+            (
+                term.coefficient.as_fraction()
+                for term in generator.polynomial.terms
+                if term.exponents[0] == 0 and term.exponents[1] == 0
+            ),
+            Fraction(0),
+        )
+        == 0
+        for generator in ideal.generators
+    )
+
+
+def _records_from_worker_seeds(
+    seeds: tuple[ProjectiveSingularityPointSeed, ...],
+    *,
+    axis: tuple[str, str, str],
+    maximum_points: int,
+) -> tuple[ProjectivePlaneCurveSingularPointRecord, ...]:
+    if sum(seed.presentation.degree for seed in seeds) > maximum_points:
+        raise RuntimeError("point worker exceeded the admitted geometric point bound")
+    records: list[ProjectivePlaneCurveSingularPointRecord] = []
+    profiles_by_presentation: dict[str, NumberFieldEmbeddingProfile] = {}
+    for seed in seeds:
+        zero = SimpleNumberFieldElement(
+            presentation=seed.presentation,
+            coefficients_ascending=tuple(
+                CanonicalRational(num="0", den="1")
+                for _ in range(seed.presentation.degree)
+            ),
+        )
+        presentation_key = seed.presentation.model_dump_json()
+        profile = profiles_by_presentation.get(presentation_key)
+        if profile is None:
+            profile = embeddings(seed.presentation)
+            profiles_by_presentation[presentation_key] = profile
+        records.extend(
+            ProjectivePlaneCurveSingularPointRecord(
+                point=AlgebraicProjectivePlanePoint(
+                    axis=axis,
+                    embedding=record.embedding,
+                    coordinates=seed.coordinates,
+                    chart_index=seed.chart_index,
+                ),
+                first_jet=ProjectivePlaneCurveFirstJet._from_kernel(
+                    value=zero,
+                    gradient=(zero, zero, zero),
+                ),
+            )
+            for record in profile.records
+        )
+    return tuple(sorted(records, key=lambda record: record.point.model_dump_json()))
+
+
+def _complete_zero_dimensional_points(
+    saturation: RationalPolynomialIdeal,
+    *,
+    source: RationalPolynomial,
+    partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
+    axis: tuple[str, str, str],
+    budget: IdealComputationBudget,
+    deadline: float,
+    maximum_points: int,
+) -> (
+    tuple[ProjectivePlaneCurveSingularPointRecord, ...]
+    | IncompleteProjectivePlaneCurveSingularityComputation
+):
+    chart_zero = _specialize_ideal(
+        saturation,
+        substitutions={0: 1},
+        remaining_indices=(1, 2),
+    )
+    chart_zero_primes = run_singular_minimal_primes(
+        chart_zero,
+        budget,
+        wall_seconds=_remaining(deadline),
+    )
+    if chart_zero_primes.outcome != "COMPUTED":
+        return _failure("CHART_ZERO_COMPONENTS", chart_zero_primes)
+
+    chart_one = _specialize_ideal(
+        saturation,
+        substitutions={0: 0, 1: 1},
+        remaining_indices=(2,),
+    )
+    chart_one_primes = run_singular_minimal_primes(
+        chart_one,
+        budget,
+        wall_seconds=_remaining(deadline),
+    )
+    if chart_one_primes.outcome != "COMPUTED":
+        return _failure("CHART_ONE_COMPONENTS", chart_one_primes)
+
+    worker_request = ProjectiveSingularityPointWorkerRequest(
+        source=source,
+        partials=partials,
+        chart_zero_components=chart_zero_primes.components or (),
+        chart_one_components=chart_one_primes.components or (),
+        chart_two_present=_chart_two_is_present(saturation),
+    )
+    worker_response = run_point_construction_worker(
+        worker_request,
+        deadline=deadline,
+    )
+    return _records_from_worker_seeds(
+        worker_response.seeds,
+        axis=axis,
+        maximum_points=maximum_points,
+    )
+
+
+def _profile(
+    *,
+    source: RationalPolynomial,
+    partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
+    outcome: ProjectivePlaneCurveSingularityOutcome,
+) -> ProjectivePlaneCurveSingularityProfile:
+    return ProjectivePlaneCurveSingularityProfile._from_kernel(
+        source=source,
+        axis=(source.variables[0], source.variables[1], source.variables[2]),
+        partials=partials,
+        outcome=outcome,
+    )
+
+
+def _singularity_profile_request(
+    request: ProjectivePlaneCurveSingularityRequest,
+) -> ProjectivePlaneCurveSingularityProfile:
+    deadline = _deadline_for(request)
+
+    try:
+        source_backend = _normalized_source(request.polynomial)
+        admission = _admit_singularity(source_backend)
+    except _SingularityAdmissionError as exc:
+        # This is deterministic semantic admission, not a backend failure.
+        from jacobian.catalog.models import OperationDomainValidationError
+
+        raise OperationDomainValidationError(
+            location=("polynomial",),
+            code="projective_plane_curve.normalized_height_bound",
+            message=str(exc),
+        ) from exc
+
+    axis = (
+        request.polynomial.variables[0],
+        request.polynomial.variables[1],
+        request.polynomial.variables[2],
+    )
+    source = _to_public_polynomial(source_backend, axis)
+    partials_backend = (
+        source_backend.diff(source_backend.gens[0]),
+        source_backend.diff(source_backend.gens[1]),
+        source_backend.diff(source_backend.gens[2]),
+    )
+    partials = (
+        _to_public_polynomial(partials_backend[0], axis),
+        _to_public_polynomial(partials_backend[1], axis),
+        _to_public_polynomial(partials_backend[2], axis),
+    )
+    if _remaining(deadline) <= 0:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_timeout_failure("SATURATION"),
+        )
+    budget = _ideal_budget(request)
+    jacobian_ideal = RationalPolynomialIdeal(
+        variables=axis,
+        generators=(source, *partials),
+    )
+    irrelevant_ideal = RationalPolynomialIdeal(
+        variables=axis,
+        generators=tuple(_variable_polynomial(axis, index) for index in range(3)),
+    )
+    saturation_backend = run_singular_ideal_operation(
+        "saturation",
+        jacobian_ideal,
+        irrelevant_ideal,
+        budget,
+        wall_seconds=_remaining(deadline),
+    )
+    if saturation_backend.outcome != "COMPUTED" or saturation_backend.ideal is None:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_failure("SATURATION", saturation_backend),
+        )
+    saturation = saturation_backend.ideal
+
+    if admission.has_repeated_component:
+        components_backend = run_singular_minimal_primes(
+            saturation,
+            budget,
+            wall_seconds=_remaining(deadline),
+        )
+        if components_backend.outcome != "COMPUTED":
+            return _profile(
+                source=source,
+                partials=partials,
+                outcome=_failure("PROJECTIVE_COMPONENTS", components_backend),
+            )
+        components = components_backend.components or ()
+        if not components:
+            return _profile(
+                source=source,
+                partials=partials,
+                outcome=_local_failure(
+                    "a repeated component produced no rational minimal component"
+                ),
+            )
+        outcome: ProjectivePlaneCurveSingularityOutcome = (
+            PositiveDimensionalProjectivePlaneCurveSingularLocus._from_kernel(
+                ideal=saturation,
+                components=components,
+            )
+        )
+    elif _is_unit_ideal(saturation):
+        outcome = SmoothProjectivePlaneCurve._from_kernel(saturation)
+    else:
+        try:
+            points = _complete_zero_dimensional_points(
+                saturation,
+                source=source,
+                partials=partials,
+                axis=axis,
+                budget=budget,
+                deadline=deadline,
+                maximum_points=admission.geometric_point_bound,
+            )
+        except OperationExecutionTimeoutError:
+            outcome = _timeout_failure("POINT_CONSTRUCTION")
+        except OperationExecutionCancelledError:
+            outcome = _cancelled_failure("POINT_CONSTRUCTION")
+        except PointConstructionLimitError as exc:
+            outcome = _local_limit_failure(str(exc))
+        except (ValueError, TypeError, ArithmeticError, RuntimeError):
+            outcome = _local_failure(
+                "exact point construction rejected malformed backend algebra"
+            )
+        else:
+            if isinstance(points, IncompleteProjectivePlaneCurveSingularityComputation):
+                outcome = points
+            else:
+                outcome = ZeroDimensionalProjectivePlaneCurveSingularLocus._from_kernel(
+                    ideal=saturation,
+                    points=points,
+                )
+
+    if _remaining(deadline) <= 0:
+        return _profile(
+            source=source,
+            partials=partials,
+            outcome=_timeout_failure("RESULT_CONSTRUCTION"),
+        )
+    return _profile(source=source, partials=partials, outcome=outcome)
+
+
+def singularity_profile(
+    polynomial: RationalPolynomial,
+    resource_budget: ProjectivePlaneCurveSingularityBudget | None = None,
+) -> ProjectivePlaneCurveSingularityProfile:
+    """Compute the complete geometric singular locus of one admitted curve."""
+
+    started = monotonic()
+    request = ProjectivePlaneCurveSingularityRequest(
+        polynomial=polynomial,
+        resource_budget=resource_budget or ProjectivePlaneCurveSingularityBudget(),
+    )
+    if current_request_execution() is not None:
+        return _singularity_profile_request(request)
+    with request_execution(started):
+        return _singularity_profile_request(request)
+
+
+__all__ = ["singularity_profile"]

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity_models.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity_models.py
@@ -1,0 +1,398 @@
+"""Typed contracts for exact projective plane-curve singular loci."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import Field, StrictInt, StringConstraints, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.geometry.projective.values import AlgebraicProjectivePlanePoint
+from jacobian.math.number_theory.number_fields.values import SimpleNumberFieldElement
+from jacobian.math.polynomials.values import (
+    PolynomialVariable,
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+    require_polynomial_budget,
+)
+
+MAX_PROJECTIVE_PLANE_CURVE_DEGREE = 3
+MAX_PROJECTIVE_PLANE_CURVE_TERMS = 10
+MAX_PROJECTIVE_PLANE_CURVE_COEFFICIENT_DIGITS = 16
+MAX_PROJECTIVE_SINGULAR_POINTS = 4
+MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE = 4
+MAX_PROJECTIVE_SINGULARITY_WALL_SECONDS = 60
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"projective_plane_curve.{reason}", message)
+
+
+class ProjectivePlaneCurveSingularityBudget(StrictModel):
+    """The one request-scoped wall deadline for all exact backend phases."""
+
+    wall_seconds: StrictInt = Field(
+        default=30,
+        ge=1,
+        le=MAX_PROJECTIVE_SINGULARITY_WALL_SECONDS,
+        description=(
+            "One shared deadline, in seconds, covering saturation, prime "
+            "decomposition, exact point construction, and serialization."
+        ),
+    )
+
+
+class ProjectivePlaneCurveSingularityRequest(StrictModel):
+    """One bounded nonzero homogeneous ternary polynomial over ``QQ``."""
+
+    polynomial: RationalPolynomial = Field(
+        description=(
+            "A nonzero homogeneous polynomial in exactly three ordered variables. "
+            "The first envelope admits total degree 1 through 3, at most 10 terms, "
+            "and at most 16 digits in each rational coefficient component."
+        )
+    )
+    resource_budget: ProjectivePlaneCurveSingularityBudget = Field(
+        default_factory=ProjectivePlaneCurveSingularityBudget
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_term_bound(cls, data: Any) -> Any:
+        if not isinstance(data, Mapping):
+            return data
+        polynomial = data.get("polynomial")
+        if isinstance(polynomial, Mapping):
+            sparse = polynomial.get("polynomial")
+            if isinstance(sparse, Mapping):
+                terms = sparse.get("terms")
+                if isinstance(terms, (list, tuple)) and len(terms) > (
+                    MAX_PROJECTIVE_PLANE_CURVE_TERMS
+                ):
+                    raise _validation_error(
+                        "term_bound",
+                        "projective plane-curve source exceeds the 10-term envelope",
+                    )
+        return canonicalize_json_containers(data)
+
+    @model_validator(mode="after")
+    def require_backend_domain(self) -> Self:
+        try:
+            require_polynomial_budget(
+                self.polynomial,
+                maximum_terms=MAX_PROJECTIVE_PLANE_CURVE_TERMS,
+                maximum_exponent=MAX_PROJECTIVE_PLANE_CURVE_DEGREE,
+                maximum_coefficient_digits=(
+                    MAX_PROJECTIVE_PLANE_CURVE_COEFFICIENT_DIGITS
+                ),
+                label="projective plane-curve source",
+            )
+        except ValueError as exc:
+            raise _validation_error("source_bound", str(exc)) from exc
+        if len(self.polynomial.variables) != 3:
+            raise _validation_error(
+                "axis",
+                "a projective plane curve requires exactly three ordered variables",
+            )
+        terms = self.polynomial.polynomial.terms
+        if not terms:
+            raise _validation_error(
+                "zero_source", "the zero polynomial does not define a plane curve"
+            )
+        total_degrees = {sum(term.exponents) for term in terms}
+        if len(total_degrees) != 1:
+            raise _validation_error(
+                "homogeneity", "the projective plane-curve source must be homogeneous"
+            )
+        degree = next(iter(total_degrees))
+        if not 1 <= degree <= MAX_PROJECTIVE_PLANE_CURVE_DEGREE:
+            raise _validation_error(
+                "degree_bound",
+                "the first projective singularity envelope admits degree 1 through 3",
+            )
+        return self
+
+
+class ProjectivePlaneCurveFirstJet(StrictModel):
+    """The exact value and ordered first partials at one algebraic point."""
+
+    value: SimpleNumberFieldElement
+    gradient: tuple[
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+    ]
+
+    @model_validator(mode="after")
+    def require_one_field(self) -> Self:
+        presentation = self.value.presentation
+        entries = (self.value, *self.gradient)
+        if any(entry.presentation != presentation for entry in entries):
+            raise _validation_error(
+                "first_jet_field",
+                "a projective first jet must use one number-field presentation",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        value: SimpleNumberFieldElement,
+        gradient: tuple[
+            SimpleNumberFieldElement,
+            SimpleNumberFieldElement,
+            SimpleNumberFieldElement,
+        ],
+    ) -> Self:
+        """Construct the exact zero jet after owner-local replay established it."""
+
+        return cls.model_construct(value=value, gradient=gradient)
+
+
+class ProjectivePlaneCurveSingularPointRecord(StrictModel):
+    """One normalized geometric singular point and its exact zero first jet."""
+
+    point: AlgebraicProjectivePlanePoint
+    first_jet: ProjectivePlaneCurveFirstJet
+
+    @model_validator(mode="after")
+    def bind_point_and_jet(self) -> Self:
+        if self.first_jet.value.presentation != self.point.embedding.presentation:
+            raise _validation_error(
+                "point_jet_field",
+                "a singular point and its first jet must share one field presentation",
+            )
+        return self
+
+
+class SmoothProjectivePlaneCurve(StrictModel):
+    status: Literal["SMOOTH_OVER_ALGEBRAIC_CLOSURE"]
+    saturated_jacobian_ideal: RationalPolynomialIdeal
+
+    @classmethod
+    def _from_kernel(cls, ideal: RationalPolynomialIdeal) -> Self:
+        """Construct the smooth branch after the kernel established ``<1>``."""
+
+        return cls.model_construct(
+            status="SMOOTH_OVER_ALGEBRAIC_CLOSURE",
+            saturated_jacobian_ideal=ideal,
+        )
+
+
+class ZeroDimensionalProjectivePlaneCurveSingularLocus(StrictModel):
+    status: Literal["SINGULAR_ZERO_DIMENSIONAL"]
+    saturated_jacobian_ideal: RationalPolynomialIdeal
+    projective_dimension: Literal[0] = 0
+    points: tuple[ProjectivePlaneCurveSingularPointRecord, ...] = Field(
+        min_length=1, max_length=MAX_PROJECTIVE_SINGULAR_POINTS
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_complete_point_family(self) -> Self:
+        keys = tuple(record.point.model_dump_json() for record in self.points)
+        if keys != tuple(sorted(keys)) or len(set(keys)) != len(keys):
+            raise _validation_error(
+                "point_order",
+                "singular points must be unique and canonically ordered",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        ideal: RationalPolynomialIdeal,
+        points: tuple[ProjectivePlaneCurveSingularPointRecord, ...],
+    ) -> Self:
+        """Construct the finite branch after exact chart enumeration."""
+
+        return cls.model_construct(
+            status="SINGULAR_ZERO_DIMENSIONAL",
+            saturated_jacobian_ideal=ideal,
+            projective_dimension=0,
+            points=points,
+        )
+
+
+class PositiveDimensionalProjectivePlaneCurveSingularLocus(StrictModel):
+    status: Literal["SINGULAR_POSITIVE_DIMENSIONAL"]
+    saturated_jacobian_ideal: RationalPolynomialIdeal
+    affine_cone_dimension: Literal[2] = 2
+    projective_dimension: Literal[1] = 1
+    rational_minimal_components: tuple[RationalPolynomialIdeal, ...] = Field(
+        min_length=1, max_length=16
+    )
+
+    @model_validator(mode="after")
+    def bind_component_ring(self) -> Self:
+        if any(
+            component.variables != self.saturated_jacobian_ideal.variables
+            for component in self.rational_minimal_components
+        ):
+            raise _validation_error(
+                "component_axis",
+                "all rational minimal components must use the projective axis",
+            )
+        keys = tuple(
+            component.model_dump_json()
+            for component in self.rational_minimal_components
+        )
+        if keys != tuple(sorted(keys)) or len(set(keys)) != len(keys):
+            raise _validation_error(
+                "component_order",
+                "rational minimal components must be unique and canonically ordered",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        ideal: RationalPolynomialIdeal,
+        components: tuple[RationalPolynomialIdeal, ...],
+    ) -> Self:
+        """Construct the positive-dimensional branch after exact decomposition."""
+
+        return cls.model_construct(
+            status="SINGULAR_POSITIVE_DIMENSIONAL",
+            saturated_jacobian_ideal=ideal,
+            affine_cone_dimension=2,
+            projective_dimension=1,
+            rational_minimal_components=components,
+        )
+
+
+SafeExecutionDetail = Annotated[
+    str,
+    StringConstraints(min_length=1, max_length=256, strict=True),
+]
+
+
+class IncompleteProjectivePlaneCurveSingularityComputation(StrictModel):
+    status: Literal[
+        "BACKEND_UNAVAILABLE",
+        "TIMEOUT",
+        "CANCELLED",
+        "LIMIT_EXCEEDED",
+        "BACKEND_ERROR",
+    ]
+    stage: Literal[
+        "SATURATION",
+        "PROJECTIVE_COMPONENTS",
+        "CHART_ZERO_COMPONENTS",
+        "CHART_ONE_COMPONENTS",
+        "POINT_CONSTRUCTION",
+        "RESULT_CONSTRUCTION",
+    ]
+    detail: SafeExecutionDetail
+
+
+ProjectivePlaneCurveSingularityOutcome = Annotated[
+    SmoothProjectivePlaneCurve
+    | ZeroDimensionalProjectivePlaneCurveSingularLocus
+    | PositiveDimensionalProjectivePlaneCurveSingularLocus
+    | IncompleteProjectivePlaneCurveSingularityComputation,
+    Field(discriminator="status"),
+]
+
+
+class ProjectivePlaneCurveSingularityProfile(StrictModel):
+    """A source-bound exact global singular-locus computation over ``QQbar``."""
+
+    source_polynomial: RationalPolynomial
+    axis: tuple[
+        PolynomialVariable,
+        PolynomialVariable,
+        PolynomialVariable,
+    ]
+    partial_derivatives: tuple[
+        RationalPolynomial,
+        RationalPolynomial,
+        RationalPolynomial,
+    ]
+    base_field: Literal["QQ"] = "QQ"
+    geometric_scope: Literal["ALGEBRAIC_CLOSURE"] = "ALGEBRAIC_CLOSURE"
+    outcome: ProjectivePlaneCurveSingularityOutcome
+
+    @model_validator(mode="after")
+    def bind_profile_axis(self) -> Self:
+        if self.source_polynomial.variables != self.axis:
+            raise _validation_error(
+                "source_axis", "the normalized source must use the declared axis"
+            )
+        if any(
+            derivative.variables != self.axis for derivative in self.partial_derivatives
+        ):
+            raise _validation_error(
+                "partial_axis", "all partial derivatives must use the source axis"
+            )
+        mathematical = (
+            SmoothProjectivePlaneCurve,
+            ZeroDimensionalProjectivePlaneCurveSingularLocus,
+            PositiveDimensionalProjectivePlaneCurveSingularLocus,
+        )
+        if (
+            isinstance(self.outcome, mathematical)
+            and self.outcome.saturated_jacobian_ideal.variables != self.axis
+        ):
+            raise _validation_error(
+                "saturation_axis",
+                "the saturated Jacobian ideal must use the source axis",
+            )
+        if isinstance(
+            self.outcome, ZeroDimensionalProjectivePlaneCurveSingularLocus
+        ) and any(record.point.axis != self.axis for record in self.outcome.points):
+            raise _validation_error(
+                "point_axis", "every singular point must use the source axis"
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source: RationalPolynomial,
+        axis: tuple[
+            PolynomialVariable,
+            PolynomialVariable,
+            PolynomialVariable,
+        ],
+        partials: tuple[
+            RationalPolynomial,
+            RationalPolynomial,
+            RationalPolynomial,
+        ],
+        outcome: ProjectivePlaneCurveSingularityOutcome,
+    ) -> Self:
+        """Construct one trusted profile after its exact kernel transaction."""
+
+        return cls.model_construct(
+            source_polynomial=source,
+            axis=axis,
+            partial_derivatives=partials,
+            base_field="QQ",
+            geometric_scope="ALGEBRAIC_CLOSURE",
+            outcome=outcome,
+        )
+
+
+__all__ = [
+    "MAX_PROJECTIVE_PLANE_CURVE_COEFFICIENT_DIGITS",
+    "MAX_PROJECTIVE_PLANE_CURVE_DEGREE",
+    "MAX_PROJECTIVE_PLANE_CURVE_TERMS",
+    "MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE",
+    "MAX_PROJECTIVE_SINGULAR_POINTS",
+    "IncompleteProjectivePlaneCurveSingularityComputation",
+    "PositiveDimensionalProjectivePlaneCurveSingularLocus",
+    "ProjectivePlaneCurveFirstJet",
+    "ProjectivePlaneCurveSingularPointRecord",
+    "ProjectivePlaneCurveSingularityBudget",
+    "ProjectivePlaneCurveSingularityOutcome",
+    "ProjectivePlaneCurveSingularityProfile",
+    "ProjectivePlaneCurveSingularityRequest",
+    "SmoothProjectivePlaneCurve",
+    "ZeroDimensionalProjectivePlaneCurveSingularLocus",
+]

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity_models.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity_models.py
@@ -23,6 +23,7 @@ MAX_PROJECTIVE_PLANE_CURVE_TERMS = 10
 MAX_PROJECTIVE_PLANE_CURVE_COEFFICIENT_DIGITS = 16
 MAX_PROJECTIVE_SINGULAR_POINTS = 4
 MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE = 4
+MAX_PROJECTIVE_SINGULAR_COMPONENTS = 16
 MAX_PROJECTIVE_SINGULARITY_WALL_SECONDS = 60
 
 
@@ -223,7 +224,7 @@ class PositiveDimensionalProjectivePlaneCurveSingularLocus(StrictModel):
     affine_cone_dimension: Literal[2] = 2
     projective_dimension: Literal[1] = 1
     rational_minimal_components: tuple[RationalPolynomialIdeal, ...] = Field(
-        min_length=1, max_length=16
+        min_length=1, max_length=MAX_PROJECTIVE_SINGULAR_COMPONENTS
     )
 
     @model_validator(mode="after")
@@ -383,6 +384,7 @@ __all__ = [
     "MAX_PROJECTIVE_PLANE_CURVE_COEFFICIENT_DIGITS",
     "MAX_PROJECTIVE_PLANE_CURVE_DEGREE",
     "MAX_PROJECTIVE_PLANE_CURVE_TERMS",
+    "MAX_PROJECTIVE_SINGULAR_COMPONENTS",
     "MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE",
     "MAX_PROJECTIVE_SINGULAR_POINTS",
     "IncompleteProjectivePlaneCurveSingularityComputation",

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity_point_process.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity_point_process.py
@@ -1,0 +1,104 @@
+"""Killable process boundary for exact projective singular-point construction."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from time import monotonic
+
+from pydantic import ValidationError
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_worker import (
+    ProjectiveSingularityPointWorkerComplete,
+    ProjectiveSingularityPointWorkerRequest,
+)
+
+_POINT_WORKER = Path(__file__).resolve().with_name("_singularity_point_worker.py")
+_POINT_WORKER_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_POINT_WORKER_FILE_SIZE_BYTES = 1024 * 1024
+_POINT_WORKER_STDOUT_BYTES = 256 * 1024
+_POINT_WORKER_STDERR_BYTES = 64 * 1024
+
+
+class PointConstructionLimitError(RuntimeError):
+    """The isolated point result exceeded its proved exact-output envelope."""
+
+
+def run_point_construction_worker(
+    request: ProjectiveSingularityPointWorkerRequest,
+    *,
+    deadline: float,
+) -> ProjectiveSingularityPointWorkerComplete:
+    """Run one deadline-bound exact chart-to-residue-field transaction."""
+
+    from jacobian.process import (
+        ProcessResourceLimits,
+        run_bounded_process,
+        worker_environment,
+    )
+
+    payload = request.model_dump_json().encode("utf-8")
+    try:
+        with TemporaryDirectory(
+            prefix="jacobian-projective-singular-points-"
+        ) as worker_directory:
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                raise OperationExecutionTimeoutError(
+                    "request deadline expired before projective point construction"
+                )
+            completed = run_bounded_process(
+                [sys.executable, str(_POINT_WORKER)],
+                input_bytes=payload,
+                timeout_seconds=remaining,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_POINT_WORKER_STDOUT_BYTES,
+                stderr_limit=_POINT_WORKER_STDERR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(remaining)),
+                    address_space_bytes=_POINT_WORKER_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_POINT_WORKER_FILE_SIZE_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OperationExecutionTimeoutError:
+        raise
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded projective singular-point worker could not be started"
+        ) from exc
+
+    if completed.cancelled:
+        raise OperationExecutionCancelledError(
+            "request cancelled during projective singular-point construction"
+        )
+    if completed.timed_out:
+        raise OperationExecutionTimeoutError(
+            "request deadline expired during projective singular-point construction"
+        )
+    if completed.stdout_exceeded:
+        raise PointConstructionLimitError(
+            "projective singular-point result exceeded its exact-output bound"
+        )
+    if completed.stderr_exceeded or completed.returncode != 0:
+        raise RuntimeError(
+            "bounded projective singular-point worker did not establish a complete result"
+        )
+    try:
+        return ProjectiveSingularityPointWorkerComplete.model_validate_json(
+            completed.stdout,
+            strict=True,
+        )
+    except ValidationError as exc:
+        raise RuntimeError(
+            "bounded projective singular-point worker returned malformed output"
+        ) from exc
+
+
+__all__ = ["PointConstructionLimitError", "run_point_construction_worker"]

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity_point_worker.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity_point_worker.py
@@ -1,0 +1,466 @@
+"""One-shot exact point-construction kernel for projective singular loci."""
+
+from __future__ import annotations
+
+import sys
+from fractions import Fraction
+from math import comb
+from typing import Any, Literal, Self
+
+import sympy
+from pydantic import Field, StrictBool, StrictInt, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE,
+    MAX_PROJECTIVE_SINGULAR_POINTS,
+)
+from jacobian.math.number_theory.number_fields.values import (
+    SimpleNumberFieldElement,
+    SimpleNumberFieldPresentation,
+)
+from jacobian.math.polynomials._conversions import (
+    rational_polynomial_to_sympy,
+    symbols_for_variables,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+)
+
+_MAX_POINT_COORDINATE_DIGITS = 256
+_MAX_SHAPE_ATTEMPTS = comb(MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE, 2) + 1
+
+
+class ProjectiveSingularityPointSeed(StrictModel):
+    """One residue-field point before its exact embeddings are enumerated."""
+
+    presentation: SimpleNumberFieldPresentation
+    coordinates: tuple[
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+    ]
+    chart_index: StrictInt = Field(ge=0, le=2)
+
+    @model_validator(mode="after")
+    def bind_field_and_chart(self) -> Self:
+        if any(
+            coordinate.presentation != self.presentation
+            for coordinate in self.coordinates
+        ):
+            raise ValueError("point-seed coordinates do not share one presentation")
+        coordinate_is_zero = tuple(
+            all(
+                coefficient.as_fraction() == 0
+                for coefficient in coordinate.coefficients_ascending
+            )
+            for coordinate in self.coordinates
+        )
+        coordinate_is_one = tuple(
+            coordinate.coefficients_ascending[0].as_fraction() == 1
+            and all(
+                coefficient.as_fraction() == 0
+                for coefficient in coordinate.coefficients_ascending[1:]
+            )
+            for coordinate in self.coordinates
+        )
+        if (
+            any(not coordinate_is_zero[index] for index in range(self.chart_index))
+            or not coordinate_is_one[self.chart_index]
+        ):
+            raise ValueError("point seed is not normalized in its declared chart")
+        return self
+
+
+class ProjectiveSingularityPointWorkerRequest(StrictModel):
+    """Canonical exact input for one complete point-construction transaction."""
+
+    source: RationalPolynomial
+    partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial]
+    chart_zero_components: tuple[RationalPolynomialIdeal, ...] = Field(
+        max_length=MAX_PROJECTIVE_SINGULAR_POINTS
+    )
+    chart_one_components: tuple[RationalPolynomialIdeal, ...] = Field(
+        max_length=MAX_PROJECTIVE_SINGULAR_POINTS
+    )
+    chart_two_present: StrictBool
+
+    @model_validator(mode="after")
+    def bind_component_axes(self) -> Self:
+        axis = self.source.variables
+        if len(axis) != 3 or any(
+            partial.variables != axis for partial in self.partials
+        ):
+            raise ValueError("point worker source and partial axes do not agree")
+        if any(
+            component.variables != axis[1:] for component in self.chart_zero_components
+        ):
+            raise ValueError("first-chart component has the wrong axis")
+        if any(
+            component.variables != axis[2:] for component in self.chart_one_components
+        ):
+            raise ValueError("second-chart component has the wrong axis")
+        if (
+            len(self.chart_zero_components) + len(self.chart_one_components)
+            > MAX_PROJECTIVE_SINGULAR_POINTS
+        ):
+            raise ValueError("chart components exceed the geometric point bound")
+        return self
+
+
+class ProjectiveSingularityPointWorkerComplete(StrictModel):
+    """Complete residue-field seeds for the disjoint projective chart cover."""
+
+    kind: Literal["complete"]
+    seeds: tuple[ProjectiveSingularityPointSeed, ...] = Field(
+        min_length=1,
+        max_length=MAX_PROJECTIVE_SINGULAR_POINTS,
+    )
+
+    @model_validator(mode="after")
+    def require_complete_canonical_family(self) -> Self:
+        if sum(seed.presentation.degree for seed in self.seeds) > (
+            MAX_PROJECTIVE_SINGULAR_POINTS
+        ):
+            raise ValueError("embedded point count exceeds the geometric point bound")
+        keys = tuple(seed.model_dump_json() for seed in self.seeds)
+        if keys != tuple(sorted(keys)) or len(keys) != len(set(keys)):
+            raise ValueError("point seeds are not unique and canonically ordered")
+        return self
+
+
+def _shape_data(
+    component: RationalPolynomialIdeal,
+) -> tuple[sympy.Symbol, sympy.Poly, tuple[sympy.Poly, sympy.Poly]]:
+    """Return a deterministic rational univariate representation of a chart prime."""
+
+    coordinate_symbols = symbols_for_variables(component.variables)
+    if len(coordinate_symbols) != 2:
+        raise ValueError("shape construction requires a two-axis chart")
+    parameter = sympy.Symbol("__jacobian_shape_parameter")
+    expressions = [
+        rational_polynomial_to_sympy(generator).as_expr()
+        for generator in component.generators
+    ]
+
+    for coefficient in range(_MAX_SHAPE_ATTEMPTS):
+        basis = sympy.groebner(
+            [
+                *expressions,
+                parameter - coordinate_symbols[0] - coefficient * coordinate_symbols[1],
+            ],
+            *coordinate_symbols,
+            parameter,
+            order="lex",
+            domain=sympy.QQ,
+        )
+        univariate = [
+            polynomial
+            for polynomial in basis.polys
+            if polynomial.as_expr().free_symbols <= {parameter}
+            and polynomial.degree(parameter) > 0
+        ]
+        if len(univariate) != 1:
+            continue
+        eliminant = sympy.Poly(
+            univariate[0].monic().as_expr(), parameter, domain=sympy.QQ
+        )
+        if not 1 <= int(eliminant.degree()) <= MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE:
+            raise ValueError("a chart residue field exceeds the degree-four bound")
+
+        coordinate_polynomials: list[sympy.Poly] = []
+        for coordinate_index, coordinate in enumerate(coordinate_symbols):
+            other = coordinate_symbols[1 - coordinate_index]
+            selected: sympy.Poly | None = None
+            for polynomial in basis.polys:
+                expression = polynomial.as_expr()
+                if polynomial.degree(coordinate) != 1 or polynomial.degree(other) != 0:
+                    continue
+                as_coordinate = sympy.Poly(expression, coordinate)
+                leading = as_coordinate.coeff_monomial(coordinate)
+                remainder = sympy.expand(expression - leading * coordinate)
+                if leading.free_symbols or remainder.free_symbols - {parameter}:
+                    continue
+                selected = sympy.Poly(
+                    sympy.expand(-remainder / leading), parameter, domain=sympy.QQ
+                )
+                break
+            if selected is None:
+                break
+            coordinate_polynomials.append(selected)
+        if len(coordinate_polynomials) == 2:
+            return (
+                parameter,
+                eliminant,
+                (coordinate_polynomials[0], coordinate_polynomials[1]),
+            )
+    raise ValueError("no separating chart coordinate fit the seven-attempt bound")
+
+
+def _univariate_component_polynomial(
+    component: RationalPolynomialIdeal,
+) -> tuple[sympy.Symbol, sympy.Poly]:
+    (variable,) = symbols_for_variables(component.variables)
+    nonzero: list[sympy.Poly] = []
+    for generator in component.generators:
+        converted = rational_polynomial_to_sympy(generator)
+        if not converted.is_zero:
+            nonzero.append(converted)
+    if not nonzero:
+        raise ValueError("a finite chart component returned the zero ideal")
+    polynomial = nonzero[0]
+    for generator in nonzero[1:]:
+        polynomial = sympy.gcd(polynomial, generator)
+    polynomial = sympy.Poly(polynomial.monic().as_expr(), variable, domain=sympy.QQ)
+    if not 1 <= int(polynomial.degree()) <= MAX_PROJECTIVE_SINGULAR_FIELD_DEGREE:
+        raise ValueError("a chart residue field exceeds the degree-four bound")
+    return variable, polynomial
+
+
+def _primitive_integer_factor(polynomial: sympy.Poly) -> tuple[str, ...]:
+    _denominator, integer_polynomial = polynomial.clear_denoms(convert=True)
+    _content, primitive = integer_polynomial.primitive()
+    if primitive.LC() < 0:
+        primitive = -primitive
+    coefficients = tuple(int(coefficient) for coefficient in primitive.all_coeffs())
+    if any(
+        len(str(abs(coefficient))) > _MAX_POINT_COORDINATE_DIGITS
+        for coefficient in coefficients
+    ):
+        raise ValueError("a residue-field polynomial exceeds the carrier digit bound")
+    return tuple(format_canonical_integer(coefficient) for coefficient in coefficients)
+
+
+def _canonical_rational(value: Any) -> CanonicalRational:
+    rational = sympy.Rational(value)
+    numerator = int(rational.p)
+    denominator = int(rational.q)
+    if (
+        len(str(abs(numerator))) > _MAX_POINT_COORDINATE_DIGITS
+        or len(str(denominator)) > _MAX_POINT_COORDINATE_DIGITS
+    ):
+        raise ValueError("a point coordinate exceeds the carrier digit bound")
+    return CanonicalRational.from_fraction(Fraction(numerator, denominator))
+
+
+def _field_element(
+    presentation: SimpleNumberFieldPresentation,
+    polynomial: sympy.Poly,
+) -> SimpleNumberFieldElement:
+    parameter = polynomial.gens[0]
+    if polynomial.degree(parameter) >= presentation.degree:
+        raise ValueError("a point coordinate is not reduced in its residue field")
+    return SimpleNumberFieldElement(
+        presentation=presentation,
+        coefficients_ascending=tuple(
+            _canonical_rational(polynomial.nth(degree))
+            for degree in range(presentation.degree)
+        ),
+    )
+
+
+def _rational_field_element(
+    presentation: SimpleNumberFieldPresentation,
+    value: Any,
+) -> SimpleNumberFieldElement:
+    return SimpleNumberFieldElement(
+        presentation=presentation,
+        coefficients_ascending=(_canonical_rational(value),),
+    )
+
+
+def _seed_for_factor(
+    *,
+    factor: sympy.Poly,
+    parameter: sympy.Symbol,
+    coordinate_polynomials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+    chart_index: int,
+    source: sympy.Poly,
+    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+) -> ProjectiveSingularityPointSeed:
+    if int(factor.degree()) == 1:
+        presentation = SimpleNumberFieldPresentation(coefficients_descending=("1", "0"))
+        root = -factor.nth(0) / factor.nth(1)
+        coordinate_values = tuple(
+            _rational_field_element(presentation, polynomial.eval(root))
+            for polynomial in coordinate_polynomials
+        )
+    else:
+        presentation = SimpleNumberFieldPresentation(
+            coefficients_descending=_primitive_integer_factor(factor)
+        )
+        coordinate_values = tuple(
+            _field_element(
+                presentation,
+                sympy.Poly(
+                    polynomial.rem(factor).as_expr(), parameter, domain=sympy.QQ
+                ),
+            )
+            for polynomial in coordinate_polynomials
+        )
+    coordinates = (
+        coordinate_values[0],
+        coordinate_values[1],
+        coordinate_values[2],
+    )
+
+    modulus = sympy.Poly(
+        sum(
+            int(coefficient) * parameter ** (presentation.degree - index)
+            for index, coefficient in enumerate(presentation.coefficients_descending)
+        ),
+        parameter,
+        domain=sympy.QQ,
+    )
+    coordinate_expressions = tuple(
+        sum(
+            sympy.Rational(*coefficient.as_integer_ratio()) * parameter**index
+            for index, coefficient in enumerate(coordinate.coefficients_ascending)
+        )
+        for coordinate in coordinates
+    )
+    substitutions = dict(zip(source.gens, coordinate_expressions, strict=True))
+    evaluated = tuple(
+        sympy.Poly(
+            sympy.expand(polynomial.as_expr().subs(substitutions)),
+            parameter,
+            domain=sympy.QQ,
+        ).rem(modulus)
+        for polynomial in (source, *partials)
+    )
+    if any(not value.is_zero for value in evaluated):
+        raise ValueError("exact point replay did not annihilate the first jet")
+    return ProjectiveSingularityPointSeed(
+        presentation=presentation,
+        coordinates=coordinates,
+        chart_index=chart_index,
+    )
+
+
+def _factor_seeds(
+    *,
+    eliminant: sympy.Poly,
+    parameter: sympy.Symbol,
+    coordinate_polynomials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+    chart_index: int,
+    source: sympy.Poly,
+    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+) -> tuple[ProjectiveSingularityPointSeed, ...]:
+    _coefficient, factors = eliminant.factor_list()
+    if any(multiplicity != 1 for _factor, multiplicity in factors):
+        raise ValueError("a minimal-prime eliminant retained multiplicity")
+    return tuple(
+        _seed_for_factor(
+            factor=sympy.Poly(factor.monic().as_expr(), parameter, domain=sympy.QQ),
+            parameter=parameter,
+            coordinate_polynomials=coordinate_polynomials,
+            chart_index=chart_index,
+            source=source,
+            partials=partials,
+        )
+        for factor, _multiplicity in factors
+    )
+
+
+def _two_axis_seeds(
+    component: RationalPolynomialIdeal,
+    *,
+    source: sympy.Poly,
+    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+) -> tuple[ProjectiveSingularityPointSeed, ...]:
+    parameter, eliminant, (first, second) = _shape_data(component)
+    one = sympy.Poly(1, parameter, domain=sympy.QQ)
+    return _factor_seeds(
+        eliminant=eliminant,
+        parameter=parameter,
+        coordinate_polynomials=(one, first, second),
+        chart_index=0,
+        source=source,
+        partials=partials,
+    )
+
+
+def _one_axis_seeds(
+    component: RationalPolynomialIdeal,
+    *,
+    source: sympy.Poly,
+    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+) -> tuple[ProjectiveSingularityPointSeed, ...]:
+    parameter, eliminant = _univariate_component_polynomial(component)
+    zero = sympy.Poly(0, parameter, domain=sympy.QQ)
+    one = sympy.Poly(1, parameter, domain=sympy.QQ)
+    coordinate = sympy.Poly(parameter, parameter, domain=sympy.QQ)
+    return _factor_seeds(
+        eliminant=eliminant,
+        parameter=parameter,
+        coordinate_polynomials=(zero, one, coordinate),
+        chart_index=1,
+        source=source,
+        partials=partials,
+    )
+
+
+def _chart_two_seed(
+    *,
+    source: sympy.Poly,
+    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
+) -> ProjectiveSingularityPointSeed:
+    parameter = sympy.Symbol("__jacobian_rational_parameter")
+    factor = sympy.Poly(parameter, parameter, domain=sympy.QQ)
+    zero = sympy.Poly(0, parameter, domain=sympy.QQ)
+    one = sympy.Poly(1, parameter, domain=sympy.QQ)
+    return _seed_for_factor(
+        factor=factor,
+        parameter=parameter,
+        coordinate_polynomials=(zero, zero, one),
+        chart_index=2,
+        source=source,
+        partials=partials,
+    )
+
+
+def compute_point_worker_response(
+    request: ProjectiveSingularityPointWorkerRequest,
+) -> ProjectiveSingularityPointWorkerComplete:
+    """Construct every residue-field seed in one isolated exact transaction."""
+
+    source = rational_polynomial_to_sympy(request.source)
+    partials = (
+        rational_polynomial_to_sympy(request.partials[0]),
+        rational_polynomial_to_sympy(request.partials[1]),
+        rational_polynomial_to_sympy(request.partials[2]),
+    )
+    seeds: list[ProjectiveSingularityPointSeed] = []
+    for component in request.chart_zero_components:
+        seeds.extend(_two_axis_seeds(component, source=source, partials=partials))
+    for component in request.chart_one_components:
+        seeds.extend(_one_axis_seeds(component, source=source, partials=partials))
+    if request.chart_two_present:
+        seeds.append(_chart_two_seed(source=source, partials=partials))
+    ordered = tuple(sorted(seeds, key=lambda seed: seed.model_dump_json()))
+    return ProjectiveSingularityPointWorkerComplete(kind="complete", seeds=ordered)
+
+
+def main() -> int:
+    request = ProjectiveSingularityPointWorkerRequest.model_validate_json(
+        sys.stdin.buffer.read(),
+        strict=True,
+    )
+    response = compute_point_worker_response(request)
+    sys.stdout.write(response.model_dump_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ProjectiveSingularityPointSeed",
+    "ProjectiveSingularityPointWorkerComplete",
+    "ProjectiveSingularityPointWorkerRequest",
+    "compute_point_worker_response",
+]

--- a/src/jacobian/math/geometry/algebraic_curves/_tools.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_tools.py
@@ -13,6 +13,8 @@ from jacobian.math.geometry.algebraic_curves._models import (
     AffineCurveResult,
     ProjectiveClosureRequest,
     ProjectiveClosureResult,
+    ProjectivePlaneCurveSingularityProfile,
+    ProjectivePlaneCurveSingularityRequest,
     RationalConicParametrizationRequest,
     RationalConicParametrizationResult,
 )
@@ -21,6 +23,7 @@ from jacobian.math.geometry.algebraic_curves.operations import (
     affine_curve_check,
     projective_closure,
     rational_conic_parametrization,
+    singularity_profile,
 )
 
 
@@ -61,6 +64,14 @@ def compute_rational_conic_parametrization(
         inverse_parameter=data.inverse_parameter,
         finite_parameter_denominator=data.finite_parameter_denominator,
     )
+
+
+def compute_projective_plane_curve_singularity_profile(
+    request: ProjectivePlaneCurveSingularityRequest,
+) -> ProjectivePlaneCurveSingularityProfile:
+    """Compute one exact source-bound global projective singular locus."""
+
+    return singularity_profile(request.polynomial, request.resource_budget)
 
 
 def _polynomial(
@@ -105,6 +116,37 @@ def _op[RequestT: StrictModel, ResultT: StrictModel](
 
 
 TOOLS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "algebraic_geometry.projective_plane_curve.singularity_profile.compute",
+        "Compute a projective plane-curve singularity profile",
+        "Compute the complete saturated projective Jacobian locus over the "
+        "algebraic closure of QQ for one bounded homogeneous ternary polynomial. "
+        "The result distinguishes the unit-ideal smooth case, a complete finite "
+        "family of exact embedded number-field points, a positive-dimensional "
+        "locus, and operational noncompletion.",
+        ProjectivePlaneCurveSingularityRequest,
+        ProjectivePlaneCurveSingularityProfile,
+        compute_projective_plane_curve_singularity_profile,
+        "algebraic-geometry",
+        "projective-curve",
+        "singular-locus",
+        "exact",
+        examples=(
+            example(
+                "conjugate_singularities",
+                "Find both non-rational singular points [1:i:0] and [1:-i:0] "
+                "of Z*(X^2+Y^2+Z^2), retaining their distinct exact embeddings.",
+                {
+                    "polynomial": _polynomial(
+                        ("X", "Y", "Z"),
+                        (1, (2, 0, 1)),
+                        (1, (0, 2, 1)),
+                        (1, (0, 0, 3)),
+                    )
+                },
+            ),
+        ),
+    ),
     _op(
         "algebraic_geometry.affine_plane_curve.check",
         "Check an affine plane curve",

--- a/src/jacobian/math/geometry/algebraic_curves/operations.py
+++ b/src/jacobian/math/geometry/algebraic_curves/operations.py
@@ -17,6 +17,7 @@ from jacobian.math.geometry.algebraic_curves._models import (
     _validation_error,
     _validation_error_from,
 )
+from jacobian.math.geometry.algebraic_curves._singularity import singularity_profile
 from jacobian.math.polynomials._conversions import (
     rational_polynomial_from_sympy,
     rational_polynomial_to_sympy,
@@ -164,4 +165,5 @@ __all__ = [
     "affine_curve_check",
     "projective_closure",
     "rational_conic_parametrization",
+    "singularity_profile",
 ]

--- a/src/jacobian/math/geometry/projective/__init__.py
+++ b/src/jacobian/math/geometry/projective/__init__.py
@@ -1,3 +1,5 @@
 """Projective-geometry operation ownership."""
 
-__all__: list[str] = []
+from jacobian.math.geometry.projective.values import AlgebraicProjectivePlanePoint
+
+__all__ = ["AlgebraicProjectivePlanePoint"]

--- a/src/jacobian/math/geometry/projective/values.py
+++ b/src/jacobian/math/geometry/projective/values.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 from math import gcd, lcm
 from typing import Annotated, Self
 
-from pydantic import StringConstraints, model_validator
+from pydantic import Field, StrictInt, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.math.number_theory.number_fields.values import (
+    NumberFieldEmbedding,
+    SimpleNumberFieldElement,
+)
+from jacobian.math.polynomials.values import PolynomialVariable
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -105,4 +110,75 @@ class PrimitiveProjectiveTriple(StrictModel):
         return self
 
 
-__all__ = ["PrimitiveProjectiveTriple", "RationalProjectiveLine"]
+class AlgebraicProjectivePlanePoint(StrictModel):
+    """A canonical projective-plane point in one exact embedded number field.
+
+    Coordinates use the field presentation's reduced power basis.  The selected
+    embedding supplies the geometric point over ``QQbar``.  Normalization uses
+    the first nonzero projective coordinate, which is exactly one; this makes
+    chart membership and equality independent of a backend's root objects.
+    """
+
+    axis: tuple[
+        PolynomialVariable,
+        PolynomialVariable,
+        PolynomialVariable,
+    ]
+    embedding: NumberFieldEmbedding
+    coordinates: tuple[
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+        SimpleNumberFieldElement,
+    ]
+    chart_index: StrictInt = Field(ge=0, le=2)
+
+    @model_validator(mode="after")
+    def bind_parent_and_normalization(self) -> Self:
+        if len(set(self.axis)) != 3:
+            raise _validation_error(
+                "projective_plane_axis",
+                "an algebraic projective-plane point needs three distinct axes",
+            )
+        presentation = self.embedding.presentation
+        if any(
+            coordinate.presentation != presentation for coordinate in self.coordinates
+        ):
+            raise _validation_error(
+                "projective_point_field",
+                "all projective coordinates and the selected embedding must share one field presentation",
+            )
+        zero = tuple(
+            coefficient.as_fraction() == 0
+            for coordinate in self.coordinates
+            for coefficient in coordinate.coefficients_ascending
+        )
+        degree = presentation.degree
+        coordinate_is_zero = tuple(
+            all(zero[index * degree : (index + 1) * degree]) for index in range(3)
+        )
+        coordinate_is_one = tuple(
+            coordinate.coefficients_ascending[0].as_fraction() == 1
+            and all(
+                coefficient.as_fraction() == 0
+                for coefficient in coordinate.coefficients_ascending[1:]
+            )
+            for coordinate in self.coordinates
+        )
+        if any(not coordinate_is_zero[index] for index in range(self.chart_index)):
+            raise _validation_error(
+                "projective_point_chart",
+                "coordinates before the declared projective chart must be zero",
+            )
+        if not coordinate_is_one[self.chart_index]:
+            raise _validation_error(
+                "projective_point_normalization",
+                "the declared projective chart coordinate must be exactly one",
+            )
+        return self
+
+
+__all__ = [
+    "AlgebraicProjectivePlanePoint",
+    "PrimitiveProjectiveTriple",
+    "RationalProjectiveLine",
+]

--- a/src/jacobian/math/polynomials/ideals/_singular.py
+++ b/src/jacobian/math/polynomials/ideals/_singular.py
@@ -482,12 +482,28 @@ def run_singular_ideal_operation(
     left: RationalPolynomialIdeal,
     right: RationalPolynomialIdeal | None,
     budget: IdealComputationBudget,
+    *,
+    wall_seconds: float | None = None,
 ) -> SingularIdealResult:
-    """Run one exact ideal operation in a bounded, request-scoped process."""
+    """Run one exact ideal operation in a bounded, request-scoped process.
+
+    ``wall_seconds`` lets an owner charge this call to a shared absolute
+    deadline without widening the declared ideal-computation budget.
+    """
+
+    allowance = min(
+        float(budget.wall_seconds),
+        float(budget.wall_seconds if wall_seconds is None else wall_seconds),
+    )
+    if not math.isfinite(allowance) or allowance <= 0:
+        return SingularIdealResult(
+            outcome="TIMEOUT",
+            detail="Singular exceeded the declared wall-time limit.",
+        )
 
     completed = run_bounded_singular(
         _script(operation, left, right),
-        wall_seconds=budget.wall_seconds,
+        wall_seconds=allowance,
     )
     if completed is None:
         return SingularIdealResult(

--- a/tests/math/geometry/algebraic_curves/test_plane_algebraic_curves.py
+++ b/tests/math/geometry/algebraic_curves/test_plane_algebraic_curves.py
@@ -118,6 +118,7 @@ def test_catalog_contains_only_audited_operations() -> None:
         "algebraic_geometry.affine_plane_curve.check",
         "algebraic_geometry.conic.rational_parametrization.compute",
         "algebraic_geometry.plane_curve.projective_closure.compute",
+        "algebraic_geometry.projective_plane_curve.singularity_profile.compute",
         "algebraic_geometry.projective_curve.affine_chart.compute",
     }
 

--- a/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
+++ b/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
@@ -484,7 +484,7 @@ def test_derived_result_bound_covers_the_maximal_admitted_ideal_shape() -> None:
             polynomial=SparseRationalPolynomial(
                 terms=tuple(
                     RationalPolynomialTerm(
-                        coefficient=_rational(99_999_999 if index == 0 else index),
+                        coefficient=_rational(99_999_999 if index == 1 else index),
                         exponents=exponents,
                     )
                     for index, exponents in enumerate(
@@ -495,6 +495,7 @@ def test_derived_result_bound_covers_the_maximal_admitted_ideal_shape() -> None:
         )
     )
     admission = _admit_singularity(source_backend)
+    assert admission.macaulay_minor_component_digits == 139
     numerator = 10 ** (admission.macaulay_minor_component_digits - 1)
     denominator_base = 10**admission.macaulay_minor_component_digits
 

--- a/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
+++ b/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import shutil
 import threading
 from fractions import Fraction
+from itertools import product
 from typing import cast
 
 import pytest
@@ -12,8 +13,18 @@ import sympy
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.canonical import encode_strict_json
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.algebraic_curves._singularity import (
+    _admit_singularity,
+    _ideal_projection_limit_failure,
+    _normalized_source,
+    _profile,
+    _to_public_polynomial,
+)
 from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    MAX_PROJECTIVE_SINGULAR_COMPONENTS,
+    PositiveDimensionalProjectivePlaneCurveSingularLocus,
     ProjectivePlaneCurveSingularityProfile,
     ProjectivePlaneCurveSingularityRequest,
 )
@@ -88,6 +99,41 @@ def _chart_polynomial(
 def _compute(source: RationalPolynomial) -> ProjectivePlaneCurveSingularityProfile:
     return compute_projective_plane_curve_singularity_profile(
         ProjectivePlaneCurveSingularityRequest(polynomial=source)
+    )
+
+
+def _ideal_with_shape(
+    *,
+    coefficient: CanonicalRational,
+    generator_count: int,
+    terms_per_generator: int,
+    axis: tuple[str, str, str] = _AXIS,
+) -> RationalPolynomialIdeal:
+    exponents = tuple(
+        sorted(
+            (
+                exponent
+                for exponent in product(range(5), repeat=3)
+                if sum(exponent) <= 4
+            ),
+            reverse=True,
+        )[:terms_per_generator]
+    )
+    generator = RationalPolynomial(
+        variables=axis,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=coefficient,
+                    exponents=exponent,
+                )
+                for exponent in exponents
+            )
+        ),
+    )
+    return RationalPolynomialIdeal(
+        variables=axis,
+        generators=(generator,) * generator_count,
     )
 
 
@@ -393,6 +439,130 @@ def test_normalized_height_is_rejected_before_singular_launch() -> None:
     assert caught.value.errors()[0]["type"] == (
         "projective_plane_curve.normalized_height_bound"
     )
+
+
+def test_decoded_ideal_cannot_exceed_the_admitted_coefficient_bound() -> None:
+    source = _normalized_source(
+        _polynomial(
+            (99_999_999, (3, 0, 0)),
+            (1, (2, 1, 0)),
+        )
+    )
+    admission = _admit_singularity(source)
+    over_bound = CanonicalRational(
+        num="1" + "0" * admission.macaulay_minor_component_digits,
+        den="1",
+    )
+    ideal = _ideal_with_shape(
+        coefficient=over_bound,
+        generator_count=1,
+        terms_per_generator=1,
+    )
+
+    failure = _ideal_projection_limit_failure(
+        "SATURATION",
+        (ideal,),
+        admission,
+        maximum_ideals=1,
+    )
+
+    assert failure is not None
+    assert failure.status == "LIMIT_EXCEEDED"
+    assert failure.stage == "SATURATION"
+
+
+def test_derived_result_bound_covers_the_maximal_admitted_ideal_shape() -> None:
+    maximal_axis = ("X" * 32, "Y" * 32, "Z" * 32)
+    cubic_exponents = tuple(
+        sorted(
+            exponent for exponent in product(range(4), repeat=3) if sum(exponent) == 3
+        )
+    )
+    source_backend = _normalized_source(
+        RationalPolynomial(
+            variables=maximal_axis,
+            polynomial=SparseRationalPolynomial(
+                terms=tuple(
+                    RationalPolynomialTerm(
+                        coefficient=_rational(99_999_999 if index == 0 else index),
+                        exponents=exponents,
+                    )
+                    for index, exponents in enumerate(
+                        reversed(cubic_exponents), start=1
+                    )
+                )
+            ),
+        )
+    )
+    admission = _admit_singularity(source_backend)
+    numerator = 10 ** (admission.macaulay_minor_component_digits - 1)
+    denominator_base = 10**admission.macaulay_minor_component_digits
+
+    saturation = _ideal_with_shape(
+        coefficient=CanonicalRational(
+            num=str(numerator),
+            den=str(denominator_base - 1),
+        ),
+        generator_count=64,
+        terms_per_generator=16,
+        axis=maximal_axis,
+    )
+    components = tuple(
+        _ideal_with_shape(
+            coefficient=CanonicalRational(
+                num=str(numerator),
+                den=str(denominator_base - (10 * index + 1)),
+            ),
+            generator_count=4,
+            terms_per_generator=16,
+            axis=maximal_axis,
+        )
+        for index in range(MAX_PROJECTIVE_SINGULAR_COMPONENTS)
+    )
+    components = tuple(sorted(components, key=lambda ideal: ideal.model_dump_json()))
+
+    assert (
+        _ideal_projection_limit_failure(
+            "SATURATION",
+            (saturation,),
+            admission,
+            maximum_ideals=1,
+        )
+        is None
+    )
+    assert (
+        _ideal_projection_limit_failure(
+            "PROJECTIVE_COMPONENTS",
+            components,
+            admission,
+            maximum_ideals=MAX_PROJECTIVE_SINGULAR_COMPONENTS,
+        )
+        is None
+    )
+
+    axis = cast(
+        tuple[str, str, str], tuple(str(symbol) for symbol in source_backend.gens)
+    )
+    source = _to_public_polynomial(source_backend, axis)
+    partials = cast(
+        tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
+        tuple(
+            _to_public_polynomial(source_backend.diff(symbol), axis)
+            for symbol in source_backend.gens
+        ),
+    )
+    profile = _profile(
+        source=source,
+        partials=partials,
+        outcome=PositiveDimensionalProjectivePlaneCurveSingularLocus._from_kernel(
+            ideal=saturation,
+            components=components,
+        ),
+    )
+
+    encoded_size = len(encode_strict_json(profile.model_dump(mode="json")))
+    assert encoded_size <= admission.predicted_result_bytes
+    assert admission.predicted_result_bytes < 10 * 1_024 * 1_024
 
 
 def test_every_outcome_discriminator_is_required_by_schema_and_runtime() -> None:

--- a/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
+++ b/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
@@ -27,6 +27,7 @@ from jacobian.math.geometry.algebraic_curves._tools import (
 from jacobian.math.geometry.algebraic_curves.operations import singularity_profile
 from jacobian.math.number_theory.number_fields.values import (
     ComplexNumberFieldEmbedding,
+    RealNumberFieldEmbedding,
 )
 from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
 from jacobian.math.polynomials.values import (
@@ -123,6 +124,47 @@ def test_conjugate_nonrational_singularities_keep_distinct_embedding_identity() 
 
     payload = result.model_dump(mode="json")
     assert ProjectivePlaneCurveSingularityProfile.model_validate(payload) == result
+
+
+def test_geometrically_split_cubic_keeps_its_complete_galois_orbit() -> None:
+    # This is Norm_{QQ(cuberoot(2))/QQ}(X + alpha*Y + alpha^2*Z).
+    # Its three conjugate lines meet in one degree-three closed-point orbit.
+    result = _compute(
+        _polynomial(
+            (1, (3, 0, 0)),
+            (-6, (1, 1, 1)),
+            (2, (0, 3, 0)),
+            (4, (0, 0, 3)),
+        )
+    )
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert len(result.outcome.points) == 3
+    presentations = {
+        record.point.embedding.presentation for record in result.outcome.points
+    }
+    assert len(presentations) == 1
+    (presentation,) = presentations
+    assert presentation.degree == 3
+    assert presentation.coefficients_descending[0] != "1"
+
+    real_embeddings = [
+        record.point.embedding
+        for record in result.outcome.points
+        if isinstance(record.point.embedding, RealNumberFieldEmbedding)
+    ]
+    complex_embeddings = [
+        record.point.embedding
+        for record in result.outcome.points
+        if isinstance(record.point.embedding, ComplexNumberFieldEmbedding)
+    ]
+    assert len(real_embeddings) == 1
+    assert len(complex_embeddings) == 2
+    assert real_embeddings[0].root.real_root_index == 0
+    assert sorted(embedding.root.root_index for embedding in complex_embeddings) == [
+        1,
+        2,
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
+++ b/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
@@ -1,0 +1,398 @@
+"""Exact global projective plane-curve singular-locus evidence."""
+
+from __future__ import annotations
+
+import shutil
+import threading
+from fractions import Fraction
+from typing import cast
+
+import pytest
+import sympy
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.algebraic_curves._singularity_models import (
+    ProjectivePlaneCurveSingularityProfile,
+    ProjectivePlaneCurveSingularityRequest,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_worker import (
+    _shape_data,
+)
+from jacobian.math.geometry.algebraic_curves._tools import (
+    TOOLS,
+    compute_projective_plane_curve_singularity_profile,
+)
+from jacobian.math.geometry.algebraic_curves.operations import singularity_profile
+from jacobian.math.number_theory.number_fields.values import (
+    ComplexNumberFieldEmbedding,
+)
+from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+from jacobian.process import bounded_process_cancellation
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("Singular") is None,
+    reason="the exact projective singular-locus backend is unavailable",
+)
+
+_AXIS = ("X", "Y", "Z")
+
+
+def _rational(value: int | Fraction) -> CanonicalRational:
+    fraction = Fraction(value)
+    return CanonicalRational.from_fraction(fraction)
+
+
+def _polynomial(
+    *terms: tuple[int | Fraction, tuple[int, int, int]],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=_AXIS,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=_rational(coefficient),
+                    exponents=exponents,
+                )
+                for coefficient, exponents in terms
+            )
+        ),
+    )
+
+
+def _chart_polynomial(
+    *terms: tuple[int, tuple[int, int]],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=("u", "v"),
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=_rational(coefficient),
+                    exponents=exponents,
+                )
+                for coefficient, exponents in terms
+            )
+        ),
+    )
+
+
+def _compute(source: RationalPolynomial) -> ProjectivePlaneCurveSingularityProfile:
+    return compute_projective_plane_curve_singularity_profile(
+        ProjectivePlaneCurveSingularityRequest(polynomial=source)
+    )
+
+
+def test_conjugate_nonrational_singularities_keep_distinct_embedding_identity() -> None:
+    result = _compute(
+        _polynomial(
+            (1, (2, 0, 1)),
+            (1, (0, 2, 1)),
+            (1, (0, 0, 3)),
+        )
+    )
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert len(result.outcome.points) == 2
+    roots: list[int] = []
+    for record in result.outcome.points:
+        point = record.point
+        assert isinstance(point.embedding, ComplexNumberFieldEmbedding)
+        assert point.embedding.presentation.coefficients_descending == ("1", "0", "1")
+        roots.append(point.embedding.root.root_index)
+        assert tuple(
+            tuple(
+                coefficient.as_fraction()
+                for coefficient in coordinate.coefficients_ascending
+            )
+            for coordinate in point.coordinates
+        ) == (
+            (Fraction(1), Fraction(0)),
+            (Fraction(0), Fraction(1)),
+            (Fraction(0), Fraction(0)),
+        )
+        assert point.chart_index == 0
+    assert roots == [0, 1]
+
+    payload = result.model_dump(mode="json")
+    assert ProjectivePlaneCurveSingularityProfile.model_validate(payload) == result
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        _polynomial((1, (2, 0, 0)), (1, (0, 2, 0)), (1, (0, 0, 2))),
+        _polynomial((1, (3, 0, 0)), (1, (0, 3, 0)), (1, (0, 0, 3))),
+    ],
+)
+def test_smooth_curve_retains_the_saturated_unit_ideal(
+    source: RationalPolynomial,
+) -> None:
+    result = _compute(source)
+
+    assert result.outcome.status == "SMOOTH_OVER_ALGEBRAIC_CLOSURE"
+    saturation = result.outcome.saturated_jacobian_ideal
+    assert len(saturation.generators) == 1
+    assert rational_polynomial_to_sympy(saturation.generators[0]).as_expr() == 1
+
+
+@pytest.mark.parametrize(
+    ("source", "chart_index", "coordinates"),
+    [
+        (
+            _polynomial((1, (3, 0, 0)), (-1, (0, 2, 1))),
+            2,
+            (Fraction(0), Fraction(0), Fraction(1)),
+        ),
+        (
+            _polynomial((1, (2, 1, 0)), (-1, (0, 0, 3))),
+            1,
+            (Fraction(0), Fraction(1), Fraction(0)),
+        ),
+    ],
+)
+def test_disjoint_chart_cover_finds_singularities_at_infinity(
+    source: RationalPolynomial,
+    chart_index: int,
+    coordinates: tuple[Fraction, Fraction, Fraction],
+) -> None:
+    result = _compute(source)
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert len(result.outcome.points) == 1
+    point = result.outcome.points[0].point
+    assert point.chart_index == chart_index
+    assert (
+        tuple(
+            coordinate.coefficients_ascending[0].as_fraction()
+            for coordinate in point.coordinates
+        )
+        == coordinates
+    )
+
+
+def test_nodal_cubic_returns_an_exact_zero_first_jet() -> None:
+    result = _compute(
+        _polynomial(
+            (-1, (3, 0, 0)),
+            (-1, (2, 0, 1)),
+            (1, (0, 2, 1)),
+        )
+    )
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    (record,) = result.outcome.points
+    assert all(
+        coefficient.as_fraction() == 0
+        for value in (record.first_jet.value, *record.first_jet.gradient)
+        for coefficient in value.coefficients_ascending
+    )
+
+
+def test_result_deserialization_does_not_replay_the_zero_jet() -> None:
+    result = _compute(
+        _polynomial(
+            (-1, (3, 0, 0)),
+            (-1, (2, 0, 1)),
+            (1, (0, 2, 1)),
+        )
+    )
+    payload = result.model_dump(mode="json")
+    payload["outcome"]["points"][0]["first_jet"]["value"]["coefficients_ascending"][0][
+        "num"
+    ] = "1"
+
+    parsed = ProjectivePlaneCurveSingularityProfile.model_validate(payload)
+
+    assert parsed.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert (
+        parsed.outcome.points[0].first_jet.value.coefficients_ascending[0].as_fraction()
+        == 1
+    )
+
+
+def test_three_coordinate_lines_return_one_point_in_each_disjoint_chart() -> None:
+    result = _compute(_polynomial((1, (1, 1, 1))))
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert len(result.outcome.points) == 3
+    assert {record.point.chart_index for record in result.outcome.points} == {0, 1, 2}
+
+
+def test_concurrent_lines_reduce_a_nonreduced_local_scheme_to_one_point() -> None:
+    result = _compute(
+        _polynomial(
+            (1, (2, 1, 0)),
+            (-1, (1, 2, 0)),
+        )
+    )
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert len(result.outcome.points) == 1
+    assert result.outcome.points[0].point.chart_index == 2
+
+
+def test_second_chart_keeps_a_complete_quadratic_galois_orbit() -> None:
+    result = _compute(
+        _polynomial(
+            (1, (1, 2, 0)),
+            (1, (1, 0, 2)),
+        )
+    )
+
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    second_chart = [
+        record for record in result.outcome.points if record.point.chart_index == 1
+    ]
+    assert len(second_chart) == 2
+    assert [
+        cast(ComplexNumberFieldEmbedding, record.point.embedding).root.root_index
+        for record in second_chart
+    ] == [0, 1]
+
+
+def test_repeated_line_is_positive_dimensional_without_squarefree_replacement() -> None:
+    source = _polynomial((1, (2, 0, 1)))
+    result = _compute(source)
+
+    assert result.outcome.status == "SINGULAR_POSITIVE_DIMENSIONAL"
+    assert result.outcome.projective_dimension == 1
+    assert result.outcome.affine_cone_dimension == 2
+    assert result.source_polynomial == source
+    assert result.outcome.rational_minimal_components
+    assert any(
+        rational_polynomial_to_sympy(generator).as_expr() == sympy.Symbol("X")
+        for component in result.outcome.rational_minimal_components
+        for generator in component.generators
+    )
+
+
+def test_nonzero_rational_scalar_associates_have_the_same_profile() -> None:
+    primitive = _polynomial(
+        (1, (3, 0, 0)),
+        (-1, (0, 2, 1)),
+    )
+    scaled = _polynomial(
+        (Fraction(-2, 3), (3, 0, 0)),
+        (Fraction(2, 3), (0, 2, 1)),
+    )
+
+    assert _compute(primitive) == _compute(scaled)
+
+
+def test_shape_search_passes_two_colliding_integer_forms_before_separating() -> None:
+    four_points = RationalPolynomialIdeal(
+        variables=("u", "v"),
+        generators=(
+            _chart_polynomial((1, (2, 0)), (-1, (1, 0))),
+            _chart_polynomial((1, (0, 2)), (-1, (0, 1))),
+        ),
+    )
+
+    parameter, eliminant, coordinates = _shape_data(four_points)
+
+    assert eliminant.degree() == 4
+    assert (
+        sympy.expand(coordinates[0].as_expr() + 2 * coordinates[1].as_expr())
+        == parameter
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "code"),
+    [
+        (
+            RationalPolynomial(
+                variables=_AXIS,
+                polynomial=SparseRationalPolynomial(terms=()),
+            ),
+            "projective_plane_curve.zero_source",
+        ),
+        (
+            _polynomial((1, (2, 0, 0)), (1, (0, 1, 0))),
+            "projective_plane_curve.homogeneity",
+        ),
+        (
+            _polynomial((1, (4, 0, 0)), (1, (0, 4, 0))),
+            "projective_plane_curve.source_bound",
+        ),
+    ],
+)
+def test_request_rejects_sources_outside_the_exact_projective_domain(
+    source: RationalPolynomial,
+    code: str,
+) -> None:
+    with pytest.raises(ValidationError) as caught:
+        ProjectivePlaneCurveSingularityRequest(polynomial=source)
+    assert caught.value.errors()[0]["type"] == code
+
+
+def test_normalized_height_is_rejected_before_singular_launch() -> None:
+    accepted = _polynomial(
+        (99_999_999, (3, 0, 0)),
+        (1, (0, 2, 1)),
+    )
+    assert _compute(accepted).outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+
+    source = _polynomial(
+        (100_000_000, (3, 0, 0)),
+        (1, (0, 2, 1)),
+    )
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        singularity_profile(source)
+    assert caught.value.errors()[0]["type"] == (
+        "projective_plane_curve.normalized_height_bound"
+    )
+
+
+def test_every_outcome_discriminator_is_required_by_schema_and_runtime() -> None:
+    schema = ProjectivePlaneCurveSingularityProfile.model_json_schema()
+    for definition in (
+        "SmoothProjectivePlaneCurve",
+        "ZeroDimensionalProjectivePlaneCurveSingularLocus",
+        "PositiveDimensionalProjectivePlaneCurveSingularLocus",
+        "IncompleteProjectivePlaneCurveSingularityComputation",
+    ):
+        assert "status" in schema["$defs"][definition]["required"]
+
+
+def test_catalog_contract_and_example_round_trip() -> None:
+    tool = next(
+        tool
+        for tool in TOOLS
+        if tool.operation_id
+        == "algebraic_geometry.projective_plane_curve.singularity_profile.compute"
+    )
+
+    request = tool.request_type.model_validate(tool.examples[0].input)
+    result = tool.run(request)
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    assert tool.result_type.model_validate(result.model_dump(mode="json")) == result
+
+
+def test_cancelled_saturation_is_not_a_mathematical_outcome() -> None:
+    cancellation = threading.Event()
+    cancellation.set()
+    source = _polynomial((1, (2, 0, 0)), (1, (0, 2, 0)), (1, (0, 0, 2)))
+
+    with bounded_process_cancellation(cancellation):
+        result = _compute(source)
+
+    assert result.outcome.status == "CANCELLED"
+    assert result.outcome.stage == "SATURATION"
+
+
+def test_native_operation_accepts_the_canonical_polynomial_value() -> None:
+    source = _polynomial((1, (2, 0, 0)), (1, (0, 2, 0)), (1, (0, 0, 2)))
+
+    assert singularity_profile(source).outcome.status == (
+        "SMOOTH_OVER_ALGEBRAIC_CLOSURE"
+    )

--- a/tests/process/geometry/test_projective_singularity_point_worker.py
+++ b/tests/process/geometry/test_projective_singularity_point_worker.py
@@ -1,0 +1,125 @@
+"""Process-boundary tests for exact projective singular-point construction."""
+
+from __future__ import annotations
+
+import threading
+from fractions import Fraction
+from time import monotonic
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_process import (
+    run_point_construction_worker,
+)
+from jacobian.math.geometry.algebraic_curves._singularity_point_worker import (
+    ProjectiveSingularityPointWorkerRequest,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+from jacobian.process import bounded_process_cancellation
+
+
+def _polynomial(
+    variables: tuple[str, ...],
+    *terms: tuple[int, tuple[int, ...]],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(num=str(coefficient), den="1"),
+                    exponents=exponents,
+                )
+                for coefficient, exponents in terms
+            )
+        ),
+    )
+
+
+def _conjugate_point_request() -> ProjectiveSingularityPointWorkerRequest:
+    axis = ("X", "Y", "Z")
+    source = _polynomial(
+        axis,
+        (1, (2, 0, 1)),
+        (1, (0, 2, 1)),
+        (1, (0, 0, 3)),
+    )
+    partials = (
+        _polynomial(axis, (2, (1, 0, 1))),
+        _polynomial(axis, (2, (0, 1, 1))),
+        _polynomial(
+            axis,
+            (1, (2, 0, 0)),
+            (1, (0, 2, 0)),
+            (3, (0, 0, 2)),
+        ),
+    )
+    component = RationalPolynomialIdeal(
+        variables=("Y", "Z"),
+        generators=(
+            _polynomial(("Y", "Z"), (1, (2, 0)), (1, (0, 0))),
+            _polynomial(("Y", "Z"), (1, (0, 1))),
+        ),
+    )
+    return ProjectiveSingularityPointWorkerRequest(
+        source=source,
+        partials=partials,
+        chart_zero_components=(component,),
+        chart_one_components=(),
+        chart_two_present=False,
+    )
+
+
+def test_point_worker_returns_one_exact_quadratic_residue_field_seed() -> None:
+    result = run_point_construction_worker(
+        _conjugate_point_request(),
+        deadline=monotonic() + 30,
+    )
+
+    assert result.kind == "complete"
+    assert len(result.seeds) == 1
+    seed = result.seeds[0]
+    assert seed.presentation.coefficients_descending == ("1", "0", "1")
+    assert tuple(
+        tuple(
+            coefficient.as_fraction()
+            for coefficient in coordinate.coefficients_ascending
+        )
+        for coordinate in seed.coordinates
+    ) == (
+        (Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(1)),
+        (Fraction(0), Fraction(0)),
+    )
+
+
+def test_expired_point_worker_deadline_fails_before_launch() -> None:
+    with pytest.raises(OperationExecutionTimeoutError):
+        run_point_construction_worker(
+            _conjugate_point_request(),
+            deadline=monotonic() - 1,
+        )
+
+
+def test_point_worker_preserves_request_cancellation() -> None:
+    cancellation = threading.Event()
+    cancellation.set()
+
+    with (
+        bounded_process_cancellation(cancellation),
+        pytest.raises(OperationExecutionCancelledError),
+    ):
+        run_point_construction_worker(
+            _conjugate_point_request(),
+            deadline=monotonic() + 30,
+        )

--- a/tests/process/polynomials/ideals/test_singular_process.py
+++ b/tests/process/polynomials/ideals/test_singular_process.py
@@ -111,6 +111,19 @@ def test_timeout_is_not_reported_as_a_mathematical_result(
     assert result.ideal is None
 
 
+def test_exhausted_shared_deadline_does_not_launch_singular() -> None:
+    result = run_singular_ideal_operation(
+        "radical",
+        _ideal(),
+        None,
+        IdealComputationBudget(wall_seconds=60),
+        wall_seconds=0.0,
+    )
+
+    assert result.outcome == "TIMEOUT"
+    assert result.ideal is None
+
+
 def test_cancellation_is_preserved_as_its_own_outcome(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

#2870 asks for the complete projective singular locus of a bounded plane curve over the algebraic closure of `QQ`. Restricting the result to rational points would change that postcondition: for example, `Z(X^2 + Y^2 + Z^2)` has the two singular points `[1:i:0]` and `[1:-i:0]` and no rational singular point representing either one.

This PR is stacked on #3064, which supplies the exact embedded number-field identity needed to distinguish those conjugate geometric points after strict JSON serialization.

Closes #2870.

## Solution

Add `algebraic_geometry.projective_plane_curve.singularity_profile.compute` and the matching native `singularity_profile` function for nonzero homogeneous ternary polynomials over `QQ` of degree one through three.

The kernel normalizes the source up to rational scalar and asks the existing Singular 4.4 adapter for

```text
<F, F_X, F_Y, F_Z> : <X,Y,Z>^infinity.
```

The unit ideal is the exact smooth outcome. In characteristic zero, a plane curve has a positive-dimensional singular locus exactly when its equation has a repeated irreducible component; that branch retains the saturated ideal and Singular's complete rational minimal-prime family without advertising it as an absolute decomposition.

For a finite singular locus, three disjoint projective charts avoid duplicate points. Singular computes rational minimal primes in the first two charts; the final chart is the single point `[0:0:1]`, tested directly against the saturated ideal. One killable SymPy 1.14 worker then uses exact lexicographic Groebner bases, square-free factorization, and rational-univariate residue fields to construct point seeds. It replays `F` and all three partials exactly modulo each defining polynomial before the number-field embedding operation expands every residue-field seed into its full geometric Galois orbit. Singular and SymPy remain private maintained kernels; the public result uses Jacobian's canonical polynomials, ideals, embedded number fields, field elements, and projective points.

All phases share one request deadline. Owner-local admission derives the Macaulay, quotient-degree, point-count, shape-search, and result-size envelopes once. Every decoded ideal is checked for component, generator, term, degree, and coefficient bounds before it can enter point construction or a result. A contradiction becomes a stage-specific `LIMIT_EXCEEDED` outcome, including at result serialization, rather than a host or transport exception.

## Testing

The mathematical regressions include:

- `Z(X^2 + Y^2 + Z^2)`, which returns the distinct `QQ(i)` embeddings `[1:-i:0]` and `[1:i:0]`;
- `X^3 - 6XYZ + 2Y^3 + 4Z^3`, whose singular locus is a complete degree-three mixed-signature Galois orbit and exercises the nonmonic presentation `2t^3 - 1`;
- smooth conics and cubics, singularities in all three disjoint charts, a nodal cubic, concurrent and repeated lines, scalar associates, exact result round trips, cancellation, and the maximal admitted result shape.

Validation on the reviewed patch stack:

```sh
make affected AFFECTED_BASE=origin/feat/issue-1689-number-field-embeddings
```

This passed scoped Ruff and mypy; 6,454 math, 113 catalog, 810 catalog-example, 4 CLI, 114 dispatch, 912 integration, 274 tooling, 31 MCP, 200 process, and 187 Singular tests.

The dependency then advanced by a documentation-only commit. `git range-diff` showed all five patches unchanged on the final stack, after which these final-stack checks passed:

```sh
uv run --locked pytest -q -n 0 \
  tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py \
  tests/process/geometry/test_projective_singularity_point_worker.py
make docs-linkcheck
```

## Public contract impact

Adds one catalog operation, one native function, and canonical algebraic projective-plane point/result types. Exact mathematical outcomes are discriminated from backend unavailability, timeout, cancellation, malformed backend output, and resource-limit exhaustion.

## Operation boundary ownership

- Changed stage: request bounds, exact backend adapter, result construction, catalog publication, and process projection.
- Request-bounds owner and controlling quantities: `algebraic_curves._singularity` owns normalized degree/height/term admission, derived Macaulay growth, quotient degree, geometric point count, separating-form count, decoded ideal shape, exact output, and the shared deadline.
- Work, intermediate, memory, and exact-output bounds: degree at most 3, 10 source terms, 8 normalized coefficient digits, a 15-monomial Macaulay layer, residue degree and geometric point count at most 4, at most 7 separating forms, at most 16 retained rational components, and owner-checked families of at most 64 generators and 1,024 terms of degree at most 4. The largest source derives a 139-digit ideal-component bound; maximal canonical serialization remains below 10 MiB.
- Wall deadline, calibration workload, safety margin, and caller-selectable range: one caller-selectable 1–60 second deadline, default 30 seconds, covers normalization, Singular saturation/minimal primes, isolated point construction, embedding enumeration, result construction, and serialization. Mathematical admission is not inferred from elapsed wall time.
- Backend or kernel path: Singular 4.4 `sat` and `minAssGTZE`; pinned SymPy 1.14 exact `QQ` Groebner bases and factorization in one bounded worker.
- Result construction: the trusted owner converts only bounded exact backend values, replays the defining first-jet invariant before constructing point records, and preserves the saturated ideal as the defining locus evidence. Malformed or oversized projections remain typed operational outcomes.
- Independent-result verifier (only if the public contract accepts independently supplied result data): none; the operation does not accept caller-supplied result data.
- Native/MCP parity: both call the same typed owner function and have identical mathematical admission and results.
- Serialized-result and round-trip evidence: the Gaussian nonrational regression round-trips through the strict result schema; the maximal 139-digit ideal-family shape is canonically serialized within the admitted byte formula.

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Producer→consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: nonzero homogeneous polynomials in exactly three ordered variables over `QQ`, degree 1–3. The square-free/repeated-component dimension dichotomy uses characteristic zero.
- Structurally valid but mathematically invalid fixture and outcome: result deserialization is deliberately structural and does not replay a forged nonzero first jet. Only trusted producer construction follows exact substitution and reduction of `F` and all partials.
- Serialized-subtype trust boundary: requests validate the complete public domain; Singular output is decoded into bounded canonical ideals; the isolated worker and embedding owner establish field/point invariants; ordinary result parsing is structural.
- Exact-success defining invariant: the returned ideal is the projective saturation above; each finite point belongs to one disjoint chart, and `F=F_X=F_Y=F_Z=0` exactly in its presented residue field; embedding enumeration returns the complete geometric orbit.
- Discriminated result schema and impossible combinations: smooth, zero-dimensional, positive-dimensional, and incomplete branches use required status discriminators and branch-specific fields.

## Catalog admission

- Concrete gap: no operation computes and serializes the complete projective singular locus over `QQbar`.
- Why existing operations or typed values are insufficient: generic ideal operations can produce individual algebraic intermediates but do not establish chart-complete embedded points, Galois-orbit completeness, or the plane-curve dimension branch as one stable postcondition.
- Stable mathematical result: a source-bound global singularity profile retaining the normalized equation, its ordered first derivatives, saturated Jacobian ideal, and the complete dimension-appropriate locus data.
- Semantic domain and admitted execution envelope: bounded degree-1–3 homogeneous plane curves over `QQ`, with the derived limits described above.
- Controlling work, intermediate, memory, and output quantities: Macaulay dimension and coefficient height, decoded ideal family shape, quotient degree, separating forms, geometric embeddings, worker output, and final canonical bytes.
- Exact representation, algorithm regimes, and maintained backend: canonical rational polynomials/ideals and embedded simple number fields; Singular for projective ideal operations and SymPy for exact residue-field construction.
- Remaining fixed caps and their classification: degree 3 and the associated degree-4 point carrier define this first complete-result envelope; term/generator/component caps conservatively bound private backend expansion and exact output.
- Motivating source request exercised through the public boundary: the nonrational singular pair of `Z(X^2 + Y^2 + Z^2)`.
- Final-tree outcome for that request: two distinct embedded `QQ(i)` projective points with root indexes 0 and 1.
- Effect of private normalization or presolve on admission: nonzero rational scalar associates share one primitive positive-leading integer source; normalization does not remove repeated components or change the singular locus.
- Admission decision: admit the operation as one atomic exact global singular-locus postcondition.

## Closure matrix

None. #2870 requests this single operation and leaves no residual candidate surface.

## Checklist

- [x] `make handoff LANE=... TESTS=...` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, backend, Harbor/Oracle)
- [x] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (not applicable)
- [x] Catalog changes have an explicit owner-local `_tools.py` publication outcome
- [x] No compatibility aliases, forwarding modules, or generic `_operations.py` shadow paths were introduced
- [x] Runtime-bound changes name the request-bounds owner and execute the same semantic path for native and MCP callers
- [x] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable
- [x] Public operation changes include a behavioral regression copied from a motivating parent-gap request
- [x] New or changed bounds include boundary, algorithm-crossover, and realistic source-backed scale evidence
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable; the added projective point is a domain-owned canonical value)
