### PR TITLE
feat(mcp): log math.find match queries

### DIFF
--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -69,12 +69,14 @@ session handling.
 
 Each admitted `math.find` match request writes a bounded correlation identifier
 at INFO as `math.find query_hash=<16 hex characters>`. The value is the first
-16 hexadecimal characters of the SHA-256 digest of the UTF-8 mathematical
-need. Identical needs produce the same identifier; the identifier is not
-reversible to the need, and the need itself is not written. Inspection
+16 hexadecimal characters of an HMAC-SHA-256 digest of the UTF-8 mathematical
+need, keyed by a random process-local secret. Identical needs produce the same
+identifier only within that process; identifiers change after a restart and
+can differ across replicas. The key and need are not written. Inspection
 requests and `math.run` payloads are not included. Use the identifier to
-correlate discovery demand. Treat it as operator-correlation data when
-choosing access controls and retention; it does not contain the query text.
+correlate discovery demand within one process. Treat it as operator-correlation
+data when choosing access controls and retention; it does not contain the
+query text.
 
 ## Install the example service files
 

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -67,12 +67,14 @@ session handling.
 
 ## Observe discovery demand
 
-Each admitted `math.find` match request writes its mathematical need to the
-application log at INFO level as `math.find query='<need>'`. Control characters,
-including line breaks, are escaped so one query cannot forge additional log
-entries. Inspection requests and `math.run` payloads are not included. Treat
-these query logs as caller data when choosing access controls, retention, and
-redaction outside Jacobian.
+Each admitted `math.find` match request writes a bounded correlation identifier
+at INFO as `math.find query_hash=<16 hex characters>`. The value is the first
+16 hexadecimal characters of the SHA-256 digest of the UTF-8 mathematical
+need. Identical needs produce the same identifier; the identifier is not
+reversible to the need, and the need itself is not written. Inspection
+requests and `math.run` payloads are not included. Use the identifier to
+correlate discovery demand. Treat it as operator-correlation data when
+choosing access controls and retention; it does not contain the query text.
 
 ## Install the example service files
 

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -65,6 +65,15 @@ authenticated service. Streamable HTTP is stateless by default. Use
 `--stateful-http` only when the deployment deliberately provides stateful
 session handling.
 
+## Observe discovery demand
+
+Each admitted `math.find` match request writes its mathematical need to the
+application log at INFO level as `math.find query='<need>'`. Control characters,
+including line breaks, are escaped so one query cannot forge additional log
+entries. Inspection requests and `math.run` payloads are not included. Treat
+these query logs as caller data when choosing access controls, retention, and
+redaction outside Jacobian.
+
 ## Install the example service files
 
 [`deploy/systemd/jacobian-mcp.service`](../../deploy/systemd/jacobian-mcp.service)

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import logging
+import secrets
 import time
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -52,6 +54,7 @@ _MAX_VALIDATION_ERRORS = 64
 _MAX_VALIDATION_LOCATION_COMPONENTS = 32
 _MAX_VALIDATION_LOCATION_LENGTH = 128
 _FIND_QUERY_HASH_HEX_LENGTH = 16
+_FIND_QUERY_LOG_KEY = secrets.token_bytes(32)
 
 logger = logging.getLogger(__name__)
 
@@ -63,10 +66,11 @@ def math_find(
 ) -> OperationFindResponse:
     active_catalog = _catalog(ctx)
     if isinstance(request, OperationMatchRequest):
-        # Logs a 16-hex SHA-256 prefix, not the caller need.
-        need_hash = hashlib.sha256(request.need.encode("utf-8")).hexdigest()[
-            :_FIND_QUERY_HASH_HEX_LENGTH
-        ]
+        # The process-local HMAC key prevents log readers from recovering a
+        # short caller need through an offline digest lookup.
+        need_hash = hmac.new(
+            _FIND_QUERY_LOG_KEY, request.need.encode("utf-8"), hashlib.sha256
+        ).hexdigest()[:_FIND_QUERY_HASH_HEX_LENGTH]
         logger.info("math.find query_hash=%s", need_hash)
         match_response = _operation_match_response(
             active_catalog,

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import time
@@ -50,6 +51,7 @@ from jacobian.mcp.runtime import (
 _MAX_VALIDATION_ERRORS = 64
 _MAX_VALIDATION_LOCATION_COMPONENTS = 32
 _MAX_VALIDATION_LOCATION_LENGTH = 128
+_FIND_QUERY_HASH_HEX_LENGTH = 16
 
 logger = logging.getLogger(__name__)
 
@@ -61,12 +63,10 @@ def math_find(
 ) -> OperationFindResponse:
     active_catalog = _catalog(ctx)
     if isinstance(request, OperationMatchRequest):
-        # Log a bounded hash of the need instead of the full caller-supplied
-        # value to avoid persisting sensitive mathematical objects or constraints
-        # in ordinary process logs. The SHA-256 digest is non-reversible and fixed-length.
-        import hashlib
-
-        need_hash = hashlib.sha256(request.need.encode("utf-8")).hexdigest()[:16]
+        # Logs a 16-hex SHA-256 prefix, not the caller need.
+        need_hash = hashlib.sha256(request.need.encode("utf-8")).hexdigest()[
+            :_FIND_QUERY_HASH_HEX_LENGTH
+        ]
         logger.info("math.find query_hash=%s", need_hash)
         match_response = _operation_match_response(
             active_catalog,

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -50,6 +51,8 @@ _MAX_VALIDATION_ERRORS = 64
 _MAX_VALIDATION_LOCATION_COMPONENTS = 32
 _MAX_VALIDATION_LOCATION_LENGTH = 128
 
+logger = logging.getLogger(__name__)
+
 
 def math_find(
     request: OperationFindRequest,
@@ -58,6 +61,9 @@ def math_find(
 ) -> OperationFindResponse:
     active_catalog = _catalog(ctx)
     if isinstance(request, OperationMatchRequest):
+        # repr keeps caller-controlled line breaks and control characters from
+        # forging additional operator-log entries.
+        logger.info("math.find query=%r", request.need)
         match_response = _operation_match_response(
             active_catalog,
             need=request.need,

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -61,9 +61,13 @@ def math_find(
 ) -> OperationFindResponse:
     active_catalog = _catalog(ctx)
     if isinstance(request, OperationMatchRequest):
-        # repr keeps caller-controlled line breaks and control characters from
-        # forging additional operator-log entries.
-        logger.info("math.find query=%r", request.need)
+        # Log a bounded hash of the need instead of the full caller-supplied
+        # value to avoid persisting sensitive mathematical objects or constraints
+        # in ordinary process logs. The SHA-256 digest is non-reversible and fixed-length.
+        import hashlib
+
+        need_hash = hashlib.sha256(request.need.encode("utf-8")).hexdigest()[:16]
+        logger.info("math.find query_hash=%s", need_hash)
         match_response = _operation_match_response(
             active_catalog,
             need=request.need,

--- a/tests/mcp/test_catalog_isolation.py
+++ b/tests/mcp/test_catalog_isolation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 from types import SimpleNamespace
 from typing import Any, cast
@@ -63,19 +64,20 @@ def test_math_find_inspection_does_not_log_a_query_or_acquire_a_runtime(
     ]
 
 
-def test_math_find_logs_the_match_query_on_one_line(
+def test_math_find_logs_a_hashed_match_query(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     state = AppState(
         operation_catalog=cast(Catalog, _Catalog()),
     )
     context = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=state))
+    need = "find an exact gcd\nwithout logging a run payload"
 
     with caplog.at_level(logging.INFO, logger="jacobian.mcp.tools"):
         math_find(
             OperationMatchRequest(
                 op="match",
-                need="find an exact gcd\nwithout logging a run payload",
+                need=need,
             ),
             ctx=cast(Any, context),
         )
@@ -84,6 +86,10 @@ def test_math_find_logs_the_match_query_on_one_line(
         record for record in caplog.records if record.name == "jacobian.mcp.tools"
     ]
     assert len(records) == 1
-    assert records[0].getMessage() == (
-        "math.find query='find an exact gcd\\nwithout logging a run payload'"
-    )
+    message = records[0].getMessage()
+    query_hash = hashlib.sha256(need.encode("utf-8")).hexdigest()[:16]
+    assert message == f"math.find query_hash={query_hash}"
+    assert need not in message
+    assert "find an exact gcd" not in message
+    assert "query='" not in message
+    assert "\n" not in message

--- a/tests/mcp/test_catalog_isolation.py
+++ b/tests/mcp/test_catalog_isolation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import logging
 from types import SimpleNamespace
 from typing import Any, cast
@@ -9,6 +10,7 @@ import pytest
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationMatchResult
+from jacobian.mcp import tools
 from jacobian.mcp.models import OperationInspectRequest, OperationMatchRequest
 from jacobian.mcp.runtime import AppState
 from jacobian.mcp.tools import math_find
@@ -87,7 +89,9 @@ def test_math_find_logs_a_hashed_match_query(
     ]
     assert len(records) == 1
     message = records[0].getMessage()
-    query_hash = hashlib.sha256(need.encode("utf-8")).hexdigest()[:16]
+    query_hash = hmac.new(
+        tools._FIND_QUERY_LOG_KEY, need.encode("utf-8"), hashlib.sha256
+    ).hexdigest()[:16]
     assert message == f"math.find query_hash={query_hash}"
     assert need not in message
     assert "find an exact gcd" not in message

--- a/tests/mcp/test_catalog_isolation.py
+++ b/tests/mcp/test_catalog_isolation.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from typing import Any, cast
+
+import pytest
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationMatchResult
@@ -38,15 +41,49 @@ def test_math_find_does_not_acquire_an_execution_runtime() -> None:
     assert result.root.kind == "matches"
 
 
-def test_math_find_inspection_does_not_acquire_an_execution_runtime() -> None:
+def test_math_find_inspection_does_not_log_a_query_or_acquire_a_runtime(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     state = AppState(
         operation_catalog=cast(Catalog, _Catalog()),
     )
     context = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=state))
 
-    result = math_find(
-        OperationInspectRequest(op="inspect", operation_id="integer.compute.unknown"),
-        ctx=cast(Any, context),
-    )
+    with caplog.at_level(logging.INFO, logger="jacobian.mcp.tools"):
+        result = math_find(
+            OperationInspectRequest(
+                op="inspect", operation_id="integer.compute.unknown"
+            ),
+            ctx=cast(Any, context),
+        )
 
     assert result.root.kind == "error"
+    assert not [
+        record for record in caplog.records if record.name == "jacobian.mcp.tools"
+    ]
+
+
+def test_math_find_logs_the_match_query_on_one_line(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    state = AppState(
+        operation_catalog=cast(Catalog, _Catalog()),
+    )
+    context = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=state))
+
+    with caplog.at_level(logging.INFO, logger="jacobian.mcp.tools"):
+        math_find(
+            OperationMatchRequest(
+                op="match",
+                need="find an exact gcd\nwithout logging a run payload",
+            ),
+            ctx=cast(Any, context),
+        )
+
+    records = [
+        record for record in caplog.records if record.name == "jacobian.mcp.tools"
+    ]
+    assert len(records) == 1
+    assert records[0].getMessage() == (
+        "math.find query='find an exact gcd\\nwithout logging a run payload'"
+    )


### PR DESCRIPTION
## Problem

Operators can see that an agent called `math.find`, but cannot correlate discovery demand without echoing the mathematical need. No issue exists; this is a bounded operator-observability gap identified from live request logs.

## Outcome

Each admitted `math.find` match request logs a bounded SHA-256 prefix of the validated need at INFO as `math.find query_hash=<16 hex characters>`. The need itself is not written. Inspection requests and `math.run` payloads remain unlogged, and no MCP request/result schema or mathematical behavior changes.

The remote deployment guide documents the hashed event and its correlation semantics.

## Validation

- Commands run:
  - `make handoff-scoped LANE=mcp TESTS=tests/mcp/test_catalog_isolation.py PATHS="src/jacobian/mcp/tools.py tests/mcp/test_catalog_isolation.py"`
  - `make test-mcp` (46 passed)
  - `make docs-linkcheck`
- Final head SHA tested: `41454ea6136cedbe38bf3ed58d10b095716d007b`
- Relevant CI checks or links: pending

## Contract impact

- Public contract impact: none; application-log observability only
- [x] Schema and runtime accept/reject the same requests
- [ ] Cheap malformed or over-budget input is rejected before expensive work — N/A, unchanged
- [ ] Exact results fit the complete canonical output boundary — N/A, unchanged
- [ ] All mandatory phases share one request deadline — N/A, unchanged
- [ ] Native and MCP behavior agree, where both are public — N/A, no mathematical behavior change
- [ ] Producer → serialization → consumer composition was tested — N/A, no value change
- [ ] Defining invariant and adversarial regression are covered — N/A, no mathematical invariant change

## Review closure

- [x] Every substantive review thread has a root-cause fix, regression proof, and reply
- [x] Merge conflicts were resolved against the intended base
- [x] Validation was rerun after the final commit or autofix
- [ ] CI evidence matches the final head SHA — pending
- [x] The appropriate repository validation target and MCP specialist lane are listed above
- [x] Repository conventions were checked: no compatibility or shadow paths were added; no shared abstraction was introduced

## Conditional detail

### Operation boundary

- Changed stage and owner: MCP handler application-log observability in `jacobian.mcp`
- Semantic admission and controlling quantities: unchanged; logging occurs only after typed `OperationMatchRequest` admission and writes a 16-hex SHA-256 prefix of the UTF-8 need
- Execution envelope: unchanged
- Backend or kernel path: unchanged
- Result construction: unchanged
- Independent-result verifier: none
- Native/MCP parity: mathematical results are unchanged; the shared MCP handler emits the same operator log over local and remote transports
- Serialized-result and round-trip evidence: unchanged; the full MCP lane passed

### Canonical value audit

Not applicable; no mathematical request, result, producer, consumer, or canonical value changes.

### Catalog admission

Not applicable; catalog membership and discovery ranking are unchanged.

### Residual scope

None.
