### PR TITLE
feat(group-actions): add subset-family orbit profiles

### DIFF
--- a/src/jacobian/math/groups/actions/__init__.py
+++ b/src/jacobian/math/groups/actions/__init__.py
@@ -6,6 +6,7 @@ from jacobian.math.groups.actions.operations import (
     element_cycles,
     polya_inventory,
     subset_canonicalization,
+    subset_family_orbit_profile,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "element_cycles",
     "polya_inventory",
     "subset_canonicalization",
+    "subset_family_orbit_profile",
 ]

--- a/src/jacobian/math/groups/actions/_models.py
+++ b/src/jacobian/math/groups/actions/_models.py
@@ -369,7 +369,8 @@ class SubsetFamilyOrbitProfileResult(StrictModel):
                 self.rows,
                 key=lambda row: (
                     row.representative.positions,
-                    row.representative.action.model_dump(),
+                    row.representative.action.domain,
+                    row.representative.action.generators,
                 ),
             )
         ):

--- a/src/jacobian/math/groups/actions/_models.py
+++ b/src/jacobian/math/groups/actions/_models.py
@@ -364,6 +364,24 @@ class SubsetFamilyOrbitProfileResult(StrictModel):
 
     @model_validator(mode="after")
     def bind_subset_family_orbit_profile(self) -> Self:
+        if len(self.subsets) != self.family_size:
+            raise _validation_error(
+                "orbit_profile_family_size_mismatch",
+                "subsets must contain exactly family_size source members",
+            )
+        canonical_subsets = tuple(
+            _canonical_subset_positions(self.action, subset) for subset in self.subsets
+        )
+        if canonical_subsets != self.subsets:
+            raise _validation_error(
+                "orbit_profile_subsets_not_canonical",
+                "subsets must use increasing canonical action positions",
+            )
+        if len(set(canonical_subsets)) != len(canonical_subsets):
+            raise _validation_error(
+                "orbit_profile_duplicate_subsets",
+                "subsets must be pairwise distinct",
+            )
         seen_indices: set[int] = set()
         seen_representatives: set[tuple[int, ...]] = set()
         total_supplied = 0

--- a/src/jacobian/math/groups/actions/_models.py
+++ b/src/jacobian/math/groups/actions/_models.py
@@ -363,7 +363,7 @@ class SubsetFamilyOrbitProfileResult(StrictModel):
     total_full_orbit_size: int = Field(ge=0, le=MAX_ORBIT_PROFILE_IMAGES)
 
     @model_validator(mode="after")
-    def bind_subset_family_orbit_profile(self) -> Self:
+    def bind_subset_family_orbit_profile(self) -> Self:  # noqa: C901
         if self.rows != tuple(
             sorted(
                 self.rows,

--- a/src/jacobian/math/groups/actions/_models.py
+++ b/src/jacobian/math/groups/actions/_models.py
@@ -364,6 +364,19 @@ class SubsetFamilyOrbitProfileResult(StrictModel):
 
     @model_validator(mode="after")
     def bind_subset_family_orbit_profile(self) -> Self:
+        if self.rows != tuple(
+            sorted(
+                self.rows,
+                key=lambda row: (
+                    row.representative.positions,
+                    row.representative.action.model_dump(),
+                ),
+            )
+        ):
+            raise _validation_error(
+                "orbit_profile_rows_not_canonical",
+                "rows must be ordered by representative and action presentation",
+            )
         if len(self.subsets) != self.family_size:
             raise _validation_error(
                 "orbit_profile_family_size_mismatch",

--- a/src/jacobian/math/groups/actions/_models.py
+++ b/src/jacobian/math/groups/actions/_models.py
@@ -15,6 +15,10 @@ MAX_GENERATORS = 50
 MAX_LABEL_LENGTH = 64
 MAX_COLORS = 50
 MAX_TERMS = 5000
+MAX_FAMILY_MEMBERS = 5000
+MAX_ORBIT_PROFILE_IMAGES = 200000
+MAX_ORBIT_PROFILE_INCIDENCES = 1000000
+MAX_ORBIT_PROFILE_TRANSPORTERS = 100000
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -238,6 +242,210 @@ class SubsetCanonicalizationResult(StrictModel):
             transporter=transporter,
             orbit_size=orbit_size,
             stabilizer_size=stabilizer_size,
+        )
+
+
+# ---------------------------------------------------------------------------
+# group_action.subset_family.orbit_profile.compute
+# ---------------------------------------------------------------------------
+
+
+class SubsetFamilyOrbitProfileRequest(StrictModel):
+    """Request an exact orbit partition of a materialized subset family.
+
+    The finite permutation action is supplied once and remains the parent of
+    every source row. ``subsets`` are distinct increasing position tuples in
+    source order. Duplicates are rejected before the group is expanded, and
+    the empty family is valid.
+    """
+
+    action: FinitePermutationAction
+    subsets: tuple[FiniteActionSubset, ...] = Field(
+        max_length=MAX_FAMILY_MEMBERS,
+        description=(
+            "Distinct increasing position tuples in source order, each indexing "
+            "the supplied action domain. The generated group must have order at "
+            f"most {MAX_GROUP_ORDER}, and the admitted family, generated orbit "
+            "images, retained incidences, and output must fit the operation "
+            "ledger."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_bound_and_distinct_subsets(self) -> Self:
+        if not self.subsets:
+            return self
+        for subset in self.subsets:
+            _canonical_subset_positions(self.action, subset)
+        if len(set(self.subsets)) != len(self.subsets):
+            raise _validation_error(
+                "subset_family_duplicates", "supplied subsets must be pairwise distinct"
+            )
+        return self
+
+
+class SubsetFamilyOrbitProfileRow(StrictModel):
+    """One orbit class of the supplied subset family.
+
+    ``source_indices`` are indices into the request's source order. The class
+    contains exactly those supplied subsets that lie in the ambient orbit;
+    ``supplied_count`` may be smaller than ``orbit_size`` when the family is
+    not invariant.
+    """
+
+    representative: ActionBoundSubset
+    source_indices: tuple[int, ...] = Field(
+        min_length=1,
+        max_length=MAX_FAMILY_MEMBERS,
+        description=(
+            "Increasing source indices of all supplied members of this orbit."
+        ),
+    )
+    supplied_count: int = Field(
+        ge=1,
+        le=MAX_FAMILY_MEMBERS,
+        description="Number of supplied family members in this ambient orbit.",
+    )
+    orbit_size: int = Field(
+        ge=1,
+        le=MAX_GROUP_ORDER,
+        description=(
+            "Number of distinct images of the representative under the "
+            "generated group, including ambient images absent from the request."
+        ),
+    )
+    stabilizer_size: int = Field(
+        ge=1,
+        le=MAX_GROUP_ORDER,
+        description=(
+            "Order of the setwise stabilizer of the representative; its "
+            "product with orbit_size equals the generated group order."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def bind_orbit_profile_row(self) -> Self:
+        if self.supplied_count != len(self.source_indices):
+            raise _validation_error(
+                "orbit_profile_row_count_mismatch",
+                "supplied_count must equal the number of retained source indices",
+            )
+        if tuple(sorted(set(self.source_indices))) != self.source_indices:
+            raise _validation_error(
+                "orbit_profile_source_indices_not_canonical",
+                "source indices must be distinct and increasing",
+            )
+        if self.orbit_size * self.stabilizer_size > MAX_GROUP_ORDER:
+            raise _validation_error(
+                "orbit_stabilizer_product_exceeds_bound",
+                "orbit_size * stabilizer_size must stay within the group-order bound",
+            )
+        return self
+
+
+class SubsetFamilyOrbitProfileResult(StrictModel):
+    """Complete source-indexed orbit partition of a materialized subset family.
+
+    Rows are sorted by the canonical representative's increasing position
+    tuple and then by its action presentation. Together the ``source_indices``
+    fields form the exact partition of the supplied source range. The family is
+    a union of complete ambient orbits exactly when every supplied class count
+    equals its full orbit size.
+    """
+
+    action: FinitePermutationAction
+    group_order: int = Field(ge=1, le=MAX_GROUP_ORDER)
+    family_size: int = Field(ge=0, le=MAX_FAMILY_MEMBERS)
+    rows: tuple[SubsetFamilyOrbitProfileRow, ...] = Field(max_length=MAX_FAMILY_MEMBERS)
+    is_union_of_complete_orbits: bool
+    total_supplied_subsets: int = Field(ge=0, le=MAX_FAMILY_MEMBERS)
+    total_full_orbit_size: int = Field(ge=0, le=MAX_ORBIT_PROFILE_IMAGES)
+
+    @model_validator(mode="after")
+    def bind_subset_family_orbit_profile(self) -> Self:
+        seen_indices: set[int] = set()
+        seen_representatives: set[tuple[int, ...]] = set()
+        total_supplied = 0
+        total_orbits = 0
+        complete = True
+        for row in self.rows:
+            if row.orbit_size * row.stabilizer_size != self.group_order:
+                raise _validation_error(
+                    "orbit_profile_orbit_stabilizer_mismatch",
+                    "every row must satisfy orbit_size * stabilizer_size == group_order",
+                )
+            if row.representative.action != self.action:
+                raise _validation_error(
+                    "orbit_profile_representative_action_mismatch",
+                    "every orbit representative must be bound to the source action",
+                )
+            representative = row.representative.positions
+            if representative in seen_representatives:
+                raise _validation_error(
+                    "orbit_profile_duplicate_representatives",
+                    "orbit representatives must be pairwise distinct",
+                )
+            seen_representatives.add(representative)
+            for index in row.source_indices:
+                if not 0 <= index < self.family_size:
+                    raise _validation_error(
+                        "orbit_profile_source_index_out_of_range",
+                        "every source index must address the supplied family",
+                    )
+                if index in seen_indices:
+                    raise _validation_error(
+                        "orbit_profile_duplicate_source_indices",
+                        "each supplied subset must occur in exactly one orbit row",
+                    )
+                seen_indices.add(index)
+            total_supplied += row.supplied_count
+            total_orbits += row.orbit_size
+            complete = complete and row.supplied_count == row.orbit_size
+        if self.total_supplied_subsets != total_supplied:
+            raise _validation_error(
+                "orbit_profile_supplied_total_mismatch",
+                "total_supplied_subsets must equal the retained source-index count",
+            )
+        if self.total_full_orbit_size != total_orbits:
+            raise _validation_error(
+                "orbit_profile_orbit_total_mismatch",
+                "total_full_orbit_size must equal the sum of row orbit sizes",
+            )
+        if self.is_union_of_complete_orbits != complete:
+            raise _validation_error(
+                "orbit_profile_completeness_claim_mismatch",
+                "is_union_of_complete_orbits must match per-row supplied/orbit equality",
+            )
+        if len(seen_indices) != self.family_size:
+            raise _validation_error(
+                "orbit_profile_source_coverage_mismatch",
+                "orbit rows must cover every supplied family index exactly once",
+            )
+        if complete and self.family_size != self.total_full_orbit_size:
+            raise _validation_error(
+                "orbit_profile_complete_family_size_mismatch",
+                "a complete-orbit family must have family_size equal to total orbit size",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        action: FinitePermutationAction,
+        group_order: int,
+        family_size: int,
+        rows: tuple[SubsetFamilyOrbitProfileRow, ...],
+    ) -> Self:
+        return cls.model_construct(
+            action=action,
+            group_order=group_order,
+            family_size=family_size,
+            rows=rows,
+            is_union_of_complete_orbits=all(
+                row.supplied_count == row.orbit_size for row in rows
+            ),
+            total_supplied_subsets=sum(row.supplied_count for row in rows),
+            total_full_orbit_size=sum(row.orbit_size for row in rows),
         )
 
 

--- a/src/jacobian/math/groups/actions/_models.py
+++ b/src/jacobian/math/groups/actions/_models.py
@@ -354,6 +354,7 @@ class SubsetFamilyOrbitProfileResult(StrictModel):
     """
 
     action: FinitePermutationAction
+    subsets: tuple[FiniteActionSubset, ...] = Field(max_length=MAX_FAMILY_MEMBERS)
     group_order: int = Field(ge=1, le=MAX_GROUP_ORDER)
     family_size: int = Field(ge=0, le=MAX_FAMILY_MEMBERS)
     rows: tuple[SubsetFamilyOrbitProfileRow, ...] = Field(max_length=MAX_FAMILY_MEMBERS)
@@ -434,10 +435,12 @@ class SubsetFamilyOrbitProfileResult(StrictModel):
         action: FinitePermutationAction,
         group_order: int,
         family_size: int,
+        subsets: tuple[FiniteActionSubset, ...],
         rows: tuple[SubsetFamilyOrbitProfileRow, ...],
     ) -> Self:
         return cls.model_construct(
             action=action,
+            subsets=subsets,
             group_order=group_order,
             family_size=family_size,
             rows=rows,

--- a/src/jacobian/math/groups/actions/_tools.py
+++ b/src/jacobian/math/groups/actions/_tools.py
@@ -15,6 +15,8 @@ from jacobian.math.groups.actions._models import (
     PolyaInventoryResult,
     SubsetCanonicalizationRequest,
     SubsetCanonicalizationResult,
+    SubsetFamilyOrbitProfileRequest,
+    SubsetFamilyOrbitProfileResult,
 )
 from jacobian.math.groups.actions.operations import (
     burnside_count,
@@ -22,6 +24,7 @@ from jacobian.math.groups.actions.operations import (
     element_cycles,
     polya_inventory,
     subset_canonicalization,
+    subset_family_orbit_profile,
 )
 
 
@@ -43,6 +46,12 @@ def _burnside(request: BurnsideCountRequest) -> BurnsideCountResult:
 
 def _polya(request: PolyaInventoryRequest) -> PolyaInventoryResult:
     return polya_inventory(request.action, request.colors)
+
+
+def _subset_family_orbit_profile(
+    request: SubsetFamilyOrbitProfileRequest,
+) -> SubsetFamilyOrbitProfileResult:
+    return subset_family_orbit_profile(request)
 
 
 # The cyclic group C_3 acting on three labelled points by rotation.
@@ -110,6 +119,43 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                         "action": _ACTION,
                         "positions": [2],
                     },
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="group_action.subset_family.orbit_profile.compute",
+        title="Partition a finite subset family by permutation-action orbits",
+        description="Partition a supplied finite family of distinct action-bound "
+        "subsets into its ambient permutation-action orbit classes. Each exact "
+        "row retains a canonical representative, every supplied source index in "
+        "that orbit, the full ambient orbit size, and the setwise stabilizer "
+        "size; the result also states whether the family is a union of complete "
+        "ambient orbits. Empty families and invariant and non-invariant supplied "
+        "families are valid.",
+        request_type=SubsetFamilyOrbitProfileRequest,
+        result_type=SubsetFamilyOrbitProfileResult,
+        run=_subset_family_orbit_profile,
+        tags=(
+            "algebra",
+            "group",
+            "permutation",
+            "subset family",
+            "orbit profile",
+            "partition",
+            "orbit-stabilizer",
+            "exact",
+        ),
+        examples=(
+            OperationExample(
+                name="cyclic_c3_edge_pair_family",
+                description="Partition the singleton family {b} under the cyclic "
+                "group C_3 acting on three points; subsets must be bound to one "
+                "action, distinct, and ordered as source rows. The generated "
+                f"group must have order at most {MAX_GROUP_ORDER}.",
+                input={
+                    "action": _ACTION,
+                    "subsets": [[1]],
                 },
             ),
         ),

--- a/src/jacobian/math/groups/actions/_tools.py
+++ b/src/jacobian/math/groups/actions/_tools.py
@@ -51,7 +51,7 @@ def _polya(request: PolyaInventoryRequest) -> PolyaInventoryResult:
 def _subset_family_orbit_profile(
     request: SubsetFamilyOrbitProfileRequest,
 ) -> SubsetFamilyOrbitProfileResult:
-    return subset_family_orbit_profile(request)
+    return subset_family_orbit_profile(request.action, request.subsets)
 
 
 # The cyclic group C_3 acting on three labelled points by rotation.

--- a/src/jacobian/math/groups/actions/operations.py
+++ b/src/jacobian/math/groups/actions/operations.py
@@ -351,10 +351,9 @@ def subset_family_orbit_profile(
             raise ValueError("orbit generation lost the representative source subset")
         # Each serialized representative currently retains its action carrier;
         # charge that repeated projection for every output row.
-        retained_incidences += (
-            len(representative) * (1 + len(supplied))
-            + len(action.domain) * (1 + len(action.generators))
-        )
+        retained_incidences += len(representative) * (1 + len(supplied)) + len(
+            action.domain
+        ) * (1 + len(action.generators))
         if retained_incidences > MAX_ORBIT_PROFILE_INCIDENCES:
             raise OperationDomainValidationError(
                 location=("subsets",),

--- a/src/jacobian/math/groups/actions/operations.py
+++ b/src/jacobian/math/groups/actions/operations.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.groups.actions._models import (
+    MAX_FAMILY_MEMBERS,
     MAX_GROUP_ORDER,
     MAX_ORBIT_PROFILE_IMAGES,
     MAX_ORBIT_PROFILE_INCIDENCES,
@@ -286,11 +287,23 @@ def subset_family_orbit_profile(
     than the unrelated carrier size alone.
     """
 
-    group = _enumerate_group(action)
-    group_order = len(group)
     source_positions = tuple(
         _canonical_family_subset(action, subset) for subset in subsets
     )
+    if len(source_positions) > MAX_FAMILY_MEMBERS:
+        raise OperationDomainValidationError(
+            location=("subsets",),
+            code="finite_group_action.subset_family_size_exceeded",
+            message=f"at most {MAX_FAMILY_MEMBERS} subsets are admitted",
+        )
+    if len(set(source_positions)) != len(source_positions):
+        raise OperationDomainValidationError(
+            location=("subsets",),
+            code="finite_group_action.subset_family_duplicates",
+            message="supplied subsets must be pairwise distinct",
+        )
+    group = _enumerate_group(action)
+    group_order = len(group)
 
     source_index = {
         positions: index for index, positions in enumerate(source_positions)

--- a/src/jacobian/math/groups/actions/operations.py
+++ b/src/jacobian/math/groups/actions/operations.py
@@ -368,16 +368,12 @@ def subset_family_orbit_profile(
             ),
         )
     )
-    return SubsetFamilyOrbitProfileResult(
+    return SubsetFamilyOrbitProfileResult._from_kernel(
         action=action,
         group_order=group_order,
         family_size=len(source_positions),
+        subsets=source_positions,
         rows=rows,
-        is_union_of_complete_orbits=all(
-            row.supplied_count == row.orbit_size for row in rows
-        ),
-        total_supplied_subsets=sum(row.supplied_count for row in rows),
-        total_full_orbit_size=sum(row.orbit_size for row in rows),
     )
 
 

--- a/src/jacobian/math/groups/actions/operations.py
+++ b/src/jacobian/math/groups/actions/operations.py
@@ -381,7 +381,8 @@ def subset_family_orbit_profile(
             orbit_rows,
             key=lambda row: (
                 row.representative.positions,
-                row.representative.action.model_dump(),
+                row.representative.action.domain,
+                row.representative.action.generators,
             ),
         )
     )

--- a/src/jacobian/math/groups/actions/operations.py
+++ b/src/jacobian/math/groups/actions/operations.py
@@ -287,15 +287,15 @@ def subset_family_orbit_profile(
     than the unrelated carrier size alone.
     """
 
-    source_positions = tuple(
-        _canonical_family_subset(action, subset) for subset in subsets
-    )
-    if len(source_positions) > MAX_FAMILY_MEMBERS:
+    if len(subsets) > MAX_FAMILY_MEMBERS:
         raise OperationDomainValidationError(
             location=("subsets",),
             code="finite_group_action.subset_family_size_exceeded",
             message=f"at most {MAX_FAMILY_MEMBERS} subsets are admitted",
         )
+    source_positions = tuple(
+        _canonical_family_subset(action, subset) for subset in subsets
+    )
     if len(set(source_positions)) != len(source_positions):
         raise OperationDomainValidationError(
             location=("subsets",),

--- a/src/jacobian/math/groups/actions/operations.py
+++ b/src/jacobian/math/groups/actions/operations.py
@@ -349,7 +349,12 @@ def subset_family_orbit_profile(
         )
         if not supplied:
             raise ValueError("orbit generation lost the representative source subset")
-        retained_incidences += len(representative) * (1 + len(supplied))
+        # Each serialized representative currently retains its action carrier;
+        # charge that repeated projection for every output row.
+        retained_incidences += (
+            len(representative) * (1 + len(supplied))
+            + len(action.domain) * (1 + len(action.generators))
+        )
         if retained_incidences > MAX_ORBIT_PROFILE_INCIDENCES:
             raise OperationDomainValidationError(
                 location=("subsets",),

--- a/src/jacobian/math/groups/actions/operations.py
+++ b/src/jacobian/math/groups/actions/operations.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.groups.actions._models import (
     MAX_GROUP_ORDER,
+    MAX_ORBIT_PROFILE_IMAGES,
+    MAX_ORBIT_PROFILE_INCIDENCES,
+    MAX_ORBIT_PROFILE_TRANSPORTERS,
     ActionBoundSubset,
     BurnsideCountResult,
     CycleIndexResult,
@@ -12,6 +15,9 @@ from jacobian.math.groups.actions._models import (
     FinitePermutationAction,
     PolyaInventoryResult,
     SubsetCanonicalizationResult,
+    SubsetFamilyOrbitProfileRequest,
+    SubsetFamilyOrbitProfileResult,
+    SubsetFamilyOrbitProfileRow,
 )
 
 CycleTypeCount = tuple[tuple[int, ...], int]
@@ -251,6 +257,112 @@ def _polya_inventory_data(
     return degree, tuple(terms)
 
 
+def subset_family_orbit_profile(
+    request: SubsetFamilyOrbitProfileRequest,
+) -> SubsetFamilyOrbitProfileResult:
+    """Partition a materialized family by ambient permutation-action orbits.
+
+    The kernel expands the generated group once. It materializes only the
+    distinct ambient orbits represented by the supplied family, then binds every
+    source index to its orbit class. Admission charges source incidences,
+    generated images, representative transporters, and retained output rather
+    than the unrelated carrier size alone.
+    """
+
+    action = request.action
+    group = _enumerate_group(action)
+    group_order = len(group)
+    source_positions = request.subsets
+
+    source_index = {
+        positions: index for index, positions in enumerate(source_positions)
+    }
+    unclassified = set(source_positions)
+    orbit_rows: list[SubsetFamilyOrbitProfileRow] = []
+    generated_images = 0
+    generated_transporters = 0
+    retained_incidences = 0
+
+    while unclassified:
+        seed = min(unclassified)
+        orbit_images: set[tuple[int, ...]] = set()
+        for permutation in group:
+            orbit_images.add(_transport_subset(permutation, seed))
+            generated_images += 1
+            if generated_images > MAX_ORBIT_PROFILE_IMAGES:
+                raise OperationDomainValidationError(
+                    location=("subsets",),
+                    code="finite_group_action.subset_family_orbit_work_exceeded",
+                    message=(
+                        f"generated orbit-image work exceeds the bounded maximum "
+                        f"{MAX_ORBIT_PROFILE_IMAGES}"
+                    ),
+                )
+
+        orbit_size = len(orbit_images)
+        representative = min(orbit_images)
+        generated_transporters += orbit_size
+        if generated_transporters > MAX_ORBIT_PROFILE_TRANSPORTERS:
+            raise OperationDomainValidationError(
+                location=("subsets",),
+                code="finite_group_action.subset_family_orbit_transport_work_exceeded",
+                message=(
+                    f"generated orbit-canonicalization work exceeds the bounded "
+                    f"maximum {MAX_ORBIT_PROFILE_TRANSPORTERS}"
+                ),
+            )
+        supplied = sorted(
+            index
+            for image in orbit_images
+            if (index := source_index.get(image)) is not None
+        )
+        if not supplied:
+            raise ValueError("orbit generation lost the representative source subset")
+        retained_incidences += len(representative) * (1 + len(supplied))
+        if retained_incidences > MAX_ORBIT_PROFILE_INCIDENCES:
+            raise OperationDomainValidationError(
+                location=("subsets",),
+                code="finite_group_action.subset_family_orbit_result_exceeded",
+                message=(
+                    "retained orbit-profile incidence work exceeds the bounded "
+                    f"maximum {MAX_ORBIT_PROFILE_INCIDENCES}"
+                ),
+            )
+        orbit_rows.append(
+            SubsetFamilyOrbitProfileRow(
+                representative=ActionBoundSubset(
+                    action=action, positions=representative
+                ),
+                source_indices=tuple(supplied),
+                supplied_count=len(supplied),
+                orbit_size=orbit_size,
+                stabilizer_size=group_order // orbit_size,
+            )
+        )
+        unclassified -= set(orbit_images)
+
+    rows = tuple(
+        sorted(
+            orbit_rows,
+            key=lambda row: (
+                row.representative.positions,
+                row.representative.action.model_dump(),
+            ),
+        )
+    )
+    return SubsetFamilyOrbitProfileResult(
+        action=action,
+        group_order=group_order,
+        family_size=len(source_positions),
+        rows=rows,
+        is_union_of_complete_orbits=all(
+            row.supplied_count == row.orbit_size for row in rows
+        ),
+        total_supplied_subsets=sum(row.supplied_count for row in rows),
+        total_full_orbit_size=sum(row.orbit_size for row in rows),
+    )
+
+
 def element_cycles(
     action: FinitePermutationAction, element: int
 ) -> ElementCyclesResult:
@@ -315,4 +427,5 @@ __all__ = [
     "element_cycles",
     "polya_inventory",
     "subset_canonicalization",
+    "subset_family_orbit_profile",
 ]

--- a/src/jacobian/math/groups/actions/operations.py
+++ b/src/jacobian/math/groups/actions/operations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.groups.actions._models import (
     MAX_GROUP_ORDER,
@@ -15,7 +17,6 @@ from jacobian.math.groups.actions._models import (
     FinitePermutationAction,
     PolyaInventoryResult,
     SubsetCanonicalizationResult,
-    SubsetFamilyOrbitProfileRequest,
     SubsetFamilyOrbitProfileResult,
     SubsetFamilyOrbitProfileRow,
 )
@@ -131,6 +132,22 @@ def _cycle_decomposition(
     lengths = tuple(sorted((len(c) for c in cycles), reverse=True))
     fixed = tuple(i for i in range(n) if perm[i] == i)
     return tuple(cycles), lengths, lengths, fixed
+
+
+def _canonical_family_subset(
+    action: FinitePermutationAction, subset: tuple[int, ...]
+) -> tuple[int, ...]:
+    """Canonicalize one family row or fail with the owner-local typed error."""
+
+    try:
+        return ActionBoundSubset(action=action, positions=subset).positions
+    except ValidationError as error:
+        detail = error.errors()[0]
+        raise OperationDomainValidationError(
+            location=("subsets", *tuple(detail.get("loc", ()))),
+            code=detail["type"],
+            message=detail["msg"],
+        ) from error
 
 
 def _support(perm: tuple[int, ...]) -> tuple[int, ...]:
@@ -258,7 +275,7 @@ def _polya_inventory_data(
 
 
 def subset_family_orbit_profile(
-    request: SubsetFamilyOrbitProfileRequest,
+    action: FinitePermutationAction, subsets: tuple[tuple[int, ...], ...]
 ) -> SubsetFamilyOrbitProfileResult:
     """Partition a materialized family by ambient permutation-action orbits.
 
@@ -269,10 +286,11 @@ def subset_family_orbit_profile(
     than the unrelated carrier size alone.
     """
 
-    action = request.action
     group = _enumerate_group(action)
     group_order = len(group)
-    source_positions = request.subsets
+    source_positions = tuple(
+        _canonical_family_subset(action, subset) for subset in subsets
+    )
 
     source_index = {
         positions: index for index, positions in enumerate(source_positions)

--- a/tests/dispatch/test_group_action_dispatch.py
+++ b/tests/dispatch/test_group_action_dispatch.py
@@ -1,0 +1,22 @@
+"""Dispatch execution tests for finite group-action orbit profiles."""
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import invoke_operation
+
+_ACTION = {"domain": ["a", "b", "c"], "generators": [[1, 2, 0]]}
+
+
+def test_math_run_executes_subset_family_orbit_profile() -> None:
+    result = invoke_operation(
+        "group_action.subset_family.orbit_profile.compute",
+        {"action": _ACTION, "subsets": [[1], [0], [2]]},
+        Catalog.open(),
+    )
+
+    assert result.output["family_size"] == 3
+    assert result.output["group_order"] == 3
+    assert result.output["is_union_of_complete_orbits"] is True
+    assert len(result.output["rows"]) == 1
+    assert result.output["rows"][0]["source_indices"] == [0, 1, 2]
+    assert result.output["rows"][0]["orbit_size"] == 3
+    assert result.output["rows"][0]["stabilizer_size"] == 1

--- a/tests/math/groups/actions/test_subset_family_orbit_profile.py
+++ b/tests/math/groups/actions/test_subset_family_orbit_profile.py
@@ -1,0 +1,390 @@
+"""Contract tests for orbit profiles of materialized subset families."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from sympy.combinatorics import Permutation, PermutationGroup
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.groups.actions._models import (
+    ActionBoundSubset,
+    FinitePermutationAction,
+    SubsetFamilyOrbitProfileRequest,
+    SubsetFamilyOrbitProfileResult,
+)
+from jacobian.math.groups.actions._tools import TOOLS
+from jacobian.math.groups.actions.operations import (
+    _enumerate_group,
+    subset_family_orbit_profile,
+)
+
+
+def _cyclic_c3() -> FinitePermutationAction:
+    return FinitePermutationAction(
+        domain=("a", "b", "c"),
+        generators=((1, 2, 0),),
+    )
+
+
+def _dihedral_d4() -> FinitePermutationAction:
+    return FinitePermutationAction(
+        domain=("v0", "v1", "v2", "v3"),
+        generators=((1, 2, 3, 0), (1, 0, 3, 2)),
+    )
+
+
+def _symmetric_s3() -> FinitePermutationAction:
+    return FinitePermutationAction(
+        domain=("p0", "p1", "p2"),
+        generators=((1, 2, 0), (1, 0, 2)),
+    )
+
+
+def _bound(
+    action: FinitePermutationAction, positions: tuple[int, ...]
+) -> ActionBoundSubset:
+    return ActionBoundSubset(action=action, positions=positions)
+
+
+def _request(
+    action: FinitePermutationAction,
+    *subsets: tuple[int, ...],
+) -> SubsetFamilyOrbitProfileRequest:
+    return SubsetFamilyOrbitProfileRequest(action=action, subsets=subsets)
+
+
+def _result(
+    action: FinitePermutationAction,
+    *subsets: tuple[int, ...],
+) -> SubsetFamilyOrbitProfileResult:
+    return subset_family_orbit_profile(_request(action, *subsets))
+
+
+def _assert_error_type(error: ValidationError, expected: str) -> None:
+    assert error.errors()[0]["type"] == expected
+
+
+def _transport(
+    permutation: tuple[int, ...], subset: tuple[int, ...]
+) -> tuple[int, ...]:
+    return tuple(sorted(permutation[position] for position in subset))
+
+
+def test_empty_family_returns_an_exact_empty_profile() -> None:
+    result = _result(_cyclic_c3())
+
+    assert result.family_size == 0
+    assert result.rows == ()
+    assert result.total_supplied_subsets == result.total_full_orbit_size == 0
+    assert result.group_order == 3
+    assert result.is_union_of_complete_orbits is True
+
+
+def test_complete_singleton_family_reports_one_orbit_with_all_source_indices() -> None:
+    action = _cyclic_c3()
+    result = _result(action, (2,), (0,), (1,))
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.representative.positions == (0,)
+    assert row.source_indices == (0, 1, 2)
+    assert row.supplied_count == row.orbit_size == 3
+    assert row.stabilizer_size == 1
+    assert result.group_order == 3
+    assert result.is_union_of_complete_orbits is True
+
+
+def test_noninvariant_family_distinguishes_supplied_and_ambient_orbit_sizes() -> None:
+    action = _dihedral_d4()
+    result = _result(action, (0, 1), (2, 3))
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.representative.positions == (0, 1)
+    assert row.source_indices == (0, 1)
+    assert row.supplied_count == 2
+    assert row.orbit_size == 4
+    assert row.stabilizer_size == 2
+    assert result.total_supplied_subsets == 2
+    assert result.total_full_orbit_size == 4
+    assert result.is_union_of_complete_orbits is False
+
+
+def test_two_distinct_orbit_classes_partition_source_rows() -> None:
+    action = _dihedral_d4()
+    result = _result(action, (), (0, 2), (0, 1, 2, 3), (0,))
+
+    assert tuple(row.representative.positions for row in result.rows) == (
+        (),
+        (0,),
+        (0, 1, 2, 3),
+        (0, 2),
+    )
+    assert [row.source_indices for row in result.rows] == [(0,), (3,), (2,), (1,)]
+    assert [row.orbit_size for row in result.rows] == [1, 4, 1, 2]
+    assert [row.stabilizer_size for row in result.rows] == [8, 2, 8, 4]
+    assert result.is_union_of_complete_orbits is False
+    assert result.total_full_orbit_size == 8
+
+
+def test_nonfaithful_action_has_nontrivial_point_stabilizers() -> None:
+    action = _symmetric_s3()
+    action_with_fixed_point = FinitePermutationAction(
+        domain=action.domain,
+        generators=(action.generators[0],),
+    )
+    result = _result(action_with_fixed_point, (0,), (1,))
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.representative.positions == (0,)
+    assert row.source_indices == (0, 1)
+    assert row.supplied_count == 2
+    assert row.orbit_size == 3
+    assert row.stabilizer_size == 1
+    assert result.group_order == 3
+    assert result.is_union_of_complete_orbits is False
+
+
+def test_empty_and_full_subsets_have_whole_group_stabilizers() -> None:
+    action = _dihedral_d4()
+    result = _result(action, (), (0, 1, 2, 3))
+
+    assert [row.orbit_size for row in result.rows] == [1, 1]
+    assert [row.stabilizer_size for row in result.rows] == [8, 8]
+    assert result.is_union_of_complete_orbits is True
+
+
+@pytest.mark.property
+@pytest.mark.parametrize(
+    "action",
+    [_cyclic_c3(), _symmetric_s3(), _dihedral_d4()],
+)
+def test_profile_agrees_with_sympy_orbit_partition(
+    action: FinitePermutationAction,
+) -> None:
+    """Compare against independent SymPy enumeration for every singleton subset."""
+
+    result = _result(action, *((position,) for position in range(len(action.domain))))
+    elements = tuple(
+        tuple(permutation)
+        for permutation in PermutationGroup(
+            [Permutation(list(generator)) for generator in action.generators]
+        ).generate_schreier_sims(af=True)
+    )
+    expected: dict[tuple[int, ...], set[int]] = {}
+    for index, position in enumerate(range(len(action.domain))):
+        subset = (position,)
+        orbit = {_transport(permutation, subset) for permutation in elements}
+        expected.setdefault(min(orbit), set()).add(index)
+
+    assert tuple(row.representative.positions for row in result.rows) == tuple(
+        sorted(expected)
+    )
+    assert all(
+        tuple(sorted(expected[row.representative.positions])) == row.source_indices
+        for row in result.rows
+    )
+    assert all(
+        row.orbit_size * row.stabilizer_size == len(_enumerate_group(action))
+        for row in result.rows
+    )
+
+
+def test_generator_reordering_preserves_the_mathematical_profile() -> None:
+    first = _symmetric_s3()
+    second = FinitePermutationAction(
+        domain=first.domain,
+        generators=tuple(reversed(first.generators)),
+    )
+    first_result = _result(first, (0,), (0, 1))
+    second_result = _result(second, (0,), (0, 1))
+
+    assert first_result.group_order == second_result.group_order
+    assert first_result.family_size == second_result.family_size
+    assert first_result.is_union_of_complete_orbits == (
+        second_result.is_union_of_complete_orbits
+    )
+    assert first_result.total_supplied_subsets == second_result.total_supplied_subsets
+    assert first_result.total_full_orbit_size == second_result.total_full_orbit_size
+    assert tuple(
+        (
+            row.representative.positions,
+            row.source_indices,
+            row.supplied_count,
+            row.orbit_size,
+            row.stabilizer_size,
+        )
+        for row in first_result.rows
+    ) == tuple(
+        (
+            row.representative.positions,
+            row.source_indices,
+            row.supplied_count,
+            row.orbit_size,
+            row.stabilizer_size,
+        )
+        for row in second_result.rows
+    )
+
+
+def test_domain_relabelling_changes_only_the_bound_action_representation() -> None:
+    first = _symmetric_s3()
+    relabelled = FinitePermutationAction(
+        domain=("x", "y", "z"),
+        generators=first.generators,
+    )
+    first_result = _result(first, (0,))
+    relabelled_result = _result(relabelled, (0,))
+
+    assert first_result.group_order == relabelled_result.group_order
+    assert first_result.family_size == relabelled_result.family_size
+    assert (
+        first_result.is_union_of_complete_orbits
+        == relabelled_result.is_union_of_complete_orbits
+    )
+    assert (
+        first_result.rows[0].representative.positions
+        == relabelled_result.rows[0].representative.positions
+    )
+    assert (
+        first_result.rows[0].source_indices == relabelled_result.rows[0].source_indices
+    )
+
+
+def test_request_rejects_invalid_and_out_of_domain_positions() -> None:
+    action = _cyclic_c3()
+    with pytest.raises(ValidationError) as exc_info:
+        _request(action, (0, 0))
+    _assert_error_type(
+        exc_info.value, "finite_group_action.subset_positions_not_distinct"
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        _request(action, (3,))
+    _assert_error_type(
+        exc_info.value, "finite_group_action.subset_position_out_of_range"
+    )
+
+
+def test_request_rejects_duplicate_family_members() -> None:
+    action = _cyclic_c3()
+    with pytest.raises(ValidationError) as exc_info:
+        _request(action, (0, 1), (0, 1))
+    _assert_error_type(exc_info.value, "finite_group_action.subset_family_duplicates")
+
+    with pytest.raises(ValidationError) as exc_info:
+        _request(action, (0,), (0,))
+    _assert_error_type(exc_info.value, "finite_group_action.subset_family_duplicates")
+
+
+def test_request_rejects_group_immediately_above_enumeration_bound() -> None:
+    # S_9 has order 362880 and S_10 has order 3628800, so this crosses the
+    # existing 10000-element action bound without relying on factorial text.
+    degree = 9
+    action = FinitePermutationAction(
+        domain=tuple(f"p{position}" for position in range(degree)),
+        generators=((*range(1, degree), 0), (1, 0, *range(2, degree))),
+    )
+
+    with pytest.raises(OperationDomainValidationError) as error:
+        _result(action, (0,))
+
+    assert error.value.errors()[0]["type"] == (
+        "finite_group_action.group_order_exceeds_bound"
+    )
+    assert error.value.errors()[0]["loc"] == ("action",)
+
+
+@pytest.mark.parametrize(
+    ("forged_field", "value"),
+    [
+        ("source_indices", (0, 0)),
+        ("supplied_count", 2),
+        ("orbit_size", 2),
+        ("stabilizer_size", 2),
+    ],
+)
+def test_result_rejects_inconsistent_row_claims(
+    forged_field: str, value: tuple[int, ...] | int
+) -> None:
+    result = _result(_cyclic_c3(), (0,))
+    forged = result.model_dump()
+    if isinstance(value, tuple):
+        forged["rows"][0][forged_field] = list(value)
+    else:
+        forged["rows"][0][forged_field] = value
+
+    with pytest.raises(ValidationError):
+        SubsetFamilyOrbitProfileResult.model_validate(forged)
+
+
+def test_result_rejects_lost_source_coverage_and_wrong_completeness() -> None:
+    action = _cyclic_c3()
+    result = _result(action, (0,), (1,))
+    forged = result.model_dump()
+    forged["rows"][0]["source_indices"] = [0]
+    forged["rows"][0]["supplied_count"] = 1
+    forged["is_union_of_complete_orbits"] = True
+    forged["total_supplied_subsets"] = 1
+
+    with pytest.raises(ValidationError) as exc_info:
+        SubsetFamilyOrbitProfileResult.model_validate(forged)
+    _assert_error_type(
+        exc_info.value, "finite_group_action.orbit_profile_completeness_claim_mismatch"
+    )
+
+
+def test_result_rejects_duplicate_orbit_representatives() -> None:
+    result = _result(_dihedral_d4(), (), (0, 1, 2, 3))
+    forged = result.model_dump()
+    forged["rows"][0]["representative"] = forged["rows"][1]["representative"]
+
+    with pytest.raises(ValidationError) as exc_info:
+        SubsetFamilyOrbitProfileResult.model_validate(forged)
+    _assert_error_type(
+        exc_info.value, "finite_group_action.orbit_profile_duplicate_representatives"
+    )
+
+
+def test_result_rejects_representative_bound_to_a_different_action() -> None:
+    result = _result(_cyclic_c3(), (0,))
+    forged = result.model_dump()
+    forged["rows"][0]["representative"]["action"] = _dihedral_d4().model_dump()
+
+    with pytest.raises(ValidationError) as exc_info:
+        SubsetFamilyOrbitProfileResult.model_validate(forged)
+    _assert_error_type(
+        exc_info.value,
+        "finite_group_action.orbit_profile_representative_action_mismatch",
+    )
+
+
+def test_serialized_result_round_trips_unchanged() -> None:
+    action = _dihedral_d4()
+    result = _result(action, (0, 1), (2, 3))
+
+    restored = SubsetFamilyOrbitProfileResult.model_validate(result.model_dump())
+
+    assert restored == result
+
+
+def test_public_declaration_exposes_and_executes_copyable_example() -> None:
+    operation = next(
+        tool
+        for tool in TOOLS
+        if tool.operation_id == "group_action.subset_family.orbit_profile.compute"
+    )
+
+    assert operation.examples
+    request = operation.request_type.model_validate(operation.examples[0].input)
+    result = operation.run(request)
+
+    assert isinstance(result, SubsetFamilyOrbitProfileResult)
+    assert result.family_size == 1
+    assert result.rows[0].representative.positions == (0,)
+    assert result.rows[0].orbit_size == 3
+    schema = operation.request_type.model_json_schema()
+    assert schema["properties"]["subsets"]["maxItems"] == 5000
+    assert "supplied action domain" in schema["properties"]["subsets"]["description"]
+    assert set(operation.examples[0].input) == {"action", "subsets"}

--- a/tests/math/groups/actions/test_subset_family_orbit_profile.py
+++ b/tests/math/groups/actions/test_subset_family_orbit_profile.py
@@ -58,7 +58,7 @@ def _result(
     action: FinitePermutationAction,
     *subsets: tuple[int, ...],
 ) -> SubsetFamilyOrbitProfileResult:
-    return subset_family_orbit_profile(_request(action, *subsets))
+    return subset_family_orbit_profile(action, subsets)
 
 
 def _assert_error_type(error: ValidationError, expected: str) -> None:


### PR DESCRIPTION
## Summary

Add `group_action.subset_family.orbit_profile.compute` (#3162). The operation takes one finite permutation action and a materialized family of distinct domain subsets, then partitions the supplied family by ambient action orbits.

Each exact row retains:

- the canonical representative subset (lexicographically least ambient image);
- every supplied source index in that orbit;
- supplied intersection size;
- full ambient orbit size;
- setwise stabilizer size.

The result also returns `is_union_of_complete_orbits`, allowing a non-invariant input family to be distinguished from one that is a union of complete ambient orbits. The empty family is valid and retains the supplied action.

## Design and implementation

- Reuses the existing `FinitePermutationAction` carrier and public action domain rather than adding an operation-local action model.
- The action is supplied once, and each family row is an increasing position tuple. This keeps all rows source-bound and avoids repeating the action for every family member.
- The kernel enumerates the generated group once, then materializes only the distinct ambient orbits represented by the supplied family. Work is charged to:
  - generated orbit images (`200,000`);
  - generated orbit classes (`100,000`);
  - retained representative/source incidences (`1,000,000`);
  - family members (`5,000`);
  - the existing generated group order (`10,000`).
- Orbit-stabilizer sizes are derived from the enumerated group order and validated by the canonical result model (`orbit_size * stabilizer_size == group_order`).
- Result ordering is canonical by representative positions and action presentation.
- No SymPy object escapes the public boundary; SymPy is used only in tests as an independent orbit oracle.

## Tests

- empty family;
- complete and non-invariant families;
- multiple orbit classes;
- trivial/nonfaithful actions and nontrivial stabilizers;
- empty/full subsets with whole-group stabilizers;
- independent SymPy orbit-partition comparison;
- generator reordering and domain relabelling metamorphic checks;
- duplicate, invalid-position, and group-order rejection;
- forged row/source-coverage/representative/orbit-stabilizer claims rejected;
- serialization round trip;
- public declaration example and `math.run` dispatch parity.

Validation run:

```text
make affected AFFECTED_BASE=origin/main
# 81 math, 103 catalog, 882 integration catalog, 115 dispatch tests passed
# scoped Ruff, formatting, and mypy passed
```

The property-labeled suite was also explicitly run (88 tests passed).

Closes #3162

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/williamlin1327-office/ffb2749f-dfa6-4c19-9725-d90cc36a6ca6)
