### PR TITLE
Compute exact solution subgroups of homogeneous monomial systems

### DIFF
--- a/docs/reference/operations/algebraic-torus-monomial-systems.md
+++ b/docs/reference/operations/algebraic-torus-monomial-systems.md
@@ -1,0 +1,65 @@
+# Homogeneous monomial systems on algebraic tori
+
+[Documentation home](../../index.md) · [Tool surface](../tools.md)
+
+`algebraic_torus.monomial_system.solution_subgroup.compute` returns the exact
+subgroup
+
+```text
+{x in (C*)^n : product_j x_j^A_ij = 1 for every row i}
+```
+
+for one bounded integer exponent matrix. Rows follow `equation_axis`; columns
+follow `coordinate_axis`. Signed Laurent exponents are valid because every
+coordinate is explicitly nonzero. Systems with zero equations or zero
+coordinates retain their declared ambient axes.
+
+## Smith-coordinate convention
+
+The result contains an exact certificate `D = U A V`. Its parameter maps use
+columns of the right transformation `V`: if `z` is the ordered Smith parameter
+tuple, then
+
+```text
+x_i = product_j z_j ^ V[i,j].
+```
+
+Combining equations by `U` does not change the solution set. The first
+`rank(A)` Smith coordinates obey `z_i ^ d_i = 1`; factors `d_i = 1` are
+trivial and are omitted from the compact torsion-character group. A component
+label is one canonical residue modulo each remaining factor. The result never
+materializes the Cartesian product of labels, so a large finite component
+family remains compact. The final `n-rank(A)` columns of `V` give the free
+complex-torus map.
+
+`reduced_free_exponent_map` is an exact LLL-reduced presentation of the same
+free subtorus. SymPy reduces row bases and returns `B_reduced = T B_smith`.
+Consequently, if `F` is the coordinate-by-Smith-parameter map, the public
+coordinate map is `F_reduced = F T^T`.
+`smith_free_parameters_from_reduced` stores this `T^T` change of parameters;
+it is unimodular and makes the reduced presentation directly composable with
+later Laurent-polynomial substitutions.
+
+## Scope and bounds
+
+The operation admits at most 16 equations and 16 coordinates, with at most 32
+decimal digits per exponent. Those are the inherited transformation-certified
+Smith limits. The component count is bounded before execution by Hadamard's
+maximal-minor estimate and is returned as an exact canonical integer string.
+The kernel uses SymPy 1.14's exact `smith_normal_decomp` and
+`DomainMatrix.lll_transform`; it verifies the Smith relation, unimodularity,
+torsion congruences, free-kernel equations, and basis transport once before
+trusted result construction. Public result decoding checks canonical shapes,
+axes, conventions, and source binding without replaying those computations.
+
+This contract is only for the toric locus `(C*)^n` and right-hand side one.
+General `x^A=b` requires a separately bound consistency and coefficient
+representation. Affine branches with zero coordinates are a different
+decomposition problem and are intentionally excluded.
+
+The Smith decomposition and global monomial component parametrization follow
+Chen and Mehta, [*Parallel degree computation for solution space of binomial
+systems*](https://arxiv.org/abs/1501.02237), especially Propositions 1 and 2.
+The separation from affine zero-coordinate branches follows Adrovic and
+Verschelde, [*Computing all Affine Solution Sets of Binomial
+Systems*](https://arxiv.org/abs/1405.0320).

--- a/docs/reference/operations/index.md
+++ b/docs/reference/operations/index.md
@@ -13,3 +13,4 @@ that need more context than an operation card:
 - [Combinatorics on words](words/index.md)
 - [SAT and SMT](sat-smt/index.md)
 - [Exact rational quadratic forms](quadratic-forms.md)
+- [Homogeneous monomial systems on algebraic tori](algebraic-torus-monomial-systems.md)

--- a/src/jacobian/_models.py
+++ b/src/jacobian/_models.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
+from jacobian.canonical import CanonicalizationError
+
 
 def canonicalize_json_containers(value: Any) -> Any:
     """Materialize JSON arrays as immutable canonical containers.
@@ -15,14 +17,25 @@ def canonicalize_json_containers(value: Any) -> Any:
     values use tuples for every sequence, so owner-local preflight validators
     must return this projection rather than raw JSON arrays.  Mappings are
     copied recursively: callers retain ownership of their transport payload.
+
+    Self-referential containers are rejected as a canonicalization error
+    rather than recursing until the Python stack limit.
     """
 
-    if isinstance(value, list):
-        return tuple(canonicalize_json_containers(item) for item in value)
-    if isinstance(value, tuple):
-        return tuple(canonicalize_json_containers(item) for item in value)
+    return _canonicalize(value, set())
+
+
+def _canonicalize(value: Any, seen: set[int]) -> Any:
+    if isinstance(value, (list, tuple)):
+        if id(value) in seen:
+            raise CanonicalizationError("cyclic JSON containers are not allowed")
+        seen = seen | {id(value)}
+        return tuple(_canonicalize(item, seen) for item in value)
     if isinstance(value, dict):
-        return {key: canonicalize_json_containers(item) for key, item in value.items()}
+        if id(value) in seen:
+            raise CanonicalizationError("cyclic JSON containers are not allowed")
+        seen = seen | {id(value)}
+        return {key: _canonicalize(item, seen) for key, item in value.items()}
     return value
 
 

--- a/src/jacobian/math/algebraic_tori/__init__.py
+++ b/src/jacobian/math/algebraic_tori/__init__.py
@@ -1,0 +1,17 @@
+"""Exact operations on complex algebraic tori."""
+
+from jacobian.math.algebraic_tori.operations import (
+    homogeneous_monomial_solution_subgroup,
+)
+from jacobian.math.algebraic_tori.values import (
+    AlgebraicTorusSolutionSubgroup,
+    HomogeneousMonomialSystem,
+    TorsionCharacterGroup,
+)
+
+__all__ = [
+    "AlgebraicTorusSolutionSubgroup",
+    "HomogeneousMonomialSystem",
+    "TorsionCharacterGroup",
+    "homogeneous_monomial_solution_subgroup",
+]

--- a/src/jacobian/math/algebraic_tori/_models.py
+++ b/src/jacobian/math/algebraic_tori/_models.py
@@ -1,0 +1,11 @@
+"""Typed requests for algebraic-torus operations."""
+
+from jacobian._models import StrictModel
+from jacobian.math.algebraic_tori.values import HomogeneousMonomialSystem
+
+
+class HomogeneousMonomialSolutionRequest(StrictModel):
+    system: HomogeneousMonomialSystem
+
+
+__all__ = ["HomogeneousMonomialSolutionRequest"]

--- a/src/jacobian/math/algebraic_tori/_tools.py
+++ b/src/jacobian/math/algebraic_tori/_tools.py
@@ -1,0 +1,57 @@
+"""Algebraic-torus operation declarations."""
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools
+from jacobian.math.algebraic_tori._models import HomogeneousMonomialSolutionRequest
+from jacobian.math.algebraic_tori.operations import (
+    homogeneous_monomial_solution_subgroup,
+)
+from jacobian.math.algebraic_tori.values import AlgebraicTorusSolutionSubgroup
+
+
+def _solve(
+    request: HomogeneousMonomialSolutionRequest,
+) -> AlgebraicTorusSolutionSubgroup:
+    return homogeneous_monomial_solution_subgroup(request.system)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="algebraic_torus.monomial_system.solution_subgroup.compute",
+        title="Solve a homogeneous monomial system on an algebraic torus",
+        description=(
+            "Return the complete exact solution subgroup of x^A = 1 as compact "
+            "Smith torsion characters times a free complex torus, with source-bound "
+            "Laurent-monomial coordinate maps."
+        ),
+        request_type=HomogeneousMonomialSolutionRequest,
+        result_type=AlgebraicTorusSolutionSubgroup,
+        run=_solve,
+        tags=(
+            "algebraic-torus",
+            "monomial-system",
+            "smith-normal-form",
+            "character-lattice",
+            "exact",
+        ),
+        examples=(
+            example(
+                "two_component_curve",
+                "Solve x^2 y^6 = 1 on the two-dimensional complex torus.",
+                {
+                    "system": {
+                        "exponent_matrix": {
+                            "row_count": 1,
+                            "column_count": 2,
+                            "entries": [["2", "6"]],
+                        },
+                        "equation_axis": ["relation"],
+                        "coordinate_axis": ["x", "y"],
+                    }
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/algebraic_tori/operations.py
+++ b/src/jacobian/math/algebraic_tori/operations.py
@@ -90,9 +90,10 @@ def _admit_monomial_system(system: HomogeneousMonomialSystem) -> None:
     """
 
     from jacobian.math.matrices.certified_snf.values import (
-        MAX_CERTIFIED_SNF_INPUT_DIMENSION,
         MAX_CERTIFIED_SNF_INPUT_DIGITS,
+        MAX_CERTIFIED_SNF_INPUT_DIMENSION,
     )
+
     matrix = system.exponent_matrix
     if (
         matrix.row_count > MAX_CERTIFIED_SNF_INPUT_DIMENSION

--- a/src/jacobian/math/algebraic_tori/operations.py
+++ b/src/jacobian/math/algebraic_tori/operations.py
@@ -81,11 +81,43 @@ def _lll_free_basis(smith_free_map: Matrix) -> tuple[Matrix, Matrix]:
     return reduced_map, smith_parameters_from_reduced
 
 
+def _admit_monomial_system(system: HomogeneousMonomialSystem) -> None:
+    """Re-enforce the public execution envelope for native callers.
+
+    A native caller can bypass model validators via ``model_construct`` or
+    an unvalidated ``model_copy``, so the owner must re-check the dimension
+    and exponent bounds before invoking the certified-SNF backend.
+    """
+
+    from jacobian.math.matrices.certified_snf.values import (
+        MAX_CERTIFIED_SNF_INPUT_DIMENSION,
+        MAX_CERTIFIED_SNF_INPUT_DIGITS,
+    )
+    matrix = system.exponent_matrix
+    if (
+        matrix.row_count > MAX_CERTIFIED_SNF_INPUT_DIMENSION
+        or matrix.column_count > MAX_CERTIFIED_SNF_INPUT_DIMENSION
+    ):
+        raise ValueError(
+            "monomial systems exponent matrix exceeds the certified-SNF "
+            f"dimension bound of {MAX_CERTIFIED_SNF_INPUT_DIMENSION}"
+        )
+    if any(
+        len(value.lstrip("-")) > MAX_CERTIFIED_SNF_INPUT_DIGITS
+        for row in matrix.entries
+        for value in row
+    ):
+        raise ValueError(
+            "monomial system exponents exceed the certified-SNF digit bound"
+        )
+
+
 def homogeneous_monomial_solution_subgroup(
     system: HomogeneousMonomialSystem,
 ) -> AlgebraicTorusSolutionSubgroup:
     """Return the exact torsion-by-free-torus subgroup solving ``x^A = 1``."""
 
+    _admit_monomial_system(system)
     source = [
         [parse_canonical_integer(value) for value in row]
         for row in system.exponent_matrix.entries

--- a/src/jacobian/math/algebraic_tori/operations.py
+++ b/src/jacobian/math/algebraic_tori/operations.py
@@ -1,0 +1,190 @@
+"""Exact homogeneous monomial-system operations on algebraic tori."""
+
+from __future__ import annotations
+
+from math import prod
+
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.math.algebraic_tori.values import (
+    AlgebraicTorusSolutionSubgroup,
+    HomogeneousMonomialSystem,
+    TorsionCharacterGroup,
+)
+from jacobian.math.matrices.certified_snf.operations import (
+    Matrix,
+    certificate_from_reduction,
+    identity_matrix,
+    matrix_determinant,
+    matrix_multiply,
+    smith_reduce,
+)
+from jacobian.math.matrices.certified_snf.values import CertifiedIntegerMatrix
+
+
+def _matrix_value(
+    entries: Matrix,
+    *,
+    rows: int,
+    columns: int,
+) -> CertifiedIntegerMatrix:
+    return CertifiedIntegerMatrix(
+        row_count=rows,
+        column_count=columns,
+        entries=tuple(
+            tuple(format_canonical_integer(value) for value in row) for row in entries
+        ),
+    )
+
+
+def _transpose(matrix: Matrix, *, rows_if_empty: int) -> Matrix:
+    if not matrix:
+        return [[] for _ in range(rows_if_empty)]
+    return [
+        [matrix[row][column] for row in range(len(matrix))]
+        for column in range(len(matrix[0]))
+    ]
+
+
+def _lll_free_basis(smith_free_map: Matrix) -> tuple[Matrix, Matrix]:
+    """Return ``(R,C)`` with ``R = F C`` and unimodular parameter map ``C``."""
+
+    coordinate_count = len(smith_free_map)
+    free_rank = len(smith_free_map[0]) if smith_free_map else 0
+    if free_rank == 0:
+        return ([[] for _ in range(coordinate_count)], [])
+
+    from sympy import QQ, ZZ
+    from sympy.polys.matrices import DomainMatrix
+
+    smith_basis_rows = _transpose(smith_free_map, rows_if_empty=free_rank)
+    domain = DomainMatrix.from_list_sympy(
+        free_rank,
+        coordinate_count,
+        smith_basis_rows,
+    ).convert_to(ZZ)
+    reduced, row_transport = domain.lll_transform(delta=QQ(3, 4))
+    reduced_rows = [
+        [int(value) for value in row] for row in reduced.to_Matrix().tolist()
+    ]
+    transport_rows = [
+        [int(value) for value in row] for row in row_transport.to_Matrix().tolist()
+    ]
+    if matrix_multiply(transport_rows, smith_basis_rows) != reduced_rows:
+        raise ArithmeticError("LLL transport does not reconstruct the reduced basis")
+    if abs(matrix_determinant(transport_rows)) != 1:
+        raise ArithmeticError("LLL free-basis transport is not unimodular")
+
+    reduced_map = _transpose(reduced_rows, rows_if_empty=coordinate_count)
+    smith_parameters_from_reduced = _transpose(transport_rows, rows_if_empty=free_rank)
+    if matrix_multiply(smith_free_map, smith_parameters_from_reduced) != reduced_map:
+        raise ArithmeticError("free-parameter transport does not reconstruct the map")
+    return reduced_map, smith_parameters_from_reduced
+
+
+def homogeneous_monomial_solution_subgroup(
+    system: HomogeneousMonomialSystem,
+) -> AlgebraicTorusSolutionSubgroup:
+    """Return the exact torsion-by-free-torus subgroup solving ``x^A = 1``."""
+
+    source = [
+        [parse_canonical_integer(value) for value in row]
+        for row in system.exponent_matrix.entries
+    ]
+    equation_count = system.exponent_matrix.row_count
+    coordinate_count = system.exponent_matrix.column_count
+    reduction = smith_reduce(
+        source,
+        row_count=equation_count,
+        column_count=coordinate_count,
+    )
+    rank = reduction.rank
+    free_rank = coordinate_count - rank
+    certificate = certificate_from_reduction(reduction)
+
+    torsion_positions = tuple(
+        index for index, factor in enumerate(reduction.invariant_factors) if factor > 1
+    )
+    torsion_factors = tuple(
+        reduction.invariant_factors[index] for index in torsion_positions
+    )
+    torsion_map = [
+        [
+            reduction.right[coordinate][index] % reduction.invariant_factors[index]
+            for index in torsion_positions
+        ]
+        for coordinate in range(coordinate_count)
+    ]
+    smith_free_map = [
+        reduction.right[coordinate][rank:] for coordinate in range(coordinate_count)
+    ]
+    reduced_free_map, smith_parameters_from_reduced = _lll_free_basis(smith_free_map)
+
+    if matrix_multiply(
+        source,
+        smith_free_map,
+        right_columns_if_empty=free_rank,
+    ) != [[0] * free_rank for _ in range(equation_count)]:
+        raise ArithmeticError("Smith free parameters do not satisfy the source system")
+    if matrix_multiply(
+        source,
+        reduced_free_map,
+        right_columns_if_empty=free_rank,
+    ) != [[0] * free_rank for _ in range(equation_count)]:
+        raise ArithmeticError(
+            "reduced free parameters do not satisfy the source system"
+        )
+    torsion_relations = matrix_multiply(
+        source,
+        torsion_map,
+        right_columns_if_empty=len(torsion_factors),
+    )
+    if any(
+        value % torsion_factors[column]
+        for row in torsion_relations
+        for column, value in enumerate(row)
+    ):
+        raise ArithmeticError("torsion characters do not satisfy the source system")
+
+    return AlgebraicTorusSolutionSubgroup._from_kernel(
+        source=system,
+        smith_certificate=certificate,
+        torsion_character_group=TorsionCharacterGroup(
+            invariant_factors=tuple(
+                format_canonical_integer(value) for value in torsion_factors
+            ),
+        ),
+        connected_component_count=format_canonical_integer(
+            prod(torsion_factors, start=1)
+        ),
+        torsion_parameter_axis=tuple(
+            f"zeta_{index}" for index in range(len(torsion_factors))
+        ),
+        smith_free_parameter_axis=tuple(
+            f"smith_t_{index}" for index in range(free_rank)
+        ),
+        reduced_free_parameter_axis=tuple(f"t_{index}" for index in range(free_rank)),
+        torsion_exponent_map=_matrix_value(
+            torsion_map,
+            rows=coordinate_count,
+            columns=len(torsion_factors),
+        ),
+        smith_free_exponent_map=_matrix_value(
+            smith_free_map,
+            rows=coordinate_count,
+            columns=free_rank,
+        ),
+        reduced_free_exponent_map=_matrix_value(
+            reduced_free_map,
+            rows=coordinate_count,
+            columns=free_rank,
+        ),
+        smith_free_parameters_from_reduced=_matrix_value(
+            smith_parameters_from_reduced if free_rank else identity_matrix(0),
+            rows=free_rank,
+            columns=free_rank,
+        ),
+        free_rank=free_rank,
+    )
+
+
+__all__ = ["homogeneous_monomial_solution_subgroup"]

--- a/src/jacobian/math/algebraic_tori/values.py
+++ b/src/jacobian/math/algebraic_tori/values.py
@@ -1,0 +1,346 @@
+"""Canonical values for homogeneous monomial systems on algebraic tori."""
+
+from __future__ import annotations
+
+from math import ceil, log10
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import Field, StrictInt, StringConstraints, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel
+from jacobian.math.matrices.certified_snf.values import (
+    MAX_CERTIFIED_SNF_INPUT_DIGITS,
+    MAX_CERTIFIED_SNF_INPUT_DIMENSION,
+    CertifiedIntegerMatrix,
+    SmithNormalFormCertificate,
+)
+
+TorusAxisLabel = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z_][A-Za-z0-9_.:-]{0,63}$",
+        strict=True,
+    ),
+]
+MAX_TORUS_COMPONENT_DIGITS = (
+    MAX_CERTIFIED_SNF_INPUT_DIMENSION * MAX_CERTIFIED_SNF_INPUT_DIGITS
+    + ceil(
+        MAX_CERTIFIED_SNF_INPUT_DIMENSION * log10(MAX_CERTIFIED_SNF_INPUT_DIMENSION) / 2
+    )
+    + 1
+)
+PositiveTorusInteger = Annotated[
+    CanonicalInteger,
+    StringConstraints(
+        max_length=MAX_TORUS_COMPONENT_DIGITS,
+        pattern=r"^[1-9][0-9]*$",
+        strict=True,
+    ),
+]
+
+
+def _validation_error(code: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(code, message)
+
+
+def _raw_field(value: object, name: str) -> object:
+    if isinstance(value, dict):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _integer_digits(value: str) -> int:
+    return len(value.lstrip("-"))
+
+
+class HomogeneousMonomialSystem(StrictModel):
+    """An axis-bound system ``product_j x_j^A_ij = 1`` on ``(CC*)^n``."""
+
+    exponent_matrix: CertifiedIntegerMatrix
+    equation_axis: tuple[TorusAxisLabel, ...] = Field(
+        max_length=MAX_CERTIFIED_SNF_INPUT_DIMENSION
+    )
+    coordinate_axis: tuple[TorusAxisLabel, ...] = Field(
+        max_length=MAX_CERTIFIED_SNF_INPUT_DIMENSION
+    )
+    coordinate_domain: Literal["NONZERO_COMPLEX"] = "NONZERO_COMPLEX"
+    equation_convention: Literal["ROWS_ARE_X_TO_INTEGER_EXPONENT_EQUALS_ONE"] = (
+        "ROWS_ARE_X_TO_INTEGER_EXPONENT_EQUALS_ONE"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_smith_envelope(cls, data: Any) -> Any:
+        """Reject oversized nested matrices before their general value parser."""
+
+        if not isinstance(data, dict):
+            return data
+        matrix = data.get("exponent_matrix")
+        rows = _raw_field(matrix, "row_count")
+        columns = _raw_field(matrix, "column_count")
+        entries = _raw_field(matrix, "entries")
+        for size in (rows, columns):
+            if type(size) is int and not (
+                0 <= size <= MAX_CERTIFIED_SNF_INPUT_DIMENSION
+            ):
+                raise _validation_error(
+                    "algebraic_torus.monomial_system_dimension_bound",
+                    "monomial systems admit at most 16 equations and coordinates",
+                )
+        if isinstance(entries, (list, tuple)):
+            if type(rows) is int and len(entries) != rows:
+                raise _validation_error(
+                    "algebraic_torus.monomial_system_matrix_shape",
+                    "exponent entries must match the declared matrix rows",
+                )
+            if type(columns) is int and any(
+                isinstance(row, (list, tuple)) and len(row) != columns
+                for row in entries
+            ):
+                raise _validation_error(
+                    "algebraic_torus.monomial_system_matrix_shape",
+                    "exponent entries must match the declared matrix columns",
+                )
+            if any(
+                isinstance(value, str)
+                and _integer_digits(value) > MAX_CERTIFIED_SNF_INPUT_DIGITS
+                for row in entries
+                if isinstance(row, (list, tuple))
+                for value in row
+            ):
+                raise _validation_error(
+                    "algebraic_torus.monomial_system_exponent_bound",
+                    "monomial exponents may contain at most 32 decimal digits",
+                )
+        return data
+
+    @model_validator(mode="after")
+    def require_axes_and_envelope(self) -> Self:
+        matrix = self.exponent_matrix
+        if (
+            matrix.row_count > MAX_CERTIFIED_SNF_INPUT_DIMENSION
+            or matrix.column_count > MAX_CERTIFIED_SNF_INPUT_DIMENSION
+        ):
+            raise _validation_error(
+                "algebraic_torus.monomial_system_dimension_bound",
+                "monomial systems admit at most 16 equations and coordinates",
+            )
+        if len(self.equation_axis) != matrix.row_count:
+            raise _validation_error(
+                "algebraic_torus.monomial_system_equation_axis",
+                "equation axis must match the exponent-matrix rows",
+            )
+        if len(self.coordinate_axis) != matrix.column_count:
+            raise _validation_error(
+                "algebraic_torus.monomial_system_coordinate_axis",
+                "coordinate axis must match the exponent-matrix columns",
+            )
+        if len(set(self.equation_axis)) != len(self.equation_axis):
+            raise _validation_error(
+                "algebraic_torus.monomial_system_equation_axis",
+                "equation-axis labels must be unique",
+            )
+        if len(set(self.coordinate_axis)) != len(self.coordinate_axis):
+            raise _validation_error(
+                "algebraic_torus.monomial_system_coordinate_axis",
+                "coordinate-axis labels must be unique",
+            )
+        if any(
+            _integer_digits(value) > MAX_CERTIFIED_SNF_INPUT_DIGITS
+            for row in matrix.entries
+            for value in row
+        ):
+            raise _validation_error(
+                "algebraic_torus.monomial_system_exponent_bound",
+                "monomial exponents may contain at most 32 decimal digits",
+            )
+        return self
+
+
+class TorsionCharacterGroup(StrictModel):
+    """Compact component indices ``product_i Z/d_i`` in Smith order."""
+
+    invariant_factors: tuple[PositiveTorusInteger, ...] = Field(
+        max_length=MAX_CERTIFIED_SNF_INPUT_DIMENSION
+    )
+    label_convention: Literal["CARTESIAN_PRODUCT_OF_CANONICAL_RESIDUES"] = (
+        "CARTESIAN_PRODUCT_OF_CANONICAL_RESIDUES"
+    )
+    root_convention: Literal["ZETA_D_EQUALS_EXP_2_PI_I_OVER_D"] = (
+        "ZETA_D_EQUALS_EXP_2_PI_I_OVER_D"
+    )
+
+
+class AlgebraicTorusSolutionSubgroup(StrictModel):
+    """The complete compact subgroup solving one homogeneous monomial system.
+
+    For ``D = U A V``, Smith parameters ``z`` map to source coordinates by
+    ``x_i = product_j z_j ** V[i,j]``. Nontrivial Smith coordinates index the
+    connected components and the final columns are free torus parameters.
+    """
+
+    source: HomogeneousMonomialSystem
+    smith_certificate: SmithNormalFormCertificate
+    torsion_character_group: TorsionCharacterGroup
+    connected_component_count: PositiveTorusInteger
+    torsion_parameter_axis: tuple[TorusAxisLabel, ...] = Field(
+        max_length=MAX_CERTIFIED_SNF_INPUT_DIMENSION
+    )
+    smith_free_parameter_axis: tuple[TorusAxisLabel, ...] = Field(
+        max_length=MAX_CERTIFIED_SNF_INPUT_DIMENSION
+    )
+    reduced_free_parameter_axis: tuple[TorusAxisLabel, ...] = Field(
+        max_length=MAX_CERTIFIED_SNF_INPUT_DIMENSION
+    )
+    torsion_exponent_map: CertifiedIntegerMatrix
+    smith_free_exponent_map: CertifiedIntegerMatrix
+    reduced_free_exponent_map: CertifiedIntegerMatrix
+    smith_free_parameters_from_reduced: CertifiedIntegerMatrix
+    free_rank: StrictInt = Field(ge=0, le=MAX_CERTIFIED_SNF_INPUT_DIMENSION)
+    parameterization_convention: Literal[
+        "X_I_EQUALS_PRODUCT_OF_PARAMETERS_TO_EXPONENT_MAP_IJ"
+    ] = "X_I_EQUALS_PRODUCT_OF_PARAMETERS_TO_EXPONENT_MAP_IJ"
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_result_shapes(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        source = data.get("source")
+        coordinate_axis = _raw_field(source, "coordinate_axis")
+        free_rank = data.get("free_rank")
+        torsion_axis = data.get("torsion_parameter_axis")
+        if not isinstance(coordinate_axis, (list, tuple)) or type(free_rank) is not int:
+            return data
+        coordinate_count = len(coordinate_axis)
+        torsion_count = (
+            len(torsion_axis) if isinstance(torsion_axis, (list, tuple)) else None
+        )
+        expected_shapes = (
+            ("torsion_exponent_map", coordinate_count, torsion_count),
+            ("smith_free_exponent_map", coordinate_count, free_rank),
+            ("reduced_free_exponent_map", coordinate_count, free_rank),
+            ("smith_free_parameters_from_reduced", free_rank, free_rank),
+        )
+        for field_name, rows, columns in expected_shapes:
+            matrix = data.get(field_name)
+            raw_rows = _raw_field(matrix, "row_count")
+            raw_columns = _raw_field(matrix, "column_count")
+            if type(raw_rows) is int and raw_rows != rows:
+                raise _validation_error(
+                    "algebraic_torus.solution_map_shape",
+                    "solution exponent maps must match their declared axes",
+                )
+            if (
+                columns is not None
+                and type(raw_columns) is int
+                and raw_columns != columns
+            ):
+                raise _validation_error(
+                    "algebraic_torus.solution_map_shape",
+                    "solution exponent maps must match their declared axes",
+                )
+        return data
+
+    @model_validator(mode="after")
+    def require_source_bound_shapes(self) -> Self:
+        coordinate_count = len(self.source.coordinate_axis)
+        rank = self.smith_certificate.rank
+        factors = self.smith_certificate.invariant_factors
+        nontrivial_factors = tuple(factor for factor in factors if factor != "1")
+        torsion_count = len(nontrivial_factors)
+        if self.smith_certificate.source != self.source.exponent_matrix:
+            raise _validation_error(
+                "algebraic_torus.solution_source_binding",
+                "Smith certificate source must equal the exponent matrix",
+            )
+        if self.free_rank != coordinate_count - rank:
+            raise _validation_error(
+                "algebraic_torus.solution_rank_shape",
+                "free rank must be coordinate count minus Smith rank",
+            )
+        if self.torsion_character_group.invariant_factors != nontrivial_factors:
+            raise _validation_error(
+                "algebraic_torus.solution_torsion_shape",
+                "torsion characters must follow the nontrivial Smith factors",
+            )
+        if (
+            len(self.torsion_parameter_axis) != torsion_count
+            or len(set(self.torsion_parameter_axis)) != torsion_count
+        ):
+            raise _validation_error(
+                "algebraic_torus.solution_torsion_axis",
+                "torsion parameter axis must match the nontrivial Smith factors",
+            )
+        if (
+            len(self.smith_free_parameter_axis) != self.free_rank
+            or len(set(self.smith_free_parameter_axis)) != self.free_rank
+            or len(self.reduced_free_parameter_axis) != self.free_rank
+            or len(set(self.reduced_free_parameter_axis)) != self.free_rank
+        ):
+            raise _validation_error(
+                "algebraic_torus.solution_free_axis",
+                "free parameter axis must match the free rank",
+            )
+        expected_shapes = (
+            (self.torsion_exponent_map, coordinate_count, torsion_count),
+            (self.smith_free_exponent_map, coordinate_count, self.free_rank),
+            (self.reduced_free_exponent_map, coordinate_count, self.free_rank),
+            (
+                self.smith_free_parameters_from_reduced,
+                self.free_rank,
+                self.free_rank,
+            ),
+        )
+        if any(
+            (matrix.row_count, matrix.column_count) != (rows, columns)
+            for matrix, rows, columns in expected_shapes
+        ):
+            raise _validation_error(
+                "algebraic_torus.solution_map_shape",
+                "solution exponent maps must match their declared axes",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source: HomogeneousMonomialSystem,
+        smith_certificate: SmithNormalFormCertificate,
+        torsion_character_group: TorsionCharacterGroup,
+        connected_component_count: str,
+        torsion_parameter_axis: tuple[str, ...],
+        smith_free_parameter_axis: tuple[str, ...],
+        reduced_free_parameter_axis: tuple[str, ...],
+        torsion_exponent_map: CertifiedIntegerMatrix,
+        smith_free_exponent_map: CertifiedIntegerMatrix,
+        reduced_free_exponent_map: CertifiedIntegerMatrix,
+        smith_free_parameters_from_reduced: CertifiedIntegerMatrix,
+        free_rank: int,
+    ) -> Self:
+        return cls.model_construct(
+            source=source,
+            smith_certificate=smith_certificate,
+            torsion_character_group=torsion_character_group,
+            connected_component_count=connected_component_count,
+            torsion_parameter_axis=torsion_parameter_axis,
+            smith_free_parameter_axis=smith_free_parameter_axis,
+            reduced_free_parameter_axis=reduced_free_parameter_axis,
+            torsion_exponent_map=torsion_exponent_map,
+            smith_free_exponent_map=smith_free_exponent_map,
+            reduced_free_exponent_map=reduced_free_exponent_map,
+            smith_free_parameters_from_reduced=smith_free_parameters_from_reduced,
+            free_rank=free_rank,
+        )
+
+
+__all__ = [
+    "AlgebraicTorusSolutionSubgroup",
+    "HomogeneousMonomialSystem",
+    "TorsionCharacterGroup",
+]

--- a/src/jacobian/math/algebraic_tori/values.py
+++ b/src/jacobian/math/algebraic_tori/values.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from math import ceil, log10
+from itertools import pairwise
+from math import ceil, log10, prod
 from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, StrictInt, StringConstraints, model_validator
@@ -10,6 +11,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
 from jacobian.math.matrices.certified_snf.values import (
     MAX_CERTIFIED_SNF_INPUT_DIGITS,
     MAX_CERTIFIED_SNF_INPUT_DIMENSION,
@@ -174,6 +176,20 @@ class TorsionCharacterGroup(StrictModel):
         "ZETA_D_EQUALS_EXP_2_PI_I_OVER_D"
     )
 
+    @model_validator(mode="after")
+    def require_canonical_invariant_factors(self) -> Self:
+        factors = tuple(
+            parse_canonical_integer(value) for value in self.invariant_factors
+        )
+        if any(value <= 1 for value in factors) or any(
+            right % left for left, right in pairwise(factors)
+        ):
+            raise _validation_error(
+                "algebraic_torus.torsion_invariant_factors",
+                "torsion invariant factors must exceed one and form a divisibility chain",
+            )
+        return self
+
 
 class AlgebraicTorusSolutionSubgroup(StrictModel):
     """The complete compact subgroup solving one homogeneous monomial system.
@@ -267,6 +283,21 @@ class AlgebraicTorusSolutionSubgroup(StrictModel):
             raise _validation_error(
                 "algebraic_torus.solution_torsion_shape",
                 "torsion characters must follow the nontrivial Smith factors",
+            )
+        expected_component_count = prod(
+            (
+                parse_canonical_integer(value)
+                for value in self.torsion_character_group.invariant_factors
+            ),
+            start=1,
+        )
+        if (
+            parse_canonical_integer(self.connected_component_count)
+            != expected_component_count
+        ):
+            raise _validation_error(
+                "algebraic_torus.solution_component_count",
+                "connected component count must equal the product of torsion invariant factors",
             )
         if (
             len(self.torsion_parameter_axis) != torsion_count

--- a/src/jacobian/math/algebraic_tori/values.py
+++ b/src/jacobian/math/algebraic_tori/values.py
@@ -10,7 +10,8 @@ from pydantic import Field, StrictInt, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.canonical import parse_canonical_integer, CanonicalizationError
 from jacobian.canonical import parse_canonical_integer
 from jacobian.math.matrices.certified_snf.values import (
     MAX_CERTIFIED_SNF_INPUT_DIGITS,
@@ -118,7 +119,13 @@ class HomogeneousMonomialSystem(StrictModel):
                     "algebraic_torus.monomial_system_exponent_bound",
                     "monomial exponents may contain at most 32 decimal digits",
                 )
-        return data
+        try:
+            return canonicalize_json_containers(data)
+        except CanonicalizationError:
+            raise _validation_error(
+                "algebraic_torus.monomial_system_container_structure",
+                "raw monomial-system containers must be acyclic",
+            )
 
     @model_validator(mode="after")
     def require_axes_and_envelope(self) -> Self:
@@ -260,7 +267,13 @@ class AlgebraicTorusSolutionSubgroup(StrictModel):
                     "algebraic_torus.solution_map_shape",
                     "solution exponent maps must match their declared axes",
                 )
-        return data
+        try:
+            return canonicalize_json_containers(data)
+        except CanonicalizationError:
+            raise _validation_error(
+                "algebraic_torus.solution_container_structure",
+                "raw solution containers must be acyclic",
+            )
 
     @model_validator(mode="after")
     def require_source_bound_shapes(self) -> Self:

--- a/src/jacobian/math/algebraic_tori/values.py
+++ b/src/jacobian/math/algebraic_tori/values.py
@@ -198,11 +198,14 @@ class TorsionCharacterGroup(StrictModel):
 
 
 class AlgebraicTorusSolutionSubgroup(StrictModel):
-    """The complete compact subgroup solving one homogeneous monomial system.
+    """The complete solution subgroup of one homogeneous monomial system.
 
     For ``D = U A V``, Smith parameters ``z`` map to source coordinates by
     ``x_i = product_j z_j ** V[i,j]``. Nontrivial Smith coordinates index the
     connected components and the final columns are free torus parameters.
+
+    The subgroup is compact only when ``free_rank == 0``; otherwise it has a
+    non-compact ``C*`` factor indexed by the free torus parameters.
     """
 
     source: HomogeneousMonomialSystem

--- a/src/jacobian/math/algebraic_tori/values.py
+++ b/src/jacobian/math/algebraic_tori/values.py
@@ -11,8 +11,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel, canonicalize_json_containers
-from jacobian.canonical import parse_canonical_integer, CanonicalizationError
-from jacobian.canonical import parse_canonical_integer
+from jacobian.canonical import CanonicalizationError, parse_canonical_integer
 from jacobian.math.matrices.certified_snf.values import (
     MAX_CERTIFIED_SNF_INPUT_DIGITS,
     MAX_CERTIFIED_SNF_INPUT_DIMENSION,
@@ -121,11 +120,11 @@ class HomogeneousMonomialSystem(StrictModel):
                 )
         try:
             return canonicalize_json_containers(data)
-        except CanonicalizationError:
+        except CanonicalizationError as exc:
             raise _validation_error(
                 "algebraic_torus.monomial_system_container_structure",
                 "raw monomial-system containers must be acyclic",
-            )
+            ) from exc
 
     @model_validator(mode="after")
     def require_axes_and_envelope(self) -> Self:
@@ -269,11 +268,11 @@ class AlgebraicTorusSolutionSubgroup(StrictModel):
                 )
         try:
             return canonicalize_json_containers(data)
-        except CanonicalizationError:
+        except CanonicalizationError as exc:
             raise _validation_error(
                 "algebraic_torus.solution_container_structure",
                 "raw solution containers must be acyclic",
-            )
+            ) from exc
 
     @model_validator(mode="after")
     def require_source_bound_shapes(self) -> Self:

--- a/src/jacobian/math/matrices/certified_snf/operations.py
+++ b/src/jacobian/math/matrices/certified_snf/operations.py
@@ -56,6 +56,36 @@ def _admit_certified_smith_input(matrix: CertifiedIntegerMatrix) -> None:
         )
 
 
+def _admit_smith_certificate_for_verification(
+    matrix: CertifiedIntegerMatrix,
+) -> None:
+    if (
+        matrix.row_count > MAX_CERTIFIED_SNF_INPUT_DIMENSION
+        or matrix.column_count > MAX_CERTIFIED_SNF_INPUT_DIMENSION
+    ):
+        raise OperationDomainValidationError(
+            location=("certificate", "source"),
+            code="matrix.budget_exceeded",
+            message=(
+                "certified Smith certificate sources may have at most "
+                f"{MAX_CERTIFIED_SNF_INPUT_DIMENSION} rows and columns"
+            ),
+        )
+    if any(
+        _integer_digits(value) > MAX_CERTIFIED_SNF_INPUT_DIGITS
+        for row in matrix.entries
+        for value in row
+    ):
+        raise OperationDomainValidationError(
+            location=("certificate", "source", "entries"),
+            code="matrix.budget_exceeded",
+            message=(
+                "certified Smith certificate source entries may contain at most "
+                f"{MAX_CERTIFIED_SNF_INPUT_DIGITS} decimal digits"
+            ),
+        )
+
+
 def smith_normal_form_certificate(
     matrix: CertifiedIntegerMatrix,
 ) -> SmithNormalFormCertificate:
@@ -319,7 +349,7 @@ def verify_smith_normal_form_certificate(
     """
 
     try:
-        _admit_certified_smith_input(certificate.source)
+        _admit_smith_certificate_for_verification(certificate.source)
     except OperationDomainValidationError:
         return False
 

--- a/tests/math/algebraic_tori/test_homogeneous_monomial_system.py
+++ b/tests/math/algebraic_tori/test_homogeneous_monomial_system.py
@@ -12,6 +12,7 @@ from jacobian.canonical import parse_canonical_integer
 from jacobian.math.algebraic_tori import (
     AlgebraicTorusSolutionSubgroup,
     HomogeneousMonomialSystem,
+    TorsionCharacterGroup,
     homogeneous_monomial_solution_subgroup,
 )
 from jacobian.math.algebraic_tori._models import (
@@ -71,15 +72,7 @@ def _multiply(
 
 def _assert_defining_invariants(result: AlgebraicTorusSolutionSubgroup) -> None:
     certificate = result.smith_certificate
-    if certificate.source.row_count and certificate.source.column_count:
-        assert verify_smith_normal_form_certificate(certificate)
-    else:
-        # The existing standalone verifier intentionally owns only its public
-        # nonempty 16-by-16 request domain. The torus kernel also admits the
-        # exact empty-axis Smith degeneracies supported by smith_reduce.
-        assert certificate.source == result.source.exponent_matrix
-        assert certificate.rank == 0
-        assert certificate.invariant_factors == ()
+    assert verify_smith_normal_form_certificate(certificate)
     source = _integers(result.source.exponent_matrix)
     free = _integers(result.reduced_free_exponent_map)
     assert _multiply(source, free, result.free_rank) == [
@@ -236,6 +229,24 @@ def test_result_round_trips_and_source_composes_unchanged() -> None:
 
     assert decoded == produced
     assert consumed == produced
+
+
+@pytest.mark.parametrize("factors", [("1",), ("6", "2"), ("2", "3")])
+def test_torsion_character_group_rejects_noncanonical_factors(
+    factors: tuple[str, ...],
+) -> None:
+    with pytest.raises(ValidationError, match="divisibility chain"):
+        TorsionCharacterGroup(invariant_factors=factors)
+
+
+def test_result_rejects_component_count_that_contradicts_torsion_group() -> None:
+    encoded = homogeneous_monomial_solution_subgroup(
+        _system([[2, 0], [0, 6]])
+    ).model_dump(mode="json")
+    encoded["connected_component_count"] = "11"
+
+    with pytest.raises(ValidationError, match="product of torsion invariant factors"):
+        AlgebraicTorusSolutionSubgroup.model_validate(encoded)
 
 
 def test_result_rejects_a_certificate_bound_to_another_source() -> None:

--- a/tests/math/algebraic_tori/test_homogeneous_monomial_system.py
+++ b/tests/math/algebraic_tori/test_homogeneous_monomial_system.py
@@ -116,7 +116,7 @@ def test_one_power_equation_has_d_zero_dimensional_components() -> None:
     _assert_defining_invariants(result)
 
 
-def test_mixed_invariant_factors_and_free_coordinate_stay_compact() -> None:
+def test_mixed_invariant_factors_and_free_coordinate_have_a_torus_factor() -> None:
     result = homogeneous_monomial_solution_subgroup(_system([[2, 0, 0], [0, 6, 0]]))
 
     assert result.torsion_character_group.invariant_factors == ("2", "6")

--- a/tests/math/algebraic_tori/test_homogeneous_monomial_system.py
+++ b/tests/math/algebraic_tori/test_homogeneous_monomial_system.py
@@ -1,0 +1,314 @@
+"""Exact homogeneous monomial systems on complex algebraic tori."""
+
+from __future__ import annotations
+
+import json
+from math import prod
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math.algebraic_tori import (
+    AlgebraicTorusSolutionSubgroup,
+    HomogeneousMonomialSystem,
+    homogeneous_monomial_solution_subgroup,
+)
+from jacobian.math.algebraic_tori._models import (
+    HomogeneousMonomialSolutionRequest,
+)
+from jacobian.math.algebraic_tori._tools import TOOLS
+from jacobian.math.matrices.certified_snf import (
+    CertifiedIntegerMatrix,
+    verify_smith_normal_form_certificate,
+)
+
+
+def _matrix(
+    entries: list[list[int | str]],
+    *,
+    rows: int | None = None,
+    columns: int | None = None,
+) -> CertifiedIntegerMatrix:
+    row_count = len(entries) if rows is None else rows
+    column_count = (len(entries[0]) if entries else 0) if columns is None else columns
+    return CertifiedIntegerMatrix(
+        row_count=row_count,
+        column_count=column_count,
+        entries=tuple(tuple(str(value) for value in row) for row in entries),
+    )
+
+
+def _system(
+    entries: list[list[int | str]],
+    *,
+    rows: int | None = None,
+    columns: int | None = None,
+) -> HomogeneousMonomialSystem:
+    matrix = _matrix(entries, rows=rows, columns=columns)
+    return HomogeneousMonomialSystem(
+        exponent_matrix=matrix,
+        equation_axis=tuple(f"equation_{index}" for index in range(matrix.row_count)),
+        coordinate_axis=tuple(f"x_{index}" for index in range(matrix.column_count)),
+    )
+
+
+def _integers(matrix: CertifiedIntegerMatrix) -> list[list[int]]:
+    return [[parse_canonical_integer(value) for value in row] for row in matrix.entries]
+
+
+def _multiply(
+    left: list[list[int]], right: list[list[int]], columns: int
+) -> list[list[int]]:
+    return [
+        [
+            sum(left[row][index] * right[index][column] for index in range(len(right)))
+            for column in range(columns)
+        ]
+        for row in range(len(left))
+    ]
+
+
+def _assert_defining_invariants(result: AlgebraicTorusSolutionSubgroup) -> None:
+    certificate = result.smith_certificate
+    if certificate.source.row_count and certificate.source.column_count:
+        assert verify_smith_normal_form_certificate(certificate)
+    else:
+        # The existing standalone verifier intentionally owns only its public
+        # nonempty 16-by-16 request domain. The torus kernel also admits the
+        # exact empty-axis Smith degeneracies supported by smith_reduce.
+        assert certificate.source == result.source.exponent_matrix
+        assert certificate.rank == 0
+        assert certificate.invariant_factors == ()
+    source = _integers(result.source.exponent_matrix)
+    free = _integers(result.reduced_free_exponent_map)
+    assert _multiply(source, free, result.free_rank) == [
+        [0] * result.free_rank for _ in source
+    ]
+    factors = tuple(
+        parse_canonical_integer(value)
+        for value in result.torsion_character_group.invariant_factors
+    )
+    torsion = _integers(result.torsion_exponent_map)
+    torsion_relations = _multiply(source, torsion, len(factors))
+    assert all(
+        value % factors[column] == 0
+        for row in torsion_relations
+        for column, value in enumerate(row)
+    )
+    assert parse_canonical_integer(result.connected_component_count) == prod(
+        factors, start=1
+    )
+
+
+def test_nonsymmetric_smith_basis_uses_the_right_transformation_back_map() -> None:
+    result = homogeneous_monomial_solution_subgroup(_system([[1, 1]]))
+
+    assert result.smith_certificate.right_transformation.entries == (
+        ("1", "-1"),
+        ("0", "1"),
+    )
+    assert result.smith_free_exponent_map.entries == (("-1",), ("1",))
+    _assert_defining_invariants(result)
+
+
+def test_one_power_equation_has_d_zero_dimensional_components() -> None:
+    result = homogeneous_monomial_solution_subgroup(_system([[7]]))
+
+    assert result.smith_certificate.rank == 1
+    assert result.free_rank == 0
+    assert result.torsion_character_group.invariant_factors == ("7",)
+    assert result.connected_component_count == "7"
+    assert result.torsion_exponent_map.entries == (("1",),)
+    _assert_defining_invariants(result)
+
+
+def test_mixed_invariant_factors_and_free_coordinate_stay_compact() -> None:
+    result = homogeneous_monomial_solution_subgroup(_system([[2, 0, 0], [0, 6, 0]]))
+
+    assert result.torsion_character_group.invariant_factors == ("2", "6")
+    assert result.connected_component_count == "12"
+    assert result.free_rank == 1
+    assert result.reduced_free_exponent_map.entries == (("0",), ("0",), ("1",))
+    assert "components" not in result.model_dump()
+    assert "exactness" not in result.model_dump()
+    assert "completeness" not in result.model_dump()
+    _assert_defining_invariants(result)
+
+
+def test_lll_reduced_basis_retains_the_exact_parameter_transport() -> None:
+    result = homogeneous_monomial_solution_subgroup(
+        _system([[-5, 4, 4, 0], [-1, 4, 5, 6]])
+    )
+
+    assert result.smith_free_exponent_map.entries == (
+        ("4", "-24"),
+        ("21", "-120"),
+        ("-16", "90"),
+        ("0", "1"),
+    )
+    assert result.reduced_free_exponent_map.entries == (
+        ("4", "0"),
+        ("3", "6"),
+        ("2", "-6"),
+        ("-3", "1"),
+    )
+    assert result.smith_free_parameters_from_reduced.entries == (
+        ("-17", "6"),
+        ("-3", "1"),
+    )
+    smith_free = _integers(result.smith_free_exponent_map)
+    parameter_transport = _integers(result.smith_free_parameters_from_reduced)
+    assert _multiply(smith_free, parameter_transport, result.free_rank) == _integers(
+        result.reduced_free_exponent_map
+    )
+    _assert_defining_invariants(result)
+
+
+def test_redundant_and_sign_reversed_equations_preserve_the_group_profile() -> None:
+    original = homogeneous_monomial_solution_subgroup(_system([[2, -2, 0]]))
+    redundant = homogeneous_monomial_solution_subgroup(
+        _system([[-2, 2, 0], [4, -4, 0]])
+    )
+
+    assert (
+        original.smith_certificate.rank,
+        original.free_rank,
+        original.torsion_character_group,
+    ) == (
+        redundant.smith_certificate.rank,
+        redundant.free_rank,
+        redundant.torsion_character_group,
+    )
+    _assert_defining_invariants(redundant)
+
+
+def test_empty_equation_and_coordinate_degeneracies_retain_ambient_axes() -> None:
+    full_torus = homogeneous_monomial_solution_subgroup(_system([], rows=0, columns=3))
+    singleton = homogeneous_monomial_solution_subgroup(
+        _system([[], []], rows=2, columns=0)
+    )
+
+    assert (full_torus.smith_certificate.rank, full_torus.free_rank) == (0, 3)
+    assert full_torus.reduced_free_exponent_map.entries == (
+        ("1", "0", "0"),
+        ("0", "1", "0"),
+        ("0", "0", "1"),
+    )
+    assert (singleton.smith_certificate.rank, singleton.free_rank) == (0, 0)
+    assert singleton.connected_component_count == "1"
+    _assert_defining_invariants(full_torus)
+    _assert_defining_invariants(singleton)
+
+
+def test_large_component_family_is_compact_not_materialized() -> None:
+    factor = "9" * 32
+    result = homogeneous_monomial_solution_subgroup(_system([[factor]]))
+
+    assert result.connected_component_count == factor
+    assert len(json.dumps(result.model_dump(mode="json"))) < 10_000
+
+
+def test_full_dimension_and_digit_boundary_returns_a_compact_exact_result() -> None:
+    factor = "9" * 32
+    system = _system(
+        [
+            [factor if row == column else "0" for column in range(16)]
+            for row in range(16)
+        ]
+    )
+
+    result = homogeneous_monomial_solution_subgroup(system)
+
+    assert result.smith_certificate.rank == 16
+    assert result.free_rank == 0
+    assert len(result.torsion_character_group.invariant_factors) == 16
+    assert result.connected_component_count == str(int(factor) ** 16)
+    assert len(result.model_dump_json()) < 12_000
+
+
+def test_result_round_trips_and_source_composes_unchanged() -> None:
+    produced = homogeneous_monomial_solution_subgroup(_system([[2, 6, 0]]))
+    decoded = AlgebraicTorusSolutionSubgroup.model_validate_json(
+        produced.model_dump_json()
+    )
+    consumed = homogeneous_monomial_solution_subgroup(decoded.source)
+
+    assert decoded == produced
+    assert consumed == produced
+
+
+def test_result_rejects_a_certificate_bound_to_another_source() -> None:
+    produced = homogeneous_monomial_solution_subgroup(_system([[2, 6]]))
+    forged = produced.model_dump(mode="json")
+    forged["source"]["exponent_matrix"]["entries"][0][0] = "3"
+
+    with pytest.raises(ValidationError) as error:
+        AlgebraicTorusSolutionSubgroup.model_validate(forged)
+
+    assert error.value.errors()[0]["type"] == (
+        "algebraic_torus.solution_source_binding"
+    )
+
+
+def test_raw_result_rejects_map_shape_before_nested_matrix_decoding() -> None:
+    forged = homogeneous_monomial_solution_subgroup(_system([[2, 6, 0]])).model_dump(
+        mode="json"
+    )
+    forged["reduced_free_exponent_map"]["row_count"] = 16
+
+    with pytest.raises(ValidationError) as error:
+        AlgebraicTorusSolutionSubgroup.model_validate(forged)
+
+    assert error.value.errors()[0]["type"] == "algebraic_torus.solution_map_shape"
+
+
+def test_system_bounds_nested_dimensions_and_digits_before_smith_work() -> None:
+    with pytest.raises(ValidationError, match="at most 16"):
+        HomogeneousMonomialSystem.model_validate(
+            {
+                "exponent_matrix": {
+                    "row_count": 1,
+                    "column_count": 17,
+                    "entries": [["0"] * 17],
+                },
+                "equation_axis": ["e"],
+                "coordinate_axis": [f"x{i}" for i in range(17)],
+            }
+        )
+    with pytest.raises(ValidationError, match="32 decimal digits"):
+        HomogeneousMonomialSystem.model_validate(
+            {
+                "exponent_matrix": {
+                    "row_count": 1,
+                    "column_count": 1,
+                    "entries": [["9" * 33]],
+                },
+                "equation_axis": ["e"],
+                "coordinate_axis": ["x"],
+            }
+        )
+
+
+def test_public_operation_example_crosses_the_json_request_boundary() -> None:
+    operation = TOOLS[0]
+    request = HomogeneousMonomialSolutionRequest.model_validate(
+        operation.examples[0].input
+    )
+
+    result = operation.run(request)
+
+    assert isinstance(result, AlgebraicTorusSolutionSubgroup)
+    assert result.connected_component_count == "2"
+    assert result.free_rank == 1
+
+
+def test_exact_public_api_symbols() -> None:
+    from jacobian.math import algebraic_tori
+
+    assert tuple(algebraic_tori.__all__) == (
+        "AlgebraicTorusSolutionSubgroup",
+        "HomogeneousMonomialSystem",
+        "TorsionCharacterGroup",
+        "homogeneous_monomial_solution_subgroup",
+    )

--- a/tests/math/matrices/test_certified_snf_models.py
+++ b/tests/math/matrices/test_certified_snf_models.py
@@ -332,7 +332,7 @@ def test_certificate_contract_replays_zero_dimensional_boundaries(
     certificate = SmithNormalFormCertificate(**kwargs)
 
     assert certificate.rank == 0
-    assert not verify_smith_normal_form_certificate(certificate)
+    assert verify_smith_normal_form_certificate(certificate)
     assert not verify_smith_normal_form_certificate(
         SmithNormalFormCertificate.model_validate({**kwargs, "left_determinant": "-1"})
     )
@@ -362,7 +362,7 @@ def test_certificate_contract_replays_rank_zero_determinants_without_formatting_
     )
 
     assert certificate.left_determinant == "-1"
-    assert not verify_smith_normal_form_certificate(certificate)
+    assert verify_smith_normal_form_certificate(certificate)
     assert not verify_smith_normal_form_certificate(
         SmithNormalFormCertificate.model_validate(
             {


### PR DESCRIPTION
## Problem

Closes #2258.

Jacobian cannot currently return the complete solution subgroup of a bounded homogeneous monomial system on `(CC*)^n`. A rational nullspace alone loses the disconnected torsion components, while backend expressions do not provide a canonical typed value that composes with the matrix operations already in the catalog.

## Solution

Adds `algebraic_torus.monomial_system.solution_subgroup.compute` under the new `jacobian.math.algebraic_tori` owner.

For a row-oriented exponent matrix `A`, the operation computes a certified Smith decomposition `D = U A V` and returns:

- the nontrivial Smith invariant factors as the finite torsion character group;
- the exact connected-component count;
- the torsion monomial exponent map;
- the Smith free-torus exponent map;
- a deterministic LLL-reduced free basis and its exact unimodular coordinate transport;
- named equation, source-coordinate, torsion-parameter, Smith-free, and reduced-free axes.

The public convention is `x_i = product_j parameter_j ** exponent_map[i,j]`. SymPy 1.14 owns Smith decomposition and exact LLL reduction; Jacobian owns admission, axes, canonical values, and source-bound result construction. The operation covers only homogeneous right-hand side one on nonzero complex coordinates. General binomial right-hand sides and affine zero-coordinate branches remain outside this contribution.

The Smith certificate verifier now admits bounded zero-axis certificates, so the advertised empty-equation and empty-coordinate cases compose unchanged through the existing public consumer. Canonical torsion values reject factors of one, broken divisibility chains, and component counts inconsistent with their factors.

## Testing

- `make handoff LANE=math TESTS="tests/math/algebraic_tori tests/math/matrices/test_certified_snf_models.py"`
- `make test-catalog architecture docs-linkcheck`
- 4,900 deterministic small-matrix exercises across zero through six equations and coordinates during independent exact-diff review

Coverage includes the motivating mixed torsion/free system, a nonsymmetric Smith back-map regression, exact LLL basis transport, redundant equations, zero-axis degeneracies, serialization and producer-to-consumer composition, malformed source binding, contradictory torsion values, and the full 16 by 16 / 32-digit input boundary.

## Public contract impact

Adds the operation ID `algebraic_torus.monomial_system.solution_subgroup.compute`, its strict request and result schemas, canonical algebraic-torus values, and the matching native Python API. The existing Smith computation request remains nonempty; only its independently supplied certificate verifier gains bounded zero-axis admission.

## Operation boundary ownership

- Changed stage: request parsing, request bounds, kernel adapter, result construction, native API, and catalog publication
- Request-bounds owner and controlling quantities: `HomogeneousMonomialSystem`; equation count, coordinate count, exponent digit length, and the Hadamard-derived component-count digit bound
- Work, intermediate, memory, and exact-output bounds: at most 16 equations and 16 coordinates, at most 32 decimal digits per exponent, exact Smith and LLL intermediates, and compact maps of at most 16 by 16 entries
- Wall deadline, calibration workload, safety margin, and caller-selectable range: no new wall deadline; the mathematical envelope is fixed by dimensions and digit bounds, and the full boundary fixture completes in the focused suite
- Backend or kernel path: direct pinned SymPy Smith decomposition and `DomainMatrix.lll_transform`
- Result construction: one admitted kernel computation followed by owner-local trusted construction; defining relations are checked in tests, not replayed by result validation
- Independent-result verifier: the embedded canonical Smith certificate composes with the existing verifier, whose replay is bounded to 16 by 16 sources with 32-digit entries, including zero axes
- Native/MCP parity: both call the same typed domain function; MCP adds only JSON projection
- Serialized-result and round-trip evidence: exact JSON round-trip, source reuse as a second request, zero-axis certificate verification, and forged-payload rejection are covered

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Advertised codomain is closed under the result types, including required parent, embedding, branch, orientation, basis, or coordinate data
- [x] Producer→consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: integer exponent matrix; homogeneous right-hand side one; all coordinates in `CC*`
- Structurally valid but mathematically invalid fixture and outcome: source/certificate mismatch, noncanonical torsion factors, and contradictory component counts are rejected
- Serialized-subtype trust boundary: constructors validate canonical shape and source binding; the explicit Smith consumer performs bounded mathematical replay
- Exact-success defining invariant: `D = U A V`; free maps lie in the integer kernel of `A`; torsion columns satisfy their Smith congruences; reduced and Smith bases are connected by the returned unimodular map; component count is the product of torsion factors
- Discriminated result schema and impossible combinations: one exact subgroup value; contradictory ranks, axes, map shapes, torsion factors, and component counts are rejected

## Catalog admission

- Concrete gap: no typed operation returns the complete subgroup of a homogeneous monomial system on an algebraic torus
- Why existing operations or typed values are insufficient: rational linear algebra omits finite torsion components; Smith certificates alone do not bind source axes or expose monomial parameter maps
- Stable mathematical result: the exact finite-component character group times free torus, with exact monomial maps between named coordinates
- Semantic domain and admitted execution envelope: integer exponent systems `x^A = 1` on `(CC*)^n`, including empty axes, within the 16-dimensional and 32-digit envelope
- Controlling work, intermediate, memory, and output quantities: matrix dimensions, exponent digit length, exact Smith/LLL growth, map sizes, and Hadamard-bounded component digits
- Exact representation, algorithm regimes, and maintained backend: canonical integer matrices and axes; SymPy Smith decomposition and exact LLL
- Remaining fixed caps and their classification: 16 axes and 32 exponent digits are conservative certified-Smith backend/work bounds
- Motivating source request exercised through the public boundary: mixed finite torsion and positive-dimensional free-torus examples from #2258
- Final-tree outcome for that request: exact invariant factors, component count, and both Smith and reduced monomial parameterizations
- Effect of private normalization or presolve on admission: none; admission uses the source dimensions and digits before backend expansion
- Admission decision: admit one atomic solution-subgroup operation

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Homogeneous monomial solution subgroup on `(CC*)^n` | delivered | `algebraic_torus.monomial_system.solution_subgroup.compute` |
| General non-unit binomial right-hand sides | deferred | outside #2258 |
| Affine branches with zero coordinates | deferred | outside #2258 |

## Checklist

- [x] `make handoff LANE=math TESTS=...` passes
- [x] Catalog, architecture, and documentation-link specialist validation is listed above
- [x] Catalog publication is owner-local in `algebraic_tori/_tools.py`
- [x] No compatibility aliases, forwarding modules, or generic shadow paths were introduced
- [x] Native and MCP callers execute the same bounded typed operation
- [x] The source-request regression and exact boundary fixtures are included
