### PR TITLE
Add exact point-configuration orbit profiles

### DIFF
--- a/docs/reference/operations/geometry/exact-planar-geometry.md
+++ b/docs/reference/operations/geometry/exact-planar-geometry.md
@@ -17,10 +17,10 @@ there is no geometry artifact or generic verification service.
 
 `geometry.point_configuration.euclidean_orbit_profile.compute` canonicalizes
 one bounded labelled rational point configuration. It returns the
-lexicographically least complete squared-distance matrix over source
+lexicographically least complete squared-distance matrix and ambient dimension over source
 relabelings, retaining a deterministic source-to-canonical map. The isometry
 form uses the source distances unchanged; the similarity form divides them by
-the least positive squared distance. Equal forms characterize congruence and,
+the least positive squared distance. Equal forms with the same ambient dimension characterize congruence and,
 after the common positive normalization, similarity, respectively, including
 reflections.
 

--- a/docs/reference/operations/geometry/exact-planar-geometry.md
+++ b/docs/reference/operations/geometry/exact-planar-geometry.md
@@ -13,6 +13,23 @@ Inputs are validated as their owning geometric value before computation. Results
 are returned inline and can be passed to another compatible typed operation;
 there is no geometry artifact or generic verification service.
 
+## Point-configuration orbit profiles
+
+`geometry.point_configuration.euclidean_orbit_profile.compute` canonicalizes
+one bounded labelled rational point configuration. It returns the
+lexicographically least complete squared-distance matrix over source
+relabelings, retaining a deterministic source-to-canonical map. The isometry
+form uses the source distances unchanged; the similarity form divides them by
+the least positive squared distance. Equal forms characterize congruence and,
+after the common positive normalization, similarity, respectively, including
+reflections.
+
+Admission separately bounds pairwise exact-distance output, rational height,
+and the complete exhaustive-permutation replay. The current release admits
+configurations whose complete relabeling search needs at most 8! permutations;
+larger finite sources reject before canonicalization rather than returning an
+unproved canonical form.
+
 ## Convex-polygon triangulation
 
 `geometry.polygon.triangulation.minimum_weight.compute` minimizes caller-supplied

--- a/src/jacobian/math/geometry/exact/__init__.py
+++ b/src/jacobian/math/geometry/exact/__init__.py
@@ -3,7 +3,13 @@
 from jacobian.math.geometry.exact.operations import (
     distance_graph,
     distance_profile,
+    euclidean_orbit_profile,
     pinned_line_distance_profile,
 )
 
-__all__ = ["distance_graph", "distance_profile", "pinned_line_distance_profile"]
+__all__ = [
+    "distance_graph",
+    "distance_profile",
+    "euclidean_orbit_profile",
+    "pinned_line_distance_profile",
+]

--- a/src/jacobian/math/geometry/exact/_models.py
+++ b/src/jacobian/math/geometry/exact/_models.py
@@ -135,7 +135,10 @@ class EuclideanOrbitProfileResult(StrictModel):
     def require_orbit_profile_shape(self) -> Self:
         size = len(self.configuration.points)
         if self.ambient_dimension != len(self.configuration.points[0].coordinates):
-            raise _validation_error("orbit_profile_ambient_dimension", "ambient_dimension must match the configuration coordinate axis")
+            raise _validation_error(
+                "orbit_profile_ambient_dimension",
+                "ambient_dimension must match the configuration coordinate axis",
+            )
         for form, relabeling in (
             (self.isometry_form, self.isometry_relabeling),
             (self.similarity_form, self.similarity_relabeling),

--- a/src/jacobian/math/geometry/exact/_models.py
+++ b/src/jacobian/math/geometry/exact/_models.py
@@ -137,7 +137,9 @@ class EuclideanOrbitProfileResult(StrictModel):
             (self.isometry_form, self.isometry_relabeling),
             (self.similarity_form, self.similarity_relabeling),
         ):
-            if len(form.entries) != size or any(len(row) != size for row in form.entries):
+            if len(form.entries) != size or any(
+                len(row) != size for row in form.entries
+            ):
                 raise _validation_error(
                     "orbit_profile_form_shape",
                     "every orbit form must be square on the source point axis",

--- a/src/jacobian/math/geometry/exact/_models.py
+++ b/src/jacobian/math/geometry/exact/_models.py
@@ -124,6 +124,7 @@ class EuclideanOrbitProfileResult(StrictModel):
     """Canonical unlabeled isometry and similarity forms of one source."""
 
     configuration: PointConfiguration
+    ambient_dimension: int = Field(ge=1, le=MAX_DIMENSION)
     isometry_form: RationalMatrix
     isometry_relabeling: tuple[int, ...]
     similarity_form: RationalMatrix
@@ -133,6 +134,8 @@ class EuclideanOrbitProfileResult(StrictModel):
     @model_validator(mode="after")
     def require_orbit_profile_shape(self) -> Self:
         size = len(self.configuration.points)
+        if self.ambient_dimension != len(self.configuration.points[0].coordinates):
+            raise _validation_error("orbit_profile_ambient_dimension", "ambient_dimension must match the configuration coordinate axis")
         for form, relabeling in (
             (self.isometry_form, self.isometry_relabeling),
             (self.similarity_form, self.similarity_relabeling),

--- a/src/jacobian/math/geometry/exact/_models.py
+++ b/src/jacobian/math/geometry/exact/_models.py
@@ -9,6 +9,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.matrices.values import RationalMatrix
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -123,11 +124,35 @@ class EuclideanOrbitProfileResult(StrictModel):
     """Canonical unlabeled isometry and similarity forms of one source."""
 
     configuration: PointConfiguration
-    isometry_form: tuple[tuple[CanonicalRational, ...], ...]
+    isometry_form: RationalMatrix
     isometry_relabeling: tuple[int, ...]
-    similarity_form: tuple[tuple[CanonicalRational, ...], ...]
+    similarity_form: RationalMatrix
     similarity_relabeling: tuple[int, ...]
     normalizing_squared_distance: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_orbit_profile_shape(self) -> Self:
+        size = len(self.configuration.points)
+        for form, relabeling in (
+            (self.isometry_form, self.isometry_relabeling),
+            (self.similarity_form, self.similarity_relabeling),
+        ):
+            if len(form.entries) != size or any(len(row) != size for row in form.entries):
+                raise _validation_error(
+                    "orbit_profile_form_shape",
+                    "every orbit form must be square on the source point axis",
+                )
+            if tuple(sorted(relabeling)) != tuple(range(size)):
+                raise _validation_error(
+                    "orbit_profile_relabeling",
+                    "every orbit relabeling must be a permutation of the source axis",
+                )
+        if self.normalizing_squared_distance.as_fraction() <= 0:
+            raise _validation_error(
+                "orbit_profile_normalizer",
+                "normalizing_squared_distance must be positive",
+            )
+        return self
 
 
 class DistanceGraphRequest(StrictModel):

--- a/src/jacobian/math/geometry/exact/_models.py
+++ b/src/jacobian/math/geometry/exact/_models.py
@@ -113,6 +113,23 @@ class DistanceProfileResult(StrictModel):
     entries: tuple[DistanceMultiplicityEntry, ...]
 
 
+class EuclideanOrbitProfileRequest(StrictModel):
+    """Canonicalize one exact rational point configuration."""
+
+    configuration: PointConfiguration
+
+
+class EuclideanOrbitProfileResult(StrictModel):
+    """Canonical unlabeled isometry and similarity forms of one source."""
+
+    configuration: PointConfiguration
+    isometry_form: tuple[tuple[CanonicalRational, ...], ...]
+    isometry_relabeling: tuple[int, ...]
+    similarity_form: tuple[tuple[CanonicalRational, ...], ...]
+    similarity_relabeling: tuple[int, ...]
+    normalizing_squared_distance: CanonicalRational
+
+
 class DistanceGraphRequest(StrictModel):
     """Build the graph induced by a selected squared distance."""
 
@@ -136,6 +153,8 @@ __all__ = [
     "DistanceMultiplicityEntry",
     "DistanceProfileRequest",
     "DistanceProfileResult",
+    "EuclideanOrbitProfileRequest",
+    "EuclideanOrbitProfileResult",
     "LabelledRationalPoint",
     "PinnedLineDistanceRequest",
     "PinnedLineDistanceResult",

--- a/src/jacobian/math/geometry/exact/_orbit_bounds.py
+++ b/src/jacobian/math/geometry/exact/_orbit_bounds.py
@@ -1,0 +1,44 @@
+"""Derived admission for exact point-configuration orbit canonicalization."""
+
+from __future__ import annotations
+
+from math import factorial
+from typing import NoReturn
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.exact._models import PointConfiguration
+
+MAX_ORBIT_PERMUTATIONS = 40_320
+MAX_ORBIT_DISTANCE_DIGITS = 4_096
+
+
+def _reject(message: str) -> NoReturn:
+    raise OperationDomainValidationError(
+        location=("configuration",),
+        code="point_configuration.orbit_work_bound",
+        message=message,
+    )
+
+
+def _rational_digits(value: str) -> int:
+    return len(value.lstrip("-"))
+
+
+def admit_orbit_profile(configuration: PointConfiguration) -> None:
+    """Admit one source before materializing pairwise or permutation work."""
+    permutation_count = factorial(len(configuration.points))
+    if permutation_count > MAX_ORBIT_PERMUTATIONS:
+        _reject("configuration exceeds the admitted permutation-work budget")
+
+    maximum_component_digits = 1
+    for point in configuration.points:
+        for coordinate in point.coordinates:
+            maximum_component_digits = max(
+                maximum_component_digits,
+                _rational_digits(coordinate.num),
+                _rational_digits(coordinate.den),
+            )
+    pair_count = len(configuration.points) * (len(configuration.points) - 1) // 2
+    distance_digits = 2 * maximum_component_digits + 1
+    if pair_count * distance_digits > MAX_ORBIT_DISTANCE_DIGITS:
+        _reject("pairwise squared-distance output exceeds the admitted digit budget")

--- a/src/jacobian/math/geometry/exact/_orbit_bounds.py
+++ b/src/jacobian/math/geometry/exact/_orbit_bounds.py
@@ -40,8 +40,10 @@ def admit_orbit_profile(configuration: PointConfiguration) -> None:
             )
     pair_count = len(configuration.points) * (len(configuration.points) - 1) // 2
     dimension = len(configuration.points[0].coordinates)
-    # Pairwise subtraction and summation combine independent denominators across
-    # every axis; normalizing a similarity form can spend the same envelope again.
+    # A similarity entry is a quotient of two independently bounded squared
+    # distances, so its numerator and denominator can each combine both
+    # distance envelopes. Charge both returned matrices before execution.
     distance_digits = 4 * dimension * maximum_component_digits + 2
-    if pair_count * distance_digits > MAX_ORBIT_DISTANCE_DIGITS:
+    similarity_digits = 2 * distance_digits
+    if pair_count * (distance_digits + similarity_digits) > MAX_ORBIT_DISTANCE_DIGITS:
         _reject("pairwise squared-distance output exceeds the admitted digit budget")

--- a/src/jacobian/math/geometry/exact/_orbit_bounds.py
+++ b/src/jacobian/math/geometry/exact/_orbit_bounds.py
@@ -39,6 +39,9 @@ def admit_orbit_profile(configuration: PointConfiguration) -> None:
                 _rational_digits(coordinate.den),
             )
     pair_count = len(configuration.points) * (len(configuration.points) - 1) // 2
-    distance_digits = 2 * maximum_component_digits + 1
+    dimension = len(configuration.points[0].coordinates)
+    # Pairwise subtraction and summation combine independent denominators across
+    # every axis; normalizing a similarity form can spend the same envelope again.
+    distance_digits = 4 * dimension * maximum_component_digits + 2
     if pair_count * distance_digits > MAX_ORBIT_DISTANCE_DIGITS:
         _reject("pairwise squared-distance output exceeds the admitted digit budget")

--- a/src/jacobian/math/geometry/exact/_tools.py
+++ b/src/jacobian/math/geometry/exact/_tools.py
@@ -7,12 +7,15 @@ from jacobian.math.geometry.exact._models import (
     DistanceGraphRequest,
     DistanceProfileRequest,
     DistanceProfileResult,
+    EuclideanOrbitProfileRequest,
+    EuclideanOrbitProfileResult,
     PinnedLineDistanceRequest,
     PinnedLineDistanceResult,
 )
 from jacobian.math.geometry.exact.operations import (
     distance_graph,
     distance_profile,
+    euclidean_orbit_profile,
     pinned_line_distance_profile,
 )
 from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
@@ -20,6 +23,12 @@ from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
 def _run_distance_profile(request: DistanceProfileRequest) -> DistanceProfileResult:
     return distance_profile(request.configuration)
+
+
+def _run_euclidean_orbit_profile(
+    request: EuclideanOrbitProfileRequest,
+) -> EuclideanOrbitProfileResult:
+    return euclidean_orbit_profile(request.configuration)
 
 
 def _run_distance_graph(request: DistanceGraphRequest) -> IndexedSimpleUndirectedGraph:
@@ -114,6 +123,35 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
             OperationExample(
                 name="unit_square_profile",
                 description="Distance profile of the unit square.",
+                input=UNIT_SQUARE,
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="geometry.point_configuration.euclidean_orbit_profile.compute",
+        title="Canonicalize a rational point configuration",
+        description=(
+            "For one bounded labelled rational point configuration, return the "
+            "lexicographically least complete squared-distance matrix under "
+            "relabeling, both for isometry and for similarity normalization by "
+            "the least positive squared distance, with deterministic source-to-"
+            "canonical mappings."
+        ),
+        request_type=EuclideanOrbitProfileRequest,
+        result_type=EuclideanOrbitProfileResult,
+        run=_run_euclidean_orbit_profile,
+        tags=(
+            "geometry",
+            "point-configuration",
+            "isometry",
+            "similarity",
+            "canonical-form",
+            "exact",
+        ),
+        examples=(
+            OperationExample(
+                name="unit_square",
+                description="Canonicalize the unit square and its scale class.",
                 input=UNIT_SQUARE,
             ),
         ),

--- a/src/jacobian/math/geometry/exact/operations.py
+++ b/src/jacobian/math/geometry/exact/operations.py
@@ -25,9 +25,9 @@ from jacobian.math.geometry.exact._models import (
     _require_bounded_point_configuration,
     _validation_error,
 )
-from jacobian.math.matrices.values import RationalMatrix
 from jacobian.math.geometry.exact._orbit_bounds import admit_orbit_profile
 from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+from jacobian.math.matrices.values import RationalMatrix
 
 
 def _to_fraction_point(point: LabelledRationalPoint) -> tuple[Fraction, ...]:

--- a/src/jacobian/math/geometry/exact/operations.py
+++ b/src/jacobian/math/geometry/exact/operations.py
@@ -148,6 +148,7 @@ def euclidean_orbit_profile(
 
     return EuclideanOrbitProfileResult(
         configuration=configuration,
+        ambient_dimension=len(configuration.points[0].coordinates),
         isometry_form=canonical_rational_matrix(isometry_form),
         isometry_relabeling=isometry_relabeling,
         similarity_form=canonical_rational_matrix(similarity_form),

--- a/src/jacobian/math/geometry/exact/operations.py
+++ b/src/jacobian/math/geometry/exact/operations.py
@@ -112,7 +112,12 @@ def euclidean_orbit_profile(
                 best_form = form
                 best_relabeling = permutation
         assert best_form is not None and best_relabeling is not None
-        return best_form, best_relabeling
+        # ``permutation`` indexes the source row for each canonical position;
+        # the public relabeling maps each source index to its canonical position.
+        inverse = [0] * size
+        for canonical_index, source_index in enumerate(best_relabeling):
+            inverse[source_index] = canonical_index
+        return best_form, tuple(inverse)
 
     positive_distances = [
         distances[left][right]
@@ -120,6 +125,12 @@ def euclidean_orbit_profile(
         for right in range(size)
         if right > left and distances[left][right] > 0
     ]
+    if not positive_distances:
+        raise OperationDomainValidationError(
+            location=("configuration",),
+            code="point_configuration.orbit_degenerate",
+            message="orbit profiles require at least one positive squared distance",
+        )
     minimum_positive_distance = min(positive_distances)
     isometry_form, isometry_relabeling = canonical_form(Fraction(1))
     similarity_form, similarity_relabeling = canonical_form(minimum_positive_distance)

--- a/src/jacobian/math/geometry/exact/operations.py
+++ b/src/jacobian/math/geometry/exact/operations.py
@@ -25,6 +25,7 @@ from jacobian.math.geometry.exact._models import (
     _require_bounded_point_configuration,
     _validation_error,
 )
+from jacobian.math.matrices.values import RationalMatrix
 from jacobian.math.geometry.exact._orbit_bounds import admit_orbit_profile
 from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
@@ -137,10 +138,12 @@ def euclidean_orbit_profile(
 
     def canonical_rational_matrix(
         form: tuple[tuple[Fraction, ...], ...],
-    ) -> tuple[tuple[CanonicalRational, ...], ...]:
-        return tuple(
-            tuple(CanonicalRational.from_fraction(value) for value in row)
-            for row in form
+    ) -> RationalMatrix:
+        return RationalMatrix(
+            entries=tuple(
+                tuple(CanonicalRational.from_fraction(value) for value in row)
+                for row in form
+            )
         )
 
     return EuclideanOrbitProfileResult(

--- a/src/jacobian/math/geometry/exact/operations.py
+++ b/src/jacobian/math/geometry/exact/operations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import Counter
 from fractions import Fraction
-from itertools import combinations
+from itertools import combinations, permutations
 
 from pydantic_core import PydanticCustomError
 
@@ -17,6 +17,7 @@ from jacobian.math.geometry.exact._line_arithmetic import (
 from jacobian.math.geometry.exact._models import (
     DistanceMultiplicityEntry,
     DistanceProfileResult,
+    EuclideanOrbitProfileResult,
     LabelledRationalPoint,
     PinnedLineConfiguration,
     PinnedLineDistanceResult,
@@ -24,6 +25,7 @@ from jacobian.math.geometry.exact._models import (
     _require_bounded_point_configuration,
     _validation_error,
 )
+from jacobian.math.geometry.exact._orbit_bounds import admit_orbit_profile
 from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
 
@@ -78,6 +80,67 @@ def distance_graph(
     return IndexedSimpleUndirectedGraph(
         vertex_count=len(points),
         edges=edges,
+    )
+
+
+def euclidean_orbit_profile(
+    configuration: PointConfiguration,
+) -> EuclideanOrbitProfileResult:
+    """Return canonical unlabeled isometry and similarity distance forms."""
+    admit_orbit_profile(configuration)
+    points = [_to_fraction_point(point) for point in configuration.points]
+    size = len(points)
+    distances = [
+        [_squared_distance(points[left], points[right]) for right in range(size)]
+        for left in range(size)
+    ]
+
+    def canonical_form(
+        scale: Fraction,
+    ) -> tuple[tuple[tuple[Fraction, ...], ...], tuple[int, ...]]:
+        best_form: tuple[tuple[Fraction, ...], ...] | None = None
+        best_relabeling: tuple[int, ...] | None = None
+        for permutation in permutations(range(size)):
+            form = tuple(
+                tuple(
+                    distances[permutation[left]][permutation[right]] / scale
+                    for right in range(size)
+                )
+                for left in range(size)
+            )
+            if best_form is None or form < best_form:
+                best_form = form
+                best_relabeling = permutation
+        assert best_form is not None and best_relabeling is not None
+        return best_form, best_relabeling
+
+    positive_distances = [
+        distances[left][right]
+        for left in range(size)
+        for right in range(size)
+        if right > left and distances[left][right] > 0
+    ]
+    minimum_positive_distance = min(positive_distances)
+    isometry_form, isometry_relabeling = canonical_form(Fraction(1))
+    similarity_form, similarity_relabeling = canonical_form(minimum_positive_distance)
+
+    def canonical_rational_matrix(
+        form: tuple[tuple[Fraction, ...], ...],
+    ) -> tuple[tuple[CanonicalRational, ...], ...]:
+        return tuple(
+            tuple(CanonicalRational.from_fraction(value) for value in row)
+            for row in form
+        )
+
+    return EuclideanOrbitProfileResult(
+        configuration=configuration,
+        isometry_form=canonical_rational_matrix(isometry_form),
+        isometry_relabeling=isometry_relabeling,
+        similarity_form=canonical_rational_matrix(similarity_form),
+        similarity_relabeling=similarity_relabeling,
+        normalizing_squared_distance=CanonicalRational.from_fraction(
+            minimum_positive_distance
+        ),
     )
 
 
@@ -152,5 +215,6 @@ def pinned_line_distance_profile(
 __all__ = [
     "distance_graph",
     "distance_profile",
+    "euclidean_orbit_profile",
     "pinned_line_distance_profile",
 ]

--- a/tests/math/geometry/test_exact_geometry.py
+++ b/tests/math/geometry/test_exact_geometry.py
@@ -21,6 +21,7 @@ from jacobian.math.geometry.exact._models import (
 from jacobian.math.geometry.exact.operations import (
     distance_graph,
     distance_profile,
+    euclidean_orbit_profile,
     pinned_line_distance_profile,
 )
 from jacobian.math.graphs.spectra._models import GraphSpectrumRequest
@@ -163,6 +164,110 @@ class TestDistanceGraph:
             ).graph
             == produced
         )
+
+
+class TestEuclideanOrbitProfile:
+    def test_unit_square_relabelings_are_canonical(self) -> None:
+        configuration = PointConfiguration(
+            points=(
+                _make_point("a", [("0", "1"), ("0", "1")]),
+                _make_point("c", [("0", "1"), ("1", "1")]),
+                _make_point("d", [("1", "1"), ("1", "1")]),
+                _make_point("b", [("1", "1"), ("0", "1")]),
+            )
+        )
+        result = euclidean_orbit_profile(configuration)
+        one = CanonicalRational(num="1", den="1")
+        expected = (
+            (Fraction(0), Fraction(1), Fraction(1), Fraction(2)),
+            (Fraction(1), Fraction(0), Fraction(2), Fraction(1)),
+            (Fraction(1), Fraction(2), Fraction(0), Fraction(1)),
+            (Fraction(2), Fraction(1), Fraction(1), Fraction(0)),
+        )
+        assert (
+            tuple(
+                tuple(value.as_fraction() for value in row)
+                for row in result.isometry_form
+            )
+            == expected
+        )
+        assert result.isometry_relabeling == (0, 1, 3, 2)
+        assert result.normalizing_squared_distance == one
+        assert result.similarity_form == result.isometry_form
+        assert result.similarity_relabeling == result.isometry_relabeling
+        assert type(result).model_validate(result.model_dump(mode="json")) == result
+
+    def test_scaled_rectangle_matches_only_under_similarity(self) -> None:
+        unit = PointConfiguration(
+            points=(
+                _make_point("a", [("0", "1"), ("0", "1")]),
+                _make_point("b", [("2", "1"), ("0", "1")]),
+                _make_point("c", [("2", "1"), ("1", "1")]),
+                _make_point("d", [("0", "1"), ("1", "1")]),
+            )
+        )
+        scaled = PointConfiguration(
+            points=(
+                _make_point("a", [("0", "1"), ("0", "1")]),
+                _make_point("b", [("6", "1"), ("0", "1")]),
+                _make_point("c", [("6", "1"), ("3", "1")]),
+                _make_point("d", [("0", "1"), ("3", "1")]),
+            )
+        )
+        unit_result = euclidean_orbit_profile(unit)
+        scaled_result = euclidean_orbit_profile(scaled)
+        assert unit_result.isometry_form != scaled_result.isometry_form
+        assert unit_result.similarity_form == scaled_result.similarity_form
+        assert scaled_result.normalizing_squared_distance == _cr(Fraction(9, 1))
+
+    def test_rectangle_and_square_are_not_congruent(self) -> None:
+        square = PointConfiguration(
+            points=tuple(
+                _make_point(label, [(x, "1"), (y, "1")])
+                for label, x, y in (
+                    ("a", "0", "0"),
+                    ("b", "1", "0"),
+                    ("c", "1", "1"),
+                    ("d", "0", "1"),
+                )
+            )
+        )
+        rectangle = PointConfiguration(
+            points=tuple(
+                _make_point(label, [(x, "1"), (y, "1")])
+                for label, x, y in (
+                    ("a", "0", "0"),
+                    ("b", "2", "0"),
+                    ("c", "2", "1"),
+                    ("d", "0", "1"),
+                )
+            )
+        )
+        square_result = euclidean_orbit_profile(square)
+        rectangle_result = euclidean_orbit_profile(rectangle)
+        assert square_result.isometry_form != rectangle_result.isometry_form
+        assert square_result.similarity_form != rectangle_result.similarity_form
+
+    def test_replays_permuted_source_matrix(self) -> None:
+        configuration = PointConfiguration(
+            points=(
+                _make_point("a", [("0", "1"), ("0", "1")]),
+                _make_point("b", [("3", "1"), ("1", "1")]),
+                _make_point("c", [("1", "1"), ("4", "1")]),
+            )
+        )
+        result = euclidean_orbit_profile(configuration)
+        points = [
+            tuple(x.as_fraction() for x in point.coordinates)
+            for point in configuration.points
+        ]
+        for source, target in enumerate(result.isometry_relabeling):
+            for other_source, other_target in enumerate(result.isometry_relabeling):
+                delta = sum(
+                    (points[source][axis] - points[other_source][axis]) ** 2
+                    for axis in range(2)
+                )
+                assert result.isometry_form[target][other_target].as_fraction() == delta
 
     def test_rejects_single_point_configuration(self) -> None:
         import pytest

--- a/tests/math/geometry/test_exact_geometry.py
+++ b/tests/math/geometry/test_exact_geometry.py
@@ -187,7 +187,7 @@ class TestEuclideanOrbitProfile:
         assert (
             tuple(
                 tuple(value.as_fraction() for value in row)
-                for row in result.isometry_form
+                for row in result.isometry_form.entries
             )
             == expected
         )
@@ -267,7 +267,7 @@ class TestEuclideanOrbitProfile:
                     (points[source][axis] - points[other_source][axis]) ** 2
                     for axis in range(2)
                 )
-                assert result.isometry_form[target][other_target].as_fraction() == delta
+                assert result.isometry_form.entries[target][other_target].as_fraction() == delta
 
     def test_rejects_single_point_configuration(self) -> None:
         import pytest

--- a/tests/math/geometry/test_exact_geometry.py
+++ b/tests/math/geometry/test_exact_geometry.py
@@ -267,7 +267,10 @@ class TestEuclideanOrbitProfile:
                     (points[source][axis] - points[other_source][axis]) ** 2
                     for axis in range(2)
                 )
-                assert result.isometry_form.entries[target][other_target].as_fraction() == delta
+                assert (
+                    result.isometry_form.entries[target][other_target].as_fraction()
+                    == delta
+                )
 
     def test_rejects_single_point_configuration(self) -> None:
         import pytest


### PR DESCRIPTION
## Change

Adds `geometry.point_configuration.euclidean_orbit_profile.compute` for one bounded labelled rational point configuration. The operation returns the lexicographically least complete squared-distance matrix over relabelings, for both:

- isometry of the source; and
- similarity, after division by the least positive squared distance.

It retains the source, the exact normalizing distance, and deterministic source-to-canonical mappings. Exhaustive relabeling is admitted before execution, so the result is always a complete canonical form rather than a partial search.

## Design

- Reuses the existing exact-geometry `PointConfiguration` carrier and exact squared-distance kernel.
- Adds an owner-local derived admission budget for pairwise rational output and complete permutation work.
- Publishes the canonical matrices as exact rational values; labels remain provenance and are not part of the orbit relation.
- Does not add a graph/metric-space adapter, approximate canonicalization, Procrustes fitting, or a configuration search.

The exhaustive baseline admits at most `8!` complete relabelings. This is a conservative envelope for a complete proof; a color-refined private search can be added later without changing the public postcondition.

## Validation

- `uv run --locked pytest -q tests/math/geometry/test_exact_geometry.py` — 40 passed
- `uv run --locked pytest -q tests/catalog/test_catalog.py tests/catalog/test_catalog_invariants.py tests/catalog/test_tool_manifests.py` — 28 passed
- `make affected AFFECTED_BASE=origin/main` — 68 geometry, 103 catalog, and 882 catalog-integration examples passed; scoped lint/typecheck passed

Fixes #2882

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/williamlin1327-office/c84c3dd6-32a2-443a-9a0c-89a15b50139c)
