### PR TITLE
Certify isolated real roots in rational boxes

### DIFF
--- a/src/jacobian/math/polynomials/intervals/_models.py
+++ b/src/jacobian/math/polynomials/intervals/_models.py
@@ -260,7 +260,7 @@ def _estimate_growth(
 def _require_enclosure_preflight(
     polynomial: RationalPolynomial,
     box: RationalBox,
-) -> None:
+) -> _GrowthEstimate:
     if polynomial.domain != box.domain or polynomial.variables != box.variables:
         raise _validation_error(
             "polynomial box must use the polynomial's complete ordered axis and QQ parent"
@@ -299,6 +299,7 @@ def _require_enclosure_preflight(
             "polynomial-box enclosure result would exceed the "
             f"{MAX_BOX_ENCLOSURE_RESULT_BYTES}-byte canonical output bound"
         )
+    return growth
 
 
 class PolynomialBoxEnclosureRequest(StrictModel):

--- a/src/jacobian/math/polynomials/root_boxes/__init__.py
+++ b/src/jacobian/math/polynomials/root_boxes/__init__.py
@@ -1,0 +1,5 @@
+"""Exact local real-root certification for rational polynomial systems."""
+
+from jacobian.math.polynomials.root_boxes.operations import certify_real_root_box
+
+__all__ = ["certify_real_root_box"]

--- a/src/jacobian/math/polynomials/root_boxes/_kernel.py
+++ b/src/jacobian/math/polynomials/root_boxes/_kernel.py
@@ -1,0 +1,366 @@
+"""Exact rational midpoint Krawczyk kernel for polynomial systems."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Literal
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.analysis.intervals import RationalBox
+
+from ._models import (
+    MAX_ROOT_BOX_INTERMEDIATE_DIGITS,
+    MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS,
+)
+
+type FractionInterval = tuple[Fraction, Fraction]
+type FractionMatrix = tuple[tuple[Fraction, ...], ...]
+type FractionIntervalMatrix = tuple[tuple[FractionInterval, ...], ...]
+
+
+class RootBoxKernelBudgetError(ValueError):
+    """Exact interval-matrix arithmetic exceeded its admitted height bound."""
+
+
+@dataclass(frozen=True, slots=True)
+class MidpointKernelData:
+    center: tuple[Fraction, ...]
+    value_at_center: tuple[Fraction, ...]
+    jacobian_at_center: FractionMatrix
+    jacobian_enclosure: FractionIntervalMatrix
+
+
+@dataclass(frozen=True, slots=True)
+class KrawczykKernelData(MidpointKernelData):
+    preconditioner: FractionMatrix
+    krawczyk_image: tuple[FractionInterval, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentExclusionKernelResult:
+    status: Literal["NO_ROOT_COMPONENT"]
+    component_index: int
+    enclosure: FractionInterval
+
+
+@dataclass(frozen=True, slots=True)
+class SingularMidpointKernelResult:
+    status: Literal["UNKNOWN_SINGULAR_MIDPOINT"]
+    data: MidpointKernelData
+
+
+@dataclass(frozen=True, slots=True)
+class KrawczykKernelResult:
+    status: Literal[
+        "CERTIFIED_UNIQUE_NONSINGULAR",
+        "NO_ROOT_KRAWCZYK",
+        "UNKNOWN_KRAWCZYK",
+    ]
+    evidence: KrawczykKernelData
+
+
+type RootBoxKernelResult = (
+    ComponentExclusionKernelResult | SingularMidpointKernelResult | KrawczykKernelResult
+)
+
+
+def _component_digits(value: Fraction) -> int:
+    return max(
+        len(format_canonical_integer(abs(value.numerator))),
+        len(format_canonical_integer(value.denominator)),
+    )
+
+
+def _numerator_digits(value: Fraction) -> int:
+    return len(format_canonical_integer(abs(value.numerator)))
+
+
+def _denominator_digits(value: Fraction) -> int:
+    return len(format_canonical_integer(value.denominator))
+
+
+def _require_height(value: Fraction, *, maximum: int, label: str) -> Fraction:
+    if _component_digits(value) > maximum:
+        raise RootBoxKernelBudgetError(
+            f"{label} exceeds the {maximum:,}-digit exact-arithmetic bound"
+        )
+    return value
+
+
+def _checked_add(left: Fraction, right: Fraction) -> Fraction:
+    if (
+        max(
+            _denominator_digits(left) + _denominator_digits(right),
+            _numerator_digits(left) + _denominator_digits(right) + 1,
+            _numerator_digits(right) + _denominator_digits(left) + 1,
+        )
+        > MAX_ROOT_BOX_INTERMEDIATE_DIGITS
+    ):
+        raise RootBoxKernelBudgetError(
+            "rational addition exceeds the admitted intermediate-height bound"
+        )
+    return _require_height(
+        left + right,
+        maximum=MAX_ROOT_BOX_INTERMEDIATE_DIGITS,
+        label="rational sum",
+    )
+
+
+def _checked_multiply(left: Fraction, right: Fraction) -> Fraction:
+    if _component_digits(left) + _component_digits(right) > (
+        MAX_ROOT_BOX_INTERMEDIATE_DIGITS + 1
+    ):
+        raise RootBoxKernelBudgetError(
+            "rational multiplication exceeds the admitted intermediate-height bound"
+        )
+    return _require_height(
+        left * right,
+        maximum=MAX_ROOT_BOX_INTERMEDIATE_DIGITS,
+        label="rational product",
+    )
+
+
+def _add_intervals(
+    left: FractionInterval,
+    right: FractionInterval,
+) -> FractionInterval:
+    return (
+        _checked_add(left[0], right[0]),
+        _checked_add(left[1], right[1]),
+    )
+
+
+def _multiply_intervals(
+    left: FractionInterval,
+    right: FractionInterval,
+) -> FractionInterval:
+    products = tuple(
+        _checked_multiply(left_value, right_value)
+        for left_value in left
+        for right_value in right
+    )
+    return min(products), max(products)
+
+
+def _scale_interval(
+    interval: FractionInterval,
+    scalar: Fraction,
+) -> FractionInterval:
+    lower = _checked_multiply(interval[0], scalar)
+    upper = _checked_multiply(interval[1], scalar)
+    return (lower, upper) if scalar >= 0 else (upper, lower)
+
+
+def _invert_matrix(matrix: FractionMatrix) -> FractionMatrix | None:
+    """Invert a bounded exact matrix through python-flint, or report singularity."""
+
+    from flint import fmpq, fmpq_mat
+
+    order = len(matrix)
+    backend = fmpq_mat(
+        [[fmpq(value.numerator, value.denominator) for value in row] for row in matrix]
+    )
+    try:
+        inverse = backend.inv()
+    except ZeroDivisionError:
+        return None
+    result = tuple(
+        tuple(
+            _require_height(
+                Fraction(
+                    int(inverse[row, column].p),
+                    int(inverse[row, column].q),
+                ),
+                maximum=MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS,
+                label="exact midpoint-Jacobian inverse component",
+            )
+            for column in range(order)
+        )
+        for row in range(order)
+    )
+    return result
+
+
+def _matrix_interval_product(
+    left: FractionMatrix,
+    right: FractionIntervalMatrix,
+) -> FractionIntervalMatrix:
+    order = len(left)
+    rows: list[tuple[FractionInterval, ...]] = []
+    for row in range(order):
+        output_row: list[FractionInterval] = []
+        for column in range(order):
+            total = (Fraction(0), Fraction(0))
+            for inner in range(order):
+                total = _add_intervals(
+                    total,
+                    _scale_interval(right[inner][column], left[row][inner]),
+                )
+            output_row.append(total)
+        rows.append(tuple(output_row))
+    return tuple(rows)
+
+
+def _identity_minus(
+    matrix: FractionIntervalMatrix,
+) -> FractionIntervalMatrix:
+    return tuple(
+        tuple(
+            (
+                _checked_add(Fraction(row == column), -entry[1]),
+                _checked_add(Fraction(row == column), -entry[0]),
+            )
+            for column, entry in enumerate(source_row)
+        )
+        for row, source_row in enumerate(matrix)
+    )
+
+
+def _matrix_interval_vector_product(
+    matrix: FractionIntervalMatrix,
+    vector: tuple[FractionInterval, ...],
+) -> tuple[FractionInterval, ...]:
+    result: list[FractionInterval] = []
+    for row in matrix:
+        total = (Fraction(0), Fraction(0))
+        for entry, coordinate in zip(row, vector, strict=True):
+            total = _add_intervals(total, _multiply_intervals(entry, coordinate))
+        result.append(total)
+    return tuple(result)
+
+
+def _matrix_vector_product(
+    matrix: FractionMatrix,
+    vector: tuple[Fraction, ...],
+) -> tuple[Fraction, ...]:
+    result: list[Fraction] = []
+    for row in matrix:
+        total = Fraction(0)
+        for entry, value in zip(row, vector, strict=True):
+            total = _checked_add(total, _checked_multiply(entry, value))
+        result.append(total)
+    return tuple(result)
+
+
+def _krawczyk_image(
+    box: RationalBox,
+    data: MidpointKernelData,
+    preconditioner: FractionMatrix,
+) -> tuple[FractionInterval, ...]:
+    centered_box = tuple(
+        (
+            interval.lower.as_fraction() - center,
+            interval.upper.as_fraction() - center,
+        )
+        for interval, center in zip(box.intervals, data.center, strict=True)
+    )
+    if all(value == 0 for value in data.value_at_center):
+        residual_center = data.center
+    else:
+        residual_center = tuple(
+            _checked_add(center, -correction)
+            for center, correction in zip(
+                data.center,
+                _matrix_vector_product(preconditioner, data.value_at_center),
+                strict=True,
+            )
+        )
+    constant_jacobian = all(
+        enclosure == (data.jacobian_at_center[row][column],) * 2
+        for row, entries in enumerate(data.jacobian_enclosure)
+        for column, enclosure in enumerate(entries)
+    )
+    if constant_jacobian:
+        remainder = ((Fraction(0), Fraction(0)),) * len(data.center)
+    else:
+        remainder = _matrix_interval_vector_product(
+            _identity_minus(
+                _matrix_interval_product(preconditioner, data.jacobian_enclosure)
+            ),
+            centered_box,
+        )
+    image = tuple(
+        (
+            _checked_add(center, interval[0]),
+            _checked_add(center, interval[1]),
+        )
+        for center, interval in zip(residual_center, remainder, strict=True)
+    )
+    for interval in image:
+        for endpoint in interval:
+            _require_height(
+                endpoint,
+                maximum=MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS,
+                label="Krawczyk-image endpoint",
+            )
+    return image
+
+
+def _strictly_inside(
+    image: tuple[FractionInterval, ...],
+    box: RationalBox,
+) -> bool:
+    return all(
+        source.lower.as_fraction() < enclosure[0]
+        and enclosure[1] < source.upper.as_fraction()
+        for enclosure, source in zip(image, box.intervals, strict=True)
+    )
+
+
+def _is_disjoint(
+    image: tuple[FractionInterval, ...],
+    box: RationalBox,
+) -> bool:
+    return any(
+        enclosure[1] < source.lower.as_fraction()
+        or source.upper.as_fraction() < enclosure[0]
+        for enclosure, source in zip(image, box.intervals, strict=True)
+    )
+
+
+def certify_root_box_kernel(
+    box: RationalBox,
+    prepared: ComponentExclusionKernelResult | MidpointKernelData,
+) -> RootBoxKernelResult:
+    """Run one exact deterministic midpoint Krawczyk attempt."""
+
+    if isinstance(prepared, ComponentExclusionKernelResult):
+        return prepared
+
+    preconditioner = _invert_matrix(prepared.jacobian_at_center)
+    if preconditioner is None:
+        return SingularMidpointKernelResult(
+            status="UNKNOWN_SINGULAR_MIDPOINT",
+            data=prepared,
+        )
+
+    image = _krawczyk_image(box, prepared, preconditioner)
+    evidence = KrawczykKernelData(
+        center=prepared.center,
+        value_at_center=prepared.value_at_center,
+        jacobian_at_center=prepared.jacobian_at_center,
+        jacobian_enclosure=prepared.jacobian_enclosure,
+        preconditioner=preconditioner,
+        krawczyk_image=image,
+    )
+    if _is_disjoint(image, box):
+        return KrawczykKernelResult(status="NO_ROOT_KRAWCZYK", evidence=evidence)
+    if _strictly_inside(image, box):
+        return KrawczykKernelResult(
+            status="CERTIFIED_UNIQUE_NONSINGULAR",
+            evidence=evidence,
+        )
+    return KrawczykKernelResult(status="UNKNOWN_KRAWCZYK", evidence=evidence)
+
+
+__all__ = [
+    "ComponentExclusionKernelResult",
+    "KrawczykKernelData",
+    "KrawczykKernelResult",
+    "MidpointKernelData",
+    "RootBoxKernelBudgetError",
+    "RootBoxKernelResult",
+    "SingularMidpointKernelResult",
+    "certify_root_box_kernel",
+]

--- a/src/jacobian/math/polynomials/root_boxes/_models.py
+++ b/src/jacobian/math/polynomials/root_boxes/_models.py
@@ -1,0 +1,376 @@
+"""Typed contracts for exact boxed real-root certification."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import ConfigDict, Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._digest import Sha256Digest
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.canonical import CanonicalLimits, encode_strict_json, sha256_digest
+from jacobian.math.analysis.intervals import ClosedRationalInterval, RationalBox
+from jacobian.math.matrices.values import RationalMatrix
+from jacobian.math.polynomials.maps._models import VariablePoint
+from jacobian.math.polynomials.maps.values import RationalPolynomialMap
+
+MAX_ROOT_BOX_DIMENSION = 5
+MAX_ROOT_BOX_COMPONENT_TERMS = 64
+MAX_ROOT_BOX_AGGREGATE_TERMS = 256
+MAX_ROOT_BOX_TOTAL_DEGREE = 8
+MAX_ROOT_BOX_ENDPOINT_DIGITS = 128
+MAX_ROOT_BOX_POINT_VALUE_DIGITS = 512
+MAX_ROOT_BOX_ENCLOSURE_DIGITS = 2_048
+MAX_ROOT_BOX_INTERMEDIATE_DIGITS = 65_536
+MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS = 32_768
+MAX_ROOT_BOX_SOURCE_BYTES = 512 * 1_024
+MAX_ROOT_BOX_RESULT_BYTES = CanonicalLimits().max_output_bytes
+
+ROOT_BOX_ADMISSION_SUMMARY = (
+    f"Bounds: square systems through dimension {MAX_ROOT_BOX_DIMENSION}; "
+    f"{MAX_ROOT_BOX_COMPONENT_TERMS} terms per component and "
+    f"{MAX_ROOT_BOX_AGGREGATE_TERMS} aggregate terms; total degree "
+    f"{MAX_ROOT_BOX_TOTAL_DEGREE}; {MAX_ROOT_BOX_ENDPOINT_DIGITS}-digit box "
+    f"endpoint components; {MAX_ROOT_BOX_POINT_VALUE_DIGITS}-digit admitted "
+    f"point values; {MAX_ROOT_BOX_ENCLOSURE_DIGITS:,}-digit scalar interval "
+    f"enclosures; {MAX_ROOT_BOX_INTERMEDIATE_DIGITS:,}-digit interval-matrix "
+    f"intermediates; {MAX_ROOT_BOX_SOURCE_BYTES:,}-byte retained source; and "
+    f"{MAX_ROOT_BOX_RESULT_BYTES:,}-byte canonical result."
+)
+
+
+def _validation_error(message: str) -> PydanticCustomError:
+    return PydanticCustomError("polynomial.root_box_invariant", message)
+
+
+def _source_payload(
+    polynomial_map: RationalPolynomialMap,
+    box: RationalBox,
+) -> dict[str, object]:
+    return {
+        "polynomial_map": polynomial_map.model_dump(mode="json"),
+        "box": box.model_dump(mode="json"),
+    }
+
+
+def root_box_source_digest(
+    polynomial_map: RationalPolynomialMap,
+    box: RationalBox,
+) -> Sha256Digest:
+    """Bind one ordered polynomial system to one exact rational box."""
+
+    return sha256_digest(encode_strict_json(_source_payload(polynomial_map, box)))
+
+
+class PolynomialSystemRootBoxRequest(StrictModel):
+    """Certify one bounded square polynomial system on one rational box."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Certify a square ordered QQ polynomial system on a complete "
+                "closed rational box. The map input axis and box axis must agree "
+                "exactly. The deterministic method uses the exact inverse of the "
+                "Jacobian at the box midpoint; failure to prove exclusion or "
+                "strict Krawczyk inclusion returns UNKNOWN. "
+                f"{ROOT_BOX_ADMISSION_SUMMARY}"
+            )
+        }
+    )
+
+    polynomial_map: RationalPolynomialMap = Field(
+        description=(
+            "Ordered square QQ polynomial system. Its output-polynomial order is "
+            "the equation axis, and every component uses input_variables exactly."
+        )
+    )
+    box: RationalBox = Field(
+        description=(
+            "Complete closed QQ box in exactly polynomial_map.input_variables order. "
+            "Point and boundary-root boxes are accepted but cannot satisfy strict "
+            "interior inclusion."
+        )
+    )
+
+
+type RootBoxIntervalRow = Annotated[
+    tuple[ClosedRationalInterval, ...],
+    Field(min_length=1, max_length=MAX_ROOT_BOX_DIMENSION),
+]
+
+
+class RootBoxJacobianEnclosure(StrictModel):
+    """A nonempty square row-major interval enclosure of a Jacobian matrix."""
+
+    entries: tuple[RootBoxIntervalRow, ...] = Field(
+        min_length=1,
+        max_length=MAX_ROOT_BOX_DIMENSION,
+        description=(
+            "Rows follow the source system's output order; columns follow its "
+            "ordered input-variable axis."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_square_shape(self) -> Self:
+        order = len(self.entries)
+        if any(len(row) != order for row in self.entries):
+            raise _validation_error("Jacobian enclosure must be square")
+        return self
+
+
+class RootBoxMidpointData(StrictModel):
+    """Exact midpoint value and derivative data for one certification attempt."""
+
+    center: VariablePoint
+    value_at_center: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_ROOT_BOX_DIMENSION
+    )
+    jacobian_at_center: RationalMatrix
+    jacobian_enclosure: RootBoxJacobianEnclosure
+
+    @model_validator(mode="after")
+    def require_one_square_system(self) -> Self:
+        order = len(self.center.values)
+        if len(self.value_at_center) != order:
+            raise _validation_error(
+                "midpoint value count must match the coordinate dimension"
+            )
+        if len(self.jacobian_at_center.entries) != order or any(
+            len(row) != order for row in self.jacobian_at_center.entries
+        ):
+            raise _validation_error(
+                "midpoint Jacobian shape must match the coordinate dimension"
+            )
+        if len(self.jacobian_enclosure.entries) != order:
+            raise _validation_error(
+                "Jacobian enclosure shape must match the coordinate dimension"
+            )
+        return self
+
+
+class RootBoxKrawczykEvidence(RootBoxMidpointData):
+    """Exact data defining one midpoint-preconditioned Krawczyk image."""
+
+    preconditioner: RationalMatrix = Field(
+        description="Exact two-sided inverse of jacobian_at_center over QQ."
+    )
+    krawczyk_image: RationalBox
+
+    @model_validator(mode="after")
+    def require_krawczyk_axes_and_shape(self) -> Self:
+        order = len(self.center.values)
+        if len(self.preconditioner.entries) != order or any(
+            len(row) != order for row in self.preconditioner.entries
+        ):
+            raise _validation_error(
+                "preconditioner shape must match the coordinate dimension"
+            )
+        if self.krawczyk_image.variables != self.center.variables:
+            raise _validation_error(
+                "Krawczyk image and center must use the same ordered axis"
+            )
+        return self
+
+
+class RootBoxComponentExclusion(StrictModel):
+    """One component range excludes zero on the complete source box."""
+
+    method: Literal["COMPONENT_RANGE_EXCLUSION"] = "COMPONENT_RANGE_EXCLUSION"
+    component_index: int = Field(ge=0, le=MAX_ROOT_BOX_DIMENSION - 1, strict=True)
+    enclosure: ClosedRationalInterval
+
+
+class RootBoxKrawczykDisjointness(StrictModel):
+    """The exact Krawczyk image is disjoint from the complete source box."""
+
+    method: Literal["KRAWCZYK_DISJOINTNESS"] = "KRAWCZYK_DISJOINTNESS"
+    evidence: RootBoxKrawczykEvidence
+
+
+type RootBoxNoRootEvidence = Annotated[
+    RootBoxComponentExclusion | RootBoxKrawczykDisjointness,
+    Field(discriminator="method"),
+]
+
+
+class RootBoxCertifiedUniqueNonsingular(StrictModel):
+    """Strict Krawczyk inclusion proves one unique nonsingular real zero."""
+
+    status: Literal["CERTIFIED_UNIQUE_NONSINGULAR"] = "CERTIFIED_UNIQUE_NONSINGULAR"
+    evidence: RootBoxKrawczykEvidence
+
+
+class RootBoxNoRoot(StrictModel):
+    """Exact complete-box evidence proves that the system has no zero."""
+
+    status: Literal["NO_ROOT"] = "NO_ROOT"
+    evidence: RootBoxNoRootEvidence
+
+
+class RootBoxSingularMidpointAttempt(StrictModel):
+    """The deterministic midpoint Jacobian has no exact inverse."""
+
+    kind: Literal["MIDPOINT_JACOBIAN_SINGULAR"] = "MIDPOINT_JACOBIAN_SINGULAR"
+    data: RootBoxMidpointData
+
+
+class RootBoxInconclusiveKrawczykAttempt(StrictModel):
+    """The Krawczyk image proves neither strict inclusion nor disjointness."""
+
+    kind: Literal["KRAWCZYK_INCONCLUSIVE"] = "KRAWCZYK_INCONCLUSIVE"
+    evidence: RootBoxKrawczykEvidence
+
+
+type RootBoxUnknownAttempt = Annotated[
+    RootBoxSingularMidpointAttempt | RootBoxInconclusiveKrawczykAttempt,
+    Field(discriminator="kind"),
+]
+
+
+class RootBoxUnknown(StrictModel):
+    """One exact bounded attempt did not establish a root conclusion."""
+
+    status: Literal["UNKNOWN"] = "UNKNOWN"
+    attempt: RootBoxUnknownAttempt
+
+
+type RootBoxConclusion = Annotated[
+    RootBoxCertifiedUniqueNonsingular | RootBoxNoRoot | RootBoxUnknown,
+    Field(discriminator="status"),
+]
+
+
+def root_box_record_digest(
+    source_digest: Sha256Digest,
+    conclusion: RootBoxConclusion,
+) -> Sha256Digest:
+    """Bind the exact returned evidence to its already-bound source."""
+
+    return sha256_digest(
+        encode_strict_json(
+            {
+                "source_digest": source_digest,
+                "conclusion": conclusion.model_dump(mode="json"),
+            }
+        )
+    )
+
+
+def _midpoint_data(conclusion: RootBoxConclusion) -> RootBoxMidpointData | None:
+    if isinstance(conclusion, RootBoxCertifiedUniqueNonsingular):
+        return conclusion.evidence
+    if isinstance(conclusion, RootBoxNoRoot):
+        if isinstance(conclusion.evidence, RootBoxKrawczykDisjointness):
+            return conclusion.evidence.evidence
+        return None
+    if isinstance(conclusion.attempt, RootBoxSingularMidpointAttempt):
+        return conclusion.attempt.data
+    return conclusion.attempt.evidence
+
+
+class PolynomialSystemRootBoxResult(StrictModel):
+    """One source-bound exact conclusion or explicit non-conclusion."""
+
+    polynomial_map: RationalPolynomialMap
+    box: RationalBox
+    source_digest: Sha256Digest
+    conclusion: RootBoxConclusion
+    record_digest: Sha256Digest = Field(
+        description=(
+            "Canonical integrity binding for the retained source and evidence. "
+            "It is not an independently supplied proof-verification API."
+        )
+    )
+
+    @model_validator(mode="after")
+    def require_source_and_evidence_binding(self) -> Self:
+        if self.source_digest != root_box_source_digest(self.polynomial_map, self.box):
+            raise _validation_error(
+                "source digest does not bind the polynomial system and box"
+            )
+        if self.record_digest != root_box_record_digest(
+            self.source_digest, self.conclusion
+        ):
+            raise _validation_error(
+                "record digest does not bind the returned exact evidence"
+            )
+        order = len(self.polynomial_map.input_variables)
+        if order > MAX_ROOT_BOX_DIMENSION:
+            raise _validation_error(
+                "retained polynomial system exceeds the root-box dimension bound"
+            )
+        if len(self.polynomial_map.output_polynomials) != order:
+            raise _validation_error("retained polynomial system must be square")
+        if (
+            self.box.domain != "QQ"
+            or self.box.variables != self.polynomial_map.input_variables
+        ):
+            raise _validation_error(
+                "retained box must use the polynomial system's complete ordered axis"
+            )
+        if (
+            isinstance(self.conclusion, RootBoxNoRoot)
+            and isinstance(self.conclusion.evidence, RootBoxComponentExclusion)
+            and self.conclusion.evidence.component_index >= order
+        ):
+            raise _validation_error(
+                "excluded component index must belong to the source system"
+            )
+        data = _midpoint_data(self.conclusion)
+        if data is not None and data.center.variables != self.box.variables:
+            raise _validation_error(
+                "midpoint evidence must use the retained source axis"
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: PolynomialSystemRootBoxRequest,
+        *,
+        conclusion: RootBoxConclusion,
+    ) -> Self:
+        """Build a result after the admitted kernel established its outcome."""
+
+        source_digest = root_box_source_digest(request.polynomial_map, request.box)
+        return cls(
+            polynomial_map=request.polynomial_map,
+            box=request.box,
+            source_digest=source_digest,
+            conclusion=conclusion,
+            record_digest=root_box_record_digest(source_digest, conclusion),
+        )
+
+
+__all__ = [
+    "MAX_ROOT_BOX_AGGREGATE_TERMS",
+    "MAX_ROOT_BOX_COMPONENT_TERMS",
+    "MAX_ROOT_BOX_DIMENSION",
+    "MAX_ROOT_BOX_ENCLOSURE_DIGITS",
+    "MAX_ROOT_BOX_ENDPOINT_DIGITS",
+    "MAX_ROOT_BOX_INTERMEDIATE_DIGITS",
+    "MAX_ROOT_BOX_POINT_VALUE_DIGITS",
+    "MAX_ROOT_BOX_RESULT_BYTES",
+    "MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS",
+    "MAX_ROOT_BOX_SOURCE_BYTES",
+    "MAX_ROOT_BOX_TOTAL_DEGREE",
+    "ROOT_BOX_ADMISSION_SUMMARY",
+    "PolynomialSystemRootBoxRequest",
+    "PolynomialSystemRootBoxResult",
+    "RootBoxCertifiedUniqueNonsingular",
+    "RootBoxComponentExclusion",
+    "RootBoxConclusion",
+    "RootBoxInconclusiveKrawczykAttempt",
+    "RootBoxJacobianEnclosure",
+    "RootBoxKrawczykDisjointness",
+    "RootBoxKrawczykEvidence",
+    "RootBoxMidpointData",
+    "RootBoxNoRoot",
+    "RootBoxSingularMidpointAttempt",
+    "RootBoxUnknown",
+    "root_box_record_digest",
+    "root_box_source_digest",
+]

--- a/src/jacobian/math/polynomials/root_boxes/_models.py
+++ b/src/jacobian/math/polynomials/root_boxes/_models.py
@@ -329,16 +329,17 @@ class PolynomialSystemRootBoxResult(StrictModel):
     @classmethod
     def _from_kernel(
         cls,
-        request: PolynomialSystemRootBoxRequest,
         *,
+        polynomial_map: RationalPolynomialMap,
+        box: RationalBox,
         conclusion: RootBoxConclusion,
     ) -> Self:
         """Build a result after the admitted kernel established its outcome."""
 
-        source_digest = root_box_source_digest(request.polynomial_map, request.box)
+        source_digest = root_box_source_digest(polynomial_map, box)
         return cls(
-            polynomial_map=request.polynomial_map,
-            box=request.box,
+            polynomial_map=polynomial_map,
+            box=box,
             source_digest=source_digest,
             conclusion=conclusion,
             record_digest=root_box_record_digest(source_digest, conclusion),

--- a/src/jacobian/math/polynomials/root_boxes/_tools.py
+++ b/src/jacobian/math/polynomials/root_boxes/_tools.py
@@ -1,0 +1,94 @@
+"""Public declaration for exact boxed real-root certification."""
+
+from typing import Any
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools
+
+from ._models import (
+    ROOT_BOX_ADMISSION_SUMMARY,
+    PolynomialSystemRootBoxRequest,
+    PolynomialSystemRootBoxResult,
+)
+from .operations import certify_real_root_box
+
+
+def compute_polynomial_system_root_box(
+    request: PolynomialSystemRootBoxRequest,
+) -> PolynomialSystemRootBoxResult:
+    return certify_real_root_box(request.polynomial_map, request.box)
+
+
+def _rational(numerator: int, denominator: int = 1) -> dict[str, str]:
+    return {"num": str(numerator), "den": str(denominator)}
+
+
+def _term(coefficient: int, exponent: int) -> dict[str, Any]:
+    return {
+        "coefficient": _rational(coefficient),
+        "exponents": [exponent],
+    }
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="polynomial.system.real_root_box.certify",
+        title="Certify a real root of a polynomial system in a box",
+        description=(
+            "Deterministically certify that one complete rational box contains "
+            "exactly one nonsingular real zero of a square QQ polynomial system, "
+            "prove complete-box exclusion, or return UNKNOWN. Exact midpoint, "
+            "preconditioner, point value, interval Jacobian, and Krawczyk-image "
+            "data retain the defining evidence; failed inclusion is never a root "
+            "conclusion. "
+            f"{ROOT_BOX_ADMISSION_SUMMARY}"
+        ),
+        request_type=PolynomialSystemRootBoxRequest,
+        result_type=PolynomialSystemRootBoxResult,
+        run=compute_polynomial_system_root_box,
+        tags=(
+            "polynomial",
+            "system",
+            "multivariate",
+            "real-root",
+            "isolating-box",
+            "krawczyk",
+            "interval-newton",
+            "existence",
+            "uniqueness",
+            "nonsingular",
+            "no-root",
+            "exact",
+            "rational",
+            "certificate",
+            "bounded",
+        ),
+        examples=(
+            example(
+                "square_root_two",
+                "Certify the unique positive zero of x^2 - 2 in [1, 2]; "
+                "the system must be square and the box must use its complete "
+                "ordered axis.",
+                {
+                    "polynomial_map": {
+                        "input_variables": ["x"],
+                        "output_polynomials": [
+                            {
+                                "domain": "QQ",
+                                "variables": ["x"],
+                                "polynomial": {"terms": [_term(1, 2), _term(-2, 0)]},
+                            }
+                        ],
+                    },
+                    "box": {
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "intervals": [{"lower": _rational(1), "upper": _rational(2)}],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/polynomials/root_boxes/operations.py
+++ b/src/jacobian/math/polynomials/root_boxes/operations.py
@@ -14,7 +14,6 @@ from jacobian.math.analysis.intervals import ClosedRationalInterval, RationalBox
 from jacobian.math.matrices.values import rational_matrix_from_fractions
 from jacobian.math.polynomials.intervals._kernel import natural_interval_extension
 from jacobian.math.polynomials.intervals._models import (
-    _estimate_growth,
     _require_enclosure_preflight,
 )
 from jacobian.math.polynomials.maps._models import VariablePoint
@@ -43,7 +42,6 @@ from ._models import (
     MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS,
     MAX_ROOT_BOX_SOURCE_BYTES,
     MAX_ROOT_BOX_TOTAL_DEGREE,
-    PolynomialSystemRootBoxRequest,
     PolynomialSystemRootBoxResult,
     RootBoxCertifiedUniqueNonsingular,
     RootBoxComponentExclusion,
@@ -172,8 +170,7 @@ def _admitted_enclosure(
     label: str,
     result_digits: int,
 ) -> tuple[Fraction, Fraction]:
-    _require_enclosure_preflight(polynomial, box)
-    growth = _estimate_growth(polynomial, box)
+    growth = _require_enclosure_preflight(polynomial, box)
     if max(growth.result_numerator_digits, growth.result_denominator_digits) > (
         result_digits
     ):

--- a/src/jacobian/math/polynomials/root_boxes/operations.py
+++ b/src/jacobian/math/polynomials/root_boxes/operations.py
@@ -43,7 +43,6 @@ from ._models import (
     MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS,
     MAX_ROOT_BOX_SOURCE_BYTES,
     MAX_ROOT_BOX_TOTAL_DEGREE,
-    PolynomialSystemRootBoxRequest,
     PolynomialSystemRootBoxResult,
     RootBoxCertifiedUniqueNonsingular,
     RootBoxComponentExclusion,
@@ -82,7 +81,9 @@ def _total_degree(polynomial: RationalPolynomial) -> int:
     )
 
 
-def _source_payload(polynomial_map: RationalPolynomialMap, box: RationalBox) -> dict[str, object]:
+def _source_payload(
+    polynomial_map: RationalPolynomialMap, box: RationalBox
+) -> dict[str, object]:
     return {
         "polynomial_map": polynomial_map.model_dump(mode="json"),
         "box": box.model_dump(mode="json"),
@@ -110,7 +111,9 @@ def _point_box(box: RationalBox, point: tuple[Fraction, ...]) -> RationalBox:
     )
 
 
-def _admit_source_shape(polynomial_map: RationalPolynomialMap, box: RationalBox) -> None:
+def _admit_source_shape(
+    polynomial_map: RationalPolynomialMap, box: RationalBox
+) -> None:
     order = len(polynomial_map.input_variables)
     if order > MAX_ROOT_BOX_DIMENSION:
         raise _domain_error(
@@ -196,9 +199,7 @@ def _bounded_component_exclusion(
 ) -> ComponentExclusionKernelResult | None:
     """Return any cheap exact component exclusion without making it mandatory."""
 
-    for component_index, polynomial in enumerate(
-        polynomial_map.output_polynomials
-    ):
+    for component_index, polynomial in enumerate(polynomial_map.output_polynomials):
         try:
             enclosure = _admitted_enclosure(
                 polynomial,
@@ -344,7 +345,9 @@ def _require_krawczyk_height_envelope(
         )
 
 
-def _prepare_root_box(polynomial_map: RationalPolynomialMap, box: RationalBox) -> _PreparedRootBox:
+def _prepare_root_box(
+    polynomial_map: RationalPolynomialMap, box: RationalBox
+) -> _PreparedRootBox:
     try:
         _admit_source_shape(polynomial_map, box)
         component_exclusion = _bounded_component_exclusion(polynomial_map, box)

--- a/src/jacobian/math/polynomials/root_boxes/operations.py
+++ b/src/jacobian/math/polynomials/root_boxes/operations.py
@@ -1,0 +1,522 @@
+"""Exact local real-root certification for rational polynomial systems."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from math import factorial
+
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian.canonical import encode_strict_json, format_canonical_integer
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.analysis.intervals import ClosedRationalInterval, RationalBox
+from jacobian.math.matrices.values import rational_matrix_from_fractions
+from jacobian.math.polynomials.intervals._kernel import natural_interval_extension
+from jacobian.math.polynomials.intervals._models import (
+    _estimate_growth,
+    _require_enclosure_preflight,
+)
+from jacobian.math.polynomials.maps._models import VariablePoint
+from jacobian.math.polynomials.maps.operations import jacobian_matrix
+from jacobian.math.polynomials.maps.values import RationalPolynomialMap
+from jacobian.math.polynomials.values import RationalPolynomial
+
+from ._kernel import (
+    ComponentExclusionKernelResult,
+    KrawczykKernelData,
+    KrawczykKernelResult,
+    MidpointKernelData,
+    RootBoxKernelBudgetError,
+    SingularMidpointKernelResult,
+    certify_root_box_kernel,
+)
+from ._models import (
+    MAX_ROOT_BOX_AGGREGATE_TERMS,
+    MAX_ROOT_BOX_COMPONENT_TERMS,
+    MAX_ROOT_BOX_DIMENSION,
+    MAX_ROOT_BOX_ENCLOSURE_DIGITS,
+    MAX_ROOT_BOX_ENDPOINT_DIGITS,
+    MAX_ROOT_BOX_INTERMEDIATE_DIGITS,
+    MAX_ROOT_BOX_POINT_VALUE_DIGITS,
+    MAX_ROOT_BOX_RESULT_BYTES,
+    MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS,
+    MAX_ROOT_BOX_SOURCE_BYTES,
+    MAX_ROOT_BOX_TOTAL_DEGREE,
+    PolynomialSystemRootBoxRequest,
+    PolynomialSystemRootBoxResult,
+    RootBoxCertifiedUniqueNonsingular,
+    RootBoxComponentExclusion,
+    RootBoxConclusion,
+    RootBoxInconclusiveKrawczykAttempt,
+    RootBoxJacobianEnclosure,
+    RootBoxKrawczykDisjointness,
+    RootBoxKrawczykEvidence,
+    RootBoxMidpointData,
+    RootBoxNoRoot,
+    RootBoxSingularMidpointAttempt,
+    RootBoxUnknown,
+)
+
+_RESULT_RATIONAL_COMPONENTS = (
+    4 * MAX_ROOT_BOX_DIMENSION * MAX_ROOT_BOX_DIMENSION + 4 * MAX_ROOT_BOX_DIMENSION
+)
+_RESULT_ENVELOPE_RESERVE_BYTES = 8_192
+
+
+type _PreparedRootBox = ComponentExclusionKernelResult | MidpointKernelData
+
+
+def _domain_error(message: str) -> OperationDomainValidationError:
+    return OperationDomainValidationError(
+        location=("polynomial_map", "box"),
+        code="polynomial.root_box_admission",
+        message=message,
+    )
+
+
+def _total_degree(polynomial: RationalPolynomial) -> int:
+    return max(
+        (sum(term.exponents) for term in polynomial.polynomial.terms),
+        default=0,
+    )
+
+
+def _source_payload(request: PolynomialSystemRootBoxRequest) -> dict[str, object]:
+    return {
+        "polynomial_map": request.polynomial_map.model_dump(mode="json"),
+        "box": request.box.model_dump(mode="json"),
+    }
+
+
+def _center_values(box: RationalBox) -> tuple[Fraction, ...]:
+    return tuple(
+        (interval.lower.as_fraction() + interval.upper.as_fraction()) / 2
+        for interval in box.intervals
+    )
+
+
+def _point_box(box: RationalBox, point: tuple[Fraction, ...]) -> RationalBox:
+    return RationalBox(
+        domain=box.domain,
+        variables=box.variables,
+        intervals=tuple(
+            ClosedRationalInterval(
+                lower=CanonicalRational.from_fraction(value),
+                upper=CanonicalRational.from_fraction(value),
+            )
+            for value in point
+        ),
+    )
+
+
+def _admit_source_shape(request: PolynomialSystemRootBoxRequest) -> None:
+    polynomial_map = request.polynomial_map
+    box = request.box
+    order = len(polynomial_map.input_variables)
+    if order > MAX_ROOT_BOX_DIMENSION:
+        raise _domain_error(
+            f"root-box systems are limited to dimension {MAX_ROOT_BOX_DIMENSION}"
+        )
+    if len(polynomial_map.output_polynomials) != order:
+        raise _domain_error("root-box certification requires a square system")
+    if box.domain != "QQ" or box.variables != polynomial_map.input_variables:
+        raise _domain_error(
+            "root box must use the polynomial system's complete ordered axis and QQ parent"
+        )
+    aggregate_terms = sum(
+        len(polynomial.polynomial.terms)
+        for polynomial in polynomial_map.output_polynomials
+    )
+    if aggregate_terms > MAX_ROOT_BOX_AGGREGATE_TERMS:
+        raise _domain_error(
+            "root-box system exceeds the "
+            f"{MAX_ROOT_BOX_AGGREGATE_TERMS}-term aggregate budget"
+        )
+    for polynomial in polynomial_map.output_polynomials:
+        if len(polynomial.polynomial.terms) > MAX_ROOT_BOX_COMPONENT_TERMS:
+            raise _domain_error(
+                "root-box component exceeds the "
+                f"{MAX_ROOT_BOX_COMPONENT_TERMS}-term budget"
+            )
+        if _total_degree(polynomial) > MAX_ROOT_BOX_TOTAL_DEGREE:
+            raise _domain_error(
+                f"root-box component exceeds total degree {MAX_ROOT_BOX_TOTAL_DEGREE}"
+            )
+    for variable, interval in zip(box.variables, box.intervals, strict=True):
+        for endpoint in (interval.lower, interval.upper):
+            require_bounded_rational(
+                endpoint,
+                max_digits=MAX_ROOT_BOX_ENDPOINT_DIGITS,
+                label=f"root-box {variable} endpoint",
+            )
+    source_bytes = len(encode_strict_json(_source_payload(request)))
+    if source_bytes > MAX_ROOT_BOX_SOURCE_BYTES:
+        raise _domain_error(
+            "root-box retained source exceeds the "
+            f"{MAX_ROOT_BOX_SOURCE_BYTES:,}-byte budget"
+        )
+    maximum_result_bytes = (
+        source_bytes
+        + _RESULT_RATIONAL_COMPONENTS * (2 * MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS + 64)
+        + _RESULT_ENVELOPE_RESERVE_BYTES
+    )
+    if maximum_result_bytes > MAX_ROOT_BOX_RESULT_BYTES:
+        raise _domain_error(
+            "root-box exact evidence would exceed the canonical output bound"
+        )
+
+
+def _admitted_enclosure(
+    polynomial: RationalPolynomial,
+    box: RationalBox,
+    *,
+    label: str,
+    result_digits: int,
+) -> tuple[Fraction, Fraction]:
+    _require_enclosure_preflight(polynomial, box)
+    growth = _estimate_growth(polynomial, box)
+    if max(growth.result_numerator_digits, growth.result_denominator_digits) > (
+        result_digits
+    ):
+        raise _domain_error(
+            f"{label} interval enclosure exceeds the "
+            f"{result_digits:,}-digit result bound"
+        )
+    if growth.intermediate_digits > MAX_ROOT_BOX_INTERMEDIATE_DIGITS:
+        raise _domain_error(
+            f"{label} interval enclosure exceeds the "
+            f"{MAX_ROOT_BOX_INTERMEDIATE_DIGITS:,}-digit intermediate bound"
+        )
+    enclosure = natural_interval_extension(polynomial, box)
+    return enclosure.lower.as_fraction(), enclosure.upper.as_fraction()
+
+
+def _bounded_component_exclusion(
+    request: PolynomialSystemRootBoxRequest,
+) -> ComponentExclusionKernelResult | None:
+    """Return any cheap exact component exclusion without making it mandatory."""
+
+    for component_index, polynomial in enumerate(
+        request.polynomial_map.output_polynomials
+    ):
+        try:
+            enclosure = _admitted_enclosure(
+                polynomial,
+                request.box,
+                label="system component",
+                result_digits=MAX_ROOT_BOX_ENCLOSURE_DIGITS,
+            )
+        except OperationDomainValidationError:
+            # A component range is only a presolve. The Krawczyk attempt does
+            # not need F(X), so an expensive range must not reject an otherwise
+            # admissible midpoint/Jacobian computation.
+            continue
+        if enclosure[1] < 0 or enclosure[0] > 0:
+            return ComponentExclusionKernelResult(
+                status="NO_ROOT_COMPONENT",
+                component_index=component_index,
+                enclosure=enclosure,
+            )
+    return None
+
+
+def _fraction_digits(value: Fraction) -> int:
+    return max(
+        len(format_canonical_integer(abs(value.numerator))),
+        len(format_canonical_integer(value.denominator)),
+    )
+
+
+def _sum_height_bound(count: int, term_digits: int) -> int:
+    # The extra digit also covers the checked-add guard before cancellation.
+    return max(1, count * term_digits + len(str(count)) + 1)
+
+
+def _require_stage_height(bound: int, *, label: str) -> None:
+    if bound > MAX_ROOT_BOX_INTERMEDIATE_DIGITS:
+        raise _domain_error(
+            f"source-derived {label} exceeds the "
+            f"{MAX_ROOT_BOX_INTERMEDIATE_DIGITS:,}-digit intermediate bound"
+        )
+
+
+def _require_krawczyk_height_envelope(
+    data: MidpointKernelData,
+    box: RationalBox,
+) -> None:
+    """Prove the complete exact Krawczyk arithmetic envelope before FLINT."""
+
+    order = len(data.jacobian_at_center)
+    entry_digits = max(
+        _fraction_digits(value) for row in data.jacobian_at_center for value in row
+    )
+    # Clear denominators row by row. Each determinant term then has at most
+    # order squared entry digits; multiplying a cofactor by its row denominator
+    # has the same bound. The factorial term accounts for determinant sums.
+    inverse_digits = (
+        order * (order + 1) * entry_digits
+        + len(format_canonical_integer(factorial(order)))
+        + 1
+    )
+    if inverse_digits > MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS:
+        raise _domain_error(
+            "exact midpoint-Jacobian inverse exceeds the "
+            f"{MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS:,}-digit result bound"
+        )
+
+    zero_value = all(value == 0 for value in data.value_at_center)
+    constant_jacobian = all(
+        enclosure == (data.jacobian_at_center[row][column],) * 2
+        for row, entries in enumerate(data.jacobian_enclosure)
+        for column, enclosure in enumerate(entries)
+    )
+    center_digits = max(_fraction_digits(value) for value in data.center)
+
+    if zero_value:
+        residual_digits = center_digits
+    else:
+        value_digits = max(_fraction_digits(value) for value in data.value_at_center)
+        correction_product_digits = inverse_digits + value_digits
+        _require_stage_height(
+            correction_product_digits,
+            label="preconditioner-value product",
+        )
+        correction_digits = _sum_height_bound(
+            order,
+            correction_product_digits,
+        )
+        _require_stage_height(
+            correction_digits,
+            label="preconditioner-value sum",
+        )
+        residual_digits = center_digits + correction_digits + 1
+        _require_stage_height(residual_digits, label="Krawczyk residual center")
+
+    if constant_jacobian:
+        image_digits = residual_digits
+    else:
+        enclosure_digits = max(
+            _fraction_digits(endpoint)
+            for row in data.jacobian_enclosure
+            for enclosure in row
+            for endpoint in enclosure
+        )
+        matrix_product_term_digits = inverse_digits + enclosure_digits
+        _require_stage_height(
+            matrix_product_term_digits,
+            label="preconditioner-Jacobian product",
+        )
+        matrix_product_digits = _sum_height_bound(
+            order,
+            matrix_product_term_digits,
+        )
+        _require_stage_height(
+            matrix_product_digits,
+            label="preconditioner-Jacobian sum",
+        )
+        remainder_matrix_digits = matrix_product_digits + 2
+        _require_stage_height(
+            remainder_matrix_digits,
+            label="Krawczyk remainder matrix",
+        )
+        centered_box_digits = max(
+            _fraction_digits(endpoint.as_fraction() - center)
+            for interval, center in zip(box.intervals, data.center, strict=True)
+            for endpoint in (interval.lower, interval.upper)
+        )
+        remainder_product_digits = remainder_matrix_digits + centered_box_digits
+        _require_stage_height(
+            remainder_product_digits,
+            label="remainder-matrix box product",
+        )
+        remainder_digits = _sum_height_bound(
+            order,
+            remainder_product_digits,
+        )
+        _require_stage_height(remainder_digits, label="Krawczyk remainder sum")
+        image_digits = residual_digits + remainder_digits + 1
+        _require_stage_height(image_digits, label="Krawczyk image")
+
+    if image_digits > MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS:
+        raise _domain_error(
+            "source-derived Krawczyk image exceeds the "
+            f"{MAX_ROOT_BOX_RESULT_COMPONENT_DIGITS:,}-digit result bound"
+        )
+
+
+def _prepare_root_box(request: PolynomialSystemRootBoxRequest) -> _PreparedRootBox:
+    try:
+        _admit_source_shape(request)
+        component_exclusion = _bounded_component_exclusion(request)
+        if component_exclusion is not None:
+            return component_exclusion
+
+        jacobian = jacobian_matrix(request.polynomial_map)
+        center = _center_values(request.box)
+        center_box = _point_box(request.box, center)
+        value_at_center = tuple(
+            _admitted_enclosure(
+                polynomial,
+                center_box,
+                label="system component midpoint value",
+                result_digits=MAX_ROOT_BOX_POINT_VALUE_DIGITS,
+            )[0]
+            for polynomial in request.polynomial_map.output_polynomials
+        )
+        jacobian_at_center_flat = tuple(
+            _admitted_enclosure(
+                polynomial,
+                center_box,
+                label="Jacobian midpoint value",
+                result_digits=MAX_ROOT_BOX_POINT_VALUE_DIGITS,
+            )[0]
+            for polynomial in jacobian.entries
+        )
+        jacobian_enclosure_flat = tuple(
+            _admitted_enclosure(
+                polynomial,
+                request.box,
+                label="Jacobian entry",
+                result_digits=MAX_ROOT_BOX_ENCLOSURE_DIGITS,
+            )
+            for polynomial in jacobian.entries
+        )
+        order = len(request.polynomial_map.input_variables)
+        jacobian_at_center = tuple(
+            jacobian_at_center_flat[row * order : (row + 1) * order]
+            for row in range(order)
+        )
+        prepared = MidpointKernelData(
+            center=center,
+            value_at_center=value_at_center,
+            jacobian_at_center=jacobian_at_center,
+            jacobian_enclosure=tuple(
+                jacobian_enclosure_flat[row * order : (row + 1) * order]
+                for row in range(order)
+            ),
+        )
+        _require_krawczyk_height_envelope(prepared, request.box)
+        return prepared
+    except OperationDomainValidationError:
+        raise
+    except PydanticCustomError as exc:
+        raise _domain_error(exc.message()) from exc
+    except ValueError as exc:
+        raise _domain_error(str(exc)) from exc
+
+
+def _wire_interval(interval: tuple[Fraction, Fraction]) -> ClosedRationalInterval:
+    return ClosedRationalInterval(
+        lower=CanonicalRational.from_fraction(interval[0]),
+        upper=CanonicalRational.from_fraction(interval[1]),
+    )
+
+
+def _wire_midpoint_data(
+    variables: tuple[str, ...],
+    data: MidpointKernelData,
+) -> RootBoxMidpointData:
+    return RootBoxMidpointData(
+        center=VariablePoint(
+            variables=variables,
+            values=tuple(
+                CanonicalRational.from_fraction(value) for value in data.center
+            ),
+        ),
+        value_at_center=tuple(
+            CanonicalRational.from_fraction(value) for value in data.value_at_center
+        ),
+        jacobian_at_center=rational_matrix_from_fractions(data.jacobian_at_center),
+        jacobian_enclosure=RootBoxJacobianEnclosure(
+            entries=tuple(
+                tuple(_wire_interval(interval) for interval in row)
+                for row in data.jacobian_enclosure
+            )
+        ),
+    )
+
+
+def _wire_krawczyk_evidence(
+    variables: tuple[str, ...],
+    data: KrawczykKernelData,
+) -> RootBoxKrawczykEvidence:
+    midpoint = _wire_midpoint_data(variables, data)
+    return RootBoxKrawczykEvidence(
+        center=midpoint.center,
+        value_at_center=midpoint.value_at_center,
+        jacobian_at_center=midpoint.jacobian_at_center,
+        jacobian_enclosure=midpoint.jacobian_enclosure,
+        preconditioner=rational_matrix_from_fractions(data.preconditioner),
+        krawczyk_image=RationalBox(
+            variables=variables,
+            intervals=tuple(
+                _wire_interval(interval) for interval in data.krawczyk_image
+            ),
+        ),
+    )
+
+
+def _run_request(
+    request: PolynomialSystemRootBoxRequest,
+) -> PolynomialSystemRootBoxResult:
+    prepared = _prepare_root_box(request)
+    try:
+        kernel_result = certify_root_box_kernel(
+            request.box,
+            prepared,
+        )
+    except RootBoxKernelBudgetError as exc:
+        raise OperationDomainValidationError(
+            location=("polynomial_map", "box"),
+            code="polynomial.root_box_intermediate_bound",
+            message=str(exc),
+        ) from exc
+
+    variables = request.polynomial_map.input_variables
+    conclusion: RootBoxConclusion
+    if isinstance(kernel_result, ComponentExclusionKernelResult):
+        conclusion = RootBoxNoRoot(
+            evidence=RootBoxComponentExclusion(
+                component_index=kernel_result.component_index,
+                enclosure=_wire_interval(kernel_result.enclosure),
+            )
+        )
+    elif isinstance(kernel_result, SingularMidpointKernelResult):
+        conclusion = RootBoxUnknown(
+            attempt=RootBoxSingularMidpointAttempt(
+                data=_wire_midpoint_data(variables, kernel_result.data)
+            )
+        )
+    elif isinstance(kernel_result, KrawczykKernelResult):
+        evidence = _wire_krawczyk_evidence(variables, kernel_result.evidence)
+        if kernel_result.status == "CERTIFIED_UNIQUE_NONSINGULAR":
+            conclusion = RootBoxCertifiedUniqueNonsingular(evidence=evidence)
+        elif kernel_result.status == "NO_ROOT_KRAWCZYK":
+            conclusion = RootBoxNoRoot(
+                evidence=RootBoxKrawczykDisjointness(evidence=evidence)
+            )
+        else:
+            conclusion = RootBoxUnknown(
+                attempt=RootBoxInconclusiveKrawczykAttempt(evidence=evidence)
+            )
+    else:
+        raise AssertionError("unknown root-box kernel outcome")
+    return PolynomialSystemRootBoxResult._from_kernel(
+        request,
+        conclusion=conclusion,
+    )
+
+
+def certify_real_root_box(
+    polynomial_map: RationalPolynomialMap,
+    box: RationalBox,
+) -> PolynomialSystemRootBoxResult:
+    """Certify a unique nonsingular real zero, exclusion, or non-conclusion."""
+
+    return _run_request(
+        PolynomialSystemRootBoxRequest(polynomial_map=polynomial_map, box=box)
+    )
+
+
+__all__ = ["certify_real_root_box"]

--- a/src/jacobian/math/polynomials/root_boxes/operations.py
+++ b/src/jacobian/math/polynomials/root_boxes/operations.py
@@ -82,10 +82,10 @@ def _total_degree(polynomial: RationalPolynomial) -> int:
     )
 
 
-def _source_payload(request: PolynomialSystemRootBoxRequest) -> dict[str, object]:
+def _source_payload(polynomial_map: RationalPolynomialMap, box: RationalBox) -> dict[str, object]:
     return {
-        "polynomial_map": request.polynomial_map.model_dump(mode="json"),
-        "box": request.box.model_dump(mode="json"),
+        "polynomial_map": polynomial_map.model_dump(mode="json"),
+        "box": box.model_dump(mode="json"),
     }
 
 
@@ -110,9 +110,7 @@ def _point_box(box: RationalBox, point: tuple[Fraction, ...]) -> RationalBox:
     )
 
 
-def _admit_source_shape(request: PolynomialSystemRootBoxRequest) -> None:
-    polynomial_map = request.polynomial_map
-    box = request.box
+def _admit_source_shape(polynomial_map: RationalPolynomialMap, box: RationalBox) -> None:
     order = len(polynomial_map.input_variables)
     if order > MAX_ROOT_BOX_DIMENSION:
         raise _domain_error(
@@ -150,7 +148,7 @@ def _admit_source_shape(request: PolynomialSystemRootBoxRequest) -> None:
                 max_digits=MAX_ROOT_BOX_ENDPOINT_DIGITS,
                 label=f"root-box {variable} endpoint",
             )
-    source_bytes = len(encode_strict_json(_source_payload(request)))
+    source_bytes = len(encode_strict_json(_source_payload(polynomial_map, box)))
     if source_bytes > MAX_ROOT_BOX_SOURCE_BYTES:
         raise _domain_error(
             "root-box retained source exceeds the "
@@ -193,17 +191,18 @@ def _admitted_enclosure(
 
 
 def _bounded_component_exclusion(
-    request: PolynomialSystemRootBoxRequest,
+    polynomial_map: RationalPolynomialMap,
+    box: RationalBox,
 ) -> ComponentExclusionKernelResult | None:
     """Return any cheap exact component exclusion without making it mandatory."""
 
     for component_index, polynomial in enumerate(
-        request.polynomial_map.output_polynomials
+        polynomial_map.output_polynomials
     ):
         try:
             enclosure = _admitted_enclosure(
                 polynomial,
-                request.box,
+                box,
                 label="system component",
                 result_digits=MAX_ROOT_BOX_ENCLOSURE_DIGITS,
             )
@@ -345,16 +344,16 @@ def _require_krawczyk_height_envelope(
         )
 
 
-def _prepare_root_box(request: PolynomialSystemRootBoxRequest) -> _PreparedRootBox:
+def _prepare_root_box(polynomial_map: RationalPolynomialMap, box: RationalBox) -> _PreparedRootBox:
     try:
-        _admit_source_shape(request)
-        component_exclusion = _bounded_component_exclusion(request)
+        _admit_source_shape(polynomial_map, box)
+        component_exclusion = _bounded_component_exclusion(polynomial_map, box)
         if component_exclusion is not None:
             return component_exclusion
 
-        jacobian = jacobian_matrix(request.polynomial_map)
-        center = _center_values(request.box)
-        center_box = _point_box(request.box, center)
+        jacobian = jacobian_matrix(polynomial_map)
+        center = _center_values(box)
+        center_box = _point_box(box, center)
         value_at_center = tuple(
             _admitted_enclosure(
                 polynomial,
@@ -362,7 +361,7 @@ def _prepare_root_box(request: PolynomialSystemRootBoxRequest) -> _PreparedRootB
                 label="system component midpoint value",
                 result_digits=MAX_ROOT_BOX_POINT_VALUE_DIGITS,
             )[0]
-            for polynomial in request.polynomial_map.output_polynomials
+            for polynomial in polynomial_map.output_polynomials
         )
         jacobian_at_center_flat = tuple(
             _admitted_enclosure(
@@ -376,13 +375,13 @@ def _prepare_root_box(request: PolynomialSystemRootBoxRequest) -> _PreparedRootB
         jacobian_enclosure_flat = tuple(
             _admitted_enclosure(
                 polynomial,
-                request.box,
+                box,
                 label="Jacobian entry",
                 result_digits=MAX_ROOT_BOX_ENCLOSURE_DIGITS,
             )
             for polynomial in jacobian.entries
         )
-        order = len(request.polynomial_map.input_variables)
+        order = len(polynomial_map.input_variables)
         jacobian_at_center = tuple(
             jacobian_at_center_flat[row * order : (row + 1) * order]
             for row in range(order)
@@ -396,7 +395,7 @@ def _prepare_root_box(request: PolynomialSystemRootBoxRequest) -> _PreparedRootB
                 for row in range(order)
             ),
         )
-        _require_krawczyk_height_envelope(prepared, request.box)
+        _require_krawczyk_height_envelope(prepared, box)
         return prepared
     except OperationDomainValidationError:
         raise
@@ -458,12 +457,13 @@ def _wire_krawczyk_evidence(
 
 
 def _run_request(
-    request: PolynomialSystemRootBoxRequest,
+    polynomial_map: RationalPolynomialMap,
+    box: RationalBox,
 ) -> PolynomialSystemRootBoxResult:
-    prepared = _prepare_root_box(request)
+    prepared = _prepare_root_box(polynomial_map, box)
     try:
         kernel_result = certify_root_box_kernel(
-            request.box,
+            box,
             prepared,
         )
     except RootBoxKernelBudgetError as exc:
@@ -473,7 +473,7 @@ def _run_request(
             message=str(exc),
         ) from exc
 
-    variables = request.polynomial_map.input_variables
+    variables = polynomial_map.input_variables
     conclusion: RootBoxConclusion
     if isinstance(kernel_result, ComponentExclusionKernelResult):
         conclusion = RootBoxNoRoot(
@@ -503,7 +503,8 @@ def _run_request(
     else:
         raise AssertionError("unknown root-box kernel outcome")
     return PolynomialSystemRootBoxResult._from_kernel(
-        request,
+        polynomial_map=polynomial_map,
+        box=box,
         conclusion=conclusion,
     )
 
@@ -515,7 +516,8 @@ def certify_real_root_box(
     """Certify a unique nonsingular real zero, exclusion, or non-conclusion."""
 
     return _run_request(
-        PolynomialSystemRootBoxRequest(polynomial_map=polynomial_map, box=box)
+        polynomial_map,
+        box,
     )
 
 

--- a/tests/math/polynomials/root_boxes/test_root_box_certification.py
+++ b/tests/math/polynomials/root_boxes/test_root_box_certification.py
@@ -1,0 +1,562 @@
+"""Exact Krawczyk certification for square rational polynomial systems."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.analysis.intervals import ClosedRationalInterval, RationalBox
+from jacobian.math.matrices.operations import determinant_result
+from jacobian.math.polynomials.maps.values import RationalPolynomialMap
+from jacobian.math.polynomials.root_boxes import certify_real_root_box
+from jacobian.math.polynomials.root_boxes._models import (
+    MAX_ROOT_BOX_DIMENSION,
+    PolynomialSystemRootBoxRequest,
+    PolynomialSystemRootBoxResult,
+    RootBoxCertifiedUniqueNonsingular,
+    RootBoxComponentExclusion,
+    RootBoxInconclusiveKrawczykAttempt,
+    RootBoxKrawczykDisjointness,
+    RootBoxNoRoot,
+    RootBoxSingularMidpointAttempt,
+    RootBoxUnknown,
+)
+from jacobian.math.polynomials.root_boxes._tools import (
+    TOOLS,
+    compute_polynomial_system_root_box,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _q(value: int | Fraction) -> CanonicalRational:
+    return CanonicalRational.from_fraction(Fraction(value))
+
+
+def _interval(
+    lower: int | Fraction,
+    upper: int | Fraction,
+) -> ClosedRationalInterval:
+    return ClosedRationalInterval(lower=_q(lower), upper=_q(upper))
+
+
+def _box(
+    variables: tuple[str, ...],
+    intervals: tuple[tuple[int | Fraction, int | Fraction], ...],
+) -> RationalBox:
+    return RationalBox(
+        variables=variables,
+        intervals=tuple(_interval(lower, upper) for lower, upper in intervals),
+    )
+
+
+def _polynomial(
+    variables: tuple[str, ...],
+    terms: Mapping[tuple[int, ...], int | Fraction],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=_q(coefficient),
+                    exponents=exponents,
+                )
+                for exponents, coefficient in sorted(terms.items(), reverse=True)
+                if coefficient
+            )
+        ),
+    )
+
+
+def _map(
+    variables: tuple[str, ...],
+    components: tuple[Mapping[tuple[int, ...], int | Fraction], ...],
+) -> RationalPolynomialMap:
+    return RationalPolynomialMap(
+        input_variables=variables,
+        output_polynomials=tuple(_polynomial(variables, terms) for terms in components),
+    )
+
+
+def _certify(
+    polynomial_map: RationalPolynomialMap,
+    box: RationalBox,
+) -> PolynomialSystemRootBoxResult:
+    return compute_polynomial_system_root_box(
+        PolynomialSystemRootBoxRequest(polynomial_map=polynomial_map, box=box)
+    )
+
+
+def _fraction(value: CanonicalRational) -> Fraction:
+    return value.as_fraction()
+
+
+def _matrix_product(
+    left: tuple[tuple[CanonicalRational, ...], ...],
+    right: tuple[tuple[CanonicalRational, ...], ...],
+) -> tuple[tuple[Fraction, ...], ...]:
+    return tuple(
+        tuple(
+            sum(
+                (
+                    _fraction(left[row][inner]) * _fraction(right[inner][column])
+                    for inner in range(len(left))
+                ),
+                Fraction(0),
+            )
+            for column in range(len(right[0]))
+        )
+        for row in range(len(left))
+    )
+
+
+def test_square_root_two_has_exact_replayable_krawczyk_certificate() -> None:
+    polynomial_map = _map(("x",), ({(2,): 1, (0,): -2},))
+    box = _box(("x",), ((1, 2),))
+
+    result = _certify(polynomial_map, box)
+
+    assert isinstance(result.conclusion, RootBoxCertifiedUniqueNonsingular)
+    evidence = result.conclusion.evidence
+    assert evidence.center.values == (_q(Fraction(3, 2)),)
+    assert evidence.value_at_center == (_q(Fraction(1, 4)),)
+    assert evidence.jacobian_at_center.entries == ((_q(3),),)
+    assert evidence.preconditioner.entries == ((_q(Fraction(1, 3)),),)
+    assert evidence.jacobian_enclosure.entries == (((_interval(2, 4)),),)
+    assert evidence.krawczyk_image.intervals == (
+        _interval(Fraction(5, 4), Fraction(19, 12)),
+    )
+    source = box.intervals[0]
+    image = evidence.krawczyk_image.intervals[0]
+    assert source.lower.as_fraction() < image.lower.as_fraction()
+    assert image.upper.as_fraction() < source.upper.as_fraction()
+    assert _matrix_product(
+        evidence.preconditioner.entries,
+        evidence.jacobian_at_center.entries,
+    ) == ((Fraction(1),),)
+    assert determinant_result(evidence.jacobian_at_center).determinant == _q(3)
+
+
+def test_native_operation_matches_catalog_projection() -> None:
+    polynomial_map = _map(("x",), ({(2,): 1, (0,): -2},))
+    box = _box(("x",), ((1, 2),))
+
+    assert certify_real_root_box(polynomial_map, box) == _certify(polynomial_map, box)
+
+
+def test_component_interval_exclusion_proves_no_root_on_complete_box() -> None:
+    result = _certify(
+        _map(("x",), ({(2,): 1, (0,): 1},)),
+        _box(("x",), ((-1, 1),)),
+    )
+
+    assert isinstance(result.conclusion, RootBoxNoRoot)
+    assert isinstance(result.conclusion.evidence, RootBoxComponentExclusion)
+    assert result.conclusion.evidence.component_index == 0
+    assert result.conclusion.evidence.enclosure == _interval(1, 2)
+
+
+def test_component_exclusion_skips_an_unneeded_expensive_system_range() -> None:
+    exponent_pairs = tuple(
+        (left, degree - left) for degree in range(9) for left in range(degree + 1)
+    )
+    small_primes = (
+        2,
+        3,
+        5,
+        7,
+        11,
+        13,
+        17,
+        19,
+        23,
+        29,
+        31,
+        37,
+        41,
+        43,
+        47,
+        53,
+        59,
+        61,
+        67,
+        71,
+        73,
+        79,
+        83,
+        89,
+        97,
+        101,
+        103,
+        107,
+        109,
+        113,
+        127,
+        131,
+        137,
+        139,
+        149,
+        151,
+        157,
+        163,
+        167,
+        173,
+        179,
+        181,
+        191,
+        193,
+        197,
+    )
+    denominators: list[int] = []
+    for prime in small_primes:
+        denominator = 1
+        while denominator * prime < 10**128:
+            denominator *= prime
+        denominators.append(denominator)
+    expensive_component: dict[tuple[int, ...], int | Fraction] = {
+        exponents: Fraction(1, denominator)
+        for exponents, denominator in zip(
+            exponent_pairs,
+            denominators,
+            strict=True,
+        )
+    }
+
+    components: tuple[Mapping[tuple[int, ...], int | Fraction], ...] = (
+        {(0, 0): 1},
+        expensive_component,
+    )
+    result = _certify(
+        _map(("x", "y"), components),
+        _box(("x", "y"), ((0, 1), (0, 1))),
+    )
+
+    assert isinstance(result.conclusion, RootBoxNoRoot)
+    assert isinstance(result.conclusion.evidence, RootBoxComponentExclusion)
+    assert result.conclusion.evidence.component_index == 0
+    assert result.conclusion.evidence.enclosure == _interval(1, 1)
+
+
+def test_disjoint_krawczyk_image_proves_no_root_when_component_range_does_not() -> None:
+    result = _certify(
+        _map(("x",), ({(2,): 1, (1,): -3, (0,): 3},)),
+        _box(("x",), ((2, 3),)),
+    )
+
+    assert isinstance(result.conclusion, RootBoxNoRoot)
+    assert isinstance(result.conclusion.evidence, RootBoxKrawczykDisjointness)
+    evidence = result.conclusion.evidence.evidence
+    assert evidence.krawczyk_image.intervals == (
+        _interval(Fraction(11, 8), Fraction(15, 8)),
+    )
+    assert evidence.krawczyk_image.intervals[0].upper.as_fraction() < 2
+
+
+def test_singular_midpoint_is_an_explicit_non_conclusion() -> None:
+    result = _certify(
+        _map(("x",), ({(2,): 1},)),
+        _box(("x",), ((-1, 1),)),
+    )
+
+    assert isinstance(result.conclusion, RootBoxUnknown)
+    assert isinstance(result.conclusion.attempt, RootBoxSingularMidpointAttempt)
+    data = result.conclusion.attempt.data
+    assert data.value_at_center == (_q(0),)
+    assert data.jacobian_at_center.entries == ((_q(0),),)
+    assert data.jacobian_enclosure.entries == (((_interval(-2, 2)),),)
+
+
+def test_tiny_residual_on_positive_dimensional_locus_is_not_a_root_claim() -> None:
+    epsilon = Fraction(1, 10**20)
+    result = _certify(
+        _map(
+            ("x", "y"),
+            (
+                {(1, 0): 1, (0, 1): -1},
+                {(2, 0): 1, (1, 1): -2, (0, 2): 1},
+            ),
+        ),
+        _box(("x", "y"), ((0, 2 * epsilon), (0, 4 * epsilon))),
+    )
+
+    assert isinstance(result.conclusion, RootBoxUnknown)
+    assert isinstance(result.conclusion.attempt, RootBoxSingularMidpointAttempt)
+    data = result.conclusion.attempt.data
+    assert data.center.values == (_q(epsilon), _q(2 * epsilon))
+    assert data.value_at_center == (_q(-epsilon), _q(epsilon * epsilon))
+    assert determinant_result(data.jacobian_at_center).determinant == _q(0)
+
+
+@pytest.mark.parametrize("endpoints", (((0, 1),), ((0, 0),)))
+def test_boundary_and_point_roots_remain_unknown(
+    endpoints: tuple[tuple[int, int], ...],
+) -> None:
+    result = _certify(
+        _map(("x",), ({(1,): 1},)),
+        _box(("x",), endpoints),
+    )
+
+    assert isinstance(result.conclusion, RootBoxUnknown)
+    assert isinstance(result.conclusion.attempt, RootBoxInconclusiveKrawczykAttempt)
+    assert result.conclusion.attempt.evidence.krawczyk_image.intervals == (
+        _interval(0, 0),
+    )
+
+
+def test_five_variable_tiny_box_regression_certifies_a_coupled_system() -> None:
+    variables = tuple(f"x{index}" for index in range(5))
+    square_terms: dict[tuple[int, ...], int] = {}
+    for left in range(5):
+        for right in range(left, 5):
+            exponents = tuple(
+                int(axis == left) + int(axis == right) for axis in range(5)
+            )
+            square_terms[exponents] = 1 if left == right else 2
+    components = []
+    for output in range(5):
+        terms = dict(square_terms)
+        terms[tuple(int(axis == output) for axis in range(5))] = 1
+        components.append(terms)
+    radius = Fraction(1, 10**55)
+
+    result = _certify(
+        _map(variables, tuple(components)),
+        _box(variables, tuple((-radius, radius) for _ in variables)),
+    )
+
+    assert isinstance(result.conclusion, RootBoxCertifiedUniqueNonsingular)
+    evidence = result.conclusion.evidence
+    expected_image = _interval(-50 * radius * radius, 50 * radius * radius)
+    assert evidence.krawczyk_image.intervals == (expected_image,) * 5
+    assert _matrix_product(
+        evidence.preconditioner.entries,
+        evidence.jacobian_at_center.entries,
+    ) == tuple(
+        tuple(Fraction(row == column) for column in range(5)) for row in range(5)
+    )
+    for interval in evidence.krawczyk_image.intervals:
+        assert -radius < interval.lower.as_fraction()
+        assert interval.upper.as_fraction() < radius
+
+
+def test_five_variable_shifted_tiny_boxes_retain_shared_denominators() -> None:
+    variables = tuple(f"x{index}" for index in range(5))
+    scale = 10**55
+    radius = Fraction(1, scale)
+    roots = tuple(Fraction(scale + 2 * index + 1, scale) for index in range(5))
+    components: tuple[Mapping[tuple[int, ...], int | Fraction], ...] = tuple(
+        {
+            tuple(int(axis == output) for axis in range(5)): 1,
+            (0, 0, 0, 0, 0): -root,
+        }
+        for output, root in enumerate(roots)
+    )
+
+    result = _certify(
+        _map(variables, components),
+        _box(
+            variables,
+            tuple((root - radius, root + radius) for root in roots),
+        ),
+    )
+
+    assert isinstance(result.conclusion, RootBoxCertifiedUniqueNonsingular)
+    evidence = result.conclusion.evidence
+    assert evidence.center.values == tuple(_q(root) for root in roots)
+    assert evidence.value_at_center == (_q(0),) * 5
+    assert evidence.krawczyk_image.intervals == tuple(
+        _interval(root, root) for root in roots
+    )
+
+
+def test_permuting_the_complete_axis_preserves_the_geometric_root() -> None:
+    source = _certify(
+        _map(
+            ("x", "y"),
+            (
+                {(1, 0): 1, (0, 1): 1, (0, 0): -3},
+                {(1, 0): 1, (0, 1): -1, (0, 0): -1},
+            ),
+        ),
+        _box(
+            ("x", "y"),
+            ((Fraction(3, 2), Fraction(5, 2)), (Fraction(1, 2), Fraction(3, 2))),
+        ),
+    )
+    transported = _certify(
+        _map(
+            ("y", "x"),
+            (
+                {(1, 0): 1, (0, 1): 1, (0, 0): -3},
+                {(1, 0): -1, (0, 1): 1, (0, 0): -1},
+            ),
+        ),
+        _box(
+            ("y", "x"),
+            ((Fraction(1, 2), Fraction(3, 2)), (Fraction(3, 2), Fraction(5, 2))),
+        ),
+    )
+
+    assert isinstance(source.conclusion, RootBoxCertifiedUniqueNonsingular)
+    assert isinstance(transported.conclusion, RootBoxCertifiedUniqueNonsingular)
+    assert tuple(
+        interval.lower.as_fraction()
+        for interval in source.conclusion.evidence.krawczyk_image.intervals
+    ) == (Fraction(2), Fraction(1))
+    assert tuple(
+        interval.lower.as_fraction()
+        for interval in transported.conclusion.evidence.krawczyk_image.intervals
+    ) == (Fraction(1), Fraction(2))
+    assert source.source_digest != transported.source_digest
+
+
+def test_non_square_system_and_mismatched_axis_are_domain_rejections() -> None:
+    x = _polynomial(("x",), {(1,): 1})
+    nonsquare = RationalPolynomialMap(input_variables=("x",), output_polynomials=(x, x))
+    with pytest.raises(
+        OperationDomainValidationError, match="requires a square system"
+    ):
+        certify_real_root_box(nonsquare, _box(("x",), ((-1, 1),)))
+
+    square = RationalPolynomialMap(input_variables=("x",), output_polynomials=(x,))
+    with pytest.raises(OperationDomainValidationError, match="complete ordered axis"):
+        certify_real_root_box(square, _box(("y",), ((-1, 1),)))
+
+
+def test_dimension_and_component_term_boundaries_are_rejected() -> None:
+    variables = tuple(f"x{index}" for index in range(MAX_ROOT_BOX_DIMENSION + 1))
+    coordinate_components = tuple(
+        {tuple(int(axis == output) for axis in range(len(variables))): 1}
+        for output in range(len(variables))
+    )
+    with pytest.raises(OperationDomainValidationError, match="dimension 5"):
+        certify_real_root_box(
+            _map(variables, coordinate_components),
+            _box(variables, tuple((-1, 1) for _ in variables)),
+        )
+
+    overfull = _map(
+        ("x",),
+        ({(degree,): 1 for degree in range(65)},),
+    )
+    with pytest.raises(OperationDomainValidationError, match="64-term budget"):
+        certify_real_root_box(overfull, _box(("x",), ((-1, 1),)))
+
+
+def test_endpoint_digit_budget_is_owned_by_operation_admission() -> None:
+    endpoint = Fraction(10**128, 1)
+    with pytest.raises(OperationDomainValidationError, match="128-digit bound"):
+        certify_real_root_box(
+            _map(("x",), ({(1,): 1},)),
+            _box(("x",), ((endpoint, endpoint + 1),)),
+        )
+
+
+@pytest.mark.parametrize("mutation", ("polynomial", "box", "preconditioner"))
+def test_record_digest_rejects_independent_source_or_evidence_mutation(
+    mutation: str,
+) -> None:
+    result = _certify(
+        _map(("x",), ({(2,): 1, (0,): -2},)),
+        _box(("x",), ((1, 2),)),
+    )
+    payload = result.model_dump(mode="json")
+    if mutation == "polynomial":
+        payload["polynomial_map"]["output_polynomials"][0]["polynomial"]["terms"][1][
+            "coefficient"
+        ] = {"num": "-3", "den": "1"}
+    elif mutation == "box":
+        payload["box"]["intervals"][0]["upper"] = {"num": "3", "den": "1"}
+    else:
+        payload["conclusion"]["evidence"]["preconditioner"]["entries"][0][0] = {
+            "num": "1",
+            "den": "2",
+        }
+
+    with pytest.raises(ValidationError, match="digest"):
+        PolynomialSystemRootBoxResult.model_validate(payload)
+
+
+def test_produced_result_round_trips_and_schema_discriminates_every_branch() -> None:
+    result = _certify(
+        _map(("x",), ({(2,): 1, (0,): -2},)),
+        _box(("x",), ((1, 2),)),
+    )
+
+    assert (
+        PolynomialSystemRootBoxResult.model_validate_json(
+            result.model_dump_json(), strict=True
+        )
+        == result
+    )
+    schema = json.dumps(PolynomialSystemRootBoxResult.model_json_schema())
+    assert '"discriminator": {"mapping"' in schema
+    assert '"propertyName": "status"' in schema
+    assert '"propertyName": "method"' in schema
+    assert '"propertyName": "kind"' in schema
+
+
+def test_conclusion_union_rejects_cross_branch_field_combinations() -> None:
+    certified = _certify(
+        _map(("x",), ({(2,): 1, (0,): -2},)),
+        _box(("x",), ((1, 2),)),
+    ).model_dump(mode="json")
+    certified["conclusion"]["status"] = "UNKNOWN"
+    with pytest.raises(ValidationError):
+        PolynomialSystemRootBoxResult.model_validate(certified)
+
+    unknown = _certify(
+        _map(("x",), ({(2,): 1},)),
+        _box(("x",), ((-1, 1),)),
+    ).model_dump(mode="json")
+    unknown["conclusion"]["status"] = "CERTIFIED_UNIQUE_NONSINGULAR"
+    with pytest.raises(ValidationError):
+        PolynomialSystemRootBoxResult.model_validate(unknown)
+
+
+def test_public_declaration_has_one_executable_square_system_example() -> None:
+    assert len(TOOLS) == 1
+    tool = TOOLS[0]
+    assert tool.operation_id == "polynomial.system.real_root_box.certify"
+    assert tool.request_type is PolynomialSystemRootBoxRequest
+    assert tool.result_type is PolynomialSystemRootBoxResult
+    assert len(tool.examples) == 1
+    request = tool.request_type.model_validate(tool.examples[0].input)
+    result = tool.run(request)
+    assert isinstance(result.conclusion, RootBoxCertifiedUniqueNonsingular)
+
+
+def test_linear_system_krawczyk_image_is_the_exact_known_root() -> None:
+    polynomial_map = _map(
+        ("x", "y"),
+        (
+            {(1, 0): 1, (0, 1): 1, (0, 0): -3},
+            {(1, 0): 1, (0, 1): -1, (0, 0): -1},
+        ),
+    )
+    box = _box(
+        ("x", "y"),
+        (
+            (Fraction(3, 2), Fraction(5, 2)),
+            (Fraction(1, 2), Fraction(3, 2)),
+        ),
+    )
+    result = _certify(polynomial_map, box)
+
+    assert isinstance(result.conclusion, RootBoxCertifiedUniqueNonsingular)
+    image = result.conclusion.evidence.krawczyk_image
+    assert image.intervals == (_interval(2, 2), _interval(1, 1))
+    assert tuple(interval.lower.as_fraction() for interval in image.intervals) == (
+        Fraction(2),
+        Fraction(1),
+    )


### PR DESCRIPTION
## Problem

Small floating residuals do not establish that a coupled polynomial system has a nearby exact real zero. Jacobian already exposes polynomial maps, symbolic Jacobians, rational boxes, and scalar interval extensions, but it cannot turn one supplied multivariate box into a local existence/uniqueness conclusion.

Closes #2109.

## Solution

Add `polynomial.system.real_root_box.certify` and the matching native `certify_real_root_box` function. For one square `QQ` polynomial system and one complete ordered rational box, the operation deterministically returns exactly one of:

- `CERTIFIED_UNIQUE_NONSINGULAR` when the exact midpoint Krawczyk image lies strictly inside the box;
- `NO_ROOT` when one exact component range excludes zero or the Krawczyk image is disjoint from the box; or
- `UNKNOWN` for a singular midpoint Jacobian, a boundary/point-box root, or an inconclusive image.

The result retains the source system and box together with exact midpoint values, the midpoint Jacobian, its interval enclosure, the rational preconditioner, and the Krawczyk image when that method runs. A canonical digest binds the trusted producer result to those values; this is deliberately not an independently supplied proof-verification API.

The kernel uses the existing SymPy-backed Jacobian operation and exact natural polynomial interval extension. It uses python-flint's `fmpq_mat.inv()` for the bounded exact rational inverse rather than adding a matrix inversion implementation. All Krawczyk matrix/interval arithmetic remains exact `Fraction` arithmetic.

## Testing

Final tree on current `main`:

```text
make affected AFFECTED_BASE=origin/main
  scoped Ruff/format/mypy: passed
  math: 22 passed
  catalog: 113 passed
  catalog examples/integration: 815 passed
```

An independent exact differential sweep compared every conclusion for 620 nonconstant integer polynomials of degree at most three across six unit boxes with SymPy's exact root count: 3,720 cases, comprising 1,928 `NO_ROOT`, 68 certificates, and 1,724 `UNKNOWN` outcomes, with no false conclusion.

Regression coverage also includes:

- a coupled five-variable system on a radius-`10^-55` box;
- five shifted radius-`10^-55` boxes whose centers share 55-digit denominators;
- an exact tiny nonzero residual on a positive-dimensional singular locus;
- boundary and point-box roots;
- component exclusion before an irrelevant inadmissible range/Jacobian expansion;
- axis permutation, source/evidence mutation, contradictory result branches, and serialized round trips.

The exact five-polynomial certificate mentioned in the issue comments was not available in this checkout, so this PR does not claim to replay that external artifact. The committed five-dimensional fixtures exercise its disclosed scale and the separate near-singular failure mode.

## Public contract impact

Adds one immutable catalog operation, one native function, and owner-local request/result/evidence models. The source axis is ordered and must match the rational box exactly. Failed inclusion and singular midpoint Jacobians remain explicit non-conclusions.

## Operation boundary ownership

- Changed stage: request admission, exact kernel adapter, trusted result construction, and catalog publication.
- Request-bounds owner and controlling quantities: `jacobian.math.polynomials.root_boxes.operations`; dimension, component/aggregate terms, total degree, inherited coefficient bounds, endpoint digits, retained-source bytes, exact midpoint/enclosure height, matrix-stage height, and canonical result bytes.
- Work, intermediate, memory, and exact-output bounds: dimension 5; 64 terms per component; 256 aggregate terms; total degree 8; 128-digit box endpoints; 512-digit midpoint values; 2,048-digit Jacobian/component enclosures; 65,536-digit exact matrix intermediates; 32,768-digit inverse/image components; 512 KiB retained source; 10 MiB canonical result.
- Wall deadline, calibration workload, safety margin, and caller-selectable range: no separate wall clock is imposed on this small in-process exact path. Finite source, intermediate-height, and output bounds govern the complete attempt; callers cannot select a larger envelope.
- Backend or kernel path: existing SymPy Jacobian construction, existing exact natural interval extension, python-flint exact `fmpq_mat` inversion, then bounded rational interval-matrix arithmetic.
- Result construction: owner-local conversion to canonical rational, matrix, point, and box values after the trusted kernel classifies the exact image.
- Independent-result verifier: none; no independently supplied result data is accepted.
- Native/MCP parity: both call the same typed admission, kernel, and result path.
- Serialized-result and round-trip evidence: strict round-trip, source/evidence mutation, and discriminated-union tests are included.

## Canonical value audit

- [x] Existing canonical values searched and reused: `RationalPolynomialMap`, `RationalBox`, `VariablePoint`, and `RationalMatrix`.
- [x] Root-attempt evidence is owner-local because it binds those values under the Krawczyk postcondition.
- [x] The codomain retains the complete source axis and exact data needed to reconstruct the reported image.
- [x] Producer-to-consumer matrix composition and strict serialization are tested.
- Theorem-dependent preconditions and validated input subtype: square ordered `QQ` systems on a complete closed `QQ` box; strict interior inclusion uses the exact inverse of the midpoint Jacobian.
- Structurally valid but mathematically invalid fixture and outcome: a singular positive-dimensional locus and singular midpoint both return `UNKNOWN`; non-square or axis-mismatched requests are rejected.
- Serialized-subtype trust boundary: trusted producer construction plus canonical integrity binding; altered source/evidence without the matching record digest is rejected.
- Exact-success defining invariant: `K = c - C F(c) + (I - C J(X))(X - c)` with `C = J(c)^-1`; strict `K ⊂ int(X)` certifies one unique nonsingular zero, while `K ∩ X = ∅` certifies no zero.
- Discriminated result schema and impossible combinations: `status`, `method`, and `kind` discriminators reject cross-branch payloads.

## Catalog admission

- Concrete gap: no installed operation certifies a local zero count for a supplied multivariate rational box.
- Why existing operations are insufficient: Jacobians and scalar enclosures are inputs to the theorem, not the theorem's local root postcondition.
- Stable mathematical result: one source-bound exact certificate, exclusion, or non-conclusion for one box.
- Semantic domain and admitted execution envelope: square rational polynomial systems within the explicit limits above.
- Controlling work, intermediate, memory, and output quantities: sparse support/degree, exact enclosure growth, row-cleared inverse height, each downstream matrix/vector stage, retained source, and canonical output.
- Exact representation, algorithm regimes, and maintained backend: rational values throughout; exact midpoint Krawczyk; SymPy for differentiation and python-flint for inversion.
- Remaining fixed caps and their classification: conservative operation-envelope caps, not mathematical restrictions on polynomial systems.
- Motivating source request exercised through the public boundary: source-shaped five-dimensional `10^-55` boxes and the exact singular tiny-residual regression are committed; the undisclosed external system remains an explicit proof gap.
- Final-tree outcome for that request: the regular fixtures certify; the singular fixture returns `UNKNOWN`.
- Effect of private normalization or presolve on admission: a bounded component exclusion may return before Jacobian construction; otherwise exact midpoint/Jacobian data are computed once and reused.
- Admission decision: publish the single atomic local-certification operation.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Boxed local real-root certification | delivered | `polynomial.system.real_root_box.certify` |

## Checklist

- [x] Repository-selected affected validation passes on the final tree.
- [x] No additional specialist lane is relevant.
- [x] Catalog publication is owner-local in `_tools.py`.
- [x] No compatibility aliases, forwarding modules, or shadow operation paths were introduced.
- [x] Native and MCP callers execute the same bounded semantic path.
- [x] Exact conclusions and `UNKNOWN` are distinct discriminated branches.
- [x] Source-shaped scale and adversarial regressions exercise the public boundary.
