### PR TITLE
Align algebraic profile result envelopes

### DIFF
--- a/src/jacobian/math/polynomials/real_algebra/_common_interlacing_models.py
+++ b/src/jacobian/math/polynomials/real_algebra/_common_interlacing_models.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from itertools import pairwise
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
-from pydantic import Field, StrictInt, model_validator
+from pydantic import BeforeValidator, Field, StrictInt, WithJsonSchema, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
@@ -14,6 +14,7 @@ from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math._labels import OpaqueLabel
 from jacobian.math.number_theory.algebraic_numbers.real import (
     RationalIsolatingInterval,
+    RealAlgebraicValue,
     _UnrecognizedRealAlgebraicValue,
 )
 from jacobian.math.polynomials.values import (
@@ -33,6 +34,40 @@ MAX_COMMON_INTERLACING_TOTAL_TERMS = (
     MAX_COMMON_INTERLACING_TOTAL_DEGREE + MAX_COMMON_INTERLACING_FAMILY_SIZE
 )
 MAX_COMMON_INTERLACING_INPUT_DIGITS = 64
+
+
+def _require_common_interlacing_factor_degree(value: Any) -> Any:
+    polynomial = (
+        value.polynomial
+        if isinstance(value, RealAlgebraicValue)
+        else value.get("polynomial")
+        if isinstance(value, Mapping)
+        else None
+    )
+    if isinstance(polynomial, (list, tuple)) and len(polynomial) - 1 > (
+        MAX_COMMON_INTERLACING_FACTOR_DEGREE
+    ):
+        raise _validation_error(
+            "factor_degree",
+            "common interlacing roots admit factor degree at most "
+            f"{MAX_COMMON_INTERLACING_FACTOR_DEGREE}",
+        )
+    return value
+
+
+def _common_interlacing_factor_schema() -> dict[str, Any]:
+    schema = RealAlgebraicValue.model_json_schema()
+    polynomial = schema.get("properties", {}).get("polynomial")
+    if isinstance(polynomial, dict):
+        polynomial["maxItems"] = MAX_COMMON_INTERLACING_FACTOR_DEGREE + 1
+    return schema
+
+
+_CommonInterlacingRealAlgebraicValue = Annotated[
+    _UnrecognizedRealAlgebraicValue,
+    BeforeValidator(_require_common_interlacing_factor_degree),
+    WithJsonSchema(_common_interlacing_factor_schema()),
+]
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -182,7 +217,7 @@ class CommonInterlacingRequest(StrictModel):
 class PolynomialRealRoot(StrictModel):
     """One distinct source root with exact multiplicity and algebraic identity."""
 
-    value: _UnrecognizedRealAlgebraicValue
+    value: _CommonInterlacingRealAlgebraicValue
     multiplicity: StrictInt = Field(
         ge=1,
         le=MAX_COMMON_INTERLACING_SOURCE_DEGREE,

--- a/src/jacobian/math/polynomials/real_algebra/_common_interlacing_models.py
+++ b/src/jacobian/math/polynomials/real_algebra/_common_interlacing_models.py
@@ -37,6 +37,7 @@ MAX_COMMON_INTERLACING_INPUT_DIGITS = 64
 
 
 def _require_common_interlacing_factor_degree(value: Any) -> Any:
+    value = canonicalize_json_containers(value)
     polynomial = (
         value.polynomial
         if isinstance(value, RealAlgebraicValue)

--- a/src/jacobian/math/polynomials/real_algebra/_plane_component_models.py
+++ b/src/jacobian/math/polynomials/real_algebra/_plane_component_models.py
@@ -1066,7 +1066,10 @@ class PlaneComponentProfileRequest(StrictModel):
 class PlaneComponentProfileResult(StrictModel):
     """The retained source and either an exact profile or no conclusion."""
 
-    semialgebraic_set: PlaneSemialgebraicSet
+    semialgebraic_set: Annotated[
+        PlaneSemialgebraicSet,
+        WithJsonSchema(_plane_component_semialgebraic_set_schema()),
+    ]
     samples: tuple[IsolatedRealPlanePoint, ...] = Field(
         max_length=MAX_PLANE_COMPONENT_SAMPLES
     )

--- a/tests/math/polynomials/test_common_interlacing.py
+++ b/tests/math/polynomials/test_common_interlacing.py
@@ -36,6 +36,7 @@ from jacobian.math.polynomials.real_algebra._common_interlacing_models import (
     EmptyGapObstruction,
     LabelledRationalPolynomial,
     NonRealRootObstruction,
+    PolynomialRealRoot,
     PolynomialRootReference,
 )
 from jacobian.math.polynomials.real_algebra._common_interlacing_process import (
@@ -434,6 +435,27 @@ def test_worker_root_polynomial_length_is_capped_before_decoding() -> None:
             },
             [(factor, 1)],
             [1],
+        )
+
+
+def test_result_root_schema_and_runtime_keep_the_factor_degree_bound() -> None:
+    schema = PolynomialRealRoot.model_json_schema()
+    assert schema["properties"]["value"]["properties"]["polynomial"]["maxItems"] == 9
+
+    with pytest.raises(ValidationError, match="factor degree at most 8"):
+        PolynomialRealRoot.model_validate(
+            {
+                "value": {
+                    "polynomial": ["1", *("0" for _ in range(15)), "-2"],
+                    "real_root_index": 0,
+                },
+                "multiplicity": 1,
+                "isolating_interval": {
+                    "lower": {"num": "-1", "den": "1"},
+                    "upper": {"num": "1", "den": "1"},
+                    "interval_type": "OPEN",
+                },
+            }
         )
 
 

--- a/tests/math/polynomials/test_plane_component_admission.py
+++ b/tests/math/polynomials/test_plane_component_admission.py
@@ -40,6 +40,7 @@ from jacobian.math.polynomials.real_algebra._plane_component_models import (
     MAX_PLANE_COMPONENTS,
     IsolatedRealPlanePoint,
     PlaneComponentProfileComputed,
+    PlaneComponentProfileNoncompletion,
     PlaneComponentProfileRequest,
     PlaneComponentProfileResult,
     PlaneSemialgebraicComponent,
@@ -311,6 +312,37 @@ def test_request_schema_exposes_the_runtime_polynomial_envelope() -> None:
     for candidate in candidates:
         with pytest.raises(ValidationError):
             PlaneComponentProfileRequest.model_validate(candidate)
+
+
+def test_result_schema_exposes_the_runtime_polynomial_envelope() -> None:
+    schema = PlaneComponentProfileResult.model_json_schema()
+    polynomial = schema["properties"]["semialgebraic_set"]["properties"]["polynomials"][
+        "items"
+    ]
+    terms = polynomial["properties"]["polynomial"]["properties"]["terms"]
+    assert terms["maxItems"] == MAX_PLANE_COMPONENT_TERMS_PER_POLYNOMIAL
+
+    result = PlaneComponentProfileResult(
+        semialgebraic_set=PlaneSemialgebraicSet(
+            axis=("x", "y"),
+            polynomials=(_polynomial(((1, (1, 0)),)),),
+            sign_conditions=(),
+        ),
+        samples=(),
+        outcome=PlaneComponentProfileNoncompletion(
+            status="BACKEND_UNAVAILABLE",
+            reason="SUPPORTED_QEPCAD_NOT_INSTALLED",
+        ),
+    ).model_dump(mode="json")
+    result["semialgebraic_set"]["polynomials"][0]["polynomial"]["terms"].extend(
+        {
+            "coefficient": {"num": "1", "den": "1"},
+            "exponents": [0, 0],
+        }
+        for _ in range(MAX_PLANE_COMPONENT_TERMS_PER_POLYNOMIAL)
+    )
+    with pytest.raises(ValidationError):
+        PlaneComponentProfileResult.model_validate(result)
 
 
 def test_term_and_total_term_boundaries_reject_before_backend_execution() -> None:


### PR DESCRIPTION
## Problem

The merged plane-component change widened the shared real-algebraic carrier to degree 16. Two source-bound result schemas still advertised or accepted values outside their owner operation envelopes: common-interlacing root rows remained runtime-valid through degree 16, and plane-component results still exposed the generic polynomial schema.

## Outcome

- Give common interlacing an owner-local degree-eight root-result validator and schema.
- Reuse the plane-component operation-specific semialgebraic-set schema on `PlaneComponentProfileResult`.
- Add behavioral schema/runtime regressions for both result boundaries.

This is the post-merge follow-up for #3095.

## Validation

- `uv run --locked pytest -q tests/math/polynomials/test_plane_component_admission.py tests/math/polynomials/test_plane_component_models.py tests/math/polynomials/test_plane_component_profile.py tests/math/polynomials/test_qepcad_plane_samples.py tests/math/polynomials/test_common_interlacing.py::test_result_root_schema_and_runtime_keep_the_factor_degree_bound`
- Result: 40 passed, 9 expected exact plane-component backend-unavailable skips.
- Ruff check and format check passed for all touched files.