### PR TITLE
fix(optimization): admit independent interval LPs before normalization

### DIFF
--- a/src/jacobian/math/optimization/_general_linear_program.py
+++ b/src/jacobian/math/optimization/_general_linear_program.py
@@ -620,11 +620,107 @@ def _map_standard_result(
     )
 
 
+def _box_program_result(
+    program: GeneralFormRationalLinearProgram,
+) -> GeneralRationalLinearProgramResult | None:
+    """Solve independent source intervals with linear work and exact certificates.
+
+    Source validation establishes nonempty intervals, n <= 32, and D <= 128
+    digits per rational component. Endpoints and multipliers retain D digits;
+    slacks need at most 2D+1. Summing n endpoint/coefficient products needs at
+    most 2nD + ceil(log10(n)) + 1 digits, below the canonical rational limit.
+    No normalized variables, basis enumeration, or solver launch is needed.
+    """
+    if program.constraints:
+        return None
+
+    point: list[Fraction] = []
+    lower_dual: list[Fraction] = []
+    upper_dual: list[Fraction] = []
+    direction = [Fraction()] * len(program.variables)
+    unbounded = False
+    for index, (variable, coefficient) in enumerate(
+        zip(program.variables, program.objective.coefficients, strict=True)
+    ):
+        lower = (
+            variable.lower_bound.as_fraction()
+            if variable.lower_bound is not None
+            else None
+        )
+        upper = (
+            variable.upper_bound.as_fraction()
+            if variable.upper_bound is not None
+            else None
+        )
+        c = coefficient.as_fraction()
+        effective = c if program.objective.sense == "MINIMIZE" else -c
+        active = lower if effective > 0 else upper if effective < 0 else None
+        point.append(
+            active
+            if active is not None
+            else lower
+            if lower is not None
+            else upper
+            if upper is not None
+            else Fraction()
+        )
+        lower_dual.append(c if effective > 0 and lower is not None else Fraction())
+        upper_dual.append(c if effective < 0 and upper is not None else Fraction())
+        if effective != 0 and active is None and not unbounded:
+            direction[index] = Fraction(-1 if effective > 0 else 1)
+            unbounded = True
+
+    objective, residuals, slacks, lower_slacks, upper_slacks = _primal_data(
+        program, tuple(point)
+    )
+    wire_objective = CanonicalRational.from_fraction(objective)
+    primal, wire_residuals, wire_slacks, wire_lower_slacks, wire_upper_slacks = (
+        tuple(CanonicalRational.from_fraction(value) for value in values)
+        for values in (point, residuals, slacks, lower_slacks, upper_slacks)
+    )
+    if unbounded:
+        return GeneralRationalLinearProgramResult._from_kernel(
+            program=program,
+            status="UNBOUNDED",
+            primal_candidate=primal,
+            primal_objective=wire_objective,
+            primal_residuals=wire_residuals,
+            constraint_slacks=wire_slacks,
+            lower_bound_slacks=wire_lower_slacks,
+            upper_bound_slacks=wire_upper_slacks,
+            recession_direction=tuple(
+                CanonicalRational.from_fraction(value) for value in direction
+            ),
+        )
+    return GeneralRationalLinearProgramResult._from_kernel(
+        program=program,
+        status="OPTIMAL",
+        primal_candidate=primal,
+        primal_objective=wire_objective,
+        primal_residuals=wire_residuals,
+        constraint_slacks=wire_slacks,
+        lower_bound_slacks=wire_lower_slacks,
+        upper_bound_slacks=wire_upper_slacks,
+        constraint_dual=(),
+        lower_bound_dual=tuple(
+            CanonicalRational.from_fraction(value) for value in lower_dual
+        ),
+        upper_bound_dual=tuple(
+            CanonicalRational.from_fraction(value) for value in upper_dual
+        ),
+        dual_objective=wire_objective,
+        stationarity_residuals=(CanonicalRational.from_fraction(Fraction()),)
+        * len(program.variables),
+    )
+
+
 def general_linear_program(
     program: GeneralFormRationalLinearProgram,
 ) -> GeneralRationalLinearProgramResult:
     from jacobian.math.optimization.operations import linear_program
 
+    if (box_result := _box_program_result(program)) is not None:
+        return box_result
     if (presolved := _one_variable_interval_result(program)) is not None:
         return presolved
 

--- a/tests/integration/linear/test_general_rational_linear_program.py
+++ b/tests/integration/linear/test_general_rational_linear_program.py
@@ -350,13 +350,28 @@ def test_general_lp_rejects_variables_beyond_the_public_envelope() -> None:
 
 def test_general_lp_defers_free_split_admission_to_the_normalized_columns() -> None:
     variables = [_variable(f"x{index}") for index in range(17)]
+    result = _run(
+        _program(
+            variables=variables,
+            sense="MINIMIZE",
+            objective=[q(1) for _ in variables],
+            constraints=[],
+        )
+    )
+    assert result.status == "UNBOUNDED"
+    assert _fractions(result.primal_candidate) == (Fraction(),) * 17
+    assert (
+        _fractions(result.recession_direction) == (Fraction(-1),) + (Fraction(),) * 16
+    )
+
+    # Coupled constraints still require normalized-column admission.
     with pytest.raises(OperationDomainValidationError):
         _run(
             _program(
                 variables=variables,
                 sense="MINIMIZE",
                 objective=[q(1) for _ in variables],
-                constraints=[],
+                constraints=[_row("coupled", [q(1) for _ in variables], "EQ", q(0))],
             )
         )
 

--- a/tests/math/optimization/test_general_linear_box.py
+++ b/tests/math/optimization/test_general_linear_box.py
@@ -1,0 +1,183 @@
+"""Independent bounded coordinates retain exact source-coordinate LP evidence."""
+
+from collections.abc import Sequence
+from fractions import Fraction
+from itertools import product
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.optimization import general_linear_program
+from jacobian.math.optimization._general_models import (
+    MAX_GENERAL_LINEAR_PROGRAM_VARIABLES,
+    MAX_GENERAL_RATIONAL_INPUT_DIGITS,
+    GeneralFormRationalLinearProgram,
+    GeneralRationalLinearProgramResult,
+    RationalObjectiveSense,
+)
+
+
+def _program(
+    bounds: Sequence[tuple[Fraction | None, Fraction | None]],
+    coefficients: list[Fraction],
+    sense: RationalObjectiveSense = "MINIMIZE",
+) -> GeneralFormRationalLinearProgram:
+    return GeneralFormRationalLinearProgram.model_validate(
+        {
+            "variables": [
+                {
+                    "name": f"x{i}",
+                    "lower_bound": CanonicalRational.from_fraction(lower)
+                    if lower is not None
+                    else None,
+                    "upper_bound": CanonicalRational.from_fraction(upper)
+                    if upper is not None
+                    else None,
+                }
+                for i, (lower, upper) in enumerate(bounds)
+            ],
+            "objective": {
+                "sense": sense,
+                "coefficients": [
+                    CanonicalRational.from_fraction(c) for c in coefficients
+                ],
+            },
+            "constraints": [],
+        }
+    )
+
+
+@pytest.mark.parametrize("size", [4, MAX_GENERAL_LINEAR_PROGRAM_VARIABLES])
+def test_independent_box_is_admitted_through_the_source_variable_limit(
+    size: int,
+) -> None:
+    program = _program([(Fraction(), Fraction(1))] * size, [Fraction(1)] * size)
+    result = general_linear_program(program)
+    assert result.status == "OPTIMAL"
+    assert (
+        result.primal_candidate == (CanonicalRational.from_fraction(Fraction()),) * size
+    )
+    assert result.primal_objective == CanonicalRational.from_fraction(Fraction())
+    assert (
+        result.lower_bound_dual
+        == (CanonicalRational.from_fraction(Fraction(1)),) * size
+    )
+    assert result.program == program
+    assert (
+        GeneralRationalLinearProgramResult.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+@pytest.mark.parametrize("sense", ["MINIMIZE", "MAXIMIZE"])
+def test_box_optimality_agrees_with_exhaustive_vertices(
+    sense: RationalObjectiveSense,
+) -> None:
+    bounds = [
+        (Fraction(-2), Fraction(3)),
+        (Fraction(1, 3), Fraction(5, 2)),
+        (Fraction(7), Fraction(7)),
+    ]
+    for raw in product((-1, 0, 1), repeat=3):
+        coefficients = list(map(Fraction, raw))
+        result = general_linear_program(_program(bounds, coefficients, sense))
+        candidates = [
+            sum(c * x for c, x in zip(coefficients, vertex, strict=True))
+            for vertex in product(*bounds)
+        ]
+        optimum = min(candidates) if sense == "MINIMIZE" else max(candidates)
+        assert result.status == "OPTIMAL"
+        assert (
+            result.primal_objective is not None
+            and result.primal_objective.as_fraction() == optimum
+        )
+        assert result.dual_objective == result.primal_objective
+        assert result.primal_candidate is not None
+        assert (
+            result.lower_bound_dual is not None and result.upper_bound_dual is not None
+        )
+        sign = 1 if sense == "MINIMIZE" else -1
+        for c, point, lower_dual, upper_dual, (lower, upper) in zip(
+            coefficients,
+            result.primal_candidate,
+            result.lower_bound_dual,
+            result.upper_bound_dual,
+            bounds,
+            strict=True,
+        ):
+            x, ld, ud = (
+                point.as_fraction(),
+                lower_dual.as_fraction(),
+                upper_dual.as_fraction(),
+            )
+            assert lower <= x <= upper
+            assert ld + ud == c
+            assert sign * ld >= 0 and sign * ud <= 0
+            assert ld * (x - lower) == ud * (upper - x) == 0
+
+
+@pytest.mark.parametrize("sense", ["MINIMIZE", "MAXIMIZE"])
+def test_box_unbounded_direction_is_feasible_and_improves_objective(
+    sense: RationalObjectiveSense,
+) -> None:
+    bounds = [
+        (Fraction(0), Fraction(1)),
+        (None, None),
+        (None, Fraction(4)),
+        (Fraction(2), None),
+    ]
+    coefficients = [Fraction(0), Fraction(-2), Fraction(3), Fraction(5)]
+    result = general_linear_program(_program(bounds, coefficients, sense))
+    assert result.status == "UNBOUNDED"
+    assert (
+        result.primal_candidate is not None and result.recession_direction is not None
+    )
+    point = [x.as_fraction() for x in result.primal_candidate]
+    ray = [x.as_fraction() for x in result.recession_direction]
+    slope = sum(c * d for c, d in zip(coefficients, ray, strict=True))
+    assert slope < 0 if sense == "MINIMIZE" else slope > 0
+    for x, d, (lower, upper) in zip(point, ray, bounds, strict=True):
+        assert lower is None or (x >= lower and d >= 0)
+        assert upper is None or (x <= upper and d <= 0)
+    assert result.lower_bound_dual is None and result.upper_bound_dual is None
+    assert result.dual_objective is None
+    assert (
+        GeneralRationalLinearProgramResult.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+def test_zero_objective_with_free_and_one_sided_coordinates_is_optimal() -> None:
+    bounds = [
+        (None, None),
+        (Fraction(2), None),
+        (None, Fraction(-3)),
+        (Fraction(7), Fraction(7)),
+    ]
+    result = general_linear_program(_program(bounds, [Fraction()] * len(bounds)))
+    assert result.status == "OPTIMAL"
+    assert result.primal_candidate is not None
+    assert [x.as_fraction() for x in result.primal_candidate] == [0, 2, -3, 7]
+    assert (
+        result.primal_objective is not None
+        and result.primal_objective.as_fraction() == 0
+    )
+
+
+def test_box_exact_objective_retains_growth_beyond_source_scalar_limit() -> None:
+    size = MAX_GENERAL_LINEAR_PROGRAM_VARIABLES
+    large = 10 ** (MAX_GENERAL_RATIONAL_INPUT_DIGITS - 1)
+    endpoints = [Fraction(1, large + 2 * i + 1) for i in range(size)]
+    coefficients = [Fraction(1, large + 2 * (size + i) + 1) for i in range(size)]
+    program = _program([(x, x) for x in endpoints], coefficients)
+    result = general_linear_program(program)
+    expected = sum(c * x for c, x in zip(coefficients, endpoints, strict=True))
+    assert expected.denominator >= 10**MAX_GENERAL_RATIONAL_INPUT_DIGITS
+    assert result.status == "OPTIMAL"
+    assert result.primal_objective is not None
+    assert result.primal_objective.as_fraction() == expected
+    assert result.dual_objective == result.primal_objective
+    assert (
+        GeneralRationalLinearProgramResult.model_validate_json(result.model_dump_json())
+        == result
+    )


### PR DESCRIPTION
## Problem

Minimizing the sum of four independently bounded variables on `[0,1]` fails normalized simplex-basis admission, although choosing zero in each coordinate proves the exact optimum. Larger independent boxes also hit the normalized-column limit. Closes #3189.

## Outcome

Solve programs with no constraint rows directly in source coordinates before normalization. Each coordinate selects its improving endpoint, with exact bound duals; a missing improving endpoint yields a feasible point and the first improving coordinate ray. Zero coefficients use the existing lower/upper/zero convention. This admits all 32 source variables without expanding bounds into slack equations.

Constraint-bearing programs retain their existing interval or normalized solver path. Operation IDs, schemas, source limits, and canonical result types are unchanged.

## Validation

- `make handoff-scoped LANE=math TESTS=tests/math/optimization PATHS="src/jacobian/math/optimization/_general_linear_program.py tests/math/optimization/test_general_linear_box.py"`: scoped Ruff/mypy and 22 tests passed.
- `make handoff-scoped LANE=integration TESTS=tests/integration/linear/test_general_rational_linear_program.py PATHS="src/jacobian/math/optimization/_general_linear_program.py tests/math/optimization/test_general_linear_box.py tests/integration/linear/test_general_rational_linear_program.py"`: scoped Ruff/mypy and 24 tests passed.
- Four- and 32-variable regressions fail on the base for the original basis/column admission errors. Exhaustive small-box vertex comparisons cover both senses, signs, fixed coordinates, dual feasibility, stationarity, and complementary slackness. Additional checks cover unbounded rays, zero objectives, exact scalar growth, and JSON round trips.
- Local `math.run` on the 32-variable unit box matches the native result exactly, including source coordinates and dual multipliers.
- Flameox/py-spy at 100 Hz profiled 100 native solves plus JSON serialization after one warmup on the same three-variable unit box. The baseline loop took 8.237 s and the new loop 0.0244 s; both passed the optimum/point oracle and returned 1,222-byte results. These are single-run observations, not a general speedup estimate. The baseline profile shows substantial SymPy work; the direct path removes that solver invocation.
- Final head SHA tested: 2722ce68a5db1872b0065c9837591bd185d9baae
- CI: pending on this head.

## Contract impact

Public execution admits independent bound-only programs throughout the existing source envelope.

- [x] Exact results fit the canonical output boundary.
- [x] Native and MCP results agree on the motivating request.
- [x] Defining invariants and adversarial regressions are covered.
- Source parsing and rejection bounds are unchanged. Generic coupled-program admission restrictions remain.
- No subprocess or new deadline is introduced. The direct path has bounded linear work in the admitted coordinates.
- Result serialization/deserialization was tested; no new producer or consumer type is introduced.

## Review closure

The complete branch diff was reviewed. No unresolved findings remain. Validation covers the committed behavioral tree; GitHub CI is pending.

### Operation boundary

- Owner/stage: optimization, private presolve and trusted result construction.
- Admission: at most 32 variables, at most 128 digits per source rational component, and no constraint rows. Source validation already establishes nonempty variable intervals.
- Work and output: O(n) rational operations and O(n) result coordinates. Endpoint/multiplier components retain D digits; slack components need at most 2D+1. The objective sum needs at most `2nD + ceil(log10(n)) + 1` digits, safely below the canonical rational limit.
- Kernel: exact endpoint selection, with raw source-sense duals or a feasible recession direction. Coupled programs continue to use the existing backend.
- Result construction: existing `GeneralRationalLinearProgramResult._from_kernel`, retaining the original program and coordinate order. Tests independently establish the optimum/certificate identities.
- Catalog membership and canonical value ownership are unchanged.
