### PR TITLE
Compute exact planar framework rigidity profiles

### DIFF
--- a/src/jacobian/math/geometry/framework/__init__.py
+++ b/src/jacobian/math/geometry/framework/__init__.py
@@ -1,0 +1,19 @@
+"""Exact planar framework operations and values."""
+
+from jacobian.math.geometry.exact._models import (
+    LabelledRationalPoint,
+    PointConfiguration,
+)
+from jacobian.math.geometry.framework._models import (
+    PlanarRigidityProfile,
+)
+from jacobian.math.geometry.framework.operations import planar_rigidity_profile
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+__all__ = [
+    "LabelledRationalPoint",
+    "PlanarRigidityProfile",
+    "PointConfiguration",
+    "SimpleUndirectedGraph",
+    "planar_rigidity_profile",
+]

--- a/src/jacobian/math/geometry/framework/_bounds.py
+++ b/src/jacobian/math/geometry/framework/_bounds.py
@@ -1,0 +1,40 @@
+"""Shared raw and canonical work bounds for planar rigidity profiles."""
+
+from __future__ import annotations
+
+MAX_FRAMEWORK_COORDINATE_WORK = 100_000_000
+"""Decimal-limb and rational-difference work admitted before matrix expansion."""
+
+
+def rational_parse_work(components: tuple[str, str]) -> int:
+    """Bound base-10**9 multiply-add visits for two rational components."""
+
+    work = 0
+    for component in components:
+        digits = len(component.lstrip("-"))
+        limbs = (digits + 8) // 9
+        work += limbs * (limbs + 1)
+    return work
+
+
+def rational_height(components: tuple[str, str]) -> int:
+    """Return the largest canonical decimal component width."""
+
+    return max(len(component.lstrip("-")) for component in components)
+
+
+def difference_work(left: tuple[str, str], right: tuple[str, str]) -> int:
+    """Price subtraction plus both signed canonical sparse-entry projections."""
+
+    height = max(rational_height(left), rational_height(right))
+    # A quadratic height charge conservatively covers the two cross-products,
+    # subtraction, reduction, and decimal projection of both signed entries.
+    return 32 * height * height + 32 * height
+
+
+__all__ = [
+    "MAX_FRAMEWORK_COORDINATE_WORK",
+    "difference_work",
+    "rational_height",
+    "rational_parse_work",
+]

--- a/src/jacobian/math/geometry/framework/_models.py
+++ b/src/jacobian/math/geometry/framework/_models.py
@@ -1,0 +1,244 @@
+"""Typed contracts for exact planar framework rigidity profiles."""
+
+from __future__ import annotations
+
+from typing import Any, Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.geometry.exact._models import (
+    MAX_PAIRS,
+    MAX_POINTS,
+    PointConfiguration,
+)
+from jacobian.math.geometry.framework._bounds import (
+    MAX_FRAMEWORK_COORDINATE_WORK,
+    difference_work,
+    rational_parse_work,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.matrices._operation_models import MatrixRankResult
+from jacobian.math.matrices.values import SparseRationalMatrix
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"geometry.framework.{reason}", message)
+
+
+def _require_planar_framework_shape(
+    configuration: PointConfiguration,
+    graph: SimpleUndirectedGraph,
+) -> None:
+    """Require one planar realization of exactly the graph's labelled vertices."""
+
+    if len(configuration.points[0].coordinates) != 2:
+        raise _validation_error(
+            "configuration_must_be_planar",
+            "framework configuration points must have exactly two coordinates",
+        )
+    point_labels = tuple(point.label for point in configuration.points)
+    if len(graph.vertices) != len(point_labels) or set(graph.vertices) != set(
+        point_labels
+    ):
+        raise _validation_error(
+            "graph_vertices_must_match_point_labels",
+            "graph vertices must equal the configuration point-label set",
+        )
+
+
+def _raw_field(value: object, name: str) -> object:
+    if isinstance(value, dict):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _raw_rational_components(value: object) -> tuple[str, str] | None:
+    numerator = _raw_field(value, "num")
+    denominator = _raw_field(value, "den")
+    if not isinstance(numerator, str) or not isinstance(denominator, str):
+        return None
+    return numerator, denominator
+
+
+def _raw_coordinate_map(
+    raw_points: list[object] | tuple[object, ...],
+) -> tuple[
+    dict[str, tuple[tuple[str, str], tuple[str, str]]],
+    int,
+]:
+    coordinates: dict[str, tuple[tuple[str, str], tuple[str, str]]] = {}
+    source_parse_work = 0
+    for raw_point in raw_points:
+        label = _raw_field(raw_point, "label")
+        raw_coordinates = _raw_field(raw_point, "coordinates")
+        if not isinstance(label, str) or not isinstance(raw_coordinates, (list, tuple)):
+            continue
+        if len(raw_coordinates) != 2:
+            raise _validation_error(
+                "configuration_must_be_planar",
+                "framework configuration points must have exactly two coordinates",
+            )
+        component_pairs = tuple(
+            components
+            for raw_coordinate in raw_coordinates
+            if (components := _raw_rational_components(raw_coordinate)) is not None
+        )
+        source_parse_work += sum(map(rational_parse_work, component_pairs))
+        if source_parse_work > MAX_FRAMEWORK_COORDINATE_WORK:
+            raise _coordinate_work_error()
+        if len(component_pairs) == 2:
+            coordinates[label] = (component_pairs[0], component_pairs[1])
+    return coordinates, source_parse_work
+
+
+def _coordinate_work_error() -> PydanticCustomError:
+    return _validation_error(
+        "coordinate_work_exceeds_bound",
+        "framework coordinate normalization and edge differences exceed "
+        f"the {MAX_FRAMEWORK_COORDINATE_WORK:,}-unit work bound",
+    )
+
+
+def _require_raw_execution_envelope(data: object) -> None:
+    if not isinstance(data, dict):
+        return
+    raw_points = _raw_field(data.get("configuration"), "points")
+    raw_edges = _raw_field(data.get("graph"), "edges")
+    if not isinstance(raw_points, (list, tuple)):
+        return
+    if len(raw_points) > MAX_POINTS:
+        raise _validation_error(
+            "point_count_exceeds_bound",
+            f"framework configurations contain at most {MAX_POINTS} points",
+        )
+    coordinates, total_work = _raw_coordinate_map(raw_points)
+    if not isinstance(raw_edges, (list, tuple)):
+        return
+    if len(raw_edges) > MAX_PAIRS:
+        raise _validation_error(
+            "edge_count_exceeds_bound",
+            f"a graph on a framework configuration contains at most {MAX_PAIRS} edges",
+        )
+    for raw_edge in raw_edges:
+        if not isinstance(raw_edge, (list, tuple)) or len(raw_edge) != 2:
+            continue
+        left_label, right_label = raw_edge
+        if left_label not in coordinates or right_label not in coordinates:
+            continue
+        total_work += sum(
+            difference_work(left_coordinate, right_coordinate)
+            for left_coordinate, right_coordinate in zip(
+                coordinates[left_label], coordinates[right_label], strict=True
+            )
+        )
+        if total_work > MAX_FRAMEWORK_COORDINATE_WORK:
+            raise _coordinate_work_error()
+
+
+class PlanarRigidityProfileRequest(StrictModel):
+    """One labelled rational planar framework.
+
+    The configuration's point order defines the vertex and coordinate-column
+    axis. The graph must contain exactly the same labels. Graph edge tuple order
+    is not authoritative: the result derives a lexicographically sorted edge
+    axis.
+    """
+
+    configuration: PointConfiguration = Field(
+        description=(
+            "A labelled rational point configuration in exactly two dimensions; "
+            "its declared point order is the rigidity-matrix vertex axis."
+        )
+    )
+    graph: SimpleUndirectedGraph = Field(
+        description=(
+            "A simple undirected graph whose vertex set exactly equals the "
+            "configuration point-label set. Edge tuple order is ignored when "
+            "deriving the sorted result edge axis."
+        )
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_execution_envelope(cls, data: Any) -> Any:
+        """Reject excessive coordinate work before nested rational parsing."""
+
+        _require_raw_execution_envelope(data)
+        return canonicalize_json_containers(data)
+
+    @model_validator(mode="after")
+    def require_planar_framework(self) -> Self:
+        _require_planar_framework_shape(self.configuration, self.graph)
+        return self
+
+
+class PlanarRigidityProfile(StrictModel):
+    """Exact source-bound rigidity matrix and rational rank of one framework.
+
+    ``matrix_rank.matrix`` has one row per ``edge_axis`` entry and two columns
+    per ``vertex_axis`` entry. Columns ``2*i`` and ``2*i + 1`` are respectively
+    the x and y coordinates of vertex ``vertex_axis[i]``. A false
+    ``is_infinitesimally_rigid`` value says only that the supplied realization
+    fails the infinitesimal rank criterion; it is not a local- or global-
+    non-rigidity conclusion.
+    """
+
+    configuration: PointConfiguration
+    graph: SimpleUndirectedGraph
+    vertex_axis: tuple[str, ...] = Field(min_length=2, max_length=MAX_POINTS)
+    edge_axis: tuple[tuple[str, str], ...] = Field(max_length=MAX_PAIRS)
+    matrix_rank: MatrixRankResult
+    maximal_infinitesimal_rigidity_rank: int = Field(ge=1, le=2 * MAX_POINTS - 3)
+    is_infinitesimally_rigid: bool
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls.model_construct(**values)
+
+    @model_validator(mode="after")
+    def require_structural_source_binding(self) -> Self:
+        _require_planar_framework_shape(self.configuration, self.graph)
+        source_vertex_axis = tuple(point.label for point in self.configuration.points)
+        if self.vertex_axis != source_vertex_axis:
+            raise _validation_error(
+                "vertex_axis_must_follow_configuration_order",
+                "vertex axis must equal the configuration's declared point order",
+            )
+        if self.edge_axis != tuple(sorted(self.graph.edges)):
+            raise _validation_error(
+                "edge_axis_must_be_sorted_graph_edges",
+                "edge axis must be the lexicographically sorted graph edges",
+            )
+        matrix = self.matrix_rank.matrix
+        if not isinstance(matrix, SparseRationalMatrix):
+            raise _validation_error(
+                "rigidity_matrix_must_be_coordinate_sparse",
+                "rigidity matrix must use the coordinate-sparse rational carrier",
+            )
+        if matrix.row_count != len(self.edge_axis) or matrix.column_count != 2 * len(
+            self.vertex_axis
+        ):
+            raise _validation_error(
+                "rigidity_matrix_axes_must_match_framework_axes",
+                "rigidity matrix axes must be |edge_axis| by 2|vertex_axis|",
+            )
+        maximal_rank = 2 * len(self.vertex_axis) - 3
+        if self.maximal_infinitesimal_rigidity_rank != maximal_rank:
+            raise _validation_error(
+                "maximal_rank_must_equal_two_vertices_minus_three",
+                "maximal infinitesimal-rigidity rank must equal 2|V|-3",
+            )
+        if self.is_infinitesimally_rigid != (self.matrix_rank.rank == maximal_rank):
+            raise _validation_error(
+                "rigidity_decision_must_match_rank",
+                "infinitesimal-rigidity decision must equal rank == 2|V|-3",
+            )
+        return self
+
+
+__all__ = [
+    "PlanarRigidityProfile",
+    "PlanarRigidityProfileRequest",
+]

--- a/src/jacobian/math/geometry/framework/_tools.py
+++ b/src/jacobian/math/geometry/framework/_tools.py
@@ -1,0 +1,80 @@
+"""Exact planar framework operation declarations."""
+
+from typing import Any
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool
+from jacobian.math.geometry.framework._models import (
+    PlanarRigidityProfile,
+    PlanarRigidityProfileRequest,
+)
+from jacobian.math.geometry.framework.operations import planar_rigidity_profile
+
+
+def _run_planar_rigidity_profile(
+    request: PlanarRigidityProfileRequest,
+) -> PlanarRigidityProfile:
+    return planar_rigidity_profile(request.configuration, request.graph)
+
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="geometry.framework.planar_rigidity_profile.compute",
+        title="Compute an exact planar framework rigidity profile",
+        description=(
+            "Given a labelled rational planar point configuration and a simple "
+            "undirected graph on exactly the same labels, construct the exact "
+            "coordinate-sparse rigidity matrix on the configuration's vertex "
+            "axis and the lexicographically sorted graph-edge axis, then return "
+            "its exact rational rank and pivot columns. Rank 2|V|-3 establishes "
+            "infinitesimal rigidity of the supplied realization; a smaller rank "
+            "does not decide local or global rigidity."
+        ),
+        request_type=PlanarRigidityProfileRequest,
+        result_type=PlanarRigidityProfile,
+        run=_run_planar_rigidity_profile,
+        tags=("geometry", "framework", "rigidity-matrix", "exact-rational"),
+        examples=(
+            example(
+                "rational_triangle",
+                "Compute the exact rigidity matrix and rank of a non-collinear "
+                "rational triangle; the graph labels must exactly match the "
+                "planar configuration labels.",
+                {
+                    "configuration": {
+                        "points": [
+                            {
+                                "label": "a",
+                                "coordinates": [
+                                    {"num": "0", "den": "1"},
+                                    {"num": "0", "den": "1"},
+                                ],
+                            },
+                            {
+                                "label": "b",
+                                "coordinates": [
+                                    {"num": "1", "den": "1"},
+                                    {"num": "0", "den": "1"},
+                                ],
+                            },
+                            {
+                                "label": "c",
+                                "coordinates": [
+                                    {"num": "0", "den": "1"},
+                                    {"num": "1", "den": "1"},
+                                ],
+                            },
+                        ]
+                    },
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["b", "c"], ["a", "c"], ["a", "b"]],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/geometry/framework/operations.py
+++ b/src/jacobian/math/geometry/framework/operations.py
@@ -1,0 +1,237 @@
+"""Exact planar framework rigidity operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import NoReturn
+
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+)
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.exact._models import PointConfiguration
+from jacobian.math.geometry.framework._bounds import (
+    MAX_FRAMEWORK_COORDINATE_WORK,
+    difference_work,
+    rational_parse_work,
+)
+from jacobian.math.geometry.framework._models import (
+    PlanarRigidityProfile,
+    _require_planar_framework_shape,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.matrices._operation_models import MAX_INPUT_SCALAR_DIGITS
+from jacobian.math.matrices.operations import rank_result
+from jacobian.math.matrices.values import (
+    SparseRationalMatrix,
+    SparseRationalMatrixEntry,
+)
+
+_MATRIX_SCALAR_LIMIT = 10**MAX_INPUT_SCALAR_DIGITS
+
+
+@dataclass(frozen=True, slots=True)
+class _FrameworkAdmission:
+    vertex_axis: tuple[str, ...]
+    edge_axis: tuple[tuple[str, str], ...]
+    coordinates: dict[str, tuple[Fraction, Fraction]]
+    source_parse_work: int
+    coordinate_difference_work: int
+
+
+def _reject(location: tuple[str | int, ...], code: str, message: str) -> NoReturn:
+    raise OperationDomainValidationError(
+        location=location,
+        code=f"geometry.framework.{code}",
+        message=message,
+    )
+
+
+def _admit_framework(
+    configuration: PointConfiguration,
+    graph: SimpleUndirectedGraph,
+) -> _FrameworkAdmission:
+    try:
+        _require_planar_framework_shape(configuration, graph)
+    except PydanticCustomError as exc:
+        _reject(("configuration",), exc.type, exc.message())
+
+    vertex_axis = tuple(point.label for point in configuration.points)
+    edge_axis = tuple(sorted(graph.edges))
+    canonical_coordinates = {
+        point.label: (point.coordinates[0], point.coordinates[1])
+        for point in configuration.points
+    }
+    source_parse_work = sum(
+        rational_parse_work((coordinate.num, coordinate.den))
+        for coordinates in canonical_coordinates.values()
+        for coordinate in coordinates
+    )
+    if source_parse_work > MAX_FRAMEWORK_COORDINATE_WORK:
+        _reject(
+            ("configuration", "points"),
+            "coordinate_work_exceeds_bound",
+            "framework coordinate normalization and edge differences exceed "
+            f"the {MAX_FRAMEWORK_COORDINATE_WORK:,}-unit work bound",
+        )
+    coordinate_difference_work = 0
+    for left_label, right_label in edge_axis:
+        left = canonical_coordinates[left_label]
+        right = canonical_coordinates[right_label]
+        coordinate_difference_work += sum(
+            difference_work(
+                (left_coordinate.num, left_coordinate.den),
+                (right_coordinate.num, right_coordinate.den),
+            )
+            for left_coordinate, right_coordinate in zip(left, right, strict=True)
+        )
+        if (
+            source_parse_work + coordinate_difference_work
+            > MAX_FRAMEWORK_COORDINATE_WORK
+        ):
+            _reject(
+                ("configuration", "points"),
+                "coordinate_work_exceeds_bound",
+                "framework coordinate normalization and edge differences exceed "
+                f"the {MAX_FRAMEWORK_COORDINATE_WORK:,}-unit work bound",
+            )
+
+    coordinates = {
+        label: (values[0].as_fraction(), values[1].as_fraction())
+        for label, values in canonical_coordinates.items()
+    }
+    return _FrameworkAdmission(
+        vertex_axis=vertex_axis,
+        edge_axis=edge_axis,
+        coordinates=coordinates,
+        source_parse_work=source_parse_work,
+        coordinate_difference_work=coordinate_difference_work,
+    )
+
+
+def _matrix_scalar(value: Fraction) -> CanonicalRational:
+    numerator = value.numerator
+    denominator = value.denominator
+    if abs(numerator) >= _MATRIX_SCALAR_LIMIT or denominator >= _MATRIX_SCALAR_LIMIT:
+        _reject(
+            ("configuration", "points"),
+            "rigidity_matrix_scalar_exceeds_rank_bound",
+            "a derived rigidity-matrix scalar exceeds matrix.rank.compute's "
+            f"{MAX_INPUT_SCALAR_DIGITS}-digit input bound",
+        )
+    return CanonicalRational.from_fraction(value)
+
+
+def _rigidity_matrix(admission: _FrameworkAdmission) -> SparseRationalMatrix:
+    vertex_positions = {
+        label: index for index, label in enumerate(admission.vertex_axis)
+    }
+    entries: list[SparseRationalMatrixEntry] = []
+    for row, (left_label, right_label) in enumerate(admission.edge_axis):
+        left = admission.coordinates[left_label]
+        right = admission.coordinates[right_label]
+        left_vertex = vertex_positions[left_label]
+        right_vertex = vertex_positions[right_label]
+        row_entries: list[SparseRationalMatrixEntry] = []
+        for coordinate, (left_value, right_value) in enumerate(
+            zip(left, right, strict=True)
+        ):
+            difference = left_value - right_value
+            if difference == 0:
+                continue
+            row_entries.extend(
+                (
+                    SparseRationalMatrixEntry(
+                        row=row,
+                        column=2 * left_vertex + coordinate,
+                        value=_matrix_scalar(difference),
+                    ),
+                    SparseRationalMatrixEntry(
+                        row=row,
+                        column=2 * right_vertex + coordinate,
+                        value=_matrix_scalar(-difference),
+                    ),
+                )
+            )
+        entries.extend(sorted(row_entries, key=lambda entry: entry.column))
+    return SparseRationalMatrix(
+        row_count=len(admission.edge_axis),
+        column_count=2 * len(admission.vertex_axis),
+        entries=tuple(entries),
+    )
+
+
+def _reserve_profile_output_bytes(
+    configuration: PointConfiguration,
+    graph: SimpleUndirectedGraph,
+    admission: _FrameworkAdmission,
+    matrix: SparseRationalMatrix,
+) -> int:
+    """Preflight the largest canonical profile for this exact retained source."""
+
+    rank_bound = min(matrix.row_count, matrix.column_count)
+    largest_pivots = tuple(range(matrix.column_count - rank_bound, matrix.column_count))
+    maximal_rank = 2 * len(admission.vertex_axis) - 3
+    candidate = {
+        "configuration": configuration.model_dump(mode="json"),
+        "graph": graph.model_dump(mode="json"),
+        "vertex_axis": list(admission.vertex_axis),
+        "edge_axis": [list(edge) for edge in admission.edge_axis],
+        "matrix_rank": {
+            "matrix": matrix.model_dump(mode="json"),
+            "rank": rank_bound,
+            "pivot_columns": list(largest_pivots),
+        },
+        "maximal_infinitesimal_rigidity_rank": maximal_rank,
+        "is_infinitesimally_rigid": False,
+    }
+    try:
+        return len(encode_strict_json(candidate))
+    except CanonicalizationError:
+        _reject(
+            ("configuration",),
+            "result_exceeds_canonical_output",
+            "the complete source-bound rigidity profile would exceed the "
+            f"{CanonicalLimits().max_output_bytes:,}-byte canonical output limit",
+        )
+
+
+def planar_rigidity_profile(
+    configuration: PointConfiguration,
+    graph: SimpleUndirectedGraph,
+) -> PlanarRigidityProfile:
+    """Return the exact planar rigidity matrix and rational rank."""
+
+    admission = _admit_framework(configuration, graph)
+    matrix = _rigidity_matrix(admission)
+    _reserve_profile_output_bytes(configuration, graph, admission, matrix)
+    try:
+        matrix_rank = rank_result(matrix)
+    except OperationDomainValidationError as exc:
+        error = exc.errors()[0]
+        _reject(
+            ("configuration", "points"),
+            "rigidity_matrix_rank_admission_failed",
+            "the derived rigidity matrix is outside matrix.rank.compute "
+            f"admission: {error['msg']}",
+        )
+
+    maximal_rank = 2 * len(admission.vertex_axis) - 3
+    return PlanarRigidityProfile._from_kernel(
+        configuration=configuration,
+        graph=graph,
+        vertex_axis=admission.vertex_axis,
+        edge_axis=admission.edge_axis,
+        matrix_rank=matrix_rank,
+        maximal_infinitesimal_rigidity_rank=maximal_rank,
+        is_infinitesimally_rigid=matrix_rank.rank == maximal_rank,
+    )
+
+
+__all__ = ["planar_rigidity_profile"]

--- a/tests/math/geometry/framework/test_planar_rigidity_profile.py
+++ b/tests/math/geometry/framework/test_planar_rigidity_profile.py
@@ -1,0 +1,535 @@
+"""Contract evidence for exact planar framework rigidity profiles."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+from tests.fixtures.accounting import assert_charged_work_parity
+
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.exact._models import (
+    LabelledRationalPoint,
+    PointConfiguration,
+)
+from jacobian.math.geometry.framework._bounds import (
+    MAX_FRAMEWORK_COORDINATE_WORK,
+    difference_work,
+    rational_parse_work,
+)
+from jacobian.math.geometry.framework._models import (
+    PlanarRigidityProfile,
+    PlanarRigidityProfileRequest,
+)
+from jacobian.math.geometry.framework._tools import TOOLS
+from jacobian.math.geometry.framework.operations import (
+    _admit_framework,
+    _reserve_profile_output_bytes,
+    _rigidity_matrix,
+    planar_rigidity_profile,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.matrices._operation_models import MatrixRankRequest
+from jacobian.math.matrices.operations import rank_result
+from jacobian.math.matrices.values import SparseRationalMatrix
+
+
+def q(numerator: int, denominator: int = 1) -> CanonicalRational:
+    return CanonicalRational.from_fraction(Fraction(numerator, denominator))
+
+
+def configuration(
+    points: tuple[tuple[str, int, int], ...],
+) -> PointConfiguration:
+    return PointConfiguration(
+        points=tuple(
+            LabelledRationalPoint(label=label, coordinates=(q(x), q(y)))
+            for label, x, y in points
+        )
+    )
+
+
+def graph(
+    vertices: tuple[str, ...], edges: tuple[tuple[str, str], ...]
+) -> SimpleUndirectedGraph:
+    return SimpleUndirectedGraph(vertices=vertices, edges=edges)
+
+
+def sparse_entries(
+    matrix: SparseRationalMatrix,
+) -> dict[tuple[int, int], Fraction]:
+    return {
+        (entry.row, entry.column): entry.value.as_fraction() for entry in matrix.entries
+    }
+
+
+def rigidity_matrix(profile: PlanarRigidityProfile) -> SparseRationalMatrix:
+    matrix = profile.matrix_rank.matrix
+    assert isinstance(matrix, SparseRationalMatrix)
+    return matrix
+
+
+def test_catalog_publishes_only_the_planar_rigidity_profile() -> None:
+    assert {tool.operation_id for tool in TOOLS} == {
+        "geometry.framework.planar_rigidity_profile.compute"
+    }
+
+
+def test_catalog_request_parses_strict_canonical_json_arrays() -> None:
+    payload = TOOLS[0].examples[0].input
+
+    request = PlanarRigidityProfileRequest.model_validate_json(
+        encode_strict_json(payload), strict=True
+    )
+
+    assert tuple(point.label for point in request.configuration.points) == (
+        "a",
+        "b",
+        "c",
+    )
+    assert request.graph.edges == (("b", "c"), ("a", "c"), ("a", "b"))
+
+
+def test_native_api_exports_the_reused_framework_values() -> None:
+    import jacobian.math.geometry.framework as framework
+
+    assert framework.__all__ == [
+        "LabelledRationalPoint",
+        "PlanarRigidityProfile",
+        "PointConfiguration",
+        "SimpleUndirectedGraph",
+        "planar_rigidity_profile",
+    ]
+    assert framework.LabelledRationalPoint is LabelledRationalPoint
+    assert framework.PointConfiguration is PointConfiguration
+    assert framework.SimpleUndirectedGraph is SimpleUndirectedGraph
+    assert framework.PlanarRigidityProfile is PlanarRigidityProfile
+    assert framework.planar_rigidity_profile is planar_rigidity_profile
+
+
+@pytest.mark.parametrize("point_count", (0, 1))
+def test_framework_source_excludes_zero_and_one_vertex_configurations(
+    point_count: int,
+) -> None:
+    points = tuple(
+        LabelledRationalPoint(label=f"v{index}", coordinates=(q(index), q(0)))
+        for index in range(point_count)
+    )
+
+    with pytest.raises(ValidationError, match="at least 2 items"):
+        PointConfiguration(points=points)
+
+
+def test_noncollinear_triangle_has_full_infinitesimal_rank() -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 0, 1)))
+    source_graph = graph(("a", "b", "c"), (("b", "c"), ("a", "c"), ("a", "b")))
+
+    result = planar_rigidity_profile(source, source_graph)
+
+    assert result.configuration is source
+    assert result.graph is source_graph
+    assert result.vertex_axis == ("a", "b", "c")
+    assert result.edge_axis == (("a", "b"), ("a", "c"), ("b", "c"))
+    assert result.matrix_rank.rank == 3
+    assert result.matrix_rank.pivot_columns == (0, 1, 2)
+    assert result.maximal_infinitesimal_rigidity_rank == 3
+    assert result.is_infinitesimally_rigid is True
+    assert sparse_entries(rigidity_matrix(result)) == {
+        (0, 0): Fraction(-1),
+        (0, 2): Fraction(1),
+        (1, 1): Fraction(-1),
+        (1, 5): Fraction(1),
+        (2, 2): Fraction(1),
+        (2, 3): Fraction(-1),
+        (2, 4): Fraction(-1),
+        (2, 5): Fraction(1),
+    }
+
+
+@pytest.mark.parametrize(
+    ("edges", "expected_rank", "expected_rigid"),
+    (
+        ((("a", "b"), ("b", "c"), ("c", "d"), ("a", "d")), 4, False),
+        (
+            (
+                ("a", "b"),
+                ("b", "c"),
+                ("c", "d"),
+                ("a", "d"),
+                ("a", "c"),
+            ),
+            5,
+            True,
+        ),
+    ),
+)
+def test_square_cycle_and_diagonal_distinguish_infinitesimal_rank(
+    edges: tuple[tuple[str, str], ...], expected_rank: int, expected_rigid: bool
+) -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 1, 1), ("d", 0, 1)))
+
+    result = planar_rigidity_profile(source, graph(("a", "b", "c", "d"), edges))
+
+    assert result.matrix_rank.rank == expected_rank
+    assert result.maximal_infinitesimal_rigidity_rank == 5
+    assert result.is_infinitesimally_rigid is expected_rigid
+
+
+def test_collinear_complete_triangle_fails_only_the_infinitesimal_criterion() -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 2, 0)))
+    source_graph = graph(("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c")))
+
+    result = planar_rigidity_profile(source, source_graph)
+
+    assert result.matrix_rank.rank == 2
+    assert result.maximal_infinitesimal_rigidity_rank == 3
+    assert result.is_infinitesimally_rigid is False
+
+
+def test_edge_tuple_permutation_has_one_deterministic_derived_axis() -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 0, 1)))
+    first = graph(("a", "b", "c"), (("b", "c"), ("a", "b"), ("a", "c")))
+    second = graph(("c", "a", "b"), (("a", "c"), ("b", "c"), ("a", "b")))
+
+    left = planar_rigidity_profile(source, first)
+    right = planar_rigidity_profile(source, second)
+
+    assert left.edge_axis == right.edge_axis
+    assert left.matrix_rank.matrix == right.matrix_rank.matrix
+    assert left.matrix_rank.rank == right.matrix_rank.rank
+    assert left.matrix_rank.pivot_columns == right.matrix_rank.pivot_columns
+
+
+def test_empty_edge_graph_retains_zero_row_and_coordinate_axes() -> None:
+    source = configuration((("right", 1, 0), ("left", 0, 0)))
+
+    result = planar_rigidity_profile(source, graph(("left", "right"), ()))
+
+    matrix = rigidity_matrix(result)
+    assert matrix.row_count == 0
+    assert matrix.column_count == 4
+    assert matrix.entries == ()
+    assert result.vertex_axis == ("right", "left")
+    assert result.edge_axis == ()
+    assert result.matrix_rank.rank == 0
+    assert result.matrix_rank.pivot_columns == ()
+    assert result.is_infinitesimally_rigid is False
+
+
+def test_repeated_coordinates_produce_an_exact_zero_edge_row() -> None:
+    source = configuration((("a", 0, 0), ("b", 0, 0), ("c", 1, 0)))
+
+    result = planar_rigidity_profile(
+        source,
+        graph(("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c"))),
+    )
+
+    matrix = rigidity_matrix(result)
+    assert matrix.row_count == 3
+    assert not any(entry.row == 0 for entry in matrix.entries)
+    assert result.matrix_rank.rank == 2
+    assert result.is_infinitesimally_rigid is False
+
+
+@pytest.mark.parametrize(
+    "bad_graph",
+    (
+        graph(("a", "b"), (("a", "b"),)),
+        graph(("a", "b", "c", "d"), (("a", "b"),)),
+        graph(("a", "b", "d"), (("a", "b"),)),
+    ),
+)
+def test_graph_labels_must_equal_configuration_labels_before_execution(
+    bad_graph: SimpleUndirectedGraph,
+) -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 0, 1)))
+
+    with pytest.raises(ValidationError, match="point-label set"):
+        PlanarRigidityProfileRequest(configuration=source, graph=bad_graph)
+    with pytest.raises(OperationDomainValidationError, match="point-label set"):
+        planar_rigidity_profile(source, bad_graph)
+
+
+def test_configuration_must_be_planar() -> None:
+    source = PointConfiguration(
+        points=(
+            LabelledRationalPoint(label="a", coordinates=(q(0), q(0), q(0))),
+            LabelledRationalPoint(label="b", coordinates=(q(1), q(0), q(0))),
+        )
+    )
+    source_graph = graph(("a", "b"), (("a", "b"),))
+
+    with pytest.raises(ValidationError, match="exactly two coordinates"):
+        PlanarRigidityProfileRequest(configuration=source, graph=source_graph)
+    with pytest.raises(OperationDomainValidationError, match="exactly two coordinates"):
+        planar_rigidity_profile(source, source_graph)
+
+
+def test_derived_matrix_composes_unchanged_with_matrix_rank_compute() -> None:
+    source = configuration((("a", 0, 0), ("b", 2, 0), ("c", 2, 1), ("d", 0, 1)))
+    source_graph = graph(
+        ("a", "b", "c", "d"),
+        (("a", "b"), ("b", "c"), ("c", "d"), ("a", "d"), ("a", "c")),
+    )
+
+    profile = planar_rigidity_profile(source, source_graph)
+    serialized_matrix = profile.matrix_rank.matrix.model_dump(mode="json")
+    request = MatrixRankRequest.model_validate({"matrix": serialized_matrix})
+    composed = rank_result(request.matrix)
+
+    assert request.matrix == profile.matrix_rank.matrix
+    assert composed == profile.matrix_rank
+
+
+def test_profile_round_trip_is_structural_and_source_bound() -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 0, 1)))
+    result = planar_rigidity_profile(
+        source,
+        graph(("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c"))),
+    )
+
+    assert (
+        PlanarRigidityProfile.model_validate_json(result.model_dump_json(), strict=True)
+        == result
+    )
+    forged = result.model_dump(mode="json")
+    forged["edge_axis"] = [["a", "c"], ["a", "b"], ["b", "c"]]
+    with pytest.raises(ValidationError, match="lexicographically sorted"):
+        PlanarRigidityProfile.model_validate(forged)
+
+
+def test_output_reservation_covers_sources_axes_and_one_nested_matrix() -> None:
+    source = configuration((("a", 0, 0), ("b", 1, 0), ("c", 0, 1)))
+    source_graph = graph(("a", "b", "c"), (("b", "c"), ("a", "c"), ("a", "b")))
+    admission = _admit_framework(source, source_graph)
+    matrix = _rigidity_matrix(admission)
+
+    reserved_bytes = _reserve_profile_output_bytes(
+        source, source_graph, admission, matrix
+    )
+    result = planar_rigidity_profile(source, source_graph)
+    payload = result.model_dump(mode="json")
+    actual_bytes = len(encode_strict_json(payload))
+
+    assert set(payload) == {
+        "configuration",
+        "graph",
+        "vertex_axis",
+        "edge_axis",
+        "matrix_rank",
+        "maximal_infinitesimal_rigidity_rank",
+        "is_infinitesimally_rigid",
+    }
+    assert payload["matrix_rank"]["matrix"] == matrix.model_dump(mode="json")
+    assert actual_bytes <= reserved_bytes <= CanonicalLimits().max_output_bytes
+
+
+def test_output_reservation_admits_the_maximal_framework_matrix_shape() -> None:
+    source = configuration(
+        tuple((f"v{index:02d}", index, index * index) for index in range(64))
+    )
+    labels = tuple(point.label for point in source.points)
+    edges = tuple(
+        (labels[left], labels[right])
+        for left in range(len(labels))
+        for right in range(left + 1, len(labels))
+    )
+    source_graph = graph(labels, tuple(reversed(edges)))
+    admission = _admit_framework(source, source_graph)
+    matrix = _rigidity_matrix(admission)
+
+    reserved_bytes = _reserve_profile_output_bytes(
+        source, source_graph, admission, matrix
+    )
+
+    assert matrix.row_count == 2_016
+    assert matrix.column_count == 128
+    assert len(matrix.entries) == 8_064
+    assert admission.edge_axis == edges
+    assert reserved_bytes <= CanonicalLimits().max_output_bytes
+
+
+def test_rigidity_rows_replay_the_squared_length_differentials() -> None:
+    source = PointConfiguration(
+        points=(
+            LabelledRationalPoint(label="v", coordinates=(q(1, 3), q(-2, 5))),
+            LabelledRationalPoint(label="u", coordinates=(q(-4, 7), q(3, 2))),
+            LabelledRationalPoint(label="w", coordinates=(q(5, 6), q(1, 4))),
+        )
+    )
+    source_graph = graph(("u", "v", "w"), (("v", "w"), ("u", "w"), ("u", "v")))
+
+    result = planar_rigidity_profile(source, source_graph)
+    matrix = rigidity_matrix(result)
+    actual = sparse_entries(matrix)
+    point_coordinates = {
+        point.label: tuple(value.as_fraction() for value in point.coordinates)
+        for point in source.points
+    }
+    positions = {label: index for index, label in enumerate(result.vertex_axis)}
+    expected: dict[tuple[int, int], Fraction] = {}
+    for row, (left, right) in enumerate(result.edge_axis):
+        for coordinate in range(2):
+            difference = (
+                point_coordinates[left][coordinate]
+                - point_coordinates[right][coordinate]
+            )
+            if difference:
+                expected[(row, 2 * positions[left] + coordinate)] = difference
+                expected[(row, 2 * positions[right] + coordinate)] = -difference
+
+    assert matrix.row_count == len(result.edge_axis)
+    assert matrix.column_count == 2 * len(result.vertex_axis)
+    assert actual == expected
+
+
+def test_coordinate_scalar_boundary_is_owned_before_rank_backend() -> None:
+    accepted_value = 10**255
+    accepted = configuration((("a", 0, 0), ("b", accepted_value, 0)))
+    source_graph = graph(("a", "b"), (("a", "b"),))
+
+    result = planar_rigidity_profile(accepted, source_graph)
+
+    assert result.matrix_rank.rank == 1
+    rejected_value = 10**256
+    rejected = configuration((("a", 0, 0), ("b", rejected_value, 0)))
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="256-digit input bound",
+    ):
+        planar_rigidity_profile(rejected, source_graph)
+
+
+def test_coordinate_work_admission_charges_every_derived_difference() -> None:
+    height = 50
+    value = 10 ** (height - 1)
+    source = configuration(
+        tuple((f"v{index:02d}", index * value, index) for index in range(32))
+    )
+    labels = tuple(point.label for point in source.points)
+    edges = tuple(
+        (labels[left], labels[right])
+        for left in range(len(labels))
+        for right in range(left + 1, len(labels))
+    )
+    source_graph = graph(labels, edges)
+
+    admission = _admit_framework(source, source_graph)
+
+    canonical_coordinates = {point.label: point.coordinates for point in source.points}
+    executed = {
+        "source_parse": sum(
+            rational_parse_work((coordinate.num, coordinate.den))
+            for point in source.points
+            for coordinate in point.coordinates
+        ),
+        "coordinate_difference": sum(
+            difference_work(
+                (
+                    canonical_coordinates[left][coordinate].num,
+                    canonical_coordinates[left][coordinate].den,
+                ),
+                (
+                    canonical_coordinates[right][coordinate].num,
+                    canonical_coordinates[right][coordinate].den,
+                ),
+            )
+            for left, right in edges
+            for coordinate in range(2)
+        ),
+    }
+    charged = {
+        "source_parse": admission.source_parse_work,
+        "coordinate_difference": admission.coordinate_difference_work,
+    }
+    assert admission.source_parse_work + admission.coordinate_difference_work <= (
+        MAX_FRAMEWORK_COORDINATE_WORK
+    )
+    assert charged == executed
+    assert_charged_work_parity(charged=charged, executed=executed)
+
+
+def test_coordinate_work_accepts_and_rejects_the_exact_edge_boundary() -> None:
+    base = 10**39
+    source = configuration(
+        tuple((f"v{index:02d}", base + index, base + 2 * index) for index in range(64))
+    )
+    labels = tuple(point.label for point in source.points)
+    all_edges = tuple(
+        (labels[left], labels[right])
+        for left in range(len(labels))
+        for right in range(left + 1, len(labels))
+    )
+    source_parse_work = sum(
+        rational_parse_work((coordinate.num, coordinate.den))
+        for point in source.points
+        for coordinate in point.coordinates
+    )
+    first_left, first_right = all_edges[0]
+    coordinates = {point.label: point.coordinates for point in source.points}
+    edge_work = sum(
+        difference_work(
+            (coordinates[first_left][axis].num, coordinates[first_left][axis].den),
+            (
+                coordinates[first_right][axis].num,
+                coordinates[first_right][axis].den,
+            ),
+        )
+        for axis in range(2)
+    )
+    accepted_edge_count = (
+        MAX_FRAMEWORK_COORDINATE_WORK - source_parse_work
+    ) // edge_work
+    accepted_graph = graph(labels, all_edges[:accepted_edge_count])
+    rejected_graph = graph(labels, all_edges[: accepted_edge_count + 1])
+
+    admission = _admit_framework(source, accepted_graph)
+
+    assert admission.source_parse_work == source_parse_work
+    assert admission.coordinate_difference_work == accepted_edge_count * edge_work
+    assert source_parse_work + accepted_edge_count * edge_work <= (
+        MAX_FRAMEWORK_COORDINATE_WORK
+    )
+    assert source_parse_work + (accepted_edge_count + 1) * edge_work > (
+        MAX_FRAMEWORK_COORDINATE_WORK
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="work bound"):
+        planar_rigidity_profile(source, rejected_graph)
+
+    with pytest.raises(ValidationError, match="work bound"):
+        PlanarRigidityProfileRequest.model_validate(
+            {
+                "configuration": source.model_dump(mode="json"),
+                "graph": rejected_graph.model_dump(mode="json"),
+            }
+        )
+
+
+def test_edgeless_native_call_still_enforces_source_parse_work() -> None:
+    large_coordinate = CanonicalRational(
+        num="1" + "0" * (MAX_CANONICAL_RATIONAL_DIGITS - 1),
+        den="9" * MAX_CANONICAL_RATIONAL_DIGITS,
+    )
+    source = PointConfiguration(
+        points=(
+            LabelledRationalPoint(
+                label="a", coordinates=(large_coordinate, large_coordinate)
+            ),
+            LabelledRationalPoint(
+                label="b", coordinates=(large_coordinate, large_coordinate)
+            ),
+        )
+    )
+    source_work = sum(
+        rational_parse_work((coordinate.num, coordinate.den))
+        for point in source.points
+        for coordinate in point.coordinates
+    )
+
+    assert source_work > MAX_FRAMEWORK_COORDINATE_WORK
+    with pytest.raises(OperationDomainValidationError, match="work bound"):
+        planar_rigidity_profile(source, graph(("a", "b"), ()))


### PR DESCRIPTION
Closes #2905.

This PR adds the missing source-bound operation for one realised planar framework. It is stacked on #3066 because the result deliberately reuses that PR's dimension-retaining sparse rational matrix and exact sparse-rank path.

## Design

`geometry.framework.planar_rigidity_profile.compute` accepts the existing labelled rational `PointConfiguration` and `SimpleUndirectedGraph`. The configuration order defines the vertex and coordinate-column axis. The result derives a lexicographically sorted edge axis, so permuting the graph's edge tuple cannot change the matrix, rank, or pivots.

Each edge row is the exact differential of its squared-length constraint, with the common factor 2 omitted. The result retains the source framework, axes, coordinate-sparse matrix, exact rank and pivot columns, the bound `2|V|-3`, and the corresponding infinitesimal-rigidity decision.

The rank is delegated once to the existing exact sparse-rank operation, which uses the maintained SymPy sparse linear-algebra kernel. No numerical tolerance or new algebra backend is introduced. Admission prices raw rational parsing, every coordinate difference, derived scalar height, the sparse-rank work envelope, and the complete retained-source result. The outer output reservation counts the nested matrix exactly once.

A false decision means only that the supplied realisation fails the infinitesimal rank criterion. It does not claim that the abstract graph or framework is locally, globally, or generically non-rigid.

## Evidence

- 25 focused geometry tests, including triangle, square-cycle, diagonal, collinear, empty-edge, repeated-coordinate, edge-permutation, row-replay, and exact boundary regressions
- 113 catalog tests
- 811 advertised-example/catalog integration tests
- 35 architecture tests
- scoped Ruff, formatting, and mypy
- import contracts: 4 kept, 0 broken
- `git diff --check`

## Suggested review order

1. `_models.py` and `_bounds.py` for the public semantics and admission envelope
2. `operations.py` for matrix construction and exact-rank composition
3. the focused test module for defining and adversarial cases
