### PR TITLE
Compose proper classes of integral binary quadratic forms

### DIFF
--- a/.agents/skills/recent-conjecture-evaluations/scripts/search_inventory.py
+++ b/.agents/skills/recent-conjecture-evaluations/scripts/search_inventory.py
@@ -12,7 +12,9 @@ TEXT_SUFFIXES = {".md", ".json", ".jsonl", ".txt", ".yaml", ".yml"}
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("query", help="Case-insensitive overlap phrase")
-    parser.add_argument("roots", nargs="+", type=Path, help="Report or trajectory roots")
+    parser.add_argument(
+        "roots", nargs="+", type=Path, help="Report or trajectory roots"
+    )
     parser.add_argument("--limit", type=int, default=100)
     args = parser.parse_args()
 

--- a/docs/reference/mathematical-backends.md
+++ b/docs/reference/mathematical-backends.md
@@ -90,10 +90,7 @@ def determinant_and_rank(
     from flint import fmpq, fmpq_mat
 
     backend = fmpq_mat(
-        [
-            [fmpq(value.numerator, value.denominator) for value in row]
-            for row in rows
-        ]
+        [[fmpq(value.numerator, value.denominator) for value in row] for row in rows]
     )
     determinant = backend.det()
     return (

--- a/docs/reference/operations/index.md
+++ b/docs/reference/operations/index.md
@@ -12,4 +12,4 @@ that need more context than an operation card:
 
 - [Combinatorics on words](words/index.md)
 - [SAT and SMT](sat-smt/index.md)
-- [Exact rational quadratic forms](quadratic-forms.md)
+- [Exact quadratic forms](quadratic-forms.md)

--- a/docs/reference/operations/quadratic-forms.md
+++ b/docs/reference/operations/quadratic-forms.md
@@ -49,10 +49,10 @@ H(X,Y) = F(x1,y1) * G(x2,y2),
 ```
 
 and the canonical reduced product with an exact `SL_2(ZZ)` reduction matrix.
-The public execution envelope matches complete reduced-class enumeration:
-with `A = floor_sqrt((-D)//3)+1`, the discriminant is admitted when
-`A*(A+2) <= 10000`. This bounds the class operands, direct-composition
-intermediates, exact witness, and returned coefficients before execution.
+Composition is admitted by its own work bounds (direct O(1) Buell
+formula and O(log|D|) Gauss reduction), independent of the reduced-class
+enumeration budget. The reduced product coefficients are bounded by
+`|D|/3`, so the discriminant is admitted only when `|D|/3 <= 10^6`.
 
 The private kernel uses the classical direct Gauss-composition formula with a
 ternary Bézout relation, then applies the existing exact Gauss reduction. The

--- a/docs/reference/operations/quadratic-forms.md
+++ b/docs/reference/operations/quadratic-forms.md
@@ -1,4 +1,4 @@
-# Exact rational quadratic forms
+# Exact quadratic forms
 
 [Documentation home](../../index.md) · [Tool surface](../tools.md)
 
@@ -22,3 +22,40 @@ are deliberately not independently accepted or returned by this leaf.
 Evaluation is direct exact rational arithmetic. It supports degenerate and
 indefinite forms because one value at one supplied vector is always finite;
 representation numbers and theta prefixes are not part of this contract.
+
+## Proper classes of positive-definite integral binary forms
+
+`number_theory.binary_quadratic_form.reduced_classes.compute` returns each
+proper class as a `ProperBinaryQuadraticFormClass`. Its representative is the
+unique canonical Gauss-reduced primitive form
+
+```text
+Q(x,y) = a*x^2 + b*x*y + c*y^2,
+|b| <= a <= c,
+b >= 0 when |b| = a or a = c.
+```
+
+The class retains its quadratic-order discriminant through the representative;
+nonfundamental discriminants refer to proper classes of the corresponding
+quadratic order, not automatically to the maximal order of its fraction field.
+
+`number_theory.binary_quadratic_form.class_compose.compute` multiplies two
+proper classes of the same discriminant. It returns a direct composed form, a
+bilinear map in monomial order
+`(x1*x2, x1*y2, y1*x2, y1*y2)` satisfying
+
+```text
+H(X,Y) = F(x1,y1) * G(x2,y2),
+```
+
+and the canonical reduced product with an exact `SL_2(ZZ)` reduction matrix.
+The public execution envelope matches complete reduced-class enumeration:
+with `A = floor_sqrt((-D)//3)+1`, the discriminant is admitted when
+`A*(A+2) <= 10000`. This bounds the class operands, direct-composition
+intermediates, exact witness, and returned coefficients before execution.
+
+The private kernel uses the classical direct Gauss-composition formula with a
+ternary Bézout relation, then applies the existing exact Gauss reduction. The
+kernel is Jacobian-owned because Python-FLINT does not expose binary-form
+composition and PARI/cypari2 is not part of the supported runtime. Backend
+objects and algorithm-specific class labels do not cross the public boundary.

--- a/src/jacobian/math/number_theory/number_fields/_real_embedding_order_worker.py
+++ b/src/jacobian/math/number_theory/number_fields/_real_embedding_order_worker.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from typing import Any
+from typing import Any, Literal
 
+from jacobian._exact import CanonicalRational
 from jacobian.canonical import parse_canonical_integer
+from jacobian.math.number_theory.algebraic_numbers.real import RationalIsolatingInterval
 from jacobian.math.number_theory.number_fields._real_embedding_order_protocol import (
     SelectedImageWorkerComplete,
     SelectedImageWorkerError,
@@ -49,11 +51,11 @@ def compute_selected_image_isolation(
         return SelectedImageWorkerComplete(
             kind="complete",
             order="EQ",
-            isolating_interval={
-                "lower": "0",
-                "upper": "0",
-                "interval_type": "SINGLETON",
-            },
+            isolating_interval=RationalIsolatingInterval(
+                lower=CanonicalRational(num="0", den="1"),
+                upper=CanonicalRational(num="0", den="1"),
+                interval_type="SINGLETON",
+            ),
         )
 
     descending = list(value.to_list())
@@ -62,15 +64,19 @@ def compute_selected_image_isolation(
             int(descending[0].numerator), int(descending[0].denominator)
         )
         endpoint = f"{rational.numerator}/{rational.denominator}"
-        order = "LT" if rational < 0 else "GT"
+        order: Literal["LT", "EQ", "GT"] = "LT" if rational < 0 else "GT"
         return SelectedImageWorkerComplete(
             kind="complete",
             order=order,
-            isolating_interval={
-                "lower": endpoint,
-                "upper": endpoint,
-                "interval_type": "SINGLETON",
-            },
+            isolating_interval=RationalIsolatingInterval(
+                lower=CanonicalRational(
+                    num=endpoint.split("/")[0], den=endpoint.split("/")[1]
+                ),
+                upper=CanonicalRational(
+                    num=endpoint.split("/")[0], den=endpoint.split("/")[1]
+                ),
+                interval_type="SINGLETON",
+            ),
         )
 
     image = algebraic_field.to_sympy(value)
@@ -138,13 +144,17 @@ def compute_selected_image_isolation(
     return SelectedImageWorkerComplete(
         kind="complete",
         order=order,
-        isolating_interval={
-            "lower": f"{lower_fraction.numerator}/{lower_fraction.denominator}",
-            "upper": f"{upper_fraction.numerator}/{upper_fraction.denominator}",
-            "interval_type": (
-                "SINGLETON" if lower_fraction == upper_fraction else "OPEN"
+        isolating_interval=RationalIsolatingInterval(
+            lower=CanonicalRational(
+                num=str(lower_fraction.numerator),
+                den=str(lower_fraction.denominator),
             ),
-        },
+            upper=CanonicalRational(
+                num=str(upper_fraction.numerator),
+                den=str(upper_fraction.denominator),
+            ),
+            interval_type=("SINGLETON" if lower_fraction == upper_fraction else "OPEN"),
+        ),
     )
 
 

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/__init__.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/__init__.py
@@ -1,11 +1,14 @@
 """Supported native APIs for integral binary quadratic forms."""
 
 from jacobian.math.number_theory.quadratic_forms.binary._models import (
+    BinaryQuadraticFormClassCompositionResult,
     BinaryQuadraticFormRepresentation,
     PrimitivePositiveDefiniteBinaryQuadraticForm,
+    ProperBinaryQuadraticFormClass,
 )
 from jacobian.math.number_theory.quadratic_forms.binary.operations import (
     check,
+    compose_classes,
     evaluate,
     proper_equivalence,
     reduced_classes,
@@ -14,9 +17,12 @@ from jacobian.math.number_theory.quadratic_forms.binary.operations import (
 )
 
 __all__ = [
+    "BinaryQuadraticFormClassCompositionResult",
     "BinaryQuadraticFormRepresentation",
     "PrimitivePositiveDefiniteBinaryQuadraticForm",
+    "ProperBinaryQuadraticFormClass",
     "check",
+    "compose_classes",
     "evaluate",
     "proper_equivalence",
     "reduced_classes",

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/_kernel.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/_kernel.py
@@ -1,5 +1,6 @@
 """Reusable exact kernels for integral binary quadratic forms."""
 
+from dataclasses import dataclass
 from math import isqrt
 
 from jacobian.math.number_theory.quadratic_forms.binary._models import (
@@ -7,6 +8,7 @@ from jacobian.math.number_theory.quadratic_forms.binary._models import (
     BinaryQuadraticFormRepresentation,
     PrimitivePositiveDefiniteBinaryQuadraticForm,
     _has_sum_of_two_squares_mod_four_obstruction,
+    _is_reduced_coefficients,
     _representation_y_bound,
     _require_representation_budget,
 )
@@ -29,15 +31,140 @@ def evaluate(a: int, b: int, c: int, x: int, y: int) -> int:
 
 def is_reduced(a: int, b: int, c: int) -> bool:
     """Check Gauss reduction: ``|b| <= a <= c``, with tie-breaking ``b >= 0``."""
-    if a <= 0 or c <= 0:
-        return False
-    if abs(b) > a:
-        return False
-    if a > c:
-        return False
-    if abs(b) == a and b < 0:
-        return False
-    return not (a == c and b < 0)
+    return a > 0 and c > 0 and _is_reduced_coefficients(a, b, c)
+
+
+def _extended_gcd(a: int, b: int) -> tuple[int, int, int]:
+    """Return nonnegative gcd and deterministic Bezout coefficients."""
+    old_r, r = abs(a), abs(b)
+    old_s, s = 1, 0
+    old_t, t = 0, 1
+    while r:
+        quotient = old_r // r
+        old_r, r = r, old_r - quotient * r
+        old_s, s = s, old_s - quotient * s
+        old_t, t = t, old_t - quotient * t
+    return old_r, old_s if a >= 0 else -old_s, old_t if b >= 0 else -old_t
+
+
+def _extended_gcd_three(a: int, b: int, c: int) -> tuple[int, int, int, int]:
+    gcd_ab, coefficient_a, coefficient_b = _extended_gcd(a, b)
+    common_divisor, coefficient_ab, coefficient_c = _extended_gcd(gcd_ab, c)
+    return (
+        common_divisor,
+        coefficient_ab * coefficient_a,
+        coefficient_ab * coefficient_b,
+        coefficient_c,
+    )
+
+
+def _exact_quotient(numerator: int, denominator: int, label: str) -> int:
+    quotient, remainder = divmod(numerator, denominator)
+    if remainder:
+        raise ArithmeticError(f"{label} is not integral")
+    return quotient
+
+
+@dataclass(frozen=True, slots=True)
+class DirectComposition:
+    """One direct Gauss composite and its bilinear substitution."""
+
+    a: int
+    b: int
+    c: int
+    x_coefficients: tuple[int, int, int, int]
+    y_coefficients: tuple[int, int, int, int]
+
+
+def compose(
+    first: PrimitivePositiveDefiniteBinaryQuadraticForm,
+    second: PrimitivePositiveDefiniteBinaryQuadraticForm,
+) -> DirectComposition:
+    """Return a direct Gauss composite using Buell's ternary-Bezout formula."""
+    if first.discriminant != second.discriminant:
+        raise ValueError("forms must have the same discriminant")
+
+    a1, b1 = first.a, first.b
+    a2, b2 = second.a, second.b
+    discriminant = first.discriminant
+    beta = _exact_quotient(b1 + b2, 2, "composition parity term")
+    common_divisor, t, u, v = _extended_gcd_three(a1, a2, beta)
+    if common_divisor <= 0:
+        raise ArithmeticError("composition common divisor must be positive")
+
+    composed_a = _exact_quotient(
+        a1 * a2,
+        common_divisor * common_divisor,
+        "composition leading coefficient",
+    )
+    discriminant_term = _exact_quotient(
+        b1 * b2 + discriminant,
+        2,
+        "composition discriminant term",
+    )
+    middle_numerator = a1 * b2 * t + a2 * b1 * u + v * discriminant_term
+    initial_b = _exact_quotient(
+        middle_numerator, common_divisor, "composition middle coefficient"
+    )
+
+    x_coefficients = (
+        common_divisor,
+        _exact_quotient(
+            (b2 - initial_b) * common_divisor,
+            2 * a2,
+            "first mixed composition coefficient",
+        ),
+        _exact_quotient(
+            (b1 - initial_b) * common_divisor,
+            2 * a1,
+            "second mixed composition coefficient",
+        ),
+        _exact_quotient(
+            (b1 * b2 + discriminant - initial_b * (b1 + b2)) * common_divisor,
+            4 * a1 * a2,
+            "trailing mixed composition coefficient",
+        ),
+    )
+    y_coefficients = (
+        0,
+        _exact_quotient(a1, common_divisor, "first Y coefficient"),
+        _exact_quotient(a2, common_divisor, "second Y coefficient"),
+        _exact_quotient(beta, common_divisor, "trailing Y coefficient"),
+    )
+
+    # Replace the incidental middle coefficient by its deterministic residue
+    # in [-A, A). This is the SL_2(Z) substitution x -> x+k*y. Adjust the
+    # direct-composition map by the inverse substitution so its identity stays
+    # attached to the normalized form.
+    composed_b = (initial_b + composed_a) % (2 * composed_a) - composed_a
+    shift = _exact_quotient(
+        composed_b - initial_b,
+        2 * composed_a,
+        "composition normalization shift",
+    )
+    normalized_x_coefficients = tuple(
+        x_value - shift * y_value
+        for x_value, y_value in zip(x_coefficients, y_coefficients, strict=True)
+    )
+    x_coefficients = (
+        normalized_x_coefficients[0],
+        normalized_x_coefficients[1],
+        normalized_x_coefficients[2],
+        normalized_x_coefficients[3],
+    )
+    c_numerator = composed_b * composed_b - discriminant
+    composed_c = _exact_quotient(
+        c_numerator,
+        4 * composed_a,
+        "composition trailing coefficient",
+    )
+    return DirectComposition(
+        a=composed_a,
+        b=composed_b,
+        c=composed_c,
+        x_coefficients=x_coefficients,
+        y_coefficients=y_coefficients,
+    )
 
 
 def _reduce_step(
@@ -142,4 +269,12 @@ def representations(
     return tuple(sorted(rows, key=lambda row: (row.x, row.y)))
 
 
-__all__ = ["evaluate", "gcd", "is_reduced", "reduce", "representations"]
+__all__ = [
+    "DirectComposition",
+    "compose",
+    "evaluate",
+    "gcd",
+    "is_reduced",
+    "reduce",
+    "representations",
+]

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/_models.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -29,6 +29,9 @@ MAX_REDUCED_CLASS_OUTPUT_ROWS = MAX_REDUCED_CLASS_SEARCH_STATES
 # range; every accepted evaluation must stay inside it so ``math.run`` returns
 # a typed result instead of failing transport canonicalization.
 MAX_EVALUATED_VALUE = (1 << 53) - 1
+CompositionWitnessInteger = Annotated[
+    int, Field(ge=-MAX_EVALUATED_VALUE, le=MAX_EVALUATED_VALUE)
+]
 
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
@@ -55,6 +58,11 @@ def _require_positive_primitive_form(form: tuple[int, int, int]) -> None:
         )
 
 
+def _is_reduced_coefficients(a: int, b: int, c: int) -> bool:
+    """Return the canonical positive-definite Gauss-reduction predicate."""
+    return abs(b) <= a <= c and (abs(b) != a or b >= 0) and (a != c or b >= 0)
+
+
 class PrimitivePositiveDefiniteBinaryQuadraticForm(StrictModel):
     """A canonical primitive positive-definite integral binary quadratic form.
 
@@ -74,6 +82,27 @@ class PrimitivePositiveDefiniteBinaryQuadraticForm(StrictModel):
     def discriminant(self) -> int:
         """Return the derived discriminant ``b^2 - 4*a*c``."""
         return self.b * self.b - 4 * self.a * self.c
+
+
+class ProperBinaryQuadraticFormClass(StrictModel):
+    """One proper class identified by its canonical Gauss-reduced representative."""
+
+    representative: PrimitivePositiveDefiniteBinaryQuadraticForm
+
+    @model_validator(mode="after")
+    def require_reduced_representative(self) -> Self:
+        form = self.representative
+        if not _is_reduced_coefficients(form.a, form.b, form.c):
+            raise _validation_error(
+                "integral_binary_quadratic_form.class_representative_not_reduced",
+                "proper form classes require a canonical Gauss-reduced representative",
+            )
+        return self
+
+    @property
+    def discriminant(self) -> int:
+        """Return the discriminant of the represented quadratic order."""
+        return self.representative.discriminant
 
 
 class BinaryQuadraticFormCheckRequest(StrictModel):
@@ -123,6 +152,18 @@ class BinaryQuadraticFormReducedClassesRequest(StrictModel):
             f"A*(A+2) is at most {MAX_REDUCED_CLASS_SEARCH_STATES}."
         ),
     )
+
+
+class BinaryQuadraticFormClassComposeRequest(StrictModel):
+    """Request the proper-class product of two reduced forms of one discriminant.
+
+    Both classes must have the same discriminant. Composition is admitted when
+    that discriminant fits the complete reduced-class scan envelope
+    ``A*(A+2) <= 10000`` published by ``reduced_classes.compute``.
+    """
+
+    first: ProperBinaryQuadraticFormClass
+    second: ProperBinaryQuadraticFormClass
 
 
 def _reduced_class_search_state_count(discriminant: int) -> int:
@@ -390,11 +431,80 @@ class ProperEquivalenceResult(StrictModel):
         )
 
 
+class DirectBinaryQuadraticCompositionMap(StrictModel):
+    """A bilinear map witnessing direct composition of two binary forms.
+
+    Coefficients use monomial order ``x1*x2, x1*y2, y1*x2, y1*y2``. If these
+    rows define ``X`` and ``Y``, then the composed form satisfies
+    ``H(X,Y) = F(x1,y1) * G(x2,y2)``.
+    """
+
+    x_coefficients: tuple[
+        CompositionWitnessInteger,
+        CompositionWitnessInteger,
+        CompositionWitnessInteger,
+        CompositionWitnessInteger,
+    ]
+    y_coefficients: tuple[
+        CompositionWitnessInteger,
+        CompositionWitnessInteger,
+        CompositionWitnessInteger,
+        CompositionWitnessInteger,
+    ]
+    monomial_order: Literal["X1_X2__X1_Y2__Y1_X2__Y1_Y2"] = "X1_X2__X1_Y2__Y1_X2__Y1_Y2"
+
+
+class BinaryQuadraticFormClassCompositionResult(StrictModel):
+    """One exact proper-class product with direct and reduction witnesses."""
+
+    first: ProperBinaryQuadraticFormClass
+    second: ProperBinaryQuadraticFormClass
+    composed_form: PrimitivePositiveDefiniteBinaryQuadraticForm
+    direct_composition_map: DirectBinaryQuadraticCompositionMap
+    product: ProperBinaryQuadraticFormClass
+    reduction_matrix: tuple[tuple[int, int], tuple[int, int]]
+
+    @model_validator(mode="after")
+    def require_one_discriminant(self) -> Self:
+        discriminants = {
+            self.first.discriminant,
+            self.second.discriminant,
+            self.composed_form.discriminant,
+            self.product.discriminant,
+        }
+        if len(discriminants) != 1:
+            raise _validation_error(
+                "integral_binary_quadratic_form.composition_discriminant_mismatch",
+                "composition sources, direct form, and reduced product must share one discriminant",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        first: ProperBinaryQuadraticFormClass,
+        second: ProperBinaryQuadraticFormClass,
+        composed_form: PrimitivePositiveDefiniteBinaryQuadraticForm,
+        direct_composition_map: DirectBinaryQuadraticCompositionMap,
+        product: ProperBinaryQuadraticFormClass,
+        reduction_matrix: tuple[tuple[int, int], tuple[int, int]],
+    ) -> Self:
+        return cls.model_construct(
+            first=first,
+            second=second,
+            composed_form=composed_form,
+            direct_composition_map=direct_composition_map,
+            product=product,
+            reduction_matrix=reduction_matrix,
+        )
+
+
 class ReducedClassesResult(StrictModel):
     """Result of enumerating reduced classes of a discriminant."""
 
     discriminant: int
-    classes: tuple[PrimitivePositiveDefiniteBinaryQuadraticForm, ...] = Field(
+    classes: tuple[ProperBinaryQuadraticFormClass, ...] = Field(
         max_length=MAX_REDUCED_CLASS_OUTPUT_ROWS
     )
     class_number: int
@@ -413,7 +523,7 @@ class ReducedClassesResult(StrictModel):
         cls,
         *,
         discriminant: int,
-        classes: tuple[PrimitivePositiveDefiniteBinaryQuadraticForm, ...],
+        classes: tuple[ProperBinaryQuadraticFormClass, ...],
     ) -> Self:
         """Construct a trusted result from the owner-local class enumerator."""
         return cls.model_construct(

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/_models.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/_models.py
@@ -157,9 +157,9 @@ class BinaryQuadraticFormReducedClassesRequest(StrictModel):
 class BinaryQuadraticFormClassComposeRequest(StrictModel):
     """Request the proper-class product of two reduced forms of one discriminant.
 
-    Both classes must have the same discriminant. Composition is admitted when
-    that discriminant fits the complete reduced-class scan envelope
-    ``A*(A+2) <= 10000`` published by ``reduced_classes.compute``.
+    Both classes must have the same discriminant. Composition is admitted by
+    its own work bounds (direct O(1) composition and O(log|D|) reduction),
+    independent of the reduced-class enumeration budget.
     """
 
     first: ProperBinaryQuadraticFormClass
@@ -193,6 +193,34 @@ def _require_reduced_class_search_budget(discriminant: int) -> int:
             "reduced-class enumeration exceeds the supported candidate budget",
         )
     return state_count
+
+
+def _require_composition_budget(
+    first: PrimitivePositiveDefiniteBinaryQuadraticForm,
+    second: PrimitivePositiveDefiniteBinaryQuadraticForm,
+) -> None:
+    """Admit a direct composition by its own work bounds.
+
+    Direct Gauss composition (Buell's ternary-Bezout formula) is O(1)
+    extended-gcd and exact-quotient work on operands bounded by
+    ``MAX_COEFFICIENT``.  Gauss reduction of the composite is O(log|D|)
+    iterations.  Neither requires class enumeration, so the admission
+    derives from the discriminant validity and the coefficient bounds
+    rather than the unrelated reduced-class scan budget.
+    """
+    if first.discriminant != second.discriminant:
+        raise ValueError("forms must have the same discriminant")
+    discriminant = first.discriminant
+    if discriminant > -3:
+        raise _validation_error(
+            "integral_binary_quadratic_form.discriminant_too_large",
+            "discriminant must be at most -3",
+        )
+    if discriminant % 4 not in (0, 1):
+        raise _validation_error(
+            "integral_binary_quadratic_form.invalid_discriminant_congruence",
+            "discriminant must be congruent to 0 or 1 modulo 4",
+        )
 
 
 def _representation_y_bound(

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/_models.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/_models.py
@@ -207,6 +207,12 @@ def _require_composition_budget(
     iterations.  Neither requires class enumeration, so the admission
     derives from the discriminant validity and the coefficient bounds
     rather than the unrelated reduced-class scan budget.
+
+    The direct composite coefficients and the reduced product can exceed
+    ``MAX_COEFFICIENT`` when the discriminant is large. A reduced form
+    of discriminant ``D`` satisfies ``a <= sqrt(|D|/3)`` and
+    ``c = (b^2 - D) / (4*a) <= |D| / 3``, so reject the request when
+    ``|D| / 3`` exceeds the coefficient bound.
     """
     if first.discriminant != second.discriminant:
         raise ValueError("forms must have the same discriminant")
@@ -220,6 +226,11 @@ def _require_composition_budget(
         raise _validation_error(
             "integral_binary_quadratic_form.invalid_discriminant_congruence",
             "discriminant must be congruent to 0 or 1 modulo 4",
+        )
+    if abs(discriminant) // 3 > MAX_COEFFICIENT:
+        raise _validation_error(
+            "integral_binary_quadratic_form.composition_output_overflow",
+            "composition product exceeds the coefficient bound",
         )
 
 

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/_tools.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/_tools.py
@@ -161,8 +161,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
             example(
                 "compose_classes_discriminant_neg_23",
                 "Compose the class [2,-1,3] with itself at discriminant -23; "
-                "both inputs must be canonical reduced representatives within "
-                "the reduced-class scan envelope.",
+                "both inputs must be canonical reduced representatives of the same "
+                "discriminant.",
                 {
                     "first": {"representative": {"a": 2, "b": -1, "c": 3}},
                     "second": {"representative": {"a": 2, "b": -1, "c": 3}},

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/_tools.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/_tools.py
@@ -17,6 +17,8 @@ from jacobian.math.number_theory.quadratic_forms.binary import operations as nat
 from jacobian.math.number_theory.quadratic_forms.binary._models import (
     BinaryQuadraticFormCheckRequest,
     BinaryQuadraticFormCheckResult,
+    BinaryQuadraticFormClassComposeRequest,
+    BinaryQuadraticFormClassCompositionResult,
     BinaryQuadraticFormEvaluateRequest,
     BinaryQuadraticFormEvaluateResult,
     BinaryQuadraticFormProperEquivRequest,
@@ -101,6 +103,21 @@ def compute_representations(
     )
 
 
+def compute_class_compose(
+    request: BinaryQuadraticFormClassComposeRequest,
+) -> BinaryQuadraticFormClassCompositionResult:
+    if request.first.discriminant != request.second.discriminant:
+        raise OperationDomainValidationError(
+            location=("first", "second"),
+            code="integral_binary_quadratic_form.class_discriminant_mismatch",
+            message="proper form classes must have the same discriminant",
+        )
+    return _admit(
+        lambda: native.compose_classes(request.first, request.second),
+        ("first", "second"),
+    )
+
+
 def _op[
     RequestT: StrictModel,
     ResultT: StrictModel,
@@ -127,6 +144,32 @@ def _op[
 
 
 TOOLS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "number_theory.binary_quadratic_form.class_compose.compute",
+        "Compose proper binary quadratic-form classes",
+        "Compute the exact proper-class product of two canonical Gauss-reduced "
+        "primitive positive-definite binary quadratic forms of one discriminant. "
+        "Return a direct composed form, its bilinear composition map, and the "
+        "canonical reduced product with an SL_2(Z) reduction witness.",
+        BinaryQuadraticFormClassComposeRequest,
+        BinaryQuadraticFormClassCompositionResult,
+        compute_class_compose,
+        "number-theory",
+        "quadratic-forms",
+        "exact",
+        examples=(
+            example(
+                "compose_classes_discriminant_neg_23",
+                "Compose the class [2,-1,3] with itself at discriminant -23; "
+                "both inputs must be canonical reduced representatives within "
+                "the reduced-class scan envelope.",
+                {
+                    "first": {"representative": {"a": 2, "b": -1, "c": 3}},
+                    "second": {"representative": {"a": 2, "b": -1, "c": 3}},
+                },
+            ),
+        ),
+    ),
     _op(
         "number_theory.binary_quadratic_form.check",
         "Check a binary quadratic form",

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/operations.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/operations.py
@@ -27,7 +27,8 @@ from jacobian.math.number_theory.quadratic_forms.binary._models import (
     ProperBinaryQuadraticFormClass,
     ProperEquivalenceResult,
     _require_evaluated_value_bound,
-    _require_reduced_class_search_budget,
+    _require_composition_budget,
+_require_reduced_class_search_budget,
     _require_representation_coordinate,
 )
 
@@ -173,9 +174,9 @@ def compose_classes(
     second: ProperBinaryQuadraticFormClass,
 ) -> BinaryQuadraticFormClassCompositionResult:
     """Return the exact proper-class product with direct-composition evidence."""
-    if first.discriminant != second.discriminant:
-        raise ValueError("proper form classes must have the same discriminant")
-    _require_reduced_class_search_budget(first.discriminant)
+    _require_composition_budget(
+        first.representative, second.representative
+    )
     direct = _compose(first.representative, second.representative)
     composed_form = PrimitivePositiveDefiniteBinaryQuadraticForm(
         a=direct.a, b=direct.b, c=direct.c

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/operations.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/operations.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from jacobian.math.number_theory.quadratic_forms.binary._kernel import (
+    compose as _compose,
+)
+from jacobian.math.number_theory.quadratic_forms.binary._kernel import (
     gcd as _gcd,
 )
 from jacobian.math.number_theory.quadratic_forms.binary._kernel import (
@@ -17,8 +20,11 @@ from jacobian.math.number_theory.quadratic_forms.binary._kernel import (
 from jacobian.math.number_theory.quadratic_forms.binary._models import (
     MAX_COEFFICIENT,
     BinaryQuadraticFormCheckResult,
+    BinaryQuadraticFormClassCompositionResult,
     BinaryQuadraticFormRepresentation,
+    DirectBinaryQuadraticCompositionMap,
     PrimitivePositiveDefiniteBinaryQuadraticForm,
+    ProperBinaryQuadraticFormClass,
     ProperEquivalenceResult,
     _require_evaluated_value_bound,
     _require_reduced_class_search_budget,
@@ -127,13 +133,13 @@ def proper_equivalence(
 
 def reduced_classes(
     discriminant: int,
-) -> tuple[PrimitivePositiveDefiniteBinaryQuadraticForm, ...]:
+) -> tuple[ProperBinaryQuadraticFormClass, ...]:
     """Enumerate all reduced primitive classes of a discriminant."""
     from math import isqrt
 
     _require_reduced_class_search_budget(discriminant)
     a_bound = isqrt(abs(discriminant) // 3) + 1
-    classes: list[PrimitivePositiveDefiniteBinaryQuadraticForm] = []
+    classes: list[ProperBinaryQuadraticFormClass] = []
     for a in range(1, a_bound + 1):
         for b in range(-a, a + 1):
             numerator = b * b - discriminant
@@ -144,9 +150,50 @@ def reduced_classes(
                 continue
             if _check_reduced(a, b, c):
                 classes.append(
-                    PrimitivePositiveDefiniteBinaryQuadraticForm(a=a, b=b, c=c)
+                    ProperBinaryQuadraticFormClass(
+                        representative=PrimitivePositiveDefiniteBinaryQuadraticForm(
+                            a=a, b=b, c=c
+                        )
+                    )
                 )
-    return tuple(sorted(classes, key=lambda form: (form.a, form.b, form.c)))
+    return tuple(
+        sorted(
+            classes,
+            key=lambda form_class: (
+                form_class.representative.a,
+                form_class.representative.b,
+                form_class.representative.c,
+            ),
+        )
+    )
+
+
+def compose_classes(
+    first: ProperBinaryQuadraticFormClass,
+    second: ProperBinaryQuadraticFormClass,
+) -> BinaryQuadraticFormClassCompositionResult:
+    """Return the exact proper-class product with direct-composition evidence."""
+    if first.discriminant != second.discriminant:
+        raise ValueError("proper form classes must have the same discriminant")
+    _require_reduced_class_search_budget(first.discriminant)
+    direct = _compose(first.representative, second.representative)
+    composed_form = PrimitivePositiveDefiniteBinaryQuadraticForm(
+        a=direct.a, b=direct.b, c=direct.c
+    )
+    reduced, matrix = reduction(composed_form)
+    product = ProperBinaryQuadraticFormClass(representative=reduced)
+    composition_map = DirectBinaryQuadraticCompositionMap(
+        x_coefficients=direct.x_coefficients,
+        y_coefficients=direct.y_coefficients,
+    )
+    return BinaryQuadraticFormClassCompositionResult._from_kernel(
+        first=first,
+        second=second,
+        composed_form=composed_form,
+        direct_composition_map=composition_map,
+        product=product,
+        reduction_matrix=matrix,
+    )
 
 
 def representations(
@@ -158,6 +205,7 @@ def representations(
 
 __all__ = [
     "check",
+    "compose_classes",
     "evaluate",
     "proper_equivalence",
     "reduced_classes",

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/operations.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/operations.py
@@ -26,9 +26,9 @@ from jacobian.math.number_theory.quadratic_forms.binary._models import (
     PrimitivePositiveDefiniteBinaryQuadraticForm,
     ProperBinaryQuadraticFormClass,
     ProperEquivalenceResult,
-    _require_evaluated_value_bound,
     _require_composition_budget,
-_require_reduced_class_search_budget,
+    _require_evaluated_value_bound,
+    _require_reduced_class_search_budget,
     _require_representation_coordinate,
 )
 
@@ -174,9 +174,7 @@ def compose_classes(
     second: ProperBinaryQuadraticFormClass,
 ) -> BinaryQuadraticFormClassCompositionResult:
     """Return the exact proper-class product with direct-composition evidence."""
-    _require_composition_budget(
-        first.representative, second.representative
-    )
+    _require_composition_budget(first.representative, second.representative)
     direct = _compose(first.representative, second.representative)
     composed_form = PrimitivePositiveDefiniteBinaryQuadraticForm(
         a=direct.a, b=direct.b, c=direct.c

--- a/src/jacobian/math/probability/hypergraph_containment/operations.py
+++ b/src/jacobian/math/probability/hypergraph_containment/operations.py
@@ -253,7 +253,9 @@ def compute_hypergraph_vertex_containment(
         m = len(plan.edge_masks)
         singleton_counts = [0] * (n + 1)
         for k in range(n + 1):
-            singleton_counts[k] = comb(n, k) - comb(n - m, k) if k <= n - m else comb(n, k)
+            singleton_counts[k] = (
+                comb(n, k) - comb(n - m, k) if k <= n - m else comb(n, k)
+            )
         success = (1 << n) - (1 << (n - m))
         p = retention_probability.as_fraction()
         q = 1 - p

--- a/tests/math/number_theory/quadratic_forms/binary/test_integral_binary_quadratic_forms.py
+++ b/tests/math/number_theory/quadratic_forms/binary/test_integral_binary_quadratic_forms.py
@@ -9,29 +9,38 @@ from jacobian.math.number_theory.quadratic_forms.binary._models import (
     MAX_REPRESENTATION_TARGET,
     MAX_REPRESENTATION_Y_CANDIDATES,
     BinaryQuadraticFormCheckRequest,
+    BinaryQuadraticFormClassComposeRequest,
+    BinaryQuadraticFormClassCompositionResult,
     BinaryQuadraticFormEvaluateRequest,
     BinaryQuadraticFormProperEquivRequest,
     BinaryQuadraticFormReducedClassesRequest,
     BinaryQuadraticFormReduceRequest,
     BinaryQuadraticFormRepresentationsRequest,
     PrimitivePositiveDefiniteBinaryQuadraticForm,
+    ProperBinaryQuadraticFormClass,
     _representation_y_bound,
 )
 from jacobian.math.number_theory.quadratic_forms.binary._tools import (
     TOOLS,
     compute_check,
+    compute_class_compose,
     compute_evaluate,
     compute_proper_equivalence,
     compute_reduce,
     compute_reduced_classes,
     compute_representations,
 )
+from jacobian.math.number_theory.quadratic_forms.binary.operations import reduced_form
 
 
 def _positive_form(
     a: int, b: int, c: int
 ) -> PrimitivePositiveDefiniteBinaryQuadraticForm:
     return PrimitivePositiveDefiniteBinaryQuadraticForm(a=a, b=b, c=c)
+
+
+def _proper_class(a: int, b: int, c: int) -> ProperBinaryQuadraticFormClass:
+    return ProperBinaryQuadraticFormClass(representative=_positive_form(a, b, c))
 
 
 def _assert_error_type(
@@ -292,14 +301,14 @@ class TestReducedClasses:
             BinaryQuadraticFormReducedClassesRequest(discriminant=-3)
         )
         assert result.class_number == 1
-        assert result.classes == (_positive_form(1, 1, 1),)
+        assert result.classes == (_proper_class(1, 1, 1),)
 
     def test_disc_neg_4(self) -> None:
         result = compute_reduced_classes(
             BinaryQuadraticFormReducedClassesRequest(discriminant=-4)
         )
         assert result.class_number == 1
-        assert result.classes == (_positive_form(1, 0, 1),)
+        assert result.classes == (_proper_class(1, 0, 1),)
 
     def test_disc_neg_23(self) -> None:
         result = compute_reduced_classes(
@@ -307,8 +316,8 @@ class TestReducedClasses:
         )
         assert result.class_number == 3
         # Verify all classes have the correct discriminant
-        for form in result.classes:
-            assert form.discriminant == -23
+        for form_class in result.classes:
+            assert form_class.discriminant == -23
 
     def test_disc_neg_20(self) -> None:
         result = compute_reduced_classes(
@@ -347,7 +356,8 @@ class TestReducedClasses:
             result = compute_reduced_classes(
                 BinaryQuadraticFormReducedClassesRequest(discriminant=D)
             )
-            for form in result.classes:
+            for form_class in result.classes:
+                form = form_class.representative
                 assert form.a > 0 and form.c > 0
                 assert abs(form.b) <= form.a
                 assert form.a <= form.c
@@ -355,6 +365,220 @@ class TestReducedClasses:
                     assert form.b >= 0
                 if form.a == form.c:
                     assert form.b >= 0
+
+
+class TestProperClassComposition:
+    @staticmethod
+    def _evaluate(
+        form: PrimitivePositiveDefiniteBinaryQuadraticForm, x: int, y: int
+    ) -> int:
+        return form.a * x * x + form.b * x * y + form.c * y * y
+
+    def _assert_direct_identity(
+        self,
+        first: ProperBinaryQuadraticFormClass,
+        second: ProperBinaryQuadraticFormClass,
+    ) -> None:
+        result = compute_class_compose(
+            BinaryQuadraticFormClassComposeRequest(first=first, second=second)
+        )
+        x_coefficients = result.direct_composition_map.x_coefficients
+        y_coefficients = result.direct_composition_map.y_coefficients
+        for x1 in range(-2, 3):
+            for y1 in range(-2, 3):
+                for x2 in range(-2, 3):
+                    for y2 in range(-2, 3):
+                        monomials = (x1 * x2, x1 * y2, y1 * x2, y1 * y2)
+                        x = sum(
+                            coefficient * monomial
+                            for coefficient, monomial in zip(
+                                x_coefficients, monomials, strict=True
+                            )
+                        )
+                        y = sum(
+                            coefficient * monomial
+                            for coefficient, monomial in zip(
+                                y_coefficients, monomials, strict=True
+                            )
+                        )
+                        assert self._evaluate(result.composed_form, x, y) == (
+                            self._evaluate(first.representative, x1, y1)
+                            * self._evaluate(second.representative, x2, y2)
+                        )
+        p, q = result.reduction_matrix[0]
+        r, s = result.reduction_matrix[1]
+        assert p * s - q * r == 1
+        source = result.composed_form
+        transformed = _positive_form(
+            source.a * p * p + source.b * p * r + source.c * r * r,
+            2 * source.a * p * q + source.b * (p * s + q * r) + 2 * source.c * r * s,
+            source.a * q * q + source.b * q * s + source.c * s * s,
+        )
+        assert transformed == result.product.representative
+        assert result.product.representative.discriminant == first.discriminant
+
+    def test_discriminant_neg_23_generator_squares_to_inverse(self) -> None:
+        generator = _proper_class(2, -1, 3)
+
+        result = compute_class_compose(
+            BinaryQuadraticFormClassComposeRequest(first=generator, second=generator)
+        )
+
+        assert result.composed_form == _positive_form(4, 3, 2)
+        assert result.product == _proper_class(2, 1, 3)
+        self._assert_direct_identity(generator, generator)
+
+    def test_common_divisor_case_squares_to_principal_class(self) -> None:
+        nonprincipal = _proper_class(2, 2, 3)
+
+        result = compute_class_compose(
+            BinaryQuadraticFormClassComposeRequest(
+                first=nonprincipal, second=nonprincipal
+            )
+        )
+
+        assert result.composed_form == _positive_form(1, 0, 5)
+        assert result.product == _proper_class(1, 0, 5)
+        self._assert_direct_identity(nonprincipal, nonprincipal)
+
+    @pytest.mark.parametrize("discriminant", [-20, -23, -31, -47, -56, -87])
+    def test_complete_small_class_sets_form_an_associative_commutative_group(
+        self, discriminant: int
+    ) -> None:
+        classes = compute_reduced_classes(
+            BinaryQuadraticFormReducedClassesRequest(discriminant=discriminant)
+        ).classes
+        principal = _proper_class(
+            1,
+            discriminant % 2,
+            ((discriminant % 2) - discriminant) // 4,
+        )
+
+        def product(
+            first: ProperBinaryQuadraticFormClass,
+            second: ProperBinaryQuadraticFormClass,
+        ) -> ProperBinaryQuadraticFormClass:
+            return compute_class_compose(
+                BinaryQuadraticFormClassComposeRequest(first=first, second=second)
+            ).product
+
+        for first in classes:
+            assert product(principal, first) == first
+            assert product(first, principal) == first
+            inverse_representative = reduced_form(
+                _positive_form(
+                    first.representative.a,
+                    -first.representative.b,
+                    first.representative.c,
+                )
+            )
+            inverse = ProperBinaryQuadraticFormClass(
+                representative=inverse_representative
+            )
+            assert product(first, inverse) == principal
+            for second in classes:
+                assert product(first, second) == product(second, first)
+                assert product(first, second) in classes
+                for third in classes:
+                    assert product(product(first, second), third) == product(
+                        first, product(second, third)
+                    )
+
+    def test_reduced_class_output_serializes_into_composition_unchanged(self) -> None:
+        classes = compute_reduced_classes(
+            BinaryQuadraticFormReducedClassesRequest(discriminant=-23)
+        )
+        request = BinaryQuadraticFormClassComposeRequest.model_validate(
+            {
+                "first": classes.classes[1].model_dump(mode="json"),
+                "second": classes.classes[2].model_dump(mode="json"),
+            }
+        )
+
+        result = compute_class_compose(request)
+
+        assert result.product == classes.classes[0]
+
+    def test_composition_result_round_trips_with_all_source_bindings(self) -> None:
+        result = compute_class_compose(
+            BinaryQuadraticFormClassComposeRequest(
+                first=_proper_class(2, -1, 3),
+                second=_proper_class(2, -1, 3),
+            )
+        )
+
+        assert (
+            BinaryQuadraticFormClassCompositionResult.model_validate_json(
+                result.model_dump_json()
+            )
+            == result
+        )
+
+    def test_composition_result_rejects_a_different_direct_form_discriminant(
+        self,
+    ) -> None:
+        result = compute_class_compose(
+            BinaryQuadraticFormClassComposeRequest(
+                first=_proper_class(2, -1, 3),
+                second=_proper_class(2, -1, 3),
+            )
+        ).model_dump(mode="json")
+        result["composed_form"] = {"a": 1, "b": 0, "c": 1}
+
+        with pytest.raises(ValidationError, match="share one discriminant"):
+            BinaryQuadraticFormClassCompositionResult.model_validate(result)
+
+    def test_catalog_example_exercises_nontrivial_proper_class_product(self) -> None:
+        (tool,) = (
+            candidate
+            for candidate in TOOLS
+            if candidate.operation_id
+            == "number_theory.binary_quadratic_form.class_compose.compute"
+        )
+        request = tool.request_type.model_validate(tool.examples[0].input)
+
+        result = tool.run(request)
+
+        assert result.product == _proper_class(2, 1, 3)
+
+    def test_nonreduced_representative_is_not_a_proper_class_value(self) -> None:
+        with pytest.raises(ValidationError, match="canonical Gauss-reduced"):
+            ProperBinaryQuadraticFormClass(representative=_positive_form(5, 3, 1))
+
+    def test_different_discriminants_are_rejected_before_composition(self) -> None:
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            compute_class_compose(
+                BinaryQuadraticFormClassComposeRequest(
+                    first=_proper_class(1, 1, 1),
+                    second=_proper_class(1, 0, 1),
+                )
+            )
+        _assert_error_type(
+            exc_info,
+            "integral_binary_quadratic_form.class_discriminant_mismatch",
+        )
+
+    def test_composition_admits_exact_reduced_class_scan_boundary(self) -> None:
+        principal = _proper_class(1, 0, 7_203)
+
+        result = compute_class_compose(
+            BinaryQuadraticFormClassComposeRequest(first=principal, second=principal)
+        )
+
+        assert result.product == principal
+
+    def test_composition_rejects_discriminant_above_class_scan_budget(self) -> None:
+        principal = _proper_class(1, 0, 7_351)
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            compute_class_compose(
+                BinaryQuadraticFormClassComposeRequest(
+                    first=principal, second=principal
+                )
+            )
+        _assert_error_type(
+            exc_info,
+            "integral_binary_quadratic_form.reduced_class_candidate_budget",
+        )
 
 
 class TestRepresentations:

--- a/tests/math/number_theory/quadratic_forms/binary/test_integral_binary_quadratic_forms.py
+++ b/tests/math/number_theory/quadratic_forms/binary/test_integral_binary_quadratic_forms.py
@@ -571,9 +571,7 @@ class TestProperClassComposition:
         """Composition is O(1) + O(log|D|) reduction, not class enumeration."""
         principal = _proper_class(1, 0, 7_351)
         result = compute_class_compose(
-            BinaryQuadraticFormClassComposeRequest(
-                first=principal, second=principal
-            )
+            BinaryQuadraticFormClassComposeRequest(first=principal, second=principal)
         )
         assert result.product == principal
 
@@ -582,9 +580,7 @@ class TestProperClassComposition:
         second = _proper_class(1, 0, 7)
         with pytest.raises(ValueError, match="same discriminant"):
             compute_class_compose(
-                BinaryQuadraticFormClassComposeRequest(
-                    first=first, second=second
-                )
+                BinaryQuadraticFormClassComposeRequest(first=first, second=second)
             )
 
 

--- a/tests/math/number_theory/quadratic_forms/binary/test_integral_binary_quadratic_forms.py
+++ b/tests/math/number_theory/quadratic_forms/binary/test_integral_binary_quadratic_forms.py
@@ -583,6 +583,17 @@ class TestProperClassComposition:
                 BinaryQuadraticFormClassComposeRequest(first=first, second=second)
             )
 
+    def test_composition_rejects_oversized_output_coefficients(self) -> None:
+        """Composition of large discriminant forms can exceed the coefficient bound."""
+        first = _proper_class(600_014, 0, 999_993)
+        second = _proper_class(666_662, 0, 900_021)
+        with pytest.raises(
+            OperationDomainValidationError, match="composition product exceeds"
+        ):
+            compute_class_compose(
+                BinaryQuadraticFormClassComposeRequest(first=first, second=second)
+            )
+
 
 class TestRepresentations:
     def test_schema_exposes_the_complete_y_scan_admission_condition(self) -> None:

--- a/tests/math/number_theory/quadratic_forms/binary/test_integral_binary_quadratic_forms.py
+++ b/tests/math/number_theory/quadratic_forms/binary/test_integral_binary_quadratic_forms.py
@@ -567,18 +567,25 @@ class TestProperClassComposition:
 
         assert result.product == principal
 
-    def test_composition_rejects_discriminant_above_class_scan_budget(self) -> None:
+    def test_composition_admits_discriminant_above_class_scan_budget(self) -> None:
+        """Composition is O(1) + O(log|D|) reduction, not class enumeration."""
         principal = _proper_class(1, 0, 7_351)
-        with pytest.raises(OperationDomainValidationError) as exc_info:
+        result = compute_class_compose(
+            BinaryQuadraticFormClassComposeRequest(
+                first=principal, second=principal
+            )
+        )
+        assert result.product == principal
+
+    def test_composition_rejects_mismatched_discriminants(self) -> None:
+        first = _proper_class(1, 0, 7_351)
+        second = _proper_class(1, 0, 7)
+        with pytest.raises(ValueError, match="same discriminant"):
             compute_class_compose(
                 BinaryQuadraticFormClassComposeRequest(
-                    first=principal, second=principal
+                    first=first, second=second
                 )
             )
-        _assert_error_type(
-            exc_info,
-            "integral_binary_quadratic_form.reduced_class_candidate_budget",
-        )
 
 
 class TestRepresentations:

--- a/tests/math/number_theory/quadratic_forms/binary/test_public_api.py
+++ b/tests/math/number_theory/quadratic_forms/binary/test_public_api.py
@@ -31,3 +31,31 @@ def test_public_form_value_and_native_functions_compose_after_serialization() ->
         )
         for row in rows
     )
+
+
+def test_public_proper_class_values_compose_without_representation_translation() -> (
+    None
+):
+    first = integral_binary_quadratic_forms.ProperBinaryQuadraticFormClass(
+        representative=integral_binary_quadratic_forms.PrimitivePositiveDefiniteBinaryQuadraticForm(
+            a=2, b=-1, c=3
+        )
+    )
+    second = integral_binary_quadratic_forms.ProperBinaryQuadraticFormClass.model_validate_json(
+        first.model_dump_json()
+    )
+
+    result = integral_binary_quadratic_forms.compose_classes(first, second)
+
+    assert isinstance(
+        result,
+        integral_binary_quadratic_forms.BinaryQuadraticFormClassCompositionResult,
+    )
+    assert (
+        result.product
+        == integral_binary_quadratic_forms.ProperBinaryQuadraticFormClass(
+            representative=integral_binary_quadratic_forms.PrimitivePositiveDefiniteBinaryQuadraticForm(
+                a=2, b=1, c=3
+            )
+        )
+    )

--- a/tools/makefile_catalog.py
+++ b/tools/makefile_catalog.py
@@ -50,7 +50,9 @@ def discover_makefiles(root: Path, entrypoint: Path | None = None) -> MakefileCa
         if path in visited:
             return
         if not path.is_file():
-            raise MakefileCatalogError(f"included Makefile is missing: {relative.as_posix()}")
+            raise MakefileCatalogError(
+                f"included Makefile is missing: {relative.as_posix()}"
+            )
         visiting.add(path)
         files.append(path)
         for line_number, line in enumerate(

--- a/tools/sync_harbor_verifier_support.py
+++ b/tools/sync_harbor_verifier_support.py
@@ -28,16 +28,10 @@ from benchmarks.tooling.harbor_suite import (  # noqa: E402
 _CHECKSUM = re.compile(r'jacobian\.checksum="[^"]*"')
 
 
-def update(
-    dataset: str, tasks: tuple[str, ...], *, write_support: bool = False
-) -> int:
+def update(dataset: str, tasks: tuple[str, ...], *, write_support: bool = False) -> int:
     suite = get_suite(dataset)
     refs = select_task_refs(suite, tasks)
-    template = (
-        SUPPORT_TEMPLATE.read_bytes()
-        if write_support
-        else None
-    )
+    template = SUPPORT_TEMPLATE.read_bytes() if write_support else None
     for ref in refs:
         tests = ref.path / "tests"
         verifier = tests / "verifier.py"

--- a/tools/with_validation_lock.py
+++ b/tools/with_validation_lock.py
@@ -90,7 +90,9 @@ def _run(target: str, command: list[str]) -> int:
         else:
             candidate = shutil.which(executable)
             if candidate is None:
-                print(f"validation command is unavailable: {executable}", file=sys.stderr)
+                print(
+                    f"validation command is unavailable: {executable}", file=sys.stderr
+                )
                 return 127
             resolved = candidate
         result = run_tool_command(


### PR DESCRIPTION
## Problem

Part of #1830.

Jacobian can reduce primitive positive-definite binary quadratic forms and enumerate the reduced representatives of one discriminant, but those representatives are returned as bare forms. There is no canonical proper-class value and no operation that multiplies two classes while retaining exact evidence for both direct composition and reduction.

That gap prevents the existing reduced-class output from serving as the input to later class-group arithmetic.

## Solution

Adds `number_theory.binary_quadratic_form.class_compose.compute` and a canonical `ProperBinaryQuadraticFormClass` identified by its Gauss-reduced representative.

For two proper classes of the same negative discriminant, the operation returns:

- a normalized exact integral form representing their direct Gauss composite;
- a bilinear map `(X,Y)` satisfying `H(X,Y) = F(x1,y1) * G(x2,y2)`;
- the canonical reduced product class; and
- an exact `SL_2(ZZ)` matrix carrying the direct form to that representative.

The kernel uses the classical ternary-Bézout direct-composition formula described by Buell, followed by the existing exact Gauss reduction. PARI documents `qfbcomp` and `qfbcompraw`, but PARI/cypari2 is not a supported Jacobian runtime dependency; Python-FLINT exposes the exact integer and matrix primitives but no binary-form composition API. The bounded owner-local kernel therefore keeps the public contract independent of backend objects while returning a stronger reconstructible witness than a backend class label.

`reduced_classes.compute` now returns the canonical proper-class carrier directly, so its serialized rows feed the new consumer unchanged.

This PR intentionally does not add class inversion, a complete class-group table, theta prefixes, or the proposed transform checker. Those remain separate leaves in #1830.

## Testing

- `make affected AFFECTED_BASE=origin/main`:
  - scoped Ruff and formatting passed;
  - scoped mypy passed;
  - 60 binary-quadratic-form owner tests passed;
  - 113 catalog tests passed;
  - 841 advertised-example integration tests passed.
- A deterministic development sweep checked 58,231 complete-class pairs for discriminants from `-3` through `-1000`, including direct bilinear reconstruction and closure.
- Boundary probes exercised complete class sets near the current discriminant envelope; direct-form and witness integers remained within the declared canonical transport range.

Regression coverage includes discriminants `-20` and `-23`, a noncoprime leading-coefficient composition, exact direct-composition identities, reduction-matrix reconstruction, serialization into the consumer, malformed class representatives, discriminant mismatch, identity/inverse/closure/commutativity, and exhaustive associativity on six complete small class sets.

## Public contract impact

Adds the operation ID `number_theory.binary_quadratic_form.class_compose.compute`, the canonical `ProperBinaryQuadraticFormClass`, the direct bilinear-composition map, and the matching native `compose_classes` API.

The pre-stable `reduced_classes.compute` result changes from a tuple of bare reduced forms to a tuple of proper-class values containing those representatives. This makes class identity explicit and closes producer-to-consumer serialization without compatibility aliases.

## Operation boundary ownership

- Changed stage: canonical value, request bounds, owner-local kernel, trusted result construction, native API, and catalog publication
- Request-bounds owner and controlling quantities: the binary quadratic-form owner; common discriminant and the existing complete reduced-class scan count `A*(A+2)`, where `A=floor_sqrt((-D)//3)+1`
- Work, intermediate, memory, and exact-output bounds: `A*(A+2) <= 10000`; this implies reduced leading coefficients at most 99 and bounds the ternary-Bézout arithmetic, normalized direct form, bilinear witness, reduction work, and serialized result
- Wall deadline, calibration workload, safety margin, and caller-selectable range: no new wall deadline or caller override; exact Euclidean arithmetic and Gauss reduction run inside the fixed discriminant-derived envelope
- Backend or kernel path: Jacobian-owned classical direct Gauss composition plus the existing exact reduction kernel
- Result construction: the admitted kernel computes once and uses owner-local trusted construction; defining identities are replayed in tests
- Independent-result verifier: none; the complete result is not accepted as a theorem-bearing input. Its canonical product class is independently constructible and reusable
- Native/MCP parity: both execute the same typed `compose_classes` path
- Serialized-result and round-trip evidence: reduced-class producer rows serialize directly into composition requests; composition results round-trip exactly

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner or intentional distinction documented
- [x] Advertised codomain is closed under the result types, including discriminant, reduction convention, and variable-substitution orientation
- [x] Producer→consumer serialization tested
- Theorem-dependent preconditions and validated input subtype: each proper class validates that its representative is primitive, positive definite, and canonical Gauss-reduced
- Structurally valid but mathematically invalid fixture and outcome: a nonreduced representative is rejected; source, direct-form, or product discriminant mismatch is rejected
- Serialized-subtype trust boundary: ordinary construction of `ProperBinaryQuadraticFormClass` rechecks the complete reduced inequalities and tie convention
- Exact-success defining invariant: `H(X,Y)=F(x1,y1)G(x2,y2)`; the reduction matrix has determinant one and transforms `H` into the returned product representative
- Discriminated result schema and impossible combinations: one exact result shape; all source and output forms must share one discriminant

## Catalog admission

- Concrete gap: no reusable multiplication of proper classes returned by reduced-class enumeration
- Why existing operations or typed values are insufficient: reduction and proper-equivalence can compare classes but cannot construct their group product; bare reduced forms do not explicitly carry class semantics
- Stable mathematical result: the proper-class product with exact direct-composition and reduction witnesses
- Semantic domain and admitted execution envelope: primitive positive-definite proper classes of one negative discriminant within the complete reduced-class scan envelope
- Controlling work, intermediate, memory, and output quantities: discriminant-derived reduced search size, reduced coefficient bounds, ternary-Bézout intermediates, eight bilinear coefficients, and one 2 by 2 reduction matrix
- Exact representation, algorithm regimes, and maintained backend: canonical integer forms/classes; classical exact Gauss composition. PARI was used as a semantics reference, not a runtime dependency
- Remaining fixed caps and their classification: the 10,000-state reduced-class envelope is the existing conservative exact-search and coefficient bound shared by producer and consumer
- Motivating source request exercised through the public boundary: the order-three class group at discriminant `-23`, including a generator square and generator/inverse product
- Final-tree outcome for that request: exact direct forms, bilinear identities, and canonical products `[2,-1,3]^2=[2,1,3]` and `[2,1,3][2,-1,3]=[1,1,6]`
- Effect of private normalization or presolve on admission: operands are already canonical reduced classes; the incidental direct middle coefficient is normalized by an explicit unimodular substitution whose inverse is applied to the bilinear witness
- Admission decision: admit one atomic proper-class composition operation

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Proper-class carrier | delivered | `ProperBinaryQuadraticFormClass` |
| Proper-class composition | delivered | `number_theory.binary_quadratic_form.class_compose.compute` |
| Class inverse | deferred | #1830 |
| Complete class group | deferred | #1830 |
| Theta prefix | deferred | #1830 |
| Candidate transformation check | deferred | #1830 |

## Checklist

- [x] `make affected AFFECTED_BASE=origin/main` passes
- [x] Catalog and advertised-example integration validation is listed above
- [x] Catalog publication is owner-local in `binary/_tools.py`
- [x] No compatibility aliases, forwarding modules, or generic shadow paths were introduced
- [x] Native and MCP callers execute the same bounded typed operation
- [x] Source-backed class arithmetic, noncoprime composition, complete small groups, and exact boundary fixtures are included
