### PR TITLE
Stop treating canonical JSON bytes as mathematical admission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,9 @@ partitioning must not introduce kernel-owned durable state.
   exported Python functions or values.
 - Validate the complete request envelope before invoking a backend. Request
   admission must account for mathematical work, intermediate growth, exact
-  output, and any *actual* final canonical transport limit. Every accepted
+  output cardinality or representation growth, and any *actual, explicitly
+  configured* final transport limit. The canonical codec's default is not a
+  mathematical or MCP response-byte limit. Every accepted
   request must return a typed result rather than expose a backend, transport,
   or host exception. Follow the
   [operation library](docs/reference/domain-operation-library.md) when changing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,9 @@ contracts and validate it through its own repository-local workflow.
 
 - Do not turn a timeout, cancellation, error, incomplete enumeration, or
   missing witness into a mathematical conclusion.
+- Bound mathematical output through cardinality and intrinsic representation
+  growth. Use encoded bytes only for a concrete configured transport or worker
+  channel; the canonical encoder's ordinary mode is not an admission budget.
 - Keep execution status, input validity, and the domain mathematical conclusion
   separate.
 - Do not promote an evaluator score, solver status, model answer, or search

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -138,7 +138,9 @@ invoke that owner once, and project the typed result once. The internal
 `execute_operation` seam owns this complete envelope for `math.run`, direct
 operation tools, and native dispatch; only the final projector differs. The
 request context remains bound through canonical projection. It does not contain
-domain admission, backend logic, result-specific replay, or workflow state.
+domain admission, backend logic, result-specific replay, workflow state, or a
+transport byte ceiling. An HTTP request-body limit is enforced before shared
+dispatch; stdio and in-process composition do not inherit it.
 
 Owners call `request_checkpoint(stage)` immediately after an external or
 backend return and at documented bounded intervals in long native loops. The

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -114,10 +114,21 @@ computational engines behind Jacobian's public mathematical contracts.
 
 ## Transport and mathematical ownership
 
-The MCP Python SDK owns the fixed transport boundary: registration of
+The MCP Python SDK owns the transport boundary: registration of
 `math.find` and `math.run`, their outer argument and output schemas, protocol
 validation, and structured JSON delivery. Jacobian does not duplicate those
-checks.
+checks. The SDK's Streamable HTTP request-body ceiling is an input constraint;
+it does not define a tool-result byte ceiling. No MCP response-size limit is
+therefore inferred from the canonical codec's defaults.
+
+Mathematical values enforce canonical representation and intrinsic
+representation bounds, never JSON response bytes. Operation owners bound work,
+intermediate growth, and unavoidable result cardinality. Native functions
+return their exact typed values without inheriting an MCP or JSON byte budget.
+If a deployment adds a real delivery ceiling, the MCP adapter owns and applies
+that ceiling explicitly. Canonical encoding is deterministic measurement by
+default and enforces output bytes only when its caller supplies limits for a
+concrete boundary.
 
 `math.run` still needs a small dispatch boundary because
 its `payload` has an operation-specific schema that is known only after its
@@ -188,9 +199,10 @@ Defining-invariant evidence belongs in the operation's tests; a full replay is
 not part of ordinary execution. An adapter may reject malformed backend data
 while converting it, but that is integration safety rather than a separate
 mathematical result stage.
-After owner admission succeeds, dispatch and MCP project the typed result into
-the final transport envelope; they must not discover a mathematical or work
-bound only after execution. Independently supplied result data uses an
+After owner admission succeeds, dispatch and MCP project the typed result for
+delivery. A configured delivery limit may still fail operationally, but it
+does not retroactively make the mathematical request invalid. Independently
+supplied result data uses an
 explicit, bounded replay verifier rather than ordinary result construction.
 
 ## Bounded worker adapters

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -531,7 +531,9 @@ Use encoded byte counts only at a concrete byte boundary: bounded process
 stdin/stdout, a digest whose definition includes encoded bytes, or an explicitly
 configured transport limit. The canonical encoder measures without an output
 ceiling by default; pass `CanonicalLimits` only when the caller owns such a
-boundary. An unexplained reserve added to the codec's default is not an output
+boundary. Shared dispatch is not such a boundary: it preserves strict JSON
+semantics without imposing an HTTP, stdio, or in-process payload size. An
+unexplained reserve added to the codec's default is not an output
 proof. The architecture check rejects `max_output_bytes` in reusable
 `values.py` carriers; express their safety envelope through cardinality,
 component digits, depth, or another intrinsic representation quantity.

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -501,17 +501,18 @@ their owners:
    quantities bound that finite region?
 3. **Computation:** what bounds the algorithm's work and intermediate values
    before the backend expands, enumerates, or solves anything?
-4. **Output:** what bounds the exact returned value, witness, residual, or
-   certificate, and how is that bound related to the admitted request?
+4. **Output:** what bounds the unavoidable cardinality and representation
+   growth of the exact returned value, witness, residual, or certificate?
 
 The operation's mathematical contract owns the semantic domain and result
 meaning. The domain owner owns request admission and the execution plan. The
 kernel or maintained backend performs only the work described by that plan.
 Result construction owns conversion; the operation's tests own defining-
 invariant evidence. Dispatch and MCP own only the final transport projection.
-A transport failure must therefore
-be rejected by request admission or returned as a typed operational outcome;
-it must not first appear as an uncaught post-execution serializer exception.
+A transport-specific byte ceiling is not mathematical admission: when a real
+delivery boundary configures one, exceeding it is a typed operational outcome.
+Do not copy that ceiling into a request model, shared carrier, native function,
+or owner work plan.
 
 The operation identifier and result semantics own the first obligation. The
 request contract enforces the second and the preconditions needed for the
@@ -519,11 +520,21 @@ third and fourth. Tightening or widening a safe execution envelope must not
 silently change the mathematical meaning of the operation.
 
 A backend or result conversion may still validate an invariant, but it must
-not be the first place an accepted request discovers that its exact answer is
-too large. If a bound is conservative, name the quantity it bounds, state why
-it is safe for the algorithm, and test both the rejected adversarial case and a
-useful case near the boundary. Do not use a post-hoc output-term cap,
-truncation, sentinel, or host exception as a hidden computational budget.
+not discover an unbounded cardinality or host representation failure only after
+performing the work. If a bound is conservative, name the mathematical
+quantity it bounds, state why it is safe for the algorithm, and test both the
+rejected adversarial case and a useful case near the boundary. Do not use JSON
+bytes, a post-hoc output-term cap, truncation, sentinel, or host exception as a
+hidden computational budget.
+
+Use encoded byte counts only at a concrete byte boundary: bounded process
+stdin/stdout, a digest whose definition includes encoded bytes, or an explicitly
+configured transport limit. The canonical encoder measures without an output
+ceiling by default; pass `CanonicalLimits` only when the caller owns such a
+boundary. An unexplained reserve added to the codec's default is not an output
+proof. The architecture check rejects `max_output_bytes` in reusable
+`values.py` carriers; express their safety envelope through cardinality,
+component digits, depth, or another intrinsic representation quantity.
 
 For every non-trivially priced operation, owner tests must instrument the
 priced kernel primitives on a representative near-envelope request and assert

--- a/docs/reference/mathematical-backends.md
+++ b/docs/reference/mathematical-backends.md
@@ -141,7 +141,10 @@ self-contained bounded value do not need an artificial source digest.
 Structurally decode projections, but do not pass worker output through the
 complete public result model or any nested validator that replays mathematical
 work. Size stdin and stdout limits for the actual UTF-8 worker payload, not for
-a different public representation.
+a different public representation. Pass those channel-specific limits to both
+the process supervisor and any canonical encoder or decoder at that boundary;
+the codec's ordinary unbounded-output mode must not silently substitute a
+different default.
 
 Child processes use the shared bounded-process supervisor. Backend adapters test
 their codec, source binding, and outcome projection; the supervisor's owning

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -11,6 +11,12 @@ Built-in membership follows the
 [public mathematical operation admission contract](public-operation-admission.md),
 which keeps the public catalog distinct from the broader native Python API.
 
+MCP tool results do not inherit the canonical codec's default byte ceiling.
+The Python MCP SDK limits incoming Streamable HTTP request bodies, not tool
+result responses. A deployment may configure a concrete response limit, but
+that is an operational delivery policy owned by the adapter: it does not narrow
+the mathematical domain, shared result type, or native Python API.
+
 Larger workflows are caller-owned: retain the returned value and choose the
 next operation. When its inspected input schema accepts a canonical value from
 the first result, pass that value unchanged; otherwise construct the requested

--- a/src/jacobian/canonical.py
+++ b/src/jacobian/canonical.py
@@ -219,7 +219,7 @@ def encode_strict_json(
     *,
     limits: CanonicalLimits | None = None,
 ) -> bytes:
-    """Encode bounded JSON deterministically without semantic normalization."""
+    """Encode JSON deterministically, enforcing bytes only when requested."""
 
     active_limits = limits or CanonicalLimits()
     _validate_json_value(value, limits=active_limits, depth=0)
@@ -227,7 +227,7 @@ def encode_strict_json(
         encoded = rfc8785.dumps(value)
     except (rfc8785.CanonicalizationError, RecursionError) as exc:
         raise CanonicalizationError("value cannot be encoded as strict JSON") from exc
-    if len(encoded) > active_limits.max_output_bytes:
+    if limits is not None and len(encoded) > active_limits.max_output_bytes:
         raise CanonicalizationError("JSON exceeds the configured size limit")
     return encoded
 
@@ -273,7 +273,7 @@ def canonicalize_json(
     *,
     limits: CanonicalLimits | None = None,
 ) -> bytes:
-    """Normalize exact JSON and encode it using RFC 8785 key ordering."""
+    """Normalize exact JSON, enforcing encoded bytes only when requested."""
 
     active_limits = limits or CanonicalLimits()
     parsed = (
@@ -286,6 +286,6 @@ def canonicalize_json(
         encoded = rfc8785.dumps(normalized)
     except (rfc8785.CanonicalizationError, RecursionError) as exc:
         raise CanonicalizationError("value cannot be canonically encoded") from exc
-    if len(encoded) > active_limits.max_output_bytes:
+    if limits is not None and len(encoded) > active_limits.max_output_bytes:
         raise CanonicalizationError("canonical JSON exceeds the configured size limit")
     return encoded

--- a/src/jacobian/dispatch.py
+++ b/src/jacobian/dispatch.py
@@ -17,7 +17,11 @@ from jacobian._execution import (
     request_execution,
 )
 from jacobian._models import StrictModel
-from jacobian.canonical import CanonicalizationError, encode_strict_json
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+)
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
     OperationDomainValidationError,
@@ -62,7 +66,9 @@ def parse_operation_input[ModelT: BaseModel](
 ) -> ModelT:
     """Parse one bounded request once into its owning strict model."""
 
-    encoded = encode_strict_json(payload)
+    # This is the encoded request boundary, so the canonical input ceiling is
+    # explicit. Result projection does not inherit this transport policy.
+    encoded = encode_strict_json(payload, limits=CanonicalLimits())
     return model.model_validate_json(encoded, strict=True)
 
 

--- a/src/jacobian/dispatch.py
+++ b/src/jacobian/dispatch.py
@@ -19,7 +19,6 @@ from jacobian._execution import (
 from jacobian._models import StrictModel
 from jacobian.canonical import (
     CanonicalizationError,
-    CanonicalLimits,
     encode_strict_json,
 )
 from jacobian.catalog.catalog import Catalog
@@ -66,9 +65,10 @@ def parse_operation_input[ModelT: BaseModel](
 ) -> ModelT:
     """Parse one bounded request once into its owning strict model."""
 
-    # This is the encoded request boundary, so the canonical input ceiling is
-    # explicit. Result projection does not inherit this transport policy.
-    encoded = encode_strict_json(payload, limits=CanonicalLimits())
+    # Round-trip through strict JSON so Python-only values cannot bypass the
+    # public JSON contract. Dispatch is shared by native, stdio, and HTTP
+    # callers, so concrete transport byte ceilings belong in their adapters.
+    encoded = encode_strict_json(payload)
     return model.model_validate_json(encoded, strict=True)
 
 

--- a/src/jacobian/math/combinatorics/exact_cover.py
+++ b/src/jacobian/math/combinatorics/exact_cover.py
@@ -9,10 +9,6 @@ from pydantic import ConfigDict, Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.canonical import (
-    CanonicalizationError,
-    encode_strict_json,
-)
 from jacobian.math._labels import OpaqueLabel
 
 
@@ -142,68 +138,6 @@ class GeneralizedExactCoverInstance(StrictModel):
                 f"{MAX_EXACT_COVER_INCIDENCES}-incidence bound"
             )
         return self
-
-
-def _coverage_wire_value(
-    instance: GeneralizedExactCoverInstance,
-) -> list[dict[str, object]]:
-    return [
-        {"item_id": item, "kind": "PRIMARY", "multiplicity": 1}
-        for item in instance.primary_items
-    ] + [
-        {"item_id": item, "kind": "SECONDARY", "multiplicity": 1}
-        for item in instance.secondary_items
-    ]
-
-
-def _require_output_headroom(instance: GeneralizedExactCoverInstance) -> None:
-    """Prove that every result shape fits before the search begins.
-
-    A witness contains at most one selected row per primary item. The coverage
-    ledger contains one bounded record per declared item. The exact source is
-    retained once so conclusions remain replayable. Materializing the largest
-    possible FOUND wire value and both non-positive wire values gives the exact
-    serialized upper bound for this source; it does not rely on label lengths
-    or a fixed structural reserve.
-    """
-
-    try:
-        source = instance.model_dump(mode="json")
-        selected_count = min(len(instance.primary_items), len(instance.rows))
-        selected_row_ids = sorted(
-            instance.rows,
-            key=lambda row: len(encode_strict_json(row.row_id)),
-            reverse=True,
-        )[:selected_count]
-        common = {
-            "instance": source,
-            "search_node_limit": MAX_EXACT_COVER_SEARCH_NODES_PER_PASS,
-        }
-        found_wire = {
-            **common,
-            "status": "FOUND",
-            "selected_row_ids": sorted(row.row_id for row in selected_row_ids),
-            "item_multiplicities": _coverage_wire_value(instance),
-        }
-        no_cover_wire = {
-            **common,
-            "status": "NO_COVER",
-            "selected_row_ids": None,
-            "item_multiplicities": None,
-        }
-        unknown_wire = {
-            **common,
-            "status": "UNKNOWN",
-            "selected_row_ids": None,
-            "item_multiplicities": None,
-        }
-        for wire in (found_wire, no_cover_wire, unknown_wire):
-            encode_strict_json(wire)
-    except CanonicalizationError as exc:
-        raise _combinatorics_validation_error(
-            "the exact-cover result retains its source and would exceed the "
-            "canonical output limit; shorten labels or shrink the incidence data"
-        ) from exc
 
 
 class GeneralizedExactCoverRequest(StrictModel):
@@ -423,7 +357,6 @@ def find_generalized_exact_cover(
             "search_node_limit must be between 1 and "
             f"{MAX_EXACT_COVER_SEARCH_NODES_PER_PASS}"
         )
-    _require_output_headroom(instance)
     return _solve_generalized_exact_cover(instance, search_node_limit)
 
 

--- a/src/jacobian/math/geometry/exact/pinned_distance/operations.py
+++ b/src/jacobian/math/geometry/exact/pinned_distance/operations.py
@@ -8,13 +8,7 @@ from math import gcd
 from typing import NoReturn
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
-from jacobian.canonical import (
-    CanonicalizationError,
-    CanonicalLimits,
-    encode_strict_json,
-    format_canonical_integer,
-    strict_json_object_size,
-)
+from jacobian.canonical import format_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry.exact._models import PointConfiguration
 from jacobian.math.geometry.exact.pinned_distance._models import (
@@ -25,12 +19,7 @@ from jacobian.math.geometry.exact.pinned_distance._models import (
 
 __all__ = ["compute_pinned_distance_support_profile"]
 
-MAX_RESULT_BYTES = CanonicalLimits().max_output_bytes
 MAX_DISTANCE_INTERMEDIATE_DIGITS = 4 * MAX_CANONICAL_RATIONAL_DIGITS
-
-
-def _array_size(item_sizes: list[int]) -> int:
-    return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,61 +42,9 @@ def _reject(code: str, message: str) -> NoReturn:
     )
 
 
-def _result_bytes(
-    configuration: PointConfiguration,
-    source_bytes: int,
-    plans: tuple[_EntryPlan, ...],
-) -> int:
-    label_sizes = {
-        point.label: len(encode_strict_json(point.label))
-        for point in configuration.points
-    }
-    entry_sizes: list[int] = []
-    for entry in plans:
-        class_sizes = [
-            strict_json_object_size(
-                (
-                    (
-                        "squared_distance",
-                        len(
-                            encode_strict_json(
-                                item.squared_distance.model_dump(mode="json")
-                            )
-                        ),
-                    ),
-                    (
-                        "target_labels",
-                        _array_size(
-                            [label_sizes[label] for label in item.target_labels]
-                        ),
-                    ),
-                )
-            )
-            for item in entry.distance_classes
-        ]
-        entry_sizes.append(
-            strict_json_object_size(
-                (
-                    ("source_label", label_sizes[entry.source_label]),
-                    ("distance_classes", _array_size(class_sizes)),
-                )
-            )
-        )
-    return strict_json_object_size(
-        (
-            ("configuration", source_bytes),
-            ("entries", _array_size(entry_sizes)),
-        )
-    )
-
-
 def _admit_configuration(configuration: PointConfiguration) -> tuple[_EntryPlan, ...]:
     if not isinstance(configuration, PointConfiguration):
         _reject("invalid_configuration", "configuration must be a point configuration")
-    try:
-        source_bytes = len(encode_strict_json(configuration.model_dump(mode="json")))
-    except CanonicalizationError as exc:
-        _reject("source_representation", str(exc))
 
     distances_by_source: list[dict[Fraction, list[str]]] = [
         {} for _point in configuration.points
@@ -148,18 +85,7 @@ def _admit_configuration(configuration: PointConfiguration) -> tuple[_EntryPlan,
             _EntryPlan(source_label=source.label, distance_classes=tuple(classes))
         )
 
-    completed_plans = tuple(plans)
-    try:
-        result_bytes = _result_bytes(configuration, source_bytes, completed_plans)
-    except CanonicalizationError as exc:
-        _reject("result_representation", str(exc))
-    if result_bytes > MAX_RESULT_BYTES:
-        _reject(
-            "result_size_bound",
-            f"the complete distance profile exceeds the {MAX_RESULT_BYTES}-byte output bound",
-        )
-
-    return completed_plans
+    return tuple(plans)
 
 
 def compute_pinned_distance_support_profile(

--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py
@@ -1,14 +1,8 @@
 """Maximal-clique hypergraph operation declarations."""
 
-from jacobian.canonical import (
-    CanonicalizationError,
-    CanonicalLimits,
-    encode_strict_json,
-)
 from jacobian.catalog.models import (
     MathTool,
     MathTools,
-    OperationDomainValidationError,
     OperationExample,
 )
 from jacobian.math.graphs.maximal_clique_hypergraph._models import (
@@ -23,19 +17,7 @@ from jacobian.math.graphs.maximal_clique_hypergraph.operations import (
 def compute_maximal_clique_hypergraph(
     request: MaximalCliqueHypergraphRequest,
 ) -> MaximalCliqueHypergraphResult:
-    result = construct_maximal_clique_hypergraph(request.graph)
-    try:
-        encode_strict_json(result.model_dump(mode="json"))
-    except CanonicalizationError as error:
-        raise OperationDomainValidationError(
-            location=("graph",),
-            code="graph.maximal_clique_hypergraph.output_bound",
-            message=(
-                "the source-bound maximal-clique hypergraph result exceeds the "
-                f"{CanonicalLimits().max_output_bytes}-byte canonical output bound"
-            ),
-        ) from error
-    return result
+    return construct_maximal_clique_hypergraph(request.graph)
 
 
 TOOLS: MathTools = (

--- a/src/jacobian/math/logic/games/finite/values.py
+++ b/src/jacobian/math/logic/games/finite/values.py
@@ -11,13 +11,11 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
-from jacobian.canonical import CanonicalLimits, canonicalize_json
 from jacobian.math._labels import OpaqueLabel
 
 MAX_TERMINAL_GAME_POSITIONS = 4_096
 MAX_TERMINAL_GAME_MOVES = 65_536
 MAX_TERMINAL_GAME_WORK_UNITS = 3_000_000
-MAX_TERMINAL_GAME_RESULT_BYTES = 4 * 1024 * 1024
 
 PositionOwner = Literal["MAX", "MIN", "TERMINAL"]
 
@@ -304,54 +302,10 @@ def _require_terminal_game_envelope(game: DeterministicTerminalGame) -> None:
             "payoff levels, arena size, or payoff digit length",
         )
 
-    labels = tuple(position.label for position in game.positions)
-    longest_label = max(labels, key=lambda label: len(canonicalize_json([label])))
-    widest_payoff = max(
-        payoffs,
-        key=lambda payoff: len(payoff.num) + len(payoff.den),
-    )
-    max_positions = tuple(
-        position for position in game.positions if position.owner == "MAX"
-    )
-    min_positions = tuple(
-        position for position in game.positions if position.owner == "MIN"
-    )
-    result_upper_bound = {
-        "game": game.model_dump(mode="json"),
-        "value_classes": [
-            {
-                "payoff": widest_payoff.model_dump(mode="json"),
-                "positions": [position.label],
-            }
-            for position in game.positions
-        ],
-        "max_strategy": [
-            {"position": position.label, "target": longest_label}
-            for position in max_positions
-        ],
-        "min_strategy": [
-            {"position": position.label, "target": longest_label}
-            for position in min_positions
-        ],
-    }
-    try:
-        canonicalize_json(
-            result_upper_bound,
-            limits=CanonicalLimits(
-                max_output_bytes=MAX_TERMINAL_GAME_RESULT_BYTES,
-            ),
-        )
-    except ValueError as exc:
-        raise PydanticCustomError(
-            "finite_game.result_size_exceeded",
-            "terminal-game solution exceeds the exact result-size bound",
-        ) from exc
-
 
 __all__ = [
     "MAX_TERMINAL_GAME_MOVES",
     "MAX_TERMINAL_GAME_POSITIONS",
-    "MAX_TERMINAL_GAME_RESULT_BYTES",
     "MAX_TERMINAL_GAME_WORK_UNITS",
     "DeterministicGameMove",
     "DeterministicGamePosition",

--- a/src/jacobian/math/number_theory/sequences/core/operations.py
+++ b/src/jacobian/math/number_theory/sequences/core/operations.py
@@ -21,7 +21,7 @@ from jacobian.math.number_theory.sequences.core._models import (
     IntegerSequenceValueResult,
 )
 from jacobian.math.number_theory.sequences.core.values import (
-    MAX_SEQUENCE_WIRE_BYTES,
+    MAX_SEQUENCE_TOTAL_DIGITS,
     IntegerSequence,
 )
 
@@ -49,14 +49,14 @@ def _admit(
                 f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit bound"
             ),
         )
-    estimated = output_items * (output_digits + 3) + 64
-    if output_items and estimated > MAX_SEQUENCE_WIRE_BYTES:
+    total_output_digits = output_items * output_digits
+    if output_items and total_output_digits > MAX_SEQUENCE_TOTAL_DIGITS:
         raise OperationDomainValidationError(
             location=("values",),
-            code="sequences.result_transport_too_large",
+            code="sequences.result_representation_too_large",
             message=(
                 "the exact result exceeds the "
-                f"{MAX_SEQUENCE_WIRE_BYTES}-byte transport envelope"
+                f"{MAX_SEQUENCE_TOTAL_DIGITS}-digit representation bound"
             ),
         )
     return values

--- a/src/jacobian/math/number_theory/sequences/core/values.py
+++ b/src/jacobian/math/number_theory/sequences/core/values.py
@@ -14,11 +14,13 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.canonical import CanonicalLimits
 
 MAX_SEQUENCE_LENGTH = 100_000
 MAX_INTEGER_SEQUENCE_ITEM_DIGITS = MAX_CANONICAL_RATIONAL_DIGITS
-MAX_SEQUENCE_WIRE_BYTES = CanonicalLimits().max_output_bytes // 2
+# Bound validation and resident exact-source work directly. This admits all
+# 100,000 entries when their average magnitude has at most 50 decimal digits;
+# it is independent of JSON escaping and delivery format.
+MAX_SEQUENCE_TOTAL_DIGITS = 5_000_000
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -48,13 +50,12 @@ class IntegerSequence(StrictModel):
                 "sequence item exceeds the "
                 f"{MAX_INTEGER_SEQUENCE_ITEM_DIGITS}-digit bound",
             )
-        estimated = sum(len(value) + 3 for value in self.values) + 64
-        if estimated > MAX_SEQUENCE_WIRE_BYTES:
+        total_digits = sum(len(value.lstrip("-")) for value in self.values)
+        if total_digits > MAX_SEQUENCE_TOTAL_DIGITS:
             raise _validation_error(
-                "transport_too_large",
-                "sequence request exceeds the "
-                f"{MAX_SEQUENCE_WIRE_BYTES}-byte transport envelope; "
-                "chunk the sequence into <=10MiB pieces and compose via typed values",
+                "representation_too_large",
+                "sequence exceeds the "
+                f"{MAX_SEQUENCE_TOTAL_DIGITS}-digit representation bound",
             )
         return self
 
@@ -62,6 +63,6 @@ class IntegerSequence(StrictModel):
 __all__ = [
     "MAX_INTEGER_SEQUENCE_ITEM_DIGITS",
     "MAX_SEQUENCE_LENGTH",
-    "MAX_SEQUENCE_WIRE_BYTES",
+    "MAX_SEQUENCE_TOTAL_DIGITS",
     "IntegerSequence",
 ]

--- a/src/jacobian/math/polynomials/ideals/operations.py
+++ b/src/jacobian/math/polynomials/ideals/operations.py
@@ -14,7 +14,6 @@ from jacobian._execution import (
     current_request_execution,
     request_cancelled,
 )
-from jacobian.canonical import CanonicalizationError, canonicalize_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.polynomials._conversions import (
     rational_polynomial_to_sympy,
@@ -284,19 +283,6 @@ def _decimal_digit_count(value: int) -> int:
     elif value >= 10**estimate:
         estimate += 1
     return estimate
-
-
-def _require_transportable_minimal_primes_result(
-    result: IdealMinimalPrimesResult,
-) -> None:
-    """Reject a family whose complete public result exceeds JSON limits."""
-
-    try:
-        canonicalize_json(result.model_dump(mode="json"))
-    except CanonicalizationError as error:
-        raise _ResultLimitExceededError(
-            "the exact minimal-prime result exceeds the canonical transport bound"
-        ) from error
 
 
 _SYMPY_WORKER_SCRIPT = r"""
@@ -781,7 +767,6 @@ def ideal_minimal_primes(
             components=components,
             backend_version=backend.backend_version,
         )
-        _require_transportable_minimal_primes_result(result)
         return result
     except _ResultLimitExceededError as error:
         return IdealMinimalPrimesResult(

--- a/tests/dispatch/test_finite_dim_algebras_dispatch.py
+++ b/tests/dispatch/test_finite_dim_algebras_dispatch.py
@@ -1,12 +1,9 @@
 """Dispatch-boundary tests for finite-dimensional algebra operations."""
 
 import pytest
+from pydantic import ValidationError
 
-from jacobian.canonical import (
-    CanonicalizationError,
-    CanonicalLimits,
-    encode_strict_json,
-)
+from jacobian.canonical import CanonicalLimits, encode_strict_json
 from jacobian.dispatch import parse_operation_input
 from jacobian.math.finite_dim_algebras._models import (
     MAX_DIM,
@@ -16,8 +13,8 @@ from jacobian.math.finite_dim_algebras._models import (
 )
 
 
-def test_published_dimension_fits_canonical_request_byte_limit() -> None:
-    """Worst-case valid tensors survive the canonical dispatch envelope."""
+def test_published_dimension_matches_structural_request_bound() -> None:
+    """Worst-case valid tensors survive strict dispatch parsing."""
     n = MAX_DIM
     residue = 250
     inner = [residue] * n
@@ -46,5 +43,5 @@ def test_published_dimension_fits_canonical_request_byte_limit() -> None:
             "multiplication": [oversized_row] * (n + 1),
         }
     }
-    with pytest.raises(CanonicalizationError):
+    with pytest.raises(ValidationError):
         parse_operation_input(CenterRequest, oversized)

--- a/tests/dispatch/test_large_composition.py
+++ b/tests/dispatch/test_large_composition.py
@@ -1,0 +1,37 @@
+"""Producer-consumer composition across the shared dispatch boundary."""
+
+from itertools import islice
+
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import invoke_operation
+
+
+def test_dispatch_accepts_valid_payload_beyond_default_transport_bytes() -> None:
+    """Shared dispatch must not impose an unconfigured transport ceiling."""
+    vertex_prefix = chr(0x1D567) * 60
+    edge_prefix = chr(0x1D556) * 60
+    vertices = [f"{vertex_prefix}{index:04}" for index in range(256)]
+    memberships = islice(
+        (
+            (vertices[first], vertices[second], vertices[third], vertices[fourth])
+            for first in range(253)
+            for second in range(first + 1, 254)
+            for third in range(second + 1, 255)
+            for fourth in range(third + 1, 256)
+        ),
+        9_000,
+    )
+    edges = [
+        [f"{edge_prefix}{index:04}", list(members)]
+        for index, members in enumerate(memberships)
+    ]
+    payload = {"hypergraph": {"vertices": vertices, "edges": edges}}
+
+    assert len(encode_strict_json(payload)) > CanonicalLimits().max_input_bytes
+    result = invoke_operation(
+        "hypergraph.parameters.compute", payload, Catalog.open()
+    )
+
+    assert result.output["edge_count"] == 9_000
+    assert result.output["total_incidences"] == 36_000

--- a/tests/dispatch/test_large_composition.py
+++ b/tests/dispatch/test_large_composition.py
@@ -29,9 +29,7 @@ def test_dispatch_accepts_valid_payload_beyond_default_transport_bytes() -> None
     payload = {"hypergraph": {"vertices": vertices, "edges": edges}}
 
     assert len(encode_strict_json(payload)) > CanonicalLimits().max_input_bytes
-    result = invoke_operation(
-        "hypergraph.parameters.compute", payload, Catalog.open()
-    )
+    result = invoke_operation("hypergraph.parameters.compute", payload, Catalog.open())
 
     assert result.output["edge_count"] == 9_000
     assert result.output["total_incidences"] == 36_000

--- a/tests/math/canonical/test_json.py
+++ b/tests/math/canonical/test_json.py
@@ -43,6 +43,17 @@ def test_strict_json_encoding_preserves_unreduced_rationals_and_unicode() -> Non
     assert encode_strict_json(decomposed) == b'"e\xcc\x81"'
 
 
+def test_canonical_encoding_enforces_only_a_caller_supplied_byte_limit() -> None:
+    value = {"value": "longer than this boundary"}
+
+    assert encode_strict_json(value)
+    assert canonicalize_json(value)
+    with pytest.raises(CanonicalizationError, match="configured size limit"):
+        encode_strict_json(value, limits=CanonicalLimits(max_output_bytes=8))
+    with pytest.raises(CanonicalizationError, match="configured size limit"):
+        canonicalize_json(value, limits=CanonicalLimits(max_output_bytes=8))
+
+
 @pytest.mark.parametrize(
     ("fields", "value"),
     [

--- a/tests/math/combinatorics/test_exact_cover.py
+++ b/tests/math/combinatorics/test_exact_cover.py
@@ -428,9 +428,7 @@ def test_search_and_retained_output_boundaries_are_preflighted() -> None:
             search_node_limit=MAX_EXACT_COVER_SEARCH_NODES_PER_PASS + 1,
         )
 
-    # The item/row/incidence counts alone do not bound UTF-8 source bytes.
-    # This canonical instance fits every combinatorial count but its retained
-    # source would exceed the transport's identical output limit.
+    # UTF-8 bytes do not narrow the mathematical cardinality/work envelope.
     prefix = "🟦" * 60
     primary = tuple(f"{prefix}p{index:03d}" for index in range(128))
     secondary = tuple(f"{prefix}s{index:03d}" for index in range(128))
@@ -444,11 +442,11 @@ def test_search_and_retained_output_boundaries_are_preflighted() -> None:
         ),
     )
     request = GeneralizedExactCoverRequest(instance=large_source)
-    with pytest.raises(ValueError, match="canonical output"):
-        find_generalized_exact_cover(
-            request.instance,
-            search_node_limit=request.search_node_limit,
-        )
+    result = find_generalized_exact_cover(
+        request.instance,
+        search_node_limit=request.search_node_limit,
+    )
+    assert result.status == "FOUND"
 
 
 def test_schema_publishes_the_exact_cover_contract() -> None:

--- a/tests/math/geometry/exact/pinned_distance/test_pinned_distance.py
+++ b/tests/math/geometry/exact/pinned_distance/test_pinned_distance.py
@@ -238,7 +238,7 @@ def test_long_target_labels_are_counted_once_per_entry() -> None:
     assert len(result.entries) == 64
 
 
-def test_oversized_source_is_rejected_at_operation_boundary() -> None:
+def test_large_canonical_source_is_not_rejected_by_json_bytes() -> None:
     huge = CanonicalRational.from_fraction(Fraction(10**32767))
     config = PointConfiguration(
         points=tuple(
@@ -250,17 +250,7 @@ def test_oversized_source_is_rejected_at_operation_boundary() -> None:
         )
     )
 
-    with pytest.raises(OperationDomainValidationError, match="JSON exceeds"):
-        compute_pinned_distance_support_profile(config)
+    result = compute_pinned_distance_support_profile(config)
 
-
-def test_aggregate_profile_size_is_rejected_before_result_construction() -> None:
-    scale = 10**15999
-    config = PointConfiguration(
-        points=tuple(_pt(f"p{index}", (index * scale,)) for index in range(24))
-    )
-
-    with pytest.raises(
-        OperationDomainValidationError, match="complete distance profile"
-    ):
-        compute_pinned_distance_support_profile(config)
+    assert result.configuration == config
+    assert len(result.entries) == len(config.points)

--- a/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
+++ b/tests/math/graphs/maximal_clique_hypergraph/test_maximal_clique_hypergraph.py
@@ -263,7 +263,7 @@ def test_rejects_complete_family_above_hypergraph_edge_bound() -> None:
         construct_maximal_clique_hypergraph(graph)
 
 
-def test_wire_adapter_rejects_result_beyond_transport_limit() -> None:
+def test_wire_adapter_does_not_impose_an_unconfigured_transport_limit() -> None:
     left = [f"{chr(0x1D552) * 60}L{index:03}" for index in range(102)]
     right = [f"{chr(0x1D553) * 60}R{index:03}" for index in range(102)]
     graph = _graph(
@@ -273,11 +273,11 @@ def test_wire_adapter_rejects_result_beyond_transport_limit() -> None:
     native = construct_maximal_clique_hypergraph(graph)
     assert native.clique_count == 10_404
 
-    with pytest.raises(
-        OperationDomainValidationError,
-        match="canonical output bound",
-    ):
-        compute_maximal_clique_hypergraph(MaximalCliqueHypergraphRequest(graph=graph))
+    projected = compute_maximal_clique_hypergraph(
+        MaximalCliqueHypergraphRequest(graph=graph)
+    )
+
+    assert projected == native
 
 
 def test_hypergraph_serializes_unchanged_into_transversal_consumer() -> None:

--- a/tests/math/logic/games/finite/test_deterministic_terminal_game.py
+++ b/tests/math/logic/games/finite/test_deterministic_terminal_game.py
@@ -366,7 +366,7 @@ def test_threshold_work_is_admitted_and_rejected_before_solving() -> None:
     assert exc_info.value.errors()[0]["type"] == "finite_game.threshold_work_exceeded"
 
 
-def test_result_size_is_rejected_independently_of_threshold_work() -> None:
+def test_result_bytes_do_not_reject_admitted_threshold_work() -> None:
     size = 170
     labels = tuple(f"v{index:04d}" + "x" * 59 for index in range(size))
     payload = {
@@ -380,9 +380,10 @@ def test_result_size_is_rejected_independently_of_threshold_work() -> None:
     }
 
     game = DeterministicTerminalGame.model_validate(payload)
-    with pytest.raises(OperationDomainValidationError) as exc_info:
-        solve_terminal_game(game)
-    assert exc_info.value.errors()[0]["type"] == "finite_game.result_size_exceeded"
+    result = solve_terminal_game(game)
+
+    assert result.game == game
+    assert len(result.max_strategy) == size
 
 
 def test_public_request_and_example_return_the_declared_result() -> None:

--- a/tests/math/number_theory/sequences/core/test_models.py
+++ b/tests/math/number_theory/sequences/core/test_models.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from jacobian.math.number_theory.sequences.core.values import (
     MAX_INTEGER_SEQUENCE_ITEM_DIGITS,
+    MAX_SEQUENCE_TOTAL_DIGITS,
     IntegerSequence,
 )
 
@@ -26,3 +27,14 @@ def test_integer_sequence_rejects_items_over_digit_bound(sign: str) -> None:
         IntegerSequence(values=(value,))
 
     assert exc_info.value.errors()[0]["type"] == "sequences.item_too_large"
+
+
+def test_integer_sequence_bounds_total_mathematical_representation() -> None:
+    value = "1" * MAX_INTEGER_SEQUENCE_ITEM_DIGITS
+    accepted_count = MAX_SEQUENCE_TOTAL_DIGITS // len(value)
+
+    assert IntegerSequence(values=(value,) * accepted_count)
+    with pytest.raises(ValidationError) as exc_info:
+        IntegerSequence(values=(value,) * (accepted_count + 1))
+
+    assert exc_info.value.errors()[0]["type"] == "sequences.representation_too_large"

--- a/tests/math/polynomials/ideals/test_minimal_primes.py
+++ b/tests/math/polynomials/ideals/test_minimal_primes.py
@@ -7,9 +7,7 @@ import shutil
 import pytest
 from pydantic import ValidationError
 
-from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError, OperationResult
-from jacobian.math.polynomials.ideals import operations as operations_module
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.polynomials.ideals._models import (
     MAX_OUTPUT_GENERATORS,
     MAX_OUTPUT_TERMS,
@@ -23,8 +21,6 @@ from jacobian.math.polynomials.ideals.operations import (
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
     RationalPolynomialIdeal,
-    RationalPolynomialTerm,
-    SparseRationalPolynomial,
 )
 
 
@@ -82,27 +78,6 @@ def _axes_components() -> tuple[RationalPolynomialIdeal, ...]:
             key=lambda ideal: ideal.model_dump_json(),
         )
     )
-
-
-def _transport_oversized_components() -> tuple[RationalPolynomialIdeal, ...]:
-    variables = ("x",)
-    coefficient = CanonicalRational(
-        num="9" * 32_768,
-        den="9" * 32_767 + "8",
-    )
-    polynomial = RationalPolynomial(
-        variables=variables,
-        polynomial=SparseRationalPolynomial(
-            terms=tuple(
-                RationalPolynomialTerm(
-                    coefficient=coefficient,
-                    exponents=(exponent,),
-                )
-                for exponent in range(160, -1, -1)
-            )
-        ),
-    )
-    return (_ideal(variables, polynomial),)
 
 
 def _product_ideal(
@@ -638,35 +613,6 @@ def test_coordinate_axes_are_the_two_qq_minimal_primes() -> None:
 
     assert result.outcome == "COMPUTED"
     assert result.components == _axes_components()
-
-
-@pytest.mark.scale
-def test_transport_oversize_is_typed_before_operation_result_validation(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    request = IdealMinimalPrimesRequest(
-        ideal=_ideal(("x",), _poly(("x",), (1, 1, (1,))))
-    )
-    components = _transport_oversized_components()
-    monkeypatch.setattr(
-        operations_module,
-        "run_singular_minimal_primes",
-        lambda ideal, budget: SingularMinimalPrimesResult(
-            outcome="COMPUTED",
-            components=components,
-            backend_version="4.4.0",
-        ),
-    )
-    result = _run_minimal_primes(request)
-
-    assert result.outcome == "LIMIT_EXCEEDED"
-    assert result.components is None
-    public = OperationResult(
-        operation_id="polynomial.ideal.minimal_primes.compute",
-        runtime_ms=0,
-        output=result.model_dump(mode="json"),
-    )
-    assert public.output["outcome"] == "LIMIT_EXCEEDED"
 
 
 @pytest.mark.skipif(

--- a/tests/tooling/test_architecture.py
+++ b/tests/tooling/test_architecture.py
@@ -36,6 +36,18 @@ def test_generic_private_operation_shadows_are_rejected(tmp_path: Path) -> None:
     ]
 
 
+def test_mathematical_value_carriers_cannot_own_output_byte_limits(
+    tmp_path: Path,
+) -> None:
+    source = "from jacobian.canonical import CanonicalLimits\nlimit = CanonicalLimits().max_output_bytes\n"
+    _write(tmp_path, "src/jacobian/math/example/values.py", source)
+    _write(tmp_path, "src/jacobian/math/example/operations.py", source)
+
+    assert _violations(tmp_path, "carrier-transport-limit") == [
+        "src/jacobian/math/example/values.py"
+    ]
+
+
 def test_direct_process_use_is_confined_to_process_owner(tmp_path: Path) -> None:
     _write(tmp_path, "src/jacobian/process.py", "import subprocess\n")
     _write(tmp_path, "src/jacobian/math/example.py", "import subprocess\n")

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -1162,6 +1162,28 @@ def _generic_operation_shadow_violations(
     return ()
 
 
+def _carrier_transport_limit_violations(
+    relative: PurePosixPath, tree: ast.Module
+) -> tuple[Violation, ...]:
+    """Keep JSON response-byte policy out of reusable mathematical values."""
+
+    if not (
+        relative.is_relative_to(PurePosixPath("src/jacobian/math"))
+        and relative.name == "values.py"
+    ):
+        return ()
+    return tuple(
+        _violation(
+            relative,
+            node,
+            "carrier-transport-limit",
+            "mathematical values must use representation bounds, not canonical output-byte limits",
+        )
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr == "max_output_bytes"
+    )
+
+
 def _check_file(root: Path, path: Path) -> tuple[Violation, ...]:
     relative = PurePosixPath(path.relative_to(root).as_posix())
     try:
@@ -1170,6 +1192,7 @@ def _check_file(root: Path, path: Path) -> tuple[Violation, ...]:
         return (Violation(str(relative), "parse-error", f"cannot parse file: {exc}"),)
     return (
         *_generic_operation_shadow_violations(relative),
+        *_carrier_transport_limit_violations(relative, tree),
         *_process_violations(relative, tree),
         *_bounded_process_violations(relative, tree),
         *_resolver_violations(relative, tree),


### PR DESCRIPTION
Advances #3121.

## Problem

Jacobian's canonical encoder imposed a 10 MiB output ceiling whenever callers omitted `CanonicalLimits`. Mathematical carriers and operation admission then treated that codec default as a universal result boundary, even though MCP 2.1 documents only a configurable incoming Streamable HTTP request-body limit and no corresponding tool-result ceiling.

This rejected exact native and MCP results because of their JSON rendering rather than their mathematical cardinality, work, or intrinsic representation. Exact cover also materialized three worst-case wire variants before search solely to prove they fit that implicit limit.

## Outcome

Canonical encoding and normalization now enforce output bytes only when the caller supplies limits for a concrete boundary. Strict request parsing opts into its input envelope explicitly; Smith and other bounded worker channels retain their owner-specific limits.

Reusable `values.py` carriers may no longer consult `max_output_bytes`. Integer sequences instead bound total canonical decimal digits, and finite games retain their arena, payoff-height, and threshold-work bounds. Exact cover, pinned-distance profiles, and maximal-clique hypergraphs no longer reject otherwise admitted results because their canonical JSON exceeds 10 MiB.

The architecture and reference documentation now distinguish mathematical representation, operation work/cardinality, native results, configured MCP delivery policy, worker IPC, and canonical measurement. This PR intentionally does not delete every owner-local byte estimate: the remaining #3121 audit must distinguish genuine worker/digest/configured-channel limits from operation admission that should move to mathematical quantities.

## Validation

- `make check` at `748ce3b933e27fd249332886cad86fd5d3c76eec` — Ruff, formatting, mypy, 8,462 passed, 9 optional-backend skips.
- `make docs-linkcheck` — documentation commands and Markdown links passed.
- `make test-mcp` — 33 passed.
- `make test-process` — 248 passed, 2 optional QEPCAD skips.
- Focused affected-owner and architecture tests — 114 passed.
- `make test-singular` on the final tree — 220 passed.
- Final head SHA for affected final-tree validation: `65069f05f2df1d0380780266fc07ad5e70f47e27`.

## Contract impact

- Public contract impact: previously rejected large exact-cover, pinned-distance, maximal-clique-hypergraph, and finite-game results may now succeed when their mathematical work and representation bounds admit them. Operation IDs, schemas, and mathematical postconditions are unchanged.
- [x] Schema and runtime accept/reject the same requests
- [x] Cheap malformed or over-budget input is rejected before expensive work
- [x] All mandatory phases share one request deadline
- [x] Native and MCP behavior agree, where both are public
- [x] Producer → serialization → consumer composition was tested
- [x] Defining invariant and adversarial regression are covered

The template's “exact results fit the complete canonical output boundary” item is intentionally not checked: there is no universal canonical response-byte boundary after this change. Concrete worker and configured transport channels still enforce their own limits.

## Review closure

- [ ] Every substantive review thread has a root-cause fix, regression proof, and reply
- [x] Merge conflicts were resolved against the intended base
- [x] Validation was rerun after the final commit
- [ ] CI evidence matches the final head SHA
- [x] The appropriate broad and specialist validation lanes are listed above
- [x] No compatibility path, generic execution framework, or universal memory estimator was added

## Operation boundary

- Changed stage and owner: canonical request parsing, mathematical admission, result projection, and worker/transport documentation.
- Semantic admission and controlling quantities: carriers use canonical component digits and cardinality; owners retain search, incidence, matrix, arena, and intermediate-growth bounds.
- Execution envelope: no universal response-byte ceiling; concrete request and process channels opt into their own byte limits.
- Backend or kernel path: unchanged.
- Result construction: exact typed values are returned without a transport-derived ceiling.
- Independent-result verifier: unchanged.
- Native/MCP parity: both receive the same admitted mathematical result; deployments may add an operational response policy outside mathematical admission.
- Serialized-result evidence: canonical encoding tests cover default measurement and explicit enforcement; owner regressions cover results above the former default.

## Suggested review order

1. `jacobian.canonical`, dispatch request parsing, and the canonical regression.
2. The four removed transport-admission paths and sequence representation bound.
3. The carrier architecture rule and normative documentation.