### PR TITLE
feat(matroids): classify constrained prime-field flats

### DIFF
--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/__init__.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/__init__.py
@@ -1,0 +1,27 @@
+"""Exact clause-constrained prime-field flat classification."""
+
+from jacobian.math.combinatorics.matroids.prime_field_flats._models import (
+    ClauseConstrainedPrimeFieldFlatClassification,
+    ClauseConstrainedPrimeFieldFlatProblem,
+    PrimeFieldFlatClassificationComplete,
+    PrimeFieldFlatClassificationIncomplete,
+    PrimeFieldFlatOrbitRepresentative,
+    PrimeFieldFlatRankInterval,
+    PrimeFieldFlatSymmetryGenerator,
+    PrimeFieldVectorConfiguration,
+)
+from jacobian.math.combinatorics.matroids.prime_field_flats.operations import (
+    classify_clause_constrained_prime_field_flats,
+)
+
+__all__ = [
+    "ClauseConstrainedPrimeFieldFlatClassification",
+    "ClauseConstrainedPrimeFieldFlatProblem",
+    "PrimeFieldFlatClassificationComplete",
+    "PrimeFieldFlatClassificationIncomplete",
+    "PrimeFieldFlatOrbitRepresentative",
+    "PrimeFieldFlatRankInterval",
+    "PrimeFieldFlatSymmetryGenerator",
+    "PrimeFieldVectorConfiguration",
+    "classify_clause_constrained_prime_field_flats",
+]

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/__init__.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/__init__.py
@@ -8,6 +8,7 @@ from jacobian.math.combinatorics.matroids.prime_field_flats._models import (
     PrimeFieldFlatOrbitRepresentative,
     PrimeFieldFlatRankInterval,
     PrimeFieldFlatSymmetryGenerator,
+    PrimeFieldRowMatrix,
     PrimeFieldVectorConfiguration,
 )
 from jacobian.math.combinatorics.matroids.prime_field_flats.operations import (
@@ -22,6 +23,7 @@ __all__ = [
     "PrimeFieldFlatOrbitRepresentative",
     "PrimeFieldFlatRankInterval",
     "PrimeFieldFlatSymmetryGenerator",
+    "PrimeFieldRowMatrix",
     "PrimeFieldVectorConfiguration",
     "classify_clause_constrained_prime_field_flats",
 ]

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_kernel.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_kernel.py
@@ -23,6 +23,7 @@ from jacobian.math.combinatorics.matroids.prime_field_flats._models import (
     PrimeFieldVectorSpaceBasis,
     _validation_error,
 )
+from jacobian.math.matrices.finite_fields import PrimeFieldMatrix, rref
 
 MAX_PRIME_FIELD_FLAT_SEARCH_STATE_ORBITS = 100_000
 MAX_PRIME_FIELD_FLAT_SEARCH_WORK = 5_000_000_000
@@ -336,37 +337,14 @@ def _rref_basis(
         "row_reduction",
         input_cells * max(rank_bound, 1) + input_cells + rank_bound * ambient_dimension,
     )
-    matrix = [list(row) for row in rows]
-    pivot = 0
-    row_index = 0
-    while row_index < len(matrix) and pivot < ambient_dimension:
-        selected = next(
-            (index for index in range(row_index, len(matrix)) if matrix[index][pivot]),
-            None,
-        )
-        if selected is None:
-            pivot += 1
-            continue
-        matrix[row_index], matrix[selected] = matrix[selected], matrix[row_index]
-        inverse = pow(matrix[row_index][pivot], -1, prime)
-        matrix[row_index] = [value * inverse % prime for value in matrix[row_index]]
-        for index in range(len(matrix)):
-            if index == row_index or not matrix[index][pivot]:
-                continue
-            factor = matrix[index][pivot]
-            matrix[index] = [
-                (value - factor * pivot_value) % prime
-                for value, pivot_value in zip(
-                    matrix[index], matrix[row_index], strict=True
-                )
-            ]
-        row_index += 1
-        pivot += 1
+    reduced_rows, pivot_columns = rref(
+        PrimeFieldMatrix(prime=prime, entries=rows, columns=ambient_dimension)
+    )
     _require_execution_active(ledger.deadline, "after exact modular row reduction")
     # The elimination loop clears each pivot both above and below its pivot
     # row.  Return the final first ``row_index`` rows, not snapshots taken
     # before later pivot columns clear earlier pivot coordinates.
-    return tuple(tuple(row) for row in matrix[:row_index])
+    return reduced_rows[: len(pivot_columns)]
 
 
 def _pivot_columns(basis: tuple[ResidueRow, ...]) -> tuple[int, ...]:

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_kernel.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_kernel.py
@@ -1,0 +1,880 @@
+"""Exact bounded kernel for clause-constrained prime-field flats."""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass, field
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+)
+from jacobian.math.combinatorics.matroids.prime_field_flats._models import (
+    MAX_PRIME_FIELD_FLAT_CLAUSE_MEMBERSHIPS,
+    MAX_PRIME_FIELD_FLAT_GROUP_ORDER,
+    MAX_PRIME_FIELD_FLAT_RESULT_ORBITS,
+    ClauseConstrainedPrimeFieldFlatClassification,
+    ClauseConstrainedPrimeFieldFlatProblem,
+    PrimeFieldFlatIncompleteReason,
+    PrimeFieldFlatOrbitRepresentative,
+    PrimeFieldVectorSpaceBasis,
+    _validation_error,
+)
+
+MAX_PRIME_FIELD_FLAT_SEARCH_STATE_ORBITS = 100_000
+MAX_PRIME_FIELD_FLAT_SEARCH_WORK = 5_000_000_000
+MAX_PRIME_FIELD_FLAT_ORBIT_CACHE_ENTRIES = 500_000
+_PRIME_FIELD_FLAT_WALL_SECONDS = 3600.0
+_CANONICAL_PROJECTION_PASSES = 3
+
+type ResidueRow = tuple[int, ...]
+type ClosedCandidateSet = tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _PrimeFieldFlatPlan:
+    deadline: float | None
+    candidate_rows: tuple[ResidueRow, ...]
+    forbidden_rows: tuple[ResidueRow, ...]
+    candidate_permutations: tuple[tuple[int, ...], ...]
+    symmetry_group_order: int
+    state_orbit_limit: int
+    result_orbit_limit: int
+    search_work_limit: int
+    clause_membership_count: int
+    representative_encoding_work: int
+    ledger: _WorkLedger
+
+
+@dataclass(frozen=True, slots=True)
+class _FlatState:
+    closed_candidates: ClosedCandidateSet
+    row_space_basis: tuple[ResidueRow, ...]
+    rank: int
+
+
+class _SearchStoppedError(Exception):
+    def __init__(
+        self,
+        reason: PrimeFieldFlatIncompleteReason,
+        *,
+        visited_count: int = 0,
+        consumed_work: int = 0,
+    ) -> None:
+        self.reason = reason
+        self.visited_count = visited_count
+        self.consumed_work = consumed_work
+        super().__init__(reason)
+
+
+@dataclass(slots=True)
+class _WorkLedger:
+    limit: int
+    deadline: float | None
+    consumed: int = 0
+    state_orbit_count: int = 0
+    charged_by_primitive: dict[str, int] = field(default_factory=dict)
+
+    def charge(self, primitive: str, units: int) -> None:
+        units = max(units, 1)
+        if self.consumed + units > self.limit:
+            raise _SearchStoppedError(
+                "SEARCH_WORK_LIMIT",
+                visited_count=self.state_orbit_count,
+                consumed_work=self.consumed,
+            )
+        self.consumed += units
+        self.charged_by_primitive[primitive] = (
+            self.charged_by_primitive.get(primitive, 0) + units
+        )
+
+
+def _require_execution_active(deadline: float | None, phase: str) -> None:
+    request_checkpoint(phase)
+    if deadline is not None and deadline <= time.monotonic():
+        raise OperationExecutionTimeoutError(f"request deadline expired {phase}")
+
+
+def _bind_owner_deadline() -> float:
+    execution = current_request_execution()
+    started = execution.started_at if execution is not None else time.monotonic()
+    owner_deadline = started + _PRIME_FIELD_FLAT_WALL_SECONDS
+    deadline = (
+        min(owner_deadline, execution.deadline)
+        if execution is not None and execution.deadline is not None
+        else owner_deadline
+    )
+    bind_request_deadline(deadline)
+    return deadline
+
+
+def _span_membership_scalar_work(
+    *,
+    query_count: int,
+    rank: int,
+    ambient_dimension: int,
+) -> int:
+    return max(query_count, 1) * max(ambient_dimension, 1) * (2 * max(rank, 1) + 2)
+
+
+def _subset_container_work(element_count: int, *, sorting: bool = False) -> int:
+    size = max(element_count, 1)
+    comparison_levels = size.bit_length() if sorting else 1
+    return size * (8 * comparison_levels + 8)
+
+
+def _clause_scan_work(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+    closed_count: int,
+    *,
+    clause_membership_count: int,
+) -> int:
+    return (
+        max(closed_count, 1)
+        + clause_membership_count
+        + len(problem.clauses)
+        + problem.candidates.vector_count
+        + 1
+    )
+
+
+def _modular_row_bits(prime: int) -> int:
+    return max(prime.bit_length(), 1)
+
+
+def _representative_encoding_work(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+) -> int:
+    ambient_dimension = len(problem.candidates.coordinate_axis)
+    candidate_count = problem.candidates.vector_count
+    residue_cells = 2 * ambient_dimension * ambient_dimension
+    return (
+        4_096
+        + candidate_count * (len(str(max(candidate_count, 1))) + 3)
+        + residue_cells * (_modular_row_bits(problem.candidates.prime) + 8)
+    )
+
+
+def _admission_work_charges(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+) -> tuple[tuple[str, int], ...]:
+    ambient_dimension = len(problem.candidates.coordinate_axis)
+    candidate_count = problem.candidates.vector_count
+    forbidden_count = problem.forbidden_vectors.row_count
+    generator_count = len(problem.symmetry_generators)
+    source_cells = (candidate_count + forbidden_count) * ambient_dimension
+    residue_bits = _modular_row_bits(problem.candidates.prime)
+    normalization_work = 16 * (source_cells + 1) * residue_bits
+    compatibility_elements = (
+        candidate_count * ambient_dimension
+        + MAX_PRIME_FIELD_FLAT_CLAUSE_MEMBERSHIPS
+        + forbidden_count * ambient_dimension
+        + candidate_count
+        + forbidden_count
+        + 1
+    )
+    compatibility_work = generator_count * _subset_container_work(
+        compatibility_elements,
+        sorting=True,
+    )
+    paired_degree = ambient_dimension + candidate_count
+    group_recognition_work = (
+        (generator_count + 3)
+        * (MAX_PRIME_FIELD_FLAT_GROUP_ORDER + 1)
+        * _subset_container_work(paired_degree)
+    )
+    source_projection_work = (
+        2 * _CANONICAL_PROJECTION_PASSES * compatibility_elements * residue_bits
+    )
+    return (
+        ("admission_normalization", normalization_work + 1),
+        ("admission_symmetry", compatibility_work + group_recognition_work),
+        ("source_encoding", source_projection_work),
+    )
+
+
+def _permuted_row(
+    row: ResidueRow,
+    coordinate_permutation: tuple[int, ...],
+) -> ResidueRow:
+    image = [0] * len(row)
+    for source, target in enumerate(coordinate_permutation):
+        image[target] = row[source]
+    return tuple(image)
+
+
+def _compose_permutations(
+    left: tuple[int, ...], right: tuple[int, ...]
+) -> tuple[int, ...]:
+    return tuple(left[right[index]] for index in range(len(left)))
+
+
+def _require_symmetry_compatibility(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+) -> tuple[tuple[int, ...], ...]:
+    clauses = set(problem.clauses)
+    forbidden_rows = set(problem.forbidden_vectors.entries)
+    candidate_permutations: list[tuple[int, ...]] = []
+    for generator in problem.symmetry_generators:
+        coordinate_permutation = tuple(generator.coordinate_permutation)
+        candidate_permutation = tuple(generator.candidate_permutation)
+        for source, target in enumerate(candidate_permutation):
+            if (
+                _permuted_row(
+                    problem.candidates.vectors.entries[source],
+                    coordinate_permutation,
+                )
+                != problem.candidates.vectors.entries[target]
+            ):
+                raise _validation_error(
+                    "candidate_symmetry",
+                    "each paired generator must send every candidate row to its "
+                    "declared modular image",
+                )
+        transformed_clauses = {
+            tuple(sorted(candidate_permutation[index] for index in clause))
+            for clause in clauses
+        }
+        if transformed_clauses != clauses:
+            raise _validation_error(
+                "clause_symmetry",
+                "each candidate generator must preserve the complete clause family",
+            )
+        transformed_forbidden = {
+            _permuted_row(row, coordinate_permutation) for row in forbidden_rows
+        }
+        if transformed_forbidden != forbidden_rows:
+            raise _validation_error(
+                "forbidden_symmetry",
+                "each coordinate generator must preserve the forbidden row set",
+            )
+        candidate_permutations.append(candidate_permutation)
+    return tuple(candidate_permutations)
+
+
+def _paired_group_order(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+    *,
+    deadline: float | None,
+) -> int:
+    if not problem.symmetry_generators:
+        return 1
+    ambient_dimension = len(problem.candidates.coordinate_axis)
+    candidate_count = problem.candidates.vector_count
+    paired_generators = tuple(
+        (
+            *generator.coordinate_permutation,
+            *(ambient_dimension + image for image in generator.candidate_permutation),
+        )
+        for generator in problem.symmetry_generators
+    )
+    degree = ambient_dimension + candidate_count
+    identity = tuple(range(degree))
+    seen = {identity}
+    pending = deque((identity,))
+    while pending:
+        _require_execution_active(deadline, "during finite symmetry recognition")
+        current = pending.popleft()
+        for generator in paired_generators:
+            image = _compose_permutations(generator, current)
+            if image in seen:
+                continue
+            if len(seen) >= MAX_PRIME_FIELD_FLAT_GROUP_ORDER:
+                raise _validation_error(
+                    "symmetry_group_order_bound",
+                    "the paired symmetry group exceeds the admitted order bound of "
+                    f"{MAX_PRIME_FIELD_FLAT_GROUP_ORDER}",
+                )
+            seen.add(image)
+            pending.append(image)
+    return len(seen)
+
+
+def _admit_problem(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+) -> _PrimeFieldFlatPlan:
+    deadline = _bind_owner_deadline()
+    _require_execution_active(deadline, "before prime-field-flat admission")
+    ledger = _WorkLedger(limit=MAX_PRIME_FIELD_FLAT_SEARCH_WORK, deadline=deadline)
+    for primitive, units in _admission_work_charges(problem):
+        ledger.charge(primitive, units)
+    candidate_permutations = _require_symmetry_compatibility(problem)
+    _require_execution_active(deadline, "before finite symmetry recognition")
+    group_order = _paired_group_order(problem, deadline=deadline)
+    _require_execution_active(deadline, "after finite symmetry recognition")
+    return _PrimeFieldFlatPlan(
+        deadline=deadline,
+        candidate_rows=problem.candidates.vectors.entries,
+        forbidden_rows=problem.forbidden_vectors.entries,
+        candidate_permutations=candidate_permutations,
+        symmetry_group_order=group_order,
+        state_orbit_limit=MAX_PRIME_FIELD_FLAT_SEARCH_STATE_ORBITS,
+        result_orbit_limit=MAX_PRIME_FIELD_FLAT_RESULT_ORBITS,
+        search_work_limit=MAX_PRIME_FIELD_FLAT_SEARCH_WORK,
+        clause_membership_count=sum(len(clause) for clause in problem.clauses),
+        representative_encoding_work=_representative_encoding_work(problem),
+        ledger=ledger,
+    )
+
+
+def _rref_basis(
+    rows: tuple[ResidueRow, ...],
+    *,
+    ambient_dimension: int,
+    prime: int,
+    ledger: _WorkLedger,
+) -> tuple[ResidueRow, ...]:
+    if not rows:
+        return ()
+    _require_execution_active(ledger.deadline, "before exact modular row reduction")
+    rank_bound = min(len(rows), ambient_dimension)
+    input_cells = len(rows) * ambient_dimension
+    ledger.charge(
+        "row_reduction",
+        input_cells * max(rank_bound, 1) + input_cells + rank_bound * ambient_dimension,
+    )
+    matrix = [list(row) for row in rows]
+    pivot = 0
+    row_index = 0
+    while row_index < len(matrix) and pivot < ambient_dimension:
+        selected = next(
+            (index for index in range(row_index, len(matrix)) if matrix[index][pivot]),
+            None,
+        )
+        if selected is None:
+            pivot += 1
+            continue
+        matrix[row_index], matrix[selected] = matrix[selected], matrix[row_index]
+        inverse = pow(matrix[row_index][pivot], -1, prime)
+        matrix[row_index] = [value * inverse % prime for value in matrix[row_index]]
+        for index in range(len(matrix)):
+            if index == row_index or not matrix[index][pivot]:
+                continue
+            factor = matrix[index][pivot]
+            matrix[index] = [
+                (value - factor * pivot_value) % prime
+                for value, pivot_value in zip(
+                    matrix[index], matrix[row_index], strict=True
+                )
+            ]
+        row_index += 1
+        pivot += 1
+    _require_execution_active(ledger.deadline, "after exact modular row reduction")
+    # The elimination loop clears each pivot both above and below its pivot
+    # row.  Return the final first ``row_index`` rows, not snapshots taken
+    # before later pivot columns clear earlier pivot coordinates.
+    return tuple(tuple(row) for row in matrix[:row_index])
+
+
+def _pivot_columns(basis: tuple[ResidueRow, ...]) -> tuple[int, ...]:
+    return tuple(
+        next(index for index, value in enumerate(row) if value) for row in basis
+    )
+
+
+def _row_is_in_span(
+    row: ResidueRow,
+    basis: tuple[ResidueRow, ...],
+    pivots: tuple[int, ...],
+    nonpivots: tuple[int, ...],
+    prime: int,
+) -> bool:
+    return all(
+        row[column]
+        == sum(
+            row[pivot] * basis_row[column]
+            for basis_row, pivot in zip(basis, pivots, strict=True)
+        )
+        % prime
+        for column in nonpivots
+    )
+
+
+def _closed_candidates(
+    candidate_rows: tuple[ResidueRow, ...],
+    basis: tuple[ResidueRow, ...],
+    *,
+    prime: int,
+    ledger: _WorkLedger,
+) -> ClosedCandidateSet:
+    ambient_dimension = (
+        len(candidate_rows[0]) if candidate_rows else (len(basis[0]) if basis else 1)
+    )
+    ledger.charge(
+        "candidate_span_scan",
+        _span_membership_scalar_work(
+            query_count=len(candidate_rows),
+            rank=len(basis),
+            ambient_dimension=ambient_dimension,
+        ),
+    )
+    pivots = _pivot_columns(basis)
+    pivot_set = set(pivots)
+    nonpivots = tuple(
+        column for column in range(ambient_dimension) if column not in pivot_set
+    )
+    return tuple(
+        index
+        for index, row in enumerate(candidate_rows)
+        if _row_is_in_span(row, basis, pivots, nonpivots, prime)
+    )
+
+
+class _SubsetOrbitCanonicalizer:
+    def __init__(self, generators: tuple[tuple[int, ...], ...]) -> None:
+        self._generators = generators
+        self._cache: dict[ClosedCandidateSet, tuple[ClosedCandidateSet, int]] = {}
+
+    def canonicalize(
+        self, subset: ClosedCandidateSet, ledger: _WorkLedger
+    ) -> tuple[ClosedCandidateSet, int]:
+        ledger.charge("subset_lookup", _subset_container_work(len(subset)))
+        cached = self._cache.get(subset)
+        if cached is not None:
+            return cached
+        if not self._generators:
+            ledger.charge("subset_cache", _subset_container_work(len(subset)))
+            result = (subset, 1)
+            self._cache[subset] = result
+            return result
+
+        ledger.charge("subset_storage", 2 * _subset_container_work(len(subset)))
+        seen = {subset}
+        pending = deque((subset,))
+        while pending:
+            _require_execution_active(
+                ledger.deadline, "during prime-field-flat orbit canonicalization"
+            )
+            current = pending.popleft()
+            for generator in self._generators:
+                ledger.charge(
+                    "subset_action",
+                    _subset_container_work(len(current), sorting=True),
+                )
+                image = tuple(sorted(generator[index] for index in current))
+                if image not in seen:
+                    ledger.charge(
+                        "subset_storage", 2 * _subset_container_work(len(image))
+                    )
+                    seen.add(image)
+                    pending.append(image)
+        retained_elements = len(seen) * max(len(subset), 1)
+        ledger.charge(
+            "subset_cache", _subset_container_work(retained_elements, sorting=True)
+        )
+        canonical = min(seen)
+        result = (canonical, len(seen))
+        if len(self._cache) + len(seen) <= MAX_PRIME_FIELD_FLAT_ORBIT_CACHE_ENTRIES:
+            for image in seen:
+                self._cache[image] = result
+        return result
+
+
+def _annihilator_basis(
+    basis: tuple[ResidueRow, ...], *, ambient_dimension: int, prime: int
+) -> tuple[ResidueRow, ...]:
+    pivots = _pivot_columns(basis)
+    pivot_set = set(pivots)
+    vectors: list[ResidueRow] = []
+    for free_column in range(ambient_dimension):
+        if free_column in pivot_set:
+            continue
+        vector = [0] * ambient_dimension
+        vector[free_column] = 1
+        for row_index, pivot in enumerate(pivots):
+            vector[pivot] = (-basis[row_index][free_column]) % prime
+        vectors.append(tuple(vector))
+    return tuple(vectors)
+
+
+def _basis_value(
+    basis: tuple[ResidueRow, ...], *, prime: int, ambient_dimension: int
+) -> PrimeFieldVectorSpaceBasis:
+    return PrimeFieldVectorSpaceBasis(
+        prime=prime,
+        ambient_dimension=ambient_dimension,
+        vectors=basis,
+    )
+
+
+def _state_from_closed(
+    closed: ClosedCandidateSet,
+    *,
+    plan: _PrimeFieldFlatPlan,
+    prime: int,
+    ambient_dimension: int,
+    ledger: _WorkLedger,
+) -> _FlatState:
+    ledger.charge(
+        "state_construction",
+        _subset_container_work(len(closed))
+        + max(len(closed), 1) * max(ambient_dimension, 1),
+    )
+    basis = _rref_basis(
+        tuple(plan.candidate_rows[index] for index in closed),
+        ambient_dimension=ambient_dimension,
+        prime=prime,
+        ledger=ledger,
+    )
+    return _FlatState(closed_candidates=closed, row_space_basis=basis, rank=len(basis))
+
+
+def _canonical_closure(
+    rows: tuple[ResidueRow, ...],
+    *,
+    plan: _PrimeFieldFlatPlan,
+    prime: int,
+    ambient_dimension: int,
+    ledger: _WorkLedger,
+    canonicalizer: _SubsetOrbitCanonicalizer,
+) -> ClosedCandidateSet:
+    basis = _rref_basis(
+        rows,
+        ambient_dimension=ambient_dimension,
+        prime=prime,
+        ledger=ledger,
+    )
+    closed = _closed_candidates(
+        plan.candidate_rows,
+        basis,
+        prime=prime,
+        ledger=ledger,
+    )
+    canonical, _orbit_size = canonicalizer.canonicalize(closed, ledger)
+    return canonical
+
+
+def _contains_forbidden_row(
+    state: _FlatState,
+    *,
+    plan: _PrimeFieldFlatPlan,
+    prime: int,
+    ambient_dimension: int,
+    ledger: _WorkLedger,
+) -> bool:
+    ledger.charge(
+        "forbidden_span_scan",
+        _span_membership_scalar_work(
+            query_count=len(plan.forbidden_rows),
+            rank=state.rank,
+            ambient_dimension=ambient_dimension,
+        ),
+    )
+    pivots = _pivot_columns(state.row_space_basis)
+    pivot_set = set(pivots)
+    nonpivots = tuple(
+        column for column in range(ambient_dimension) if column not in pivot_set
+    )
+    return any(
+        _row_is_in_span(
+            row,
+            state.row_space_basis,
+            pivots,
+            nonpivots,
+            prime,
+        )
+        for row in plan.forbidden_rows
+    )
+
+
+def _branch_candidates(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+    closed: ClosedCandidateSet,
+    ledger: _WorkLedger,
+    *,
+    clause_membership_count: int,
+) -> tuple[int, ...]:
+    ledger.charge(
+        "clause_scan",
+        _clause_scan_work(
+            problem,
+            len(closed),
+            clause_membership_count=clause_membership_count,
+        ),
+    )
+    closed_set = set(closed)
+    unmet_clause = next(
+        (clause for clause in problem.clauses if closed_set.isdisjoint(clause)),
+        None,
+    )
+    if unmet_clause is not None:
+        return tuple(index for index in unmet_clause if index not in closed_set)
+    return tuple(
+        index
+        for index in range(problem.candidates.vector_count)
+        if index not in closed_set
+    )
+
+
+def _clauses_are_satisfied(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+    closed: ClosedCandidateSet,
+    ledger: _WorkLedger,
+    *,
+    clause_membership_count: int,
+) -> bool:
+    ledger.charge(
+        "clause_scan",
+        _clause_scan_work(
+            problem,
+            len(closed),
+            clause_membership_count=clause_membership_count,
+        ),
+    )
+    closed_set = set(closed)
+    return all(not closed_set.isdisjoint(clause) for clause in problem.clauses)
+
+
+def _search_satisfying_states(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+    plan: _PrimeFieldFlatPlan,
+) -> tuple[
+    dict[ClosedCandidateSet, _FlatState],
+    set[ClosedCandidateSet],
+    _WorkLedger,
+    _SubsetOrbitCanonicalizer,
+    int,
+]:
+    ambient_dimension = len(problem.candidates.coordinate_axis)
+    prime = problem.candidates.prime
+    ledger = plan.ledger
+    canonicalizer = _SubsetOrbitCanonicalizer(plan.candidate_permutations)
+    visited: set[ClosedCandidateSet] = set()
+    satisfying: dict[ClosedCandidateSet, _FlatState] = {}
+    satisfying_elements = 0
+    initial = _canonical_closure(
+        (),
+        plan=plan,
+        prime=prime,
+        ambient_dimension=ambient_dimension,
+        ledger=ledger,
+        canonicalizer=canonicalizer,
+    )
+    ledger.charge("search_frontier", 2 * _subset_container_work(len(initial)))
+    pending = [initial]
+    queued = {initial}
+    while pending:
+        _require_execution_active(plan.deadline, "during prime-field-flat search")
+        ledger.charge("search_frontier", 3 * _subset_container_work(len(pending[-1])))
+        closed = pending.pop()
+        queued.discard(closed)
+        if closed in visited:
+            continue
+        if len(visited) >= plan.state_orbit_limit:
+            raise _SearchStoppedError(
+                "STATE_ORBIT_LIMIT",
+                visited_count=len(visited),
+                consumed_work=ledger.consumed,
+            )
+        ledger.charge("search_frontier", _subset_container_work(len(closed)))
+        visited.add(closed)
+        ledger.state_orbit_count = len(visited)
+        state = _state_from_closed(
+            closed,
+            plan=plan,
+            prime=prime,
+            ambient_dimension=ambient_dimension,
+            ledger=ledger,
+        )
+        if state.rank > problem.maximum_rank or _contains_forbidden_row(
+            state,
+            plan=plan,
+            prime=prime,
+            ambient_dimension=ambient_dimension,
+            ledger=ledger,
+        ):
+            continue
+        clauses_satisfied = _clauses_are_satisfied(
+            problem,
+            closed,
+            ledger,
+            clause_membership_count=plan.clause_membership_count,
+        )
+        if clauses_satisfied and state.rank >= problem.minimum_rank:
+            retained_work = _subset_container_work(len(closed))
+            ledger.charge("search_frontier", retained_work)
+            if closed not in satisfying:
+                ledger.charge("search_frontier", retained_work)
+                satisfying[closed] = state
+                satisfying_elements += max(len(closed), 1)
+        if state.rank == problem.maximum_rank:
+            continue
+        child_keys: set[ClosedCandidateSet] = set()
+        child_key_elements = 0
+        for index in _branch_candidates(
+            problem,
+            closed,
+            ledger,
+            clause_membership_count=plan.clause_membership_count,
+        ):
+            ledger.charge("search_frontier", ambient_dimension + state.rank + 1)
+            child = _canonical_closure(
+                (*state.row_space_basis, plan.candidate_rows[index]),
+                plan=plan,
+                prime=prime,
+                ambient_dimension=ambient_dimension,
+                ledger=ledger,
+                canonicalizer=canonicalizer,
+            )
+            child_work = _subset_container_work(len(child))
+            ledger.charge("search_frontier", child_work)
+            if child not in child_keys:
+                ledger.charge("search_frontier", child_work)
+                child_keys.add(child)
+                child_key_elements += max(len(child), 1)
+        ledger.charge(
+            "search_frontier",
+            3 * _subset_container_work(child_key_elements, sorting=True),
+        )
+        new_children = tuple(
+            sorted(
+                child
+                for child in child_keys
+                if child not in visited and child not in queued
+            )
+        )
+        new_child_elements = sum(max(len(child), 1) for child in new_children)
+        if len(visited) + len(queued) + len(new_children) > plan.state_orbit_limit:
+            raise _SearchStoppedError(
+                "STATE_ORBIT_LIMIT",
+                visited_count=len(visited),
+                consumed_work=ledger.consumed,
+            )
+        ledger.charge("search_frontier", 2 * _subset_container_work(new_child_elements))
+        queued.update(new_children)
+        pending.extend(reversed(new_children))
+    return satisfying, visited, ledger, canonicalizer, satisfying_elements
+
+
+def _representatives_from_states(
+    satisfying: dict[ClosedCandidateSet, _FlatState],
+    *,
+    satisfying_elements: int,
+    plan: _PrimeFieldFlatPlan,
+    prime: int,
+    ambient_dimension: int,
+    ledger: _WorkLedger,
+    canonicalizer: _SubsetOrbitCanonicalizer,
+) -> tuple[tuple[PrimeFieldFlatOrbitRepresentative, ...], int]:
+    representatives: list[PrimeFieldFlatOrbitRepresentative] = []
+    solution_flat_count = 0
+    ledger.charge(
+        "result_construction",
+        _subset_container_work(satisfying_elements, sorting=True),
+    )
+    for closed, state in sorted(satisfying.items()):
+        _require_execution_active(
+            ledger.deadline, "during prime-field-flat representative construction"
+        )
+        _canonical, orbit_size = canonicalizer.canonicalize(closed, ledger)
+        ledger.charge(
+            "result_construction",
+            (
+                2 * ambient_dimension * ambient_dimension
+                + state.rank * ambient_dimension
+                + len(closed)
+                + 16
+            ),
+        )
+        representative = PrimeFieldFlatOrbitRepresentative._from_kernel(
+            closed_candidate_indices=closed,
+            rank=state.rank,
+            row_space_basis=_basis_value(
+                state.row_space_basis,
+                prime=prime,
+                ambient_dimension=ambient_dimension,
+            ),
+            annihilator_basis=_basis_value(
+                _annihilator_basis(
+                    state.row_space_basis,
+                    ambient_dimension=ambient_dimension,
+                    prime=prime,
+                ),
+                prime=prime,
+                ambient_dimension=ambient_dimension,
+            ),
+            orbit_size=orbit_size,
+            stabilizer_order=plan.symmetry_group_order // orbit_size,
+        )
+        ledger.charge(
+            "result_encoding",
+            2 * _CANONICAL_PROJECTION_PASSES * plan.representative_encoding_work,
+        )
+        representatives.append(representative)
+        solution_flat_count += orbit_size
+    return tuple(representatives), solution_flat_count
+
+
+def _incomplete_result(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+    plan: _PrimeFieldFlatPlan,
+    *,
+    reason: PrimeFieldFlatIncompleteReason,
+    visited_count: int,
+    consumed_search_work: int,
+) -> ClauseConstrainedPrimeFieldFlatClassification:
+    return ClauseConstrainedPrimeFieldFlatClassification._incomplete_from_kernel(
+        problem=problem,
+        symmetry_group_order=plan.symmetry_group_order,
+        reason=reason,
+        explored_state_orbit_count=visited_count,
+        state_orbit_limit=plan.state_orbit_limit,
+        result_orbit_limit=plan.result_orbit_limit,
+        consumed_search_work=consumed_search_work,
+        search_work_limit=plan.search_work_limit,
+    )
+
+
+def _classify(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+    plan: _PrimeFieldFlatPlan,
+) -> ClauseConstrainedPrimeFieldFlatClassification:
+    try:
+        (
+            satisfying,
+            _visited,
+            ledger,
+            canonicalizer,
+            satisfying_elements,
+        ) = _search_satisfying_states(problem, plan)
+        ambient_dimension = len(problem.candidates.coordinate_axis)
+        representatives, solution_flat_count = _representatives_from_states(
+            satisfying,
+            satisfying_elements=satisfying_elements,
+            plan=plan,
+            prime=problem.candidates.prime,
+            ambient_dimension=ambient_dimension,
+            ledger=ledger,
+            canonicalizer=canonicalizer,
+        )
+    except _SearchStoppedError as stopped:
+        return _incomplete_result(
+            problem,
+            plan,
+            reason=stopped.reason,
+            visited_count=stopped.visited_count,
+            consumed_search_work=stopped.consumed_work,
+        )
+    result = ClauseConstrainedPrimeFieldFlatClassification._complete_from_kernel(
+        problem=problem,
+        symmetry_group_order=plan.symmetry_group_order,
+        representatives=representatives,
+        solution_flat_count=solution_flat_count,
+    )
+    _require_execution_active(plan.deadline, "before prime-field-flat result delivery")
+    return result
+
+
+def classify_clause_constrained_prime_field_flats_kernel(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+) -> ClauseConstrainedPrimeFieldFlatClassification:
+    """Return complete satisfying prime-field flat orbits when bounded search ends."""
+
+    plan = _admit_problem(problem)
+    return _classify(problem, plan)
+
+
+__all__ = ["classify_clause_constrained_prime_field_flats_kernel"]

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_kernel.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_kernel.py
@@ -338,7 +338,9 @@ def _rref_basis(
         input_cells * max(rank_bound, 1) + input_cells + rank_bound * ambient_dimension,
     )
     reduced_rows, pivot_columns = rref(
-        PrimeFieldMatrix(prime=prime, entries=rows, columns=ambient_dimension)
+        PrimeFieldMatrix._from_admitted(
+            prime=prime, entries=rows, columns=ambient_dimension
+        )
     )
     _require_execution_active(ledger.deadline, "after exact modular row reduction")
     # The elimination loop clears each pivot both above and below its pivot

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
@@ -75,6 +75,13 @@ def _require_raw_envelope(data: object) -> None:
                 raise _validation_error(
                     "raw_matrix_bound", "candidate matrix exceeds the raw row envelope"
                 )
+        for key, maximum in (
+            ("coordinate_axis", MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION),
+            ("vector_labels", MAX_PRIME_FIELD_FLAT_CANDIDATES),
+        ):
+            value = candidates.get(key)
+            if isinstance(value, (list, tuple)) and len(value) > maximum:
+                raise _validation_error("raw_container_bound", f"{key} exceeds the raw envelope")
     for key, maximum in (
         ("clauses", MAX_PRIME_FIELD_FLAT_CLAUSES),
         ("symmetry_generators", MAX_PRIME_FIELD_FLAT_SYMMETRY_GENERATORS),
@@ -84,6 +91,26 @@ def _require_raw_envelope(data: object) -> None:
             raise _validation_error(
                 "raw_container_bound", f"{key} exceeds the raw envelope"
             )
+    clauses = data.get("clauses")
+    if isinstance(clauses, (list, tuple)) and any(
+        not isinstance(clause, (list, tuple))
+        or len(clause) > MAX_PRIME_FIELD_FLAT_CANDIDATES
+        for clause in clauses
+    ):
+        raise _validation_error("raw_container_bound", "clause exceeds the raw envelope")
+    generators = data.get("symmetry_generators")
+    if isinstance(generators, (list, tuple)) and any(
+        isinstance(generator, Mapping)
+        and any(
+            isinstance(generator.get(key), (list, tuple)) and len(generator[key]) > maximum
+            for key, maximum in (
+                ("coordinate_permutation", MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION),
+                ("candidate_permutation", MAX_PRIME_FIELD_FLAT_CANDIDATES),
+            )
+        )
+        for generator in generators
+    ):
+        raise _validation_error("raw_container_bound", "symmetry generator exceeds the raw envelope")
     forbidden = data.get("forbidden_vectors")
     if isinstance(forbidden, Mapping):
         rows = forbidden.get("entries")

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
@@ -171,6 +171,10 @@ class PrimeFieldRowMatrix(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical_matrix(self) -> Self:
+        from sympy import isprime
+
+        if not isprime(self.prime):
+            raise _validation_error("matrix_prime", "matrix prime must be prime")
         if any(
             len(row) != self.columns or any(value >= self.prime for value in row)
             for row in self.entries

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
@@ -227,7 +227,7 @@ class PrimeFieldVectorConfiguration(StrictModel):
             label="prime-field vector configuration",
         )
         _require_raw_envelope({"candidates": data})
-        return _canonicalize_or_fail(data)
+        return canonicalize_json_containers(data)
 
     @model_validator(mode="after")
     def require_prime_and_labels(self) -> Self:
@@ -296,7 +296,7 @@ class PrimeFieldFlatSymmetryGenerator(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def canonicalize_containers(cls, data: object) -> object:
-        return _canonicalize_or_fail(data)
+        return canonicalize_json_containers(data)
 
 
 class ClauseConstrainedPrimeFieldFlatProblem(StrictModel):
@@ -334,7 +334,7 @@ class ClauseConstrainedPrimeFieldFlatProblem(StrictModel):
             label="prime-field-flat problem",
         )
         _require_raw_envelope(data)
-        return _canonicalize_or_fail(data)
+        return canonicalize_json_containers(data)
 
     @model_validator(mode="after")
     def require_source_bound_problem(self) -> Self:

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
@@ -61,8 +61,20 @@ def _require_raw_envelope(data: object) -> None:
         return
     candidates = data.get("candidates")
     if isinstance(candidates, Mapping):
+        _require_mapping_keys(
+            candidates,
+            allowed=frozenset({"prime", "coordinate_axis", "vector_labels", "vectors"}),
+            reason="configuration_shape",
+            label="candidate configuration",
+        )
         vectors = candidates.get("vectors")
         if isinstance(vectors, Mapping):
+            _require_mapping_keys(
+                vectors,
+                allowed=frozenset({"prime", "entries", "columns"}),
+                reason="matrix_shape",
+                label="candidate matrix",
+            )
             rows = vectors.get("entries")
             if isinstance(rows, (list, tuple)) and (
                 len(rows) > MAX_PRIME_FIELD_FLAT_CANDIDATES
@@ -102,6 +114,14 @@ def _require_raw_envelope(data: object) -> None:
         raise _validation_error(
             "raw_container_bound", "clause exceeds the raw envelope"
         )
+    rank_interval = data.get("rank_interval")
+    if isinstance(rank_interval, Mapping):
+        _require_mapping_keys(
+            rank_interval,
+            allowed=frozenset({"minimum", "maximum"}),
+            reason="rank_interval_shape",
+            label="rank interval",
+        )
     generators = data.get("symmetry_generators")
     if isinstance(generators, (list, tuple)) and any(
         isinstance(generator, Mapping)
@@ -120,6 +140,12 @@ def _require_raw_envelope(data: object) -> None:
         )
     forbidden = data.get("forbidden_vectors")
     if isinstance(forbidden, Mapping):
+        _require_mapping_keys(
+            forbidden,
+            allowed=frozenset({"prime", "entries", "columns"}),
+            reason="matrix_shape",
+            label="forbidden matrix",
+        )
         rows = forbidden.get("entries")
         if isinstance(rows, (list, tuple)) and (
             len(rows) > MAX_PRIME_FIELD_FLAT_FORBIDDEN_VECTORS

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
@@ -11,6 +11,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import CanonicalizationError
 from jacobian.math._labels import OpaqueLabel
+from jacobian.math.matrices.finite_fields import PrimeFieldMatrix
 
 MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION = 16
 MAX_PRIME_FIELD_FLAT_CANDIDATES = 128
@@ -54,6 +55,34 @@ def _canonicalize_or_fail(data: object) -> object:
         ) from exc
 
 
+def _require_raw_envelope(data: object) -> None:
+    """Reject oversized JSON containers before canonicalization copies them."""
+    if not isinstance(data, Mapping):
+        return
+    candidates = data.get("candidates")
+    if isinstance(candidates, Mapping):
+        vectors = candidates.get("vectors")
+        if isinstance(vectors, Mapping):
+            rows = vectors.get("entries")
+            if isinstance(rows, (list, tuple)) and (
+                len(rows) > MAX_PRIME_FIELD_FLAT_CANDIDATES
+                or any(not isinstance(row, (list, tuple)) or len(row) > MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION for row in rows)
+            ):
+                raise _validation_error("raw_matrix_bound", "candidate matrix exceeds the raw row envelope")
+    for key, maximum in (("clauses", MAX_PRIME_FIELD_FLAT_CLAUSES), ("symmetry_generators", MAX_PRIME_FIELD_FLAT_SYMMETRY_GENERATORS)):
+        value = data.get(key)
+        if isinstance(value, (list, tuple)) and len(value) > maximum:
+            raise _validation_error("raw_container_bound", f"{key} exceeds the raw envelope")
+    forbidden = data.get("forbidden_vectors")
+    if isinstance(forbidden, Mapping):
+        rows = forbidden.get("entries")
+        if isinstance(rows, (list, tuple)) and (
+            len(rows) > MAX_PRIME_FIELD_FLAT_FORBIDDEN_VECTORS
+            or any(not isinstance(row, (list, tuple)) or len(row) > MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION for row in rows)
+        ):
+            raise _validation_error("raw_matrix_bound", "forbidden matrix exceeds the raw row envelope")
+
+
 class PrimeFieldRowMatrix(StrictModel):
     """Dense canonical residue rows in one explicit prime field."""
 
@@ -78,6 +107,14 @@ class PrimeFieldRowMatrix(StrictModel):
     @property
     def row_count(self) -> int:
         return len(self.entries)
+
+    def as_prime_field_matrix(self) -> PrimeFieldMatrix:
+        """Map this labelled-configuration carrier to the canonical matrix value."""
+        return PrimeFieldMatrix(self.prime, self.entries, self.columns)
+
+    @classmethod
+    def from_prime_field_matrix(cls, matrix: PrimeFieldMatrix) -> Self:
+        return cls(prime=matrix.prime, entries=matrix.entries, columns=matrix.columns)
 
 
 class PrimeFieldVectorConfiguration(StrictModel):
@@ -108,6 +145,7 @@ class PrimeFieldVectorConfiguration(StrictModel):
             reason="configuration_shape",
             label="prime-field vector configuration",
         )
+        _require_raw_envelope({"candidates": data})
         return _canonicalize_or_fail(data)
 
     @model_validator(mode="after")
@@ -214,6 +252,7 @@ class ClauseConstrainedPrimeFieldFlatProblem(StrictModel):
             reason="problem_shape",
             label="prime-field-flat problem",
         )
+        _require_raw_envelope(data)
         return _canonicalize_or_fail(data)
 
     @model_validator(mode="after")
@@ -331,6 +370,10 @@ class PrimeFieldVectorSpaceBasis(StrictModel):
                 "each basis vector must match the ambient dimension and prime",
             )
         return self
+
+    def as_prime_field_matrix(self) -> PrimeFieldMatrix:
+        """Expose a returned basis to the canonical finite-field matrix API."""
+        return PrimeFieldMatrix(self.prime, self.vectors, self.ambient_dimension)
 
 
 class PrimeFieldFlatOrbitRepresentative(StrictModel):

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
@@ -66,21 +66,38 @@ def _require_raw_envelope(data: object) -> None:
             rows = vectors.get("entries")
             if isinstance(rows, (list, tuple)) and (
                 len(rows) > MAX_PRIME_FIELD_FLAT_CANDIDATES
-                or any(not isinstance(row, (list, tuple)) or len(row) > MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION for row in rows)
+                or any(
+                    not isinstance(row, (list, tuple))
+                    or len(row) > MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION
+                    for row in rows
+                )
             ):
-                raise _validation_error("raw_matrix_bound", "candidate matrix exceeds the raw row envelope")
-    for key, maximum in (("clauses", MAX_PRIME_FIELD_FLAT_CLAUSES), ("symmetry_generators", MAX_PRIME_FIELD_FLAT_SYMMETRY_GENERATORS)):
+                raise _validation_error(
+                    "raw_matrix_bound", "candidate matrix exceeds the raw row envelope"
+                )
+    for key, maximum in (
+        ("clauses", MAX_PRIME_FIELD_FLAT_CLAUSES),
+        ("symmetry_generators", MAX_PRIME_FIELD_FLAT_SYMMETRY_GENERATORS),
+    ):
         value = data.get(key)
         if isinstance(value, (list, tuple)) and len(value) > maximum:
-            raise _validation_error("raw_container_bound", f"{key} exceeds the raw envelope")
+            raise _validation_error(
+                "raw_container_bound", f"{key} exceeds the raw envelope"
+            )
     forbidden = data.get("forbidden_vectors")
     if isinstance(forbidden, Mapping):
         rows = forbidden.get("entries")
         if isinstance(rows, (list, tuple)) and (
             len(rows) > MAX_PRIME_FIELD_FLAT_FORBIDDEN_VECTORS
-            or any(not isinstance(row, (list, tuple)) or len(row) > MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION for row in rows)
+            or any(
+                not isinstance(row, (list, tuple))
+                or len(row) > MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION
+                for row in rows
+            )
         ):
-            raise _validation_error("raw_matrix_bound", "forbidden matrix exceeds the raw row envelope")
+            raise _validation_error(
+                "raw_matrix_bound", "forbidden matrix exceeds the raw row envelope"
+            )
 
 
 class PrimeFieldRowMatrix(StrictModel):

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
@@ -81,7 +81,9 @@ def _require_raw_envelope(data: object) -> None:
         ):
             value = candidates.get(key)
             if isinstance(value, (list, tuple)) and len(value) > maximum:
-                raise _validation_error("raw_container_bound", f"{key} exceeds the raw envelope")
+                raise _validation_error(
+                    "raw_container_bound", f"{key} exceeds the raw envelope"
+                )
     for key, maximum in (
         ("clauses", MAX_PRIME_FIELD_FLAT_CLAUSES),
         ("symmetry_generators", MAX_PRIME_FIELD_FLAT_SYMMETRY_GENERATORS),
@@ -97,12 +99,15 @@ def _require_raw_envelope(data: object) -> None:
         or len(clause) > MAX_PRIME_FIELD_FLAT_CANDIDATES
         for clause in clauses
     ):
-        raise _validation_error("raw_container_bound", "clause exceeds the raw envelope")
+        raise _validation_error(
+            "raw_container_bound", "clause exceeds the raw envelope"
+        )
     generators = data.get("symmetry_generators")
     if isinstance(generators, (list, tuple)) and any(
         isinstance(generator, Mapping)
         and any(
-            isinstance(generator.get(key), (list, tuple)) and len(generator[key]) > maximum
+            isinstance(generator.get(key), (list, tuple))
+            and len(generator[key]) > maximum
             for key, maximum in (
                 ("coordinate_permutation", MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION),
                 ("candidate_permutation", MAX_PRIME_FIELD_FLAT_CANDIDATES),
@@ -110,7 +115,9 @@ def _require_raw_envelope(data: object) -> None:
         )
         for generator in generators
     ):
-        raise _validation_error("raw_container_bound", "symmetry generator exceeds the raw envelope")
+        raise _validation_error(
+            "raw_container_bound", "symmetry generator exceeds the raw envelope"
+        )
     forbidden = data.get("forbidden_vectors")
     if isinstance(forbidden, Mapping):
         rows = forbidden.get("entries")

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_models.py
@@ -1,0 +1,601 @@
+"""Canonical values for clause-constrained prime-field flat classification."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.canonical import CanonicalizationError
+from jacobian.math._labels import OpaqueLabel
+
+MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION = 16
+MAX_PRIME_FIELD_FLAT_CANDIDATES = 128
+MAX_PRIME_FIELD_FLAT_FORBIDDEN_VECTORS = 128
+MAX_PRIME_FIELD_FLAT_CLAUSES = 128
+MAX_PRIME_FIELD_FLAT_CLAUSE_MEMBERSHIPS = 4_096
+MAX_PRIME_FIELD_FLAT_SYMMETRY_GENERATORS = 16
+MAX_PRIME_FIELD_FLAT_GROUP_ORDER = 10_000
+MAX_PRIME_FIELD_FLAT_RESULT_ORBITS = 100_000
+MAX_PRIME_FIELD_FLAT_PRIME = 2_147_483_647
+
+CandidateIndex = Annotated[StrictInt, Field(ge=0, lt=MAX_PRIME_FIELD_FLAT_CANDIDATES)]
+CandidateClause = Annotated[
+    tuple[CandidateIndex, ...], Field(max_length=MAX_PRIME_FIELD_FLAT_CANDIDATES)
+]
+FieldResidue = Annotated[StrictInt, Field(ge=0)]
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"prime_field_flat.{reason}", message)
+
+
+def _require_mapping_keys(
+    data: Mapping[str, object],
+    *,
+    allowed: frozenset[str],
+    reason: str,
+    label: str,
+) -> None:
+    if any(key not in allowed for key in data):
+        raise _validation_error(reason, f"{label} contains unknown fields")
+
+
+def _canonicalize_or_fail(data: object) -> object:
+    try:
+        return canonicalize_json_containers(data)
+    except CanonicalizationError as exc:
+        raise _validation_error(
+            "raw_container_structure",
+            "raw prime-field-flat containers must be acyclic",
+        ) from exc
+
+
+class PrimeFieldRowMatrix(StrictModel):
+    """Dense canonical residue rows in one explicit prime field."""
+
+    prime: StrictInt = Field(ge=2, le=MAX_PRIME_FIELD_FLAT_PRIME)
+    entries: tuple[tuple[FieldResidue, ...], ...] = Field(
+        max_length=MAX_PRIME_FIELD_FLAT_CANDIDATES
+    )
+    columns: StrictInt = Field(ge=0, le=MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION)
+
+    @model_validator(mode="after")
+    def require_canonical_matrix(self) -> Self:
+        if any(
+            len(row) != self.columns or any(value >= self.prime for value in row)
+            for row in self.entries
+        ):
+            raise _validation_error(
+                "matrix_shape",
+                "every row must match the column count and hold canonical residues",
+            )
+        return self
+
+    @property
+    def row_count(self) -> int:
+        return len(self.entries)
+
+
+class PrimeFieldVectorConfiguration(StrictModel):
+    """A finite labelled row-vector configuration over ``GF(prime)``."""
+
+    prime: StrictInt = Field(
+        ge=2,
+        le=MAX_PRIME_FIELD_FLAT_PRIME,
+        description="Explicit prime field characteristic defining GF(prime).",
+    )
+    coordinate_axis: tuple[OpaqueLabel, ...] = Field(
+        min_length=1,
+        max_length=MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION,
+    )
+    vector_labels: tuple[OpaqueLabel, ...] = Field(
+        max_length=MAX_PRIME_FIELD_FLAT_CANDIDATES
+    )
+    vectors: PrimeFieldRowMatrix
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_configuration(cls, data: object) -> object:
+        if not isinstance(data, Mapping):
+            return data
+        _require_mapping_keys(
+            data,
+            allowed=frozenset({"prime", "coordinate_axis", "vector_labels", "vectors"}),
+            reason="configuration_shape",
+            label="prime-field vector configuration",
+        )
+        return _canonicalize_or_fail(data)
+
+    @model_validator(mode="after")
+    def require_prime_and_labels(self) -> Self:
+        from sympy import isprime
+
+        if not isprime(self.prime):
+            raise _validation_error("prime", "prime must be a prime integer")
+        if len(set(self.coordinate_axis)) != len(self.coordinate_axis):
+            raise _validation_error(
+                "duplicate_coordinate_label",
+                "configuration coordinate labels must be pairwise distinct",
+            )
+        if len(set(self.vector_labels)) != len(self.vector_labels):
+            raise _validation_error(
+                "duplicate_vector_label",
+                "configuration vector labels must be pairwise distinct",
+            )
+        if self.vectors.prime != self.prime:
+            raise _validation_error(
+                "matrix_prime",
+                "the candidate matrix must use the configuration prime",
+            )
+        if self.vectors.row_count != len(self.vector_labels):
+            raise _validation_error(
+                "vector_label_count",
+                "vector_labels must contain one label for every declared row",
+            )
+        if self.vectors.columns != len(self.coordinate_axis):
+            raise _validation_error(
+                "coordinate_axis_count",
+                "the candidate matrix column count must equal the axis length",
+            )
+        return self
+
+    @property
+    def vector_count(self) -> int:
+        return self.vectors.row_count
+
+
+class PrimeFieldFlatRankInterval(StrictModel):
+    """Inclusive admitted ranks for returned prime-field flats."""
+
+    minimum: StrictInt = Field(ge=0, le=MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION)
+    maximum: StrictInt = Field(ge=0, le=MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION)
+
+    @model_validator(mode="after")
+    def require_ordered_interval(self) -> Self:
+        if self.minimum > self.maximum:
+            raise _validation_error(
+                "rank_interval_order", "minimum rank must not exceed maximum rank"
+            )
+        return self
+
+
+class PrimeFieldFlatSymmetryGenerator(StrictModel):
+    """One compatible permutation of coordinates and labelled candidates."""
+
+    coordinate_permutation: tuple[StrictInt, ...] = Field(
+        min_length=1,
+        max_length=MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION,
+    )
+    candidate_permutation: tuple[StrictInt, ...] = Field(
+        max_length=MAX_PRIME_FIELD_FLAT_CANDIDATES
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def canonicalize_containers(cls, data: object) -> object:
+        return _canonicalize_or_fail(data)
+
+
+class ClauseConstrainedPrimeFieldFlatProblem(StrictModel):
+    """One finite exact prime-field flat classification problem."""
+
+    candidates: PrimeFieldVectorConfiguration
+    clauses: tuple[CandidateClause, ...] = Field(
+        default=(),
+        max_length=MAX_PRIME_FIELD_FLAT_CLAUSES,
+    )
+    forbidden_vectors: PrimeFieldRowMatrix
+    rank_interval: PrimeFieldFlatRankInterval | None = None
+    symmetry_generators: tuple[PrimeFieldFlatSymmetryGenerator, ...] = Field(
+        default=(),
+        max_length=MAX_PRIME_FIELD_FLAT_SYMMETRY_GENERATORS,
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_problem(cls, data: object) -> object:
+        if not isinstance(data, Mapping):
+            return data
+        _require_mapping_keys(
+            data,
+            allowed=frozenset(
+                {
+                    "candidates",
+                    "clauses",
+                    "forbidden_vectors",
+                    "rank_interval",
+                    "symmetry_generators",
+                }
+            ),
+            reason="problem_shape",
+            label="prime-field-flat problem",
+        )
+        return _canonicalize_or_fail(data)
+
+    @model_validator(mode="after")
+    def require_source_bound_problem(self) -> Self:
+        candidate_count = self.candidates.vector_count
+        normalized_clauses = tuple(
+            sorted({tuple(sorted(set(clause))) for clause in self.clauses})
+        )
+        if any(
+            index >= candidate_count
+            for clause in normalized_clauses
+            for index in clause
+        ):
+            raise _validation_error(
+                "clause_candidate_index",
+                "every clause index must refer to a candidate row",
+            )
+        if sum(map(len, normalized_clauses)) > MAX_PRIME_FIELD_FLAT_CLAUSE_MEMBERSHIPS:
+            raise _validation_error(
+                "clause_membership_bound",
+                "canonical clause memberships exceed the structural bound",
+            )
+        object.__setattr__(self, "clauses", normalized_clauses)
+
+        ambient_dimension = len(self.candidates.coordinate_axis)
+        if self.forbidden_vectors.prime != self.candidates.prime:
+            raise _validation_error(
+                "forbidden_prime", "forbidden rows must use the candidate prime"
+            )
+        if self.forbidden_vectors.columns != ambient_dimension:
+            raise _validation_error(
+                "forbidden_coordinate_axis",
+                "forbidden rows must use the candidates' coordinate axis",
+            )
+        if self.forbidden_vectors.row_count > MAX_PRIME_FIELD_FLAT_FORBIDDEN_VECTORS:
+            raise _validation_error(
+                "forbidden_count_bound",
+                "at most "
+                f"{MAX_PRIME_FIELD_FLAT_FORBIDDEN_VECTORS} forbidden rows are admitted",
+            )
+        if (
+            self.rank_interval is not None
+            and self.rank_interval.maximum > ambient_dimension
+        ):
+            raise _validation_error(
+                "rank_ambient_bound",
+                "the maximum flat rank cannot exceed the ambient dimension",
+            )
+
+        canonical_generators: dict[
+            tuple[tuple[int, ...], tuple[int, ...]],
+            PrimeFieldFlatSymmetryGenerator,
+        ] = {}
+        for generator in self.symmetry_generators:
+            coordinate_permutation = tuple(generator.coordinate_permutation)
+            candidate_permutation = tuple(generator.candidate_permutation)
+            if len(coordinate_permutation) != ambient_dimension or sorted(
+                coordinate_permutation
+            ) != list(range(ambient_dimension)):
+                raise _validation_error(
+                    "coordinate_permutation",
+                    "every coordinate generator must permute the complete ambient axis",
+                )
+            if len(candidate_permutation) != candidate_count or sorted(
+                candidate_permutation
+            ) != list(range(candidate_count)):
+                raise _validation_error(
+                    "candidate_permutation",
+                    "every candidate generator must permute all candidate rows",
+                )
+            canonical_generators[(coordinate_permutation, candidate_permutation)] = (
+                generator
+            )
+        object.__setattr__(
+            self,
+            "symmetry_generators",
+            tuple(canonical_generators[key] for key in sorted(canonical_generators)),
+        )
+        return self
+
+    @property
+    def minimum_rank(self) -> int:
+        return self.rank_interval.minimum if self.rank_interval is not None else 0
+
+    @property
+    def maximum_rank(self) -> int:
+        return (
+            self.rank_interval.maximum
+            if self.rank_interval is not None
+            else len(self.candidates.coordinate_axis)
+        )
+
+
+class PrimeFieldVectorSpaceBasis(StrictModel):
+    """A canonical GF(prime) basis with its ambient dimension retained."""
+
+    prime: StrictInt = Field(ge=2, le=MAX_PRIME_FIELD_FLAT_PRIME)
+    ambient_dimension: StrictInt = Field(
+        ge=1, le=MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION
+    )
+    vectors: tuple[tuple[FieldResidue, ...], ...] = Field(
+        default=(),
+        max_length=MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION,
+    )
+
+    @model_validator(mode="after")
+    def require_vector_shape(self) -> Self:
+        if any(
+            len(vector) != self.ambient_dimension
+            or any(value >= self.prime for value in vector)
+            for vector in self.vectors
+        ):
+            raise _validation_error(
+                "basis_shape",
+                "each basis vector must match the ambient dimension and prime",
+            )
+        return self
+
+
+class PrimeFieldFlatOrbitRepresentative(StrictModel):
+    """One canonical closed flat and its exact orbit--stabilizer data."""
+
+    closed_candidate_indices: tuple[CandidateIndex, ...] = Field(
+        max_length=MAX_PRIME_FIELD_FLAT_CANDIDATES
+    )
+    rank: StrictInt = Field(ge=0, le=MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION)
+    row_space_basis: PrimeFieldVectorSpaceBasis
+    annihilator_basis: PrimeFieldVectorSpaceBasis
+    orbit_size: StrictInt = Field(ge=1, le=MAX_PRIME_FIELD_FLAT_GROUP_ORDER)
+    stabilizer_order: StrictInt = Field(ge=1, le=MAX_PRIME_FIELD_FLAT_GROUP_ORDER)
+
+    @model_validator(mode="after")
+    def require_canonical_local_shape(self) -> Self:
+        if self.closed_candidate_indices != tuple(
+            sorted(set(self.closed_candidate_indices))
+        ):
+            raise _validation_error(
+                "closed_candidate_order",
+                "closed candidate indices must be distinct and increasing",
+            )
+        if len(self.row_space_basis.vectors) != self.rank:
+            raise _validation_error(
+                "row_basis_rank", "row-space basis length must equal the flat rank"
+            )
+        if self.row_space_basis.prime != self.annihilator_basis.prime:
+            raise _validation_error(
+                "basis_prime", "row-space and annihilator bases must use one prime"
+            )
+        if self.row_space_basis.ambient_dimension != (
+            self.annihilator_basis.ambient_dimension
+        ):
+            raise _validation_error(
+                "basis_ambient_dimension",
+                "row-space and annihilator bases must use one ambient dimension",
+            )
+        if self.rank + len(self.annihilator_basis.vectors) != (
+            self.row_space_basis.ambient_dimension
+        ):
+            raise _validation_error(
+                "annihilator_dimension",
+                "row rank plus annihilator dimension must equal the ambient dimension",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        closed_candidate_indices: tuple[int, ...],
+        rank: int,
+        row_space_basis: PrimeFieldVectorSpaceBasis,
+        annihilator_basis: PrimeFieldVectorSpaceBasis,
+        orbit_size: int,
+        stabilizer_order: int,
+    ) -> Self:
+        return cls.model_construct(
+            closed_candidate_indices=closed_candidate_indices,
+            rank=rank,
+            row_space_basis=row_space_basis,
+            annihilator_basis=annihilator_basis,
+            orbit_size=orbit_size,
+            stabilizer_order=stabilizer_order,
+        )
+
+
+class PrimeFieldFlatClassificationComplete(StrictModel):
+    """Every satisfying prime-field flat once per supplied symmetry orbit."""
+
+    status: Literal["COMPLETE_EXACT"]
+    representatives: tuple[PrimeFieldFlatOrbitRepresentative, ...] = Field(
+        max_length=MAX_PRIME_FIELD_FLAT_RESULT_ORBITS
+    )
+    orbit_count: StrictInt = Field(ge=0, le=MAX_PRIME_FIELD_FLAT_RESULT_ORBITS)
+    solution_flat_count: StrictInt = Field(ge=0)
+
+    @model_validator(mode="after")
+    def require_complete_accounting(self) -> Self:
+        if self.orbit_count != len(self.representatives):
+            raise _validation_error(
+                "orbit_count", "orbit_count must equal the representative count"
+            )
+        if self.solution_flat_count != sum(
+            representative.orbit_size for representative in self.representatives
+        ):
+            raise _validation_error(
+                "solution_flat_count",
+                "solution_flat_count must equal the sum of representative orbit sizes",
+            )
+        representative_keys = tuple(
+            representative.closed_candidate_indices
+            for representative in self.representatives
+        )
+        if representative_keys != tuple(sorted(set(representative_keys))):
+            raise _validation_error(
+                "representative_order",
+                "orbit representatives must use distinct keys in increasing order",
+            )
+        return self
+
+
+PrimeFieldFlatIncompleteReason = Literal[
+    "STATE_ORBIT_LIMIT", "SEARCH_WORK_LIMIT", "RESULT_ORBIT_LIMIT"
+]
+
+
+class PrimeFieldFlatClassificationIncomplete(StrictModel):
+    """The bounded search stopped without making a completeness claim."""
+
+    status: Literal["INCOMPLETE"]
+    reason: PrimeFieldFlatIncompleteReason
+    explored_state_orbit_count: StrictInt = Field(ge=0)
+    state_orbit_limit: StrictInt = Field(ge=1)
+    result_orbit_limit: StrictInt = Field(ge=0, le=MAX_PRIME_FIELD_FLAT_RESULT_ORBITS)
+    consumed_search_work: StrictInt = Field(ge=0)
+    search_work_limit: StrictInt = Field(ge=1)
+
+    @model_validator(mode="after")
+    def bind_diagnostics_to_limits(self) -> Self:
+        if self.explored_state_orbit_count > self.state_orbit_limit:
+            raise _validation_error(
+                "explored_state_orbit_count",
+                "explored state-orbit count cannot exceed its search limit",
+            )
+        if self.consumed_search_work > self.search_work_limit:
+            raise _validation_error(
+                "consumed_search_work",
+                "consumed request work cannot exceed its work limit",
+            )
+        return self
+
+
+PrimeFieldFlatClassificationOutcome = Annotated[
+    PrimeFieldFlatClassificationComplete | PrimeFieldFlatClassificationIncomplete,
+    Field(discriminator="status"),
+]
+
+
+class ClauseConstrainedPrimeFieldFlatClassification(StrictModel):
+    """Source-bound complete family or a typed non-conclusive bounded stop."""
+
+    problem: ClauseConstrainedPrimeFieldFlatProblem
+    symmetry_group_order: StrictInt = Field(ge=1, le=MAX_PRIME_FIELD_FLAT_GROUP_ORDER)
+    outcome: PrimeFieldFlatClassificationOutcome
+
+    @model_validator(mode="after")
+    def bind_outcome_to_problem(self) -> Self:
+        if not isinstance(self.outcome, PrimeFieldFlatClassificationComplete):
+            return self
+        candidate_count = self.problem.candidates.vector_count
+        ambient_dimension = len(self.problem.candidates.coordinate_axis)
+        for representative in self.outcome.representatives:
+            if any(
+                index >= candidate_count
+                for index in representative.closed_candidate_indices
+            ):
+                raise _validation_error(
+                    "representative_candidate_index",
+                    "representative indices must refer to source candidates",
+                )
+            if (
+                not self.problem.minimum_rank
+                <= representative.rank
+                <= (self.problem.maximum_rank)
+            ):
+                raise _validation_error(
+                    "representative_rank",
+                    "representative rank must lie in the requested interval",
+                )
+            if representative.row_space_basis.prime != self.problem.candidates.prime:
+                raise _validation_error(
+                    "representative_prime",
+                    "representative bases must use the source prime",
+                )
+            if representative.row_space_basis.ambient_dimension != ambient_dimension:
+                raise _validation_error(
+                    "representative_ambient_dimension",
+                    "representative bases must use the source coordinate dimension",
+                )
+            if (
+                representative.orbit_size * representative.stabilizer_order
+                != self.symmetry_group_order
+            ):
+                raise _validation_error(
+                    "orbit_stabilizer",
+                    "each orbit size times stabilizer order must equal the symmetry-group order",
+                )
+        return self
+
+    @classmethod
+    def _complete_from_kernel(
+        cls,
+        *,
+        problem: ClauseConstrainedPrimeFieldFlatProblem,
+        symmetry_group_order: int,
+        representatives: tuple[PrimeFieldFlatOrbitRepresentative, ...],
+        solution_flat_count: int,
+    ) -> Self:
+        return cls.model_construct(
+            problem=problem,
+            symmetry_group_order=symmetry_group_order,
+            outcome=PrimeFieldFlatClassificationComplete.model_construct(
+                status="COMPLETE_EXACT",
+                representatives=representatives,
+                orbit_count=len(representatives),
+                solution_flat_count=solution_flat_count,
+            ),
+        )
+
+    @classmethod
+    def _incomplete_from_kernel(
+        cls,
+        *,
+        problem: ClauseConstrainedPrimeFieldFlatProblem,
+        symmetry_group_order: int,
+        reason: PrimeFieldFlatIncompleteReason,
+        explored_state_orbit_count: int,
+        state_orbit_limit: int,
+        result_orbit_limit: int,
+        consumed_search_work: int,
+        search_work_limit: int,
+    ) -> Self:
+        return cls.model_construct(
+            problem=problem,
+            symmetry_group_order=symmetry_group_order,
+            outcome=PrimeFieldFlatClassificationIncomplete.model_construct(
+                status="INCOMPLETE",
+                reason=reason,
+                explored_state_orbit_count=explored_state_orbit_count,
+                state_orbit_limit=state_orbit_limit,
+                result_orbit_limit=result_orbit_limit,
+                consumed_search_work=consumed_search_work,
+                search_work_limit=search_work_limit,
+            ),
+        )
+
+
+class ClauseConstrainedPrimeFieldFlatRequest(StrictModel):
+    """Wire request for one clause-constrained prime-field flat problem."""
+
+    problem: ClauseConstrainedPrimeFieldFlatProblem
+
+
+__all__ = [
+    "MAX_PRIME_FIELD_FLAT_AMBIENT_DIMENSION",
+    "MAX_PRIME_FIELD_FLAT_CANDIDATES",
+    "MAX_PRIME_FIELD_FLAT_CLAUSES",
+    "MAX_PRIME_FIELD_FLAT_CLAUSE_MEMBERSHIPS",
+    "MAX_PRIME_FIELD_FLAT_FORBIDDEN_VECTORS",
+    "MAX_PRIME_FIELD_FLAT_GROUP_ORDER",
+    "MAX_PRIME_FIELD_FLAT_PRIME",
+    "MAX_PRIME_FIELD_FLAT_RESULT_ORBITS",
+    "MAX_PRIME_FIELD_FLAT_SYMMETRY_GENERATORS",
+    "ClauseConstrainedPrimeFieldFlatClassification",
+    "ClauseConstrainedPrimeFieldFlatProblem",
+    "ClauseConstrainedPrimeFieldFlatRequest",
+    "PrimeFieldFlatClassificationComplete",
+    "PrimeFieldFlatClassificationIncomplete",
+    "PrimeFieldFlatClassificationOutcome",
+    "PrimeFieldFlatOrbitRepresentative",
+    "PrimeFieldFlatRankInterval",
+    "PrimeFieldFlatSymmetryGenerator",
+    "PrimeFieldRowMatrix",
+    "PrimeFieldVectorConfiguration",
+    "PrimeFieldVectorSpaceBasis",
+]

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/_tools.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/_tools.py
@@ -1,0 +1,84 @@
+"""Public declaration for clause-constrained prime-field flat classification."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.combinatorics.matroids.prime_field_flats._models import (
+    ClauseConstrainedPrimeFieldFlatClassification,
+    ClauseConstrainedPrimeFieldFlatRequest,
+)
+from jacobian.math.combinatorics.matroids.prime_field_flats.operations import (
+    classify_clause_constrained_prime_field_flats as _classify_native,
+)
+
+
+def classify_clause_constrained_prime_field_flats(
+    request: ClauseConstrainedPrimeFieldFlatRequest,
+) -> ClauseConstrainedPrimeFieldFlatClassification:
+    return _classify_native(request.problem)
+
+
+CLASSIFY_CONSTRAINED_PRIME_FIELD_FLATS_OPERATION = MathTool(
+    operation_id="matroid.prime_field_flat.constrained_orbits.compute",
+    title="Classify clause-constrained GF(p) flats up to finite symmetry",
+    description=(
+        "For a bounded labelled prime-field row configuration, covering clauses, "
+        "forbidden span incidences, an optional rank interval, and compatible "
+        "paired coordinate/candidate permutation generators, return every closed "
+        "row-matroid flat satisfying the constraints once per symmetry orbit. "
+        "Each complete representative retains its closed candidate set, exact "
+        "GF(p) RREF row-space basis, canonical annihilator basis, rank, orbit "
+        "size, and stabilizer order. A bounded state, work, or exact-output stop "
+        "returns INCOMPLETE and makes no family-completeness claim."
+    ),
+    request_type=ClauseConstrainedPrimeFieldFlatRequest,
+    result_type=ClauseConstrainedPrimeFieldFlatClassification,
+    run=classify_clause_constrained_prime_field_flats,
+    tags=(
+        "matroid",
+        "prime-field-flat",
+        "covering-clause",
+        "finite-symmetry",
+        "orbit-stabilizer",
+        "exact",
+    ),
+    discovery_terms=(
+        "clause-constrained prime-field flats",
+        "GF(p) represented matroid flat orbits",
+        "forbidden row-span incidence",
+    ),
+    examples=(
+        OperationExample(
+            name="gf3_lines_containing_x_axis",
+            description=(
+                "Classify GF(3) closed spans in a three-row configuration while "
+                "forbidding the all-one row; all matrix rows must use the "
+                "declared prime and canonical residues."
+            ),
+            input={
+                "problem": {
+                    "candidates": {
+                        "prime": 3,
+                        "coordinate_axis": ["x", "y", "z"],
+                        "vector_labels": ["a", "b", "c"],
+                        "vectors": {
+                            "prime": 3,
+                            "entries": [[1, 2, 0], [1, 0, 2], [0, 1, 1]],
+                            "columns": 3,
+                        },
+                    },
+                    "clauses": [[1, 2]],
+                    "forbidden_vectors": {
+                        "prime": 3,
+                        "entries": [[1, 1, 1]],
+                        "columns": 3,
+                    },
+                    "rank_interval": {"minimum": 0, "maximum": 3},
+                    "symmetry_generators": [],
+                }
+            },
+        ),
+    ),
+)
+
+TOOLS: MathTools = (CLASSIFY_CONSTRAINED_PRIME_FIELD_FLATS_OPERATION,)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/combinatorics/matroids/prime_field_flats/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/prime_field_flats/operations.py
@@ -1,0 +1,32 @@
+"""Native clause-constrained prime-field flat operations."""
+
+from __future__ import annotations
+
+from pydantic_core import PydanticCustomError
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics.matroids.prime_field_flats._kernel import (
+    classify_clause_constrained_prime_field_flats_kernel,
+)
+from jacobian.math.combinatorics.matroids.prime_field_flats._models import (
+    ClauseConstrainedPrimeFieldFlatClassification,
+    ClauseConstrainedPrimeFieldFlatProblem,
+)
+
+
+def classify_clause_constrained_prime_field_flats(
+    problem: ClauseConstrainedPrimeFieldFlatProblem,
+) -> ClauseConstrainedPrimeFieldFlatClassification:
+    """Classify every admitted clause-constrained GF(p) flat modulo symmetry."""
+
+    try:
+        return classify_clause_constrained_prime_field_flats_kernel(problem)
+    except PydanticCustomError as exc:
+        raise OperationDomainValidationError(
+            location=("problem",),
+            code=exc.type,
+            message=exc.message(),
+        ) from exc
+
+
+__all__ = ["classify_clause_constrained_prime_field_flats"]

--- a/src/jacobian/math/matrices/finite_fields/linear_algebra.py
+++ b/src/jacobian/math/matrices/finite_fields/linear_algebra.py
@@ -66,7 +66,7 @@ class PrimeFieldMatrix:
     @classmethod
     def _from_admitted(
         cls, *, prime: int, entries: tuple[tuple[int, ...], ...], columns: int
-    ) -> "PrimeFieldMatrix":
+    ) -> PrimeFieldMatrix:
         """Build a matrix whose field and canonical rows were already admitted."""
         matrix = object.__new__(cls)
         object.__setattr__(matrix, "prime", prime)

--- a/src/jacobian/math/matrices/finite_fields/linear_algebra.py
+++ b/src/jacobian/math/matrices/finite_fields/linear_algebra.py
@@ -63,6 +63,17 @@ class PrimeFieldMatrix:
         if not isprime(self.prime):
             raise ValueError("prime must be a prime integer")
 
+    @classmethod
+    def _from_admitted(
+        cls, *, prime: int, entries: tuple[tuple[int, ...], ...], columns: int
+    ) -> "PrimeFieldMatrix":
+        """Build a matrix whose field and canonical rows were already admitted."""
+        matrix = object.__new__(cls)
+        object.__setattr__(matrix, "prime", prime)
+        object.__setattr__(matrix, "entries", entries)
+        object.__setattr__(matrix, "columns", columns)
+        return matrix
+
 
 def _backend_matrix(matrix: PrimeFieldMatrix) -> Any:
     from flint import nmod_mat

--- a/tests/math/combinatorics/matroids/prime_field_flats/test_classification.py
+++ b/tests/math/combinatorics/matroids/prime_field_flats/test_classification.py
@@ -1,0 +1,436 @@
+"""Defining tests for clause-constrained prime-field flat classification."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import combinations
+from typing import cast
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import MathTool
+from jacobian.math.combinatorics.matroids.prime_field_flats import (
+    classify_clause_constrained_prime_field_flats,
+)
+from jacobian.math.combinatorics.matroids.prime_field_flats._kernel import (
+    _admit_problem,
+    _classify,
+    _subset_container_work,
+)
+from jacobian.math.combinatorics.matroids.prime_field_flats._models import (
+    ClauseConstrainedPrimeFieldFlatClassification,
+    ClauseConstrainedPrimeFieldFlatProblem,
+    ClauseConstrainedPrimeFieldFlatRequest,
+    PrimeFieldFlatRankInterval,
+    PrimeFieldFlatSymmetryGenerator,
+    PrimeFieldVectorConfiguration,
+)
+from jacobian.math.combinatorics.matroids.prime_field_flats._tools import TOOLS
+from jacobian.math.combinatorics.matroids.rational_flats import (
+    RationalFlatRankInterval,
+    RationalVectorConfiguration,
+    classify_clause_constrained_rational_flats,
+)
+from jacobian.math.combinatorics.matroids.rational_flats._models import (
+    ClauseConstrainedRationalFlatProblem,
+)
+from jacobian.math.matrices.values import (
+    SparseRationalMatrix,
+    SparseRationalMatrixEntry,
+)
+
+
+def _operation() -> MathTool[
+    ClauseConstrainedPrimeFieldFlatRequest,
+    ClauseConstrainedPrimeFieldFlatClassification,
+]:
+    return cast(
+        MathTool[
+            ClauseConstrainedPrimeFieldFlatRequest,
+            ClauseConstrainedPrimeFieldFlatClassification,
+        ],
+        next(
+            operation
+            for operation in TOOLS
+            if operation.operation_id
+            == "matroid.prime_field_flat.constrained_orbits.compute"
+        ),
+    )
+
+
+def _problem(
+    rows: tuple[tuple[int, ...], ...],
+    *,
+    prime: int,
+    clauses: tuple[tuple[int, ...], ...] = (),
+    forbidden_rows: tuple[tuple[int, ...], ...] = (),
+    rank_interval: tuple[int, int] | None = None,
+    symmetry_generators: tuple[PrimeFieldFlatSymmetryGenerator, ...] = (),
+) -> ClauseConstrainedPrimeFieldFlatProblem:
+    columns = len(rows[0]) if rows else 1
+    return ClauseConstrainedPrimeFieldFlatProblem(
+        candidates=PrimeFieldVectorConfiguration(
+            prime=prime,
+            coordinate_axis=tuple(f"x{index}" for index in range(columns)),
+            vector_labels=tuple(f"v{index}" for index in range(len(rows))),
+            vectors={
+                "prime": prime,
+                "entries": [[value % prime for value in row] for row in rows],
+                "columns": columns,
+            },  # type: ignore[arg-type]
+        ),
+        clauses=clauses,
+        forbidden_vectors={
+            "prime": prime,
+            "entries": [[value % prime for value in row] for row in forbidden_rows],
+            "columns": columns,
+        },  # type: ignore[arg-type]
+        rank_interval=(
+            PrimeFieldFlatRankInterval(
+                minimum=rank_interval[0], maximum=rank_interval[1]
+            )
+            if rank_interval is not None
+            else None
+        ),
+        symmetry_generators=symmetry_generators,
+    )
+
+
+def _run(
+    rows: tuple[tuple[int, ...], ...], *, prime: int, **kwargs: object
+) -> ClauseConstrainedPrimeFieldFlatClassification:
+    if "clauses" in kwargs:
+        kwargs["clauses"] = tuple(kwargs["clauses"])  # type: ignore[arg-type]
+    if "forbidden_rows" in kwargs:
+        kwargs["forbidden_rows"] = tuple(kwargs["forbidden_rows"])  # type: ignore[arg-type]
+    if "symmetry_generators" in kwargs:
+        kwargs["symmetry_generators"] = tuple(kwargs["symmetry_generators"])  # type: ignore[arg-type]
+    problem = _problem(rows, prime=prime, **kwargs)  # type: ignore[arg-type]
+    return classify_clause_constrained_prime_field_flats(problem)
+
+
+def _sparse_rational(
+    rows: tuple[tuple[int, ...], ...], *, columns: int
+) -> SparseRationalMatrix:
+    return SparseRationalMatrix(
+        row_count=len(rows),
+        column_count=columns,
+        entries=tuple(
+            SparseRationalMatrixEntry(
+                row=row,
+                column=column,
+                value=CanonicalRational.from_fraction(Fraction(value)),
+            )
+            for row, values in enumerate(rows)
+            for column, value in enumerate(values)
+            if value
+        ),
+    )
+
+
+def _rational_problem(
+    rows: tuple[tuple[int, ...], ...],
+    *,
+    clauses: tuple[tuple[int, ...], ...] = (),
+    forbidden_rows: tuple[tuple[int, ...], ...] = (),
+    rank_interval: tuple[int, int] | None = None,
+) -> ClauseConstrainedRationalFlatProblem:
+    columns = len(rows[0])
+    return ClauseConstrainedRationalFlatProblem(
+        candidates=RationalVectorConfiguration(
+            coordinate_axis=tuple(f"x{index}" for index in range(columns)),
+            vector_labels=tuple(f"v{index}" for index in range(len(rows))),
+            vectors=_sparse_rational(rows, columns=columns),
+        ),
+        clauses=clauses,
+        forbidden_vectors=_sparse_rational(forbidden_rows, columns=columns),
+        rank_interval=(
+            RationalFlatRankInterval(minimum=rank_interval[0], maximum=rank_interval[1])
+            if rank_interval is not None
+            else None
+        ),
+        symmetry_generators=(),
+    )
+
+
+def _modular_rank(rows: tuple[tuple[int, ...], ...], prime: int) -> int:
+    if not rows:
+        return 0
+    vectors: list[list[int]] = []
+    for row in rows:
+        vector = [value % prime for value in row]
+        for basis in vectors:
+            pivot = next((index for index, value in enumerate(basis) if value), None)
+            if pivot is not None and vector[pivot]:
+                factor = vector[pivot] * pow(basis[pivot], -1, prime) % prime
+                vector = [
+                    (value - factor * basis_value) % prime
+                    for value, basis_value in zip(vector, basis, strict=True)
+                ]
+        if any(vector):
+            pivot = next(index for index, value in enumerate(vector) if value)
+            inverse = pow(vector[pivot], -1, prime)
+            vectors.append([value * inverse % prime for value in vector])
+    return len(vectors)
+
+
+def _modular_closed(
+    rows: tuple[tuple[int, ...], ...], subset: tuple[int, ...], prime: int
+) -> tuple[int, ...]:
+    selected = tuple(rows[index] for index in subset)
+    rank = _modular_rank(selected, prime)
+    return tuple(
+        index
+        for index, row in enumerate(rows)
+        if _modular_rank((*selected, row), prime) == rank
+    )
+
+
+def test_integer_configuration_distinguishes_rational_and_gf3_matroids() -> None:
+    rows = ((1, 2, 3), (4, 5, 6), (7, 8, 9))
+
+    rational = classify_clause_constrained_rational_flats(
+        _rational_problem(rows, forbidden_rows=((1, 1, 1),))
+    )
+    modular = _run(rows, prime=3, forbidden_rows=((1, 1, 1),))
+
+    assert rational.outcome.status == "COMPLETE_EXACT"
+    assert modular.outcome.status == "COMPLETE_EXACT"
+    assert tuple(
+        representative.closed_candidate_indices
+        for representative in rational.outcome.representatives
+    ) == ((), (0,), (1,), (2,))
+    assert tuple(
+        representative.closed_candidate_indices
+        for representative in modular.outcome.representatives
+    ) == ((), (0, 1, 2))
+
+
+def test_zero_rank_flat_and_modular_parallel_rows_are_labelled() -> None:
+    result = _run(((0, 0), (1, 0), (2, 0), (0, 1)), prime=3)
+
+    assert result.outcome.status == "COMPLETE_EXACT"
+    assert tuple(
+        representative.closed_candidate_indices
+        for representative in result.outcome.representatives
+    ) == ((0,), (0, 1, 2), (0, 1, 2, 3), (0, 3))
+    assert result.outcome.representatives[0].rank == 0
+    assert result.outcome.representatives[0].row_space_basis.vectors == ()
+    assert len(result.outcome.representatives[0].annihilator_basis.vectors) == 2
+
+
+def test_empty_configuration_has_one_zero_rank_flat() -> None:
+    result = _run((), prime=3)
+
+    assert result.outcome.status == "COMPLETE_EXACT"
+    assert result.outcome.solution_flat_count == 1
+    assert result.outcome.representatives[0].closed_candidate_indices == ()
+    assert result.outcome.representatives[0].rank == 0
+    assert tuple(result.outcome.representatives[0].annihilator_basis.vectors) == ((1,),)
+
+
+def test_empty_clause_and_zero_forbidden_vector_make_exact_empty_family() -> None:
+    empty_clause = _run(((1, 0),), prime=3, clauses=((),))
+    zero_forbidden = _run(((1, 0),), prime=3, forbidden_rows=((0, 0),))
+
+    for result in (empty_clause, zero_forbidden):
+        assert result.outcome.status == "COMPLETE_EXACT"
+        assert result.outcome.representatives == ()
+        assert result.outcome.solution_flat_count == 0
+
+
+def test_required_clause_and_rank_interval_filter_the_complete_family() -> None:
+    result = _run(
+        ((1, 0), (0, 1), (1, 1)),
+        prime=5,
+        clauses=((2,),),
+        rank_interval=(1, 2),
+    )
+
+    assert result.outcome.status == "COMPLETE_EXACT"
+    assert tuple(
+        (representative.closed_candidate_indices, representative.rank)
+        for representative in result.outcome.representatives
+    ) == (((0, 1, 2), 2), ((2,), 1))
+
+
+def test_coordinate_swap_identifies_modular_coordinate_lines() -> None:
+    result = _run(
+        ((1, 0), (0, 1)),
+        prime=5,
+        rank_interval=(1, 1),
+        symmetry_generators=(
+            PrimeFieldFlatSymmetryGenerator(
+                coordinate_permutation=(1, 0), candidate_permutation=(1, 0)
+            ),
+        ),
+    )
+
+    assert result.outcome.status == "COMPLETE_EXACT"
+    assert result.symmetry_group_order == 2
+    assert result.outcome.solution_flat_count == 2
+    assert len(result.outcome.representatives) == 1
+    representative = result.outcome.representatives[0]
+    assert representative.closed_candidate_indices == (0,)
+    assert representative.orbit_size == 2
+    assert representative.stabilizer_order == 1
+
+
+def test_symmetry_requires_modular_row_equality_not_rational_primitivity() -> None:
+    # Over QQ, (2,1) is a distinct primitive row. Over GF(3), it equals (1,2)
+    # after scaling, so this paired action is valid only in the prime field.
+    result = _run(
+        ((1, 2), (2, 1)),
+        prime=3,
+        symmetry_generators=(
+            PrimeFieldFlatSymmetryGenerator(
+                coordinate_permutation=(1, 0), candidate_permutation=(1, 0)
+            ),
+        ),
+    )
+
+    assert result.outcome.status == "COMPLETE_EXACT"
+    assert result.symmetry_group_order == 2
+    assert result.outcome.solution_flat_count == 2
+    assert len(result.outcome.representatives) == 2
+
+
+def test_incompatible_symmetry_is_a_typed_domain_error() -> None:
+    import pytest
+
+    from jacobian.catalog.models import OperationDomainValidationError
+
+    problem = _problem(
+        ((1, 0), (0, 1)),
+        prime=5,
+        symmetry_generators=(
+            PrimeFieldFlatSymmetryGenerator(
+                coordinate_permutation=(1, 0), candidate_permutation=(0, 1)
+            ),
+        ),
+    )
+
+    with pytest.raises(OperationDomainValidationError) as error:
+        classify_clause_constrained_prime_field_flats(problem)
+
+    assert error.value.errors()[0]["type"] == "prime_field_flat.candidate_symmetry"
+
+
+def test_multiple_generating_sets_deduplicate_to_one_closed_flat() -> None:
+    result = _run(((1, 0), (2, 0), (3, 0), (0, 1)), prime=7)
+
+    assert result.outcome.status == "COMPLETE_EXACT"
+    assert (0, 1, 2, 3) in {
+        representative.closed_candidate_indices
+        for representative in result.outcome.representatives
+    }
+
+
+def test_small_sources_match_independent_modular_oracle() -> None:
+    rows = ((0, 0, 0), (1, 0, 0), (2, 0, 0), (0, 1, 0), (1, 1, 0), (0, 0, 1))
+    clauses = ((1, 3), (4, 5))
+    forbidden_rows = ((1, 2, 0),)
+    prime = 5
+    result = _run(
+        rows,
+        prime=prime,
+        clauses=clauses,
+        forbidden_rows=forbidden_rows,
+        rank_interval=(1, 2),
+    )
+
+    expected: set[tuple[int, ...]] = set()
+    indices = tuple(range(len(rows)))
+    for size in range(len(indices) + 1):
+        for subset in combinations(indices, size):
+            closed = _modular_closed(rows, subset, prime)
+            if len(closed) != size:
+                continue
+            rank = _modular_rank(tuple(rows[index] for index in closed), prime)
+            if not 1 <= rank <= 2:
+                continue
+            if any(set(closed).isdisjoint(clause) for clause in clauses):
+                continue
+            if any(
+                _modular_rank(
+                    (*tuple(rows[index] for index in closed), forbidden), prime
+                )
+                == rank
+                for forbidden in forbidden_rows
+            ):
+                continue
+            expected.add(closed)
+
+    assert result.outcome.status == "COMPLETE_EXACT"
+    assert {
+        representative.closed_candidate_indices
+        for representative in result.outcome.representatives
+    } == expected
+
+
+def test_representatives_replay_all_defining_invariants_over_gf_p() -> None:
+    rows = ((1, 2, 3), (4, 5, 6), (7, 8, 9))
+    prime = 5
+    forbidden_rows = ((1, 1, 1),)
+    result = _run(rows, prime=prime, forbidden_rows=forbidden_rows)
+
+    assert result.outcome.status == "COMPLETE_EXACT"
+    for representative in result.outcome.representatives:
+        basis = representative.row_space_basis.vectors
+        closed = representative.closed_candidate_indices
+        for row in basis:
+            assert row == tuple(value % prime for value in row)
+        for row in basis:
+            for annihilator in representative.annihilator_basis.vectors:
+                assert (
+                    sum(
+                        left * right
+                        for left, right in zip(row, annihilator, strict=True)
+                    )
+                    % prime
+                    == 0
+                )
+        assert len(basis) == representative.rank
+        for index, row in enumerate(rows):
+            in_span = _modular_rank((*basis, row), prime) == representative.rank
+            assert in_span == (index in closed)
+        for forbidden in forbidden_rows:
+            assert _modular_rank((*basis, forbidden), prime) > representative.rank
+
+
+def test_catalog_example_request_and_result_round_trip() -> None:
+    operation = _operation()
+    request = ClauseConstrainedPrimeFieldFlatRequest.model_validate(
+        operation.examples[0].input
+    )
+    result = operation.run(request)
+
+    assert result.outcome.status == "COMPLETE_EXACT"
+    assert (
+        ClauseConstrainedPrimeFieldFlatRequest.model_validate_json(
+            request.model_dump_json()
+        )
+        == request
+    )
+    assert (
+        ClauseConstrainedPrimeFieldFlatClassification.model_validate_json(
+            result.model_dump_json()
+        )
+        == result
+    )
+
+
+def test_work_limit_returns_incomplete_not_empty_complete() -> None:
+    from dataclasses import replace
+
+    problem = _problem(((1, 0), (0, 1), (1, 1)), prime=5, clauses=((2,),))
+    plan = _admit_problem(problem)
+    exact_cutoff = plan.ledger.consumed + _subset_container_work(0) + 1
+    plan.ledger.limit = exact_cutoff
+    plan = replace(plan, search_work_limit=exact_cutoff)
+
+    result = _classify(problem, plan)
+
+    assert result.outcome.status == "INCOMPLETE"
+    assert result.outcome.reason == "SEARCH_WORK_LIMIT"
+    assert result.outcome.explored_state_orbit_count == 0
+    assert result.outcome.consumed_search_work < exact_cutoff


### PR DESCRIPTION
Closes #3161

## Summary
Adds `matroid.prime_field_flat.constrained_orbits.compute`, the explicit `GF(prime)` sibling of the existing rational flat classifier.

Given a bounded labelled prime-field row configuration, covering clauses, forbidden rows, an optional rank interval, and compatible paired coordinate/candidate symmetry generators, it returns every closed flat satisfying those constraints once per symmetry orbit.

Each representative retains:
- closed candidate indices;
- exact GF(p) rank;
- canonical GF(p) RREF row-space basis;
- canonical annihilator basis;
- orbit size and stabilizer order.

The result discriminates `COMPLETE_EXACT` from a typed `INCOMPLETE` stop. An incomplete search never claims an exact empty family.

## Design choice
The issue classifies this as a contract/representation extension rather than a new operation ID. The rational operation’s request, bases, and mathematical parent are explicitly `QQ`, so silently accepting integers modulo a prime would conflate parents. The issue’s second publication direction—retain the rational operation and add a prime-field sibling when coherent generalization is impossible—preserves the published rational contract while making the characteristic explicit in the request, forbidden rows, matrices, and returned bases.

The kernel performs exact modular RREF, closure, span tests, forbidden-incidence checks, clause-guided traversal, orbit canonicalization, and orbit–stabilizer accounting. Prime-field matrix operations can replay one proposed span but do not perform complete closed-state search or symmetry reduction.

## Boundedness
- Prime representation: explicit prime, canonical residues, prime ≤ 2,147,483,647.
- Structural bounds mirror the rational owner: ambient dimension ≤16, candidates ≤128, forbidden rows ≤128, clauses/memberships ≤128/4,096, generators ≤16, group order ≤10,000, result orbits ≤100,000.
- A request-scoped work ledger charges every modular normalization, symmetry compatibility/recognition, row reduction, candidate and forbidden span scan, clause scan, state construction, orbit action/storage/cache, frontier update, result construction, and result encoding before execution.
- Prime-field arithmetic gets its own charge derivation in residue-bit units rather than reusing rational bigint/minor-height estimates.
- State orbits are capped at 100,000 and total work at 5,000,000,000. A wall deadline is a killable safety net only.
- A work or state stop returns `INCOMPLETE`; it never produces a false `COMPLETE_EXACT` or empty family.

## Evidence
- Integer configuration `(1,2,3),(4,5,6),(7,8,9)` has rank-2 rational closure but rank-1 GF(3) closure; the GF(3) and rational outputs differ as required.
- Zero-rank flat, modular parallel rows, empty configuration, empty clause, zero forbidden vector, rank interval, clauses, and modular symmetry.
- Symmetry compatibility requires modular row equality, not rational projective primitivity.
- Multiple generating sets deduplicate to one closed flat.
- Independent modular brute-force oracle over a six-row GF(5) source.
- Every returned basis replays RREF/annihilator orthogonality, closure, forbidden exclusion, and rank invariants over GF(p).
- Request/result and catalog example round trips.
- Deliberate work-limit `INCOMPLETE`.

## Validation
On final head `245fed790`, `make affected AFFECTED_BASE=origin/main` passed:
- scoped Ruff and format;
- strict mypy;
- 13 owner tests;
- 103 catalog tests;
- 882 catalog-example integration tests.

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/williamlin1327-office/035f48a3-f930-46e5-98de-d95d2b7218ea)
