### PR TITLE
fix(markov-chain): admit stationary solves by closed-class work

### DIFF
--- a/src/jacobian/math/probability/markov_chains/operations.py
+++ b/src/jacobian/math/probability/markov_chains/operations.py
@@ -16,6 +16,7 @@ from jacobian.math.probability.markov_chains._models import (
     StationaryDistributionResult,
 )
 from jacobian.math.probability.markov_chains.values import (
+    MAX_STATIONARY_STATES,
     TransitionMatrix,
     TransitionMatrixAdmissionError,
     _decimal_digits,
@@ -79,10 +80,10 @@ def mixing_time(
     )
 
 
-def _stationary_distribution_extremes(
+def _closed_communicating_classes(
     matrix: TransitionMatrix,
-) -> list[tuple[tuple[int, ...], tuple[Fraction, ...]]]:
-    """Return one normalized stationary vector for every closed class."""
+) -> tuple[tuple[int, ...], ...]:
+    """Decompose an admitted carrier once in bounded quadratic support work."""
 
     import networkx as nx
 
@@ -107,6 +108,15 @@ def _stationary_distribution_extremes(
         ),
         key=lambda component: component,
     )
+    return tuple(closed_classes)
+
+
+def _stationary_distribution_extremes(
+    matrix: TransitionMatrix, closed_classes: tuple[tuple[int, ...], ...]
+) -> list[tuple[tuple[int, ...], tuple[Fraction, ...]]]:
+    """Solve the admitted classes and embed their vectors in source order."""
+
+    n = len(matrix)
     extremes: list[tuple[tuple[int, ...], tuple[Fraction, ...]]] = []
     from jacobian.math.probability.markov_chains._flint import solve_stationary_class
 
@@ -129,8 +139,8 @@ def stationary_distribution_extremes(
 ) -> list[tuple[tuple[int, ...], tuple[Fraction, ...]]]:
     """Return one normalized stationary vector for every closed class."""
 
-    _admit_stationary(matrix)
-    return _stationary_distribution_extremes(matrix)
+    closed_classes = _admit_stationary(matrix)
+    return _stationary_distribution_extremes(matrix, closed_classes)
 
 
 def stationary_distribution(
@@ -138,8 +148,8 @@ def stationary_distribution(
 ) -> tuple[Fraction, ...]:
     """Return the unique stationary distribution, rejecting non-unique chains."""
 
-    _admit_stationary(matrix)
-    extremes = _stationary_distribution_extremes(matrix)
+    closed_classes = _admit_stationary(matrix)
+    extremes = _stationary_distribution_extremes(matrix, closed_classes)
     if len(extremes) != 1:
         raise ValueError(
             "the Markov chain does not have a unique stationary distribution"
@@ -190,11 +200,26 @@ def _admit_transition_matrix(matrix: TransitionMatrix) -> None:
         _reject(exc.location, exc.reason, str(exc))
 
 
-def _admit_stationary(matrix: TransitionMatrix) -> None:
+def _admit_stationary(matrix: TransitionMatrix) -> tuple[tuple[int, ...], ...]:
     try:
-        require_stationary_distribution_admission(matrix)
+        require_transition_matrix(matrix, maximum_states=MAX_STATIONARY_STATES)
+        if any(
+            max(_decimal_digits(value.numerator), _decimal_digits(value.denominator))
+            > MAX_CANONICAL_RATIONAL_DIGITS
+            for row in matrix
+            for value in row
+        ):
+            _reject(
+                ("matrix",),
+                "stationary_source_height_exceeds_bound",
+                "stationary source probabilities exceed the "
+                f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit canonical bound",
+            )
+        closed_classes = _closed_communicating_classes(matrix)
+        require_stationary_distribution_admission(matrix, closed_classes)
     except TransitionMatrixAdmissionError as exc:
         _reject(exc.location, exc.reason, str(exc))
+    return closed_classes
 
 
 def _admit_mixing(
@@ -292,7 +317,9 @@ def mixing_time_result(
             max_steps=max_steps,
             steps_examined=0,
         )
-    extremes = _stationary_distribution_extremes(matrix)
+    extremes = _stationary_distribution_extremes(
+        matrix, _closed_communicating_classes(matrix)
+    )
     stationary = extremes[0][1]
     outcome = mixing_time(matrix, stationary, epsilon, max_steps)
     distance = CanonicalRational.from_integer_ratio(
@@ -314,8 +341,8 @@ def stationary_distribution_result(
 ) -> StationaryDistributionResult:
     """Compute the complete stationary family for a canonical matrix value."""
 
-    _admit_stationary(matrix)
-    extremes = _stationary_distribution_extremes(matrix)
+    closed_classes = _admit_stationary(matrix)
+    extremes = _stationary_distribution_extremes(matrix, closed_classes)
     return StationaryDistributionResult._from_kernel(
         transition_matrix=as_canonical_transition_matrix(matrix),
         extreme_distributions=tuple(

--- a/src/jacobian/math/probability/markov_chains/values.py
+++ b/src/jacobian/math/probability/markov_chains/values.py
@@ -89,19 +89,34 @@ def _decimal_digits(value: int) -> int:
     return estimate
 
 
-def require_stationary_distribution_admission(matrix: TransitionMatrix) -> None:
-    """Bound exact stationary coordinates for a native transition matrix."""
+def require_stationary_distribution_admission(
+    matrix: TransitionMatrix, closed_classes: tuple[tuple[int, ...], ...]
+) -> None:
+    """Price solves on the already validated carrier's closed classes.
 
-    require_transition_matrix(matrix, maximum_states=MAX_STATIONARY_STATES)
-    dimension = len(matrix)
-    if dimension**3 > MAX_STATIONARY_SOLVE_WORK:
+    Support decomposition uses at most n squared cells. Exact solve work is
+    the sum of the closed-class dimension cubes; transient states introduce
+    no solve rows. Each class has its own determinant-height bound. Embedding
+    all class vectors retains at most n squared canonical rational entries,
+    since there are at most n closed classes and n is at most 128.
+    """
+
+    if sum(len(states) ** 3 for states in closed_classes) > MAX_STATIONARY_SOLVE_WORK:
         raise TransitionMatrixAdmissionError(
             "stationary_solve_work_exceeds_bound",
             "stationary closed-class systems exceed the exact solve-work bound",
         )
+    for states in closed_classes:
+        _require_stationary_class_height(matrix, states)
+
+
+def _require_stationary_class_height(
+    matrix: TransitionMatrix, states: tuple[int, ...]
+) -> None:
+    dimension = len(states)
     row_bounds: list[int] = []
-    for column in range(dimension - 1):
-        entries = tuple(matrix[row][column] for row in range(dimension))
+    for column in states[:-1]:
+        entries = tuple(matrix[row][column] for row in states)
         denominator_digits = sum(
             _decimal_digits(value.denominator) for value in entries
         )

--- a/tests/math/probability/markov_chains/test_regressions.py
+++ b/tests/math/probability/markov_chains/test_regressions.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import sys
 from fractions import Fraction
+from types import FrameType
 
 import pytest
 from pydantic import ValidationError
@@ -9,6 +11,7 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.probability.markov_chains import (
     ergodic_properties,
     stationary_distribution,
+    stationary_distribution_result,
 )
 from jacobian.math.probability.markov_chains._models import (
     StationaryDistributionRequest,
@@ -289,3 +292,109 @@ def test_transition_contract_rejects_non_stochastic_matrices(
         with pytest.raises(OperationDomainValidationError) as domain_error:
             compute_ergodic_decision(request)
         assert domain_error.value.errors()[0]["type"] == error_code
+
+
+@pytest.mark.parametrize("class_size", [1, 2])
+def test_stationary_family_admits_many_small_closed_classes(class_size: int) -> None:
+    from jacobian.math.probability.markov_chains.values import MAX_STATIONARY_STATES
+
+    size = MAX_STATIONARY_STATES
+    matrix = tuple(
+        tuple(
+            Fraction(1, class_size)
+            if i // class_size == j // class_size
+            else Fraction()
+            for j in range(size)
+        )
+        for i in range(size)
+    )
+    result = stationary_distribution_result(matrix)
+    assert len(result.extreme_distributions) == size // class_size
+    for index, extreme in enumerate(result.extreme_distributions):
+        states = tuple(range(index * class_size, (index + 1) * class_size))
+        assert extreme.closed_class == states
+        expected = tuple(
+            Fraction(1, class_size) if j in states else Fraction() for j in range(size)
+        )
+        assert tuple(value.as_fraction() for value in extreme.distribution) == expected
+
+
+def test_stationary_admission_does_not_charge_transient_states_as_solve_rows() -> None:
+    from jacobian.math.probability.markov_chains.values import MAX_STATIONARY_STATES
+
+    size = MAX_STATIONARY_STATES
+    matrix = tuple(
+        tuple(Fraction(1, 2) if j >= size - 2 else Fraction() for j in range(size))
+        for _ in range(size)
+    )
+    assert stationary_distribution(matrix) == matrix[0]
+
+
+def test_stationary_class_decomposition_and_solve_work_are_not_repeated() -> None:
+    from tests.fixtures.accounting import assert_charged_work_parity
+
+    from jacobian.math.probability.markov_chains import operations
+    from jacobian.math.probability.markov_chains._flint import solve_stationary_class
+    from jacobian.math.probability.markov_chains.values import MAX_STATIONARY_STATES
+
+    size = MAX_STATIONARY_STATES
+    matrix = tuple(
+        tuple(Fraction(int(i == j)) for j in range(size)) for i in range(size)
+    )
+    executed = {"support_cells": 0, "solve_cubes": 0}
+
+    def observe(frame: FrameType, event: str, _arg: object) -> None:
+        if event != "call":
+            return
+        if frame.f_code is operations._closed_communicating_classes.__code__:
+            executed["support_cells"] += len(frame.f_locals["matrix"]) ** 2
+        elif frame.f_code is solve_stationary_class.__code__:
+            executed["solve_cubes"] += len(frame.f_locals["closed_class"]) ** 3
+
+    previous = sys.getprofile()
+    sys.setprofile(observe)
+    try:
+        result = stationary_distribution_result(matrix)
+        serialized = result.model_dump_json()
+        type(result).model_validate_json(serialized)
+    finally:
+        sys.setprofile(previous)
+
+    charged = {"support_cells": size**2, "solve_cubes": size}
+    assert executed == charged
+    assert_charged_work_parity(charged=charged, executed=executed)
+    assert len(result.extreme_distributions) == size
+
+
+@pytest.mark.parametrize(("first_size", "admitted"), [(99, True), (100, False)])
+def test_stationary_sums_work_across_closed_classes(
+    first_size: int, admitted: bool
+) -> None:
+    from jacobian.math.probability.markov_chains.values import MAX_STATIONARY_STATES
+
+    size = MAX_STATIONARY_STATES
+    matrix = tuple(
+        tuple(
+            Fraction(1, first_size if i < first_size else size - first_size)
+            if (i < first_size) == (j < first_size)
+            else Fraction()
+            for j in range(size)
+        )
+        for i in range(size)
+    )
+    if not admitted:
+        with pytest.raises(OperationDomainValidationError, match="solve-work bound"):
+            stationary_distribution_result(matrix)
+        return
+    result = stationary_distribution_result(matrix)
+    assert [item.closed_class for item in result.extreme_distributions] == [
+        tuple(range(first_size)),
+        tuple(range(first_size, size)),
+    ]
+    for state, extreme in zip(
+        (0, first_size), result.extreme_distributions, strict=True
+    ):
+        assert (
+            tuple(value.as_fraction() for value in extreme.distribution)
+            == matrix[state]
+        )

--- a/tests/math/probability/markov_chains/test_stationary_height.py
+++ b/tests/math/probability/markov_chains/test_stationary_height.py
@@ -1,7 +1,11 @@
+from fractions import Fraction
+
 import pytest
 
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
 from jacobian.canonical import format_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.probability.markov_chains import stationary_distribution_result
 from jacobian.math.probability.markov_chains._models import (
     StationaryDistributionRequest,
     TransitionMatrixRequest,
@@ -63,3 +67,36 @@ def test_useful_near_boundary_stationary_request_remains_admitted() -> None:
     )
 
     assert len(request.matrix) == 2
+
+
+@pytest.mark.parametrize("exponent", [100, MAX_CANONICAL_RATIONAL_DIGITS - 1])
+def test_transient_height_is_only_charged_for_retaining_the_source(
+    exponent: int,
+) -> None:
+    p = Fraction(1, 10**exponent)
+    matrix = (
+        (Fraction(), p, 1 - p),
+        (Fraction(), Fraction(1), Fraction()),
+        (Fraction(), Fraction(), Fraction(1)),
+    )
+    result = stationary_distribution_result(matrix)
+    assert [item.closed_class for item in result.extreme_distributions] == [(1,), (2,)]
+    assert (
+        tuple(value.as_fraction() for value in result.transition_matrix[0]) == matrix[0]
+    )
+    type(result).model_validate_json(result.model_dump_json())
+
+
+def test_native_stationary_rejects_unrepresentable_transient_source() -> None:
+    p = Fraction(1, 10**MAX_CANONICAL_RATIONAL_DIGITS)
+    matrix = (
+        (Fraction(), p, 1 - p),
+        (Fraction(), Fraction(1), Fraction()),
+        (Fraction(), Fraction(), Fraction(1)),
+    )
+    with pytest.raises(OperationDomainValidationError) as error:
+        stationary_distribution_result(matrix)
+    assert (
+        error.value.errors()[0]["type"]
+        == "markov_chain.stationary_source_height_exceeds_bound"
+    )


### PR DESCRIPTION
## Problem

Fixes #3188. A 101-state identity Markov chain was rejected by a whole-carrier cubic work charge, although the kernel solves its 101 singleton closed classes independently.

## Outcome

Decompose closed classes once, admit the sum of their dimension cubes and their individual rational-height bounds, and reuse those classes during execution. The existing 128-state carrier and complete source-bound stationary family remain unchanged. Native source probabilities receive a separate canonical-height check before decomposition, including transient entries that do not contribute solve rows.

## Validation

The three motivating regressions fail on the base: 128 singleton classes, 64 two-state classes, and transient states feeding a two-state closed class. The corrected tree passes:

- `make test-math TESTS=tests/math/probability/markov_chains` — 50 passed.
- Scoped Ruff and mypy checks — all four changed files passed.
- `make test-catalog` — 105 passed.
- `make test-integration TESTS=tests/integration/catalog/` — 882 passed.
- Local MCP execution of the 128-state identity — all 128 unit-vector extremes verified.

Tests retain rejection of a genuinely large irreducible class, cover aggregate work on both sides of the bound, check transient source values at the canonical digit boundary, and measure that decomposition/solves are not replayed during serialization.

Final head tested: `9a2d1bc71f2fdc0674991978605cfa58ec778ef3`.

## Contract impact

The admitted domain widens for decomposable stationary systems. Operation IDs, schemas, native signatures, class ordering, and mathematical results are unchanged. Oversized native source rationals now produce a typed admission error before result construction.

## Operation boundary

Admission prices quadratic source/support traversal, the sum of closed-class solve cubes against the existing 1,000,000-unit limit, per-class determinant height, and at most n² embedded probability coordinates. FLINT still owns each exact solve. No timeout or transport limit changes are introduced.

## Review closure

Complete branch diff reviewed against `main`; no compatibility paths added. Review threads and CI evidence are pending.
