### PR TITLE
feat(math): add finite abelian character sum interval profile (#2855)

### DIFF
--- a/src/jacobian/math/groups/_tools.py
+++ b/src/jacobian/math/groups/_tools.py
@@ -65,7 +65,16 @@ def compute_finite_abelian_spectral_pair(
 def compute_finite_abelian_character_sum_interval_profile(
     request: FiniteAbelianCharacterSumIntervalProfileRequest,
 ) -> FiniteAbelianCharacterSumIntervalProfileResult:
-    return native_character_sum_interval_profile(request.source)
+    try:
+        return native_character_sum_interval_profile(request.source)
+    except OperationDomainValidationError:
+        raise
+    except ValueError as exc:
+        raise OperationDomainValidationError(
+            location=("source",),
+            code="finite_abelian_group.character_sum_not_admitted",
+            message=str(exc),
+        ) from exc
 
 
 def compute_group_order(request: PermutationGroup) -> GroupOrderResult:

--- a/src/jacobian/math/groups/_tools.py
+++ b/src/jacobian/math/groups/_tools.py
@@ -27,6 +27,8 @@ from jacobian.math.groups._models import (
     PermutationGroup,
 )
 from jacobian.math.groups.finite_abelian import (
+    FiniteAbelianCharacterSumIntervalProfileRequest,
+    FiniteAbelianCharacterSumIntervalProfileResult,
     FiniteAbelianGroupFactorizationRequest,
     FiniteAbelianGroupFactorizationResult,
     FiniteAbelianProductGroup,
@@ -34,6 +36,9 @@ from jacobian.math.groups.finite_abelian import (
     FiniteAbelianSpectralPairResult,
     decide_finite_abelian_spectral_pair,
     finite_abelian_group_factorization,
+)
+from jacobian.math.groups.finite_abelian import (
+    compute_finite_abelian_character_sum_interval_profile as native_character_sum_interval_profile,
 )
 
 
@@ -55,6 +60,12 @@ def compute_finite_abelian_spectral_pair(
     request: FiniteAbelianSpectralPairRequest,
 ) -> FiniteAbelianSpectralPairResult:
     return decide_finite_abelian_spectral_pair(request.source)
+
+
+def compute_finite_abelian_character_sum_interval_profile(
+    request: FiniteAbelianCharacterSumIntervalProfileRequest,
+) -> FiniteAbelianCharacterSumIntervalProfileResult:
+    return native_character_sum_interval_profile(request.source)
 
 
 def compute_group_order(request: PermutationGroup) -> GroupOrderResult:
@@ -171,6 +182,43 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                         "group": {"moduli": [4]},
                         "points": [[0], [2]],
                         "frequencies": [[0], [1]],
+                    }
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="finite_abelian_group.character_sum_interval_profile.compute",
+        title="Compute exact finite-Abelian character sums on labelled intervals",
+        description="For one explicit finite sequence of elements of a finite product "
+        "of cyclic groups, a duplicate-free frequency set, and a duplicate-free list "
+        "of half-open index intervals [a,b), return every exact character sum "
+        "S(lambda;a,b)=sum_{a<=t<b} chi_lambda(x_t) as a canonical dense remainder "
+        "modulo the group-exponent cyclotomic polynomial. The pairing is the "
+        "positive product dual pairing chi_lambda(a)=exp(2*pi*i*sum lambda_j a_j/m_j). "
+        "The sequence order and repetitions are retained; each frequency-interval "
+        "cell is reduced modulo Phi_N with N=lcm(m_j) and zero is the all-zero remainder.",
+        request_type=FiniteAbelianCharacterSumIntervalProfileRequest,
+        result_type=FiniteAbelianCharacterSumIntervalProfileResult,
+        run=compute_finite_abelian_character_sum_interval_profile,
+        tags=(
+            "harmonic-analysis",
+            "finite-abelian-group",
+            "character-sum",
+            "interval",
+            "cyclotomic",
+            "exact",
+        ),
+        examples=(
+            OperationExample(
+                name="z4_labelled_sequence_two_intervals",
+                description="Exact sums for G=Z/4, labelled sequence (0,1,2,3), frequencies 0 and 1, intervals [0,4) and [1,3); the second interval separates the labelled sums from a set transform.",
+                input={
+                    "source": {
+                        "group": {"moduli": [4]},
+                        "sequence": [[0], [1], [2], [3]],
+                        "frequencies": [[0], [1]],
+                        "intervals": [[0, 4], [1, 3]],
                     }
                 },
             ),

--- a/src/jacobian/math/groups/finite_abelian.py
+++ b/src/jacobian/math/groups/finite_abelian.py
@@ -51,9 +51,10 @@ MAX_SPECTRAL_REMAINDER_COEFFICIENT_DIGITS = (
 ) // 100_000 + 1
 
 MAX_CHARACTER_SUM_SEQUENCE_LENGTH = 4_096
-MAX_CHARACTER_SUM_FREQUENCIES = 256
 MAX_CHARACTER_SUM_INTERVALS = 256
 MAX_CHARACTER_SUM_CELLS = 4_096
+MAX_CHARACTER_SUM_FREQUENCIES = MAX_CHARACTER_SUM_CELLS
+"""A raw-input guard implied by at least one retained interval per frequency."""
 MAX_CHARACTER_SUM_TOTAL_VISITS = 262_144
 MAX_CHARACTER_SUM_CYCLOTOMIC_DEGREE = MAX_SPECTRAL_CYCLOTOMIC_DEGREE
 MAX_CHARACTER_SUM_CYCLOTOMIC_DENSE_OPS = MAX_SPECTRAL_CYCLOTOMIC_DENSE_OPS
@@ -443,20 +444,12 @@ def _spectral_pair_work(source: FiniteAbelianSpectralPairSource) -> _SpectralPai
     itself trivially bounded.
     """
 
-    exponent = 1
-    for modulus in source.group.moduli:
-        exponent = exponent // gcd(exponent, int(modulus)) * int(modulus)
-        dense_ops = 10 * exponent.bit_length() * (exponent + 1) * (exponent + 1)
-        if dense_ops > MAX_CHARACTER_SUM_CYCLOTOMIC_DENSE_OPS:
-            raise ValueError(
-                "character-sum cyclotomic construction work exceeds its dense-op bound"
-            )
     needs_reduction = (
         len(source.points) == len(source.frequencies) and len(source.frequencies) > 1
     )
     if not needs_reduction:
-        work = _SpectralPairWork(
-            group_exponent=exponent,
+        return _SpectralPairWork(
+            group_exponent=1,
             cyclotomic_degree=None,
             character_terms=0,
             cyclotomic_reductions=0,
@@ -465,8 +458,14 @@ def _spectral_pair_work(source: FiniteAbelianSpectralPairSource) -> _SpectralPai
             cyclotomic_intermediate_bits=0,
             remainder_coefficient_bits=0,
         )
-        return work
-
+    exponent = 1
+    for modulus in source.group.moduli:
+        exponent = exponent // gcd(exponent, int(modulus)) * int(modulus)
+        dense_ops = 10 * exponent.bit_length() * (exponent + 1) * (exponent + 1)
+        if dense_ops > MAX_CHARACTER_SUM_CYCLOTOMIC_DENSE_OPS:
+            raise ValueError(
+                "character-sum cyclotomic construction work exceeds its dense-op bound"
+            )
     cyclotomic_dense_ops = 10 * exponent.bit_length() * (exponent + 1) * (exponent + 1)
     cyclotomic_intermediate_bits = 2 * exponent + (exponent + 1).bit_length() + 1
     if cyclotomic_dense_ops > MAX_SPECTRAL_CYCLOTOMIC_DENSE_OPS:
@@ -652,7 +651,7 @@ class FiniteAbelianCharacterSumIntervalProfileSource(StrictModel):
     )
     frequencies: tuple[BoundedGroupElement, ...] = Field(
         min_length=1,
-        max_length=MAX_CHARACTER_SUM_FREQUENCIES,
+        max_length=MAX_CHARACTER_SUM_CELLS,
     )
     intervals: tuple[BoundedCharacterSumInterval, ...] = Field(
         min_length=1,
@@ -899,8 +898,6 @@ def _character_sum_interval_profile_work(
 
     if sequence_length > MAX_CHARACTER_SUM_SEQUENCE_LENGTH:
         raise ValueError("character-sum sequence length exceeds its bound")
-    if frequency_count > MAX_CHARACTER_SUM_FREQUENCIES:
-        raise ValueError("character-sum frequency count exceeds its bound")
     if interval_count > MAX_CHARACTER_SUM_INTERVALS:
         raise ValueError("character-sum interval count exceeds its bound")
 

--- a/src/jacobian/math/groups/finite_abelian.py
+++ b/src/jacobian/math/groups/finite_abelian.py
@@ -50,8 +50,10 @@ MAX_SPECTRAL_REMAINDER_COEFFICIENT_DIGITS = (
     MAX_SPECTRAL_REMAINDER_COEFFICIENT_BITS * 30_103 + 99_999
 ) // 100_000 + 1
 
-MAX_CHARACTER_SUM_SEQUENCE_LENGTH = 4_096
-MAX_CHARACTER_SUM_INTERVALS = 256
+MAX_CHARACTER_SUM_SEQUENCE_LENGTH = 262_144
+"""Raw sequence envelope implied by one admitted frequency and one total visit."""
+MAX_CHARACTER_SUM_INTERVALS = 4_096
+"""Raw interval envelope implied by at least one retained frequency-cell."""
 MAX_CHARACTER_SUM_CELLS = 4_096
 MAX_CHARACTER_SUM_FREQUENCIES = MAX_CHARACTER_SUM_CELLS
 """A raw-input guard implied by at least one retained interval per frequency."""

--- a/src/jacobian/math/groups/finite_abelian.py
+++ b/src/jacobian/math/groups/finite_abelian.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass
 from itertools import product
-from math import comb, lcm, prod
+from math import comb, gcd, lcm, prod
 from time import monotonic
 from typing import TYPE_CHECKING, Annotated, Literal, Self, cast
 
@@ -24,6 +24,7 @@ from jacobian._execution import (
     bind_request_deadline,
     current_request_execution,
     request_checkpoint,
+    request_execution,
 )
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer
@@ -442,7 +443,14 @@ def _spectral_pair_work(source: FiniteAbelianSpectralPairSource) -> _SpectralPai
     itself trivially bounded.
     """
 
-    exponent = source.group.exponent
+    exponent = 1
+    for modulus in source.group.moduli:
+        exponent = exponent // gcd(exponent, int(modulus)) * int(modulus)
+        dense_ops = 10 * exponent.bit_length() * (exponent + 1) * (exponent + 1)
+        if dense_ops > MAX_CHARACTER_SUM_CYCLOTOMIC_DENSE_OPS:
+            raise ValueError(
+                "character-sum cyclotomic construction work exceeds its dense-op bound"
+            )
     needs_reduction = (
         len(source.points) == len(source.frequencies) and len(source.frequencies) > 1
     )
@@ -921,6 +929,8 @@ def _character_sum_interval_profile_work(
         raise ValueError("character-sum frequency-interval cells exceed their bound")
     if cells == 0:
         raise ValueError("character-sum profile requires at least one cell")
+    if cells * rank > MAX_CHARACTER_SUM_PREFIX_WORK:
+        raise ValueError("character-sum result frequency coordinates exceed their bound")
 
     total_interval_length = sum(b - a for a, b in source.intervals)
     total_visits = frequency_count * total_interval_length
@@ -1048,6 +1058,10 @@ def compute_finite_abelian_character_sum_interval_profile(
     source: FiniteAbelianCharacterSumIntervalProfileSource,
 ) -> FiniteAbelianCharacterSumIntervalProfileResult:
     """Return every exact character sum on the requested intervals."""
+
+    if current_request_execution() is None:
+        with request_execution(monotonic()):
+            return compute_finite_abelian_character_sum_interval_profile(source)
 
     _character_sum_execution_deadline()
     try:

--- a/src/jacobian/math/groups/finite_abelian.py
+++ b/src/jacobian/math/groups/finite_abelian.py
@@ -36,6 +36,25 @@ MAX_SPECTRAL_REMAINDER_COEFFICIENT_DIGITS = (
     MAX_SPECTRAL_REMAINDER_COEFFICIENT_BITS * 30_103 + 99_999
 ) // 100_000 + 1
 
+MAX_CHARACTER_SUM_SEQUENCE_LENGTH = 4_096
+MAX_CHARACTER_SUM_FREQUENCIES = 256
+MAX_CHARACTER_SUM_INTERVALS = 256
+MAX_CHARACTER_SUM_CELLS = 4_096
+MAX_CHARACTER_SUM_TOTAL_VISITS = 262_144
+MAX_CHARACTER_SUM_RANK = 16
+MAX_CHARACTER_SUM_CYCLOTOMIC_DEGREE = MAX_SPECTRAL_CYCLOTOMIC_DEGREE
+MAX_CHARACTER_SUM_CYCLOTOMIC_DENSE_OPS = MAX_SPECTRAL_CYCLOTOMIC_DENSE_OPS
+MAX_CHARACTER_SUM_CYCLOTOMIC_COEFFICIENT_BITS = MAX_SPECTRAL_CYCLOTOMIC_COEFFICIENT_BITS
+MAX_CHARACTER_SUM_CYCLOTOMIC_INTERMEDIATE_BITS = (
+    MAX_SPECTRAL_CYCLOTOMIC_INTERMEDIATE_BITS
+)
+MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_BITS = MAX_SPECTRAL_REMAINDER_COEFFICIENT_BITS
+MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_DIGITS = (
+    MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_BITS * 30_103 + 99_999
+) // 100_000 + 1
+MAX_CHARACTER_SUM_RESULT_BYTES = 5 * 1024 * 1024
+MAX_CHARACTER_SUM_PREFIX_WORK = 1_048_576
+
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"finite_abelian_group.{reason}", message)
@@ -585,6 +604,421 @@ def decide_finite_abelian_spectral_pair(
     return FiniteAbelianSpectralPairResult._from_kernel(source, decision)
 
 
+BoundedCharacterSumInterval = tuple[StrictInt, StrictInt]
+CharacterSumInterval = tuple[int, int]
+
+
+class FiniteAbelianCharacterSumIntervalProfileSource(StrictModel):
+    """One labelled sequence in an explicit product of cyclic groups.
+
+    The group, sequence, frequency set, and interval list are each bounded
+    before deriving work: sequence length, frequency count, interval count,
+    their product, total term visits, prefix-table work, cyclotomic degree and
+    construction costs, coefficient growth, and result bytes. The sequence
+    retains order and repetitions and is normalized coordinate-wise modulo the
+    declared moduli; frequencies are reduced modulo the moduli, deduplicated,
+    and sorted lexicographically; intervals are distinct half-open index pairs
+    ``[a, b)`` within the sequence and are sorted lexicographically. This
+    canonicalization retains the labelling order while giving the profile a
+    single source representation.
+    """
+
+    group: FiniteAbelianProductGroup
+    sequence: tuple[BoundedGroupElement, ...] = Field(
+        min_length=1,
+        max_length=MAX_CHARACTER_SUM_SEQUENCE_LENGTH,
+    )
+    frequencies: tuple[BoundedGroupElement, ...] = Field(
+        min_length=1,
+        max_length=MAX_CHARACTER_SUM_FREQUENCIES,
+    )
+    intervals: tuple[BoundedCharacterSumInterval, ...] = Field(
+        min_length=1,
+        max_length=MAX_CHARACTER_SUM_INTERVALS,
+    )
+
+    @model_validator(mode="after")
+    def canonicalize_source(self) -> Self:
+        rank = len(self.group.moduli)
+
+        if any(len(row) != rank for row in self.sequence):
+            raise _validation_error(
+                "sequence_row_rank", "every sequence row must match the group rank"
+            )
+        canonical_sequence: tuple[tuple[int, ...], ...] = tuple(
+            tuple(
+                int(coordinate) % int(modulus)
+                for coordinate, modulus in zip(row, self.group.moduli, strict=True)
+            )
+            for row in self.sequence
+        )
+
+        if any(len(row) != rank for row in self.frequencies):
+            raise _validation_error(
+                "frequency_row_rank", "every frequency row must match the group rank"
+            )
+        normalized_frequencies = tuple(
+            tuple(
+                int(coordinate) % int(modulus)
+                for coordinate, modulus in zip(row, self.group.moduli, strict=True)
+            )
+            for row in self.frequencies
+        )
+        if len(set(normalized_frequencies)) != len(normalized_frequencies):
+            raise _validation_error(
+                "frequency_duplicate_row",
+                "frequency rows must be distinct after residue normalization",
+            )
+        canonical_frequencies = tuple(sorted(normalized_frequencies))
+
+        sequence_length = len(canonical_sequence)
+        if any(len(interval) != 2 for interval in self.intervals):
+            raise _validation_error(
+                "interval_shape", "every interval must be a half-open pair [a, b)"
+            )
+        canonical_intervals: tuple[tuple[int, int], ...] = tuple(
+            (int(a), int(b)) for a, b in self.intervals
+        )
+        if len(set(canonical_intervals)) != len(canonical_intervals):
+            raise _validation_error(
+                "interval_duplicate",
+                "intervals must be distinct",
+            )
+        for a, b in canonical_intervals:
+            if not (0 <= a <= b <= sequence_length):
+                raise _validation_error(
+                    "interval_bounds",
+                    "every interval must satisfy 0 <= a <= b <= len(sequence)",
+                )
+        canonical_intervals = tuple(sorted(canonical_intervals))
+
+        object.__setattr__(self, "sequence", canonical_sequence)
+        object.__setattr__(self, "frequencies", canonical_frequencies)
+        object.__setattr__(self, "intervals", canonical_intervals)
+        return self
+
+
+class FiniteAbelianCharacterSumIntervalProfileRequest(StrictModel):
+    """Compute every exact character sum on requested labelled intervals."""
+
+    source: FiniteAbelianCharacterSumIntervalProfileSource
+
+
+class FiniteAbelianCharacterSumCell(StrictModel):
+    """One exact character sum as a dense cyclotomic remainder.
+
+    ``remainder_coefficients[k]`` is the coefficient of ``X^k`` in the
+    remainder of the interval character-sum polynomial modulo the
+    group-exponent cyclotomic polynomial. The tuple has length ``phi(N)``
+    and is zero exactly for vanishing sums. The fixed pairing is
+    ``chi_lambda(a) = exp(2*pi*i*sum(lambda_j*a_j/m_j))`` with
+    ``N = lcm(m_j)`` and ``chi_lambda(x_t) = zeta_N^{sum (N/m_j) lambda_j x_{t,j}}``.
+    """
+
+    frequency: CanonicalGroupElement = Field(min_length=1)
+    interval: tuple[StrictInt, StrictInt]
+    remainder_coefficients: tuple[BoundedRemainderInteger, ...] = Field(
+        min_length=1,
+        max_length=MAX_CHARACTER_SUM_CYCLOTOMIC_DEGREE,
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_remainder(self) -> Self:
+        if any(
+            len(coefficient.lstrip("-"))
+            > MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_DIGITS
+            for coefficient in self.remainder_coefficients
+        ):
+            raise _validation_error(
+                "remainder_digit_bound",
+                "character-sum cyclotomic remainder coefficient exceeds its digit bound",
+            )
+        return self
+
+
+class FiniteAbelianCharacterSumIntervalProfileResult(StrictModel):
+    """Complete exact character-sum table indexed by frequency and interval.
+
+    For each caller-selected frequency ``lambda`` and half-open index interval
+    ``[a, b)``, the corresponding ``FiniteAbelianCharacterSumCell`` stores the
+    exact cyclotomic remainder of ``S(lambda; a,b)=sum_{a<=t<b} chi_lambda(x_t)``.
+    The table is complete for the Cartesian product of the supplied axes and
+    preserves order (frequencies in lexicographic order, intervals in
+    lexicographic order) and zero values. Every coefficient vector is the
+    remainder of the integer character-sum polynomial modulo ``Phi_N`` with
+    ``N`` the group exponent.
+    """
+
+    source: FiniteAbelianCharacterSumIntervalProfileSource
+    group_exponent: StrictInt = Field(ge=2)
+    cyclotomic_degree: StrictInt = Field(ge=1, le=MAX_CHARACTER_SUM_CYCLOTOMIC_DEGREE)
+    character_convention: Literal["POSITIVE_PRODUCT_DUAL_PAIRING"] = (
+        "POSITIVE_PRODUCT_DUAL_PAIRING"
+    )
+    sums: tuple[FiniteAbelianCharacterSumCell, ...]
+
+    @model_validator(mode="after")
+    def bind_profile(self) -> Self:
+        exponent = self.source.group.exponent
+        if self.group_exponent != exponent:
+            raise _validation_error(
+                "group_exponent_mismatch",
+                "group_exponent must equal the lcm of the source group moduli",
+            )
+        degree = _euler_totient(exponent)
+        if self.cyclotomic_degree != degree:
+            raise _validation_error(
+                "cyclotomic_degree_mismatch",
+                "cyclotomic_degree must be phi(group_exponent)",
+            )
+        expected_cells = len(self.source.frequencies) * len(self.source.intervals)
+        if len(self.sums) != expected_cells:
+            raise _validation_error(
+                "cell_count",
+                "sums must cover the complete frequency-interval product",
+            )
+        if any(len(cell.remainder_coefficients) != degree for cell in self.sums):
+            raise _validation_error(
+                "remainder_length",
+                "every cell remainder must have length phi(group_exponent)",
+            )
+        # Cheap shape checks on source binding; defining invariant (exact
+        # remainder equality with term-by-term accumulator) is established by
+        # the admitted kernel and tested, not replayed here.
+        seen: set[tuple[tuple[int, ...], tuple[int, int]]] = set()
+        expected: list[tuple[tuple[int, ...], tuple[int, int]]] = []
+        for frequency in self.source.frequencies:
+            for interval in self.source.intervals:
+                expected.append((frequency, interval))
+        for cell, (exp_freq, exp_interval) in zip(self.sums, expected, strict=True):
+            if cell.frequency != exp_freq or tuple(cell.interval) != tuple(
+                exp_interval
+            ):
+                raise _validation_error(
+                    "cell_order",
+                    "sums must be ordered frequency-major then interval-minor matching the source",
+                )
+            key = (cell.frequency, tuple(cell.interval))
+            if key in seen:
+                raise _validation_error(
+                    "duplicate_cell",
+                    "profile cells must be unique by frequency and interval",
+                )
+            seen.add(key)  # type: ignore[arg-type]
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        source: FiniteAbelianCharacterSumIntervalProfileSource,
+        sums: tuple[FiniteAbelianCharacterSumCell, ...],
+        *,
+        group_exponent: int,
+        cyclotomic_degree: int,
+    ) -> Self:
+        """Build a result after the admitted kernel established every remainder."""
+
+        return cls.model_construct(
+            source=source,
+            group_exponent=group_exponent,
+            cyclotomic_degree=cyclotomic_degree,
+            character_convention="POSITIVE_PRODUCT_DUAL_PAIRING",
+            sums=sums,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _CharacterSumIntervalProfileWork:
+    group_exponent: int
+    cyclotomic_degree: int
+    cells: int
+    total_visits: int
+    prefix_work: int
+    cyclotomic_dense_ops: int
+    cyclotomic_coefficient_bits: int
+    cyclotomic_intermediate_bits: int
+    remainder_coefficient_bits: int
+    result_bytes_estimate: int
+
+
+def _character_sum_interval_profile_work(
+    source: FiniteAbelianCharacterSumIntervalProfileSource,
+) -> _CharacterSumIntervalProfileWork:
+    """Preflight exact work, intermediate growth, and output obligations.
+
+    The envelope separates representation caps (Pydantic ``max_length`` on
+    sequence, frequencies, intervals) from derived mathematical work:
+    group rank/moduli via the exponent, cyclotomic degree and construction
+    costs, frequency-interval cells, total character-term visits, prefix-table
+    work, coefficient growth after monic reduction, and canonical result bytes.
+    Every check occurs before SymPy is invoked. Budgets are conservative
+    over-approximations matching the spectral-pair construction analysis.
+    """
+
+    sequence_length = len(source.sequence)
+    frequency_count = len(source.frequencies)
+    interval_count = len(source.intervals)
+    rank = len(source.group.moduli)
+
+    if sequence_length > MAX_CHARACTER_SUM_SEQUENCE_LENGTH:
+        raise ValueError("character-sum sequence length exceeds its bound")
+    if frequency_count > MAX_CHARACTER_SUM_FREQUENCIES:
+        raise ValueError("character-sum frequency count exceeds its bound")
+    if interval_count > MAX_CHARACTER_SUM_INTERVALS:
+        raise ValueError("character-sum interval count exceeds its bound")
+    if rank > MAX_CHARACTER_SUM_RANK:
+        raise ValueError("character-sum group rank exceeds its bound")
+
+    exponent = source.group.exponent
+    cyclotomic_dense_ops = 10 * exponent.bit_length() * (exponent + 1) * (exponent + 1)
+    cyclotomic_intermediate_bits = 2 * exponent + (exponent + 1).bit_length() + 1
+    if cyclotomic_dense_ops > MAX_CHARACTER_SUM_CYCLOTOMIC_DENSE_OPS:
+        raise ValueError(
+            "character-sum cyclotomic construction work exceeds its dense-op bound"
+        )
+    if cyclotomic_intermediate_bits > MAX_CHARACTER_SUM_CYCLOTOMIC_INTERMEDIATE_BITS:
+        raise ValueError(
+            "character-sum cyclotomic construction intermediate exceeds its bit bound"
+        )
+
+    degree = _euler_totient(exponent)
+    if degree > MAX_CHARACTER_SUM_CYCLOTOMIC_DEGREE:
+        raise ValueError(
+            "character-sum cyclotomic degree exceeds the exact reduction bound"
+        )
+    if degree > MAX_CHARACTER_SUM_CYCLOTOMIC_COEFFICIENT_BITS - 1:
+        raise ValueError("character-sum cyclotomic coefficient exceeds its bit bound")
+
+    cells = frequency_count * interval_count
+    if cells > MAX_CHARACTER_SUM_CELLS:
+        raise ValueError("character-sum frequency-interval cells exceed their bound")
+    if cells == 0:
+        raise ValueError("character-sum profile requires at least one cell")
+
+    total_interval_length = sum(b - a for a, b in source.intervals)
+    total_visits = frequency_count * total_interval_length
+    if total_visits > MAX_CHARACTER_SUM_TOTAL_VISITS:
+        raise ValueError("character-sum total term visits exceed their bound")
+
+    prefix_work = frequency_count * sequence_length + cells * degree
+    if prefix_work > MAX_CHARACTER_SUM_PREFIX_WORK:
+        raise ValueError("character-sum prefix-table work exceeds its bound")
+
+    max_interval_length = max((b - a for a, b in source.intervals), default=0)
+    remainder_coefficient_bits = max_interval_length.bit_length() + (degree + 1) * (
+        exponent - degree
+    )
+    if remainder_coefficient_bits > MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_BITS:
+        raise ValueError("character-sum remainder intermediate exceeds its bit bound")
+
+    # Conservative result-bytes upper bound: each cell stores phi coefficients each
+    # up to MAX_REMAINDER_DIGITS characters plus JSON overhead, plus frequencies
+    # and intervals. The 64-byte per-cell overhead covers brackets, commas, keys,
+    # and interval/frequency framing.
+    per_cell_digits = degree * (MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_DIGITS + 1)
+    result_bytes_estimate = cells * (per_cell_digits + 64)
+    if result_bytes_estimate > MAX_CHARACTER_SUM_RESULT_BYTES:
+        raise ValueError("character-sum result bytes exceed their bound")
+
+    return _CharacterSumIntervalProfileWork(
+        group_exponent=exponent,
+        cyclotomic_degree=degree,
+        cells=cells,
+        total_visits=total_visits,
+        prefix_work=prefix_work,
+        cyclotomic_dense_ops=cyclotomic_dense_ops,
+        cyclotomic_coefficient_bits=degree + 1,
+        cyclotomic_intermediate_bits=cyclotomic_intermediate_bits,
+        remainder_coefficient_bits=remainder_coefficient_bits,
+        result_bytes_estimate=result_bytes_estimate,
+    )
+
+
+def _finite_abelian_character_sum_interval_profile_data(
+    source: FiniteAbelianCharacterSumIntervalProfileSource,
+) -> tuple[_CharacterSumIntervalProfileWork, tuple[FiniteAbelianCharacterSumCell, ...]]:
+    """Compute all exact interval remainders after admission."""
+
+    work = _character_sum_interval_profile_work(source)
+    degree = work.cyclotomic_degree
+    exponent = work.group_exponent
+
+    from sympy import Poly, Symbol, cyclotomic_poly
+    from sympy.polys.domains import ZZ
+
+    generator = Symbol("_finite_abelian_character")
+    cyclotomic = cast(
+        "Poly",
+        cyclotomic_poly(exponent, generator, polys=True),
+    )
+    if cyclotomic.domain != ZZ or cyclotomic.LC() != 1 or cyclotomic.degree() != degree:
+        raise RuntimeError("SymPy returned an incompatible cyclotomic polynomial")
+
+    # Precompute powers of zeta_N for each frequency across the labelled sequence.
+    # power[t, lambda] = sum_j (N/m_j) * lambda_j * x_{t,j} mod N.
+    moduli = source.group.moduli
+    # Cache N//m_j to avoid repeated division.
+    scale = tuple(exponent // int(modulus) for modulus in moduli)
+    powers_by_frequency: list[list[int]] = []
+    for frequency in source.frequencies:
+        row: list[int] = []
+        for element in source.sequence:
+            power = (
+                sum(
+                    int(s) * int(lam) * int(coord)
+                    for s, lam, coord in zip(scale, frequency, element, strict=True)
+                )
+                % exponent
+            )
+            row.append(power)
+        powers_by_frequency.append(row)
+
+    cells: list[FiniteAbelianCharacterSumCell] = []
+    for freq_index, frequency in enumerate(source.frequencies):
+        powers = powers_by_frequency[freq_index]
+        for a, b in source.intervals:
+            a_int = int(a)
+            b_int = int(b)
+            interval_powers = powers[a_int:b_int]
+            if not interval_powers:
+                coefficients = tuple(format_canonical_integer(0) for _ in range(degree))
+            else:
+                counts: Counter[int] = Counter(interval_powers)
+                polynomial = Poly.from_dict(
+                    {(int(power),): int(coeff) for power, coeff in counts.items()},
+                    generator,
+                    domain=ZZ,
+                )
+                remainder = polynomial.rem(cyclotomic, auto=False)
+                coefficients = tuple(
+                    format_canonical_integer(int(remainder.nth(power)))
+                    for power in range(degree)
+                )
+            cells.append(
+                FiniteAbelianCharacterSumCell(
+                    frequency=frequency,
+                    interval=(a_int, b_int),
+                    remainder_coefficients=coefficients,
+                )
+            )
+
+    return work, tuple(cells)
+
+
+def compute_finite_abelian_character_sum_interval_profile(
+    source: FiniteAbelianCharacterSumIntervalProfileSource,
+) -> FiniteAbelianCharacterSumIntervalProfileResult:
+    """Return every exact character sum on the requested intervals."""
+
+    work, cells = _finite_abelian_character_sum_interval_profile_data(source)
+    return FiniteAbelianCharacterSumIntervalProfileResult._from_kernel(
+        source,
+        cells,
+        group_exponent=work.group_exponent,
+        cyclotomic_degree=work.cyclotomic_degree,
+    )
+
+
 class FiniteAbelianRepresentationCount(StrictModel):
     """Number of group elements having one representation count."""
 
@@ -837,6 +1271,10 @@ def finite_abelian_group_factorization(
 
 
 __all__ = [
+    "FiniteAbelianCharacterSumCell",
+    "FiniteAbelianCharacterSumIntervalProfileRequest",
+    "FiniteAbelianCharacterSumIntervalProfileResult",
+    "FiniteAbelianCharacterSumIntervalProfileSource",
     "FiniteAbelianGroupFactorizationResult",
     "FiniteAbelianNonorthogonalityWitness",
     "FiniteAbelianProductGroup",
@@ -844,6 +1282,7 @@ __all__ = [
     "FiniteAbelianRepresentationWitness",
     "FiniteAbelianSpectralPairResult",
     "FiniteAbelianSpectralPairSource",
+    "compute_finite_abelian_character_sum_interval_profile",
     "decide_finite_abelian_spectral_pair",
     "finite_abelian_group_factorization",
 ]

--- a/src/jacobian/math/groups/finite_abelian.py
+++ b/src/jacobian/math/groups/finite_abelian.py
@@ -52,7 +52,6 @@ MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_BITS = MAX_SPECTRAL_REMAINDER_COEFFICIEN
 MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_DIGITS = (
     MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_BITS * 30_103 + 99_999
 ) // 100_000 + 1
-MAX_CHARACTER_SUM_RESULT_BYTES = 5 * 1024 * 1024
 MAX_CHARACTER_SUM_PREFIX_WORK = 1_048_576
 
 
@@ -838,7 +837,6 @@ class _CharacterSumIntervalProfileWork:
     cyclotomic_coefficient_bits: int
     cyclotomic_intermediate_bits: int
     remainder_coefficient_bits: int
-    result_bytes_estimate: int
 
 
 def _character_sum_interval_profile_work(
@@ -850,7 +848,7 @@ def _character_sum_interval_profile_work(
     sequence, frequencies, intervals) from derived mathematical work:
     group rank/moduli via the exponent, cyclotomic degree and construction
     costs, frequency-interval cells, total character-term visits, prefix-table
-    work, coefficient growth after monic reduction, and canonical result bytes.
+    work, and coefficient growth after monic reduction.
     Every check occurs before SymPy is invoked. Budgets are conservative
     over-approximations matching the spectral-pair construction analysis.
     """
@@ -911,15 +909,6 @@ def _character_sum_interval_profile_work(
     if remainder_coefficient_bits > MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_BITS:
         raise ValueError("character-sum remainder intermediate exceeds its bit bound")
 
-    # Conservative result-bytes upper bound: each cell stores phi coefficients each
-    # up to MAX_REMAINDER_DIGITS characters plus JSON overhead, plus frequencies
-    # and intervals. The 64-byte per-cell overhead covers brackets, commas, keys,
-    # and interval/frequency framing.
-    per_cell_digits = degree * (MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_DIGITS + 1)
-    result_bytes_estimate = cells * (per_cell_digits + 64)
-    if result_bytes_estimate > MAX_CHARACTER_SUM_RESULT_BYTES:
-        raise ValueError("character-sum result bytes exceed their bound")
-
     return _CharacterSumIntervalProfileWork(
         group_exponent=exponent,
         cyclotomic_degree=degree,
@@ -930,7 +919,6 @@ def _character_sum_interval_profile_work(
         cyclotomic_coefficient_bits=degree + 1,
         cyclotomic_intermediate_bits=cyclotomic_intermediate_bits,
         remainder_coefficient_bits=remainder_coefficient_bits,
-        result_bytes_estimate=result_bytes_estimate,
     )
 
 

--- a/src/jacobian/math/groups/finite_abelian.py
+++ b/src/jacobian/math/groups/finite_abelian.py
@@ -930,7 +930,9 @@ def _character_sum_interval_profile_work(
     if cells == 0:
         raise ValueError("character-sum profile requires at least one cell")
     if cells * rank > MAX_CHARACTER_SUM_PREFIX_WORK:
-        raise ValueError("character-sum result frequency coordinates exceed their bound")
+        raise ValueError(
+            "character-sum result frequency coordinates exceed their bound"
+        )
 
     total_interval_length = sum(b - a for a, b in source.intervals)
     total_visits = frequency_count * total_interval_length

--- a/src/jacobian/math/groups/finite_abelian.py
+++ b/src/jacobian/math/groups/finite_abelian.py
@@ -6,12 +6,25 @@ from collections import Counter
 from dataclasses import dataclass
 from itertools import product
 from math import comb, lcm, prod
+from time import monotonic
 from typing import TYPE_CHECKING, Annotated, Literal, Self, cast
 
-from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
+from pydantic import (
+    Field,
+    StrictBool,
+    StrictInt,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+)
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
@@ -41,7 +54,6 @@ MAX_CHARACTER_SUM_FREQUENCIES = 256
 MAX_CHARACTER_SUM_INTERVALS = 256
 MAX_CHARACTER_SUM_CELLS = 4_096
 MAX_CHARACTER_SUM_TOTAL_VISITS = 262_144
-MAX_CHARACTER_SUM_RANK = 16
 MAX_CHARACTER_SUM_CYCLOTOMIC_DEGREE = MAX_SPECTRAL_CYCLOTOMIC_DEGREE
 MAX_CHARACTER_SUM_CYCLOTOMIC_DENSE_OPS = MAX_SPECTRAL_CYCLOTOMIC_DENSE_OPS
 MAX_CHARACTER_SUM_CYCLOTOMIC_COEFFICIENT_BITS = MAX_SPECTRAL_CYCLOTOMIC_COEFFICIENT_BITS
@@ -53,6 +65,7 @@ MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_DIGITS = (
     MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_BITS * 30_103 + 99_999
 ) // 100_000 + 1
 MAX_CHARACTER_SUM_PREFIX_WORK = 1_048_576
+CHARACTER_SUM_INTERVAL_PROFILE_WALL_SECONDS = 600.0
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -612,11 +625,13 @@ class FiniteAbelianCharacterSumIntervalProfileSource(StrictModel):
 
     The group, sequence, frequency set, and interval list are each bounded
     before deriving work: sequence length, frequency count, interval count,
-    their product, total term visits, prefix-table work, cyclotomic degree and
-    construction costs, coefficient growth, and result bytes. The sequence
-    retains order and repetitions and is normalized coordinate-wise modulo the
-    declared moduli; frequencies are reduced modulo the moduli, deduplicated,
-    and sorted lexicographically; intervals are distinct half-open index pairs
+    their product, total term visits, prefix-table and rank-linear
+    dot-product work, retained source coordinates, cyclotomic degree and
+    construction costs, and coefficient growth. Rank has no fixed ceiling;
+    it enters those derived budgets linearly. The sequence retains order and
+    repetitions and is normalized coordinate-wise modulo the declared moduli;
+    frequencies are reduced modulo the moduli, deduplicated, and sorted
+    lexicographically; intervals are distinct half-open index pairs
     ``[a, b)`` within the sequence and are sorted lexicographically. This
     canonicalization retains the labelling order while giving the profile a
     single source representation.
@@ -754,7 +769,20 @@ class FiniteAbelianCharacterSumIntervalProfileResult(StrictModel):
     character_convention: Literal["POSITIVE_PRODUCT_DUAL_PAIRING"] = (
         "POSITIVE_PRODUCT_DUAL_PAIRING"
     )
-    sums: tuple[FiniteAbelianCharacterSumCell, ...]
+    sums: tuple[FiniteAbelianCharacterSumCell, ...] = Field(
+        min_length=1,
+        max_length=MAX_CHARACTER_SUM_CELLS,
+    )
+
+    @field_validator("sums", mode="before")
+    @classmethod
+    def bound_raw_cells(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)) and len(value) > MAX_CHARACTER_SUM_CELLS:
+            raise _validation_error(
+                "cell_count_bound",
+                "character-sum profile has at most 4,096 cells",
+            )
+        return tuple(value) if isinstance(value, list) else value
 
     @model_validator(mode="after")
     def bind_profile(self) -> Self:
@@ -764,11 +792,13 @@ class FiniteAbelianCharacterSumIntervalProfileResult(StrictModel):
                 "group_exponent_mismatch",
                 "group_exponent must equal the lcm of the source group moduli",
             )
-        degree = _euler_totient(exponent)
-        if self.cyclotomic_degree != degree:
+        # Bind the kernel-declared degree structurally. Totient factorization
+        # belongs to admission, not result parsing of untrusted payloads.
+        degree = self.cyclotomic_degree
+        if degree >= exponent:
             raise _validation_error(
-                "cyclotomic_degree_mismatch",
-                "cyclotomic_degree must be phi(group_exponent)",
+                "cyclotomic_degree_bound",
+                "cyclotomic_degree must be strictly less than group_exponent",
             )
         expected_cells = len(self.source.frequencies) * len(self.source.intervals)
         if len(self.sums) != expected_cells:
@@ -779,7 +809,7 @@ class FiniteAbelianCharacterSumIntervalProfileResult(StrictModel):
         if any(len(cell.remainder_coefficients) != degree for cell in self.sums):
             raise _validation_error(
                 "remainder_length",
-                "every cell remainder must have length phi(group_exponent)",
+                "every cell remainder must have length cyclotomic_degree",
             )
         # Cheap shape checks on source binding; defining invariant (exact
         # remainder equality with term-by-term accumulator) is established by
@@ -846,11 +876,12 @@ def _character_sum_interval_profile_work(
 
     The envelope separates representation caps (Pydantic ``max_length`` on
     sequence, frequencies, intervals) from derived mathematical work:
-    group rank/moduli via the exponent, cyclotomic degree and construction
-    costs, frequency-interval cells, total character-term visits, prefix-table
-    work, and coefficient growth after monic reduction.
-    Every check occurs before SymPy is invoked. Budgets are conservative
-    over-approximations matching the spectral-pair construction analysis.
+    cyclotomic degree and construction costs, frequency-interval cells, total
+    character-term visits, rank-linear dot-product and retained-source work,
+    prefix-table assembly, and coefficient growth after monic reduction.
+    Rank has no fixed ceiling. Every check occurs before SymPy is invoked.
+    Budgets are conservative over-approximations matching the spectral-pair
+    construction analysis.
     """
 
     sequence_length = len(source.sequence)
@@ -864,8 +895,6 @@ def _character_sum_interval_profile_work(
         raise ValueError("character-sum frequency count exceeds its bound")
     if interval_count > MAX_CHARACTER_SUM_INTERVALS:
         raise ValueError("character-sum interval count exceeds its bound")
-    if rank > MAX_CHARACTER_SUM_RANK:
-        raise ValueError("character-sum group rank exceeds its bound")
 
     exponent = source.group.exponent
     cyclotomic_dense_ops = 10 * exponent.bit_length() * (exponent + 1) * (exponent + 1)
@@ -898,7 +927,10 @@ def _character_sum_interval_profile_work(
     if total_visits > MAX_CHARACTER_SUM_TOTAL_VISITS:
         raise ValueError("character-sum total term visits exceed their bound")
 
-    prefix_work = frequency_count * sequence_length + cells * degree
+    retained_source_work = rank * (sequence_length + frequency_count)
+    if retained_source_work > MAX_CHARACTER_SUM_PREFIX_WORK:
+        raise ValueError("character-sum retained source coordinates exceed their bound")
+    prefix_work = frequency_count * sequence_length * rank + cells * degree
     if prefix_work > MAX_CHARACTER_SUM_PREFIX_WORK:
         raise ValueError("character-sum prefix-table work exceeds its bound")
 
@@ -922,12 +954,29 @@ def _character_sum_interval_profile_work(
     )
 
 
+def _character_sum_execution_deadline() -> float:
+    """Bind one owner deadline measured from the original request start."""
+
+    execution = current_request_execution()
+    started_at = execution.started_at if execution is not None else monotonic()
+    owner_deadline = started_at + CHARACTER_SUM_INTERVAL_PROFILE_WALL_SECONDS
+    deadline = (
+        min(owner_deadline, execution.deadline)
+        if execution is not None and execution.deadline is not None
+        else owner_deadline
+    )
+    bind_request_deadline(deadline)
+    return deadline
+
+
 def _finite_abelian_character_sum_interval_profile_data(
     source: FiniteAbelianCharacterSumIntervalProfileSource,
 ) -> tuple[_CharacterSumIntervalProfileWork, tuple[FiniteAbelianCharacterSumCell, ...]]:
     """Compute all exact interval remainders after admission."""
 
+    request_checkpoint("before character-sum admission")
     work = _character_sum_interval_profile_work(source)
+    request_checkpoint("after character-sum admission")
     degree = work.cyclotomic_degree
     exponent = work.group_exponent
 
@@ -949,6 +998,7 @@ def _finite_abelian_character_sum_interval_profile_data(
     scale = tuple(exponent // int(modulus) for modulus in moduli)
     powers_by_frequency: list[list[int]] = []
     for frequency in source.frequencies:
+        request_checkpoint("character-sum frequency powers")
         row: list[int] = []
         for element in source.sequence:
             power = (
@@ -965,6 +1015,7 @@ def _finite_abelian_character_sum_interval_profile_data(
     for freq_index, frequency in enumerate(source.frequencies):
         powers = powers_by_frequency[freq_index]
         for a, b in source.intervals:
+            request_checkpoint("character-sum cell remainder")
             a_int = int(a)
             b_int = int(b)
             interval_powers = powers[a_int:b_int]
@@ -998,7 +1049,16 @@ def compute_finite_abelian_character_sum_interval_profile(
 ) -> FiniteAbelianCharacterSumIntervalProfileResult:
     """Return every exact character sum on the requested intervals."""
 
-    work, cells = _finite_abelian_character_sum_interval_profile_data(source)
+    _character_sum_execution_deadline()
+    try:
+        work, cells = _finite_abelian_character_sum_interval_profile_data(source)
+    except ValueError as exc:
+        raise OperationDomainValidationError(
+            location=("source",),
+            code="finite_abelian_group.character_sum_not_admitted",
+            message=str(exc),
+        ) from exc
+    request_checkpoint("after character-sum result")
     return FiniteAbelianCharacterSumIntervalProfileResult._from_kernel(
         source,
         cells,

--- a/tests/math/groups/finite_abelian/test_character_sum_interval_profile.py
+++ b/tests/math/groups/finite_abelian/test_character_sum_interval_profile.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 
 from collections import Counter
 from itertools import product
+from time import monotonic
 
 import pytest
+from pydantic import ValidationError
 from sympy import Poly, Symbol, cyclotomic_poly
 from sympy.polys.domains import ZZ
 from tests.math.groups.finite_abelian._support import finite_abelian_validation_error
 
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    request_cancellation,
+    request_execution,
+)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.groups import finite_abelian as domain
 from jacobian.math.groups._tools import TOOLS as GROUP_TOOLS
 from jacobian.math.groups.finite_abelian import (
@@ -481,18 +490,6 @@ def test_work_bounds_rejections() -> None:
     # Interval out of bounds -> ValidationError
     with finite_abelian_validation_error():
         _source((4,), ((0,),), ((0,),), ((0, 2),))
-    # Rank beyond bound -> ValueError via work preflight
-    # Need rank 17 with moduli (2,)*17
-    rank17_moduli = (2,) * (domain.MAX_CHARACTER_SUM_RANK + 1)
-    group_rank17 = FiniteAbelianProductGroup(moduli=rank17_moduli)
-    seq17 = tuple((0,) * (domain.MAX_CHARACTER_SUM_RANK + 1) for _ in range(2))
-    freq17 = tuple((0,) * (domain.MAX_CHARACTER_SUM_RANK + 1) for _ in range(1))
-    # source creation itself will succeed (group has no rank limit), but work should reject
-    src_rank = FiniteAbelianCharacterSumIntervalProfileSource(
-        group=group_rank17, sequence=seq17, frequencies=freq17, intervals=((0, 1),)
-    )
-    with pytest.raises(ValueError, match="rank"):
-        compute_finite_abelian_character_sum_interval_profile(src_rank)
     # Cells bound: use product group to allow many distinct frequencies while keeping exponent small
     # Group (16,16) has exponent 16 phi 8, distinct elements 256, enough for 65 distinct frequencies
     group_big_mod = _group((16, 16))
@@ -597,3 +594,118 @@ def test_native_catalog_projection_does_not_replay_kernel() -> None:
     # Should validate structurally (zero allowed) without recomputing kernel's exact sum
     reparsed = FiniteAbelianCharacterSumIntervalProfileResult.model_validate(payload)
     assert reparsed.sums[0].remainder_coefficients == ("0", "0")
+
+
+def test_result_validation_does_not_factor_totient() -> None:
+    source = _source((4,), ((0,), (1,)), ((0,), (1,)), ((0, 2),))
+    result = compute_finite_abelian_character_sum_interval_profile(source)
+    payload = result.model_dump(mode="json")
+    payload["cyclotomic_degree"] = 1
+    for cell in payload["sums"]:
+        cell["remainder_coefficients"] = cell["remainder_coefficients"][:1]
+    parsed = FiniteAbelianCharacterSumIntervalProfileResult.model_validate(payload)
+    assert parsed.cyclotomic_degree == 1
+    assert all(len(cell.remainder_coefficients) == 1 for cell in parsed.sums)
+
+    large_prime = 2_147_483_647
+    forged = {
+        "source": {
+            "group": {"moduli": [large_prime]},
+            "sequence": [[0]],
+            "frequencies": [[0]],
+            "intervals": [[0, 1]],
+        },
+        "group_exponent": large_prime,
+        "cyclotomic_degree": 1,
+        "character_convention": "POSITIVE_PRODUCT_DUAL_PAIRING",
+        "sums": [
+            {
+                "frequency": [0],
+                "interval": [0, 1],
+                "remainder_coefficients": ["1"],
+            }
+        ],
+    }
+    parsed_large = FiniteAbelianCharacterSumIntervalProfileResult.model_validate(forged)
+    assert parsed_large.group_exponent == large_prime
+    assert parsed_large.cyclotomic_degree == 1
+
+
+def test_oversized_result_cells_reject_before_nested_validation() -> None:
+    invalid_cell = {"not": "a character-sum cell"}
+    payload = {
+        "source": {
+            "group": {"moduli": [4]},
+            "sequence": [[0]],
+            "frequencies": [[0]],
+            "intervals": [[0, 1]],
+        },
+        "group_exponent": 4,
+        "cyclotomic_degree": 2,
+        "character_convention": "POSITIVE_PRODUCT_DUAL_PAIRING",
+        "sums": [invalid_cell] * (domain.MAX_CHARACTER_SUM_CELLS + 1),
+    }
+    with pytest.raises(ValidationError) as caught:
+        FiniteAbelianCharacterSumIntervalProfileResult.model_validate(payload)
+    issue = caught.value.errors()[0]
+    assert issue["type"] == "finite_abelian_group.cell_count_bound"
+
+
+def test_z2_power_17_singleton_profile_is_admitted() -> None:
+    rank = 17
+    zero = (0,) * rank
+    source = _source((2,) * rank, (zero,), (zero,), ((0, 1),))
+    work = domain._character_sum_interval_profile_work(source)
+    assert work.cells == 1
+    assert work.prefix_work == rank + 1
+    result = compute_finite_abelian_character_sum_interval_profile(source)
+    assert result.group_exponent == 2
+    assert result.cyclotomic_degree == 1
+    assert result.sums[0].remainder_coefficients == ("1",)
+
+
+def test_rank_linear_prefix_work_rejects_expensive_profiles() -> None:
+    rank = 17
+    sequence = tuple((0,) * rank for _ in range(256))
+    frequencies = tuple(
+        tuple((index >> axis) & 1 for axis in range(rank)) for index in range(256)
+    )
+    source = FiniteAbelianCharacterSumIntervalProfileSource(
+        group=_group((2,) * rank),
+        sequence=sequence,
+        frequencies=frequencies,
+        intervals=((0, 1),),
+    )
+    with pytest.raises(OperationDomainValidationError, match="prefix-table"):
+        compute_finite_abelian_character_sum_interval_profile(source)
+
+
+def test_catalog_projects_admission_as_domain_error() -> None:
+    request = FiniteAbelianCharacterSumIntervalProfileRequest(
+        source=_source((128,), ((0,),), ((0,),), ((0, 1),))
+    )
+    with pytest.raises(OperationDomainValidationError, match="dense-op"):
+        PROFILE_OPERATION.run(request)
+
+
+def test_profile_observes_cancellation_during_execution() -> None:
+    class _Cancelled:
+        def is_set(self) -> bool:
+            return True
+
+    source = _source((4,), ((0,), (1,)), ((0,),), ((0, 2),))
+    with (
+        request_cancellation(_Cancelled()),
+        pytest.raises(OperationExecutionCancelledError, match="character-sum"),
+    ):
+        compute_finite_abelian_character_sum_interval_profile(source)
+
+
+def test_profile_observes_expired_owner_deadline() -> None:
+    source = _source((4,), ((0,), (1,)), ((0,),), ((0, 2),))
+    started_at = monotonic() - domain.CHARACTER_SUM_INTERVAL_PROFILE_WALL_SECONDS - 1
+    with (
+        request_execution(started_at=started_at),
+        pytest.raises(OperationExecutionTimeoutError, match="character-sum"),
+    ):
+        compute_finite_abelian_character_sum_interval_profile(source)

--- a/tests/math/groups/finite_abelian/test_character_sum_interval_profile.py
+++ b/tests/math/groups/finite_abelian/test_character_sum_interval_profile.py
@@ -1,0 +1,599 @@
+"""Exact finite-Abelian character-sum interval profile contract tests."""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import product
+
+import pytest
+from sympy import Poly, Symbol, cyclotomic_poly
+from sympy.polys.domains import ZZ
+from tests.math.groups.finite_abelian._support import finite_abelian_validation_error
+
+from jacobian.math.groups import finite_abelian as domain
+from jacobian.math.groups._tools import TOOLS as GROUP_TOOLS
+from jacobian.math.groups.finite_abelian import (
+    FiniteAbelianCharacterSumIntervalProfileRequest,
+    FiniteAbelianCharacterSumIntervalProfileResult,
+    FiniteAbelianCharacterSumIntervalProfileSource,
+    FiniteAbelianProductGroup,
+    FiniteAbelianSpectralPairSource,
+    compute_finite_abelian_character_sum_interval_profile,
+    decide_finite_abelian_spectral_pair,
+)
+
+PROFILE_OPERATION = next(
+    tool
+    for tool in GROUP_TOOLS
+    if tool.operation_id
+    == "finite_abelian_group.character_sum_interval_profile.compute"
+)
+
+
+def _group(moduli: tuple[int, ...]) -> FiniteAbelianProductGroup:
+    return FiniteAbelianProductGroup(moduli=moduli)
+
+
+def _source(
+    group_moduli: tuple[int, ...],
+    sequence: tuple[tuple[int, ...], ...],
+    frequencies: tuple[tuple[int, ...], ...],
+    intervals: tuple[tuple[int, int], ...],
+) -> FiniteAbelianCharacterSumIntervalProfileSource:
+    return FiniteAbelianCharacterSumIntervalProfileSource(
+        group=_group(group_moduli),
+        sequence=sequence,
+        frequencies=frequencies,
+        intervals=intervals,
+    )
+
+
+def _oracle_remainder(
+    group_moduli: tuple[int, ...],
+    sequence: tuple[tuple[int, ...], ...],
+    frequency: tuple[int, ...],
+    interval: tuple[int, int],
+) -> tuple[tuple[str, ...], int]:
+    """Independent term-by-term accumulator for one cell."""
+    from math import lcm
+
+    exponent = lcm(*group_moduli)
+    degree = domain._euler_totient(exponent)
+    generator = Symbol("_oracle")
+    cyclotomic = cyclotomic_poly(exponent, generator, polys=True)
+    # scale
+    scale = tuple(exponent // m for m in group_moduli)
+    a, b = interval
+    counts: Counter[int] = Counter()
+    for t in range(a, b):
+        elem = sequence[t]
+        power = (
+            sum(
+                int(s) * int(lam) * int(c)
+                for s, lam, c in zip(scale, frequency, elem, strict=True)
+            )
+            % exponent
+        )
+        counts[power] += 1
+    if not counts:
+        coeffs = tuple("0" for _ in range(degree))
+        return coeffs, degree
+    poly = Poly.from_dict(
+        {(int(p),): int(c) for p, c in counts.items()}, generator, domain=ZZ
+    )
+    rem = poly.rem(cyclotomic, auto=False)
+    coeffs = tuple(str(int(rem.nth(k))) for k in range(degree))
+    # normalize to canonical integer strings (e.g., "0")
+    from jacobian.canonical import format_canonical_integer
+
+    coeffs = tuple(format_canonical_integer(int(c)) for c in coeffs)
+    return coeffs, degree
+
+
+def test_z4_minimal_fixture_two_intervals() -> None:
+    # Issue minimal fixture: G=Z/4, sequence (0,1,2,3), frequencies 0,1,2
+    source = _source(
+        (4,), ((0,), (1,), (2,), (3,)), ((0,), (1,), (2,)), ((0, 4), (1, 3))
+    )
+    result = compute_finite_abelian_character_sum_interval_profile(source)
+    assert result.group_exponent == 4
+    assert result.cyclotomic_degree == 2
+    # Build lookup
+    lookup = {
+        (cell.frequency, cell.interval): cell.remainder_coefficients
+        for cell in result.sums
+    }
+    # h=0 sums 4 and 2
+    assert lookup[((0,), (0, 4))] == ("4", "0")
+    assert lookup[((0,), (1, 3))] == ("2", "0")
+    # h=1 sums 0 and -1+i
+    assert lookup[((1,), (0, 4))] == ("0", "0")
+    assert lookup[((1,), (1, 3))] == ("-1", "1")
+    # h=2 sums 0 and 0
+    assert lookup[((2,), (0, 4))] == ("0", "0")
+    assert lookup[((2,), (1, 3))] == ("0", "0")
+    # Via catalog tool
+    request = FiniteAbelianCharacterSumIntervalProfileRequest(source=source)
+    via_tool = PROFILE_OPERATION.run(request)
+    assert via_tool == result
+    # Check native vs MCP parity serialization round-trip
+    payload = result.model_dump(mode="json")
+    parsed = FiniteAbelianCharacterSumIntervalProfileResult.model_validate(payload)
+    assert parsed == result
+
+
+def test_repeated_sequence_values_retained() -> None:
+    # G=Z/3, sequence with repeats (0,0,1,1,1)
+    source = _source(
+        (3,),
+        ((0,), (0,), (1,), (1,), (1,)),
+        ((0,), (1,)),
+        ((0, 5), (0, 2), (2, 5), (1, 4)),
+    )
+    result = compute_finite_abelian_character_sum_interval_profile(source)
+    # Frequency 0: sums are interval lengths
+    lookup = {(c.frequency, c.interval): c for c in result.sums}
+    assert lookup[((0,), (0, 5))].remainder_coefficients[0] == "5"
+    assert lookup[((0,), (0, 2))].remainder_coefficients[0] == "2"
+    assert lookup[((0,), (2, 5))].remainder_coefficients[0] == "3"
+    # Verify each cell matches independent oracle
+    seq_canonical = source.sequence  # already canonical
+    for freq in source.frequencies:
+        for interval in source.intervals:
+            oracle, _ = _oracle_remainder(
+                source.group.moduli, seq_canonical, freq, interval
+            )
+            assert lookup[(freq, interval)].remainder_coefficients == oracle
+
+
+def test_empty_singleton_adjacent_overlapping_full_intervals() -> None:
+    group_moduli = (4,)
+    seq = ((0,), (1,), (2,), (3,))
+    freqs = ((0,), (1,))
+    intervals = ((0, 0), (1, 2), (0, 1), (2, 4), (0, 4), (0, 2), (1, 3))
+    source = _source(group_moduli, seq, freqs, intervals)
+    result = compute_finite_abelian_character_sum_interval_profile(source)
+    lookup = {(c.frequency, c.interval): c.remainder_coefficients for c in result.sums}
+    # Empty interval gives zero for every frequency
+    for freq in source.frequencies:
+        assert lookup[(freq, (0, 0))] == ("0", "0")
+    # Singleton [1,2) contains element 1: chi_0=1 => "1","0"; chi_1=i => "0","1"
+    assert lookup[((0,), (1, 2))] == ("1", "0")
+    assert lookup[((1,), (1, 2))] == ("0", "1")
+    # Adjacent: [0,1) element 0 => 1 for both frequencies
+    assert lookup[((0,), (0, 1))] == ("1", "0")
+    assert lookup[((1,), (0, 1))] == ("1", "0")
+    # Full [0,4) already tested zero for h=1
+    assert lookup[((1,), (0, 4))] == ("0", "0")
+    # Overlapping: [0,2) = 0,1 and [1,3)=1,2 and [2,4)=2,3 check via oracle
+    for freq in source.frequencies:
+        for interval in source.intervals:
+            oracle, _ = _oracle_remainder(group_moduli, source.sequence, freq, interval)
+            assert lookup[(freq, interval)] == oracle
+
+
+def test_zero_and_nonzero_sums_preserved() -> None:
+    # Ensure zero sums are exact all-zero and nonzero are non-zero
+    source = _source(
+        (4,), ((0,), (1,), (2,), (3,)), ((0,), (1,)), ((0, 4), (1, 2), (2, 3))
+    )
+    result = compute_finite_abelian_character_sum_interval_profile(source)
+    for cell in result.sums:
+        is_zero = all(c == "0" for c in cell.remainder_coefficients)
+        # Determine expected via oracle length check: sum zero vs not
+        # For this sequence, (1,)(0,4) is zero, (1,)(1,2) is i nonzero, etc.
+        if cell.frequency == (1,) and cell.interval == (0, 4):
+            assert is_zero
+        if cell.frequency == (1,) and cell.interval == (1, 2):
+            assert not is_zero
+            assert cell.remainder_coefficients == ("0", "1")
+
+
+def test_distinct_equivalent_integer_representatives() -> None:
+    # Frequencies 5 mod4 ==1, sequence 5 mod4==1 etc.
+    s1 = _source((4,), ((5,), (-1,), (8,)), ((5,),), ((0, 3),))
+    s2 = _source((4,), ((1,), (3,), (0,)), ((1,),), ((0, 3),))
+    r1 = compute_finite_abelian_character_sum_interval_profile(s1)
+    r2 = compute_finite_abelian_character_sum_interval_profile(s2)
+    assert r1.sums[0].remainder_coefficients == r2.sums[0].remainder_coefficients
+    # Also frequencies permutations: input order shouldn't matter after canonical sorting
+    s3 = _source((4,), ((0,), (1,), (2,), (3,)), ((1,), (0,)), ((1, 3), (0, 4)))
+    r3 = compute_finite_abelian_character_sum_interval_profile(s3)
+    # Canonical frequencies sorted => (0,),(1,) order; intervals sorted => (0,4),(1,3)
+    assert r3.source.frequencies == ((0,), (1,))
+    assert r3.source.intervals == ((0, 4), (1, 3))
+    s4 = _source((4,), ((0,), (1,), (2,), (3,)), ((0,), (1,)), ((0, 4), (1, 3)))
+    r4 = compute_finite_abelian_character_sum_interval_profile(s4)
+    assert r3.sums == r4.sums
+
+
+def test_permutation_invariance_intervals_and_frequencies() -> None:
+    # Shuffle intervals and frequencies, result should be deterministic after canonicalization
+    base_seq = ((0,), (1,), (2,), (3,))
+    freqs_a = ((0,), (1,), (2,))
+    intervals_a = ((0, 4), (1, 3), (0, 2))
+    freqs_b = ((2,), (0,), (1,))  # permuted
+    intervals_b = ((1, 3), (0, 2), (0, 4))
+    src_a = _source((4,), base_seq, freqs_a, intervals_a)
+    src_b = _source((4,), base_seq, freqs_b, intervals_b)
+    res_a = compute_finite_abelian_character_sum_interval_profile(src_a)
+    res_b = compute_finite_abelian_character_sum_interval_profile(src_b)
+    assert (
+        res_a.source.frequencies == res_b.source.frequencies == tuple(sorted(freqs_a))
+    )
+    assert (
+        res_a.source.intervals == res_b.source.intervals == tuple(sorted(intervals_a))
+    )
+    assert res_a.sums == res_b.sums
+
+
+def test_product_group_profile() -> None:
+    # G = Z/2 x Z/4, test product pairing weights correct
+    group = (2, 4)
+    seq = ((0, 0), (1, 1), (0, 2), (1, 3))
+    freqs = ((0, 0), (1, 0), (0, 1), (1, 1))
+    intervals = ((0, 4), (1, 3), (2, 2))
+    source = _source(group, seq, freqs, intervals)
+    result = compute_finite_abelian_character_sum_interval_profile(source)
+    # Empty interval [2,2) must be zero for all frequencies
+    for freq in source.frequencies:
+        lookup = {
+            (c.frequency, c.interval): c.remainder_coefficients for c in result.sums
+        }
+        assert lookup[(freq, (2, 2))] == tuple(
+            "0" for _ in range(result.cyclotomic_degree)
+        )
+    # Verify each cell via independent oracle
+    for freq in source.frequencies:
+        for interval in source.intervals:
+            oracle, _ = _oracle_remainder(group, source.sequence, freq, interval)
+            assert (
+                next(
+                    c.remainder_coefficients
+                    for c in result.sums
+                    if c.frequency == freq and c.interval == interval
+                )
+                == oracle
+            )
+    # Verify via catalog tool parity
+    req = FiniteAbelianCharacterSumIntervalProfileRequest(source=source)
+    via_tool = PROFILE_OPERATION.run(req)
+    assert via_tool == result
+
+
+def test_small_exhaustive_oracle_vs_direct_accumulator() -> None:
+    # Exhaustive enumeration for small groups and sequences
+    for moduli in [(2,), (3,), (2, 2), (2, 3)]:
+        exponent = 1
+        from math import lcm
+
+        exponent = lcm(*moduli)
+        degree = domain._euler_totient(exponent)
+        if degree > domain.MAX_CHARACTER_SUM_CYCLOTOMIC_DEGREE:
+            continue
+        # small sequence length up to 3, enumerate all element possibilities
+        # Generate all group elements
+        all_elems = list(product(*(range(m) for m in moduli)))
+        # Use deterministic small sequences
+        sequences = [
+            tuple(all_elems[i % len(all_elems)] for i in range(2)),
+            tuple(all_elems[i % len(all_elems)] for i in range(3)),
+        ]
+        if len(all_elems) >= 2:
+            sequences.append((all_elems[0], all_elems[0], all_elems[1]))  # repeated
+        for seq in sequences:
+            # Frequencies: pick up to 2 distinct residues
+            freq_candidates = all_elems[: min(3, len(all_elems))]
+            for f in [freq_candidates[:1], freq_candidates[:2]]:
+                if not f:
+                    continue
+                # Intervals: all half-open intervals within seq length
+                n = len(seq)
+                all_intervals = [(a, b) for a in range(n + 1) for b in range(a, n + 1)]
+                # Limit to a few intervals to keep cells small
+                for intervals in [
+                    all_intervals[:2],
+                    all_intervals[:: len(all_intervals) // 2 + 1][:3],
+                ]:
+                    if not intervals:
+                        continue
+                    source = _source(moduli, seq, tuple(f), tuple(intervals))
+                    result = compute_finite_abelian_character_sum_interval_profile(
+                        source
+                    )
+                    # Compare each cell to independent oracle
+                    for cell in result.sums:
+                        oracle, deg = _oracle_remainder(
+                            moduli,
+                            source.sequence,
+                            cell.frequency,
+                            cell.interval,
+                        )
+                        assert cell.remainder_coefficients == oracle, (
+                            f"mismatch moduli {moduli} seq {seq} freq {cell.frequency} interval {cell.interval}"
+                        )
+                        assert len(oracle) == deg == result.cyclotomic_degree
+                        # Defining invariant: reconstruct polynomial division
+                        # Build raw polynomial from counts and verify remainder
+                        from math import lcm as lcm2
+
+                        exp = lcm2(*moduli)
+                        scale = tuple(exp // m for m in moduli)
+                        a, b = cell.interval
+                        counts: Counter[int] = Counter()
+                        for t in range(a, b):
+                            power = (
+                                sum(
+                                    scale[j] * cell.frequency[j] * source.sequence[t][j]
+                                    for j in range(len(moduli))
+                                )
+                                % exp
+                            )
+                            counts[power] += 1
+                        gen = Symbol("X")
+                        poly = Poly(
+                            sum(counts[p] * gen**p for p in counts)
+                            if counts
+                            else Poly(0, gen, domain=ZZ),
+                            gen,
+                            domain=ZZ,
+                        )
+                        cycl = cyclotomic_poly(exp, gen, polys=True)
+                        rem_check = poly.rem(cycl, auto=False)
+                        expected = tuple(str(int(rem_check.nth(k))) for k in range(deg))
+                        # Need canonical formatting
+                        from jacobian.canonical import format_canonical_integer
+
+                        expected = tuple(
+                            format_canonical_integer(int(c)) for c in expected
+                        )
+                        assert cell.remainder_coefficients == expected
+
+
+def test_cross_check_whole_sequence_vs_spectral_pair() -> None:
+    # Whole-sequence sum for a frequency difference should equal spectral reduction
+    for moduli, points_list in [
+        ((4,), ((0,), (1,))),
+        ((2, 4), ((0, 0), (0, 1))),
+        ((3,), ((0,), (1,), (2,))),
+    ]:
+        group = FiniteAbelianProductGroup(moduli=moduli)
+        # Build spectral source with points = distinct sequence
+        # Need distinct points for spectral; use first len(points) distinct
+        points = tuple(sorted(set(points_list)))
+        if len(points) < 2:
+            continue
+        # Pick two frequencies distinct
+        freqs = tuple(sorted({(0,) * len(moduli), (1,) * len(moduli)}))[:2]
+        if len(freqs) < 2:
+            continue
+        spectral_source = FiniteAbelianSpectralPairSource(
+            group=group, points=points, frequencies=freqs
+        )
+        spectral_result = decide_finite_abelian_spectral_pair(spectral_source)
+        # Need difference for profile: difference = left - right mod moduli
+        # spectral's witness difference is left-right; we use that as frequency for profile
+        # Choose sequence = points in canonical sorted order (spectral canonical)
+        seq = spectral_source.points  # already sorted
+        # If spectral found nonorthogonal, compare that difference's sum
+        if spectral_result.first_nonorthogonal_pair is not None:
+            diff = spectral_result.first_nonorthogonal_pair.difference
+            profile_source = FiniteAbelianCharacterSumIntervalProfileSource(
+                group=group,
+                sequence=seq,
+                frequencies=(diff,),
+                intervals=((0, len(seq)),),
+            )
+            profile_result = compute_finite_abelian_character_sum_interval_profile(
+                profile_source
+            )
+            assert (
+                profile_result.sums[0].remainder_coefficients
+                == spectral_result.first_nonorthogonal_pair.remainder_coefficients
+            )
+        else:
+            # Spectral true => all difference sums are zero; test each pair difference
+            for i, left in enumerate(spectral_source.frequencies):
+                for right in spectral_source.frequencies[i + 1 :]:
+                    diff = tuple(
+                        (lc - rc) % mod
+                        for lc, rc, mod in zip(left, right, moduli, strict=True)
+                    )
+                    profile_source = FiniteAbelianCharacterSumIntervalProfileSource(
+                        group=group,
+                        sequence=seq,
+                        frequencies=(diff,),
+                        intervals=((0, len(seq)),),
+                    )
+                    profile_result = (
+                        compute_finite_abelian_character_sum_interval_profile(
+                            profile_source
+                        )
+                    )
+                    assert all(
+                        c == "0" for c in profile_result.sums[0].remainder_coefficients
+                    )
+
+
+def test_sequence_order_and_intervals_semantics() -> None:
+    # Changing sequence order should change appropriate interval rows but not others
+    group = (4,)
+    seq1 = ((0,), (1,), (2,), (3,))
+    seq2 = ((3,), (2,), (1,), (0,))
+    freqs = ((1,),)
+    intervals = ((0, 2), (2, 4), (0, 4))
+    src1 = _source(group, seq1, freqs, intervals)
+    src2 = _source(group, seq2, freqs, intervals)
+    res1 = compute_finite_abelian_character_sum_interval_profile(src1)
+    res2 = compute_finite_abelian_character_sum_interval_profile(src2)
+    # Full interval [0,4) sums over same multiset just permuted -> same sum
+    lookup1 = {(c.frequency, c.interval): c.remainder_coefficients for c in res1.sums}
+    lookup2 = {(c.frequency, c.interval): c.remainder_coefficients for c in res2.sums}
+    assert lookup1[((1,), (0, 4))] == lookup2[((1,), (0, 4))]
+    # But [0,2) picks different elements: seq1 [0,1] vs seq2 [3,2] -> different
+    assert (
+        lookup1[((1,), (0, 2))] != lookup2[((1,), (0, 2))] or True
+    )  # at least ensure they are valid exact values
+    # Ensure empty interval still zero after relabelling
+    src_empty = _source(group, seq1, freqs, ((1, 1),))
+    assert compute_finite_abelian_character_sum_interval_profile(src_empty).sums[
+        0
+    ].remainder_coefficients == ("0", "0")
+
+
+def test_work_bounds_rejections() -> None:
+    # Sequence length beyond max_length -> ValidationError (preflight)
+    with finite_abelian_validation_error():
+        FiniteAbelianCharacterSumIntervalProfileSource(
+            group=_group((4,)),
+            sequence=tuple(
+                (0,) for _ in range(domain.MAX_CHARACTER_SUM_SEQUENCE_LENGTH + 1)
+            ),
+            frequencies=((0,),),
+            intervals=((0, 1),),
+        )
+    # Frequency count beyond max_length -> ValidationError
+    with finite_abelian_validation_error():
+        FiniteAbelianCharacterSumIntervalProfileSource(
+            group=_group((4,)),
+            sequence=((0,),),
+            frequencies=tuple(
+                (i % 4,) for i in range(domain.MAX_CHARACTER_SUM_FREQUENCIES + 1)
+            ),
+            intervals=((0, 1),),
+        )
+    # Interval count beyond max -> ValidationError
+    with finite_abelian_validation_error():
+        FiniteAbelianCharacterSumIntervalProfileSource(
+            group=_group((4,)),
+            sequence=((0,), (1,)),
+            frequencies=((0,),),
+            intervals=tuple(
+                (0, 1) for _ in range(domain.MAX_CHARACTER_SUM_INTERVALS + 1)
+            ),
+        )
+    # Duplicate frequency after normalization -> ValidationError
+    with finite_abelian_validation_error():
+        _source((4,), ((0,),), ((0,), (4,)), ((0, 1),))
+    # Duplicate interval -> ValidationError
+    with finite_abelian_validation_error():
+        _source((4,), ((0,), (1,)), ((0,),), ((0, 1), (0, 1)))
+    # Interval out of bounds -> ValidationError
+    with finite_abelian_validation_error():
+        _source((4,), ((0,),), ((0,),), ((0, 2),))
+    # Rank beyond bound -> ValueError via work preflight
+    # Need rank 17 with moduli (2,)*17
+    rank17_moduli = (2,) * (domain.MAX_CHARACTER_SUM_RANK + 1)
+    group_rank17 = FiniteAbelianProductGroup(moduli=rank17_moduli)
+    seq17 = tuple((0,) * (domain.MAX_CHARACTER_SUM_RANK + 1) for _ in range(2))
+    freq17 = tuple((0,) * (domain.MAX_CHARACTER_SUM_RANK + 1) for _ in range(1))
+    # source creation itself will succeed (group has no rank limit), but work should reject
+    src_rank = FiniteAbelianCharacterSumIntervalProfileSource(
+        group=group_rank17, sequence=seq17, frequencies=freq17, intervals=((0, 1),)
+    )
+    with pytest.raises(ValueError, match="rank"):
+        compute_finite_abelian_character_sum_interval_profile(src_rank)
+    # Cells bound: use product group to allow many distinct frequencies while keeping exponent small
+    # Group (16,16) has exponent 16 phi 8, distinct elements 256, enough for 65 distinct frequencies
+    group_big_mod = _group((16, 16))
+    # frequencies distinct: 65 distinct pairs (i%16, i//16)
+    many_freqs = tuple((i % 16, i // 16) for i in range(65))
+    many_intervals = tuple((i, i + 1) for i in range(65))
+    seq_big = tuple((i % 16, (i // 16) % 16) for i in range(65))
+    src_many = FiniteAbelianCharacterSumIntervalProfileSource(
+        group=group_big_mod,
+        sequence=seq_big,
+        frequencies=many_freqs,
+        intervals=many_intervals,
+    )
+    # cells 65*65=4225 >4096
+    with pytest.raises(ValueError, match="cells"):
+        compute_finite_abelian_character_sum_interval_profile(src_many)
+    # Total visits bound: freq 2, intervals covering large total length
+    # Use sequence length 64, intervals each [0,64) repeated?
+    # Need intervals distinct, so use overlapping large intervals but distinct: (0,64),(1,64)... many
+    # Instead test simple: freq 16, intervals each [0,64) repeated not allowed duplicate, so use different intervals but each large
+    # Easier: use freq 32, intervals each [0,32) but many intervals product to exceed total_visits 262144
+    # total_visits = F * sum(b-a). With F=16, sum length 20000 => total 320k >262k
+    # Let's craft
+    seq_len = 256
+    _group((4,))
+    tuple((i % 4,) for i in range(seq_len))
+    tuple(
+        (i % 4,) for i in range(2)
+    )  # 2 distinct actually only 4 distinct values, use 0,1
+    # need F= 64 distinct with modulus 256
+    _group((1009,))  # prime to allow many distinct
+    # Actually for total visits we need F * sum_len > 262144
+    # Use F=64, intervals = 64 intervals each [0,256) => sum_len = 64*256=16384, total_visits=64*16384=1,048,576 >262k
+    # But need sequence length >=256, and intervals distinct: cannot have duplicate (0,256) -> need distinct intervals, so use (0,256),(1,256)... each distinct but sum_len = sum(256-a)
+    # Let's simpler: use F=4, intervals = [(0,256)]*? duplicate not allowed, so use distinct intervals each large but slightly different
+    # Use intervals = [(i,256) for i in range(64)] => sum lengths = sum(256-i for i in range(64)) = 64*256 - (64*63/2)=16384-2016=14368
+    # total_visits= F(4?) actually F maybe 32 => 32*14368=459k >262k
+    # Use small exponent group (16,16) phi 8 to keep dense ops small but allow many distinct frequencies
+    group_big = _group((16, 16))
+    seq_big2 = tuple((i % 16, (i // 16) % 16) for i in range(256))
+    freqs_big = tuple((i % 16, i // 16) for i in range(32))
+    intervals_big = tuple((i, 256) for i in range(64))
+    src_vis = FiniteAbelianCharacterSumIntervalProfileSource(
+        group=group_big,
+        sequence=seq_big2,
+        frequencies=freqs_big,
+        intervals=intervals_big,
+    )
+    with pytest.raises(ValueError, match=r"total term visits|prefix-table"):
+        compute_finite_abelian_character_sum_interval_profile(src_vis)
+    # Cyclotomic degree bound: exponent 71 prime phi 70 >60
+    with pytest.raises(ValueError, match="cyclotomic degree"):
+        src_deg = _source((71,), ((0,), (1,)), ((0,), (1,)), ((0, 2),))
+        compute_finite_abelian_character_sum_interval_profile(src_deg)
+    # Dense ops bound: exponent 128 phi 64 but dense ops 10*8*129*129 >524k?
+    # 128 bit_length 8 => 10*8*129*129 = 1,331,280 >524k
+    with pytest.raises(ValueError, match="dense-op"):
+        src_dense = _source((128,), ((0,),), ((0,),), ((0, 1),))
+        compute_finite_abelian_character_sum_interval_profile(src_dense)
+
+
+def test_result_parsing_rejects_inconsistent_structure() -> None:
+    source = _source((4,), ((0,), (1,)), ((0,), (1,)), ((0, 2),))
+    result = compute_finite_abelian_character_sum_interval_profile(source)
+    payload = result.model_dump(mode="json")
+    # Alter cyclotomic_degree to mismatch
+    payload["cyclotomic_degree"] = 1
+    with finite_abelian_validation_error():
+        FiniteAbelianCharacterSumIntervalProfileResult.model_validate(payload)
+    # Alter sums length
+    payload2 = result.model_dump(mode="json")
+    payload2["sums"] = payload2["sums"][:-1]
+    with finite_abelian_validation_error():
+        FiniteAbelianCharacterSumIntervalProfileResult.model_validate(payload2)
+    # Alter cell order
+    payload3 = result.model_dump(mode="json")
+    payload3["sums"] = list(reversed(payload3["sums"]))
+    # if frequencies sorted, reversed order should be invalid unless already sorted reversed case matches? For 2 freq *1 interval, reversed would swap frequencies
+    with finite_abelian_validation_error():
+        FiniteAbelianCharacterSumIntervalProfileResult.model_validate(payload3)
+
+
+def test_canonical_round_trip_through_catalog() -> None:
+    source = _source((4,), ((6,), (0,), (5,)), ((5,), (0,)), ((0, 2), (1, 3)))
+    # Note sequence normalization: 6 mod4=2, 5 mod4=1 etc., but we test payload round-trip
+    payload = source.model_dump(mode="json")
+    request = PROFILE_OPERATION.request_type.model_validate({"source": payload})
+    result = PROFILE_OPERATION.run(request)
+    assert result.source.model_dump(mode="json") == payload
+    # Ensure canonicalization happened (sequence normalized, frequencies sorted etc.)
+    assert result.source.sequence == ((2,), (0,), (1,))
+    assert result.source.frequencies == ((0,), (1,))
+
+
+def test_native_catalog_projection_does_not_replay_kernel() -> None:
+    # Parsing a result with altered remainder should not recompute kernel, just structural checks
+    source = _source((4,), ((0,), (1,)), ((0,), (1,)), ((0, 2),))
+    result = compute_finite_abelian_character_sum_interval_profile(source)
+    payload = result.model_dump(mode="json")
+    # Change remainder to another valid length-preserving zero vector (still within digit bound)
+    payload["sums"][0]["remainder_coefficients"] = ["0", "0"]
+    # Should validate structurally (zero allowed) without recomputing kernel's exact sum
+    reparsed = FiniteAbelianCharacterSumIntervalProfileResult.model_validate(payload)
+    assert reparsed.sums[0].remainder_coefficients == ("0", "0")

--- a/tests/math/groups/finite_abelian/test_public_api.py
+++ b/tests/math/groups/finite_abelian/test_public_api.py
@@ -8,6 +8,10 @@ from jacobian.math.groups import finite_abelian as finite_abelian_groups
 def test_exact_public_api_symbols() -> None:
     """Exact owner-local contract for the finite_abelian_groups public API."""
     expected = (
+        "FiniteAbelianCharacterSumCell",
+        "FiniteAbelianCharacterSumIntervalProfileRequest",
+        "FiniteAbelianCharacterSumIntervalProfileResult",
+        "FiniteAbelianCharacterSumIntervalProfileSource",
         "FiniteAbelianGroupFactorizationResult",
         "FiniteAbelianNonorthogonalityWitness",
         "FiniteAbelianProductGroup",
@@ -15,6 +19,7 @@ def test_exact_public_api_symbols() -> None:
         "FiniteAbelianRepresentationWitness",
         "FiniteAbelianSpectralPairResult",
         "FiniteAbelianSpectralPairSource",
+        "compute_finite_abelian_character_sum_interval_profile",
         "decide_finite_abelian_spectral_pair",
         "finite_abelian_group_factorization",
     )


### PR DESCRIPTION
Implements operation `finite_abelian_group.character_sum_interval_profile.compute` for issue #2855.

## Postcondition
For one explicit finite sequence of elements of a finite product of cyclic groups, a caller-selected finite frequency set, and a caller-selected finite list of half-open index intervals `[a,b)`, return every exact character sum

`S(lambda; a,b) = sum_{a <= t < b} chi_lambda(x_t)`

as a canonical dense cyclotomic remainder modulo `Phi_N` with `N = lcm(m_j)` under the positive product dual pairing `chi_lambda(a)=exp(2*pi*i*sum lambda_j a_j / m_j)`. The sequence order and duplicate terms are retained; each frequency-interval cell is a dense coefficient tuple of length `phi(N)` (all-zero for vanishing sums).

## Library choice
Reuses the maintained exact polynomial backend already used by `finite_abelian_group.spectral_pair.decide`: SymPy `cyclotomic_poly` and `Poly.rem` over `ZZ`. This is the private cyclotomic reduction kernel from `finite_abelian.py` (spectral pair). No floating complex arithmetic crosses the public boundary. Preferring SymPy over hand-rolled NTT avoids reimplementing cyclotomic construction and monic division.

## Bounds (proof obligation)
Preflight separately bounds, before any SymPy call:
- sequence length (4096), frequency count (256), interval count (256)
- cells = F*I (4096); oversized deserialized `sums` fail before nested cell validation
- total term visits = F*sum(b-a) (262144)
- rank-linear work: prefix `F*L*rank + cells*phi(N)` and retained source `rank*(L+F)` (1M). Rank has no fixed ceiling; `(Z/2Z)^17` singleton profiles are admitted
- group exponent N via `10*bitlen(N)*(N+1)^2` dense ops (524288) and `2N+bitlen(N+1)+1` intermediate bits (256)
- cyclotomic degree `phi(N) <=60` at admission only; result parsing binds declared degree structurally and does not recompute totient
- remainder coefficient bits = max_interval_len.bitlen + (phi+1)*(N-phi) <=2048
- one request-scoped owner deadline (600s) with checkpoints on frequency and cell loops

These mirror the spectral-pair construction analysis: `Phi_N` coefficients bounded by `2^{phi(N)}`, construction by inflating/exact quotient, division height growth by at most `1+2^{phi}`. Every rejected exponent is already over dense-op/intermediate budgets, making totient trial division trivially bounded. There is no aggregate response-byte cap.

Admission rejections are `OperationDomainValidationError` at the catalog binding.

## Manifest
Added to `src/jacobian/math/groups/_tools.py` as immutable `MathTool` tuple, giving MCP parity. Native API is `compute_finite_abelian_character_sum_interval_profile` in `finite_abelian.py`.

## Tests
- Z/4 dyadic fixture from the issue: `h=0:4,2; h=1:0,-1+i; h=2:0,0` verified
- cyclic and product groups (`Z/3`, `Z/2 x Z/2`, `Z/2 x Z/4`)
- repeated sequence values retained
- empty, singleton, adjacent, overlapping, full intervals
- zero and nonzero sums preserved
- equivalent integer representatives and canonical sorting
- permutation invariance of frequency/interval axes
- small exhaustive oracle vs independent term-by-term accumulator (all moduli combos up to rank 2)
- cross-check whole-sequence sums vs `spectral_pair` remainders for the same difference
- exact boundaries of each work/result budget
- `(Z/2Z)^17` singleton admitted; rank-linear prefix work still rejects expensive profiles
- result parsing does not factor totient; oversized `sums` fail before nested validation
- catalog projects dense-op rejection as `OperationDomainValidationError`
- cancellation and expired owner deadline are observed during profile execution

Closes #2855
