### PR TITLE
Fix PR CI range after auto-lint pushes

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           # Optional fine-grained PAT or app token. Pushes made with it raise
@@ -104,9 +105,14 @@ jobs:
           # GitHub suppresses workflow runs for pushes made with GITHUB_TOKEN,
           # so the new head would otherwise carry no fresh required checks and
           # stay unmergeable until a human pushes. Dispatch CI explicitly with
-          # the pull_request lane selection; its check runs
-          # attach to this exact head SHA. With AUTOFIX_TOKEN configured the
-          # push itself raises synchronize events, so no dispatch is needed.
+          # the pull_request lane selection and the immutable base/head range;
+          # its check runs attach to this exact head SHA. With AUTOFIX_TOKEN
+          # configured the push itself raises synchronize events, so no
+          # dispatch is needed.
           if [[ -z "${AUTOFIX_TOKEN}" ]]; then
-            gh workflow run ci.yml --ref "$PR_HEAD_REF" -f pr_lanes=true
+            gh workflow run ci.yml \
+              --ref "$PR_HEAD_REF" \
+              -f pr_lanes=true \
+              -f base_sha="$PR_BASE_SHA" \
+              -f head_sha="$(git rev-parse HEAD)"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,8 @@ jobs:
               echo "::error::dispatched head_sha does not match the checked-out commit"
               exit 1
             }
-            git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA" || {
-              echo "::error::dispatched base_sha is not an ancestor of head_sha"
+            git merge-base "$BASE_SHA" "$HEAD_SHA" >/dev/null || {
+              echo "::error::dispatched base_sha and head_sha have no common ancestor"
               exit 1
             }
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,24 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
-    # The autofix bot dispatches CI on the head SHA it just pushed (GITHUB_TOKEN
-    # pushes raise no events). Selecting the pull_request lane set keeps the
-    # dispatched run identical to what a human push would run.
+    # The autofix bot dispatches CI on the exact base/head range it just pushed
+    # (GITHUB_TOKEN pushes raise no events). Selecting the pull_request lane set
+    # keeps the dispatched run identical to what a human push would run.
     inputs:
       pr_lanes:
         description: Select the pull_request lane set instead of the main gate.
         type: boolean
         default: false
+      base_sha:
+        description: Exact PR base commit for an explicitly dispatched PR-lane run.
+        type: string
+        required: false
+        default: ""
+      head_sha:
+        description: Exact PR head commit for an explicitly dispatched PR-lane run.
+        type: string
+        required: false
+        default: ""
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -87,17 +97,36 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_LANES: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.pr_lanes) }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || github.sha }}
-          HEAD_SHA: ${{ github.sha }}
+          DISPATCH_BASE_SHA: ${{ inputs.base_sha }}
+          DISPATCH_HEAD_SHA: ${{ inputs.head_sha }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || github.sha }}
+          EVENT_HEAD_SHA: ${{ github.sha }}
         run: |
           event="$EVENT_NAME"
           if [ "$PR_LANES" = true ]; then
             event=pull_request
           fi
-          if [ "$event" = pull_request ] && [ "$BASE_SHA" = "$HEAD_SHA" ]; then
-            # A manually dispatched PR-lane run has no pull-request base SHA.
-            # Preserve evidence by using the planner's full-suite event policy.
-            event=workflow_dispatch
+          BASE_SHA="$EVENT_BASE_SHA"
+          HEAD_SHA="$EVENT_HEAD_SHA"
+          if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$PR_LANES" = true ]; then
+            test -n "$DISPATCH_BASE_SHA" || {
+              echo "::error::PR-lane dispatch requires base_sha"
+              exit 1
+            }
+            test -n "$DISPATCH_HEAD_SHA" || {
+              echo "::error::PR-lane dispatch requires head_sha"
+              exit 1
+            }
+            BASE_SHA="$DISPATCH_BASE_SHA"
+            HEAD_SHA="$DISPATCH_HEAD_SHA"
+            test "$HEAD_SHA" = "$(git rev-parse HEAD)" || {
+              echo "::error::dispatched head_sha does not match the checked-out commit"
+              exit 1
+            }
+            git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA" || {
+              echo "::error::dispatched base_sha is not an ancestor of head_sha"
+              exit 1
+            }
           fi
           if [ "$event" = pull_request ] || [ "$event" = merge_group ]; then
             git diff --no-ext-diff --no-textconv --name-only "$BASE_SHA...$HEAD_SHA" > changed-paths.txt

--- a/tests/tooling/test_product_ci_contract.py
+++ b/tests/tooling/test_product_ci_contract.py
@@ -150,7 +150,7 @@ def test_autofix_dispatch_binds_pr_plans_to_the_exact_commit_range() -> None:
     assert 'BASE_SHA="$DISPATCH_BASE_SHA"' in ci
     assert 'HEAD_SHA="$DISPATCH_HEAD_SHA"' in ci
     assert 'test "$HEAD_SHA" = "$(git rev-parse HEAD)"' in ci
-    assert 'git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"' in ci
+    assert 'git merge-base "$BASE_SHA" "$HEAD_SHA" >/dev/null' in ci
     assert 'PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}' in autofix
     assert '-f base_sha="$PR_BASE_SHA"' in autofix
     assert '-f head_sha="$(git rev-parse HEAD)"' in autofix

--- a/tests/tooling/test_product_ci_contract.py
+++ b/tests/tooling/test_product_ci_contract.py
@@ -145,13 +145,13 @@ def test_autofix_dispatch_binds_pr_plans_to_the_exact_commit_range() -> None:
 
     assert "base_sha:" in ci
     assert "head_sha:" in ci
-    assert 'DISPATCH_BASE_SHA: ${{ inputs.base_sha }}' in ci
-    assert 'DISPATCH_HEAD_SHA: ${{ inputs.head_sha }}' in ci
+    assert "DISPATCH_BASE_SHA: ${{ inputs.base_sha }}" in ci
+    assert "DISPATCH_HEAD_SHA: ${{ inputs.head_sha }}" in ci
     assert 'BASE_SHA="$DISPATCH_BASE_SHA"' in ci
     assert 'HEAD_SHA="$DISPATCH_HEAD_SHA"' in ci
     assert 'test "$HEAD_SHA" = "$(git rev-parse HEAD)"' in ci
     assert 'git merge-base "$BASE_SHA" "$HEAD_SHA" >/dev/null' in ci
-    assert 'PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}' in autofix
+    assert "PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}" in autofix
     assert '-f base_sha="$PR_BASE_SHA"' in autofix
     assert '-f head_sha="$(git rev-parse HEAD)"' in autofix
 

--- a/tests/tooling/test_product_ci_contract.py
+++ b/tests/tooling/test_product_ci_contract.py
@@ -132,11 +132,28 @@ def test_product_ci_uses_a_versioned_checked_in_test_plan() -> None:
     assert "python tools/ci_test_plan.py" in workflow
     assert '--base "$BASE_SHA"' in workflow
     assert '--head "$HEAD_SHA"' in workflow
-    assert "event=workflow_dispatch" in workflow
+    assert 'event="$EVENT_NAME"' in workflow
     assert "run_scale: ${{ steps.plan.outputs.run_scale }}" in workflow
     assert "python_lanes: ${{ steps.plan.outputs.python_lanes }}" in workflow
     assert "math_shards: ${{ steps.plan.outputs.math_shards }}" in workflow
     assert (ROOT / "tools" / "ci_test_plan.py").exists()
+
+
+def test_autofix_dispatch_binds_pr_plans_to_the_exact_commit_range() -> None:
+    ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    autofix = (ROOT / ".github/workflows/autofix.yml").read_text(encoding="utf-8")
+
+    assert "base_sha:" in ci
+    assert "head_sha:" in ci
+    assert 'DISPATCH_BASE_SHA: ${{ inputs.base_sha }}' in ci
+    assert 'DISPATCH_HEAD_SHA: ${{ inputs.head_sha }}' in ci
+    assert 'BASE_SHA="$DISPATCH_BASE_SHA"' in ci
+    assert 'HEAD_SHA="$DISPATCH_HEAD_SHA"' in ci
+    assert 'test "$HEAD_SHA" = "$(git rev-parse HEAD)"' in ci
+    assert 'git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"' in ci
+    assert 'PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}' in autofix
+    assert '-f base_sha="$PR_BASE_SHA"' in autofix
+    assert '-f head_sha="$(git rev-parse HEAD)"' in autofix
 
 
 def test_static_job_runs_docs_linkcheck() -> None:


### PR DESCRIPTION
## Problem

When the auto-lint workflow pushes a formatting commit with `GITHUB_TOKEN`, its manual CI dispatch did not preserve the pull request base SHA. CI therefore saw the PR head as both sides of the comparison, produced an empty changed-path set, and could plan the full repository suite instead of the PR lanes.

## Change

Pass the exact pre-lint base SHA and post-lint head SHA through the dispatch inputs. The CI planner treats that dispatch as a PR-lane run, verifies the checked-out head and merge-base, and computes the requested range before selecting lanes.

## Validation

- 43 focused workflow-contract tests passed.
- Ruff, YAML parsing, and the workflow contract checks passed.
- `actionlint` and `yamllint` were unavailable in the local environment.