### PR TITLE
Compute exact rank for sparse rational matrices

### DIFF
--- a/src/jacobian/math/geometry/framework/__init__.py
+++ b/src/jacobian/math/geometry/framework/__init__.py
@@ -1,0 +1,19 @@
+"""Exact planar framework operations and values."""
+
+from jacobian.math.geometry.exact._models import (
+    LabelledRationalPoint,
+    PointConfiguration,
+)
+from jacobian.math.geometry.framework._models import (
+    PlanarRigidityProfile,
+)
+from jacobian.math.geometry.framework.operations import planar_rigidity_profile
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+__all__ = [
+    "LabelledRationalPoint",
+    "PlanarRigidityProfile",
+    "PointConfiguration",
+    "SimpleUndirectedGraph",
+    "planar_rigidity_profile",
+]

--- a/src/jacobian/math/geometry/framework/_bounds.py
+++ b/src/jacobian/math/geometry/framework/_bounds.py
@@ -1,0 +1,40 @@
+"""Shared raw and canonical work bounds for planar rigidity profiles."""
+
+from __future__ import annotations
+
+MAX_FRAMEWORK_COORDINATE_WORK = 100_000_000
+"""Decimal-limb and rational-difference work admitted before matrix expansion."""
+
+
+def rational_parse_work(components: tuple[str, str]) -> int:
+    """Bound base-10**9 multiply-add visits for two rational components."""
+
+    work = 0
+    for component in components:
+        digits = len(component.lstrip("-"))
+        limbs = (digits + 8) // 9
+        work += limbs * (limbs + 1)
+    return work
+
+
+def rational_height(components: tuple[str, str]) -> int:
+    """Return the largest canonical decimal component width."""
+
+    return max(len(component.lstrip("-")) for component in components)
+
+
+def difference_work(left: tuple[str, str], right: tuple[str, str]) -> int:
+    """Price subtraction plus both signed canonical sparse-entry projections."""
+
+    height = max(rational_height(left), rational_height(right))
+    # A quadratic height charge conservatively covers the two cross-products,
+    # subtraction, reduction, and decimal projection of both signed entries.
+    return 32 * height * height + 32 * height
+
+
+__all__ = [
+    "MAX_FRAMEWORK_COORDINATE_WORK",
+    "difference_work",
+    "rational_height",
+    "rational_parse_work",
+]

--- a/src/jacobian/math/geometry/framework/_models.py
+++ b/src/jacobian/math/geometry/framework/_models.py
@@ -1,0 +1,244 @@
+"""Typed contracts for exact planar framework rigidity profiles."""
+
+from __future__ import annotations
+
+from typing import Any, Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.geometry.exact._models import (
+    MAX_PAIRS,
+    MAX_POINTS,
+    PointConfiguration,
+)
+from jacobian.math.geometry.framework._bounds import (
+    MAX_FRAMEWORK_COORDINATE_WORK,
+    difference_work,
+    rational_parse_work,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.matrices._operation_models import MatrixRankResult
+from jacobian.math.matrices.values import SparseRationalMatrix
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"geometry.framework.{reason}", message)
+
+
+def _require_planar_framework_shape(
+    configuration: PointConfiguration,
+    graph: SimpleUndirectedGraph,
+) -> None:
+    """Require one planar realization of exactly the graph's labelled vertices."""
+
+    if len(configuration.points[0].coordinates) != 2:
+        raise _validation_error(
+            "configuration_must_be_planar",
+            "framework configuration points must have exactly two coordinates",
+        )
+    point_labels = tuple(point.label for point in configuration.points)
+    if len(graph.vertices) != len(point_labels) or set(graph.vertices) != set(
+        point_labels
+    ):
+        raise _validation_error(
+            "graph_vertices_must_match_point_labels",
+            "graph vertices must equal the configuration point-label set",
+        )
+
+
+def _raw_field(value: object, name: str) -> object:
+    if isinstance(value, dict):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _raw_rational_components(value: object) -> tuple[str, str] | None:
+    numerator = _raw_field(value, "num")
+    denominator = _raw_field(value, "den")
+    if not isinstance(numerator, str) or not isinstance(denominator, str):
+        return None
+    return numerator, denominator
+
+
+def _raw_coordinate_map(
+    raw_points: list[object] | tuple[object, ...],
+) -> tuple[
+    dict[str, tuple[tuple[str, str], tuple[str, str]]],
+    int,
+]:
+    coordinates: dict[str, tuple[tuple[str, str], tuple[str, str]]] = {}
+    source_parse_work = 0
+    for raw_point in raw_points:
+        label = _raw_field(raw_point, "label")
+        raw_coordinates = _raw_field(raw_point, "coordinates")
+        if not isinstance(label, str) or not isinstance(raw_coordinates, (list, tuple)):
+            continue
+        if len(raw_coordinates) != 2:
+            raise _validation_error(
+                "configuration_must_be_planar",
+                "framework configuration points must have exactly two coordinates",
+            )
+        component_pairs = tuple(
+            components
+            for raw_coordinate in raw_coordinates
+            if (components := _raw_rational_components(raw_coordinate)) is not None
+        )
+        source_parse_work += sum(map(rational_parse_work, component_pairs))
+        if source_parse_work > MAX_FRAMEWORK_COORDINATE_WORK:
+            raise _coordinate_work_error()
+        if len(component_pairs) == 2:
+            coordinates[label] = (component_pairs[0], component_pairs[1])
+    return coordinates, source_parse_work
+
+
+def _coordinate_work_error() -> PydanticCustomError:
+    return _validation_error(
+        "coordinate_work_exceeds_bound",
+        "framework coordinate normalization and edge differences exceed "
+        f"the {MAX_FRAMEWORK_COORDINATE_WORK:,}-unit work bound",
+    )
+
+
+def _require_raw_execution_envelope(data: object) -> None:
+    if not isinstance(data, dict):
+        return
+    raw_points = _raw_field(data.get("configuration"), "points")
+    raw_edges = _raw_field(data.get("graph"), "edges")
+    if not isinstance(raw_points, (list, tuple)):
+        return
+    if len(raw_points) > MAX_POINTS:
+        raise _validation_error(
+            "point_count_exceeds_bound",
+            f"framework configurations contain at most {MAX_POINTS} points",
+        )
+    coordinates, total_work = _raw_coordinate_map(raw_points)
+    if not isinstance(raw_edges, (list, tuple)):
+        return
+    if len(raw_edges) > MAX_PAIRS:
+        raise _validation_error(
+            "edge_count_exceeds_bound",
+            f"a graph on a framework configuration contains at most {MAX_PAIRS} edges",
+        )
+    for raw_edge in raw_edges:
+        if not isinstance(raw_edge, (list, tuple)) or len(raw_edge) != 2:
+            continue
+        left_label, right_label = raw_edge
+        if left_label not in coordinates or right_label not in coordinates:
+            continue
+        total_work += sum(
+            difference_work(left_coordinate, right_coordinate)
+            for left_coordinate, right_coordinate in zip(
+                coordinates[left_label], coordinates[right_label], strict=True
+            )
+        )
+        if total_work > MAX_FRAMEWORK_COORDINATE_WORK:
+            raise _coordinate_work_error()
+
+
+class PlanarRigidityProfileRequest(StrictModel):
+    """One labelled rational planar framework.
+
+    The configuration's point order defines the vertex and coordinate-column
+    axis. The graph must contain exactly the same labels. Graph edge tuple order
+    is not authoritative: the result derives a lexicographically sorted edge
+    axis.
+    """
+
+    configuration: PointConfiguration = Field(
+        description=(
+            "A labelled rational point configuration in exactly two dimensions; "
+            "its declared point order is the rigidity-matrix vertex axis."
+        )
+    )
+    graph: SimpleUndirectedGraph = Field(
+        description=(
+            "A simple undirected graph whose vertex set exactly equals the "
+            "configuration point-label set. Edge tuple order is ignored when "
+            "deriving the sorted result edge axis."
+        )
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_execution_envelope(cls, data: Any) -> Any:
+        """Reject excessive coordinate work before nested rational parsing."""
+
+        _require_raw_execution_envelope(data)
+        return canonicalize_json_containers(data)
+
+    @model_validator(mode="after")
+    def require_planar_framework(self) -> Self:
+        _require_planar_framework_shape(self.configuration, self.graph)
+        return self
+
+
+class PlanarRigidityProfile(StrictModel):
+    """Exact source-bound rigidity matrix and rational rank of one framework.
+
+    ``matrix_rank.matrix`` has one row per ``edge_axis`` entry and two columns
+    per ``vertex_axis`` entry. Columns ``2*i`` and ``2*i + 1`` are respectively
+    the x and y coordinates of vertex ``vertex_axis[i]``. A false
+    ``is_infinitesimally_rigid`` value says only that the supplied realization
+    fails the infinitesimal rank criterion; it is not a local- or global-
+    non-rigidity conclusion.
+    """
+
+    configuration: PointConfiguration
+    graph: SimpleUndirectedGraph
+    vertex_axis: tuple[str, ...] = Field(min_length=2, max_length=MAX_POINTS)
+    edge_axis: tuple[tuple[str, str], ...] = Field(max_length=MAX_PAIRS)
+    matrix_rank: MatrixRankResult
+    maximal_infinitesimal_rigidity_rank: int = Field(ge=1, le=2 * MAX_POINTS - 3)
+    is_infinitesimally_rigid: bool
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls.model_construct(**values)
+
+    @model_validator(mode="after")
+    def require_structural_source_binding(self) -> Self:
+        _require_planar_framework_shape(self.configuration, self.graph)
+        source_vertex_axis = tuple(point.label for point in self.configuration.points)
+        if self.vertex_axis != source_vertex_axis:
+            raise _validation_error(
+                "vertex_axis_must_follow_configuration_order",
+                "vertex axis must equal the configuration's declared point order",
+            )
+        if self.edge_axis != tuple(sorted(self.graph.edges)):
+            raise _validation_error(
+                "edge_axis_must_be_sorted_graph_edges",
+                "edge axis must be the lexicographically sorted graph edges",
+            )
+        matrix = self.matrix_rank.matrix
+        if not isinstance(matrix, SparseRationalMatrix):
+            raise _validation_error(
+                "rigidity_matrix_must_be_coordinate_sparse",
+                "rigidity matrix must use the coordinate-sparse rational carrier",
+            )
+        if matrix.row_count != len(self.edge_axis) or matrix.column_count != 2 * len(
+            self.vertex_axis
+        ):
+            raise _validation_error(
+                "rigidity_matrix_axes_must_match_framework_axes",
+                "rigidity matrix axes must be |edge_axis| by 2|vertex_axis|",
+            )
+        maximal_rank = 2 * len(self.vertex_axis) - 3
+        if self.maximal_infinitesimal_rigidity_rank != maximal_rank:
+            raise _validation_error(
+                "maximal_rank_must_equal_two_vertices_minus_three",
+                "maximal infinitesimal-rigidity rank must equal 2|V|-3",
+            )
+        if self.is_infinitesimally_rigid != (self.matrix_rank.rank == maximal_rank):
+            raise _validation_error(
+                "rigidity_decision_must_match_rank",
+                "infinitesimal-rigidity decision must equal rank == 2|V|-3",
+            )
+        return self
+
+
+__all__ = [
+    "PlanarRigidityProfile",
+    "PlanarRigidityProfileRequest",
+]

--- a/src/jacobian/math/geometry/framework/_tools.py
+++ b/src/jacobian/math/geometry/framework/_tools.py
@@ -14,7 +14,9 @@ from jacobian.math.geometry.framework.operations import planar_rigidity_profile
 def _run_planar_rigidity_profile(
     request: PlanarRigidityProfileRequest,
 ) -> PlanarRigidityProfile:
-    return planar_rigidity_profile(request.configuration, request.graph)
+    return planar_rigidity_profile(
+        request.configuration, request.graph, enforce_transport_limit=True
+    )
 
 
 TOOLS: tuple[MathTool[Any, Any], ...] = (

--- a/src/jacobian/math/geometry/framework/_tools.py
+++ b/src/jacobian/math/geometry/framework/_tools.py
@@ -1,0 +1,80 @@
+"""Exact planar framework operation declarations."""
+
+from typing import Any
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool
+from jacobian.math.geometry.framework._models import (
+    PlanarRigidityProfile,
+    PlanarRigidityProfileRequest,
+)
+from jacobian.math.geometry.framework.operations import planar_rigidity_profile
+
+
+def _run_planar_rigidity_profile(
+    request: PlanarRigidityProfileRequest,
+) -> PlanarRigidityProfile:
+    return planar_rigidity_profile(request.configuration, request.graph)
+
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="geometry.framework.planar_rigidity_profile.compute",
+        title="Compute an exact planar framework rigidity profile",
+        description=(
+            "Given a labelled rational planar point configuration and a simple "
+            "undirected graph on exactly the same labels, construct the exact "
+            "coordinate-sparse rigidity matrix on the configuration's vertex "
+            "axis and the lexicographically sorted graph-edge axis, then return "
+            "its exact rational rank and pivot columns. Rank 2|V|-3 establishes "
+            "infinitesimal rigidity of the supplied realization; a smaller rank "
+            "does not decide local or global rigidity."
+        ),
+        request_type=PlanarRigidityProfileRequest,
+        result_type=PlanarRigidityProfile,
+        run=_run_planar_rigidity_profile,
+        tags=("geometry", "framework", "rigidity-matrix", "exact-rational"),
+        examples=(
+            example(
+                "rational_triangle",
+                "Compute the exact rigidity matrix and rank of a non-collinear "
+                "rational triangle; the graph labels must exactly match the "
+                "planar configuration labels.",
+                {
+                    "configuration": {
+                        "points": [
+                            {
+                                "label": "a",
+                                "coordinates": [
+                                    {"num": "0", "den": "1"},
+                                    {"num": "0", "den": "1"},
+                                ],
+                            },
+                            {
+                                "label": "b",
+                                "coordinates": [
+                                    {"num": "1", "den": "1"},
+                                    {"num": "0", "den": "1"},
+                                ],
+                            },
+                            {
+                                "label": "c",
+                                "coordinates": [
+                                    {"num": "0", "den": "1"},
+                                    {"num": "1", "den": "1"},
+                                ],
+                            },
+                        ]
+                    },
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["b", "c"], ["a", "c"], ["a", "b"]],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/geometry/framework/operations.py
+++ b/src/jacobian/math/geometry/framework/operations.py
@@ -48,7 +48,11 @@ class _FrameworkAdmission:
 def _reject(location: tuple[str | int, ...], code: str, message: str) -> NoReturn:
     raise OperationDomainValidationError(
         location=location,
-        code=(code if code.startswith("geometry.framework.") else f"geometry.framework.{code}"),
+        code=(
+            code
+            if code.startswith("geometry.framework.")
+            else f"geometry.framework.{code}"
+        ),
         message=message,
     )
 

--- a/src/jacobian/math/geometry/framework/operations.py
+++ b/src/jacobian/math/geometry/framework/operations.py
@@ -48,7 +48,7 @@ class _FrameworkAdmission:
 def _reject(location: tuple[str | int, ...], code: str, message: str) -> NoReturn:
     raise OperationDomainValidationError(
         location=location,
-        code=f"geometry.framework.{code}",
+        code=(code if code.startswith("geometry.framework.") else f"geometry.framework.{code}"),
         message=message,
     )
 
@@ -205,12 +205,15 @@ def _reserve_profile_output_bytes(
 def planar_rigidity_profile(
     configuration: PointConfiguration,
     graph: SimpleUndirectedGraph,
+    *,
+    enforce_transport_limit: bool = False,
 ) -> PlanarRigidityProfile:
     """Return the exact planar rigidity matrix and rational rank."""
 
     admission = _admit_framework(configuration, graph)
     matrix = _rigidity_matrix(admission)
-    _reserve_profile_output_bytes(configuration, graph, admission, matrix)
+    if enforce_transport_limit:
+        _reserve_profile_output_bytes(configuration, graph, admission, matrix)
     try:
         matrix_rank = rank_result(matrix)
     except OperationDomainValidationError as exc:

--- a/src/jacobian/math/geometry/framework/operations.py
+++ b/src/jacobian/math/geometry/framework/operations.py
@@ -1,0 +1,237 @@
+"""Exact planar framework rigidity operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import NoReturn
+
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+)
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.exact._models import PointConfiguration
+from jacobian.math.geometry.framework._bounds import (
+    MAX_FRAMEWORK_COORDINATE_WORK,
+    difference_work,
+    rational_parse_work,
+)
+from jacobian.math.geometry.framework._models import (
+    PlanarRigidityProfile,
+    _require_planar_framework_shape,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.matrices._operation_models import MAX_INPUT_SCALAR_DIGITS
+from jacobian.math.matrices.operations import rank_result
+from jacobian.math.matrices.values import (
+    SparseRationalMatrix,
+    SparseRationalMatrixEntry,
+)
+
+_MATRIX_SCALAR_LIMIT = 10**MAX_INPUT_SCALAR_DIGITS
+
+
+@dataclass(frozen=True, slots=True)
+class _FrameworkAdmission:
+    vertex_axis: tuple[str, ...]
+    edge_axis: tuple[tuple[str, str], ...]
+    coordinates: dict[str, tuple[Fraction, Fraction]]
+    source_parse_work: int
+    coordinate_difference_work: int
+
+
+def _reject(location: tuple[str | int, ...], code: str, message: str) -> NoReturn:
+    raise OperationDomainValidationError(
+        location=location,
+        code=f"geometry.framework.{code}",
+        message=message,
+    )
+
+
+def _admit_framework(
+    configuration: PointConfiguration,
+    graph: SimpleUndirectedGraph,
+) -> _FrameworkAdmission:
+    try:
+        _require_planar_framework_shape(configuration, graph)
+    except PydanticCustomError as exc:
+        _reject(("configuration",), exc.type, exc.message())
+
+    vertex_axis = tuple(point.label for point in configuration.points)
+    edge_axis = tuple(sorted(graph.edges))
+    canonical_coordinates = {
+        point.label: (point.coordinates[0], point.coordinates[1])
+        for point in configuration.points
+    }
+    source_parse_work = sum(
+        rational_parse_work((coordinate.num, coordinate.den))
+        for coordinates in canonical_coordinates.values()
+        for coordinate in coordinates
+    )
+    if source_parse_work > MAX_FRAMEWORK_COORDINATE_WORK:
+        _reject(
+            ("configuration", "points"),
+            "coordinate_work_exceeds_bound",
+            "framework coordinate normalization and edge differences exceed "
+            f"the {MAX_FRAMEWORK_COORDINATE_WORK:,}-unit work bound",
+        )
+    coordinate_difference_work = 0
+    for left_label, right_label in edge_axis:
+        left = canonical_coordinates[left_label]
+        right = canonical_coordinates[right_label]
+        coordinate_difference_work += sum(
+            difference_work(
+                (left_coordinate.num, left_coordinate.den),
+                (right_coordinate.num, right_coordinate.den),
+            )
+            for left_coordinate, right_coordinate in zip(left, right, strict=True)
+        )
+        if (
+            source_parse_work + coordinate_difference_work
+            > MAX_FRAMEWORK_COORDINATE_WORK
+        ):
+            _reject(
+                ("configuration", "points"),
+                "coordinate_work_exceeds_bound",
+                "framework coordinate normalization and edge differences exceed "
+                f"the {MAX_FRAMEWORK_COORDINATE_WORK:,}-unit work bound",
+            )
+
+    coordinates = {
+        label: (values[0].as_fraction(), values[1].as_fraction())
+        for label, values in canonical_coordinates.items()
+    }
+    return _FrameworkAdmission(
+        vertex_axis=vertex_axis,
+        edge_axis=edge_axis,
+        coordinates=coordinates,
+        source_parse_work=source_parse_work,
+        coordinate_difference_work=coordinate_difference_work,
+    )
+
+
+def _matrix_scalar(value: Fraction) -> CanonicalRational:
+    numerator = value.numerator
+    denominator = value.denominator
+    if abs(numerator) >= _MATRIX_SCALAR_LIMIT or denominator >= _MATRIX_SCALAR_LIMIT:
+        _reject(
+            ("configuration", "points"),
+            "rigidity_matrix_scalar_exceeds_rank_bound",
+            "a derived rigidity-matrix scalar exceeds matrix.rank.compute's "
+            f"{MAX_INPUT_SCALAR_DIGITS}-digit input bound",
+        )
+    return CanonicalRational.from_fraction(value)
+
+
+def _rigidity_matrix(admission: _FrameworkAdmission) -> SparseRationalMatrix:
+    vertex_positions = {
+        label: index for index, label in enumerate(admission.vertex_axis)
+    }
+    entries: list[SparseRationalMatrixEntry] = []
+    for row, (left_label, right_label) in enumerate(admission.edge_axis):
+        left = admission.coordinates[left_label]
+        right = admission.coordinates[right_label]
+        left_vertex = vertex_positions[left_label]
+        right_vertex = vertex_positions[right_label]
+        row_entries: list[SparseRationalMatrixEntry] = []
+        for coordinate, (left_value, right_value) in enumerate(
+            zip(left, right, strict=True)
+        ):
+            difference = left_value - right_value
+            if difference == 0:
+                continue
+            row_entries.extend(
+                (
+                    SparseRationalMatrixEntry(
+                        row=row,
+                        column=2 * left_vertex + coordinate,
+                        value=_matrix_scalar(difference),
+                    ),
+                    SparseRationalMatrixEntry(
+                        row=row,
+                        column=2 * right_vertex + coordinate,
+                        value=_matrix_scalar(-difference),
+                    ),
+                )
+            )
+        entries.extend(sorted(row_entries, key=lambda entry: entry.column))
+    return SparseRationalMatrix(
+        row_count=len(admission.edge_axis),
+        column_count=2 * len(admission.vertex_axis),
+        entries=tuple(entries),
+    )
+
+
+def _reserve_profile_output_bytes(
+    configuration: PointConfiguration,
+    graph: SimpleUndirectedGraph,
+    admission: _FrameworkAdmission,
+    matrix: SparseRationalMatrix,
+) -> int:
+    """Preflight the largest canonical profile for this exact retained source."""
+
+    rank_bound = min(matrix.row_count, matrix.column_count)
+    largest_pivots = tuple(range(matrix.column_count - rank_bound, matrix.column_count))
+    maximal_rank = 2 * len(admission.vertex_axis) - 3
+    candidate = {
+        "configuration": configuration.model_dump(mode="json"),
+        "graph": graph.model_dump(mode="json"),
+        "vertex_axis": list(admission.vertex_axis),
+        "edge_axis": [list(edge) for edge in admission.edge_axis],
+        "matrix_rank": {
+            "matrix": matrix.model_dump(mode="json"),
+            "rank": rank_bound,
+            "pivot_columns": list(largest_pivots),
+        },
+        "maximal_infinitesimal_rigidity_rank": maximal_rank,
+        "is_infinitesimally_rigid": False,
+    }
+    try:
+        return len(encode_strict_json(candidate))
+    except CanonicalizationError:
+        _reject(
+            ("configuration",),
+            "result_exceeds_canonical_output",
+            "the complete source-bound rigidity profile would exceed the "
+            f"{CanonicalLimits().max_output_bytes:,}-byte canonical output limit",
+        )
+
+
+def planar_rigidity_profile(
+    configuration: PointConfiguration,
+    graph: SimpleUndirectedGraph,
+) -> PlanarRigidityProfile:
+    """Return the exact planar rigidity matrix and rational rank."""
+
+    admission = _admit_framework(configuration, graph)
+    matrix = _rigidity_matrix(admission)
+    _reserve_profile_output_bytes(configuration, graph, admission, matrix)
+    try:
+        matrix_rank = rank_result(matrix)
+    except OperationDomainValidationError as exc:
+        error = exc.errors()[0]
+        _reject(
+            ("configuration", "points"),
+            "rigidity_matrix_rank_admission_failed",
+            "the derived rigidity matrix is outside matrix.rank.compute "
+            f"admission: {error['msg']}",
+        )
+
+    maximal_rank = 2 * len(admission.vertex_axis) - 3
+    return PlanarRigidityProfile._from_kernel(
+        configuration=configuration,
+        graph=graph,
+        vertex_axis=admission.vertex_axis,
+        edge_axis=admission.edge_axis,
+        matrix_rank=matrix_rank,
+        maximal_infinitesimal_rigidity_rank=maximal_rank,
+        is_infinitesimally_rigid=matrix_rank.rank == maximal_rank,
+    )
+
+
+__all__ = ["planar_rigidity_profile"]

--- a/src/jacobian/math/matrices/__init__.py
+++ b/src/jacobian/math/matrices/__init__.py
@@ -15,10 +15,16 @@ from jacobian.math.matrices.operations import (
     solve_linear_system,
     trace,
 )
-from jacobian.math.matrices.values import SmithNormalForm
+from jacobian.math.matrices.values import (
+    SmithNormalForm,
+    SparseRationalMatrix,
+    SparseRationalMatrixEntry,
+)
 
 __all__ = [
     "SmithNormalForm",
+    "SparseRationalMatrix",
+    "SparseRationalMatrixEntry",
     "adjugate",
     "characteristic_polynomial",
     "determinant",

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -273,9 +273,19 @@ class MatrixRankRequest(_MatrixRequest):
 
     @classmethod
     def _require_raw_matrix_input(cls, value: object) -> None:
+        entries = value.get("entries") if isinstance(value, dict) else getattr(value, "entries", None)
+        has_coordinate_entries = isinstance(entries, (list, tuple)) and any(
+            isinstance(entry, dict)
+            and {"row", "column", "value"}.issubset(entry)
+            for entry in entries
+        )
         if isinstance(value, SparseRationalMatrix) or (
             isinstance(value, dict)
-            and ("row_count" in value or "column_count" in value)
+            and (
+                "row_count" in value
+                or "column_count" in value
+                or has_coordinate_entries
+            )
         ):
             _require_raw_sparse_matrix(value, label="matrix input")
             return

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -273,10 +273,13 @@ class MatrixRankRequest(_MatrixRequest):
 
     @classmethod
     def _require_raw_matrix_input(cls, value: object) -> None:
-        entries = value.get("entries") if isinstance(value, dict) else getattr(value, "entries", None)
+        entries = (
+            value.get("entries")
+            if isinstance(value, dict)
+            else getattr(value, "entries", None)
+        )
         has_coordinate_entries = isinstance(entries, (list, tuple)) and any(
-            isinstance(entry, dict)
-            and {"row", "column", "value"}.issubset(entry)
+            isinstance(entry, dict) and {"row", "column", "value"}.issubset(entry)
             for entry in entries
         )
         if isinstance(value, SparseRationalMatrix) or (

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -15,8 +15,11 @@ from jacobian.math.matrices.values import (
     MAX_MATRIX_DIMENSION,
     MAX_MATRIX_SCALAR_DIGITS,
     MAX_RATIONAL_MATRIX_ORDER,
+    MAX_SPARSE_RATIONAL_MATRIX_AXIS,
+    MAX_SPARSE_RATIONAL_MATRIX_NONZEROS,
     IntegerMatrix,
     RationalMatrix,
+    SparseRationalMatrix,
     integer_matrix_axis_schema,
     require_matrix_scalar_digits,
 )
@@ -37,6 +40,10 @@ MAX_PERMANENT_MATRIX_ORDER = MAX_PERMANENT_RYSER_SUBSETS.bit_length() - 1
 # through order 50. Pin each admitted output axis to that envelope.
 MAX_KRONECKER_PRODUCT_AXIS = 50
 MAX_EXACT_LINEAR_MATRIX_WORK = 100_000_000
+# Sparse Gauss-Jordan elimination can fill the Cartesian closure of the
+# nonzero rows and columns. Bound that predicted intermediate directly rather
+# than imposing a smaller limit on either declared matrix axis.
+MAX_SPARSE_RANK_INTERMEDIATE_CELLS = 1_000_000
 
 
 def _require_raw_scalar_digits(value: object, *, label: str) -> None:
@@ -94,10 +101,51 @@ def _require_raw_matrix(value: object, *, label: str, maximum_axis: int) -> None
             _require_raw_scalar_digits(scalar, label=label)
 
 
+def _require_raw_sparse_matrix(value: object, *, label: str) -> None:
+    """Bound sparse rank coordinates and scalars before nested parsing."""
+
+    if isinstance(value, dict):
+        unexpected = set(value).difference(
+            {"domain", "row_count", "column_count", "entries"}
+        )
+        if unexpected:
+            raise _validation_error(
+                "shape_mismatch", f"{label} contains unknown fields"
+            )
+        entries = value.get("entries")
+    else:
+        entries = getattr(value, "entries", None)
+    if not isinstance(entries, (list, tuple)):
+        return
+    if len(entries) > MAX_SPARSE_RATIONAL_MATRIX_NONZEROS:
+        raise _validation_error(
+            "budget_exceeded",
+            f"{label} stores at most {MAX_SPARSE_RATIONAL_MATRIX_NONZEROS} nonzeros",
+        )
+    for entry in entries:
+        if isinstance(entry, dict):
+            if set(entry).difference({"row", "column", "value"}):
+                raise _validation_error(
+                    "shape_mismatch", f"{label} entries contain unknown fields"
+                )
+            value = entry.get("value")
+        else:
+            value = getattr(entry, "value", None)
+        _require_raw_scalar_digits(value, label=label)
+
+
 class _MatrixRequest(StrictModel):
     """Raw transport preflight shared by bounded base-matrix requests."""
 
     _raw_matrix_axis_limit: ClassVar[int] = MAX_MATRIX_DIMENSION
+
+    @classmethod
+    def _require_raw_matrix_input(cls, value: object) -> None:
+        _require_raw_matrix(
+            value,
+            label="matrix input",
+            maximum_axis=cls._raw_matrix_axis_limit,
+        )
 
     @model_validator(mode="before")
     @classmethod
@@ -110,11 +158,7 @@ class _MatrixRequest(StrictModel):
             )
         for name in ("matrix", "left", "right"):
             if name in data:
-                _require_raw_matrix(
-                    data[name],
-                    label="matrix input",
-                    maximum_axis=cls._raw_matrix_axis_limit,
-                )
+                cls._require_raw_matrix_input(data[name])
         rhs = data.get("rhs")
         if isinstance(rhs, (list, tuple)):
             if len(rhs) > MAX_MATRIX_DIMENSION:
@@ -223,8 +267,18 @@ class MatrixDeterminantRequest(_MatrixRequest):
 class MatrixRankRequest(_MatrixRequest):
     """One bounded rectangular matrix whose exact rank is requested."""
 
-    matrix: RationalMatrix
+    matrix: RationalMatrix | SparseRationalMatrix
     _raw_matrix_axis_limit: ClassVar[int] = MAX_RATIONAL_MATRIX_ORDER
+
+    @classmethod
+    def _require_raw_matrix_input(cls, value: object) -> None:
+        if isinstance(value, SparseRationalMatrix) or (
+            isinstance(value, dict)
+            and ("row_count" in value or "column_count" in value)
+        ):
+            _require_raw_sparse_matrix(value, label="matrix input")
+            return
+        super()._require_raw_matrix_input(value)
 
 
 _ComputationIntegerMatrix = Annotated[
@@ -324,9 +378,9 @@ class MatrixDeterminantResult(StrictModel):
 class MatrixRankResult(StrictModel):
     """One structurally bounded rank outcome bound to its source matrix."""
 
-    matrix: RationalMatrix
-    rank: int = Field(ge=0, le=MAX_EXACT_LINEAR_MATRIX_AXIS)
-    pivot_columns: tuple[int, ...] = Field(max_length=MAX_EXACT_LINEAR_MATRIX_AXIS)
+    matrix: RationalMatrix | SparseRationalMatrix
+    rank: int = Field(ge=0, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
+    pivot_columns: tuple[int, ...] = Field(max_length=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
 
     @classmethod
     def _from_kernel(cls, **values: Any) -> Self:
@@ -338,7 +392,16 @@ class MatrixRankResult(StrictModel):
             raise _validation_error(
                 "budget_exceeded", "rank must equal the pivot column count"
             )
-        column_count = len(self.matrix.entries[0])
+        if isinstance(self.matrix, RationalMatrix):
+            row_count = len(self.matrix.entries)
+            column_count = len(self.matrix.entries[0])
+        else:
+            row_count = self.matrix.row_count
+            column_count = self.matrix.column_count
+        if self.rank > min(row_count, column_count):
+            raise _validation_error(
+                "shape_mismatch", "rank cannot exceed either source matrix axis"
+            )
         if self.pivot_columns != tuple(sorted(set(self.pivot_columns))) or any(
             not 0 <= column < column_count for column in self.pivot_columns
         ):

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -40,9 +40,10 @@ MAX_PERMANENT_MATRIX_ORDER = MAX_PERMANENT_RYSER_SUBSETS.bit_length() - 1
 # through order 50. Pin each admitted output axis to that envelope.
 MAX_KRONECKER_PRODUCT_AXIS = 50
 MAX_EXACT_LINEAR_MATRIX_WORK = 100_000_000
-# Sparse Gauss-Jordan elimination can fill the Cartesian closure of the
-# nonzero rows and columns. Bound that predicted intermediate directly rather
-# than imposing a smaller limit on either declared matrix axis.
+# Sparse Gauss-Jordan elimination can fill the Cartesian closure within each
+# connected bipartite support component. Bound the sum of those component
+# closures directly rather than coupling disjoint blocks or imposing a smaller
+# limit on either declared matrix axis.
 MAX_SPARSE_RANK_INTERMEDIATE_CELLS = 1_000_000
 
 

--- a/src/jacobian/math/matrices/_tools.py
+++ b/src/jacobian/math/matrices/_tools.py
@@ -74,7 +74,7 @@ def compute_kronecker_product(
 
 
 def compute_rank(request: MatrixRankRequest) -> MatrixRankResult:
-    return rank_result(request.matrix)
+    return rank_result(request.matrix, enforce_transport_limit=True)
 
 
 def compute_rational_linear_solve(

--- a/src/jacobian/math/matrices/_tools.py
+++ b/src/jacobian/math/matrices/_tools.py
@@ -306,7 +306,7 @@ TOOLS = (
     matrix_operation(
         "matrix.rank.compute",
         "Compute exact rational matrix rank",
-        "Compute the rank and RREF pivot columns of one rectangular matrix over QQ through 64 rows and columns, subject to scalar-work and result-height bounds.",
+        "Compute the rank and RREF pivot columns of one dense or coordinate-sparse rectangular matrix over QQ. Dense matrices are admitted through 64 axes; sparse matrices retain declared axes through 8192 and are admitted by active support, scalar work, intermediate height, and exact output size.",
         MatrixRankRequest,
         MatrixRankResult,
         compute_rank,
@@ -339,6 +339,23 @@ TOOLS = (
                                 {"num": "0", "den": "1"},
                             ],
                         ]
+                    }
+                },
+            ),
+            example(
+                "rank_sparse_last_column",
+                "Compute rank while retaining a sparse matrix's declared column axis.",
+                {
+                    "matrix": {
+                        "row_count": 1,
+                        "column_count": 128,
+                        "entries": [
+                            {
+                                "row": 0,
+                                "column": 127,
+                                "value": {"num": "1", "den": "1"},
+                            }
+                        ],
                     }
                 },
             ),

--- a/src/jacobian/math/matrices/_tools.py
+++ b/src/jacobian/math/matrices/_tools.py
@@ -306,7 +306,7 @@ TOOLS = (
     matrix_operation(
         "matrix.rank.compute",
         "Compute exact rational matrix rank",
-        "Compute the rank and RREF pivot columns of one dense or coordinate-sparse rectangular matrix over QQ. Dense matrices are admitted through 64 axes; sparse matrices retain declared axes through 8192 and are admitted by active support, scalar work, intermediate height, and exact output size.",
+        "Compute the rank and RREF pivot columns of one dense or coordinate-sparse rectangular matrix over QQ. Dense matrices are admitted through 64 axes; sparse matrices retain declared axes through 8192 and are admitted by connected support components, scalar work, intermediate height, and exact output size.",
         MatrixRankRequest,
         MatrixRankResult,
         compute_rank,

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -1195,20 +1195,25 @@ def rank_result(
     if isinstance(matrix, SparseRationalMatrix):
         plan = _admit(_admit_sparse_rank, matrix)
         if enforce_transport_limit:
-            _require_sparse_rank_transport_envelope(
-                matrix,
-                rank_bound=sum(
-                    min(len(component.rows), len(component.columns))
-                    for component in plan.components
-                ),
-                active_columns=tuple(
-                    sorted(
-                        column
+            try:
+                _require_sparse_rank_transport_envelope(
+                    matrix,
+                    rank_bound=sum(
+                        min(len(component.rows), len(component.columns))
                         for component in plan.components
-                        for column in component.columns
-                    )
-                ),
-            )
+                    ),
+                    active_columns=tuple(
+                        sorted(
+                            column
+                            for component in plan.components
+                            for column in component.columns
+                        )
+                    ),
+                )
+            except PydanticCustomError as exc:
+                raise OperationDomainValidationError(
+                    location=("matrix",), code=exc.type, message=exc.message()
+                ) from exc
         pivot_columns = _sympy_sparse_rank_pivots(plan)
     else:
         _admit(_admit_exact_linear_matrix, matrix.entries)

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -9,6 +9,7 @@ lazily so importing ``jacobian.math`` does not eagerly load packaged backends.
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from fractions import Fraction
 from math import lcm
 from typing import TYPE_CHECKING, Any, cast
@@ -16,7 +17,13 @@ from typing import TYPE_CHECKING, Any, cast
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
-from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+    format_canonical_integer,
+    parse_canonical_integer,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices import _conversions as conversions
 from jacobian.math.matrices._operation_models import (
@@ -32,6 +39,7 @@ from jacobian.math.matrices._operation_models import (
     MAX_MATRIX_PRODUCT_MULTIPLY_ADDS,
     MAX_MATRIX_PRODUCT_OUTPUT_DIGIT_WORK,
     MAX_PERMANENT_RYSER_SUBSETS,
+    MAX_SPARSE_RANK_INTERMEDIATE_CELLS,
     CharacteristicPolynomialResult,
     MatrixAdjugateResult,
     MatrixDeterminantResult,
@@ -56,6 +64,7 @@ from jacobian.math.matrices.values import (
     IntegerMatrix,
     RationalMatrix,
     SmithNormalForm,
+    SparseRationalMatrix,
     rational_matrix_from_fractions,
 )
 
@@ -452,6 +461,164 @@ def _admit_exact_linear_matrix(
             "budget_exceeded",
             "exact linear algebra exceeds the canonical result-height bound",
         )
+
+
+@dataclass(frozen=True, slots=True)
+class _SparseRankPlan:
+    entries: tuple[tuple[int, int, Fraction], ...]
+    row_count: int
+    column_count: int
+
+
+def _sparse_rank_work(
+    *,
+    row_count: int,
+    column_count: int,
+    entry_count: int,
+    support_cells: int,
+    rank_bound: int,
+    scalar_digits: int,
+) -> int:
+    return (
+        row_count
+        + column_count
+        + entry_count * scalar_digits
+        + support_cells * rank_bound * scalar_digits
+    )
+
+
+def _require_sparse_rank_transport_envelope(
+    matrix: SparseRationalMatrix,
+    *,
+    rank_bound: int,
+    active_columns: tuple[int, ...],
+) -> None:
+    """Prove that any exact pivot result fits the canonical output boundary."""
+
+    largest_possible_pivots = list(active_columns[-rank_bound:]) if rank_bound else []
+    output_limit = CanonicalLimits().max_output_bytes
+    try:
+        encode_strict_json(
+            {
+                "matrix": matrix.model_dump(mode="json"),
+                "rank": rank_bound,
+                "pivot_columns": largest_possible_pivots,
+            }
+        )
+    except CanonicalizationError as exc:
+        raise _validation_error(
+            "budget_exceeded",
+            "the sparse rank result retains its source matrix and would exceed "
+            f"the {output_limit:,}-byte canonical output limit",
+        ) from exc
+
+
+def _admit_sparse_rank(matrix: SparseRationalMatrix) -> _SparseRankPlan:
+    """Derive one bounded sparse QQ elimination plan from active support."""
+
+    from jacobian.math.matrices.values import require_matrix_scalar_digits
+
+    require_matrix_scalar_digits(
+        tuple((entry.value,) for entry in matrix.entries),
+        maximum=MAX_INPUT_SCALAR_DIGITS,
+        label="matrix input",
+    )
+    entries = tuple(
+        (entry.row, entry.column, entry.value.as_fraction()) for entry in matrix.entries
+    )
+    scalar_digits = max(
+        (
+            len(component.lstrip("-"))
+            for entry in matrix.entries
+            for component in (entry.value.num, entry.value.den)
+        ),
+        default=1,
+    )
+    active_rows = tuple(sorted({row for row, _column, _value in entries}))
+    active_columns = tuple(sorted({column for _row, column, _value in entries}))
+    rank_bound = min(len(active_rows), len(active_columns))
+    support_cells = len(active_rows) * len(active_columns)
+    if support_cells > MAX_SPARSE_RANK_INTERMEDIATE_CELLS:
+        raise _validation_error(
+            "budget_exceeded",
+            "sparse rank elimination exceeds the "
+            f"{MAX_SPARSE_RANK_INTERMEDIATE_CELLS:,}-cell active-support bound",
+        )
+    work = _sparse_rank_work(
+        row_count=matrix.row_count,
+        column_count=matrix.column_count,
+        entry_count=len(entries),
+        support_cells=support_cells,
+        rank_bound=rank_bound,
+        scalar_digits=scalar_digits,
+    )
+    if work > MAX_EXACT_LINEAR_MATRIX_WORK:
+        raise _validation_error(
+            "budget_exceeded",
+            "sparse rank elimination exceeds the "
+            f"{MAX_EXACT_LINEAR_MATRIX_WORK:,}-unit scalar-work budget",
+        )
+
+    grouped: dict[int, list[Fraction]] = {row: [] for row in active_rows}
+    for row, _column, value in entries:
+        grouped[row].append(value)
+    row_numerator_bits: list[int] = []
+    row_denominator_bits: list[int] = []
+    for row in active_rows:
+        values = grouped[row]
+        denominator = 1
+        for value in values:
+            denominator = lcm(denominator, value.denominator)
+            if (
+                _bit_bound_decimal_digits(denominator.bit_length())
+                > MAX_MATRIX_SCALAR_DIGITS
+            ):
+                raise _validation_error(
+                    "budget_exceeded",
+                    "sparse rank elimination exceeds the exact "
+                    "intermediate-height bound",
+                )
+        squared_norm = sum(
+            (value.numerator * (denominator // value.denominator)) ** 2
+            for value in values
+        )
+        row_numerator_bits.append((squared_norm.bit_length() + 1) // 2)
+        row_denominator_bits.append(denominator.bit_length())
+    component_bits = sum(sorted(row_numerator_bits, reverse=True)[:rank_bound]) + sum(
+        sorted(row_denominator_bits, reverse=True)[:rank_bound]
+    )
+    intermediate_digits = _bit_bound_decimal_digits(component_bits)
+    if intermediate_digits > MAX_MATRIX_SCALAR_DIGITS:
+        raise _validation_error(
+            "budget_exceeded",
+            "sparse rank elimination exceeds the exact intermediate-height bound",
+        )
+    _require_sparse_rank_transport_envelope(
+        matrix,
+        rank_bound=rank_bound,
+        active_columns=active_columns,
+    )
+    return _SparseRankPlan(
+        entries=entries,
+        row_count=matrix.row_count,
+        column_count=matrix.column_count,
+    )
+
+
+def _sympy_sparse_rank_pivots(plan: _SparseRankPlan) -> tuple[int, ...]:
+    """Compute exact pivots with SymPy's maintained sparse QQ kernel."""
+
+    if not plan.entries:
+        return ()
+    from sympy import QQ
+    from sympy.polys.matrices import DomainMatrix
+
+    rows: dict[int, dict[int, Any]] = {}
+    for row, column, value in plan.entries:
+        rows.setdefault(row, {})[column] = QQ(value.numerator, value.denominator)
+    source = DomainMatrix(rows, (plan.row_count, plan.column_count), QQ)
+    _reduced, pivots = source.rref(method="GJ")
+    return tuple(int(column) for column in pivots)
 
 
 def _flint_rref(
@@ -955,9 +1122,15 @@ def determinant_result(matrix: RationalMatrix) -> MatrixDeterminantResult:
     return MatrixDeterminantResult(determinant=CanonicalRational.from_fraction(value))
 
 
-def rank_result(matrix: RationalMatrix) -> MatrixRankResult:
-    _admit(_admit_exact_linear_matrix, matrix.entries)
-    _, pivot_columns = _flint_rref(matrix)
+def rank_result(
+    matrix: RationalMatrix | SparseRationalMatrix,
+) -> MatrixRankResult:
+    if isinstance(matrix, SparseRationalMatrix):
+        plan = _admit(_admit_sparse_rank, matrix)
+        pivot_columns = _sympy_sparse_rank_pivots(plan)
+    else:
+        _admit(_admit_exact_linear_matrix, matrix.entries)
+        _, pivot_columns = _flint_rref(matrix)
     return MatrixRankResult._from_kernel(
         matrix=matrix,
         rank=len(pivot_columns),

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -239,12 +239,17 @@ def determinant(matrix: MatrixBase) -> Any:
     return sympy.Rational(value.numerator, value.denominator)
 
 
-def rank(matrix: MatrixBase) -> tuple[int, tuple[int, ...]]:
-    result = rank_result(
-        conversions.rational_matrix_from_sympy(
-            _exact_matrix(matrix, maximum_dimension=MAX_EXACT_LINEAR_MATRIX_AXIS)
+def rank(
+    matrix: MatrixBase | SparseRationalMatrix,
+) -> tuple[int, tuple[int, ...]]:
+    if isinstance(matrix, SparseRationalMatrix):
+        result = rank_result(matrix)
+    else:
+        result = rank_result(
+            conversions.rational_matrix_from_sympy(
+                _exact_matrix(matrix, maximum_dimension=MAX_EXACT_LINEAR_MATRIX_AXIS)
+            )
         )
-    )
     return result.rank, result.pivot_columns
 
 

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -602,12 +602,6 @@ def _admit_sparse_rank(matrix: SparseRationalMatrix) -> _SparseRankPlan:
         label="matrix input",
     )
     components = _sparse_rank_components(matrix.entries)
-    rank_bound = sum(
-        min(len(component.rows), len(component.columns)) for component in components
-    )
-    active_columns = tuple(
-        sorted(column for component in components for column in component.columns)
-    )
     # Independent support components become diagonal blocks after row and
     # column permutations. Exact row operations cannot create a nonzero
     # between blocks, so intermediate cells, arithmetic work, and minor-height
@@ -668,11 +662,6 @@ def _admit_sparse_rank(matrix: SparseRationalMatrix) -> _SparseRankPlan:
                 "budget_exceeded",
                 "sparse rank elimination exceeds the exact intermediate-height bound",
             )
-    _require_sparse_rank_transport_envelope(
-        matrix,
-        rank_bound=rank_bound,
-        active_columns=active_columns,
-    )
     return _SparseRankPlan(
         components=components,
         row_count=matrix.row_count,
@@ -1200,9 +1189,26 @@ def determinant_result(matrix: RationalMatrix) -> MatrixDeterminantResult:
 
 def rank_result(
     matrix: RationalMatrix | SparseRationalMatrix,
+    *,
+    enforce_transport_limit: bool = False,
 ) -> MatrixRankResult:
     if isinstance(matrix, SparseRationalMatrix):
         plan = _admit(_admit_sparse_rank, matrix)
+        if enforce_transport_limit:
+            _require_sparse_rank_transport_envelope(
+                matrix,
+                rank_bound=sum(
+                    min(len(component.rows), len(component.columns))
+                    for component in plan.components
+                ),
+                active_columns=tuple(
+                    sorted(
+                        column
+                        for component in plan.components
+                        for column in component.columns
+                    )
+                ),
+            )
         pivot_columns = _sympy_sparse_rank_pivots(plan)
     else:
         _admit(_admit_exact_linear_matrix, matrix.entries)

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -65,6 +65,7 @@ from jacobian.math.matrices.values import (
     RationalMatrix,
     SmithNormalForm,
     SparseRationalMatrix,
+    SparseRationalMatrixEntry,
     rational_matrix_from_fractions,
 )
 
@@ -464,26 +465,98 @@ def _admit_exact_linear_matrix(
 
 
 @dataclass(frozen=True, slots=True)
-class _SparseRankPlan:
+class _SparseRankComponent:
+    rows: tuple[int, ...]
+    columns: tuple[int, ...]
     entries: tuple[tuple[int, int, Fraction], ...]
+    scalar_digits: int
+
+
+@dataclass(frozen=True, slots=True)
+class _SparseRankPlan:
+    components: tuple[_SparseRankComponent, ...]
     row_count: int
     column_count: int
+
+
+def _sparse_rank_components(
+    entries: tuple[SparseRationalMatrixEntry, ...],
+) -> tuple[_SparseRankComponent, ...]:
+    """Partition nonzero coordinates by bipartite support connectivity."""
+
+    row_columns: dict[int, list[int]] = {}
+    column_rows: dict[int, list[int]] = {}
+    row_entries: dict[int, list[SparseRationalMatrixEntry]] = {}
+    for entry in entries:
+        row_columns.setdefault(entry.row, []).append(entry.column)
+        column_rows.setdefault(entry.column, []).append(entry.row)
+        row_entries.setdefault(entry.row, []).append(entry)
+
+    components: list[_SparseRankComponent] = []
+    visited_rows: set[int] = set()
+    visited_columns: set[int] = set()
+    for starting_row in row_columns:
+        if starting_row in visited_rows:
+            continue
+        pending_rows = [starting_row]
+        component_rows: list[int] = []
+        component_columns: list[int] = []
+        while pending_rows:
+            row = pending_rows.pop()
+            if row in visited_rows:
+                continue
+            visited_rows.add(row)
+            component_rows.append(row)
+            for column in row_columns[row]:
+                if column in visited_columns:
+                    continue
+                visited_columns.add(column)
+                component_columns.append(column)
+                pending_rows.extend(
+                    adjacent_row
+                    for adjacent_row in column_rows[column]
+                    if adjacent_row not in visited_rows
+                )
+        rows = tuple(sorted(component_rows))
+        columns = tuple(sorted(component_columns))
+        source_entries = tuple(entry for row in rows for entry in row_entries[row])
+        components.append(
+            _SparseRankComponent(
+                rows=rows,
+                columns=columns,
+                entries=tuple(
+                    (entry.row, entry.column, entry.value.as_fraction())
+                    for entry in source_entries
+                ),
+                scalar_digits=max(
+                    len(component.lstrip("-"))
+                    for entry in source_entries
+                    for component in (entry.value.num, entry.value.den)
+                ),
+            )
+        )
+    return tuple(components)
 
 
 def _sparse_rank_work(
     *,
     row_count: int,
     column_count: int,
-    entry_count: int,
-    support_cells: int,
-    rank_bound: int,
-    scalar_digits: int,
+    components: tuple[_SparseRankComponent, ...],
 ) -> int:
     return (
         row_count
         + column_count
-        + entry_count * scalar_digits
-        + support_cells * rank_bound * scalar_digits
+        + sum(
+            component.scalar_digits
+            * (
+                len(component.entries)
+                + len(component.rows)
+                * len(component.columns)
+                * min(len(component.rows), len(component.columns))
+            )
+            for component in components
+        )
     )
 
 
@@ -514,7 +587,7 @@ def _require_sparse_rank_transport_envelope(
 
 
 def _admit_sparse_rank(matrix: SparseRationalMatrix) -> _SparseRankPlan:
-    """Derive one bounded sparse QQ elimination plan from active support."""
+    """Derive one bounded sparse QQ elimination plan from support components."""
 
     from jacobian.math.matrices.values import require_matrix_scalar_digits
 
@@ -523,34 +596,30 @@ def _admit_sparse_rank(matrix: SparseRationalMatrix) -> _SparseRankPlan:
         maximum=MAX_INPUT_SCALAR_DIGITS,
         label="matrix input",
     )
-    entries = tuple(
-        (entry.row, entry.column, entry.value.as_fraction()) for entry in matrix.entries
+    components = _sparse_rank_components(matrix.entries)
+    rank_bound = sum(
+        min(len(component.rows), len(component.columns)) for component in components
     )
-    scalar_digits = max(
-        (
-            len(component.lstrip("-"))
-            for entry in matrix.entries
-            for component in (entry.value.num, entry.value.den)
-        ),
-        default=1,
+    active_columns = tuple(
+        sorted(column for component in components for column in component.columns)
     )
-    active_rows = tuple(sorted({row for row, _column, _value in entries}))
-    active_columns = tuple(sorted({column for _row, column, _value in entries}))
-    rank_bound = min(len(active_rows), len(active_columns))
-    support_cells = len(active_rows) * len(active_columns)
+    # Independent support components become diagonal blocks after row and
+    # column permutations. Exact row operations cannot create a nonzero
+    # between blocks, so intermediate cells, arithmetic work, and minor-height
+    # bounds compose by component rather than by one global active rectangle.
+    support_cells = sum(
+        len(component.rows) * len(component.columns) for component in components
+    )
     if support_cells > MAX_SPARSE_RANK_INTERMEDIATE_CELLS:
         raise _validation_error(
             "budget_exceeded",
             "sparse rank elimination exceeds the "
-            f"{MAX_SPARSE_RANK_INTERMEDIATE_CELLS:,}-cell active-support bound",
+            f"{MAX_SPARSE_RANK_INTERMEDIATE_CELLS:,}-cell component-support bound",
         )
     work = _sparse_rank_work(
         row_count=matrix.row_count,
         column_count=matrix.column_count,
-        entry_count=len(entries),
-        support_cells=support_cells,
-        rank_bound=rank_bound,
-        scalar_digits=scalar_digits,
+        components=components,
     )
     if work > MAX_EXACT_LINEAR_MATRIX_WORK:
         raise _validation_error(
@@ -559,63 +628,65 @@ def _admit_sparse_rank(matrix: SparseRationalMatrix) -> _SparseRankPlan:
             f"{MAX_EXACT_LINEAR_MATRIX_WORK:,}-unit scalar-work budget",
         )
 
-    grouped: dict[int, list[Fraction]] = {row: [] for row in active_rows}
-    for row, _column, value in entries:
-        grouped[row].append(value)
-    row_numerator_bits: list[int] = []
-    row_denominator_bits: list[int] = []
-    for row in active_rows:
-        values = grouped[row]
-        denominator = 1
-        for value in values:
-            denominator = lcm(denominator, value.denominator)
-            if (
-                _bit_bound_decimal_digits(denominator.bit_length())
-                > MAX_MATRIX_SCALAR_DIGITS
-            ):
-                raise _validation_error(
-                    "budget_exceeded",
-                    "sparse rank elimination exceeds the exact "
-                    "intermediate-height bound",
-                )
-        squared_norm = sum(
-            (value.numerator * (denominator // value.denominator)) ** 2
-            for value in values
-        )
-        row_numerator_bits.append((squared_norm.bit_length() + 1) // 2)
-        row_denominator_bits.append(denominator.bit_length())
-    component_bits = sum(sorted(row_numerator_bits, reverse=True)[:rank_bound]) + sum(
-        sorted(row_denominator_bits, reverse=True)[:rank_bound]
-    )
-    intermediate_digits = _bit_bound_decimal_digits(component_bits)
-    if intermediate_digits > MAX_MATRIX_SCALAR_DIGITS:
-        raise _validation_error(
-            "budget_exceeded",
-            "sparse rank elimination exceeds the exact intermediate-height bound",
-        )
+    for component in components:
+        grouped: dict[int, list[Fraction]] = {row: [] for row in component.rows}
+        for row, _column, value in component.entries:
+            grouped[row].append(value)
+        row_numerator_bits: list[int] = []
+        row_denominator_bits: list[int] = []
+        for row in component.rows:
+            values = grouped[row]
+            denominator = 1
+            for value in values:
+                denominator = lcm(denominator, value.denominator)
+                if (
+                    _bit_bound_decimal_digits(denominator.bit_length())
+                    > MAX_MATRIX_SCALAR_DIGITS
+                ):
+                    raise _validation_error(
+                        "budget_exceeded",
+                        "sparse rank elimination exceeds the exact "
+                        "intermediate-height bound",
+                    )
+            squared_norm = sum(
+                (value.numerator * (denominator // value.denominator)) ** 2
+                for value in values
+            )
+            row_numerator_bits.append((squared_norm.bit_length() + 1) // 2)
+            row_denominator_bits.append(denominator.bit_length())
+        component_rank_bound = min(len(component.rows), len(component.columns))
+        component_bits = sum(
+            sorted(row_numerator_bits, reverse=True)[:component_rank_bound]
+        ) + sum(sorted(row_denominator_bits, reverse=True)[:component_rank_bound])
+        if _bit_bound_decimal_digits(component_bits) > MAX_MATRIX_SCALAR_DIGITS:
+            raise _validation_error(
+                "budget_exceeded",
+                "sparse rank elimination exceeds the exact intermediate-height bound",
+            )
     _require_sparse_rank_transport_envelope(
         matrix,
         rank_bound=rank_bound,
         active_columns=active_columns,
     )
     return _SparseRankPlan(
-        entries=entries,
+        components=components,
         row_count=matrix.row_count,
         column_count=matrix.column_count,
     )
 
 
 def _sympy_sparse_rank_pivots(plan: _SparseRankPlan) -> tuple[int, ...]:
-    """Compute exact pivots with SymPy's maintained sparse QQ kernel."""
+    """Compute exact pivots with SymPy's nonzero-driven sparse QQ kernel."""
 
-    if not plan.entries:
+    if not plan.components:
         return ()
     from sympy import QQ
     from sympy.polys.matrices import DomainMatrix
 
     rows: dict[int, dict[int, Any]] = {}
-    for row, column, value in plan.entries:
-        rows.setdefault(row, {})[column] = QQ(value.numerator, value.denominator)
+    for component in plan.components:
+        for row, column, value in component.entries:
+            rows.setdefault(row, {})[column] = QQ(value.numerator, value.denominator)
     source = DomainMatrix(rows, (plan.row_count, plan.column_count), QQ)
     _reduced, pivots = source.rref(method="GJ")
     return tuple(int(column) for column in pivots)

--- a/src/jacobian/math/matrices/values.py
+++ b/src/jacobian/math/matrices/values.py
@@ -170,8 +170,8 @@ class SparseRationalMatrix(StrictModel):
     """A dimension-retaining coordinate-sparse matrix over QQ."""
 
     domain: Literal["QQ"] = "QQ"
-    row_count: int = Field(ge=1, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
-    column_count: int = Field(ge=1, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
+    row_count: int = Field(ge=0, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
+    column_count: int = Field(ge=0, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
     entries: tuple[SparseRationalMatrixEntry, ...] = Field(
         default=(), max_length=MAX_SPARSE_RATIONAL_MATRIX_NONZEROS
     )
@@ -243,11 +243,14 @@ def dense_rational_matrix_from_sparse(matrix: SparseRationalMatrix) -> RationalM
     """Convert bounded sparse coordinates to the canonical dense QQ matrix."""
 
     if (
-        matrix.row_count > MAX_RATIONAL_MATRIX_ORDER
+        matrix.row_count == 0
+        or matrix.column_count == 0
+        or matrix.row_count > MAX_RATIONAL_MATRIX_ORDER
         or matrix.column_count > MAX_RATIONAL_MATRIX_ORDER
     ):
         raise ValueError(
-            "sparse matrix axes exceed the canonical dense matrix representation"
+            "sparse matrix axes cannot be represented by the nonempty canonical "
+            "dense matrix"
         )
     zero = CanonicalRational(num="0", den="1")
     coordinates = {(entry.row, entry.column): entry.value for entry in matrix.entries}

--- a/tests/dispatch/test_matrix_dispatch.py
+++ b/tests/dispatch/test_matrix_dispatch.py
@@ -130,6 +130,43 @@ def test_dispatch_returns_typed_results_at_the_boundary_order() -> None:
     assert len(result.output["coefficients_descending"]) == MAX_MATRIX_DIMENSION + 1
 
 
+def test_dispatch_retains_a_sparse_rank_source_and_its_declared_axis() -> None:
+    result = invoke_operation(
+        "matrix.rank.compute",
+        {
+            "matrix": {
+                "row_count": 1,
+                "column_count": 128,
+                "entries": [
+                    {
+                        "row": 0,
+                        "column": 127,
+                        "value": {"num": "1", "den": "1"},
+                    }
+                ],
+            }
+        },
+        Catalog.open(),
+    )
+
+    assert result.output == {
+        "matrix": {
+            "domain": "QQ",
+            "row_count": 1,
+            "column_count": 128,
+            "entries": [
+                {
+                    "row": 0,
+                    "column": 127,
+                    "value": {"num": "1", "den": "1"},
+                }
+            ],
+        },
+        "rank": 1,
+        "pivot_columns": [127],
+    }
+
+
 def test_native_and_dispatch_determinants_share_the_canonical_boundary() -> None:
     import sympy
 

--- a/tests/math/geometry/framework/test_planar_rigidity_profile.py
+++ b/tests/math/geometry/framework/test_planar_rigidity_profile.py
@@ -1,0 +1,535 @@
+"""Contract evidence for exact planar framework rigidity profiles."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+from tests.fixtures.accounting import assert_charged_work_parity
+
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.exact._models import (
+    LabelledRationalPoint,
+    PointConfiguration,
+)
+from jacobian.math.geometry.framework._bounds import (
+    MAX_FRAMEWORK_COORDINATE_WORK,
+    difference_work,
+    rational_parse_work,
+)
+from jacobian.math.geometry.framework._models import (
+    PlanarRigidityProfile,
+    PlanarRigidityProfileRequest,
+)
+from jacobian.math.geometry.framework._tools import TOOLS
+from jacobian.math.geometry.framework.operations import (
+    _admit_framework,
+    _reserve_profile_output_bytes,
+    _rigidity_matrix,
+    planar_rigidity_profile,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.matrices._operation_models import MatrixRankRequest
+from jacobian.math.matrices.operations import rank_result
+from jacobian.math.matrices.values import SparseRationalMatrix
+
+
+def q(numerator: int, denominator: int = 1) -> CanonicalRational:
+    return CanonicalRational.from_fraction(Fraction(numerator, denominator))
+
+
+def configuration(
+    points: tuple[tuple[str, int, int], ...],
+) -> PointConfiguration:
+    return PointConfiguration(
+        points=tuple(
+            LabelledRationalPoint(label=label, coordinates=(q(x), q(y)))
+            for label, x, y in points
+        )
+    )
+
+
+def graph(
+    vertices: tuple[str, ...], edges: tuple[tuple[str, str], ...]
+) -> SimpleUndirectedGraph:
+    return SimpleUndirectedGraph(vertices=vertices, edges=edges)
+
+
+def sparse_entries(
+    matrix: SparseRationalMatrix,
+) -> dict[tuple[int, int], Fraction]:
+    return {
+        (entry.row, entry.column): entry.value.as_fraction() for entry in matrix.entries
+    }
+
+
+def rigidity_matrix(profile: PlanarRigidityProfile) -> SparseRationalMatrix:
+    matrix = profile.matrix_rank.matrix
+    assert isinstance(matrix, SparseRationalMatrix)
+    return matrix
+
+
+def test_catalog_publishes_only_the_planar_rigidity_profile() -> None:
+    assert {tool.operation_id for tool in TOOLS} == {
+        "geometry.framework.planar_rigidity_profile.compute"
+    }
+
+
+def test_catalog_request_parses_strict_canonical_json_arrays() -> None:
+    payload = TOOLS[0].examples[0].input
+
+    request = PlanarRigidityProfileRequest.model_validate_json(
+        encode_strict_json(payload), strict=True
+    )
+
+    assert tuple(point.label for point in request.configuration.points) == (
+        "a",
+        "b",
+        "c",
+    )
+    assert request.graph.edges == (("b", "c"), ("a", "c"), ("a", "b"))
+
+
+def test_native_api_exports_the_reused_framework_values() -> None:
+    import jacobian.math.geometry.framework as framework
+
+    assert framework.__all__ == [
+        "LabelledRationalPoint",
+        "PlanarRigidityProfile",
+        "PointConfiguration",
+        "SimpleUndirectedGraph",
+        "planar_rigidity_profile",
+    ]
+    assert framework.LabelledRationalPoint is LabelledRationalPoint
+    assert framework.PointConfiguration is PointConfiguration
+    assert framework.SimpleUndirectedGraph is SimpleUndirectedGraph
+    assert framework.PlanarRigidityProfile is PlanarRigidityProfile
+    assert framework.planar_rigidity_profile is planar_rigidity_profile
+
+
+@pytest.mark.parametrize("point_count", (0, 1))
+def test_framework_source_excludes_zero_and_one_vertex_configurations(
+    point_count: int,
+) -> None:
+    points = tuple(
+        LabelledRationalPoint(label=f"v{index}", coordinates=(q(index), q(0)))
+        for index in range(point_count)
+    )
+
+    with pytest.raises(ValidationError, match="at least 2 items"):
+        PointConfiguration(points=points)
+
+
+def test_noncollinear_triangle_has_full_infinitesimal_rank() -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 0, 1)))
+    source_graph = graph(("a", "b", "c"), (("b", "c"), ("a", "c"), ("a", "b")))
+
+    result = planar_rigidity_profile(source, source_graph)
+
+    assert result.configuration is source
+    assert result.graph is source_graph
+    assert result.vertex_axis == ("a", "b", "c")
+    assert result.edge_axis == (("a", "b"), ("a", "c"), ("b", "c"))
+    assert result.matrix_rank.rank == 3
+    assert result.matrix_rank.pivot_columns == (0, 1, 2)
+    assert result.maximal_infinitesimal_rigidity_rank == 3
+    assert result.is_infinitesimally_rigid is True
+    assert sparse_entries(rigidity_matrix(result)) == {
+        (0, 0): Fraction(-1),
+        (0, 2): Fraction(1),
+        (1, 1): Fraction(-1),
+        (1, 5): Fraction(1),
+        (2, 2): Fraction(1),
+        (2, 3): Fraction(-1),
+        (2, 4): Fraction(-1),
+        (2, 5): Fraction(1),
+    }
+
+
+@pytest.mark.parametrize(
+    ("edges", "expected_rank", "expected_rigid"),
+    (
+        ((("a", "b"), ("b", "c"), ("c", "d"), ("a", "d")), 4, False),
+        (
+            (
+                ("a", "b"),
+                ("b", "c"),
+                ("c", "d"),
+                ("a", "d"),
+                ("a", "c"),
+            ),
+            5,
+            True,
+        ),
+    ),
+)
+def test_square_cycle_and_diagonal_distinguish_infinitesimal_rank(
+    edges: tuple[tuple[str, str], ...], expected_rank: int, expected_rigid: bool
+) -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 1, 1), ("d", 0, 1)))
+
+    result = planar_rigidity_profile(source, graph(("a", "b", "c", "d"), edges))
+
+    assert result.matrix_rank.rank == expected_rank
+    assert result.maximal_infinitesimal_rigidity_rank == 5
+    assert result.is_infinitesimally_rigid is expected_rigid
+
+
+def test_collinear_complete_triangle_fails_only_the_infinitesimal_criterion() -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 2, 0)))
+    source_graph = graph(("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c")))
+
+    result = planar_rigidity_profile(source, source_graph)
+
+    assert result.matrix_rank.rank == 2
+    assert result.maximal_infinitesimal_rigidity_rank == 3
+    assert result.is_infinitesimally_rigid is False
+
+
+def test_edge_tuple_permutation_has_one_deterministic_derived_axis() -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 0, 1)))
+    first = graph(("a", "b", "c"), (("b", "c"), ("a", "b"), ("a", "c")))
+    second = graph(("c", "a", "b"), (("a", "c"), ("b", "c"), ("a", "b")))
+
+    left = planar_rigidity_profile(source, first)
+    right = planar_rigidity_profile(source, second)
+
+    assert left.edge_axis == right.edge_axis
+    assert left.matrix_rank.matrix == right.matrix_rank.matrix
+    assert left.matrix_rank.rank == right.matrix_rank.rank
+    assert left.matrix_rank.pivot_columns == right.matrix_rank.pivot_columns
+
+
+def test_empty_edge_graph_retains_zero_row_and_coordinate_axes() -> None:
+    source = configuration((("right", 1, 0), ("left", 0, 0)))
+
+    result = planar_rigidity_profile(source, graph(("left", "right"), ()))
+
+    matrix = rigidity_matrix(result)
+    assert matrix.row_count == 0
+    assert matrix.column_count == 4
+    assert matrix.entries == ()
+    assert result.vertex_axis == ("right", "left")
+    assert result.edge_axis == ()
+    assert result.matrix_rank.rank == 0
+    assert result.matrix_rank.pivot_columns == ()
+    assert result.is_infinitesimally_rigid is False
+
+
+def test_repeated_coordinates_produce_an_exact_zero_edge_row() -> None:
+    source = configuration((("a", 0, 0), ("b", 0, 0), ("c", 1, 0)))
+
+    result = planar_rigidity_profile(
+        source,
+        graph(("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c"))),
+    )
+
+    matrix = rigidity_matrix(result)
+    assert matrix.row_count == 3
+    assert not any(entry.row == 0 for entry in matrix.entries)
+    assert result.matrix_rank.rank == 2
+    assert result.is_infinitesimally_rigid is False
+
+
+@pytest.mark.parametrize(
+    "bad_graph",
+    (
+        graph(("a", "b"), (("a", "b"),)),
+        graph(("a", "b", "c", "d"), (("a", "b"),)),
+        graph(("a", "b", "d"), (("a", "b"),)),
+    ),
+)
+def test_graph_labels_must_equal_configuration_labels_before_execution(
+    bad_graph: SimpleUndirectedGraph,
+) -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 0, 1)))
+
+    with pytest.raises(ValidationError, match="point-label set"):
+        PlanarRigidityProfileRequest(configuration=source, graph=bad_graph)
+    with pytest.raises(OperationDomainValidationError, match="point-label set"):
+        planar_rigidity_profile(source, bad_graph)
+
+
+def test_configuration_must_be_planar() -> None:
+    source = PointConfiguration(
+        points=(
+            LabelledRationalPoint(label="a", coordinates=(q(0), q(0), q(0))),
+            LabelledRationalPoint(label="b", coordinates=(q(1), q(0), q(0))),
+        )
+    )
+    source_graph = graph(("a", "b"), (("a", "b"),))
+
+    with pytest.raises(ValidationError, match="exactly two coordinates"):
+        PlanarRigidityProfileRequest(configuration=source, graph=source_graph)
+    with pytest.raises(OperationDomainValidationError, match="exactly two coordinates"):
+        planar_rigidity_profile(source, source_graph)
+
+
+def test_derived_matrix_composes_unchanged_with_matrix_rank_compute() -> None:
+    source = configuration((("a", 0, 0), ("b", 2, 0), ("c", 2, 1), ("d", 0, 1)))
+    source_graph = graph(
+        ("a", "b", "c", "d"),
+        (("a", "b"), ("b", "c"), ("c", "d"), ("a", "d"), ("a", "c")),
+    )
+
+    profile = planar_rigidity_profile(source, source_graph)
+    serialized_matrix = profile.matrix_rank.matrix.model_dump(mode="json")
+    request = MatrixRankRequest.model_validate({"matrix": serialized_matrix})
+    composed = rank_result(request.matrix)
+
+    assert request.matrix == profile.matrix_rank.matrix
+    assert composed == profile.matrix_rank
+
+
+def test_profile_round_trip_is_structural_and_source_bound() -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 0, 1)))
+    result = planar_rigidity_profile(
+        source,
+        graph(("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c"))),
+    )
+
+    assert (
+        PlanarRigidityProfile.model_validate_json(result.model_dump_json(), strict=True)
+        == result
+    )
+    forged = result.model_dump(mode="json")
+    forged["edge_axis"] = [["a", "c"], ["a", "b"], ["b", "c"]]
+    with pytest.raises(ValidationError, match="lexicographically sorted"):
+        PlanarRigidityProfile.model_validate(forged)
+
+
+def test_output_reservation_covers_sources_axes_and_one_nested_matrix() -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 0, 1)))
+    source_graph = graph(("a", "b", "c"), (("b", "c"), ("a", "c"), ("a", "b")))
+    admission = _admit_framework(source, source_graph)
+    matrix = _rigidity_matrix(admission)
+
+    reserved_bytes = _reserve_profile_output_bytes(
+        source, source_graph, admission, matrix
+    )
+    result = planar_rigidity_profile(source, source_graph)
+    payload = result.model_dump(mode="json")
+    actual_bytes = len(encode_strict_json(payload))
+
+    assert set(payload) == {
+        "configuration",
+        "graph",
+        "vertex_axis",
+        "edge_axis",
+        "matrix_rank",
+        "maximal_infinitesimal_rigidity_rank",
+        "is_infinitesimally_rigid",
+    }
+    assert payload["matrix_rank"]["matrix"] == matrix.model_dump(mode="json")
+    assert actual_bytes <= reserved_bytes <= CanonicalLimits().max_output_bytes
+
+
+def test_output_reservation_admits_the_maximal_framework_matrix_shape() -> None:
+    source = configuration(
+        tuple((f"v{index:02d}", index, index * index) for index in range(64))
+    )
+    labels = tuple(point.label for point in source.points)
+    edges = tuple(
+        (labels[left], labels[right])
+        for left in range(len(labels))
+        for right in range(left + 1, len(labels))
+    )
+    source_graph = graph(labels, tuple(reversed(edges)))
+    admission = _admit_framework(source, source_graph)
+    matrix = _rigidity_matrix(admission)
+
+    reserved_bytes = _reserve_profile_output_bytes(
+        source, source_graph, admission, matrix
+    )
+
+    assert matrix.row_count == 2_016
+    assert matrix.column_count == 128
+    assert len(matrix.entries) == 8_064
+    assert admission.edge_axis == edges
+    assert reserved_bytes <= CanonicalLimits().max_output_bytes
+
+
+def test_rigidity_rows_replay_the_squared_length_differentials() -> None:
+    source = PointConfiguration(
+        points=(
+            LabelledRationalPoint(label="v", coordinates=(q(1, 3), q(-2, 5))),
+            LabelledRationalPoint(label="u", coordinates=(q(-4, 7), q(3, 2))),
+            LabelledRationalPoint(label="w", coordinates=(q(5, 6), q(1, 4))),
+        )
+    )
+    source_graph = graph(("u", "v", "w"), (("v", "w"), ("u", "w"), ("u", "v")))
+
+    result = planar_rigidity_profile(source, source_graph)
+    matrix = rigidity_matrix(result)
+    actual = sparse_entries(matrix)
+    point_coordinates = {
+        point.label: tuple(value.as_fraction() for value in point.coordinates)
+        for point in source.points
+    }
+    positions = {label: index for index, label in enumerate(result.vertex_axis)}
+    expected: dict[tuple[int, int], Fraction] = {}
+    for row, (left, right) in enumerate(result.edge_axis):
+        for coordinate in range(2):
+            difference = (
+                point_coordinates[left][coordinate]
+                - point_coordinates[right][coordinate]
+            )
+            if difference:
+                expected[(row, 2 * positions[left] + coordinate)] = difference
+                expected[(row, 2 * positions[right] + coordinate)] = -difference
+
+    assert matrix.row_count == len(result.edge_axis)
+    assert matrix.column_count == 2 * len(result.vertex_axis)
+    assert actual == expected
+
+
+def test_coordinate_scalar_boundary_is_owned_before_rank_backend() -> None:
+    accepted_value = 10**255
+    accepted = configuration((("a", 0, 0), ("b", accepted_value, 0)))
+    source_graph = graph(("a", "b"), (("a", "b"),))
+
+    result = planar_rigidity_profile(accepted, source_graph)
+
+    assert result.matrix_rank.rank == 1
+    rejected_value = 10**256
+    rejected = configuration((("a", 0, 0), ("b", rejected_value, 0)))
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="256-digit input bound",
+    ):
+        planar_rigidity_profile(rejected, source_graph)
+
+
+def test_coordinate_work_admission_charges_every_derived_difference() -> None:
+    height = 50
+    value = 10 ** (height - 1)
+    source = configuration(
+        tuple((f"v{index:02d}", index * value, index) for index in range(32))
+    )
+    labels = tuple(point.label for point in source.points)
+    edges = tuple(
+        (labels[left], labels[right])
+        for left in range(len(labels))
+        for right in range(left + 1, len(labels))
+    )
+    source_graph = graph(labels, edges)
+
+    admission = _admit_framework(source, source_graph)
+
+    canonical_coordinates = {point.label: point.coordinates for point in source.points}
+    executed = {
+        "source_parse": sum(
+            rational_parse_work((coordinate.num, coordinate.den))
+            for point in source.points
+            for coordinate in point.coordinates
+        ),
+        "coordinate_difference": sum(
+            difference_work(
+                (
+                    canonical_coordinates[left][coordinate].num,
+                    canonical_coordinates[left][coordinate].den,
+                ),
+                (
+                    canonical_coordinates[right][coordinate].num,
+                    canonical_coordinates[right][coordinate].den,
+                ),
+            )
+            for left, right in edges
+            for coordinate in range(2)
+        ),
+    }
+    charged = {
+        "source_parse": admission.source_parse_work,
+        "coordinate_difference": admission.coordinate_difference_work,
+    }
+    assert admission.source_parse_work + admission.coordinate_difference_work <= (
+        MAX_FRAMEWORK_COORDINATE_WORK
+    )
+    assert charged == executed
+    assert_charged_work_parity(charged=charged, executed=executed)
+
+
+def test_coordinate_work_accepts_and_rejects_the_exact_edge_boundary() -> None:
+    base = 10**39
+    source = configuration(
+        tuple((f"v{index:02d}", base + index, base + 2 * index) for index in range(64))
+    )
+    labels = tuple(point.label for point in source.points)
+    all_edges = tuple(
+        (labels[left], labels[right])
+        for left in range(len(labels))
+        for right in range(left + 1, len(labels))
+    )
+    source_parse_work = sum(
+        rational_parse_work((coordinate.num, coordinate.den))
+        for point in source.points
+        for coordinate in point.coordinates
+    )
+    first_left, first_right = all_edges[0]
+    coordinates = {point.label: point.coordinates for point in source.points}
+    edge_work = sum(
+        difference_work(
+            (coordinates[first_left][axis].num, coordinates[first_left][axis].den),
+            (
+                coordinates[first_right][axis].num,
+                coordinates[first_right][axis].den,
+            ),
+        )
+        for axis in range(2)
+    )
+    accepted_edge_count = (
+        MAX_FRAMEWORK_COORDINATE_WORK - source_parse_work
+    ) // edge_work
+    accepted_graph = graph(labels, all_edges[:accepted_edge_count])
+    rejected_graph = graph(labels, all_edges[: accepted_edge_count + 1])
+
+    admission = _admit_framework(source, accepted_graph)
+
+    assert admission.source_parse_work == source_parse_work
+    assert admission.coordinate_difference_work == accepted_edge_count * edge_work
+    assert source_parse_work + accepted_edge_count * edge_work <= (
+        MAX_FRAMEWORK_COORDINATE_WORK
+    )
+    assert source_parse_work + (accepted_edge_count + 1) * edge_work > (
+        MAX_FRAMEWORK_COORDINATE_WORK
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="work bound"):
+        planar_rigidity_profile(source, rejected_graph)
+
+    with pytest.raises(ValidationError, match="work bound"):
+        PlanarRigidityProfileRequest.model_validate(
+            {
+                "configuration": source.model_dump(mode="json"),
+                "graph": rejected_graph.model_dump(mode="json"),
+            }
+        )
+
+
+def test_edgeless_native_call_still_enforces_source_parse_work() -> None:
+    large_coordinate = CanonicalRational(
+        num="1" + "0" * (MAX_CANONICAL_RATIONAL_DIGITS - 1),
+        den="9" * MAX_CANONICAL_RATIONAL_DIGITS,
+    )
+    source = PointConfiguration(
+        points=(
+            LabelledRationalPoint(
+                label="a", coordinates=(large_coordinate, large_coordinate)
+            ),
+            LabelledRationalPoint(
+                label="b", coordinates=(large_coordinate, large_coordinate)
+            ),
+        )
+    )
+    source_work = sum(
+        rational_parse_work((coordinate.num, coordinate.den))
+        for point in source.points
+        for coordinate in point.coordinates
+    )
+
+    assert source_work > MAX_FRAMEWORK_COORDINATE_WORK
+    with pytest.raises(OperationDomainValidationError, match="work bound"):
+        planar_rigidity_profile(source, graph(("a", "b"), ()))

--- a/tests/math/matrices/test_public_api.py
+++ b/tests/math/matrices/test_public_api.py
@@ -253,6 +253,8 @@ def test_exact_public_api_symbols() -> None:
     """Exact owner-local contract for the matrices public API."""
     expected = (
         "SmithNormalForm",
+        "SparseRationalMatrix",
+        "SparseRationalMatrixEntry",
         "adjugate",
         "characteristic_polynomial",
         "determinant",

--- a/tests/math/matrices/test_public_api.py
+++ b/tests/math/matrices/test_public_api.py
@@ -47,6 +47,25 @@ def test_exact_matrix_operations() -> None:
     assert pivots == (0,)
 
 
+def test_native_rank_accepts_dimension_retaining_sparse_values() -> None:
+    source = matrices.SparseRationalMatrix.model_validate(
+        {
+            "row_count": 1,
+            "column_count": 128,
+            "entries": [
+                {
+                    "row": 0,
+                    "column": 127,
+                    "value": {"num": "1", "den": "1"},
+                }
+            ],
+        }
+    )
+
+    assert matrices.rank(source) == (1, (127,))
+    assert matrices.SparseRationalMatrixEntry is type(source.entries[0])
+
+
 def test_characteristic_polynomial_preserves_exact_algebraic_inputs() -> None:
     source = sympy.Matrix([[sympy.sqrt(2), 0], [0, 1]])
 

--- a/tests/math/matrices/test_rational_linear_source_binding.py
+++ b/tests/math/matrices/test_rational_linear_source_binding.py
@@ -109,9 +109,7 @@ def test_sparse_rational_matrix_strict_json_retains_zero_axes(
         "entries": [],
     }
 
-    matrix = SparseRationalMatrix.model_validate_json(
-        json.dumps(payload), strict=True
-    )
+    matrix = SparseRationalMatrix.model_validate_json(json.dumps(payload), strict=True)
 
     assert matrix.model_dump(mode="json") == payload
     assert (

--- a/tests/math/matrices/test_rational_linear_source_binding.py
+++ b/tests/math/matrices/test_rational_linear_source_binding.py
@@ -95,6 +95,91 @@ def test_sparse_rational_matrix_round_trips_through_its_dense_owner() -> None:
     assert dense_rational_matrix_from_sparse(restored) == dense
 
 
+@pytest.mark.parametrize(
+    ("row_count", "column_count"),
+    ((0, 5), (4, 0), (0, 0)),
+)
+def test_sparse_rational_matrix_strict_json_retains_zero_axes(
+    row_count: int, column_count: int
+) -> None:
+    payload = {
+        "domain": "QQ",
+        "row_count": row_count,
+        "column_count": column_count,
+        "entries": [],
+    }
+
+    matrix = SparseRationalMatrix.model_validate_json(
+        json.dumps(payload), strict=True
+    )
+
+    assert matrix.model_dump(mode="json") == payload
+    assert (
+        SparseRationalMatrix.model_validate_json(matrix.model_dump_json(), strict=True)
+        == matrix
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {
+            "row_count": 0,
+            "column_count": 2,
+            "entries": [{"row": 0, "column": 1, "value": q(1)}],
+        },
+        {
+            "row_count": 2,
+            "column_count": 0,
+            "entries": [{"row": 1, "column": 0, "value": q(1)}],
+        },
+    ),
+)
+def test_sparse_rational_matrix_rejects_entries_on_a_zero_axis(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="coordinates exceed declared axes"):
+        SparseRationalMatrix.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("row_count", "column_count"),
+    ((0, 5), (4, 0), (0, 0)),
+)
+def test_zero_axis_sparse_matrix_has_no_dense_canonical_conversion(
+    row_count: int, column_count: int
+) -> None:
+    matrix = SparseRationalMatrix(
+        row_count=row_count,
+        column_count=column_count,
+    )
+
+    with pytest.raises(ValueError, match="nonempty canonical dense matrix"):
+        dense_rational_matrix_from_sparse(matrix)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {
+            "variables": ["x"],
+            "coefficients": {"row_count": 0, "column_count": 1, "entries": []},
+            "rhs": [],
+        },
+        {
+            "variables": [],
+            "coefficients": {"row_count": 1, "column_count": 0, "entries": []},
+            "rhs": [q(0)],
+        },
+    ),
+)
+def test_linear_rational_system_keeps_its_nonempty_domain(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        LinearRationalSystem.model_validate(payload)
+
+
 def _underdetermined_system() -> dict[str, object]:
     return _system(
         ["x", "y", "z"],

--- a/tests/math/matrices/test_sparse_rank.py
+++ b/tests/math/matrices/test_sparse_rank.py
@@ -5,14 +5,20 @@ from __future__ import annotations
 import json
 from fractions import Fraction
 from itertools import islice
+from math import isqrt
+from typing import Any
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
 from sympy import primerange
+from tests.fixtures.accounting import assert_charged_work_parity
 
 from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.matrices import operations
 from jacobian.math.matrices._operation_models import (
+    MAX_EXACT_LINEAR_MATRIX_WORK,
     MAX_INPUT_SCALAR_DIGITS,
     MAX_SPARSE_RANK_INTERMEDIATE_CELLS,
     MatrixRankRequest,
@@ -40,6 +46,21 @@ def _entry(
         column=column,
         value=CanonicalRational.from_fraction(value),
     )
+
+
+def _connected_fill_matrix(order: int) -> SparseRationalMatrix:
+    entries = [_entry(0, column) for column in range(order)]
+    for row in range(1, order):
+        entries.extend((_entry(row, 0), _entry(row, row, Fraction(2))))
+    return SparseRationalMatrix(
+        row_count=order,
+        column_count=order,
+        entries=tuple(entries),
+    )
+
+
+def _connected_fill_work(order: int) -> int:
+    return 2 * order + (3 * order - 2) + order**3
 
 
 @pytest.mark.parametrize(
@@ -173,28 +194,89 @@ def test_sparse_rank_request_preflights_its_scalar_budget() -> None:
         )
 
 
-def test_sparse_rank_rejects_above_the_active_support_bound() -> None:
-    order = int(MAX_SPARSE_RANK_INTERMEDIATE_CELLS**0.5) + 1
+def test_sparse_rank_accepts_a_max_axis_diagonal() -> None:
+    order = MAX_SPARSE_RATIONAL_MATRIX_AXIS
+    value = Fraction(1, int("9" * MAX_INPUT_SCALAR_DIGITS))
     matrix = SparseRationalMatrix(
         row_count=order,
         column_count=order,
-        entries=tuple(_entry(index, index) for index in range(order)),
+        entries=tuple(_entry(index, index, value) for index in range(order)),
     )
 
-    with pytest.raises(OperationDomainValidationError, match="active-support bound"):
+    result = rank_result(matrix)
+
+    assert result.rank == order
+    assert result.pivot_columns == tuple(range(order))
+    assert result.matrix is matrix
+
+
+def test_sparse_rank_accepts_a_max_axis_partial_permutation() -> None:
+    axis = MAX_SPARSE_RATIONAL_MATRIX_AXIS
+    entry_count = axis // 2
+    matrix = SparseRationalMatrix(
+        row_count=axis,
+        column_count=axis,
+        entries=tuple(_entry(row, axis - 1 - row) for row in range(entry_count)),
+    )
+
+    result = rank_result(matrix)
+
+    assert result.rank == entry_count
+    assert result.pivot_columns == tuple(range(entry_count, axis))
+    assert result.matrix is matrix
+
+
+def test_sparse_rank_rejects_a_connected_component_above_the_support_bound() -> None:
+    order = isqrt(MAX_SPARSE_RANK_INTERMEDIATE_CELLS) + 1
+    matrix = _connected_fill_matrix(order)
+
+    with pytest.raises(OperationDomainValidationError, match="component-support bound"):
         rank_result(matrix)
 
 
-def test_sparse_rank_rejects_above_the_scalar_work_bound() -> None:
-    order = 500
-    matrix = SparseRationalMatrix(
-        row_count=order,
-        column_count=order,
-        entries=tuple(_entry(index, index) for index in range(order)),
-    )
+def test_sparse_rank_charges_every_near_envelope_kernel_primitive() -> None:
+    order = 464
+    matrix = _connected_fill_matrix(order)
+    executed = {"coordinate_load": 0, "gauss_jordan": 0}
+    original_kernel = operations._sympy_sparse_rank_pivots
+
+    def counted_kernel(plan: Any) -> tuple[int, ...]:
+        for component in plan.components:
+            executed["coordinate_load"] += (
+                len(component.entries) * component.scalar_digits
+            )
+            executed["gauss_jordan"] += (
+                len(component.rows)
+                * len(component.columns)
+                * min(len(component.rows), len(component.columns))
+                * component.scalar_digits
+            )
+        return original_kernel(plan)
+
+    with patch.object(
+        operations, "_sympy_sparse_rank_pivots", side_effect=counted_kernel
+    ):
+        result = rank_result(matrix)
+
+    charged = {
+        "coordinate_load": len(matrix.entries),
+        "gauss_jordan": order**3,
+    }
+    assert _connected_fill_work(order) == 99_899_662
+    assert _connected_fill_work(order) <= MAX_EXACT_LINEAR_MATRIX_WORK
+    assert result.rank == order
+    assert result.pivot_columns == tuple(range(order))
+    assert_charged_work_parity(charged=charged, executed=executed)
+
+
+def test_sparse_rank_rejects_the_first_connected_order_above_the_work_bound() -> None:
+    order = 465
+    matrix = _connected_fill_matrix(order)
 
     with pytest.raises(OperationDomainValidationError, match="scalar-work budget"):
         rank_result(matrix)
+    assert _connected_fill_work(order) == 100_546_948
+    assert _connected_fill_work(order) > MAX_EXACT_LINEAR_MATRIX_WORK
 
 
 def test_sparse_rank_rejects_above_the_intermediate_height_bound() -> None:

--- a/tests/math/matrices/test_sparse_rank.py
+++ b/tests/math/matrices/test_sparse_rank.py
@@ -1,0 +1,253 @@
+"""Exact rank contracts for canonical coordinate-sparse rational matrices."""
+
+from __future__ import annotations
+
+import json
+from fractions import Fraction
+from itertools import islice
+
+import pytest
+from pydantic import ValidationError
+from sympy import primerange
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.matrices._operation_models import (
+    MAX_INPUT_SCALAR_DIGITS,
+    MAX_SPARSE_RANK_INTERMEDIATE_CELLS,
+    MatrixRankRequest,
+    MatrixRankResult,
+)
+from jacobian.math.matrices._tools import compute_rank
+from jacobian.math.matrices.operations import rank_result
+from jacobian.math.matrices.values import (
+    MAX_SPARSE_RATIONAL_MATRIX_AXIS,
+    RationalMatrix,
+    SparseRationalMatrix,
+    SparseRationalMatrixEntry,
+    rational_matrix_from_fractions,
+    sparse_rational_matrix_from_dense,
+)
+
+
+def _entry(
+    row: int,
+    column: int,
+    value: Fraction = Fraction(1),
+) -> SparseRationalMatrixEntry:
+    return SparseRationalMatrixEntry(
+        row=row,
+        column=column,
+        value=CanonicalRational.from_fraction(value),
+    )
+
+
+@pytest.mark.parametrize(
+    ("row_count", "column_count"),
+    ((0, 128), (128, 0), (0, 0)),
+)
+def test_sparse_rank_retains_empty_axes_from_strict_json(
+    row_count: int, column_count: int
+) -> None:
+    payload = {
+        "matrix": {
+            "domain": "QQ",
+            "row_count": row_count,
+            "column_count": column_count,
+            "entries": [],
+        }
+    }
+    request = MatrixRankRequest.model_validate_json(json.dumps(payload), strict=True)
+
+    result = compute_rank(request)
+
+    assert result.matrix is request.matrix
+    assert result.rank == 0
+    assert result.pivot_columns == ()
+    assert result.matrix.model_dump(mode="json") == payload["matrix"]
+    assert (
+        MatrixRankResult.model_validate_json(result.model_dump_json(), strict=True)
+        == result
+    )
+
+
+def test_sparse_rank_reports_a_pivot_at_column_127() -> None:
+    matrix = SparseRationalMatrix(
+        row_count=1,
+        column_count=128,
+        entries=(_entry(0, 127),),
+    )
+
+    result = rank_result(matrix)
+
+    assert result.matrix is matrix
+    assert result.rank == 1
+    assert result.pivot_columns == (127,)
+
+
+def test_sparse_rank_pivots_define_exact_row_reduction() -> None:
+    matrix = SparseRationalMatrix(
+        row_count=3,
+        column_count=128,
+        entries=(
+            _entry(0, 1),
+            _entry(0, 127, Fraction(2)),
+            _entry(1, 1, Fraction(2)),
+            _entry(1, 127, Fraction(4)),
+            _entry(2, 5, Fraction(3)),
+            _entry(2, 127),
+        ),
+    )
+
+    result = rank_result(matrix)
+
+    assert result.rank == 2
+    assert result.pivot_columns == (1, 5)
+
+
+def test_dense_and_sparse_rank_paths_agree_without_changing_representation() -> None:
+    dense = rational_matrix_from_fractions(
+        (
+            (Fraction(1, 2), Fraction(0), Fraction(2), Fraction(1)),
+            (Fraction(1), Fraction(0), Fraction(4), Fraction(2)),
+            (Fraction(0), Fraction(3), Fraction(1), Fraction(0)),
+        )
+    )
+    sparse = sparse_rational_matrix_from_dense(dense)
+
+    dense_result = rank_result(dense)
+    sparse_result = rank_result(sparse)
+
+    assert isinstance(dense_result.matrix, RationalMatrix)
+    assert dense_result.matrix is dense
+    assert isinstance(sparse_result.matrix, SparseRationalMatrix)
+    assert sparse_result.matrix is sparse
+    assert sparse_result.rank == dense_result.rank
+    assert sparse_result.pivot_columns == dense_result.pivot_columns
+
+
+def test_sparse_rank_admits_a_2016_by_128_active_support_profile() -> None:
+    row_count = 2_016
+    column_count = 128
+    independent_rows = 125
+    entries: list[SparseRationalMatrixEntry] = []
+    for row in range(row_count):
+        basis_column = row % independent_rows
+        entries.append(_entry(row, basis_column))
+        if basis_column < column_count - independent_rows:
+            entries.append(_entry(row, independent_rows + basis_column))
+    matrix = SparseRationalMatrix(
+        row_count=row_count,
+        column_count=column_count,
+        entries=tuple(entries),
+    )
+
+    result = rank_result(matrix)
+
+    assert result.rank == independent_rows
+    assert result.pivot_columns == tuple(range(independent_rows))
+    assert result.matrix is matrix
+
+
+def test_sparse_rank_request_preflights_its_scalar_budget() -> None:
+    with pytest.raises(
+        ValidationError, match=rf"{MAX_INPUT_SCALAR_DIGITS} decimal digits"
+    ):
+        MatrixRankRequest.model_validate(
+            {
+                "matrix": {
+                    "row_count": 1,
+                    "column_count": 1,
+                    "entries": [
+                        {
+                            "row": 0,
+                            "column": 0,
+                            "value": {
+                                "num": "9" * (MAX_INPUT_SCALAR_DIGITS + 1),
+                                "den": "1",
+                            },
+                        }
+                    ],
+                }
+            }
+        )
+
+
+def test_sparse_rank_rejects_above_the_active_support_bound() -> None:
+    order = int(MAX_SPARSE_RANK_INTERMEDIATE_CELLS**0.5) + 1
+    matrix = SparseRationalMatrix(
+        row_count=order,
+        column_count=order,
+        entries=tuple(_entry(index, index) for index in range(order)),
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="active-support bound"):
+        rank_result(matrix)
+
+
+def test_sparse_rank_rejects_above_the_scalar_work_bound() -> None:
+    order = 500
+    matrix = SparseRationalMatrix(
+        row_count=order,
+        column_count=order,
+        entries=tuple(_entry(index, index) for index in range(order)),
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="scalar-work budget"):
+        rank_result(matrix)
+
+
+def test_sparse_rank_rejects_above_the_intermediate_height_bound() -> None:
+    scalar_limit = 10**MAX_INPUT_SCALAR_DIGITS - 1
+    denominators: list[int] = []
+    for prime in islice(primerange(2, 10_000), 130):
+        denominator = 1
+        while denominator * prime <= scalar_limit:
+            denominator *= prime
+        denominators.append(denominator)
+    matrix = SparseRationalMatrix(
+        row_count=1,
+        column_count=len(denominators),
+        entries=tuple(
+            _entry(0, column, Fraction(1, denominator))
+            for column, denominator in enumerate(denominators)
+        ),
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="intermediate-height"):
+        rank_result(matrix)
+
+
+@pytest.mark.scale
+def test_sparse_rank_rejects_a_source_bound_result_above_the_output_limit() -> None:
+    value = CanonicalRational(
+        num="1" + "0" * (MAX_INPUT_SCALAR_DIGITS - 1),
+        den="9" * MAX_INPUT_SCALAR_DIGITS,
+    )
+    matrix = SparseRationalMatrix(
+        row_count=4,
+        column_count=MAX_SPARSE_RATIONAL_MATRIX_AXIS,
+        entries=tuple(
+            SparseRationalMatrixEntry(row=row, column=column, value=value)
+            for row in range(4)
+            for column in range(MAX_SPARSE_RATIONAL_MATRIX_AXIS)
+        ),
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="canonical output limit"):
+        rank_result(matrix)
+
+
+def test_sparse_rank_result_rejects_rank_above_a_source_axis() -> None:
+    with pytest.raises(
+        ValidationError, match="cannot exceed either source matrix axis"
+    ):
+        MatrixRankResult(
+            matrix=SparseRationalMatrix(
+                row_count=1,
+                column_count=2,
+                entries=(_entry(0, 0), _entry(0, 1)),
+            ),
+            rank=2,
+            pivot_columns=(0, 1),
+        )

--- a/tests/math/matrices/test_sparse_rank.py
+++ b/tests/math/matrices/test_sparse_rank.py
@@ -317,7 +317,7 @@ def test_sparse_rank_rejects_a_source_bound_result_above_the_output_limit() -> N
     )
 
     with pytest.raises(OperationDomainValidationError, match="canonical output limit"):
-        rank_result(matrix)
+        rank_result(matrix, enforce_transport_limit=True)
 
 
 def test_sparse_rank_result_rejects_rank_above_a_source_axis() -> None:


### PR DESCRIPTION
## Problem

Part of #2905.

The planned planar-rigidity profile must retain its exact `|E| × 2|V|` matrix and pass that value unchanged to `matrix.rank.compute`. That composition currently breaks in two places:

- `SparseRationalMatrix` cannot represent a zero-row or zero-column matrix, including the `0 × 2|V|` matrix of an empty-edge framework.
- `matrix.rank.compute` accepts only dense `RationalMatrix`, whose exact-linear-algebra envelope is limited to 64 rows and columns.

Callers would otherwise have to densify a large sparse matrix, discard its declared axes, or implement rank outside the operation boundary.

This PR supplies that matrix prerequisite only. It does not construct rigidity matrices or close #2905; in particular, the issue comment requiring a lexicographically sorted derived `edge_axis` remains work for the geometry operation.

## Solution

Extend the existing `matrix.rank.compute` postcondition to canonical coordinate-sparse matrices over `QQ`, while leaving the dense FLINT path unchanged.

`SparseRationalMatrix` now admits `0 × n`, `m × 0`, and `0 × 0` values. Coordinates remain invalid on a zero axis, dense conversion rejects shapes that the nonempty dense carrier cannot represent, and consumers such as `LinearRationalSystem` retain their own nonempty domain.

Sparse admission decomposes the bipartite nonzero-support graph into connected components. For a component with active rows `R`, active columns `C`, nonzero count `z`, and maximum scalar digit count `d`, it charges `|R||C|` support cells and

```text
rows + columns + sum(d * (z + |R||C|min(|R|, |C|))).
```

Independent support components become diagonal blocks after row and column permutations, so exact row operations cannot create fill between them. This admits large diagonal and partial-permutation matrices without pricing them as dense 8,192-square matrices. Component-local Hadamard and denominator bounds cover intermediate height, and the retained source plus worst-case pivot tuple is encoded before backend execution to enforce the actual output envelope.

The components are used only for admission. The kernel passes the original global sparse matrix to SymPy 1.14.0 as a `DomainMatrix` over `QQ` and calls `rref(method="GJ")`, which selects SymPy's maintained sparse Gauss-Jordan path backed by `sdm_irref`. Canonical row-major coordinates, sorted admission components, and exact RREF over `QQ` make the source-column pivot tuple deterministic.

Suggested review order:

1. zero-axis carrier semantics in `values.py`;
2. request/result and catalog changes;
3. component admission and the SymPy adapter in `operations.py`;
4. sparse-rank, consumer-closure, and dispatch regressions.

## Testing

```sh
make handoff LANE=math TESTS='tests/math/matrices/test_sparse_rank.py tests/math/matrices/test_rational_linear_source_binding.py'
```

This passed repository-wide Ruff, format checking, and mypy over 980 source files, plus 50 focused tests.

Broader owner and boundary checks also passed:

```sh
.venv/bin/pytest -n auto --dist worksteal --timeout=120 -m 'not property and not exhaustive and not scale' tests/math/matrices --durations=10
# 600 passed

.venv/bin/pytest -n 2 --dist worksteal --timeout=30 tests/catalog --durations=10
# 113 passed

.venv/bin/pytest -n 2 --dist worksteal --timeout=120 -m 'not property and not exhaustive and not scale' tests/integration/catalog --durations=10
# 810 passed

.venv/bin/pytest -n 2 --dist worksteal --timeout=30 tests/dispatch/test_matrix_dispatch.py --durations=10
# 10 passed

.venv/bin/lint-imports
# 4 contracts kept, 0 broken
```

Regressions cover strict JSON round trips and rank zero for all three zero-axis shapes; dense/sparse rank and pivot parity; the complete 64-vertex rigidity shape (`2,016 × 128`); 8,192-square diagonal and partial-permutation matrices; connected support/work boundaries; intermediate-height and exact-output limits; malformed zero-axis coordinates; and forged source/rank relationships.

- Specialist validation run: the catalog, catalog-integration, dispatch, and import-boundary commands above.

## Public contract impact

`SparseRationalMatrix.row_count` and `column_count` now admit zero through 8,192. The existing `matrix.rank.compute` request/result schemas and native `rank_result` function now accept `RationalMatrix | SparseRationalMatrix`. The operation ID and dense semantics are unchanged. Sparse results retain the exact source, including inactive and zero axes, and return exact RREF pivot columns over `QQ`.

No compatibility alias or second operation ID is introduced.

## Operation boundary ownership

- Changed stage: request parsing, request bounds, sparse kernel adapter, trusted result construction, and catalog schema/description; transport projection is unchanged.
- Request-bounds owner and controlling quantities: `_admit_sparse_rank`; declared axes, stored nonzeros, scalar digits, bipartite support components, component rank bounds, intermediate height, and retained-result size.
- Work, intermediate, memory, and exact-output bounds: 100,000,000 scalar-work units; 1,000,000 summed component-support cells; component-local rational-height bounds; existing sparse-carrier limits; and pre-execution encoding of the retained source plus the largest possible active pivot tuple.
- Wall deadline, calibration workload, safety margin, and caller-selectable range: no operation-specific wall cap or caller-selectable range is added. Admission is mathematical; the existing request deadline remains a safety backstop.
- Backend or kernel path: unchanged FLINT RREF for dense inputs; pinned SymPy 1.14.0 sparse `DomainMatrix.rref(method="GJ")` / `sdm_irref` for sparse inputs.
- Result construction: the trusted kernel supplies exact source-column pivots; `MatrixRankResult._from_kernel` retains the original source and derives rank from the pivot count.
- Independent-result verifier: none; independently supplied mathematical results are not accepted.
- Native/MCP parity: both paths reach the same `rank_result` admission and kernel selection through `compute_rank`.
- Serialized-result and round-trip evidence: strict request/result round trips cover all zero-axis shapes, and dispatch tests cover sparse projection.

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Advertised codomain is closed under the result types, including required parent, embedding, branch, orientation, basis, or coordinate data
- [x] Producer→consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: none; inputs are canonical dense or coordinate-sparse matrices over `QQ`.
- Structurally valid but mathematically invalid fixture and outcome: a coordinate on a zero axis is rejected, as is a supplied rank above either source axis.
- Serialized-subtype trust boundary: constructors validate axes, canonical coordinates, scalar bounds, and structural rank/pivot consistency. Exact rank claims are created only by the trusted kernel.
- Exact-success defining invariant: the retained matrix is unchanged, `rank == len(pivot_columns)`, and the pivot tuple is the exact ordered RREF pivot-column tuple over `QQ`.
- Discriminated result schema and impossible combinations: the strict dense/sparse source union is distinguished by carrier fields; duplicate, unordered, out-of-axis pivots and ranks above a source axis are rejected. There are no status branches.

## Catalog admission

- Concrete gap: exact sparse-matrix producers cannot compose with `matrix.rank.compute`, and empty-axis sparse matrices cannot be represented.
- Why existing operations or typed values are insufficient: rank accepts only the dense nonempty carrier and its 64-axis envelope.
- Stable mathematical result: exact rational rank and RREF pivot columns, bound to the unchanged source matrix.
- Semantic domain and admitted execution envelope: dense inputs are unchanged; coordinate-sparse `QQ` matrices retain declared axes through 8,192 and are admitted by representation, support-component, work, height, and canonical-output bounds.
- Controlling work, intermediate, memory, and output quantities: declared axes, nonzero count, component scalar digits, summed component rectangles, component rank bounds, rational minor-height estimates, and retained-source serialization.
- Exact representation, algorithm regimes, and maintained backend: canonical rational coordinates; FLINT for dense inputs and pinned SymPy sparse exact Gauss-Jordan elimination for sparse inputs.
- Remaining fixed caps and their classification: 8,192-axis and existing nonzero limits belong to the carrier; component-cell, scalar-work, height, and canonical-output limits are operation execution bounds. The dense 64-axis envelope is unchanged.
- Motivating source request exercised through the public boundary: empty-edge `0 × 128` and complete 64-vertex `2,016 × 128` sparse matrix shapes from #2905.
- Final-tree outcome for that request: those exact matrices can be retained and ranked through the existing operation; construction and axis binding of the rigidity profile remain in #2905.
- Effect of private normalization or presolve on admission: no coordinates or axes are discarded. Component decomposition is deterministic request-scoped admission data; the backend receives the original matrix.
- Admission decision: widen `matrix.rank.compute`; do not add a near-duplicate sparse-rank operation.

## Closure matrix

Not applicable. This prerequisite does not close #2905.

## Checklist

- [x] `make handoff LANE=... TESTS=...` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (not applicable)
- [x] Catalog changes have an explicit owner-local `_tools.py` publication outcome
- [x] No compatibility aliases, forwarding modules, or generic `_operations.py` shadow paths were introduced
- [x] Runtime-bound changes name the request-bounds owner and execute the same semantic path for native and MCP callers
- [x] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable
- [x] Public operation changes include regressions derived from #2905's empty-edge and complete-graph shapes
- [x] New bounds include connected boundary cases and realistic sparse-scale evidence
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable; no shared abstraction was added)
