### PR TITLE
Keep prime navigation ranking test within discovery limit

### DIFF
--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -257,7 +257,10 @@ def test_natural_prime_power_query_ranks_factorization_before_prime_navigation()
     result = catalog.search(
         OperationDiscoveryRequest(
             query="factor an integer into prime powers",
-            limit=10,
+            # Keep the complete navigation comparison within the public
+            # discovery limit; new factor-related operations may occupy the
+            # first ten slots without changing the relative ordering.
+            limit=20,
         )
     )
     positions = {


### PR DESCRIPTION
## Summary
- allow the natural prime-power discovery assertion to inspect the full public limit
- preserve the relative ordering assertion as factor-related operations are added

## Validation
- `uv run pytest tests/catalog/test_catalog.py::test_natural_prime_power_query_ranks_factorization_before_prime_navigation -q`
- `uv run ruff check tests/catalog/test_catalog.py`

The previous limit of 10 made this test fail when a newly published factor operation occupied a result slot, even though all expected operations still ranked correctly.