### PR TITLE
fix: align hidden worker diagnostic tests

### DIFF
--- a/src/jacobian/math/polynomials/real_algebra/_plane_component_models.py
+++ b/src/jacobian/math/polynomials/real_algebra/_plane_component_models.py
@@ -432,8 +432,6 @@ class PlaneComponentProfileComputed(StrictModel):
         return self
 
 
-
-
 def _raw_collection_limit(
     value: object,
     *,

--- a/tests/process/test_contiguous_sum_worker.py
+++ b/tests/process/test_contiguous_sum_worker.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-import jacobian.math.number_theory._factorization_kernels as factorization_kernels
 from jacobian import process as process_runtime
 from jacobian.math.number_theory._contiguous_sum import compute_contiguous_sum_profile
 from jacobian.math.number_theory._contiguous_sum_models import (
@@ -18,7 +17,6 @@ from jacobian.process import BoundedProcessResult, ProcessResourceLimits
 def test_timed_out_high_magnitude_profile_is_unknown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("JACOBIAN_REVISION", "a" * 40)
     recorded: dict[str, object] = {}
 
     def timed_out_worker(*_args: object, **kwargs: object) -> BoundedProcessResult:
@@ -41,17 +39,13 @@ def test_timed_out_high_magnitude_profile_is_unknown(
         )
     )
 
-    assert result.status == "UNKNOWN"
-    assert result.rows == ()
-    assert result.detail
-    assert result.diagnostic is not None
-    assert result.diagnostic.failure == "WORKER_TIMEOUT"
-    assert result.diagnostic.timeout_layer == "WORKER_WALL"
-    assert result.diagnostic.elapsed_ms >= 0
-    assert result.diagnostic.worker_timeout_ms > 0
-    assert result.diagnostic.budget_seconds == 60
-    assert result.diagnostic.operation_version == "1"
-    assert result.diagnostic.repository_revision == "a" * 40
+    assert result.model_dump() == {
+        "status": "UNKNOWN",
+        "lower_bound": "1099511627776",
+        "upper_bound": "1099511627776",
+        "rows": (),
+        "detail": "the bounded factorization worker did not establish the complete profile",
+    }
     assert recorded["resource_limits"] == ProcessResourceLimits(
         cpu_seconds=60,
         address_space_bytes=_FACTORIZATION_WORKER_ADDRESS_SPACE_BYTES,
@@ -60,107 +54,55 @@ def test_timed_out_high_magnitude_profile_is_unknown(
     assert str(recorded["cwd"]).split("/")[-1].startswith("jacobian-direct-factor-")
 
 
-def test_worker_overshoot_retains_full_elapsed_diagnostic(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        process_runtime,
-        "run_bounded_process",
-        lambda *_args, **_kwargs: BoundedProcessResult(
+@pytest.mark.parametrize(
+    "completed",
+    [
+        BoundedProcessResult(
             returncode=None,
             stdout=b"",
             stderr=b"",
             stdout_exceeded=False,
             stderr_exceeded=False,
-            timed_out=True,
+            timed_out=False,
+            cancelled=True,
         ),
-    )
-    clock = iter((100.0, 170.001))
-    monkeypatch.setattr(factorization_kernels, "monotonic", lambda: next(clock))
-
-    result = compute_contiguous_sum_profile(
-        ContiguousSumProfileRequest(
-            lower_bound="1099511627776",
-            upper_bound="1099511627776",
-        )
-    )
-
-    assert result.status == "UNKNOWN"
-    assert result.diagnostic is not None
-    assert result.diagnostic.elapsed_ms == 70_001
-
-
-@pytest.mark.parametrize(
-    ("completed", "failure", "timeout_layer"),
-    [
-        (
-            BoundedProcessResult(
-                returncode=None,
-                stdout=b"",
-                stderr=b"",
-                stdout_exceeded=False,
-                stderr_exceeded=False,
-                timed_out=False,
-                cancelled=True,
-            ),
-            "WORKER_CANCELLED",
-            "REQUEST_CANCELLATION",
+        BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=True,
+            stderr_exceeded=False,
+            timed_out=False,
         ),
-        (
-            BoundedProcessResult(
-                returncode=None,
-                stdout=b"",
-                stderr=b"",
-                stdout_exceeded=True,
-                stderr_exceeded=False,
-                timed_out=False,
-            ),
-            "STDOUT_LIMIT_EXCEEDED",
-            "OUTPUT_LIMIT",
+        BoundedProcessResult(
+            returncode=-9,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
         ),
-        (
-            BoundedProcessResult(
-                returncode=-9,
-                stdout=b"",
-                stderr=b"",
-                stdout_exceeded=False,
-                stderr_exceeded=False,
-                timed_out=False,
-            ),
-            "WORKER_RESOURCE_LIMIT",
-            "PROCESS_RESOURCE",
+        BoundedProcessResult(
+            returncode=0xC0000005,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
         ),
-        (
-            BoundedProcessResult(
-                returncode=0xC0000005,
-                stdout=b"",
-                stderr=b"",
-                stdout_exceeded=False,
-                stderr_exceeded=False,
-                timed_out=False,
-            ),
-            "WORKER_EXITED",
-            "WORKER_EXIT",
-        ),
-        (
-            BoundedProcessResult(
-                returncode=0,
-                stdout=b"not json",
-                stderr=b"",
-                stdout_exceeded=False,
-                stderr_exceeded=False,
-                timed_out=False,
-            ),
-            "MALFORMED_OUTPUT",
-            "RESULT_VALIDATION",
+        BoundedProcessResult(
+            returncode=0,
+            stdout=b"not json",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
         ),
     ],
 )
-def test_worker_stop_reason_is_retained(
+def test_worker_stop_reason_is_hidden_from_public_result(
     monkeypatch: pytest.MonkeyPatch,
     completed: BoundedProcessResult,
-    failure: str,
-    timeout_layer: str,
 ) -> None:
     monkeypatch.setattr(
         process_runtime, "run_bounded_process", lambda *_args, **_kwargs: completed
@@ -173,7 +115,10 @@ def test_worker_stop_reason_is_retained(
         )
     )
 
-    assert result.status == "UNKNOWN"
-    assert result.diagnostic is not None
-    assert result.diagnostic.failure == failure
-    assert result.diagnostic.timeout_layer == timeout_layer
+    assert result.model_dump() == {
+        "status": "UNKNOWN",
+        "lower_bound": "1099511627776",
+        "upper_bound": "1099511627776",
+        "rows": (),
+        "detail": "the bounded factorization worker did not establish the complete profile",
+    }


### PR DESCRIPTION
## Summary

- align contiguous-sum process tests with the intentionally hidden worker diagnostics from `05af450`
- assert that worker stop reasons collapse to the same public `UNKNOWN` result without private diagnostics
- remove the stray blank lines that fail the main static formatting gate

## Validation

- `make handoff-scoped LANE=process TESTS=tests/process/test_contiguous_sum_worker.py PATHS="tests/process/test_contiguous_sum_worker.py src/jacobian/math/polynomials/real_algebra/_plane_component_models.py"` (6 passed)
- `make test-process` via affected validation (247 passed, 2 skipped: exact plane-component backend unavailable)
- `make test-math TESTS=tests/math/polynomials` via affected validation (635 passed, 65 skipped: optional exact backends unavailable)
- full `mypy`, architecture, repository hygiene, import contracts, docs link check, npm tests, package build, and wheel contents passed
- full Ruff lint and format passed

`make affected` reached the pinned exact-algebra lanes, but this host does not have Singular 4.4 or QEPCAD 1.74. The PR CI clean checkout owns those fixed-backend checks. Local `deptry .` is also contaminated by the preserved untracked `lean/.lake` tree; the clean CI checkout does not contain it.