### PR TITLE
Bound exact rational cancellation presolve

### DIFF
--- a/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
@@ -103,6 +103,7 @@ def _add_bounded_fraction(
 
 def _single_sum_digit_bounds(
     fractions: tuple[Fraction, ...],
+    initial_work: int = 0,
 ) -> tuple[Fraction, int, int]:
     numerators_by_denominator: dict[int, int] = {}
     for fraction in fractions:
@@ -122,9 +123,20 @@ def _single_sum_digit_bounds(
             Fraction(numerator, denominator)
             for denominator, numerator in numerators_by_denominator.items()
         ]
-        projection_work = 0
+        projection_work = initial_work
         while len(terms) > 1:
             if len(terms) <= 256:
+                pair_count = len(terms) * (len(terms) - 1) // 2
+                max_denominator_digits = max(
+                    len(format_canonical_integer(term.denominator)) for term in terms
+                )
+                projection_work += pair_count * max_denominator_digits
+                if projection_work > MAX_ENUMERATION_WORK:
+                    _reject(
+                        ("values",),
+                        "rational_fixed_arity.work_bound",
+                        "fixed-arity exact sum exceeds the admitted work bound",
+                    )
                 pair = max(
                     (
                         (
@@ -309,7 +321,7 @@ def _admit(  # noqa: C901
         sum_numerator_digits = sum_denominator_digits = 1
     elif candidate_count == 1:
         single_sum, sum_numerator_digits, sum_denominator_digits = (
-            _single_sum_digit_bounds(fractions)
+            _single_sum_digit_bounds(fractions, work)
         )
     elif candidate_count:
         # The sole empty sum is exactly 0/1, independent of source widths.

--- a/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
@@ -118,12 +118,32 @@ def _single_sum_digit_bounds(
     if not numerators_by_denominator:
         total = Fraction(0)
     else:
-        total = Fraction(0)
+        terms = [
+            Fraction(numerator, denominator)
+            for denominator, numerator in numerators_by_denominator.items()
+        ]
         projection_work = 0
-        for denominator, numerator in numerators_by_denominator.items():
-            total, projection_work = _add_bounded_fraction(
-                total, Fraction(numerator, denominator), projection_work
+        while len(terms) > 1:
+            if len(terms) <= 256:
+                pair = max(
+                    (
+                        (len(format_canonical_integer(gcd(left.denominator, right.denominator))), -i, -j),
+                        i,
+                        j,
+                    )
+                    for i, left in enumerate(terms)
+                    for j, right in enumerate(terms[i + 1 :], i + 1)
+                )
+                _, left_index, right_index = pair
+            else:
+                left_index, right_index = 0, 1
+            left, right = terms[left_index], terms[right_index]
+            combined, projection_work = _add_bounded_fraction(
+                left, right, projection_work
             )
+            terms[right_index] = combined
+            del terms[left_index]
+        total = terms[0] if terms else Fraction(0)
     return (
         total,
         len(format_canonical_integer(total.numerator)),

--- a/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
@@ -31,6 +31,7 @@ MAX_SAFE_JSON_INTEGER = (1 << 53) - 1
 class _AdmissionPlan:
     fractions: tuple[Fraction, ...]
     candidate_count: int
+    single_sum: Fraction | None = None
 
 
 def _reject(location: tuple[str | int, ...], code: str, message: str) -> None:
@@ -51,9 +52,56 @@ def _common_denominator_digits(fractions: tuple[Fraction, ...]) -> int:
     return len(format_canonical_integer(common_denominator))
 
 
-def _single_sum_digit_bounds(fractions: tuple[Fraction, ...]) -> tuple[int, int]:
-    total = sum(fractions, Fraction(0))
+def _single_sum_digit_bounds(
+    fractions: tuple[Fraction, ...],
+) -> tuple[Fraction, int, int]:
+    numerators_by_denominator: dict[int, int] = {}
+    for fraction in fractions:
+        denominator = fraction.denominator
+        numerators_by_denominator[denominator] = (
+            numerators_by_denominator.get(denominator, 0) + fraction.numerator
+        )
+    numerators_by_denominator = {
+        denominator: numerator
+        for denominator, numerator in numerators_by_denominator.items()
+        if numerator
+    }
+    if not numerators_by_denominator:
+        total = Fraction(0)
+    else:
+        common_denominator = 1
+        projection_work = 0
+        for denominator in numerators_by_denominator:
+            common_denominator = common_denominator // gcd(
+                common_denominator, denominator
+            ) * denominator
+            denominator_digits = len(format_canonical_integer(common_denominator))
+            projection_work += denominator_digits
+            if denominator_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+                _reject(
+                    ("values",),
+                    "rational_fixed_arity.rational_growth",
+                    "fixed-arity sums may exceed the canonical rational digit bound",
+                )
+            if projection_work > MAX_ENUMERATION_WORK:
+                _reject(
+                    ("values",),
+                    "rational_fixed_arity.work_bound",
+                    "fixed-arity exact sum exceeds the admitted work bound",
+                )
+        common_numerator = 0
+        for denominator, numerator in numerators_by_denominator.items():
+            projection_work += len(format_canonical_integer(abs(numerator))) + denominator_digits
+            if projection_work > MAX_ENUMERATION_WORK:
+                _reject(
+                    ("values",),
+                    "rational_fixed_arity.work_bound",
+                    "fixed-arity exact sum exceeds the admitted work bound",
+                )
+            common_numerator += numerator * (common_denominator // denominator)
+        total = Fraction(common_numerator, common_denominator)
     return (
+        total,
         len(format_canonical_integer(total.numerator)),
         len(format_canonical_integer(total.denominator)),
     )
@@ -204,9 +252,12 @@ def _admit(  # noqa: C901
     )
     shared_denominator = len({value.den for value in values}) == 1 if values else True
     common_denominator_digits = _common_denominator_digits(fractions)
-    if candidate_count == 1:
-        sum_numerator_digits, sum_denominator_digits = _single_sum_digit_bounds(
-            fractions
+    single_sum: Fraction | None = None
+    if candidate_count == 1 and arity == 0:
+        sum_numerator_digits = sum_denominator_digits = 1
+    elif candidate_count == 1:
+        single_sum, sum_numerator_digits, sum_denominator_digits = (
+            _single_sum_digit_bounds(fractions)
         )
     elif candidate_count:
         # The sole empty sum is exactly 0/1, independent of source widths.
@@ -283,6 +334,7 @@ def _admit(  # noqa: C901
     return _AdmissionPlan(
         fractions=fractions,
         candidate_count=candidate_count,
+        single_sum=single_sum,
     )
 
 
@@ -300,9 +352,12 @@ def compute_rational_fixed_arity_sum_profile(
     fractions = plan.fractions
     sum_to_count: dict[Fraction, int] = {}
 
-    for indices in combinations(range(len(values)), arity):
-        total = sum((fractions[i] for i in indices), Fraction(0))
-        sum_to_count[total] = sum_to_count.get(total, 0) + 1
+    if plan.candidate_count == 1:
+        sum_to_count[plan.single_sum or Fraction(0)] = 1
+    else:
+        for indices in combinations(range(len(values)), arity):
+            total = sum((fractions[i] for i in indices), Fraction(0))
+            sum_to_count[total] = sum_to_count.get(total, 0) + 1
 
     rows = [
         SumProfileRow(

--- a/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
@@ -127,7 +127,15 @@ def _single_sum_digit_bounds(
             if len(terms) <= 256:
                 pair = max(
                     (
-                        (len(format_canonical_integer(gcd(left.denominator, right.denominator))), -i, -j),
+                        (
+                            len(
+                                format_canonical_integer(
+                                    gcd(left.denominator, right.denominator)
+                                )
+                            ),
+                            -i,
+                            -j,
+                        ),
                         i,
                         j,
                     )

--- a/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
@@ -52,6 +52,52 @@ def _common_denominator_digits(fractions: tuple[Fraction, ...]) -> int:
     return len(format_canonical_integer(common_denominator))
 
 
+def _add_bounded_fraction(
+    left: Fraction,
+    right: Fraction,
+    work: int,
+) -> tuple[Fraction, int]:
+    left_factor = left.denominator // gcd(left.denominator, right.denominator)
+    right_factor = right.denominator // gcd(left.denominator, right.denominator)
+    shared_factor = gcd(left.denominator, right.denominator)
+    estimated_digits = max(
+        len(format_canonical_integer(abs(left.numerator)))
+        + len(format_canonical_integer(right_factor)),
+        len(format_canonical_integer(abs(right.numerator)))
+        + len(format_canonical_integer(left_factor)),
+    ) + 1
+    work += estimated_digits
+    if work > MAX_ENUMERATION_WORK:
+        _reject(
+            ("values",),
+            "rational_fixed_arity.work_bound",
+            "fixed-arity exact sum exceeds the admitted work bound",
+        )
+    numerator = left.numerator * right_factor + right.numerator * left_factor
+    common = gcd(abs(numerator), left_factor)
+    numerator //= common
+    left_factor //= common
+    common = gcd(abs(numerator), right_factor)
+    numerator //= common
+    right_factor //= common
+    common = gcd(abs(numerator), shared_factor)
+    numerator //= common
+    shared_factor //= common
+    denominator = left_factor * right_factor * shared_factor
+    result = Fraction(numerator, denominator)
+    result_digits = max(
+        len(format_canonical_integer(result.numerator)),
+        len(format_canonical_integer(result.denominator)),
+    )
+    if result_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        _reject(
+            ("values",),
+            "rational_fixed_arity.rational_growth",
+            "fixed-arity sums may exceed the canonical rational digit bound",
+        )
+    return result, work + result_digits
+
+
 def _single_sum_digit_bounds(
     fractions: tuple[Fraction, ...],
 ) -> tuple[Fraction, int, int]:
@@ -69,39 +115,12 @@ def _single_sum_digit_bounds(
     if not numerators_by_denominator:
         total = Fraction(0)
     else:
-        common_denominator = 1
+        total = Fraction(0)
         projection_work = 0
-        for denominator in numerators_by_denominator:
-            common_denominator = (
-                common_denominator // gcd(common_denominator, denominator) * denominator
-            )
-            denominator_digits = len(format_canonical_integer(common_denominator))
-            projection_work += denominator_digits
-            if denominator_digits > MAX_CANONICAL_RATIONAL_DIGITS:
-                _reject(
-                    ("values",),
-                    "rational_fixed_arity.rational_growth",
-                    "fixed-arity sums may exceed the canonical rational digit bound",
-                )
-            if projection_work > MAX_ENUMERATION_WORK:
-                _reject(
-                    ("values",),
-                    "rational_fixed_arity.work_bound",
-                    "fixed-arity exact sum exceeds the admitted work bound",
-                )
-        common_numerator = 0
         for denominator, numerator in numerators_by_denominator.items():
-            projection_work += (
-                len(format_canonical_integer(abs(numerator))) + denominator_digits
+            total, projection_work = _add_bounded_fraction(
+                total, Fraction(numerator, denominator), projection_work
             )
-            if projection_work > MAX_ENUMERATION_WORK:
-                _reject(
-                    ("values",),
-                    "rational_fixed_arity.work_bound",
-                    "fixed-arity exact sum exceeds the admitted work bound",
-                )
-            common_numerator += numerator * (common_denominator // denominator)
-        total = Fraction(common_numerator, common_denominator)
     return (
         total,
         len(format_canonical_integer(total.numerator)),

--- a/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
@@ -72,9 +72,9 @@ def _single_sum_digit_bounds(
         common_denominator = 1
         projection_work = 0
         for denominator in numerators_by_denominator:
-            common_denominator = common_denominator // gcd(
-                common_denominator, denominator
-            ) * denominator
+            common_denominator = (
+                common_denominator // gcd(common_denominator, denominator) * denominator
+            )
             denominator_digits = len(format_canonical_integer(common_denominator))
             projection_work += denominator_digits
             if denominator_digits > MAX_CANONICAL_RATIONAL_DIGITS:
@@ -91,7 +91,9 @@ def _single_sum_digit_bounds(
                 )
         common_numerator = 0
         for denominator, numerator in numerators_by_denominator.items():
-            projection_work += len(format_canonical_integer(abs(numerator))) + denominator_digits
+            projection_work += (
+                len(format_canonical_integer(abs(numerator))) + denominator_digits
+            )
             if projection_work > MAX_ENUMERATION_WORK:
                 _reject(
                     ("values",),

--- a/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
@@ -60,12 +60,15 @@ def _add_bounded_fraction(
     left_factor = left.denominator // gcd(left.denominator, right.denominator)
     right_factor = right.denominator // gcd(left.denominator, right.denominator)
     shared_factor = gcd(left.denominator, right.denominator)
-    estimated_digits = max(
-        len(format_canonical_integer(abs(left.numerator)))
-        + len(format_canonical_integer(right_factor)),
-        len(format_canonical_integer(abs(right.numerator)))
-        + len(format_canonical_integer(left_factor)),
-    ) + 1
+    estimated_digits = (
+        max(
+            len(format_canonical_integer(abs(left.numerator)))
+            + len(format_canonical_integer(right_factor)),
+            len(format_canonical_integer(abs(right.numerator)))
+            + len(format_canonical_integer(left_factor)),
+        )
+        + 1
+    )
     work += estimated_digits
     if work > MAX_ENUMERATION_WORK:
         _reject(

--- a/tests/math/combinatorics/additive/rational_fixed_arity/test_rational_fixed_arity.py
+++ b/tests/math/combinatorics/additive/rational_fixed_arity/test_rational_fixed_arity.py
@@ -173,3 +173,18 @@ def test_arity_zero_does_not_sum_wide_source_values() -> None:
     )
     result = compute_rational_fixed_arity_sum_profile(values, 0)
     assert result.rows[0].sum_value == _cr(0)
+
+
+def test_cross_denominator_cancellation_is_preserved() -> None:
+    q = 10**11
+    r = q + 1
+    p = q + r
+    values = (
+        _cr(1, p * q),
+        _cr(1, p * r),
+        _cr(-1, q * r),
+    )
+
+    result = compute_rational_fixed_arity_sum_profile(values, len(values))
+
+    assert result.rows[0].sum_value == _cr(0)

--- a/tests/math/combinatorics/additive/rational_fixed_arity/test_rational_fixed_arity.py
+++ b/tests/math/combinatorics/additive/rational_fixed_arity/test_rational_fixed_arity.py
@@ -150,3 +150,26 @@ def test_reduced_denominators_use_lcm_growth_bound() -> None:
     assert result.rows[0].sum_value.as_fraction() == sum(
         (value.as_fraction() for value in values), Fraction(0)
     )
+
+
+def test_exact_cancellation_is_presolved_without_lcm_expansion() -> None:
+    digits = 17_001
+    first = "1" + "0" * digits
+    second = first + "1"
+    values = (
+        CanonicalRational(num="1", den=first),
+        CanonicalRational(num="-1", den=first),
+        CanonicalRational(num="1", den=second),
+        CanonicalRational(num="-1", den=second),
+    )
+    result = compute_rational_fixed_arity_sum_profile(values, len(values))
+    assert result.rows[0].sum_value == _cr(0)
+
+
+def test_arity_zero_does_not_sum_wide_source_values() -> None:
+    values = (
+        CanonicalRational(num="1", den="1" + "0" * 17_001),
+        CanonicalRational(num="1", den="1" + "0" * 17_001 + "1"),
+    )
+    result = compute_rational_fixed_arity_sum_profile(values, 0)
+    assert result.rows[0].sum_value == _cr(0)


### PR DESCRIPTION
Follow-up to #3039.

The merged rational fixed-arity operation computed one-candidate sums during admission without charging intermediate bigint growth, then recomputed the same sum in the kernel. It also evaluated the full source sum for arity zero even though the only result is 0/1.

This follow-up groups exact numerator cancellations before forming a common denominator, charges bounded LCM/scaling work, handles arity zero before summing source values, and reuses the admitted one-candidate sum in result construction.

Validation:
- 17 focused rational fixed-arity tests
- Ruff
- mypy

Closes the post-merge review findings from #3039.