### PR TITLE
Add integer.divisibility_poset.compute operation

### DIFF
--- a/src/jacobian/math/combinatorics/posets/core/_models.py
+++ b/src/jacobian/math/combinatorics/posets/core/_models.py
@@ -20,6 +20,7 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 
 MAX_POSET_ELEMENTS = 64
 MAX_POSET_RELATIONS = MAX_POSET_ELEMENTS * MAX_POSET_ELEMENTS
+MAX_ELEMENT_LABEL_LENGTH = 32
 MAX_LINEAR_EXTENSION_ELEMENTS = 20
 MAX_ANTICHAIN_PROFILE_ELEMENTS = 14
 MAX_ANTICHAIN_PROFILE_CANDIDATES = 1 << MAX_ANTICHAIN_PROFILE_ELEMENTS
@@ -28,6 +29,7 @@ ElementLabel = Annotated[
     str,
     StringConstraints(
         pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,31}$",
+        max_length=MAX_ELEMENT_LABEL_LENGTH,
         strict=True,
     ),
 ]
@@ -772,6 +774,7 @@ class AntichainProfileResult(StrictModel):
 __all__ = [
     "MAX_ANTICHAIN_PROFILE_CANDIDATES",
     "MAX_ANTICHAIN_PROFILE_ELEMENTS",
+    "MAX_ELEMENT_LABEL_LENGTH",
     "MAX_LINEAR_EXTENSION_ELEMENTS",
     "MAX_POSET_ELEMENTS",
     "MAX_POSET_RELATIONS",

--- a/src/jacobian/math/number_theory/__init__.py
+++ b/src/jacobian/math/number_theory/__init__.py
@@ -1,5 +1,6 @@
 """Supported exact number-theory API."""
 
+from jacobian.math.number_theory._divisibility_poset import divisibility_poset
 from jacobian.math.number_theory._friable_kernel import count_friable
 from jacobian.math.number_theory._friable_models import FriableCountResult
 from jacobian.math.number_theory._prime_shift_models import PrimeShiftProfileResult
@@ -39,6 +40,7 @@ __all__ = [
     "chinese_remainder",
     "contiguous_sum_profile",
     "count_friable",
+    "divisibility_poset",
     "euler_totient",
     "factorial_valuation",
     "floor_square_root",

--- a/src/jacobian/math/number_theory/_divisibility_poset.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from jacobian.canonical import parse_canonical_integer
 from jacobian.catalog._examples import example
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.posets.core._models import (
     FinitePoset,
     PresentationPair,
@@ -14,13 +16,53 @@ from jacobian.math.number_theory._divisibility_poset_kernels import (
     construct_divisibility_poset,
 )
 from jacobian.math.number_theory._divisibility_poset_models import (
+    MAX_DIVISIBILITY_SET_SIZE,
     DivisibilityPosetRequest,
 )
 from jacobian.math.number_theory._support import number_theory_operation
 
 
+def _admit_values(values: tuple[str, ...]) -> None:
+    if type(values) is not tuple:
+        raise OperationDomainValidationError(
+            location=("values",),
+            code="divisibility_poset.values_type",
+            message="values must be a tuple of canonical positive integers",
+        )
+    if not 1 <= len(values) <= MAX_DIVISIBILITY_SET_SIZE:
+        raise OperationDomainValidationError(
+            location=("values",),
+            code="divisibility_poset.values_size",
+            message=(
+                "values must contain between 1 and "
+                f"{MAX_DIVISIBILITY_SET_SIZE} distinct integers"
+            ),
+        )
+    try:
+        parsed = tuple(parse_canonical_integer(value) for value in values)
+    except (TypeError, ValueError) as exc:
+        raise OperationDomainValidationError(
+            location=("values",),
+            code="divisibility_poset.values_domain",
+            message="values must be canonical positive integers",
+        ) from exc
+    if any(value <= 0 for value in parsed):
+        raise OperationDomainValidationError(
+            location=("values",),
+            code="divisibility_poset.values_domain",
+            message="values must be canonical positive integers",
+        )
+    if len(set(values)) != len(values):
+        raise OperationDomainValidationError(
+            location=("values",),
+            code="divisibility_poset.values_unique",
+            message="values must be distinct",
+        )
+
+
 def divisibility_poset(values: tuple[str, ...]) -> FinitePoset:
     """Return the canonical proper-divisibility poset of positive integers."""
+    _admit_values(values)
     data = construct_divisibility_poset(values)
     return materialize_finite_poset(
         tuple(sorted(values)),

--- a/src/jacobian/math/number_theory/_divisibility_poset.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset.py
@@ -19,11 +19,11 @@ from jacobian.math.number_theory._divisibility_poset_models import (
 from jacobian.math.number_theory._support import number_theory_operation
 
 
-def compute_divisibility_poset(request: DivisibilityPosetRequest) -> FinitePoset:
-    """Return the canonical proper-divisibility poset of a finite set of integers."""
-    data = construct_divisibility_poset(request.values)
+def divisibility_poset(values: tuple[str, ...]) -> FinitePoset:
+    """Return the canonical proper-divisibility poset of positive integers."""
+    data = construct_divisibility_poset(values)
     return materialize_finite_poset(
-        tuple(sorted(request.values)),
+        tuple(sorted(values)),
         tuple(
             PresentationPair(lower=lower, upper=upper)
             for lower, upper in data.strict_order_pairs
@@ -31,6 +31,11 @@ def compute_divisibility_poset(request: DivisibilityPosetRequest) -> FinitePoset
         RelationInterpretation.COMPARABLE_PAIRS,
         ReflexivePairPolicy.FORBIDDEN,
     )
+
+
+def compute_divisibility_poset(request: DivisibilityPosetRequest) -> FinitePoset:
+    """Adapt the wire request to the native divisibility-poset operation."""
+    return divisibility_poset(request.values)
 
 
 DIVISIBILITY_POSET_OPERATION = number_theory_operation(
@@ -57,4 +62,8 @@ DIVISIBILITY_POSET_OPERATION = number_theory_operation(
 )
 
 
-__all__ = ["DIVISIBILITY_POSET_OPERATION", "compute_divisibility_poset"]
+__all__ = [
+    "DIVISIBILITY_POSET_OPERATION",
+    "compute_divisibility_poset",
+    "divisibility_poset",
+]

--- a/src/jacobian/math/number_theory/_divisibility_poset.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset.py
@@ -3,22 +3,33 @@
 from __future__ import annotations
 
 from jacobian.catalog._examples import example
+from jacobian.math.combinatorics.posets.core._models import (
+    FinitePoset,
+    PresentationPair,
+    ReflexivePairPolicy,
+    RelationInterpretation,
+)
+from jacobian.math.combinatorics.posets.core.operations import materialize_finite_poset
 from jacobian.math.number_theory._divisibility_poset_kernels import (
     construct_divisibility_poset,
 )
 from jacobian.math.number_theory._divisibility_poset_models import (
     DivisibilityPosetRequest,
-    DivisibilityPosetResult,
 )
 from jacobian.math.number_theory._support import number_theory_operation
 
 
-def compute_divisibility_poset(request: DivisibilityPosetRequest) -> DivisibilityPosetResult:
+def compute_divisibility_poset(request: DivisibilityPosetRequest) -> FinitePoset:
     """Return the canonical proper-divisibility poset of a finite set of integers."""
     data = construct_divisibility_poset(request.values)
-    return DivisibilityPosetResult(
-        values=request.values,
-        strict_order_pairs=data.strict_order_pairs,
+    return materialize_finite_poset(
+        tuple(sorted(request.values)),
+        tuple(
+            PresentationPair(lower=lower, upper=upper)
+            for lower, upper in data.strict_order_pairs
+        ),
+        RelationInterpretation.COMPARABLE_PAIRS,
+        ReflexivePairPolicy.FORBIDDEN,
     )
 
 
@@ -29,7 +40,7 @@ DIVISIBILITY_POSET_OPERATION = number_theory_operation(
     "proper-divisibility poset where a < b exactly when a divides b "
     "and a != b. The result is a source-labelled directed relation.",
     DivisibilityPosetRequest,
-    DivisibilityPosetResult,
+    FinitePoset,
     compute_divisibility_poset,
     "number-theory",
     "divisibility",
@@ -46,4 +57,4 @@ DIVISIBILITY_POSET_OPERATION = number_theory_operation(
 )
 
 
-__all__ = ["compute_divisibility_poset", "DIVISIBILITY_POSET_OPERATION"]
+__all__ = ["DIVISIBILITY_POSET_OPERATION", "compute_divisibility_poset"]

--- a/src/jacobian/math/number_theory/_divisibility_poset.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset.py
@@ -34,12 +34,12 @@ def _admit_values(values: FiniteIntegerSet) -> tuple[str, ...]:
             message="values must be a canonical finite set of positive integers",
         )
     elements = values.elements
-    if not 1 <= len(elements) <= min(MAX_DIVISIBILITY_SET_SIZE, MAX_POSET_ELEMENTS):
+    if not 0 <= len(elements) <= min(MAX_DIVISIBILITY_SET_SIZE, MAX_POSET_ELEMENTS):
         raise OperationDomainValidationError(
             location=("values",),
             code="divisibility_poset.values_size",
             message=(
-                "values must contain between 1 and "
+                "values must contain between 0 and "
                 f"{min(MAX_DIVISIBILITY_SET_SIZE, MAX_POSET_ELEMENTS)} distinct integers"
             ),
         )

--- a/src/jacobian/math/number_theory/_divisibility_poset.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset.py
@@ -1,0 +1,49 @@
+"""Finite divisibility poset construction and declaration."""
+
+from __future__ import annotations
+
+from jacobian.catalog._examples import example
+from jacobian.math.number_theory._divisibility_poset_kernels import (
+    construct_divisibility_poset,
+)
+from jacobian.math.number_theory._divisibility_poset_models import (
+    DivisibilityPosetRequest,
+    DivisibilityPosetResult,
+)
+from jacobian.math.number_theory._support import number_theory_operation
+
+
+def compute_divisibility_poset(request: DivisibilityPosetRequest) -> DivisibilityPosetResult:
+    """Return the canonical proper-divisibility poset of a finite set of integers."""
+    data = construct_divisibility_poset(request.values)
+    return DivisibilityPosetResult(
+        values=request.values,
+        strict_order_pairs=data.strict_order_pairs,
+    )
+
+
+DIVISIBILITY_POSET_OPERATION = number_theory_operation(
+    "integer.divisibility_poset.compute",
+    "Construct finite divisibility poset",
+    "Given a finite set of positive integers, return the canonical "
+    "proper-divisibility poset where a < b exactly when a divides b "
+    "and a != b. The result is a source-labelled directed relation.",
+    DivisibilityPosetRequest,
+    DivisibilityPosetResult,
+    compute_divisibility_poset,
+    "number-theory",
+    "divisibility",
+    "poset",
+    "exact",
+    examples=(
+        example(
+            "divisibility_236",
+            "For {2,3,6}, the proper-divisibility poset has 2<6 and 3<6; "
+            "values must be positive canonical decimal integers.",
+            {"values": ["2", "3", "6"]},
+        ),
+    ),
+)
+
+
+__all__ = ["compute_divisibility_poset", "DIVISIBILITY_POSET_OPERATION"]

--- a/src/jacobian/math/number_theory/_divisibility_poset.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset.py
@@ -7,11 +7,12 @@ from jacobian.catalog._examples import example
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.posets.core._models import (
     FinitePoset,
-    PresentationPair,
-    ReflexivePairPolicy,
-    RelationInterpretation,
+    IncomparablePair,
+    OrderedPair,
+    _transitive_reduction,
+    canonical_poset_ranks,
+    finite_poset_digest,
 )
-from jacobian.math.combinatorics.posets.core.operations import materialize_finite_poset
 from jacobian.math.number_theory._divisibility_poset_kernels import (
     construct_divisibility_poset,
 )
@@ -64,14 +65,52 @@ def divisibility_poset(values: tuple[str, ...]) -> FinitePoset:
     """Return the canonical proper-divisibility poset of positive integers."""
     _admit_values(values)
     data = construct_divisibility_poset(values)
-    return materialize_finite_poset(
-        tuple(sorted(values)),
-        tuple(
-            PresentationPair(lower=lower, upper=upper)
-            for lower, upper in data.strict_order_pairs
-        ),
-        RelationInterpretation.COMPARABLE_PAIRS,
-        ReflexivePairPolicy.FORBIDDEN,
+    elements = tuple(sorted(values))
+    strict = set(data.strict_order_pairs)
+    covers = _transitive_reduction(elements, strict)
+    strict_pairs = tuple(
+        OrderedPair(lower=lower, upper=upper) for lower, upper in sorted(strict)
+    )
+    cover_pairs = tuple(
+        OrderedPair(lower=lower, upper=upper) for lower, upper in sorted(covers)
+    )
+    incomparable = tuple(
+        IncomparablePair(left=left, right=right)
+        for index, left in enumerate(elements)
+        for right in elements[index + 1 :]
+        if (left, right) not in strict and (right, left) not in strict
+    )
+    minimal = tuple(
+        element
+        for element in elements
+        if not any(upper == element for _, upper in strict)
+    )
+    maximal = tuple(
+        element
+        for element in elements
+        if not any(lower == element for lower, _ in strict)
+    )
+    ranks = canonical_poset_ranks(elements, covers)
+    digest = finite_poset_digest(
+        elements=elements,
+        strict_order_pairs=strict_pairs,
+        cover_relations=cover_pairs,
+        incomparable_pairs=incomparable,
+        minimal_elements=minimal,
+        maximal_elements=maximal,
+        graded=ranks is not None,
+        ranks=ranks,
+    )
+    return FinitePoset.model_construct(
+        elements=elements,
+        strict_order_pairs=strict_pairs,
+        cover_relations=cover_pairs,
+        incomparable_pairs=incomparable,
+        minimal_elements=minimal,
+        maximal_elements=maximal,
+        graded=ranks is not None,
+        ranks=ranks,
+        poset_digest=digest,
     )
 
 

--- a/src/jacobian/math/number_theory/_divisibility_poset.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset.py
@@ -6,6 +6,8 @@ from jacobian.canonical import parse_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.posets.core._models import (
+    MAX_ELEMENT_LABEL_LENGTH,
+    MAX_POSET_ELEMENTS,
     FinitePoset,
     IncomparablePair,
     OrderedPair,
@@ -30,13 +32,26 @@ def _admit_values(values: tuple[str, ...]) -> None:
             code="divisibility_poset.values_type",
             message="values must be a tuple of canonical positive integers",
         )
-    if not 1 <= len(values) <= MAX_DIVISIBILITY_SET_SIZE:
+    if not 1 <= len(values) <= min(MAX_DIVISIBILITY_SET_SIZE, MAX_POSET_ELEMENTS):
         raise OperationDomainValidationError(
             location=("values",),
             code="divisibility_poset.values_size",
             message=(
                 "values must contain between 1 and "
-                f"{MAX_DIVISIBILITY_SET_SIZE} distinct integers"
+                "between 1 and "
+                f"{min(MAX_DIVISIBILITY_SET_SIZE, MAX_POSET_ELEMENTS)} distinct integers"
+            ),
+        )
+    if any(
+        type(value) is not str or len(value) > MAX_ELEMENT_LABEL_LENGTH
+        for value in values
+    ):
+        raise OperationDomainValidationError(
+            location=("values",),
+            code="divisibility_poset.values_label_length",
+            message=(
+                "values must use positive canonical integers no longer than "
+                f"{MAX_ELEMENT_LABEL_LENGTH} characters"
             ),
         )
     try:

--- a/src/jacobian/math/number_theory/_divisibility_poset.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from jacobian.canonical import parse_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics.finite_structures.sets._models import FiniteIntegerSet
 from jacobian.math.combinatorics.posets.core._models import (
     MAX_ELEMENT_LABEL_LENGTH,
     MAX_POSET_ELEMENTS,
@@ -25,26 +26,26 @@ from jacobian.math.number_theory._divisibility_poset_models import (
 from jacobian.math.number_theory._support import number_theory_operation
 
 
-def _admit_values(values: tuple[str, ...]) -> None:
-    if type(values) is not tuple:
+def _admit_values(values: FiniteIntegerSet) -> tuple[str, ...]:
+    if not isinstance(values, FiniteIntegerSet):
         raise OperationDomainValidationError(
             location=("values",),
             code="divisibility_poset.values_type",
-            message="values must be a tuple of canonical positive integers",
+            message="values must be a canonical finite set of positive integers",
         )
-    if not 1 <= len(values) <= min(MAX_DIVISIBILITY_SET_SIZE, MAX_POSET_ELEMENTS):
+    elements = values.elements
+    if not 1 <= len(elements) <= min(MAX_DIVISIBILITY_SET_SIZE, MAX_POSET_ELEMENTS):
         raise OperationDomainValidationError(
             location=("values",),
             code="divisibility_poset.values_size",
             message=(
                 "values must contain between 1 and "
-                "between 1 and "
                 f"{min(MAX_DIVISIBILITY_SET_SIZE, MAX_POSET_ELEMENTS)} distinct integers"
             ),
         )
     if any(
         type(value) is not str or len(value) > MAX_ELEMENT_LABEL_LENGTH
-        for value in values
+        for value in elements
     ):
         raise OperationDomainValidationError(
             location=("values",),
@@ -55,7 +56,7 @@ def _admit_values(values: tuple[str, ...]) -> None:
             ),
         )
     try:
-        parsed = tuple(parse_canonical_integer(value) for value in values)
+        parsed = tuple(parse_canonical_integer(value) for value in elements)
     except (TypeError, ValueError) as exc:
         raise OperationDomainValidationError(
             location=("values",),
@@ -68,19 +69,14 @@ def _admit_values(values: tuple[str, ...]) -> None:
             code="divisibility_poset.values_domain",
             message="values must be canonical positive integers",
         )
-    if len(set(values)) != len(values):
-        raise OperationDomainValidationError(
-            location=("values",),
-            code="divisibility_poset.values_unique",
-            message="values must be distinct",
-        )
+    return elements
 
 
-def divisibility_poset(values: tuple[str, ...]) -> FinitePoset:
+def divisibility_poset(values: FiniteIntegerSet) -> FinitePoset:
     """Return the canonical proper-divisibility poset of positive integers."""
-    _admit_values(values)
-    data = construct_divisibility_poset(values)
-    elements = tuple(sorted(values))
+    admitted_values = _admit_values(values)
+    data = construct_divisibility_poset(admitted_values)
+    elements = tuple(sorted(admitted_values))
     strict = set(data.strict_order_pairs)
     covers = _transitive_reduction(elements, strict)
     strict_pairs = tuple(
@@ -152,7 +148,7 @@ DIVISIBILITY_POSET_OPERATION = number_theory_operation(
             "divisibility_236",
             "For {2,3,6}, the proper-divisibility poset has 2<6 and 3<6; "
             "values must be positive canonical decimal integers.",
-            {"values": ["2", "3", "6"]},
+            {"values": {"elements": ["2", "3", "6"]}},
         ),
     ),
 )

--- a/src/jacobian/math/number_theory/_divisibility_poset.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset.py
@@ -13,7 +13,9 @@ from jacobian.math.number_theory._divisibility_poset_models import (
 from jacobian.math.number_theory._support import number_theory_operation
 
 
-def compute_divisibility_poset(request: DivisibilityPosetRequest) -> DivisibilityPosetResult:
+def compute_divisibility_poset(
+    request: DivisibilityPosetRequest,
+) -> DivisibilityPosetResult:
     """Return the canonical proper-divisibility poset of a finite set of integers."""
     data = construct_divisibility_poset(request.values)
     return DivisibilityPosetResult(
@@ -46,4 +48,4 @@ DIVISIBILITY_POSET_OPERATION = number_theory_operation(
 )
 
 
-__all__ = ["compute_divisibility_poset", "DIVISIBILITY_POSET_OPERATION"]
+__all__ = ["DIVISIBILITY_POSET_OPERATION", "compute_divisibility_poset"]

--- a/src/jacobian/math/number_theory/_divisibility_poset_kernels.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset_kernels.py
@@ -1,0 +1,31 @@
+"""Exact kernel for finite divisibility poset construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class DivisibilityPosetData:
+    """Private canonical data returned by the poset kernel."""
+
+    strict_order_pairs: tuple[tuple[str, str], ...]
+
+
+def construct_divisibility_poset(values: tuple[str, ...]) -> DivisibilityPosetData:
+    """Return the canonical proper-divisibility poset of a finite set.
+
+    The poset has a < b exactly when a divides b and a != b.
+    """
+    int_values = [int(v) for v in values]
+    n = len(int_values)
+
+    pairs: list[tuple[str, str]] = []
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            if int_values[j] % int_values[i] == 0:
+                pairs.append((values[i], values[j]))
+
+    return DivisibilityPosetData(strict_order_pairs=tuple(pairs))

--- a/src/jacobian/math/number_theory/_divisibility_poset_models.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset_models.py
@@ -2,16 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Self
-
-from pydantic import Field, model_validator
-from pydantic_core import PydanticCustomError
+from pydantic import Field
 
 from jacobian._models import StrictModel
-from jacobian.canonical import parse_canonical_integer
-from jacobian.math.combinatorics.posets.core._models import (
-    MAX_POSET_ELEMENTS,
-    ElementLabel,
+from jacobian.math.combinatorics.finite_structures.sets._models import (
+    FiniteIntegerSet,
 )
 
 MAX_DIVISIBILITY_SET_SIZE = 500
@@ -20,29 +15,13 @@ MAX_DIVISIBILITY_SET_SIZE = 500
 class DivisibilityPosetRequest(StrictModel):
     """Construct the proper-divisibility poset of a finite set of positive integers."""
 
-    values: tuple[ElementLabel, ...] = Field(
-        min_length=1,
-        max_length=min(MAX_DIVISIBILITY_SET_SIZE, MAX_POSET_ELEMENTS),
+    values: FiniteIntegerSet = Field(
         description=(
             "Finite set of positive canonical decimal integers. The poset "
             "has a < b exactly when a divides b and a != b."
         ),
-        examples=["2", "3", "6"],
+        examples=[{"elements": ["2", "3", "6"]}],
     )
-
-    @model_validator(mode="after")
-    def require_positive_unique_values(self) -> Self:
-        if any(parse_canonical_integer(value) <= 0 for value in self.values):
-            raise PydanticCustomError(
-                "divisibility_poset.positive_values",
-                "values must be positive canonical integers",
-            )
-        if len(set(self.values)) != len(self.values):
-            raise PydanticCustomError(
-                "divisibility_poset.values_unique",
-                "values must be distinct",
-            )
-        return self
 
 
 __all__ = [

--- a/src/jacobian/math/number_theory/_divisibility_poset_models.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset_models.py
@@ -45,25 +45,7 @@ class DivisibilityPosetRequest(StrictModel):
         return self
 
 
-class DivisibilityPosetResult(StrictModel):
-    """The canonical proper-divisibility poset."""
-
-    values: tuple[str, ...] = Field(min_length=1)
-    strict_order_pairs: tuple[tuple[str, str], ...] = Field(default=())
-
-    @model_validator(mode="after")
-    def require_canonical_pairs(self) -> Self:
-        for a, b in self.strict_order_pairs:
-            if a == b:
-                raise PydanticCustomError(
-                    "divisibility_poset.no_reflexive",
-                    "strict order pairs must not be reflexive",
-                )
-        return self
-
-
 __all__ = [
     "MAX_DIVISIBILITY_SET_SIZE",
     "DivisibilityPosetRequest",
-    "DivisibilityPosetResult",
 ]

--- a/src/jacobian/math/number_theory/_divisibility_poset_models.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset_models.py
@@ -1,0 +1,50 @@
+"""Typed contracts for finite divisibility poset construction."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+
+MAX_DIVISIBILITY_SET_SIZE = 500
+
+
+class DivisibilityPosetRequest(StrictModel):
+    """Construct the proper-divisibility poset of a finite set of positive integers."""
+
+    values: tuple[str, ...] = Field(
+        min_length=1,
+        max_length=MAX_DIVISIBILITY_SET_SIZE,
+        description=(
+            "Finite set of positive canonical decimal integers. The poset "
+            "has a < b exactly when a divides b and a != b."
+        ),
+        examples=["2", "3", "6"],
+    )
+
+
+class DivisibilityPosetResult(StrictModel):
+    """The canonical proper-divisibility poset."""
+
+    values: tuple[str, ...] = Field(min_length=1)
+    strict_order_pairs: tuple[tuple[str, str], ...] = Field(default=())
+
+    @model_validator(mode="after")
+    def require_canonical_pairs(self) -> Self:
+        for a, b in self.strict_order_pairs:
+            if a == b:
+                raise PydanticCustomError(
+                    "divisibility_poset.no_reflexive",
+                    "strict order pairs must not be reflexive",
+                )
+        return self
+
+
+__all__ = [
+    "MAX_DIVISIBILITY_SET_SIZE",
+    "DivisibilityPosetRequest",
+    "DivisibilityPosetResult",
+]

--- a/src/jacobian/math/number_theory/_divisibility_poset_models.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset_models.py
@@ -9,7 +9,10 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.canonical import parse_canonical_integer
-from jacobian.math.combinatorics.posets.core._models import ElementLabel
+from jacobian.math.combinatorics.posets.core._models import (
+    MAX_POSET_ELEMENTS,
+    ElementLabel,
+)
 
 MAX_DIVISIBILITY_SET_SIZE = 500
 
@@ -19,7 +22,7 @@ class DivisibilityPosetRequest(StrictModel):
 
     values: tuple[ElementLabel, ...] = Field(
         min_length=1,
-        max_length=MAX_DIVISIBILITY_SET_SIZE,
+        max_length=min(MAX_DIVISIBILITY_SET_SIZE, MAX_POSET_ELEMENTS),
         description=(
             "Finite set of positive canonical decimal integers. The poset "
             "has a < b exactly when a divides b and a != b."

--- a/src/jacobian/math/number_theory/_divisibility_poset_models.py
+++ b/src/jacobian/math/number_theory/_divisibility_poset_models.py
@@ -8,6 +8,8 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math.combinatorics.posets.core._models import ElementLabel
 
 MAX_DIVISIBILITY_SET_SIZE = 500
 
@@ -15,7 +17,7 @@ MAX_DIVISIBILITY_SET_SIZE = 500
 class DivisibilityPosetRequest(StrictModel):
     """Construct the proper-divisibility poset of a finite set of positive integers."""
 
-    values: tuple[str, ...] = Field(
+    values: tuple[ElementLabel, ...] = Field(
         min_length=1,
         max_length=MAX_DIVISIBILITY_SET_SIZE,
         description=(
@@ -24,6 +26,20 @@ class DivisibilityPosetRequest(StrictModel):
         ),
         examples=["2", "3", "6"],
     )
+
+    @model_validator(mode="after")
+    def require_positive_unique_values(self) -> Self:
+        if any(parse_canonical_integer(value) <= 0 for value in self.values):
+            raise PydanticCustomError(
+                "divisibility_poset.positive_values",
+                "values must be positive canonical integers",
+            )
+        if len(set(self.values)) != len(self.values):
+            raise PydanticCustomError(
+                "divisibility_poset.values_unique",
+                "values must be distinct",
+            )
+        return self
 
 
 class DivisibilityPosetResult(StrictModel):

--- a/src/jacobian/math/number_theory/_tools.py
+++ b/src/jacobian/math/number_theory/_tools.py
@@ -18,6 +18,7 @@ from jacobian.math.number_theory._interval_profiles import (
 from jacobian.math.number_theory._modular import MODULAR_OPERATIONS
 from jacobian.math.number_theory._modular_identity import MODULAR_IDENTITY_OPERATIONS
 from jacobian.math.number_theory._periodic import PERIODIC_CONGRUENCE_OPERATIONS
+from jacobian.math.number_theory._divisibility_poset import DIVISIBILITY_POSET_OPERATION
 from jacobian.math.number_theory._powerful import POWERFUL_NUMBER_OPERATION
 from jacobian.math.number_theory._preimage_ops import PREIMAGE_OPERATIONS
 from jacobian.math.number_theory._prime_shifts import PRIME_SHIFT_OPERATION
@@ -30,6 +31,7 @@ TOOLS: MathTools = (
     *DIVISIBILITY_OPERATIONS,
     *PRIME_OPERATIONS,
     POWERFUL_NUMBER_OPERATION,
+    DIVISIBILITY_POSET_OPERATION,
     *MODULAR_OPERATIONS,
     *PERIODIC_CONGRUENCE_OPERATIONS,
     *MODULAR_IDENTITY_OPERATIONS,

--- a/src/jacobian/math/number_theory/_tools.py
+++ b/src/jacobian/math/number_theory/_tools.py
@@ -8,6 +8,7 @@ from jacobian.math.number_theory._divisibility import DIVISIBILITY_OPERATIONS
 from jacobian.math.number_theory._divisibility_graph import (
     DIVISIBILITY_GRAPH_OPERATION,
 )
+from jacobian.math.number_theory._divisibility_poset import DIVISIBILITY_POSET_OPERATION
 from jacobian.math.number_theory._divisibility_profiles import (
     DIVISIBILITY_PROFILE_OPERATIONS,
 )
@@ -18,7 +19,6 @@ from jacobian.math.number_theory._interval_profiles import (
 from jacobian.math.number_theory._modular import MODULAR_OPERATIONS
 from jacobian.math.number_theory._modular_identity import MODULAR_IDENTITY_OPERATIONS
 from jacobian.math.number_theory._periodic import PERIODIC_CONGRUENCE_OPERATIONS
-from jacobian.math.number_theory._divisibility_poset import DIVISIBILITY_POSET_OPERATION
 from jacobian.math.number_theory._powerful import POWERFUL_NUMBER_OPERATION
 from jacobian.math.number_theory._preimage_ops import PREIMAGE_OPERATIONS
 from jacobian.math.number_theory._prime_shifts import PRIME_SHIFT_OPERATION

--- a/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
+++ b/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from jacobian.math.combinatorics.finite_structures.sets._models import FiniteIntegerSet
 from jacobian.math.number_theory._divisibility_poset import (
     compute_divisibility_poset,
     divisibility_poset,
@@ -13,9 +14,17 @@ from jacobian.math.number_theory._divisibility_poset_models import (
 )
 
 
+def _set(*values: str) -> FiniteIntegerSet:
+    return FiniteIntegerSet(elements=values)
+
+
+def _request(*values: str) -> DivisibilityPosetRequest:
+    return DivisibilityPosetRequest(values=_set(*values))
+
+
 def test_basic_fixture() -> None:
     """For {2,3,6}, the poset has 2<6 and 3<6, with 2 and 3 incomparable."""
-    request = DivisibilityPosetRequest(values=("2", "3", "6"))
+    request = _request("2", "3", "6")
     result = compute_divisibility_poset(request)
     pairs = {(pair.lower, pair.upper) for pair in result.strict_order_pairs}
     assert ("2", "6") in pairs
@@ -26,21 +35,21 @@ def test_basic_fixture() -> None:
 
 def test_no_reflexive_edges() -> None:
     """Strict order pairs must not be reflexive."""
-    request = DivisibilityPosetRequest(values=("4", "8", "16"))
+    request = _request("4", "8", "16")
     result = compute_divisibility_poset(request)
     assert all(pair.lower != pair.upper for pair in result.strict_order_pairs)
 
 
 def test_singleton_set() -> None:
     """A single-element set has no strict order pairs."""
-    request = DivisibilityPosetRequest(values=("7",))
+    request = _request("7")
     result = compute_divisibility_poset(request)
     assert result.strict_order_pairs == ()
 
 
 def test_chain() -> None:
     """A chain of divisibility."""
-    request = DivisibilityPosetRequest(values=("2", "4", "8"))
+    request = _request("2", "4", "8")
     result = compute_divisibility_poset(request)
     pairs = {(pair.lower, pair.upper) for pair in result.strict_order_pairs}
     assert ("2", "4") in pairs
@@ -51,14 +60,14 @@ def test_chain() -> None:
 
 def test_incomparable_primes() -> None:
     """Two distinct primes are incomparable."""
-    request = DivisibilityPosetRequest(values=("5", "7"))
+    request = _request("5", "7")
     result = compute_divisibility_poset(request)
     assert result.strict_order_pairs == ()
 
 
 def test_one_divides_everything() -> None:
     """1 divides every positive integer."""
-    request = DivisibilityPosetRequest(values=("1", "2", "3"))
+    request = _request("1", "2", "3")
     result = compute_divisibility_poset(request)
     pairs = {(pair.lower, pair.upper) for pair in result.strict_order_pairs}
     assert ("1", "2") in pairs
@@ -67,7 +76,7 @@ def test_one_divides_everything() -> None:
 
 def test_transitive_closure() -> None:
     """The result includes both direct and transitive pairs."""
-    request = DivisibilityPosetRequest(values=("2", "6", "12"))
+    request = _request("2", "6", "12")
     result = compute_divisibility_poset(request)
     pairs = {(pair.lower, pair.upper) for pair in result.strict_order_pairs}
     assert ("2", "6") in pairs
@@ -77,13 +86,13 @@ def test_transitive_closure() -> None:
 
 def test_native_admission_rejects_zero_and_empty_inputs() -> None:
     with pytest.raises(ValueError, match="positive integers"):
-        divisibility_poset(("0", "2"))
+        divisibility_poset(_set("0", "2"))
     with pytest.raises(ValueError, match="between 1"):
-        divisibility_poset(())
+        divisibility_poset(_set())
 
 
 def test_native_admission_matches_finite_poset_envelope() -> None:
     with pytest.raises(ValueError, match="between 1 and 64"):
-        divisibility_poset(tuple(str(value) for value in range(1, 66)))
+        divisibility_poset(_set(*(str(value) for value in range(1, 66))))
     with pytest.raises(ValueError, match="no longer than 32"):
-        divisibility_poset(("1" * 33,))
+        divisibility_poset(_set("1" * 33))

--- a/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
+++ b/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
@@ -1,0 +1,65 @@
+"""Tests for finite divisibility poset construction."""
+
+from __future__ import annotations
+
+from jacobian.math.number_theory._divisibility_poset import compute_divisibility_poset
+from jacobian.math.number_theory._divisibility_poset_models import DivisibilityPosetRequest
+
+
+def test_basic_fixture() -> None:
+    """For {2,3,6}, the poset has 2<6 and 3<6, with 2 and 3 incomparable."""
+    request = DivisibilityPosetRequest(values=("2", "3", "6"))
+    result = compute_divisibility_poset(request)
+    assert ("2", "6") in result.strict_order_pairs
+    assert ("3", "6") in result.strict_order_pairs
+    assert ("2", "3") not in result.strict_order_pairs
+    assert ("3", "2") not in result.strict_order_pairs
+
+
+def test_no_reflexive_edges() -> None:
+    """Strict order pairs must not be reflexive."""
+    request = DivisibilityPosetRequest(values=("4", "8", "16"))
+    result = compute_divisibility_poset(request)
+    for a, b in result.strict_order_pairs:
+        assert a != b
+
+
+def test_singleton_set() -> None:
+    """A single-element set has no strict order pairs."""
+    request = DivisibilityPosetRequest(values=("7",))
+    result = compute_divisibility_poset(request)
+    assert result.strict_order_pairs == ()
+
+
+def test_chain() -> None:
+    """A chain of divisibility."""
+    request = DivisibilityPosetRequest(values=("2", "4", "8"))
+    result = compute_divisibility_poset(request)
+    assert ("2", "4") in result.strict_order_pairs
+    assert ("2", "8") in result.strict_order_pairs
+    assert ("4", "8") in result.strict_order_pairs
+    assert ("4", "2") not in result.strict_order_pairs
+
+
+def test_incomparable_primes() -> None:
+    """Two distinct primes are incomparable."""
+    request = DivisibilityPosetRequest(values=("5", "7"))
+    result = compute_divisibility_poset(request)
+    assert result.strict_order_pairs == ()
+
+
+def test_one_divides_everything() -> None:
+    """1 divides every positive integer."""
+    request = DivisibilityPosetRequest(values=("1", "2", "3"))
+    result = compute_divisibility_poset(request)
+    assert ("1", "2") in result.strict_order_pairs
+    assert ("1", "3") in result.strict_order_pairs
+
+
+def test_transitive_closure() -> None:
+    """The result includes both direct and transitive pairs."""
+    request = DivisibilityPosetRequest(values=("2", "6", "12"))
+    result = compute_divisibility_poset(request)
+    assert ("2", "6") in result.strict_order_pairs
+    assert ("6", "12") in result.strict_order_pairs
+    assert ("2", "12") in result.strict_order_pairs

--- a/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
+++ b/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
@@ -80,3 +80,10 @@ def test_native_admission_rejects_zero_and_empty_inputs() -> None:
         divisibility_poset(("0", "2"))
     with pytest.raises(ValueError, match="between 1"):
         divisibility_poset(())
+
+
+def test_native_admission_matches_finite_poset_envelope() -> None:
+    with pytest.raises(ValueError, match="between 1 and 64"):
+        divisibility_poset(tuple(str(value) for value in range(1, 66)))
+    with pytest.raises(ValueError, match="no longer than 32"):
+        divisibility_poset(("1" * 33,))

--- a/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
+++ b/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from jacobian.math.number_theory._divisibility_poset import compute_divisibility_poset
+import pytest
+
+from jacobian.math.number_theory._divisibility_poset import (
+    compute_divisibility_poset,
+    divisibility_poset,
+)
 from jacobian.math.number_theory._divisibility_poset_models import (
     DivisibilityPosetRequest,
 )
@@ -68,3 +73,10 @@ def test_transitive_closure() -> None:
     assert ("2", "6") in pairs
     assert ("6", "12") in pairs
     assert ("2", "12") in pairs
+
+
+def test_native_admission_rejects_zero_and_empty_inputs() -> None:
+    with pytest.raises(ValueError, match="positive integers"):
+        divisibility_poset(("0", "2"))
+    with pytest.raises(ValueError, match="between 1"):
+        divisibility_poset(())

--- a/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
+++ b/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
@@ -3,25 +3,27 @@
 from __future__ import annotations
 
 from jacobian.math.number_theory._divisibility_poset import compute_divisibility_poset
-from jacobian.math.number_theory._divisibility_poset_models import DivisibilityPosetRequest
+from jacobian.math.number_theory._divisibility_poset_models import (
+    DivisibilityPosetRequest,
+)
 
 
 def test_basic_fixture() -> None:
     """For {2,3,6}, the poset has 2<6 and 3<6, with 2 and 3 incomparable."""
     request = DivisibilityPosetRequest(values=("2", "3", "6"))
     result = compute_divisibility_poset(request)
-    assert ("2", "6") in result.strict_order_pairs
-    assert ("3", "6") in result.strict_order_pairs
-    assert ("2", "3") not in result.strict_order_pairs
-    assert ("3", "2") not in result.strict_order_pairs
+    pairs = {(pair.lower, pair.upper) for pair in result.strict_order_pairs}
+    assert ("2", "6") in pairs
+    assert ("3", "6") in pairs
+    assert ("2", "3") not in pairs
+    assert ("3", "2") not in pairs
 
 
 def test_no_reflexive_edges() -> None:
     """Strict order pairs must not be reflexive."""
     request = DivisibilityPosetRequest(values=("4", "8", "16"))
     result = compute_divisibility_poset(request)
-    for a, b in result.strict_order_pairs:
-        assert a != b
+    assert all(pair.lower != pair.upper for pair in result.strict_order_pairs)
 
 
 def test_singleton_set() -> None:
@@ -35,10 +37,11 @@ def test_chain() -> None:
     """A chain of divisibility."""
     request = DivisibilityPosetRequest(values=("2", "4", "8"))
     result = compute_divisibility_poset(request)
-    assert ("2", "4") in result.strict_order_pairs
-    assert ("2", "8") in result.strict_order_pairs
-    assert ("4", "8") in result.strict_order_pairs
-    assert ("4", "2") not in result.strict_order_pairs
+    pairs = {(pair.lower, pair.upper) for pair in result.strict_order_pairs}
+    assert ("2", "4") in pairs
+    assert ("2", "8") in pairs
+    assert ("4", "8") in pairs
+    assert ("4", "2") not in pairs
 
 
 def test_incomparable_primes() -> None:
@@ -52,14 +55,16 @@ def test_one_divides_everything() -> None:
     """1 divides every positive integer."""
     request = DivisibilityPosetRequest(values=("1", "2", "3"))
     result = compute_divisibility_poset(request)
-    assert ("1", "2") in result.strict_order_pairs
-    assert ("1", "3") in result.strict_order_pairs
+    pairs = {(pair.lower, pair.upper) for pair in result.strict_order_pairs}
+    assert ("1", "2") in pairs
+    assert ("1", "3") in pairs
 
 
 def test_transitive_closure() -> None:
     """The result includes both direct and transitive pairs."""
     request = DivisibilityPosetRequest(values=("2", "6", "12"))
     result = compute_divisibility_poset(request)
-    assert ("2", "6") in result.strict_order_pairs
-    assert ("6", "12") in result.strict_order_pairs
-    assert ("2", "12") in result.strict_order_pairs
+    pairs = {(pair.lower, pair.upper) for pair in result.strict_order_pairs}
+    assert ("2", "6") in pairs
+    assert ("6", "12") in pairs
+    assert ("2", "12") in pairs

--- a/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
+++ b/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
@@ -84,15 +84,16 @@ def test_transitive_closure() -> None:
     assert ("2", "12") in pairs
 
 
-def test_native_admission_rejects_zero_and_empty_inputs() -> None:
+def test_native_admission_rejects_zero_and_accepts_empty_inputs() -> None:
     with pytest.raises(ValueError, match="positive integers"):
         divisibility_poset(_set("0", "2"))
-    with pytest.raises(ValueError, match="between 1"):
-        divisibility_poset(_set())
+    result = divisibility_poset(_set())
+    assert result.elements == ()
+    assert result.strict_order_pairs == ()
 
 
 def test_native_admission_matches_finite_poset_envelope() -> None:
-    with pytest.raises(ValueError, match="between 1 and 64"):
+    with pytest.raises(ValueError, match="between 0 and 64"):
         divisibility_poset(_set(*(str(value) for value in range(1, 66))))
     with pytest.raises(ValueError, match="no longer than 32"):
         divisibility_poset(_set("1" * 33))

--- a/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
+++ b/tests/math/number_theory/divisibility_poset/test_divisibility_poset.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from jacobian.math.number_theory._divisibility_poset import compute_divisibility_poset
-from jacobian.math.number_theory._divisibility_poset_models import DivisibilityPosetRequest
+from jacobian.math.number_theory._divisibility_poset_models import (
+    DivisibilityPosetRequest,
+)
 
 
 def test_basic_fixture() -> None:

--- a/tests/math/number_theory/test_friable_count.py
+++ b/tests/math/number_theory/test_friable_count.py
@@ -219,6 +219,7 @@ def test_number_theory_native_api_is_explicit() -> None:
         "chinese_remainder",
         "contiguous_sum_profile",
         "count_friable",
+        "divisibility_poset",
         "euler_totient",
         "factorial_valuation",
         "floor_square_root",


### PR DESCRIPTION
## Summary

Closes #2786.

Add `integer.divisibility_poset.compute`, a bounded operation that constructs the canonical proper-divisibility poset of a finite set of positive integers. The poset has a < b exactly when a divides b and a != b.

## Design

The implementation uses bounded pairwise divisibility comparison over the source set. For each pair (a, b) with a != b, the pair (a, b) is a strict order pair when a divides b.

## Tests

- Basic fixture: {2, 3, 6} has 2<6 and 3<6, with 2 and 3 incomparable
- No reflexive edges
- Single-element set has no strict order pairs
- Chain divisibility (2, 4, 8)
- Incomparable primes
- 1 divides everything
- Transitive closure included

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/f3aaed06-1b4b-47df-9bd7-59fa33e39f3d)