### PR TITLE
fix(mcp): keep the production tool surface bounded

### DIFF
--- a/.github/scripts/manage-test-timings
+++ b/.github/scripts/manage-test-timings
@@ -20,7 +20,7 @@ from typing import Any, cast
 ROOT = Path(__file__).resolve().parents[2]
 TIMING_SUITES = ("benchmark", "math")
 MAX_BYTES = 5 * 1024 * 1024
-MAX_ENTRIES = 10_000
+MAX_ENTRIES = 20_000
 MAX_CANDIDATES = 5
 HTTP_TIMEOUT_SECONDS = 10
 MAX_TIMING_HISTORY_AGE = timedelta(days=30)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,14 +29,12 @@ operations, but admit it separately only when it establishes a distinct stable
 postcondition. Alternative algorithms for the same postcondition remain private
 kernel choices.
 
-It exposes the admitted catalog directly through MCP, plus fixed discovery and
-migration tools:
+It exposes two MCP tools:
 
 | Agent verb | MCP tool | Meaning |
 | --- | --- | --- |
-| Execute | the operation ID | Call one operation through its typed owner-local schema. |
-| Search | `math.find` | Search mathematical vocabulary or inspect an exact contract. |
-| Transitional execute | `math.run` | Generic dispatch retained while direct discovery is evaluated. |
+| Search | `math.find` | Find or inspect an operation. |
+| Execute | `math.run` | Run one operation and return its mathematical value. |
 
 Jacobian supplies bounded typed operations and immutable discovery. Use
 “operation” or “math tool,” not “product” or “provider,” for built-ins. It is
@@ -45,13 +43,12 @@ preserve an explicit transport/security boundary only when the task actually
 changes one.
 
 The authoritative operation path and ownership vocabulary are defined in the
-[architecture](docs/explanation/architecture.md). In summary, the MCP tool list
-is derived from immutable declarations. A direct call parses one strict request
-against its named operation, executes one owner-local bounded domain operation,
-and returns that operation's canonical mathematical result through the delivery
-boundary. `math.find` is a separate semantic discovery surface. Any execution
-plan is request-scoped internal data, not caller-visible workflow state or a new
-MCP verb.
+[architecture](docs/explanation/architecture.md). In summary, `math.find`
+selects an immutable declaration and `math.run` parses one strict request,
+executes one owner-local bounded domain operation, and returns a canonical
+mathematical result through the delivery boundary. Any execution plan is
+request-scoped internal data, not caller-visible workflow state or a new MCP
+verb.
 
 The domain function may use a maintained library as a private computational
 engine; prefer an established backend over hand-rolling a kernel whenever it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,7 @@
 # Contributing to Jacobian
 
-Jacobian is a pre-stable **math toolbox for agents**: admitted operations are
-direct typed MCP tools, `math.find` provides semantic catalog discovery,
-results are math-first, and composition is agent-owned. The generic `math.run`
-path remains isolated during the direct-tool migration.
+Jacobian is a pre-stable **math toolbox for agents**: atomic tools behind
+`math.find` / `math.run`, math-first results, and agent-owned composition.
 Contributions should preserve that product model—see
 [product-blueprint](docs/explanation/product-blueprint.md) and
 [architecture](docs/explanation/architecture.md).

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ test-catalog: ## Immutable catalog and discovery behavior (2 workers, 30s).
 		$(if $(TESTS),$(TESTS),tests/catalog) \
 		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
-test-dispatch: ## Strict parsing and direct dispatch behavior (2 workers, 30s).
-	$(UV_RUN) pytest -n 2 --dist worksteal --timeout=30 \
+test-dispatch: ## Strict parsing and direct dispatch behavior (2 workers, 120s).
+	$(UV_RUN) pytest -n 2 --dist worksteal --timeout=120 \
 		$(if $(TESTS),$(TESTS),tests/dispatch) \
 		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@
 </p>
 
 Jacobian is an MCP server that gives AI agents a searchable vocabulary of typed
-mathematical operations. Every admitted operation is directly callable under
-its operation ID, with its owner-local request schema and canonical result
-schema. `math.find` remains available for semantic catalog search and exact
-contract inspection; `math.run` remains temporarily available while the direct
-tool migration is evaluated. The same mathematical library is also available
-through a CLI and native Python API.
+mathematical operations. `math.find` discovers an operation, and `math.run`
+executes exactly one bounded mathematical contract and returns its typed
+result. The same mathematical library is also available through a CLI and
+native Python API.
 
 Each operation establishes one stable, reusable mathematical postcondition
 rather than prescribing a workflow or proof strategy. Results are exact where
@@ -106,12 +104,9 @@ jacobian run integer.compute.extended_gcd --json '{"left":"84","right":"30"}'
 ```
 
 The second command returns the gcd and Bézout coefficients as JSON. In an MCP
-host, call `integer.compute.extended_gcd` directly with
-`{"left":"84","right":"30"}`; the result is the gcd and coefficients,
-without an `operation_id` + `payload` dispatch envelope. Use `math.find` when
-semantic catalog search or exact contract inspection is useful. See
-[Discover and invoke operations](docs/how-to/invoke-domain-operations.md) for
-that agent workflow.
+host, use `math.find` to inspect the same contract and `math.run` with the same
+payload shape. See [Discover and invoke operations](docs/how-to/invoke-domain-operations.md)
+for that agent workflow.
 
 ## Available mathematics
 
@@ -123,10 +118,9 @@ The built-in portfolio covers work in:
 - bounded SAT and SMT solving;
 - finite algebra, probability, geometry, and topology.
 
-SAT and SMT operations use the maintained Z3 Python binding directly. Client
-tool search can discover their direct operation tools. Use `math.find` to search
-the mathematical vocabulary, browse an unfamiliar domain, or inspect an exact
-contract when that adds value beyond client-managed tool discovery.
+SAT and SMT operations use the maintained Z3 Python binding directly. Use
+`math.find` to search for an operation, browse an unfamiliar domain, and inspect
+one operation before calling `math.run` once.
 
 See the [domain operation library](docs/reference/domain-operation-library.md)
 for the maintained operation portfolio and

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/morluto/jacobian" alt="MIT 许可证"></a>
 </p>
 
-Jacobian 是一个 MCP 服务器，为 AI 智能体提供一套可搜索、类型化的数学操作。每个已准入的操作都以其操作 ID 作为 MCP 工具名直接调用，并公开所属领域定义的请求和结果模式。`math.find` 用于数学词汇搜索与精确契约查看；在直接工具迁移完成评估前，`math.run` 暂时保留。同样的数学库也可以通过 CLI 和原生 Python API 直接使用。
+Jacobian 是一个 MCP 服务器，为 AI 智能体提供一套可搜索、类型化的数学操作。`math.find` 用来发现操作，`math.run` 每次只执行一个有界契约，并返回类型化结果。同样的数学库也可以通过 CLI 和原生 Python API 直接使用。
 
 每个操作只确立一个稳定、可复用的数学后置条件，而不是规定工作流或证明策略。声称精确的地方就会保持精确，近似、不完备或不确定性也会显式标出。
 
@@ -70,11 +70,9 @@ jacobian inspect integer.compute.extended_gcd
 jacobian run integer.compute.extended_gcd --json '{"left":"84","right":"30"}'
 ```
 
-第二条命令会以 JSON 返回最大公约数和 Bézout 系数。在 MCP 主机中，直接调用
-`integer.compute.extended_gcd`，参数为 `{"left":"84","right":"30"}`；
-无需构造 `operation_id` 与 `payload` 的通用调度封装。需要数学词汇搜索或精确
-契约示例时再使用 `math.find`。具体的智能体调用流程见
-[发现和调用操作](docs/how-to/invoke-domain-operations.md)。
+第二条命令会以 JSON 返回最大公约数和 Bézout 系数。在 MCP 主机中，用
+`math.find` 查看同一份契约，再用相同形状的 payload 调用 `math.run`。具体的
+智能体调用流程见[发现和调用操作](docs/how-to/invoke-domain-operations.md)。
 
 ## 可用的数学能力
 
@@ -86,7 +84,7 @@ jacobian run integer.compute.extended_gcd --json '{"left":"84","right":"30"}'
 - 有界 SAT 和 SMT 求解；
 - 有限代数、概率、几何与拓扑。
 
-SAT 和 SMT 操作直接调用 Z3 的 Python 绑定。客户端工具搜索可以发现这些直接操作；需要搜索数学词汇、浏览不熟悉的领域或查看精确契约时，再使用 `math.find`。
+SAT 和 SMT 操作直接调用 Z3 的 Python 绑定。用 `math.find` 搜索操作、浏览不熟悉的领域，先查看单个操作的契约，再用 `math.run` 执行一次。
 
 请参阅[领域操作库](docs/reference/domain-operation-library.md)了解操作契约与准入规则，用 `math.find` 浏览实际的操作目录，并参阅[后端要求](docs/how-to/backend-requirements.md)。
 

--- a/benchmarks/docs/run-codex-visibility-evaluation.md
+++ b/benchmarks/docs/run-codex-visibility-evaluation.md
@@ -30,14 +30,17 @@ make direct-mcp-catalog-eval \
   DIRECT_MCP_EVAL_OUTPUT=tmp/direct-mcp-catalog-evaluation.json
 ```
 
-They exercise the production in-memory MCP server and record catalog/schema
-coverage, serialized definition bytes, `tools/list` latency, `math.find`
-ranking, direct and `math.run` execution parity, and exact typed composition.
+They construct an explicit in-memory experimental surface and record
+catalog/schema coverage, serialized definition bytes, `tools/list` latency,
+`math.find` ranking, direct and `math.run` execution parity, and exact typed
+composition. Production exposes only `math.find` and `math.run`.
 They intentionally report model selection, deferred client search, and exact
 per-task loaded-definition bytes as unmeasured.
 
-For agent trials, start the anonymous loopback server, then select an arm and
-an output directory:
+For production-surface agent trials, start the anonymous loopback server and
+use the `legacy` arm. Direct arms require a separately instrumented evaluation
+endpoint and are retained only for reproducing the frozen experiment. Then
+select an arm and an output directory:
 
 ```sh
 uv run python -m jacobian.mcp.remote_cli \
@@ -48,7 +51,7 @@ make codex-visibility \
   VISIBILITY_CASES=benchmarks/config/direct-mcp-agent-adoption-v1.json \
   VISIBILITY_MCP_URL=http://127.0.0.1:8765/mcp \
   VISIBILITY_MODEL=<model> \
-  VISIBILITY_SURFACE_ARM=direct \
+  VISIBILITY_SURFACE_ARM=legacy \
   VISIBILITY_CASES_SELECTED="straightforward-determinant alternate-term-sandpile-group complete-subset-sum-profile structured-polynomial-gcd canonical-cnf-composition" \
   VISIBILITY_REPETITIONS=2 \
   VISIBILITY_OUTPUT=tmp/direct-mcp-agent-direct-r2

--- a/benchmarks/tooling/mcp_catalog_evaluation.py
+++ b/benchmarks/tooling/mcp_catalog_evaluation.py
@@ -1,4 +1,4 @@
-"""Deterministic catalog-scale controls for the direct MCP migration.
+"""Deterministic catalog-scale controls for the historical direct MCP experiment.
 
 This evaluator proves only locally observable availability, schema, discovery,
 execution, and composition facts.  Agent selection and deferred-loading claims
@@ -25,7 +25,9 @@ from tools.command_runner import git_head_sha
 
 from jacobian._models import StrictModel
 from jacobian.catalog.catalog import Catalog
-from jacobian.mcp.server import create_server
+from jacobian.mcp.direct_tools import direct_operation_tools
+from jacobian.mcp.runtime import AppState
+from jacobian.mcp.server import _build_server
 from mcp import Client
 
 _ROOT = Path(__file__).resolve().parents[2]
@@ -446,7 +448,7 @@ async def run_evaluation(
     *,
     list_repetitions: int,
 ) -> dict[str, Any]:
-    """Run all locally observable controls against the production MCP server."""
+    """Run locally observable controls against an experimental direct surface."""
 
     catalog = Catalog.open()
     catalog_snapshot = catalog.snapshot()
@@ -454,7 +456,10 @@ async def run_evaluation(
         descriptor.operation_id for descriptor in catalog_snapshot.operations
     )
     construction_started = time.perf_counter()
-    server = create_server()
+    server = _build_server(
+        state=AppState(operation_catalog=catalog),
+        evaluation_tools=direct_operation_tools(catalog),
+    )
     construction_elapsed = time.perf_counter() - construction_started
     client_started = time.perf_counter()
     async with Client(server, raise_exceptions=True) as client:
@@ -585,7 +590,7 @@ async def run_evaluation(
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Run deterministic catalog-scale direct MCP migration controls."
+        description="Run deterministic catalog-scale direct MCP experiment controls."
     )
     parser.add_argument("--suite", type=Path, default=_DEFAULT_SUITE)
     parser.add_argument("--output", type=Path, required=True)

--- a/deploy/smoke_remote.py
+++ b/deploy/smoke_remote.py
@@ -20,6 +20,8 @@ from mcp import Client
 
 from .smoke import exit_for_smoke_failure, raise_for_http_error
 
+REQUIRED_TOOLS = {"math.find", "math.run"}
+
 
 def _require_server_info(server_info: Implementation | None) -> Implementation:
     if server_info is None:
@@ -73,13 +75,11 @@ def _headers() -> dict[str, str] | None:
 
 def _validate_tool_surface(
     listed: Any,
-    operation_ids: set[str],
     failures: list[str],
 ) -> set[str]:
     tool_names = {tool.name for tool in listed.tools}
-    expected = {"math.find", "math.run"} | operation_ids
-    missing = sorted(expected - tool_names)
-    unexpected = sorted(tool_names - expected)
+    missing = sorted(REQUIRED_TOOLS - tool_names)
+    unexpected = sorted(tool_names - REQUIRED_TOOLS)
     if missing:
         failures.append(
             f"deployed MCP tool surface is missing required tools: {missing!r}"
@@ -174,7 +174,7 @@ async def inspect(
         operation_ids = {
             operation["operation_id"] for operation in catalog["operations"]
         }
-        tool_names = _validate_tool_surface(listed, operation_ids, failures)
+        tool_names = _validate_tool_surface(listed, failures)
         missing = sorted(required_operations - operation_ids)
         if missing:
             failures.append(

--- a/deploy/smoke_stdio.py
+++ b/deploy/smoke_stdio.py
@@ -7,16 +7,7 @@ import asyncio
 import os
 from pathlib import Path
 
-from jacobian.catalog.catalog import Catalog
-
-
-def expected_tool_names() -> set[str]:
-    """Return the MCP surface published by the installed package."""
-
-    snapshot = Catalog.open().snapshot()
-    return {"math.find", "math.run"} | {
-        operation.operation_id for operation in snapshot.operations
-    }
+EXPECTED_TOOL_NAMES = {"math.find", "math.run"}
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -40,7 +31,7 @@ async def inspect(server: Path, *, timeout_seconds: float) -> None:
     )
     async with Client(stdio_client(parameters), raise_exceptions=True) as client:
         listed = await asyncio.wait_for(client.list_tools(), timeout_seconds)
-        if {tool.name for tool in listed.tools} != expected_tool_names():
+        if {tool.name for tool in listed.tools} != EXPECTED_TOOL_NAMES:
             raise RuntimeError(
                 "installed MCP server exposed an unexpected tool surface"
             )

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -5,12 +5,8 @@ This page describes the package boundaries and ordinary execution path that
 implement it.
 
 The serving process compiles one immutable catalog directly from explicit
-`MathTool` entries. At server construction it derives one MCP Python SDK `Tool`
-from every declaration, using the unchanged operation ID as the tool name and
-the owner-local request and result models as its schemas. `math.find` provides a
-separate semantic discovery surface. `math.run` remains an isolated transitional
-execution surface while direct discovery and catalog-scale behavior are
-evaluated.
+`MathTool` entries and exposes `math.find` and `math.run` through the MCP Python
+SDK.
 
 For most native functions, the ordinary call path is deliberately small:
 
@@ -34,12 +30,12 @@ intrinsic cross-field relations needed to construct the request value. It must
 not call a mathematical backend, enumerate a search space, select an algorithm,
 reserve result work, or cache execution data in a private model attribute.
 
-The ordinary MCP path wraps that same native operation with strict wire parsing
-and transport projection:
+The MCP path wraps that same native operation with discovery, wire parsing, and
+transport projection:
 
 ```text
-direct operation tool + JSON object
-  -> catalog-derived typed registration
+operation ID + JSON
+  -> declaration
   -> strict typed request
   -> owner-local native operation
   -> bounded Jacobian kernel or private backend adapter
@@ -76,23 +72,12 @@ computational engines behind Jacobian's public mathematical contracts.
 
 ## Transport and mathematical ownership
 
-The MCP Python SDK owns the transport boundary: the concrete registered tool
-objects, protocol validation, cancellation signal, and structured JSON
-delivery. Jacobian derives the direct tool inventory from the immutable catalog
-snapshot and uses the SDK argument hook only to carry the raw request object
-without Python-mode coercion. Inside one request-scoped execution envelope,
-Jacobian parses that object with the selected owner's strict JSON model, invokes
-the owner, and serializes the result. The direct tool returns the owner's result
-model itself, without a generic operation-ID or output envelope.
+The MCP Python SDK owns the fixed transport boundary: registration of
+`math.find` and `math.run`, their outer argument and output schemas, protocol
+validation, and structured JSON delivery. Jacobian does not duplicate those
+checks.
 
-MCP requires every input schema to have an object root. Owner schemas are used
-unchanged when they already have that root. A root union whose every branch is
-an object receives only the required top-level `type: object` transport
-projection; a non-object request schema fails server construction. Existing
-operation IDs already satisfy the MCP name grammar, so the naming projection is
-the reversible identity function and fixed-tool collisions fail closed.
-
-The transitional `math.run` path still needs a small dispatch boundary because
+`math.run` still needs a small dispatch boundary because
 its `payload` has an operation-specific schema that is known only after its
 immutable `operation_id` is resolved. Dispatch therefore does only this:
 resolve the declaration, parse the payload once with that owner's request model,
@@ -101,18 +86,17 @@ domain admission, backend logic, result-specific replay, or workflow state.
 
 Rejections retain the phase that owns them:
 
-| Phase | Python boundary | Direct MCP projection |
+| Phase | Python boundary | MCP projection |
 | --- | --- | --- |
 | JSON canonicalization or structural Pydantic parsing | `OperationRequestValidationError` | `INVALID_PARAMS` |
 | Native mathematical or resource admission | `OperationDomainValidationError` | `INVALID_PARAMS` |
 | Unexpected backend or execution failure | Operational exception | Tool error |
 
-The direct adapter does not turn native admission into structural request
-validation. MCP deliberately projects both validation classes through
+Dispatch does not turn native admission into structural request validation.
+MCP deliberately projects both validation classes through
 `INVALID_PARAMS` because both mean that the selected operation cannot accept
-the supplied request; operational failures remain distinct and establish no
-mathematical conclusion. Field diagnostics are bounded and omit raw caller
-values.
+the supplied payload; operational failures remain distinct and establish no
+mathematical conclusion.
 
 Jacobian is a typed, bounded tool layer over maintained mathematical libraries.
 The runtime ownership rule above keeps replay out of ordinary execution and
@@ -133,10 +117,10 @@ Catalog construction discovers packaged `_tools.py` modules under
 operation ID, and freezes the resulting inventory. There is no parallel
 decision ledger, central domain list, or external plugin discovery.
 `jacobian.catalog` owns declaration models, search, and immutable lookup;
-`jacobian.dispatch` owns the transitional generic and CLI invocation path;
-`jacobian.mcp` owns direct typed registration and delivery; the CLI is a
-separate delivery boundary. The private root model and exact-scalar helpers
-contain only behavior genuinely shared by unrelated owners.
+`jacobian.dispatch` owns strict invocation;
+`jacobian.mcp` and the CLI are delivery boundaries. The private root model and
+exact-scalar helpers contain only behavior genuinely shared by unrelated
+owners.
 
 An immutable declaration may carry a small `discovery_terms` vocabulary of
 reviewed, established names for its exact postcondition. Terms are catalog
@@ -153,11 +137,10 @@ Defining-invariant evidence belongs in the operation's tests; a full replay is
 not part of ordinary execution. An adapter may reject malformed backend data
 while converting it, but that is integration safety rather than a separate
 mathematical result stage.
-After owner admission succeeds, direct MCP returns the typed result through the
-SDK projection; the transitional dispatcher wraps the same result for its
-generic boundary. Neither path may discover a mathematical or work bound only
-after execution. Independently supplied result data uses an explicit, bounded
-replay verifier rather than ordinary result construction.
+After owner admission succeeds, dispatch and MCP project the typed result into
+the final transport envelope; they must not discover a mathematical or work
+bound only after execution. Independently supplied result data uses an
+explicit, bounded replay verifier rather than ordinary result construction.
 
 ## Bounded worker adapters
 

--- a/docs/explanation/product-blueprint.md
+++ b/docs/explanation/product-blueprint.md
@@ -1,13 +1,8 @@
 # Product blueprint
 
-Jacobian exposes each admitted stateless function over typed mathematical
-values as a directly callable MCP tool. Its operation ID is also its MCP tool
-name, and its owner-local request and result models are the callable schemas.
-`math.find` separately provides semantic mathematical catalog search and exact
-contract inspection. The generic `math.run` path remains temporarily available
-while direct discovery is evaluated; ordinary direct calls do not require it.
-The caller owns composition: decomposition, sequencing, retention of values,
-and stopping.
+Jacobian exposes stateless functions over typed mathematical values through two
+MCP verbs: find an operation and run one operation. The caller owns composition:
+decomposition, sequencing, retention of values, and stopping.
 
 The server owns typed operation contracts, strict request validation, resource
 bounds, immutable discovery, and the final MCP projection.

--- a/docs/how-to/invoke-domain-operations.md
+++ b/docs/how-to/invoke-domain-operations.md
@@ -1,15 +1,15 @@
 # Discover and invoke domain operations
 
-Use client tool discovery to load a relevant direct Jacobian operation, then
-call that operation with an object matching its request model. The ordinary
-path is:
+Use `math.find` progressively, then call `math.run` once with the selected
+operation ID and a `payload` matching its request model. The ordinary path is:
 
-1. Let client tool search discover one atomic mathematical outcome such as
-   "integer nth root" or "real root isolation", not a complete proof goal.
-2. Load the selected direct operation's callable schema. Use `math.find` only
-   when semantic vocabulary search, namespace browsing, or exact example
-   inspection adds value beyond client tool discovery.
-3. Call exactly that operation with one typed JSON object.
+1. Search globally for one atomic mathematical outcome when the operation is
+   unknown. Use a short phrase such as "integer nth root" or "real root
+   isolation", not a complete proof goal. Search ranking is deterministic
+   lexical retrieval, not a recommendation.
+2. Inspect the selected operation before forming an unfamiliar payload. Its
+   schemas and examples are authoritative for that installed catalog.
+3. Run exactly that operation with one typed payload.
 4. Retain the mathematical result and decide the next move yourself.
 
 For example, search for a small number of matrix operations, then inspect an
@@ -32,15 +32,11 @@ explicit fallback for a full catalog export:
 {"request":{"op":"browse","namespace":"matrix","limit":20}}
 ```
 
-After discovery, call the selected operation directly. For example, invoke
-`integer.compute.extended_gcd` with:
+After inspection, run the selected operation. For example:
 
 ```json
-{"left":"84","right":"30"}
+{"operation_id":"integer.compute.extended_gcd","payload":{"left":"84","right":"30"}}
 ```
-
-The result is the operation's canonical result object; it has no generic
-`operation_id`, `runtime_ms`, or `output` wrapper.
 
 ## Compose a returned value
 
@@ -51,9 +47,9 @@ normalization, axes, ambient object, or other mathematical context may be part
 of the value. Extract a scalar, witness, or projection only when the inspected
 input schema explicitly asks for it.
 
-For example, `sat.cnf.canonicalize` returns `cnf`, and both `sat.solve`
+For example, `sat.cnf.canonicalize` returns `output.cnf`, and both `sat.solve`
 and `sat.assignment.check` accept that entire canonical CNF as their `cnf`
-request field. The caller chooses whether solving or checking is the useful
+payload field. The caller chooses whether solving or checking is the useful
 next move; Jacobian does not retain values, workflow state, artifacts, ports,
 or workspace documents.
 
@@ -62,16 +58,16 @@ or workspace documents.
 A successful tool call returns the operation's own mathematical result model.
 For `sat.solve`, `SAT` and `UNSAT` have their stated meanings, while `UNKNOWN`
 is a non-conclusion; its `exhausted` field may say whether a time, work, or
-memory budget was exhausted. A malformed request or unknown tool name is a tool
-error, not a mathematical result. A client timeout aborts transport and is also
-not a conclusion. Preserve the selected operation, exact request or digest, and
-the changed budget, backend, representation, or partition before retrying.
+memory budget was exhausted. A malformed payload or unknown operation ID is a
+tool error, not a mathematical result. A client timeout aborts transport and is
+also not a conclusion. Preserve the selected operation, exact payload or digest,
+and the changed budget, backend, representation, or partition before retrying.
 
 ## Use the same contract from the CLI
 
 The installed CLI is useful for checking one operation locally before wiring it
 into an MCP host. `inspect` prints the exact current schemas and examples;
-`run` accepts the same JSON object as the direct MCP tool:
+`run` accepts the same payload as `math.run`:
 
 ```sh
 jacobian inspect integer.compute.extended_gcd

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,8 @@
 # Jacobian documentation
 
-Jacobian is a stateless mathematical tool layer for agents: every admitted
-operation is a directly callable typed MCP tool, `math.find` provides semantic
-catalog search and inspection, and the caller composes returned mathematical
-values. The generic `math.run` path remains temporarily available during the
-direct-tool migration.
+Jacobian is a stateless mathematical tool layer for agents: `math.find`
+discovers typed operations, `math.run` executes one bounded operation, and the
+caller composes the returned mathematical values.
 
 ## Choose a path
 
@@ -47,9 +45,8 @@ direct-tool migration.
 - [Testing strategy](reference/testing-strategy.md) — validation ownership and
   focused test lanes.
 
-The direct MCP tool list is derived from the admitted immutable catalog.
-`math.find` and `operation://catalog` expose searchable and bulk views of that
-same authoritative membership and its current schemas.
+The live `math.find` catalog is authoritative for available operations and their
+current schemas.
 
 ## Contributing
 

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -2,9 +2,8 @@
 
 Every built-in operation is a direct typed mathematical function with one
 domain owner. Declaration modules export immutable tuples of
-`MathTool` values. MCP registration derives one direct typed tool from every
-entry; `math.find` reads the same catalog for semantic discovery. The
-transitional `math.run` path validates and executes the same declarations.
+`MathTool` values. `math.find` reads those entries and `math.run`
+validates then executes exactly one of them.
 
 The canonical operation path and ownership boundaries are defined in the
 [architecture](../explanation/architecture.md). A domain function may use a

--- a/docs/reference/public-operation-admission.md
+++ b/docs/reference/public-operation-admission.md
@@ -4,8 +4,8 @@
 
 This document uses **catalog admission** narrowly. It decides whether a
 candidate operation belongs in the immutable public catalog. It does not define
-the **request admission** or execution plan for an individual direct operation
-call; those are owned by the mathematical domain and must account for work,
+the **request admission** or execution plan for an individual `math.run` call;
+those are owned by the mathematical domain and must account for work,
 intermediates, exact output, and transport representation.
 The [runtime ownership rule](../explanation/architecture.md#runtime-ownership-rule)
 defines how that per-call plan is computed and reused.
@@ -13,13 +13,12 @@ defines how that per-call plan is computed and reused.
 - Status: Current catalog-maintenance contract
 - Owner-local manifests: `src/jacobian/math/**/_tools.py`
 
-The public direct MCP catalog is a curated basis of mathematical operations,
-not an inventory of every callable helper in `jacobian.math` or in an installed
-backend. `math.find` is a semantic search view of that same membership. A
-declaration in an owner's immutable `TOOLS` tuple is the publication decision.
-Useful native-only functions remain package exports without a `MathTool`
-declaration. Catalog construction discovers manifests directly and fails closed
-on malformed declarations or duplicate operation IDs.
+The public `math.find` / `math.run` catalog is a curated basis of mathematical
+operations, not an inventory of every callable helper in `jacobian.math` or in
+an installed backend. A declaration in an owner's immutable `TOOLS` tuple is
+the publication decision. Useful native-only functions remain package exports
+without a `MathTool` declaration. Catalog construction discovers manifests
+directly and fails closed on malformed declarations or duplicate operation IDs.
 
 Before applying these gates, identify the reusable gap. Show why the current
 public operations and shared mathematical values do not cleanly provide the

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,24 +1,11 @@
 # Tool reference
 
-Jacobian exposes every admitted mathematical operation as one directly callable
-MCP tool. The tool name is the unchanged operation ID, its input schema is the
-owner-local request contract, and its structured output is the owner-local
-result contract. For example:
-
-```text
-integer.compute.extended_gcd({"left":"84","right":"30"})
-```
-
-returns the gcd and Bézout coefficients directly, without a generic
-`operation_id`, `payload`, or `output` envelope.
-
-Two fixed tools remain alongside those direct operations:
+Jacobian exposes two MCP tools for atomic mathematics.
 
 - `math.find` searches, browses, or inspects the immutable built-in operation
-  catalog. Direct execution does not require it.
-- `math.run` is the transitional generic execution surface retained while
-  direct discovery and catalog-scale behavior are evaluated. New callers should
-  use direct operation tools.
+  catalog.
+- `math.run` executes one operation with a typed `payload` and returns that
+  operation's typed mathematical result.
 
 Built-in membership follows the
 [public mathematical operation admission contract](public-operation-admission.md),
@@ -30,14 +17,14 @@ the first result, pass that value unchanged; otherwise construct the requested
 payload from the relevant fields. Incomplete or unknown outcomes belong to the
 operation's own result model.
 
-For the ordinary discovery-to-direct-execution path, see
+For the ordinary search-to-inspection-to-execution path, see
 [Discover and invoke operations](../how-to/invoke-domain-operations.md).
 
 ## Execution deadlines
 
 Exact mathematical operations may legitimately run for minutes or longer.
 Absent an explicit latency requirement, callers should not impose one short
-timeout on every direct operation call. An operation's admitted work and
+timeout on every `math.run` call. An operation's admitted work and
 declared resource budget determine its execution envelope; any MCP or client
 read timeout must cover that envelope plus bounded transport overhead.
 
@@ -47,31 +34,27 @@ time, error, timeout layer, and repository revision before retrying or
 reporting a gap. A retry should state what changed: budget, backend,
 representation, or deterministic partition.
 
-When semantic catalog discovery is useful, use `math.find` progressively:
-`search` finds a few relevance-ranked candidates, `browse` pages compact
-operation cards in operation-ID order (optionally within one exact primary
-namespace), and `inspect` supplies the selected operation's exact input/output
-schemas and valid examples. Search and browse results retain `catalog_resource`
-as the explicit pointer to the bulk catalog export.
+Use `math.find` progressively: `search` finds a few relevance-ranked candidates,
+`browse` pages compact operation cards in operation-ID order (optionally within
+one exact primary namespace), and `inspect` supplies the selected operation's
+exact input/output schemas and valid examples. Search and browse results retain
+`catalog_resource` as the explicit pointer to the bulk catalog export.
 
-## Form a direct request from a tool contract
+## Form a payload from an inspected contract
 
-Client tool discovery loads the direct operation's callable schema. Start from
-one of its valid examples, when `math.find` inspection publishes one, and adapt
-it to the mathematical input. Otherwise form the call arguments from the input
-schema and field descriptions. They state the required representation,
-including units, bounds, and canonical encodings or ordering where they matter.
-
-An `INVALID_PARAMS` response from a direct operation means either that its JSON
-object was structurally malformed or that the operation's mathematical or
-resource admission rejected an otherwise well-formed request. The structured
-diagnostic identifies bounded field locations and codes without echoing raw
-caller values. A timeout or backend failure is an operational error instead; it
-does not show that the request is mathematically inadmissible and establishes no
-mathematical conclusion.
+Inspect an operation before constructing an unfamiliar payload. Start from one
+of its valid examples, when it has one, and adapt it to the mathematical input.
+Otherwise form the payload from the input schema and field descriptions. They
+state the required representation, including units, bounds, and canonical
+encodings or ordering where they matter. An `INVALID_PARAMS` response from
+`math.run` means either that the payload was structurally malformed or that the
+operation's mathematical or resource admission rejected an otherwise
+well-formed request. Use its structured diagnostic to make the smallest
+correction before drawing a mathematical conclusion. A timeout or backend
+failure is an operational error instead; it does not show that the request is
+mathematically inadmissible and establishes no mathematical conclusion.
 
 `browse` is recomputed from immutable declarations on every request, with a
 caller-supplied pagination cursor. The built-in MCP resource
-`operation://catalog` provides an exact bulk export. Ordinary capability routing
-should use client tool discovery; use `math.find` for mathematical vocabulary
-search and exact catalog inspection.
+`operation://catalog` provides an exact bulk export; ordinary discovery should
+prefer `math.find`.

--- a/src/jacobian/mcp/guidance.py
+++ b/src/jacobian/mcp/guidance.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 SERVER_DESCRIPTION = (
-    "Direct typed tools for atomic, composable computations in higher mathematics."
+    "Search and run atomic, composable Jacobian tools for higher mathematics."
 )
 
 SERVER_INSTRUCTIONS = (
     "Jacobian provides local typed operations for mathematical computation and "
-    "structural analysis. Each admitted operation is directly callable under its "
-    "operation ID with its owner-local input schema and returns its canonical result. "
-    "Use math.find only when semantic catalog search or exact contract inspection adds "
-    "value beyond client tool discovery. The caller owns composition and may retain a "
-    "returned value when a later operation accepts it. math.run remains available "
-    "during the direct-tool migration but is not required for ordinary operation calls."
+    "structural analysis. Reach for math.find and math.run proactively when a problem "
+    "contains an exact computation, finite search, or structural analysis that may "
+    "match a public MCP operation. Use math.find to discover or inspect operations and "
+    "math.run to execute them. Each call returns an operation-owned canonical "
+    "mathematical value that a caller may retain and reuse when a later contract accepts it."
 )
 
 MATH_FIND_DESCRIPTION = """\

--- a/src/jacobian/mcp/server.py
+++ b/src/jacobian/mcp/server.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
 from typing import Any
 
 from mcp.server import MCPServer
+from mcp.server.mcpserver.tools import Tool
 
 from jacobian import __version__
 from jacobian.catalog.catalog import Catalog
-from jacobian.mcp.direct_tools import direct_operation_tools
 from jacobian.mcp.guidance import SERVER_DESCRIPTION, SERVER_INSTRUCTIONS
 from jacobian.mcp.protocol import register_core_projection
 from jacobian.mcp.runtime import AppState
@@ -34,8 +34,14 @@ def _build_server(
     state: AppState,
     token_verifier: Any | None = None,
     auth: Any | None = None,
+    evaluation_tools: Sequence[Tool] = (),
 ) -> MCPServer[AppState]:
-    """Register Jacobian's fixed MCP projection over one immutable state."""
+    """Register Jacobian's fixed MCP projection over one immutable state.
+
+    ``evaluation_tools`` exists only for frozen surface experiments. Production
+    constructors leave it empty so the catalog is discovered through the fixed
+    MCP tools instead of being eagerly expanded into hundreds of definitions.
+    """
 
     @asynccontextmanager
     async def lifespan(_server: MCPServer[AppState]) -> AsyncIterator[AppState]:
@@ -50,7 +56,7 @@ def _build_server(
         lifespan=lifespan,
         token_verifier=token_verifier,
         auth=auth,
-        tools=direct_operation_tools(state.operation_catalog),
+        tools=list(evaluation_tools),
     )
     register_core_projection(server, state)
     return server

--- a/tests/mcp/test_direct_operations.py
+++ b/tests/mcp/test_direct_operations.py
@@ -1,4 +1,4 @@
-"""Direct catalog-derived MCP operation registration and invocation."""
+"""Experimental direct catalog projection used by frozen evaluations."""
 
 from __future__ import annotations
 
@@ -18,7 +18,11 @@ from jacobian._execution import (
 from jacobian._models import StrictModel
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import MathTool
-from jacobian.mcp.direct_tools import _operation_input_schema, _operation_tool_name
+from jacobian.mcp.direct_tools import (
+    _operation_input_schema,
+    _operation_tool_name,
+    direct_operation_tools,
+)
 from jacobian.mcp.runtime import AppState
 from jacobian.mcp.server import _build_server, create_server
 
@@ -35,30 +39,38 @@ def _operations(*operation_ids: str) -> tuple[MathTool[Any, Any], ...]:
     return tuple(operations)
 
 
-def _server(*operation_ids: str) -> Any:
+def _direct_server(catalog: Catalog) -> Any:
     return _build_server(
-        state=AppState(operation_catalog=Catalog(_operations(*operation_ids)))
+        state=AppState(operation_catalog=catalog),
+        evaluation_tools=direct_operation_tools(catalog),
     )
 
 
-def test_every_catalog_operation_is_one_direct_identity_named_tool() -> None:
+def _server(*operation_ids: str) -> Any:
+    return _direct_server(Catalog(_operations(*operation_ids)))
+
+
+def test_production_server_does_not_eagerly_expose_catalog_operations() -> None:
     async def scenario() -> None:
         from mcp import Client
 
-        catalog_ids = {
-            descriptor.operation_id
-            for descriptor in Catalog.open().snapshot().operations
-        }
         async with Client(create_server(), raise_exceptions=True) as client:
             listed_ids = {tool.name for tool in (await client.list_tools()).tools}
 
-        assert listed_ids == catalog_ids | _FIXED_TOOLS
-        assert all(
-            _operation_tool_name(operation_id) == operation_id
-            for operation_id in catalog_ids
-        )
+        assert listed_ids == _FIXED_TOOLS
 
     asyncio.run(scenario())
+
+
+def test_experimental_direct_projection_preserves_identity_names() -> None:
+    catalog_ids = {
+        descriptor.operation_id for descriptor in Catalog.open().snapshot().operations
+    }
+
+    assert all(
+        _operation_tool_name(operation_id) == operation_id
+        for operation_id in catalog_ids
+    )
 
 
 def test_direct_schemas_are_owner_contracts_with_only_mcp_root_projection() -> None:
@@ -232,7 +244,7 @@ def test_direct_parsing_and_execution_share_one_request_envelope() -> None:
         result_type=Result,
         run=run,
     )
-    server = _build_server(state=AppState(operation_catalog=Catalog((operation,))))
+    server = _direct_server(Catalog((operation,)))
 
     async def scenario() -> None:
         from mcp import Client
@@ -331,7 +343,7 @@ def test_direct_calls_do_not_expose_unexpected_owner_failures() -> None:
         result_type=Result,
         run=crash,
     )
-    server = _build_server(state=AppState(operation_catalog=Catalog((operation,))))
+    server = _direct_server(Catalog((operation,)))
 
     async def scenario() -> None:
         from mcp import Client
@@ -368,7 +380,7 @@ def test_direct_calls_preserve_owner_cancellation_diagnosis() -> None:
         result_type=Result,
         run=cancel,
     )
-    server = _build_server(state=AppState(operation_catalog=Catalog((operation,))))
+    server = _direct_server(Catalog((operation,)))
 
     async def scenario() -> None:
         from mcp import Client

--- a/tests/mcp/test_mcp_cancellation.py
+++ b/tests/mcp/test_mcp_cancellation.py
@@ -57,15 +57,21 @@ def test_stdio_cancellation_reaps_tree_and_server_remains_responsive(
                 marker = tmp_path / f"request-{attempt}.json"
                 with pytest.raises(MCPError, match="timed out"):
                     await client.call_tool(
-                        "test.process.wait",
-                        {"marker": str(marker)},
+                        "math.run",
+                        {
+                            "operation_id": "test.process.wait",
+                            "payload": {"marker": str(marker)},
+                        },
                         read_timeout_seconds=2,
                     )
                 await _assert_pids_exit(await _read_pids(marker))
             follow_up = await client.call_tool(
-                "integer.compute.extended_gcd",
-                {"left": "84", "right": "30"},
+                "math.run",
+                {
+                    "operation_id": "integer.compute.extended_gcd",
+                    "payload": {"left": "84", "right": "30"},
+                },
             )
-            assert follow_up.structured_content["gcd"] == "6"
+            assert follow_up.structured_content["output"]["gcd"] == "6"
 
     asyncio.run(scenario())

--- a/tests/mcp/test_mcp_catalog_and_policy.py
+++ b/tests/mcp/test_mcp_catalog_and_policy.py
@@ -136,8 +136,8 @@ def test_mcp_compact_operation_index_is_searchable_and_paginated() -> None:
                 {
                     "request": {
                         "op": "search",
-                        "query": "definitely-no-matching-operation",
-                        "cursor": first["next_cursor"],
+                        "query": "exact",
+                        "cursor": "integer.compute.unknown",
                         "limit": 20,
                     }
                 },

--- a/tests/mcp/test_mcp_entrypoint.py
+++ b/tests/mcp/test_mcp_entrypoint.py
@@ -9,11 +9,7 @@ import sys
 from importlib.metadata import version
 from pathlib import Path
 
-from jacobian.catalog.catalog import Catalog
-
 MCP_TOOL_NAMES = {
-    descriptor.operation_id for descriptor in Catalog.open().snapshot().operations
-} | {
     "math.find",
     "math.run",
 }

--- a/tests/mcp/test_mcp_invocation_journey.py
+++ b/tests/mcp/test_mcp_invocation_journey.py
@@ -77,14 +77,18 @@ def test_mcp_runs_independent_sync_operations_concurrently() -> None:
             results = await asyncio.gather(
                 *(
                     client.call_tool(
-                        "test.concurrent.kernel",
-                        {"value": value},
+                        "math.run",
+                        {
+                            "operation_id": "test.concurrent.kernel",
+                            "payload": {"value": value},
+                        },
                     )
                     for value in range(2)
                 )
             )
         assert any(
-            result.structured_content["simultaneous_calls"] == 2 for result in results
+            result.structured_content["output"]["simultaneous_calls"] == 2
+            for result in results
         )
 
     asyncio.run(scenario())

--- a/tests/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/mcp/test_mcp_sdk_2_conformance.py
@@ -205,14 +205,7 @@ def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources(
         assert hasattr(server, "list_tools") and hasattr(server, "call_tool")
         async with Client(server, raise_exceptions=True) as client:
             listed = await client.list_tools()
-            operation_ids = {
-                descriptor.operation_id
-                for descriptor in Catalog.open().snapshot().operations
-            }
-            assert {tool.name for tool in listed.tools} == operation_ids | {
-                "math.find",
-                "math.run",
-            }
+            assert {tool.name for tool in listed.tools} == {"math.find", "math.run"}
 
             invoke = next(tool for tool in listed.tools if tool.name == "math.run")
             assert set(invoke.input_schema["properties"]) == {

--- a/tests/process/tooling/test_deploy_helpers.py
+++ b/tests/process/tooling/test_deploy_helpers.py
@@ -56,21 +56,26 @@ def test_remote_smoke_accepts_the_current_typed_discovery_response() -> None:
     assert failures == []
 
 
-def test_remote_smoke_derives_tool_surface_from_deployed_catalog() -> None:
-    remote_operation = "test.remote.previous_release"
+def test_remote_smoke_rejects_eager_catalog_tool_exposure() -> None:
     listed = SimpleNamespace(
         tools=[
             SimpleNamespace(name="math.find"),
             SimpleNamespace(name="math.run"),
-            SimpleNamespace(name=remote_operation),
+            SimpleNamespace(name="matrix.determinant.compute"),
         ]
     )
     failures: list[str] = []
 
-    tool_names = _validate_tool_surface(listed, {remote_operation}, failures)
+    tool_names = _validate_tool_surface(listed, failures)
 
-    assert tool_names == {"math.find", "math.run", remote_operation}
-    assert failures == []
+    assert tool_names == {
+        "math.find",
+        "math.run",
+        "matrix.determinant.compute",
+    }
+    assert failures == [
+        "deployed MCP tool surface has unexpected tools: ['matrix.determinant.compute']"
+    ]
 
 
 def test_remote_smoke_rejects_divergent_model_visible_discovery() -> None:

--- a/tests/tooling/test_ci_test_plan.py
+++ b/tests/tooling/test_ci_test_plan.py
@@ -248,7 +248,8 @@ def test_merge_group_always_owns_full_math_and_public_contracts() -> None:
 
 def test_merge_group_selects_scale_evidence_for_its_owning_math_domain() -> None:
     plan = _plan(
-        ["src/jacobian/math/lattice_polytopes/_operations.py"], event="merge_group"
+        ["src/jacobian/math/geometry/polytopes/lattice/operations.py"],
+        event="merge_group",
     )
 
     assert plan.run_math is True

--- a/tests/tooling/test_manage_test_timings.py
+++ b/tests/tooling/test_manage_test_timings.py
@@ -193,6 +193,16 @@ def test_math_timing_history_uses_four_shards_and_math_node_ids() -> None:
     ) == {"tests/math/logic/test_cnf.py::test_case": 1.25}
 
 
+def test_math_timing_history_admits_more_than_ten_thousand_cases() -> None:
+    module = _script()
+    durations = {
+        f"tests/math/generated/test_{index}.py::test_case": 0.01
+        for index in range(10_100)
+    }
+
+    assert len(module.validate_durations(durations, "timings.json", "math")) == 10_100
+
+
 def test_math_timing_history_merges_four_shards(tmp_path: Path) -> None:
     module = _script()
     first = tmp_path / "first.json"

--- a/tests/tooling/test_pytest_timing.py
+++ b/tests/tooling/test_pytest_timing.py
@@ -1,0 +1,18 @@
+"""Regression tests for pytest timing evidence collection."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tools import pytest_timing
+
+
+def test_worker_failure_without_output_is_not_masked_by_timing_hook() -> None:
+    state = pytest_timing._TimingState()
+    node = SimpleNamespace(
+        config=SimpleNamespace(stash={pytest_timing._TIMING_STATE: state})
+    )
+
+    pytest_timing.pytest_testnodedown(node, RuntimeError("worker terminated"))
+
+    assert state.workers == {}

--- a/tools/pytest_timing.py
+++ b/tools/pytest_timing.py
@@ -68,7 +68,13 @@ def pytest_testnodedown(node: Any, error: BaseException | None) -> None:
     del error
     config = node.config
     state = config.stash[_TIMING_STATE]
-    timing = node.workeroutput.get("jacobian_timing")
+    workeroutput = getattr(node, "workeroutput", None)
+    if not isinstance(workeroutput, dict):
+        # xdist does not attach worker output when a worker terminates before
+        # its session-finish hook. Preserve xdist's original worker failure
+        # instead of replacing it with a timing-plugin AttributeError.
+        return
+    timing = workeroutput.get("jacobian_timing")
     if not isinstance(timing, dict):
         return
     worker_id = timing.get("id")


### PR DESCRIPTION
## Summary

- expose only math.find and math.run from production MCP constructors instead of eagerly registering every catalog operation
- keep the direct typed-tool projection available only to the explicit frozen catalog experiment
- make stdio and remote deployment smokes fail closed when catalog operations leak into tools/list
- align the product, architecture, invocation, and admission docs with the deployable two-tool surface
- repair the current main CI regressions: a stale MCP cursor fixture, the math timing artifact entry ceiling, missing xdist workeroutput handling, a stale scale-owner fixture, and the dispatch lane timeout

## Operational evidence

The currently deployed PR #3018 artifact exposes 806 tools and serializes about 2,819,213 bytes of tool definitions. This branch, after rebasing onto current main, keeps the full operation catalog available while tools/list returns only math.find and math.run; the serialized tool definitions are about 11.7 KB, a reduction of roughly 99.6%.

The deployed service and tailscaled were active. Since the previous deployment, journald showed no traceback, OOM, or HTTP 5xx. Several 400 responses contained the retired request.search.domain field, which is consistent with stale client schema/cache behavior rather than a server crash.

## CI fixes

- raise dispatch test watchdog from 30s to 120s; the current coverage run has individual calls near the old limit and main lost an xdist worker
- preserve the original xdist worker failure when workeroutput is absent instead of masking it with AttributeError
- admit the observed 10,073-entry math timing artifact while retaining the existing 5 MiB byte cap
- use a genuinely invalid catalog cursor in the MCP regression
- point the scale-selection fixture at the canonical lattice-polytope owner after the ownership refactor

## Validation

- make test-catalog: 113 passed
- make test-dispatch with the failed main seed: 114 passed
- make test-tooling: 276 passed
- make test-mcp: 33 passed
- focused deployment helpers: 14 passed
- catalog example integration: 836 passed
- full ordinary integration: 938 passed
- docs link check, Ruff, formatting, scoped mypy, and git diff checks passed
- installed stdio smoke passed math.find inspection and two math.run extended-GCD calls

The planner-selected local math lane was also attempted. On this shared host, its 8-worker run caused SMT operations with explicit 1,000 ms request deadlines to time out under contention; 6,733 tests passed and 69 logic tests returned UNKNOWN. Three representative failures passed serially, and the same 202-test logic slice improved from 77 failures at 8 workers to 3 at 2 workers. No SMT contract is changed here; hosted sharded CI remains the authoritative evidence.

Supersedes the production exposure introduced by #3018 while retaining its direct projection for controlled evaluation.