### PR TITLE
Keep rooted-tree math tests below complete-boundary imports

### DIFF
--- a/tests/math/graphs/rooted_trees/test_fine_partition.py
+++ b/tests/math/graphs/rooted_trees/test_fine_partition.py
@@ -6,7 +6,6 @@ import networkx as nx
 import pytest
 from pydantic import ValidationError
 
-from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.rooted_trees import (
     RootedTreeFinePartition,
@@ -14,6 +13,7 @@ from jacobian.math.graphs.rooted_trees import (
     RootedTreeNotATree,
     construct_fine_partition,
 )
+from jacobian.math.graphs.rooted_trees._tools import TOOLS
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 
@@ -446,8 +446,11 @@ def test_every_nonisomorphic_tree_through_order_seven_satisfies_contract() -> No
 
 
 def test_catalog_example_executes_and_round_trips() -> None:
-    operation = Catalog.open().operation("graph.rooted_tree.fine_partition.construct")
-    assert operation is not None
+    operation = next(
+        tool
+        for tool in TOOLS
+        if tool.operation_id == "graph.rooted_tree.fine_partition.construct"
+    )
     assert len(operation.examples) == 1
     request = operation.request_type.model_validate(operation.examples[0].input)
 


### PR DESCRIPTION
## Summary
- keep the rooted-tree math test independent of the complete catalog boundary
- exercise the owner manifest directly for the catalog example round-trip

## Validation
- `uv run ruff check tests/math/graphs/rooted_trees/test_fine_partition.py`
- `uv run pytest tests/math/graphs/rooted_trees/test_fine_partition.py tests/tooling/test_pytest_collection_ownership.py -q` (33 passed)

This restores the tooling lane requirement that math tests do not import complete product boundaries.