### PR TITLE
Remove redundant singular-point recomputation

### DIFF
--- a/docs/reference/operations/geometry/projective-plane-curve-singularities.md
+++ b/docs/reference/operations/geometry/projective-plane-curve-singularities.md
@@ -54,10 +54,12 @@ returns two distinct points with the shared presentation
 `[1:-i:0]` and `[1:i:0]` survive strict JSON serialization as different
 embedded points.
 
-Before returning a point, the kernel substitutes its reduced coordinates into
-`F` and every partial and reduces exactly modulo the defining polynomial. The
-four remainders must all vanish. Numerical matching and backend root objects do
-not cross the public boundary.
+The point worker constructs reduced coordinates from the exact disjoint-chart
+components and their irreducible residue-field presentations. Direct
+defining-invariant tests independently substitute those coordinates into `F`
+and every partial and reduce modulo the presentation; the execution path does
+not replay that computation as a verifier. Numerical matching and backend root
+objects do not cross the public boundary.
 
 ## Execution envelope
 

--- a/docs/reference/operations/geometry/projective-plane-curve-singularities.md
+++ b/docs/reference/operations/geometry/projective-plane-curve-singularities.md
@@ -88,7 +88,7 @@ All Singular calls and exact point construction share one request-scoped
 deadline. Singular and the one-shot SymPy point worker are killable and have
 fixed diagnostic, address-space, file-size, and exact-output limits. Singular
 is the private exact ideal engine; the isolated SymPy transaction supplies
-factorization, Gröbner shape conversion, and residue-field replay. Public
+factorization, Gröbner shape conversion, and residue-field construction. Public
 identities use only Jacobian's canonical polynomials, ideals, number fields,
 field elements, and embeddings.
 

--- a/src/jacobian/math/geometry/algebraic_curves/_models.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_models.py
@@ -192,8 +192,8 @@ class RationalConicParametrizationResult(StrictModel):
         """Check only bounded wire-shape relations between result fields.
 
         The admitted line-pencil kernel establishes the parametrization
-        identities. Parsing a serialized result must not reconstruct and replay
-        that computation; independently supplied claims are outside this result
+        identities. Parsing a serialized result must not rerun that computation;
+        independently supplied claims are outside this result
         contract.
         """
         try:

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity.py
@@ -502,8 +502,6 @@ def _complete_zero_dimensional_points(
     saturation: RationalPolynomialIdeal,
     *,
     admission: _SingularityAdmission,
-    source: RationalPolynomial,
-    partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
     axis: tuple[str, str, str],
     budget: IdealComputationBudget,
     deadline: float,
@@ -557,8 +555,7 @@ def _complete_zero_dimensional_points(
         return projection_failure
 
     worker_request = ProjectiveSingularityPointWorkerRequest(
-        source=source,
-        partials=partials,
+        variables=axis,
         chart_zero_components=chart_zero_components,
         chart_one_components=chart_one_components,
         chart_two_present=_chart_two_is_present(saturation),
@@ -748,8 +745,6 @@ def _singularity_profile_request(
             points = _complete_zero_dimensional_points(
                 saturation,
                 admission=admission,
-                source=source,
-                partials=partials,
                 axis=axis,
                 budget=budget,
                 deadline=deadline,

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity_models.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity_models.py
@@ -148,7 +148,7 @@ class ProjectivePlaneCurveFirstJet(StrictModel):
             SimpleNumberFieldElement,
         ],
     ) -> Self:
-        """Construct the exact zero jet after owner-local replay established it."""
+        """Construct the exact zero jet established by point construction."""
 
         return cls.model_construct(value=value, gradient=gradient)
 

--- a/src/jacobian/math/geometry/algebraic_curves/_singularity_point_worker.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_singularity_point_worker.py
@@ -26,7 +26,7 @@ from jacobian.math.polynomials._conversions import (
     symbols_for_variables,
 )
 from jacobian.math.polynomials.values import (
-    RationalPolynomial,
+    PolynomialVariable,
     RationalPolynomialIdeal,
 )
 
@@ -78,8 +78,7 @@ class ProjectiveSingularityPointSeed(StrictModel):
 class ProjectiveSingularityPointWorkerRequest(StrictModel):
     """Canonical exact input for one complete point-construction transaction."""
 
-    source: RationalPolynomial
-    partials: tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial]
+    variables: tuple[PolynomialVariable, PolynomialVariable, PolynomialVariable]
     chart_zero_components: tuple[RationalPolynomialIdeal, ...] = Field(
         max_length=MAX_PROJECTIVE_SINGULAR_POINTS
     )
@@ -90,17 +89,14 @@ class ProjectiveSingularityPointWorkerRequest(StrictModel):
 
     @model_validator(mode="after")
     def bind_component_axes(self) -> Self:
-        axis = self.source.variables
-        if len(axis) != 3 or any(
-            partial.variables != axis for partial in self.partials
-        ):
-            raise ValueError("point worker source and partial axes do not agree")
         if any(
-            component.variables != axis[1:] for component in self.chart_zero_components
+            component.variables != self.variables[1:]
+            for component in self.chart_zero_components
         ):
             raise ValueError("first-chart component has the wrong axis")
         if any(
-            component.variables != axis[2:] for component in self.chart_one_components
+            component.variables != self.variables[2:]
+            for component in self.chart_one_components
         ):
             raise ValueError("second-chart component has the wrong axis")
         if (
@@ -278,8 +274,6 @@ def _seed_for_factor(
     parameter: sympy.Symbol,
     coordinate_polynomials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
     chart_index: int,
-    source: sympy.Poly,
-    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
 ) -> ProjectiveSingularityPointSeed:
     if int(factor.degree()) == 1:
         presentation = SimpleNumberFieldPresentation(coefficients_descending=("1", "0"))
@@ -306,33 +300,6 @@ def _seed_for_factor(
         coordinate_values[1],
         coordinate_values[2],
     )
-
-    modulus = sympy.Poly(
-        sum(
-            int(coefficient) * parameter ** (presentation.degree - index)
-            for index, coefficient in enumerate(presentation.coefficients_descending)
-        ),
-        parameter,
-        domain=sympy.QQ,
-    )
-    coordinate_expressions = tuple(
-        sum(
-            sympy.Rational(*coefficient.as_integer_ratio()) * parameter**index
-            for index, coefficient in enumerate(coordinate.coefficients_ascending)
-        )
-        for coordinate in coordinates
-    )
-    substitutions = dict(zip(source.gens, coordinate_expressions, strict=True))
-    evaluated = tuple(
-        sympy.Poly(
-            sympy.expand(polynomial.as_expr().subs(substitutions)),
-            parameter,
-            domain=sympy.QQ,
-        ).rem(modulus)
-        for polynomial in (source, *partials)
-    )
-    if any(not value.is_zero for value in evaluated):
-        raise ValueError("exact point replay did not annihilate the first jet")
     return ProjectiveSingularityPointSeed(
         presentation=presentation,
         coordinates=coordinates,
@@ -346,8 +313,6 @@ def _factor_seeds(
     parameter: sympy.Symbol,
     coordinate_polynomials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
     chart_index: int,
-    source: sympy.Poly,
-    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
 ) -> tuple[ProjectiveSingularityPointSeed, ...]:
     _coefficient, factors = eliminant.factor_list()
     if any(multiplicity != 1 for _factor, multiplicity in factors):
@@ -358,8 +323,6 @@ def _factor_seeds(
             parameter=parameter,
             coordinate_polynomials=coordinate_polynomials,
             chart_index=chart_index,
-            source=source,
-            partials=partials,
         )
         for factor, _multiplicity in factors
     )
@@ -367,9 +330,6 @@ def _factor_seeds(
 
 def _two_axis_seeds(
     component: RationalPolynomialIdeal,
-    *,
-    source: sympy.Poly,
-    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
 ) -> tuple[ProjectiveSingularityPointSeed, ...]:
     parameter, eliminant, (first, second) = _shape_data(component)
     one = sympy.Poly(1, parameter, domain=sympy.QQ)
@@ -378,16 +338,11 @@ def _two_axis_seeds(
         parameter=parameter,
         coordinate_polynomials=(one, first, second),
         chart_index=0,
-        source=source,
-        partials=partials,
     )
 
 
 def _one_axis_seeds(
     component: RationalPolynomialIdeal,
-    *,
-    source: sympy.Poly,
-    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
 ) -> tuple[ProjectiveSingularityPointSeed, ...]:
     parameter, eliminant = _univariate_component_polynomial(component)
     zero = sympy.Poly(0, parameter, domain=sympy.QQ)
@@ -398,16 +353,10 @@ def _one_axis_seeds(
         parameter=parameter,
         coordinate_polynomials=(zero, one, coordinate),
         chart_index=1,
-        source=source,
-        partials=partials,
     )
 
 
-def _chart_two_seed(
-    *,
-    source: sympy.Poly,
-    partials: tuple[sympy.Poly, sympy.Poly, sympy.Poly],
-) -> ProjectiveSingularityPointSeed:
+def _chart_two_seed() -> ProjectiveSingularityPointSeed:
     parameter = sympy.Symbol("__jacobian_rational_parameter")
     factor = sympy.Poly(parameter, parameter, domain=sympy.QQ)
     zero = sympy.Poly(0, parameter, domain=sympy.QQ)
@@ -417,8 +366,6 @@ def _chart_two_seed(
         parameter=parameter,
         coordinate_polynomials=(zero, zero, one),
         chart_index=2,
-        source=source,
-        partials=partials,
     )
 
 
@@ -427,19 +374,13 @@ def compute_point_worker_response(
 ) -> ProjectiveSingularityPointWorkerComplete:
     """Construct every residue-field seed in one isolated exact transaction."""
 
-    source = rational_polynomial_to_sympy(request.source)
-    partials = (
-        rational_polynomial_to_sympy(request.partials[0]),
-        rational_polynomial_to_sympy(request.partials[1]),
-        rational_polynomial_to_sympy(request.partials[2]),
-    )
     seeds: list[ProjectiveSingularityPointSeed] = []
     for component in request.chart_zero_components:
-        seeds.extend(_two_axis_seeds(component, source=source, partials=partials))
+        seeds.extend(_two_axis_seeds(component))
     for component in request.chart_one_components:
-        seeds.extend(_one_axis_seeds(component, source=source, partials=partials))
+        seeds.extend(_one_axis_seeds(component))
     if request.chart_two_present:
-        seeds.append(_chart_two_seed(source=source, partials=partials))
+        seeds.append(_chart_two_seed())
     ordered = tuple(sorted(seeds, key=lambda seed: seed.model_dump_json()))
     return ProjectiveSingularityPointWorkerComplete(kind="complete", seeds=ordered)
 

--- a/src/jacobian/math/number_theory/algebraic_numbers/complex.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/complex.py
@@ -292,7 +292,7 @@ class ComplexAlgebraicValue(_ComplexAlgebraicValueShape):
 
     Parsing checks only its bounded canonical shape. Mathematical consumers
     must recognize irreducibility and the selected nonreal root within their
-    own admitted execution path; model validation never replays that work.
+    own admitted execution path; model validation does not recompute that work.
     """
 
     @classmethod

--- a/src/jacobian/math/number_theory/algebraic_numbers/quadratic.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/quadratic.py
@@ -18,7 +18,7 @@ _MAX_DIGITS = 256
 # For a,b with numerator and denominator at most 256 decimal digits,
 # a^2 - d*b^2 has a denominator of at most 1,024 digits and a numerator
 # of at most 1,032 digits after bringing the two terms to that denominator
-# (d <= 10^6).  The trace is smaller.  This covers producer and replay.
+# (d <= 10^6).  The trace is smaller.  This covers production and reconstruction.
 _MAX_EMBEDDING_PROFILE_RESULT_DIGITS = 1_032
 
 

--- a/tests/math/geometry/algebraic_curves/test_plane_algebraic_curves.py
+++ b/tests/math/geometry/algebraic_curves/test_plane_algebraic_curves.py
@@ -185,7 +185,7 @@ def test_rational_conic_parametrization_has_canonical_known_answer() -> None:
         ),
     ],
 )
-def test_parametrization_replays_substitution_and_inverse_identities(
+def test_parametrization_satisfies_substitution_and_inverse_identities(
     source: RationalPolynomial,
     point: tuple[CanonicalRational, CanonicalRational],
 ) -> None:

--- a/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
+++ b/tests/math/geometry/algebraic_curves/test_projective_singularity_profile.py
@@ -102,6 +102,39 @@ def _compute(source: RationalPolynomial) -> ProjectivePlaneCurveSingularityProfi
     )
 
 
+def _assert_singular_point_defining_identities(
+    result: ProjectivePlaneCurveSingularityProfile,
+) -> None:
+    assert result.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
+    parameter = sympy.Symbol("alpha")
+    for record in result.outcome.points:
+        presentation = record.point.embedding.presentation
+        modulus = sympy.Poly.from_list(
+            [int(coefficient) for coefficient in presentation.coefficients_descending],
+            gens=parameter,
+            domain=sympy.QQ,
+        )
+        coordinate_expressions = tuple(
+            sum(
+                sympy.Rational(*coefficient.as_integer_ratio()) * parameter**power
+                for power, coefficient in enumerate(coordinate.coefficients_ascending)
+            )
+            for coordinate in record.point.coordinates
+        )
+        for polynomial in (
+            result.source_polynomial,
+            *result.partial_derivatives,
+        ):
+            backend = rational_polynomial_to_sympy(polynomial)
+            substitutions = dict(zip(backend.gens, coordinate_expressions, strict=True))
+            value = sympy.Poly(
+                sympy.expand(backend.as_expr().subs(substitutions)),
+                parameter,
+                domain=sympy.QQ,
+            ).rem(modulus)
+            assert value.is_zero
+
+
 def _ideal_with_shape(
     *,
     coefficient: CanonicalRational,
@@ -167,6 +200,7 @@ def test_conjugate_nonrational_singularities_keep_distinct_embedding_identity() 
         )
         assert point.chart_index == 0
     assert roots == [0, 1]
+    _assert_singular_point_defining_identities(result)
 
     payload = result.model_dump(mode="json")
     assert ProjectivePlaneCurveSingularityProfile.model_validate(payload) == result
@@ -211,6 +245,7 @@ def test_geometrically_split_cubic_keeps_its_complete_galois_orbit() -> None:
         1,
         2,
     ]
+    _assert_singular_point_defining_identities(result)
 
 
 @pytest.mark.parametrize(
@@ -282,28 +317,7 @@ def test_nodal_cubic_returns_an_exact_zero_first_jet() -> None:
         for value in (record.first_jet.value, *record.first_jet.gradient)
         for coefficient in value.coefficients_ascending
     )
-
-
-def test_result_deserialization_does_not_replay_the_zero_jet() -> None:
-    result = _compute(
-        _polynomial(
-            (-1, (3, 0, 0)),
-            (-1, (2, 0, 1)),
-            (1, (0, 2, 1)),
-        )
-    )
-    payload = result.model_dump(mode="json")
-    payload["outcome"]["points"][0]["first_jet"]["value"]["coefficients_ascending"][0][
-        "num"
-    ] = "1"
-
-    parsed = ProjectivePlaneCurveSingularityProfile.model_validate(payload)
-
-    assert parsed.outcome.status == "SINGULAR_ZERO_DIMENSIONAL"
-    assert (
-        parsed.outcome.points[0].first_jet.value.coefficients_ascending[0].as_fraction()
-        == 1
-    )
+    _assert_singular_point_defining_identities(result)
 
 
 def test_three_coordinate_lines_return_one_point_in_each_disjoint_chart() -> None:

--- a/tests/math/number_theory/number_fields/_embedding_invariants.py
+++ b/tests/math/number_theory/number_fields/_embedding_invariants.py
@@ -1,4 +1,4 @@
-"""Independent defining-invariant replay for embedding-profile tests."""
+"""Independent defining-invariant checks for embedding-profile tests."""
 
 from __future__ import annotations
 
@@ -133,7 +133,7 @@ def require_rectangle_selects_root(
     value: ComplexAlgebraicValue,
     rectangle: RationalComplexIsolatingRectangle,
 ) -> Literal["NEGATIVE_IMAGINARY", "POSITIVE_IMAGINARY"]:
-    """Replay root identity, count, and half-plane for test evidence."""
+    """Check root identity, count, and half-plane for test evidence."""
 
     import sympy
 
@@ -181,7 +181,7 @@ def require_real_interval_selects_root(
     embedding: RealNumberFieldEmbedding,
     interval: RationalIsolatingInterval,
 ) -> None:
-    """Replay real root identity and count for test evidence."""
+    """Check real root identity and count for test evidence."""
 
     import sympy
 

--- a/tests/math/number_theory/number_fields/test_embeddings.py
+++ b/tests/math/number_theory/number_fields/test_embeddings.py
@@ -10,7 +10,7 @@ from types import CodeType
 
 import pytest
 from pydantic import ValidationError
-from tests.math.number_theory.number_fields._embedding_replay import (
+from tests.math.number_theory.number_fields._embedding_invariants import (
     require_real_interval_selects_root,
     require_rectangle_selects_root,
 )
@@ -360,7 +360,7 @@ def test_profile_and_canonical_values_round_trip_without_backend_objects() -> No
     assert "sympy" not in profile.model_dump_json().lower()
 
 
-def test_structural_complex_root_parsing_does_not_replay_sympy() -> None:
+def test_structural_complex_root_parsing_does_not_run_sympy() -> None:
     profiler = cProfile.Profile()
     value = profiler.runcall(
         lambda: ComplexAlgebraicValue(polynomial=("1", "0", "-1"), root_index=0)
@@ -438,7 +438,7 @@ def test_degree_coefficient_isolation_work_and_result_bounds_are_preflighted() -
         ("1", "1", "-7", "-5", "15", "6", "-10", "-1", "1"),
     ],
 )
-def test_every_kernel_isolator_replays_and_result_stays_below_preflight_bound(
+def test_kernel_isolators_and_result_satisfy_the_exact_contract(
     coefficients: tuple[str, ...],
 ) -> None:
     field = _field(*coefficients)

--- a/tests/math/number_theory/number_fields/test_embeddings.py
+++ b/tests/math/number_theory/number_fields/test_embeddings.py
@@ -37,6 +37,9 @@ from jacobian.math.number_theory.number_fields import (
     SimpleNumberFieldPresentation,
     embeddings,
 )
+from jacobian.math.number_theory.number_fields._embedding_limits import (
+    MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES,
+)
 from jacobian.math.number_theory.number_fields._embedding_protocol import (
     NumberFieldEmbeddingWorkerComplete,
     NumberFieldEmbeddingWorkerRequest,
@@ -49,7 +52,6 @@ from jacobian.math.number_theory.number_fields._models import (
 )
 from jacobian.math.number_theory.number_fields._tools import TOOLS
 from jacobian.math.number_theory.number_fields.operations import (
-    MAX_NUMBER_FIELD_EMBEDDING_RESULT_BYTES,
     NumberFieldEmbeddingAdmissionError,
     _admit_number_field_embeddings,
 )

--- a/tests/process/geometry/test_projective_singularity_point_worker.py
+++ b/tests/process/geometry/test_projective_singularity_point_worker.py
@@ -48,22 +48,6 @@ def _polynomial(
 
 def _conjugate_point_request() -> ProjectiveSingularityPointWorkerRequest:
     axis = ("X", "Y", "Z")
-    source = _polynomial(
-        axis,
-        (1, (2, 0, 1)),
-        (1, (0, 2, 1)),
-        (1, (0, 0, 3)),
-    )
-    partials = (
-        _polynomial(axis, (2, (1, 0, 1))),
-        _polynomial(axis, (2, (0, 1, 1))),
-        _polynomial(
-            axis,
-            (1, (2, 0, 0)),
-            (1, (0, 2, 0)),
-            (3, (0, 0, 2)),
-        ),
-    )
     component = RationalPolynomialIdeal(
         variables=("Y", "Z"),
         generators=(
@@ -72,8 +56,7 @@ def _conjugate_point_request() -> ProjectiveSingularityPointWorkerRequest:
         ),
     )
     return ProjectiveSingularityPointWorkerRequest(
-        source=source,
-        partials=partials,
+        variables=axis,
         chart_zero_components=(component,),
         chart_one_components=(),
         chart_two_present=False,


### PR DESCRIPTION
## Problem

The projective singularity operation landed in #3065 with the exact embedded number-field carrier needed for non-rational singular points. Its point worker then performed a second source-and-first-derivative substitution pass before returning each residue-field seed. That duplicated work already established by the saturated Jacobian ideal and made worker result construction responsible for a general verification phase that the public contract does not need.

Closes #2870. This is the focused default-branch follow-up to the merged stacked implementation in #3065.

## Solution

Keep singular-locus ownership where it belongs: Singular computes the saturated projective Jacobian ideal and its rational minimal primes, while the bounded SymPy worker constructs only the exact residue-field coordinates and embedding seeds derived from those ideals. The private worker request no longer echoes the source equation or its partial derivatives, and the worker no longer substitutes them back into each point.

The defining identities remain explicit mathematical evidence in the owning tests. They reduce the normalized equation and all three returned partials at every exact projective point, including the conjugate `QQ(i)` pair and the mixed-signature cubic orbit. Result deserialization remains structural; no replacement verifier or mutation-only test is introduced.

The reference now describes this ideal-derived residue-field construction directly and places the substitution identities in tests rather than promising a runtime pass.

## Testing

- Projective singularity profile: 23 passed
- Point-worker and number-field embedding tests: 36 passed
- Plane algebraic-curve tests: 34 passed
- Scoped Ruff, format, and mypy checks: passed for all changed Python files
- `make docs-linkcheck`
- `git diff --check origin/main...HEAD`

The broader branch validation also passed 6,904 math tests, 113 catalog tests, 837 catalog-integration tests, and the 200-test process lane before the final documentation-only correction.

## Public contract impact

None. Operation IDs, request/result schemas, admitted bounds, exact outcomes, and native/MCP behavior are unchanged. This removes redundant private worker input and computation.

## Operation boundary ownership

- Changed stage: private point-worker request and residue-field result construction
- Request-bounds owner and controlling quantities: unchanged in `algebraic_curves._singularity`
- Work, intermediate, memory, and exact-output bounds: unchanged; the worker now receives fewer values and performs strictly less work
- Wall deadline, calibration workload, safety margin, and caller-selectable range: unchanged shared request deadline
- Backend or kernel path: Singular saturation/minimal primes followed by bounded SymPy residue-field construction and the number-field embedding owner
- Result construction: exact field-bound projective points are constructed from ideal-derived residue seeds; defining identities are exercised directly in tests
- Independent-result verifier: none; the operation accepts only a source curve
- Native/MCP parity: unchanged
- Serialized-result and round-trip evidence: conjugate and cubic-orbit exact result round trips remain covered

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Advertised codomain remains closed under the existing embedded number-field point carrier
- [x] Producer→consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: unchanged bounded homogeneous ternary `QQ` polynomial contract
- Structurally valid but mathematically invalid fixture and outcome: not applicable to this cleanup; independently supplied profiles are not accepted
- Serialized-subtype trust boundary: unchanged structural result decoding and owner-produced exact point construction
- Exact-success defining invariant: `F(P)=F_X(P)=F_Y(P)=F_Z(P)=0` is checked directly for the returned exact points
- Discriminated result schema and impossible combinations: unchanged

## Catalog admission

Not applicable. Catalog membership and the admitted operation contract are unchanged.

## Closure matrix

None. #3065 delivered the single requested operation; this follow-up removes its redundant worker pass.

## Checklist

- [x] Focused owner and specialist validation passes
- [x] No compatibility aliases, forwarding modules, or shadow operation paths were introduced
- [x] Runtime bounds and native/MCP semantics are unchanged
- [x] Exact defining-invariant regressions remain at the public typed interface
- [x] No generic verifier or durable state was introduced
