### PR TITLE
Compute adaptive range enclosures for elementary expressions

### DIFF
--- a/src/jacobian/math/analysis/__init__.py
+++ b/src/jacobian/math/analysis/__init__.py
@@ -1,5 +1,13 @@
 """Validated real-analysis operation ownership."""
 
-from jacobian.math.analysis.operations import expression_enclosure, second_jet_enclosure
+from jacobian.math.analysis.operations import (
+    adaptive_range_enclosure,
+    expression_enclosure,
+    second_jet_enclosure,
+)
 
-__all__ = ["expression_enclosure", "second_jet_enclosure"]
+__all__ = [
+    "adaptive_range_enclosure",
+    "expression_enclosure",
+    "second_jet_enclosure",
+]

--- a/src/jacobian/math/analysis/_adaptive_range_enclosure.py
+++ b/src/jacobian/math/analysis/_adaptive_range_enclosure.py
@@ -16,6 +16,7 @@ from jacobian._execution import (
     bind_request_deadline,
     current_request_execution,
 )
+from jacobian._flint import flint_workprec
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import CanonicalLimits, canonicalize_json
 from jacobian.catalog._examples import example
@@ -35,6 +36,7 @@ from jacobian.math.analysis._models import (
     IntervalExpressionDomainFailure,
     IntervalExpressionNode,
     RationalIntervalBox,
+    _bound_raw_box,
     _bound_raw_rational,
     _bounded_expression_nodes,
     _IntervalExpressionBoxRequest,
@@ -76,8 +78,20 @@ class AdaptiveRangeBudgetExhausted(StrictModel):
     reason: AdaptiveRangeBudgetReason
 
 
+class AdaptiveRangeDomainUnproven(StrictModel):
+    """No global range is claimed because one final Arb leaf is uncertain."""
+
+    status: Literal["DOMAIN_UNPROVEN"] = "DOMAIN_UNPROVEN"
+    reason: AdaptiveRangeBudgetReason = Field(
+        description=(
+            "The deterministic finite refinement resource that prevented every "
+            "uncertain leaf from obtaining an Arb enclosure."
+        )
+    )
+
+
 type AdaptiveRangeDisposition = Annotated[
-    AdaptiveRangeTargetMet | AdaptiveRangeBudgetExhausted,
+    AdaptiveRangeTargetMet | AdaptiveRangeBudgetExhausted | AdaptiveRangeDomainUnproven,
     Field(discriminator="status"),
 ]
 
@@ -148,8 +162,39 @@ class AdaptiveRangeEnclosureRequest(_IntervalExpressionBoxRequest):
         return self
 
 
-class AdaptiveRangeLeaf(StrictModel):
-    """One canonically addressed leaf and its sound expression enclosure."""
+@dataclass(frozen=True, slots=True)
+class _AdaptiveRangeProblem:
+    """Canonical domain input shared by native and wire execution paths."""
+
+    expression: IntervalExpressionNode
+    box: RationalIntervalBox
+    target_width: CanonicalRational
+    precision_bits: int
+    maximum_precision_bits: int
+    max_leaves: int
+    max_depth: int
+    max_evaluations: int
+    wall_seconds: int
+
+
+def _problem_from_request(
+    request: AdaptiveRangeEnclosureRequest,
+) -> _AdaptiveRangeProblem:
+    return _AdaptiveRangeProblem(
+        expression=request.expression,
+        box=request.box,
+        target_width=request.target_width,
+        precision_bits=request.precision_bits,
+        maximum_precision_bits=request.maximum_precision_bits,
+        max_leaves=request.max_leaves,
+        max_depth=request.max_depth,
+        max_evaluations=request.max_evaluations,
+        wall_seconds=request.wall_seconds,
+    )
+
+
+class _AdaptiveRangeLeafPath(StrictModel):
+    """One canonically addressed leaf in the exact midpoint partition."""
 
     path: tuple[StrictInt, ...] = Field(
         max_length=MAX_ADAPTIVE_RANGE_DEPTH,
@@ -160,7 +205,6 @@ class AdaptiveRangeLeaf(StrictModel):
         ),
     )
     box: RationalIntervalBox
-    enclosure: DyadicClosedInterval
 
     @field_validator("path", mode="before")
     @classmethod
@@ -178,6 +222,26 @@ class AdaptiveRangeLeaf(StrictModel):
         return self
 
 
+class AdaptiveRangeLeaf(_AdaptiveRangeLeafPath):
+    """One leaf with a sound expression enclosure."""
+
+    status: Literal["ENCLOSED"] = "ENCLOSED"
+    enclosure: DyadicClosedInterval
+
+
+class AdaptiveRangeDomainUnprovenLeaf(_AdaptiveRangeLeafPath):
+    """One leaf whose fixed-precision Arb evaluation remained uncertain."""
+
+    status: Literal["DOMAIN_UNPROVEN"] = "DOMAIN_UNPROVEN"
+    domain_failure: IntervalExpressionDomainFailure
+
+
+type AdaptiveRangeFinalLeaf = Annotated[
+    AdaptiveRangeLeaf | AdaptiveRangeDomainUnprovenLeaf,
+    Field(discriminator="status"),
+]
+
+
 def _precision_schedule(initial: int, maximum: int) -> tuple[int, ...]:
     schedule = [initial]
     while schedule[-1] < maximum:
@@ -186,24 +250,35 @@ def _precision_schedule(initial: int, maximum: int) -> tuple[int, ...]:
 
 
 def _dyadic_fraction(value: ExactDyadic) -> Fraction:
+    _require_adaptive_dyadic_endpoint(value)
+    return value.as_fraction()
+
+
+def _require_adaptive_dyadic_endpoint(value: ExactDyadic) -> None:
     if abs(value.exponent) > MAX_ADAPTIVE_RANGE_DYADIC_EXPONENT:
         raise _validation_error(
             "adaptive dyadic exponent exceeds the admitted source-and-precision bound"
         )
-    return value.as_fraction()
+
+
+def _require_adaptive_dyadic_interval(enclosure: DyadicClosedInterval) -> None:
+    _require_adaptive_dyadic_endpoint(enclosure.lower)
+    _require_adaptive_dyadic_endpoint(enclosure.upper)
 
 
 def _enclosure_width(enclosure: DyadicClosedInterval) -> Fraction:
     return _dyadic_fraction(enclosure.upper) - _dyadic_fraction(enclosure.lower)
 
 
-def _interval_hull(leaves: tuple[AdaptiveRangeLeaf, ...]) -> DyadicClosedInterval:
+def _enclosure_hull(
+    enclosures: tuple[DyadicClosedInterval, ...],
+) -> DyadicClosedInterval:
     lower = min(
-        (leaf.enclosure.lower for leaf in leaves),
+        (enclosure.lower for enclosure in enclosures),
         key=_dyadic_fraction,
     )
     upper = max(
-        (leaf.enclosure.upper for leaf in leaves),
+        (enclosure.upper for enclosure in enclosures),
         key=_dyadic_fraction,
     )
     return DyadicClosedInterval(lower=lower, upper=upper)
@@ -264,6 +339,31 @@ def _paths_are_complete(paths: tuple[tuple[int, ...], ...]) -> bool:
     return sum(1 << (depth - len(path)) for path in paths) == 1 << depth
 
 
+def _bind_domain_failure_to_expression(
+    expression: IntervalExpressionNode,
+    failure: IntervalExpressionDomainFailure,
+) -> None:
+    node = expression
+    for child_index in failure.node_path:
+        if child_index >= len(node.children):
+            raise _validation_error(
+                "domain-failure node path does not exist in the source expression"
+            )
+        node = node.children[child_index]
+    if node.op != failure.operation:
+        raise _validation_error(
+            "domain-failure operation does not match the source expression node"
+        )
+    if failure.operation == "pow" and (node.exponent is None or node.exponent >= 0):
+        raise _validation_error(
+            "negative-power domain failure requires a negative source exponent"
+        )
+    if failure.reason == "SQRT_ARGUMENT_NOT_STRICTLY_POSITIVE_FOR_SECOND_JET":
+        raise _validation_error(
+            "second-jet differentiability evidence is not a range-domain failure"
+        )
+
+
 def _bind_leaf_partition(result: AdaptiveRangeEnclosureResult) -> None:
     if len(result.leaves) > result.max_leaves:
         raise _validation_error("adaptive result exceeds the requested leaf budget")
@@ -283,91 +383,24 @@ def _bind_leaf_partition(result: AdaptiveRangeEnclosureResult) -> None:
             raise _validation_error(
                 "adaptive leaf box does not match its source-bound midpoint path"
             )
-        _enclosure_width(leaf.enclosure)
-
-
-def _bind_evaluation_schedule(
-    result: AdaptiveRangeEnclosureResult, schedule: tuple[int, ...]
-) -> int:
-    root_evaluations = result.evaluations_used - 2 * (len(result.leaves) - 1)
-    if not 1 <= root_evaluations <= len(schedule):
-        raise _validation_error(
-            "adaptive evaluation count does not reconstruct its finite schedule"
-        )
-    if result.maximum_precision_bits_used != schedule[root_evaluations - 1]:
-        raise _validation_error(
-            "adaptive used precision does not match its doubling schedule"
-        )
-    if len(result.leaves) > 1 and root_evaluations != len(schedule):
-        raise _validation_error(
-            "adaptive bisection may begin only after the precision schedule"
-        )
-    if result.evaluations_used > result.max_evaluations:
-        raise _validation_error(
-            "adaptive result exceeds the requested evaluation budget"
-        )
-    return root_evaluations
-
-
-def _bind_budget_reason(
-    result: AdaptiveRangeEnclosureResult,
-    schedule: tuple[int, ...],
-    root_evaluations: int,
-) -> None:
-    if not isinstance(result.disposition, AdaptiveRangeBudgetExhausted):
-        return
-    reason = result.disposition.reason
-    if reason != "MAX_EVALUATIONS" and root_evaluations != len(schedule):
-        raise _validation_error(
-            "only MAX_EVALUATIONS may stop an incomplete precision schedule"
-        )
-    if reason == "MAX_EVALUATIONS":
-        remaining = result.max_evaluations - result.evaluations_used
-        required = 1 if root_evaluations < len(schedule) else 2
-        if remaining >= required:
-            raise _validation_error(
-                "MAX_EVALUATIONS must lack the next complete evaluation action"
-            )
-        if root_evaluations < len(schedule):
-            return
-
-    splittable = any(
-        len(leaf.path) < result.max_depth and _widest_coordinate(leaf.box) is not None
-        for leaf in result.leaves
-    )
-    if reason in ("MAX_LEAVES", "MAX_EVALUATIONS"):
-        if not splittable:
-            raise _validation_error(
-                f"{reason} cannot stop when no retained leaf is splittable"
-            )
-        if reason == "MAX_LEAVES" and len(result.leaves) != result.max_leaves:
-            raise _validation_error(
-                "MAX_LEAVES requires the requested leaf budget to be full"
-            )
-        return
-    if splittable:
-        raise _validation_error(f"{reason} cannot stop while a leaf remains splittable")
-    has_positive_coordinate = any(
-        _widest_coordinate(leaf.box) is not None for leaf in result.leaves
-    )
-    if (reason == "MAX_DEPTH") != has_positive_coordinate:
-        raise _validation_error(
-            "MAX_DEPTH and MAX_PRECISION must identify the deterministic no-split cause"
-        )
-    if reason == "MAX_PRECISION" and (
-        result.maximum_precision_bits_used != result.maximum_precision_bits
-    ):
-        raise _validation_error(
-            "MAX_PRECISION requires completing the precision schedule"
-        )
+        if isinstance(leaf, AdaptiveRangeDomainUnprovenLeaf):
+            _bind_domain_failure_to_expression(result.expression, leaf.domain_failure)
+        else:
+            _require_adaptive_dyadic_interval(leaf.enclosure)
 
 
 class AdaptiveRangeEnclosureResult(AdaptiveRangeEnclosureRequest):
-    """A complete source-bound range enclosure and exact finite leaf cover."""
+    """A complete source-bound range enclosure or typed finite nonconclusion."""
 
-    enclosure: DyadicClosedInterval
+    enclosure: DyadicClosedInterval | None = Field(
+        default=None,
+        description=(
+            "The hull of every retained leaf enclosure; absent exactly when the "
+            "disposition is DOMAIN_UNPROVEN."
+        ),
+    )
     disposition: AdaptiveRangeDisposition
-    leaves: tuple[AdaptiveRangeLeaf, ...] = Field(
+    leaves: tuple[AdaptiveRangeFinalLeaf, ...] = Field(
         min_length=1,
         max_length=MAX_ADAPTIVE_RANGE_LEAVES,
         description=(
@@ -383,53 +416,86 @@ class AdaptiveRangeEnclosureResult(AdaptiveRangeEnclosureRequest):
     def preserve_bounded_leaves(cls, value: object) -> object:
         if isinstance(value, (list, tuple)) and len(value) > MAX_ADAPTIVE_RANGE_LEAVES:
             raise _validation_error("adaptive result exceeds its leaf bound")
+        if isinstance(value, (list, tuple)):
+            for leaf in value:
+                if not isinstance(leaf, Mapping):
+                    continue
+                path = leaf.get("path")
+                if (
+                    isinstance(path, (list, tuple))
+                    and len(path) > MAX_ADAPTIVE_RANGE_DEPTH
+                ):
+                    raise _validation_error(
+                        "adaptive leaf path exceeds the bisection-depth bound"
+                    )
+                _bound_raw_box(leaf.get("box"))
         return tuple(value) if isinstance(value, list) else value
 
     @model_validator(mode="after")
-    def bind_partition_and_hull_to_source(self) -> Self:
+    def bind_partition_and_disposition_state(self) -> Self:
         _bind_leaf_partition(self)
-        hull = _interval_hull(self.leaves)
-        if self.enclosure != hull:
+        if self.enclosure is not None:
+            _require_adaptive_dyadic_interval(self.enclosure)
+        if self.evaluations_used > self.max_evaluations:
             raise _validation_error(
-                "adaptive global enclosure must equal the hull of every leaf enclosure"
+                "adaptive result exceeds the requested evaluation budget"
             )
-        target = self.target_width.as_fraction()
-        if target <= 0:
-            raise _validation_error("adaptive target width must be positive")
-        target_met = _enclosure_width(hull) <= target
-        if target_met != isinstance(self.disposition, AdaptiveRangeTargetMet):
+        if not (
+            self.precision_bits
+            <= self.maximum_precision_bits_used
+            <= self.maximum_precision_bits
+        ):
             raise _validation_error(
-                "adaptive disposition must agree with the requested target width"
+                "adaptive used precision must lie in the requested precision range"
             )
-
-        schedule = _precision_schedule(self.precision_bits, self.maximum_precision_bits)
-        root_evaluations = _bind_evaluation_schedule(self, schedule)
-        _bind_budget_reason(self, schedule, root_evaluations)
+        unproven = tuple(
+            leaf
+            for leaf in self.leaves
+            if isinstance(leaf, AdaptiveRangeDomainUnprovenLeaf)
+        )
+        if isinstance(self.disposition, AdaptiveRangeDomainUnproven):
+            if not unproven:
+                raise _validation_error(
+                    "DOMAIN_UNPROVEN requires at least one uncertain final leaf"
+                )
+            if self.enclosure is not None:
+                raise _validation_error(
+                    "DOMAIN_UNPROVEN cannot carry a global enclosure"
+                )
+            return self
+        if unproven:
+            raise _validation_error(
+                "an uncertain adaptive leaf requires DOMAIN_UNPROVEN disposition"
+            )
+        if self.enclosure is None:
+            raise _validation_error(
+                "a concluded adaptive disposition requires a global enclosure"
+            )
         return self
 
     @classmethod
     def _from_kernel(
         cls,
-        request: AdaptiveRangeEnclosureRequest,
+        problem: _AdaptiveRangeProblem,
         *,
-        enclosure: DyadicClosedInterval,
+        enclosure: DyadicClosedInterval | None,
         disposition: AdaptiveRangeDisposition,
-        leaves: tuple[AdaptiveRangeLeaf, ...],
+        leaves: tuple[AdaptiveRangeFinalLeaf, ...],
         evaluations_used: int,
         maximum_precision_bits_used: int,
     ) -> AdaptiveRangeEnclosureResult:
         """Construct a result after the kernel established every range claim."""
 
         return cls.model_construct(
-            expression=request.expression,
-            box=request.box,
-            precision_bits=request.precision_bits,
-            target_width=request.target_width,
-            maximum_precision_bits=request.maximum_precision_bits,
-            max_leaves=request.max_leaves,
-            max_depth=request.max_depth,
-            max_evaluations=request.max_evaluations,
-            wall_seconds=request.wall_seconds,
+            expression=problem.expression,
+            box=problem.box,
+            precision_bits=problem.precision_bits,
+            target_width=problem.target_width,
+            maximum_precision_bits=problem.maximum_precision_bits,
+            max_leaves=problem.max_leaves,
+            max_depth=problem.max_depth,
+            max_evaluations=problem.max_evaluations,
+            wall_seconds=problem.wall_seconds,
             enclosure=enclosure,
             disposition=disposition,
             leaves=leaves,
@@ -444,6 +510,18 @@ class _AdaptiveRangeAdmission:
     planned_evaluations: int
     target_width: Fraction
     deadline: float
+
+
+@dataclass(frozen=True, slots=True)
+class _EvaluatedAdaptiveRangeLeaf:
+    path: tuple[int, ...]
+    box: RationalIntervalBox
+    enclosure: DyadicClosedInterval | None = None
+    domain_failure: IntervalExpressionDomainFailure | None = None
+
+    def __post_init__(self) -> None:
+        if (self.enclosure is None) == (self.domain_failure is None):
+            raise AssertionError("one adaptive leaf must carry exactly one outcome")
 
 
 def _midpoint_component_digits(box: RationalIntervalBox, depth: int) -> int:
@@ -461,19 +539,33 @@ def _midpoint_component_digits(box: RationalIntervalBox, depth: int) -> int:
     return 2 * source_digits + depth + 2
 
 
-def _estimated_result_bytes(request: AdaptiveRangeEnclosureRequest) -> int:
-    source_bytes = len(canonicalize_json(request.model_dump(mode="json")))
-    endpoint_digits = _midpoint_component_digits(request.box, request.max_depth)
+def _estimated_result_bytes(problem: _AdaptiveRangeProblem) -> int:
+    source_bytes = len(
+        canonicalize_json(
+            {
+                "expression": problem.expression.model_dump(mode="json"),
+                "box": problem.box.model_dump(mode="json"),
+                "target_width": problem.target_width.model_dump(mode="json"),
+                "precision_bits": problem.precision_bits,
+                "maximum_precision_bits": problem.maximum_precision_bits,
+                "max_leaves": problem.max_leaves,
+                "max_depth": problem.max_depth,
+                "max_evaluations": problem.max_evaluations,
+                "wall_seconds": problem.wall_seconds,
+            }
+        )
+    )
+    endpoint_digits = _midpoint_component_digits(problem.box, problem.max_depth)
     axis_bytes = sum(
-        len(variable.encode("utf-8")) + 3 for variable in request.box.variables
+        len(variable.encode("utf-8")) + 3 for variable in problem.box.variables
     )
     box_bytes = (
-        128 + axis_bytes + len(request.box.variables) * (4 * endpoint_digits + 128)
+        128 + axis_bytes + len(problem.box.variables) * (4 * endpoint_digits + 128)
     )
     dyadic_interval_bytes = 2 * (MAX_DYADIC_MANTISSA_DIGITS + 64) + 64
-    path_bytes = 2 * request.max_depth + 32
+    path_bytes = 2 * problem.max_depth + 32
     leaf_bytes = box_bytes + dyadic_interval_bytes + path_bytes + 128
-    return source_bytes + request.max_leaves * leaf_bytes + 4_096
+    return source_bytes + problem.max_leaves * leaf_bytes + 4_096
 
 
 def _require_deadline(deadline: float, stage: str) -> None:
@@ -483,19 +575,97 @@ def _require_deadline(deadline: float, stage: str) -> None:
         )
 
 
+def _require_parameter_envelope(problem: _AdaptiveRangeProblem) -> None:
+    bounds = (
+        ("precision_bits", problem.precision_bits, 32, 4_096),
+        (
+            "maximum_precision_bits",
+            problem.maximum_precision_bits,
+            32,
+            4_096,
+        ),
+        ("max_leaves", problem.max_leaves, 1, MAX_ADAPTIVE_RANGE_LEAVES),
+        ("max_depth", problem.max_depth, 0, MAX_ADAPTIVE_RANGE_DEPTH),
+        (
+            "max_evaluations",
+            problem.max_evaluations,
+            1,
+            MAX_ADAPTIVE_RANGE_EVALUATIONS,
+        ),
+        (
+            "wall_seconds",
+            problem.wall_seconds,
+            1,
+            MAX_ADAPTIVE_RANGE_WALL_SECONDS,
+        ),
+    )
+    for field, value, minimum, maximum in bounds:
+        if type(value) is not int or not minimum <= value <= maximum:
+            raise OperationDomainValidationError(
+                location=(field,),
+                code="analysis.adaptive_range.parameter_bound",
+                message=(f"{field} must be an integer between {minimum} and {maximum}"),
+            )
+    if problem.maximum_precision_bits < problem.precision_bits:
+        raise OperationDomainValidationError(
+            location=("maximum_precision_bits", "precision_bits"),
+            code="analysis.adaptive_range.precision_schedule",
+            message="maximum_precision_bits must be at least precision_bits",
+        )
+
+
+def _require_complete_source_axis(
+    problem: _AdaptiveRangeProblem,
+    nodes: tuple[IntervalExpressionNode, ...],
+) -> None:
+    used_variables: set[str] = set()
+    for node in nodes:
+        if node.op != "var":
+            continue
+        if node.variable is None:
+            raise OperationDomainValidationError(
+                location=("expression",),
+                code="analysis.adaptive_range.named_variable",
+                message="adaptive range variable nodes must be named",
+            )
+        used_variables.add(node.variable)
+    box_variables = set(problem.box.variables)
+    missing = used_variables - box_variables
+    if missing:
+        raise OperationDomainValidationError(
+            location=("box", "variables"),
+            code="analysis.adaptive_range.missing_variable",
+            message=(
+                "expression variables are missing from the box: "
+                + ", ".join(sorted(missing))
+            ),
+        )
+    unused = box_variables - used_variables
+    if unused:
+        raise OperationDomainValidationError(
+            location=("box", "variables"),
+            code="analysis.adaptive_range.unused_variable",
+            message=(
+                "box variables are unused by the expression: "
+                + ", ".join(sorted(unused))
+            ),
+        )
+
+
 def _admit_adaptive_range(
-    request: AdaptiveRangeEnclosureRequest, *, started_at: float
+    problem: _AdaptiveRangeProblem, *, started_at: float
 ) -> _AdaptiveRangeAdmission:
-    deadline = started_at + request.wall_seconds
+    _require_parameter_envelope(problem)
+    deadline = started_at + problem.wall_seconds
     bind_request_deadline(deadline)
     _require_deadline(deadline, "before semantic preflight")
 
     try:
-        target_width = request.target_width.as_fraction()
+        target_width = problem.target_width.as_fraction()
         if target_width <= 0:
             raise ValueError("adaptive target width must be positive")
         if (
-            canonical_rational_component_digits(request.target_width)
+            canonical_rational_component_digits(problem.target_width)
             > MAX_RATIONAL_DIGITS
         ):
             raise ValueError(
@@ -508,13 +678,14 @@ def _admit_adaptive_range(
             message=str(exc),
         ) from exc
 
-    nodes = _bounded_expression_nodes(request.expression)
+    nodes = _bounded_expression_nodes(problem.expression)
+    _require_complete_source_axis(problem, nodes)
     schedule = _precision_schedule(
-        request.precision_bits, request.maximum_precision_bits
+        problem.precision_bits, problem.maximum_precision_bits
     )
     planned_evaluations = min(
-        request.max_evaluations,
-        len(schedule) + 2 * (request.max_leaves - 1),
+        problem.max_evaluations,
+        len(schedule) + 2 * (problem.max_leaves - 1),
     )
     node_evaluations = len(nodes) * planned_evaluations
     if node_evaluations > MAX_ADAPTIVE_RANGE_NODE_EVALUATIONS:
@@ -526,7 +697,7 @@ def _admit_adaptive_range(
                 f"evaluations exceeds the {MAX_ADAPTIVE_RANGE_NODE_EVALUATIONS}-unit bound"
             ),
         )
-    precision_work = node_evaluations * request.maximum_precision_bits
+    precision_work = node_evaluations * problem.maximum_precision_bits
     if precision_work > MAX_ADAPTIVE_RANGE_PRECISION_WORK:
         raise OperationDomainValidationError(
             location=("maximum_precision_bits", "max_evaluations"),
@@ -536,7 +707,7 @@ def _admit_adaptive_range(
                 f"exceeds the {MAX_ADAPTIVE_RANGE_PRECISION_WORK}-unit bound"
             ),
         )
-    estimated_result_bytes = _estimated_result_bytes(request)
+    estimated_result_bytes = _estimated_result_bytes(problem)
     if estimated_result_bytes > MAX_ADAPTIVE_RANGE_RESULT_BYTES:
         raise OperationDomainValidationError(
             location=("max_leaves", "max_depth", "box"),
@@ -549,7 +720,7 @@ def _admit_adaptive_range(
 
     try:
         preflight = _preflight_box_expression(
-            request.expression, _rational_box_bounds(request.box)
+            problem.expression, _rational_box_bounds(problem.box)
         )
     except ValueError as exc:
         raise OperationDomainValidationError(
@@ -577,46 +748,51 @@ def _admit_adaptive_range(
 
 def _evaluate_leaf(
     expression: IntervalExpressionNode,
+    path: tuple[int, ...],
     box: RationalIntervalBox,
     precision_bits: int,
     *,
     deadline: float,
-) -> DyadicClosedInterval:
+) -> _EvaluatedAdaptiveRangeLeaf:
     _require_deadline(deadline, "before an Arb leaf evaluation")
+    domain_failure: IntervalExpressionDomainFailure | None = None
     try:
-        from flint import ctx
-
-        with ctx.workprec(precision_bits):
+        with flint_workprec(precision_bits, deadline=deadline):
             variables = {
                 variable: arb_source_interval(interval)
                 for variable, interval in zip(box.variables, box.intervals, strict=True)
             }
             result = _evaluate_box_expression(expression, variables)
             if isinstance(result, IntervalExpressionDomainFailure):
-                raise RuntimeError(
-                    "pinned Arb disagreed with the admitted real source domain"
-                )
-            if isinstance(result, _BoxEvaluationFailure) or not result.is_finite():
+                domain_failure = result
+                endpoints = None
+            elif isinstance(result, _BoxEvaluationFailure) or not result.is_finite():
                 raise RuntimeError(
                     "pinned Arb returned no finite adaptive leaf enclosure"
                 )
-            lower_mantissa, lower_exponent = result.lower().man_exp()
-            upper_mantissa, upper_exponent = result.upper().man_exp()
-            endpoints = dyadic_endpoints(
-                lower_mantissa,
-                lower_exponent,
-                upper_mantissa,
-                upper_exponent,
-            )
-    except OperationExecutionTimeoutError:
-        raise
-    except RuntimeError:
-        raise
+            else:
+                lower_mantissa, lower_exponent = result.lower().man_exp()
+                upper_mantissa, upper_exponent = result.upper().man_exp()
+                endpoints = dyadic_endpoints(
+                    lower_mantissa,
+                    lower_exponent,
+                    upper_mantissa,
+                    upper_exponent,
+                )
     except (OverflowError, ValueError, ZeroDivisionError) as exc:
         raise RuntimeError(
             "pinned Arb rejected an admitted adaptive leaf evaluation"
         ) from exc
     _require_deadline(deadline, "after an Arb leaf evaluation")
+    if domain_failure is not None:
+        # The exact source-box preflight proved the real domain once. Arb's
+        # fixed-precision interval extension can still be unable to prove a
+        # domain-sensitive node, so retain that bounded leaf for refinement.
+        return _EvaluatedAdaptiveRangeLeaf(
+            path=path,
+            box=box,
+            domain_failure=domain_failure,
+        )
     if endpoints is None or any(
         abs(endpoint.exponent) > MAX_ADAPTIVE_RANGE_DYADIC_EXPONENT
         for endpoint in endpoints
@@ -624,40 +800,85 @@ def _evaluate_leaf(
         raise RuntimeError(
             "pinned Arb produced an adaptive endpoint outside the admitted dyadic envelope"
         )
-    return DyadicClosedInterval(lower=endpoints[0], upper=endpoints[1])
+    return _EvaluatedAdaptiveRangeLeaf(
+        path=path,
+        box=box,
+        enclosure=DyadicClosedInterval(lower=endpoints[0], upper=endpoints[1]),
+    )
+
+
+def _public_leaves(
+    leaves: tuple[_EvaluatedAdaptiveRangeLeaf, ...],
+) -> tuple[AdaptiveRangeFinalLeaf, ...]:
+    ordered = tuple(sorted(leaves, key=lambda leaf: leaf.path))
+    public: list[AdaptiveRangeFinalLeaf] = []
+    for leaf in ordered:
+        if leaf.domain_failure is not None:
+            public.append(
+                AdaptiveRangeDomainUnprovenLeaf(
+                    path=leaf.path,
+                    box=leaf.box,
+                    domain_failure=leaf.domain_failure,
+                )
+            )
+            continue
+        assert leaf.enclosure is not None
+        public.append(
+            AdaptiveRangeLeaf(
+                path=leaf.path,
+                box=leaf.box,
+                enclosure=leaf.enclosure,
+            )
+        )
+    return tuple(public)
+
+
+def _evaluated_hull(
+    leaves: tuple[_EvaluatedAdaptiveRangeLeaf, ...],
+) -> DyadicClosedInterval:
+    enclosed = tuple(leaf.enclosure for leaf in leaves if leaf.enclosure is not None)
+    if len(enclosed) != len(leaves):
+        raise AssertionError("a global adaptive hull requires every leaf enclosure")
+    return _enclosure_hull(enclosed)
 
 
 def _result(
-    request: AdaptiveRangeEnclosureRequest,
-    leaves: tuple[AdaptiveRangeLeaf, ...],
+    problem: _AdaptiveRangeProblem,
+    leaves: tuple[_EvaluatedAdaptiveRangeLeaf, ...],
     *,
     target_width: Fraction,
     evaluations_used: int,
     maximum_precision_bits_used: int,
     reason: AdaptiveRangeBudgetReason | None,
 ) -> AdaptiveRangeEnclosureResult:
-    leaves = tuple(sorted(leaves, key=lambda leaf: leaf.path))
-    hull = _interval_hull(leaves)
-    target_met = _enclosure_width(hull) <= target_width
+    public_leaves = _public_leaves(leaves)
+    has_unproven = any(leaf.domain_failure is not None for leaf in leaves)
     disposition: AdaptiveRangeDisposition
-    if target_met:
-        disposition = AdaptiveRangeTargetMet()
-    else:
+    enclosure: DyadicClosedInterval | None
+    if has_unproven:
         assert reason is not None
-        disposition = AdaptiveRangeBudgetExhausted(reason=reason)
+        enclosure = None
+        disposition = AdaptiveRangeDomainUnproven(reason=reason)
+    else:
+        enclosure = _evaluated_hull(leaves)
+        if _enclosure_width(enclosure) <= target_width:
+            disposition = AdaptiveRangeTargetMet()
+        else:
+            assert reason is not None
+            disposition = AdaptiveRangeBudgetExhausted(reason=reason)
     return AdaptiveRangeEnclosureResult._from_kernel(
-        request,
-        enclosure=hull,
+        problem,
+        enclosure=enclosure,
         disposition=disposition,
-        leaves=leaves,
+        leaves=public_leaves,
         evaluations_used=evaluations_used,
         maximum_precision_bits_used=maximum_precision_bits_used,
     )
 
 
 def _finish_result(
-    request: AdaptiveRangeEnclosureRequest,
-    leaves: tuple[AdaptiveRangeLeaf, ...],
+    problem: _AdaptiveRangeProblem,
+    leaves: tuple[_EvaluatedAdaptiveRangeLeaf, ...],
     *,
     admission: _AdaptiveRangeAdmission,
     evaluations_used: int,
@@ -665,7 +886,7 @@ def _finish_result(
     reason: AdaptiveRangeBudgetReason | None,
 ) -> AdaptiveRangeEnclosureResult:
     result = _result(
-        request,
+        problem,
         leaves,
         target_width=admission.target_width,
         evaluations_used=evaluations_used,
@@ -676,36 +897,44 @@ def _finish_result(
     return result
 
 
-def _compute_adaptive_range_enclosure(
-    request: AdaptiveRangeEnclosureRequest, *, native_started_at: float | None = None
+def _evaluated_target_met(
+    leaves: tuple[_EvaluatedAdaptiveRangeLeaf, ...], target_width: Fraction
+) -> bool:
+    if any(leaf.enclosure is None for leaf in leaves):
+        return False
+    return _enclosure_width(_evaluated_hull(leaves)) <= target_width
+
+
+def _leaf_selection_key(
+    leaf: _EvaluatedAdaptiveRangeLeaf,
+) -> tuple[int, Fraction, tuple[int, ...]]:
+    if leaf.domain_failure is not None:
+        return (0, Fraction(), leaf.path)
+    assert leaf.enclosure is not None
+    return (1, -_enclosure_width(leaf.enclosure), leaf.path)
+
+
+def _run_adaptive_range_enclosure(
+    problem: _AdaptiveRangeProblem, *, started_at: float
 ) -> AdaptiveRangeEnclosureResult:
-    execution = current_request_execution()
-    started_at = (
-        execution.started_at
-        if execution is not None
-        else native_started_at
-        if native_started_at is not None
-        else monotonic()
-    )
-    admission = _admit_adaptive_range(request, started_at=started_at)
+    admission = _admit_adaptive_range(problem, started_at=started_at)
     schedule = admission.precision_schedule
     evaluations = 0
 
-    root_path: tuple[int, ...] = ()
-    best = _evaluate_leaf(
-        request.expression,
-        request.box,
+    root = _evaluate_leaf(
+        problem.expression,
+        (),
+        problem.box,
         schedule[0],
         deadline=admission.deadline,
     )
     evaluations += 1
     precision_used = schedule[0]
-    leaves: tuple[AdaptiveRangeLeaf, ...] = (
-        AdaptiveRangeLeaf(path=root_path, box=request.box, enclosure=best),
-    )
-    if _enclosure_width(best) <= admission.target_width:
+    best = root if root.enclosure is not None else None
+    leaves: tuple[_EvaluatedAdaptiveRangeLeaf, ...] = (root,)
+    if _evaluated_target_met(leaves, admission.target_width):
         return _finish_result(
-            request,
+            problem,
             leaves,
             admission=admission,
             evaluations_used=evaluations,
@@ -714,9 +943,9 @@ def _compute_adaptive_range_enclosure(
         )
 
     for precision in schedule[1:]:
-        if evaluations >= request.max_evaluations:
+        if evaluations >= problem.max_evaluations:
             return _finish_result(
-                request,
+                problem,
                 leaves,
                 admission=admission,
                 evaluations_used=evaluations,
@@ -724,21 +953,27 @@ def _compute_adaptive_range_enclosure(
                 reason="MAX_EVALUATIONS",
             )
         candidate = _evaluate_leaf(
-            request.expression,
-            request.box,
+            problem.expression,
+            (),
+            problem.box,
             precision,
             deadline=admission.deadline,
         )
         evaluations += 1
         precision_used = precision
-        if _enclosure_width(candidate) < _enclosure_width(best):
-            best = candidate
-            leaves = (
-                AdaptiveRangeLeaf(path=root_path, box=request.box, enclosure=best),
+        if candidate.enclosure is not None and (
+            best is None
+            or (
+                best.enclosure is not None
+                and _enclosure_width(candidate.enclosure)
+                < _enclosure_width(best.enclosure)
             )
-        if _enclosure_width(best) <= admission.target_width:
+        ):
+            best = candidate
+        leaves = (best if best is not None else candidate,)
+        if _evaluated_target_met(leaves, admission.target_width):
             return _finish_result(
-                request,
+                problem,
                 leaves,
                 admission=admission,
                 evaluations_used=evaluations,
@@ -746,12 +981,28 @@ def _compute_adaptive_range_enclosure(
                 reason=None,
             )
 
+    reason: AdaptiveRangeBudgetReason
     while True:
         _require_deadline(admission.deadline, "before partition refinement")
+        blocked_unproven = tuple(
+            leaf
+            for leaf in leaves
+            if leaf.domain_failure is not None
+            and (
+                len(leaf.path) >= problem.max_depth
+                or _widest_coordinate(leaf.box) is None
+            )
+        )
+        if blocked_unproven:
+            has_positive_coordinate = any(
+                _widest_coordinate(leaf.box) is not None for leaf in blocked_unproven
+            )
+            reason = "MAX_DEPTH" if has_positive_coordinate else "MAX_PRECISION"
+            break
         candidates = tuple(
             leaf
             for leaf in leaves
-            if len(leaf.path) < request.max_depth
+            if len(leaf.path) < problem.max_depth
             and _widest_coordinate(leaf.box) is not None
         )
         if not candidates:
@@ -760,58 +1011,60 @@ def _compute_adaptive_range_enclosure(
             )
             reason = "MAX_DEPTH" if any_positive_coordinate else "MAX_PRECISION"
             break
-        if len(leaves) >= request.max_leaves:
+        if len(leaves) >= problem.max_leaves:
             reason = "MAX_LEAVES"
             break
-        if request.max_evaluations - evaluations < 2:
+        if problem.max_evaluations - evaluations < 2:
             reason = "MAX_EVALUATIONS"
             break
         selected = min(
             candidates,
-            key=lambda leaf: (-_enclosure_width(leaf.enclosure), leaf.path),
+            key=_leaf_selection_key,
         )
         coordinate = _widest_coordinate(selected.box)
         assert coordinate is not None
         child_boxes = _split_box(selected.box, coordinate)
-        child_enclosures = tuple(
+        children = tuple(
             _evaluate_leaf(
-                request.expression,
+                problem.expression,
+                (*selected.path, bit),
                 child_box,
-                request.maximum_precision_bits,
+                problem.maximum_precision_bits,
                 deadline=admission.deadline,
             )
-            for child_box in child_boxes
+            for bit, child_box in enumerate(child_boxes)
         )
         evaluations += 2
-        children = tuple(
-            AdaptiveRangeLeaf(
-                path=(*selected.path, bit),
-                box=child_box,
-                enclosure=enclosure,
-            )
-            for bit, (child_box, enclosure) in enumerate(
-                zip(child_boxes, child_enclosures, strict=True)
-            )
-        )
         leaves = tuple(leaf for leaf in leaves if leaf.path != selected.path) + children
         leaves = tuple(sorted(leaves, key=lambda leaf: leaf.path))
-        if _enclosure_width(_interval_hull(leaves)) <= admission.target_width:
+        if _evaluated_target_met(leaves, admission.target_width):
             return _finish_result(
-                request,
+                problem,
                 leaves,
                 admission=admission,
                 evaluations_used=evaluations,
-                maximum_precision_bits_used=request.maximum_precision_bits,
+                maximum_precision_bits_used=problem.maximum_precision_bits,
                 reason=None,
             )
 
     return _finish_result(
-        request,
+        problem,
         leaves,
         admission=admission,
         evaluations_used=evaluations,
         maximum_precision_bits_used=precision_used,
         reason=reason,
+    )
+
+
+def _compute_adaptive_range_enclosure(
+    request: AdaptiveRangeEnclosureRequest,
+) -> AdaptiveRangeEnclosureResult:
+    execution = current_request_execution()
+    started_at = execution.started_at if execution is not None else monotonic()
+    return _run_adaptive_range_enclosure(
+        _problem_from_request(request),
+        started_at=started_at,
     )
 
 
@@ -827,10 +1080,10 @@ def adaptive_range_enclosure(
     max_evaluations: int = 128,
     wall_seconds: int = 30,
 ) -> AdaptiveRangeEnclosureResult:
-    """Return a sound complete range hull over a deterministic finite cover."""
+    """Return a sound complete range hull or a typed finite nonconclusion."""
 
     started_at = monotonic()
-    request = AdaptiveRangeEnclosureRequest(
+    problem = _AdaptiveRangeProblem(
         expression=expression,
         box=box,
         precision_bits=precision_bits,
@@ -841,7 +1094,7 @@ def adaptive_range_enclosure(
         max_evaluations=max_evaluations,
         wall_seconds=wall_seconds,
     )
-    return _compute_adaptive_range_enclosure(request, native_started_at=started_at)
+    return _run_adaptive_range_enclosure(problem, started_at=started_at)
 
 
 ADAPTIVE_RANGE_ENCLOSURE_OPERATIONS = (
@@ -852,11 +1105,15 @@ ADAPTIVE_RANGE_ENCLOSURE_OPERATIONS = (
             "Return a sound dyadic hull over every leaf of a deterministic complete "
             "rational-box partition. Precision doubles to the requested maximum; "
             "the narrowest source-box enclosure is retained (earliest precision on "
-            "ties), then the widest currently splittable certified-range leaf is "
-            "bisected on its widest source coordinate, with canonical path and axis "
-            "ties. TARGET_MET means the hull width is at most target_width. "
+            "ties). Domain-uncertain leaves are then refined first in canonical path "
+            "order; otherwise the widest splittable certified-range leaf is bisected "
+            "on its widest source coordinate, with canonical path and axis ties. "
+            "TARGET_MET means the hull width is at most target_width. "
             "BUDGET_EXHAUSTED retains the same global soundness after the declared "
-            "finite schedule stops. The envelope admits at most "
+            "finite schedule stops. DOMAIN_UNPROVEN carries the complete final cover "
+            "but no global enclosure when fixed-precision Arb leaves a local real-"
+            "domain obligation uncertain after bounded refinement. The envelope "
+            "admits at most "
             f"{MAX_ADAPTIVE_RANGE_LEAVES:,} leaves, depth "
             f"{MAX_ADAPTIVE_RANGE_DEPTH}, {MAX_ADAPTIVE_RANGE_EVALUATIONS:,} "
             "evaluations and 4,096 precision bits, "
@@ -937,6 +1194,8 @@ __all__ = [
     "MAX_ADAPTIVE_RANGE_RESULT_BYTES",
     "MAX_ADAPTIVE_RANGE_WALL_SECONDS",
     "AdaptiveRangeBudgetExhausted",
+    "AdaptiveRangeDomainUnproven",
+    "AdaptiveRangeDomainUnprovenLeaf",
     "AdaptiveRangeEnclosureRequest",
     "AdaptiveRangeEnclosureResult",
     "AdaptiveRangeLeaf",

--- a/src/jacobian/math/analysis/_adaptive_range_enclosure.py
+++ b/src/jacobian/math/analysis/_adaptive_range_enclosure.py
@@ -321,10 +321,6 @@ def _bind_budget_reason(
         raise _validation_error(
             "only MAX_EVALUATIONS may stop an incomplete precision schedule"
         )
-    if reason == "MAX_LEAVES" and len(result.leaves) != result.max_leaves:
-        raise _validation_error(
-            "MAX_LEAVES requires the requested leaf budget to be full"
-        )
     if reason == "MAX_EVALUATIONS":
         remaining = result.max_evaluations - result.evaluations_used
         required = 1 if root_evaluations < len(schedule) else 2
@@ -332,12 +328,23 @@ def _bind_budget_reason(
             raise _validation_error(
                 "MAX_EVALUATIONS must lack the next complete evaluation action"
             )
-    if reason not in ("MAX_DEPTH", "MAX_PRECISION"):
-        return
+        if root_evaluations < len(schedule):
+            return
+
     splittable = any(
         len(leaf.path) < result.max_depth and _widest_coordinate(leaf.box) is not None
         for leaf in result.leaves
     )
+    if reason in ("MAX_LEAVES", "MAX_EVALUATIONS"):
+        if not splittable:
+            raise _validation_error(
+                f"{reason} cannot stop when no retained leaf is splittable"
+            )
+        if reason == "MAX_LEAVES" and len(result.leaves) != result.max_leaves:
+            raise _validation_error(
+                "MAX_LEAVES requires the requested leaf budget to be full"
+            )
+        return
     if splittable:
         raise _validation_error(f"{reason} cannot stop while a leaf remains splittable")
     has_positive_coordinate = any(
@@ -741,13 +748,6 @@ def _compute_adaptive_range_enclosure(
 
     while True:
         _require_deadline(admission.deadline, "before partition refinement")
-        if len(leaves) >= request.max_leaves:
-            reason: AdaptiveRangeBudgetReason = "MAX_LEAVES"
-            break
-        if request.max_evaluations - evaluations < 2:
-            reason = "MAX_EVALUATIONS"
-            break
-
         candidates = tuple(
             leaf
             for leaf in leaves
@@ -759,6 +759,12 @@ def _compute_adaptive_range_enclosure(
                 _widest_coordinate(leaf.box) is not None for leaf in leaves
             )
             reason = "MAX_DEPTH" if any_positive_coordinate else "MAX_PRECISION"
+            break
+        if len(leaves) >= request.max_leaves:
+            reason = "MAX_LEAVES"
+            break
+        if request.max_evaluations - evaluations < 2:
+            reason = "MAX_EVALUATIONS"
             break
         selected = min(
             candidates,

--- a/src/jacobian/math/analysis/_adaptive_range_enclosure.py
+++ b/src/jacobian/math/analysis/_adaptive_range_enclosure.py
@@ -1,0 +1,939 @@
+"""Adaptive complete range enclosures over exact rational box partitions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from fractions import Fraction
+from time import monotonic
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictInt, field_validator, model_validator
+
+from jacobian._exact import CanonicalRational, canonical_rational_component_digits
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+)
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.canonical import CanonicalLimits, canonicalize_json
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationDomainValidationError
+from jacobian.math.analysis._arb import arb_source_interval, dyadic_endpoints
+from jacobian.math.analysis._box_enclosure import (
+    _BoxEvaluationFailure,
+    _evaluate_box_expression,
+    _preflight_box_expression,
+)
+from jacobian.math.analysis._models import (
+    MAX_BOX_PREFLIGHT_TEMPORARY_BITS,
+    MAX_DYADIC_MANTISSA_DIGITS,
+    MAX_RATIONAL_DIGITS,
+    DyadicClosedInterval,
+    ExactDyadic,
+    IntervalExpressionDomainFailure,
+    IntervalExpressionNode,
+    RationalIntervalBox,
+    _bound_raw_rational,
+    _bounded_expression_nodes,
+    _IntervalExpressionBoxRequest,
+    _rational_box_bounds,
+    _validation_error,
+)
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+
+MAX_ADAPTIVE_RANGE_LEAVES = 1_024
+MAX_ADAPTIVE_RANGE_DEPTH = 32
+MAX_ADAPTIVE_RANGE_EVALUATIONS = 4_096
+MAX_ADAPTIVE_RANGE_NODE_EVALUATIONS = 131_072
+MAX_ADAPTIVE_RANGE_PRECISION_WORK = 268_435_456
+MAX_ADAPTIVE_RANGE_WALL_SECONDS = 120
+MAX_ADAPTIVE_RANGE_RESULT_BYTES = CanonicalLimits().max_output_bytes
+
+# Admission bounds every exact source-box value by an 8,192-bit rational and
+# every Arb work precision by 4,096 bits. An outward endpoint can therefore
+# require at most their sum in its binary exponent. The existing temporary
+# Fraction ceiling is a slightly larger, named bound that also keeps public
+# result validation from expanding an enormous authored dyadic exponent.
+MAX_ADAPTIVE_RANGE_DYADIC_EXPONENT = MAX_BOX_PREFLIGHT_TEMPORARY_BITS
+
+type AdaptiveRangeBudgetReason = Literal[
+    "MAX_LEAVES", "MAX_DEPTH", "MAX_EVALUATIONS", "MAX_PRECISION"
+]
+
+
+class AdaptiveRangeTargetMet(StrictModel):
+    """The complete enclosure is no wider than the requested target."""
+
+    status: Literal["TARGET_MET"] = "TARGET_MET"
+
+
+class AdaptiveRangeBudgetExhausted(StrictModel):
+    """The complete enclosure is sound but the finite schedule stopped first."""
+
+    status: Literal["BUDGET_EXHAUSTED"] = "BUDGET_EXHAUSTED"
+    reason: AdaptiveRangeBudgetReason
+
+
+type AdaptiveRangeDisposition = Annotated[
+    AdaptiveRangeTargetMet | AdaptiveRangeBudgetExhausted,
+    Field(discriminator="status"),
+]
+
+
+class AdaptiveRangeEnclosureRequest(_IntervalExpressionBoxRequest):
+    """Bound one complete elementary-expression range by adaptive bisection."""
+
+    target_width: CanonicalRational = Field(
+        description=(
+            "A positive exact rational target for upper-lower. Components admit "
+            "at most 128 decimal digits."
+        )
+    )
+    maximum_precision_bits: StrictInt = Field(
+        default=512,
+        ge=32,
+        le=4096,
+        description=(
+            "Final precision in the deterministic doubling schedule; it must be "
+            "at least precision_bits."
+        ),
+    )
+    max_leaves: StrictInt = Field(
+        default=32,
+        ge=1,
+        le=MAX_ADAPTIVE_RANGE_LEAVES,
+        description="Maximum retained leaves in the complete binary partition.",
+    )
+    max_depth: StrictInt = Field(
+        default=8,
+        ge=0,
+        le=MAX_ADAPTIVE_RANGE_DEPTH,
+        description="Maximum number of exact midpoint bisections on one leaf path.",
+    )
+    max_evaluations: StrictInt = Field(
+        default=128,
+        ge=1,
+        le=MAX_ADAPTIVE_RANGE_EVALUATIONS,
+        description=(
+            "Maximum Arb expression evaluations. A split is attempted only when "
+            "two child evaluations remain."
+        ),
+    )
+    wall_seconds: StrictInt = Field(
+        default=30,
+        ge=1,
+        le=MAX_ADAPTIVE_RANGE_WALL_SECONDS,
+        description=(
+            "Shared owner deadline in seconds, measured from dispatch start (or "
+            "native-function entry) through final result construction."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw_adaptive_fields(cls, value: object) -> object:
+        value = canonicalize_json_containers(value)
+        if isinstance(value, Mapping):
+            _bound_raw_rational(value.get("target_width"), "adaptive target width")
+        return value
+
+    @model_validator(mode="after")
+    def require_precision_schedule(self) -> Self:
+        if self.maximum_precision_bits < self.precision_bits:
+            raise _validation_error(
+                "maximum_precision_bits must be at least precision_bits"
+            )
+        return self
+
+
+class AdaptiveRangeLeaf(StrictModel):
+    """One canonically addressed leaf and its sound expression enclosure."""
+
+    path: tuple[StrictInt, ...] = Field(
+        max_length=MAX_ADAPTIVE_RANGE_DEPTH,
+        description=(
+            "Binary child choices from the source box. At every step 0 selects "
+            "the lower and 1 the upper exact-midpoint child of the widest positive "
+            "coordinate, with source-axis ties."
+        ),
+    )
+    box: RationalIntervalBox
+    enclosure: DyadicClosedInterval
+
+    @field_validator("path", mode="before")
+    @classmethod
+    def preserve_bounded_path(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)) and len(value) > MAX_ADAPTIVE_RANGE_DEPTH:
+            raise _validation_error(
+                "adaptive leaf path exceeds the bisection-depth bound"
+            )
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def require_binary_path(self) -> Self:
+        if any(bit not in (0, 1) for bit in self.path):
+            raise _validation_error("adaptive leaf paths contain only 0 and 1")
+        return self
+
+
+def _precision_schedule(initial: int, maximum: int) -> tuple[int, ...]:
+    schedule = [initial]
+    while schedule[-1] < maximum:
+        schedule.append(min(2 * schedule[-1], maximum))
+    return tuple(schedule)
+
+
+def _dyadic_fraction(value: ExactDyadic) -> Fraction:
+    if abs(value.exponent) > MAX_ADAPTIVE_RANGE_DYADIC_EXPONENT:
+        raise _validation_error(
+            "adaptive dyadic exponent exceeds the admitted source-and-precision bound"
+        )
+    return value.as_fraction()
+
+
+def _enclosure_width(enclosure: DyadicClosedInterval) -> Fraction:
+    return _dyadic_fraction(enclosure.upper) - _dyadic_fraction(enclosure.lower)
+
+
+def _interval_hull(leaves: tuple[AdaptiveRangeLeaf, ...]) -> DyadicClosedInterval:
+    lower = min(
+        (leaf.enclosure.lower for leaf in leaves),
+        key=_dyadic_fraction,
+    )
+    upper = max(
+        (leaf.enclosure.upper for leaf in leaves),
+        key=_dyadic_fraction,
+    )
+    return DyadicClosedInterval(lower=lower, upper=upper)
+
+
+def _widest_coordinate(box: RationalIntervalBox) -> int | None:
+    widest_index: int | None = None
+    widest_width = Fraction(0)
+    for index, interval in enumerate(box.intervals):
+        width = interval.upper.as_fraction() - interval.lower.as_fraction()
+        if width > widest_width:
+            widest_index = index
+            widest_width = width
+    return widest_index
+
+
+def _split_box(
+    box: RationalIntervalBox, coordinate: int
+) -> tuple[RationalIntervalBox, RationalIntervalBox]:
+    selected = box.intervals[coordinate]
+    midpoint = CanonicalRational.from_fraction(
+        (selected.lower.as_fraction() + selected.upper.as_fraction()) / 2
+    )
+    lower_intervals = list(box.intervals)
+    upper_intervals = list(box.intervals)
+    lower_intervals[coordinate] = ClosedRationalInterval(
+        lower=selected.lower, upper=midpoint
+    )
+    upper_intervals[coordinate] = ClosedRationalInterval(
+        lower=midpoint, upper=selected.upper
+    )
+    return (
+        RationalIntervalBox(variables=box.variables, intervals=tuple(lower_intervals)),
+        RationalIntervalBox(variables=box.variables, intervals=tuple(upper_intervals)),
+    )
+
+
+def _box_at_path(
+    source: RationalIntervalBox, path: tuple[int, ...]
+) -> RationalIntervalBox:
+    box = source
+    for bit in path:
+        coordinate = _widest_coordinate(box)
+        if coordinate is None:
+            raise _validation_error(
+                "a positive-depth leaf cannot descend from a degenerate box"
+            )
+        children = _split_box(box, coordinate)
+        box = children[bit]
+    return box
+
+
+def _paths_are_complete(paths: tuple[tuple[int, ...], ...]) -> bool:
+    for index, path in enumerate(paths):
+        if any(other[: len(path)] == path for other in paths[index + 1 :]):
+            return False
+    depth = max(map(len, paths), default=0)
+    return sum(1 << (depth - len(path)) for path in paths) == 1 << depth
+
+
+def _bind_leaf_partition(result: AdaptiveRangeEnclosureResult) -> None:
+    if len(result.leaves) > result.max_leaves:
+        raise _validation_error("adaptive result exceeds the requested leaf budget")
+    paths = tuple(leaf.path for leaf in result.leaves)
+    if paths != tuple(sorted(paths)) or len(set(paths)) != len(paths):
+        raise _validation_error(
+            "adaptive leaves must have unique lexicographically ordered paths"
+        )
+    if any(len(path) > result.max_depth for path in paths):
+        raise _validation_error("adaptive leaf exceeds the requested depth budget")
+    if not _paths_are_complete(paths):
+        raise _validation_error(
+            "adaptive leaf paths must be a complete prefix-free binary cover"
+        )
+    for leaf in result.leaves:
+        if leaf.box != _box_at_path(result.box, leaf.path):
+            raise _validation_error(
+                "adaptive leaf box does not match its source-bound midpoint path"
+            )
+        _enclosure_width(leaf.enclosure)
+
+
+def _bind_evaluation_schedule(
+    result: AdaptiveRangeEnclosureResult, schedule: tuple[int, ...]
+) -> int:
+    root_evaluations = result.evaluations_used - 2 * (len(result.leaves) - 1)
+    if not 1 <= root_evaluations <= len(schedule):
+        raise _validation_error(
+            "adaptive evaluation count does not reconstruct its finite schedule"
+        )
+    if result.maximum_precision_bits_used != schedule[root_evaluations - 1]:
+        raise _validation_error(
+            "adaptive used precision does not match its doubling schedule"
+        )
+    if len(result.leaves) > 1 and root_evaluations != len(schedule):
+        raise _validation_error(
+            "adaptive bisection may begin only after the precision schedule"
+        )
+    if result.evaluations_used > result.max_evaluations:
+        raise _validation_error(
+            "adaptive result exceeds the requested evaluation budget"
+        )
+    return root_evaluations
+
+
+def _bind_budget_reason(
+    result: AdaptiveRangeEnclosureResult,
+    schedule: tuple[int, ...],
+    root_evaluations: int,
+) -> None:
+    if not isinstance(result.disposition, AdaptiveRangeBudgetExhausted):
+        return
+    reason = result.disposition.reason
+    if reason != "MAX_EVALUATIONS" and root_evaluations != len(schedule):
+        raise _validation_error(
+            "only MAX_EVALUATIONS may stop an incomplete precision schedule"
+        )
+    if reason == "MAX_LEAVES" and len(result.leaves) != result.max_leaves:
+        raise _validation_error(
+            "MAX_LEAVES requires the requested leaf budget to be full"
+        )
+    if reason == "MAX_EVALUATIONS":
+        remaining = result.max_evaluations - result.evaluations_used
+        required = 1 if root_evaluations < len(schedule) else 2
+        if remaining >= required:
+            raise _validation_error(
+                "MAX_EVALUATIONS must lack the next complete evaluation action"
+            )
+    if reason not in ("MAX_DEPTH", "MAX_PRECISION"):
+        return
+    splittable = any(
+        len(leaf.path) < result.max_depth and _widest_coordinate(leaf.box) is not None
+        for leaf in result.leaves
+    )
+    if splittable:
+        raise _validation_error(f"{reason} cannot stop while a leaf remains splittable")
+    has_positive_coordinate = any(
+        _widest_coordinate(leaf.box) is not None for leaf in result.leaves
+    )
+    if (reason == "MAX_DEPTH") != has_positive_coordinate:
+        raise _validation_error(
+            "MAX_DEPTH and MAX_PRECISION must identify the deterministic no-split cause"
+        )
+    if reason == "MAX_PRECISION" and (
+        result.maximum_precision_bits_used != result.maximum_precision_bits
+    ):
+        raise _validation_error(
+            "MAX_PRECISION requires completing the precision schedule"
+        )
+
+
+class AdaptiveRangeEnclosureResult(AdaptiveRangeEnclosureRequest):
+    """A complete source-bound range enclosure and exact finite leaf cover."""
+
+    enclosure: DyadicClosedInterval
+    disposition: AdaptiveRangeDisposition
+    leaves: tuple[AdaptiveRangeLeaf, ...] = Field(
+        min_length=1,
+        max_length=MAX_ADAPTIVE_RANGE_LEAVES,
+        description=(
+            "Canonical path-ordered complete partition. Leaf interiors are "
+            "disjoint; adjacent closed leaves share their bisection face."
+        ),
+    )
+    evaluations_used: StrictInt = Field(ge=1, le=MAX_ADAPTIVE_RANGE_EVALUATIONS)
+    maximum_precision_bits_used: StrictInt = Field(ge=32, le=4096)
+
+    @field_validator("leaves", mode="before")
+    @classmethod
+    def preserve_bounded_leaves(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)) and len(value) > MAX_ADAPTIVE_RANGE_LEAVES:
+            raise _validation_error("adaptive result exceeds its leaf bound")
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def bind_partition_and_hull_to_source(self) -> Self:
+        _bind_leaf_partition(self)
+        hull = _interval_hull(self.leaves)
+        if self.enclosure != hull:
+            raise _validation_error(
+                "adaptive global enclosure must equal the hull of every leaf enclosure"
+            )
+        target = self.target_width.as_fraction()
+        if target <= 0:
+            raise _validation_error("adaptive target width must be positive")
+        target_met = _enclosure_width(hull) <= target
+        if target_met != isinstance(self.disposition, AdaptiveRangeTargetMet):
+            raise _validation_error(
+                "adaptive disposition must agree with the requested target width"
+            )
+
+        schedule = _precision_schedule(self.precision_bits, self.maximum_precision_bits)
+        root_evaluations = _bind_evaluation_schedule(self, schedule)
+        _bind_budget_reason(self, schedule, root_evaluations)
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: AdaptiveRangeEnclosureRequest,
+        *,
+        enclosure: DyadicClosedInterval,
+        disposition: AdaptiveRangeDisposition,
+        leaves: tuple[AdaptiveRangeLeaf, ...],
+        evaluations_used: int,
+        maximum_precision_bits_used: int,
+    ) -> AdaptiveRangeEnclosureResult:
+        """Construct a result after the kernel established every range claim."""
+
+        return cls.model_construct(
+            expression=request.expression,
+            box=request.box,
+            precision_bits=request.precision_bits,
+            target_width=request.target_width,
+            maximum_precision_bits=request.maximum_precision_bits,
+            max_leaves=request.max_leaves,
+            max_depth=request.max_depth,
+            max_evaluations=request.max_evaluations,
+            wall_seconds=request.wall_seconds,
+            enclosure=enclosure,
+            disposition=disposition,
+            leaves=leaves,
+            evaluations_used=evaluations_used,
+            maximum_precision_bits_used=maximum_precision_bits_used,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _AdaptiveRangeAdmission:
+    precision_schedule: tuple[int, ...]
+    planned_evaluations: int
+    target_width: Fraction
+    deadline: float
+
+
+def _midpoint_component_digits(box: RationalIntervalBox, depth: int) -> int:
+    source_digits = max(
+        (
+            canonical_rational_component_digits(endpoint)
+            for interval in box.intervals
+            for endpoint in (interval.lower, interval.upper)
+        ),
+        default=1,
+    )
+    # A depth-d bisection endpoint is ((2**d-j)l + j*u)/2**d. Before
+    # reduction, each component therefore uses at most two source components,
+    # a d-bit coefficient, and one carry digit.
+    return 2 * source_digits + depth + 2
+
+
+def _estimated_result_bytes(request: AdaptiveRangeEnclosureRequest) -> int:
+    source_bytes = len(canonicalize_json(request.model_dump(mode="json")))
+    endpoint_digits = _midpoint_component_digits(request.box, request.max_depth)
+    axis_bytes = sum(
+        len(variable.encode("utf-8")) + 3 for variable in request.box.variables
+    )
+    box_bytes = (
+        128 + axis_bytes + len(request.box.variables) * (4 * endpoint_digits + 128)
+    )
+    dyadic_interval_bytes = 2 * (MAX_DYADIC_MANTISSA_DIGITS + 64) + 64
+    path_bytes = 2 * request.max_depth + 32
+    leaf_bytes = box_bytes + dyadic_interval_bytes + path_bytes + 128
+    return source_bytes + request.max_leaves * leaf_bytes + 4_096
+
+
+def _require_deadline(deadline: float, stage: str) -> None:
+    if monotonic() >= deadline:
+        raise OperationExecutionTimeoutError(
+            f"adaptive range enclosure deadline expired {stage}"
+        )
+
+
+def _admit_adaptive_range(
+    request: AdaptiveRangeEnclosureRequest, *, started_at: float
+) -> _AdaptiveRangeAdmission:
+    deadline = started_at + request.wall_seconds
+    bind_request_deadline(deadline)
+    _require_deadline(deadline, "before semantic preflight")
+
+    try:
+        target_width = request.target_width.as_fraction()
+        if target_width <= 0:
+            raise ValueError("adaptive target width must be positive")
+        if (
+            canonical_rational_component_digits(request.target_width)
+            > MAX_RATIONAL_DIGITS
+        ):
+            raise ValueError(
+                f"adaptive target width exceeds the {MAX_RATIONAL_DIGITS}-digit bound"
+            )
+    except ValueError as exc:
+        raise OperationDomainValidationError(
+            location=("target_width",),
+            code="analysis.adaptive_range.target_width",
+            message=str(exc),
+        ) from exc
+
+    nodes = _bounded_expression_nodes(request.expression)
+    schedule = _precision_schedule(
+        request.precision_bits, request.maximum_precision_bits
+    )
+    planned_evaluations = min(
+        request.max_evaluations,
+        len(schedule) + 2 * (request.max_leaves - 1),
+    )
+    node_evaluations = len(nodes) * planned_evaluations
+    if node_evaluations > MAX_ADAPTIVE_RANGE_NODE_EVALUATIONS:
+        raise OperationDomainValidationError(
+            location=("max_evaluations",),
+            code="analysis.adaptive_range.node_evaluations",
+            message=(
+                f"adaptive range work of {node_evaluations} expression-node "
+                f"evaluations exceeds the {MAX_ADAPTIVE_RANGE_NODE_EVALUATIONS}-unit bound"
+            ),
+        )
+    precision_work = node_evaluations * request.maximum_precision_bits
+    if precision_work > MAX_ADAPTIVE_RANGE_PRECISION_WORK:
+        raise OperationDomainValidationError(
+            location=("maximum_precision_bits", "max_evaluations"),
+            code="analysis.adaptive_range.precision_work",
+            message=(
+                f"adaptive range precision work of {precision_work} node-bit units "
+                f"exceeds the {MAX_ADAPTIVE_RANGE_PRECISION_WORK}-unit bound"
+            ),
+        )
+    estimated_result_bytes = _estimated_result_bytes(request)
+    if estimated_result_bytes > MAX_ADAPTIVE_RANGE_RESULT_BYTES:
+        raise OperationDomainValidationError(
+            location=("max_leaves", "max_depth", "box"),
+            code="analysis.adaptive_range.result_bytes",
+            message=(
+                f"adaptive range result estimate of {estimated_result_bytes} bytes "
+                f"exceeds the {MAX_ADAPTIVE_RANGE_RESULT_BYTES}-byte canonical output bound"
+            ),
+        )
+
+    try:
+        preflight = _preflight_box_expression(
+            request.expression, _rational_box_bounds(request.box)
+        )
+    except ValueError as exc:
+        raise OperationDomainValidationError(
+            location=("expression",),
+            code="analysis.adaptive_range.intermediate_bound",
+            message=str(exc),
+        ) from exc
+    if isinstance(preflight, IntervalExpressionDomainFailure):
+        raise OperationDomainValidationError(
+            location=("expression", *preflight.node_path),
+            code="analysis.adaptive_range.domain_unproven",
+            message=(
+                "the exact source-box interval extension did not establish the "
+                f"real domain for {preflight.operation}"
+            ),
+        )
+    _require_deadline(deadline, "after semantic preflight")
+    return _AdaptiveRangeAdmission(
+        precision_schedule=schedule,
+        planned_evaluations=planned_evaluations,
+        target_width=target_width,
+        deadline=deadline,
+    )
+
+
+def _evaluate_leaf(
+    expression: IntervalExpressionNode,
+    box: RationalIntervalBox,
+    precision_bits: int,
+    *,
+    deadline: float,
+) -> DyadicClosedInterval:
+    _require_deadline(deadline, "before an Arb leaf evaluation")
+    try:
+        from flint import ctx
+
+        with ctx.workprec(precision_bits):
+            variables = {
+                variable: arb_source_interval(interval)
+                for variable, interval in zip(box.variables, box.intervals, strict=True)
+            }
+            result = _evaluate_box_expression(expression, variables)
+            if isinstance(result, IntervalExpressionDomainFailure):
+                raise RuntimeError(
+                    "pinned Arb disagreed with the admitted real source domain"
+                )
+            if isinstance(result, _BoxEvaluationFailure) or not result.is_finite():
+                raise RuntimeError(
+                    "pinned Arb returned no finite adaptive leaf enclosure"
+                )
+            lower_mantissa, lower_exponent = result.lower().man_exp()
+            upper_mantissa, upper_exponent = result.upper().man_exp()
+            endpoints = dyadic_endpoints(
+                lower_mantissa,
+                lower_exponent,
+                upper_mantissa,
+                upper_exponent,
+            )
+    except OperationExecutionTimeoutError:
+        raise
+    except RuntimeError:
+        raise
+    except (OverflowError, ValueError, ZeroDivisionError) as exc:
+        raise RuntimeError(
+            "pinned Arb rejected an admitted adaptive leaf evaluation"
+        ) from exc
+    _require_deadline(deadline, "after an Arb leaf evaluation")
+    if endpoints is None or any(
+        abs(endpoint.exponent) > MAX_ADAPTIVE_RANGE_DYADIC_EXPONENT
+        for endpoint in endpoints
+    ):
+        raise RuntimeError(
+            "pinned Arb produced an adaptive endpoint outside the admitted dyadic envelope"
+        )
+    return DyadicClosedInterval(lower=endpoints[0], upper=endpoints[1])
+
+
+def _result(
+    request: AdaptiveRangeEnclosureRequest,
+    leaves: tuple[AdaptiveRangeLeaf, ...],
+    *,
+    target_width: Fraction,
+    evaluations_used: int,
+    maximum_precision_bits_used: int,
+    reason: AdaptiveRangeBudgetReason | None,
+) -> AdaptiveRangeEnclosureResult:
+    leaves = tuple(sorted(leaves, key=lambda leaf: leaf.path))
+    hull = _interval_hull(leaves)
+    target_met = _enclosure_width(hull) <= target_width
+    disposition: AdaptiveRangeDisposition
+    if target_met:
+        disposition = AdaptiveRangeTargetMet()
+    else:
+        assert reason is not None
+        disposition = AdaptiveRangeBudgetExhausted(reason=reason)
+    return AdaptiveRangeEnclosureResult._from_kernel(
+        request,
+        enclosure=hull,
+        disposition=disposition,
+        leaves=leaves,
+        evaluations_used=evaluations_used,
+        maximum_precision_bits_used=maximum_precision_bits_used,
+    )
+
+
+def _finish_result(
+    request: AdaptiveRangeEnclosureRequest,
+    leaves: tuple[AdaptiveRangeLeaf, ...],
+    *,
+    admission: _AdaptiveRangeAdmission,
+    evaluations_used: int,
+    maximum_precision_bits_used: int,
+    reason: AdaptiveRangeBudgetReason | None,
+) -> AdaptiveRangeEnclosureResult:
+    result = _result(
+        request,
+        leaves,
+        target_width=admission.target_width,
+        evaluations_used=evaluations_used,
+        maximum_precision_bits_used=maximum_precision_bits_used,
+        reason=reason,
+    )
+    _require_deadline(admission.deadline, "after result construction")
+    return result
+
+
+def _compute_adaptive_range_enclosure(
+    request: AdaptiveRangeEnclosureRequest, *, native_started_at: float | None = None
+) -> AdaptiveRangeEnclosureResult:
+    execution = current_request_execution()
+    started_at = (
+        execution.started_at
+        if execution is not None
+        else native_started_at
+        if native_started_at is not None
+        else monotonic()
+    )
+    admission = _admit_adaptive_range(request, started_at=started_at)
+    schedule = admission.precision_schedule
+    evaluations = 0
+
+    root_path: tuple[int, ...] = ()
+    best = _evaluate_leaf(
+        request.expression,
+        request.box,
+        schedule[0],
+        deadline=admission.deadline,
+    )
+    evaluations += 1
+    precision_used = schedule[0]
+    leaves: tuple[AdaptiveRangeLeaf, ...] = (
+        AdaptiveRangeLeaf(path=root_path, box=request.box, enclosure=best),
+    )
+    if _enclosure_width(best) <= admission.target_width:
+        return _finish_result(
+            request,
+            leaves,
+            admission=admission,
+            evaluations_used=evaluations,
+            maximum_precision_bits_used=precision_used,
+            reason=None,
+        )
+
+    for precision in schedule[1:]:
+        if evaluations >= request.max_evaluations:
+            return _finish_result(
+                request,
+                leaves,
+                admission=admission,
+                evaluations_used=evaluations,
+                maximum_precision_bits_used=precision_used,
+                reason="MAX_EVALUATIONS",
+            )
+        candidate = _evaluate_leaf(
+            request.expression,
+            request.box,
+            precision,
+            deadline=admission.deadline,
+        )
+        evaluations += 1
+        precision_used = precision
+        if _enclosure_width(candidate) < _enclosure_width(best):
+            best = candidate
+            leaves = (
+                AdaptiveRangeLeaf(path=root_path, box=request.box, enclosure=best),
+            )
+        if _enclosure_width(best) <= admission.target_width:
+            return _finish_result(
+                request,
+                leaves,
+                admission=admission,
+                evaluations_used=evaluations,
+                maximum_precision_bits_used=precision_used,
+                reason=None,
+            )
+
+    while True:
+        _require_deadline(admission.deadline, "before partition refinement")
+        if len(leaves) >= request.max_leaves:
+            reason: AdaptiveRangeBudgetReason = "MAX_LEAVES"
+            break
+        if request.max_evaluations - evaluations < 2:
+            reason = "MAX_EVALUATIONS"
+            break
+
+        candidates = tuple(
+            leaf
+            for leaf in leaves
+            if len(leaf.path) < request.max_depth
+            and _widest_coordinate(leaf.box) is not None
+        )
+        if not candidates:
+            any_positive_coordinate = any(
+                _widest_coordinate(leaf.box) is not None for leaf in leaves
+            )
+            reason = "MAX_DEPTH" if any_positive_coordinate else "MAX_PRECISION"
+            break
+        selected = min(
+            candidates,
+            key=lambda leaf: (-_enclosure_width(leaf.enclosure), leaf.path),
+        )
+        coordinate = _widest_coordinate(selected.box)
+        assert coordinate is not None
+        child_boxes = _split_box(selected.box, coordinate)
+        child_enclosures = tuple(
+            _evaluate_leaf(
+                request.expression,
+                child_box,
+                request.maximum_precision_bits,
+                deadline=admission.deadline,
+            )
+            for child_box in child_boxes
+        )
+        evaluations += 2
+        children = tuple(
+            AdaptiveRangeLeaf(
+                path=(*selected.path, bit),
+                box=child_box,
+                enclosure=enclosure,
+            )
+            for bit, (child_box, enclosure) in enumerate(
+                zip(child_boxes, child_enclosures, strict=True)
+            )
+        )
+        leaves = tuple(leaf for leaf in leaves if leaf.path != selected.path) + children
+        leaves = tuple(sorted(leaves, key=lambda leaf: leaf.path))
+        if _enclosure_width(_interval_hull(leaves)) <= admission.target_width:
+            return _finish_result(
+                request,
+                leaves,
+                admission=admission,
+                evaluations_used=evaluations,
+                maximum_precision_bits_used=request.maximum_precision_bits,
+                reason=None,
+            )
+
+    return _finish_result(
+        request,
+        leaves,
+        admission=admission,
+        evaluations_used=evaluations,
+        maximum_precision_bits_used=precision_used,
+        reason=reason,
+    )
+
+
+def adaptive_range_enclosure(
+    expression: IntervalExpressionNode,
+    box: RationalIntervalBox,
+    target_width: CanonicalRational,
+    *,
+    precision_bits: int = 128,
+    maximum_precision_bits: int = 512,
+    max_leaves: int = 32,
+    max_depth: int = 8,
+    max_evaluations: int = 128,
+    wall_seconds: int = 30,
+) -> AdaptiveRangeEnclosureResult:
+    """Return a sound complete range hull over a deterministic finite cover."""
+
+    started_at = monotonic()
+    request = AdaptiveRangeEnclosureRequest(
+        expression=expression,
+        box=box,
+        precision_bits=precision_bits,
+        target_width=target_width,
+        maximum_precision_bits=maximum_precision_bits,
+        max_leaves=max_leaves,
+        max_depth=max_depth,
+        max_evaluations=max_evaluations,
+        wall_seconds=wall_seconds,
+    )
+    return _compute_adaptive_range_enclosure(request, native_started_at=started_at)
+
+
+ADAPTIVE_RANGE_ENCLOSURE_OPERATIONS = (
+    MathTool(
+        operation_id="interval.expression.adaptive_range_enclosure.compute",
+        title="Enclose an expression range over an adaptive rational partition",
+        description=(
+            "Return a sound dyadic hull over every leaf of a deterministic complete "
+            "rational-box partition. Precision doubles to the requested maximum; "
+            "the narrowest source-box enclosure is retained (earliest precision on "
+            "ties), then the widest currently splittable certified-range leaf is "
+            "bisected on its widest source coordinate, with canonical path and axis "
+            "ties. TARGET_MET means the hull width is at most target_width. "
+            "BUDGET_EXHAUSTED retains the same global soundness after the declared "
+            "finite schedule stops. The envelope admits at most "
+            f"{MAX_ADAPTIVE_RANGE_LEAVES:,} leaves, depth "
+            f"{MAX_ADAPTIVE_RANGE_DEPTH}, {MAX_ADAPTIVE_RANGE_EVALUATIONS:,} "
+            "evaluations and 4,096 precision bits, "
+            f"{MAX_ADAPTIVE_RANGE_NODE_EVALUATIONS:,} expression-node evaluations, "
+            f"{MAX_ADAPTIVE_RANGE_PRECISION_WORK:,} precision-weighted node-bit "
+            "units, and one complete result within the 10 MiB canonical output bound."
+        ),
+        request_type=AdaptiveRangeEnclosureRequest,
+        result_type=AdaptiveRangeEnclosureResult,
+        run=_compute_adaptive_range_enclosure,
+        tags=(
+            "analysis",
+            "interval",
+            "expression",
+            "range",
+            "adaptive",
+            "partition",
+            "arb",
+            "validated",
+            "bounded",
+        ),
+        examples=(
+            example(
+                "quadratic_unit_interval",
+                (
+                    "Enclose x(1-x) over 0 <= x <= 1 until width 7/16; "
+                    "the complete named source axis and finite refinement budgets "
+                    "must be supplied."
+                ),
+                {
+                    "expression": {
+                        "op": "mul",
+                        "children": [
+                            {"op": "var", "variable": "x"},
+                            {
+                                "op": "sub",
+                                "children": [
+                                    {
+                                        "op": "const",
+                                        "value": {"num": "1", "den": "1"},
+                                    },
+                                    {"op": "var", "variable": "x"},
+                                ],
+                            },
+                        ],
+                    },
+                    "box": {
+                        "variables": ["x"],
+                        "intervals": [
+                            {
+                                "lower": {"num": "0", "den": "1"},
+                                "upper": {"num": "1", "den": "1"},
+                            }
+                        ],
+                    },
+                    "precision_bits": 128,
+                    "target_width": {"num": "7", "den": "16"},
+                    "maximum_precision_bits": 128,
+                    "max_leaves": 4,
+                    "max_depth": 2,
+                    "max_evaluations": 7,
+                    "wall_seconds": 30,
+                },
+            ),
+        ),
+    ),
+)
+
+
+__all__ = [
+    "ADAPTIVE_RANGE_ENCLOSURE_OPERATIONS",
+    "MAX_ADAPTIVE_RANGE_DEPTH",
+    "MAX_ADAPTIVE_RANGE_DYADIC_EXPONENT",
+    "MAX_ADAPTIVE_RANGE_EVALUATIONS",
+    "MAX_ADAPTIVE_RANGE_LEAVES",
+    "MAX_ADAPTIVE_RANGE_NODE_EVALUATIONS",
+    "MAX_ADAPTIVE_RANGE_PRECISION_WORK",
+    "MAX_ADAPTIVE_RANGE_RESULT_BYTES",
+    "MAX_ADAPTIVE_RANGE_WALL_SECONDS",
+    "AdaptiveRangeBudgetExhausted",
+    "AdaptiveRangeEnclosureRequest",
+    "AdaptiveRangeEnclosureResult",
+    "AdaptiveRangeLeaf",
+    "AdaptiveRangeTargetMet",
+    "adaptive_range_enclosure",
+]

--- a/src/jacobian/math/analysis/_adaptive_range_enclosure.py
+++ b/src/jacobian/math/analysis/_adaptive_range_enclosure.py
@@ -6,9 +6,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from fractions import Fraction
 from time import monotonic
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, StrictInt, field_validator, model_validator
+from pydantic.json_schema import JsonSchemaValue
 
 from jacobian._exact import CanonicalRational, canonical_rational_component_digits
 from jacobian._execution import (
@@ -30,6 +31,8 @@ from jacobian.math.analysis._box_enclosure import (
 from jacobian.math.analysis._models import (
     MAX_BOX_PREFLIGHT_TEMPORARY_BITS,
     MAX_DYADIC_MANTISSA_DIGITS,
+    MAX_RATIONAL_BOX_ENDPOINT_DIGITS,
+    MAX_RATIONAL_BOX_PARTITION_DEPTH,
     MAX_RATIONAL_DIGITS,
     DyadicClosedInterval,
     ExactDyadic,
@@ -46,7 +49,7 @@ from jacobian.math.analysis._models import (
 from jacobian.math.analysis.intervals import ClosedRationalInterval
 
 MAX_ADAPTIVE_RANGE_LEAVES = 1_024
-MAX_ADAPTIVE_RANGE_DEPTH = 32
+MAX_ADAPTIVE_RANGE_DEPTH = MAX_RATIONAL_BOX_PARTITION_DEPTH
 MAX_ADAPTIVE_RANGE_EVALUATIONS = 4_096
 MAX_ADAPTIVE_RANGE_NODE_EVALUATIONS = 131_072
 MAX_ADAPTIVE_RANGE_PRECISION_WORK = 268_435_456
@@ -63,6 +66,12 @@ MAX_ADAPTIVE_RANGE_DYADIC_EXPONENT = MAX_BOX_PREFLIGHT_TEMPORARY_BITS
 type AdaptiveRangeBudgetReason = Literal[
     "MAX_LEAVES", "MAX_DEPTH", "MAX_EVALUATIONS", "MAX_PRECISION"
 ]
+
+
+def _adaptive_source_endpoint_digit_cap(max_depth: int) -> int:
+    if max_depth == 0:
+        return MAX_RATIONAL_BOX_ENDPOINT_DIGITS
+    return (MAX_RATIONAL_BOX_ENDPOINT_DIGITS - max_depth - 2) // 2
 
 
 class AdaptiveRangeTargetMet(StrictModel):
@@ -95,10 +104,25 @@ type AdaptiveRangeDisposition = Annotated[
     Field(discriminator="status"),
 ]
 
+type _AdaptiveRangeConcludedDisposition = Annotated[
+    AdaptiveRangeTargetMet | AdaptiveRangeBudgetExhausted,
+    Field(discriminator="status"),
+]
+
 
 class AdaptiveRangeEnclosureRequest(_IntervalExpressionBoxRequest):
     """Bound one complete elementary-expression range by adaptive bisection."""
 
+    box: RationalIntervalBox = Field(
+        description=(
+            "Complete source box. With max_depth=0, endpoint components admit at "
+            f"most {MAX_RATIONAL_BOX_ENDPOINT_DIGITS} decimal digits. For positive "
+            "greatest reachable leaf depth d after all refinement caps, the source "
+            "cap is "
+            f"floor(({MAX_RATIONAL_BOX_ENDPOINT_DIGITS} - d - 2) / 2), so every "
+            "derived midpoint remains inside the shared rational-box envelope."
+        )
+    )
     target_width: CanonicalRational = Field(
         description=(
             "A positive exact rational target for upper-lower. Components admit "
@@ -151,6 +175,13 @@ class AdaptiveRangeEnclosureRequest(_IntervalExpressionBoxRequest):
         value = canonicalize_json_containers(value)
         if isinstance(value, Mapping):
             _bound_raw_rational(value.get("target_width"), "adaptive target width")
+            if cls is AdaptiveRangeEnclosureRequest:
+                _bound_raw_box(
+                    value.get("box"),
+                    max_digits=_adaptive_source_endpoint_digit_cap(
+                        _raw_maximum_leaf_depth(value)
+                    ),
+                )
         return value
 
     @model_validator(mode="after")
@@ -204,7 +235,13 @@ class _AdaptiveRangeLeafPath(StrictModel):
             "coordinate, with source-axis ties."
         ),
     )
-    box: RationalIntervalBox
+    box: RationalIntervalBox = Field(
+        description=(
+            "The exact source-bound midpoint subbox. Every serialized endpoint "
+            "numerator and denominator has at most "
+            f"{MAX_RATIONAL_BOX_ENDPOINT_DIGITS} decimal digits."
+        )
+    )
 
     @field_validator("path", mode="before")
     @classmethod
@@ -247,6 +284,79 @@ def _precision_schedule(initial: int, maximum: int) -> tuple[int, ...]:
     while schedule[-1] < maximum:
         schedule.append(min(2 * schedule[-1], maximum))
     return tuple(schedule)
+
+
+def _planned_schedule_and_splits(
+    *,
+    precision_bits: int,
+    maximum_precision_bits: int,
+    max_leaves: int,
+    max_depth: int,
+    max_evaluations: int,
+    splittable: bool,
+) -> tuple[tuple[int, ...], int, int]:
+    schedule = _precision_schedule(precision_bits, maximum_precision_bits)
+    root_evaluations = min(max_evaluations, len(schedule))
+    planned_splits = 0
+    if root_evaluations == len(schedule) and splittable:
+        planned_splits = min(
+            max_leaves - 1,
+            (1 << max_depth) - 1,
+            (max_evaluations - root_evaluations) // 2,
+        )
+    return schedule, root_evaluations, planned_splits
+
+
+def _raw_maximum_leaf_depth(value: Mapping[object, object]) -> int:
+    precision_bits = value.get("precision_bits", 128)
+    maximum_precision_bits = value.get("maximum_precision_bits", 512)
+    max_leaves = value.get("max_leaves", 32)
+    max_depth = value.get("max_depth", 8)
+    max_evaluations = value.get("max_evaluations", 128)
+    if not (
+        type(precision_bits) is int
+        and 32 <= precision_bits <= 4_096
+        and type(maximum_precision_bits) is int
+        and precision_bits <= maximum_precision_bits <= 4_096
+        and type(max_leaves) is int
+        and 1 <= max_leaves <= MAX_ADAPTIVE_RANGE_LEAVES
+        and type(max_depth) is int
+        and 0 <= max_depth <= MAX_ADAPTIVE_RANGE_DEPTH
+        and type(max_evaluations) is int
+        and 1 <= max_evaluations <= MAX_ADAPTIVE_RANGE_EVALUATIONS
+    ):
+        return MAX_ADAPTIVE_RANGE_DEPTH
+    _, _, split_count = _planned_schedule_and_splits(
+        precision_bits=precision_bits,
+        maximum_precision_bits=maximum_precision_bits,
+        max_leaves=max_leaves,
+        max_depth=max_depth,
+        max_evaluations=max_evaluations,
+        splittable=_raw_box_might_split(value.get("box")),
+    )
+    return min(max_depth, split_count)
+
+
+def _raw_box_might_split(box: object) -> bool:
+    if isinstance(box, RationalIntervalBox):
+        return _widest_coordinate(box) is not None
+    if not isinstance(box, Mapping):
+        return True
+    intervals = box.get("intervals")
+    if not isinstance(intervals, (list, tuple)):
+        return True
+    for interval in intervals:
+        if isinstance(interval, ClosedRationalInterval):
+            if interval.lower != interval.upper:
+                return True
+            continue
+        if not isinstance(interval, Mapping):
+            return True
+        lower = interval.get("lower")
+        upper = interval.get("upper")
+        if lower != upper:
+            return True
+    return False
 
 
 def _dyadic_fraction(value: ExactDyadic) -> Fraction:
@@ -316,21 +426,6 @@ def _split_box(
     )
 
 
-def _box_at_path(
-    source: RationalIntervalBox, path: tuple[int, ...]
-) -> RationalIntervalBox:
-    box = source
-    for bit in path:
-        coordinate = _widest_coordinate(box)
-        if coordinate is None:
-            raise _validation_error(
-                "a positive-depth leaf cannot descend from a degenerate box"
-            )
-        children = _split_box(box, coordinate)
-        box = children[bit]
-    return box
-
-
 def _paths_are_complete(paths: tuple[tuple[int, ...], ...]) -> bool:
     for index, path in enumerate(paths):
         if any(other[: len(path)] == path for other in paths[index + 1 :]):
@@ -379,21 +474,52 @@ def _bind_leaf_partition(result: AdaptiveRangeEnclosureResult) -> None:
             "adaptive leaf paths must be a complete prefix-free binary cover"
         )
     for leaf in result.leaves:
-        if leaf.box != _box_at_path(result.box, leaf.path):
-            raise _validation_error(
-                "adaptive leaf box does not match its source-bound midpoint path"
-            )
         if isinstance(leaf, AdaptiveRangeDomainUnprovenLeaf):
             _bind_domain_failure_to_expression(result.expression, leaf.domain_failure)
         else:
             _require_adaptive_dyadic_interval(leaf.enclosure)
 
 
+class _AdaptiveRangeResultSchemaBase(AdaptiveRangeEnclosureRequest):
+    """Fields shared by the two schema-visible result branches."""
+
+    evaluations_used: StrictInt = Field(ge=1, le=MAX_ADAPTIVE_RANGE_EVALUATIONS)
+    maximum_precision_bits_used: StrictInt = Field(ge=32, le=4096)
+
+
+class AdaptiveRangeConcludedResult(_AdaptiveRangeResultSchemaBase):
+    """Schema branch for a global enclosure conclusion."""
+
+    enclosure: DyadicClosedInterval
+    disposition: _AdaptiveRangeConcludedDisposition
+    leaves: tuple[AdaptiveRangeLeaf, ...] = Field(
+        min_length=1,
+        max_length=MAX_ADAPTIVE_RANGE_LEAVES,
+    )
+
+
+class AdaptiveRangeDomainUnprovenResult(_AdaptiveRangeResultSchemaBase):
+    """Schema branch for a complete cover with a local domain uncertainty."""
+
+    enclosure: None
+    disposition: AdaptiveRangeDomainUnproven
+    leaves: tuple[AdaptiveRangeFinalLeaf, ...] = Field(
+        min_length=1,
+        max_length=MAX_ADAPTIVE_RANGE_LEAVES,
+        json_schema_extra={
+            "contains": {
+                "properties": {"status": {"const": "DOMAIN_UNPROVEN"}},
+                "required": ["status"],
+            },
+            "minContains": 1,
+        },
+    )
+
+
 class AdaptiveRangeEnclosureResult(AdaptiveRangeEnclosureRequest):
     """A complete source-bound range enclosure or typed finite nonconclusion."""
 
     enclosure: DyadicClosedInterval | None = Field(
-        default=None,
         description=(
             "The hull of every retained leaf enclosure; absent exactly when the "
             "disposition is DOMAIN_UNPROVEN."
@@ -410,6 +536,23 @@ class AdaptiveRangeEnclosureResult(AdaptiveRangeEnclosureRequest):
     )
     evaluations_used: StrictInt = Field(ge=1, le=MAX_ADAPTIVE_RANGE_EVALUATIONS)
     maximum_precision_bits_used: StrictInt = Field(ge=32, le=4096)
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: Any,
+        handler: Any,
+    ) -> JsonSchemaValue:
+        """Publish mutually exclusive concluded and domain-uncertain shapes."""
+
+        return {
+            "oneOf": [
+                handler(AdaptiveRangeConcludedResult.__pydantic_core_schema__),
+                handler(AdaptiveRangeDomainUnprovenResult.__pydantic_core_schema__),
+            ],
+            "title": cls.__name__,
+            "description": cls.__doc__,
+        }
 
     @field_validator("leaves", mode="before")
     @classmethod
@@ -505,11 +648,29 @@ class AdaptiveRangeEnclosureResult(AdaptiveRangeEnclosureRequest):
 
 
 @dataclass(frozen=True, slots=True)
-class _AdaptiveRangeAdmission:
+class _AdaptiveRangeExecutionPlan:
     precision_schedule: tuple[int, ...]
+    planned_splits: int
     planned_evaluations: int
+    planned_leaf_count: int
+    planned_maximum_leaf_depth: int
+    precision_bits_per_expression_node: int
+
+
+@dataclass(frozen=True, slots=True)
+class _AdaptiveRangeAdmission:
+    plan: _AdaptiveRangeExecutionPlan
+    planned_node_evaluations: int
     target_width: Fraction
     deadline: float
+
+    @property
+    def precision_schedule(self) -> tuple[int, ...]:
+        return self.plan.precision_schedule
+
+    @property
+    def planned_evaluations(self) -> int:
+        return self.plan.planned_evaluations
 
 
 @dataclass(frozen=True, slots=True)
@@ -524,6 +685,29 @@ class _EvaluatedAdaptiveRangeLeaf:
             raise AssertionError("one adaptive leaf must carry exactly one outcome")
 
 
+def _plan_adaptive_range(problem: _AdaptiveRangeProblem) -> _AdaptiveRangeExecutionPlan:
+    schedule, root_evaluations, planned_splits = _planned_schedule_and_splits(
+        precision_bits=problem.precision_bits,
+        maximum_precision_bits=problem.maximum_precision_bits,
+        max_leaves=problem.max_leaves,
+        max_depth=problem.max_depth,
+        max_evaluations=problem.max_evaluations,
+        splittable=_widest_coordinate(problem.box) is not None,
+    )
+    planned_evaluations = root_evaluations + 2 * planned_splits
+    return _AdaptiveRangeExecutionPlan(
+        precision_schedule=schedule,
+        planned_splits=planned_splits,
+        planned_evaluations=planned_evaluations,
+        planned_leaf_count=planned_splits + 1,
+        planned_maximum_leaf_depth=min(problem.max_depth, planned_splits),
+        precision_bits_per_expression_node=(
+            sum(schedule[:root_evaluations])
+            + 2 * planned_splits * problem.maximum_precision_bits
+        ),
+    )
+
+
 def _midpoint_component_digits(box: RationalIntervalBox, depth: int) -> int:
     source_digits = max(
         (
@@ -533,13 +717,20 @@ def _midpoint_component_digits(box: RationalIntervalBox, depth: int) -> int:
         ),
         default=1,
     )
+    if depth == 0:
+        return source_digits
     # A depth-d bisection endpoint is ((2**d-j)l + j*u)/2**d. Before
     # reduction, each component therefore uses at most two source components,
     # a d-bit coefficient, and one carry digit.
     return 2 * source_digits + depth + 2
 
 
-def _estimated_result_bytes(problem: _AdaptiveRangeProblem) -> int:
+def _estimated_result_bytes(
+    problem: _AdaptiveRangeProblem,
+    *,
+    plan: _AdaptiveRangeExecutionPlan | None = None,
+) -> int:
+    active_plan = plan if plan is not None else _plan_adaptive_range(problem)
     source_bytes = len(
         canonicalize_json(
             {
@@ -555,7 +746,9 @@ def _estimated_result_bytes(problem: _AdaptiveRangeProblem) -> int:
             }
         )
     )
-    endpoint_digits = _midpoint_component_digits(problem.box, problem.max_depth)
+    endpoint_digits = _midpoint_component_digits(
+        problem.box, active_plan.planned_maximum_leaf_depth
+    )
     axis_bytes = sum(
         len(variable.encode("utf-8")) + 3 for variable in problem.box.variables
     )
@@ -563,9 +756,9 @@ def _estimated_result_bytes(problem: _AdaptiveRangeProblem) -> int:
         128 + axis_bytes + len(problem.box.variables) * (4 * endpoint_digits + 128)
     )
     dyadic_interval_bytes = 2 * (MAX_DYADIC_MANTISSA_DIGITS + 64) + 64
-    path_bytes = 2 * problem.max_depth + 32
+    path_bytes = 2 * active_plan.planned_maximum_leaf_depth + 32
     leaf_bytes = box_bytes + dyadic_interval_bytes + path_bytes + 128
-    return source_bytes + problem.max_leaves * leaf_bytes + 4_096
+    return source_bytes + active_plan.planned_leaf_count * leaf_bytes + 4_096
 
 
 def _require_deadline(deadline: float, stage: str) -> None:
@@ -652,6 +845,26 @@ def _require_complete_source_axis(
         )
 
 
+def _require_source_endpoint_envelope(
+    problem: _AdaptiveRangeProblem, *, maximum_leaf_depth: int
+) -> None:
+    digit_cap = _adaptive_source_endpoint_digit_cap(maximum_leaf_depth)
+    if any(
+        canonical_rational_component_digits(endpoint) > digit_cap
+        for interval in problem.box.intervals
+        for endpoint in (interval.lower, interval.upper)
+    ):
+        raise OperationDomainValidationError(
+            location=("box", "intervals"),
+            code="analysis.adaptive_range.source_endpoint_digits",
+            message=(
+                "adaptive source-box endpoints exceed the "
+                f"{digit_cap}-digit bound for the reachable split depth "
+                f"{maximum_leaf_depth}"
+            ),
+        )
+
+
 def _admit_adaptive_range(
     problem: _AdaptiveRangeProblem, *, started_at: float
 ) -> _AdaptiveRangeAdmission:
@@ -680,14 +893,11 @@ def _admit_adaptive_range(
 
     nodes = _bounded_expression_nodes(problem.expression)
     _require_complete_source_axis(problem, nodes)
-    schedule = _precision_schedule(
-        problem.precision_bits, problem.maximum_precision_bits
+    plan = _plan_adaptive_range(problem)
+    _require_source_endpoint_envelope(
+        problem, maximum_leaf_depth=plan.planned_maximum_leaf_depth
     )
-    planned_evaluations = min(
-        problem.max_evaluations,
-        len(schedule) + 2 * (problem.max_leaves - 1),
-    )
-    node_evaluations = len(nodes) * planned_evaluations
+    node_evaluations = len(nodes) * plan.planned_evaluations
     if node_evaluations > MAX_ADAPTIVE_RANGE_NODE_EVALUATIONS:
         raise OperationDomainValidationError(
             location=("max_evaluations",),
@@ -697,7 +907,7 @@ def _admit_adaptive_range(
                 f"evaluations exceeds the {MAX_ADAPTIVE_RANGE_NODE_EVALUATIONS}-unit bound"
             ),
         )
-    precision_work = node_evaluations * problem.maximum_precision_bits
+    precision_work = len(nodes) * plan.precision_bits_per_expression_node
     if precision_work > MAX_ADAPTIVE_RANGE_PRECISION_WORK:
         raise OperationDomainValidationError(
             location=("maximum_precision_bits", "max_evaluations"),
@@ -707,7 +917,7 @@ def _admit_adaptive_range(
                 f"exceeds the {MAX_ADAPTIVE_RANGE_PRECISION_WORK}-unit bound"
             ),
         )
-    estimated_result_bytes = _estimated_result_bytes(problem)
+    estimated_result_bytes = _estimated_result_bytes(problem, plan=plan)
     if estimated_result_bytes > MAX_ADAPTIVE_RANGE_RESULT_BYTES:
         raise OperationDomainValidationError(
             location=("max_leaves", "max_depth", "box"),
@@ -739,8 +949,8 @@ def _admit_adaptive_range(
         )
     _require_deadline(deadline, "after semantic preflight")
     return _AdaptiveRangeAdmission(
-        precision_schedule=schedule,
-        planned_evaluations=planned_evaluations,
+        plan=plan,
+        planned_node_evaluations=node_evaluations,
         target_width=target_width,
         deadline=deadline,
     )

--- a/src/jacobian/math/analysis/_adaptive_range_enclosure.py
+++ b/src/jacobian/math/analysis/_adaptive_range_enclosure.py
@@ -614,7 +614,9 @@ class AdaptiveRangeEnclosureResult(AdaptiveRangeEnclosureRequest):
             raise _validation_error(
                 "a concluded adaptive disposition requires a global enclosure"
             )
-        enclosure_width = _enclosure_width(self.enclosure)
+        enclosure_width = (
+            self.enclosure.upper.as_fraction() - self.enclosure.lower.as_fraction()
+        )
         target_width = self.target_width.as_fraction()
         if isinstance(self.disposition, AdaptiveRangeTargetMet):
             if enclosure_width > target_width:

--- a/src/jacobian/math/analysis/_adaptive_range_enclosure.py
+++ b/src/jacobian/math/analysis/_adaptive_range_enclosure.py
@@ -614,6 +614,17 @@ class AdaptiveRangeEnclosureResult(AdaptiveRangeEnclosureRequest):
             raise _validation_error(
                 "a concluded adaptive disposition requires a global enclosure"
             )
+        enclosure_width = _enclosure_width(self.enclosure)
+        target_width = self.target_width.as_fraction()
+        if isinstance(self.disposition, AdaptiveRangeTargetMet):
+            if enclosure_width > target_width:
+                raise _validation_error(
+                    "TARGET_MET requires enclosure width at most target_width"
+                )
+        elif enclosure_width <= target_width:
+            raise _validation_error(
+                "BUDGET_EXHAUSTED requires enclosure width above target_width"
+            )
         return self
 
     @classmethod

--- a/src/jacobian/math/analysis/_box_enclosure.py
+++ b/src/jacobian/math/analysis/_box_enclosure.py
@@ -13,6 +13,7 @@ from jacobian.catalog.models import MathTool, OperationDomainValidationError
 from jacobian.math.analysis._arb import arb_source_interval, dyadic_endpoints
 from jacobian.math.analysis._models import (
     MAX_BOX_PREFLIGHT_TEMPORARY_BITS,
+    MAX_RATIONAL_BOX_ENDPOINT_DIGITS,
     ExactDyadic,
     IntervalExpressionDomainFailure,
     IntervalExpressionNode,
@@ -338,8 +339,10 @@ BOX_EXPRESSION_ENCLOSURE_OPERATIONS = (
             "named-variable elementary expression over a complete ordered rational "
             "box, or report the first source node whose real domain is unproved. "
             "The fixed envelope admits at most 8 variables, 64 nodes, depth 16, "
-            "128-digit rationals, absolute power exponents up to 64, 4,096-bit "
-            "Arb precision, 8,192-bit retained exact admission bounds, and "
+            "128-digit expression constants, "
+            f"{MAX_RATIONAL_BOX_ENDPOINT_DIGITS}-digit rational-box endpoints, "
+            "absolute power exponents up to 64, 4,096-bit Arb precision, 8,192-bit "
+            "retained exact admission bounds, and "
             f"{MAX_BOX_PREFLIGHT_TEMPORARY_BITS:,}-bit Fraction temporaries."
         ),
         request_type=IntervalExpressionBoxEnclosureRequest,

--- a/src/jacobian/math/analysis/_definite_integral_enclosure.py
+++ b/src/jacobian/math/analysis/_definite_integral_enclosure.py
@@ -41,7 +41,7 @@ from jacobian.math.analysis._models import (
     MAX_BOX_INTERMEDIATE_BITS,
     MAX_DYADIC_MANTISSA_DIGITS,
     MAX_EXPRESSION_NODES,
-    MAX_RATIONAL_DIGITS,
+    MAX_RATIONAL_BOX_ENDPOINT_DIGITS,
     DyadicClosedInterval,
     ExactDyadic,
     IntervalExpressionDomainFailure,
@@ -75,14 +75,14 @@ MAX_DEFINITE_INTEGRAL_WALL_SECONDS = 120
 MAX_DEFINITE_INTEGRAL_RESULT_BYTES = CanonicalLimits().max_output_bytes
 
 # A retained rational preflight bound has at most 8,192 component bits. A source
-# endpoint has at most 128 decimal digits (< 4 * 128 bits), a midpoint path adds
+# endpoint has at most the shared rational-box digit bound, a midpoint path adds
 # at most 1,023 denominator bits, and a normalized 4,096-bit endpoint may shift
 # by its precision. The final sum adds at most ceil(log2(1,024)) magnitude bits.
 # This owner-local ceiling is therefore strictly below the ambient ExactDyadic
 # wire exponent and bounds every Fraction shift performed by result validation.
 MAX_DEFINITE_INTEGRAL_DYADIC_EXPONENT = (
     MAX_BOX_INTERMEDIATE_BITS
-    + 4 * MAX_RATIONAL_DIGITS
+    + 4 * MAX_RATIONAL_BOX_ENDPOINT_DIGITS
     + MAX_DEFINITE_INTEGRAL_DEPTH
     + 4_096
     + (MAX_DEFINITE_INTEGRAL_LEAVES - 1).bit_length()
@@ -721,7 +721,10 @@ def _admit_definite_integral(
             ),
         )
     midpoint_digits = _midpoint_component_digits(request.box, request.max_leaves - 1)
-    if midpoint_digits > 2 * MAX_RATIONAL_DIGITS + MAX_DEFINITE_INTEGRAL_DEPTH + 2:
+    if (
+        midpoint_digits
+        > 2 * MAX_RATIONAL_BOX_ENDPOINT_DIGITS + MAX_DEFINITE_INTEGRAL_DEPTH + 2
+    ):
         raise AssertionError("definite-integral midpoint accounting is inconsistent")
     estimated_result_bytes = _estimated_result_bytes(request)
     if estimated_result_bytes > MAX_DEFINITE_INTEGRAL_RESULT_BYTES:

--- a/src/jacobian/math/analysis/_models.py
+++ b/src/jacobian/math/analysis/_models.py
@@ -28,6 +28,14 @@ def _validation_error(message: str) -> PydanticCustomError:
 
 
 MAX_RATIONAL_DIGITS = 128
+# Every midpoint after at most this many binary splits has component width at most
+# ``2 * source_digits + split_depth + 2``. This owner-wide box envelope admits
+# every box produced from the 128-digit adaptive source boundary unchanged in
+# the fixed-box consumers.
+MAX_RATIONAL_BOX_PARTITION_DEPTH = 32
+MAX_RATIONAL_BOX_ENDPOINT_DIGITS = (
+    2 * MAX_RATIONAL_DIGITS + MAX_RATIONAL_BOX_PARTITION_DEPTH + 2
+)
 MAX_EXPRESSION_DEPTH = 16
 MAX_EXPRESSION_NODES = 64
 MAX_INTEGER_EXPONENT = 64
@@ -63,7 +71,9 @@ type IntervalExpressionOp = Literal[
 ]
 
 
-def _bound_raw_rational(value: object, label: str) -> None:
+def _bound_raw_rational(
+    value: object, label: str, *, max_digits: int = MAX_RATIONAL_DIGITS
+) -> None:
     """Reject oversized components before canonical-rational construction."""
 
     if isinstance(value, CanonicalRational):
@@ -74,12 +84,10 @@ def _bound_raw_rational(value: object, label: str) -> None:
         return
     if any(
         isinstance(component, str)
-        and len(component) - component.startswith("-") > MAX_RATIONAL_DIGITS
+        and len(component) - component.startswith("-") > max_digits
         for component in components
     ):
-        raise _validation_error(
-            f"{label} exceeds the {MAX_RATIONAL_DIGITS}-digit bound"
-        )
+        raise _validation_error(f"{label} exceeds the {max_digits}-digit bound")
 
 
 class IntervalExpressionNode(StrictModel):
@@ -207,7 +215,12 @@ class RationalIntervalBox(StrictModel):
     )
     intervals: tuple[ClosedRationalInterval, ...] = Field(
         max_length=MAX_BOX_VARIABLES,
-        description="Closed rational coordinate intervals aligned to variables.",
+        description=(
+            "Closed rational coordinate intervals aligned to variables. Every "
+            "serialized endpoint numerator and denominator admits at most "
+            f"{MAX_RATIONAL_BOX_ENDPOINT_DIGITS} decimal digits, including boxes "
+            "produced by bounded adaptive midpoint partitioning."
+        ),
     )
 
     @field_validator("variables", "intervals", mode="before")
@@ -230,7 +243,9 @@ class RationalIntervalBox(StrictModel):
         return self
 
 
-def _bound_raw_box(box: object) -> None:
+def _bound_raw_box(
+    box: object, *, max_digits: int = MAX_RATIONAL_BOX_ENDPOINT_DIGITS
+) -> None:
     """Bound coordinate containers and endpoints before nested construction."""
 
     if isinstance(box, RationalIntervalBox):
@@ -257,8 +272,8 @@ def _bound_raw_box(box: object) -> None:
             upper = interval.get("upper")
         else:
             continue
-        _bound_raw_rational(lower, "expression-box endpoint")
-        _bound_raw_rational(upper, "expression-box endpoint")
+        _bound_raw_rational(lower, "expression-box endpoint", max_digits=max_digits)
+        _bound_raw_rational(upper, "expression-box endpoint", max_digits=max_digits)
 
 
 class IntervalExpressionDomainFailure(StrictModel):

--- a/src/jacobian/math/analysis/_tools.py
+++ b/src/jacobian/math/analysis/_tools.py
@@ -13,6 +13,7 @@ from jacobian.math.analysis._expression_enclosure import (
     IntervalExpressionEnclosureRequest,
     IntervalExpressionEnclosureResult,
 )
+from jacobian.math.analysis._models import MAX_RATIONAL_BOX_ENDPOINT_DIGITS
 from jacobian.math.analysis._point_enclosure import (
     ArbPointEnclosureRequest,
     ArbPointEnclosureResult,
@@ -161,8 +162,10 @@ SECOND_JET_ENCLOSURE_OPERATIONS = (
             "named-variable elementary expression, every first partial, and its "
             "symmetric Hessian over a complete ordered rational box. The fixed "
             "envelope admits at most 8 variables, 64 nodes, depth 16, 128-digit "
-            "rationals, absolute power exponents up to 64, 4,096-bit Arb precision, "
-            "and 16,384 forward-jet scalar arithmetic units charged by dimension."
+            "expression constants, "
+            f"{MAX_RATIONAL_BOX_ENDPOINT_DIGITS}-digit rational-box endpoints, "
+            "absolute power exponents up to 64, 4,096-bit Arb precision, and 16,384 "
+            "forward-jet scalar arithmetic units charged by dimension."
         ),
         request_type=IntervalExpressionSecondJetEnclosureRequest,
         result_type=IntervalExpressionSecondJetEnclosureResult,

--- a/src/jacobian/math/analysis/_tools.py
+++ b/src/jacobian/math/analysis/_tools.py
@@ -2,6 +2,9 @@
 
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools
+from jacobian.math.analysis._adaptive_range_enclosure import (
+    ADAPTIVE_RANGE_ENCLOSURE_OPERATIONS,
+)
 from jacobian.math.analysis._box_enclosure import BOX_EXPRESSION_ENCLOSURE_OPERATIONS
 from jacobian.math.analysis._definite_integral_enclosure import (
     DEFINITE_INTEGRAL_ENCLOSURE_OPERATIONS,
@@ -219,6 +222,7 @@ SECOND_JET_ENCLOSURE_OPERATIONS = (
 TOOLS: MathTools = (
     *POINT_ENCLOSURE_OPERATIONS,
     *EXPRESSION_ENCLOSURE_OPERATIONS,
+    *ADAPTIVE_RANGE_ENCLOSURE_OPERATIONS,
     *BOX_EXPRESSION_ENCLOSURE_OPERATIONS,
     *DEFINITE_INTEGRAL_ENCLOSURE_OPERATIONS,
     *SECOND_JET_ENCLOSURE_OPERATIONS,

--- a/src/jacobian/math/analysis/operations.py
+++ b/src/jacobian/math/analysis/operations.py
@@ -9,6 +9,7 @@ from typing import Any
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._flint import flint_workprec
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.analysis._adaptive_range_enclosure import adaptive_range_enclosure
 from jacobian.math.analysis._arb import arb_source_interval, dyadic_endpoints
 from jacobian.math.analysis._expression_enclosure import (
     IntervalExpressionEnclosureResult,
@@ -553,4 +554,8 @@ def second_jet_enclosure(
     )
 
 
-__all__ = ["expression_enclosure", "second_jet_enclosure"]
+__all__ = [
+    "adaptive_range_enclosure",
+    "expression_enclosure",
+    "second_jet_enclosure",
+]

--- a/tests/catalog/test_validated_analysis_declarations.py
+++ b/tests/catalog/test_validated_analysis_declarations.py
@@ -18,6 +18,7 @@ def test_subject_operation_groups_preserve_wire_contracts() -> None:
             "analysis.real_function.point_enclosure.compute",
             "analysis.real_function.point_enclosure.check",
             "interval.compute.enclosure",
+            "interval.expression.adaptive_range_enclosure.compute",
             "interval.expression.box_enclosure.compute",
             "interval.expression.definite_integral_enclosure.compute",
             "interval.expression.second_jet_enclosure.compute",

--- a/tests/math/analysis/test_analysis_adaptive_range_enclosure.py
+++ b/tests/math/analysis/test_analysis_adaptive_range_enclosure.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 from flint import ctx
+from jsonschema import Draft202012Validator
 from pydantic import ValidationError
 from tests.fixtures.accounting import assert_charged_work_parity
 from tests.math.analysis._analysis_support import analysis_validation_error
@@ -39,7 +40,10 @@ from jacobian.math.analysis._box_enclosure import (
     IntervalExpressionBoxEnclosureRequest,
     _box_expression_enclosure,
 )
-from jacobian.math.analysis._models import DyadicClosedInterval
+from jacobian.math.analysis._models import (
+    MAX_RATIONAL_BOX_ENDPOINT_DIGITS,
+    DyadicClosedInterval,
+)
 
 
 def _q(numerator: int, denominator: int = 1) -> dict[str, str]:
@@ -109,6 +113,19 @@ def _quadratic() -> dict[str, Any]:
             {"op": "sub", "children": [_const(1), _var("x")]},
         ],
     }
+
+
+def _balanced_sum(variables: tuple[str, ...]) -> dict[str, Any]:
+    level = [_var(variable) for variable in variables]
+    while len(level) > 1:
+        next_level = [
+            {"op": "add", "children": level[index : index + 2]}
+            for index in range(0, len(level) - 1, 2)
+        ]
+        if len(level) % 2:
+            next_level.append(level[-1])
+        level = next_level
+    return level[0]
 
 
 def _result_enclosure(
@@ -610,16 +627,14 @@ def test_nonpositive_target_is_semantic_request_rejection(target: Fraction) -> N
 
 def test_result_sensitive_output_bound_rejects_only_the_large_envelope() -> None:
     variables = tuple(f"x{index}" for index in range(8))
-    expression: dict[str, Any] = _var(variables[0])
-    for variable in variables[1:]:
-        expression = {"op": "add", "children": [expression, _var(variable)]}
+    expression = _balanced_sum(variables)
     large = _request(
         expression,
         tuple((variable, Fraction(0), Fraction(10**127)) for variable in variables),
         target_width=Fraction(1),
         max_leaves=1024,
         max_depth=32,
-        max_evaluations=1,
+        max_evaluations=2047,
     )
     assert (
         _estimated_result_bytes(_problem_from_request(large))
@@ -647,6 +662,33 @@ def test_result_sensitive_output_bound_rejects_only_the_large_envelope() -> None
     )
 
 
+def test_depth_zero_eight_variable_request_reserves_one_result_leaf() -> None:
+    variables = tuple(f"x{index}" for index in range(8))
+    request = _request(
+        _balanced_sum(variables),
+        tuple((variable, Fraction(0), Fraction(10**127)) for variable in variables),
+        target_width=Fraction(1),
+        precision_bits=4096,
+        maximum_precision_bits=4096,
+        max_leaves=1024,
+        max_depth=0,
+        max_evaluations=4096,
+    )
+    problem = _problem_from_request(request)
+
+    admission = _admit_adaptive_range(problem, started_at=monotonic())
+    result = _compute_adaptive_range_enclosure(request)
+
+    assert admission.planned_evaluations == 1
+    assert admission.plan.planned_leaf_count == 1
+    assert admission.planned_node_evaluations == 15
+    assert _estimated_result_bytes(problem) < MAX_ADAPTIVE_RANGE_RESULT_BYTES
+    assert isinstance(result.disposition, AdaptiveRangeBudgetExhausted)
+    assert result.disposition.reason == "MAX_DEPTH"
+    assert result.evaluations_used == 1
+    assert len(result.leaves) == 1
+
+
 def test_precision_weighted_work_is_rejected_before_arb() -> None:
     level = [_var("x") for _ in range(32)]
     while len(level) > 1:
@@ -669,6 +711,72 @@ def test_precision_weighted_work_is_rejected_before_arb() -> None:
     with pytest.raises(OperationDomainValidationError) as caught:
         _compute_adaptive_range_enclosure(request)
     assert caught.value.errors()[0]["type"] == "analysis.adaptive_range.precision_work"
+
+
+def test_depth_zero_33_node_request_charges_only_the_reachable_root() -> None:
+    expression = _balanced_sum(("x",) * 17)
+    request = _request(
+        expression,
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(20),
+        precision_bits=4096,
+        maximum_precision_bits=4096,
+        max_leaves=1024,
+        max_depth=0,
+        max_evaluations=4096,
+    )
+
+    admission = _admit_adaptive_range(
+        _problem_from_request(request), started_at=monotonic()
+    )
+    result = _compute_adaptive_range_enclosure(request)
+
+    assert admission.planned_evaluations == 1
+    assert admission.plan.planned_leaf_count == 1
+    assert admission.planned_node_evaluations == 33
+    assert isinstance(result.disposition, AdaptiveRangeTargetMet)
+    assert result.evaluations_used == 1
+    assert len(result.leaves) == 1
+
+
+@pytest.mark.parametrize(
+    ("interval", "maximum_precision", "max_evaluations", "expected"),
+    [
+        ((Fraction(0), Fraction(1)), 512, 3, (3, 0, 1, 0, 224)),
+        ((Fraction(0), Fraction(1)), 32, 5, (5, 2, 3, 2, 160)),
+        ((Fraction(0), Fraction(0)), 32, 4096, (1, 0, 1, 0, 32)),
+    ],
+)
+def test_admission_plan_intersects_schedule_evaluation_and_split_caps(
+    interval: tuple[Fraction, Fraction],
+    maximum_precision: int,
+    max_evaluations: int,
+    expected: tuple[int, int, int, int, int],
+) -> None:
+    request = _request(
+        _var("x"),
+        (("x", interval[0], interval[1]),),
+        target_width=Fraction(2),
+        precision_bits=32,
+        maximum_precision_bits=maximum_precision,
+        max_leaves=1024,
+        max_depth=32,
+        max_evaluations=max_evaluations,
+    )
+
+    admission = _admit_adaptive_range(
+        _problem_from_request(request), started_at=monotonic()
+    )
+    plan = admission.plan
+
+    assert (
+        plan.planned_evaluations,
+        plan.planned_splits,
+        plan.planned_leaf_count,
+        plan.planned_maximum_leaf_depth,
+        plan.precision_bits_per_expression_node,
+    ) == expected
+    assert admission.planned_node_evaluations == plan.planned_evaluations
 
 
 @pytest.mark.parametrize(
@@ -742,6 +850,44 @@ def test_native_and_request_paths_return_the_same_exact_result() -> None:
         wall_seconds=request.wall_seconds,
     )
     assert native == dispatched
+
+
+def test_derived_midpoint_box_round_trips_into_fixed_box_consumer() -> None:
+    q = 6 * 10**127 + 1
+    result = _run(
+        _var("x"),
+        (("x", Fraction(0), Fraction(1, q)),),
+        target_width=Fraction(1, 9 * 10**127),
+        precision_bits=128,
+        maximum_precision_bits=128,
+        max_leaves=2,
+        max_depth=1,
+        max_evaluations=3,
+    )
+
+    assert len(result.leaves) == 2
+    first_leaf = result.leaves[0]
+    assert isinstance(first_leaf, AdaptiveRangeLeaf)
+    midpoint = first_leaf.box.intervals[0].upper
+    assert midpoint.as_fraction() == Fraction(1, 2 * q)
+    assert len(midpoint.den) == 129
+
+    parsed = AdaptiveRangeEnclosureResult.model_validate_json(
+        result.model_dump_json(), strict=True
+    )
+    parsed_first_leaf = parsed.leaves[0]
+    assert isinstance(parsed_first_leaf, AdaptiveRangeLeaf)
+    consumer_request = IntervalExpressionBoxEnclosureRequest(
+        expression=parsed.expression,
+        box=parsed_first_leaf.box,
+        precision_bits=128,
+    )
+    consumed = _box_expression_enclosure(consumer_request)
+
+    assert consumed.status == "ENCLOSED"
+    assert consumed.lower is not None and consumed.upper is not None
+    assert consumed.lower.as_fraction() <= 0
+    assert consumed.upper.as_fraction() >= Fraction(1, 2 * q)
 
 
 def test_concurrent_adaptive_operations_isolate_32_and_512_bit_precision() -> None:
@@ -828,8 +974,7 @@ def test_admission_charge_covers_every_real_leaf_evaluation(
     assert calls == result.evaluations_used == 7
 
 
-@pytest.mark.parametrize("mutation", ["path", "box"])
-def test_round_trip_rejects_forged_partition_structure(mutation: str) -> None:
+def test_round_trip_rejects_forged_partition_path_structure() -> None:
     result = _run(
         _quadratic(),
         (("x", Fraction(0), Fraction(1)),),
@@ -845,13 +990,27 @@ def test_round_trip_rejects_forged_partition_structure(mutation: str) -> None:
         == result
     )
     payload = deepcopy(result.model_dump(mode="json"))
-    if mutation == "path":
-        payload["leaves"][0]["path"] = [0, 1]
-    else:
-        payload["leaves"][0]["box"]["intervals"][0]["upper"] = _q(1, 3)
+    payload["leaves"][0]["path"] = [0, 1]
 
     with pytest.raises(ValidationError):
         AdaptiveRangeEnclosureResult.model_validate(payload)
+
+
+def test_result_deserialization_does_not_reconstruct_partition_boxes() -> None:
+    result = _run(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+    payload = deepcopy(result.model_dump(mode="json"))
+    payload["leaves"][0]["box"]["intervals"][0]["upper"] = _q(1, 3)
+
+    parsed = AdaptiveRangeEnclosureResult.model_validate(payload)
+
+    assert parsed.leaves[0].box.intervals[0].upper.as_fraction() == Fraction(1, 3)
 
 
 @pytest.mark.parametrize(
@@ -890,11 +1049,13 @@ def test_result_preflights_authored_leaf_endpoints_before_fraction_work() -> Non
     )
     payload = result.model_dump(mode="json")
     payload["leaves"][0]["box"]["intervals"][0]["upper"] = {
-        "num": "9" * 129,
+        "num": "9" * (MAX_RATIONAL_BOX_ENDPOINT_DIGITS + 1),
         "den": "1",
     }
 
-    with pytest.raises(ValidationError, match="128-digit bound"):
+    with pytest.raises(
+        ValidationError, match=rf"{MAX_RATIONAL_BOX_ENDPOINT_DIGITS}-digit bound"
+    ):
         AdaptiveRangeEnclosureResult.model_validate(payload)
 
 
@@ -1017,17 +1178,25 @@ def test_result_reservation_dominates_actual_canonical_output() -> None:
     )
 
 
-def test_disposition_schema_is_a_status_discriminated_union() -> None:
+def test_result_schema_has_status_discriminated_conclusion_branches() -> None:
     schema = AdaptiveRangeEnclosureResult.model_json_schema()
-    reference = schema["properties"]["disposition"]["$ref"]
+    branch_references = {
+        branch["$ref"].removeprefix("#/$defs/") for branch in schema["oneOf"]
+    }
+    assert branch_references == {
+        "AdaptiveRangeConcludedResult",
+        "AdaptiveRangeDomainUnprovenResult",
+    }
+    concluded = schema["$defs"]["AdaptiveRangeConcludedResult"]
+    domain_unproven = schema["$defs"]["AdaptiveRangeDomainUnprovenResult"]
+    reference = concluded["properties"]["disposition"]["$ref"]
     disposition = schema["$defs"][reference.removeprefix("#/$defs/")]
-    leaf_reference = schema["properties"]["leaves"]["items"]["$ref"]
+    leaf_reference = domain_unproven["properties"]["leaves"]["items"]["$ref"]
     leaf = schema["$defs"][leaf_reference.removeprefix("#/$defs/")]
 
     assert disposition["discriminator"]["propertyName"] == "status"
     assert set(disposition["discriminator"]["mapping"]) == {
         "BUDGET_EXHAUSTED",
-        "DOMAIN_UNPROVEN",
         "TARGET_MET",
     }
     assert leaf["discriminator"]["propertyName"] == "status"
@@ -1035,9 +1204,84 @@ def test_disposition_schema_is_a_status_discriminated_union() -> None:
         "DOMAIN_UNPROVEN",
         "ENCLOSED",
     }
-    assert {
-        variant.get("type") for variant in schema["properties"]["enclosure"]["anyOf"]
-    } == {
-        "null",
-        None,
+    assert concluded["properties"]["enclosure"] == {
+        "$ref": "#/$defs/DyadicClosedInterval"
     }
+    assert domain_unproven["properties"]["enclosure"]["type"] == "null"
+    assert domain_unproven["properties"]["leaves"]["minContains"] == 1
+
+
+def test_derived_box_endpoint_envelope_is_schema_visible_to_producer_and_consumer() -> (
+    None
+):
+    adaptive_schema = AdaptiveRangeEnclosureRequest.model_json_schema()
+    consumer_schema = IntervalExpressionBoxEnclosureRequest.model_json_schema()
+    endpoint_bound = str(MAX_RATIONAL_BOX_ENDPOINT_DIGITS)
+
+    assert endpoint_bound in adaptive_schema["properties"]["box"]["description"]
+    for schema in (adaptive_schema, consumer_schema):
+        intervals = schema["$defs"]["RationalIntervalBox"]["properties"]["intervals"]
+        assert endpoint_bound in intervals["description"]
+
+
+def test_result_schema_and_parser_reject_contradictory_outcome_shapes() -> None:
+    concluded = _run(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+    uncertain = _run(
+        {
+            "op": "log",
+            "children": [
+                {
+                    "op": "add",
+                    "children": [_var("x"), _const(1, 10**127)],
+                }
+            ],
+        },
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(100),
+        precision_bits=32,
+        maximum_precision_bits=32,
+        max_leaves=1,
+        max_depth=8,
+        max_evaluations=1,
+    )
+    concluded_payload = concluded.model_dump(mode="json")
+    uncertain_payload = uncertain.model_dump(mode="json")
+    schema = AdaptiveRangeEnclosureResult.model_json_schema()
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    assert not list(validator.iter_errors(concluded_payload))
+    assert not list(validator.iter_errors(uncertain_payload))
+
+    concluded_without_enclosure = deepcopy(concluded_payload)
+    concluded_without_enclosure["enclosure"] = None
+    domain_missing_enclosure = deepcopy(uncertain_payload)
+    domain_missing_enclosure.pop("enclosure")
+    domain_with_enclosure = deepcopy(uncertain_payload)
+    domain_with_enclosure["enclosure"] = concluded_payload["enclosure"]
+    domain_without_uncertain_leaf = deepcopy(concluded_payload)
+    domain_without_uncertain_leaf["enclosure"] = None
+    domain_without_uncertain_leaf["disposition"] = {
+        "status": "DOMAIN_UNPROVEN",
+        "reason": "MAX_LEAVES",
+    }
+    concluded_with_uncertain_leaf = deepcopy(uncertain_payload)
+    concluded_with_uncertain_leaf["enclosure"] = concluded_payload["enclosure"]
+    concluded_with_uncertain_leaf["disposition"] = {"status": "TARGET_MET"}
+
+    for forged in (
+        concluded_without_enclosure,
+        domain_missing_enclosure,
+        domain_with_enclosure,
+        domain_without_uncertain_leaf,
+        concluded_with_uncertain_leaf,
+    ):
+        assert list(validator.iter_errors(forged))
+        with pytest.raises(ValidationError):
+            AdaptiveRangeEnclosureResult.model_validate(forged)

--- a/tests/math/analysis/test_analysis_adaptive_range_enclosure.py
+++ b/tests/math/analysis/test_analysis_adaptive_range_enclosure.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from fractions import Fraction
+from math import sin
+from time import monotonic
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from tests.fixtures.accounting import assert_charged_work_parity
+from tests.math.analysis._analysis_support import analysis_validation_error
+
+from jacobian._execution import OperationExecutionTimeoutError, request_execution
+from jacobian.canonical import canonicalize_json
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.analysis._adaptive_range_enclosure import (
+    MAX_ADAPTIVE_RANGE_RESULT_BYTES,
+    AdaptiveRangeBudgetExhausted,
+    AdaptiveRangeEnclosureRequest,
+    AdaptiveRangeEnclosureResult,
+    AdaptiveRangeTargetMet,
+    _admit_adaptive_range,
+    _compute_adaptive_range_enclosure,
+    _enclosure_width,
+    _estimated_result_bytes,
+    _interval_hull,
+    adaptive_range_enclosure,
+)
+from jacobian.math.analysis._box_enclosure import (
+    IntervalExpressionBoxEnclosureRequest,
+    _box_expression_enclosure,
+)
+
+
+def _q(numerator: int, denominator: int = 1) -> dict[str, str]:
+    value = Fraction(numerator, denominator)
+    return {"num": str(value.numerator), "den": str(value.denominator)}
+
+
+def _var(name: str) -> dict[str, Any]:
+    return {"op": "var", "variable": name}
+
+
+def _const(value: int) -> dict[str, Any]:
+    return {"op": "const", "value": _q(value)}
+
+
+def _request(
+    expression: dict[str, Any],
+    coordinates: tuple[tuple[str, Fraction, Fraction], ...],
+    *,
+    target_width: Fraction,
+    precision_bits: int = 128,
+    maximum_precision_bits: int = 128,
+    max_leaves: int = 8,
+    max_depth: int = 3,
+    max_evaluations: int = 32,
+    wall_seconds: int = 30,
+) -> AdaptiveRangeEnclosureRequest:
+    return AdaptiveRangeEnclosureRequest.model_validate(
+        {
+            "expression": expression,
+            "box": {
+                "variables": [name for name, _, _ in coordinates],
+                "intervals": [
+                    {
+                        "lower": _q(lower.numerator, lower.denominator),
+                        "upper": _q(upper.numerator, upper.denominator),
+                    }
+                    for _, lower, upper in coordinates
+                ],
+            },
+            "target_width": _q(target_width.numerator, target_width.denominator),
+            "precision_bits": precision_bits,
+            "maximum_precision_bits": maximum_precision_bits,
+            "max_leaves": max_leaves,
+            "max_depth": max_depth,
+            "max_evaluations": max_evaluations,
+            "wall_seconds": wall_seconds,
+        }
+    )
+
+
+def _run(
+    expression: dict[str, Any],
+    coordinates: tuple[tuple[str, Fraction, Fraction], ...],
+    **kwargs: Any,
+) -> AdaptiveRangeEnclosureResult:
+    return _compute_adaptive_range_enclosure(
+        _request(expression, coordinates, **kwargs)
+    )
+
+
+def _quadratic() -> dict[str, Any]:
+    return {
+        "op": "mul",
+        "children": [
+            _var("x"),
+            {"op": "sub", "children": [_const(1), _var("x")]},
+        ],
+    }
+
+
+def test_quadratic_target_met_reconstructs_the_complete_four_leaf_cover() -> None:
+    result = _run(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+
+    assert isinstance(result.disposition, AdaptiveRangeTargetMet)
+    assert tuple(leaf.path for leaf in result.leaves) == (
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+    )
+    assert tuple(
+        (
+            leaf.box.intervals[0].lower.as_fraction(),
+            leaf.box.intervals[0].upper.as_fraction(),
+        )
+        for leaf in result.leaves
+    ) == (
+        (Fraction(0), Fraction(1, 4)),
+        (Fraction(1, 4), Fraction(1, 2)),
+        (Fraction(1, 2), Fraction(3, 4)),
+        (Fraction(3, 4), Fraction(1)),
+    )
+    assert result.enclosure == _interval_hull(result.leaves)
+    assert result.enclosure.lower.as_fraction() <= 0
+    assert result.enclosure.upper.as_fraction() >= Fraction(1, 4)
+    assert _enclosure_width(result.enclosure) <= Fraction(7, 16)
+    assert result.evaluations_used == 7
+
+
+def test_each_returned_leaf_box_composes_with_the_existing_box_operation() -> None:
+    result = _run(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+
+    for leaf in result.leaves:
+        replay = _box_expression_enclosure(
+            IntervalExpressionBoxEnclosureRequest(
+                expression=result.expression,
+                box=leaf.box,
+                precision_bits=result.maximum_precision_bits_used,
+            )
+        )
+        assert replay.status == "ENCLOSED"
+        assert replay.lower == leaf.enclosure.lower
+        assert replay.upper == leaf.enclosure.upper
+
+
+def test_sine_enclosure_contains_both_interior_extrema_on_zero_to_seven() -> None:
+    result = _run(
+        {"op": "sin", "children": [_var("x")]},
+        (("x", Fraction(0), Fraction(7)),),
+        target_width=Fraction(3),
+        max_leaves=1,
+        max_depth=0,
+        max_evaluations=1,
+    )
+
+    assert isinstance(result.disposition, AdaptiveRangeTargetMet)
+    assert result.enclosure.lower.as_fraction() <= -1
+    assert result.enclosure.upper.as_fraction() >= 1
+
+
+def test_two_variable_coupling_contains_a_secondary_grid_oracle() -> None:
+    expression = {
+        "op": "add",
+        "children": [
+            {
+                "op": "sin",
+                "children": [{"op": "add", "children": [_var("x"), _var("y")]}],
+            },
+            {"op": "mul", "children": [_var("x"), _var("y")]},
+        ],
+    }
+    result = _run(
+        expression,
+        (
+            ("x", Fraction(0), Fraction(1, 2)),
+            ("y", Fraction(0), Fraction(1, 2)),
+        ),
+        target_width=Fraction(2),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+
+    lower = float(result.enclosure.lower.as_fraction())
+    upper = float(result.enclosure.upper.as_fraction())
+    for x_index in range(17):
+        for y_index in range(17):
+            x = x_index / 32
+            y = y_index / 32
+            assert lower <= sin(x + y) + x * y <= upper
+
+
+def test_dependency_expression_never_loses_zero() -> None:
+    result = _run(
+        {"op": "sub", "children": [_var("x"), _var("x")]},
+        (("x", Fraction(-1), Fraction(1)),),
+        target_width=Fraction(1, 2),
+        max_leaves=8,
+        max_depth=3,
+        max_evaluations=15,
+    )
+
+    assert result.enclosure.lower.as_fraction() <= 0
+    assert result.enclosure.upper.as_fraction() >= 0
+
+
+def test_leaf_and_coordinate_ties_follow_path_then_source_axis_order() -> None:
+    sum_xy = {"op": "add", "children": [_var("x"), _var("y")]}
+    result = _run(
+        {"op": "sub", "children": [sum_xy, deepcopy(sum_xy)]},
+        (
+            ("x", Fraction(0), Fraction(1)),
+            ("y", Fraction(0), Fraction(1)),
+        ),
+        target_width=Fraction(1, 100),
+        max_leaves=3,
+        max_depth=2,
+        max_evaluations=5,
+    )
+
+    assert tuple(leaf.path for leaf in result.leaves) == ((0, 0), (0, 1), (1,))
+    first = result.leaves[0].box.intervals
+    assert (first[0].lower.as_fraction(), first[0].upper.as_fraction()) == (
+        Fraction(0),
+        Fraction(1, 2),
+    )
+    assert (first[1].lower.as_fraction(), first[1].upper.as_fraction()) == (
+        Fraction(0),
+        Fraction(1, 2),
+    )
+
+
+def test_small_matrix_norm_squared_fixture_certifies_a_strict_upper_bound() -> None:
+    # For the real symmetric matrix [[sin x, cos y], [cos y, -sin x]], the
+    # squared operator norm is sin(x)^2 + cos(y)^2.
+    expression = {
+        "op": "add",
+        "children": [
+            {
+                "op": "pow",
+                "exponent": 2,
+                "children": [{"op": "sin", "children": [_var("x")]}],
+            },
+            {
+                "op": "pow",
+                "exponent": 2,
+                "children": [{"op": "cos", "children": [_var("y")]}],
+            },
+        ],
+    }
+    result = _run(
+        expression,
+        (
+            ("x", Fraction(0), Fraction(1)),
+            ("y", Fraction(0), Fraction(1)),
+        ),
+        target_width=Fraction(3),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+
+    assert result.enclosure.lower.as_fraction() <= 0
+    assert result.enclosure.upper.as_fraction() < 3
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "reason"),
+    [
+        ({"max_leaves": 1, "max_depth": 3, "max_evaluations": 3}, "MAX_LEAVES"),
+        (
+            {"max_leaves": 4, "max_depth": 3, "max_evaluations": 1},
+            "MAX_EVALUATIONS",
+        ),
+        ({"max_leaves": 4, "max_depth": 0, "max_evaluations": 3}, "MAX_DEPTH"),
+    ],
+)
+def test_budget_exhaustion_reasons_are_deterministic(
+    kwargs: dict[str, int], reason: str
+) -> None:
+    result = _run(
+        _var("x"),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(1, 8),
+        **kwargs,
+    )
+
+    assert isinstance(result.disposition, AdaptiveRangeBudgetExhausted)
+    assert result.disposition.reason == reason
+    assert result.enclosure.lower.as_fraction() <= 0
+    assert result.enclosure.upper.as_fraction() >= 1
+
+
+def test_zero_dimensional_precision_schedule_has_a_typed_exhaustion() -> None:
+    result = _run(
+        {"op": "exp", "children": [_const(1)]},
+        (),
+        target_width=Fraction(1, 10**60),
+        precision_bits=32,
+        maximum_precision_bits=100,
+        max_leaves=4,
+        max_depth=4,
+        max_evaluations=5,
+    )
+
+    assert isinstance(result.disposition, AdaptiveRangeBudgetExhausted)
+    assert result.disposition.reason == "MAX_PRECISION"
+    assert result.evaluations_used == 3
+    assert result.maximum_precision_bits_used == 100
+    assert result.leaves[0].path == ()
+    assert result.leaves[0].box.variables == ()
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        {"op": "log", "children": [_var("x")]},
+        {"op": "div", "children": [_const(1), _var("x")]},
+        {"op": "sqrt", "children": [_var("x")]},
+    ],
+)
+def test_source_domain_failure_is_request_rejection(
+    expression: dict[str, Any],
+) -> None:
+    request = _request(
+        expression,
+        (("x", Fraction(-1), Fraction(1)),),
+        target_width=Fraction(1),
+    )
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        _compute_adaptive_range_enclosure(request)
+    assert caught.value.errors()[0]["type"] == "analysis.adaptive_range.domain_unproven"
+
+
+def test_raw_target_and_cross_precision_bounds_reject_before_execution() -> None:
+    payload = {
+        "expression": _var("x"),
+        "box": {
+            "variables": ["x"],
+            "intervals": [{"lower": _q(0), "upper": _q(1)}],
+        },
+        "target_width": {"num": "9" * 129, "den": "1"},
+        "precision_bits": 128,
+        "maximum_precision_bits": 64,
+    }
+    with analysis_validation_error():
+        AdaptiveRangeEnclosureRequest.model_validate(payload)
+
+    payload["target_width"] = _q(1)
+    with analysis_validation_error():
+        AdaptiveRangeEnclosureRequest.model_validate(payload)
+
+
+@pytest.mark.parametrize("target", [Fraction(0), Fraction(-1)])
+def test_nonpositive_target_is_semantic_request_rejection(target: Fraction) -> None:
+    request = _request(
+        _var("x"),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=target,
+    )
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        _compute_adaptive_range_enclosure(request)
+    assert caught.value.errors()[0]["type"] == "analysis.adaptive_range.target_width"
+
+
+def test_result_sensitive_output_bound_rejects_only_the_large_envelope() -> None:
+    variables = tuple(f"x{index}" for index in range(8))
+    expression: dict[str, Any] = _var(variables[0])
+    for variable in variables[1:]:
+        expression = {"op": "add", "children": [expression, _var(variable)]}
+    large = _request(
+        expression,
+        tuple((variable, Fraction(0), Fraction(10**127)) for variable in variables),
+        target_width=Fraction(1),
+        max_leaves=1024,
+        max_depth=32,
+        max_evaluations=1,
+    )
+    assert _estimated_result_bytes(large) > MAX_ADAPTIVE_RANGE_RESULT_BYTES
+    with pytest.raises(OperationDomainValidationError) as caught:
+        _compute_adaptive_range_enclosure(large)
+    assert caught.value.errors()[0]["type"] == "analysis.adaptive_range.result_bytes"
+
+    small = _request(
+        _var("x"),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(2),
+        max_leaves=1024,
+        max_depth=32,
+        max_evaluations=1,
+    )
+    assert _estimated_result_bytes(small) < MAX_ADAPTIVE_RANGE_RESULT_BYTES
+    assert isinstance(
+        _compute_adaptive_range_enclosure(small).disposition,
+        AdaptiveRangeTargetMet,
+    )
+
+
+def test_precision_weighted_work_is_rejected_before_arb() -> None:
+    level = [_var("x") for _ in range(32)]
+    while len(level) > 1:
+        level = [
+            {"op": "add", "children": level[index : index + 2]}
+            for index in range(0, len(level), 2)
+        ]
+    expression = level[0]
+    request = _request(
+        expression,
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(1),
+        precision_bits=4096,
+        maximum_precision_bits=4096,
+        max_leaves=1024,
+        max_depth=32,
+        max_evaluations=4096,
+    )
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        _compute_adaptive_range_enclosure(request)
+    assert caught.value.errors()[0]["type"] == "analysis.adaptive_range.precision_work"
+
+
+@pytest.mark.parametrize(
+    ("field", "at_limit", "above_limit"),
+    [
+        ("max_leaves", 1024, 1025),
+        ("max_depth", 32, 33),
+        ("max_evaluations", 4096, 4097),
+        ("maximum_precision_bits", 4096, 4097),
+    ],
+)
+def test_adaptive_budget_field_boundaries_are_schema_visible(
+    field: str, at_limit: int, above_limit: int
+) -> None:
+    payload: dict[str, Any] = {
+        "expression": _var("x"),
+        "box": {
+            "variables": ["x"],
+            "intervals": [{"lower": _q(0), "upper": _q(1)}],
+        },
+        "target_width": _q(2),
+        "precision_bits": 32,
+        "maximum_precision_bits": 32,
+        "max_leaves": 1,
+        "max_depth": 0,
+        "max_evaluations": 1,
+        "wall_seconds": 30,
+    }
+    payload[field] = at_limit
+    AdaptiveRangeEnclosureRequest.model_validate(payload)
+
+    payload[field] = above_limit
+    with analysis_validation_error():
+        AdaptiveRangeEnclosureRequest.model_validate(payload)
+
+
+def test_past_request_context_expires_before_semantic_preflight() -> None:
+    request = _request(
+        _var("x"),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(2),
+        wall_seconds=1,
+    )
+
+    with (
+        request_execution(monotonic() - 2),
+        pytest.raises(OperationExecutionTimeoutError, match="before semantic"),
+    ):
+        _compute_adaptive_range_enclosure(request)
+
+
+def test_native_and_request_paths_return_the_same_exact_result() -> None:
+    request = _request(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+    dispatched = _compute_adaptive_range_enclosure(request)
+    native = adaptive_range_enclosure(
+        request.expression,
+        request.box,
+        request.target_width,
+        precision_bits=request.precision_bits,
+        maximum_precision_bits=request.maximum_precision_bits,
+        max_leaves=request.max_leaves,
+        max_depth=request.max_depth,
+        max_evaluations=request.max_evaluations,
+        wall_seconds=request.wall_seconds,
+    )
+    assert native == dispatched
+
+
+def test_admission_charge_covers_every_real_leaf_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jacobian.math.analysis._adaptive_range_enclosure as adaptive
+
+    request = _request(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+    admission = _admit_adaptive_range(request, started_at=monotonic())
+    original = adaptive._evaluate_leaf
+    calls = 0
+
+    def counting(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(adaptive, "_evaluate_leaf", counting)
+    result = _compute_adaptive_range_enclosure(request)
+
+    assert_charged_work_parity(
+        charged={"arb_expression_evaluations": admission.planned_evaluations},
+        executed={"arb_expression_evaluations": calls},
+    )
+    assert calls == result.evaluations_used == 7
+
+
+@pytest.mark.parametrize("mutation", ["path", "box", "hull", "disposition"])
+def test_round_trip_rejects_forged_partition_or_target_claim(mutation: str) -> None:
+    result = _run(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+    assert (
+        AdaptiveRangeEnclosureResult.model_validate_json(
+            result.model_dump_json(), strict=True
+        )
+        == result
+    )
+    payload = deepcopy(result.model_dump(mode="json"))
+    if mutation == "path":
+        payload["leaves"][0]["path"] = [0, 1]
+    elif mutation == "box":
+        payload["leaves"][0]["box"]["intervals"][0]["upper"] = _q(1, 3)
+    elif mutation == "hull":
+        payload["enclosure"]["lower"] = {"mantissa": "0", "exponent": 0}
+    else:
+        payload["disposition"] = {
+            "status": "BUDGET_EXHAUSTED",
+            "reason": "MAX_LEAVES",
+        }
+
+    with pytest.raises(ValidationError):
+        AdaptiveRangeEnclosureResult.model_validate(payload)
+
+
+def test_result_reservation_dominates_actual_canonical_output() -> None:
+    request = _request(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+    result = _compute_adaptive_range_enclosure(request)
+
+    assert len(canonicalize_json(result.model_dump(mode="json"))) <= (
+        _estimated_result_bytes(request)
+    )
+
+
+def test_disposition_schema_is_a_status_discriminated_union() -> None:
+    schema = AdaptiveRangeEnclosureResult.model_json_schema()
+    reference = schema["properties"]["disposition"]["$ref"]
+    disposition = schema["$defs"][reference.removeprefix("#/$defs/")]
+
+    assert disposition["discriminator"]["propertyName"] == "status"
+    assert set(disposition["discriminator"]["mapping"]) == {
+        "BUDGET_EXHAUSTED",
+        "TARGET_MET",
+    }

--- a/tests/math/analysis/test_analysis_adaptive_range_enclosure.py
+++ b/tests/math/analysis/test_analysis_adaptive_range_enclosure.py
@@ -1,36 +1,45 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from fractions import Fraction
 from math import sin
+from threading import Event
 from time import monotonic
 from typing import Any
 
 import pytest
+from flint import ctx
 from pydantic import ValidationError
 from tests.fixtures.accounting import assert_charged_work_parity
 from tests.math.analysis._analysis_support import analysis_validation_error
 
 from jacobian._execution import OperationExecutionTimeoutError, request_execution
+from jacobian._flint import flint_workprec
 from jacobian.canonical import canonicalize_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.analysis._adaptive_range_enclosure import (
+    MAX_ADAPTIVE_RANGE_DYADIC_EXPONENT,
     MAX_ADAPTIVE_RANGE_RESULT_BYTES,
     AdaptiveRangeBudgetExhausted,
+    AdaptiveRangeDomainUnproven,
+    AdaptiveRangeDomainUnprovenLeaf,
     AdaptiveRangeEnclosureRequest,
     AdaptiveRangeEnclosureResult,
+    AdaptiveRangeLeaf,
     AdaptiveRangeTargetMet,
     _admit_adaptive_range,
     _compute_adaptive_range_enclosure,
     _enclosure_width,
     _estimated_result_bytes,
-    _interval_hull,
+    _problem_from_request,
     adaptive_range_enclosure,
 )
 from jacobian.math.analysis._box_enclosure import (
     IntervalExpressionBoxEnclosureRequest,
     _box_expression_enclosure,
 )
+from jacobian.math.analysis._models import DyadicClosedInterval
 
 
 def _q(numerator: int, denominator: int = 1) -> dict[str, str]:
@@ -102,6 +111,20 @@ def _quadratic() -> dict[str, Any]:
     }
 
 
+def _result_enclosure(
+    result: AdaptiveRangeEnclosureResult,
+) -> DyadicClosedInterval:
+    assert result.enclosure is not None
+    return result.enclosure
+
+
+def _enclosed_leaves(
+    result: AdaptiveRangeEnclosureResult,
+) -> tuple[AdaptiveRangeLeaf, ...]:
+    assert all(isinstance(leaf, AdaptiveRangeLeaf) for leaf in result.leaves)
+    return tuple(leaf for leaf in result.leaves if isinstance(leaf, AdaptiveRangeLeaf))
+
+
 def test_quadratic_target_met_reconstructs_the_complete_four_leaf_cover() -> None:
     result = _run(
         _quadratic(),
@@ -131,10 +154,21 @@ def test_quadratic_target_met_reconstructs_the_complete_four_leaf_cover() -> Non
         (Fraction(1, 2), Fraction(3, 4)),
         (Fraction(3, 4), Fraction(1)),
     )
-    assert result.enclosure == _interval_hull(result.leaves)
-    assert result.enclosure.lower.as_fraction() <= 0
-    assert result.enclosure.upper.as_fraction() >= Fraction(1, 4)
-    assert _enclosure_width(result.enclosure) <= Fraction(7, 16)
+    leaves = _enclosed_leaves(result)
+    enclosure = _result_enclosure(result)
+    expected_lower = min(
+        (leaf.enclosure.lower for leaf in leaves),
+        key=lambda endpoint: endpoint.as_fraction(),
+    )
+    expected_upper = max(
+        (leaf.enclosure.upper for leaf in leaves),
+        key=lambda endpoint: endpoint.as_fraction(),
+    )
+    assert enclosure.lower == expected_lower
+    assert enclosure.upper == expected_upper
+    assert enclosure.lower.as_fraction() <= 0
+    assert enclosure.upper.as_fraction() >= Fraction(1, 4)
+    assert _enclosure_width(enclosure) <= Fraction(7, 16)
     assert result.evaluations_used == 7
 
 
@@ -148,7 +182,7 @@ def test_each_returned_leaf_box_composes_with_the_existing_box_operation() -> No
         max_evaluations=7,
     )
 
-    for leaf in result.leaves:
+    for leaf in _enclosed_leaves(result):
         replay = _box_expression_enclosure(
             IntervalExpressionBoxEnclosureRequest(
                 expression=result.expression,
@@ -172,8 +206,9 @@ def test_sine_enclosure_contains_both_interior_extrema_on_zero_to_seven() -> Non
     )
 
     assert isinstance(result.disposition, AdaptiveRangeTargetMet)
-    assert result.enclosure.lower.as_fraction() <= -1
-    assert result.enclosure.upper.as_fraction() >= 1
+    enclosure = _result_enclosure(result)
+    assert enclosure.lower.as_fraction() <= -1
+    assert enclosure.upper.as_fraction() >= 1
 
 
 def test_two_variable_coupling_contains_a_secondary_grid_oracle() -> None:
@@ -199,8 +234,9 @@ def test_two_variable_coupling_contains_a_secondary_grid_oracle() -> None:
         max_evaluations=7,
     )
 
-    lower = float(result.enclosure.lower.as_fraction())
-    upper = float(result.enclosure.upper.as_fraction())
+    enclosure = _result_enclosure(result)
+    lower = float(enclosure.lower.as_fraction())
+    upper = float(enclosure.upper.as_fraction())
     for x_index in range(17):
         for y_index in range(17):
             x = x_index / 32
@@ -218,8 +254,9 @@ def test_dependency_expression_never_loses_zero() -> None:
         max_evaluations=15,
     )
 
-    assert result.enclosure.lower.as_fraction() <= 0
-    assert result.enclosure.upper.as_fraction() >= 0
+    enclosure = _result_enclosure(result)
+    assert enclosure.lower.as_fraction() <= 0
+    assert enclosure.upper.as_fraction() >= 0
 
 
 def test_leaf_and_coordinate_ties_follow_path_then_source_axis_order() -> None:
@@ -298,10 +335,11 @@ def test_reduced_matrix_norm_fixture_needs_refinement_for_one_third_bound() -> N
     )
 
     assert one_box.status == "ENCLOSED"
+    assert one_box.upper is not None
     assert one_box.upper.as_fraction() >= Fraction(1, 9)
     assert isinstance(result.disposition, AdaptiveRangeTargetMet)
     assert len(result.leaves) == 4
-    assert result.enclosure.upper.as_fraction() < Fraction(1, 9)
+    assert _result_enclosure(result).upper.as_fraction() < Fraction(1, 9)
 
 
 @pytest.mark.parametrize(
@@ -327,8 +365,9 @@ def test_budget_exhaustion_reasons_are_deterministic(
 
     assert isinstance(result.disposition, AdaptiveRangeBudgetExhausted)
     assert result.disposition.reason == reason
-    assert result.enclosure.lower.as_fraction() <= 0
-    assert result.enclosure.upper.as_fraction() >= 1
+    enclosure = _result_enclosure(result)
+    assert enclosure.lower.as_fraction() <= 0
+    assert enclosure.upper.as_fraction() >= 1
 
 
 def test_zero_dimensional_precision_schedule_has_a_typed_exhaustion() -> None:
@@ -394,55 +433,6 @@ def test_no_split_depth_cause_precedes_irrelevant_budget_caps(
 
 
 @pytest.mark.parametrize(
-    ("coordinates", "request_overrides", "forged_reason"),
-    [
-        (
-            (),
-            {
-                "expression": {"op": "exp", "children": [_const(1)]},
-                "precision_bits": 32,
-                "maximum_precision_bits": 100,
-                "max_leaves": 1,
-                "max_depth": 4,
-                "max_evaluations": 5,
-            },
-            "MAX_LEAVES",
-        ),
-        (
-            (("x", Fraction(0), Fraction(1)),),
-            {
-                "expression": _var("x"),
-                "max_leaves": 4,
-                "max_depth": 0,
-                "max_evaluations": 1,
-            },
-            "MAX_EVALUATIONS",
-        ),
-    ],
-)
-def test_round_trip_rejects_an_irrelevant_no_split_budget_reason(
-    coordinates: tuple[tuple[str, Fraction, Fraction], ...],
-    request_overrides: dict[str, Any],
-    forged_reason: str,
-) -> None:
-    expression = request_overrides.pop("expression")
-    result = _run(
-        expression,
-        coordinates,
-        target_width=Fraction(1, 10**60),
-        **request_overrides,
-    )
-    payload = result.model_dump(mode="json")
-    payload["disposition"] = {
-        "status": "BUDGET_EXHAUSTED",
-        "reason": forged_reason,
-    }
-
-    with pytest.raises(ValidationError):
-        AdaptiveRangeEnclosureResult.model_validate(payload)
-
-
-@pytest.mark.parametrize(
     "expression",
     [
         {"op": "log", "children": [_var("x")]},
@@ -462,6 +452,128 @@ def test_source_domain_failure_is_request_rejection(
     with pytest.raises(OperationDomainValidationError) as caught:
         _compute_adaptive_range_enclosure(request)
     assert caught.value.errors()[0]["type"] == "analysis.adaptive_range.domain_unproven"
+
+
+def test_arb_domain_uncertainty_is_a_typed_leaf_nonconclusion() -> None:
+    expression = {
+        "op": "log",
+        "children": [
+            {
+                "op": "add",
+                "children": [_var("x"), _const(1, 10**127)],
+            }
+        ],
+    }
+
+    result = _run(
+        expression,
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(100),
+        precision_bits=32,
+        maximum_precision_bits=32,
+        max_leaves=1,
+        max_depth=8,
+        max_evaluations=1,
+    )
+
+    assert isinstance(result.disposition, AdaptiveRangeDomainUnproven)
+    assert result.disposition.reason == "MAX_LEAVES"
+    assert result.enclosure is None
+    assert len(result.leaves) == 1
+    leaf = result.leaves[0]
+    assert isinstance(leaf, AdaptiveRangeDomainUnprovenLeaf)
+    assert leaf.path == ()
+    assert leaf.domain_failure.operation == "log"
+    assert leaf.domain_failure.reason == "LOG_ARGUMENT_NOT_STRICTLY_POSITIVE"
+
+
+def test_arb_domain_uncertainty_can_resolve_under_midpoint_refinement() -> None:
+    expression = {
+        "op": "log",
+        "children": [
+            {
+                "op": "add",
+                "children": [_var("x"), _const(1, 2**40)],
+            }
+        ],
+    }
+
+    result = _run(
+        expression,
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(100),
+        precision_bits=32,
+        maximum_precision_bits=32,
+        max_leaves=16,
+        max_depth=15,
+        max_evaluations=31,
+    )
+
+    assert isinstance(result.disposition, AdaptiveRangeTargetMet)
+    assert result.enclosure is not None
+    assert all(isinstance(leaf, AdaptiveRangeLeaf) for leaf in result.leaves)
+    assert any(len(leaf.path) > 0 for leaf in result.leaves)
+
+
+def test_arb_domain_uncertainty_resolves_before_partition_at_higher_precision() -> None:
+    expression = {
+        "op": "log",
+        "children": [
+            {
+                "op": "add",
+                "children": [_var("x"), _const(1, 2**40)],
+            }
+        ],
+    }
+
+    result = _run(
+        expression,
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(100),
+        precision_bits=32,
+        maximum_precision_bits=128,
+        max_leaves=1,
+        max_depth=8,
+        max_evaluations=3,
+    )
+
+    assert isinstance(result.disposition, AdaptiveRangeTargetMet)
+    assert result.evaluations_used == 2
+    assert result.maximum_precision_bits_used == 64
+    assert tuple(leaf.path for leaf in result.leaves) == ((),)
+    assert all(isinstance(leaf, AdaptiveRangeLeaf) for leaf in result.leaves)
+
+
+def test_unresolved_leaf_depth_precedes_unrelated_refinement_budgets() -> None:
+    expression = {
+        "op": "log",
+        "children": [
+            {
+                "op": "add",
+                "children": [_var("x"), _const(1, 2**40)],
+            }
+        ],
+    }
+
+    result = _run(
+        expression,
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(100),
+        precision_bits=32,
+        maximum_precision_bits=32,
+        max_leaves=16,
+        max_depth=4,
+        max_evaluations=31,
+    )
+
+    assert isinstance(result.disposition, AdaptiveRangeDomainUnproven)
+    assert result.disposition.reason == "MAX_DEPTH"
+    assert len(result.leaves) == 5
+    assert any(
+        isinstance(leaf, AdaptiveRangeDomainUnprovenLeaf)
+        and len(leaf.path) == result.max_depth
+        for leaf in result.leaves
+    )
 
 
 def test_raw_target_and_cross_precision_bounds_reject_before_execution() -> None:
@@ -509,7 +621,10 @@ def test_result_sensitive_output_bound_rejects_only_the_large_envelope() -> None
         max_depth=32,
         max_evaluations=1,
     )
-    assert _estimated_result_bytes(large) > MAX_ADAPTIVE_RANGE_RESULT_BYTES
+    assert (
+        _estimated_result_bytes(_problem_from_request(large))
+        > MAX_ADAPTIVE_RANGE_RESULT_BYTES
+    )
     with pytest.raises(OperationDomainValidationError) as caught:
         _compute_adaptive_range_enclosure(large)
     assert caught.value.errors()[0]["type"] == "analysis.adaptive_range.result_bytes"
@@ -522,7 +637,10 @@ def test_result_sensitive_output_bound_rejects_only_the_large_envelope() -> None
         max_depth=32,
         max_evaluations=1,
     )
-    assert _estimated_result_bytes(small) < MAX_ADAPTIVE_RANGE_RESULT_BYTES
+    assert (
+        _estimated_result_bytes(_problem_from_request(small))
+        < MAX_ADAPTIVE_RANGE_RESULT_BYTES
+    )
     assert isinstance(
         _compute_adaptive_range_enclosure(small).disposition,
         AdaptiveRangeTargetMet,
@@ -626,6 +744,56 @@ def test_native_and_request_paths_return_the_same_exact_result() -> None:
     assert native == dispatched
 
 
+def test_concurrent_adaptive_operations_isolate_32_and_512_bit_precision() -> None:
+    expression = {"op": "exp", "children": [_const(1)]}
+    low_request = _request(
+        expression,
+        (),
+        target_width=Fraction(1),
+        precision_bits=32,
+        maximum_precision_bits=32,
+        max_leaves=1,
+        max_depth=0,
+        max_evaluations=1,
+    )
+    high_request = low_request.model_copy(
+        update={"precision_bits": 512, "maximum_precision_bits": 512}
+    )
+    expected_low = _compute_adaptive_range_enclosure(low_request)
+    expected_high = _compute_adaptive_range_enclosure(high_request)
+    original_precision = ctx.prec
+    holder_entered = Event()
+    high_attempting = Event()
+    high_finished = Event()
+
+    def low_worker() -> AdaptiveRangeEnclosureResult:
+        with flint_workprec(32):
+            holder_entered.set()
+            assert high_attempting.wait(timeout=1)
+            assert not high_finished.wait(timeout=0.25)
+            assert ctx.prec == 32
+            return _compute_adaptive_range_enclosure(low_request)
+
+    def high_worker() -> AdaptiveRangeEnclosureResult:
+        assert holder_entered.wait(timeout=1)
+        high_attempting.set()
+        try:
+            return _compute_adaptive_range_enclosure(high_request)
+        finally:
+            high_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        low_future = workers.submit(low_worker)
+        high_future = workers.submit(high_worker)
+        low = low_future.result(timeout=2)
+        high = high_future.result(timeout=2)
+
+    assert low == expected_low
+    assert high == expected_high
+    assert _result_enclosure(low) != _result_enclosure(high)
+    assert ctx.prec == original_precision
+
+
 def test_admission_charge_covers_every_real_leaf_evaluation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -639,7 +807,9 @@ def test_admission_charge_covers_every_real_leaf_evaluation(
         max_depth=2,
         max_evaluations=7,
     )
-    admission = _admit_adaptive_range(request, started_at=monotonic())
+    admission = _admit_adaptive_range(
+        _problem_from_request(request), started_at=monotonic()
+    )
     original = adaptive._evaluate_leaf
     calls = 0
 
@@ -658,8 +828,8 @@ def test_admission_charge_covers_every_real_leaf_evaluation(
     assert calls == result.evaluations_used == 7
 
 
-@pytest.mark.parametrize("mutation", ["path", "box", "hull", "disposition"])
-def test_round_trip_rejects_forged_partition_or_target_claim(mutation: str) -> None:
+@pytest.mark.parametrize("mutation", ["path", "box"])
+def test_round_trip_rejects_forged_partition_structure(mutation: str) -> None:
     result = _run(
         _quadratic(),
         (("x", Fraction(0), Fraction(1)),),
@@ -677,17 +847,157 @@ def test_round_trip_rejects_forged_partition_or_target_claim(mutation: str) -> N
     payload = deepcopy(result.model_dump(mode="json"))
     if mutation == "path":
         payload["leaves"][0]["path"] = [0, 1]
-    elif mutation == "box":
-        payload["leaves"][0]["box"]["intervals"][0]["upper"] = _q(1, 3)
-    elif mutation == "hull":
-        payload["enclosure"]["lower"] = {"mantissa": "0", "exponent": 0}
     else:
-        payload["disposition"] = {
-            "status": "BUDGET_EXHAUSTED",
-            "reason": "MAX_LEAVES",
-        }
+        payload["leaves"][0]["box"]["intervals"][0]["upper"] = _q(1, 3)
 
     with pytest.raises(ValidationError):
+        AdaptiveRangeEnclosureResult.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("evaluations_used", 8, "requested evaluation budget"),
+        ("maximum_precision_bits_used", 256, "requested precision range"),
+    ],
+)
+def test_result_structural_counters_remain_within_the_request(
+    field: str, value: int, message: str
+) -> None:
+    result = _run(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+    payload = result.model_dump(mode="json")
+    payload[field] = value
+
+    with pytest.raises(ValidationError, match=message):
+        AdaptiveRangeEnclosureResult.model_validate(payload)
+
+
+def test_result_preflights_authored_leaf_endpoints_before_fraction_work() -> None:
+    result = _run(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+    payload = result.model_dump(mode="json")
+    payload["leaves"][0]["box"]["intervals"][0]["upper"] = {
+        "num": "9" * 129,
+        "den": "1",
+    }
+
+    with pytest.raises(ValidationError, match="128-digit bound"):
+        AdaptiveRangeEnclosureResult.model_validate(payload)
+
+
+def test_result_structurally_bounds_authored_dyadic_exponents() -> None:
+    result = _run(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+    payload = result.model_dump(mode="json")
+    payload["leaves"][0]["enclosure"]["lower"]["exponent"] = (
+        MAX_ADAPTIVE_RANGE_DYADIC_EXPONENT + 1
+    )
+
+    with pytest.raises(ValidationError, match="source-and-precision bound"):
+        AdaptiveRangeEnclosureResult.model_validate(payload)
+
+
+def test_result_deserialization_does_not_replay_computed_math(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jacobian.math.analysis._adaptive_range_enclosure as adaptive
+
+    result = _run(
+        _quadratic(),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(7, 16),
+        max_leaves=4,
+        max_depth=2,
+        max_evaluations=7,
+    )
+
+    def replayed(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("computed mathematics was replayed during deserialization")
+
+    for name in (
+        "_enclosure_width",
+        "_evaluated_hull",
+        "_precision_schedule",
+    ):
+        monkeypatch.setattr(adaptive, name, replayed)
+
+    parsed = AdaptiveRangeEnclosureResult.model_validate(result.model_dump(mode="json"))
+    assert parsed == result
+
+
+def test_domain_unproven_result_cannot_carry_a_global_enclosure() -> None:
+    expression = {
+        "op": "log",
+        "children": [
+            {
+                "op": "add",
+                "children": [_var("x"), _const(1, 10**127)],
+            }
+        ],
+    }
+    result = _run(
+        expression,
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(100),
+        precision_bits=32,
+        maximum_precision_bits=32,
+        max_leaves=1,
+        max_depth=8,
+        max_evaluations=1,
+    )
+    payload = result.model_dump(mode="json")
+    payload["enclosure"] = {
+        "lower": {"mantissa": "0", "exponent": 0},
+        "upper": {"mantissa": "1", "exponent": 0},
+    }
+
+    with pytest.raises(ValidationError, match="cannot carry a global enclosure"):
+        AdaptiveRangeEnclosureResult.model_validate(payload)
+
+
+def test_domain_failure_evidence_is_bound_to_the_source_expression_node() -> None:
+    expression = {
+        "op": "log",
+        "children": [
+            {
+                "op": "add",
+                "children": [_var("x"), _const(1, 10**127)],
+            }
+        ],
+    }
+    result = _run(
+        expression,
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(100),
+        precision_bits=32,
+        maximum_precision_bits=32,
+        max_leaves=1,
+        max_depth=8,
+        max_evaluations=1,
+    )
+    payload = result.model_dump(mode="json")
+    payload["leaves"][0]["domain_failure"]["node_path"] = [0]
+
+    with pytest.raises(ValidationError, match="does not match the source expression"):
         AdaptiveRangeEnclosureResult.model_validate(payload)
 
 
@@ -703,7 +1013,7 @@ def test_result_reservation_dominates_actual_canonical_output() -> None:
     result = _compute_adaptive_range_enclosure(request)
 
     assert len(canonicalize_json(result.model_dump(mode="json"))) <= (
-        _estimated_result_bytes(request)
+        _estimated_result_bytes(_problem_from_request(request))
     )
 
 
@@ -711,9 +1021,23 @@ def test_disposition_schema_is_a_status_discriminated_union() -> None:
     schema = AdaptiveRangeEnclosureResult.model_json_schema()
     reference = schema["properties"]["disposition"]["$ref"]
     disposition = schema["$defs"][reference.removeprefix("#/$defs/")]
+    leaf_reference = schema["properties"]["leaves"]["items"]["$ref"]
+    leaf = schema["$defs"][leaf_reference.removeprefix("#/$defs/")]
 
     assert disposition["discriminator"]["propertyName"] == "status"
     assert set(disposition["discriminator"]["mapping"]) == {
         "BUDGET_EXHAUSTED",
+        "DOMAIN_UNPROVEN",
         "TARGET_MET",
+    }
+    assert leaf["discriminator"]["propertyName"] == "status"
+    assert set(leaf["discriminator"]["mapping"]) == {
+        "DOMAIN_UNPROVEN",
+        "ENCLOSED",
+    }
+    assert {
+        variant.get("type") for variant in schema["properties"]["enclosure"]["anyOf"]
+    } == {
+        "null",
+        None,
     }

--- a/tests/math/analysis/test_analysis_adaptive_range_enclosure.py
+++ b/tests/math/analysis/test_analysis_adaptive_range_enclosure.py
@@ -1285,3 +1285,16 @@ def test_result_schema_and_parser_reject_contradictory_outcome_shapes() -> None:
         assert list(validator.iter_errors(forged))
         with pytest.raises(ValidationError):
             AdaptiveRangeEnclosureResult.model_validate(forged)
+
+    target_contradiction = deepcopy(concluded_payload)
+    target_contradiction["target_width"] = {"num": "1", "den": "1000000"}
+    with pytest.raises(ValidationError, match="TARGET_MET"):
+        AdaptiveRangeEnclosureResult.model_validate(target_contradiction)
+
+    budget_contradiction = deepcopy(concluded_payload)
+    budget_contradiction["disposition"] = {
+        "status": "BUDGET_EXHAUSTED",
+        "reason": "MAX_LEAVES",
+    }
+    with pytest.raises(ValidationError, match="BUDGET_EXHAUSTED"):
+        AdaptiveRangeEnclosureResult.model_validate(budget_contradiction)

--- a/tests/math/analysis/test_analysis_adaptive_range_enclosure.py
+++ b/tests/math/analysis/test_analysis_adaptive_range_enclosure.py
@@ -42,8 +42,8 @@ def _var(name: str) -> dict[str, Any]:
     return {"op": "var", "variable": name}
 
 
-def _const(value: int) -> dict[str, Any]:
-    return {"op": "const", "value": _q(value)}
+def _const(value: int, denominator: int = 1) -> dict[str, Any]:
+    return {"op": "const", "value": _q(value, denominator)}
 
 
 def _request(
@@ -248,38 +248,60 @@ def test_leaf_and_coordinate_ties_follow_path_then_source_axis_order() -> None:
     )
 
 
-def test_small_matrix_norm_squared_fixture_certifies_a_strict_upper_bound() -> None:
-    # For the real symmetric matrix [[sin x, cos y], [cos y, -sin x]], the
-    # squared operator norm is sin(x)^2 + cos(y)^2.
+def test_reduced_matrix_norm_fixture_needs_refinement_for_one_third_bound() -> None:
+    # For the real symmetric matrix [[a, b], [b, -a]], the squared operator
+    # norm is a^2+b^2.  This reduced HRT-shaped fixture uses a=sin(x)-x and
+    # b=cos(x)-1, so the source's strict norm < 1/3 target is upper^2 < 1/9.
+    sine_remainder = {
+        "op": "sub",
+        "children": [{"op": "sin", "children": [_var("x")]}, _var("x")],
+    }
+    cosine_remainder = {
+        "op": "sub",
+        "children": [{"op": "cos", "children": [_var("x")]}, _const(1)],
+    }
     expression = {
         "op": "add",
         "children": [
             {
                 "op": "pow",
                 "exponent": 2,
-                "children": [{"op": "sin", "children": [_var("x")]}],
+                "children": [sine_remainder],
             },
             {
                 "op": "pow",
                 "exponent": 2,
-                "children": [{"op": "cos", "children": [_var("y")]}],
+                "children": [cosine_remainder],
             },
         ],
     }
+    source_box = ("x", Fraction(0), Fraction(1, 2))
+    one_box = _box_expression_enclosure(
+        IntervalExpressionBoxEnclosureRequest.model_validate(
+            {
+                "expression": expression,
+                "box": {
+                    "variables": ["x"],
+                    "intervals": [{"lower": _q(0), "upper": _q(1, 2)}],
+                },
+                "precision_bits": 128,
+            }
+        )
+    )
     result = _run(
         expression,
-        (
-            ("x", Fraction(0), Fraction(1)),
-            ("y", Fraction(0), Fraction(1)),
-        ),
-        target_width=Fraction(3),
+        (source_box,),
+        target_width=Fraction(1, 8),
         max_leaves=4,
         max_depth=2,
         max_evaluations=7,
     )
 
-    assert result.enclosure.lower.as_fraction() <= 0
-    assert result.enclosure.upper.as_fraction() < 3
+    assert one_box.status == "ENCLOSED"
+    assert one_box.upper.as_fraction() >= Fraction(1, 9)
+    assert isinstance(result.disposition, AdaptiveRangeTargetMet)
+    assert len(result.leaves) == 4
+    assert result.enclosure.upper.as_fraction() < Fraction(1, 9)
 
 
 @pytest.mark.parametrize(
@@ -327,6 +349,97 @@ def test_zero_dimensional_precision_schedule_has_a_typed_exhaustion() -> None:
     assert result.maximum_precision_bits_used == 100
     assert result.leaves[0].path == ()
     assert result.leaves[0].box.variables == ()
+
+
+@pytest.mark.parametrize(
+    ("max_leaves", "max_evaluations"),
+    [(1, 5), (2, 3)],
+)
+def test_no_split_precision_cause_precedes_irrelevant_budget_caps(
+    max_leaves: int, max_evaluations: int
+) -> None:
+    result = _run(
+        {"op": "exp", "children": [_const(1)]},
+        (),
+        target_width=Fraction(1, 10**60),
+        precision_bits=32,
+        maximum_precision_bits=100,
+        max_leaves=max_leaves,
+        max_depth=4,
+        max_evaluations=max_evaluations,
+    )
+
+    assert isinstance(result.disposition, AdaptiveRangeBudgetExhausted)
+    assert result.disposition.reason == "MAX_PRECISION"
+
+
+@pytest.mark.parametrize(
+    ("max_leaves", "max_evaluations"),
+    [(1, 1), (4, 1)],
+)
+def test_no_split_depth_cause_precedes_irrelevant_budget_caps(
+    max_leaves: int, max_evaluations: int
+) -> None:
+    result = _run(
+        _var("x"),
+        (("x", Fraction(0), Fraction(1)),),
+        target_width=Fraction(1, 8),
+        max_leaves=max_leaves,
+        max_depth=0,
+        max_evaluations=max_evaluations,
+    )
+
+    assert isinstance(result.disposition, AdaptiveRangeBudgetExhausted)
+    assert result.disposition.reason == "MAX_DEPTH"
+
+
+@pytest.mark.parametrize(
+    ("coordinates", "request_overrides", "forged_reason"),
+    [
+        (
+            (),
+            {
+                "expression": {"op": "exp", "children": [_const(1)]},
+                "precision_bits": 32,
+                "maximum_precision_bits": 100,
+                "max_leaves": 1,
+                "max_depth": 4,
+                "max_evaluations": 5,
+            },
+            "MAX_LEAVES",
+        ),
+        (
+            (("x", Fraction(0), Fraction(1)),),
+            {
+                "expression": _var("x"),
+                "max_leaves": 4,
+                "max_depth": 0,
+                "max_evaluations": 1,
+            },
+            "MAX_EVALUATIONS",
+        ),
+    ],
+)
+def test_round_trip_rejects_an_irrelevant_no_split_budget_reason(
+    coordinates: tuple[tuple[str, Fraction, Fraction], ...],
+    request_overrides: dict[str, Any],
+    forged_reason: str,
+) -> None:
+    expression = request_overrides.pop("expression")
+    result = _run(
+        expression,
+        coordinates,
+        target_width=Fraction(1, 10**60),
+        **request_overrides,
+    )
+    payload = result.model_dump(mode="json")
+    payload["disposition"] = {
+        "status": "BUDGET_EXHAUSTED",
+        "reason": forged_reason,
+    }
+
+    with pytest.raises(ValidationError):
+        AdaptiveRangeEnclosureResult.model_validate(payload)
 
 
 @pytest.mark.parametrize(

--- a/tests/math/analysis/test_analysis_definite_integral_enclosure.py
+++ b/tests/math/analysis/test_analysis_definite_integral_enclosure.py
@@ -762,6 +762,18 @@ def test_precision_work_boundary_is_derived_from_actual_subproblems() -> None:
         _admit_definite_integral(rejected, started_at=monotonic())
 
 
+def test_widened_box_endpoints_retain_definite_integral_admission() -> None:
+    lower = Fraction(10**128)
+    request = _request(
+        _var(),
+        lower=lower,
+        upper=lower + 1,
+        max_leaves=MAX_DEFINITE_INTEGRAL_LEAVES,
+    )
+
+    _admit_definite_integral(request, started_at=monotonic())
+
+
 def test_leaf_and_wall_field_bounds_reject_one_beyond() -> None:
     payload = _request(_var()).model_dump(mode="json")
     payload["max_leaves"] = MAX_DEFINITE_INTEGRAL_LEAVES + 1

--- a/tests/math/analysis/test_analysis_expression_box_enclosure.py
+++ b/tests/math/analysis/test_analysis_expression_box_enclosure.py
@@ -20,6 +20,7 @@ from jacobian.math.analysis._expression_enclosure import (
     IntervalExpressionEnclosureRequest,
 )
 from jacobian.math.analysis._models import (
+    MAX_RATIONAL_BOX_ENDPOINT_DIGITS,
     RationalIntervalBox,
 )
 from jacobian.math.analysis.operations import expression_enclosure
@@ -85,16 +86,20 @@ def test_analysis_and_geometry_boxes_compose_through_the_same_interval_value() -
     assert geometry_box.intervals[0] is interval
 
 
-def test_analysis_request_keeps_its_endpoint_digit_admission() -> None:
+def test_analysis_request_accepts_the_shared_derived_endpoint_envelope() -> None:
     interval = ClosedRationalInterval.model_validate(
-        {"lower": _q(0), "upper": {"num": "1" * 129, "den": "1"}}
+        {
+            "lower": _q(0),
+            "upper": {"num": "1" * MAX_RATIONAL_BOX_ENDPOINT_DIGITS, "den": "1"},
+        }
     )
     box = RationalIntervalBox(variables=("x",), intervals=(interval,))
 
-    with analysis_validation_error():
-        IntervalExpressionBoxEnclosureRequest.model_validate(
-            {"expression": {"op": "var", "variable": "x"}, "box": box}
-        )
+    request = IntervalExpressionBoxEnclosureRequest.model_validate(
+        {"expression": {"op": "var", "variable": "x"}, "box": box}
+    )
+
+    assert request.box == box
 
 
 @pytest.mark.parametrize("op", ["exp", "log"])
@@ -590,7 +595,7 @@ def test_box_interval_endpoints_are_ordered_and_bounded() -> None:
             (("x", Fraction(1), Fraction(0)),),
         )
 
-    too_many_digits = "1" * 129
+    too_many_digits = "1" * (MAX_RATIONAL_BOX_ENDPOINT_DIGITS + 1)
     with analysis_validation_error():
         IntervalExpressionBoxEnclosureRequest.model_validate(
             {

--- a/tests/mcp/test_direct_operations.py
+++ b/tests/mcp/test_direct_operations.py
@@ -150,6 +150,62 @@ def test_direct_calls_return_owner_results_without_dispatch_envelopes() -> None:
     asyncio.run(scenario())
 
 
+def test_direct_adaptive_call_preserves_typed_arb_domain_uncertainty() -> None:
+    operation_id = "interval.expression.adaptive_range_enclosure.compute"
+    operation = _operations(operation_id)[0]
+    payload = {
+        "expression": {
+            "op": "log",
+            "children": [
+                {
+                    "op": "add",
+                    "children": [
+                        {"op": "var", "variable": "x"},
+                        {
+                            "op": "const",
+                            "value": {"num": "1", "den": "1" + "0" * 127},
+                        },
+                    ],
+                }
+            ],
+        },
+        "box": {
+            "variables": ["x"],
+            "intervals": [
+                {
+                    "lower": {"num": "0", "den": "1"},
+                    "upper": {"num": "1", "den": "1"},
+                }
+            ],
+        },
+        "precision_bits": 32,
+        "maximum_precision_bits": 32,
+        "target_width": {"num": "100", "den": "1"},
+        "max_leaves": 1,
+        "max_depth": 8,
+        "max_evaluations": 1,
+        "wall_seconds": 30,
+    }
+    request = operation.request_type.model_validate(payload)
+    expected = operation.run(request).model_dump(mode="json")
+
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(_server(operation_id), raise_exceptions=True) as client:
+            result = await client.call_tool(operation_id, payload)
+
+        assert result.structured_content == expected
+        assert result.structured_content["disposition"] == {
+            "status": "DOMAIN_UNPROVEN",
+            "reason": "MAX_LEAVES",
+        }
+        assert result.structured_content["enclosure"] is None
+        assert result.structured_content["leaves"][0]["status"] == "DOMAIN_UNPROVEN"
+
+    asyncio.run(scenario())
+
+
 def test_direct_parsing_and_execution_share_one_request_envelope() -> None:
     observed_envelopes: list[bool] = []
 


### PR DESCRIPTION
## Problem

`interval.expression.box_enclosure.compute` encloses one caller-supplied box, but it does not establish that a finite refinement covers the original domain or return the global hull over every leaf. A caller-side loop would also lose the operation's single work ledger, deadline, deterministic stopping semantics, and source-bound result.

The HRT-shaped regression demonstrates the gap with a reduced squared matrix norm. The existing one-box enclosure has upper bound `>= 1/9`, while a complete four-leaf refinement returns an upper bound `< 1/9`, establishing the corresponding norm bound `< 1/3`.

Closes #2903.

## Solution

Add `interval.expression.adaptive_range_enclosure.compute` and the matching native `adaptive_range_enclosure` function.

The operation:

- evaluates the source box on a deterministic doubling-precision schedule;
- bisects exact rational boxes by widest coordinate, refining domain-uncertain leaves first and otherwise the widest certified-range leaf, with canonical tie-breaking;
- returns the complete path-ordered leaf cover and its dyadic hull; and
- distinguishes `TARGET_MET`, sound `BUDGET_EXHAUSTED`, and `DOMAIN_UNPROVEN` through mutually exclusive result schemas.

Exact source-domain failures remain request rejection. Fixed-precision Arb uncertainty becomes a typed leaf nonconclusion, while timeouts and malformed backend results remain operational failures. In particular, `BUDGET_EXHAUSTED` carries a sound global hull, but `DOMAIN_UNPROVEN` cannot carry one.

Suggested review order: the request/result and admission contracts in `_adaptive_range_enclosure.py`, the refinement loop and result construction, then the defining-invariant tests and catalog/MCP wiring.

## Testing

Final-tree handoff and focused mathematical validation:

```sh
make handoff LANE=math TESTS='tests/math/analysis/test_analysis_adaptive_range_enclosure.py tests/math/analysis/test_analysis_expression_box_enclosure.py'
```

Repository-wide Ruff, format checking, and mypy over 981 source files passed; 97 focused tests passed. A scoped run including the unchanged second-jet consumer also passed 118 tests:

```sh
make handoff-scoped \
  LANE=math \
  TESTS="tests/math/analysis/test_analysis_adaptive_range_enclosure.py tests/math/analysis/test_analysis_expression_box_enclosure.py tests/math/analysis/test_analysis_expression_second_jet_enclosure.py" \
  PATHS="src/jacobian/math/analysis/_models.py src/jacobian/math/analysis/_adaptive_range_enclosure.py src/jacobian/math/analysis/_box_enclosure.py src/jacobian/math/analysis/_tools.py src/jacobian/math/analysis/operations.py src/jacobian/math/analysis/__init__.py tests/math/analysis/test_analysis_adaptive_range_enclosure.py tests/math/analysis/test_analysis_expression_box_enclosure.py tests/catalog/test_validated_analysis_declarations.py"
```

Boundary and advertised-example checks:

```sh
uv run --locked pytest -q -n 0 tests/catalog/test_validated_analysis_declarations.py
# 1 passed

make test-mcp TESTS=tests/mcp/test_direct_operations.py
# 9 passed

make test-integration TESTS=tests/integration/catalog/test_builtin_examples.py PYTEST_ARGS='-k adaptive_range'
# 1 passed

git diff --check origin/main..HEAD
```

- Specialist validation run: direct MCP projection and the advertised catalog example, as listed above.

## Public contract impact

This adds `interval.expression.adaptive_range_enclosure.compute`, its request/result models, and the native Python function.

The shared analysis rational-box endpoint envelope widens from 128 to 290 decimal digits so exact midpoint boxes remain valid inputs to existing fixed-box and second-jet consumers. Expression constants remain limited to 128 digits. This is an acceptance widening; no compatibility alias or forwarding path is added.

## Operation boundary ownership

- Changed stage: request parsing and bounds, deterministic kernel scheduling, Arb adapter use, canonical result construction, native export, catalog admission, and MCP projection.
- Request-bounds owner and controlling quantities: the analysis owner charges expression shape, rational height, reachable precision evaluations and splits, leaf count, intermediate growth, and exact output before Arb execution.

| Quantity | Admitted bound |
| --- | --- |
| Expression | 8 variables, 64 nodes, depth 16, 128-digit constants, absolute integer exponents up to 64 |
| Source endpoints | At depth 0, 290 digits; for positive reachable depth `d`, `floor((290 - d - 2) / 2)` |
| Refinement | 1,024 leaves, depth 32, 4,096 evaluations, precision 32–4,096 bits |
| Work | 131,072 expression-node evaluations and 268,435,456 precision-weighted node-bit units |
| Exact intermediates | 8,192-bit retained rational components and 16,385-bit transient `Fraction` components |
| Result | 10 MiB canonical output; dyadic mantissas up to 1,235 digits and adaptive exponents up to 16,385 |
| Deadline | `wall_seconds` defaults to 30 and is caller-selectable from 1–120 seconds |

- Work, intermediate, memory, and exact-output bounds: admission reserves only the reachable precision schedule, split count, leaf count, and path depth. Memory is bounded through expression, leaf, precision, exact-intermediate, and retained-output caps; there is no separate host-heap claim.
- Wall deadline, calibration workload, safety margin, and caller-selectable range: one deadline covers dispatch/native entry, semantic preflight, serialized FLINT-context waits, Arb evaluation, and result construction. The 120-second ceiling is an operational backstop, not a latency or complexity claim; no wall-time calibration claim is made.
- Backend or kernel path: Jacobian owns exact midpoint partitioning, scheduling, budgets, and hull construction. Pinned python-flint 0.9.0/Arb owns outward-rounded natural interval evaluation.
- Result construction: the kernel converts Arb endpoints to canonical exact dyadics and constructs authoritative results through a trusted factory. Backend non-finiteness or conversion failure does not become a mathematical disposition.
- Independent-result verifier: none. This is a source-bound computation and does not accept independently supplied mathematical evidence. Ordinary deserialization performs structural validation without replaying the partition or interval theorem.
- Native/MCP parity: both entry points execute the same admission and kernel; MCP adds only strict request parsing and transport projection.
- Serialized-result and round-trip evidence: complete results round-trip strictly through JSON. For `q = 6*10**127 + 1`, the produced midpoint `1/(2q)` has a 129-digit denominator and is accepted unchanged by the existing fixed-box consumer.

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Advertised codomain is closed under the result types, including required parent, embedding, branch, orientation, basis, or coordinate data
- [x] Producer→consumer serialization tested
- Existing values reused: `IntervalExpressionNode`, `CanonicalRational`, `ClosedRationalInterval`, `RationalIntervalBox`, `ExactDyadic`, `DyadicClosedInterval`, and `IntervalExpressionDomainFailure`. Adaptive leaf paths, dispositions, and complete-cover results are analysis-owned additions because no existing value carries their partition and budget semantics.
- Theorem-dependent preconditions and validated input subtype: a complete named-variable rational box and non-evaluating elementary-expression tree whose exact interval preflight establishes every real-domain obligation.
- Structurally valid but mathematically invalid fixture and outcome: `log(x)`, `1/x`, and `sqrt(x)` over `[-1,1]` are rejected during semantic admission.
- Serialized-subtype trust boundary: request parsing is strict and semantic admission runs once. Result parsing checks source binding, budgets, complete prefix-free paths, dyadic representation, disposition shape, and domain-failure node binding; it intentionally does not reconstruct leaf boxes or replay computed interval mathematics. Forged paths and contradictory result branches are rejected.
- Exact-success defining invariant: for returned leaves `(D_j, I_j)`, tests establish `D = union(D_j)`, `e(D_j) subseteq I_j`, and `[L,U] = [min_j lower(I_j), max_j upper(I_j)]`.
- Discriminated result schema and impossible combinations: generated JSON Schema exposes exclusive concluded and `DOMAIN_UNPROVEN` branches. Draft 2020-12 and Pydantic tests reject null concluded enclosures, non-null uncertain enclosures, missing enclosures, uncertain leaves under concluded status, and uncertain status without an uncertain leaf.

## Catalog admission

- Concrete gap: no existing operation returns a global range enclosure over a complete finite refinement of a rational box.
- Why existing operations or typed values are insufficient: fixed-box enclosure and second jets do not choose a complete partition, share refinement budgets, or return its global hull.
- Stable mathematical result: a sound dyadic range hull over a deterministic complete rational partition, or a typed finite nonconclusion when Arb cannot prove every local domain obligation.
- Semantic domain and admitted execution envelope: bounded elementary-expression trees on complete compact rational boxes, under the limits listed above.
- Controlling work, intermediate, memory, and output quantities: reachable schedule evaluations, split count, expression-node work, precision-weighted work, exact rational growth, retained leaf count, and canonical output size.
- Exact representation, algorithm regimes, and maintained backend: exact rational midpoint boxes and path addresses, exact dyadic enclosures, one deterministic refinement regime, and pinned Arb natural interval arithmetic.
- Remaining fixed caps and their classification: expression/rational/dyadic limits are representation caps; leaf, depth, evaluation, precision-work, and output limits are conservative execution caps; wall time is an operational safety backstop.
- Motivating source request exercised through the public boundary: the reduced HRT-shaped `2 × 2` matrix-norm fixture from #2903.
- Final-tree outcome for that request: the one-box enclosure cannot prove the strict `1/3` norm bound; four adaptive leaves return `TARGET_MET` and a squared-norm upper bound `< 1/9`.
- Effect of private normalization or presolve on admission: JSON-container normalization does not change the mathematical input. Exact interval preflight may reject an unproved source domain; reachability planning only reserves resources and does not establish a range conclusion.
- Admission decision: admit this reusable analysis operation in the owner-local `_tools.py` manifest.

## Closure matrix

None. #2903 requests this single operation; matrix syntax, Fourier/Zak transforms, torus objects, and problem-specific HRT operations remain outside its scope.

## Checklist

- [x] `make handoff LANE=... TESTS=...` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor preparation/validation is not applicable; no Harbor task or verifier changes
- [x] Catalog admission is explicit in the analysis owner-local `_tools.py`
- [x] No compatibility aliases, forwarding modules, or generic `_operations.py` shadow paths were introduced
- [x] Runtime bounds are analysis-owned and native/MCP callers execute the same semantic path
- [x] Result semantics distinguish sound conclusions, finite budget exhaustion, domain uncertainty, and operational failure
- [x] The HRT-shaped motivating request is covered by a behavioral regression
- [x] Boundary and source-backed scale cases cover the new bounds; algorithm crossover is not applicable to the single deterministic regime
- [x] Shared endpoint-envelope constants and validators serve the adaptive producer and existing box consumers
