### PR TITLE
fix(graphs): explain canonical edge endpoint ordering

### DIFF
--- a/src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py
+++ b/src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py
@@ -38,15 +38,19 @@ TOOLS: MathTools = (
         examples=(
             OperationExample(
                 name="triangle_with_pendant",
-                description="Triangle 0-1-2 with pendant vertex 3 attached to 2.",
+                description=(
+                    "Triangle x-y-z with pendant vertex r attached to z. "
+                    "Edge endpoints use lexicographic label order, independent "
+                    "of the vertex list order."
+                ),
                 input={
                     "graph": {
-                        "vertices": ["0", "1", "2", "3"],
+                        "vertices": ["x", "y", "z", "r"],
                         "edges": [
-                            ["0", "1"],
-                            ["0", "2"],
-                            ["1", "2"],
-                            ["2", "3"],
+                            ["x", "y"],
+                            ["x", "z"],
+                            ["y", "z"],
+                            ["r", "z"],
                         ],
                     },
                 },

--- a/src/jacobian/math/graphs/values.py
+++ b/src/jacobian/math/graphs/values.py
@@ -66,9 +66,21 @@ def _require_unicode_scalar_text(value: str, *, kind: str) -> None:
 class SimpleUndirectedGraph(StrictModel):
     """Immutable canonical value for a finite simple undirected graph."""
 
-    vertices: tuple[str, ...] = Field(max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES)
+    vertices: tuple[str, ...] = Field(
+        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+        description=(
+            "Unique Unicode NFC vertex labels containing valid Unicode scalar "
+            "values. Vertex list order is preserved and need not be sorted."
+        ),
+    )
     edges: tuple[tuple[str, str], ...] = Field(
-        max_length=MAX_INDEXED_SIMPLE_GRAPH_EDGES
+        max_length=MAX_INDEXED_SIMPLE_GRAPH_EDGES,
+        description=(
+            "Unique pairs of distinct declared vertices. Each pair must have "
+            "left < right in lexicographic label order (Unicode code points, "
+            "not positions in vertices). For vertices ['x', 'r'], the edge is "
+            "['r', 'x']. Edge list order is preserved and need not be sorted."
+        ),
     )
 
     @model_validator(mode="after")
@@ -92,7 +104,9 @@ class SimpleUndirectedGraph(StrictModel):
         ):
             raise PydanticCustomError(
                 "graph.edges_must_contain_two_declared_vertices_in_orde",
-                "edges must contain two declared vertices in order",
+                "edges must contain two distinct declared vertices with left < right "
+                "in lexicographic label order (Unicode code points, not positions "
+                "in vertices); orient each pair by label, e.g. ['r', 'x']",
             )
         if len(set(self.edges)) != len(self.edges):
             raise PydanticCustomError(

--- a/tests/math/graphs/test_colored_graph_canonicalization.py
+++ b/tests/math/graphs/test_colored_graph_canonicalization.py
@@ -417,7 +417,7 @@ def test_maximum_dense_shape_is_not_capped_by_serialized_result_size() -> None:
                     "edges": [["b", "a"]],
                 }
             },
-            "in order",
+            "lexicographic label order",
         ),
         (
             {

--- a/tests/math/graphs/test_values.py
+++ b/tests/math/graphs/test_values.py
@@ -32,8 +32,17 @@ def test_graph_rejects_edges_with_undeclared_vertices() -> None:
 
 
 def test_graph_rejects_edges_out_of_order() -> None:
-    with pytest.raises(ValidationError):
-        SimpleUndirectedGraph(vertices=("a", "b"), edges=(("b", "a"),))
+    with pytest.raises(ValidationError, match="lexicographic label order"):
+        SimpleUndirectedGraph(vertices=("x", "r"), edges=(("x", "r"),))
+
+
+def test_graph_edge_orientation_is_independent_of_vertex_and_edge_list_order() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("x", "y", "r"), edges=(("x", "y"), ("r", "x"))
+    )
+    assert SimpleUndirectedGraph.model_validate_json(graph.model_dump_json()) == graph
+    assert graph.vertices == ("x", "y", "r")
+    assert graph.edges == (("x", "y"), ("r", "x"))
 
 
 def test_graph_rejects_duplicate_edges() -> None:

--- a/tests/mcp/test_graph_edge_order_guidance.py
+++ b/tests/mcp/test_graph_edge_order_guidance.py
@@ -1,0 +1,78 @@
+"""Graph inspection and validation explain how to orient undirected edges."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from mcp.shared.exceptions import MCPError
+
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_graph_inspection_and_error_explain_endpoint_order_before_recovery() -> None:
+    async def scenario() -> None:
+        operation_id = "graph.maximal_clique_hypergraph.construct"
+        edges = [
+            ["x", "y"],
+            ["x", "z"],
+            ["x", "r"],
+            ["y", "z"],
+            ["y", "r"],
+            ["z", "r"],
+            ["x", "u"],
+            ["y", "u"],
+            ["z", "u"],
+            ["x", "w"],
+            ["y", "w"],
+            ["u", "w"],
+            ["x", "v"],
+            ["u", "v"],
+        ]
+        graph = {
+            "vertices": ["x", "y", "z", "r", "u", "v", "w"],
+            "edges": edges,
+        }
+        async with Client(create_server(), raise_exceptions=True) as client:
+            inspected = await client.call_tool(
+                "math.find",
+                {"request": {"op": "inspect", "operation_id": operation_id}},
+            )
+            contract = inspected.structured_content["operation"]
+            schema = contract["input_schema"]["$defs"]["SimpleUndirectedGraph"]
+            description = schema["properties"]["edges"]["description"]
+            assert "lexicographic label order" in description
+            assert "not positions in vertices" in description
+            example = contract["examples"][0]["input"]
+            assert example["graph"]["vertices"] != sorted(example["graph"]["vertices"])
+            example_result = await client.call_tool(
+                "math.run", {"operation_id": operation_id, "payload": example}
+            )
+            assert example_result.structured_content["output"]["clique_count"] == 2
+
+            with pytest.raises(MCPError) as rejected:
+                await client.call_tool(
+                    "math.run",
+                    {"operation_id": operation_id, "payload": {"graph": graph}},
+                )
+            error = rejected.value.data["errors"][0]
+            assert error["location"] == ["graph"]
+            assert "lexicographic label order" in error["message"]
+            assert "not positions in vertices" in error["message"]
+
+            graph["edges"] = [sorted(edge) for edge in edges]
+            result = await client.call_tool(
+                "math.run", {"operation_id": operation_id, "payload": {"graph": graph}}
+            )
+            output = result.structured_content["output"]
+            assert output["graph"] == graph
+            assert output["clique_count"] == 4
+            assert {tuple(members) for _, members in output["hypergraph"]["edges"]} == {
+                ("r", "x", "y", "z"),
+                ("u", "x", "y", "z"),
+                ("u", "w", "x", "y"),
+                ("u", "v", "x"),
+            }
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

`graph.maximal_clique_hypergraph.construct` rejects `vertices: ["x", "r"]` with `edges: [["x", "r"]]` because each edge must use lexicographic label order. The live inspection schema omitted that rule, and the error only said “in order,” leaving vertex-list order as a plausible interpretation. This was reproduced through MCP; reversing each affected pair in the reported seven-vertex graph returned its four maximal cliques.

This PR addresses the reported reproduction directly; no separate issue was filed.

## Outcome

Document the existing endpoint rule on the shared `SimpleUndirectedGraph` schema, including a concrete example and the distinction between label order and vertex-list position. Explain it in the validation error and revise the clique example to use an unsorted vertex list. Accepted inputs, error codes, mathematical results, and list-order preservation are unchanged.

## Validation

The new MCP regression failed on the base because the edge description was missing. The native regression independently failed because the error lacked the ordering explanation. The MCP journey checks inspection, executes the published example, rejects the reported input, and verifies all four maximal cliques after endpoint repair.

- `make affected AFFECTED_BASE=origin/main` — scoped static checks passed; graph tests reported 1,018 passes and one assertion expecting the old error text.
- `make handoff-scoped LANE=math TESTS=tests/math/graphs/test_colored_graph_canonicalization.py PATHS="src/jacobian/math/graphs/values.py src/jacobian/math/graphs/maximal_clique_hypergraph/_tools.py tests/math/graphs/test_values.py tests/math/graphs/test_colored_graph_canonicalization.py tests/mcp/test_graph_edge_order_guidance.py"` — after updating that assertion, all five files passed lint/type checks and all 28 owner tests passed.
- `make test-catalog` — 105 passed.
- `make test-integration TESTS=tests/integration/catalog/` — 882 passed.
- `make test-mcp` — 36 passed, including the reported payload recovery.
- Final head SHA tested: `59ad7282ff2eae33149f4e1dca2b128e387a23b5`.

## Contract impact

Public contract impact is limited to schema descriptions, a discovery example, and validation-message wording. Runtime acceptance, operation IDs, native signatures, result shapes, and execution bounds are unchanged. Native rejection and MCP rejection/recovery are covered. Kernel, deadline, output-bound, and producer-consumer changes are not applicable.

## Review closure

The complete branch diff was reviewed against `main`; only the graph guidance and its regression coverage are included. No compatibility or shadow paths were added. Review threads and CI evidence are pending.
