### PR TITLE
fix(finite-fields): authenticate supplied polynomial tables before analysis

### DIFF
--- a/src/jacobian/math/finite_fields/operations.py
+++ b/src/jacobian/math/finite_fields/operations.py
@@ -718,9 +718,9 @@ def evaluate_finite_polynomial(
     )
 
 
-def finite_map_table(polynomial_map: FinitePolynomialMap) -> FiniteMapTable:
-    """Enumerate a complete finite polynomial-map table in canonical order."""
-
+def _admit_map_evaluation(
+    polynomial_map: FinitePolynomialMap, *, location: tuple[str, ...]
+) -> None:
     work = (
         polynomial_map.domain.order
         * len(polynomial_map.polynomial.coefficients)
@@ -728,10 +728,16 @@ def finite_map_table(polynomial_map: FinitePolynomialMap) -> FiniteMapTable:
     )
     if work > _MAX_FINITE_MAP_WORK:
         raise OperationDomainValidationError(
-            location=("polynomial_map",),
+            location=location,
             code="finite_field.finite_map_exceeds_operation_work_budget",
             message="finite map exceeds the operation work budget",
         )
+
+
+def finite_map_table(polynomial_map: FinitePolynomialMap) -> FiniteMapTable:
+    """Enumerate a complete finite polynomial-map table in canonical order."""
+
+    _admit_map_evaluation(polynomial_map, location=("polynomial_map",))
     from jacobian.math.finite_fields import _flint
 
     sources = _field_elements(polynomial_map.domain)
@@ -748,15 +754,42 @@ def finite_map_table(polynomial_map: FinitePolynomialMap) -> FiniteMapTable:
     )
 
 
+def _authenticate_map_table(table: FiniteMapTable) -> None:
+    """Establish the caller-supplied evaluation relation within consumer work.
+
+    Shape validation and serialization cannot establish polynomial evaluation.
+    Each public consumer admits and computes that relation once; trusted result
+    construction and deserialization never invoke this recognition step.
+    """
+    _admit_map_evaluation(table.map, location=("table", "map"))
+    from jacobian.math.finite_fields import _flint
+
+    expected = _flint.evaluate_polynomial_values(
+        table.map.polynomial.coefficients,
+        tuple(source for source, _ in table.entries),
+    )
+    if any(
+        target.coordinates != coordinates
+        for (_, target), coordinates in zip(table.entries, expected, strict=True)
+    ):
+        raise OperationDomainValidationError(
+            location=("table", "entries"),
+            code="finite_field.finite_map_table_targets_match_bound_polynomial",
+            message="finite map table targets must match the bound polynomial",
+        )
+
+
 def fiber_partition(table: FiniteMapTable) -> FiberPartition:
     """Partition the complete domain by exact map image."""
 
+    _authenticate_map_table(table)
     return FiberPartition.from_table(table)
 
 
 def analyze_collisions(table: FiniteMapTable) -> CollisionResult:
     """Return either the first canonical collision or an injectivity result."""
 
+    _authenticate_map_table(table)
     seen: dict[str, tuple[FiniteFieldElement, FiniteFieldElement]] = {}
     for source, target in table.entries:
         previous = seen.get(target.digest)
@@ -775,6 +808,7 @@ def analyze_collisions(table: FiniteMapTable) -> CollisionResult:
 def analyze_permutation(table: FiniteMapTable) -> PermutationResult:
     """Return either an inverse table or a non-permutation result."""
 
+    _authenticate_map_table(table)
     inverse_entries = tuple(
         sorted(
             ((target, source) for source, target in table.entries),

--- a/tests/math/finite_fields/test_polynomial_maps.py
+++ b/tests/math/finite_fields/test_polynomial_maps.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.finite_fields import (
     FiniteMapTable,
     FinitePolynomialMap,
@@ -124,3 +127,57 @@ def test_slice_b_reuses_one_table_for_fiber_and_certificate_handoff() -> None:
 
     assert partition.table is table
     assert collision.table is table
+
+
+@pytest.mark.parametrize(
+    "consumer", [fiber_partition, analyze_collisions, analyze_permutation]
+)
+@pytest.mark.parametrize("mutation", ["target", "polynomial"])
+def test_consumers_authenticate_the_supplied_polynomial_table(
+    consumer: Callable[[FiniteMapTable], object],
+    mutation: str,
+) -> None:
+    table = finite_map_table(_map(2))
+    payload = table.model_dump(mode="json")
+    if mutation == "target":
+        payload["entries"][1][1] = payload["entries"][0][1]
+    else:
+        payload["map"]["polynomial"]["coefficients"] = [payload["entries"][0][0]]
+    candidate = FiniteMapTable.model_validate(payload)
+
+    with pytest.raises(OperationDomainValidationError) as error:
+        consumer(candidate)
+    assert error.value.errors()[0]["type"] == (
+        "finite_field.finite_map_table_targets_match_bound_polynomial"
+    )
+
+
+@pytest.mark.parametrize(
+    "consumer", [fiber_partition, analyze_collisions, analyze_permutation]
+)
+def test_table_authentication_rejects_unadmitted_evaluation_work(
+    consumer: Callable[[FiniteMapTable], object],
+) -> None:
+    field = finite_field(2, (1, 1, 0, 1, 1, 0, 0, 0, 1))
+    one = element(field, (1,) + (0,) * 7)
+    table = finite_map_table(finite_polynomial_map(finite_polynomial(field, (one,))))
+    candidate_map = finite_polynomial_map(finite_polynomial(field, (one,) * 512))
+    candidate = FiniteMapTable(map=candidate_map, entries=table.entries)
+
+    with pytest.raises(OperationDomainValidationError) as error:
+        consumer(candidate)
+    assert error.value.errors()[0]["type"] == (
+        "finite_field.finite_map_exceeds_operation_work_budget"
+    )
+
+
+@pytest.mark.parametrize("exponents", [(), (2,), (3,)])
+def test_serialized_producer_tables_enter_every_consumer(
+    exponents: tuple[int, ...],
+) -> None:
+    table = finite_map_table(_map(*exponents))
+    candidate = FiniteMapTable.model_validate_json(table.model_dump_json())
+    for consumer in (fiber_partition, analyze_collisions, analyze_permutation):
+        result = consumer(candidate)
+        assert result == consumer(table)
+        assert result.table is candidate


### PR DESCRIPTION
## Problem

The finite polynomial-map consumers can report injectivity and permutation success for a table that disagrees with its bound polynomial. Over GF(2), changing the zero polynomial's table from `(0,0),(1,0)` to `(0,0),(1,1)` produces `INJECTIVE` and `PERMUTATION` through `math.run`.

Addresses the reproduced regression in #2136. [Current reproduction](https://github.com/morluto/jacobian/issues/2136#issuecomment-5546659255).

## Outcome

Each of the three consumers establishes the supplied evaluation relation before deriving fibers, collisions, or permutation status. One shared helper uses the existing FLINT evaluator and the producer's existing evaluation-work admission. An inconsistent table receives an `OperationDomainValidationError` identifying `table.entries`; excessive evaluation work is rejected before the evaluator runs.

This puts recognition at the consuming operation boundary. No evaluation replay is added to model parsing or serialization, and producer/result construction remains trusted. No new public types, operation IDs, arithmetic implementation, or compatibility path are introduced.

## Validation

- `make handoff-scoped LANE=math TESTS=tests/math/finite_fields PATHS="src/jacobian/math/finite_fields/operations.py tests/math/finite_fields/test_polynomial_maps.py"`: Ruff, formatting, mypy, and 95 tests passed.
- `make test-catalog`: 105 passed.
- `make test-integration TESTS=tests/integration/catalog/`: 882 passed.
- Six target/coefficient mutation cases fail on the base because no error is raised. Regression coverage also includes over-budget authentication and serialized zero, permutation, and non-permutation producer tables.
- Independent integer/polynomial-reduction oracles checked all 99 degree-at-most-two coefficient tuples over GF(2), GF(3), and GF(4), including all three consumers.
- Local MCP: valid zero-polynomial tables remain accepted by all three consumers; changed targets now yield the typed relation error instead of false mathematical conclusions.
- Final head tested: 889f7a1ac6d8e6d0d384ee1482e6a4b13ad27b32. CI pending on this head.

## Contract impact

- [x] Cheap malformed and excessive-work requests are rejected before evaluation.
- [x] Exact results retain the existing canonical representation.
- [x] Native and MCP rejection agree on the forged-table reproduction.
- [x] Producer → serialization → consumer composition was tested.
- [x] Defining-invariant and adversarial regressions are covered.

The accepted mathematical postcondition is unchanged; caller-supplied tables that do not evaluate their bound polynomial are now rejected. Request/result schemas are unchanged. Authentication participates in ordinary operation execution and does not create a separate worker, timeout, or result-validation pass.

## Review closure

The complete diff received primary and independent review; no unresolved findings remain. Validation covers the committed behavioral tree. GitHub CI is pending.

### Operation boundary

- Owner/stage: finite fields, consumer recognition before aggregation.
- Admission: reuse `q * coefficient_count * extension_degree <= 1,000,000` before one FLINT batch evaluation. Field order, degree, parent identity, and complete canonical source ordering remain bounded by existing types.
- Work/intermediates: one bounded evaluation vector and coordinate comparison per consumer call, then the existing aggregation. No duplicate evaluation during model parsing, result construction, or JSON projection.
- Kernel: existing `evaluate_polynomial_values`; exact field coordinates are compared without coercion.
- Result construction: unchanged trusted factories and source-table identity.
- Canonical ownership: the existing `FiniteMapTable` and result types are reused. The input table's claimed relation is established by the consuming operation, rather than trusted from its type name or provenance.
