### PR TITLE
Remove geometry graph compatibility export

### DIFF
--- a/src/jacobian/math/geometry/framework/__init__.py
+++ b/src/jacobian/math/geometry/framework/__init__.py
@@ -8,12 +8,10 @@ from jacobian.math.geometry.framework._models import (
     PlanarRigidityProfile,
 )
 from jacobian.math.geometry.framework.operations import planar_rigidity_profile
-from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 __all__ = [
     "LabelledRationalPoint",
     "PlanarRigidityProfile",
     "PointConfiguration",
-    "SimpleUndirectedGraph",
     "planar_rigidity_profile",
 ]

--- a/tests/math/geometry/framework/test_planar_rigidity_profile.py
+++ b/tests/math/geometry/framework/test_planar_rigidity_profile.py
@@ -100,12 +100,11 @@ def test_native_api_exports_the_reused_framework_values() -> None:
         "LabelledRationalPoint",
         "PlanarRigidityProfile",
         "PointConfiguration",
-        "SimpleUndirectedGraph",
         "planar_rigidity_profile",
     ]
     assert framework.LabelledRationalPoint is LabelledRationalPoint
     assert framework.PointConfiguration is PointConfiguration
-    assert framework.SimpleUndirectedGraph is SimpleUndirectedGraph
+    assert not hasattr(framework, "SimpleUndirectedGraph")
     assert framework.PlanarRigidityProfile is PlanarRigidityProfile
     assert framework.planar_rigidity_profile is planar_rigidity_profile
 


### PR DESCRIPTION
## Problem
The merged planar-geometry package re-exports `SimpleUndirectedGraph` even though that value is owned by `jacobian.math.graphs`. This creates a duplicate public owner and causes the namespace ownership check to accept a compatibility alias.

## Solution
Remove the compatibility re-export from `jacobian.math.geometry.framework`. The geometry tests already import the graph value from its canonical owner; their package-export assertion now verifies that the alias is absent.

## Testing
- `uv run --locked pytest -q tests/math/geometry/framework/test_planar_rigidity_profile.py tests/math/public_api/test_namespace.py` (32 passed)
- `uv run --locked ruff check src/jacobian/math/geometry/framework/__init__.py tests/math/geometry/framework/test_planar_rigidity_profile.py tests/math/public_api/test_namespace.py`
- `git diff --check`

## Public contract impact
The compatibility export is intentionally removed. The canonical graph value remains available from `jacobian.math.graphs` / `jacobian.math.graphs.values`; no operation IDs or mathematical semantics change.

## Operation boundary ownership
Not applicable; this removes a package-level compatibility export.

## Checklist
- [x] Focused tests pass
- [x] No compatibility aliases remain in the changed package
- [x] Canonical graph owner is unchanged
