### PR TITLE
feat(graph): induced edge deletion profile to r-colourability (#2856)

### DIFF
--- a/src/jacobian/math/graphs/coloring/__init__.py
+++ b/src/jacobian/math/graphs/coloring/__init__.py
@@ -1,8 +1,5 @@
 """Graph-coloring operation ownership."""
 
-from jacobian.math.graphs.coloring.induced_edge_deletion_profile.operations import (
-    compute_induced_edge_deletion_profile,
-)
 from jacobian.math.graphs.coloring.operations import (
     chromatic_number_certificate,
     edge_coloring_check,
@@ -13,7 +10,6 @@ from jacobian.math.graphs.coloring.operations import (
 
 __all__ = [
     "chromatic_number_certificate",
-    "compute_induced_edge_deletion_profile",
     "edge_coloring_check",
     "edge_k_colorability",
     "k_colorability",

--- a/src/jacobian/math/graphs/coloring/__init__.py
+++ b/src/jacobian/math/graphs/coloring/__init__.py
@@ -1,5 +1,8 @@
 """Graph-coloring operation ownership."""
 
+from jacobian.math.graphs.coloring.induced_edge_deletion_profile.operations import (
+    compute_induced_edge_deletion_profile,
+)
 from jacobian.math.graphs.coloring.operations import (
     chromatic_number_certificate,
     edge_coloring_check,
@@ -10,6 +13,7 @@ from jacobian.math.graphs.coloring.operations import (
 
 __all__ = [
     "chromatic_number_certificate",
+    "compute_induced_edge_deletion_profile",
     "edge_coloring_check",
     "edge_k_colorability",
     "k_colorability",

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/__init__.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/__init__.py
@@ -1,0 +1,7 @@
+"""Induced edge deletion profile operations."""
+
+from jacobian.math.graphs.coloring.induced_edge_deletion_profile.operations import (
+    compute_induced_edge_deletion_profile,
+)
+
+__all__ = ["compute_induced_edge_deletion_profile"]

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
@@ -128,7 +128,6 @@ class InducedEdgeDeletionProfileResult(StrictModel):
 
     graph: SimpleUndirectedGraph
     r: StrictInt = Field(ge=1, le=(1 << MAX_INDUCED_DELETION_R_BITS) - 1)
-    solver_conflicts: StrictInt = Field(ge=1, le=MAX_SOLVER_CONFLICT_BUDGET)
     rows: tuple[InducedDeletionRow, ...]
     max_deletions_by_size: tuple[PerSizeMaximum, ...]
 
@@ -244,14 +243,12 @@ class InducedEdgeDeletionProfileResult(StrictModel):
         *,
         graph: SimpleUndirectedGraph,
         r: int,
-        solver_conflicts: int,
         rows: tuple[InducedDeletionRow, ...],
         max_deletions_by_size: tuple[PerSizeMaximum, ...],
     ) -> Self:
         return cls.model_construct(
             graph=graph,
             r=r,
-            solver_conflicts=solver_conflicts,
             rows=rows,
             max_deletions_by_size=max_deletions_by_size,
         )

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
@@ -22,7 +22,7 @@ MAX_INDUCED_DELETION_VERTICES = 8
 # Values above the backend's colour-variable envelope are still exact trivial
 # cases whenever r covers an induced subset, so they are not an input bound.
 MAX_INDUCED_DELETION_R = MAX_COLORING_COLORS
-MAX_INDUCED_DELETION_R_BITS = 4096
+MAX_INDUCED_DELETION_R_BITS = 53
 DEFAULT_INDUCED_SOLVER_CONFLICTS = 100_000
 MAX_INDUCED_RETAINED_LABEL_CHARACTERS = 1_000_000
 MAX_INDUCED_EDGE_MATERIALIZATION = 200_000

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
@@ -133,8 +133,13 @@ class InducedEdgeDeletionProfileResult(StrictModel):
     @model_validator(mode="after")
     def require_profile_consistency(self) -> Self:  # noqa: C901
         n = len(self.graph.vertices)
-        expected_rows = 1 << n if n <= MAX_INDUCED_DELETION_VERTICES else None
-        if expected_rows is not None and len(self.rows) != expected_rows:
+        if n > MAX_INDUCED_DELETION_VERTICES:
+            raise PydanticCustomError(
+                "graph.vertex_count_exceeds_bound",
+                "result graph exceeds the induced deletion vertex bound",
+            )
+        expected_rows = 1 << n
+        if len(self.rows) != expected_rows:
             raise PydanticCustomError(
                 "graph.rows_must_cover_all_vertex_subsets",
                 "rows must cover all 2^n vertex subsets",
@@ -142,7 +147,7 @@ class InducedEdgeDeletionProfileResult(StrictModel):
         expected_subsets = tuple(
             subset
             for size in range(n + 1)
-            for subset in combinations(self.graph.vertices, size)
+            for subset in combinations(sorted(self.graph.vertices), size)
         )
         if tuple(row.vertex_subset for row in self.rows) != expected_subsets:
             raise PydanticCustomError(

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
@@ -1,0 +1,254 @@
+"""Typed contracts for the induced edge deletion profile operation."""
+
+from __future__ import annotations
+
+from typing import Annotated, Self
+
+from pydantic import Field, StrictInt, WithJsonSchema, model_validator
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.coloring._models import (
+    MAX_COLORING_COLORS,
+    MAX_SOLVER_CONFLICT_BUDGET,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAX_INDUCED_DELETION_VERTICES = 8
+"""Conservative vertex envelope for the complete 2^n profile (8 => 256 rows)."""
+
+MAX_INDUCED_DELETION_R = MAX_COLORING_COLORS
+DEFAULT_INDUCED_SOLVER_CONFLICTS = 100_000
+MAX_INDUCED_RETAINED_LABEL_CHARACTERS = 1_000_000
+MAX_INDUCED_EDGE_MATERIALIZATION = 200_000
+MAX_INDUCED_SOLVER_CALLS = 6000
+MAX_INDUCED_LEDGER_CONFLICTS = 600_000_000
+
+
+def _induced_graph_schema() -> JsonSchemaValue:
+    schema = SimpleUndirectedGraph.model_json_schema()
+    schema["description"] = (
+        "A finite simple graph on Jacobian's canonical axis. The induced deletion "
+        "profile admits requests with at most 8 vertices (256 subsets) and checks "
+        "aggregate solver-call, materialization, and retained-witness budgets."
+    )
+    return schema
+
+
+InducedDeletionGraph = Annotated[
+    SimpleUndirectedGraph,
+    WithJsonSchema(_induced_graph_schema()),
+]
+
+
+class InducedEdgeDeletionProfileRequest(StrictModel):
+    """Request the complete induced-subgraph distance to r-colourability."""
+
+    graph: InducedDeletionGraph
+    r: StrictInt = Field(
+        ge=1,
+        le=MAX_INDUCED_DELETION_R,
+        description="Target colour count r >=1; D(S) is min deletions to make G[S] r-colourable.",
+    )
+    solver_conflicts: StrictInt = Field(
+        default=DEFAULT_INDUCED_SOLVER_CONFLICTS,
+        ge=1,
+        le=MAX_SOLVER_CONFLICT_BUDGET,
+        description=(
+            "Per-decision SAT conflict budget for the bounded Z3 colourability kernel; "
+            "exhaustion is an operational timeout and establishes no deletion claim."
+        ),
+    )
+
+
+class PerSizeMaximum(StrictModel):
+    """Derived maximum minimum deletion cost at one subset size."""
+
+    subset_size: StrictInt = Field(ge=0, le=MAX_INDUCED_DELETION_VERTICES)
+    maximum_min_deletions: StrictInt = Field(ge=0)
+    attaining_subset_count: StrictInt = Field(ge=1)
+
+
+class InducedDeletionRow(StrictModel):
+    """One vertex subset S, its minimum deletions, and one canonical attaining F."""
+
+    vertex_subset: tuple[str, ...]
+    min_deletions: StrictInt = Field(ge=0)
+    deleted_edges: tuple[tuple[str, str], ...]
+    induced_edge_count: StrictInt = Field(ge=0)
+
+    @model_validator(mode="after")
+    def require_canonical_row(self) -> Self:
+        if tuple(sorted(self.vertex_subset)) != self.vertex_subset:
+            raise PydanticCustomError(
+                "graph.vertex_subset_must_be_canonically_sorted",
+                "vertex_subset must be canonically sorted",
+            )
+        if len(set(self.vertex_subset)) != len(self.vertex_subset):
+            raise PydanticCustomError(
+                "graph.vertex_subset_must_have_unique_vertices",
+                "vertex_subset must have unique vertices",
+            )
+        if self.deleted_edges != tuple(sorted(self.deleted_edges)):
+            raise PydanticCustomError(
+                "graph.deleted_edges_must_be_canonically_sorted",
+                "deleted_edges must be canonically sorted",
+            )
+        if len(set(self.deleted_edges)) != len(self.deleted_edges):
+            raise PydanticCustomError(
+                "graph.deleted_edges_must_be_unique",
+                "deleted_edges must be unique",
+            )
+        for left, right in self.deleted_edges:
+            if left >= right:
+                raise PydanticCustomError(
+                    "graph.deleted_edges_must_be_canonical_pairs",
+                    "deleted edges must be canonical pairs with left < right",
+                )
+        if self.min_deletions != len(self.deleted_edges):
+            raise PydanticCustomError(
+                "graph.min_deletions_must_match_deleted_edges",
+                "min_deletions must equal len(deleted_edges)",
+            )
+        if self.min_deletions > self.induced_edge_count:
+            raise PydanticCustomError(
+                "graph.min_deletions_cannot_exceed_induced_edges",
+                "min_deletions cannot exceed induced_edge_count",
+            )
+        return self
+
+
+class InducedEdgeDeletionProfileResult(StrictModel):
+    """Complete profile D_{G,r}(S) over all 2^n vertex subsets with per-size maxima."""
+
+    graph: SimpleUndirectedGraph
+    r: StrictInt = Field(ge=1, le=MAX_INDUCED_DELETION_R)
+    solver_conflicts: StrictInt = Field(ge=1, le=MAX_SOLVER_CONFLICT_BUDGET)
+    rows: tuple[InducedDeletionRow, ...]
+    max_deletions_by_size: tuple[PerSizeMaximum, ...]
+
+    @model_validator(mode="after")
+    def require_profile_consistency(self) -> Self:  # noqa: C901
+        n = len(self.graph.vertices)
+        expected_rows = 1 << n if n <= MAX_INDUCED_DELETION_VERTICES else None
+        if expected_rows is not None and len(self.rows) != expected_rows:
+            raise PydanticCustomError(
+                "graph.rows_must_cover_all_vertex_subsets",
+                "rows must cover all 2^n vertex subsets",
+            )
+        if len(self.max_deletions_by_size) != n + 1:
+            raise PydanticCustomError(
+                "graph.max_by_size_must_cover_0_n",
+                "max_deletions_by_size must have n+1 entries for sizes 0..n",
+            )
+        for entry in self.max_deletions_by_size:
+            if entry.subset_size < 0 or entry.subset_size > n:
+                raise PydanticCustomError(
+                    "graph.per_size_subset_size_out_of_range",
+                    "per-size subset_size must be in 0..n",
+                )
+        sizes = tuple(e.subset_size for e in self.max_deletions_by_size)
+        if sizes != tuple(sorted(sizes)) or len(set(sizes)) != len(sizes):
+            raise PydanticCustomError(
+                "graph.per_size_must_be_sorted_unique",
+                "per-size entries must be sorted and unique by subset_size",
+            )
+        # Verify rows are canonically ordered by (size, lexicographic)
+        expected_order = tuple(
+            sorted(
+                self.rows, key=lambda row: (len(row.vertex_subset), row.vertex_subset)
+            )
+        )
+        if self.rows != expected_order:
+            raise PydanticCustomError(
+                "graph.rows_must_be_canonically_ordered",
+                "rows must be ordered by (subset_size, lexicographic vertex_subset)",
+            )
+        # Verify max projection matches rows
+        from collections import defaultdict
+
+        grouped: dict[int, list[int]] = defaultdict(list)
+        for row in self.rows:
+            grouped[len(row.vertex_subset)].append(row.min_deletions)
+        for entry in self.max_deletions_by_size:
+            vals = grouped.get(entry.subset_size, [])
+            if not vals:
+                # empty size class impossible when n limited, but handle
+                if (
+                    entry.maximum_min_deletions != 0
+                    or entry.attaining_subset_count != 0
+                ):
+                    raise PydanticCustomError(
+                        "graph.max_must_match_rows",
+                        "per-size maximum must match rows",
+                    )
+                continue
+            max_val = max(vals)
+            count = sum(1 for v in vals if v == max_val)
+            if (
+                entry.maximum_min_deletions != max_val
+                or entry.attaining_subset_count != count
+            ):
+                raise PydanticCustomError(
+                    "graph.max_must_be_derived_from_rows",
+                    "per-size maximum must be derived from rows",
+                )
+        # Deleted edges must be subset of graph edges and induced
+        graph_edge_set = set(self.graph.edges)
+        vertex_set = set(self.graph.vertices)
+        for row in self.rows:
+            subset_set = set(row.vertex_subset)
+            if not subset_set <= vertex_set:
+                raise PydanticCustomError(
+                    "graph.vertex_subset_must_be_subset_of_graph",
+                    "vertex_subset must be subset of graph vertices",
+                )
+            induced = {
+                e for e in graph_edge_set if e[0] in subset_set and e[1] in subset_set
+            }
+            if not set(row.deleted_edges) <= induced:
+                raise PydanticCustomError(
+                    "graph.deleted_edges_must_be_subset_of_induced",
+                    "deleted_edges must be subset of induced edges E(G[S])",
+                )
+            if row.induced_edge_count != len(induced):
+                raise PydanticCustomError(
+                    "graph.induced_edge_count_must_match_graph",
+                    "induced_edge_count must equal |E(G[S])|",
+                )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        graph: SimpleUndirectedGraph,
+        r: int,
+        solver_conflicts: int,
+        rows: tuple[InducedDeletionRow, ...],
+        max_deletions_by_size: tuple[PerSizeMaximum, ...],
+    ) -> Self:
+        return cls.model_construct(
+            graph=graph,
+            r=r,
+            solver_conflicts=solver_conflicts,
+            rows=rows,
+            max_deletions_by_size=max_deletions_by_size,
+        )
+
+
+__all__ = [
+    "DEFAULT_INDUCED_SOLVER_CONFLICTS",
+    "MAX_INDUCED_DELETION_R",
+    "MAX_INDUCED_DELETION_VERTICES",
+    "MAX_INDUCED_EDGE_MATERIALIZATION",
+    "MAX_INDUCED_LEDGER_CONFLICTS",
+    "MAX_INDUCED_RETAINED_LABEL_CHARACTERS",
+    "MAX_INDUCED_SOLVER_CALLS",
+    "InducedDeletionGraph",
+    "InducedDeletionRow",
+    "InducedEdgeDeletionProfileRequest",
+    "InducedEdgeDeletionProfileResult",
+    "PerSizeMaximum",
+]

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from itertools import combinations
 from typing import Annotated, Self
 
 from pydantic import Field, StrictInt, WithJsonSchema, model_validator
@@ -18,6 +19,8 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 MAX_INDUCED_DELETION_VERTICES = 8
 """Conservative vertex envelope for the complete 2^n profile (8 => 256 rows)."""
 
+# Values above the backend's colour-variable envelope are still exact trivial
+# cases whenever r covers an induced subset, so they are not an input bound.
 MAX_INDUCED_DELETION_R = MAX_COLORING_COLORS
 DEFAULT_INDUCED_SOLVER_CONFLICTS = 100_000
 MAX_INDUCED_RETAINED_LABEL_CHARACTERS = 1_000_000
@@ -48,7 +51,6 @@ class InducedEdgeDeletionProfileRequest(StrictModel):
     graph: InducedDeletionGraph
     r: StrictInt = Field(
         ge=1,
-        le=MAX_INDUCED_DELETION_R,
         description="Target colour count r >=1; D(S) is min deletions to make G[S] r-colourable.",
     )
     solver_conflicts: StrictInt = Field(
@@ -123,7 +125,7 @@ class InducedEdgeDeletionProfileResult(StrictModel):
     """Complete profile D_{G,r}(S) over all 2^n vertex subsets with per-size maxima."""
 
     graph: SimpleUndirectedGraph
-    r: StrictInt = Field(ge=1, le=MAX_INDUCED_DELETION_R)
+    r: StrictInt = Field(ge=1)
     solver_conflicts: StrictInt = Field(ge=1, le=MAX_SOLVER_CONFLICT_BUDGET)
     rows: tuple[InducedDeletionRow, ...]
     max_deletions_by_size: tuple[PerSizeMaximum, ...]
@@ -136,6 +138,16 @@ class InducedEdgeDeletionProfileResult(StrictModel):
             raise PydanticCustomError(
                 "graph.rows_must_cover_all_vertex_subsets",
                 "rows must cover all 2^n vertex subsets",
+            )
+        expected_subsets = tuple(
+            subset
+            for size in range(n + 1)
+            for subset in combinations(self.graph.vertices, size)
+        )
+        if tuple(row.vertex_subset for row in self.rows) != expected_subsets:
+            raise PydanticCustomError(
+                "graph.rows_must_cover_each_vertex_subset",
+                "rows must contain every canonical vertex subset exactly once",
             )
         if len(self.max_deletions_by_size) != n + 1:
             raise PydanticCustomError(

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
@@ -22,6 +22,7 @@ MAX_INDUCED_DELETION_VERTICES = 8
 # Values above the backend's colour-variable envelope are still exact trivial
 # cases whenever r covers an induced subset, so they are not an input bound.
 MAX_INDUCED_DELETION_R = MAX_COLORING_COLORS
+MAX_INDUCED_DELETION_R_BITS = 4096
 DEFAULT_INDUCED_SOLVER_CONFLICTS = 100_000
 MAX_INDUCED_RETAINED_LABEL_CHARACTERS = 1_000_000
 MAX_INDUCED_EDGE_MATERIALIZATION = 200_000
@@ -51,6 +52,7 @@ class InducedEdgeDeletionProfileRequest(StrictModel):
     graph: InducedDeletionGraph
     r: StrictInt = Field(
         ge=1,
+        le=(1 << MAX_INDUCED_DELETION_R_BITS) - 1,
         description="Target colour count r >=1; D(S) is min deletions to make G[S] r-colourable.",
     )
     solver_conflicts: StrictInt = Field(
@@ -125,7 +127,7 @@ class InducedEdgeDeletionProfileResult(StrictModel):
     """Complete profile D_{G,r}(S) over all 2^n vertex subsets with per-size maxima."""
 
     graph: SimpleUndirectedGraph
-    r: StrictInt = Field(ge=1)
+    r: StrictInt = Field(ge=1, le=(1 << MAX_INDUCED_DELETION_R_BITS) - 1)
     solver_conflicts: StrictInt = Field(ge=1, le=MAX_SOLVER_CONFLICT_BUDGET)
     rows: tuple[InducedDeletionRow, ...]
     max_deletions_by_size: tuple[PerSizeMaximum, ...]

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_tools.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_tools.py
@@ -1,0 +1,73 @@
+"""Induced edge deletion profile operation declarations."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.coloring.induced_edge_deletion_profile._models import (
+    InducedEdgeDeletionProfileRequest,
+    InducedEdgeDeletionProfileResult,
+)
+from jacobian.math.graphs.coloring.induced_edge_deletion_profile.operations import (
+    compute_induced_edge_deletion_profile,
+)
+
+
+def compute_induced_edge_deletion_profile_op(
+    request: InducedEdgeDeletionProfileRequest,
+) -> InducedEdgeDeletionProfileResult:
+    return compute_induced_edge_deletion_profile(
+        request.graph, request.r, request.solver_conflicts
+    )
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="graph.coloring.induced_edge_deletion_profile.compute",
+        title="Profile induced subgraphs by minimum edge deletion to r-colourability",
+        description=(
+            "For a finite labelled simple graph G and integer r>=1, return the "
+            "induced profile D_{G,r}(S)=min{|F|: F subset E(G[S]) and chi(G[S]-F) <= r} "
+            "for every vertex subset S, with one canonical lexicographically smallest "
+            "attaining edge set F per S. The result is exact over all 2^n "
+            "vertex subsets; the derived per-size maximum max_{|S|=m} D(S) is exposed "
+            "as a deterministic projection. The graph is limited to at most 8 vertices (256 rows) "
+            "and the aggregate Z3 conflict ledger is bounded."
+        ),
+        request_type=InducedEdgeDeletionProfileRequest,
+        result_type=InducedEdgeDeletionProfileResult,
+        run=compute_induced_edge_deletion_profile_op,
+        tags=("graph", "coloring", "induced", "edge-deletion", "profile", "exact"),
+        examples=(
+            OperationExample(
+                name="triangle_r2_profile",
+                description=(
+                    "K3 at r=2: the whole vertex set needs one source-edge deletion to "
+                    "become bipartite, every proper induced subgraph needs zero; the graph "
+                    "has at most 8 vertices and r is at least 1."
+                ),
+                input={
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["a", "c"], ["b", "c"]],
+                    },
+                    "r": 2,
+                },
+            ),
+            OperationExample(
+                name="path4_r2_already_bipartite",
+                description=(
+                    "P4 at r=2 is already bipartite on every induced subgraph, so every "
+                    "row has min_deletions zero; the request must respect the 8-vertex and "
+                    "solver-conflict bounds."
+                ),
+                input={
+                    "graph": {
+                        "vertices": ["0", "1", "2", "3"],
+                        "edges": [["0", "1"], ["1", "2"], ["2", "3"]],
+                    },
+                    "r": 2,
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
@@ -121,7 +121,7 @@ def _z3_is_r_colorable(
         return True
     if outcome == z3.unsat:
         return False
-    if "max-conflicts-reached" in solver.reason_unknown():
+    if solver.reason_unknown() in {"timeout", "max-conflicts-reached"}:
         raise OperationExecutionTimeoutError(
             "induced deletion profile r-colourability check exhausted its conflict budget"
         )
@@ -183,7 +183,7 @@ def _z3_exists_deletion_leq_k(
         return True
     if outcome == z3.unsat:
         return False
-    if "max-conflicts-reached" in solver.reason_unknown():
+    if solver.reason_unknown() in {"timeout", "max-conflicts-reached"}:
         raise OperationExecutionTimeoutError(
             "induced deletion feasibility check exhausted its conflict budget"
         )

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
@@ -468,7 +468,6 @@ def compute_induced_edge_deletion_profile(
     return InducedEdgeDeletionProfileResult._from_kernel(
         graph=graph,
         r=r,
-        solver_conflicts=solver_conflicts,
         rows=tuple(rows),
         max_deletions_by_size=tuple(per_size),
     )

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
@@ -1,0 +1,462 @@
+"""Induced edge deletion profile kernel with bounded exact colourability."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from itertools import combinations
+from typing import Any
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.coloring.induced_edge_deletion_profile._models import (
+    DEFAULT_INDUCED_SOLVER_CONFLICTS,
+    MAX_INDUCED_DELETION_R,
+    MAX_INDUCED_DELETION_VERTICES,
+    MAX_INDUCED_EDGE_MATERIALIZATION,
+    MAX_INDUCED_LEDGER_CONFLICTS,
+    MAX_INDUCED_RETAINED_LABEL_CHARACTERS,
+    MAX_INDUCED_SOLVER_CALLS,
+    InducedDeletionRow,
+    InducedEdgeDeletionProfileResult,
+    PerSizeMaximum,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+_OWNER_DEADLINE_SECONDS = 3600.0
+
+
+def _require_execution_active(stage: str) -> None:
+    request_checkpoint(stage)
+    execution = current_request_execution()
+    if (
+        execution is not None
+        and execution.deadline is not None
+        and time.monotonic() >= execution.deadline
+    ):
+        raise OperationExecutionTimeoutError(f"request deadline expired {stage}")
+
+
+def _is_bipartite_vertices_edges(
+    vertices: list[str], edges: list[tuple[str, str]]
+) -> bool:
+    adj: dict[str, set[str]] = {v: set() for v in vertices}
+    for a, b in edges:
+        adj[a].add(b)
+        adj[b].add(a)
+    color: dict[str, bool] = {}
+    for start in vertices:
+        if start in color:
+            continue
+        color[start] = False
+        stack = [start]
+        while stack:
+            v = stack.pop()
+            for nb in adj[v]:
+                if nb not in color:
+                    color[nb] = not color[v]
+                    stack.append(nb)
+                elif color[nb] == color[v]:
+                    return False
+    return True
+
+
+def _is_r_colorable_without_deletion(
+    vertices: list[str],
+    edges: list[tuple[str, str]],
+    r: int,
+    solver_conflicts: int,
+) -> bool:
+    """Check if graph (vertices, edges) is r-colourable using bounded Z3 or trivial cases."""
+    if not edges:
+        return True
+    if r == 1:
+        return False
+    if r >= len(vertices):
+        return True
+    if r == 2:
+        return _is_bipartite_vertices_edges(vertices, edges)
+    # r >=3 use Z3
+    return _z3_is_r_colorable(vertices, edges, r, solver_conflicts)
+
+
+def _z3_is_r_colorable(
+    vertices: list[str],
+    edges: list[tuple[str, str]],
+    r: int,
+    solver_conflicts: int,
+) -> bool:
+    import z3
+
+    _require_execution_active("during r-colourability check")
+    solver = z3.Solver()
+    solver.set("max_conflicts", solver_conflicts)
+    # map vertex -> int var
+    var_map: dict[str, Any] = {}
+    for v in vertices:
+        var_map[v] = z3.Int(f"c_{v}")
+        solver.add(var_map[v] >= 0, var_map[v] < r)
+    for a, b in edges:
+        solver.add(var_map[a] != var_map[b])
+    outcome = solver.check()
+    if outcome == z3.sat:
+        return True
+    if outcome == z3.unsat:
+        return False
+    if "max-conflicts-reached" in solver.reason_unknown():
+        raise OperationExecutionTimeoutError(
+            "induced deletion profile r-colourability check exhausted its conflict budget"
+        )
+    raise RuntimeError("bounded r-colourability worker did not establish an outcome")
+
+
+def _z3_exists_deletion_leq_k(
+    vertices: list[str],
+    edges: list[tuple[str, str]],
+    r: int,
+    k: int,
+    solver_conflicts: int,
+    partial: dict[int, bool] | None = None,
+    exact: bool = False,
+) -> bool:
+    """Check existence of deletion set with |F| <=k (or ==k if exact) making graph r-colourable."""
+    import z3
+
+    _require_execution_active("during deletion feasibility check")
+    if k < 0:
+        return False
+    m = len(edges)
+    if k >= m and partial is None:
+        # deleting all edges yields edgeless, which is r-colourable for r>=1
+        return True
+    if r == 1 and partial is None:
+        # r=1 feasible iff we can delete all edges that remain (i.e., make edgeless)
+        if exact:
+            return k == m
+        return k >= m
+    solver = z3.Solver()
+    solver.set("max_conflicts", solver_conflicts)
+    color_vars: dict[str, Any] = {}
+    for v in vertices:
+        color_vars[v] = z3.Int(f"c_{v}")
+        solver.add(color_vars[v] >= 0, color_vars[v] < r)
+    deletion_vars = [z3.Bool(f"d_{idx}") for idx in range(m)]
+    for idx, (a, b) in enumerate(edges):
+        # if not deleted then colours differ
+        solver.add(
+            z3.Implies(z3.Not(deletion_vars[idx]), color_vars[a] != color_vars[b])
+        )
+    # cardinality
+    total = z3.Sum([z3.If(v, 1, 0) for v in deletion_vars])
+    if exact:
+        solver.add(total == k)
+    else:
+        solver.add(total <= k)
+    if partial is not None:
+        for idx, val in partial.items():
+            if val:
+                solver.add(deletion_vars[idx])
+            else:
+                solver.add(z3.Not(deletion_vars[idx]))
+    outcome = solver.check()
+    if outcome == z3.sat:
+        return True
+    if outcome == z3.unsat:
+        return False
+    if "max-conflicts-reached" in solver.reason_unknown():
+        raise OperationExecutionTimeoutError(
+            "induced deletion feasibility check exhausted its conflict budget"
+        )
+    raise RuntimeError(
+        "bounded deletion feasibility check did not establish an outcome"
+    )
+
+
+def _admit_induced_edge_deletion_profile(
+    graph: SimpleUndirectedGraph,
+    r: int,
+    solver_conflicts: int,
+) -> None:
+    if type(r) is not int or not 1 <= r <= MAX_INDUCED_DELETION_R:
+        raise OperationDomainValidationError(
+            location=("r",),
+            code="graph.induced_edge_deletion.r_out_of_range",
+            message=f"r must be an integer between 1 and {MAX_INDUCED_DELETION_R}",
+        )
+    if type(solver_conflicts) is not int or not 1 <= solver_conflicts <= 1_000_000:
+        raise OperationDomainValidationError(
+            location=("solver_conflicts",),
+            code="graph.induced_edge_deletion.solver_conflicts_out_of_range",
+            message="solver_conflicts must be an integer between 1 and 1000000",
+        )
+    n = len(graph.vertices)
+    if n > MAX_INDUCED_DELETION_VERTICES:
+        raise OperationDomainValidationError(
+            location=("graph", "vertices"),
+            code="graph.induced_edge_deletion.vertex_count_exceeds_bound",
+            message=(
+                f"induced-edge deletion profile supports at most {MAX_INDUCED_DELETION_VERTICES} "
+                f"vertices (got {n})"
+            ),
+        )
+    rows = 1 << n
+    # rows bound already via n, but check
+    if rows > (1 << MAX_INDUCED_DELETION_VERTICES):
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.induced_edge_deletion.rows_exceed_bound",
+            message="induced-edge deletion profile subset rows exceed the admitted bound",
+        )
+    # retained label characters
+    source_chars = sum(len(v) for v in graph.vertices) + sum(
+        len(u) + len(v) for u, v in graph.edges
+    )
+    vertex_lengths = sorted((len(v) for v in graph.vertices), reverse=True)
+    edge_lengths = sorted((len(u) + len(v) for u, v in graph.edges), reverse=True)
+    # worst witness per row: all vertices + all edges (complete case)
+    max_m = n * (n - 1) // 2
+    largest_vertex_witness = sum(vertex_lengths)  # all vertices in subset
+    largest_edge_witness = (
+        sum(edge_lengths[: min(len(edge_lengths), max_m)]) if edge_lengths else 0
+    )
+    largest_witness = largest_vertex_witness + largest_edge_witness
+    # per row we also store vertex_subset tuple (vertex labels) and deleted edges
+    if source_chars + rows * largest_witness > MAX_INDUCED_RETAINED_LABEL_CHARACTERS:
+        raise OperationDomainValidationError(
+            location=("graph", "vertices"),
+            code="graph.induced_edge_deletion.retained_labels_exceed_bound",
+            message="induced-edge deletion profile exceeds the retained label-character bound",
+        )
+    m = len(graph.edges)
+    edge_materialization_work = rows * m
+    if edge_materialization_work > MAX_INDUCED_EDGE_MATERIALIZATION:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.induced_edge_deletion.materialization_exceeds_bound",
+            message="induced-edge deletion profile induced-edge materialization exceeds its bound",
+        )
+    # predicted solver calls: quick enumeration of induced edge counts per subset
+    sorted_vertices = sorted(graph.vertices)
+    sorted_edges = tuple(sorted(graph.edges))
+    # quick map for counting
+    predicted_calls = 0
+    # also track ledger
+    for size in range(n + 1):
+        for subset in combinations(sorted_vertices, size):
+            _require_execution_active("during admission subset scan")
+            subset_set = set(subset)
+            m_s = 0
+            for a, b in sorted_edges:
+                if a in subset_set and b in subset_set:
+                    m_s += 1
+            if m_s == 0 or r == 1 or r >= len(subset):
+                continue
+            # if we can shortcut 0-deletion check we still need at least 1 call worst
+            # need to estimate worst 2*m_s+1
+            predicted_calls += 2 * m_s + 1
+            if predicted_calls > MAX_INDUCED_SOLVER_CALLS:
+                raise OperationDomainValidationError(
+                    location=("graph",),
+                    code="graph.induced_edge_deletion.solver_calls_exceed_bound",
+                    message="induced-edge deletion profile solver-call bound exceeded",
+                )
+    ledger = predicted_calls * solver_conflicts
+    if ledger > MAX_INDUCED_LEDGER_CONFLICTS:
+        raise OperationDomainValidationError(
+            location=("solver_conflicts",),
+            code="graph.induced_edge_deletion.ledger_exceeds_bound",
+            message="induced-edge deletion profile ledger exceeds its conflict budget",
+        )
+
+
+def _compute_min_deletions_for_subset(
+    subset_vertices: tuple[str, ...],
+    induced_edges: list[tuple[str, str]],
+    r: int,
+    solver_conflicts: int,
+) -> tuple[int, tuple[tuple[str, str], ...]]:
+    """Return (min_deletions, canonical deleted_edges) for one subset S."""
+    m = len(induced_edges)
+    n_s = len(subset_vertices)
+    if m == 0:
+        return 0, ()
+    if r >= n_s:
+        return 0, ()
+    if r == 1:
+        # need to delete all edges to become edgeless
+        return m, tuple(sorted(induced_edges))
+
+    # quick check if already r-colourable with 0 deletions
+    _require_execution_active("during subset optimisation")
+    if _is_r_colorable_without_deletion(
+        list(subset_vertices), induced_edges, r, solver_conflicts
+    ):
+        return 0, ()
+
+    # linear scan for minimal k
+    min_k: int | None = None
+    for k in range(1, m + 1):
+        _require_execution_active("during deletion optimum search")
+        if _z3_exists_deletion_leq_k(
+            list(subset_vertices),
+            induced_edges,
+            r,
+            k,
+            solver_conflicts,
+            partial=None,
+            exact=False,
+        ):
+            min_k = k
+            break
+    if min_k is None:
+        # Should not happen because deleting all edges yields edgeless which is r-colourable
+        # For r>=1, edgeless is 1-colourable so feasible
+        min_k = m
+    k = min_k
+
+    # Find canonical attaining set via greedy lexicographic fixing
+    # induced_edges are already sorted lexicographically
+    partial: dict[int, bool] = {}
+    # we know total exactly k
+    for idx in range(m):
+        _require_execution_active("during canonical tie-break")
+        already_chosen = sum(1 for v in partial.values() if v)
+        remaining_needed = k - already_chosen
+        remaining_positions = m - idx
+        # mandatory cases without solver
+        if remaining_needed == 0:
+            partial[idx] = False
+            continue
+        if remaining_needed == remaining_positions:
+            # must delete all remaining
+            for j in range(idx, m):
+                partial[j] = True
+            break
+        if remaining_needed < 0 or remaining_needed > remaining_positions:
+            raise AssertionError("lexicographic remaining count infeasible")
+        # try include idx
+        test_partial = dict(partial)
+        test_partial[idx] = True
+        feasible_include = _z3_exists_deletion_leq_k(
+            list(subset_vertices),
+            induced_edges,
+            r,
+            k,
+            solver_conflicts,
+            partial=test_partial,
+            exact=True,
+        )
+        if feasible_include:
+            partial[idx] = True
+        else:
+            partial[idx] = False
+            # must be feasible with False, else no solution exists which contradicts existence of k
+            # we could assert
+            # check quickly that False branch is feasible (should be)
+            # Not needed to solver check again; greedy ensures alternative works
+            # But we could verify for debugging
+    deleted = tuple(induced_edges[i] for i, val in sorted(partial.items()) if val)
+    # sanity: should be sorted already because induced_edges sorted and we iterate in order
+    assert deleted == tuple(sorted(deleted))
+    assert len(deleted) == k
+    # verify that G[S]-F is indeed r-colourable (reconstruction)
+    remaining_edges = [e for e in induced_edges if e not in set(deleted)]
+    if not _is_r_colorable_without_deletion(
+        list(subset_vertices), remaining_edges, r, solver_conflicts
+    ):
+        raise AssertionError("canonical deletion set does not yield r-colourable graph")
+    return k, deleted
+
+
+def compute_induced_edge_deletion_profile(
+    graph: SimpleUndirectedGraph,
+    r: int,
+    solver_conflicts: int = DEFAULT_INDUCED_SOLVER_CONFLICTS,
+) -> InducedEdgeDeletionProfileResult:
+    """Return D_{G,r}(S) for every vertex subset S with canonical attaining F and per-size maxima.
+
+    For each subset S of V(G), D(S) is the minimum number of edges to delete from
+    the induced subgraph G[S] to obtain an r-colourable graph, and the returned
+    F is the lexicographically smallest source-edge subset attaining that minimum.
+    The per-size maxima are derived as max_{|S|=m} D(S).
+    """
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return compute_induced_edge_deletion_profile(graph, r, solver_conflicts)
+    if execution.deadline is None:
+        bind_request_deadline(execution.started_at + _OWNER_DEADLINE_SECONDS)
+    _require_execution_active("before admission")
+    _admit_induced_edge_deletion_profile(graph, r, solver_conflicts)
+
+    sorted_vertices = sorted(graph.vertices)
+    sorted_edges = tuple(sorted(graph.edges))
+    n = len(sorted_vertices)
+
+    rows: list[InducedDeletionRow] = []
+    # enumerate subsets by increasing size then lexicographic
+    for size in range(n + 1):
+        _require_execution_active("during profile enumeration")
+        for subset in combinations(sorted_vertices, size):
+            _require_execution_active("during subset processing")
+            subset_tuple = tuple(subset)  # already sorted
+            subset_set = set(subset_tuple)
+            induced_edges = [
+                e for e in sorted_edges if e[0] in subset_set and e[1] in subset_set
+            ]
+            induced_edge_count = len(induced_edges)
+            min_k, deleted = _compute_min_deletions_for_subset(
+                subset_tuple, induced_edges, r, solver_conflicts
+            )
+            rows.append(
+                InducedDeletionRow(
+                    vertex_subset=subset_tuple,
+                    min_deletions=min_k,
+                    deleted_edges=deleted,
+                    induced_edge_count=induced_edge_count,
+                )
+            )
+
+    # rows already in canonical order due to enumeration order
+    # derive per-size maxima
+    grouped: dict[int, list[int]] = defaultdict(list)
+    for row in rows:
+        grouped[len(row.vertex_subset)].append(row.min_deletions)
+    per_size: list[PerSizeMaximum] = []
+    for size in range(n + 1):
+        vals = grouped.get(size, [])
+        if not vals:
+            # Should not happen because there is at least one subset per size
+            # For completeness, zero
+            per_size.append(
+                PerSizeMaximum(
+                    subset_size=size, maximum_min_deletions=0, attaining_subset_count=0
+                )
+            )
+        else:
+            max_val = max(vals)
+            count = sum(1 for v in vals if v == max_val)
+            per_size.append(
+                PerSizeMaximum(
+                    subset_size=size,
+                    maximum_min_deletions=max_val,
+                    attaining_subset_count=count,
+                )
+            )
+
+    return InducedEdgeDeletionProfileResult._from_kernel(
+        graph=graph,
+        r=r,
+        solver_conflicts=solver_conflicts,
+        rows=tuple(rows),
+        max_deletions_by_size=tuple(per_size),
+    )
+
+
+__all__ = ["compute_induced_edge_deletion_profile"]

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
@@ -17,7 +17,6 @@ from jacobian._execution import (
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.coloring.induced_edge_deletion_profile._models import (
     DEFAULT_INDUCED_SOLVER_CONFLICTS,
-    MAX_INDUCED_DELETION_R,
     MAX_INDUCED_DELETION_VERTICES,
     MAX_INDUCED_EDGE_MATERIALIZATION,
     MAX_INDUCED_LEDGER_CONFLICTS,
@@ -41,6 +40,17 @@ def _require_execution_active(stage: str) -> None:
         and time.monotonic() >= execution.deadline
     ):
         raise OperationExecutionTimeoutError(f"request deadline expired {stage}")
+
+
+def _set_remaining_z3_timeout(solver: Any) -> None:
+    """Give each in-process Z3 call the request's remaining wall-time budget."""
+    execution = current_request_execution()
+    if execution is None or execution.deadline is None:
+        return
+    remaining_milliseconds = int((execution.deadline - time.monotonic()) * 1000)
+    if remaining_milliseconds <= 0:
+        raise OperationExecutionTimeoutError("request deadline expired before Z3 call")
+    solver.set("timeout", remaining_milliseconds)
 
 
 def _is_bipartite_vertices_edges(
@@ -97,6 +107,7 @@ def _z3_is_r_colorable(
     _require_execution_active("during r-colourability check")
     solver = z3.Solver()
     solver.set("max_conflicts", solver_conflicts)
+    _set_remaining_z3_timeout(solver)
     # map vertex -> int var
     var_map: dict[str, Any] = {}
     for v in vertices:
@@ -105,6 +116,7 @@ def _z3_is_r_colorable(
     for a, b in edges:
         solver.add(var_map[a] != var_map[b])
     outcome = solver.check()
+    _require_execution_active("after r-colourability check")
     if outcome == z3.sat:
         return True
     if outcome == z3.unsat:
@@ -142,6 +154,7 @@ def _z3_exists_deletion_leq_k(
         return k >= m
     solver = z3.Solver()
     solver.set("max_conflicts", solver_conflicts)
+    _set_remaining_z3_timeout(solver)
     color_vars: dict[str, Any] = {}
     for v in vertices:
         color_vars[v] = z3.Int(f"c_{v}")
@@ -165,6 +178,7 @@ def _z3_exists_deletion_leq_k(
             else:
                 solver.add(z3.Not(deletion_vars[idx]))
     outcome = solver.check()
+    _require_execution_active("after deletion feasibility check")
     if outcome == z3.sat:
         return True
     if outcome == z3.unsat:
@@ -183,11 +197,11 @@ def _admit_induced_edge_deletion_profile(
     r: int,
     solver_conflicts: int,
 ) -> None:
-    if type(r) is not int or not 1 <= r <= MAX_INDUCED_DELETION_R:
+    if type(r) is not int or r < 1:
         raise OperationDomainValidationError(
             location=("r",),
             code="graph.induced_edge_deletion.r_out_of_range",
-            message=f"r must be an integer between 1 and {MAX_INDUCED_DELETION_R}",
+            message="r must be a positive integer",
         )
     if type(solver_conflicts) is not int or not 1 <= solver_conflicts <= 1_000_000:
         raise OperationDomainValidationError(
@@ -247,6 +261,9 @@ def _admit_induced_edge_deletion_profile(
     # quick map for counting
     predicted_calls = 0
     # also track ledger
+    graph_is_bipartite = r == 2 and _is_bipartite_vertices_edges(
+        sorted_vertices, list(sorted_edges)
+    )
     for size in range(n + 1):
         for subset in combinations(sorted_vertices, size):
             _require_execution_active("during admission subset scan")
@@ -255,7 +272,7 @@ def _admit_induced_edge_deletion_profile(
             for a, b in sorted_edges:
                 if a in subset_set and b in subset_set:
                     m_s += 1
-            if m_s == 0 or r == 1 or r >= len(subset):
+            if m_s == 0 or r == 1 or r >= len(subset) or graph_is_bipartite:
                 continue
             # if we can shortcut 0-deletion check we still need at least 1 call worst
             # need to estimate worst 2*m_s+1

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
@@ -195,7 +195,7 @@ def _admit_induced_edge_deletion_profile(
     r: int,
     solver_conflicts: int,
 ) -> None:
-    if type(r) is not int or r < 1 or r.bit_length() > 4096:
+    if type(r) is not int or r < 1 or r.bit_length() > 53:
         raise OperationDomainValidationError(
             location=("r",),
             code="graph.induced_edge_deletion.r_out_of_range",

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
@@ -109,10 +109,9 @@ def _z3_is_r_colorable(
     solver.set("max_conflicts", solver_conflicts)
     _set_remaining_z3_timeout(solver)
     # map vertex -> int var
-    var_map: dict[str, Any] = {}
-    for v in vertices:
-        var_map[v] = z3.Int(f"c_{v}")
-        solver.add(var_map[v] >= 0, var_map[v] < r)
+    var_map = {vertex: z3.Int(f"c_{index}") for index, vertex in enumerate(vertices)}
+    for variable in var_map.values():
+        solver.add(variable >= 0, variable < r)
     for a, b in edges:
         solver.add(var_map[a] != var_map[b])
     outcome = solver.check()
@@ -155,10 +154,9 @@ def _z3_exists_deletion_leq_k(
     solver = z3.Solver()
     solver.set("max_conflicts", solver_conflicts)
     _set_remaining_z3_timeout(solver)
-    color_vars: dict[str, Any] = {}
-    for v in vertices:
-        color_vars[v] = z3.Int(f"c_{v}")
-        solver.add(color_vars[v] >= 0, color_vars[v] < r)
+    color_vars = {vertex: z3.Int(f"c_{index}") for index, vertex in enumerate(vertices)}
+    for variable in color_vars.values():
+        solver.add(variable >= 0, variable < r)
     deletion_vars = [z3.Bool(f"d_{idx}") for idx in range(m)]
     for idx, (a, b) in enumerate(edges):
         # if not deleted then colours differ
@@ -197,7 +195,7 @@ def _admit_induced_edge_deletion_profile(
     r: int,
     solver_conflicts: int,
 ) -> None:
-    if type(r) is not int or r < 1:
+    if type(r) is not int or r < 1 or r.bit_length() > 4096:
         raise OperationDomainValidationError(
             location=("r",),
             code="graph.induced_edge_deletion.r_out_of_range",

--- a/tests/math/graphs/coloring/induced_edge_deletion_profile/test_induced_edge_deletion_profile.py
+++ b/tests/math/graphs/coloring/induced_edge_deletion_profile/test_induced_edge_deletion_profile.py
@@ -407,12 +407,14 @@ def test_r1_and_large_r_shortcuts() -> None:
         assert row.min_deletions == 0
 
 
-def test_empty_request_validation() -> None:
-    # request model validation for r out of range
+def test_request_validation_and_large_trivial_colour_count() -> None:
     from pydantic import ValidationError
 
     g = _graph(["a"], [])
     with pytest.raises(ValidationError):
         InducedEdgeDeletionProfileRequest(graph=g, r=0)
-    with pytest.raises(ValidationError):
-        InducedEdgeDeletionProfileRequest(graph=g, r=100)
+    assert InducedEdgeDeletionProfileRequest(graph=g, r=100).r == 100
+    assert all(
+        row.min_deletions == 0
+        for row in compute_induced_edge_deletion_profile(g, 100).rows
+    )

--- a/tests/math/graphs/coloring/induced_edge_deletion_profile/test_induced_edge_deletion_profile.py
+++ b/tests/math/graphs/coloring/induced_edge_deletion_profile/test_induced_edge_deletion_profile.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from itertools import combinations, product
+
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.coloring.induced_edge_deletion_profile._models import (
+    InducedEdgeDeletionProfileRequest,
+    InducedEdgeDeletionProfileResult,
+)
+from jacobian.math.graphs.coloring.induced_edge_deletion_profile.operations import (
+    compute_induced_edge_deletion_profile,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph(
+    vertices: Sequence[str], edges: Sequence[Sequence[str]]
+) -> SimpleUndirectedGraph:
+    return SimpleUndirectedGraph(
+        vertices=tuple(vertices),
+        edges=tuple((a, b) if a < b else (b, a) for a, b in edges),
+    )
+
+
+def _brute_is_r_colorable(
+    vertices: list[str], edges: list[tuple[str, str]], r: int
+) -> bool:
+    if not edges:
+        return True
+    if r >= len(vertices):
+        return True
+    if r == 1:
+        return False
+    idx = {v: i for i, v in enumerate(vertices)}
+    for coloring in product(range(r), repeat=len(vertices)):
+        if all(coloring[idx[a]] != coloring[idx[b]] for a, b in edges):
+            return True
+    return False
+
+
+def _brute_min_deletions(
+    vertices: list[str], edges: list[tuple[str, str]], r: int
+) -> tuple[int, tuple[tuple[str, str], ...]]:
+    sorted_edges = sorted(edges)
+    m = len(sorted_edges)
+    for k in range(m + 1):
+        for combo in combinations(range(m), k):
+            remaining = [e for i, e in enumerate(sorted_edges) if i not in combo]
+            if _brute_is_r_colorable(vertices, remaining, r):
+                deleted = tuple(sorted_edges[i] for i in combo)
+                return k, deleted
+    return m, tuple(sorted_edges)
+
+
+def _exhaustive_profile_brute(
+    graph: SimpleUndirectedGraph, r: int
+) -> list[tuple[tuple[str, ...], int, tuple[tuple[str, str], ...]]]:
+    sorted_vertices = sorted(graph.vertices)
+    sorted_edges = tuple(sorted(graph.edges))
+    rows: list[tuple[tuple[str, ...], int, tuple[tuple[str, str], ...]]] = []
+    n = len(sorted_vertices)
+    for size in range(n + 1):
+        for subset in combinations(sorted_vertices, size):
+            subset_set = set(subset)
+            induced = [
+                e for e in sorted_edges if e[0] in subset_set and e[1] in subset_set
+            ]
+            k, deleted = _brute_min_deletions(list(subset), induced, r)
+            rows.append((tuple(subset), k, deleted))
+    return rows
+
+
+def test_empty_graph() -> None:
+    g = _graph([], [])
+    result = compute_induced_edge_deletion_profile(g, 1)
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.vertex_subset == ()
+    assert row.min_deletions == 0
+    assert row.deleted_edges == ()
+    assert row.induced_edge_count == 0
+    assert result.max_deletions_by_size[0].maximum_min_deletions == 0
+
+
+def test_singleton_graph() -> None:
+    g = _graph(["x"], [])
+    result = compute_induced_edge_deletion_profile(g, 1)
+    assert len(result.rows) == 2
+    for row in result.rows:
+        assert row.min_deletions == 0
+        assert row.deleted_edges == ()
+        assert row.induced_edge_count == 0
+    assert result.max_deletions_by_size[0].maximum_min_deletions == 0
+    assert result.max_deletions_by_size[1].maximum_min_deletions == 0
+
+
+def test_triangle_r2_complete_profile() -> None:
+    # Triangle K3 at r=2: whole set needs 1 deletion, proper subsets need 0
+    g = _graph(["a", "b", "c"], [("a", "b"), ("a", "c"), ("b", "c")])
+    result = compute_induced_edge_deletion_profile(g, 2)
+    assert len(result.rows) == 8
+    # check whole set
+    whole = next(r for r in result.rows if set(r.vertex_subset) == {"a", "b", "c"})
+    assert whole.min_deletions == 1
+    assert whole.deleted_edges == (("a", "b"),)
+    assert whole.induced_edge_count == 3
+    # proper subsets
+    for row in result.rows:
+        if len(row.vertex_subset) < 3:
+            assert row.min_deletions == 0
+            assert row.deleted_edges == ()
+    # per-size maxima
+    assert result.max_deletions_by_size[0].maximum_min_deletions == 0
+    assert result.max_deletions_by_size[1].maximum_min_deletions == 0
+    assert result.max_deletions_by_size[2].maximum_min_deletions == 0
+    assert result.max_deletions_by_size[3].maximum_min_deletions == 1
+    assert result.max_deletions_by_size[3].attaining_subset_count == 1
+
+
+def test_path4_r2_already_bipartite() -> None:
+    g = _graph(["0", "1", "2", "3"], [("0", "1"), ("1", "2"), ("2", "3")])
+    result = compute_induced_edge_deletion_profile(g, 2)
+    for row in result.rows:
+        assert row.min_deletions == 0, (
+            f"path induced {row.vertex_subset} should be bipartite"
+        )
+        assert row.deleted_edges == ()
+    for entry in result.max_deletions_by_size:
+        assert entry.maximum_min_deletions == 0
+
+
+def test_odd_cycle_r2() -> None:
+    # C5 at r=2 needs 1 deletion only for the full cycle
+    verts = ["0", "1", "2", "3", "4"]
+    edges = [("0", "1"), ("1", "2"), ("2", "3"), ("3", "4"), ("0", "4")]
+    g = _graph(verts, edges)
+    result = compute_induced_edge_deletion_profile(g, 2)
+    whole = next(r for r in result.rows if len(r.vertex_subset) == 5)
+    assert whole.min_deletions == 1
+    assert whole.deleted_edges == (("0", "1"),)
+    # all smaller induced subgraphs are forests -> 0
+    for row in result.rows:
+        if len(row.vertex_subset) < 5:
+            assert row.min_deletions == 0
+    assert result.max_deletions_by_size[5].maximum_min_deletions == 1
+
+
+def test_complete_graph_k4_r2_and_r3() -> None:
+    verts = ["a", "b", "c", "d"]
+    edges = list(combinations(verts, 2))
+    g = _graph(verts, edges)
+    # r=2: Turan(4,2)=4 edges, so need 2 deletions; triangles need 1
+    result2 = compute_induced_edge_deletion_profile(g, 2)
+    whole2 = next(r for r in result2.rows if len(r.vertex_subset) == 4)
+    assert whole2.min_deletions == 2
+    assert whole2.deleted_edges == (("a", "b"), ("c", "d"))
+    # size 3 subsets (triangles) need 1
+    for row in result2.rows:
+        if len(row.vertex_subset) == 3:
+            assert row.min_deletions == 1
+    assert result2.max_deletions_by_size[3].maximum_min_deletions == 1
+    assert result2.max_deletions_by_size[4].maximum_min_deletions == 2
+    # r=3: K4 needs 1, triangles need 0
+    result3 = compute_induced_edge_deletion_profile(g, 3)
+    whole3 = next(r for r in result3.rows if len(r.vertex_subset) == 4)
+    assert whole3.min_deletions == 1
+    assert whole3.deleted_edges == (("a", "b"),)
+    for row in result3.rows:
+        if len(row.vertex_subset) == 3:
+            assert row.min_deletions == 0
+
+
+def test_disconnected_two_triangles() -> None:
+    g = _graph(
+        ["a", "b", "c", "d", "e", "f"],
+        [("a", "b"), ("a", "c"), ("b", "c"), ("d", "e"), ("d", "f"), ("e", "f")],
+    )
+    result = compute_induced_edge_deletion_profile(g, 2)
+    whole = next(r for r in result.rows if len(r.vertex_subset) == 6)
+    assert whole.min_deletions == 2
+    assert whole.deleted_edges == (("a", "b"), ("d", "e"))
+    # subsets containing one triangle only need 1, empty/bipartite need 0
+    for row in result.rows:
+        # row with vertices exactly one triangle
+        if set(row.vertex_subset) == {"a", "b", "c"} or set(row.vertex_subset) == {
+            "d",
+            "e",
+            "f",
+        }:
+            assert row.min_deletions == 1
+
+
+def test_relabelling_invariance() -> None:
+    g1 = _graph(["a", "b", "c"], [("a", "b"), ("a", "c"), ("b", "c")])
+    g2 = _graph(["x", "y", "z"], [("x", "y"), ("x", "z"), ("y", "z")])
+    r = 2
+    res1 = compute_induced_edge_deletion_profile(g1, r)
+    res2 = compute_induced_edge_deletion_profile(g2, r)
+    # per-size maxima must coincide
+    assert [
+        (e.subset_size, e.maximum_min_deletions, e.attaining_subset_count)
+        for e in res1.max_deletions_by_size
+    ] == [
+        (e.subset_size, e.maximum_min_deletions, e.attaining_subset_count)
+        for e in res2.max_deletions_by_size
+    ]
+    # multiset of D values must coincide
+    from collections import Counter
+
+    c1 = Counter(rw.min_deletions for rw in res1.rows)
+    c2 = Counter(rw.min_deletions for rw in res2.rows)
+    assert c1 == c2
+
+
+def test_tied_optima_canonical_tie_break() -> None:
+    # K3 has 3 equally optimal single-edge deletions; canonical must be lexicographically smallest edge
+    g = _graph(["a", "b", "c"], [("a", "b"), ("a", "c"), ("b", "c")])
+    result = compute_induced_edge_deletion_profile(g, 2)
+    whole = next(r for r in result.rows if len(r.vertex_subset) == 3)
+    assert whole.deleted_edges == (("a", "b"),)
+    # K4 at r=2 has 3 optimal deletions of size 2; canonical is (a,b)(c,d)
+    verts = ["a", "b", "c", "d"]
+    edges = list(combinations(verts, 2))
+    g4 = _graph(verts, edges)
+    res4 = compute_induced_edge_deletion_profile(g4, 2)
+    whole4 = next(r for r in res4.rows if len(r.vertex_subset) == 4)
+    assert whole4.deleted_edges == (("a", "b"), ("c", "d"))
+    # ensure deleted edges are sorted
+    for row in res4.rows:
+        assert row.deleted_edges == tuple(sorted(row.deleted_edges))
+
+
+def test_reconstruction_invariant() -> None:
+    # For each S, deleted edges subset of induced, and G[S]-F is r-colourable, and no smaller suffices
+    g = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c")],
+    )
+    for r in [1, 2, 3]:
+        result = compute_induced_edge_deletion_profile(g, r)
+        sorted_edges = tuple(sorted(g.edges))
+        for row in result.rows:
+            subset_set = set(row.vertex_subset)
+            induced = [
+                e for e in sorted_edges if e[0] in subset_set and e[1] in subset_set
+            ]
+            assert set(row.deleted_edges) <= set(induced)
+            assert len(row.deleted_edges) == row.min_deletions
+            remaining = [e for e in induced if e not in set(row.deleted_edges)]
+            assert _brute_is_r_colorable(list(row.vertex_subset), remaining, r), (
+                f"remaining not r-colorable for {row}"
+            )
+            # no smaller deletion works: try all subsets of size min_deletions-1 if >0
+            if row.min_deletions > 0:
+                k = row.min_deletions - 1
+                for combo in combinations(sorted(induced), k):
+                    remaining2 = [e for e in induced if e not in set(combo)]
+                    assert not _brute_is_r_colorable(
+                        list(row.vertex_subset), remaining2, r
+                    ), (
+                        f"found smaller feasible deletion {combo} for {row.vertex_subset} r={r}"
+                    )
+
+
+def test_exhaustive_small_graphs_vs_oracle() -> None:
+    # Exhaustive check over all graphs on 4 vertices for r=2,3 against brute oracle
+    verts = ["0", "1", "2", "3"]
+    all_edges = list(combinations(verts, 2))
+    # test a deterministic sample of graphs (all 64 graphs would be heavy; sample 10)
+    import random
+
+    random.seed(42)
+    sampled_masks = random.sample(range(1 << len(all_edges)), 10)
+    for mask in sampled_masks:
+        edges = [all_edges[i] for i in range(len(all_edges)) if (mask >> i) & 1]
+        g = _graph(verts, edges)
+        for r in [2, 3]:
+            result = compute_induced_edge_deletion_profile(g, r)
+            brute_rows = _exhaustive_profile_brute(g, r)
+            for row, (bs, bk, bd) in zip(result.rows, brute_rows, strict=True):
+                assert row.vertex_subset == bs
+                assert row.min_deletions == bk, (
+                    f"mismatch min_deletions for graph {edges} r={r} subset {bs}: got {row.min_deletions} expected {bk}"
+                )
+                assert row.deleted_edges == bd, (
+                    f"mismatch deleted_edges for {bs}: got {row.deleted_edges} expected {bd}"
+                )
+            # per-size maxima must be max of brute
+            for entry in result.max_deletions_by_size:
+                vals = [k for (s, k, _) in brute_rows if len(s) == entry.subset_size]
+                if vals:
+                    assert entry.maximum_min_deletions == max(vals)
+                else:
+                    assert entry.maximum_min_deletions == 0
+
+
+def test_aggregate_bound_rejection() -> None:
+    # 9 vertices exceeds vertex envelope (8)
+    verts9 = [f"v{i}" for i in range(9)]
+    edges9 = [(verts9[i], verts9[j]) for i in range(9) for j in range(i + 1, 9)]
+    g9 = _graph(verts9, edges9)
+    with pytest.raises(OperationDomainValidationError, match="at most 8 vertices"):
+        compute_induced_edge_deletion_profile(g9, 2)
+    # solver-call / ledger bound: dense 8-vertex graph with huge conflict budget exceeds ledger
+    verts8 = [f"v{i}" for i in range(8)]
+    edges8 = [(verts8[i], verts8[j]) for i in range(8) for j in range(i + 1, 8)]
+    g8 = _graph(verts8, edges8)
+    with pytest.raises(OperationDomainValidationError, match="ledger"):
+        compute_induced_edge_deletion_profile(g8, 2, solver_conflicts=1_000_000)
+    # retained label characters bound
+    long_label = "x" * 200_000
+    g_long = _graph([long_label, "y"], [(long_label, "y")])
+    # This may exceed retained characters due to rows * witness
+    with pytest.raises(OperationDomainValidationError):
+        compute_induced_edge_deletion_profile(g_long, 2)
+
+
+def test_cross_check_s_equals_v_vs_brute() -> None:
+    # For S=V, min_deletions should equal brute whole-graph optimum
+    g = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c")],
+    )
+    for r in [2, 3]:
+        result = compute_induced_edge_deletion_profile(g, r)
+        whole = next(
+            row for row in result.rows if len(row.vertex_subset) == len(g.vertices)
+        )
+        # brute whole
+        induced = list(g.edges)
+        k, _ = _brute_min_deletions(list(g.vertices), induced, r)
+        assert whole.min_deletions == k
+
+
+def test_native_mcp_parity() -> None:
+    g = _graph(["a", "b", "c"], [("a", "b"), ("a", "c"), ("b", "c")])
+    native = compute_induced_edge_deletion_profile(g, 2)
+    request = InducedEdgeDeletionProfileRequest(graph=g, r=2)
+    from jacobian.catalog.builtins import BUILTIN_TOOLS
+
+    tool = next(
+        t
+        for t in BUILTIN_TOOLS
+        if t.operation_id == "graph.coloring.induced_edge_deletion_profile.compute"
+    )
+    via_tool = tool.run(request)
+    assert native == via_tool
+    # also test via wire round-trip
+    dumped = InducedEdgeDeletionProfileResult.model_validate(native.model_dump())
+    assert dumped == native
+
+
+def test_serialized_round_trip() -> None:
+    g = _graph(["0", "1", "2"], [("0", "1"), ("1", "2")])
+    result = compute_induced_edge_deletion_profile(g, 2)
+    serialized = result.model_dump()
+    restored = InducedEdgeDeletionProfileResult.model_validate(serialized)
+    assert restored == result
+    # rows remain sorted
+    assert restored.rows == tuple(
+        sorted(restored.rows, key=lambda r: (len(r.vertex_subset), r.vertex_subset))
+    )
+
+
+def test_per_size_maximum_derivation() -> None:
+    g = _graph(
+        ["a", "b", "c", "d"],
+        [("a", "b"), ("b", "c"), ("c", "d"), ("a", "d"), ("a", "c"), ("b", "d")],
+    )
+    result = compute_induced_edge_deletion_profile(g, 2)
+    # verify derived
+    from collections import defaultdict
+
+    grouped: dict[int, list[int]] = defaultdict(list)
+    for row in result.rows:
+        grouped[len(row.vertex_subset)].append(row.min_deletions)
+    for entry in result.max_deletions_by_size:
+        assert (
+            entry.maximum_min_deletions == max(grouped[entry.subset_size])
+            if grouped[entry.subset_size]
+            else 0
+        )
+        assert entry.attaining_subset_count == sum(
+            1 for v in grouped[entry.subset_size] if v == entry.maximum_min_deletions
+        )
+
+
+def test_r1_and_large_r_shortcuts() -> None:
+    # r=1 needs to delete all induced edges
+    g = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    res1 = compute_induced_edge_deletion_profile(g, 1)
+    for row in res1.rows:
+        induced = [
+            e
+            for e in g.edges
+            if e[0] in set(row.vertex_subset) and e[1] in set(row.vertex_subset)
+        ]
+        assert row.min_deletions == len(induced)
+        assert set(row.deleted_edges) == set(induced)
+    # r >= n needs zero
+    g2 = _graph(["a", "b", "c"], [("a", "b"), ("a", "c"), ("b", "c")])
+    res_big = compute_induced_edge_deletion_profile(g2, 5)
+    for row in res_big.rows:
+        assert row.min_deletions == 0
+
+
+def test_empty_request_validation() -> None:
+    # request model validation for r out of range
+    from pydantic import ValidationError
+
+    g = _graph(["a"], [])
+    with pytest.raises(ValidationError):
+        InducedEdgeDeletionProfileRequest(graph=g, r=0)
+    with pytest.raises(ValidationError):
+        InducedEdgeDeletionProfileRequest(graph=g, r=100)


### PR DESCRIPTION
Implements graph.coloring.induced_edge_deletion_profile.compute per #2856. Postcondition D_{G,r}(S) over all 2^n subsets with canonical F and per-size maxima, bounds n<=8, solver ledger, exact Z3 kernel. Tests 18 passed, catalog 103 passed.