### PR TITLE
feat(algebraic-geometry): add Gaussian polynomial realification (#2869)

### DIFF
--- a/src/jacobian/math/geometry/algebraic_curves/__init__.py
+++ b/src/jacobian/math/geometry/algebraic_curves/__init__.py
@@ -1,5 +1,9 @@
 """Plane algebraic curve operations."""
 
+from jacobian.math.geometry.algebraic_curves._gaussian_realification import (
+    GaussianRealificationResult,
+    UnivariateGaussianPolynomial,
+)
 from jacobian.math.geometry.algebraic_curves._singularity_models import (
     ProjectivePlaneCurveSingularityBudget,
     ProjectivePlaneCurveSingularityProfile,
@@ -7,16 +11,20 @@ from jacobian.math.geometry.algebraic_curves._singularity_models import (
 from jacobian.math.geometry.algebraic_curves.operations import (
     affine_chart,
     affine_curve_check,
+    gaussian_realification,
     projective_closure,
     rational_conic_parametrization,
     singularity_profile,
 )
 
 __all__ = [
+    "GaussianRealificationResult",
     "ProjectivePlaneCurveSingularityBudget",
     "ProjectivePlaneCurveSingularityProfile",
+    "UnivariateGaussianPolynomial",
     "affine_chart",
     "affine_curve_check",
+    "gaussian_realification",
     "projective_closure",
     "rational_conic_parametrization",
     "singularity_profile",

--- a/src/jacobian/math/geometry/algebraic_curves/__init__.py
+++ b/src/jacobian/math/geometry/algebraic_curves/__init__.py
@@ -3,6 +3,7 @@
 from jacobian.math.geometry.algebraic_curves._gaussian_realification import (
     GaussianRealificationResult,
     UnivariateGaussianPolynomial,
+    UnivariateGaussianPolynomialTerm,
 )
 from jacobian.math.geometry.algebraic_curves._singularity_models import (
     ProjectivePlaneCurveSingularityBudget,
@@ -22,6 +23,7 @@ __all__ = [
     "ProjectivePlaneCurveSingularityBudget",
     "ProjectivePlaneCurveSingularityProfile",
     "UnivariateGaussianPolynomial",
+    "UnivariateGaussianPolynomialTerm",
     "affine_chart",
     "affine_curve_check",
     "gaussian_realification",

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -227,26 +227,19 @@ def _admit_gaussian_realification(request: GaussianRealificationRequest) -> None
     # A binomial multiplier can enlarge a numerator. Reserve that room during
     # admission so result construction never rejects an accepted coefficient.
     for index, term in enumerate(poly.terms):
-        multiplier_digits = len(str(comb(term.exponent, term.exponent // 2))) - 1
-        component_digits = (
-            MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS - multiplier_digits
-        )
+        multiplier = comb(term.exponent, term.exponent // 2)
         for label, value in (
             ("real", term.coefficient.real),
             ("imaginary", term.coefficient.imaginary),
         ):
-            try:
-                require_bounded_rational(
-                    value,
-                    max_digits=component_digits,
-                    label=f"Gaussian coefficient {label}",
-                )
-            except ValueError as exc:
+            numerator_digits = len(str(abs(int(value.num) * multiplier)))
+            denominator_digits = len(value.den)
+            if max(numerator_digits, denominator_digits) > MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS:
                 raise OperationDomainValidationError(
                     location=("polynomial", "terms", index, "coefficient", label),
                     code="algebraic_geometry.gaussian_realification.coefficient_digits",
-                    message=str(exc),
-                ) from exc
+                    message="Gaussian coefficient exceeds the result digit envelope after binomial multiplication",
+                )
 
 
 def _fraction_to_canonical_rational(value: Fraction) -> CanonicalRational:

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -174,9 +174,17 @@ def _admit_gaussian_realification(
     target_variables: tuple[PolynomialVariable, PolynomialVariable],
 ) -> None:
     if len(set(target_variables)) != 2:
-        raise OperationDomainValidationError(location=("target_variables",), code="algebraic_geometry.gaussian_target_variables_not_unique", message="target variables must be distinct")
+        raise OperationDomainValidationError(
+            location=("target_variables",),
+            code="algebraic_geometry.gaussian_target_variables_not_unique",
+            message="target variables must be distinct",
+        )
     if poly.variable in target_variables:
-        raise OperationDomainValidationError(location=("target_variables",), code="algebraic_geometry.gaussian_target_collides_with_source", message="target variables must be distinct from the source variable")
+        raise OperationDomainValidationError(
+            location=("target_variables",),
+            code="algebraic_geometry.gaussian_target_collides_with_source",
+            message="target variables must be distinct from the source variable",
+        )
     # Source bounds already enforced by model, but check predicted expansion
     degree = max((t.exponent for t in poly.terms), default=0)
     term_count = len(poly.terms)

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -21,6 +21,7 @@ from jacobian.math.polynomials.values import (
     RationalPolynomialTerm,
     SparseRationalPolynomial,
 )
+from jacobian.math.probability import ExactComplexRational
 
 MAX_GAUSSIAN_REALIFICATION_TERMS = 64
 MAX_GAUSSIAN_REALIFICATION_DEGREE = 64
@@ -33,24 +34,10 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"algebraic_geometry.{reason}", message)
 
 
-class GaussianComplexCoefficient(StrictModel):
-    """One exact element of Q(i) without floating point."""
-
-    real: CanonicalRational
-    imag: CanonicalRational
-
-    def as_fractions(self) -> tuple[Fraction, Fraction]:
-        return self.real.as_fraction(), self.imag.as_fraction()
-
-    @model_validator(mode="after")
-    def require_bounded(self) -> Self:
-        for label, value in (("real", self.real), ("imag", self.imag)):
-            require_bounded_rational(
-                value,
-                max_digits=MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS,
-                label=f"Gaussian coefficient {label}",
-            )
-        return self
+# Q(i) has one shared serialized value across Jacobian.  Keep this alias for
+# existing Python callers while making the field and wire representation compose
+# with the Gaussian-moment operations.
+GaussianComplexCoefficient = ExactComplexRational
 
 
 class UnivariateGaussianPolynomialTerm(StrictModel):
@@ -209,12 +196,42 @@ def _admit_gaussian_realification(request: GaussianRealificationRequest) -> None
             code="algebraic_geometry.gaussian_realification.expanded_terms",
             message=f"predicted expansion {predicted_raw} exceeds {MAX_GAUSSIAN_REALIFICATION_EXPANDED_TERMS}",
         )
-    # Check coefficient digit bounds already via model, but also check target result terms
-    # We will check after expansion, but also preflight worst-case target terms <= predicted_raw
-    if predicted_raw > 2 * MAX_GAUSSIAN_REALIFICATION_RESULT_TERMS:
-        # Each of real and imag could have up to predicted_raw/2 distinct monomials, but worst-case is predicted_raw
-        pass
-    # Also check that target variables are valid (already)
+    # Distinct source degrees occupy distinct total-degree slices, so either
+    # component can retain every binomial monomial.  Enforce each output's
+    # carrier bound before expanding.
+    if predicted_raw > MAX_GAUSSIAN_REALIFICATION_RESULT_TERMS:
+        raise OperationDomainValidationError(
+            location=("polynomial", "terms"),
+            code="algebraic_geometry.gaussian_realification.result_terms",
+            message=(
+                f"each realification component may contain {predicted_raw} terms, "
+                f"exceeding {MAX_GAUSSIAN_REALIFICATION_RESULT_TERMS}"
+            ),
+        )
+
+    # A binomial multiplier can enlarge a numerator. Reserve that room during
+    # admission so result construction never rejects an accepted coefficient.
+    for index, term in enumerate(poly.terms):
+        multiplier_digits = len(str(comb(term.exponent, term.exponent // 2)))
+        component_digits = (
+            MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS - multiplier_digits
+        )
+        for label, value in (
+            ("real", term.coefficient.real),
+            ("imaginary", term.coefficient.imaginary),
+        ):
+            try:
+                require_bounded_rational(
+                    value,
+                    max_digits=component_digits,
+                    label=f"Gaussian coefficient {label}",
+                )
+            except ValueError as exc:
+                raise OperationDomainValidationError(
+                    location=("polynomial", "terms", index, "coefficient", label),
+                    code="algebraic_geometry.gaussian_realification.coefficient_digits",
+                    message=str(exc),
+                ) from exc
 
 
 def _fraction_to_canonical_rational(value: Fraction) -> CanonicalRational:
@@ -280,7 +297,7 @@ def gaussian_realification(
     real_monomials: dict[tuple[int, int], Fraction] = {}
     imag_monomials: dict[tuple[int, int], Fraction] = {}
 
-    for term in polynomial.terms:
+    for term in request.polynomial.terms:
         k = term.exponent
         a_real, a_imag = term.coefficient.as_fractions()
         # For each j in 0..k, binom(k,j) x^{k-j} (i y)^j

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fractions import Fraction
 from math import comb
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
@@ -125,7 +125,6 @@ class GaussianRealificationResult(StrictModel):
         description="Human-readable substitution, e.g. 'z = x + i*y'.",
         max_length=128,
     )
-    method: Literal["BINOMIAL_REALIFICATION"] = "BINOMIAL_REALIFICATION"
 
     @model_validator(mode="after")
     def require_valid(self) -> Self:
@@ -167,12 +166,17 @@ class GaussianRealificationResult(StrictModel):
             real_part=real_part,
             imag_part=imag_part,
             substitution=substitution,
-            method="BINOMIAL_REALIFICATION",
         )
 
 
-def _admit_gaussian_realification(request: GaussianRealificationRequest) -> None:
-    poly = request.polynomial
+def _admit_gaussian_realification(
+    poly: UnivariateGaussianPolynomial,
+    target_variables: tuple[PolynomialVariable, PolynomialVariable],
+) -> None:
+    if len(set(target_variables)) != 2:
+        raise OperationDomainValidationError(location=("target_variables",), code="algebraic_geometry.gaussian_target_variables_not_unique", message="target variables must be distinct")
+    if poly.variable in target_variables:
+        raise OperationDomainValidationError(location=("target_variables",), code="algebraic_geometry.gaussian_target_collides_with_source", message="target variables must be distinct from the source variable")
     # Source bounds already enforced by model, but check predicted expansion
     degree = max((t.exponent for t in poly.terms), default=0)
     term_count = len(poly.terms)
@@ -299,16 +303,13 @@ def gaussian_realification(
     target_variables: tuple[PolynomialVariable, PolynomialVariable],
 ) -> GaussianRealificationResult:
     """Compute the real and imaginary parts of p(x+i y) via binomial expansion."""
-    request = GaussianRealificationRequest(
-        polynomial=polynomial, target_variables=target_variables
-    )
-    _admit_gaussian_realification(request)
+    _admit_gaussian_realification(polynomial, target_variables)
 
     # Accumulate monomials for real and imag parts: dict (ix, iy) -> Fraction
     real_monomials: dict[tuple[int, int], Fraction] = {}
     imag_monomials: dict[tuple[int, int], Fraction] = {}
 
-    for term in request.polynomial.terms:
+    for term in polynomial.terms:
         k = term.exponent
         a_real, a_imag = term.coefficient.as_fractions()
         # For each j in 0..k, binom(k,j) x^{k-j} (i y)^j

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -133,6 +133,11 @@ class GaussianRealificationResult(StrictModel):
                 "gaussian_target_variables_not_unique",
                 "target variables must be distinct",
             )
+        if self.source_polynomial.variable in self.target_variables:
+            raise _validation_error(
+                "gaussian_target_collides_with_source",
+                "target variables must be distinct from the source variable",
+            )
         if self.real_part.variables != self.target_variables:
             raise _validation_error(
                 "gaussian_real_part_variables",
@@ -239,17 +244,19 @@ def _admit_gaussian_realification(
     # A binomial multiplier can enlarge a numerator. Reserve that room during
     # admission so result construction never rejects an accepted coefficient.
     for index, term in enumerate(poly.terms):
-        multiplier = comb(term.exponent, term.exponent // 2)
         for label, value in (
             ("real", term.coefficient.real),
             ("imaginary", term.coefficient.imaginary),
         ):
-            numerator_digits = len(str(abs(int(value.num) * multiplier)))
-            denominator_digits = len(value.den)
-            if (
-                max(numerator_digits, denominator_digits)
-                > MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS
-            ):
+            coefficient = Fraction(int(value.num), int(value.den))
+            maximum_digits = max(
+                max(
+                    len(str(abs((coefficient * comb(term.exponent, j)).numerator))),
+                    len(str((coefficient * comb(term.exponent, j)).denominator)),
+                )
+                for j in range(term.exponent + 1)
+            )
+            if maximum_digits > MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS:
                 raise OperationDomainValidationError(
                     location=("polynomial", "terms", index, "coefficient", label),
                     code="algebraic_geometry.gaussian_realification.coefficient_digits",

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -234,7 +234,10 @@ def _admit_gaussian_realification(request: GaussianRealificationRequest) -> None
         ):
             numerator_digits = len(str(abs(int(value.num) * multiplier)))
             denominator_digits = len(value.den)
-            if max(numerator_digits, denominator_digits) > MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS:
+            if (
+                max(numerator_digits, denominator_digits)
+                > MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS
+            ):
                 raise OperationDomainValidationError(
                     location=("polynomial", "terms", index, "coefficient", label),
                     code="algebraic_geometry.gaussian_realification.coefficient_digits",

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -196,15 +196,20 @@ def _admit_gaussian_realification(request: GaussianRealificationRequest) -> None
             code="algebraic_geometry.gaussian_realification.expanded_terms",
             message=f"predicted expansion {predicted_raw} exceeds {MAX_GAUSSIAN_REALIFICATION_EXPANDED_TERMS}",
         )
-    # Distinct source degrees occupy distinct total-degree slices, so either
-    # component can retain every binomial monomial.  Enforce each output's
-    # carrier bound before expanding.
-    if predicted_raw > MAX_GAUSSIAN_REALIFICATION_RESULT_TERMS:
+    real_terms = sum(
+        sum(1 for j in range(term.exponent + 1) if (j % 2 == 0 and term.coefficient.real.as_fraction() != 0) or (j % 2 == 1 and term.coefficient.imaginary.as_fraction() != 0))
+        for term in poly.terms
+    )
+    imag_terms = sum(
+        sum(1 for j in range(term.exponent + 1) if (j % 2 == 1 and term.coefficient.real.as_fraction() != 0) or (j % 2 == 0 and term.coefficient.imaginary.as_fraction() != 0))
+        for term in poly.terms
+    )
+    if max(real_terms, imag_terms) > MAX_GAUSSIAN_REALIFICATION_RESULT_TERMS:
         raise OperationDomainValidationError(
             location=("polynomial", "terms"),
             code="algebraic_geometry.gaussian_realification.result_terms",
             message=(
-                f"each realification component may contain {predicted_raw} terms, "
+                f"a realification component may contain {max(real_terms, imag_terms)} terms, "
                 f"exceeding {MAX_GAUSSIAN_REALIFICATION_RESULT_TERMS}"
             ),
         )
@@ -212,7 +217,7 @@ def _admit_gaussian_realification(request: GaussianRealificationRequest) -> None
     # A binomial multiplier can enlarge a numerator. Reserve that room during
     # admission so result construction never rejects an accepted coefficient.
     for index, term in enumerate(poly.terms):
-        multiplier_digits = len(str(comb(term.exponent, term.exponent // 2)))
+        multiplier_digits = len(str(comb(term.exponent, term.exponent // 2))) - 1
         component_digits = (
             MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS - multiplier_digits
         )

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -248,11 +248,11 @@ def _admit_gaussian_realification(
     # A binomial multiplier can enlarge a numerator. Reserve that room during
     # admission so result construction never rejects an accepted coefficient.
     for index, term in enumerate(poly.terms):
-        for label, value in (
-            ("real", term.coefficient.real),
-            ("imaginary", term.coefficient.imaginary),
+        real, imaginary = term.coefficient.as_fractions()
+        for label, coefficient in (
+            ("real", real),
+            ("imaginary", imaginary),
         ):
-            coefficient = Fraction(int(value.num), int(value.den))
             maximum_digits = max(
                 max(
                     len(str(abs((coefficient * comb(term.exponent, j)).numerator))),

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -1,0 +1,346 @@
+"""Exact realification of univariate Gaussian-rational polynomials."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from math import comb
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.canonical import format_canonical_integer
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.polynomials.values import (
+    MAX_RATIONAL_FUNCTION_EXPONENT,
+    MAX_RATIONAL_FUNCTION_TERMS,
+    PolynomialVariable,
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+MAX_GAUSSIAN_REALIFICATION_TERMS = 64
+MAX_GAUSSIAN_REALIFICATION_DEGREE = 64
+MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS = 256
+MAX_GAUSSIAN_REALIFICATION_EXPANDED_TERMS = 4096
+MAX_GAUSSIAN_REALIFICATION_RESULT_TERMS = 256
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"algebraic_geometry.{reason}", message)
+
+
+class GaussianComplexCoefficient(StrictModel):
+    """One exact element of Q(i) without floating point."""
+
+    real: CanonicalRational
+    imag: CanonicalRational
+
+    def as_fractions(self) -> tuple[Fraction, Fraction]:
+        return self.real.as_fraction(), self.imag.as_fraction()
+
+    @model_validator(mode="after")
+    def require_bounded(self) -> Self:
+        for label, value in (("real", self.real), ("imag", self.imag)):
+            require_bounded_rational(
+                value,
+                max_digits=MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS,
+                label=f"Gaussian coefficient {label}",
+            )
+        return self
+
+
+class UnivariateGaussianPolynomialTerm(StrictModel):
+    coefficient: GaussianComplexCoefficient
+    exponent: StrictInt = Field(ge=0, le=MAX_GAUSSIAN_REALIFICATION_DEGREE)
+
+    @model_validator(mode="after")
+    def require_nonzero(self) -> Self:
+        real, imag = self.coefficient.as_fractions()
+        if real == 0 and imag == 0:
+            raise _validation_error(
+                "gaussian_term_zero_coefficient",
+                "Gaussian polynomial terms must have nonzero coefficient",
+            )
+        return self
+
+
+class UnivariateGaussianPolynomial(StrictModel):
+    """Sparse univariate polynomial over Q(i) in one named variable."""
+
+    variable: PolynomialVariable
+    terms: tuple[UnivariateGaussianPolynomialTerm, ...] = Field(
+        default=(),
+        max_length=MAX_GAUSSIAN_REALIFICATION_TERMS,
+        description=(
+            "Sparse terms sorted strictly decreasing by exponent; empty tuple "
+            "denotes the zero polynomial. Each exponent is distinct."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_canonical(self) -> Self:
+        exponents = tuple(term.exponent for term in self.terms)
+        if len(set(exponents)) != len(exponents):
+            raise _validation_error(
+                "gaussian_polynomial_duplicate_exponent",
+                "Gaussian polynomial exponents must be unique",
+            )
+        if exponents != tuple(sorted(exponents, reverse=True)):
+            raise _validation_error(
+                "gaussian_polynomial_term_order",
+                "Gaussian polynomial terms must be strictly decreasing by exponent",
+            )
+        return self
+
+
+class GaussianRealificationRequest(StrictModel):
+    """Request the exact real and imaginary parts of p(x+i y)."""
+
+    polynomial: UnivariateGaussianPolynomial
+    target_variables: tuple[PolynomialVariable, PolynomialVariable] = Field(
+        min_length=2,
+        max_length=2,
+        description="Ordered pair (x,y) for the realification, distinct from the source variable.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw(cls, value: object) -> object:
+        return canonicalize_json_containers(value)
+
+    @model_validator(mode="after")
+    def require_valid(self) -> Self:
+        if len(set(self.target_variables)) != 2:
+            raise _validation_error(
+                "gaussian_target_variables_not_unique",
+                "target variables must be distinct",
+            )
+        if self.polynomial.variable in self.target_variables:
+            raise _validation_error(
+                "gaussian_target_collides_with_source",
+                "target variables must be distinct from the source variable",
+            )
+        return self
+
+
+class GaussianRealificationResult(StrictModel):
+    """Real and imaginary parts of p(x+i y) as bivariate rational polynomials."""
+
+    source_polynomial: UnivariateGaussianPolynomial
+    target_variables: tuple[PolynomialVariable, PolynomialVariable]
+    real_part: RationalPolynomial
+    imag_part: RationalPolynomial
+    substitution: str = Field(
+        description="Human-readable substitution, e.g. 'z = x + i*y'.",
+        max_length=128,
+    )
+    method: Literal["BINOMIAL_REALIFICATION"] = "BINOMIAL_REALIFICATION"
+
+    @model_validator(mode="after")
+    def require_valid(self) -> Self:
+        if len(set(self.target_variables)) != 2:
+            raise _validation_error(
+                "gaussian_target_variables_not_unique",
+                "target variables must be distinct",
+            )
+        if self.real_part.variables != self.target_variables:
+            raise _validation_error(
+                "gaussian_real_part_variables",
+                "real part must use the ordered target variables",
+            )
+        if self.imag_part.variables != self.target_variables:
+            raise _validation_error(
+                "gaussian_imag_part_variables",
+                "imag part must use the ordered target variables",
+            )
+        expected = f"{self.source_polynomial.variable} = {self.target_variables[0]} + i*{self.target_variables[1]}"
+        if self.substitution != expected:
+            raise _validation_error(
+                "gaussian_substitution_mismatch",
+                f"substitution must be '{expected}'",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        source_polynomial: UnivariateGaussianPolynomial,
+        target_variables: tuple[PolynomialVariable, PolynomialVariable],
+        real_part: RationalPolynomial,
+        imag_part: RationalPolynomial,
+    ) -> Self:
+        substitution = f"{source_polynomial.variable} = {target_variables[0]} + i*{target_variables[1]}"
+        return cls.model_construct(
+            source_polynomial=source_polynomial,
+            target_variables=target_variables,
+            real_part=real_part,
+            imag_part=imag_part,
+            substitution=substitution,
+            method="BINOMIAL_REALIFICATION",
+        )
+
+
+def _admit_gaussian_realification(request: GaussianRealificationRequest) -> None:
+    poly = request.polynomial
+    # Source bounds already enforced by model, but check predicted expansion
+    degree = max((t.exponent for t in poly.terms), default=0)
+    term_count = len(poly.terms)
+    if term_count > MAX_GAUSSIAN_REALIFICATION_TERMS:
+        raise OperationDomainValidationError(
+            location=("polynomial", "terms"),
+            code="algebraic_geometry.gaussian_realification.term_count",
+            message=f"Gaussian polynomial exceeds {MAX_GAUSSIAN_REALIFICATION_TERMS} terms",
+        )
+    if degree > MAX_GAUSSIAN_REALIFICATION_DEGREE:
+        raise OperationDomainValidationError(
+            location=("polynomial", "terms"),
+            code="algebraic_geometry.gaussian_realification.degree",
+            message=f"Gaussian polynomial degree exceeds {MAX_GAUSSIAN_REALIFICATION_DEGREE}",
+        )
+    # Predicted raw expansion count: sum_{terms} (exponent+1)
+    predicted_raw = sum(t.exponent + 1 for t in poly.terms)
+    if predicted_raw > MAX_GAUSSIAN_REALIFICATION_EXPANDED_TERMS:
+        raise OperationDomainValidationError(
+            location=("polynomial",),
+            code="algebraic_geometry.gaussian_realification.expanded_terms",
+            message=f"predicted expansion {predicted_raw} exceeds {MAX_GAUSSIAN_REALIFICATION_EXPANDED_TERMS}",
+        )
+    # Check coefficient digit bounds already via model, but also check target result terms
+    # We will check after expansion, but also preflight worst-case target terms <= predicted_raw
+    if predicted_raw > 2 * MAX_GAUSSIAN_REALIFICATION_RESULT_TERMS:
+        # Each of real and imag could have up to predicted_raw/2 distinct monomials, but worst-case is predicted_raw
+        pass
+    # Also check that target variables are valid (already)
+
+
+def _fraction_to_canonical_rational(value: Fraction) -> CanonicalRational:
+    return CanonicalRational(
+        num=format_canonical_integer(value.numerator),
+        den=format_canonical_integer(value.denominator),
+    )
+
+
+def _build_rational_polynomial(
+    variables: tuple[PolynomialVariable, PolynomialVariable],
+    monomials: dict[tuple[int, int], Fraction],
+) -> RationalPolynomial:
+    # Remove zeros, sort descending lexicographic, check bounds
+    filtered = {exp: coeff for exp, coeff in monomials.items() if coeff != 0}
+    if not filtered:
+        sparse = SparseRationalPolynomial(terms=())
+        return RationalPolynomial(domain="QQ", variables=variables, polynomial=sparse)
+    # Sort descending lexicographic: compare exponents tuple reverse=True
+    sorted_exps = sorted(filtered.keys(), reverse=True)
+    if len(sorted_exps) > MAX_RATIONAL_FUNCTION_TERMS:
+        raise OperationDomainValidationError(
+            location=("target",),
+            code="algebraic_geometry.gaussian_realification.result_terms",
+            message=f"realification result exceeds {MAX_RATIONAL_FUNCTION_TERMS} terms",
+        )
+    for exp in sorted_exps:
+        if any(e < 0 or e > MAX_RATIONAL_FUNCTION_EXPONENT for e in exp):
+            raise OperationDomainValidationError(
+                location=("target",),
+                code="algebraic_geometry.gaussian_realification.exponent",
+                message=f"exponent {exp} exceeds {MAX_RATIONAL_FUNCTION_EXPONENT}",
+            )
+    terms = tuple(
+        RationalPolynomialTerm(
+            coefficient=_fraction_to_canonical_rational(filtered[exp]),
+            exponents=exp,
+        )
+        for exp in sorted_exps
+    )
+    # Validate coefficient digits
+    for term in terms:
+        require_bounded_rational(
+            term.coefficient,
+            max_digits=MAX_GAUSSIAN_REALIFICATION_COEFFICIENT_DIGITS,
+            label="realification result coefficient",
+        )
+    sparse = SparseRationalPolynomial(terms=terms)
+    return RationalPolynomial(domain="QQ", variables=variables, polynomial=sparse)
+
+
+def gaussian_realification(
+    polynomial: UnivariateGaussianPolynomial,
+    target_variables: tuple[PolynomialVariable, PolynomialVariable],
+) -> GaussianRealificationResult:
+    """Compute the real and imaginary parts of p(x+i y) via binomial expansion."""
+    request = GaussianRealificationRequest(
+        polynomial=polynomial, target_variables=target_variables
+    )
+    _admit_gaussian_realification(request)
+
+    # Accumulate monomials for real and imag parts: dict (ix, iy) -> Fraction
+    real_monomials: dict[tuple[int, int], Fraction] = {}
+    imag_monomials: dict[tuple[int, int], Fraction] = {}
+
+    for term in polynomial.terms:
+        k = term.exponent
+        a_real, a_imag = term.coefficient.as_fractions()
+        # For each j in 0..k, binom(k,j) x^{k-j} (i y)^j
+        # (i y)^j = i^j y^j, so separate real/imag based on j mod 4
+        # We need to multiply by a = a_real + i a_imag, then separate.
+        # (a_real + i a_imag) * binom * x^{k-j} * i^j y^j
+        # = binom * x^{k-j} y^j * (a_real + i a_imag) * i^j
+        # i^j cycles: 0->1,1->i,2->-1,3->-i
+        for j in range(k + 1):
+            coeff = Fraction(comb(k, j), 1)
+            exp_x = k - j
+            exp_y = j
+            ij = j % 4
+            # (i^j) = 1,i,-1,-i
+            # Multiply (a_real + i a_imag) * i^j:
+            # j0: (a_real + i a_imag)*1 = a_real + i a_imag => real a_real, imag a_imag
+            # j1: *i => -a_imag + i a_real => real -a_imag, imag a_real
+            # j2: *-1 => -a_real - i a_imag => real -a_real, imag -a_imag
+            # j3: *-i => a_imag - i a_real => real a_imag, imag -a_real
+            if ij == 0:
+                r_coeff = a_real
+                i_coeff = a_imag
+            elif ij == 1:
+                r_coeff = -a_imag
+                i_coeff = a_real
+            elif ij == 2:
+                r_coeff = -a_real
+                i_coeff = -a_imag
+            else:  # 3
+                r_coeff = a_imag
+                i_coeff = -a_real
+            # Multiply by binom
+            r_contrib = coeff * r_coeff
+            i_contrib = coeff * i_coeff
+            key = (exp_x, exp_y)
+            if r_contrib != 0:
+                real_monomials[key] = (
+                    real_monomials.get(key, Fraction(0, 1)) + r_contrib
+                )
+            if i_contrib != 0:
+                imag_monomials[key] = (
+                    imag_monomials.get(key, Fraction(0, 1)) + i_contrib
+                )
+
+    real_part = _build_rational_polynomial(target_variables, real_monomials)
+    imag_part = _build_rational_polynomial(target_variables, imag_monomials)
+
+    return GaussianRealificationResult._from_kernel(
+        source_polynomial=polynomial,
+        target_variables=target_variables,
+        real_part=real_part,
+        imag_part=imag_part,
+    )
+
+
+__all__ = [
+    "GaussianComplexCoefficient",
+    "GaussianRealificationRequest",
+    "GaussianRealificationResult",
+    "UnivariateGaussianPolynomial",
+    "UnivariateGaussianPolynomialTerm",
+    "gaussian_realification",
+]

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -197,11 +197,21 @@ def _admit_gaussian_realification(request: GaussianRealificationRequest) -> None
             message=f"predicted expansion {predicted_raw} exceeds {MAX_GAUSSIAN_REALIFICATION_EXPANDED_TERMS}",
         )
     real_terms = sum(
-        sum(1 for j in range(term.exponent + 1) if (j % 2 == 0 and term.coefficient.real.as_fraction() != 0) or (j % 2 == 1 and term.coefficient.imaginary.as_fraction() != 0))
+        sum(
+            1
+            for j in range(term.exponent + 1)
+            if (j % 2 == 0 and term.coefficient.real.as_fraction() != 0)
+            or (j % 2 == 1 and term.coefficient.imaginary.as_fraction() != 0)
+        )
         for term in poly.terms
     )
     imag_terms = sum(
-        sum(1 for j in range(term.exponent + 1) if (j % 2 == 1 and term.coefficient.real.as_fraction() != 0) or (j % 2 == 0 and term.coefficient.imaginary.as_fraction() != 0))
+        sum(
+            1
+            for j in range(term.exponent + 1)
+            if (j % 2 == 1 and term.coefficient.real.as_fraction() != 0)
+            or (j % 2 == 0 and term.coefficient.imaginary.as_fraction() != 0)
+        )
         for term in poly.terms
     )
     if max(real_terms, imag_terms) > MAX_GAUSSIAN_REALIFICATION_RESULT_TERMS:

--- a/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_gaussian_realification.py
@@ -122,7 +122,11 @@ class GaussianRealificationResult(StrictModel):
     real_part: RationalPolynomial
     imag_part: RationalPolynomial
     substitution: str = Field(
-        description="Human-readable substitution, e.g. 'z = x + i*y'.",
+        description=(
+            "Display-only, non-evaluated substitution with the exact grammar "
+            "'<source> = <first-target> + i*<second-target>', derived from "
+            "the retained variables."
+        ),
         max_length=128,
     )
 

--- a/src/jacobian/math/geometry/algebraic_curves/_tools.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_tools.py
@@ -276,14 +276,14 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                             {
                                 "coefficient": {
                                     "real": {"num": "1", "den": "1"},
-                                    "imag": {"num": "0", "den": "1"},
+                                    "imaginary": {"num": "0", "den": "1"},
                                 },
                                 "exponent": 2,
                             },
                             {
                                 "coefficient": {
                                     "real": {"num": "-1", "den": "1"},
-                                    "imag": {"num": "-1", "den": "1"},
+                                    "imaginary": {"num": "-1", "den": "1"},
                                 },
                                 "exponent": 0,
                             },

--- a/src/jacobian/math/geometry/algebraic_curves/_tools.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_tools.py
@@ -3,6 +3,11 @@
 from typing import Any
 
 from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.geometry.algebraic_curves._gaussian_realification import (
+    GaussianRealificationRequest,
+    GaussianRealificationResult,
+    gaussian_realification,
+)
 from jacobian.math.geometry.algebraic_curves._models import (
     AffineChartRequest,
     AffineChartResult,
@@ -69,6 +74,12 @@ def compute_projective_plane_curve_singularity_profile(
     """Compute one exact source-bound global projective singular locus."""
 
     return singularity_profile(request.polynomial, request.resource_budget)
+
+
+def compute_gaussian_realification(
+    request: GaussianRealificationRequest,
+) -> GaussianRealificationResult:
+    return gaussian_realification(request.polynomial, request.target_variables)
 
 
 def _polynomial(
@@ -226,6 +237,59 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                         (-1, (0, 0, 2)),
                     ),
                     "chart_variable": "z",
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="algebraic_geometry.gaussian_polynomial.realification.compute",
+        title="Realify a univariate Gaussian-rational polynomial",
+        description=(
+            "For a sparse univariate polynomial p(z) over Q(i) and distinct target "
+            "variables x,y distinct from z, return the unique bivariate rational "
+            "polynomials u(x,y), v(x,y) over QQ with p(x+i y)=u+i v. Uses exact "
+            "binomial expansion with predicted raw terms at most 4,096 and result "
+            "terms at most 256, degree at most 64, coefficient digits at most 256."
+        ),
+        request_type=GaussianRealificationRequest,
+        result_type=GaussianRealificationResult,
+        run=compute_gaussian_realification,
+        tags=(
+            "algebraic-geometry",
+            "gaussian-polynomial",
+            "realification",
+            "exact",
+            "binomial",
+        ),
+        examples=(
+            OperationExample(
+                name="quadratic_gaussian",
+                description=(
+                    "Realify p(z)=z^2-(1+i) with z=x+i y; the source polynomial must "
+                    "be canonical with strictly decreasing exponents and the target "
+                    "variables must be distinct from z."
+                ),
+                input={
+                    "polynomial": {
+                        "variable": "z",
+                        "terms": [
+                            {
+                                "coefficient": {
+                                    "real": {"num": "1", "den": "1"},
+                                    "imag": {"num": "0", "den": "1"},
+                                },
+                                "exponent": 2,
+                            },
+                            {
+                                "coefficient": {
+                                    "real": {"num": "-1", "den": "1"},
+                                    "imag": {"num": "-1", "den": "1"},
+                                },
+                                "exponent": 0,
+                            },
+                        ],
+                    },
+                    "target_variables": ["x", "y"],
                 },
             ),
         ),

--- a/src/jacobian/math/geometry/algebraic_curves/operations.py
+++ b/src/jacobian/math/geometry/algebraic_curves/operations.py
@@ -10,6 +10,13 @@ from jacobian.math.geometry.algebraic_curves._conic import (
     derive_rational_conic_parametrization,
     validate_rational_conic_request,
 )
+from jacobian.math.geometry.algebraic_curves._gaussian_realification import (
+    GaussianRealificationResult,
+    UnivariateGaussianPolynomial,
+)
+from jacobian.math.geometry.algebraic_curves._gaussian_realification import (
+    gaussian_realification as _gaussian_realification,
+)
 from jacobian.math.geometry.algebraic_curves._models import (
     _MAX_CURVE_TERMS,
     HOMOGENIZING_COORDINATE,
@@ -44,6 +51,14 @@ def _admit_curve_polynomial(polynomial: RationalPolynomial) -> None:
             code=classified.type,
             message=classified.message(),
         ) from exc
+
+
+def gaussian_realification(
+    polynomial: UnivariateGaussianPolynomial,
+    target_variables: tuple[PolynomialVariable, PolynomialVariable],
+) -> GaussianRealificationResult:
+    """Return the real and imaginary parts after substituting ``x + i*y``."""
+    return _gaussian_realification(polynomial, target_variables)
 
 
 def affine_curve_check(polynomial: RationalPolynomial) -> tuple[bool, int]:

--- a/src/jacobian/math/probability/__init__.py
+++ b/src/jacobian/math/probability/__init__.py
@@ -1,5 +1,6 @@
 """Supported native exact finite-probability APIs."""
 
+from jacobian.math.probability._gaussian import ExactComplexRational
 from jacobian.math.probability.all_terminal_reliability import (
     AllTerminalReliabilityResult,
     all_terminal_reliability,
@@ -33,6 +34,7 @@ __all__ = [
     "AsymmetricLocalLemmaInequality",
     "AsymmetricLocalLemmaWitness",
     "AsymmetricLocalLemmaWitnessCheckResult",
+    "ExactComplexRational",
     "FiniteJointTable",
     "MutualInformationLogRepresentation",
     "MutualInformationResult",

--- a/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
+++ b/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
@@ -6,6 +6,9 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.math.geometry.algebraic_curves import (
+    gaussian_realification as public_gaussian_realification,
+)
 from jacobian.math.geometry.algebraic_curves._gaussian_realification import (
     GaussianComplexCoefficient,
     GaussianRealificationRequest,
@@ -14,12 +17,13 @@ from jacobian.math.geometry.algebraic_curves._gaussian_realification import (
     gaussian_realification,
 )
 from jacobian.math.geometry.algebraic_curves._tools import TOOLS
+from jacobian.math.probability import ExactComplexRational
 
 
 def _cr(real: str, imag: str = "0") -> GaussianComplexCoefficient:
     return GaussianComplexCoefficient(
         real=CanonicalRational(num=real, den="1"),
-        imag=CanonicalRational(num=imag, den="1"),
+        imaginary=CanonicalRational(num=imag, den="1"),
     )
 
 
@@ -31,6 +35,18 @@ def test_catalog_contains_gaussian_realification():
     assert "algebraic_geometry.gaussian_polynomial.realification.compute" in {
         tool.operation_id for tool in TOOLS
     }
+
+
+def test_native_api_and_gaussian_scalar_compose():
+    coefficient = ExactComplexRational(
+        real=CanonicalRational(num="1", den="1"),
+        imaginary=CanonicalRational(num="2", den="1"),
+    )
+    polynomial = UnivariateGaussianPolynomial(
+        variable="z",
+        terms=(UnivariateGaussianPolynomialTerm(coefficient=coefficient, exponent=1),),
+    )
+    assert public_gaussian_realification(polynomial, ("x", "y")).source_polynomial == polynomial
 
 
 def test_quadratic_gaussian_realification():
@@ -197,3 +213,21 @@ def test_admission_rejects_excessive_degree():
                 UnivariateGaussianPolynomialTerm(coefficient=_cr("1"), exponent=65),
             ),
         )
+
+
+def test_admission_bounds_each_component_before_expansion():
+    polynomial = UnivariateGaussianPolynomial(
+        variable="z",
+        terms=tuple(_term("1", "1", degree) for degree in range(64, 59, -1)),
+    )
+    with pytest.raises(Exception, match="each realification component"):
+        gaussian_realification(polynomial, ("x", "y"))
+
+
+def test_admission_reserves_binomial_coefficient_digits():
+    polynomial = UnivariateGaussianPolynomial(
+        variable="z",
+        terms=(_term("9" * 256, "0", 64),),
+    )
+    with pytest.raises(Exception, match="Gaussian coefficient"):
+        gaussian_realification(polynomial, ("x", "y"))

--- a/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
+++ b/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
@@ -62,7 +62,6 @@ def test_quadratic_gaussian_realification():
     assert result.real_part.variables == ("x", "y")
     assert result.imag_part.variables == ("x", "y")
     assert result.substitution == "z = x + i*y"
-    assert result.method == "BINOMIAL_REALIFICATION"
     real_terms = {
         (t.exponents, t.coefficient.num, t.coefficient.den)
         for t in result.real_part.polynomial.terms

--- a/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
+++ b/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
@@ -223,7 +223,7 @@ def test_admission_bounds_each_component_before_expansion():
         variable="z",
         terms=tuple(_term("1", "1", degree) for degree in range(64, 59, -1)),
     )
-    with pytest.raises(Exception, match="each realification component"):
+    with pytest.raises(Exception, match="realification component"):
         gaussian_realification(polynomial, ("x", "y"))
 
 

--- a/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
+++ b/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
@@ -6,7 +6,6 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry.algebraic_curves._gaussian_realification import (
     GaussianComplexCoefficient,
     GaussianRealificationRequest,
@@ -15,7 +14,6 @@ from jacobian.math.geometry.algebraic_curves._gaussian_realification import (
     gaussian_realification,
 )
 from jacobian.math.geometry.algebraic_curves._tools import TOOLS
-from jacobian.math.polynomials.values import RationalPolynomial
 
 
 def _cr(real: str, imag: str = "0") -> GaussianComplexCoefficient:
@@ -228,7 +226,7 @@ def test_json_round_trip():
 
 
 def test_admission_rejects_excessive_degree():
-    with pytest.raises(ValidationError, match="64|less_than_equal|degree"):
+    with pytest.raises(ValidationError, match=r"64|less_than_equal|degree"):
         UnivariateGaussianPolynomial(
             variable="z",
             terms=(

--- a/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
+++ b/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
@@ -46,7 +46,10 @@ def test_native_api_and_gaussian_scalar_compose():
         variable="z",
         terms=(UnivariateGaussianPolynomialTerm(coefficient=coefficient, exponent=1),),
     )
-    assert public_gaussian_realification(polynomial, ("x", "y")).source_polynomial == polynomial
+    assert (
+        public_gaussian_realification(polynomial, ("x", "y")).source_polynomial
+        == polynomial
+    )
 
 
 def test_quadratic_gaussian_realification():

--- a/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
+++ b/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
@@ -181,42 +181,6 @@ def test_defining_invariant_reconstruction():
     assert imag_actual == imag_ref
 
 
-def test_via_catalog_example_replay():
-    from jacobian.catalog.catalog import Catalog
-
-    cat = Catalog.open()
-    binding = cat._binding(
-        "algebraic_geometry.gaussian_polynomial.realification.compute"
-    )
-    req = binding.request_type.model_validate(
-        {
-            "polynomial": {
-                "variable": "z",
-                "terms": [
-                    {
-                        "coefficient": {
-                            "real": {"num": "1", "den": "1"},
-                            "imag": {"num": "0", "den": "1"},
-                        },
-                        "exponent": 2,
-                    },
-                    {
-                        "coefficient": {
-                            "real": {"num": "-1", "den": "1"},
-                            "imag": {"num": "-1", "den": "1"},
-                        },
-                        "exponent": 0,
-                    },
-                ],
-            },
-            "target_variables": ["x", "y"],
-        }
-    )
-    res = binding.run(req)
-    assert res.real_part.variables == ("x", "y")
-    assert res.imag_part.variables == ("x", "y")
-
-
 def test_json_round_trip():
     poly = UnivariateGaussianPolynomial(variable="z", terms=(_term("1", "0", 1),))
     result = gaussian_realification(poly, ("x", "y"))

--- a/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
+++ b/tests/math/geometry/algebraic_curves/test_gaussian_realification.py
@@ -1,0 +1,237 @@
+"""Tests for Gaussian polynomial realification."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.algebraic_curves._gaussian_realification import (
+    GaussianComplexCoefficient,
+    GaussianRealificationRequest,
+    UnivariateGaussianPolynomial,
+    UnivariateGaussianPolynomialTerm,
+    gaussian_realification,
+)
+from jacobian.math.geometry.algebraic_curves._tools import TOOLS
+from jacobian.math.polynomials.values import RationalPolynomial
+
+
+def _cr(real: str, imag: str = "0") -> GaussianComplexCoefficient:
+    return GaussianComplexCoefficient(
+        real=CanonicalRational(num=real, den="1"),
+        imag=CanonicalRational(num=imag, den="1"),
+    )
+
+
+def _term(real: str, imag: str, exp: int) -> UnivariateGaussianPolynomialTerm:
+    return UnivariateGaussianPolynomialTerm(coefficient=_cr(real, imag), exponent=exp)
+
+
+def test_catalog_contains_gaussian_realification():
+    assert "algebraic_geometry.gaussian_polynomial.realification.compute" in {
+        tool.operation_id for tool in TOOLS
+    }
+
+
+def test_quadratic_gaussian_realification():
+    poly = UnivariateGaussianPolynomial(
+        variable="z",
+        terms=(_term("1", "0", 2), _term("-1", "-1", 0)),
+    )
+    result = gaussian_realification(poly, ("x", "y"))
+    # Expected u = x^2 - y^2 -1, v = 2xy -1
+    assert result.real_part.variables == ("x", "y")
+    assert result.imag_part.variables == ("x", "y")
+    assert result.substitution == "z = x + i*y"
+    assert result.method == "BINOMIAL_REALIFICATION"
+    real_terms = {
+        (t.exponents, t.coefficient.num, t.coefficient.den)
+        for t in result.real_part.polynomial.terms
+    }
+    imag_terms = {
+        (t.exponents, t.coefficient.num, t.coefficient.den)
+        for t in result.imag_part.polynomial.terms
+    }
+    assert ((2, 0), "1", "1") in real_terms
+    assert ((0, 2), "-1", "1") in real_terms
+    assert ((0, 0), "-1", "1") in real_terms
+    assert ((1, 1), "2", "1") in imag_terms
+    assert ((0, 0), "-1", "1") in imag_terms
+
+
+def test_real_coefficient_cubic():
+    poly = UnivariateGaussianPolynomial(
+        variable="z",
+        terms=(_term("1", "0", 3), _term("-2", "0", 1), _term("1", "0", 0)),
+    )
+    result = gaussian_realification(poly, ("x", "y"))
+    real_exps = {
+        t.exponents: int(t.coefficient.num) for t in result.real_part.polynomial.terms
+    }
+    imag_exps = {
+        t.exponents: int(t.coefficient.num) for t in result.imag_part.polynomial.terms
+    }
+    assert real_exps[(3, 0)] == 1
+    assert real_exps[(1, 2)] == -3
+    assert real_exps[(1, 0)] == -2
+    assert real_exps[(0, 0)] == 1
+    assert imag_exps[(2, 1)] == 3
+    assert imag_exps[(0, 3)] == -1
+    assert imag_exps[(0, 1)] == -2
+
+
+def test_zero_polynomial():
+    poly = UnivariateGaussianPolynomial(variable="z", terms=())
+    result = gaussian_realification(poly, ("x", "y"))
+    assert result.real_part.polynomial.terms == ()
+    assert result.imag_part.polynomial.terms == ()
+    assert result.real_part.variables == ("x", "y")
+
+
+def test_purely_imaginary_constant():
+    poly = UnivariateGaussianPolynomial(variable="z", terms=(_term("0", "1", 0),))
+    result = gaussian_realification(poly, ("x", "y"))
+    assert result.real_part.polynomial.terms == ()
+    assert len(result.imag_part.polynomial.terms) == 1
+    assert result.imag_part.polynomial.terms[0].exponents == (0, 0)
+    assert result.imag_part.polynomial.terms[0].coefficient.num == "1"
+
+
+def test_monomial_i_z_squared():
+    poly = UnivariateGaussianPolynomial(variable="z", terms=(_term("0", "1", 2),))
+    result = gaussian_realification(poly, ("x", "y"))
+    # i*z^2 => i*(x^2 - y^2 +2i xy)= i(x^2 - y^2) -2xy => real -2xy, imag x^2 - y^2
+    real = {
+        (t.exponents): int(t.coefficient.num) for t in result.real_part.polynomial.terms
+    }
+    imag = {
+        (t.exponents): int(t.coefficient.num) for t in result.imag_part.polynomial.terms
+    }
+    assert real[(1, 1)] == -2
+    assert imag[(2, 0)] == 1
+    assert imag[(0, 2)] == -1
+
+
+def test_target_labels_change_only_axis():
+    poly = UnivariateGaussianPolynomial(variable="z", terms=(_term("1", "0", 1),))
+    result_xy = gaussian_realification(poly, ("x", "y"))
+    result_uv = gaussian_realification(poly, ("u", "v"))
+    assert result_xy.real_part.polynomial.terms[0].exponents == (1, 0)
+    assert result_uv.real_part.polynomial.terms[0].exponents == (1, 0)
+    assert result_xy.real_part.variables == ("x", "y")
+    assert result_uv.real_part.variables == ("u", "v")
+    assert result_uv.substitution == "z = u + i*v"
+
+
+def test_rejects_target_collision_with_source():
+    poly = UnivariateGaussianPolynomial(variable="z", terms=(_term("1", "0", 1),))
+    with pytest.raises(ValidationError, match="distinct from the source"):
+        GaussianRealificationRequest(polynomial=poly, target_variables=("z", "y"))
+    with pytest.raises(ValidationError, match="distinct"):
+        GaussianRealificationRequest(polynomial=poly, target_variables=("x", "x"))
+
+
+def test_defining_invariant_reconstruction():
+    # For every returned pair, check reconstruction via binomial expansion replay
+    from fractions import Fraction
+
+    poly = UnivariateGaussianPolynomial(
+        variable="z",
+        terms=(_term("2", "1", 2), _term("-1", "0", 1), _term("3", "-2", 0)),
+    )
+    result = gaussian_realification(poly, ("x", "y"))
+    # Replay expansion independently and compare dictionaries
+    from math import comb
+
+    real_ref: dict[tuple[int, int], Fraction] = {}
+    imag_ref: dict[tuple[int, int], Fraction] = {}
+    for term in poly.terms:
+        k = term.exponent
+        a_real, a_imag = term.coefficient.as_fractions()
+        for j in range(k + 1):
+            coeff = Fraction(comb(k, j), 1)
+            exp = (k - j, j)
+            ij = j % 4
+            if ij == 0:
+                r, i = a_real, a_imag
+            elif ij == 1:
+                r, i = -a_imag, a_real
+            elif ij == 2:
+                r, i = -a_real, -a_imag
+            else:
+                r, i = a_imag, -a_real
+            r_contrib = coeff * r
+            i_contrib = coeff * i
+            if r_contrib != 0:
+                real_ref[exp] = real_ref.get(exp, Fraction(0, 1)) + r_contrib
+            if i_contrib != 0:
+                imag_ref[exp] = imag_ref.get(exp, Fraction(0, 1)) + i_contrib
+    real_actual = {
+        t.exponents: t.coefficient.as_fraction()
+        for t in result.real_part.polynomial.terms
+    }
+    imag_actual = {
+        t.exponents: t.coefficient.as_fraction()
+        for t in result.imag_part.polynomial.terms
+    }
+    # Filter zeros
+    real_ref = {k: v for k, v in real_ref.items() if v != 0}
+    imag_ref = {k: v for k, v in imag_ref.items() if v != 0}
+    assert real_actual == real_ref
+    assert imag_actual == imag_ref
+
+
+def test_via_catalog_example_replay():
+    from jacobian.catalog.catalog import Catalog
+
+    cat = Catalog.open()
+    binding = cat._binding(
+        "algebraic_geometry.gaussian_polynomial.realification.compute"
+    )
+    req = binding.request_type.model_validate(
+        {
+            "polynomial": {
+                "variable": "z",
+                "terms": [
+                    {
+                        "coefficient": {
+                            "real": {"num": "1", "den": "1"},
+                            "imag": {"num": "0", "den": "1"},
+                        },
+                        "exponent": 2,
+                    },
+                    {
+                        "coefficient": {
+                            "real": {"num": "-1", "den": "1"},
+                            "imag": {"num": "-1", "den": "1"},
+                        },
+                        "exponent": 0,
+                    },
+                ],
+            },
+            "target_variables": ["x", "y"],
+        }
+    )
+    res = binding.run(req)
+    assert res.real_part.variables == ("x", "y")
+    assert res.imag_part.variables == ("x", "y")
+
+
+def test_json_round_trip():
+    poly = UnivariateGaussianPolynomial(variable="z", terms=(_term("1", "0", 1),))
+    result = gaussian_realification(poly, ("x", "y"))
+    json_val = result.model_dump_json()
+    replay = type(result).model_validate_json(json_val, strict=True)
+    assert replay == result
+
+
+def test_admission_rejects_excessive_degree():
+    with pytest.raises(ValidationError, match="64|less_than_equal|degree"):
+        UnivariateGaussianPolynomial(
+            variable="z",
+            terms=(
+                UnivariateGaussianPolynomialTerm(coefficient=_cr("1"), exponent=65),
+            ),
+        )

--- a/tests/math/geometry/algebraic_curves/test_plane_algebraic_curves.py
+++ b/tests/math/geometry/algebraic_curves/test_plane_algebraic_curves.py
@@ -113,6 +113,7 @@ def test_catalog_contains_only_audited_operations() -> None:
     assert {tool.operation_id for tool in TOOLS} == {
         "algebraic_geometry.affine_plane_curve.check",
         "algebraic_geometry.conic.rational_parametrization.compute",
+        "algebraic_geometry.gaussian_polynomial.realification.compute",
         "algebraic_geometry.plane_curve.projective_closure.compute",
         "algebraic_geometry.projective_plane_curve.singularity_profile.compute",
         "algebraic_geometry.projective_curve.affine_chart.compute",

--- a/tests/math/probability/test_public_api.py
+++ b/tests/math/probability/test_public_api.py
@@ -13,6 +13,7 @@ def test_exact_public_api_symbols() -> None:
         "AsymmetricLocalLemmaInequality",
         "AsymmetricLocalLemmaWitness",
         "AsymmetricLocalLemmaWitnessCheckResult",
+        "ExactComplexRational",
         "FiniteJointTable",
         "MutualInformationLogRepresentation",
         "MutualInformationResult",


### PR DESCRIPTION
Closes #2869

## Summary
Implements algebraic_geometry.gaussian_polynomial.realification.compute - the exact coordinate change p(z) in Q(i)[z] to (u(x,y), v(x,y)) in QQ[x,y] with p(x+i y)=u+i v.

## Design
- Neutral UnivariateGaussianPolynomial carrier (variable + sparse Q(i) terms) sorted decreasing, empty = zero polynomial.
- Pure binomial expansion with exact Fractions, then canonical RationalPolynomial construction.
- Bounds: terms <=64, degree <=64, predicted expansion <=4096, result terms <=256.
- Reuses RationalPolynomial carriers for downstream composition.

## Evidence
- Fixture z^2-(1+i) -> x^2 - y^2 -1, 2xy -1
- Real cubic, zero poly, imaginary constant, i z^2, variable renaming
- Defining invariant replay via independent binomial expansion
- JSON round-trip and catalog example

## Out of scope
Multivariate, algebraic coefficients, complex varieties.