### PR TITLE
Return sumset support as FiniteIntegerSet

### DIFF
--- a/src/jacobian/math/combinatorics/additive/_models.py
+++ b/src/jacobian/math/combinatorics/additive/_models.py
@@ -294,7 +294,7 @@ def _require_bounded_cartesian_product(
 def _require_sumset_result_transport_bound(
     left: FiniteIntegerSet,
     right: FiniteIntegerSet,
-) -> None:
+) -> tuple[frozenset[int], frozenset[int]]:
     """Admit the canonical support envelope before sumset enumeration.
 
     A sumset has at most one support value per Cartesian pair.  Charging the
@@ -305,13 +305,23 @@ def _require_sumset_result_transport_bound(
 
     pair_count = len(left.elements) * len(right.elements)
     if pair_count == 0:
-        return
-    left_width = max(len(value.lstrip("-")) for value in left.elements)
-    right_width = max(len(value.lstrip("-")) for value in right.elements)
-    # Adding two integers can carry one additional decimal digit; reserve a
-    # sign and the carrier's per-element JSON overhead as well.
-    max_sum_width = left_width + right_width + 1
-    predicted = 64 + pair_count * (max_sum_width + 3)
+        return frozenset(), frozenset()
+    left_values = frozenset(parse_canonical_integer(value) for value in left.elements)
+    right_values = frozenset(parse_canonical_integer(value) for value in right.elements)
+    # Every sum lies in the interval between the two endpoint sums.  This is a
+    # collision-sensitive support bound, while the endpoint combinations give
+    # the exact widest magnitude that any represented sum can have.
+    interval_bound = (
+        max(left_values) - min(left_values) + max(right_values) - min(right_values) + 1
+    )
+    support_bound = min(pair_count, interval_bound)
+    max_sum_abs = max(
+        abs(left_endpoint + right_endpoint)
+        for left_endpoint in (min(left_values), max(left_values))
+        for right_endpoint in (min(right_values), max(right_values))
+    )
+    max_sum_width = len(format_canonical_integer(max_sum_abs))
+    predicted = 64 + support_bound * (max_sum_width + 3)
     if predicted > _MAX_FINITE_SET_WIRE_BYTES:
         raise OperationDomainValidationError(
             location=("left", "right"),
@@ -323,6 +333,7 @@ def _require_sumset_result_transport_bound(
                 "cardinality or integer width"
             ),
         )
+    return left_values, right_values
 
 
 def _decimal_digit_sum_through(value: int) -> int:

--- a/src/jacobian/math/combinatorics/additive/_models.py
+++ b/src/jacobian/math/combinatorics/additive/_models.py
@@ -18,6 +18,7 @@ from jacobian.canonical import (
     parse_canonical_integer,
     strict_json_object_size,
 )
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.additive._multiset_sum import (
     MAX_ARITY,
     MAX_ARITY_DIGITS,
@@ -36,7 +37,10 @@ from jacobian.math.combinatorics.additive.values import (
     IndexedIntegerSequence,
     indexed_sequence_item_ceiling,
 )
-from jacobian.math.combinatorics.finite_structures.sets._models import FiniteIntegerSet
+from jacobian.math.combinatorics.finite_structures.sets._models import (
+    _MAX_FINITE_SET_WIRE_BYTES,
+    FiniteIntegerSet,
+)
 
 # This conservative materialized-axis cap bounds source parsing and binomial
 # preflight. Operation-specific work and result bounds impose the sharper
@@ -284,6 +288,40 @@ def _require_bounded_cartesian_product(
             "_require_bounded_cartesian_product",
             f"Cartesian product has {pair_count} pairs, exceeding the "
             f"{_MAX_CARTESIAN_PAIR_COUNT}-pair bound",
+        )
+
+
+def _require_sumset_result_transport_bound(
+    left: FiniteIntegerSet,
+    right: FiniteIntegerSet,
+) -> None:
+    """Admit the canonical support envelope before sumset enumeration.
+
+    A sumset has at most one support value per Cartesian pair.  Charging the
+    maximum possible decimal width of each pair's sum is conservative, but it
+    prevents a large-label request from doing the pairwise work only to fail
+    when the shared ``FiniteIntegerSet`` carrier validates its 5 MiB envelope.
+    """
+
+    pair_count = len(left.elements) * len(right.elements)
+    if pair_count == 0:
+        return
+    left_width = max(len(value.lstrip("-")) for value in left.elements)
+    right_width = max(len(value.lstrip("-")) for value in right.elements)
+    # Adding two integers can carry one additional decimal digit; reserve a
+    # sign and the carrier's per-element JSON overhead as well.
+    max_sum_width = left_width + right_width + 1
+    predicted = 64 + pair_count * (max_sum_width + 3)
+    if predicted > _MAX_FINITE_SET_WIRE_BYTES:
+        raise OperationDomainValidationError(
+            location=("left", "right"),
+            code="additive_combinatorics.sumset_result_transport_exceeded",
+            message=(
+                "sumset support may exceed the canonical finite-integer-set "
+                f"transport envelope ({predicted:,} > "
+                f"{_MAX_FINITE_SET_WIRE_BYTES:,} bytes); reduce operand "
+                "cardinality or integer width"
+            ),
         )
 
 

--- a/src/jacobian/math/combinatorics/additive/_models.py
+++ b/src/jacobian/math/combinatorics/additive/_models.py
@@ -315,12 +315,12 @@ def _require_sumset_result_transport_bound(
         max(left_values) - min(left_values) + max(right_values) - min(right_values) + 1
     )
     support_bound = min(pair_count, interval_bound)
-    max_sum_abs = max(
-        abs(left_endpoint + right_endpoint)
+    endpoint_sums = tuple(
+        left_endpoint + right_endpoint
         for left_endpoint in (min(left_values), max(left_values))
         for right_endpoint in (min(right_values), max(right_values))
     )
-    max_sum_width = len(format_canonical_integer(max_sum_abs))
+    max_sum_width = max(len(format_canonical_integer(value)) for value in endpoint_sums)
     predicted = 64 + support_bound * (max_sum_width + 3)
     if predicted > _MAX_FINITE_SET_WIRE_BYTES:
         raise OperationDomainValidationError(

--- a/src/jacobian/math/combinatorics/additive/_models.py
+++ b/src/jacobian/math/combinatorics/additive/_models.py
@@ -713,19 +713,19 @@ class SumsetCardinalityRequest(StrictModel):
 
 
 class SumsetCardinalityResult(StrictModel):
-    """Cardinality of the sumset and its sorted support."""
+    """Cardinality of the sumset and its canonical support set."""
 
     cardinality: int = Field(ge=0)
-    support: tuple[CanonicalInteger, ...] = Field(default=())
+    support: FiniteIntegerSet
 
     @model_validator(mode="after")
     def require_canonical_support(self) -> Self:
-        sums = list(self.support)
-        if tuple(sums) != _sorted_canonical_integers(sums):
+        elements = list(self.support.elements)
+        if tuple(elements) != _sorted_canonical_integers(elements):
             raise _validation_error(
                 "require_canonical_support", "sumset support must be sorted and unique"
             )
-        if self.cardinality != len(self.support):
+        if self.cardinality != len(self.support.elements):
             raise _validation_error(
                 "require_canonical_support", "cardinality must equal the support length"
             )
@@ -733,7 +733,10 @@ class SumsetCardinalityResult(StrictModel):
 
     @classmethod
     def _from_kernel(cls, support: tuple[CanonicalInteger, ...]) -> Self:
-        return cls.model_construct(cardinality=len(support), support=support)
+        return cls.model_construct(
+            cardinality=len(support),
+            support=FiniteIntegerSet(elements=support),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/jacobian/math/combinatorics/additive/operations.py
+++ b/src/jacobian/math/combinatorics/additive/operations.py
@@ -32,6 +32,7 @@ from jacobian.math.combinatorics.additive._models import (
     _multiset_sum_source_values,
     _require_bounded_cartesian_product,
     _require_direct_sum_result_transport_bound,
+    _require_sumset_result_transport_bound,
     _vector_from_ints,
 )
 from jacobian.math.combinatorics.additive._multiset_sum import (
@@ -195,6 +196,7 @@ def sumset_cardinality(
 ) -> SumsetCardinalityResult:
     """Compute ``|A + B|`` (the support cardinality of ``r_{A+B}``)."""
     _require_bounded_cartesian_product(left, right)
+    _require_sumset_result_transport_bound(left, right)
     counts = _representation_function(_parse_set(left), _parse_set(right))
     support = tuple(format_canonical_integer(value) for value in _sorted_sums(counts))
     return SumsetCardinalityResult._from_kernel(support)

--- a/src/jacobian/math/combinatorics/additive/operations.py
+++ b/src/jacobian/math/combinatorics/additive/operations.py
@@ -196,8 +196,8 @@ def sumset_cardinality(
 ) -> SumsetCardinalityResult:
     """Compute ``|A + B|`` (the support cardinality of ``r_{A+B}``)."""
     _require_bounded_cartesian_product(left, right)
-    _require_sumset_result_transport_bound(left, right)
-    counts = _representation_function(_parse_set(left), _parse_set(right))
+    left_values, right_values = _require_sumset_result_transport_bound(left, right)
+    counts = _representation_function(left_values, right_values)
     support = tuple(format_canonical_integer(value) for value in _sorted_sums(counts))
     return SumsetCardinalityResult._from_kernel(support)
 

--- a/tests/math/combinatorics/additive/test_additive_combinatorics.py
+++ b/tests/math/combinatorics/additive/test_additive_combinatorics.py
@@ -181,10 +181,18 @@ class TestSumsetCardinality:
         # the result carrier are materialized.
         width = 10_000
         left = FiniteIntegerSet(
-            elements=tuple("1" + str(index).zfill(width - 1) for index in range(256))
+            elements=tuple(
+                prefix + str(index).zfill(width - 1)
+                for prefix in ("1", "9")
+                for index in range(128)
+            )
         )
         right = FiniteIntegerSet(
-            elements=tuple("2" + str(index).zfill(width - 1) for index in range(256))
+            elements=tuple(
+                prefix + str(index).zfill(width - 1)
+                for prefix in ("2", "8")
+                for index in range(128)
+            )
         )
 
         with pytest.raises(OperationDomainValidationError) as exc_info:

--- a/tests/math/combinatorics/additive/test_additive_combinatorics.py
+++ b/tests/math/combinatorics/additive/test_additive_combinatorics.py
@@ -174,6 +174,26 @@ class TestSumsetCardinality:
             "12",
         )
 
+    def test_large_labels_are_rejected_before_support_materialization(self) -> None:
+        # Each operand remains within the shared finite-set input envelope, but
+        # the 256x256 pair envelope could not fit a canonical support carrying
+        # ten-thousand-digit sums.  Admission must reject before bigint sums or
+        # the result carrier are materialized.
+        width = 10_000
+        left = FiniteIntegerSet(
+            elements=tuple("1" + str(index).zfill(width - 1) for index in range(256))
+        )
+        right = FiniteIntegerSet(
+            elements=tuple("2" + str(index).zfill(width - 1) for index in range(256))
+        )
+
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            sumset_cardinality(left, right)
+
+        assert exc_info.value.errors()[0]["type"] == (
+            "additive_combinatorics.sumset_result_transport_exceeded"
+        )
+
 
 class TestDirectSumPredicate:
     def test_tiling_z4(self) -> None:

--- a/tests/math/combinatorics/additive/test_additive_combinatorics.py
+++ b/tests/math/combinatorics/additive/test_additive_combinatorics.py
@@ -146,7 +146,7 @@ class TestSumsetCardinality:
         )
         result = _run_sumset(req)
         assert result.cardinality == 5
-        assert result.support == ("0", "1", "2", "3", "4")
+        assert result.support.elements == ("0", "1", "2", "3", "4")
 
     def test_disjoint(self) -> None:
         req = SumsetCardinalityRequest(
@@ -162,7 +162,7 @@ class TestSumsetCardinality:
             right=FiniteIntegerSet(elements=("5", "0", "-5")),
         )
         result = _run_sumset(req)
-        assert result.support == (
+        assert result.support.elements == (
             "-7",
             "-5",
             "-2",


### PR DESCRIPTION
## Summary

Closes #2824.

The  field changed from a bare  to the canonical  value. This makes the sumset result directly consumable by finite-set operations, integer-set transforms, and additive profiles without manual rewiring.

## Changes

-  is now a  instead of a bare tuple
- The  field remains for scalar convenience and equals 
- Tests updated to access  where applicable
- The producer postcondition (exact A+B support) is unchanged

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/f3aaed06-1b4b-47df-9bd7-59fa33e39f3d)