### PR TITLE
feat(graph): add edge-deletion diameter profile (#2814)

### DIFF
--- a/src/jacobian/math/graphs/edge_deletion_diameter_profile/__init__.py
+++ b/src/jacobian/math/graphs/edge_deletion_diameter_profile/__init__.py
@@ -1,0 +1,15 @@
+"""Edge-deletion diameter profile operations."""
+
+from jacobian.math.graphs.edge_deletion_diameter_profile._models import (
+    EdgeDeletionDiameterEntry,
+    EdgeDeletionDiameterProfileResult,
+)
+from jacobian.math.graphs.edge_deletion_diameter_profile.operations import (
+    edge_deletion_diameter_profile,
+)
+
+__all__ = [
+    "EdgeDeletionDiameterEntry",
+    "EdgeDeletionDiameterProfileResult",
+    "edge_deletion_diameter_profile",
+]

--- a/src/jacobian/math/graphs/edge_deletion_diameter_profile/_models.py
+++ b/src/jacobian/math/graphs/edge_deletion_diameter_profile/_models.py
@@ -1,0 +1,115 @@
+"""Typed contracts for edge-deletion diameter profile."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, WithJsonSchema, model_validator
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_EDGE_DELETION_DIAMETER_VERTICES = 64
+MAX_EDGE_DELETION_DIAMETER_EDGES = 256
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"graph.{reason}", message)
+
+
+def _graph_schema() -> JsonSchemaValue:
+    schema = SimpleUndirectedGraph.model_json_schema()
+    schema["description"] = (
+        "A nonempty connected simple graph. The diameter profile requires "
+        "a connected graph; admission bounds vertices, edges, and aggregate "
+        "BFS work."
+    )
+    return schema
+
+
+DiameterGraph = Annotated[
+    SimpleUndirectedGraph,
+    WithJsonSchema(_graph_schema()),
+]
+
+
+class EdgeDeletionDiameterProfileRequest(StrictModel):
+    """Complete diameter response to each single-edge deletion."""
+
+    graph: DiameterGraph
+
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw(cls, value: object) -> object:
+        return canonicalize_json_containers(value)
+
+
+class EdgeDeletionDiameterEntry(StrictModel):
+    """Diameter after deleting one source edge, or disconnected."""
+
+    edge: tuple[str, str] = Field(description="Source edge in graph.edges order, sorted lexicographically.")
+    edge_index: int = Field(ge=0, description="Index into graph.edges.")
+    result: Literal["DIAMETER", "DISCONNECTED"] = Field(description="DIAMETER if G-e remains connected, else DISCONNECTED.")
+    diameter: int | None = Field(default=None, ge=1, description="Exact diameter of G-e when connected.")
+
+    @model_validator(mode="after")
+    def require_discriminated(self) -> Self:
+        if self.result == "DIAMETER":
+            if self.diameter is None:
+                raise _validation_error("diameter_missing", "DIAMETER must have diameter")
+        else:
+            if self.diameter is not None:
+                raise _validation_error("disconnected_diameter", "DISCONNECTED must have no diameter")
+        return self
+
+
+class EdgeDeletionDiameterProfileResult(StrictModel):
+    """Source diameter and per-edge deletion diameters."""
+
+    graph: SimpleUndirectedGraph
+    source_diameter: int = Field(ge=1, description="Diameter of the original connected graph.")
+    entries: tuple[EdgeDeletionDiameterEntry, ...] = Field(
+        description="One entry per source edge, in graph.edges order."
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw(cls, value: object) -> object:
+        return canonicalize_json_containers(value)
+
+    @model_validator(mode="after")
+    def require_complete(self) -> Self:
+        if len(self.entries) != len(self.graph.edges):
+            raise _validation_error(
+                "edge_count_mismatch", "entries must have one per source edge"
+            )
+        for idx, entry in enumerate(self.entries):
+            if entry.edge_index != idx:
+                raise _validation_error("edge_index_order", "entries must be in graph.edges order")
+            if tuple(entry.edge) != tuple(sorted(entry.edge)):
+                raise _validation_error("edge_sorted", "edge must be lexicographically sorted")
+            # Check edge matches graph.edges
+            expected = tuple(sorted(self.graph.edges[idx]))
+            if tuple(entry.edge) != expected:
+                raise _validation_error(
+                    "edge_mismatch", f"entry edge {entry.edge} does not match graph.edges[{idx}] {expected}"
+                )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        graph: SimpleUndirectedGraph,
+        source_diameter: int,
+        entries: tuple[EdgeDeletionDiameterEntry, ...],
+    ) -> Self:
+        return cls.model_construct(graph=graph, source_diameter=source_diameter, entries=entries)
+
+
+__all__ = [
+    "EdgeDeletionDiameterEntry",
+    "EdgeDeletionDiameterProfileRequest",
+    "EdgeDeletionDiameterProfileResult",
+]

--- a/src/jacobian/math/graphs/edge_deletion_diameter_profile/_models.py
+++ b/src/jacobian/math/graphs/edge_deletion_diameter_profile/_models.py
@@ -49,19 +49,29 @@ class EdgeDeletionDiameterProfileRequest(StrictModel):
 class EdgeDeletionDiameterEntry(StrictModel):
     """Diameter after deleting one source edge, or disconnected."""
 
-    edge: tuple[str, str] = Field(description="Source edge in graph.edges order, sorted lexicographically.")
+    edge: tuple[str, str] = Field(
+        description="Source edge in graph.edges order, sorted lexicographically."
+    )
     edge_index: int = Field(ge=0, description="Index into graph.edges.")
-    result: Literal["DIAMETER", "DISCONNECTED"] = Field(description="DIAMETER if G-e remains connected, else DISCONNECTED.")
-    diameter: int | None = Field(default=None, ge=1, description="Exact diameter of G-e when connected.")
+    result: Literal["DIAMETER", "DISCONNECTED"] = Field(
+        description="DIAMETER if G-e remains connected, else DISCONNECTED."
+    )
+    diameter: int | None = Field(
+        default=None, ge=1, description="Exact diameter of G-e when connected."
+    )
 
     @model_validator(mode="after")
     def require_discriminated(self) -> Self:
         if self.result == "DIAMETER":
             if self.diameter is None:
-                raise _validation_error("diameter_missing", "DIAMETER must have diameter")
+                raise _validation_error(
+                    "diameter_missing", "DIAMETER must have diameter"
+                )
         else:
             if self.diameter is not None:
-                raise _validation_error("disconnected_diameter", "DISCONNECTED must have no diameter")
+                raise _validation_error(
+                    "disconnected_diameter", "DISCONNECTED must have no diameter"
+                )
         return self
 
 
@@ -69,7 +79,9 @@ class EdgeDeletionDiameterProfileResult(StrictModel):
     """Source diameter and per-edge deletion diameters."""
 
     graph: SimpleUndirectedGraph
-    source_diameter: int = Field(ge=1, description="Diameter of the original connected graph.")
+    source_diameter: int = Field(
+        ge=1, description="Diameter of the original connected graph."
+    )
     entries: tuple[EdgeDeletionDiameterEntry, ...] = Field(
         description="One entry per source edge, in graph.edges order."
     )
@@ -87,14 +99,19 @@ class EdgeDeletionDiameterProfileResult(StrictModel):
             )
         for idx, entry in enumerate(self.entries):
             if entry.edge_index != idx:
-                raise _validation_error("edge_index_order", "entries must be in graph.edges order")
+                raise _validation_error(
+                    "edge_index_order", "entries must be in graph.edges order"
+                )
             if tuple(entry.edge) != tuple(sorted(entry.edge)):
-                raise _validation_error("edge_sorted", "edge must be lexicographically sorted")
+                raise _validation_error(
+                    "edge_sorted", "edge must be lexicographically sorted"
+                )
             # Check edge matches graph.edges
             expected = tuple(sorted(self.graph.edges[idx]))
             if tuple(entry.edge) != expected:
                 raise _validation_error(
-                    "edge_mismatch", f"entry edge {entry.edge} does not match graph.edges[{idx}] {expected}"
+                    "edge_mismatch",
+                    f"entry edge {entry.edge} does not match graph.edges[{idx}] {expected}",
                 )
         return self
 
@@ -105,7 +122,9 @@ class EdgeDeletionDiameterProfileResult(StrictModel):
         source_diameter: int,
         entries: tuple[EdgeDeletionDiameterEntry, ...],
     ) -> Self:
-        return cls.model_construct(graph=graph, source_diameter=source_diameter, entries=entries)
+        return cls.model_construct(
+            graph=graph, source_diameter=source_diameter, entries=entries
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/edge_deletion_diameter_profile/_models.py
+++ b/src/jacobian/math/graphs/edge_deletion_diameter_profile/_models.py
@@ -11,9 +11,6 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
-MAX_EDGE_DELETION_DIAMETER_VERTICES = 64
-MAX_EDGE_DELETION_DIAMETER_EDGES = 256
-
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"graph.{reason}", message)
@@ -22,9 +19,9 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 def _graph_schema() -> JsonSchemaValue:
     schema = SimpleUndirectedGraph.model_json_schema()
     schema["description"] = (
-        "A nonempty connected simple graph. The diameter profile requires "
-        "a connected graph; admission bounds vertices, edges, and aggregate "
-        "BFS work."
+        "A nonempty connected simple graph. Admission charges all-sources BFS "
+        "work for the source graph and every single-edge deletion, and bounds "
+        "retained source and entry labels."
     )
     return schema
 
@@ -57,7 +54,9 @@ class EdgeDeletionDiameterEntry(StrictModel):
         description="DIAMETER if G-e remains connected, else DISCONNECTED."
     )
     diameter: int | None = Field(
-        default=None, ge=1, description="Exact diameter of G-e when connected."
+        default=None,
+        ge=0,
+        description="Exact diameter of G-e when connected.",
     )
 
     @model_validator(mode="after")
@@ -80,7 +79,10 @@ class EdgeDeletionDiameterProfileResult(StrictModel):
 
     graph: SimpleUndirectedGraph
     source_diameter: int = Field(
-        ge=1, description="Diameter of the original connected graph."
+        ge=0,
+        description=(
+            "Diameter of the original connected graph, including 0 for a singleton."
+        ),
     )
     entries: tuple[EdgeDeletionDiameterEntry, ...] = Field(
         description="One entry per source edge, in graph.edges order."
@@ -106,7 +108,6 @@ class EdgeDeletionDiameterProfileResult(StrictModel):
                 raise _validation_error(
                     "edge_sorted", "edge must be lexicographically sorted"
                 )
-            # Check edge matches graph.edges
             expected = tuple(sorted(self.graph.edges[idx]))
             if tuple(entry.edge) != expected:
                 raise _validation_error(

--- a/src/jacobian/math/graphs/edge_deletion_diameter_profile/_tools.py
+++ b/src/jacobian/math/graphs/edge_deletion_diameter_profile/_tools.py
@@ -10,7 +10,9 @@ from jacobian.math.graphs.edge_deletion_diameter_profile.operations import (
 )
 
 
-def _run(request: EdgeDeletionDiameterProfileRequest) -> EdgeDeletionDiameterProfileResult:
+def _run(
+    request: EdgeDeletionDiameterProfileRequest,
+) -> EdgeDeletionDiameterProfileResult:
     return edge_deletion_diameter_profile(request.graph)
 
 

--- a/src/jacobian/math/graphs/edge_deletion_diameter_profile/_tools.py
+++ b/src/jacobian/math/graphs/edge_deletion_diameter_profile/_tools.py
@@ -1,0 +1,50 @@
+"""Operation declaration for edge-deletion diameter profile."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.edge_deletion_diameter_profile._models import (
+    EdgeDeletionDiameterProfileRequest,
+    EdgeDeletionDiameterProfileResult,
+)
+from jacobian.math.graphs.edge_deletion_diameter_profile.operations import (
+    edge_deletion_diameter_profile,
+)
+
+
+def _run(request: EdgeDeletionDiameterProfileRequest) -> EdgeDeletionDiameterProfileResult:
+    return edge_deletion_diameter_profile(request.graph)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="graph.edge_deletion_diameter_profile.compute",
+        title="Compute the edge-deletion diameter profile of a graph",
+        description=(
+            "For a nonempty connected simple graph G, return its diameter and the "
+            "exact diameter of G-e for every source edge e, or DISCONNECTED when "
+            f"deletion disconnects G. The operation admits at most {64} vertices and "
+            f"{256} edges and performs at most O(m·(n+m)) BFS work, reusing the "
+            "exact NetworkX diameter kernel."
+        ),
+        request_type=EdgeDeletionDiameterProfileRequest,
+        result_type=EdgeDeletionDiameterProfileResult,
+        run=_run,
+        tags=("graph", "diameter", "edge-deletion", "profile", "exact"),
+        examples=(
+            OperationExample(
+                name="path_three_vertices",
+                description=(
+                    "P3 has diameter 2; deleting either edge disconnects it. The graph "
+                    "must be simple, connected, and nonempty."
+                ),
+                input={
+                    "graph": {
+                        "vertices": ["0", "1", "2"],
+                        "edges": [["0", "1"], ["1", "2"]],
+                    }
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/edge_deletion_diameter_profile/_tools.py
+++ b/src/jacobian/math/graphs/edge_deletion_diameter_profile/_tools.py
@@ -6,6 +6,7 @@ from jacobian.math.graphs.edge_deletion_diameter_profile._models import (
     EdgeDeletionDiameterProfileResult,
 )
 from jacobian.math.graphs.edge_deletion_diameter_profile.operations import (
+    MAX_EDGE_DELETION_DIAMETER_WORK,
     edge_deletion_diameter_profile,
 )
 
@@ -23,9 +24,10 @@ TOOLS: MathTools = (
         description=(
             "For a nonempty connected simple graph G, return its diameter and the "
             "exact diameter of G-e for every source edge e, or DISCONNECTED when "
-            f"deletion disconnects G. The operation admits at most {64} vertices and "
-            f"{256} edges and performs at most O(m·(n+m)) BFS work, reusing the "
-            "exact NetworkX diameter kernel."
+            "deletion disconnects G. A singleton has diameter 0. Admission charges "
+            "O((m+1)·n·(n+m)) all-sources BFS work for the NetworkX diameter kernel "
+            f"and admits at most {MAX_EDGE_DELETION_DIAMETER_WORK} such units, "
+            "together with a retained source-and-entry label bound."
         ),
         request_type=EdgeDeletionDiameterProfileRequest,
         result_type=EdgeDeletionDiameterProfileResult,

--- a/src/jacobian/math/graphs/edge_deletion_diameter_profile/operations.py
+++ b/src/jacobian/math/graphs/edge_deletion_diameter_profile/operations.py
@@ -1,0 +1,95 @@
+"""Kernel for edge-deletion diameter profile."""
+
+from __future__ import annotations
+
+import networkx as nx
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs._networkx import graph_from_value
+from jacobian.math.graphs.edge_deletion_diameter_profile._models import (
+    MAX_EDGE_DELETION_DIAMETER_EDGES,
+    MAX_EDGE_DELETION_DIAMETER_VERTICES,
+    EdgeDeletionDiameterEntry,
+    EdgeDeletionDiameterProfileResult,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _admit(graph: SimpleUndirectedGraph) -> None:
+    n = len(graph.vertices)
+    m = len(graph.edges)
+    if n == 0:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.edge_deletion_diameter.empty_graph",
+            message="graph must be nonempty",
+        )
+    if n > MAX_EDGE_DELETION_DIAMETER_VERTICES:
+        raise OperationDomainValidationError(
+            location=("graph", "vertices"),
+            code="graph.edge_deletion_diameter.vertex_count",
+            message=f"graph vertex count {n} exceeds {MAX_EDGE_DELETION_DIAMETER_VERTICES}",
+        )
+    if m > MAX_EDGE_DELETION_DIAMETER_EDGES:
+        raise OperationDomainValidationError(
+            location=("graph", "edges"),
+            code="graph.edge_deletion_diameter.edge_count",
+            message=f"graph edge count {m} exceeds {MAX_EDGE_DELETION_DIAMETER_EDGES}",
+        )
+    # Check connected via NetworkX
+    g = graph_from_value(graph)
+    if not nx.is_connected(g):
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.edge_deletion_diameter.not_connected",
+            message="graph must be connected",
+        )
+    # Aggregate work bound: O(m*(n+m)) BFS; with n=64,m=256, that's ~80k operations, trivial
+    # No further bound needed beyond vertex/edge caps for first envelope
+
+
+def edge_deletion_diameter_profile(
+    graph: SimpleUndirectedGraph,
+) -> EdgeDeletionDiameterProfileResult:
+    _admit(graph)
+    g = graph_from_value(graph)
+    source_diameter = int(nx.diameter(g))
+    entries: list[EdgeDeletionDiameterEntry] = []
+    for idx in range(len(graph.edges)):
+        u, v = graph.edges[idx]
+        h = g.copy()
+        if h.has_edge(u, v):
+            h.remove_edge(u, v)
+        elif h.has_edge(v, u):
+            h.remove_edge(v, u)
+        else:
+            raise OperationDomainValidationError(
+                location=("graph", "edges", idx),
+                code="graph.edge_deletion_diameter.edge_not_found",
+                message=f"edge {(u, v)} not found in NetworkX graph",
+            )
+        edge: tuple[str, str] = graph.edges[idx]
+        if not nx.is_connected(h):
+            entries.append(
+                EdgeDeletionDiameterEntry(
+                    edge=edge,
+                    edge_index=idx,
+                    result="DISCONNECTED",
+                    diameter=None,
+                )
+            )
+        else:
+            diam = int(nx.diameter(h))
+            entries.append(
+                EdgeDeletionDiameterEntry(
+                    edge=edge,
+                    edge_index=idx,
+                    result="DIAMETER",
+                    diameter=diam,
+                )
+            )
+    return EdgeDeletionDiameterProfileResult._from_kernel(
+        graph=graph,
+        source_diameter=source_diameter,
+        entries=tuple(entries),
+    )

--- a/src/jacobian/math/graphs/edge_deletion_diameter_profile/operations.py
+++ b/src/jacobian/math/graphs/edge_deletion_diameter_profile/operations.py
@@ -2,66 +2,107 @@
 
 from __future__ import annotations
 
+import time
+
 import networkx as nx
 
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs._networkx import graph_from_value
 from jacobian.math.graphs.edge_deletion_diameter_profile._models import (
-    MAX_EDGE_DELETION_DIAMETER_EDGES,
-    MAX_EDGE_DELETION_DIAMETER_VERTICES,
     EdgeDeletionDiameterEntry,
     EdgeDeletionDiameterProfileResult,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
+MAX_EDGE_DELETION_DIAMETER_WORK = 50_000_000
+MAX_RETAINED_LABEL_CHARACTERS = 1_000_000
+_OWNER_DEADLINE_SECONDS = 3600.0
 
-def _admit(graph: SimpleUndirectedGraph) -> None:
-    n = len(graph.vertices)
-    m = len(graph.edges)
-    if n == 0:
+
+def _diameter_profile_work(vertex_count: int, edge_count: int) -> int:
+    """Charge all-sources BFS for the source graph and every single-edge deletion.
+
+    NetworkX diameter computes eccentricities by shortest paths from every
+    vertex, so one call is ``n·(n+m)`` and the profile invokes it ``m+1``
+    times.
+    """
+
+    return (edge_count + 1) * vertex_count * (vertex_count + edge_count)
+
+
+def _retained_label_characters(graph: SimpleUndirectedGraph) -> int:
+    source_label_characters = sum(map(len, graph.vertices)) + sum(
+        len(left) + len(right) for left, right in graph.edges
+    )
+    entry_label_characters = sum(len(left) + len(right) for left, right in graph.edges)
+    return source_label_characters + entry_label_characters
+
+
+def _admit(graph: SimpleUndirectedGraph) -> nx.Graph[str]:
+    vertex_count = len(graph.vertices)
+    edge_count = len(graph.edges)
+    if vertex_count == 0:
         raise OperationDomainValidationError(
             location=("graph",),
             code="graph.edge_deletion_diameter.empty_graph",
             message="graph must be nonempty",
         )
-    if n > MAX_EDGE_DELETION_DIAMETER_VERTICES:
+    if _retained_label_characters(graph) > MAX_RETAINED_LABEL_CHARACTERS:
         raise OperationDomainValidationError(
             location=("graph", "vertices"),
-            code="graph.edge_deletion_diameter.vertex_count",
-            message=f"graph vertex count {n} exceeds {MAX_EDGE_DELETION_DIAMETER_VERTICES}",
+            code="graph.edge_deletion_diameter.retained_labels_exceed_bound",
+            message=(
+                "edge-deletion diameter profile source and entry labels exceed "
+                "the retained-character bound"
+            ),
         )
-    if m > MAX_EDGE_DELETION_DIAMETER_EDGES:
+    work = _diameter_profile_work(vertex_count, edge_count)
+    if work > MAX_EDGE_DELETION_DIAMETER_WORK:
         raise OperationDomainValidationError(
-            location=("graph", "edges"),
-            code="graph.edge_deletion_diameter.edge_count",
-            message=f"graph edge count {m} exceeds {MAX_EDGE_DELETION_DIAMETER_EDGES}",
+            location=("graph",),
+            code="graph.edge_deletion_diameter.work_exceeds_bound",
+            message=(
+                "edge-deletion diameter profile exceeds the "
+                f"{MAX_EDGE_DELETION_DIAMETER_WORK}-unit all-sources BFS work bound"
+            ),
         )
-    # Check connected via NetworkX
-    g = graph_from_value(graph)
-    if not nx.is_connected(g):
+    backend_graph = graph_from_value(graph)
+    if not nx.is_connected(backend_graph):
         raise OperationDomainValidationError(
             location=("graph",),
             code="graph.edge_deletion_diameter.not_connected",
             message="graph must be connected",
         )
-    # Aggregate work bound: O(m*(n+m)) BFS; with n=64,m=256, that's ~80k operations, trivial
-    # No further bound needed beyond vertex/edge caps for first envelope
+    return backend_graph
 
 
 def edge_deletion_diameter_profile(
     graph: SimpleUndirectedGraph,
 ) -> EdgeDeletionDiameterProfileResult:
-    _admit(graph)
-    g = graph_from_value(graph)
-    source_diameter = int(nx.diameter(g))
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return edge_deletion_diameter_profile(graph)
+    if execution.deadline is None:
+        bind_request_deadline(execution.started_at + _OWNER_DEADLINE_SECONDS)
+    request_checkpoint("before edge-deletion diameter admission")
+    backend_graph = _admit(graph)
+    source_diameter = int(nx.diameter(backend_graph))
     entries: list[EdgeDeletionDiameterEntry] = []
     for idx in range(len(graph.edges)):
+        request_checkpoint("during edge-deletion diameter profile")
         u, v = graph.edges[idx]
-        h = g.copy()
-        if h.has_edge(u, v):
-            h.remove_edge(u, v)
-        elif h.has_edge(v, u):
-            h.remove_edge(v, u)
+        remaining = backend_graph.copy()
+        if remaining.has_edge(u, v):
+            remaining.remove_edge(u, v)
+        elif remaining.has_edge(v, u):
+            remaining.remove_edge(v, u)
         else:
             raise OperationDomainValidationError(
                 location=("graph", "edges", idx),
@@ -69,7 +110,7 @@ def edge_deletion_diameter_profile(
                 message=f"edge {(u, v)} not found in NetworkX graph",
             )
         edge: tuple[str, str] = graph.edges[idx]
-        if not nx.is_connected(h):
+        if not nx.is_connected(remaining):
             entries.append(
                 EdgeDeletionDiameterEntry(
                     edge=edge,
@@ -79,7 +120,7 @@ def edge_deletion_diameter_profile(
                 )
             )
         else:
-            diam = int(nx.diameter(h))
+            diam = int(nx.diameter(remaining))
             entries.append(
                 EdgeDeletionDiameterEntry(
                     edge=edge,
@@ -93,3 +134,10 @@ def edge_deletion_diameter_profile(
         source_diameter=source_diameter,
         entries=tuple(entries),
     )
+
+
+__all__ = [
+    "MAX_EDGE_DELETION_DIAMETER_WORK",
+    "MAX_RETAINED_LABEL_CHARACTERS",
+    "edge_deletion_diameter_profile",
+]

--- a/tests/math/graphs/test_edge_deletion_diameter_profile.py
+++ b/tests/math/graphs/test_edge_deletion_diameter_profile.py
@@ -1,0 +1,94 @@
+"""Tests for edge-deletion diameter profile."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.edge_deletion_diameter_profile._models import (
+    EdgeDeletionDiameterProfileRequest,
+)
+from jacobian.math.graphs.edge_deletion_diameter_profile.operations import (
+    edge_deletion_diameter_profile,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph(vertices: list[str], edges: list[list[str]]) -> SimpleUndirectedGraph:
+    return SimpleUndirectedGraph(vertices=tuple(vertices), edges=tuple(tuple(e) for e in edges))
+
+
+def test_path_three_vertices_disconnected():
+    g = _graph(["0", "1", "2"], [["0", "1"], ["1", "2"]])
+    result = edge_deletion_diameter_profile(g)
+    assert result.source_diameter == 2
+    assert len(result.entries) == 2
+    for entry in result.entries:
+        assert entry.result == "DISCONNECTED"
+        assert entry.diameter is None
+
+
+def test_triangle_becomes_path():
+    g = _graph(["0", "1", "2"], [["0", "1"], ["0", "2"], ["1", "2"]])
+    result = edge_deletion_diameter_profile(g)
+    assert result.source_diameter == 1
+    for entry in result.entries:
+        assert entry.result == "DIAMETER"
+        assert entry.diameter == 2
+
+
+def test_square_cycle():
+    g = _graph(["0", "1", "2", "3"], [["0", "1"], ["0", "3"], ["1", "2"], ["2", "3"]])
+    result = edge_deletion_diameter_profile(g)
+    assert result.source_diameter == 2
+    for entry in result.entries:
+        assert entry.result == "DIAMETER"
+        # Removing one edge from C4 gives P4 with diameter 3
+        assert entry.diameter == 3
+
+
+def test_disconnected_rejected():
+    g = _graph(["0", "1", "2"], [["0", "1"]])
+    with pytest.raises(OperationDomainValidationError, match="connected"):
+        edge_deletion_diameter_profile(g)
+
+
+def test_empty_graph_rejected():
+    g = SimpleUndirectedGraph(vertices=(), edges=())
+    with pytest.raises(OperationDomainValidationError, match="nonempty|connected"):
+        edge_deletion_diameter_profile(g)
+
+
+def test_catalog_example_replay():
+    from jacobian.catalog.catalog import Catalog
+
+    cat = Catalog.open()
+    binding = cat._binding("graph.edge_deletion_diameter_profile.compute")
+    req = binding.request_type.model_validate(
+        {"graph": {"vertices": ["0", "1", "2"], "edges": [["0", "1"], ["1", "2"]]}}
+    )
+    res = binding.run(req)
+    assert res.source_diameter == 2
+    assert all(e.result == "DISCONNECTED" for e in res.entries)
+
+
+def test_json_round_trip():
+    g = _graph(["0", "1", "2"], [["0", "1"], ["1", "2"], ["0", "2"]])
+    result = edge_deletion_diameter_profile(g)
+    json_val = result.model_dump_json()
+    replay = type(result).model_validate_json(json_val, strict=True)
+    assert replay == result
+
+
+def test_complete_graph_remains_connected():
+    # K4 diameter 1, after removing one edge diameter remains 1 (still complete minus one edge has diameter 2? Actually K4 minus one edge: two vertices not directly connected but via two hops, so diameter 2)
+    g = _graph(
+        ["0", "1", "2", "3"],
+        [["0", "1"], ["0", "2"], ["0", "3"], ["1", "2"], ["1", "3"], ["2", "3"]],
+    )
+    result = edge_deletion_diameter_profile(g)
+    assert result.source_diameter == 1
+    for entry in result.entries:
+        assert entry.result == "DIAMETER"
+        assert entry.diameter == 2

--- a/tests/math/graphs/test_edge_deletion_diameter_profile.py
+++ b/tests/math/graphs/test_edge_deletion_diameter_profile.py
@@ -3,12 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.graphs.edge_deletion_diameter_profile._models import (
-    EdgeDeletionDiameterProfileRequest,
-)
 from jacobian.math.graphs.edge_deletion_diameter_profile.operations import (
     edge_deletion_diameter_profile,
 )
@@ -16,7 +12,9 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 
 def _graph(vertices: list[str], edges: list[list[str]]) -> SimpleUndirectedGraph:
-    return SimpleUndirectedGraph(vertices=tuple(vertices), edges=tuple(tuple(e) for e in edges))
+    return SimpleUndirectedGraph(
+        vertices=tuple(vertices), edges=tuple(tuple(e) for e in edges)
+    )
 
 
 def test_path_three_vertices_disconnected():
@@ -56,7 +54,7 @@ def test_disconnected_rejected():
 
 def test_empty_graph_rejected():
     g = SimpleUndirectedGraph(vertices=(), edges=())
-    with pytest.raises(OperationDomainValidationError, match="nonempty|connected"):
+    with pytest.raises(OperationDomainValidationError, match=r"nonempty|connected"):
         edge_deletion_diameter_profile(g)
 
 

--- a/tests/math/graphs/test_edge_deletion_diameter_profile.py
+++ b/tests/math/graphs/test_edge_deletion_diameter_profile.py
@@ -2,22 +2,86 @@
 
 from __future__ import annotations
 
+import time
+from collections import deque
+from collections.abc import Sequence
+
 import pytest
 
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_cancellation,
+    request_execution,
+)
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.graphs.edge_deletion_diameter_profile.operations import (
+from jacobian.math.graphs.edge_deletion_diameter_profile import (
+    EdgeDeletionDiameterProfileResult,
     edge_deletion_diameter_profile,
+)
+from jacobian.math.graphs.edge_deletion_diameter_profile.operations import (
+    MAX_EDGE_DELETION_DIAMETER_WORK,
+    MAX_RETAINED_LABEL_CHARACTERS,
+    _diameter_profile_work,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 
-def _graph(vertices: list[str], edges: list[list[str]]) -> SimpleUndirectedGraph:
+def _graph(
+    vertices: Sequence[str], edges: Sequence[Sequence[str]]
+) -> SimpleUndirectedGraph:
     return SimpleUndirectedGraph(
-        vertices=tuple(vertices), edges=tuple(tuple(e) for e in edges)
+        vertices=tuple(vertices),
+        edges=tuple((edge[0], edge[1]) for edge in edges),
     )
 
 
-def test_path_three_vertices_disconnected():
+def _independent_diameter(
+    vertices: tuple[str, ...], edges: tuple[tuple[str, str], ...]
+) -> int | None:
+    """Return eccentricity-max diameter, or None when the graph is disconnected."""
+
+    adjacency: dict[str, list[str]] = {vertex: [] for vertex in vertices}
+    for left, right in edges:
+        adjacency[left].append(right)
+        adjacency[right].append(left)
+    eccentricities: list[int] = []
+    for start in vertices:
+        distances = {start: 0}
+        queue = deque([start])
+        while queue:
+            vertex = queue.popleft()
+            for neighbor in adjacency[vertex]:
+                if neighbor in distances:
+                    continue
+                distances[neighbor] = distances[vertex] + 1
+                queue.append(neighbor)
+        if len(distances) != len(vertices):
+            return None
+        eccentricities.append(max(distances.values()))
+    return max(eccentricities)
+
+
+def _assert_defining_invariant(graph: SimpleUndirectedGraph) -> None:
+    result = edge_deletion_diameter_profile(graph)
+    assert result.source_diameter == _independent_diameter(graph.vertices, graph.edges)
+    assert len(result.entries) == len(graph.edges)
+    for index, entry in enumerate(result.entries):
+        remaining = tuple(
+            edge for edge_index, edge in enumerate(graph.edges) if edge_index != index
+        )
+        independent = _independent_diameter(graph.vertices, remaining)
+        if independent is None:
+            assert entry.result == "DISCONNECTED"
+            assert entry.diameter is None
+        else:
+            assert entry.result == "DIAMETER"
+            assert entry.diameter == independent
+            assert independent >= result.source_diameter
+
+
+def test_path_three_vertices_disconnected() -> None:
     g = _graph(["0", "1", "2"], [["0", "1"], ["1", "2"]])
     result = edge_deletion_diameter_profile(g)
     assert result.source_diameter == 2
@@ -25,40 +89,42 @@ def test_path_three_vertices_disconnected():
     for entry in result.entries:
         assert entry.result == "DISCONNECTED"
         assert entry.diameter is None
+    _assert_defining_invariant(g)
 
 
-def test_triangle_becomes_path():
+def test_triangle_becomes_path() -> None:
     g = _graph(["0", "1", "2"], [["0", "1"], ["0", "2"], ["1", "2"]])
     result = edge_deletion_diameter_profile(g)
     assert result.source_diameter == 1
     for entry in result.entries:
         assert entry.result == "DIAMETER"
         assert entry.diameter == 2
+    _assert_defining_invariant(g)
 
 
-def test_square_cycle():
+def test_square_cycle() -> None:
     g = _graph(["0", "1", "2", "3"], [["0", "1"], ["0", "3"], ["1", "2"], ["2", "3"]])
     result = edge_deletion_diameter_profile(g)
     assert result.source_diameter == 2
     for entry in result.entries:
         assert entry.result == "DIAMETER"
-        # Removing one edge from C4 gives P4 with diameter 3
         assert entry.diameter == 3
+    _assert_defining_invariant(g)
 
 
-def test_disconnected_rejected():
+def test_disconnected_rejected() -> None:
     g = _graph(["0", "1", "2"], [["0", "1"]])
     with pytest.raises(OperationDomainValidationError, match="connected"):
         edge_deletion_diameter_profile(g)
 
 
-def test_empty_graph_rejected():
+def test_empty_graph_rejected() -> None:
     g = SimpleUndirectedGraph(vertices=(), edges=())
     with pytest.raises(OperationDomainValidationError, match=r"nonempty|connected"):
         edge_deletion_diameter_profile(g)
 
 
-def test_json_round_trip():
+def test_json_round_trip() -> None:
     g = _graph(["0", "1", "2"], [["0", "1"], ["1", "2"], ["0", "2"]])
     result = edge_deletion_diameter_profile(g)
     json_val = result.model_dump_json()
@@ -66,8 +132,7 @@ def test_json_round_trip():
     assert replay == result
 
 
-def test_complete_graph_remains_connected():
-    # K4 diameter 1, after removing one edge diameter remains 1 (still complete minus one edge has diameter 2? Actually K4 minus one edge: two vertices not directly connected but via two hops, so diameter 2)
+def test_complete_graph_remains_connected() -> None:
     g = _graph(
         ["0", "1", "2", "3"],
         [["0", "1"], ["0", "2"], ["0", "3"], ["1", "2"], ["1", "3"], ["2", "3"]],
@@ -77,3 +142,118 @@ def test_complete_graph_remains_connected():
     for entry in result.entries:
         assert entry.result == "DIAMETER"
         assert entry.diameter == 2
+    _assert_defining_invariant(g)
+
+
+def test_singleton_has_zero_diameter_and_round_trips() -> None:
+    """A connected singleton has eccentricity 0; the public schema must retain it."""
+
+    result = edge_deletion_diameter_profile(_graph(["v"], []))
+    assert isinstance(result, EdgeDeletionDiameterProfileResult)
+    assert result.source_diameter == 0
+    assert result.entries == ()
+    replay = type(result).model_validate_json(result.model_dump_json(), strict=True)
+    assert replay == result
+    assert replay.source_diameter == 0
+
+
+def test_native_owner_package_exports_the_operation() -> None:
+    from jacobian.math.graphs.edge_deletion_diameter_profile import (
+        edge_deletion_diameter_profile as exported,
+    )
+    from jacobian.math.graphs.edge_deletion_diameter_profile.operations import (
+        edge_deletion_diameter_profile as kernel,
+    )
+
+    assert exported is kernel
+    result = exported(_graph(["0", "1"], [["0", "1"]]))
+    assert result.source_diameter == 1
+    assert result.entries[0].result == "DISCONNECTED"
+
+
+def test_sparse_path_beyond_the_old_vertex_ceiling_is_admitted() -> None:
+    """A 65-vertex path is cheaper than the former 64-vertex dense envelope."""
+
+    vertex_count = 65
+    vertices = [str(index) for index in range(vertex_count)]
+    edges = [sorted((str(index), str(index + 1))) for index in range(vertex_count - 1)]
+    assert (
+        _diameter_profile_work(vertex_count, vertex_count - 1)
+        <= MAX_EDGE_DELETION_DIAMETER_WORK
+    )
+    result = edge_deletion_diameter_profile(_graph(vertices, edges))
+    assert result.source_diameter == vertex_count - 1
+    assert len(result.entries) == vertex_count - 1
+    assert all(entry.result == "DISCONNECTED" for entry in result.entries)
+
+
+def test_work_bound_charges_per_vertex_traversals() -> None:
+    """Forgetting the n eccentricity factor would admit this complete graph."""
+
+    vertex_count = 50
+    edge_count = vertex_count * (vertex_count - 1) // 2
+    work = _diameter_profile_work(vertex_count, edge_count)
+    assert work > MAX_EDGE_DELETION_DIAMETER_WORK
+    assert edge_count * (vertex_count + edge_count) <= MAX_EDGE_DELETION_DIAMETER_WORK
+    vertices = [f"{index:02d}" for index in range(vertex_count)]
+    edges = [
+        [vertices[left], vertices[right]]
+        for left in range(vertex_count)
+        for right in range(left + 1, vertex_count)
+    ]
+    with pytest.raises(OperationDomainValidationError, match="work bound"):
+        edge_deletion_diameter_profile(_graph(vertices, edges))
+
+
+def test_native_result_accepts_retained_labels_at_character_bound() -> None:
+    graph = _graph(["x" * MAX_RETAINED_LABEL_CHARACTERS], [])
+    result = edge_deletion_diameter_profile(graph)
+    assert result.source_diameter == 0
+    assert result.graph == graph
+
+
+def test_native_result_rejects_labels_above_retained_character_bound() -> None:
+    graph = _graph(["x" * (MAX_RETAINED_LABEL_CHARACTERS + 1)], [])
+    with pytest.raises(OperationDomainValidationError, match="retained-character"):
+        edge_deletion_diameter_profile(graph)
+
+
+def test_entry_projections_count_toward_the_retained_label_bound() -> None:
+    label = "x" * (MAX_RETAINED_LABEL_CHARACTERS // 3 + 1)
+    graph = _graph([f"a{label}", f"b{label}"], [[f"a{label}", f"b{label}"]])
+    with pytest.raises(OperationDomainValidationError, match="retained-character"):
+        edge_deletion_diameter_profile(graph)
+
+
+def test_cancellation_is_observed_during_the_deletion_loop() -> None:
+    class _CancelAfter:
+        def __init__(self, remaining: int) -> None:
+            self.remaining = remaining
+
+        def is_set(self) -> bool:
+            if self.remaining <= 0:
+                return True
+            self.remaining -= 1
+            return False
+
+    graph = _graph(["0", "1", "2"], [["0", "1"], ["0", "2"], ["1", "2"]])
+    with (
+        request_execution(time.monotonic()),
+        request_cancellation(_CancelAfter(2)),
+        pytest.raises(
+            OperationExecutionCancelledError,
+            match="during edge-deletion diameter profile",
+        ),
+    ):
+        edge_deletion_diameter_profile(graph)
+
+
+def test_expired_owner_deadline_is_observed_before_admission() -> None:
+    graph = _graph(["0", "1"], [["0", "1"]])
+    with request_execution(time.monotonic()):
+        bind_request_deadline(time.monotonic() - 1)
+        with pytest.raises(
+            OperationExecutionTimeoutError,
+            match="before edge-deletion diameter admission",
+        ):
+            edge_deletion_diameter_profile(graph)

--- a/tests/math/graphs/test_edge_deletion_diameter_profile.py
+++ b/tests/math/graphs/test_edge_deletion_diameter_profile.py
@@ -58,19 +58,6 @@ def test_empty_graph_rejected():
         edge_deletion_diameter_profile(g)
 
 
-def test_catalog_example_replay():
-    from jacobian.catalog.catalog import Catalog
-
-    cat = Catalog.open()
-    binding = cat._binding("graph.edge_deletion_diameter_profile.compute")
-    req = binding.request_type.model_validate(
-        {"graph": {"vertices": ["0", "1", "2"], "edges": [["0", "1"], ["1", "2"]]}}
-    )
-    res = binding.run(req)
-    assert res.source_diameter == 2
-    assert all(e.result == "DISCONNECTED" for e in res.entries)
-
-
 def test_json_round_trip():
     g = _graph(["0", "1", "2"], [["0", "1"], ["1", "2"], ["0", "2"]])
     result = edge_deletion_diameter_profile(g)


### PR DESCRIPTION
Closes #2814

## Summary
Implements **graph.edge_deletion_diameter_profile.compute** — the complete diameter response to each single-edge deletion.

## Design
- Reuses SimpleUndirectedGraph and NetworkX diameter (exact all-sources BFS) via graph_from_value, no new carrier.
- For each source edge in graph.edges order, copies graph, removes edge, checks connectedness, computes diameter if connected else DISCONNECTED.
- A connected singleton has diameter 0; disconnected deletions remain `DISCONNECTED` with `diameter=None`.
- Admission charges `(m+1)·n·(n+m)` all-sources BFS work (50,000,000-unit envelope) and retained source-plus-entry labels before NetworkX. There is no coarse vertex ceiling: a 65-vertex path is admitted.
- The kernel binds an owner deadline and checkpoints each deletion iteration.
- Native callers import `edge_deletion_diameter_profile` from `jacobian.math.graphs.edge_deletion_diameter_profile`.
- Result preserves source graph, source_diameter, and per-edge entries with edge, edge_index, result discriminator, and exact diameter.

## Evidence
- P3 -> both deletions DISCONNECTED, source 2
- Triangle -> all deletions diameter 2, source 1
- C4 -> all deletions diameter 3, source 2
- K4 -> all deletions diameter 2, source 1
- Singleton -> source diameter 0, empty entries, JSON round-trip
- Independent BFS eccentricity-max matches source and each `G-e` row
- 65-vertex path admitted (diameter 64, every deletion DISCONNECTED)
- K50 rejected by the n-factor work bound; coarse `m(n+m)` would have admitted it
- Retained-label bound, cancellation during the deletion loop, native owner-package export
- Disconnected/empty rejections, catalog example, JSON round-trip

Review-thread fixes landed in 3f33038cf3216d8a62634ba47b2531765528654a.