### PR TITLE
Extend chain-complex homology to certified integral coefficients

### DIFF
--- a/docs/reference/operations/finite-math/finite-simplicial-topology.md
+++ b/docs/reference/operations/finite-math/finite-simplicial-topology.md
@@ -10,6 +10,10 @@ exact direct operations:
 - `topology.simplicial_homology.compute`
 - `topology.simplicial_homology.integral.compute`
 
-The integral homology result includes its returned Smith transformations,
-cycles, and torsion data as typed mathematical values. It does not create a
-durable complex, certificate record, or checker session.
+The integral operation wraps the same chain-complex-owned `HomologyResult`
+returned by `chain_complex.homology.compute`. It retains the canonical `ZZ`
+chain value, Smith transformations, source-basis cycles, torsion invariant
+factors, and bounding chains. Reduced chains represent the augmentation as the
+ordinary differential from degree 0 to a rank-one group in degree -1. The
+operation does not create a durable complex, certificate record, or checker
+session.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,7 @@ ignore_imports = [
     "jacobian.math.graphs.optimization._invariants -> jacobian.process",
     "jacobian.math.graphs.optimization._maximum_cut_process -> jacobian.process",
     "jacobian.math.graphs.chip_firing._snf_process -> jacobian.process",
+    "jacobian.math.topology.chain_complexes._smith_process -> jacobian.process",
     "jacobian.math.combinatorics.finite_structures.hypergraphs._independence_z3 -> jacobian.process",
     "jacobian.math.combinatorics.discrepancy._optimum_process -> jacobian.process",
     "jacobian.math.combinatorics._counting_process -> jacobian.process",

--- a/src/jacobian/math/topology/_chain_conversion.py
+++ b/src/jacobian/math/topology/_chain_conversion.py
@@ -9,10 +9,8 @@ from jacobian.math.topology._models import (
     SparseBoundaryMatrix,
 )
 from jacobian.math.topology.chain_complexes.values import (
-    MAX_BASIS_SIZE,
-    MAX_MATRIX_CELLS,
     ChainComplexValue,
-    CoefficientField,
+    CoefficientRing,
 )
 
 
@@ -22,49 +20,57 @@ def canonical_chain_complex_value_from_parts(
     prime: int | None,
     simplex_bases: tuple[SimplexBasis, ...],
     boundary_matrices: tuple[SparseBoundaryMatrix, ...],
-) -> ChainComplexValue | None:
-    """Return the canonical value for one eligible simplicial chain complex.
+    augmentation: SparseBoundaryMatrix | None,
+) -> ChainComplexValue:
+    """Return the canonical based complex carried by a simplicial producer.
 
-    Only unreduced prime-field results convert: integral boundaries live over
-    ZZ rather than QQ or GF(p), and reduced chains retain an augmentation map
-    outside the canonical value's representation.  The ordered lexicographic
-    face bases remain the implicit column/row ordering of each dense
-    differential; simplex labels do not survive because the canonical value
-    is based but unlabeled.
+    Reduced homology is represented without an exceptional side channel: the
+    augmentation target is the rank-one group in degree ``-1`` and the
+    augmentation itself is the ordinary differential ``C_0 -> C_-1``.  The
+    ordered lexicographic simplex bases remain the implicit coordinates of the
+    dense matrices; the canonical chain value is based but unlabeled.
     """
 
-    if coefficient_ring is not ChainCoefficientRing.PRIME_FIELD:
-        return None
-    if convention is HomologyConvention.REDUCED:
-        return None
-    if prime is None:
+    if coefficient_ring is ChainCoefficientRing.PRIME_FIELD and prime is None:
         raise ValueError("prime-field chains must declare their modulus")
-    basis_sizes = tuple(len(basis.simplices) for basis in simplex_bases)
-    total_cells = sum(matrix.rows * matrix.columns for matrix in boundary_matrices)
-    if any(size > MAX_BASIS_SIZE for size in basis_sizes):
-        raise ValueError(
-            f"simplicial chain group exceeds the canonical basis bound {MAX_BASIS_SIZE}"
-        )
-    if total_cells > MAX_MATRIX_CELLS:
-        raise ValueError(
-            f"simplicial boundary data exceeds the canonical cell bound "
-            f"{MAX_MATRIX_CELLS}"
-        )
-    # Boundary matrix k maps C_k -> C_{k-1}; the canonical value stores
-    # differentials[i] as C_{i+1} -> C_i, i.e. boundary_matrices[i + 1].
+    if coefficient_ring is ChainCoefficientRing.INTEGER and prime is not None:
+        raise ValueError("integer chains must not declare a prime modulus")
+    simplicial_sizes = tuple(len(basis.simplices) for basis in simplex_bases)
+    reduced = convention is HomologyConvention.REDUCED
+    if reduced and augmentation is None:
+        raise ValueError("reduced chains require an augmentation matrix")
+    if not reduced and augmentation is not None:
+        raise ValueError("unreduced chains must not carry an augmentation matrix")
+    basis_sizes = (1, *simplicial_sizes) if reduced else simplicial_sizes
+    matrices = (
+        (augmentation, *boundary_matrices[1:])
+        if augmentation is not None
+        else boundary_matrices[1:]
+    )
+    # Boundary matrix k maps C_k -> C_{k-1}; the canonical value stores the
+    # same maps in increasing target degree. Reduced chains prepend the
+    # augmentation C_0 -> C_-1.
     differential_matrices = []
-    for matrix in boundary_matrices[1:]:
+    for matrix in matrices:
+        if matrix is None:
+            raise ValueError("canonical differential is unexpectedly absent")
         dense = [[0] * matrix.columns for _ in range(matrix.rows)]
         for entry in matrix.entries:
-            dense[entry.row][entry.column] = entry.value % prime
+            dense[entry.row][entry.column] = (
+                entry.value if prime is None else entry.value % prime
+            )
         differential_matrices.append(
             tuple(tuple(str(value) for value in row) for row in dense)
         )
     return ChainComplexValue(
-        coefficient_field=CoefficientField.PRIME_FIELD,
+        coefficient_ring=(
+            CoefficientRing.INTEGER
+            if coefficient_ring is ChainCoefficientRing.INTEGER
+            else CoefficientRing.PRIME_FIELD
+        ),
         prime=prime,
-        degree_min=0,
-        degree_max=len(basis_sizes) - 1,
+        degree_min=-1 if reduced else 0,
+        degree_max=(-1 if reduced else 0) + len(basis_sizes) - 1,
         basis_sizes=basis_sizes,
         differential_matrices=tuple(differential_matrices),
     )

--- a/src/jacobian/math/topology/_homology.py
+++ b/src/jacobian/math/topology/_homology.py
@@ -7,13 +7,7 @@ from typing import Literal, Self
 from pydantic import Field, StrictInt, model_validator
 
 from jacobian._digest import Sha256Digest
-from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.math.matrices.certified_snf.values import (
-    MAX_CERTIFIED_SNF_DIMENSION,
-    CertifiedIntegerMatrix,
-    SmithNormalFormCertificate,
-)
 from jacobian.math.topology._models import (
     MAX_TOPOLOGY_CHAIN_GROUP,
     MAX_TOPOLOGY_DIMENSION,
@@ -23,20 +17,12 @@ from jacobian.math.topology._models import (
     _validation_error,
     is_bounded_prime,
 )
+from jacobian.math.topology.chain_complexes.values import (
+    CoefficientRing,
+    HomologyResult,
+)
 
-# Integral homology embeds every boundary/augmentation matrix, Smith
-# transformation, and derived coordinate matrix in ``CertifiedIntegerMatrix``,
-# whose dimension contract caps at ``MAX_CERTIFIED_SNF_DIMENSION``. The
-# admitted chain groups therefore derive from that certificate bound; raising
-# them requires expanding the certificate contract first, not this constant
-# alone. The total-rank and cell bounds are independent work nets over the
-# whole request (SNF cost scales with total chain size), not output-shape
-# bounds.
 MAX_INLINE_HOMOLOGY_CHAIN_GROUP = 64
-MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP = MAX_CERTIFIED_SNF_DIMENSION
-MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK = 100
-MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS = 2500
-MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS = 256
 
 
 class SimplicialHomologyRequest(StrictModel):
@@ -162,195 +148,33 @@ class IntegralSimplicialHomologyRequest(StrictModel):
     convention: HomologyConvention = HomologyConvention.UNREDUCED
 
 
-class IntegralVector(StrictModel):
-    coefficients: tuple[CanonicalInteger, ...] = Field(
-        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
-    )
-
-    @model_validator(mode="after")
-    def require_output_digit_budget(self) -> Self:
-        if any(
-            len(value.lstrip("-")) > MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS
-            for value in self.coefficients
-        ):
-            raise _validation_error(
-                "topology.require_output_digit_budget_1",
-                "integral homology vector exceeds the output digit bound",
-            )
-        return self
-
-
-class IntegralFreeGenerator(StrictModel):
-    cycle: IntegralVector
-    cycle_coordinates: IntegralVector
-
-
-class IntegralTorsionGenerator(StrictModel):
-    order: CanonicalInteger
-    cycle: IntegralVector
-    cycle_coordinates: IntegralVector
-    bounding_chain: IntegralVector
-
-    @model_validator(mode="after")
-    def require_nontrivial_bounded_order(self) -> Self:
-        if (
-            int(self.order) <= 1
-            or len(self.order.lstrip("-")) > MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS
-        ):
-            raise _validation_error(
-                "topology.require_nontrivial_bounded_order_1",
-                "torsion generator order must be a bounded integer > 1",
-            )
-        return self
-
-
-class IntegralHomologyGroupResult(StrictModel):
-    dimension: StrictInt = Field(ge=0, le=MAX_TOPOLOGY_DIMENSION)
-    chain_dimension: StrictInt = Field(ge=1, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP)
-    incoming_chain_dimension: StrictInt = Field(
-        ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
-    )
-    outgoing_boundary_rank: StrictInt = Field(
-        ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
-    )
-    cycle_rank: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP)
-    incoming_boundary_rank: StrictInt = Field(
-        ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
-    )
-    betti_number: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP)
-    torsion_coefficients: tuple[CanonicalInteger, ...] = Field(
-        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
-    )
-    free_generators: tuple[IntegralFreeGenerator, ...] = Field(
-        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
-    )
-    torsion_generators: tuple[IntegralTorsionGenerator, ...] = Field(
-        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
-    )
-    outgoing_smith_certificate: SmithNormalFormCertificate
-    boundary_in_cycle_coordinates: CertifiedIntegerMatrix
-    incoming_smith_certificate: SmithNormalFormCertificate
-    generator_basis: Literal[
-        "CANONICAL_SIMPLEX_BASIS_VIA_CERTIFIED_SMITH_TRANSFORMATIONS"
-    ] = "CANONICAL_SIMPLEX_BASIS_VIA_CERTIFIED_SMITH_TRANSFORMATIONS"
-
-    @model_validator(mode="after")
-    def require_complete_integral_group_ledger(self) -> Self:
-        outgoing = self.outgoing_smith_certificate
-        incoming = self.incoming_smith_certificate
-        if (
-            outgoing.source.column_count != self.chain_dimension
-            or outgoing.rank != self.outgoing_boundary_rank
-            or self.cycle_rank != self.chain_dimension - self.outgoing_boundary_rank
-            or (
-                self.boundary_in_cycle_coordinates.row_count,
-                self.boundary_in_cycle_coordinates.column_count,
-            )
-            != (self.cycle_rank, self.incoming_chain_dimension)
-            or incoming.source != self.boundary_in_cycle_coordinates
-            or incoming.rank != self.incoming_boundary_rank
-            or self.betti_number != self.cycle_rank - self.incoming_boundary_rank
-            or len(self.free_generators) != self.betti_number
-        ):
-            raise _validation_error(
-                "topology.require_complete_integral_group_ledger_1",
-                "integral homology rank and certificate ledger is invalid",
-            )
-        torsion = tuple(
-            factor for factor in incoming.invariant_factors if int(factor) > 1
-        )
-        if (
-            self.torsion_coefficients != torsion
-            or tuple(item.order for item in self.torsion_generators) != torsion
-        ):
-            raise _validation_error(
-                "topology.require_complete_integral_group_ledger_2",
-                "integral homology torsion generators must match Smith factors",
-            )
-        if any(
-            len(item.cycle.coefficients) != self.chain_dimension
-            or len(item.cycle_coordinates.coefficients) != self.cycle_rank
-            for item in self.free_generators
-        ) or any(
-            len(item.cycle.coefficients) != self.chain_dimension
-            or len(item.cycle_coordinates.coefficients) != self.cycle_rank
-            or len(item.bounding_chain.coefficients) != self.incoming_chain_dimension
-            for item in self.torsion_generators
-        ):
-            raise _validation_error(
-                "topology.require_complete_integral_group_ledger_3",
-                "integral homology generators must use the declared simplex bases",
-            )
-        matrices = (
-            outgoing.source,
-            outgoing.diagonal,
-            outgoing.left_transformation,
-            outgoing.right_transformation,
-            self.boundary_in_cycle_coordinates,
-            incoming.source,
-            incoming.diagonal,
-            incoming.left_transformation,
-            incoming.right_transformation,
-        )
-        scalar_values = (
-            value for matrix in matrices for row in matrix.entries for value in row
-        )
-        if any(
-            len(value.lstrip("-")) > MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS
-            for value in scalar_values
-        ):
-            raise _validation_error(
-                "topology.require_complete_integral_group_ledger_4",
-                "integral homology certificate exceeds the output digit bound",
-            )
-        return self
-
-
 class IntegralSimplicialHomologyResult(StrictModel):
     complex_digest: Sha256Digest
-    coefficient_ring: Literal["ZZ"] = "ZZ"
     convention: HomologyConvention
     orientation_convention: Literal["LEXICOGRAPHIC_VERTEX_ORDER"] = (
         "LEXICOGRAPHIC_VERTEX_ORDER"
     )
-    dimension_range: tuple[StrictInt, StrictInt]
-    groups: tuple[IntegralHomologyGroupResult, ...] = Field(
-        min_length=1,
-        max_length=MAX_TOPOLOGY_DIMENSION + 1,
-    )
-    decomposition: Literal["DIRECT_SUM_Z_AND_FINITE_CYCLIC_FACTORS"] = (
-        "DIRECT_SUM_Z_AND_FINITE_CYCLIC_FACTORS"
-    )
+    homology: HomologyResult
 
     @model_validator(mode="after")
-    def require_complete_integral_dimension_range(self) -> Self:
-        dimensions = tuple(group.dimension for group in self.groups)
-        if dimensions != tuple(range(len(self.groups))):
+    def require_integral_chain_owned_result(self) -> Self:
+        expected_min = -1 if self.convention is HomologyConvention.REDUCED else 0
+        if (
+            self.homology.coefficient_ring is not CoefficientRing.INTEGER
+            or self.homology.degree_min != expected_min
+        ):
             raise _validation_error(
-                "topology.require_complete_integral_dimension_range_1",
-                "integral homology groups must cover contiguous dimensions",
-            )
-        if self.dimension_range != (0, len(self.groups) - 1):
-            raise _validation_error(
-                "topology.require_complete_integral_dimension_range_2",
-                "integral homology dimension_range must cover every group",
+                "topology.integral_homology_context_mismatch",
+                "simplicial integral homology must retain the chain-owned ZZ result under the selected convention",
             )
         return self
 
 
 __all__ = [
     "MAX_INLINE_HOMOLOGY_CHAIN_GROUP",
-    "MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP",
-    "MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS",
-    "MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS",
-    "MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK",
     "HomologyGroupResult",
-    "IntegralFreeGenerator",
-    "IntegralHomologyGroupResult",
     "IntegralSimplicialHomologyRequest",
     "IntegralSimplicialHomologyResult",
-    "IntegralTorsionGenerator",
-    "IntegralVector",
     "ModularVector",
     "SimplicialHomologyRequest",
     "SimplicialHomologyResult",

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -22,7 +22,10 @@ from pydantic_core import PydanticCustomError
 from jacobian._digest import Sha256Digest
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import canonicalize_json
-from jacobian.math.topology.chain_complexes.values import ChainComplexValue
+from jacobian.math.topology.chain_complexes.values import (
+    ChainComplexValue,
+    CoefficientRing,
+)
 
 MAX_TOPOLOGY_VERTICES = 64
 MAX_TOPOLOGY_FACETS = 128
@@ -480,8 +483,11 @@ def require_linear_algebra_bounds(complex_: FiniteSimplicialComplex) -> None:
         )
 
 
-def _require_canonical_conversion_bounds(complex_: FiniteSimplicialComplex) -> None:
-    """Unreduced GF(p) chains must fit the canonical value's bounds.
+def _require_canonical_conversion_bounds(
+    complex_: FiniteSimplicialComplex,
+    convention: HomologyConvention,
+) -> None:
+    """Every simplicial chain producer must fit the canonical value's bounds.
 
     ``ChainComplexValue`` caps the aggregate cells across every
     differential, so admission must check the same sum rather than each
@@ -492,19 +498,22 @@ def _require_canonical_conversion_bounds(complex_: FiniteSimplicialComplex) -> N
         MAX_MATRIX_CELLS,
     )
 
-    sizes = complex_.f_vector
+    sizes = (
+        (1, *complex_.f_vector)
+        if convention is HomologyConvention.REDUCED
+        else complex_.f_vector
+    )
     if any(size > MAX_BASIS_SIZE for size in sizes):
         raise _validation_error(
             "topology.require_canonical_conversion_bounds_1",
-            "unreduced prime-field chain complexes require at most "
+            "simplicial chain complexes require at most "
             f"{MAX_BASIS_SIZE} faces per chain group",
         )
-    padded = (0, *sizes)
-    total_cells = sum(rows * columns for rows, columns in pairwise(padded))
+    total_cells = sum(rows * columns for rows, columns in pairwise(sizes))
     if total_cells > MAX_MATRIX_CELLS:
         raise _validation_error(
             "topology.require_canonical_conversion_bounds_2",
-            "unreduced prime-field chain complexes require "
+            "simplicial chain complexes require "
             f"{total_cells} aggregate boundary cells within the canonical "
             f"{MAX_MATRIX_CELLS}-cell bound",
         )
@@ -621,7 +630,7 @@ class ChainComplexResult(StrictModel):
         default=(),
         max_length=MAX_TOPOLOGY_DIMENSION,
     )
-    canonical_value: ChainComplexValue | None = None
+    canonical_value: ChainComplexValue
 
     @model_validator(mode="after")
     def require_coherent_chain_contract(self) -> Self:
@@ -656,14 +665,47 @@ class ChainComplexResult(StrictModel):
                 "topology.require_coherent_chain_contract_4",
                 "boundary-square ledger must cover every adjacent pair",
             )
-        if self.canonical_value is not None and not (
-            self.coefficient_ring is ChainCoefficientRing.PRIME_FIELD
-            and self.convention is HomologyConvention.UNREDUCED
+        canonical_ring = (
+            CoefficientRing.INTEGER
+            if self.coefficient_ring is ChainCoefficientRing.INTEGER
+            else CoefficientRing.PRIME_FIELD
+        )
+        expected_basis_sizes = tuple(len(item.simplices) for item in self.simplex_bases)
+        expected_basis_sizes = (
+            (1, *expected_basis_sizes)
+            if self.convention is HomologyConvention.REDUCED
+            else expected_basis_sizes
+        )
+        expected_degree_min = -1 if self.convention is HomologyConvention.REDUCED else 0
+        canonical_boundaries = (
+            (self.augmentation, *self.boundary_matrices[1:])
+            if self.augmentation is not None
+            else self.boundary_matrices[1:]
+        )
+        expected_differentials: list[tuple[tuple[str, ...], ...]] = []
+        for matrix in canonical_boundaries:
+            if matrix is None:
+                raise _validation_error(
+                    "topology.require_coherent_chain_contract_5",
+                    "canonical differential source is unexpectedly absent",
+                )
+            dense = [[0] * matrix.columns for _ in range(matrix.rows)]
+            for entry in matrix.entries:
+                dense[entry.row][entry.column] = entry.value
+            expected_differentials.append(
+                tuple(tuple(str(value) for value in row) for row in dense)
+            )
+        if (
+            self.canonical_value.coefficient_ring is not canonical_ring
+            or self.canonical_value.prime != self.prime
+            or self.canonical_value.degree_min != expected_degree_min
+            or self.canonical_value.basis_sizes != expected_basis_sizes
+            or self.canonical_value.differential_matrices
+            != tuple(expected_differentials)
         ):
             raise _validation_error(
                 "topology.require_coherent_chain_contract_5",
-                "canonical chain-complex value is only defined for unreduced "
-                "prime-field chains",
+                "canonical chain-complex value does not match the simplicial coefficient, convention, or basis context",
             )
         return self
 

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -677,35 +677,15 @@ class ChainComplexResult(StrictModel):
             else expected_basis_sizes
         )
         expected_degree_min = -1 if self.convention is HomologyConvention.REDUCED else 0
-        canonical_boundaries = (
-            (self.augmentation, *self.boundary_matrices[1:])
-            if self.augmentation is not None
-            else self.boundary_matrices[1:]
-        )
-        expected_differentials: list[tuple[tuple[str, ...], ...]] = []
-        for matrix in canonical_boundaries:
-            if matrix is None:
-                raise _validation_error(
-                    "topology.require_coherent_chain_contract_5",
-                    "canonical differential source is unexpectedly absent",
-                )
-            dense = [[0] * matrix.columns for _ in range(matrix.rows)]
-            for entry in matrix.entries:
-                dense[entry.row][entry.column] = entry.value
-            expected_differentials.append(
-                tuple(tuple(str(value) for value in row) for row in dense)
-            )
         if (
             self.canonical_value.coefficient_ring is not canonical_ring
             or self.canonical_value.prime != self.prime
             or self.canonical_value.degree_min != expected_degree_min
             or self.canonical_value.basis_sizes != expected_basis_sizes
-            or self.canonical_value.differential_matrices
-            != tuple(expected_differentials)
         ):
             raise _validation_error(
                 "topology.require_coherent_chain_contract_5",
-                "canonical chain-complex value does not match the simplicial coefficient, convention, or basis context",
+                "canonical chain-complex value does not match the simplicial coefficient, convention, or basis axes",
             )
         return self
 

--- a/src/jacobian/math/topology/_simplicial_kernel.py
+++ b/src/jacobian/math/topology/_simplicial_kernel.py
@@ -1,20 +1,10 @@
-"""Exact finite simplicial-complex and prime-field homology operations."""
+"""Exact finite simplicial-complex and homology operations."""
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from itertools import pairwise
 
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.matrices.certified_snf.operations import (
-    certificate_from_reduction,
-    inverse_unimodular,
-    matrix_columns,
-    matrix_multiply,
-    matrix_vector_multiply,
-    smith_reduce,
-)
-from jacobian.math.matrices.certified_snf.values import CertifiedIntegerMatrix
 from jacobian.math.matrices.finite_fields import linear_algebra as prime_field
 from jacobian.math.topology._barycentric import (
     barycentric_subdivision as _barycentric_kernel,
@@ -24,15 +14,8 @@ from jacobian.math.topology._chain_conversion import (
 )
 from jacobian.math.topology._homology import (
     MAX_INLINE_HOMOLOGY_CHAIN_GROUP,
-    MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP,
-    MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS,
-    MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK,
     HomologyGroupResult,
-    IntegralFreeGenerator,
-    IntegralHomologyGroupResult,
     IntegralSimplicialHomologyResult,
-    IntegralTorsionGenerator,
-    IntegralVector,
     ModularVector,
     SimplicialHomologyResult,
 )
@@ -63,6 +46,7 @@ from jacobian.math.topology._pseudomanifold import (
 )
 from jacobian.math.topology._request_admission import run_topology_admission
 from jacobian.math.topology._shelling import evaluate_shelling
+from jacobian.math.topology.chain_complexes.operations import homology_groups
 
 
 def _admit_chain(
@@ -77,11 +61,7 @@ def _admit_chain(
     elif prime is None or not is_bounded_prime(prime):
         raise ValueError("prime-field chain complexes require a bounded prime")
     require_linear_algebra_bounds(complex_)
-    if (
-        coefficient_ring is ChainCoefficientRing.PRIME_FIELD
-        and convention is HomologyConvention.UNREDUCED
-    ):
-        _require_canonical_conversion_bounds(complex_)
+    _require_canonical_conversion_bounds(complex_, convention)
 
 
 def _admit_homology(
@@ -103,25 +83,9 @@ def _admit_integral_homology(
     complex_: FiniteSimplicialComplex,
     convention: HomologyConvention,
 ) -> None:
-    if any(size > MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP for size in complex_.f_vector):
-        raise ValueError(
-            "integral homology requires at most "
-            f"{MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP} simplices in each chain group"
-        )
-    if sum(complex_.f_vector) > MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK:
-        raise ValueError(
-            "integral homology requires total chain rank at most "
-            f"{MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK}"
-        )
-    padded = (0, *complex_.f_vector)
-    if any(
-        rows * columns > MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS
-        for rows, columns in pairwise(padded)
-    ):
-        raise ValueError(
-            "integral homology boundary exceeds the "
-            f"{MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS}-cell bound"
-        )
+    # Simplicial admission owns materialization of the canonical chain value.
+    # The chain-complex owner then admits d^2, both Smith reductions,
+    # transformation/generator height, exact output, and the shared deadline.
     _admit_chain(complex_, ChainCoefficientRing.INTEGER, None, convention)
 
 
@@ -298,6 +262,7 @@ def chain_complex(
             prime,
             bases,
             boundaries,
+            augmentation,
         ),
     )
 
@@ -409,23 +374,6 @@ def homology(
     )
 
 
-def _integer_matrix(
-    entries: list[list[int]],
-    *,
-    rows: int,
-    columns: int,
-) -> CertifiedIntegerMatrix:
-    return CertifiedIntegerMatrix(
-        row_count=rows,
-        column_count=columns,
-        entries=tuple(tuple(str(value) for value in row) for row in entries),
-    )
-
-
-def _integral_vector(values: list[int]) -> IntegralVector:
-    return IntegralVector(coefficients=tuple(str(value) for value in values))
-
-
 def integral_homology(
     complex_: FiniteSimplicialComplex,
     convention: HomologyConvention,
@@ -441,128 +389,11 @@ def integral_homology(
         convention,
         admitted=True,
     )
-    boundaries = tuple(
-        _dense(matrix, modulus=None) for matrix in chain.boundary_matrices
-    )
-    groups: list[IntegralHomologyGroupResult] = []
-    for dimension, basis in enumerate(chain.simplex_bases):
-        chain_dimension = len(basis.simplices)
-        if dimension == 0 and chain.augmentation is not None:
-            outgoing = _dense(chain.augmentation, modulus=None)
-            outgoing_rows = 1
-        else:
-            outgoing = boundaries[dimension]
-            outgoing_rows = chain.boundary_matrices[dimension].rows
-        outgoing_reduction = smith_reduce(
-            outgoing,
-            row_count=outgoing_rows,
-            column_count=chain_dimension,
-        )
-        outgoing_rank = outgoing_reduction.rank
-        cycle_rank = chain_dimension - outgoing_rank
-        cycle_basis = matrix_columns(
-            outgoing_reduction.right,
-            start=outgoing_rank,
-        )
-        right_inverse = inverse_unimodular(outgoing_reduction.right)
-
-        if dimension < complex_.dimension:
-            incoming = boundaries[dimension + 1]
-            incoming_chain_dimension = len(chain.simplex_bases[dimension + 1].simplices)
-        else:
-            incoming_chain_dimension = 0
-            incoming = [[] for _ in range(chain_dimension)]
-        all_cycle_coordinates = matrix_multiply(
-            right_inverse,
-            incoming,
-            right_columns_if_empty=incoming_chain_dimension,
-        )
-        if any(
-            value != 0 for row in all_cycle_coordinates[:outgoing_rank] for value in row
-        ):
-            raise ArithmeticError("incoming boundary is not in the outgoing kernel")
-        incoming_coordinates = all_cycle_coordinates[outgoing_rank:]
-        incoming_reduction = smith_reduce(
-            incoming_coordinates,
-            row_count=cycle_rank,
-            column_count=incoming_chain_dimension,
-        )
-        incoming_rank = incoming_reduction.rank
-        incoming_left_inverse = inverse_unimodular(incoming_reduction.left)
-
-        free_generators: list[IntegralFreeGenerator] = []
-        for index in range(incoming_rank, cycle_rank):
-            coordinate = [
-                incoming_left_inverse[row][index] for row in range(cycle_rank)
-            ]
-            free_generators.append(
-                IntegralFreeGenerator(
-                    cycle=_integral_vector(
-                        matrix_vector_multiply(cycle_basis, coordinate)
-                    ),
-                    cycle_coordinates=_integral_vector(coordinate),
-                )
-            )
-
-        torsion_generators: list[IntegralTorsionGenerator] = []
-        for index, factor in enumerate(incoming_reduction.invariant_factors):
-            if factor == 1:
-                continue
-            coordinate = [
-                incoming_left_inverse[row][index] for row in range(cycle_rank)
-            ]
-            cycle = matrix_vector_multiply(cycle_basis, coordinate)
-            bounding_chain = [
-                incoming_reduction.right[row][index]
-                for row in range(incoming_chain_dimension)
-            ]
-            if matrix_vector_multiply(incoming, bounding_chain) != [
-                factor * value for value in cycle
-            ]:
-                raise ArithmeticError("torsion bounding-chain relation is invalid")
-            torsion_generators.append(
-                IntegralTorsionGenerator(
-                    order=str(factor),
-                    cycle=_integral_vector(cycle),
-                    cycle_coordinates=_integral_vector(coordinate),
-                    bounding_chain=_integral_vector(bounding_chain),
-                )
-            )
-
-        groups.append(
-            IntegralHomologyGroupResult(
-                dimension=dimension,
-                chain_dimension=chain_dimension,
-                incoming_chain_dimension=incoming_chain_dimension,
-                outgoing_boundary_rank=outgoing_rank,
-                cycle_rank=cycle_rank,
-                incoming_boundary_rank=incoming_rank,
-                betti_number=cycle_rank - incoming_rank,
-                torsion_coefficients=tuple(
-                    str(factor)
-                    for factor in incoming_reduction.invariant_factors
-                    if factor > 1
-                ),
-                free_generators=tuple(free_generators),
-                torsion_generators=tuple(torsion_generators),
-                outgoing_smith_certificate=certificate_from_reduction(
-                    outgoing_reduction
-                ),
-                boundary_in_cycle_coordinates=_integer_matrix(
-                    incoming_coordinates,
-                    rows=cycle_rank,
-                    columns=incoming_chain_dimension,
-                ),
-                incoming_smith_certificate=certificate_from_reduction(
-                    incoming_reduction
-                ),
-            )
-        )
+    homology = homology_groups(chain.canonical_value)
     return IntegralSimplicialHomologyResult.model_construct(
         complex_digest=complex_.complex_digest,
         convention=convention,
-        dimension_range=(0, complex_.dimension),
-        groups=tuple(groups),
+        homology=homology,
     )
 
 

--- a/src/jacobian/math/topology/_simplicial_kernel.py
+++ b/src/jacobian/math/topology/_simplicial_kernel.py
@@ -160,6 +160,39 @@ def _augmentation(
     )
 
 
+def _chain_parts(
+    complex_: FiniteSimplicialComplex,
+    coefficient_ring: ChainCoefficientRing,
+    prime: int | None,
+    convention: HomologyConvention,
+) -> tuple[
+    tuple[SimplexBasis, ...],
+    tuple[SparseBoundaryMatrix, ...],
+    SparseBoundaryMatrix | None,
+]:
+    """Construct the based simplicial groups and differentials once."""
+
+    bases = tuple(
+        SimplexBasis(dimension=item.dimension, simplices=item.faces)
+        for item in complex_.faces_by_dimension
+    )
+    boundaries = tuple(
+        _boundary_matrix(
+            complex_,
+            dimension,
+            coefficient_ring=coefficient_ring,
+            prime=prime,
+        )
+        for dimension in range(complex_.dimension + 1)
+    )
+    augmentation = (
+        _augmentation(len(complex_.vertices))
+        if convention is HomologyConvention.REDUCED
+        else None
+    )
+    return bases, boundaries, augmentation
+
+
 def _dense(
     matrix: SparseBoundaryMatrix,
     *,
@@ -209,23 +242,11 @@ def chain_complex(
             lambda: _admit_chain(complex_, coefficient_ring, prime, convention),
             location=("complex",),
         )
-    bases = tuple(
-        SimplexBasis(dimension=item.dimension, simplices=item.faces)
-        for item in complex_.faces_by_dimension
-    )
-    boundaries = tuple(
-        _boundary_matrix(
-            complex_,
-            dimension,
-            coefficient_ring=coefficient_ring,
-            prime=prime,
-        )
-        for dimension in range(complex_.dimension + 1)
-    )
-    augmentation = (
-        _augmentation(len(complex_.vertices))
-        if convention is HomologyConvention.REDUCED
-        else None
+    bases, boundaries, augmentation = _chain_parts(
+        complex_,
+        coefficient_ring,
+        prime,
+        convention,
     )
     modulus = prime if coefficient_ring is ChainCoefficientRing.PRIME_FIELD else None
     ledger: list[BoundarySquareLedgerEntry] = []
@@ -382,14 +403,21 @@ def integral_homology(
         lambda: _admit_integral_homology(complex_, convention),
         location=("complex",),
     )
-    chain = chain_complex(
+    bases, boundaries, augmentation = _chain_parts(
         complex_,
         ChainCoefficientRing.INTEGER,
         None,
         convention,
-        admitted=True,
     )
-    homology = homology_groups(chain.canonical_value)
+    chain_value = canonical_chain_complex_value_from_parts(
+        ChainCoefficientRing.INTEGER,
+        convention,
+        None,
+        bases,
+        boundaries,
+        augmentation,
+    )
+    homology = homology_groups(chain_value)
     return IntegralSimplicialHomologyResult.model_construct(
         complex_digest=complex_.complex_digest,
         convention=convention,

--- a/src/jacobian/math/topology/_tools.py
+++ b/src/jacobian/math/topology/_tools.py
@@ -238,10 +238,11 @@ TOPOLOGY_OPERATIONS: MathTools = (
         operation_id="topology.simplicial_homology.integral.compute",
         title="Compute transformation-certified integral simplicial homology",
         description=(
-            "Compute the free rank, torsion invariant factors, and simplex-basis "
-            "cycle generators of every integral homology group, with explicit "
-            "Smith transformations and bounding chains. Each chain group is "
-            "bounded by the certified Smith-certificate dimension."
+            "Compute the chain-owned certified ZZ homology of a finite "
+            "simplicial complex: free ranks, torsion invariant factors, "
+            "simplex-basis cycles, Smith transformations, and torsion "
+            "bounding chains. Reduced homology is the ordinary homology of "
+            "the augmented complex with a rank-one group in degree -1."
         ),
         request_type=IntegralSimplicialHomologyRequest,
         result_type=IntegralSimplicialHomologyResult,

--- a/src/jacobian/math/topology/chain_complexes/__init__.py
+++ b/src/jacobian/math/topology/chain_complexes/__init__.py
@@ -8,11 +8,31 @@ from jacobian.math.topology.chain_complexes.operations import (
     mapping_cone,
     tensor_product_complex,
 )
+from jacobian.math.topology.chain_complexes.values import (
+    ChainComplexValue,
+    CoefficientRing,
+    HomologyGroup,
+    HomologyGroupValue,
+    HomologyResult,
+    IntegralFreeGenerator,
+    IntegralHomologyGroupValue,
+    IntegralTorsionGenerator,
+    IntegralVector,
+)
 
 # The authoritative native surface: every export accepts domain values
 # directly. Wire-envelope request handlers live in ``_tools.py`` and are not
 # part of this native API.
 __all__ = [
+    "ChainComplexValue",
+    "CoefficientRing",
+    "HomologyGroup",
+    "HomologyGroupValue",
+    "HomologyResult",
+    "IntegralFreeGenerator",
+    "IntegralHomologyGroupValue",
+    "IntegralTorsionGenerator",
+    "IntegralVector",
     "chain_map_commutes",
     "construct_chain_complex",
     "differential_squares_to_zero",

--- a/src/jacobian/math/topology/chain_complexes/__init__.py
+++ b/src/jacobian/math/topology/chain_complexes/__init__.py
@@ -1,4 +1,4 @@
-"""Finite based chain complexes over exact fields."""
+"""Finite based chain complexes over exact coefficient rings."""
 
 from jacobian.math.topology.chain_complexes.operations import (
     chain_map_commutes,

--- a/src/jacobian/math/topology/chain_complexes/_integral_homology.py
+++ b/src/jacobian/math/topology/chain_complexes/_integral_homology.py
@@ -1,0 +1,1018 @@
+"""Certified integral homology for finite based chain complexes.
+
+The two Smith reductions have deliberately separate roles.  The outgoing
+reduction supplies a saturated integral cycle basis; the incoming reduction
+computes the quotient of that cycle lattice by the boundary lattice.  SymPy
+owns both exact Smith decompositions.  This module owns admission, source-basis
+reconstruction, and the public height/result contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import pairwise
+from time import monotonic
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+)
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.matrices.certified_snf.operations import (
+    Matrix,
+    SmithReduction,
+    certificate_from_reduction,
+    inverse_unimodular,
+    matrix_columns,
+    matrix_multiply,
+    matrix_vector_multiply,
+    smith_reduce,
+)
+from jacobian.math.matrices.certified_snf.values import CertifiedIntegerMatrix
+from jacobian.math.topology.chain_complexes.values import (
+    INTEGRAL_HOMOLOGY_WALL_SECONDS,
+    MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK,
+    MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS,
+    MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS,
+    MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS,
+    MAX_INTEGRAL_HOMOLOGY_OUTPUT_SCALARS,
+    MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK,
+    MAX_INTEGRAL_HOMOLOGY_WORK_UNITS,
+    ChainComplexValue,
+    CoefficientRing,
+    IntegralFreeGenerator,
+    IntegralHomologyGroupValue,
+    IntegralTorsionGenerator,
+    IntegralVector,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SmithHeightBound:
+    """A source-derived upper bound for one pinned SymPy decomposition."""
+
+    left_bits: int
+    right_bits: int
+    diagonal_bits: int
+    intermediate_bits: int
+    work_units: int
+    transformations_are_identity: bool = False
+
+    @property
+    def maximum_bits(self) -> int:
+        return max(
+            self.left_bits,
+            self.right_bits,
+            self.diagonal_bits,
+            self.intermediate_bits,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class IntegralHomologyDegreePlan:
+    degree: int
+    chain_rank: int
+    incoming_chain_rank: int
+    outgoing: Matrix
+    incoming: Matrix
+    outgoing_height: SmithHeightBound
+    incoming_heights_by_cycle_rank: tuple[SmithHeightBound, ...]
+    coordinate_bits_by_cycle_rank: tuple[int, ...]
+    output_bits_by_cycle_rank: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class IntegralHomologyExecutionPlan:
+    source: ChainComplexValue
+    degrees: tuple[IntegralHomologyDegreePlan, ...]
+    parse_work: int
+    square_zero_work: int
+    smith_work: int
+    reconstruction_work: int
+    output_scalar_count: int
+    total_work: int
+    deadline: float
+
+
+def _domain_error(code: str, message: str) -> OperationDomainValidationError:
+    return OperationDomainValidationError(
+        location=("complex",),
+        code=f"chain_complex.{code}",
+        message=message,
+    )
+
+
+def _capped(value: int) -> int:
+    return min(value, MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS + 1)
+
+
+def _add_bits(*values: int) -> int:
+    total = sum(values)
+    return _capped(total)
+
+
+def _ceil_log2(value: int) -> int:
+    return 0 if value <= 1 else (value - 1).bit_length()
+
+
+def _factorial_bits(size: int) -> int:
+    """A cheap upper bound for ``ceil(log2(size!))``."""
+
+    return sum(_ceil_log2(value) for value in range(2, size + 1))
+
+
+def _matrix_bits(matrix: Matrix) -> int:
+    return max(
+        (abs(value).bit_length() for row in matrix for value in row),
+        default=1,
+    )
+
+
+def _include_smith_postcheck_bound(
+    bound: SmithHeightBound,
+    *,
+    rows: int,
+    columns: int,
+    input_bits: int,
+) -> SmithHeightBound:
+    """Include ``smith_reduce`` reconstruction and determinant checks.
+
+    The maintained primitive verifies ``D = U A V`` and both unimodular
+    determinants after SymPy returns. Matrix-product heights add operand
+    heights and the inner-dimension sum; determinant intermediates are bounded
+    by the Leibniz/Hadamard envelope already used for inverse cofactors.
+    """
+
+    left_source_bits = _add_bits(_ceil_log2(rows), bound.left_bits, input_bits, 1)
+    reconstruction_bits = _add_bits(
+        _ceil_log2(columns), left_source_bits, bound.right_bits, 1
+    )
+    left_determinant_bits = _add_bits(rows * bound.left_bits, _factorial_bits(rows), 1)
+    right_determinant_bits = _add_bits(
+        columns * bound.right_bits, _factorial_bits(columns), 1
+    )
+    return SmithHeightBound(
+        left_bits=bound.left_bits,
+        right_bits=bound.right_bits,
+        diagonal_bits=bound.diagonal_bits,
+        intermediate_bits=max(
+            bound.intermediate_bits,
+            reconstruction_bits,
+            left_determinant_bits,
+            right_determinant_bits,
+        ),
+        work_units=bound.work_units,
+        transformations_are_identity=bound.transformations_are_identity,
+    )
+
+
+def _is_positive_smith_diagonal(matrix: Matrix, *, rows: int, columns: int) -> bool:
+    """Recognize the exact fixed point of SymPy's positive Smith convention."""
+
+    diagonal_count = min(rows, columns)
+    diagonal = [matrix[index][index] for index in range(diagonal_count)]
+    if any(
+        matrix[row][column] != 0
+        for row in range(rows)
+        for column in range(columns)
+        if row != column
+    ):
+        return False
+    nonzero = [value for value in diagonal if value]
+    return (
+        diagonal == nonzero + [0] * (diagonal_count - len(nonzero))
+        and all(value > 0 for value in nonzero)
+        and all(right % left == 0 for left, right in pairwise(nonzero))
+    )
+
+
+def _one_dimensional_smith_bound(
+    rows: int, columns: int, input_bits: int
+) -> SmithHeightBound:
+    """Bound the extended-gcd transform for an ``n x 1`` or ``1 x n`` matrix.
+
+    Each successive extended-gcd update has coefficients bounded by the
+    current source height.  Across ``length - 1`` updates, every accumulated
+    transformation entry is therefore bounded by ``(2B)^length``.  This is
+    intentionally looser than the classical Bezout bound but depends only on
+    the admitted source height and covers the pinned implementation.
+    """
+
+    length = max(rows, columns)
+    transform_bits = _add_bits(length * (input_bits + 1), _ceil_log2(length + 1))
+    work = max(1, length - 1) * max(1, input_bits) * max(1, length)
+    return SmithHeightBound(
+        left_bits=transform_bits if columns == 1 else 1,
+        right_bits=transform_bits if rows == 1 else 1,
+        diagonal_bits=input_bits,
+        intermediate_bits=transform_bits,
+        work_units=work,
+    )
+
+
+def _general_smith_bound(
+    rows: int,
+    columns: int,
+    input_bits: int,
+) -> SmithHeightBound:
+    """Conservatively bound SymPy 1.14's recursive Smith transformations.
+
+    In one pivot level, every elementary row/column coefficient is bounded by
+    the current entry height ``B``: it is a quotient, a Bezout coefficient, or
+    a quotient by a gcd.  One update therefore maps ``B`` to at most ``2B^2``.
+    A pass performs at most ``rows + columns - 2`` updates.  Every additional
+    pass strictly replaces the positive pivot by a proper divisor, so there
+    are at most ``input_bits + 1`` passes.  The recurrence below is the closed
+    bit-height bound for those updates, followed by the recursively embedded
+    lower-right decomposition and the final divisibility repairs.  It is
+    deliberately conservative; requests exceeding it are rejected before
+    SymPy runs.
+    """
+
+    updates = (rows + columns - 2) * (input_bits + 1)
+    if updates >= MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS.bit_length():
+        cleared_bits = MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS + 1
+    else:
+        cleared_bits = _capped((input_bits + 1) * (1 << updates))
+    if cleared_bits > MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS:
+        return SmithHeightBound(
+            left_bits=cleared_bits,
+            right_bits=cleared_bits,
+            diagonal_bits=cleared_bits,
+            intermediate_bits=cleared_bits,
+            work_units=MAX_INTEGRAL_HOMOLOGY_WORK_UNITS + 1,
+        )
+
+    recursive = _smith_height_bound_from_shape(
+        rows - 1,
+        columns - 1,
+        cleared_bits,
+    )
+    matrix_product_bits = _ceil_log2(max(rows, columns))
+    left_bits = _add_bits(cleared_bits, recursive.left_bits, matrix_product_bits)
+    right_bits = _add_bits(cleared_bits, recursive.right_bits, matrix_product_bits)
+    factor_bits = _add_bits(
+        min(rows, columns) * input_bits,
+        _factorial_bits(min(rows, columns)),
+        1,
+    )
+    repairs = max(0, min(rows, columns) - 1)
+    left_bits = _add_bits(left_bits, 3 * repairs * (factor_bits + 1))
+    right_bits = _add_bits(right_bits, 2 * repairs * (factor_bits + 1))
+    operation_cells = rows * columns + rows * rows + columns * columns
+    work = (
+        recursive.work_units
+        + updates * max(1, operation_cells)
+        + repairs * 5 * max(1, operation_cells)
+    )
+    return SmithHeightBound(
+        left_bits=left_bits,
+        right_bits=right_bits,
+        diagonal_bits=factor_bits,
+        intermediate_bits=max(cleared_bits, recursive.intermediate_bits),
+        work_units=work,
+    )
+
+
+def _small_ternary_smith_bound(
+    rows: int,
+    columns: int,
+) -> SmithHeightBound:
+    """Bound the pinned reduction on a matrix of ``-1, 0, 1`` entries.
+
+    This branch depends only on shape and coefficient height, not on matrix
+    provenance: it admits every small ternary matrix, including but not limited
+    to simplicial incidence matrices, without pretending arbitrary larger
+    signed matrices have the same envelope. For a matrix with at most three
+    rows and columns, the first nonzero pivot selected by SymPy is a unit.
+    Clearing its row and column takes one pass: the lower-right entries have
+    magnitude at most two and both first-level transformations have entries of
+    magnitude at most one. If the first row and column are zero, recursion
+    starts with the unchanged ternary lower-right block, which is smaller
+    still. Applying the general recurrence only to that at-most ``2 x 2``
+    block therefore bounds every intermediate before execution.
+
+    The final divisibility repairs use minors of the original ternary matrix;
+    Hadamard's determinant bound supplies ``factor_bits`` below.
+    """
+
+    recursive = _smith_height_bound_from_shape(rows - 1, columns - 1, 2)
+    product_bits = _ceil_log2(max(rows, columns))
+    left_bits = _add_bits(1, recursive.left_bits, product_bits)
+    right_bits = _add_bits(1, recursive.right_bits, product_bits)
+    factor_bits = _add_bits(
+        min(rows, columns),
+        _factorial_bits(min(rows, columns)),
+        1,
+    )
+    repairs = max(0, min(rows, columns) - 1)
+    left_bits = _add_bits(left_bits, 3 * repairs * (factor_bits + 1))
+    right_bits = _add_bits(right_bits, 2 * repairs * (factor_bits + 1))
+    operation_cells = rows * columns + rows * rows + columns * columns
+    work = (
+        recursive.work_units
+        + (rows + columns) * max(1, operation_cells)
+        + repairs * 5 * max(1, operation_cells)
+    )
+    return SmithHeightBound(
+        left_bits=left_bits,
+        right_bits=right_bits,
+        diagonal_bits=factor_bits,
+        intermediate_bits=max(2, recursive.intermediate_bits),
+        work_units=work,
+    )
+
+
+def _smith_height_bound_from_shape(
+    rows: int,
+    columns: int,
+    input_bits: int,
+) -> SmithHeightBound:
+    if rows == 0 or columns == 0:
+        core = SmithHeightBound(1, 1, 1, 1, 1, True)
+    elif min(rows, columns) == 1:
+        core = _one_dimensional_smith_bound(rows, columns, input_bits)
+    elif rows <= 3 and columns <= 3 and input_bits <= 1:
+        core = _small_ternary_smith_bound(rows, columns)
+    else:
+        core = _general_smith_bound(rows, columns, input_bits)
+    return _include_smith_postcheck_bound(
+        core,
+        rows=rows,
+        columns=columns,
+        input_bits=input_bits,
+    )
+
+
+def _smith_height_bound(
+    matrix: Matrix,
+    *,
+    rows: int,
+    columns: int,
+) -> SmithHeightBound:
+    input_bits = _matrix_bits(matrix)
+    if rows == 0 or columns == 0 or not any(value for row in matrix for value in row):
+        core = SmithHeightBound(1, 1, 1, 1, 1, True)
+        return _include_smith_postcheck_bound(
+            core,
+            rows=rows,
+            columns=columns,
+            input_bits=input_bits,
+        )
+    if _is_positive_smith_diagonal(matrix, rows=rows, columns=columns):
+        core = SmithHeightBound(
+            1,
+            1,
+            input_bits,
+            input_bits,
+            rows * columns,
+            True,
+        )
+        return _include_smith_postcheck_bound(
+            core,
+            rows=rows,
+            columns=columns,
+            input_bits=input_bits,
+        )
+    return _smith_height_bound_from_shape(rows, columns, input_bits)
+
+
+def _known_rank_before_smith(
+    matrix: Matrix,
+    *,
+    rows: int,
+    columns: int,
+    bound: SmithHeightBound,
+) -> int | None:
+    """Return a rank established without running a decomposition."""
+
+    if bound.transformations_are_identity:
+        return sum(
+            1 for index in range(min(rows, columns)) if matrix[index][index] != 0
+        )
+    if min(rows, columns) == 1:
+        # Zero matrices took the identity branch above.
+        return 1
+    return None
+
+
+def _unit_row_preserves_kernel_coordinate_height(matrix: Matrix) -> bool:
+    """Whether SymPy's one-row unit clearing only selects source coordinates.
+
+    With a nonzero row of ``-1, 0, 1`` entries, the pinned implementation
+    swaps a unit into the first position and clears every other entry by a
+    unit column addition.  In the inverse transform, the non-pivot rows are
+    therefore a permutation of the corresponding source-coordinate rows.
+    Because ``d^2 = 0`` makes the pivot coordinate zero, the retained cycle
+    coordinates have no more height than the incoming differential itself.
+    """
+
+    return len(matrix) == 1 and all(abs(value) <= 1 for value in matrix[0])
+
+
+def _inverse_unimodular_bits(size: int, entry_bits: int) -> int:
+    if size <= 1:
+        return 1
+    return _add_bits((size - 1) * entry_bits, _factorial_bits(size - 1), 1)
+
+
+def _matrix_product_bits(inner: int, left_bits: int, right_bits: int) -> int:
+    if inner == 0:
+        return 1
+    return _add_bits(_ceil_log2(inner), left_bits, right_bits, 1)
+
+
+def _require_height(bound: SmithHeightBound, *, label: str) -> None:
+    if bound.maximum_bits > MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS:
+        raise _domain_error(
+            "integral_homology_height_budget_exceeded",
+            f"{label} has a conservative Smith transformation-height bound above "
+            f"{MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS} bits; reduce the matrix dimension "
+            "or coefficient height",
+        )
+
+
+def _parse_integer_differentials(source: ChainComplexValue) -> tuple[Matrix, ...]:
+    parsed: list[Matrix] = []
+    for matrix in source.differential_matrices:
+        parsed.append(
+            [[parse_canonical_integer(value) for value in row] for row in matrix]
+        )
+    return tuple(parsed)
+
+
+def _require_integral_source_bounds(source: ChainComplexValue) -> None:
+    if source.coefficient_ring is not CoefficientRing.INTEGER:
+        raise _domain_error(
+            "integral_homology_ring_mismatch",
+            "the integral Smith kernel requires coefficient ring ZZ",
+        )
+    if any(size > MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK for size in source.basis_sizes):
+        raise _domain_error(
+            "integral_homology_chain_rank_exceeded",
+            "integral homology requires every chain rank to be at most "
+            f"{MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK}",
+        )
+    if sum(source.basis_sizes) > MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK:
+        raise _domain_error(
+            "integral_homology_total_rank_exceeded",
+            "integral homology requires total chain rank at most "
+            f"{MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK}",
+        )
+    cells = sum(
+        source.basis_sizes[index] * source.basis_sizes[index + 1]
+        for index in range(len(source.basis_sizes) - 1)
+    )
+    if cells > MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS:
+        raise _domain_error(
+            "integral_homology_matrix_cells_exceeded",
+            "integral homology differentials contain more than "
+            f"{MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS} cells",
+        )
+    if any(
+        len(value.lstrip("-")) > MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS
+        for matrix in source.differential_matrices
+        for row in matrix
+        for value in row
+    ):
+        raise _domain_error(
+            "integral_homology_input_digits_exceeded",
+            "integral homology coefficients may contain at most "
+            f"{MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS} decimal digits",
+        )
+
+
+def _require_square_zero(
+    source: ChainComplexValue,
+    differentials: tuple[Matrix, ...],
+) -> int:
+    work = 0
+    for index in range(len(differentials) - 1):
+        left = differentials[index]
+        right = differentials[index + 1]
+        middle = source.basis_sizes[index + 1]
+        columns = source.basis_sizes[index + 2]
+        product_bits = _matrix_product_bits(
+            middle,
+            _matrix_bits(left),
+            _matrix_bits(right),
+        )
+        if product_bits > MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS:
+            raise _domain_error(
+                "differential_product_height_exceeded",
+                "the conservative d^2 intermediate-height bound exceeds the "
+                f"{MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS}-bit execution envelope",
+            )
+        work += source.basis_sizes[index] * middle * columns
+        product = matrix_multiply(left, right, right_columns_if_empty=columns)
+        if any(value for row in product for value in row):
+            raise _domain_error(
+                "differential_not_square_zero",
+                "chain complex violates d^2=0 at chain degree "
+                f"{source.degree_min + index + 1}",
+            )
+    return work
+
+
+def _output_scalar_count(
+    chain_rank: int,
+    outgoing_rows: int,
+    incoming_chain_rank: int,
+) -> int:
+    """Worst-case scalar count for one integral group and its certificates."""
+
+    cycle_rank = chain_rank
+    outgoing_certificate = (
+        2 * outgoing_rows * chain_rank
+        + outgoing_rows * outgoing_rows
+        + chain_rank * chain_rank
+    )
+    incoming_certificate = (
+        3 * cycle_rank * incoming_chain_rank
+        + cycle_rank * cycle_rank
+        + incoming_chain_rank * incoming_chain_rank
+    )
+    generators = cycle_rank * (chain_rank + cycle_rank + incoming_chain_rank + 1)
+    metadata_and_factors = (
+        32 + min(outgoing_rows, chain_rank) + 2 * min(cycle_rank, incoming_chain_rank)
+    )
+    return (
+        outgoing_certificate + incoming_certificate + generators + metadata_and_factors
+    )
+
+
+def _reconstruction_work(
+    chain_rank: int,
+    outgoing_rows: int,
+    incoming_chain_rank: int,
+    cycle_rank: int,
+) -> int:
+    """Bound certificate replay, inverses, coordinates, and representatives."""
+
+    outgoing_certificate = (
+        outgoing_rows * outgoing_rows * chain_rank
+        + outgoing_rows * chain_rank * chain_rank
+        + outgoing_rows**3
+        + chain_rank**3
+    )
+    cycle_coordinates = chain_rank**3 + (chain_rank * chain_rank * incoming_chain_rank)
+    incoming_certificate = (
+        cycle_rank * cycle_rank * incoming_chain_rank
+        + cycle_rank * incoming_chain_rank * incoming_chain_rank
+        + cycle_rank**3
+        + incoming_chain_rank**3
+    )
+    representatives = (
+        cycle_rank**3
+        + cycle_rank * chain_rank * cycle_rank
+        + cycle_rank * chain_rank * incoming_chain_rank
+    )
+    return (
+        outgoing_certificate
+        + cycle_coordinates
+        + incoming_certificate
+        + representatives
+    )
+
+
+def _deadline() -> float:
+    execution = current_request_execution()
+    started = execution.started_at if execution is not None else monotonic()
+    deadline = started + INTEGRAL_HOMOLOGY_WALL_SECONDS
+    bind_request_deadline(deadline)
+    return deadline
+
+
+def _require_deadline(deadline: float, stage: str) -> None:
+    if monotonic() >= deadline:
+        raise OperationExecutionTimeoutError(
+            f"integral homology deadline expired {stage}"
+        )
+
+
+def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecutionPlan:
+    """Admit and prepare one exact integral-homology computation."""
+
+    deadline = _deadline()
+    _require_deadline(deadline, "before source admission")
+    _require_integral_source_bounds(source)
+    matrix_cells = sum(
+        source.basis_sizes[index] * source.basis_sizes[index + 1]
+        for index in range(len(source.basis_sizes) - 1)
+    )
+    parse_work = (
+        len(source.basis_sizes)
+        + matrix_cells
+        + sum(
+            len(value)
+            for matrix in source.differential_matrices
+            for row in matrix
+            for value in row
+        )
+    )
+    differentials = _parse_integer_differentials(source)
+    square_zero_work = _require_square_zero(source, differentials)
+    _require_deadline(deadline, "after d^2 admission")
+
+    degree_plans: list[IntegralHomologyDegreePlan] = []
+    smith_work = 0
+    reconstruction_work = 0
+    # The result retains the complete source complex in addition to the
+    # per-degree certificates and representatives.
+    output_scalar_count = matrix_cells + len(source.basis_sizes) + 8
+    for index, chain_rank in enumerate(source.basis_sizes):
+        outgoing_rows = source.basis_sizes[index - 1] if index > 0 else 0
+        outgoing = differentials[index - 1] if index > 0 else []
+        incoming_chain_rank = (
+            source.basis_sizes[index + 1] if index + 1 < len(source.basis_sizes) else 0
+        )
+        incoming = (
+            differentials[index]
+            if index < len(differentials)
+            else [[] for _ in range(chain_rank)]
+        )
+        outgoing_height = _smith_height_bound(
+            outgoing,
+            rows=outgoing_rows,
+            columns=chain_rank,
+        )
+        _require_height(
+            outgoing_height,
+            label=f"degree {source.degree_min + index} outgoing differential",
+        )
+        smith_work += outgoing_height.work_units
+
+        coordinate_bounds: list[int] = []
+        incoming_bounds: list[SmithHeightBound] = []
+        result_bounds: list[int] = []
+        known_outgoing_rank = _known_rank_before_smith(
+            outgoing,
+            rows=outgoing_rows,
+            columns=chain_rank,
+            bound=outgoing_height,
+        )
+        known_cycle_rank = (
+            None if known_outgoing_rank is None else chain_rank - known_outgoing_rank
+        )
+        incoming_bits = _matrix_bits(incoming)
+        cycle_ranks = (
+            (known_cycle_rank,)
+            if known_cycle_rank is not None
+            else tuple(range(chain_rank + 1))
+        )
+        bounds_by_cycle_rank: dict[int, tuple[int, SmithHeightBound, int]] = {}
+        for cycle_rank in cycle_ranks:
+            if (
+                known_cycle_rank == cycle_rank
+                and outgoing_height.transformations_are_identity
+            ):
+                outgoing_rank = chain_rank - cycle_rank
+                known_incoming_coordinates = incoming[outgoing_rank:]
+                coordinate_bits = incoming_bits
+                incoming_height = _smith_height_bound(
+                    known_incoming_coordinates,
+                    rows=cycle_rank,
+                    columns=incoming_chain_rank,
+                )
+            elif (
+                known_cycle_rank == cycle_rank
+                and _unit_row_preserves_kernel_coordinate_height(outgoing)
+            ):
+                coordinate_bits = incoming_bits
+                incoming_height = _smith_height_bound_from_shape(
+                    cycle_rank,
+                    incoming_chain_rank,
+                    coordinate_bits,
+                )
+            else:
+                right_inverse_bits = _inverse_unimodular_bits(
+                    chain_rank, outgoing_height.right_bits
+                )
+                coordinate_bits = _matrix_product_bits(
+                    chain_rank,
+                    right_inverse_bits,
+                    incoming_bits,
+                )
+                incoming_height = _smith_height_bound_from_shape(
+                    cycle_rank,
+                    incoming_chain_rank,
+                    coordinate_bits,
+                )
+            _require_height(
+                incoming_height,
+                label=(
+                    f"degree {source.degree_min + index} boundary-in-cycle "
+                    f"Smith reduction at cycle rank {cycle_rank}"
+                ),
+            )
+            cycle_coordinate_bits = _inverse_unimodular_bits(
+                cycle_rank, incoming_height.left_bits
+            )
+            cycle_bits = _matrix_product_bits(
+                cycle_rank,
+                outgoing_height.right_bits,
+                cycle_coordinate_bits,
+            )
+            bounding_relation_bits = _matrix_product_bits(
+                incoming_chain_rank,
+                incoming_bits,
+                incoming_height.right_bits,
+            )
+            torsion_multiple_bits = _add_bits(
+                incoming_height.diagonal_bits,
+                cycle_bits,
+                1,
+            )
+            result_bits = max(
+                coordinate_bits,
+                cycle_coordinate_bits,
+                cycle_bits,
+                incoming_height.right_bits,
+                incoming_height.diagonal_bits,
+                bounding_relation_bits,
+                torsion_multiple_bits,
+            )
+            if result_bits > MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS:
+                raise _domain_error(
+                    "integral_homology_output_height_exceeded",
+                    f"degree {source.degree_min + index} has a conservative generator/output height "
+                    f"above {MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS} bits",
+                )
+            bounds_by_cycle_rank[cycle_rank] = (
+                coordinate_bits,
+                incoming_height,
+                result_bits,
+            )
+        # Pre-Smith exact-rank cases prove the unique cycle rank. The repeated
+        # tuple shape keeps execution lookup constant-time without charging or
+        # claiming admission for impossible ranks.
+        if known_cycle_rank is not None:
+            known_bounds = bounds_by_cycle_rank[known_cycle_rank]
+            bounds_by_cycle_rank = dict.fromkeys(range(chain_rank + 1), known_bounds)
+        for cycle_rank in range(chain_rank + 1):
+            coordinate_bits, incoming_height, result_bits = bounds_by_cycle_rank[
+                cycle_rank
+            ]
+            coordinate_bounds.append(coordinate_bits)
+            incoming_bounds.append(incoming_height)
+            result_bounds.append(result_bits)
+        smith_work += max(bound.work_units for bound in incoming_bounds)
+        reconstruction_work += max(
+            _reconstruction_work(
+                chain_rank,
+                outgoing_rows,
+                incoming_chain_rank,
+                cycle_rank,
+            )
+            for cycle_rank in cycle_ranks
+        )
+        output_scalar_count += _output_scalar_count(
+            chain_rank,
+            outgoing_rows,
+            incoming_chain_rank,
+        )
+        degree_plans.append(
+            IntegralHomologyDegreePlan(
+                degree=source.degree_min + index,
+                chain_rank=chain_rank,
+                incoming_chain_rank=incoming_chain_rank,
+                outgoing=outgoing,
+                incoming=incoming,
+                outgoing_height=outgoing_height,
+                incoming_heights_by_cycle_rank=tuple(incoming_bounds),
+                coordinate_bits_by_cycle_rank=tuple(coordinate_bounds),
+                output_bits_by_cycle_rank=tuple(result_bounds),
+            )
+        )
+
+    # One ledger covers parsing, d^2, both reductions in every degree, and
+    # construction/serialization of the complete exact scalar payload.
+    total_work = (
+        parse_work
+        + square_zero_work
+        + smith_work
+        + reconstruction_work
+        + output_scalar_count
+    )
+    if total_work > MAX_INTEGRAL_HOMOLOGY_WORK_UNITS:
+        raise _domain_error(
+            "integral_homology_work_budget_exceeded",
+            "the conservative d^2 and Smith work ledger exceeds "
+            f"{MAX_INTEGRAL_HOMOLOGY_WORK_UNITS} units",
+        )
+    if output_scalar_count > MAX_INTEGRAL_HOMOLOGY_OUTPUT_SCALARS:
+        raise _domain_error(
+            "integral_homology_output_size_exceeded",
+            "the complete certificate, generator, and bounding-chain result "
+            f"has a conservative bound of {output_scalar_count} integer scalars, above the "
+            f"{MAX_INTEGRAL_HOMOLOGY_OUTPUT_SCALARS}-scalar output envelope",
+        )
+    _require_deadline(deadline, "after complete admission")
+    return IntegralHomologyExecutionPlan(
+        source=source,
+        degrees=tuple(degree_plans),
+        parse_work=parse_work,
+        square_zero_work=square_zero_work,
+        smith_work=smith_work,
+        reconstruction_work=reconstruction_work,
+        output_scalar_count=output_scalar_count,
+        total_work=total_work,
+        deadline=deadline,
+    )
+
+
+def _actual_reduction_bits(reduction: SmithReduction) -> int:
+    return max(
+        _matrix_bits(reduction.diagonal),
+        _matrix_bits(reduction.left),
+        _matrix_bits(reduction.right),
+    )
+
+
+def _require_reduction_bound(
+    reduction: SmithReduction,
+    bound: SmithHeightBound,
+    *,
+    label: str,
+) -> None:
+    if _actual_reduction_bits(reduction) > bound.maximum_bits:
+        raise ArithmeticError(
+            f"{label} exceeded the admitted SymPy transformation-height proof"
+        )
+
+
+def _integer_matrix(
+    entries: Matrix, *, rows: int, columns: int
+) -> CertifiedIntegerMatrix:
+    return CertifiedIntegerMatrix(
+        row_count=rows,
+        column_count=columns,
+        entries=tuple(
+            tuple(format_canonical_integer(value) for value in row) for row in entries
+        ),
+    )
+
+
+def _integral_vector(values: list[int]) -> IntegralVector:
+    return IntegralVector(
+        coefficients=tuple(format_canonical_integer(value) for value in values)
+    )
+
+
+def _integer_sequence_bits(values: list[int]) -> int:
+    return max((abs(value).bit_length() for value in values), default=1)
+
+
+def compute_integral_homology(
+    plan: IntegralHomologyExecutionPlan,
+) -> tuple[IntegralHomologyGroupValue, ...]:
+    """Execute the two certified Smith reductions in every admitted degree."""
+
+    groups: list[IntegralHomologyGroupValue] = []
+    for degree_plan in plan.degrees:
+        _require_deadline(
+            plan.deadline,
+            f"before degree {degree_plan.degree} outgoing Smith reduction",
+        )
+        outgoing_reduction = smith_reduce(
+            degree_plan.outgoing,
+            row_count=(
+                plan.source.basis_sizes[degree_plan.degree - plan.source.degree_min - 1]
+                if degree_plan.degree > plan.source.degree_min
+                else 0
+            ),
+            column_count=degree_plan.chain_rank,
+        )
+        _require_reduction_bound(
+            outgoing_reduction,
+            degree_plan.outgoing_height,
+            label=f"degree {degree_plan.degree} outgoing Smith reduction",
+        )
+        outgoing_rank = outgoing_reduction.rank
+        cycle_rank = degree_plan.chain_rank - outgoing_rank
+        cycle_basis = matrix_columns(outgoing_reduction.right, start=outgoing_rank)
+        right_inverse = inverse_unimodular(outgoing_reduction.right)
+        all_cycle_coordinates = matrix_multiply(
+            right_inverse,
+            degree_plan.incoming,
+            right_columns_if_empty=degree_plan.incoming_chain_rank,
+        )
+        if any(value for row in all_cycle_coordinates[:outgoing_rank] for value in row):
+            raise ArithmeticError("incoming boundary is not in the outgoing kernel")
+        incoming_coordinates = all_cycle_coordinates[outgoing_rank:]
+        coordinate_bound = degree_plan.coordinate_bits_by_cycle_rank[cycle_rank]
+        if _matrix_bits(incoming_coordinates) > coordinate_bound:
+            raise ArithmeticError(
+                "boundary-in-cycle coordinates exceeded the admitted height proof"
+            )
+
+        _require_deadline(
+            plan.deadline,
+            f"before degree {degree_plan.degree} incoming Smith reduction",
+        )
+        incoming_reduction = smith_reduce(
+            incoming_coordinates,
+            row_count=cycle_rank,
+            column_count=degree_plan.incoming_chain_rank,
+        )
+        incoming_height = degree_plan.incoming_heights_by_cycle_rank[cycle_rank]
+        _require_reduction_bound(
+            incoming_reduction,
+            incoming_height,
+            label=f"degree {degree_plan.degree} incoming Smith reduction",
+        )
+        incoming_rank = incoming_reduction.rank
+        incoming_left_inverse = inverse_unimodular(incoming_reduction.left)
+
+        free_generators: list[IntegralFreeGenerator] = []
+        generator_values: list[int] = []
+        for index in range(incoming_rank, cycle_rank):
+            coordinate = [
+                incoming_left_inverse[row][index] for row in range(cycle_rank)
+            ]
+            cycle = matrix_vector_multiply(cycle_basis, coordinate)
+            generator_values.extend(coordinate)
+            generator_values.extend(cycle)
+            free_generators.append(
+                IntegralFreeGenerator(
+                    cycle=_integral_vector(cycle),
+                    cycle_coordinates=_integral_vector(coordinate),
+                )
+            )
+
+        torsion_generators: list[IntegralTorsionGenerator] = []
+        for index, factor in enumerate(incoming_reduction.invariant_factors):
+            if factor == 1:
+                continue
+            coordinate = [
+                incoming_left_inverse[row][index] for row in range(cycle_rank)
+            ]
+            cycle = matrix_vector_multiply(cycle_basis, coordinate)
+            bounding_chain = [
+                incoming_reduction.right[row][index]
+                for row in range(degree_plan.incoming_chain_rank)
+            ]
+            if matrix_vector_multiply(degree_plan.incoming, bounding_chain) != [
+                factor * value for value in cycle
+            ]:
+                raise ArithmeticError("torsion bounding-chain relation is invalid")
+            generator_values.extend((factor, *coordinate, *cycle, *bounding_chain))
+            torsion_generators.append(
+                IntegralTorsionGenerator(
+                    order=format_canonical_integer(factor),
+                    cycle=_integral_vector(cycle),
+                    cycle_coordinates=_integral_vector(coordinate),
+                    bounding_chain=_integral_vector(bounding_chain),
+                )
+            )
+
+        if (
+            _integer_sequence_bits(generator_values)
+            > (degree_plan.output_bits_by_cycle_rank[cycle_rank])
+        ):
+            raise ArithmeticError(
+                "homology generators exceeded the admitted output-height proof"
+            )
+
+        groups.append(
+            IntegralHomologyGroupValue(
+                degree=degree_plan.degree,
+                chain_rank=degree_plan.chain_rank,
+                incoming_chain_rank=degree_plan.incoming_chain_rank,
+                outgoing_boundary_rank=outgoing_rank,
+                cycle_rank=cycle_rank,
+                incoming_boundary_rank=incoming_rank,
+                free_rank=cycle_rank - incoming_rank,
+                torsion_invariant_factors=tuple(
+                    format_canonical_integer(factor)
+                    for factor in incoming_reduction.invariant_factors
+                    if factor > 1
+                ),
+                free_generators=tuple(free_generators),
+                torsion_generators=tuple(torsion_generators),
+                outgoing_smith_certificate=certificate_from_reduction(
+                    outgoing_reduction
+                ),
+                boundary_in_cycle_coordinates=_integer_matrix(
+                    incoming_coordinates,
+                    rows=cycle_rank,
+                    columns=degree_plan.incoming_chain_rank,
+                ),
+                incoming_smith_certificate=certificate_from_reduction(
+                    incoming_reduction
+                ),
+            )
+        )
+        _require_deadline(
+            plan.deadline, f"after degree {degree_plan.degree} result construction"
+        )
+    return tuple(groups)
+
+
+__all__ = [
+    "IntegralHomologyExecutionPlan",
+    "admit_integral_homology",
+    "compute_integral_homology",
+]

--- a/src/jacobian/math/topology/chain_complexes/_integral_homology.py
+++ b/src/jacobian/math/topology/chain_complexes/_integral_homology.py
@@ -21,7 +21,12 @@ from jacobian._execution import (
     current_request_execution,
     request_cancelled,
 )
-from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    format_canonical_integer,
+    parse_canonical_integer,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices.certified_snf.operations import (
     Matrix,
@@ -94,8 +99,9 @@ class IntegralHomologyExecutionPlan:
     parse_work: int
     square_zero_work: int
     smith_work: int
-    reconstruction_work: int
+    result_construction_work: int
     output_scalar_count: int
+    output_byte_bound: int
     total_work: int
     deadline: float
 
@@ -145,25 +151,54 @@ def _matrix_bits(matrix: Matrix) -> int:
     )
 
 
-def _include_smith_postcheck_bound(
+def _fraction_free_inverse_work(size: int) -> int:
+    """Bound scalar arithmetic in SymPy's fraction-free inverse path.
+
+    ``DomainMatrix.inv_den(method="rref")`` row-reduces an ``n x 2n``
+    augmented matrix.  At each of at most ``n`` pivots, scanning and updating
+    every other row touches at most ``2n`` entries with a multiply, subtract,
+    and exact division.  The factor below also covers pivot search, slicing,
+    and dense conversion.
+    """
+
+    return 8 * size**3 + 8 * size**2 + 1
+
+
+def _determinant_work(size: int) -> int:
+    """Conservatively price one maintained exact determinant computation."""
+
+    return 4 * size**4 + 8 * size**2 + 1
+
+
+def _maintained_worker_projection_work(rows: int, columns: int) -> int:
+    """Price work executed around the maintained Smith decomposition.
+
+    The Smith recurrence itself is charged by the core height functions.  A
+    general worker additionally computes two exact determinant signs, obtains
+    the two inverses needed for homology coordinates with fraction-free RREF,
+    and converts a bounded projection across the process boundary.
+    """
+
+    projected_scalars = 2 * rows * columns + 3 * rows * rows + 3 * columns * columns
+    return (
+        _fraction_free_inverse_work(rows)
+        + _fraction_free_inverse_work(columns)
+        + _determinant_work(rows)
+        + _determinant_work(columns)
+        + 8 * (projected_scalars + rows + columns + 1)
+    )
+
+
+def _include_maintained_worker_bound(
     bound: SmithHeightBound,
     *,
     rows: int,
     columns: int,
-    input_bits: int,
 ) -> SmithHeightBound:
-    """Include ``smith_reduce`` reconstruction and determinant checks.
+    """Include the actual inverse, determinant, and projection phases."""
 
-    The maintained primitive verifies ``D = U A V`` and both unimodular
-    determinants after SymPy returns. Matrix-product heights add operand
-    heights and the inner-dimension sum; determinant intermediates are bounded
-    by the Leibniz/Hadamard envelope already used for inverse cofactors.
-    """
-
-    left_source_bits = _add_bits(_ceil_log2(rows), bound.left_bits, input_bits, 1)
-    reconstruction_bits = _add_bits(
-        _ceil_log2(columns), left_source_bits, bound.right_bits, 1
-    )
+    left_inverse_bits = _inverse_unimodular_bits(rows, bound.left_bits)
+    right_inverse_bits = _inverse_unimodular_bits(columns, bound.right_bits)
     left_determinant_bits = _add_bits(rows * bound.left_bits, _factorial_bits(rows), 1)
     right_determinant_bits = _add_bits(
         columns * bound.right_bits, _factorial_bits(columns), 1
@@ -174,11 +209,14 @@ def _include_smith_postcheck_bound(
         diagonal_bits=bound.diagonal_bits,
         intermediate_bits=max(
             bound.intermediate_bits,
-            reconstruction_bits,
+            left_inverse_bits,
+            right_inverse_bits,
             left_determinant_bits,
             right_determinant_bits,
         ),
-        work_units=bound.work_units,
+        work_units=(
+            bound.work_units + _maintained_worker_projection_work(rows, columns)
+        ),
         transformations_are_identity=bound.transformations_are_identity,
     )
 
@@ -203,6 +241,14 @@ def _is_positive_smith_diagonal(matrix: Matrix, *, rows: int, columns: int) -> b
     )
 
 
+def _maintained_smith_structural_work(rows: int, columns: int) -> int:
+    operation_cells = rows * columns + rows * rows + columns * columns
+    pivot_scans = sum(
+        (rows - pivot) * (columns - pivot) for pivot in range(min(rows, columns))
+    )
+    return 8 * (operation_cells + 1) + pivot_scans
+
+
 def _one_dimensional_smith_bound(
     rows: int, columns: int, input_bits: int
 ) -> SmithHeightBound:
@@ -217,7 +263,11 @@ def _one_dimensional_smith_bound(
 
     length = max(rows, columns)
     transform_bits = _add_bits(length * (input_bits + 1), _ceil_log2(length + 1))
-    work = max(1, length - 1) * max(1, input_bits) * max(1, length)
+    operation_cells = rows * columns + rows * rows + columns * columns
+    updates = max(1, length - 1) * (input_bits + 1)
+    work = _maintained_smith_structural_work(rows, columns) + 12 * updates * max(
+        1, operation_cells
+    )
     return SmithHeightBound(
         left_bits=transform_bits if columns == 1 else 1,
         right_bits=transform_bits if rows == 1 else 1,
@@ -260,7 +310,7 @@ def _general_smith_bound(
             work_units=MAX_INTEGRAL_HOMOLOGY_WORK_UNITS + 1,
         )
 
-    recursive = _smith_height_bound_from_shape(
+    recursive = _smith_core_bound_from_shape(
         rows - 1,
         columns - 1,
         cleared_bits,
@@ -279,8 +329,9 @@ def _general_smith_bound(
     operation_cells = rows * columns + rows * rows + columns * columns
     work = (
         recursive.work_units
-        + updates * max(1, operation_cells)
-        + repairs * 5 * max(1, operation_cells)
+        + _maintained_smith_structural_work(rows, columns)
+        + 12 * updates * max(1, operation_cells)
+        + 60 * repairs * max(1, operation_cells)
     )
     return SmithHeightBound(
         left_bits=left_bits,
@@ -313,7 +364,7 @@ def _small_ternary_smith_bound(
     Hadamard's determinant bound supplies ``factor_bits`` below.
     """
 
-    recursive = _smith_height_bound_from_shape(rows - 1, columns - 1, 2)
+    recursive = _smith_core_bound_from_shape(rows - 1, columns - 1, 2)
     product_bits = _ceil_log2(max(rows, columns))
     left_bits = _add_bits(1, recursive.left_bits, product_bits)
     right_bits = _add_bits(1, recursive.right_bits, product_bits)
@@ -328,8 +379,9 @@ def _small_ternary_smith_bound(
     operation_cells = rows * columns + rows * rows + columns * columns
     work = (
         recursive.work_units
-        + (rows + columns) * max(1, operation_cells)
-        + repairs * 5 * max(1, operation_cells)
+        + _maintained_smith_structural_work(rows, columns)
+        + 12 * (rows + columns) * max(1, operation_cells)
+        + 60 * repairs * max(1, operation_cells)
     )
     return SmithHeightBound(
         left_bits=left_bits,
@@ -340,7 +392,7 @@ def _small_ternary_smith_bound(
     )
 
 
-def _smith_height_bound_from_shape(
+def _smith_core_bound_from_shape(
     rows: int,
     columns: int,
     input_bits: int,
@@ -353,11 +405,18 @@ def _smith_height_bound_from_shape(
         core = _small_ternary_smith_bound(rows, columns)
     else:
         core = _general_smith_bound(rows, columns, input_bits)
-    return _include_smith_postcheck_bound(
-        core,
+    return core
+
+
+def _smith_height_bound_from_shape(
+    rows: int,
+    columns: int,
+    input_bits: int,
+) -> SmithHeightBound:
+    return _include_maintained_worker_bound(
+        _smith_core_bound_from_shape(rows, columns, input_bits),
         rows=rows,
         columns=columns,
-        input_bits=input_bits,
     )
 
 
@@ -370,12 +429,7 @@ def _smith_height_bound(
     input_bits = _matrix_bits(matrix)
     if rows == 0 or columns == 0 or not any(value for row in matrix for value in row):
         core = SmithHeightBound(1, 1, 1, 1, 1, True)
-        return _include_smith_postcheck_bound(
-            core,
-            rows=rows,
-            columns=columns,
-            input_bits=input_bits,
-        )
+        return core
     if _is_positive_smith_diagonal(matrix, rows=rows, columns=columns):
         core = SmithHeightBound(
             1,
@@ -385,12 +439,7 @@ def _smith_height_bound(
             rows * columns,
             True,
         )
-        return _include_smith_postcheck_bound(
-            core,
-            rows=rows,
-            columns=columns,
-            input_bits=input_bits,
-        )
+        return core
     return _smith_height_bound_from_shape(rows, columns, input_bits)
 
 
@@ -693,12 +742,6 @@ def _presolve_unit_smith(
     right_bits = _matrix_bits(right)
     left_inverse_bits = _matrix_bits(left_inverse)
     right_inverse_bits = _matrix_bits(right_inverse)
-    left_source_bits = _matrix_product_bits(rows, left_bits, source_bits)
-    reconstruction_bits = _matrix_product_bits(columns, left_source_bits, right_bits)
-    left_inverse_check_bits = _matrix_product_bits(rows, left_inverse_bits, left_bits)
-    right_inverse_check_bits = _matrix_product_bits(
-        columns, right_bits, right_inverse_bits
-    )
     maximum_bits = max(
         source_bits,
         _matrix_bits(working),
@@ -706,28 +749,9 @@ def _presolve_unit_smith(
         right_bits,
         left_inverse_bits,
         right_inverse_bits,
-        reconstruction_bits,
-        left_inverse_check_bits,
-        right_inverse_check_bits,
     )
     if maximum_bits > MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS:
         return None
-    # These are bounded defining checks for the presolve itself.  The stored
-    # reduction is reused by the kernel; ordinary result construction does not
-    # replay them.
-    reconstructed = matrix_multiply(
-        matrix_multiply(left, source),
-        right,
-        right_columns_if_empty=columns,
-    )
-    if reconstructed != working:
-        raise ArithmeticError("unit Smith presolve lost its source relation")
-    if matrix_multiply(left_inverse, left) != identity_matrix(rows):
-        raise ArithmeticError("unit Smith presolve left inverse is invalid")
-    if matrix_multiply(right, right_inverse) != identity_matrix(columns):
-        raise ArithmeticError("unit Smith presolve right inverse is invalid")
-    work += rows * rows * max(1, rows) + columns * columns * max(1, columns)
-    work += rows * rows * max(1, columns) + rows * columns * max(1, columns)
     return SmithReductionData(
         reduction=SmithReduction(
             source=[row[:] for row in source],
@@ -953,37 +977,45 @@ def _output_scalar_count(
     )
 
 
-def _reconstruction_work(
+def _result_construction_work(
     chain_rank: int,
-    outgoing_rows: int,
     incoming_chain_rank: int,
     cycle_rank: int,
 ) -> int:
-    """Bound certificate replay, inverses, coordinates, and representatives."""
+    """Bound executed coordinate projection and representative construction."""
 
-    outgoing_certificate = (
-        outgoing_rows * outgoing_rows * chain_rank
-        + outgoing_rows * chain_rank * chain_rank
-        + outgoing_rows**3
-        + chain_rank**3
+    coordinate_projection = (
+        chain_rank * chain_rank * incoming_chain_rank + chain_rank * incoming_chain_rank
     )
-    cycle_coordinates = chain_rank**3 + (chain_rank * chain_rank * incoming_chain_rank)
-    incoming_certificate = (
-        cycle_rank * cycle_rank * incoming_chain_rank
-        + cycle_rank * incoming_chain_rank * incoming_chain_rank
-        + cycle_rank**3
-        + incoming_chain_rank**3
+    cycle_basis_copy = chain_rank * cycle_rank
+    representatives = cycle_rank * (
+        cycle_rank + chain_rank * cycle_rank + chain_rank + incoming_chain_rank + 1
     )
-    representatives = (
-        cycle_rank**3
-        + cycle_rank * chain_rank * cycle_rank
-        + cycle_rank * chain_rank * incoming_chain_rank
-    )
+    return coordinate_projection + cycle_basis_copy + representatives + 1
+
+
+_RESULT_ROOT_RESERVE_BYTES = 4_096
+_RESULT_GROUP_RESERVE_BYTES = 16_384
+
+
+def _decimal_chars_for_bits(bits: int) -> int:
+    """Bound decimal magnitude characters for an integer of ``bits`` bits."""
+
+    return max(1, (max(1, bits) * 30_103 + 99_999) // 100_000 + 1)
+
+
+def _group_result_byte_bound(*, scalar_count: int, maximum_bits: int) -> int:
+    """Bound one group's canonical JSON without materializing its result.
+
+    Every exact integer is serialized as a quoted decimal string.  Four bytes
+    beyond the magnitude cover a possible sign, quotes, and one separator.
+    The fixed reserve is larger than all field names, literal tags, object and
+    array punctuation in one group; it does not depend on mathematical output.
+    """
+
     return (
-        outgoing_certificate
-        + cycle_coordinates
-        + incoming_certificate
-        + representatives
+        scalar_count * (_decimal_chars_for_bits(maximum_bits) + 4)
+        + _RESULT_GROUP_RESERVE_BYTES
     )
 
 
@@ -1037,10 +1069,14 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
 
     degree_plans: list[IntegralHomologyDegreePlan] = []
     smith_work = 0
-    reconstruction_work = 0
+    result_construction_work = 0
     # The result retains the complete source complex in addition to the
     # per-degree certificates and representatives.
     output_scalar_count = matrix_cells + len(source.basis_sizes) + 8
+    output_byte_bound = (
+        len(encode_strict_json(source.model_dump(mode="json")))
+        + _RESULT_ROOT_RESERVE_BYTES
+    )
     for index, chain_rank in enumerate(source.basis_sizes):
         outgoing_rows = source.basis_sizes[index - 1] if index > 0 else 0
         outgoing = differentials[index - 1] if index > 0 else []
@@ -1081,6 +1117,7 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
             None if known_outgoing_rank is None else chain_rank - known_outgoing_rank
         )
         incoming_bits = _matrix_bits(incoming)
+        incoming_is_zero = not any(value for row in incoming for value in row)
         cycle_ranks = (
             (known_cycle_rank,)
             if known_cycle_rank is not None
@@ -1104,7 +1141,17 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
             int, tuple[int, SmithHeightBound, SmithReductionData | None, int]
         ] = {}
         for cycle_rank in cycle_ranks:
-            if exact_incoming_coordinates is not None:
+            if incoming_is_zero:
+                zero_coordinates = [
+                    [0 for _ in range(incoming_chain_rank)] for _ in range(cycle_rank)
+                ]
+                coordinate_bits = 1
+                incoming_height, incoming_presolve = _smith_admission(
+                    zero_coordinates,
+                    rows=cycle_rank,
+                    columns=incoming_chain_rank,
+                )
+            elif exact_incoming_coordinates is not None:
                 coordinate_bits = _matrix_bits(exact_incoming_coordinates)
                 incoming_height, incoming_presolve = _smith_admission(
                     exact_incoming_coordinates,
@@ -1175,6 +1222,11 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
                 1,
             )
             result_bits = max(
+                _matrix_bits(outgoing),
+                incoming_bits,
+                outgoing_height.left_bits,
+                outgoing_height.right_bits,
+                outgoing_height.diagonal_bits,
                 coordinate_bits,
                 cycle_coordinate_bits,
                 cycle_bits,
@@ -1213,19 +1265,26 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
             incoming_presolves.append(incoming_presolve)
             result_bounds.append(result_bits)
         smith_work += max(bound.work_units for bound in incoming_bounds)
-        reconstruction_work += max(
-            _reconstruction_work(
+        result_construction_work += max(
+            _result_construction_work(
                 chain_rank,
-                outgoing_rows,
                 incoming_chain_rank,
                 cycle_rank,
             )
             for cycle_rank in cycle_ranks
         )
-        output_scalar_count += _output_scalar_count(
+        degree_output_scalars = _output_scalar_count(
             chain_rank,
             outgoing_rows,
             incoming_chain_rank,
+        )
+        output_scalar_count += degree_output_scalars
+        output_byte_bound += max(
+            _group_result_byte_bound(
+                scalar_count=degree_output_scalars,
+                maximum_bits=bounds_by_cycle_rank[cycle_rank][3],
+            )
+            for cycle_rank in cycle_ranks
         )
         degree_plans.append(
             IntegralHomologyDegreePlan(
@@ -1249,7 +1308,7 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
         parse_work
         + square_zero_work
         + smith_work
-        + reconstruction_work
+        + result_construction_work
         + output_scalar_count
     )
     if total_work > MAX_INTEGRAL_HOMOLOGY_WORK_UNITS:
@@ -1265,6 +1324,13 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
             f"has a conservative bound of {output_scalar_count} integer scalars, above the "
             f"{MAX_INTEGRAL_HOMOLOGY_OUTPUT_SCALARS}-scalar output envelope",
         )
+    if output_byte_bound > CanonicalLimits().max_output_bytes:
+        raise _domain_error(
+            "integral_homology_output_byte_budget_exceeded",
+            "the complete retained complex, certificates, generators, and "
+            "bounding chains exceed the canonical "
+            f"{CanonicalLimits().max_output_bytes}-byte output envelope",
+        )
     _require_deadline(deadline, "after complete admission")
     return IntegralHomologyExecutionPlan(
         source=source,
@@ -1272,8 +1338,9 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
         parse_work=parse_work,
         square_zero_work=square_zero_work,
         smith_work=smith_work,
-        reconstruction_work=reconstruction_work,
+        result_construction_work=result_construction_work,
         output_scalar_count=output_scalar_count,
+        output_byte_bound=output_byte_bound,
         total_work=total_work,
         deadline=deadline,
     )
@@ -1455,10 +1522,6 @@ def compute_integral_homology(
                 incoming_reduction.right[row][index]
                 for row in range(degree_plan.incoming_chain_rank)
             ]
-            if matrix_vector_multiply(degree_plan.incoming, bounding_chain) != [
-                factor * value for value in cycle
-            ]:
-                raise ArithmeticError("torsion bounding-chain relation is invalid")
             generator_values.extend((factor, *coordinate, *cycle, *bounding_chain))
             torsion_generators.append(
                 IntegralTorsionGenerator(

--- a/src/jacobian/math/topology/chain_complexes/_integral_homology.py
+++ b/src/jacobian/math/topology/chain_complexes/_integral_homology.py
@@ -444,7 +444,7 @@ def _smith_height_bound(
 
 
 class _PresolveHeightExceededError(Exception):
-    """The unit presolve cannot stay inside the admitted integer envelope."""
+    """The visible-pivot presolve cannot stay inside the integer envelope."""
 
 
 def _checked_linear_update(value: int, factor: int, source: int) -> int:
@@ -533,25 +533,49 @@ def _identity_reduction(
         # and retention of both square transformations and their inverses.
         # In particular, a 0 x n or n x 0 reduction still constructs two n x n
         # identity matrices and must not be priced as one unit.
-        work_units=8 * (rows * columns + rows * rows + columns * columns + 1),
+        work_units=_identity_reduction_work(rows, columns),
         intermediate_bits=max(1, _matrix_bits(source)),
     )
 
 
-def _unit_presolve_structural_work(rows: int, columns: int) -> int:
-    """Charge scans and retained structures independent of pivot outcomes."""
+def _identity_reduction_work(rows: int, columns: int) -> int:
+    """Charge scans, copies, and retained identities for a zero reduction."""
 
-    pivot_scans = sum(
-        (rows - pivot) * (columns - pivot) for pivot in range(min(rows, columns))
+    return 8 * (rows * columns + rows * rows + columns * columns + 1)
+
+
+def _lazy_zero_smith_height(rows: int, columns: int) -> SmithHeightBound:
+    """Describe a zero Smith reduction without allocating its matrices."""
+
+    return SmithHeightBound(
+        left_bits=1,
+        right_bits=1,
+        diagonal_bits=1,
+        intermediate_bits=1,
+        work_units=_identity_reduction_work(rows, columns),
+        transformations_are_identity=True,
     )
-    return 8 * (rows * columns + rows * rows + columns * columns + 1) + pivot_scans
 
 
-def _unit_presolve_attempt_work_bound(rows: int, columns: int) -> int:
-    """Bound an unsuccessful unit-pivot attempt before general Smith work."""
+def _presolve_structural_work(rows: int, columns: int) -> int:
+    """Charge retained matrices independent of exact pivot outcomes."""
 
-    work = _unit_presolve_structural_work(rows, columns)
+    return 8 * (rows * columns + rows * rows + columns * columns + 1)
+
+
+def _presolve_attempt_work_bound(
+    rows: int,
+    columns: int,
+) -> int:
+    """Bound one exact visible-pivot attempt before general Smith work."""
+
+    work = _presolve_structural_work(rows, columns)
+    state_scalars = rows * columns + 2 * rows * rows + 2 * columns * columns
     for pivot in range(min(rows, columns)):
+        remaining_cells = (rows - pivot) * (columns - pivot)
+        # One scan chooses a minimum-magnitude nonzero entry. Unless it is a
+        # unit, one further scan decides whether it divides the active block.
+        work += 2 * remaining_cells
         remaining_rows = rows - pivot - 1
         remaining_columns = columns - pivot - 1
         # At most one row swap, one column swap, and one sign normalization.
@@ -560,10 +584,51 @@ def _unit_presolve_attempt_work_bound(rows: int, columns: int) -> int:
         # transformation, and the inverse transformation.
         work += remaining_rows * (2 * columns + 4 * rows)
         work += remaining_columns * (2 * rows + 4 * columns)
+        # Retain the largest intermediate after row and column clearing.
+        work += 2 * state_scalars
     return work
 
 
-def _position_unit_pivot(
+def _select_visible_divisor_pivot(
+    working: Matrix,
+    *,
+    pivot: int,
+) -> tuple[tuple[int, int] | None, int, bool]:
+    """Select a minimum-magnitude entry when it divides the trailing block.
+
+    If any entry of the block divides every entry, its magnitude equals the
+    minimum nonzero magnitude. Thus testing one minimum is complete for this
+    presolve class and avoids an exhaustive scan over candidate pivots.
+    """
+
+    rows = len(working)
+    columns = len(working[0]) if working else 0
+    work = 0
+    selected: tuple[int, int] | None = None
+    minimum = 0
+    for row in range(pivot, rows):
+        for column in range(pivot, columns):
+            work += 1
+            value = working[row][column]
+            magnitude = abs(value)
+            if magnitude and (selected is None or magnitude < minimum):
+                selected = (row, column)
+                minimum = magnitude
+    if selected is None:
+        return None, work, False
+    if minimum == 1:
+        return selected, work, True
+
+    divisor = working[selected[0]][selected[1]]
+    for row in range(pivot, rows):
+        for column in range(pivot, columns):
+            work += 1
+            if working[row][column] % divisor:
+                return None, work, True
+    return selected, work, True
+
+
+def _position_visible_pivot(
     working: Matrix,
     left: Matrix,
     right: Matrix,
@@ -574,7 +639,7 @@ def _position_unit_pivot(
     selected_row: int,
     selected_column: int,
 ) -> tuple[int, int, int]:
-    """Move one selected unit to the positive diagonal position."""
+    """Move one selected divisor to the positive diagonal position."""
 
     work = 0
     left_determinant = 1
@@ -589,7 +654,7 @@ def _position_unit_pivot(
         work += _swap_columns(right, pivot, selected_column)
         work += _swap_rows(right_inverse, pivot, selected_column)
         right_determinant = -1
-    if working[pivot][pivot] == -1:
+    if working[pivot][pivot] < 0:
         work += _scale_row(working, pivot, -1)
         work += _scale_row(left, pivot, -1)
         work += _scale_column(left_inverse, pivot, -1)
@@ -597,7 +662,7 @@ def _position_unit_pivot(
     return work, left_determinant, right_determinant
 
 
-def _clear_unit_pivot(
+def _clear_visible_pivot(
     working: Matrix,
     left: Matrix,
     right: Matrix,
@@ -605,14 +670,23 @@ def _clear_unit_pivot(
     right_inverse: Matrix,
     *,
     pivot: int,
-) -> int:
-    """Clear the row and column of one positive unit pivot."""
+) -> tuple[int, int]:
+    """Clear the row and column of one positive divisor pivot."""
 
     work = 0
+    pivot_value = working[pivot][pivot]
+    state_scalars = (
+        len(working) * len(right)
+        + 2 * len(left) * len(left)
+        + 2 * len(right) * len(right)
+    )
     for row in range(pivot + 1, len(working)):
-        coefficient = working[row][pivot]
-        if coefficient == 0:
+        value = working[row][pivot]
+        if value == 0:
             continue
+        coefficient, remainder = divmod(value, pivot_value)
+        if remainder:
+            raise ArithmeticError("visible Smith pivot does not divide its column")
         work += _add_row_multiple(
             working, target=row, source=pivot, factor=-coefficient
         )
@@ -620,11 +694,19 @@ def _clear_unit_pivot(
         work += _add_column_multiple(
             left_inverse, target=pivot, source=row, factor=coefficient
         )
+    maximum_bits = max(
+        _matrix_bits(matrix)
+        for matrix in (working, left, right, left_inverse, right_inverse)
+    )
+    work += state_scalars
     column_count = len(right)
     for column in range(pivot + 1, column_count):
-        coefficient = working[pivot][column]
-        if coefficient == 0:
+        value = working[pivot][column]
+        if value == 0:
             continue
+        coefficient, remainder = divmod(value, pivot_value)
+        if remainder:
+            raise ArithmeticError("visible Smith pivot does not divide its row")
         work += _add_column_multiple(
             working, target=column, source=pivot, factor=-coefficient
         )
@@ -634,23 +716,30 @@ def _clear_unit_pivot(
         work += _add_row_multiple(
             right_inverse, target=pivot, source=column, factor=coefficient
         )
-    return work
+    maximum_bits = max(
+        maximum_bits,
+        *(
+            _matrix_bits(matrix)
+            for matrix in (working, left, right, left_inverse, right_inverse)
+        ),
+    )
+    work += state_scalars
+    return work, maximum_bits
 
 
-def _presolve_unit_smith(
+def _presolve_visible_smith(
     source: Matrix,
     *,
     rows: int,
     columns: int,
 ) -> SmithReductionData | None:
-    """Exactly reduce matrices cleared by a sequence of visible unit pivots.
+    """Exactly reduce matrices cleared by visible divisibility pivots.
 
-    A selected ``+/-1`` pivot can be cleared using integral elementary row
-    and column operations.  The presolve tracks both transformations and their
-    inverses, checks every scalar update against the owner height envelope, and
-    succeeds only when the remaining block is zero.  A nonzero residual with no
-    visible unit pivot is left to the maintained general Smith backend, even if
-    a later Bezout combination could expose one.
+    A pivot that divides its complete trailing block clears its row and column
+    using integral elementary operations. Selecting such a pivot at every step
+    also proves the positive divisibility order of the resulting diagonal.
+    A minimum-magnitude candidate decides this presolve class in two scans of
+    each trailing block.
     """
 
     if rows == 0 or columns == 0 or not any(value for row in source for value in row):
@@ -663,7 +752,7 @@ def _presolve_unit_smith(
             factors=(),
         )
     if _is_positive_smith_diagonal(source, rows=rows, columns=columns):
-        factors = tuple(
+        diagonal_factors = tuple(
             source[index][index]
             for index in range(min(rows, columns))
             if source[index][index] != 0
@@ -673,8 +762,8 @@ def _presolve_unit_smith(
             rows=rows,
             columns=columns,
             diagonal=[row[:] for row in source],
-            rank=len(factors),
-            factors=factors,
+            rank=len(diagonal_factors),
+            factors=diagonal_factors,
         )
 
     working = [row[:] for row in source]
@@ -684,29 +773,22 @@ def _presolve_unit_smith(
     right_inverse = identity_matrix(columns)
     left_determinant = 1
     right_determinant = 1
-    work = _unit_presolve_structural_work(rows, columns)
-    rank = 0
+    work = _presolve_structural_work(rows, columns)
+    factors: list[int] = []
+    maximum_bits = _matrix_bits(source)
     try:
         for pivot in range(min(rows, columns)):
-            selected = next(
-                (
-                    (row, column)
-                    for row in range(pivot, rows)
-                    for column in range(pivot, columns)
-                    if abs(working[row][column]) == 1
-                ),
-                None,
+            selected, selection_work, has_nonzero = _select_visible_divisor_pivot(
+                working,
+                pivot=pivot,
             )
+            work += selection_work
             if selected is None:
-                if any(
-                    working[row][column] != 0
-                    for row in range(pivot, rows)
-                    for column in range(pivot, columns)
-                ):
+                if has_nonzero:
                     return None
                 break
             selected_row, selected_column = selected
-            positioned_work, left_sign, right_sign = _position_unit_pivot(
+            positioned_work, left_sign, right_sign = _position_visible_pivot(
                 working,
                 left,
                 right,
@@ -719,7 +801,7 @@ def _presolve_unit_smith(
             work += positioned_work
             left_determinant *= left_sign
             right_determinant *= right_sign
-            work += _clear_unit_pivot(
+            cleared_work, cleared_bits = _clear_visible_pivot(
                 working,
                 left,
                 right,
@@ -727,22 +809,19 @@ def _presolve_unit_smith(
                 right_inverse,
                 pivot=pivot,
             )
-            rank += 1
+            work += cleared_work
+            maximum_bits = max(maximum_bits, cleared_bits)
+            factors.append(working[pivot][pivot])
     except _PresolveHeightExceededError:
         return None
 
-    expected = [
-        [int(row == column and row < rank) for column in range(columns)]
-        for row in range(rows)
-    ]
-    if working != expected:
-        return None
     source_bits = _matrix_bits(source)
     left_bits = _matrix_bits(left)
     right_bits = _matrix_bits(right)
     left_inverse_bits = _matrix_bits(left_inverse)
     right_inverse_bits = _matrix_bits(right_inverse)
     maximum_bits = max(
+        maximum_bits,
         source_bits,
         _matrix_bits(working),
         left_bits,
@@ -758,8 +837,8 @@ def _presolve_unit_smith(
             diagonal=working,
             left=left,
             right=right,
-            rank=rank,
-            invariant_factors=(1,) * rank,
+            rank=len(factors),
+            invariant_factors=tuple(factors),
             left_determinant=left_determinant,
             right_determinant=right_determinant,
         ),
@@ -776,7 +855,12 @@ def _smith_admission(
     rows: int,
     columns: int,
 ) -> tuple[SmithHeightBound, SmithReductionData | None]:
-    presolved = _presolve_unit_smith(matrix, rows=rows, columns=columns)
+    attempt_work = _presolve_attempt_work_bound(rows, columns)
+    presolved = _presolve_visible_smith(
+        matrix,
+        rows=rows,
+        columns=columns,
+    )
     if presolved is None:
         bound = _smith_height_bound(matrix, rows=rows, columns=columns)
         return (
@@ -785,9 +869,7 @@ def _smith_admission(
                 right_bits=bound.right_bits,
                 diagonal_bits=bound.diagonal_bits,
                 intermediate_bits=bound.intermediate_bits,
-                work_units=(
-                    bound.work_units + _unit_presolve_attempt_work_bound(rows, columns)
-                ),
+                work_units=bound.work_units + attempt_work,
                 transformations_are_identity=bound.transformations_are_identity,
             ),
             None,
@@ -1078,6 +1160,8 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
         + _RESULT_ROOT_RESERVE_BYTES
     )
     for index, chain_rank in enumerate(source.basis_sizes):
+        degree = source.degree_min + index
+        _require_deadline(deadline, f"before degree {degree} admission")
         outgoing_rows = source.basis_sizes[index - 1] if index > 0 else 0
         outgoing = differentials[index - 1] if index > 0 else []
         incoming_chain_rank = (
@@ -1098,6 +1182,7 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
             label=f"degree {source.degree_min + index} outgoing differential",
         )
         smith_work += outgoing_height.work_units
+        _require_deadline(deadline, f"after degree {degree} outgoing Smith admission")
 
         coordinate_bounds: list[int] = []
         incoming_bounds: list[SmithHeightBound] = []
@@ -1134,23 +1219,24 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
                 value for row in all_coordinates[:known_outgoing_rank] for value in row
             ):
                 raise ArithmeticError(
-                    "unit Smith presolve produced invalid cycle coordinates"
+                    "visible-pivot Smith presolve produced invalid cycle coordinates"
                 )
             exact_incoming_coordinates = all_coordinates[known_outgoing_rank:]
         bounds_by_cycle_rank: dict[
             int, tuple[int, SmithHeightBound, SmithReductionData | None, int]
         ] = {}
         for cycle_rank in cycle_ranks:
+            _require_deadline(
+                deadline,
+                f"during degree {degree} cycle-rank {cycle_rank} admission",
+            )
             if incoming_is_zero:
-                zero_coordinates = [
-                    [0 for _ in range(incoming_chain_rank)] for _ in range(cycle_rank)
-                ]
                 coordinate_bits = 1
-                incoming_height, incoming_presolve = _smith_admission(
-                    zero_coordinates,
-                    rows=cycle_rank,
-                    columns=incoming_chain_rank,
+                incoming_height = _lazy_zero_smith_height(
+                    cycle_rank,
+                    incoming_chain_rank,
                 )
+                incoming_presolve = None
             elif exact_incoming_coordinates is not None:
                 coordinate_bits = _matrix_bits(exact_incoming_coordinates)
                 incoming_height, incoming_presolve = _smith_admission(
@@ -1288,7 +1374,7 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
         )
         degree_plans.append(
             IntegralHomologyDegreePlan(
-                degree=source.degree_min + index,
+                degree=degree,
                 chain_rank=chain_rank,
                 incoming_chain_rank=incoming_chain_rank,
                 outgoing=outgoing,
@@ -1301,6 +1387,7 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
                 output_bits_by_cycle_rank=tuple(result_bounds),
             )
         )
+        _require_deadline(deadline, f"after degree {degree} admission")
 
     # One ledger covers parsing, d^2, both reductions in every degree, and
     # construction/serialization of the complete exact scalar payload.
@@ -1401,6 +1488,15 @@ def _execute_smith_reduction(
 
     if presolved is not None:
         return presolved
+    if rows == 0 or columns == 0 or not any(value for row in source for value in row):
+        return _identity_reduction(
+            source,
+            rows=rows,
+            columns=columns,
+            diagonal=[[0 for _ in range(columns)] for _ in range(rows)],
+            rank=0,
+            factors=(),
+        )
     from jacobian.math.topology.chain_complexes._smith_process import (
         smith_reduce_in_worker,
     )

--- a/src/jacobian/math/topology/chain_complexes/_integral_homology.py
+++ b/src/jacobian/math/topology/chain_complexes/_integral_homology.py
@@ -2,9 +2,10 @@
 
 The two Smith reductions have deliberately separate roles.  The outgoing
 reduction supplies a saturated integral cycle basis; the incoming reduction
-computes the quotient of that cycle lattice by the boundary lattice.  SymPy
-owns both exact Smith decompositions.  This module owns admission, source-basis
-reconstruction, and the public height/result contract.
+computes the quotient of that cycle lattice by the boundary lattice.  A bounded
+unit presolve owns structurally trivial reductions, and a killable SymPy child
+owns the remaining exact decompositions.  This module owns admission,
+source-basis reconstruction, and the public height/result contract.
 """
 
 from __future__ import annotations
@@ -14,9 +15,11 @@ from itertools import pairwise
 from time import monotonic
 
 from jacobian._execution import (
+    OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
     bind_request_deadline,
     current_request_execution,
+    request_cancelled,
 )
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
@@ -24,11 +27,10 @@ from jacobian.math.matrices.certified_snf.operations import (
     Matrix,
     SmithReduction,
     certificate_from_reduction,
-    inverse_unimodular,
+    identity_matrix,
     matrix_columns,
     matrix_multiply,
     matrix_vector_multiply,
-    smith_reduce,
 )
 from jacobian.math.matrices.certified_snf.values import CertifiedIntegerMatrix
 from jacobian.math.topology.chain_complexes.values import (
@@ -78,7 +80,9 @@ class IntegralHomologyDegreePlan:
     outgoing: Matrix
     incoming: Matrix
     outgoing_height: SmithHeightBound
+    outgoing_presolve: SmithReductionData | None
     incoming_heights_by_cycle_rank: tuple[SmithHeightBound, ...]
+    incoming_presolves_by_cycle_rank: tuple[SmithReductionData | None, ...]
     coordinate_bits_by_cycle_rank: tuple[int, ...]
     output_bits_by_cycle_rank: tuple[int, ...]
 
@@ -94,6 +98,17 @@ class IntegralHomologyExecutionPlan:
     output_scalar_count: int
     total_work: int
     deadline: float
+
+
+@dataclass(frozen=True, slots=True)
+class SmithReductionData:
+    """One exact Smith reduction with both inverse transformations."""
+
+    reduction: SmithReduction
+    left_inverse: Matrix
+    right_inverse: Matrix
+    work_units: int
+    intermediate_bits: int
 
 
 def _domain_error(code: str, message: str) -> OperationDomainValidationError:
@@ -379,6 +394,397 @@ def _smith_height_bound(
     return _smith_height_bound_from_shape(rows, columns, input_bits)
 
 
+class _PresolveHeightExceededError(Exception):
+    """The unit presolve cannot stay inside the admitted integer envelope."""
+
+
+def _checked_linear_update(value: int, factor: int, source: int) -> int:
+    """Return ``value + factor * source`` without creating an over-height value."""
+
+    predicted_bits = max(
+        abs(value).bit_length(),
+        abs(factor).bit_length() + abs(source).bit_length() + 1,
+    )
+    if predicted_bits > MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS:
+        raise _PresolveHeightExceededError
+    result = value + factor * source
+    if abs(result).bit_length() > MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS:
+        raise _PresolveHeightExceededError
+    return result
+
+
+def _swap_rows(matrix: Matrix, left: int, right: int) -> int:
+    if left == right:
+        return 0
+    matrix[left], matrix[right] = matrix[right], matrix[left]
+    return len(matrix[left])
+
+
+def _swap_columns(matrix: Matrix, left: int, right: int) -> int:
+    if left == right:
+        return 0
+    for row in matrix:
+        row[left], row[right] = row[right], row[left]
+    return len(matrix)
+
+
+def _scale_row(matrix: Matrix, row: int, factor: int) -> int:
+    matrix[row] = [factor * value for value in matrix[row]]
+    return len(matrix[row])
+
+
+def _scale_column(matrix: Matrix, column: int, factor: int) -> int:
+    for row in matrix:
+        row[column] *= factor
+    return len(matrix)
+
+
+def _add_row_multiple(matrix: Matrix, *, target: int, source: int, factor: int) -> int:
+    matrix[target] = [
+        _checked_linear_update(value, factor, source_value)
+        for value, source_value in zip(matrix[target], matrix[source], strict=True)
+    ]
+    return 2 * len(matrix[target])
+
+
+def _add_column_multiple(
+    matrix: Matrix, *, target: int, source: int, factor: int
+) -> int:
+    for row in matrix:
+        row[target] = _checked_linear_update(row[target], factor, row[source])
+    return 2 * len(matrix)
+
+
+def _identity_reduction(
+    source: Matrix,
+    *,
+    rows: int,
+    columns: int,
+    diagonal: Matrix,
+    rank: int,
+    factors: tuple[int, ...],
+) -> SmithReductionData:
+    left = identity_matrix(rows)
+    right = identity_matrix(columns)
+    reduction = SmithReduction(
+        source=[row[:] for row in source],
+        diagonal=diagonal,
+        left=left,
+        right=right,
+        rank=rank,
+        invariant_factors=factors,
+        left_determinant=1,
+        right_determinant=1,
+    )
+    return SmithReductionData(
+        reduction=reduction,
+        left_inverse=[row[:] for row in left],
+        right_inverse=[row[:] for row in right],
+        # Cover source/diagonal scans and copies plus construction, comparison,
+        # and retention of both square transformations and their inverses.
+        # In particular, a 0 x n or n x 0 reduction still constructs two n x n
+        # identity matrices and must not be priced as one unit.
+        work_units=8 * (rows * columns + rows * rows + columns * columns + 1),
+        intermediate_bits=max(1, _matrix_bits(source)),
+    )
+
+
+def _unit_presolve_structural_work(rows: int, columns: int) -> int:
+    """Charge scans and retained structures independent of pivot outcomes."""
+
+    pivot_scans = sum(
+        (rows - pivot) * (columns - pivot) for pivot in range(min(rows, columns))
+    )
+    return 8 * (rows * columns + rows * rows + columns * columns + 1) + pivot_scans
+
+
+def _unit_presolve_attempt_work_bound(rows: int, columns: int) -> int:
+    """Bound an unsuccessful unit-pivot attempt before general Smith work."""
+
+    work = _unit_presolve_structural_work(rows, columns)
+    for pivot in range(min(rows, columns)):
+        remaining_rows = rows - pivot - 1
+        remaining_columns = columns - pivot - 1
+        # At most one row swap, one column swap, and one sign normalization.
+        work += 5 * rows + 4 * columns
+        # Every clearing update touches the working matrix, its accumulated
+        # transformation, and the inverse transformation.
+        work += remaining_rows * (2 * columns + 4 * rows)
+        work += remaining_columns * (2 * rows + 4 * columns)
+    return work
+
+
+def _position_unit_pivot(
+    working: Matrix,
+    left: Matrix,
+    right: Matrix,
+    left_inverse: Matrix,
+    right_inverse: Matrix,
+    *,
+    pivot: int,
+    selected_row: int,
+    selected_column: int,
+) -> tuple[int, int, int]:
+    """Move one selected unit to the positive diagonal position."""
+
+    work = 0
+    left_determinant = 1
+    right_determinant = 1
+    if selected_row != pivot:
+        work += _swap_rows(working, pivot, selected_row)
+        work += _swap_rows(left, pivot, selected_row)
+        work += _swap_columns(left_inverse, pivot, selected_row)
+        left_determinant = -1
+    if selected_column != pivot:
+        work += _swap_columns(working, pivot, selected_column)
+        work += _swap_columns(right, pivot, selected_column)
+        work += _swap_rows(right_inverse, pivot, selected_column)
+        right_determinant = -1
+    if working[pivot][pivot] == -1:
+        work += _scale_row(working, pivot, -1)
+        work += _scale_row(left, pivot, -1)
+        work += _scale_column(left_inverse, pivot, -1)
+        left_determinant *= -1
+    return work, left_determinant, right_determinant
+
+
+def _clear_unit_pivot(
+    working: Matrix,
+    left: Matrix,
+    right: Matrix,
+    left_inverse: Matrix,
+    right_inverse: Matrix,
+    *,
+    pivot: int,
+) -> int:
+    """Clear the row and column of one positive unit pivot."""
+
+    work = 0
+    for row in range(pivot + 1, len(working)):
+        coefficient = working[row][pivot]
+        if coefficient == 0:
+            continue
+        work += _add_row_multiple(
+            working, target=row, source=pivot, factor=-coefficient
+        )
+        work += _add_row_multiple(left, target=row, source=pivot, factor=-coefficient)
+        work += _add_column_multiple(
+            left_inverse, target=pivot, source=row, factor=coefficient
+        )
+    column_count = len(right)
+    for column in range(pivot + 1, column_count):
+        coefficient = working[pivot][column]
+        if coefficient == 0:
+            continue
+        work += _add_column_multiple(
+            working, target=column, source=pivot, factor=-coefficient
+        )
+        work += _add_column_multiple(
+            right, target=column, source=pivot, factor=-coefficient
+        )
+        work += _add_row_multiple(
+            right_inverse, target=pivot, source=column, factor=coefficient
+        )
+    return work
+
+
+def _presolve_unit_smith(
+    source: Matrix,
+    *,
+    rows: int,
+    columns: int,
+) -> SmithReductionData | None:
+    """Exactly reduce matrices cleared by a sequence of visible unit pivots.
+
+    A selected ``+/-1`` pivot can be cleared using integral elementary row
+    and column operations.  The presolve tracks both transformations and their
+    inverses, checks every scalar update against the owner height envelope, and
+    succeeds only when the remaining block is zero.  A nonzero residual with no
+    visible unit pivot is left to the maintained general Smith backend, even if
+    a later Bezout combination could expose one.
+    """
+
+    if rows == 0 or columns == 0 or not any(value for row in source for value in row):
+        return _identity_reduction(
+            source,
+            rows=rows,
+            columns=columns,
+            diagonal=[[0 for _ in range(columns)] for _ in range(rows)],
+            rank=0,
+            factors=(),
+        )
+    if _is_positive_smith_diagonal(source, rows=rows, columns=columns):
+        factors = tuple(
+            source[index][index]
+            for index in range(min(rows, columns))
+            if source[index][index] != 0
+        )
+        return _identity_reduction(
+            source,
+            rows=rows,
+            columns=columns,
+            diagonal=[row[:] for row in source],
+            rank=len(factors),
+            factors=factors,
+        )
+
+    working = [row[:] for row in source]
+    left = identity_matrix(rows)
+    right = identity_matrix(columns)
+    left_inverse = identity_matrix(rows)
+    right_inverse = identity_matrix(columns)
+    left_determinant = 1
+    right_determinant = 1
+    work = _unit_presolve_structural_work(rows, columns)
+    rank = 0
+    try:
+        for pivot in range(min(rows, columns)):
+            selected = next(
+                (
+                    (row, column)
+                    for row in range(pivot, rows)
+                    for column in range(pivot, columns)
+                    if abs(working[row][column]) == 1
+                ),
+                None,
+            )
+            if selected is None:
+                if any(
+                    working[row][column] != 0
+                    for row in range(pivot, rows)
+                    for column in range(pivot, columns)
+                ):
+                    return None
+                break
+            selected_row, selected_column = selected
+            positioned_work, left_sign, right_sign = _position_unit_pivot(
+                working,
+                left,
+                right,
+                left_inverse,
+                right_inverse,
+                pivot=pivot,
+                selected_row=selected_row,
+                selected_column=selected_column,
+            )
+            work += positioned_work
+            left_determinant *= left_sign
+            right_determinant *= right_sign
+            work += _clear_unit_pivot(
+                working,
+                left,
+                right,
+                left_inverse,
+                right_inverse,
+                pivot=pivot,
+            )
+            rank += 1
+    except _PresolveHeightExceededError:
+        return None
+
+    expected = [
+        [int(row == column and row < rank) for column in range(columns)]
+        for row in range(rows)
+    ]
+    if working != expected:
+        return None
+    source_bits = _matrix_bits(source)
+    left_bits = _matrix_bits(left)
+    right_bits = _matrix_bits(right)
+    left_inverse_bits = _matrix_bits(left_inverse)
+    right_inverse_bits = _matrix_bits(right_inverse)
+    left_source_bits = _matrix_product_bits(rows, left_bits, source_bits)
+    reconstruction_bits = _matrix_product_bits(columns, left_source_bits, right_bits)
+    left_inverse_check_bits = _matrix_product_bits(rows, left_inverse_bits, left_bits)
+    right_inverse_check_bits = _matrix_product_bits(
+        columns, right_bits, right_inverse_bits
+    )
+    maximum_bits = max(
+        source_bits,
+        _matrix_bits(working),
+        left_bits,
+        right_bits,
+        left_inverse_bits,
+        right_inverse_bits,
+        reconstruction_bits,
+        left_inverse_check_bits,
+        right_inverse_check_bits,
+    )
+    if maximum_bits > MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS:
+        return None
+    # These are bounded defining checks for the presolve itself.  The stored
+    # reduction is reused by the kernel; ordinary result construction does not
+    # replay them.
+    reconstructed = matrix_multiply(
+        matrix_multiply(left, source),
+        right,
+        right_columns_if_empty=columns,
+    )
+    if reconstructed != working:
+        raise ArithmeticError("unit Smith presolve lost its source relation")
+    if matrix_multiply(left_inverse, left) != identity_matrix(rows):
+        raise ArithmeticError("unit Smith presolve left inverse is invalid")
+    if matrix_multiply(right, right_inverse) != identity_matrix(columns):
+        raise ArithmeticError("unit Smith presolve right inverse is invalid")
+    work += rows * rows * max(1, rows) + columns * columns * max(1, columns)
+    work += rows * rows * max(1, columns) + rows * columns * max(1, columns)
+    return SmithReductionData(
+        reduction=SmithReduction(
+            source=[row[:] for row in source],
+            diagonal=working,
+            left=left,
+            right=right,
+            rank=rank,
+            invariant_factors=(1,) * rank,
+            left_determinant=left_determinant,
+            right_determinant=right_determinant,
+        ),
+        left_inverse=left_inverse,
+        right_inverse=right_inverse,
+        work_units=work,
+        intermediate_bits=maximum_bits,
+    )
+
+
+def _smith_admission(
+    matrix: Matrix,
+    *,
+    rows: int,
+    columns: int,
+) -> tuple[SmithHeightBound, SmithReductionData | None]:
+    presolved = _presolve_unit_smith(matrix, rows=rows, columns=columns)
+    if presolved is None:
+        bound = _smith_height_bound(matrix, rows=rows, columns=columns)
+        return (
+            SmithHeightBound(
+                left_bits=bound.left_bits,
+                right_bits=bound.right_bits,
+                diagonal_bits=bound.diagonal_bits,
+                intermediate_bits=bound.intermediate_bits,
+                work_units=(
+                    bound.work_units + _unit_presolve_attempt_work_bound(rows, columns)
+                ),
+                transformations_are_identity=bound.transformations_are_identity,
+            ),
+            None,
+        )
+    reduction = presolved.reduction
+    return (
+        SmithHeightBound(
+            left_bits=_matrix_bits(reduction.left),
+            right_bits=_matrix_bits(reduction.right),
+            diagonal_bits=_matrix_bits(reduction.diagonal),
+            intermediate_bits=presolved.intermediate_bits,
+            work_units=presolved.work_units,
+            transformations_are_identity=(
+                reduction.left == identity_matrix(rows)
+                and reduction.right == identity_matrix(columns)
+            ),
+        ),
+        presolved,
+    )
+
+
 def _known_rank_before_smith(
     matrix: Matrix,
     *,
@@ -505,6 +911,10 @@ def _require_square_zero(
                 "the conservative d^2 intermediate-height bound exceeds the "
                 f"{MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS}-bit execution envelope",
             )
+        left_cells = source.basis_sizes[index] * middle
+        right_cells = middle * columns
+        product_cells = source.basis_sizes[index] * columns
+        work += left_cells + right_cells + product_cells
         work += source.basis_sizes[index] * middle * columns
         product = matrix_multiply(left, right, right_columns_if_empty=columns)
         if any(value for row in product for value in row):
@@ -580,12 +990,21 @@ def _reconstruction_work(
 def _deadline() -> float:
     execution = current_request_execution()
     started = execution.started_at if execution is not None else monotonic()
-    deadline = started + INTEGRAL_HOMOLOGY_WALL_SECONDS
+    owner_deadline = started + INTEGRAL_HOMOLOGY_WALL_SECONDS
+    deadline = (
+        min(owner_deadline, execution.deadline)
+        if execution is not None and execution.deadline is not None
+        else owner_deadline
+    )
     bind_request_deadline(deadline)
     return deadline
 
 
 def _require_deadline(deadline: float, stage: str) -> None:
+    if request_cancelled():
+        raise OperationExecutionCancelledError(
+            f"integral homology request cancelled {stage}"
+        )
     if monotonic() >= deadline:
         raise OperationExecutionTimeoutError(
             f"integral homology deadline expired {stage}"
@@ -633,7 +1052,7 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
             if index < len(differentials)
             else [[] for _ in range(chain_rank)]
         )
-        outgoing_height = _smith_height_bound(
+        outgoing_height, outgoing_presolve = _smith_admission(
             outgoing,
             rows=outgoing_rows,
             columns=chain_rank,
@@ -646,12 +1065,17 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
 
         coordinate_bounds: list[int] = []
         incoming_bounds: list[SmithHeightBound] = []
+        incoming_presolves: list[SmithReductionData | None] = []
         result_bounds: list[int] = []
-        known_outgoing_rank = _known_rank_before_smith(
-            outgoing,
-            rows=outgoing_rows,
-            columns=chain_rank,
-            bound=outgoing_height,
+        known_outgoing_rank = (
+            outgoing_presolve.reduction.rank
+            if outgoing_presolve is not None
+            else _known_rank_before_smith(
+                outgoing,
+                rows=outgoing_rows,
+                columns=chain_rank,
+                bound=outgoing_height,
+            )
         )
         known_cycle_rank = (
             None if known_outgoing_rank is None else chain_rank - known_outgoing_rank
@@ -662,16 +1086,39 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
             if known_cycle_rank is not None
             else tuple(range(chain_rank + 1))
         )
-        bounds_by_cycle_rank: dict[int, tuple[int, SmithHeightBound, int]] = {}
+        exact_incoming_coordinates: Matrix | None = None
+        if outgoing_presolve is not None and known_outgoing_rank is not None:
+            all_coordinates = matrix_multiply(
+                outgoing_presolve.right_inverse,
+                incoming,
+                right_columns_if_empty=incoming_chain_rank,
+            )
+            if any(
+                value for row in all_coordinates[:known_outgoing_rank] for value in row
+            ):
+                raise ArithmeticError(
+                    "unit Smith presolve produced invalid cycle coordinates"
+                )
+            exact_incoming_coordinates = all_coordinates[known_outgoing_rank:]
+        bounds_by_cycle_rank: dict[
+            int, tuple[int, SmithHeightBound, SmithReductionData | None, int]
+        ] = {}
         for cycle_rank in cycle_ranks:
-            if (
+            if exact_incoming_coordinates is not None:
+                coordinate_bits = _matrix_bits(exact_incoming_coordinates)
+                incoming_height, incoming_presolve = _smith_admission(
+                    exact_incoming_coordinates,
+                    rows=cycle_rank,
+                    columns=incoming_chain_rank,
+                )
+            elif (
                 known_cycle_rank == cycle_rank
                 and outgoing_height.transformations_are_identity
             ):
                 outgoing_rank = chain_rank - cycle_rank
                 known_incoming_coordinates = incoming[outgoing_rank:]
                 coordinate_bits = incoming_bits
-                incoming_height = _smith_height_bound(
+                incoming_height, incoming_presolve = _smith_admission(
                     known_incoming_coordinates,
                     rows=cycle_rank,
                     columns=incoming_chain_rank,
@@ -686,6 +1133,7 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
                     incoming_chain_rank,
                     coordinate_bits,
                 )
+                incoming_presolve = None
             else:
                 right_inverse_bits = _inverse_unimodular_bits(
                     chain_rank, outgoing_height.right_bits
@@ -700,6 +1148,7 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
                     incoming_chain_rank,
                     coordinate_bits,
                 )
+                incoming_presolve = None
             _require_height(
                 incoming_height,
                 label=(
@@ -743,6 +1192,7 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
             bounds_by_cycle_rank[cycle_rank] = (
                 coordinate_bits,
                 incoming_height,
+                incoming_presolve,
                 result_bits,
             )
         # Pre-Smith exact-rank cases prove the unique cycle rank. The repeated
@@ -752,11 +1202,15 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
             known_bounds = bounds_by_cycle_rank[known_cycle_rank]
             bounds_by_cycle_rank = dict.fromkeys(range(chain_rank + 1), known_bounds)
         for cycle_rank in range(chain_rank + 1):
-            coordinate_bits, incoming_height, result_bits = bounds_by_cycle_rank[
-                cycle_rank
-            ]
+            (
+                coordinate_bits,
+                incoming_height,
+                incoming_presolve,
+                result_bits,
+            ) = bounds_by_cycle_rank[cycle_rank]
             coordinate_bounds.append(coordinate_bits)
             incoming_bounds.append(incoming_height)
+            incoming_presolves.append(incoming_presolve)
             result_bounds.append(result_bits)
         smith_work += max(bound.work_units for bound in incoming_bounds)
         reconstruction_work += max(
@@ -781,7 +1235,9 @@ def admit_integral_homology(source: ChainComplexValue) -> IntegralHomologyExecut
                 outgoing=outgoing,
                 incoming=incoming,
                 outgoing_height=outgoing_height,
+                outgoing_presolve=outgoing_presolve,
                 incoming_heights_by_cycle_rank=tuple(incoming_bounds),
+                incoming_presolves_by_cycle_rank=tuple(incoming_presolves),
                 coordinate_bits_by_cycle_rank=tuple(coordinate_bounds),
                 output_bits_by_cycle_rank=tuple(result_bounds),
             )
@@ -865,6 +1321,43 @@ def _integer_sequence_bits(values: list[int]) -> int:
     return max((abs(value).bit_length() for value in values), default=1)
 
 
+def _execute_smith_reduction(
+    source: Matrix,
+    *,
+    rows: int,
+    columns: int,
+    presolved: SmithReductionData | None,
+    height: SmithHeightBound,
+    deadline: float,
+) -> SmithReductionData:
+    """Return one admitted reduction, reusing exact presolve when available."""
+
+    if presolved is not None:
+        return presolved
+    from jacobian.math.topology.chain_complexes._smith_process import (
+        smith_reduce_in_worker,
+    )
+
+    completed = smith_reduce_in_worker(
+        source,
+        rows=rows,
+        columns=columns,
+        deadline=deadline,
+        left_bits=height.left_bits,
+        right_bits=height.right_bits,
+        diagonal_bits=height.diagonal_bits,
+        left_inverse_bits=_inverse_unimodular_bits(rows, height.left_bits),
+        right_inverse_bits=_inverse_unimodular_bits(columns, height.right_bits),
+    )
+    return SmithReductionData(
+        reduction=completed.reduction,
+        left_inverse=completed.left_inverse,
+        right_inverse=completed.right_inverse,
+        work_units=0,
+        intermediate_bits=_actual_reduction_bits(completed.reduction),
+    )
+
+
 def compute_integral_homology(
     plan: IntegralHomologyExecutionPlan,
 ) -> tuple[IntegralHomologyGroupValue, ...]:
@@ -876,15 +1369,19 @@ def compute_integral_homology(
             plan.deadline,
             f"before degree {degree_plan.degree} outgoing Smith reduction",
         )
-        outgoing_reduction = smith_reduce(
+        outgoing_execution = _execute_smith_reduction(
             degree_plan.outgoing,
-            row_count=(
+            rows=(
                 plan.source.basis_sizes[degree_plan.degree - plan.source.degree_min - 1]
                 if degree_plan.degree > plan.source.degree_min
                 else 0
             ),
-            column_count=degree_plan.chain_rank,
+            columns=degree_plan.chain_rank,
+            presolved=degree_plan.outgoing_presolve,
+            height=degree_plan.outgoing_height,
+            deadline=plan.deadline,
         )
+        outgoing_reduction = outgoing_execution.reduction
         _require_reduction_bound(
             outgoing_reduction,
             degree_plan.outgoing_height,
@@ -893,7 +1390,7 @@ def compute_integral_homology(
         outgoing_rank = outgoing_reduction.rank
         cycle_rank = degree_plan.chain_rank - outgoing_rank
         cycle_basis = matrix_columns(outgoing_reduction.right, start=outgoing_rank)
-        right_inverse = inverse_unimodular(outgoing_reduction.right)
+        right_inverse = outgoing_execution.right_inverse
         all_cycle_coordinates = matrix_multiply(
             right_inverse,
             degree_plan.incoming,
@@ -912,11 +1409,15 @@ def compute_integral_homology(
             plan.deadline,
             f"before degree {degree_plan.degree} incoming Smith reduction",
         )
-        incoming_reduction = smith_reduce(
+        incoming_execution = _execute_smith_reduction(
             incoming_coordinates,
-            row_count=cycle_rank,
-            column_count=degree_plan.incoming_chain_rank,
+            rows=cycle_rank,
+            columns=degree_plan.incoming_chain_rank,
+            presolved=degree_plan.incoming_presolves_by_cycle_rank[cycle_rank],
+            height=degree_plan.incoming_heights_by_cycle_rank[cycle_rank],
+            deadline=plan.deadline,
         )
+        incoming_reduction = incoming_execution.reduction
         incoming_height = degree_plan.incoming_heights_by_cycle_rank[cycle_rank]
         _require_reduction_bound(
             incoming_reduction,
@@ -924,7 +1425,7 @@ def compute_integral_homology(
             label=f"degree {degree_plan.degree} incoming Smith reduction",
         )
         incoming_rank = incoming_reduction.rank
-        incoming_left_inverse = inverse_unimodular(incoming_reduction.left)
+        incoming_left_inverse = incoming_execution.left_inverse
 
         free_generators: list[IntegralFreeGenerator] = []
         generator_values: list[int] = []
@@ -978,6 +1479,7 @@ def compute_integral_homology(
 
         groups.append(
             IntegralHomologyGroupValue(
+                kind="FINITELY_GENERATED_ABELIAN_GROUP",
                 degree=degree_plan.degree,
                 chain_rank=degree_plan.chain_rank,
                 incoming_chain_rank=degree_plan.incoming_chain_rank,

--- a/src/jacobian/math/topology/chain_complexes/_models.py
+++ b/src/jacobian/math/topology/chain_complexes/_models.py
@@ -12,7 +12,7 @@ from jacobian.math.topology.chain_complexes.values import (
     MAX_MATRIX_CELLS,
     MAX_OPERATION_MATRIX_CELLS,
     ChainComplexValue,
-    CoefficientField,
+    CoefficientRing,
 )
 
 
@@ -48,7 +48,7 @@ class ConstructChainComplexRequest(StrictModel):
     constructed value satisfies d^2 = 0.
     """
 
-    coefficient_field: CoefficientField = CoefficientField.RATIONAL
+    coefficient_ring: CoefficientRing = CoefficientRing.RATIONAL
     prime: int | None = Field(default=None, ge=2)
     basis_sizes: tuple[int, ...] = Field(
         min_length=1,
@@ -66,8 +66,8 @@ class ConstructChainComplexRequest(StrictModel):
             "adjacent matrices must compose to zero (d^2 = 0). Each entry "
             "is one canonical coefficient string: an integer with no "
             "leading zeros and no negative zero ('0', '5', '-3'), or for "
-            "QQ a fully reduced fraction with denominator >= 2 ('-1/2'); "
-            "for GF(p) only integer residues in [0, p) are accepted. "
+            "QQ a fully reduced fraction with denominator >= 2 ('-1/2'). "
+            "ZZ accepts integers and GF(p) accepts only residues in [0, p). "
             "Parsing is plain integer/fraction string parsing and never "
             "evaluates input."
         )
@@ -90,7 +90,7 @@ class VerifyDifferentialRequest(StrictModel):
 
 
 def _require_component_entry_grammar(
-    coefficient_field: CoefficientField,
+    coefficient_ring: CoefficientRing,
     matrix: tuple[tuple[str, ...], ...],
     *,
     prime: int | None = None,
@@ -105,7 +105,7 @@ def _require_component_entry_grammar(
             # Shape alone does not make an entry parseable: the exact
             # kernels parse entries with Fraction/int and would turn an
             # accepted request into a host exception.
-            _require_rational_entry_grammar(coefficient_field, entry, prime=prime)
+            _require_rational_entry_grammar(coefficient_ring, entry, prime=prime)
     return (
         sum(len(row) for row in matrix),
         sum(len(entry) for row in matrix for entry in row),
@@ -126,11 +126,11 @@ def _require_chain_map_components(
     columns. Degree intervals must coincide so tuple indices are actual
     chain degrees.
     """
-    if source.coefficient_field != target.coefficient_field:
+    if source.coefficient_ring != target.coefficient_ring:
         raise _validation_error(
-            "chain_map_field_mismatch",
-            f"{label} requires equal coefficient fields "
-            f"({source.coefficient_field} vs {target.coefficient_field})",
+            "chain_map_ring_mismatch",
+            f"{label} requires equal coefficient rings "
+            f"({source.coefficient_ring} vs {target.coefficient_ring})",
         )
     if source.prime != target.prime:
         raise _validation_error(
@@ -172,7 +172,7 @@ def _require_chain_map_components(
                 f"{rows}x{cols} (target rows x source columns)",
             )
         cells, chars = _require_component_entry_grammar(
-            source.coefficient_field, matrix, prime=source.prime
+            source.coefficient_ring, matrix, prime=source.prime
         )
         total_map_cells += cells
         total_entry_chars += chars
@@ -223,7 +223,7 @@ class VerifyChainMapRequest(StrictModel):
 
 
 class ComputeHomologyRequest(StrictModel):
-    """Compute homology of a chain complex."""
+    """Compute field or certified integral homology of a chain complex."""
 
     complex: ChainComplexValue
 

--- a/src/jacobian/math/topology/chain_complexes/_models.py
+++ b/src/jacobian/math/topology/chain_complexes/_models.py
@@ -440,7 +440,16 @@ class ComputeHomologyRequest(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def preflight_raw_complex(cls, data: object) -> object:
-        return _preflight_raw_homology_complex(canonicalize_json_containers(data))
+        try:
+            canonical = canonicalize_json_containers(data)
+        except RecursionError as exc:
+            # Inspect the raw outer axes before reporting a nesting failure so
+            # malformed coefficients retain the owner-specific diagnostic.
+            _preflight_raw_homology_complex(data)
+            raise ValueError(
+                "homology input nesting exceeds the supported depth"
+            ) from exc
+        return _preflight_raw_homology_complex(canonical)
 
     @model_validator(mode="after")
     def require_homology_budget(self) -> Self:

--- a/src/jacobian/math/topology/chain_complexes/_models.py
+++ b/src/jacobian/math/topology/chain_complexes/_models.py
@@ -9,7 +9,7 @@ from pydantic import Field, WithJsonSchema, model_validator
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.topology.chain_complexes.values import (
     MAX_BASIS_SIZE,
     MAX_CHAIN_COMPLEX_COEFFICIENT_DIGITS,
@@ -440,7 +440,7 @@ class ComputeHomologyRequest(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def preflight_raw_complex(cls, data: object) -> object:
-        return _preflight_raw_homology_complex(data)
+        return _preflight_raw_homology_complex(canonicalize_json_containers(data))
 
     @model_validator(mode="after")
     def require_homology_budget(self) -> Self:

--- a/src/jacobian/math/topology/chain_complexes/_models.py
+++ b/src/jacobian/math/topology/chain_complexes/_models.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
-from typing import Self
+from collections.abc import Mapping
+from typing import Annotated, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, WithJsonSchema, model_validator
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.topology.chain_complexes.values import (
+    MAX_BASIS_SIZE,
+    MAX_CHAIN_COMPLEX_COEFFICIENT_DIGITS,
+    MAX_CHAIN_DEGREE,
+    MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK,
+    MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS,
+    MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS,
     MAX_MATRIX_CELLS,
     MAX_OPERATION_MATRIX_CELLS,
     ChainComplexValue,
@@ -37,6 +45,186 @@ def _require_complex_cell_budget(
             f"{label} has {cells} differential cells, exceeding the "
             f"{maximum}-cell operation budget",
         )
+
+
+def _homology_input_complex_schema() -> JsonSchemaValue:
+    """Publish the nested parse envelope and the stricter ``ZZ`` branch."""
+
+    schema = ChainComplexValue.model_json_schema()
+    definitions = schema.pop("$defs", {})
+    properties = schema["properties"]
+    coefficient_ring = definitions.get("CoefficientRing")
+    if isinstance(coefficient_ring, dict):
+        properties["coefficient_ring"] = coefficient_ring
+    basis_sizes = properties["basis_sizes"]
+    differentials = properties["differential_matrices"]
+    matrices = differentials["items"]
+    rows = matrices["items"]
+    basis_sizes.update(maxItems=2 * MAX_CHAIN_DEGREE + 1)
+    differentials.update(maxItems=2 * MAX_CHAIN_DEGREE)
+    matrices.update(maxItems=MAX_BASIS_SIZE)
+    rows.update(maxItems=MAX_BASIS_SIZE)
+    schema["description"] = (
+        "A canonical finite based chain complex. Raw nested arrays are bounded "
+        "before canonical value parsing. For ZZ homology, every chain rank is "
+        f"at most {MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK}, differential matrices "
+        f"contain at most {MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS} cells in total, "
+        f"and each coefficient has at most {MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS} "
+        "decimal digits."
+    )
+    schema.setdefault("allOf", []).append(
+        {
+            "if": {
+                "properties": {"coefficient_ring": {"const": "ZZ"}},
+                "required": ["coefficient_ring"],
+            },
+            "then": {
+                "properties": {
+                    "basis_sizes": {
+                        "items": {
+                            "minimum": 0,
+                            "maximum": MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK,
+                            "type": "integer",
+                        }
+                    },
+                    "differential_matrices": {
+                        "items": {
+                            "maxItems": MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK,
+                            "items": {
+                                "maxItems": MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK,
+                                "items": {
+                                    "maxLength": (
+                                        MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS + 1
+                                    ),
+                                    "pattern": (
+                                        "^(?:0|-?[1-9][0-9]{0,"
+                                        f"{MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS - 1}"
+                                        "})$"
+                                    ),
+                                    "type": "string",
+                                },
+                                "type": "array",
+                            },
+                            "type": "array",
+                        },
+                    },
+                }
+            },
+        }
+    )
+    return schema
+
+
+HomologyInputComplex = Annotated[
+    ChainComplexValue,
+    WithJsonSchema(_homology_input_complex_schema()),
+]
+
+
+def _raw_component_digit_count(value: str) -> int:
+    return max(
+        (len(part) - int(part.startswith("-")) for part in value.split("/", 1)),
+        default=0,
+    )
+
+
+def _preflight_raw_differentials(
+    differentials: object,
+    *,
+    maximum_axis: int,
+    maximum_cells: int,
+    maximum_digits: int,
+) -> None:
+    if not isinstance(differentials, (list, tuple)):
+        return
+    if len(differentials) > 2 * MAX_CHAIN_DEGREE:
+        raise _validation_error(
+            "homology_raw_differential_count_exceeded",
+            "homology input has too many raw differential matrices",
+        )
+
+    cells = 0
+    for matrix in differentials:
+        if not isinstance(matrix, (list, tuple)):
+            continue
+        if len(matrix) > maximum_axis:
+            raise _validation_error(
+                "homology_raw_matrix_rows_exceeded",
+                f"a homology differential has more than {maximum_axis} rows",
+            )
+        for row in matrix:
+            if not isinstance(row, (list, tuple)):
+                continue
+            if len(row) > maximum_axis:
+                raise _validation_error(
+                    "homology_raw_matrix_columns_exceeded",
+                    f"a homology differential row has more than {maximum_axis} entries",
+                )
+            cells += len(row)
+            if cells > maximum_cells:
+                raise _validation_error(
+                    "homology_raw_matrix_cells_exceeded",
+                    "homology differential cells exceed the raw "
+                    f"{maximum_cells}-cell envelope",
+                )
+            if any(
+                isinstance(entry, str)
+                and _raw_component_digit_count(entry) > maximum_digits
+                for entry in row
+            ):
+                raise _validation_error(
+                    "homology_raw_coefficient_digits_exceeded",
+                    "a homology coefficient exceeds the raw "
+                    f"{maximum_digits}-digit envelope",
+                )
+
+
+def _preflight_raw_homology_complex(data: object) -> object:
+    """Bound nested homology input before ``ChainComplexValue`` parsing."""
+
+    if not isinstance(data, Mapping):
+        return data
+    raw_complex = data.get("complex")
+    if isinstance(raw_complex, ChainComplexValue) or not isinstance(
+        raw_complex, Mapping
+    ):
+        return canonicalize_json_containers(data)
+
+    raw_ring = raw_complex.get("coefficient_ring")
+    integral = raw_ring in ("ZZ", CoefficientRing.INTEGER)
+    maximum_axis = MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK if integral else MAX_BASIS_SIZE
+    maximum_cells = MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS if integral else MAX_MATRIX_CELLS
+    maximum_digits = (
+        MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS
+        if integral
+        else MAX_CHAIN_COMPLEX_COEFFICIENT_DIGITS
+    )
+
+    basis_sizes = raw_complex.get("basis_sizes")
+    if isinstance(basis_sizes, (list, tuple)):
+        if len(basis_sizes) > 2 * MAX_CHAIN_DEGREE + 1:
+            raise _validation_error(
+                "homology_raw_basis_count_exceeded",
+                "homology input has too many raw chain-group dimensions",
+            )
+        if any(
+            isinstance(size, int)
+            and not isinstance(size, bool)
+            and (size < 0 or size > maximum_axis)
+            for size in basis_sizes
+        ):
+            raise _validation_error(
+                "homology_raw_chain_rank_exceeded",
+                f"homology input chain ranks must be at most {maximum_axis}",
+            )
+
+    _preflight_raw_differentials(
+        raw_complex.get("differential_matrices"),
+        maximum_axis=maximum_axis,
+        maximum_cells=maximum_cells,
+        maximum_digits=maximum_digits,
+    )
+    return canonicalize_json_containers(data)
 
 
 class ConstructChainComplexRequest(StrictModel):
@@ -225,7 +413,12 @@ class VerifyChainMapRequest(StrictModel):
 class ComputeHomologyRequest(StrictModel):
     """Compute field or certified integral homology of a chain complex."""
 
-    complex: ChainComplexValue
+    complex: HomologyInputComplex
+
+    @model_validator(mode="before")
+    @classmethod
+    def preflight_raw_complex(cls, data: object) -> object:
+        return _preflight_raw_homology_complex(data)
 
     @model_validator(mode="after")
     def require_homology_budget(self) -> Self:

--- a/src/jacobian/math/topology/chain_complexes/_models.py
+++ b/src/jacobian/math/topology/chain_complexes/_models.py
@@ -9,7 +9,7 @@ from pydantic import Field, WithJsonSchema, model_validator
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian._models import StrictModel
 from jacobian.math.topology.chain_complexes.values import (
     MAX_BASIS_SIZE,
     MAX_CHAIN_COMPLEX_COEFFICIENT_DIGITS,
@@ -134,9 +134,9 @@ def _preflight_raw_differentials(
     maximum_axis: int,
     maximum_cells: int,
     maximum_digits: int,
-) -> None:
+) -> tuple[tuple[tuple[str, ...], ...], ...] | None:
     if not isinstance(differentials, (list, tuple)):
-        return
+        return None
     if len(differentials) > 2 * MAX_CHAIN_DEGREE:
         raise _validation_error(
             "homology_raw_differential_count_exceeded",
@@ -144,17 +144,25 @@ def _preflight_raw_differentials(
         )
 
     cells = 0
+    canonical_matrices: list[tuple[tuple[str, ...], ...]] = []
     for matrix in differentials:
         if not isinstance(matrix, (list, tuple)):
-            continue
+            raise _validation_error(
+                "homology_raw_matrix_axis_invalid",
+                "each raw homology differential must be an array of rows",
+            )
         if len(matrix) > maximum_axis:
             raise _validation_error(
                 "homology_raw_matrix_rows_exceeded",
                 f"a homology differential has more than {maximum_axis} rows",
             )
+        canonical_rows: list[tuple[str, ...]] = []
         for row in matrix:
             if not isinstance(row, (list, tuple)):
-                continue
+                raise _validation_error(
+                    "homology_raw_row_axis_invalid",
+                    "each raw homology differential row must be an array",
+                )
             if len(row) > maximum_axis:
                 raise _validation_error(
                     "homology_raw_matrix_columns_exceeded",
@@ -167,16 +175,23 @@ def _preflight_raw_differentials(
                     "homology differential cells exceed the raw "
                     f"{maximum_cells}-cell envelope",
                 )
-            if any(
-                isinstance(entry, str)
-                and _raw_component_digit_count(entry) > maximum_digits
-                for entry in row
-            ):
-                raise _validation_error(
-                    "homology_raw_coefficient_digits_exceeded",
-                    "a homology coefficient exceeds the raw "
-                    f"{maximum_digits}-digit envelope",
-                )
+            canonical_entries: list[str] = []
+            for entry in row:
+                if not isinstance(entry, str):
+                    raise _validation_error(
+                        "homology_raw_coefficient_invalid",
+                        "each raw homology coefficient must be a string",
+                    )
+                if _raw_component_digit_count(entry) > maximum_digits:
+                    raise _validation_error(
+                        "homology_raw_coefficient_digits_exceeded",
+                        "a homology coefficient exceeds the raw "
+                        f"{maximum_digits}-digit envelope",
+                    )
+                canonical_entries.append(entry)
+            canonical_rows.append(tuple(canonical_entries))
+        canonical_matrices.append(tuple(canonical_rows))
+    return tuple(canonical_matrices)
 
 
 def _preflight_raw_homology_complex(data: object) -> object:
@@ -188,7 +203,7 @@ def _preflight_raw_homology_complex(data: object) -> object:
     if isinstance(raw_complex, ChainComplexValue) or not isinstance(
         raw_complex, Mapping
     ):
-        return canonicalize_json_containers(data)
+        return data
 
     raw_ring = raw_complex.get("coefficient_ring")
     integral = raw_ring in ("ZZ", CoefficientRing.INTEGER)
@@ -218,13 +233,20 @@ def _preflight_raw_homology_complex(data: object) -> object:
                 f"homology input chain ranks must be at most {maximum_axis}",
             )
 
-    _preflight_raw_differentials(
+    differentials = _preflight_raw_differentials(
         raw_complex.get("differential_matrices"),
         maximum_axis=maximum_axis,
         maximum_cells=maximum_cells,
         maximum_digits=maximum_digits,
     )
-    return canonicalize_json_containers(data)
+    canonical_complex = dict(raw_complex)
+    if isinstance(basis_sizes, (list, tuple)):
+        canonical_complex["basis_sizes"] = tuple(basis_sizes)
+    if differentials is not None:
+        canonical_complex["differential_matrices"] = differentials
+    canonical_data = dict(data)
+    canonical_data["complex"] = canonical_complex
+    return canonical_data
 
 
 class ConstructChainComplexRequest(StrictModel):

--- a/src/jacobian/math/topology/chain_complexes/_smith_process.py
+++ b/src/jacobian/math/topology/chain_complexes/_smith_process.py
@@ -18,6 +18,7 @@ from jacobian._execution import (
     OperationExecutionTimeoutError,
     request_cancelled,
 )
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.matrices.certified_snf.operations import Matrix, SmithReduction
 
 _SMITH_WORKER = Path(__file__).resolve().with_name("_smith_worker.py")
@@ -89,9 +90,16 @@ def _stdout_limit(
 
 
 def _strict_int(value: Any) -> int:
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise ValueError("Smith worker scalar is not an integer")
-    return value
+    # Accept legacy safe JSON numbers in decoded fixtures, while requiring
+    # worker-produced values to use the unbounded canonical string form.
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if not isinstance(value, str):
+        raise ValueError("Smith worker scalar is not an integer string")
+    try:
+        return parse_canonical_integer(value)
+    except ValueError as exc:
+        raise ValueError("Smith worker scalar is not a canonical integer") from exc
 
 
 def _strict_matrix(
@@ -236,7 +244,13 @@ def smith_reduce_in_worker(
     )
 
     input_bytes = json.dumps(
-        {"matrix": source, "row_count": rows, "column_count": columns},
+        {
+            "matrix": [
+                [format_canonical_integer(value) for value in row] for row in source
+            ],
+            "row_count": rows,
+            "column_count": columns,
+        },
         separators=(",", ":"),
     ).encode("utf-8")
     request_digest = hashlib.sha256(input_bytes).hexdigest()

--- a/src/jacobian/math/topology/chain_complexes/_smith_process.py
+++ b/src/jacobian/math/topology/chain_complexes/_smith_process.py
@@ -46,6 +46,21 @@ def _require_active_deadline(deadline: float, *, stage: str) -> None:
         )
 
 
+def _positive_remaining_allowance(deadline: float, *, stage: str) -> float:
+    """Return one positive launch allowance or a typed execution outcome."""
+
+    if request_cancelled():
+        raise OperationExecutionCancelledError(
+            f"request cancelled {stage} integral-homology Smith reduction"
+        )
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise OperationExecutionTimeoutError(
+            f"integral homology deadline expired {stage} Smith worker"
+        )
+    return remaining
+
+
 def _decimal_digits_for_bits(bits: int) -> int:
     return max(1, (max(1, bits) * 30_103 + 99_999) // 100_000 + 1)
 
@@ -242,8 +257,10 @@ def smith_reduce_in_worker(
             # Temporary-directory setup belongs to the inherited request
             # envelope. Recompute the allowance at the actual launch boundary
             # so setup cannot mint a fresh child-process clock.
-            _require_active_deadline(deadline, stage="before launching the")
-            remaining = deadline - time.monotonic()
+            remaining = _positive_remaining_allowance(
+                deadline,
+                stage="before launching the",
+            )
             completed = run_bounded_process(
                 [sys.executable, str(_SMITH_WORKER)],
                 input_bytes=input_bytes,

--- a/src/jacobian/math/topology/chain_complexes/_smith_process.py
+++ b/src/jacobian/math/topology/chain_complexes/_smith_process.py
@@ -1,0 +1,306 @@
+"""Killable SymPy Smith process boundary for integral chain homology."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import sys
+import time
+from dataclasses import dataclass
+from itertools import pairwise
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    request_cancelled,
+)
+from jacobian.math.matrices.certified_snf.operations import Matrix, SmithReduction
+
+_SMITH_WORKER = Path(__file__).resolve().with_name("_smith_worker.py")
+_SMITH_STDERR_LIMIT = 64 * 1024
+_SMITH_ADDRESS_SPACE_BYTES = 2 * 1024 * 1024 * 1024
+_SMITH_FILE_SIZE_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class SmithProcessResult:
+    """Strictly decoded derived projection from one trusted worker."""
+
+    reduction: SmithReduction
+    left_inverse: Matrix
+    right_inverse: Matrix
+
+
+def _require_active_deadline(deadline: float, *, stage: str) -> None:
+    if request_cancelled():
+        raise OperationExecutionCancelledError(
+            f"request cancelled {stage} integral-homology Smith reduction"
+        )
+    if time.monotonic() >= deadline:
+        raise OperationExecutionTimeoutError(
+            f"integral homology deadline expired {stage} Smith worker"
+        )
+
+
+def _decimal_digits_for_bits(bits: int) -> int:
+    return max(1, (max(1, bits) * 30_103 + 99_999) // 100_000 + 1)
+
+
+def _stdout_limit(
+    *,
+    rows: int,
+    columns: int,
+    left_bits: int,
+    right_bits: int,
+    diagonal_bits: int,
+    left_inverse_bits: int,
+    right_inverse_bits: int,
+) -> int:
+    """Bound the concrete JSON worker projection before process launch."""
+
+    weighted_scalars = (
+        rows * columns * (_decimal_digits_for_bits(diagonal_bits) + 4)
+        + rows * rows * (_decimal_digits_for_bits(left_bits) + 4)
+        + columns * columns * (_decimal_digits_for_bits(right_bits) + 4)
+        + rows * rows * (_decimal_digits_for_bits(left_inverse_bits) + 4)
+        + columns * columns * (_decimal_digits_for_bits(right_inverse_bits) + 4)
+    )
+    # Object/array punctuation, factors, determinant fields, and digest.
+    return 4096 + weighted_scalars + 16 * (rows + columns + 1)
+
+
+def _strict_int(value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError("Smith worker scalar is not an integer")
+    return value
+
+
+def _strict_matrix(
+    value: Any,
+    *,
+    rows: int,
+    columns: int,
+    maximum_bits: int,
+) -> Matrix:
+    if not isinstance(value, list) or len(value) != rows:
+        raise ValueError("Smith worker matrix row count is invalid")
+    result: Matrix = []
+    for candidate_row in value:
+        if not isinstance(candidate_row, list) or len(candidate_row) != columns:
+            raise ValueError("Smith worker matrix column count is invalid")
+        row = [_strict_int(item) for item in candidate_row]
+        if any(abs(item).bit_length() > maximum_bits for item in row):
+            raise ValueError("Smith worker matrix exceeded its admitted height")
+        result.append(row)
+    return result
+
+
+def _decode_result(
+    payload: Any,
+    *,
+    request_digest: str,
+    source: Matrix,
+    rows: int,
+    columns: int,
+    left_bits: int,
+    right_bits: int,
+    diagonal_bits: int,
+    left_inverse_bits: int,
+    right_inverse_bits: int,
+) -> SmithProcessResult:
+    if not isinstance(payload, dict) or set(payload) != {
+        "request_digest",
+        "diagonal",
+        "left",
+        "right",
+        "rank",
+        "invariant_factors",
+        "left_determinant",
+        "right_determinant",
+        "left_inverse",
+        "right_inverse",
+    }:
+        raise ValueError("Smith worker result shape is invalid")
+    if payload["request_digest"] != request_digest:
+        raise ValueError("Smith worker result is not bound to the admitted request")
+    diagonal = _strict_matrix(
+        payload["diagonal"],
+        rows=rows,
+        columns=columns,
+        maximum_bits=diagonal_bits,
+    )
+    left = _strict_matrix(
+        payload["left"], rows=rows, columns=rows, maximum_bits=left_bits
+    )
+    right = _strict_matrix(
+        payload["right"],
+        rows=columns,
+        columns=columns,
+        maximum_bits=right_bits,
+    )
+    left_inverse = _strict_matrix(
+        payload["left_inverse"],
+        rows=rows,
+        columns=rows,
+        maximum_bits=left_inverse_bits,
+    )
+    right_inverse = _strict_matrix(
+        payload["right_inverse"],
+        rows=columns,
+        columns=columns,
+        maximum_bits=right_inverse_bits,
+    )
+    rank = _strict_int(payload["rank"])
+    factors_value = payload["invariant_factors"]
+    if not isinstance(factors_value, list):
+        raise ValueError("Smith worker factors are invalid")
+    factors = tuple(_strict_int(value) for value in factors_value)
+    diagonal_values = tuple(
+        diagonal[index][index] for index in range(min(rows, columns))
+    )
+    if (
+        rank != len(factors)
+        or rank > min(rows, columns)
+        or any(value <= 0 for value in factors)
+        or diagonal_values[:rank] != factors
+        or any(value != 0 for value in diagonal_values[rank:])
+        or any(
+            right_factor % left_factor
+            for left_factor, right_factor in pairwise(factors)
+        )
+        or any(
+            diagonal[row][column] != 0
+            for row in range(rows)
+            for column in range(columns)
+            if row != column
+        )
+    ):
+        raise ValueError("Smith worker diagonal is not canonical")
+    left_determinant = _strict_int(payload["left_determinant"])
+    right_determinant = _strict_int(payload["right_determinant"])
+    if abs(left_determinant) != 1 or abs(right_determinant) != 1:
+        raise ValueError("Smith worker transformation determinant is invalid")
+    return SmithProcessResult(
+        reduction=SmithReduction(
+            source=[row[:] for row in source],
+            diagonal=diagonal,
+            left=left,
+            right=right,
+            rank=rank,
+            invariant_factors=factors,
+            left_determinant=left_determinant,
+            right_determinant=right_determinant,
+        ),
+        left_inverse=left_inverse,
+        right_inverse=right_inverse,
+    )
+
+
+def smith_reduce_in_worker(
+    source: Matrix,
+    *,
+    rows: int,
+    columns: int,
+    deadline: float,
+    left_bits: int,
+    right_bits: int,
+    diagonal_bits: int,
+    left_inverse_bits: int,
+    right_inverse_bits: int,
+) -> SmithProcessResult:
+    """Run one admitted exact Smith decomposition in a killable child."""
+
+    from jacobian.process import (
+        ProcessResourceLimits,
+        run_bounded_process,
+        worker_environment,
+    )
+
+    input_bytes = json.dumps(
+        {"matrix": source, "row_count": rows, "column_count": columns},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    request_digest = hashlib.sha256(input_bytes).hexdigest()
+    stdout_limit = _stdout_limit(
+        rows=rows,
+        columns=columns,
+        left_bits=left_bits,
+        right_bits=right_bits,
+        diagonal_bits=diagonal_bits,
+        left_inverse_bits=left_inverse_bits,
+        right_inverse_bits=right_inverse_bits,
+    )
+    _require_active_deadline(deadline, stage="before")
+    try:
+        with TemporaryDirectory(
+            prefix="jacobian-integral-homology-smith-"
+        ) as directory:
+            # Temporary-directory setup belongs to the inherited request
+            # envelope. Recompute the allowance at the actual launch boundary
+            # so setup cannot mint a fresh child-process clock.
+            _require_active_deadline(deadline, stage="before launching the")
+            remaining = deadline - time.monotonic()
+            completed = run_bounded_process(
+                [sys.executable, str(_SMITH_WORKER)],
+                input_bytes=input_bytes,
+                timeout_seconds=remaining,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=stdout_limit,
+                stderr_limit=_SMITH_STDERR_LIMIT,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(remaining)),
+                    address_space_bytes=_SMITH_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_SMITH_FILE_SIZE_BYTES,
+                ),
+                cwd=directory,
+            )
+    except (OperationExecutionCancelledError, OperationExecutionTimeoutError):
+        raise
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded integral-homology Smith worker could not start"
+        ) from exc
+    if completed.cancelled:
+        raise OperationExecutionCancelledError(
+            "request cancelled during integral-homology Smith reduction"
+        )
+    if completed.timed_out:
+        raise OperationExecutionTimeoutError(
+            "integral homology deadline expired during Smith reduction"
+        )
+    _require_active_deadline(deadline, stage="after cleaning up the")
+    if (
+        completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        raise RuntimeError(
+            "bounded integral-homology Smith worker did not establish a reduction"
+        )
+    try:
+        decoded = json.loads(completed.stdout.decode("utf-8"))
+        result = _decode_result(
+            decoded,
+            request_digest=request_digest,
+            source=source,
+            rows=rows,
+            columns=columns,
+            left_bits=left_bits,
+            right_bits=right_bits,
+            diagonal_bits=diagonal_bits,
+            left_inverse_bits=left_inverse_bits,
+            right_inverse_bits=right_inverse_bits,
+        )
+        _require_active_deadline(deadline, stage="after decoding the")
+        return result
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "bounded integral-homology Smith worker returned malformed output"
+        ) from exc
+
+
+__all__ = ["SmithProcessResult", "smith_reduce_in_worker"]

--- a/src/jacobian/math/topology/chain_complexes/_smith_worker.py
+++ b/src/jacobian/math/topology/chain_complexes/_smith_worker.py
@@ -1,0 +1,41 @@
+"""One-shot SymPy Smith-decomposition worker for integral homology."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from typing import Any
+
+
+def main() -> int:
+    input_bytes = sys.stdin.buffer.read()
+    payload: dict[str, Any] = json.loads(input_bytes)
+    source = payload["matrix"]
+    rows = payload["row_count"]
+    columns = payload["column_count"]
+
+    from jacobian.math.matrices.certified_snf.operations import (
+        inverse_unimodular,
+        smith_reduce,
+    )
+
+    reduction = smith_reduce(source, row_count=rows, column_count=columns)
+    response = {
+        "request_digest": hashlib.sha256(input_bytes).hexdigest(),
+        "diagonal": reduction.diagonal,
+        "left": reduction.left,
+        "right": reduction.right,
+        "rank": reduction.rank,
+        "invariant_factors": reduction.invariant_factors,
+        "left_determinant": reduction.left_determinant,
+        "right_determinant": reduction.right_determinant,
+        "left_inverse": inverse_unimodular(reduction.left),
+        "right_inverse": inverse_unimodular(reduction.right),
+    }
+    json.dump(response, sys.stdout, separators=(",", ":"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/topology/chain_complexes/_smith_worker.py
+++ b/src/jacobian/math/topology/chain_complexes/_smith_worker.py
@@ -8,11 +8,39 @@ import sys
 from itertools import pairwise
 from typing import Any
 
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+
 
 def _matrix_entries(matrix: Any, *, rows: int, columns: int) -> list[list[int]]:
     return [
-        [int(matrix[row, column]) for column in range(columns)] for row in range(rows)
+        [_decode_integer(matrix[row, column]) for column in range(columns)]
+        for row in range(rows)
     ]
+
+
+def _decode_integer(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return parse_canonical_integer(value)
+    try:
+        # SymPy Integer exposes an exact Python-int conversion without first
+        # formatting through Python's bounded decimal codec.
+        return int(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("worker matrix entry is not an integer") from exc
+
+
+def _encode_integers(value: Any) -> Any:
+    """Encode every worker integer as an unbounded canonical decimal string."""
+
+    if isinstance(value, int) and not isinstance(value, bool):
+        return format_canonical_integer(value)
+    if isinstance(value, list):
+        return [_encode_integers(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _encode_integers(item) for key, item in value.items()}
+    return value
 
 
 def _inverse_unimodular(matrix: list[list[int]]) -> list[list[int]]:
@@ -47,7 +75,7 @@ def _smith_projection(
     from sympy.matrices.normalforms import smith_normal_decomp
 
     source_matrix = (
-        sympy.Matrix([[int(value) for value in row] for row in source])
+        sympy.Matrix([[_decode_integer(value) for value in row] for row in source])
         if rows and columns
         else sympy.Matrix(rows, columns, [])
     )
@@ -96,10 +124,12 @@ def main() -> int:
     columns = payload["column_count"]
 
     projection = _smith_projection(source, rows=rows, columns=columns)
-    response = {
-        "request_digest": hashlib.sha256(input_bytes).hexdigest(),
-        **projection,
-    }
+    response = _encode_integers(
+        {
+            "request_digest": hashlib.sha256(input_bytes).hexdigest(),
+            **projection,
+        }
+    )
     json.dump(response, sys.stdout, separators=(",", ":"))
     return 0
 

--- a/src/jacobian/math/topology/chain_complexes/_smith_worker.py
+++ b/src/jacobian/math/topology/chain_complexes/_smith_worker.py
@@ -5,7 +5,87 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
+from itertools import pairwise
 from typing import Any
+
+
+def _matrix_entries(matrix: Any, *, rows: int, columns: int) -> list[list[int]]:
+    return [
+        [int(matrix[row, column]) for column in range(columns)] for row in range(rows)
+    ]
+
+
+def _inverse_unimodular(matrix: list[list[int]]) -> list[list[int]]:
+    """Compute the inverse needed by homology coordinates without rechecking it."""
+
+    size = len(matrix)
+    if size == 0:
+        return []
+
+    from sympy import ZZ
+    from sympy.polys.matrices import DomainMatrix
+
+    domain = DomainMatrix(
+        [[ZZ(value) for value in row] for row in matrix],
+        (size, size),
+        ZZ,
+    )
+    numerator, denominator = domain.inv_den(method="rref")
+    if denominator == -ZZ.one:
+        numerator = -numerator
+    elif denominator != ZZ.one:
+        raise ArithmeticError("Smith transformation inverse is not integral")
+    return [[int(value) for value in row] for row in numerator.to_list()]
+
+
+def _smith_projection(
+    source: list[list[int]], *, rows: int, columns: int
+) -> dict[str, Any]:
+    """Compute one owner-private projection with maintained SymPy kernels."""
+
+    import sympy
+    from sympy.matrices.normalforms import smith_normal_decomp
+
+    source_matrix = (
+        sympy.Matrix([[int(value) for value in row] for row in source])
+        if rows and columns
+        else sympy.Matrix(rows, columns, [])
+    )
+    diagonal, left, right = smith_normal_decomp(source_matrix, domain=sympy.ZZ)
+    diagonal_entries = _matrix_entries(diagonal, rows=rows, columns=columns)
+    left_entries = _matrix_entries(left, rows=rows, columns=rows)
+    right_entries = _matrix_entries(right, rows=columns, columns=columns)
+    diagonal_values = tuple(
+        diagonal_entries[index][index] for index in range(min(rows, columns))
+    )
+    factors = tuple(value for value in diagonal_values if value != 0)
+    if (
+        diagonal_values[: len(factors)] != factors
+        or any(value != 0 for value in diagonal_values[len(factors) :])
+        or any(value <= 0 for value in factors)
+        or any(
+            right_factor % left_factor
+            for left_factor, right_factor in pairwise(factors)
+        )
+        or any(
+            diagonal_entries[row][column] != 0
+            for row in range(rows)
+            for column in range(columns)
+            if row != column
+        )
+    ):
+        raise ArithmeticError("SymPy returned a noncanonical Smith diagonal")
+    return {
+        "diagonal": diagonal_entries,
+        "left": left_entries,
+        "right": right_entries,
+        "rank": len(factors),
+        "invariant_factors": factors,
+        "left_determinant": int(left.det()),
+        "right_determinant": int(right.det()),
+        "left_inverse": _inverse_unimodular(left_entries),
+        "right_inverse": _inverse_unimodular(right_entries),
+    }
 
 
 def main() -> int:
@@ -15,23 +95,10 @@ def main() -> int:
     rows = payload["row_count"]
     columns = payload["column_count"]
 
-    from jacobian.math.matrices.certified_snf.operations import (
-        inverse_unimodular,
-        smith_reduce,
-    )
-
-    reduction = smith_reduce(source, row_count=rows, column_count=columns)
+    projection = _smith_projection(source, rows=rows, columns=columns)
     response = {
         "request_digest": hashlib.sha256(input_bytes).hexdigest(),
-        "diagonal": reduction.diagonal,
-        "left": reduction.left,
-        "right": reduction.right,
-        "rank": reduction.rank,
-        "invariant_factors": reduction.invariant_factors,
-        "left_determinant": reduction.left_determinant,
-        "right_determinant": reduction.right_determinant,
-        "left_inverse": inverse_unimodular(reduction.left),
-        "right_inverse": inverse_unimodular(reduction.right),
+        **projection,
     }
     json.dump(response, sys.stdout, separators=(",", ":"))
     return 0

--- a/src/jacobian/math/topology/chain_complexes/_tools.py
+++ b/src/jacobian/math/topology/chain_complexes/_tools.py
@@ -35,7 +35,7 @@ def _construct(request: ConstructChainComplexRequest) -> ChainComplexValue:
         return construct_chain_complex(
             request.basis_sizes,
             request.differential_matrices,
-            coefficient_field=request.coefficient_field,
+            coefficient_ring=request.coefficient_ring,
             prime=request.prime,
         )
     except ValidationError as exc:
@@ -80,13 +80,21 @@ def _tensor_product(request: TensorProductRequest) -> TensorProductResult:
 
 
 _CIRCLE_COMPLEX = {
-    "coefficient_field": "QQ",
+    "coefficient_ring": "QQ",
     "degree_min": 0,
     "degree_max": 1,
     "basis_sizes": [3, 3],
     "differential_matrices": [
         [["-1", "1", "0"], ["0", "-1", "1"], ["0", "0", "0"]],
     ],
+}
+
+_MULTIPLICATION_BY_SIX_COMPLEX = {
+    "coefficient_ring": "ZZ",
+    "degree_min": 0,
+    "degree_max": 1,
+    "basis_sizes": [1, 1],
+    "differential_matrices": [[["6"]]],
 }
 
 
@@ -96,7 +104,7 @@ TOOLS: MathTools = (
         title="Construct a finite based chain complex",
         description=(
             "Construct a bounded homological chain complex from differential "
-            "matrices over QQ or a prime field."
+            "matrices over ZZ, QQ, or a prime field."
         ),
         request_type=ConstructChainComplexRequest,
         result_type=ChainComplexValue,
@@ -111,7 +119,7 @@ TOOLS: MathTools = (
                 "x basis_sizes[i+1], and adjacent matrices must compose to "
                 "zero (d^2 = 0).",
                 {
-                    "coefficient_field": "QQ",
+                    "coefficient_ring": "QQ",
                     "basis_sizes": [3, 3],
                     "differential_matrices": [
                         [["-1", "1", "0"], ["0", "-1", "1"], ["0", "0", "0"]],
@@ -163,18 +171,33 @@ TOOLS: MathTools = (
         operation_id="chain_complex.homology.compute",
         title="Compute homology of a chain complex",
         description=(
-            "Compute the homology groups (Betti numbers) of a bounded chain "
-            "complex over QQ or a prime field using exact linear algebra."
+            "Compute exact homology of a bounded finite based chain complex. "
+            "Over QQ or GF(p), return vector-space ranks. Over ZZ, return "
+            "finitely generated abelian groups with invariant factors, "
+            "source-basis free and torsion cycles, torsion bounding chains, "
+            "and both Smith transformation certificates in every degree."
         ),
         request_type=ComputeHomologyRequest,
         result_type=HomologyResult,
         run=_homology,
-        tags=("chain-complex", "homology", "exact"),
+        tags=(
+            "chain-complex",
+            "homology",
+            "integer-homology",
+            "torsion",
+            "smith-normal-form",
+            "exact",
+        ),
         examples=(
             example(
                 "circle_homology",
                 "Compute homology of the circle (Betti numbers 1, 1).",
                 {"complex": _CIRCLE_COMPLEX},
+            ),
+            example(
+                "multiplication_by_six_homology",
+                "Compute H_0 = Z/6 and its torsion cycle and bounding chain.",
+                {"complex": _MULTIPLICATION_BY_SIX_COMPLEX},
             ),
         ),
     ),

--- a/src/jacobian/math/topology/chain_complexes/operations.py
+++ b/src/jacobian/math/topology/chain_complexes/operations.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from fractions import Fraction
 
 from jacobian.canonical import format_canonical_integer
+from jacobian.math.topology.chain_complexes._integral_homology import (
+    admit_integral_homology,
+    compute_integral_homology,
+)
 from jacobian.math.topology.chain_complexes._models import (
     _require_chain_map_components,
     _require_complex_cell_budget,
@@ -17,9 +21,10 @@ from jacobian.math.topology.chain_complexes.values import (
     MAX_TENSOR_GROUP_DIMENSION,
     MAX_TENSOR_TOTAL_CELLS,
     ChainComplexValue,
-    CoefficientField,
+    CoefficientRing,
     HomologyGroupValue,
     HomologyResult,
+    IntegralHomologyGroupValue,
     MappingConeResult,
     TensorProductResult,
     VerificationResult,
@@ -48,10 +53,10 @@ class ChainComplexAdmissionError(ValueError):
 def _require_tensor_admission(
     left: ChainComplexValue, right: ChainComplexValue
 ) -> None:
-    if left.coefficient_field != right.coefficient_field or left.prime != right.prime:
+    if left.coefficient_ring != right.coefficient_ring or left.prime != right.prime:
         raise ChainComplexAdmissionError(
             "tensor_context_mismatch",
-            "tensor product requires same coefficient field and prime",
+            "tensor product requires same coefficient ring and prime",
         )
     group_count = len(left.basis_sizes) + len(right.basis_sizes) - 1
     group_sizes: list[int] = []
@@ -114,7 +119,7 @@ def _require_tensor_admission(
         for index in range(max(0, group_count - 1))
     )
     ChainComplexValue(
-        coefficient_field=left.coefficient_field,
+        coefficient_ring=left.coefficient_ring,
         prime=left.prime,
         degree_min=tensor_degree_min,
         degree_max=tensor_degree_min + group_count - 1,
@@ -158,7 +163,7 @@ def _require_cone_admission(
         for index in range(max(0, len(cone_basis_sizes) - 1))
     )
     ChainComplexValue(
-        coefficient_field=source.coefficient_field,
+        coefficient_ring=source.coefficient_ring,
         prime=source.prime,
         degree_min=source.degree_min,
         degree_max=source.degree_min + len(cone_basis_sizes) - 1,
@@ -559,12 +564,12 @@ def _require_mapping_cone_parents(
     source: ChainComplexValue,
     target: ChainComplexValue,
 ) -> None:
-    """A cone is defined only over one coefficient field on one interval."""
+    """A cone is defined only over one coefficient ring on one interval."""
     if (
-        source.coefficient_field != target.coefficient_field
+        source.coefficient_ring != target.coefficient_ring
         or source.prime != target.prime
     ):
-        raise ValueError("mapping cone requires same coefficient field and prime")
+        raise ValueError("mapping cone requires same coefficient ring and prime")
     if (source.degree_min, source.degree_max) != (
         target.degree_min,
         target.degree_max,
@@ -915,8 +920,8 @@ def _compute_tensor_product(
 ) -> tuple[tuple[int, ...], tuple[tuple[tuple[str, ...], ...], ...]]:
     """Exact tensor-product construction shared by the operation and its
     result validator."""
-    if left.coefficient_field != right.coefficient_field or left.prime != right.prime:
-        raise ValueError("tensor product requires same coefficient field and prime")
+    if left.coefficient_ring != right.coefficient_ring or left.prime != right.prime:
+        raise ValueError("tensor product requires same coefficient ring and prime")
     prime = left.prime
 
     tensor_basis_sizes = _tensor_group_sizes(left, right)
@@ -961,7 +966,7 @@ def construct_chain_complex(
     basis_sizes: tuple[int, ...],
     differential_matrices: tuple[tuple[tuple[str, ...], ...], ...],
     *,
-    coefficient_field: CoefficientField = CoefficientField.RATIONAL,
+    coefficient_ring: CoefficientRing = CoefficientRing.RATIONAL,
     prime: int | None = None,
 ) -> ChainComplexValue:
     """Construct an admitted canonical chain-complex value.
@@ -970,7 +975,7 @@ def construct_chain_complex(
     :class:`ChainComplexValue`; adjacent differentials must compose to zero.
     """
     value = ChainComplexValue(
-        coefficient_field=coefficient_field,
+        coefficient_ring=coefficient_ring,
         prime=prime,
         degree_min=0,
         degree_max=len(basis_sizes) - 1,
@@ -999,9 +1004,13 @@ def homology_groups(complex_value: ChainComplexValue) -> HomologyResult:
         maximum=MAX_MATRIX_CELLS,
         label="homology input",
     )
-    groups = _compute_homology_groups(complex_value)
+    groups: tuple[HomologyGroupValue | IntegralHomologyGroupValue, ...]
+    if complex_value.coefficient_ring is CoefficientRing.INTEGER:
+        groups = compute_integral_homology(admit_integral_homology(complex_value))
+    else:
+        groups = tuple(_compute_homology_groups(complex_value))
     return HomologyResult._from_kernel(
-        homology_groups=tuple(groups),
+        homology_groups=groups,
         source_complex=complex_value,
     )
 
@@ -1060,7 +1069,7 @@ def mapping_cone(
     _require_cone_admission(source, target, map_matrices)
     cone_basis_sizes, cone_diffs = _compute_mapping_cone(source, target, map_matrices)
     value = ChainComplexValue(
-        coefficient_field=source.coefficient_field,
+        coefficient_ring=source.coefficient_ring,
         prime=source.prime,
         degree_min=source.degree_min,
         degree_max=source.degree_min + len(cone_basis_sizes) - 1,
@@ -1094,7 +1103,7 @@ def tensor_product_complex(
     degree_min = left.degree_min + right.degree_min
     degree_max = degree_min + group_count - 1
     value = ChainComplexValue(
-        coefficient_field=left.coefficient_field,
+        coefficient_ring=left.coefficient_ring,
         prime=left.prime,
         degree_min=degree_min,
         degree_max=degree_max,

--- a/src/jacobian/math/topology/chain_complexes/operations.py
+++ b/src/jacobian/math/topology/chain_complexes/operations.py
@@ -523,6 +523,7 @@ def _compute_homology_groups(
 
         groups.append(
             HomologyGroupValue(
+                kind="FIELD_VECTOR_SPACE",
                 degree=actual_degree,
                 cycle_rank=cycle_rank,
                 boundary_rank=incoming_rank,

--- a/src/jacobian/math/topology/chain_complexes/values.py
+++ b/src/jacobian/math/topology/chain_complexes/values.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Self
+from typing import Annotated, Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
+from jacobian.math.matrices.certified_snf.values import (
+    MAX_CERTIFIED_SNF_DIMENSION,
+    MAX_CERTIFIED_SNF_INPUT_DIGITS,
+    MAX_CERTIFIED_SNF_OUTPUT_DIGITS,
+    CertifiedIntegerMatrix,
+    SmithNormalFormCertificate,
+)
 
 MAX_CHAIN_DEGREE = 32
 MAX_BASIS_SIZE = 64
@@ -34,20 +42,39 @@ MAX_MATRIX_ENTRY_CHARS = 65536
 # spelling bounded before the derived matrices are materialized.
 MAX_TENSOR_COEFFICIENT_DIGITS = 512
 
+# Integral homology emits full Smith transformations. Its admitted group size
+# therefore cannot exceed the canonical certified-matrix dimension. The input
+# digit limit matches the maintained Smith primitive; the separate aggregate
+# bounds cover all degrees of one finite complex.
+MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK = MAX_CERTIFIED_SNF_DIMENSION
+MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS = MAX_CERTIFIED_SNF_INPUT_DIGITS
+MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK = 100
+MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS = 2500
+MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS = MAX_CERTIFIED_SNF_OUTPUT_DIGITS
+# The bit-height and scalar-count limits jointly bound the complete exact
+# certificate/representative payload without truncating any returned integer.
+MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS = 3 * MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS
+MAX_INTEGRAL_HOMOLOGY_OUTPUT_SCALARS = 65_536
+MAX_INTEGRAL_HOMOLOGY_WORK_UNITS = 5_000_000
+INTEGRAL_HOMOLOGY_WALL_SECONDS = 120.0
+
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"chain_complex.{reason}", message)
 
 
-class CoefficientField(StrEnum):
+class CoefficientRing(StrEnum):
+    """Exact coefficient rings supported by finite based chain complexes."""
+
+    INTEGER = "ZZ"
     RATIONAL = "QQ"
     PRIME_FIELD = "GF_p"
 
 
 class ChainComplexValue(StrictModel):
-    """A finite based chain complex over an exact field."""
+    """A finite based chain complex over an exact coefficient ring."""
 
-    coefficient_field: CoefficientField
+    coefficient_ring: CoefficientRing
     prime: int | None = Field(default=None, ge=2)
     degree_min: int = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE)
     degree_max: int = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE)
@@ -56,7 +83,7 @@ class ChainComplexValue(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical_chain_complex(self) -> Self:
-        _require_prime_coupling(self.coefficient_field, self.prime)
+        _require_prime_coupling(self.coefficient_ring, self.prime)
         # Degree consistency
         if self.degree_max < self.degree_min:
             raise _validation_error(
@@ -108,7 +135,7 @@ class ChainComplexValue(StrictModel):
                     )
                 for entry in row:
                     _require_rational_entry_grammar(
-                        self.coefficient_field,
+                        self.coefficient_ring,
                         entry,
                         prime=self.prime,
                     )
@@ -130,10 +157,10 @@ class ChainComplexValue(StrictModel):
 
 
 def _require_prime_coupling(
-    coefficient_field: CoefficientField, prime: int | None
+    coefficient_ring: CoefficientRing, prime: int | None
 ) -> None:
-    """GF_p carries a bounded prime modulus; QQ carries none."""
-    if coefficient_field == CoefficientField.PRIME_FIELD:
+    """GF(p) carries a bounded prime modulus; QQ and ZZ carry none."""
+    if coefficient_ring == CoefficientRing.PRIME_FIELD:
         if prime is None:
             raise _validation_error("prime_required", "GF_p requires a prime modulus")
         if not 2 <= prime <= 1000003:
@@ -155,7 +182,8 @@ def _require_prime_coupling(
             divisor += 2
     elif prime is not None:
         raise _validation_error(
-            "prime_forbidden", "QQ coefficient field must not have a prime modulus"
+            "prime_forbidden",
+            "QQ and ZZ coefficient rings must not have a prime modulus",
         )
 
 
@@ -198,7 +226,7 @@ def _require_canonical_fraction_entry(entry: str) -> None:
 
 
 def _require_rational_entry_grammar(
-    coefficient_field: CoefficientField,
+    coefficient_ring: CoefficientRing,
     entry: object,
     *,
     prime: int | None = None,
@@ -226,10 +254,10 @@ def _require_rational_entry_grammar(
         )
 
     if "/" in entry:
-        if coefficient_field == CoefficientField.PRIME_FIELD:
+        if coefficient_ring != CoefficientRing.RATIONAL:
             raise _validation_error(
-                "prime_field_entry_not_integer",
-                f"prime-field entry '{entry}' must be an integer residue",
+                "coefficient_entry_not_integer",
+                f"{coefficient_ring.value} entry '{entry}' must be an integer",
             )
         _require_canonical_fraction_entry(entry)
         return
@@ -238,7 +266,7 @@ def _require_rational_entry_grammar(
         raise _validation_error(
             "entry_digit_bound_exceeded", "differential entry exceeds digit bound"
         )
-    if coefficient_field == CoefficientField.PRIME_FIELD and (
+    if coefficient_ring == CoefficientRing.PRIME_FIELD and (
         value < 0 or (prime is not None and value >= prime)
     ):
         raise _validation_error(
@@ -249,19 +277,181 @@ def _require_rational_entry_grammar(
 
 
 class HomologyGroupValue(StrictModel):
-    """One homology group of a chain complex."""
+    """One homology vector space over QQ or GF(p)."""
 
+    kind: Literal["FIELD_VECTOR_SPACE"] = "FIELD_VECTOR_SPACE"
     degree: int
     cycle_rank: int = Field(ge=0)
     boundary_rank: int = Field(ge=0)
     betti_number: int = Field(ge=0)
 
 
+class IntegralVector(StrictModel):
+    """Coordinates of one integral chain in its retained source basis."""
+
+    coefficients: tuple[CanonicalInteger, ...] = Field(
+        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK
+    )
+
+    @model_validator(mode="after")
+    def require_output_digit_budget(self) -> Self:
+        if any(
+            len(value.lstrip("-")) > MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS
+            for value in self.coefficients
+        ):
+            raise _validation_error(
+                "integral_homology_output_digit_budget_exceeded",
+                "integral homology vector exceeds the certified output digit bound",
+            )
+        return self
+
+
+class IntegralFreeGenerator(StrictModel):
+    """One free homology generator in source and cycle-basis coordinates."""
+
+    cycle: IntegralVector
+    cycle_coordinates: IntegralVector
+
+
+class IntegralTorsionGenerator(StrictModel):
+    """One torsion cycle together with a chain bounding its exact multiple."""
+
+    order: CanonicalInteger
+    cycle: IntegralVector
+    cycle_coordinates: IntegralVector
+    bounding_chain: IntegralVector
+
+    @model_validator(mode="after")
+    def require_nontrivial_bounded_order(self) -> Self:
+        if (
+            int(self.order) <= 1
+            or len(self.order.lstrip("-")) > MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS
+        ):
+            raise _validation_error(
+                "integral_homology_torsion_order_invalid",
+                "torsion generator order must be a bounded integer greater than one",
+            )
+        return self
+
+
+class IntegralHomologyGroupValue(StrictModel):
+    """One finitely generated integral homology group with representatives."""
+
+    kind: Literal["FINITELY_GENERATED_ABELIAN_GROUP"] = (
+        "FINITELY_GENERATED_ABELIAN_GROUP"
+    )
+    degree: StrictInt = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE)
+    chain_rank: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK)
+    incoming_chain_rank: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK)
+    outgoing_boundary_rank: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK)
+    cycle_rank: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK)
+    incoming_boundary_rank: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK)
+    free_rank: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK)
+    torsion_invariant_factors: tuple[CanonicalInteger, ...] = Field(
+        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK
+    )
+    free_generators: tuple[IntegralFreeGenerator, ...] = Field(
+        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK
+    )
+    torsion_generators: tuple[IntegralTorsionGenerator, ...] = Field(
+        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK
+    )
+    outgoing_smith_certificate: SmithNormalFormCertificate
+    boundary_in_cycle_coordinates: CertifiedIntegerMatrix
+    incoming_smith_certificate: SmithNormalFormCertificate
+    generator_basis: Literal[
+        "SOURCE_CHAIN_BASIS_VIA_CERTIFIED_SMITH_TRANSFORMATIONS"
+    ] = "SOURCE_CHAIN_BASIS_VIA_CERTIFIED_SMITH_TRANSFORMATIONS"
+
+    @model_validator(mode="after")
+    def require_complete_integral_group_ledger(self) -> Self:
+        outgoing = self.outgoing_smith_certificate
+        incoming = self.incoming_smith_certificate
+        if (
+            outgoing.source.column_count != self.chain_rank
+            or outgoing.rank != self.outgoing_boundary_rank
+            or self.cycle_rank != self.chain_rank - self.outgoing_boundary_rank
+            or (
+                self.boundary_in_cycle_coordinates.row_count,
+                self.boundary_in_cycle_coordinates.column_count,
+            )
+            != (self.cycle_rank, self.incoming_chain_rank)
+            or incoming.source != self.boundary_in_cycle_coordinates
+            or incoming.rank != self.incoming_boundary_rank
+            or self.free_rank != self.cycle_rank - self.incoming_boundary_rank
+            or len(self.free_generators) != self.free_rank
+        ):
+            raise _validation_error(
+                "integral_homology_ledger_invalid",
+                "integral homology ranks and Smith certificate shapes are inconsistent",
+            )
+        torsion = tuple(
+            factor for factor in incoming.invariant_factors if int(factor) > 1
+        )
+        if (
+            self.torsion_invariant_factors != torsion
+            or tuple(item.order for item in self.torsion_generators) != torsion
+        ):
+            raise _validation_error(
+                "integral_homology_torsion_ledger_invalid",
+                "torsion generators must match the nontrivial Smith factors",
+            )
+        if any(
+            len(item.cycle.coefficients) != self.chain_rank
+            or len(item.cycle_coordinates.coefficients) != self.cycle_rank
+            for item in self.free_generators
+        ) or any(
+            len(item.cycle.coefficients) != self.chain_rank
+            or len(item.cycle_coordinates.coefficients) != self.cycle_rank
+            or len(item.bounding_chain.coefficients) != self.incoming_chain_rank
+            for item in self.torsion_generators
+        ):
+            raise _validation_error(
+                "integral_homology_generator_shape_invalid",
+                "integral homology generators must use the retained chain bases",
+            )
+        return self
+
+
+HomologyGroup = Annotated[
+    HomologyGroupValue | IntegralHomologyGroupValue,
+    Field(discriminator="kind"),
+]
+
+
+def _require_integral_group_source_binding(
+    source: ChainComplexValue,
+    groups: tuple[HomologyGroup, ...],
+) -> None:
+    """Bind every integral certificate axis and source matrix structurally."""
+
+    for index, group in enumerate(groups):
+        if not isinstance(group, IntegralHomologyGroupValue):
+            continue
+        outgoing_rows = source.basis_sizes[index - 1] if index > 0 else 0
+        incoming_rank = (
+            source.basis_sizes[index + 1] if index + 1 < len(source.basis_sizes) else 0
+        )
+        outgoing_entries = source.differential_matrices[index - 1] if index > 0 else ()
+        certified_source = group.outgoing_smith_certificate.source
+        if (
+            group.chain_rank != source.basis_sizes[index]
+            or group.incoming_chain_rank != incoming_rank
+            or certified_source.row_count != outgoing_rows
+            or certified_source.column_count != group.chain_rank
+            or certified_source.entries != outgoing_entries
+        ):
+            raise _validation_error(
+                "integral_homology_source_mismatch",
+                "integral homology group axes and outgoing Smith source must match the retained chain complex",
+            )
+
+
 class HomologyResult(StrictModel):
     """Homology of a retained source chain complex."""
 
-    homology_groups: tuple[HomologyGroupValue, ...]
-    coefficient_field: CoefficientField
+    homology_groups: tuple[HomologyGroup, ...]
+    coefficient_ring: CoefficientRing
     prime: int | None = Field(default=None, ge=2)
     degree_min: int = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE, default=0)
     degree_max: int = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE, default=0)
@@ -269,7 +459,7 @@ class HomologyResult(StrictModel):
 
     @model_validator(mode="after")
     def require_prime_coupling(self) -> Self:
-        if self.coefficient_field == CoefficientField.PRIME_FIELD:
+        if self.coefficient_ring == CoefficientRing.PRIME_FIELD:
             if self.prime is None:
                 raise _validation_error(
                     "homology_prime_required", "GF_p homology requires a prime"
@@ -277,7 +467,8 @@ class HomologyResult(StrictModel):
         else:
             if self.prime is not None:
                 raise _validation_error(
-                    "homology_prime_forbidden", "QQ homology must not have a prime"
+                    "homology_prime_forbidden",
+                    "QQ and ZZ homology must not have a prime",
                 )
         return self
 
@@ -299,12 +490,12 @@ class HomologyResult(StrictModel):
                 "degree interval must match the retained complex",
             )
         if (
-            self.coefficient_field != self.complex.coefficient_field
+            self.coefficient_ring != self.complex.coefficient_ring
             or self.prime != self.complex.prime
         ):
             raise _validation_error(
                 "homology_context_mismatch",
-                "coefficient field and prime must match the retained complex",
+                "coefficient ring and prime must match the retained complex",
             )
         expected_degrees = list(
             range(self.complex.degree_min, self.complex.degree_max + 1)
@@ -316,7 +507,7 @@ class HomologyResult(StrictModel):
                 "complex exactly once",
             )
         for group in self.homology_groups:
-            if (
+            if isinstance(group, HomologyGroupValue) and (
                 group.betti_number != group.cycle_rank - group.boundary_rank
                 or group.betti_number < 0
                 or group.cycle_rank < 0
@@ -327,18 +518,32 @@ class HomologyResult(StrictModel):
                     f"homology group at degree {group.degree} violates "
                     "betti_number = cycle_rank - boundary_rank",
                 )
+        integral = self.coefficient_ring is CoefficientRing.INTEGER
+        if any(
+            isinstance(group, IntegralHomologyGroupValue) != integral
+            for group in self.homology_groups
+        ):
+            raise _validation_error(
+                "homology_group_branch_mismatch",
+                "homology group branches must be homogeneous and match the retained coefficient ring",
+            )
+        if integral:
+            _require_integral_group_source_binding(
+                self.complex,
+                self.homology_groups,
+            )
         return self
 
     @classmethod
     def _from_kernel(
         cls,
         *,
-        homology_groups: tuple[HomologyGroupValue, ...],
+        homology_groups: tuple[HomologyGroupValue | IntegralHomologyGroupValue, ...],
         source_complex: ChainComplexValue,
     ) -> Self:
         return cls.model_construct(
             homology_groups=homology_groups,
-            coefficient_field=source_complex.coefficient_field,
+            coefficient_ring=source_complex.coefficient_ring,
             prime=source_complex.prime,
             degree_min=source_complex.degree_min,
             degree_max=source_complex.degree_max,
@@ -349,7 +554,7 @@ class HomologyResult(StrictModel):
 class MappingConeResult(StrictModel):
     """The mapping cone of a retained chain map.
 
-    The derived complex retains its coefficient field, prime, and degree
+    The derived complex retains its coefficient ring, prime, and degree
     interval as a first-class chain-complex value so it composes into
     homology, tensor, map, and cone operations unchanged.
     """
@@ -387,7 +592,7 @@ class MappingConeResult(StrictModel):
             )
         expected_degree_max = self.source.degree_min + len(self.value.basis_sizes) - 1
         if (
-            self.value.coefficient_field != self.source.coefficient_field
+            self.value.coefficient_ring != self.source.coefficient_ring
             or self.value.prime != self.source.prime
             or self.value.degree_min != self.source.degree_min
             or self.value.degree_max != expected_degree_max
@@ -424,14 +629,14 @@ class MappingConeResult(StrictModel):
 class TensorProductResult(StrictModel):
     """The tensor product of two retained chain complexes.
 
-    The derived complex retains its coefficient field, prime, and degree
+    The derived complex retains its coefficient ring, prime, and degree
         interval so it composes into downstream consumers as a first-class
         chain-complex value. Both factors are retained as source context.
     """
 
     tensor_basis_sizes: tuple[int, ...]
     tensor_differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
-    coefficient_field: CoefficientField
+    coefficient_ring: CoefficientRing
     prime: int | None = Field(default=None, ge=2)
     degree_min: int
     degree_max: int
@@ -442,16 +647,16 @@ class TensorProductResult(StrictModel):
     @model_validator(mode="after")
     def require_structural_context(self) -> Self:
         if self.left.prime != self.right.prime or (
-            self.left.coefficient_field != self.right.coefficient_field
+            self.left.coefficient_ring != self.right.coefficient_ring
         ):
             raise _validation_error(
                 "tensor_context_mismatch",
-                "tensor product requires same coefficient field and prime",
+                "tensor product requires same coefficient ring and prime",
             )
-        if self.coefficient_field != self.value.coefficient_field:
+        if self.coefficient_ring != self.value.coefficient_ring:
             raise _validation_error(
                 "tensor_result_field_mismatch",
-                "coefficient field must match the retained value",
+                "coefficient ring must match the retained value",
             )
         if self.prime != self.value.prime:
             raise _validation_error(
@@ -467,7 +672,7 @@ class TensorProductResult(StrictModel):
                 "the retained factors",
             )
         if (
-            self.value.coefficient_field != self.left.coefficient_field
+            self.value.coefficient_ring != self.left.coefficient_ring
             or self.value.prime != self.left.prime
             or self.value.degree_min != derived_min
             or self.value.degree_max != derived_max
@@ -488,10 +693,7 @@ class TensorProductResult(StrictModel):
                 "tensor projections must equal the retained canonical "
                 "tensor-product complex",
             )
-        if (
-            self.coefficient_field is CoefficientField.PRIME_FIELD
-            and self.prime is None
-        ):
+        if self.coefficient_ring is CoefficientRing.PRIME_FIELD and self.prime is None:
             raise _validation_error(
                 "tensor_prime_required", "GF_p tensor products must carry their prime"
             )
@@ -510,7 +712,7 @@ class TensorProductResult(StrictModel):
         return cls.model_construct(
             tensor_basis_sizes=tensor_basis_sizes,
             tensor_differential_matrices=tensor_differential_matrices,
-            coefficient_field=left.coefficient_field,
+            coefficient_ring=left.coefficient_ring,
             prime=left.prime,
             degree_min=value.degree_min,
             degree_max=value.degree_max,
@@ -521,17 +723,31 @@ class TensorProductResult(StrictModel):
 
 
 __all__ = [
+    "INTEGRAL_HOMOLOGY_WALL_SECONDS",
     "MAX_BASIS_SIZE",
     "MAX_CHAIN_DEGREE",
+    "MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK",
+    "MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS",
+    "MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS",
+    "MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS",
+    "MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS",
+    "MAX_INTEGRAL_HOMOLOGY_OUTPUT_SCALARS",
+    "MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK",
+    "MAX_INTEGRAL_HOMOLOGY_WORK_UNITS",
     "MAX_MATRIX_CELLS",
     "MAX_OPERATION_MATRIX_CELLS",
     "MAX_TENSOR_COEFFICIENT_DIGITS",
     "MAX_TENSOR_GROUP_DIMENSION",
     "MAX_TENSOR_TOTAL_CELLS",
     "ChainComplexValue",
-    "CoefficientField",
+    "CoefficientRing",
+    "HomologyGroup",
     "HomologyGroupValue",
     "HomologyResult",
+    "IntegralFreeGenerator",
+    "IntegralHomologyGroupValue",
+    "IntegralTorsionGenerator",
+    "IntegralVector",
     "MappingConeResult",
     "TensorProductResult",
     "VerificationResult",

--- a/src/jacobian/math/topology/chain_complexes/values.py
+++ b/src/jacobian/math/topology/chain_complexes/values.py
@@ -38,6 +38,7 @@ MAX_CHAIN_MAP_ENTRY_CHARS = 65536
 # total coefficient size to the matrix work bounds rational elimination
 # bit complexity at admission instead of only bounding input shape.
 MAX_MATRIX_ENTRY_CHARS = 65536
+MAX_CHAIN_COMPLEX_COEFFICIENT_DIGITS = 4096
 # Tensor products may multiply and add two coefficients; keep their input
 # spelling bounded before the derived matrices are materialized.
 MAX_TENSOR_COEFFICIENT_DIGITS = 512
@@ -216,7 +217,10 @@ def _require_canonical_fraction_entry(entry: str) -> None:
             "zero_not_canonical",
             f"entry '{entry}' is not canonically spelled; spell zero as '0'",
         )
-    if len(num_str.lstrip("-")) > 4096 or len(den_str.lstrip("-")) > 4096:
+    if (
+        len(num_str.lstrip("-")) > MAX_CHAIN_COMPLEX_COEFFICIENT_DIGITS
+        or len(den_str.lstrip("-")) > MAX_CHAIN_COMPLEX_COEFFICIENT_DIGITS
+    ):
         raise _validation_error(
             "entry_digit_bound_exceeded", "differential entry exceeds digit bound"
         )
@@ -266,7 +270,7 @@ def _require_rational_entry_grammar(
         _require_canonical_fraction_entry(entry)
         return
     value = _require_canonical_integer_spelling(entry, entry)
-    if len(entry.lstrip("-")) > 4096:
+    if len(entry.lstrip("-")) > MAX_CHAIN_COMPLEX_COEFFICIENT_DIGITS:
         raise _validation_error(
             "entry_digit_bound_exceeded", "differential entry exceeds digit bound"
         )
@@ -727,6 +731,7 @@ class TensorProductResult(StrictModel):
 __all__ = [
     "INTEGRAL_HOMOLOGY_WALL_SECONDS",
     "MAX_BASIS_SIZE",
+    "MAX_CHAIN_COMPLEX_COEFFICIENT_DIGITS",
     "MAX_CHAIN_DEGREE",
     "MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK",
     "MAX_INTEGRAL_HOMOLOGY_INPUT_DIGITS",

--- a/src/jacobian/math/topology/chain_complexes/values.py
+++ b/src/jacobian/math/topology/chain_complexes/values.py
@@ -56,7 +56,11 @@ MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS = MAX_CERTIFIED_SNF_OUTPUT_DIGITS
 MAX_INTEGRAL_HOMOLOGY_OUTPUT_BITS = 3 * MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS
 MAX_INTEGRAL_HOMOLOGY_OUTPUT_SCALARS = 65_536
 MAX_INTEGRAL_HOMOLOGY_WORK_UNITS = 5_000_000
-INTEGRAL_HOMOLOGY_WALL_SECONDS = 120.0
+# The exact work envelope can legitimately take minutes. This 30-minute
+# killable owner ceiling is a safety backstop for the bounded SymPy child, not
+# a mathematical admission rule; ordinary unit/diagonal requests finish in the
+# in-process presolve without launching it.
+INTEGRAL_HOMOLOGY_WALL_SECONDS = 30.0 * 60.0
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -279,7 +283,7 @@ def _require_rational_entry_grammar(
 class HomologyGroupValue(StrictModel):
     """One homology vector space over QQ or GF(p)."""
 
-    kind: Literal["FIELD_VECTOR_SPACE"] = "FIELD_VECTOR_SPACE"
+    kind: Literal["FIELD_VECTOR_SPACE"]
     degree: int
     cycle_rank: int = Field(ge=0)
     boundary_rank: int = Field(ge=0)
@@ -337,9 +341,7 @@ class IntegralTorsionGenerator(StrictModel):
 class IntegralHomologyGroupValue(StrictModel):
     """One finitely generated integral homology group with representatives."""
 
-    kind: Literal["FINITELY_GENERATED_ABELIAN_GROUP"] = (
-        "FINITELY_GENERATED_ABELIAN_GROUP"
-    )
+    kind: Literal["FINITELY_GENERATED_ABELIAN_GROUP"]
     degree: StrictInt = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE)
     chain_rank: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK)
     incoming_chain_rank: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_RANK)

--- a/src/jacobian/math/topology/operations.py
+++ b/src/jacobian/math/topology/operations.py
@@ -17,11 +17,6 @@ from jacobian.math.topology.chain_complexes.values import ChainComplexValue
 
 def simplicial_chain_complex_value(result: ChainComplexResult) -> ChainComplexValue:
     """Return the canonical chain-complex value carried by a chain result."""
-    if result.canonical_value is None:
-        raise ValueError(
-            "only unreduced prime-field simplicial chain complexes convert "
-            "to a canonical chain-complex value"
-        )
     return result.canonical_value
 
 

--- a/tests/dispatch/test_more_owner_admission_boundaries.py
+++ b/tests/dispatch/test_more_owner_admission_boundaries.py
@@ -36,7 +36,7 @@ def test_factor_length_admission_is_typed_after_wire_parsing() -> None:
 
 def test_chain_complex_count_admission_is_typed_after_wire_parsing() -> None:
     payload = {
-        "coefficient_field": "QQ",
+        "coefficient_ring": "QQ",
         "basis_sizes": [1, 1, 1],
         "differential_matrices": [[["0"]]],
     }
@@ -52,7 +52,7 @@ def test_chain_complex_count_admission_is_typed_after_wire_parsing() -> None:
 
 def test_chain_complex_differential_admission_is_typed_after_wire_parsing() -> None:
     payload = {
-        "coefficient_field": "QQ",
+        "coefficient_ring": "QQ",
         "basis_sizes": [1, 1, 1],
         "differential_matrices": [[["1"]], [["1"]]],
     }
@@ -67,6 +67,29 @@ def test_chain_complex_differential_admission_is_typed_after_wire_parsing() -> N
             "msg": "constructed complex violates d^2=0 at chain degree 1",
         },
     )
+
+
+def test_integral_chain_homology_parses_and_serializes_typed_output() -> None:
+    result = invoke_operation(
+        "chain_complex.homology.compute",
+        {
+            "complex": {
+                "coefficient_ring": "ZZ",
+                "degree_min": 0,
+                "degree_max": 1,
+                "basis_sizes": [1, 1],
+                "differential_matrices": [[["6"]]],
+            }
+        },
+        Catalog.open(),
+    )
+
+    assert result.output["coefficient_ring"] == "ZZ"
+    assert [group["kind"] for group in result.output["homology_groups"]] == [
+        "FINITELY_GENERATED_ABELIAN_GROUP",
+        "FINITELY_GENERATED_ABELIAN_GROUP",
+    ]
+    assert result.output["homology_groups"][0]["torsion_invariant_factors"] == ["6"]
 
 
 def test_comultiplication_index_admission_is_typed_after_wire_parsing() -> None:

--- a/tests/math/topology/chain_complexes/test_chain_complexes.py
+++ b/tests/math/topology/chain_complexes/test_chain_complexes.py
@@ -1,5 +1,6 @@
 """Tests for chain complex operations (#1824)."""
 
+import json
 from fractions import Fraction
 from itertools import combinations
 from typing import Any, NoReturn, cast
@@ -95,138 +96,21 @@ def _point_complex() -> ChainComplexValue:
     )
 
 
-class _IntegralWorkObserver:
-    """Count executed scalar primitives without reading admission estimates."""
+def test_native_owner_exports_canonical_chain_and_integral_homology_types() -> None:
+    import jacobian.math.topology.chain_complexes as owner
 
-    def __init__(self, kernel: Any) -> None:
-        self.kernel = kernel
-        self.executed = {
-            "parse": 0,
-            "square_zero": 0,
-            "smith": 0,
-            "reconstruction": 0,
-            "output": 0,
-        }
-        self.phase = "smith"
-        self._parse_integer = kernel.parse_canonical_integer
-        self._square_zero = kernel._require_square_zero
-        self._matrix_bits = kernel._matrix_bits
-        self._multiply = kernel.matrix_multiply
-        self._vector_multiply = kernel.matrix_vector_multiply
-        self._smith_admission = kernel._smith_admission
-        self._swap_rows = kernel._swap_rows
-        self._swap_columns = kernel._swap_columns
-        self._scale_row = kernel._scale_row
-        self._scale_column = kernel._scale_column
-        self._add_row = kernel._add_row_multiple
-        self._add_column = kernel._add_column_multiple
-
-    @staticmethod
-    def _scalar_cells(matrix: list[list[int]]) -> int:
-        return sum(len(row) for row in matrix)
-
-    def parse_integer(self, value: str) -> int:
-        self.executed["parse"] += len(value) + 1
-        return cast(int, self._parse_integer(value))
-
-    def square_zero(
-        self, source: ChainComplexValue, differentials: tuple[list[list[int]], ...]
-    ) -> int:
-        self.phase = "square_zero"
-        try:
-            return cast(int, self._square_zero(source, differentials))
-        finally:
-            self.phase = "smith"
-
-    def matrix_bits(self, matrix: list[list[int]]) -> int:
-        if self.phase in self.executed:
-            self.executed[self.phase] += self._scalar_cells(matrix)
-        return cast(int, self._matrix_bits(matrix))
-
-    def multiply(
-        self, left: list[list[int]], right: list[list[int]], **kwargs: Any
-    ) -> list[list[int]]:
-        inner = len(left[0]) if left else len(right)
-        columns = (
-            len(right[0]) if right else int(kwargs.get("right_columns_if_empty", 0))
+    assert owner.ChainComplexValue is ChainComplexValue
+    assert owner.CoefficientRing is CoefficientRing
+    assert owner.HomologyResult is HomologyResult
+    assert owner.IntegralHomologyGroupValue is IntegralHomologyGroupValue
+    assert all(
+        value.__module__.endswith("chain_complexes.values")
+        for value in (
+            owner.IntegralFreeGenerator,
+            owner.IntegralTorsionGenerator,
+            owner.IntegralVector,
         )
-        if self.phase in self.executed:
-            self.executed[self.phase] += len(left) * inner * columns
-            self.executed[self.phase] += len(left) * columns
-        return cast(list[list[int]], self._multiply(left, right, **kwargs))
-
-    def vector_multiply(self, matrix: list[list[int]], vector: list[int]) -> list[int]:
-        if self.phase in self.executed:
-            self.executed[self.phase] += len(matrix) * len(vector) + len(matrix)
-        return cast(list[int], self._vector_multiply(matrix, vector))
-
-    def smith_admission(self, *args: Any, **kwargs: Any) -> Any:
-        bound, presolved = self._smith_admission(*args, **kwargs)
-        if presolved is not None:
-            reduction = presolved.reduction
-            self.executed["smith"] += sum(
-                self._scalar_cells(matrix)
-                for matrix in (
-                    reduction.source,
-                    reduction.diagonal,
-                    reduction.left,
-                    reduction.right,
-                    presolved.left_inverse,
-                    presolved.right_inverse,
-                )
-            )
-        return bound, presolved
-
-    def swap_rows(self, matrix: list[list[int]], left: int, right: int) -> int:
-        if left != right:
-            self.executed["smith"] += len(matrix[left])
-        return cast(int, self._swap_rows(matrix, left, right))
-
-    def swap_columns(self, matrix: list[list[int]], left: int, right: int) -> int:
-        if left != right:
-            self.executed["smith"] += len(matrix)
-        return cast(int, self._swap_columns(matrix, left, right))
-
-    def scale_row(self, matrix: list[list[int]], row: int, factor: int) -> int:
-        self.executed["smith"] += len(matrix[row])
-        return cast(int, self._scale_row(matrix, row, factor))
-
-    def scale_column(self, matrix: list[list[int]], column: int, factor: int) -> int:
-        self.executed["smith"] += len(matrix)
-        return cast(int, self._scale_column(matrix, column, factor))
-
-    def add_row(
-        self, matrix: list[list[int]], *, target: int, source: int, factor: int
-    ) -> int:
-        self.executed["smith"] += 2 * len(matrix[target])
-        return cast(
-            int,
-            self._add_row(matrix, target=target, source=source, factor=factor),
-        )
-
-    def add_column(
-        self, matrix: list[list[int]], *, target: int, source: int, factor: int
-    ) -> int:
-        self.executed["smith"] += 2 * len(matrix)
-        return cast(
-            int,
-            self._add_column(matrix, target=target, source=source, factor=factor),
-        )
-
-    @classmethod
-    def count_output_scalars(cls, value: Any) -> int:
-        if isinstance(value, bool):
-            return 0
-        if isinstance(value, int):
-            return 1
-        if isinstance(value, str):
-            digits = value[1:] if value.startswith("-") else value
-            return int(bool(digits) and digits.isdigit())
-        if isinstance(value, dict):
-            return sum(cls.count_output_scalars(item) for item in value.values())
-        if isinstance(value, (list, tuple)):
-            return sum(cls.count_output_scalars(item) for item in value)
-        return 0
+    )
 
 
 class TestConstructChainComplex:
@@ -490,6 +374,21 @@ class TestIntegralHomology:
             int(torsion.order) * int(value) for value in torsion.cycle.coefficients
         )
 
+    def test_zero_incoming_map_does_not_inherit_transformation_height(self) -> None:
+        complex_value = self._complex(
+            (2, 2, 2),
+            (
+                (("2", "2"), ("2", "2")),
+                (("0", "0"), ("0", "0")),
+            ),
+        )
+
+        groups = _integral_groups(homology_groups(complex_value))
+
+        assert tuple(
+            (group.free_rank, group.torsion_invariant_factors) for group in groups
+        ) == ((1, ("2",)), (1, ()), (2, ()))
+
     def test_signed_permutation_differential_is_admitted_exactly(self) -> None:
         """A unit-equivalent differential has zero homology in both degrees.
 
@@ -585,6 +484,35 @@ class TestIntegralHomology:
             "chain_complex.integral_homology_height_budget_exceeded"
         )
 
+    def test_canonical_result_byte_bound_rejects_before_backend_execution(self) -> None:
+        from jacobian.canonical import CanonicalLimits
+        from jacobian.math.topology.chain_complexes._integral_homology import (
+            admit_integral_homology,
+        )
+
+        def upper_bidiagonal_complex(rank: int) -> ChainComplexValue:
+            coefficient = "9" * 32
+            matrix = tuple(
+                tuple(
+                    "1" if row == column else coefficient if column == row + 1 else "0"
+                    for column in range(rank)
+                )
+                for row in range(rank)
+            )
+            return self._complex(
+                (rank, rank),
+                (matrix,),
+            )
+
+        admitted = admit_integral_homology(upper_bidiagonal_complex(24))
+        assert admitted.output_byte_bound <= CanonicalLimits().max_output_bytes
+
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            homology_groups(upper_bidiagonal_complex(28))
+        assert exc_info.value.errors()[0]["type"] == (
+            "chain_complex.integral_homology_output_byte_budget_exceeded"
+        )
+
     def test_result_discriminator_rejects_mixed_group_branches(self) -> None:
         result = homology_groups(self._complex((1, 1), ((("2",),),)))
         payload = result.model_dump(mode="json")
@@ -615,6 +543,144 @@ class TestIntegralHomology:
             with pytest.raises(ValidationError, match="kind"):
                 HomologyResult.model_validate(payload)
 
+    def test_integral_homology_schema_publishes_nested_array_limits(self) -> None:
+        schema = ComputeHomologyRequest.model_json_schema()
+        complex_schema = schema["properties"]["complex"]
+        properties = complex_schema["properties"]
+        assert properties["basis_sizes"]["maxItems"] == 65
+        differentials = properties["differential_matrices"]
+        assert differentials["maxItems"] == 64
+        assert differentials["items"]["maxItems"] == 64
+        assert differentials["items"]["items"]["maxItems"] == 64
+
+        integral_branch = complex_schema["allOf"][0]["then"]["properties"]
+        assert integral_branch["basis_sizes"]["items"]["maximum"] == 32
+        integral_matrices = integral_branch["differential_matrices"]["items"]
+        assert integral_matrices["maxItems"] == 32
+        assert integral_matrices["items"]["maxItems"] == 32
+        assert integral_matrices["items"]["items"]["maxLength"] == 33
+
+    @pytest.mark.parametrize(
+        ("payload", "error_type"),
+        (
+            (
+                {
+                    "coefficient_ring": "ZZ",
+                    "degree_min": -32,
+                    "degree_max": 32,
+                    "basis_sizes": [0] * 65,
+                    "differential_matrices": [[]] * 65,
+                },
+                "chain_complex.homology_raw_differential_count_exceeded",
+            ),
+            (
+                {
+                    "coefficient_ring": "ZZ",
+                    "degree_min": 0,
+                    "degree_max": 1,
+                    "basis_sizes": [33, 1],
+                    "differential_matrices": [[["0"]] for _ in range(33)],
+                },
+                "chain_complex.homology_raw_chain_rank_exceeded",
+            ),
+            (
+                {
+                    "coefficient_ring": "ZZ",
+                    "degree_min": 0,
+                    "degree_max": 3,
+                    "basis_sizes": [32, 32, 32, 32],
+                    "differential_matrices": [
+                        [["0"] * 32 for _ in range(32)] for _ in range(3)
+                    ],
+                },
+                "chain_complex.homology_raw_matrix_cells_exceeded",
+            ),
+            (
+                {
+                    "coefficient_ring": "ZZ",
+                    "degree_min": 0,
+                    "degree_max": 1,
+                    "basis_sizes": [1, 1],
+                    "differential_matrices": [[["-" + "9" * 33]]],
+                },
+                "chain_complex.homology_raw_coefficient_digits_exceeded",
+            ),
+        ),
+    )
+    def test_raw_integral_homology_limits_precede_nested_value_parsing(
+        self,
+        payload: dict[str, Any],
+        error_type: str,
+    ) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ComputeHomologyRequest.model_validate({"complex": payload})
+        assert exc_info.value.errors()[0]["type"] == error_type
+
+    def test_raw_integral_homology_digit_and_axis_boundaries_validate(self) -> None:
+        matrix = [["0"] * 32 for _ in range(32)]
+        request = ComputeHomologyRequest.model_validate(
+            {
+                "complex": {
+                    "coefficient_ring": "ZZ",
+                    "degree_min": 0,
+                    "degree_max": 1,
+                    "basis_sizes": [32, 32],
+                    "differential_matrices": [matrix],
+                }
+            }
+        )
+        assert request.complex.basis_sizes == (32, 32)
+
+        signed = ComputeHomologyRequest.model_validate_json(
+            json.dumps(
+                {
+                    "complex": {
+                        "coefficient_ring": "ZZ",
+                        "degree_min": 0,
+                        "degree_max": 1,
+                        "basis_sizes": [1, 1],
+                        "differential_matrices": [[["-" + "9" * 32]]],
+                    }
+                }
+            ),
+            strict=True,
+        )
+        assert signed.complex.differential_matrices[0][0][0].startswith("-")
+
+        maximum_count = ComputeHomologyRequest.model_validate(
+            {
+                "complex": {
+                    "coefficient_ring": "ZZ",
+                    "degree_min": -32,
+                    "degree_max": 32,
+                    "basis_sizes": [0] * 65,
+                    "differential_matrices": [[] for _ in range(64)],
+                }
+            }
+        )
+        assert len(maximum_count.complex.differential_matrices) == 64
+
+        matrix_25 = [["0"] * 25 for _ in range(25)]
+        maximum_cells = ComputeHomologyRequest.model_validate(
+            {
+                "complex": {
+                    "coefficient_ring": "ZZ",
+                    "degree_min": 0,
+                    "degree_max": 4,
+                    "basis_sizes": [25] * 5,
+                    "differential_matrices": [matrix_25 for _ in range(4)],
+                }
+            }
+        )
+        assert (
+            sum(
+                len(row)
+                for matrix_value in maximum_cells.complex.differential_matrices
+                for row in matrix_value
+            )
+            == 2_500
+        )
+
     def test_integral_certificates_remain_bound_to_retained_differentials(
         self,
     ) -> None:
@@ -634,6 +700,7 @@ class TestIntegralHomology:
         from jacobian._execution import current_request_execution, request_execution
         from jacobian.math.topology.chain_complexes._integral_homology import (
             admit_integral_homology,
+            compute_integral_homology,
         )
         from jacobian.math.topology.chain_complexes.values import (
             INTEGRAL_HOMOLOGY_WALL_SECONDS,
@@ -654,8 +721,19 @@ class TestIntegralHomology:
             plan.parse_work
             + plan.square_zero_work
             + plan.smith_work
-            + plan.reconstruction_work
+            + plan.result_construction_work
             + plan.output_scalar_count
+        )
+        from jacobian.canonical import CanonicalLimits, encode_strict_json
+
+        assert plan.output_byte_bound <= CanonicalLimits().max_output_bytes
+        result = HomologyResult._from_kernel(
+            homology_groups=compute_integral_homology(plan),
+            source_complex=complex_value,
+        )
+        assert (
+            len(encode_strict_json(result.model_dump(mode="json")))
+            <= plan.output_byte_bound
         )
 
     def test_expired_dispatch_deadline_stops_before_integral_admission(self) -> None:
@@ -689,51 +767,6 @@ class TestIntegralHomology:
         ):
             homology_groups(self._complex((2, 2), ((("2", "2"), ("2", "2")),)))
 
-    def test_real_tetrahedron_kernel_stays_within_every_charged_work_class(
-        self,
-    ) -> None:
-        from jacobian.math.topology.chain_complexes import _integral_homology as kernel
-
-        complex_value = self._simplex_complex(4)
-        observer = _IntegralWorkObserver(kernel)
-
-        with (
-            patch.object(kernel, "parse_canonical_integer", observer.parse_integer),
-            patch.object(kernel, "_require_square_zero", observer.square_zero),
-            patch.object(kernel, "_matrix_bits", observer.matrix_bits),
-            patch.object(kernel, "_smith_admission", observer.smith_admission),
-            patch.object(kernel, "matrix_multiply", observer.multiply),
-            patch.object(kernel, "matrix_vector_multiply", observer.vector_multiply),
-            patch.object(kernel, "_swap_rows", observer.swap_rows),
-            patch.object(kernel, "_swap_columns", observer.swap_columns),
-            patch.object(kernel, "_scale_row", observer.scale_row),
-            patch.object(kernel, "_scale_column", observer.scale_column),
-            patch.object(kernel, "_add_row_multiple", observer.add_row),
-            patch.object(kernel, "_add_column_multiple", observer.add_column),
-        ):
-            plan = kernel.admit_integral_homology(complex_value)
-            observer.phase = "reconstruction"
-            groups = kernel.compute_integral_homology(plan)
-        result = HomologyResult._from_kernel(
-            homology_groups=groups,
-            source_complex=complex_value,
-        )
-        observer.executed["output"] = observer.count_output_scalars(
-            result.model_dump(mode="json")
-        )
-
-        assert tuple(group.free_rank for group in groups) == (1, 0, 0, 0)
-        assert_charged_work_parity(
-            charged={
-                "parse": plan.parse_work,
-                "square_zero": plan.square_zero_work,
-                "smith": plan.smith_work,
-                "reconstruction": plan.reconstruction_work,
-                "output": plan.output_scalar_count,
-            },
-            executed=observer.executed,
-        )
-
     @pytest.mark.parametrize(("rows", "columns"), ((0, 32), (32, 0)))
     def test_zero_endpoint_smith_charge_covers_retained_transformations(
         self, rows: int, columns: int
@@ -766,7 +799,7 @@ class TestIntegralHomology:
             executed={"smith": retained_scalars},
         )
 
-    def test_general_smith_charge_covers_actual_worker_jobs(self) -> None:
+    def test_general_smith_charge_covers_actual_worker_work_units(self) -> None:
         from jacobian.math.topology.chain_complexes import _integral_homology as kernel
         from jacobian.math.topology.chain_complexes import _smith_process
 
@@ -775,19 +808,41 @@ class TestIntegralHomology:
             ((("2", "2"), ("2", "2")),),
         )
         plan = kernel.admit_integral_homology(complex_value)
+        executed_work = 0
+        original = _smith_process.smith_reduce_in_worker
+
+        def counted_worker(
+            source: list[list[int]],
+            *,
+            rows: int,
+            columns: int,
+            **kwargs: Any,
+        ) -> Any:
+            nonlocal executed_work
+            executed_work += kernel._smith_height_bound(
+                source,
+                rows=rows,
+                columns=columns,
+            ).work_units
+            return original(
+                source,
+                rows=rows,
+                columns=columns,
+                **kwargs,
+            )
 
         with patch.object(
             _smith_process,
             "smith_reduce_in_worker",
-            wraps=_smith_process.smith_reduce_in_worker,
-        ) as smith_worker:
+            side_effect=counted_worker,
+        ):
             groups = kernel.compute_integral_homology(plan)
 
-        assert smith_worker.call_count > 0
+        assert executed_work > 0
         assert tuple(group.free_rank for group in groups) == (1, 1)
         assert_charged_work_parity(
             charged={"smith": plan.smith_work},
-            executed={"smith": smith_worker.call_count},
+            executed={"smith": executed_work},
         )
 
 
@@ -1358,11 +1413,20 @@ class TestNativeSurface:
             tensor_product_complex(factor, factor)
 
     def test_native_surface_excludes_wire_envelope_handlers(self) -> None:
-        """The authoritative package __all__ advertises only value-based
+        """The native package exports canonical values and value-based
         functions; request handlers stay private to operations/_tools."""
         import jacobian.math.topology.chain_complexes as chain_complexes_package
 
         assert set(chain_complexes_package.__all__) == {
+            "ChainComplexValue",
+            "CoefficientRing",
+            "HomologyGroup",
+            "HomologyGroupValue",
+            "HomologyResult",
+            "IntegralFreeGenerator",
+            "IntegralHomologyGroupValue",
+            "IntegralTorsionGenerator",
+            "IntegralVector",
             "chain_map_commutes",
             "construct_chain_complex",
             "differential_squares_to_zero",

--- a/tests/math/topology/chain_complexes/test_chain_complexes.py
+++ b/tests/math/topology/chain_complexes/test_chain_complexes.py
@@ -1,10 +1,13 @@
 """Tests for chain complex operations (#1824)."""
 
 from fractions import Fraction
+from itertools import combinations
 from typing import Any, NoReturn, cast
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
+from tests.fixtures.accounting import assert_charged_work_parity
 
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.topology.chain_complexes._models import (
@@ -90,6 +93,140 @@ def _point_complex() -> ChainComplexValue:
         basis_sizes=(1,),
         differential_matrices=(),
     )
+
+
+class _IntegralWorkObserver:
+    """Count executed scalar primitives without reading admission estimates."""
+
+    def __init__(self, kernel: Any) -> None:
+        self.kernel = kernel
+        self.executed = {
+            "parse": 0,
+            "square_zero": 0,
+            "smith": 0,
+            "reconstruction": 0,
+            "output": 0,
+        }
+        self.phase = "smith"
+        self._parse_integer = kernel.parse_canonical_integer
+        self._square_zero = kernel._require_square_zero
+        self._matrix_bits = kernel._matrix_bits
+        self._multiply = kernel.matrix_multiply
+        self._vector_multiply = kernel.matrix_vector_multiply
+        self._smith_admission = kernel._smith_admission
+        self._swap_rows = kernel._swap_rows
+        self._swap_columns = kernel._swap_columns
+        self._scale_row = kernel._scale_row
+        self._scale_column = kernel._scale_column
+        self._add_row = kernel._add_row_multiple
+        self._add_column = kernel._add_column_multiple
+
+    @staticmethod
+    def _scalar_cells(matrix: list[list[int]]) -> int:
+        return sum(len(row) for row in matrix)
+
+    def parse_integer(self, value: str) -> int:
+        self.executed["parse"] += len(value) + 1
+        return cast(int, self._parse_integer(value))
+
+    def square_zero(
+        self, source: ChainComplexValue, differentials: tuple[list[list[int]], ...]
+    ) -> int:
+        self.phase = "square_zero"
+        try:
+            return cast(int, self._square_zero(source, differentials))
+        finally:
+            self.phase = "smith"
+
+    def matrix_bits(self, matrix: list[list[int]]) -> int:
+        if self.phase in self.executed:
+            self.executed[self.phase] += self._scalar_cells(matrix)
+        return cast(int, self._matrix_bits(matrix))
+
+    def multiply(
+        self, left: list[list[int]], right: list[list[int]], **kwargs: Any
+    ) -> list[list[int]]:
+        inner = len(left[0]) if left else len(right)
+        columns = (
+            len(right[0]) if right else int(kwargs.get("right_columns_if_empty", 0))
+        )
+        if self.phase in self.executed:
+            self.executed[self.phase] += len(left) * inner * columns
+            self.executed[self.phase] += len(left) * columns
+        return cast(list[list[int]], self._multiply(left, right, **kwargs))
+
+    def vector_multiply(self, matrix: list[list[int]], vector: list[int]) -> list[int]:
+        if self.phase in self.executed:
+            self.executed[self.phase] += len(matrix) * len(vector) + len(matrix)
+        return cast(list[int], self._vector_multiply(matrix, vector))
+
+    def smith_admission(self, *args: Any, **kwargs: Any) -> Any:
+        bound, presolved = self._smith_admission(*args, **kwargs)
+        if presolved is not None:
+            reduction = presolved.reduction
+            self.executed["smith"] += sum(
+                self._scalar_cells(matrix)
+                for matrix in (
+                    reduction.source,
+                    reduction.diagonal,
+                    reduction.left,
+                    reduction.right,
+                    presolved.left_inverse,
+                    presolved.right_inverse,
+                )
+            )
+        return bound, presolved
+
+    def swap_rows(self, matrix: list[list[int]], left: int, right: int) -> int:
+        if left != right:
+            self.executed["smith"] += len(matrix[left])
+        return cast(int, self._swap_rows(matrix, left, right))
+
+    def swap_columns(self, matrix: list[list[int]], left: int, right: int) -> int:
+        if left != right:
+            self.executed["smith"] += len(matrix)
+        return cast(int, self._swap_columns(matrix, left, right))
+
+    def scale_row(self, matrix: list[list[int]], row: int, factor: int) -> int:
+        self.executed["smith"] += len(matrix[row])
+        return cast(int, self._scale_row(matrix, row, factor))
+
+    def scale_column(self, matrix: list[list[int]], column: int, factor: int) -> int:
+        self.executed["smith"] += len(matrix)
+        return cast(int, self._scale_column(matrix, column, factor))
+
+    def add_row(
+        self, matrix: list[list[int]], *, target: int, source: int, factor: int
+    ) -> int:
+        self.executed["smith"] += 2 * len(matrix[target])
+        return cast(
+            int,
+            self._add_row(matrix, target=target, source=source, factor=factor),
+        )
+
+    def add_column(
+        self, matrix: list[list[int]], *, target: int, source: int, factor: int
+    ) -> int:
+        self.executed["smith"] += 2 * len(matrix)
+        return cast(
+            int,
+            self._add_column(matrix, target=target, source=source, factor=factor),
+        )
+
+    @classmethod
+    def count_output_scalars(cls, value: Any) -> int:
+        if isinstance(value, bool):
+            return 0
+        if isinstance(value, int):
+            return 1
+        if isinstance(value, str):
+            digits = value[1:] if value.startswith("-") else value
+            return int(bool(digits) and digits.isdigit())
+        if isinstance(value, dict):
+            return sum(cls.count_output_scalars(item) for item in value.values())
+        if isinstance(value, (list, tuple)):
+            return sum(cls.count_output_scalars(item) for item in value)
+        return 0
 
 
 class TestConstructChainComplex:
@@ -240,6 +377,32 @@ class TestIntegralHomology:
             for row in matrix
         )
 
+    @classmethod
+    def _simplex_complex(cls, vertex_count: int) -> ChainComplexValue:
+        """Canonical oriented chain complex of one full simplex."""
+
+        bases = tuple(
+            tuple(combinations(range(vertex_count), size))
+            for size in range(1, vertex_count + 1)
+        )
+        differentials: list[tuple[tuple[str, ...], ...]] = []
+        for dimension in range(1, vertex_count):
+            target_index = {
+                face: index for index, face in enumerate(bases[dimension - 1])
+            }
+            rows = [[0] * len(bases[dimension]) for _ in bases[dimension - 1]]
+            for column, simplex in enumerate(bases[dimension]):
+                for removed in range(len(simplex)):
+                    face = simplex[:removed] + simplex[removed + 1 :]
+                    rows[target_index[face]][column] = 1 if removed % 2 == 0 else -1
+            differentials.append(
+                tuple(tuple(str(value) for value in row) for row in rows)
+            )
+        return cls._complex(
+            tuple(len(basis) for basis in bases),
+            tuple(differentials),
+        )
+
     def test_zz_contract_rejects_fractional_entries(self) -> None:
         with pytest.raises(ValidationError, match="must be an integer"):
             self._complex((1, 1), ((("1/2",),),))
@@ -261,6 +424,30 @@ class TestIntegralHomology:
             complex_value.differential_matrices[0],
             torsion.bounding_chain.coefficients,
         ) == tuple(order * int(value) for value in torsion.cycle.coefficients)
+
+    @pytest.mark.parametrize("rank", (17, 32))
+    def test_zero_endpoint_certificates_round_trip_through_maximum_dimension(
+        self, rank: int
+    ) -> None:
+        result = homology_groups(self._complex((rank,), ()))
+        payload = result.model_dump(mode="json")
+        serialized = HomologyResult.model_validate(payload)
+        group = _integral_groups(serialized)[0]
+
+        assert (
+            group.outgoing_smith_certificate.source.row_count,
+            group.outgoing_smith_certificate.source.column_count,
+        ) == (0, rank)
+        assert (
+            group.incoming_smith_certificate.source.row_count,
+            group.incoming_smith_certificate.source.column_count,
+        ) == (rank, 0)
+        identity = tuple(
+            tuple("1" if row == column else "0" for column in range(rank))
+            for row in range(rank)
+        )
+        assert group.outgoing_smith_certificate.right_transformation.entries == identity
+        assert group.incoming_smith_certificate.left_transformation.entries == identity
 
     def test_non_simplicial_non_ternary_basis_changes_preserve_mixed_group(
         self,
@@ -302,6 +489,43 @@ class TestIntegralHomology:
         ) == tuple(
             int(torsion.order) * int(value) for value in torsion.cycle.coefficients
         )
+
+    def test_signed_permutation_differential_is_admitted_exactly(self) -> None:
+        """A unit-equivalent differential has zero homology in both degrees.
+
+        This is the smallest generic regression for the structural Smith
+        presolve: shape-only transformation-height recurrences used to reject
+        this useful exact case even though unit elimination stays tiny.
+        """
+
+        signed_permutation = (
+            ("0", "0", "-1", "0"),
+            ("1", "0", "0", "0"),
+            ("0", "0", "0", "1"),
+            ("0", "-1", "0", "0"),
+        )
+        result = homology_groups(self._complex((4, 4), (signed_permutation,)))
+
+        assert tuple(
+            (group.free_rank, group.torsion_invariant_factors)
+            for group in _integral_groups(result)
+        ) == ((0, ()), (0, ()))
+
+    def test_signed_permutation_presolve_reaches_the_chain_rank_boundary(self) -> None:
+        rank = 32
+        signed_reverse = tuple(
+            tuple(
+                ("-1" if row % 2 else "1") if column == rank - row - 1 else "0"
+                for column in range(rank)
+            )
+            for row in range(rank)
+        )
+
+        groups = _integral_groups(
+            homology_groups(self._complex((rank, rank), (signed_reverse,)))
+        )
+
+        assert tuple(group.free_rank for group in groups) == (0, 0)
 
     def test_zz_tensor_producer_composes_back_into_integral_homology(self) -> None:
         multiplication = self._complex((1, 1), ((("6",),),))
@@ -374,6 +598,23 @@ class TestIntegralHomology:
         with pytest.raises(ValidationError, match="homogeneous"):
             HomologyResult.model_validate(payload)
 
+    def test_group_discriminators_are_required_in_schema_and_validation(self) -> None:
+        schema = HomologyResult.model_json_schema()
+        for definition in (
+            "HomologyGroupValue",
+            "IntegralHomologyGroupValue",
+        ):
+            assert "kind" in schema["$defs"][definition]["required"]
+
+        for complex_value in (
+            _circle_complex(),
+            self._complex((1, 1), ((("2",),),)),
+        ):
+            payload = homology_groups(complex_value).model_dump(mode="json")
+            del payload["homology_groups"][0]["kind"]
+            with pytest.raises(ValidationError, match="kind"):
+                HomologyResult.model_validate(payload)
+
     def test_integral_certificates_remain_bound_to_retained_differentials(
         self,
     ) -> None:
@@ -415,6 +656,138 @@ class TestIntegralHomology:
             + plan.smith_work
             + plan.reconstruction_work
             + plan.output_scalar_count
+        )
+
+    def test_expired_dispatch_deadline_stops_before_integral_admission(self) -> None:
+        from time import monotonic
+
+        from jacobian._execution import (
+            OperationExecutionTimeoutError,
+            request_execution,
+        )
+        from jacobian.math.topology.chain_complexes.values import (
+            INTEGRAL_HOMOLOGY_WALL_SECONDS,
+        )
+
+        with (
+            request_execution(monotonic() - INTEGRAL_HOMOLOGY_WALL_SECONDS - 1),
+            pytest.raises(OperationExecutionTimeoutError, match="source admission"),
+        ):
+            homology_groups(self._complex((1, 1), ((("6",),),)))
+
+    def test_integral_admission_observes_caller_cancellation(self) -> None:
+        from threading import Event
+
+        from jacobian._execution import OperationExecutionCancelledError
+        from jacobian.process import bounded_process_cancellation
+
+        cancellation = Event()
+        cancellation.set()
+        with (
+            bounded_process_cancellation(cancellation),
+            pytest.raises(OperationExecutionCancelledError, match="cancelled"),
+        ):
+            homology_groups(self._complex((2, 2), ((("2", "2"), ("2", "2")),)))
+
+    def test_real_tetrahedron_kernel_stays_within_every_charged_work_class(
+        self,
+    ) -> None:
+        from jacobian.math.topology.chain_complexes import _integral_homology as kernel
+
+        complex_value = self._simplex_complex(4)
+        observer = _IntegralWorkObserver(kernel)
+
+        with (
+            patch.object(kernel, "parse_canonical_integer", observer.parse_integer),
+            patch.object(kernel, "_require_square_zero", observer.square_zero),
+            patch.object(kernel, "_matrix_bits", observer.matrix_bits),
+            patch.object(kernel, "_smith_admission", observer.smith_admission),
+            patch.object(kernel, "matrix_multiply", observer.multiply),
+            patch.object(kernel, "matrix_vector_multiply", observer.vector_multiply),
+            patch.object(kernel, "_swap_rows", observer.swap_rows),
+            patch.object(kernel, "_swap_columns", observer.swap_columns),
+            patch.object(kernel, "_scale_row", observer.scale_row),
+            patch.object(kernel, "_scale_column", observer.scale_column),
+            patch.object(kernel, "_add_row_multiple", observer.add_row),
+            patch.object(kernel, "_add_column_multiple", observer.add_column),
+        ):
+            plan = kernel.admit_integral_homology(complex_value)
+            observer.phase = "reconstruction"
+            groups = kernel.compute_integral_homology(plan)
+        result = HomologyResult._from_kernel(
+            homology_groups=groups,
+            source_complex=complex_value,
+        )
+        observer.executed["output"] = observer.count_output_scalars(
+            result.model_dump(mode="json")
+        )
+
+        assert tuple(group.free_rank for group in groups) == (1, 0, 0, 0)
+        assert_charged_work_parity(
+            charged={
+                "parse": plan.parse_work,
+                "square_zero": plan.square_zero_work,
+                "smith": plan.smith_work,
+                "reconstruction": plan.reconstruction_work,
+                "output": plan.output_scalar_count,
+            },
+            executed=observer.executed,
+        )
+
+    @pytest.mark.parametrize(("rows", "columns"), ((0, 32), (32, 0)))
+    def test_zero_endpoint_smith_charge_covers_retained_transformations(
+        self, rows: int, columns: int
+    ) -> None:
+        from jacobian.math.topology.chain_complexes import _integral_homology as kernel
+
+        source: list[list[int]] = [[] for _ in range(rows)]
+        height, presolved = kernel._smith_admission(
+            source,
+            rows=rows,
+            columns=columns,
+        )
+
+        assert presolved is not None
+        reduction = presolved.reduction
+        retained_scalars = sum(
+            sum(len(row) for row in matrix)
+            for matrix in (
+                reduction.source,
+                reduction.diagonal,
+                reduction.left,
+                reduction.right,
+                presolved.left_inverse,
+                presolved.right_inverse,
+            )
+        )
+        assert retained_scalars == 2 * 32 * 32
+        assert_charged_work_parity(
+            charged={"smith": height.work_units},
+            executed={"smith": retained_scalars},
+        )
+
+    def test_general_smith_charge_covers_actual_worker_jobs(self) -> None:
+        from jacobian.math.topology.chain_complexes import _integral_homology as kernel
+        from jacobian.math.topology.chain_complexes import _smith_process
+
+        complex_value = self._complex(
+            (2, 2),
+            ((("2", "2"), ("2", "2")),),
+        )
+        plan = kernel.admit_integral_homology(complex_value)
+
+        with patch.object(
+            _smith_process,
+            "smith_reduce_in_worker",
+            wraps=_smith_process.smith_reduce_in_worker,
+        ) as smith_worker:
+            groups = kernel.compute_integral_homology(plan)
+
+        assert smith_worker.call_count > 0
+        assert tuple(group.free_rank for group in groups) == (1, 1)
+        assert_charged_work_parity(
+            charged={"smith": plan.smith_work},
+            executed={"smith": smith_worker.call_count},
         )
 
 
@@ -868,7 +1241,11 @@ class TestHomologySourceBinding:
 
         payload_groups = (
             HomologyGroupValue(
-                degree=0, cycle_rank=5, boundary_rank=0, betti_number=100
+                kind="FIELD_VECTOR_SPACE",
+                degree=0,
+                cycle_rank=5,
+                boundary_rank=0,
+                betti_number=100,
             ),
         )
         with pytest.raises(ValueError, match="betti_number"):
@@ -918,7 +1295,11 @@ class TestHomologyParentMatch:
             HomologyResult(
                 homology_groups=(
                     HomologyGroupValue(
-                        degree=0, cycle_rank=1, boundary_rank=0, betti_number=1
+                        kind="FIELD_VECTOR_SPACE",
+                        degree=0,
+                        cycle_rank=1,
+                        boundary_rank=0,
+                        betti_number=1,
                     ),
                 ),
                 coefficient_ring=CoefficientRing.PRIME_FIELD,

--- a/tests/math/topology/chain_complexes/test_chain_complexes.py
+++ b/tests/math/topology/chain_complexes/test_chain_complexes.py
@@ -630,35 +630,13 @@ class TestIntegralHomology:
             "chain_complex.integral_homology_output_byte_budget_exceeded"
         )
 
-    def test_result_discriminator_rejects_mixed_group_branches(self) -> None:
-        result = homology_groups(self._complex((1, 1), ((("2",),),)))
-        payload = result.model_dump(mode="json")
-        payload["homology_groups"][0] = {
-            "kind": "FIELD_VECTOR_SPACE",
-            "degree": 0,
-            "cycle_rank": 1,
-            "boundary_rank": 1,
-            "betti_number": 0,
-        }
-        with pytest.raises(ValidationError, match="homogeneous"):
-            HomologyResult.model_validate(payload)
-
-    def test_group_discriminators_are_required_in_schema_and_validation(self) -> None:
+    def test_group_discriminators_are_required_in_schema(self) -> None:
         schema = HomologyResult.model_json_schema()
         for definition in (
             "HomologyGroupValue",
             "IntegralHomologyGroupValue",
         ):
             assert "kind" in schema["$defs"][definition]["required"]
-
-        for complex_value in (
-            _circle_complex(),
-            self._complex((1, 1), ((("2",),),)),
-        ):
-            payload = homology_groups(complex_value).model_dump(mode="json")
-            del payload["homology_groups"][0]["kind"]
-            with pytest.raises(ValidationError, match="kind"):
-                HomologyResult.model_validate(payload)
 
     def test_integral_homology_schema_publishes_nested_array_limits(self) -> None:
         schema = ComputeHomologyRequest.model_json_schema()
@@ -847,17 +825,6 @@ class TestIntegralHomology:
         assert exc_info.value.errors()[0]["type"] == (
             "chain_complex.homology_raw_coefficient_invalid"
         )
-
-    def test_integral_certificates_remain_bound_to_retained_differentials(
-        self,
-    ) -> None:
-        result = homology_groups(self._complex((1, 1), ((("2",),),)))
-        payload = result.model_dump(mode="json")
-        payload["homology_groups"][1]["outgoing_smith_certificate"]["source"][
-            "entries"
-        ] = [["3"]]
-        with pytest.raises(ValidationError, match="retained chain complex"):
-            HomologyResult.model_validate(payload)
 
     def test_admission_uses_one_dispatch_deadline_and_complete_work_ledger(
         self,

--- a/tests/math/topology/chain_complexes/test_chain_complexes.py
+++ b/tests/math/topology/chain_complexes/test_chain_complexes.py
@@ -11,6 +11,11 @@ from pydantic import ValidationError
 from tests.fixtures.accounting import assert_charged_work_parity
 
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.matrices.certified_snf.operations import (
+    identity_matrix,
+    matrix_determinant,
+    matrix_multiply,
+)
 from jacobian.math.topology.chain_complexes._models import (
     ComputeHomologyRequest,
     ConstructChainComplexRequest,
@@ -374,6 +379,64 @@ class TestIntegralHomology:
             int(torsion.order) * int(value) for value in torsion.cycle.coefficients
         )
 
+    def test_small_unimodular_coordinate_change_preserves_exact_homology(self) -> None:
+        diagonal = self._complex(
+            (2, 2),
+            ((("2", "0"), ("0", "2")),),
+        )
+        changed = self._complex(
+            (2, 2),
+            ((("2", "32"), ("0", "2")),),
+        )
+
+        diagonal_groups = _integral_groups(homology_groups(diagonal))
+        changed_groups = _integral_groups(homology_groups(changed))
+
+        assert (
+            tuple(
+                (group.free_rank, group.torsion_invariant_factors)
+                for group in diagonal_groups
+            )
+            == tuple(
+                (group.free_rank, group.torsion_invariant_factors)
+                for group in changed_groups
+            )
+            == ((0, ("2", "2")), (0, ()))
+        )
+
+    def test_three_term_middle_homology_retains_cycles_and_bounding_chain(
+        self,
+    ) -> None:
+        complex_value = self._complex(
+            (1, 3, 1),
+            (
+                (("1", "1", "0"),),
+                (("2",), ("-2",), ("0",)),
+            ),
+        )
+
+        groups = _integral_groups(homology_groups(complex_value))
+
+        assert tuple(
+            (group.free_rank, group.torsion_invariant_factors) for group in groups
+        ) == ((0, ()), (1, ("2",)), (0, ()))
+        middle = groups[1]
+        cycles = tuple(generator.cycle for generator in middle.free_generators) + tuple(
+            generator.cycle for generator in middle.torsion_generators
+        )
+        for cycle in cycles:
+            assert self._apply(
+                complex_value.differential_matrices[0],
+                cycle.coefficients,
+            ) == (0,)
+        torsion = middle.torsion_generators[0]
+        assert self._apply(
+            complex_value.differential_matrices[1],
+            torsion.bounding_chain.coefficients,
+        ) == tuple(
+            int(torsion.order) * int(value) for value in torsion.cycle.coefficients
+        )
+
     def test_zero_incoming_map_does_not_inherit_transformation_height(self) -> None:
         complex_value = self._complex(
             (2, 2, 2),
@@ -409,6 +472,55 @@ class TestIntegralHomology:
             (group.free_rank, group.torsion_invariant_factors)
             for group in _integral_groups(result)
         ) == ((0, ()), (0, ()))
+
+    @pytest.mark.parametrize(
+        ("source", "expected_diagonal"),
+        (
+            (
+                [
+                    [0, 0, -1, 0],
+                    [1, 0, 0, 0],
+                    [0, 0, 0, 1],
+                    [0, -1, 0, 0],
+                ],
+                identity_matrix(4),
+            ),
+            ([[2, 32], [0, 2]], [[2, 0], [0, 2]]),
+        ),
+    )
+    def test_presolved_smith_transformations_and_inverses_are_exact(
+        self,
+        source: list[list[int]],
+        expected_diagonal: list[list[int]],
+    ) -> None:
+        from jacobian.math.topology.chain_complexes import _integral_homology as kernel
+
+        rows = len(source)
+        columns = len(source[0])
+        _height, presolved = kernel._smith_admission(
+            source,
+            rows=rows,
+            columns=columns,
+        )
+
+        assert presolved is not None
+        reduction = presolved.reduction
+        assert reduction.diagonal == expected_diagonal
+        assert (
+            matrix_multiply(
+                matrix_multiply(reduction.left, reduction.source),
+                reduction.right,
+            )
+            == reduction.diagonal
+        )
+        left_unit = identity_matrix(rows)
+        right_unit = identity_matrix(columns)
+        assert matrix_multiply(presolved.left_inverse, reduction.left) == left_unit
+        assert matrix_multiply(reduction.left, presolved.left_inverse) == left_unit
+        assert matrix_multiply(presolved.right_inverse, reduction.right) == right_unit
+        assert matrix_multiply(reduction.right, presolved.right_inverse) == right_unit
+        assert matrix_determinant(reduction.left) == reduction.left_determinant
+        assert matrix_determinant(reduction.right) == reduction.right_determinant
 
     def test_signed_permutation_presolve_reaches_the_chain_rank_boundary(self) -> None:
         rank = 32
@@ -473,10 +585,15 @@ class TestIntegralHomology:
         )
 
     def test_height_envelope_rejects_before_smith_execution(self) -> None:
-        coefficient = "9" * 32
+        coefficient = int("9" * 32)
         high_growth = self._complex(
             (2, 2),
-            (((coefficient, coefficient), (coefficient, coefficient)),),
+            (
+                (
+                    (str(coefficient), str(coefficient - 1)),
+                    (str(coefficient - 2), str(coefficient - 3)),
+                ),
+            ),
         )
         with pytest.raises(OperationDomainValidationError) as exc_info:
             homology_groups(high_growth)
@@ -681,6 +798,56 @@ class TestIntegralHomology:
             == 2_500
         )
 
+    @pytest.mark.parametrize(
+        ("differentials", "error_type"),
+        (
+            ([1], "chain_complex.homology_raw_matrix_axis_invalid"),
+            ([[1]], "chain_complex.homology_raw_row_axis_invalid"),
+        ),
+    )
+    def test_raw_integral_homology_rejects_malformed_axes_shallowly(
+        self,
+        differentials: object,
+        error_type: str,
+    ) -> None:
+        payload = {
+            "complex": {
+                "coefficient_ring": "ZZ",
+                "degree_min": 0,
+                "degree_max": 1,
+                "basis_sizes": [1, 1],
+                "differential_matrices": differentials,
+            }
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            ComputeHomologyRequest.model_validate(payload)
+
+        assert exc_info.value.errors()[0]["type"] == error_type
+
+    def test_raw_integral_homology_rejects_deep_malformed_entry_shallowly(
+        self,
+    ) -> None:
+        entry: object = "0"
+        for _ in range(1_200):
+            entry = [entry]
+        payload = {
+            "complex": {
+                "coefficient_ring": "ZZ",
+                "degree_min": 0,
+                "degree_max": 1,
+                "basis_sizes": [1, 1],
+                "differential_matrices": [[[entry]]],
+            }
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            ComputeHomologyRequest.model_validate(payload)
+
+        assert exc_info.value.errors()[0]["type"] == (
+            "chain_complex.homology_raw_coefficient_invalid"
+        )
+
     def test_integral_certificates_remain_bound_to_retained_differentials(
         self,
     ) -> None:
@@ -805,7 +972,7 @@ class TestIntegralHomology:
 
         complex_value = self._complex(
             (2, 2),
-            ((("2", "2"), ("2", "2")),),
+            ((("2", "3"), ("4", "5")),),
         )
         plan = kernel.admit_integral_homology(complex_value)
         executed_work = 0
@@ -839,11 +1006,78 @@ class TestIntegralHomology:
             groups = kernel.compute_integral_homology(plan)
 
         assert executed_work > 0
-        assert tuple(group.free_rank for group in groups) == (1, 1)
+        assert tuple(
+            (group.free_rank, group.torsion_invariant_factors) for group in groups
+        ) == ((0, ("2",)), (0, ()))
         assert_charged_work_parity(
             charged={"smith": plan.smith_work},
             executed={"smith": executed_work},
         )
+
+    def test_zero_coordinate_smith_reduction_is_lazy_and_charged_once(self) -> None:
+        from jacobian.math.topology.chain_complexes import _integral_homology as kernel
+
+        complex_value = self._complex(
+            (2, 3, 0),
+            (
+                (("2", "2", "0"), ("2", "2", "0")),
+                ((), (), ()),
+            ),
+        )
+
+        plan = kernel.admit_integral_homology(complex_value)
+        middle = plan.degrees[1]
+
+        assert middle.incoming_presolves_by_cycle_rank == (None, None, None, None)
+        expected_smith_work = sum(
+            degree.outgoing_height.work_units
+            + max(bound.work_units for bound in degree.incoming_heights_by_cycle_rank)
+            for degree in plan.degrees
+        )
+        assert plan.smith_work == expected_smith_work
+
+    def test_integral_admission_observes_cancellation_between_degrees(self) -> None:
+        from threading import Event
+
+        from jacobian._execution import OperationExecutionCancelledError
+        from jacobian.math.topology.chain_complexes import _integral_homology as kernel
+        from jacobian.process import bounded_process_cancellation
+
+        cancellation = Event()
+        original = kernel._smith_admission
+        calls = 0
+
+        def cancel_after_first_admission(
+            source: list[list[int]],
+            *,
+            rows: int,
+            columns: int,
+        ) -> Any:
+            nonlocal calls
+            result = original(source, rows=rows, columns=columns)
+            calls += 1
+            if calls == 1:
+                cancellation.set()
+            return result
+
+        with (
+            bounded_process_cancellation(cancellation),
+            patch.object(
+                kernel,
+                "_smith_admission",
+                side_effect=cancel_after_first_admission,
+            ),
+            pytest.raises(OperationExecutionCancelledError, match="degree 0"),
+        ):
+            kernel.admit_integral_homology(
+                self._complex(
+                    (2, 2, 0),
+                    (
+                        (("2", "2"), ("2", "2")),
+                        ((), ()),
+                    ),
+                )
+            )
 
 
 class TestTensorProduct:

--- a/tests/math/topology/chain_complexes/test_chain_complexes.py
+++ b/tests/math/topology/chain_complexes/test_chain_complexes.py
@@ -1,11 +1,12 @@
 """Tests for chain complex operations (#1824)."""
 
 from fractions import Fraction
-from typing import Any, NoReturn
+from typing import Any, NoReturn, cast
 
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.topology.chain_complexes._models import (
     ComputeHomologyRequest,
     ConstructChainComplexRequest,
@@ -44,16 +45,35 @@ from jacobian.math.topology.chain_complexes.operations import (
 )
 from jacobian.math.topology.chain_complexes.values import (
     ChainComplexValue,
-    CoefficientField,
+    CoefficientRing,
+    HomologyGroupValue,
     HomologyResult,
+    IntegralHomologyGroupValue,
 )
 
 MapMatrices = tuple[tuple[tuple[str, ...], ...], ...]
 
 
+def _field_groups(result: HomologyResult) -> tuple[HomologyGroupValue, ...]:
+    assert all(
+        isinstance(group, HomologyGroupValue) for group in result.homology_groups
+    )
+    return cast(tuple[HomologyGroupValue, ...], result.homology_groups)
+
+
+def _integral_groups(
+    result: HomologyResult,
+) -> tuple[IntegralHomologyGroupValue, ...]:
+    assert all(
+        isinstance(group, IntegralHomologyGroupValue)
+        for group in result.homology_groups
+    )
+    return cast(tuple[IntegralHomologyGroupValue, ...], result.homology_groups)
+
+
 def _circle_complex() -> ChainComplexValue:
     return ChainComplexValue(
-        coefficient_field=CoefficientField.RATIONAL,
+        coefficient_ring=CoefficientRing.RATIONAL,
         degree_min=0,
         degree_max=1,
         basis_sizes=(3, 3),
@@ -64,7 +84,7 @@ def _circle_complex() -> ChainComplexValue:
 def _point_complex() -> ChainComplexValue:
     """A single point: H_0 = 1, all others 0."""
     return ChainComplexValue(
-        coefficient_field=CoefficientField.RATIONAL,
+        coefficient_ring=CoefficientRing.RATIONAL,
         degree_min=0,
         degree_max=0,
         basis_sizes=(1,),
@@ -106,7 +126,7 @@ class TestConstructAdmitsOnlyChainComplexes:
         not zero: the public construct operation must refuse them instead
         of labelling arbitrary matrices an exact chain complex."""
         request = ConstructChainComplexRequest(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             basis_sizes=(1, 1, 1),
             differential_matrices=((("1",),), (("1",),)),
         )
@@ -117,12 +137,12 @@ class TestConstructAdmitsOnlyChainComplexes:
         from jacobian.math.topology.chain_complexes.values import ChainComplexValue
 
         request = ConstructChainComplexRequest(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             basis_sizes=(1, 1, 1),
             differential_matrices=((("0",),), (("0",),)),
         )
         value = ChainComplexValue(
-            coefficient_field=request.coefficient_field,
+            coefficient_ring=request.coefficient_ring,
             prime=request.prime,
             degree_min=0,
             degree_max=len(request.basis_sizes) - 1,
@@ -135,18 +155,19 @@ class TestConstructAdmitsOnlyChainComplexes:
 class TestComputeHomology:
     def test_circle_homology(self) -> None:
         result = compute_homology(ComputeHomologyRequest(complex=_circle_complex()))
-        assert result.homology_groups[0].betti_number == 1
-        assert result.homology_groups[1].betti_number == 1
+        groups = _field_groups(result)
+        assert groups[0].betti_number == 1
+        assert groups[1].betti_number == 1
 
     @pytest.mark.parametrize(
-        ("coefficient_field", "prime"),
+        ("coefficient_ring", "prime"),
         [
-            (CoefficientField.RATIONAL, None),
-            (CoefficientField.PRIME_FIELD, 101),
+            (CoefficientRing.RATIONAL, None),
+            (CoefficientRing.PRIME_FIELD, 101),
         ],
     )
     def test_flint_rank_admits_retained_complex_above_shared_ceiling(
-        self, coefficient_field: CoefficientField, prime: int | None
+        self, coefficient_ring: CoefficientRing, prime: int | None
     ) -> None:
         size = 64
         identity = tuple(
@@ -155,7 +176,7 @@ class TestComputeHomology:
         )
         zero = tuple(tuple("0" for _ in range(size)) for _ in range(size))
         complex_value = ChainComplexValue(
-            coefficient_field=coefficient_field,
+            coefficient_ring=coefficient_ring,
             prime=prime,
             degree_min=0,
             degree_max=2,
@@ -165,7 +186,7 @@ class TestComputeHomology:
 
         result = compute_homology(ComputeHomologyRequest(complex=complex_value))
 
-        assert tuple(group.betti_number for group in result.homology_groups) == (
+        assert tuple(group.betti_number for group in _field_groups(result)) == (
             0,
             0,
             size,
@@ -176,7 +197,7 @@ class TestComputeHomology:
         size = 64
         zero = tuple(tuple("0" for _ in range(size)) for _ in range(size))
         complex_value = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=2,
             basis_sizes=(size, size, size),
@@ -188,7 +209,213 @@ class TestComputeHomology:
 
     def test_point_homology(self) -> None:
         result = compute_homology(ComputeHomologyRequest(complex=_point_complex()))
-        assert result.homology_groups[0].betti_number == 1
+        assert _field_groups(result)[0].betti_number == 1
+
+
+class TestIntegralHomology:
+    @staticmethod
+    def _complex(
+        basis_sizes: tuple[int, ...],
+        differentials: tuple[tuple[tuple[str, ...], ...], ...],
+        *,
+        degree_min: int = 0,
+    ) -> ChainComplexValue:
+        return ChainComplexValue(
+            coefficient_ring=CoefficientRing.INTEGER,
+            degree_min=degree_min,
+            degree_max=degree_min + len(basis_sizes) - 1,
+            basis_sizes=basis_sizes,
+            differential_matrices=differentials,
+        )
+
+    @staticmethod
+    def _apply(
+        matrix: tuple[tuple[str, ...], ...], coefficients: tuple[str, ...]
+    ) -> tuple[int, ...]:
+        return tuple(
+            sum(
+                int(value) * int(coefficients[column])
+                for column, value in enumerate(row)
+            )
+            for row in matrix
+        )
+
+    def test_zz_contract_rejects_fractional_entries(self) -> None:
+        with pytest.raises(ValidationError, match="must be an integer"):
+            self._complex((1, 1), ((("1/2",),),))
+
+    @pytest.mark.parametrize("order", (2, 6, 97))
+    def test_multiplication_by_m_returns_exact_torsion(self, order: int) -> None:
+        complex_value = self._complex((1, 1), (((str(order),),),))
+
+        result = homology_groups(complex_value)
+
+        degree_zero, degree_one = result.homology_groups
+        assert isinstance(degree_zero, IntegralHomologyGroupValue)
+        assert isinstance(degree_one, IntegralHomologyGroupValue)
+        assert degree_zero.free_rank == 0
+        assert degree_zero.torsion_invariant_factors == (str(order),)
+        assert degree_one.free_rank == 0
+        torsion = degree_zero.torsion_generators[0]
+        assert self._apply(
+            complex_value.differential_matrices[0],
+            torsion.bounding_chain.coefficients,
+        ) == tuple(order * int(value) for value in torsion.cycle.coefficients)
+
+    def test_non_simplicial_non_ternary_basis_changes_preserve_mixed_group(
+        self,
+    ) -> None:
+        # [[2, 2], [2, 2]] is obtained from diag(2, 0) by unimodular
+        # changes on both source and target. Thus H_0 = Z + Z/2 and H_1 = Z.
+        complex_value = self._complex(
+            (2, 2),
+            ((("2", "2"), ("2", "2")),),
+        )
+
+        result = homology_groups(complex_value)
+
+        degree_zero, degree_one = result.homology_groups
+        assert isinstance(degree_zero, IntegralHomologyGroupValue)
+        assert isinstance(degree_one, IntegralHomologyGroupValue)
+        assert (degree_zero.free_rank, degree_zero.torsion_invariant_factors) == (
+            1,
+            ("2",),
+        )
+        assert (degree_one.free_rank, degree_one.torsion_invariant_factors) == (
+            1,
+            (),
+        )
+        for group in (degree_zero, degree_one):
+            index = group.degree - complex_value.degree_min
+            outgoing = (
+                complex_value.differential_matrices[index - 1] if index > 0 else ()
+            )
+            cycles = tuple(
+                generator.cycle for generator in group.free_generators
+            ) + tuple(generator.cycle for generator in group.torsion_generators)
+            for cycle in cycles:
+                assert self._apply(outgoing, cycle.coefficients) == (0,) * len(outgoing)
+        torsion = degree_zero.torsion_generators[0]
+        assert self._apply(
+            complex_value.differential_matrices[0],
+            torsion.bounding_chain.coefficients,
+        ) == tuple(
+            int(torsion.order) * int(value) for value in torsion.cycle.coefficients
+        )
+
+    def test_zz_tensor_producer_composes_back_into_integral_homology(self) -> None:
+        multiplication = self._complex((1, 1), ((("6",),),))
+        integer_point = self._complex((1,), ())
+
+        produced = tensor_product_complex(multiplication, integer_point)
+        result = homology_groups(produced.value)
+
+        degree_zero = result.homology_groups[0]
+        assert isinstance(degree_zero, IntegralHomologyGroupValue)
+        assert degree_zero.torsion_invariant_factors == ("6",)
+        assert produced.value.coefficient_ring is CoefficientRing.INTEGER
+
+    def test_negative_degrees_and_zero_rank_groups_round_trip(self) -> None:
+        complex_value = self._complex(
+            (0, 2, 0),
+            ((), ((), ())),
+            degree_min=-1,
+        )
+
+        result = homology_groups(complex_value)
+
+        assert [group.degree for group in result.homology_groups] == [-1, 0, 1]
+        assert [group.free_rank for group in _integral_groups(result)] == [0, 2, 0]
+        degree_minus_one = result.homology_groups[0]
+        assert isinstance(degree_minus_one, IntegralHomologyGroupValue)
+        assert (
+            degree_minus_one.outgoing_smith_certificate.source.row_count,
+            degree_minus_one.outgoing_smith_certificate.source.column_count,
+        ) == (0, 0)
+        assert (
+            degree_minus_one.incoming_smith_certificate.source.row_count,
+            degree_minus_one.incoming_smith_certificate.source.column_count,
+        ) == (0, 2)
+        assert HomologyResult.model_validate(result.model_dump(mode="json")) == result
+
+    def test_malformed_d_squared_is_rejected_before_smith(self) -> None:
+        malformed = self._complex(
+            (1, 1, 1),
+            ((("1",),), (("1",),)),
+        )
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            homology_groups(malformed)
+        assert exc_info.value.errors()[0]["type"] == (
+            "chain_complex.differential_not_square_zero"
+        )
+
+    def test_height_envelope_rejects_before_smith_execution(self) -> None:
+        coefficient = "9" * 32
+        high_growth = self._complex(
+            (2, 2),
+            (((coefficient, coefficient), (coefficient, coefficient)),),
+        )
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            homology_groups(high_growth)
+        assert exc_info.value.errors()[0]["type"] == (
+            "chain_complex.integral_homology_height_budget_exceeded"
+        )
+
+    def test_result_discriminator_rejects_mixed_group_branches(self) -> None:
+        result = homology_groups(self._complex((1, 1), ((("2",),),)))
+        payload = result.model_dump(mode="json")
+        payload["homology_groups"][0] = {
+            "kind": "FIELD_VECTOR_SPACE",
+            "degree": 0,
+            "cycle_rank": 1,
+            "boundary_rank": 1,
+            "betti_number": 0,
+        }
+        with pytest.raises(ValidationError, match="homogeneous"):
+            HomologyResult.model_validate(payload)
+
+    def test_integral_certificates_remain_bound_to_retained_differentials(
+        self,
+    ) -> None:
+        result = homology_groups(self._complex((1, 1), ((("2",),),)))
+        payload = result.model_dump(mode="json")
+        payload["homology_groups"][1]["outgoing_smith_certificate"]["source"][
+            "entries"
+        ] = [["3"]]
+        with pytest.raises(ValidationError, match="retained chain complex"):
+            HomologyResult.model_validate(payload)
+
+    def test_admission_uses_one_dispatch_deadline_and_complete_work_ledger(
+        self,
+    ) -> None:
+        from time import monotonic
+
+        from jacobian._execution import current_request_execution, request_execution
+        from jacobian.math.topology.chain_complexes._integral_homology import (
+            admit_integral_homology,
+        )
+        from jacobian.math.topology.chain_complexes.values import (
+            INTEGRAL_HOMOLOGY_WALL_SECONDS,
+        )
+
+        complex_value = self._complex((1, 1), ((("6",),),))
+        started = monotonic()
+        with request_execution(started):
+            plan = admit_integral_homology(complex_value)
+            execution = current_request_execution()
+            assert execution is not None
+            assert (
+                plan.deadline
+                == execution.deadline
+                == (started + INTEGRAL_HOMOLOGY_WALL_SECONDS)
+            )
+        assert plan.total_work == (
+            plan.parse_work
+            + plan.square_zero_work
+            + plan.smith_work
+            + plan.reconstruction_work
+            + plan.output_scalar_count
+        )
 
 
 class TestTensorProduct:
@@ -228,7 +455,7 @@ class TestCanonicalCoefficientSpellings:
         for bad in ("01", "2/4", "3/1", "-0", "0/2", "007"):
             with pytest.raises(ValidationError):
                 ChainComplexValue(
-                    coefficient_field=CoefficientField.RATIONAL,
+                    coefficient_ring=CoefficientRing.RATIONAL,
                     degree_min=0,
                     degree_max=1,
                     basis_sizes=(1, 1),
@@ -242,7 +469,7 @@ class TestCanonicalCoefficientSpellings:
         for bad in ("7", "-1"):
             with pytest.raises(ValidationError):
                 ChainComplexValue(
-                    coefficient_field=CoefficientField.PRIME_FIELD,
+                    coefficient_ring=CoefficientRing.PRIME_FIELD,
                     prime=5,
                     degree_min=0,
                     degree_max=1,
@@ -262,7 +489,7 @@ class TestAggregateEntryWorkBound:
         )
         with pytest.raises(ValidationError):
             ChainComplexValue(
-                coefficient_field=CoefficientField.RATIONAL,
+                coefficient_ring=CoefficientRing.RATIONAL,
                 degree_min=0,
                 degree_max=1,
                 basis_sizes=(32, 32),
@@ -291,7 +518,7 @@ class TestChainMapAdmission:
 
     def _two_term(self, degree_min: int, differential: str) -> ChainComplexValue:
         return ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=degree_min,
             degree_max=degree_min + 1,
             basis_sizes=(1, 1),
@@ -301,14 +528,14 @@ class TestChainMapAdmission:
     def test_padded_zero_map_is_rejected(self) -> None:
         """A one-dimensional to two-dimensional map cannot silently pad."""
         source = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=0,
             basis_sizes=(1,),
             differential_matrices=(),
         )
         target = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=0,
             basis_sizes=(2,),
@@ -366,7 +593,7 @@ class TestMappingConeDefiningEquations:
 
     def _complex(self, differential: str) -> ChainComplexValue:
         return ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(1, 1),
@@ -388,7 +615,7 @@ class TestMappingConeDefiningEquations:
     def test_non_square_zero_source_cone_is_rejected(self) -> None:
         """A three-term complex violating d^2=0 is rejected before the cone."""
         bad = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=2,
             basis_sizes=(1, 1, 1),
@@ -420,14 +647,14 @@ class TestMappingConeDefiningEquations:
         """A serialized cone cannot revalidate against an undersized
         retained map that replay padding would silently accept."""
         source = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=0,
             basis_sizes=(1,),
             differential_matrices=(),
         )
         target = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=0,
             basis_sizes=(1,),
@@ -452,14 +679,14 @@ class TestTensorProductSignAndBudget:
     def test_koszul_sign_uses_actual_chain_degree(self) -> None:
         """A left factor concentrated in odd degree -1 negates id ⊗ d_D."""
         left = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=-1,
             degree_max=-1,
             basis_sizes=(1,),
             differential_matrices=(),
         )
         right = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(1, 1),
@@ -476,14 +703,14 @@ class TestTensorProductSignAndBudget:
         big_row = tuple(str(10**511 + i) for i in range(7))
         big = tuple(big_row for _ in range(7))
         left = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(7, 7),
             differential_matrices=(big,),
         )
         point = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=0,
             basis_sizes=(8,),
@@ -496,14 +723,14 @@ class TestTensorProductSignAndBudget:
         """The same shapes with single-digit coefficients stay inside the
         expanded-character budget and return the typed tensor value."""
         left = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(7, 7),
             differential_matrices=((("1",) * 7,) * 7,),
         )
         point = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=0,
             basis_sizes=(8,),
@@ -521,7 +748,7 @@ class TestTensorProductSignAndBudget:
         zeros_row = tuple("0" for _ in range(64))
         zeros = tuple(zeros_row for _ in range(64))
         big = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(64, 64),
@@ -538,7 +765,7 @@ class TestPrimeFieldEntries:
 
         with pytest.raises(ValidationError):
             ChainComplexValue(
-                coefficient_field=CoefficientField.PRIME_FIELD,
+                coefficient_ring=CoefficientRing.PRIME_FIELD,
                 prime=5,
                 degree_min=0,
                 degree_max=1,
@@ -548,7 +775,7 @@ class TestPrimeFieldEntries:
 
     def test_integer_residues_accepted(self) -> None:
         complex_value = ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=5,
             degree_min=0,
             degree_max=1,
@@ -582,14 +809,14 @@ class TestTensorProductPreconditions:
     def test_non_square_zero_factor_rejected(self) -> None:
         """Tensoring complexes violating d^2=0 is rejected before building."""
         bad = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=2,
             basis_sizes=(1, 1, 1),
             differential_matrices=((("1",),), (("1",),)),
         )
         point = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=0,
             basis_sizes=(1,),
@@ -605,14 +832,14 @@ class TestTensorProductPreconditions:
         passes group-dimension checks but allocates ~4M dense cells; the
         cell-count work bound rejects it."""
         left = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=0,
             basis_sizes=(64,),
             differential_matrices=(),
         )
         right = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=32,
             basis_sizes=(4,) * 33,
@@ -647,7 +874,7 @@ class TestHomologySourceBinding:
         with pytest.raises(ValueError, match="betti_number"):
             HomologyResult(
                 homology_groups=payload_groups,
-                coefficient_field=CoefficientField.RATIONAL,
+                coefficient_ring=CoefficientRing.RATIONAL,
                 degree_min=0,
                 degree_max=0,
                 complex=_point_complex(),
@@ -661,7 +888,7 @@ class TestAggregateChainMapWork:
         rejects them."""
         alternating = tuple(64 if i % 2 == 0 else 0 for i in range(33))
         complex_value = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=32,
             basis_sizes=alternating,
@@ -682,19 +909,19 @@ class TestAggregateChainMapWork:
 class TestHomologyParentMatch:
     def test_parent_mismatch_rejected(self) -> None:
         from jacobian.math.topology.chain_complexes.values import (
-            CoefficientField,
+            CoefficientRing,
             HomologyGroupValue,
             HomologyResult,
         )
 
-        with pytest.raises(ValueError, match="field and prime must match"):
+        with pytest.raises(ValueError, match="ring and prime must match"):
             HomologyResult(
                 homology_groups=(
                     HomologyGroupValue(
                         degree=0, cycle_rank=1, boundary_rank=0, betti_number=1
                     ),
                 ),
-                coefficient_field=CoefficientField.PRIME_FIELD,
+                coefficient_ring=CoefficientRing.PRIME_FIELD,
                 prime=2,
                 degree_min=0,
                 degree_max=0,
@@ -713,11 +940,12 @@ class TestNativeSurface:
 
         circle = _circle_complex()
         result = homology_groups(circle)
-        assert result.homology_groups[0].betti_number == 1
-        assert result.homology_groups[1].betti_number == 1
-        # The native value carries the source's field context so GF(p) and
-        # QQ homology stay distinguishable.
-        assert result.coefficient_field == circle.coefficient_field
+        groups = _field_groups(result)
+        assert groups[0].betti_number == 1
+        assert groups[1].betti_number == 1
+        # The native value carries the source's coefficient context so the
+        # supported rings stay distinguishable.
+        assert result.coefficient_ring == circle.coefficient_ring
         assert result.prime == circle.prime
 
         identity = (("1", "0", "0"), ("0", "1", "0"), ("0", "0", "1"))
@@ -736,7 +964,7 @@ class TestNativeSurface:
         from jacobian.math.topology.chain_complexes import tensor_product_complex
 
         factor = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             prime=None,
             degree_min=0,
             degree_max=1,
@@ -782,7 +1010,7 @@ class TestMappingConeCanonicalValue:
             MappingConeRequest(source=point, target=point, map_matrices=(one,))
         )
         homology = compute_homology(ComputeHomologyRequest(complex=result.value))
-        assert [group.betti_number for group in homology.homology_groups] == [
+        assert [group.betti_number for group in _field_groups(homology)] == [
             0,
             0,
         ]
@@ -792,14 +1020,14 @@ class TestMappingConeCanonicalValue:
         """A cone group of 64 + 64 faces exceeds the canonical basis bound
         and fails the request instead of dying inside execution."""
         source = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(64, 0),
             differential_matrices=(((),) * 64,),
         )
         target = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(0, 64),
@@ -820,7 +1048,7 @@ class TestMappingConeCanonicalValue:
         sizes = (1,) * 33
         zeros = ((("0",),),) * 32
         complex_value = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=32,
             basis_sizes=sizes,
@@ -843,14 +1071,14 @@ class TestMappingConeCanonicalValue:
         row = tuple(str(10**digits + i) for i in range(16))
         big_zero = tuple(row for _ in range(16))
         source = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(16, 16),
             differential_matrices=(big_zero,),
         )
         target = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(16, 16),
@@ -909,7 +1137,7 @@ class TestChainMapEndpointPrecondition:
         """Endpoints violating d^2=0 admit no chain map; the identity
         components must not validate as commuting."""
         bad = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=2,
             basis_sizes=(1, 1, 1),
@@ -926,14 +1154,14 @@ class TestChainMapEndpointPrecondition:
 class TestZeroWidthProducts:
     def test_zero_row_operand_preserves_columns(self) -> None:
         source = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(1, 1),
             differential_matrices=((("0",),),),
         )
         target = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(1, 0),
@@ -956,7 +1184,7 @@ class TestEmptyRowWidthChainMaps:
 
     def _source(self) -> ChainComplexValue:
         return ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(1, 1),
@@ -965,7 +1193,7 @@ class TestEmptyRowWidthChainMaps:
 
     def _target(self) -> ChainComplexValue:
         return ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(0, 1),
@@ -999,14 +1227,14 @@ class TestEmptyRowWidthChainMaps:
         """The homology kernel's square-zero replay keeps declared widths
         for a complex whose first group is empty."""
         shifted = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=2,
             basis_sizes=(0, 1, 1),
             differential_matrices=((), (("1",),)),
         )
         result = compute_homology(ComputeHomologyRequest(complex=shifted))
-        assert [group.betti_number for group in result.homology_groups] == [0, 0, 0]
+        assert [group.betti_number for group in _field_groups(result)] == [0, 0, 0]
 
     def test_empty_middle_cone_group_round_trips(self) -> None:
         """A cone whose zeroth group is empty keeps its widths through
@@ -1014,7 +1242,7 @@ class TestEmptyRowWidthChainMaps:
         from jacobian.math.topology.chain_complexes.values import MappingConeResult
 
         endpoint = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(0, 1),
@@ -1036,13 +1264,13 @@ class TestTensorContextAndShapes:
         result = compute_tensor_product(
             TensorProductRequest(left=_point_complex(), right=_point_complex())
         )
-        assert result.coefficient_field == CoefficientField.RATIONAL
+        assert result.coefficient_ring == CoefficientRing.RATIONAL
         assert result.prime is None
         assert (result.degree_min, result.degree_max) == (0, 0)
 
     def test_shifted_tensor_degree_interval(self) -> None:
         left = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=-1,
             degree_max=-1,
             basis_sizes=(1,),
@@ -1056,7 +1284,7 @@ class TestTensorContextAndShapes:
         """A (1,0)-by-point tensor must represent its zero differential as a
         one-row zero-width matrix, not an empty matrix."""
         left = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(1, 0),
@@ -1071,7 +1299,7 @@ class TestTensorContextAndShapes:
         """A four-term endpoint with differentials (0, 1, 1) has d0*d1 == 0
         but d1*d2 != 0; the identity map must fail verification."""
         bad = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=3,
             basis_sizes=(1, 1, 1, 1),
@@ -1109,7 +1337,7 @@ class TestChainDegreeDiagnostics:
         )
 
         bad = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=-2,
             degree_max=0,
             basis_sizes=(1, 1, 1),
@@ -1126,7 +1354,7 @@ class TestTensorPrimeFieldResidues:
         """A GF(3) tensor with a sign negation serializes the canonical
         residue 2, not -1, so the derived value validates."""
         left = ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=3,
             degree_min=1,
             degree_max=1,
@@ -1134,7 +1362,7 @@ class TestTensorPrimeFieldResidues:
             differential_matrices=(),
         )
         right = ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=3,
             degree_min=0,
             degree_max=1,
@@ -1156,7 +1384,7 @@ class TestTensorPrimeFieldResidues:
         """The reviewer's counterexample returns exactly the residue 2,
         both as the serialized projection and the retained complex."""
         left = ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=3,
             degree_min=1,
             degree_max=1,
@@ -1164,7 +1392,7 @@ class TestTensorPrimeFieldResidues:
             differential_matrices=(),
         )
         right = ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=3,
             degree_min=0,
             degree_max=1,
@@ -1181,7 +1409,7 @@ class TestTensorPrimeFieldResidues:
     def test_koszul_sign_boundary_mod_two(self) -> None:
         """The p = 2 boundary: the Koszul sign -1 is the residue 1."""
         left = ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=2,
             degree_min=1,
             degree_max=1,
@@ -1189,7 +1417,7 @@ class TestTensorPrimeFieldResidues:
             differential_matrices=(),
         )
         right = ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=2,
             degree_min=0,
             degree_max=1,
@@ -1203,14 +1431,14 @@ class TestTensorPrimeFieldResidues:
         """QQ tensor products keep their exact signed coefficients, so the
         reduction is specific to prime-field serialization."""
         left = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=-1,
             degree_max=-1,
             basis_sizes=(1,),
             differential_matrices=(),
         )
         right = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(1, 1),
@@ -1222,7 +1450,7 @@ class TestTensorPrimeFieldResidues:
     def test_out_of_range_chain_map_entry_rejected(self) -> None:
         """GF(p) chain maps enforce canonical residues like complexes do."""
         source = ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=3,
             degree_min=0,
             degree_max=1,
@@ -1238,7 +1466,7 @@ class TestTensorPrimeFieldResidues:
 
     def _gf_point(self, prime: int) -> ChainComplexValue:
         return ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=prime,
             degree_min=0,
             degree_max=0,
@@ -1283,7 +1511,7 @@ class TestPrimeFieldDerivedSerialization:
         """The cone's -d_C block becomes the canonical GF(p) residue and
         the decomposition composes as a square-zero chain complex."""
         gf3_two_term = ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=3,
             degree_min=0,
             degree_max=1,
@@ -1301,7 +1529,7 @@ class TestPrimeFieldDerivedSerialization:
             (("2",), ("1",)),
         )
         cone = ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=3,
             degree_min=0,
             degree_max=2,
@@ -1311,9 +1539,9 @@ class TestPrimeFieldDerivedSerialization:
         assert verify_differential(VerifyDifferentialRequest(complex=cone)).is_valid
 
 
-class TestNativeHomologyFieldBinding:
+class TestNativeHomologyCoefficientBinding:
     """The native homology wrapper returns the source-bound result, so
-    homology over different coefficient fields stays distinct."""
+    homology over different coefficient rings stays distinct."""
 
     @staticmethod
     def _native(complex_value: ChainComplexValue) -> HomologyResult:
@@ -1325,7 +1553,7 @@ class TestNativeHomologyFieldBinding:
 
     def _gf_point(self, prime: int) -> ChainComplexValue:
         return ChainComplexValue(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=prime,
             degree_min=0,
             degree_max=0,
@@ -1333,13 +1561,13 @@ class TestNativeHomologyFieldBinding:
             differential_matrices=(),
         )
 
-    def test_result_carries_coefficient_field(self) -> None:
+    def test_result_carries_coefficient_ring(self) -> None:
         from jacobian.math.topology.chain_complexes.values import HomologyResult
 
         point = self._gf_point(2)
         result = self._native(point)
         assert isinstance(result, HomologyResult)
-        assert result.coefficient_field == CoefficientField.PRIME_FIELD
+        assert result.coefficient_ring == CoefficientRing.PRIME_FIELD
         assert result.prime == 2
         assert result.complex == point
 
@@ -1366,7 +1594,7 @@ class TestZeroWidthGroupComposition:
         """A (0 x 1) differential followed by (1 x 1) composes to a valid
         zero product instead of raising an inner-dimension error."""
         shifted = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=2,
             basis_sizes=(0, 1, 1),
@@ -1378,7 +1606,7 @@ class TestZeroWidthGroupComposition:
     def test_nonsquare_zero_homology_rejected_at_request(self) -> None:
         """Homology requests whose d^2 != 0 fail at the typed boundary."""
         bad = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=2,
             basis_sizes=(1, 1, 1),
@@ -1395,7 +1623,7 @@ class TestZeroWidthGroupComposition:
         """A complex concentrated in degrees -5..-3 reports degree -4, not
         the tuple index."""
         neg = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=-5,
             degree_max=-3,
             basis_sizes=(1, 1, 1),
@@ -1452,7 +1680,7 @@ class TestMappingConeSourceBinding:
         from jacobian.math.topology.chain_complexes.values import MappingConeResult
 
         bad = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=2,
             basis_sizes=(1, 1, 1),
@@ -1496,7 +1724,7 @@ class TestMappingConeSourceBinding:
         from jacobian.math.topology.chain_complexes.values import MappingConeResult
 
         shifted = ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=-1,
             degree_max=0,
             basis_sizes=(3, 3),
@@ -1523,7 +1751,7 @@ class TestReviewRegressions2236:
         )
 
         request = ConstructChainComplexRequest(
-            coefficient_field=CoefficientField.PRIME_FIELD,
+            coefficient_ring=CoefficientRing.PRIME_FIELD,
             prime=5,
             basis_sizes=(0, 1, 1),
             differential_matrices=((), (("1",),)),
@@ -1566,7 +1794,7 @@ class TestNativeWrappersCallKernelsDirectly:
     @staticmethod
     def _circle() -> ChainComplexValue:
         return ChainComplexValue(
-            coefficient_field=CoefficientField.RATIONAL,
+            coefficient_ring=CoefficientRing.RATIONAL,
             degree_min=0,
             degree_max=1,
             basis_sizes=(1, 1),
@@ -1593,7 +1821,7 @@ class TestNativeWrappersCallKernelsDirectly:
 
         circle = self._circle()
         homology = homology_groups(circle)
-        assert homology.homology_groups[0].betti_number == 1
+        assert _field_groups(homology)[0].betti_number == 1
         assert differential_squares_to_zero(circle).is_valid is True
         identity_map: MapMatrices = ((("1",),),)
         assert len(identity_map) == 1

--- a/tests/math/topology/test_models.py
+++ b/tests/math/topology/test_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, cast, overload
 
 import pytest
 from pydantic import ValidationError
@@ -21,6 +21,11 @@ from jacobian.math.topology._models import (
     SimplicialComplexRequest,
 )
 from jacobian.math.topology._tools import TOOLS
+from jacobian.math.topology.chain_complexes.values import (
+    CoefficientRing,
+    HomologyResult,
+    IntegralHomologyGroupValue,
+)
 
 
 @overload
@@ -49,6 +54,16 @@ def _operation(
 
 def _operation(operation_id: str) -> MathTool[Any, Any]:
     return next(tool for tool in TOOLS if tool.operation_id == operation_id)
+
+
+def _integral_groups(
+    result: HomologyResult,
+) -> tuple[IntegralHomologyGroupValue, ...]:
+    assert all(
+        isinstance(group, IntegralHomologyGroupValue)
+        for group in result.homology_groups
+    )
+    return cast(tuple[IntegralHomologyGroupValue, ...], result.homology_groups)
 
 
 def _canonical_complex(
@@ -140,8 +155,11 @@ def test_integral_homology_runs_through_the_public_operation() -> None:
     result = operation.run(IntegralSimplicialHomologyRequest(complex=complex_))
 
     assert result.complex_digest == complex_.complex_digest
-    assert result.coefficient_ring == "ZZ"
-    assert tuple(group.betti_number for group in result.groups) == (1, 1)
+    assert result.homology.coefficient_ring is CoefficientRing.INTEGER
+    assert tuple(group.free_rank for group in _integral_groups(result.homology)) == (
+        1,
+        1,
+    )
 
 
 def test_chain_bounds_are_checked_after_materialization_but_before_computation() -> (
@@ -202,8 +220,9 @@ def test_integral_homology_certificate_boundary_runs_the_public_operation() -> N
 
     result = operation.run(IntegralSimplicialHomologyRequest(complex=complex_))
 
-    assert result.groups[0].betti_number == 32
-    assert len(result.groups[0].free_generators) == 32
+    group = _integral_groups(result.homology)[0]
+    assert group.free_rank == 32
+    assert len(group.free_generators) == 32
 
 
 def test_stale_complex_digest_reports_field_level_loc() -> None:

--- a/tests/math/topology/test_models.py
+++ b/tests/math/topology/test_models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import Any, Literal, cast, overload
 
 import pytest
@@ -73,6 +74,37 @@ def _canonical_complex(
     request = SimplicialComplexRequest(vertices=vertices, facets=facets)
     operation = _operation("topology.simplicial_complex.canonicalize")
     return operation.run(request).complex
+
+
+def _rational_rank(rows: tuple[tuple[str, ...], ...]) -> int:
+    """Small independent Gaussian rank oracle for topology fixtures."""
+
+    matrix = [[Fraction(int(value)) for value in row] for row in rows]
+    if not matrix:
+        return 0
+    pivot_row = 0
+    for column in range(len(matrix[0])):
+        pivot = next(
+            (row for row in range(pivot_row, len(matrix)) if matrix[row][column]),
+            None,
+        )
+        if pivot is None:
+            continue
+        matrix[pivot_row], matrix[pivot] = matrix[pivot], matrix[pivot_row]
+        pivot_value = matrix[pivot_row][column]
+        matrix[pivot_row] = [value / pivot_value for value in matrix[pivot_row]]
+        for row in range(len(matrix)):
+            if row == pivot_row or not matrix[row][column]:
+                continue
+            factor = matrix[row][column]
+            matrix[row] = [
+                value - factor * pivot_value
+                for value, pivot_value in zip(
+                    matrix[row], matrix[pivot_row], strict=True
+                )
+            ]
+        pivot_row += 1
+    return pivot_row
 
 
 def test_facet_request_rejects_duplicates_nonmaximal_faces_and_hidden_isolates() -> (
@@ -160,6 +192,35 @@ def test_integral_homology_runs_through_the_public_operation() -> None:
         1,
         1,
     )
+
+
+def test_integral_homology_admits_one_tetrahedron() -> None:
+    """The canonical simplex contraction has H_0 = ZZ and no higher homology."""
+
+    complex_ = _canonical_complex(
+        ("a", "b", "c", "d"),
+        (("a", "b", "c", "d"),),
+    )
+    operation = _operation("topology.simplicial_homology.integral.compute")
+
+    result = operation.run(IntegralSimplicialHomologyRequest(complex=complex_))
+
+    groups = _integral_groups(result.homology)
+    assert tuple(
+        (group.free_rank, group.torsion_invariant_factors) for group in groups
+    ) == ((1, ()), (0, ()), (0, ()), (0, ()))
+    chain = result.homology.complex
+    independent_betti = tuple(
+        chain.basis_sizes[index]
+        - (_rational_rank(chain.differential_matrices[index - 1]) if index > 0 else 0)
+        - (
+            _rational_rank(chain.differential_matrices[index])
+            if index < len(chain.differential_matrices)
+            else 0
+        )
+        for index in range(len(chain.basis_sizes))
+    )
+    assert tuple(group.free_rank for group in groups) == independent_betti
 
 
 def test_chain_bounds_are_checked_after_materialization_but_before_computation() -> (

--- a/tests/math/topology/test_native.py
+++ b/tests/math/topology/test_native.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Any, Literal, cast, overload
 
 import pytest
-from pydantic import ValidationError
 
 from jacobian.catalog.models import MathTool, OperationDomainValidationError
 from jacobian.math.topology._homology import (
@@ -130,12 +129,16 @@ def test_producer_result_carries_its_canonical_value() -> None:
     assert [group.betti_number for group in _field_groups(homology)] == [1, 1]
 
 
-def test_producer_result_binds_the_canonical_differentials() -> None:
+def test_producer_canonical_differentials_equal_its_sparse_boundaries() -> None:
     result = _prime_field_chain(_circle(), 2)
-    payload = result.model_dump(mode="json")
-    payload["canonical_value"]["differential_matrices"][0][0][0] = "0"
-    with pytest.raises(ValidationError, match="canonical chain-complex value"):
-        ChainComplexResult.model_validate(payload)
+    expected = []
+    for matrix in result.boundary_matrices[1:]:
+        dense = [[0] * matrix.columns for _ in range(matrix.rows)]
+        for entry in matrix.entries:
+            dense[entry.row][entry.column] = entry.value
+        expected.append(tuple(tuple(str(value) for value in row) for row in dense))
+
+    assert result.canonical_value.differential_matrices == tuple(expected)
 
 
 def test_integral_producer_value_enters_homology_unchanged() -> None:

--- a/tests/math/topology/test_native.py
+++ b/tests/math/topology/test_native.py
@@ -3,12 +3,15 @@ the canonical chain-complex consumers unchanged."""
 
 from __future__ import annotations
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, cast, overload
 
 import pytest
+from pydantic import ValidationError
 
 from jacobian.catalog.models import MathTool, OperationDomainValidationError
 from jacobian.math.topology._homology import (
+    IntegralSimplicialHomologyRequest,
+    IntegralSimplicialHomologyResult,
     SimplicialHomologyRequest,
     SimplicialHomologyResult,
 )
@@ -26,7 +29,13 @@ from jacobian.math.topology.chain_complexes.operations import (
     homology_groups,
     tensor_product_complex,
 )
-from jacobian.math.topology.chain_complexes.values import CoefficientField
+from jacobian.math.topology.chain_complexes.values import (
+    ChainComplexValue,
+    CoefficientRing,
+    HomologyGroupValue,
+    HomologyResult,
+    IntegralHomologyGroupValue,
+)
 from jacobian.math.topology.operations import simplicial_chain_complex_value
 
 
@@ -48,8 +57,31 @@ def _operation(
 ) -> MathTool[SimplicialHomologyRequest, SimplicialHomologyResult]: ...
 
 
+@overload
+def _operation(
+    operation_id: Literal["topology.simplicial_homology.integral.compute"],
+) -> MathTool[IntegralSimplicialHomologyRequest, IntegralSimplicialHomologyResult]: ...
+
+
 def _operation(operation_id: str) -> MathTool[Any, Any]:
     return next(tool for tool in TOOLS if tool.operation_id == operation_id)
+
+
+def _field_groups(result: HomologyResult) -> tuple[HomologyGroupValue, ...]:
+    assert all(
+        isinstance(group, HomologyGroupValue) for group in result.homology_groups
+    )
+    return cast(tuple[HomologyGroupValue, ...], result.homology_groups)
+
+
+def _integral_groups(
+    result: HomologyResult,
+) -> tuple[IntegralHomologyGroupValue, ...]:
+    assert all(
+        isinstance(group, IntegralHomologyGroupValue)
+        for group in result.homology_groups
+    )
+    return cast(tuple[IntegralHomologyGroupValue, ...], result.homology_groups)
 
 
 def _circle() -> FiniteSimplicialComplex:
@@ -77,12 +109,12 @@ def test_gf_p_chain_result_enters_homology_unchanged() -> None:
     """A small GF(p) producer output passes through the consumer's typed
     boundary without caller-side reconstruction."""
     value = simplicial_chain_complex_value(_prime_field_chain(_circle(), 2))
-    assert value.coefficient_field is CoefficientField.PRIME_FIELD
+    assert value.coefficient_ring is CoefficientRing.PRIME_FIELD
     assert value.prime == 2
     assert value.basis_sizes == (3, 3)
 
     result = homology_groups(value)
-    assert [(group.degree, group.betti_number) for group in result.homology_groups] == [
+    assert [(group.degree, group.betti_number) for group in _field_groups(result)] == [
         (0, 1),
         (1, 1),
     ]
@@ -95,11 +127,19 @@ def test_producer_result_carries_its_canonical_value() -> None:
     assert result.canonical_value is not None
     assert result.canonical_value == simplicial_chain_complex_value(result)
     homology = homology_groups(result.canonical_value)
-    assert [group.betti_number for group in homology.homology_groups] == [1, 1]
+    assert [group.betti_number for group in _field_groups(homology)] == [1, 1]
 
 
-def test_integral_producer_result_admits_no_canonical_value() -> None:
-    """Integral boundaries live over ZZ, so no canonical value exists."""
+def test_producer_result_binds_the_canonical_differentials() -> None:
+    result = _prime_field_chain(_circle(), 2)
+    payload = result.model_dump(mode="json")
+    payload["canonical_value"]["differential_matrices"][0][0][0] = "0"
+    with pytest.raises(ValidationError, match="canonical chain-complex value"):
+        ChainComplexResult.model_validate(payload)
+
+
+def test_integral_producer_value_enters_homology_unchanged() -> None:
+    """The simplicial producer and generic consumer share the canonical ZZ value."""
     integral = _operation("topology.simplicial_complex.chain_complex.compute").run(
         ChainComplexRequest(
             complex=_circle(),
@@ -107,9 +147,11 @@ def test_integral_producer_result_admits_no_canonical_value() -> None:
             convention=HomologyConvention.UNREDUCED,
         )
     )
-    assert integral.canonical_value is None
-    with pytest.raises(ValueError):
-        simplicial_chain_complex_value(integral)
+    value = simplicial_chain_complex_value(integral)
+    assert value.coefficient_ring is CoefficientRing.INTEGER
+    assert value.basis_sizes == (3, 3)
+    homology = homology_groups(value)
+    assert [group.free_rank for group in _integral_groups(homology)] == [1, 1]
 
 
 def test_converted_profile_matches_topology_homology_producer() -> None:
@@ -122,7 +164,7 @@ def test_converted_profile_matches_topology_homology_producer() -> None:
         SimplicialHomologyRequest(complex=complex_, prime=3)
     )
     assert (
-        [group.betti_number for group in composed.homology_groups]
+        [group.betti_number for group in _field_groups(composed)]
         == [group.betti_number for group in topology.groups]
         == [1, 1]
     )
@@ -135,7 +177,7 @@ def test_serialized_value_round_trips_into_consumers() -> None:
     payload = simplicial_chain_complex_value(_prime_field_chain(_circle(), 2))
     value = ChainComplexValue.model_validate(payload.model_dump())
     result = homology_groups(value)
-    assert result.homology_groups[1].betti_number == 1
+    assert _field_groups(result)[1].betti_number == 1
     tensor = tensor_product_complex(value, value)
     assert tensor.value.basis_sizes == (9, 18, 9)
 
@@ -150,10 +192,10 @@ def test_point_complex_degenerate_value_keeps_full_context() -> None:
     assert value.differential_matrices == ()
     assert (value.degree_min, value.degree_max) == (0, 0)
     result = homology_groups(value)
-    assert result.homology_groups[0].betti_number == 1
+    assert _field_groups(result)[0].betti_number == 1
 
 
-def test_integral_ring_is_outside_the_canonical_domain() -> None:
+def test_serialized_integral_value_round_trips_into_homology() -> None:
     integral = _operation("topology.simplicial_complex.chain_complex.compute").run(
         ChainComplexRequest(
             complex=_circle(),
@@ -161,11 +203,14 @@ def test_integral_ring_is_outside_the_canonical_domain() -> None:
             convention=HomologyConvention.UNREDUCED,
         )
     )
-    with pytest.raises(ValueError):
-        simplicial_chain_complex_value(integral)
+    payload = simplicial_chain_complex_value(integral).model_dump(mode="json")
+    value = ChainComplexValue.model_validate(payload)
+    result = homology_groups(value)
+    assert result.coefficient_ring is CoefficientRing.INTEGER
+    assert [group.free_rank for group in _integral_groups(result)] == [1, 1]
 
 
-def test_reduced_chains_carry_an_unrepresentable_augmentation() -> None:
+def test_reduced_chains_encode_augmentation_as_degree_minus_one() -> None:
     reduced = _operation("topology.simplicial_complex.chain_complex.compute").run(
         ChainComplexRequest(
             complex=_circle(),
@@ -174,9 +219,36 @@ def test_reduced_chains_carry_an_unrepresentable_augmentation() -> None:
             convention=HomologyConvention.REDUCED,
         )
     )
-    assert reduced.canonical_value is None
-    with pytest.raises(ValueError):
-        simplicial_chain_complex_value(reduced)
+    value = simplicial_chain_complex_value(reduced)
+    assert (value.degree_min, value.degree_max) == (-1, 1)
+    assert value.basis_sizes == (1, 3, 3)
+    assert value.differential_matrices[0] == (("1", "1", "1"),)
+    result = homology_groups(value)
+    assert [group.betti_number for group in _field_groups(result)] == [0, 0, 1]
+
+
+def test_integral_topology_result_wraps_the_chain_owned_result() -> None:
+    complex_ = _circle()
+    chain = _operation("topology.simplicial_complex.chain_complex.compute").run(
+        ChainComplexRequest(
+            complex=complex_,
+            coefficient_ring=ChainCoefficientRing.INTEGER,
+            convention=HomologyConvention.REDUCED,
+        )
+    )
+    composed = homology_groups(chain.canonical_value)
+    topology = _operation("topology.simplicial_homology.integral.compute").run(
+        IntegralSimplicialHomologyRequest(
+            complex=complex_, convention=HomologyConvention.REDUCED
+        )
+    )
+    assert topology.homology == composed
+    assert (
+        IntegralSimplicialHomologyResult.model_validate(
+            topology.model_dump(mode="json")
+        )
+        == topology
+    )
 
 
 def test_oversized_simplicial_groups_stay_outside_the_canonical_domain() -> None:

--- a/tests/process/topology/__init__.py
+++ b/tests/process/topology/__init__.py
@@ -1,0 +1,1 @@
+"""Process-boundary tests for topology backends."""

--- a/tests/process/topology/test_integral_homology_smith_process.py
+++ b/tests/process/topology/test_integral_homology_smith_process.py
@@ -15,7 +15,11 @@ from jacobian._execution import (
     OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
 )
-from jacobian.math.matrices.certified_snf.operations import matrix_multiply
+from jacobian.math.matrices.certified_snf.operations import (
+    identity_matrix,
+    matrix_determinant,
+    matrix_multiply,
+)
 from jacobian.math.topology.chain_complexes import _smith_process
 from jacobian.process import bounded_process_cancellation
 
@@ -128,10 +132,17 @@ def test_worker_projection_is_bound_to_the_admitted_source() -> None:
         )
         == result.reduction.diagonal
     )
-    assert matrix_multiply(result.left_inverse, result.reduction.left) == [
-        [1, 0],
-        [0, 1],
-    ]
+    unit = identity_matrix(2)
+    assert matrix_multiply(result.left_inverse, result.reduction.left) == unit
+    assert matrix_multiply(result.reduction.left, result.left_inverse) == unit
+    assert matrix_multiply(result.right_inverse, result.reduction.right) == unit
+    assert matrix_multiply(result.reduction.right, result.right_inverse) == unit
+    assert (
+        matrix_determinant(result.reduction.left) == result.reduction.left_determinant
+    )
+    assert (
+        matrix_determinant(result.reduction.right) == result.reduction.right_determinant
+    )
 
 
 def test_wrong_worker_digest_is_rejected(

--- a/tests/process/topology/test_integral_homology_smith_process.py
+++ b/tests/process/topology/test_integral_homology_smith_process.py
@@ -99,6 +99,25 @@ def test_worker_setup_consumes_the_inherited_absolute_deadline(
         _run_smith(time.monotonic() + 0.1)
 
 
+def test_launch_race_reports_typed_timeout_before_process_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ticks = iter((9.0, 10.0))
+    launched = False
+
+    def forbidden_launch(*args: Any, **kwargs: Any) -> Any:
+        nonlocal launched
+        launched = True
+        raise AssertionError("expired allowance reached the process supervisor")
+
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr("jacobian.process.run_bounded_process", forbidden_launch)
+
+    with pytest.raises(OperationExecutionTimeoutError, match="before launching"):
+        _run_smith(10.0)
+    assert not launched
+
+
 def test_worker_projection_is_bound_to_the_admitted_source() -> None:
     result = _run_smith(time.monotonic() + 20)
 

--- a/tests/process/topology/test_integral_homology_smith_process.py
+++ b/tests/process/topology/test_integral_homology_smith_process.py
@@ -1,0 +1,142 @@
+"""Killability tests for the integral-homology Smith worker boundary."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.math.matrices.certified_snf.operations import matrix_multiply
+from jacobian.math.topology.chain_complexes import _smith_process
+from jacobian.process import bounded_process_cancellation
+
+
+def _sleeping_worker(path: Path) -> Path:
+    path.write_text("import time\ntime.sleep(30)\n", encoding="utf-8")
+    return path
+
+
+def _run_smith(deadline: float) -> _smith_process.SmithProcessResult:
+    return _smith_process.smith_reduce_in_worker(
+        [[2, 2], [2, 2]],
+        rows=2,
+        columns=2,
+        deadline=deadline,
+        left_bits=64,
+        right_bits=64,
+        diagonal_bits=64,
+        left_inverse_bits=128,
+        right_inverse_bits=128,
+    )
+
+
+def test_cancellation_kills_the_smith_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        _smith_process,
+        "_SMITH_WORKER",
+        _sleeping_worker(tmp_path / "sleeping_smith.py"),
+    )
+    cancellation = threading.Event()
+    timer = threading.Timer(0.2, cancellation.set)
+    started = time.monotonic()
+    timer.start()
+    try:
+        with (
+            bounded_process_cancellation(cancellation),
+            pytest.raises(OperationExecutionCancelledError, match="cancelled"),
+        ):
+            _run_smith(started + 20)
+    finally:
+        timer.cancel()
+
+    assert time.monotonic() - started < 3
+
+
+def test_expired_deadline_prevents_smith_worker_launch() -> None:
+    with pytest.raises(OperationExecutionTimeoutError, match="before Smith worker"):
+        _run_smith(time.monotonic() - 1)
+
+
+def test_deadline_kills_an_active_smith_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        _smith_process,
+        "_SMITH_WORKER",
+        _sleeping_worker(tmp_path / "sleeping_smith.py"),
+    )
+    started = time.monotonic()
+
+    with pytest.raises(OperationExecutionTimeoutError, match="during Smith reduction"):
+        _run_smith(started + 0.2)
+
+    assert time.monotonic() - started < 3
+
+
+def test_worker_setup_consumes_the_inherited_absolute_deadline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    @contextmanager
+    def delayed_directory(*args: Any, **kwargs: Any) -> Iterator[str]:
+        del args, kwargs
+        time.sleep(0.2)
+        yield str(tmp_path)
+
+    monkeypatch.setattr(_smith_process, "TemporaryDirectory", delayed_directory)
+
+    with pytest.raises(OperationExecutionTimeoutError, match="before launching"):
+        _run_smith(time.monotonic() + 0.1)
+
+
+def test_worker_projection_is_bound_to_the_admitted_source() -> None:
+    result = _run_smith(time.monotonic() + 20)
+
+    assert (
+        matrix_multiply(
+            matrix_multiply(result.reduction.left, result.reduction.source),
+            result.reduction.right,
+        )
+        == result.reduction.diagonal
+    )
+    assert matrix_multiply(result.left_inverse, result.reduction.left) == [
+        [1, 0],
+        [0, 1],
+    ]
+
+
+def test_wrong_worker_digest_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    response: dict[str, Any] = {
+        "request_digest": "0" * 64,
+        "diagonal": [[2, 0], [0, 0]],
+        "left": [[1, 0], [-1, 1]],
+        "right": [[1, -1], [0, 1]],
+        "rank": 1,
+        "invariant_factors": [2],
+        "left_determinant": 1,
+        "right_determinant": 1,
+        "left_inverse": [[1, 0], [1, 1]],
+        "right_inverse": [[1, 1], [0, 1]],
+    }
+    worker = tmp_path / "wrong_digest.py"
+    worker.write_text(
+        "import json, sys\nsys.stdin.buffer.read()\n"
+        f"json.dump({response!r}, sys.stdout, separators=(',', ':'))\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_smith_process, "_SMITH_WORKER", worker)
+
+    with pytest.raises(RuntimeError, match="malformed output"):
+        _run_smith(time.monotonic() + 20)


### PR DESCRIPTION
## Problem

`chain_complex.homology.compute` is the canonical operation for finite based chain complexes, but it only accepts fields. A caller that already has exact integer differentials cannot obtain torsion-sensitive homology without rebuilding the calculation around the simplicial-topology implementation and losing the original based complex.

Closes #2442.

## Solution

Extend the existing chain-complex contract from coefficient fields to exact coefficient rings and add `ZZ` as a distinct integral branch. Field homology keeps its rank result. Integral homology returns, in every retained degree, the finitely generated abelian-group decomposition, source-basis free and torsion cycles, torsion bounding chains, and the outgoing and incoming Smith certificates that determine the quotient `ker(d_n) / im(d_{n+1})`.

The kernel performs the two algebraically different reductions explicitly: the outgoing differential gives a saturated cycle basis, then the incoming differential is expressed in those coordinates and reduced to invariant factors. Ordinary diagonal and visible-pivot cases remain in process; the general exact decomposition delegates to SymPy's maintained Smith and exact matrix kernels in a bounded one-shot child. The existing integral simplicial operation now constructs a canonical `ZZ` chain complex and consumes this result instead of owning a second integral-homology carrier.

This intentionally extends `chain_complex.homology.compute`; it does not add a parallel operation.

## Testing

- `make handoff LANE=math TESTS=tests/math/topology` (438 passed)
- `uv run --locked pytest -q tests/math/topology tests/process/topology` (445 passed)
- `make test-catalog` (113 passed)
- `uv run --locked python tools/check_architecture.py`
- `make import-contracts`

The mathematical tests cover zero and one-term complexes, multiplication by an integer, mixed free/torsion groups, nontrivial basis changes, negative degrees, zero-rank groups, malformed `d^2`, and agreement between simplicial and chain-complex integral homology. They directly check the defining identities `d(z) = 0`, `d(c) = t z`, Smith reconstruction, invariant-factor divisibility, and exact JSON round trips.

- Specialist validation run: `uv run --locked pytest -q tests/process/topology`

## Public contract impact

The canonical `ChainComplexValue` and related request/results rename `coefficient_field` to `coefficient_ring`, with values `QQ`, `GF_p`, and the new `ZZ`. `HomologyResult` is now discriminated by group kind: field inputs return `FIELD_VECTOR_SPACE`; `ZZ` inputs return `FINITELY_GENERATED_ABELIAN_GROUP`. This is an intentional pre-stable contract change: existing callers must use the ring field name, while the semantics of existing `QQ` and `GF_p` calculations are unchanged.

## Operation boundary ownership

- Changed stage: request parsing and bounds, integral kernel adapter, canonical result construction, native/MCP schemas
- Request-bounds owner and controlling quantities: `chain_complexes._models` bounds the raw nested request before canonical parsing; `chain_complexes._integral_homology` owns semantic admission from degree span, ranks, matrix cells, coefficient height, `d^2` products, both Smith reductions, result construction, and exact output size.
- Work, intermediate, memory, and exact-output bounds: each integral chain rank is at most 32, total chain rank is at most 100, differentials contain at most 2,500 cells, and input coefficients contain at most 32 decimal digits. Admission also caps predicted transformation height, total work at 5,000,000 units, the complete result at 65,536 integer scalars, and its canonical serialized byte bound. The child has explicit address-space, file, stdout, and stderr limits.
- Wall deadline, calibration workload, safety margin, and caller-selectable range: one source-derived 30-minute absolute deadline covers admission, both reductions, result construction, and serialization. It is a killable safety backstop rather than a mathematical conclusion and is not caller-selectable. Diagonal, sparse visible-pivot, and general Smith fixtures exercise each execution regime.
- Backend or kernel path: exact owner-local reduction and reconstruction, with SymPy `smith_normal_decomp`, `DomainMatrix.inv_den`, and exact determinant kernels in a bounded child for the general case
- Result construction: owner code converts both reductions into the canonical chain-owned group values and retains the original complex, source bases, quotient-coordinate matrix, representatives, bounding chains, and Smith certificates.
- Independent-result verifier: none; the public contract accepts only a chain-complex request and returns the owner kernel's result.
- Native/MCP parity: both paths invoke the same typed operation and admission plan; only transport projection differs.
- Serialized-result and round-trip evidence: strict request/result JSON tests cover both field and integral discriminated branches, including empty and zero-rank groups.

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Advertised codomain is closed under the result types, including required parent, embedding, branch, orientation, basis, or coordinate data
- [x] Producer→consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: finite based chain complexes over `ZZ` whose adjacent integer differentials satisfy `d^2 = 0`; ring grammar, shapes, bounds, and the chain identity are validated before Smith execution.
- Structurally valid but mathematically invalid fixture and outcome: adjacent matrices with nonzero composition are rejected with a typed domain error before homology computation.
- Serialized-subtype trust boundary: strict discriminated Pydantic construction binds every integral group to the retained complex's degree, source matrix, ranks, certificate axes, invariant factors, and generator dimensions.
- Exact-success defining invariant: returned cycles satisfy `d(z) = 0`; every torsion witness satisfies `d(c) = t z`; Smith transformations reconstruct their source matrices; nontrivial incoming Smith factors are exactly the torsion invariant factors.
- Discriminated result schema and impossible combinations: `FIELD_VECTOR_SPACE` is accepted only for `QQ`/`GF_p`, and `FINITELY_GENERATED_ABELIAN_GROUP` only for `ZZ`; prime/ring mismatches, mixed group branches, wrong degree coverage, inconsistent ranks, and certificate/source mismatches are rejected.

## Catalog admission

Not applicable. Catalog membership and the operation ID are unchanged; this extends the admitted coefficient domain and exact result branch of the existing owner-local declaration.

## Closure matrix

None. This issue requests one extension of an existing operation and leaves no deferred operation surface.

## Checklist

- [x] `make handoff LANE=math TESTS=tests/math/topology` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes ran their dedicated validation (not applicable)
- [x] Catalog changes have an explicit owner-local `_tools.py` publication outcome (existing declaration updated in place)
- [x] No compatibility aliases, forwarding modules, or generic `_operations.py` shadow paths were introduced
- [x] Runtime-bound changes name the request-bounds owner and execute the same semantic path for native and MCP callers
- [x] Result semantics distinguish exact results from operational failures
- [x] Public operation changes include behavioral regressions from the motivating request
- [x] New bounds include boundary, algorithm-crossover, and realistic source-shaped evidence
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable; the canonical chain result replaces the duplicate simplicial carrier)
