### PR TITLE
fix(finite-fields): authenticate orbit ledgers before aggregation

### DIFF
--- a/src/jacobian/math/finite_fields/operations.py
+++ b/src/jacobian/math/finite_fields/operations.py
@@ -664,7 +664,25 @@ def direction_rank_ledger(
 def orbit_distribution(ledger: DirectionRankLedger) -> OrbitDistribution:
     """Aggregate projective orbit counts from a complete direction-rank ledger."""
 
-    return OrbitDistribution.from_ledger(ledger)
+    if (
+        _direction_rank_work(ledger.subspace, len(ledger.entries))
+        > _MAX_DIRECTION_RANK_WORK
+    ):
+        raise OperationDomainValidationError(
+            location=("ledger",),
+            code="finite_field.orbit_ledger_exceeds_operation_work_budget",
+            message="orbit ledger authentication exceeds the operation work budget",
+        )
+    for index, entry in enumerate(ledger.entries):
+        request_checkpoint("before orbit ledger entry authentication")
+        expected = linear_map_rank(ledger.subspace, entry.direction)
+        if entry.linear_map != expected.linear_map or entry.rank != expected.rank:
+            raise OperationDomainValidationError(
+                location=("ledger", "entries", index),
+                code="finite_field.ledger_entry_matches_source_restriction",
+                message="ledger entry must match the restricted map and rank of its bound source",
+            )
+    return OrbitDistribution._from_kernel(ledger)
 
 
 def finite_polynomial(

--- a/src/jacobian/math/finite_fields/values.py
+++ b/src/jacobian/math/finite_fields/values.py
@@ -1083,8 +1083,8 @@ class OrbitDistribution(StrictModel):
         return self
 
     @classmethod
-    def from_ledger(cls, ledger: DirectionRankLedger) -> Self:
-        return cls(ledger=ledger, counts=_orbit_counts(ledger))
+    def _from_kernel(cls, ledger: DirectionRankLedger) -> Self:
+        return cls.model_construct(ledger=ledger, counts=_orbit_counts(ledger))
 
     @property
     def digest(self) -> str:

--- a/tests/math/finite_fields/test_public_api.py
+++ b/tests/math/finite_fields/test_public_api.py
@@ -8,6 +8,7 @@ from jacobian.math import finite_fields
 from jacobian.math.finite_fields import (
     Axis,
     AxisBoundMatrix,
+    DirectionRankLedger,
     FiniteDimensionalSubspace,
     FiniteFieldElement,
     ProjectiveLine,
@@ -207,6 +208,41 @@ def test_slice_a_keeps_directions_bound_through_orbit_aggregation() -> None:
     assert tuple(entry.rank for entry in ledger.entries) == (3, 3, 3, 3, 3, 3, 4, 4, 4)
     assert distribution.counts == ((1, 9), (8, 48), (16, 12))
     assert distribution.ledger is ledger
+
+
+@pytest.mark.parametrize("mutation", ["rank", "matrix", "direction", "target_axis"])
+def test_orbit_consumer_rejects_a_forged_source_bound_ledger(mutation: str) -> None:
+    subspace, directions = _slice_a_values()
+    ledger = direction_rank_ledger(subspace, directions)
+    payload = ledger.model_dump(mode="json")
+    entries = payload["entries"]
+    if mutation == "rank":
+        entries[0]["rank"] = 0
+    elif mutation == "matrix":
+        entries[0]["linear_map"]["matrix"]["entries"][0][0] ^= 1
+    elif mutation == "direction":
+        entries[0]["direction"], entries[-1]["direction"] = (
+            entries[-1]["direction"],
+            entries[0]["direction"],
+        )
+    else:
+        for entry in entries:
+            entry["linear_map"]["target_axis"]["name"] = "unrelated target"
+    candidate = DirectionRankLedger.model_validate(payload)
+    with pytest.raises(OperationDomainValidationError) as error:
+        orbit_distribution(candidate)
+    assert error.value.errors()[0]["type"] == (
+        "finite_field.ledger_entry_matches_source_restriction"
+    )
+
+
+def test_serialized_rank_ledger_composes_into_orbit_distribution() -> None:
+    subspace, directions = _slice_a_values()
+    ledger = direction_rank_ledger(subspace, directions)
+    candidate = DirectionRankLedger.model_validate_json(ledger.model_dump_json())
+    result = orbit_distribution(candidate)
+    assert result.counts == ((1, 9), (8, 48), (16, 12))
+    assert result.ledger is candidate
 
 
 def test_slice_a_rank_derives_the_restriction_from_its_source() -> None:


### PR DESCRIPTION
## Problem

`finite_field.orbit_distribution.compute` trusts caller-authored ranks and restricted maps. In its published GF(4) example, changing the first zero map's claimed rank from 0 to 1 changes the returned counts from `[[1,9],[2,8]]` to `[[1,5],[2,10]]` without changing the bound action.

Addresses the reproduced regression in #2135. [Current public-boundary evidence](https://github.com/morluto/jacobian/issues/2135#issuecomment-5546741138).

## Outcome

Authenticate every ledger entry against its source subspace and direction using the existing `linear_map_rank` operation before aggregating. The check covers the exact map, source/target axes, and rank. Inconsistent entries receive a typed error locating `ledger.entries[index]`.

The existing total direction-work bound applies before authentication, and each entry observes the current request deadline. No arithmetic implementation or new value type is added. Trusted result construction is private and avoids revalidating the computed result; the unchecked public `OrbitDistribution.from_ledger` shortcut is removed. Native callers use the existing `orbit_distribution` function.

## Validation

- `make handoff-scoped LANE=math TESTS=tests/math/finite_fields PATHS="src/jacobian/math/finite_fields/operations.py src/jacobian/math/finite_fields/values.py tests/math/finite_fields/test_public_api.py"`: scoped Ruff, formatting, mypy, and 88 tests passed.
- `make test-catalog`: 105 passed.
- `make test-integration TESTS=tests/integration/catalog/`: 882 passed.
- Four base-failing regressions independently alter rank, restricted matrix, direction assignments, and the common target axis. Valid producer JSON retains the expected orbit counts and source identity.
- Local MCP: the actual serialized producer ledger succeeds; the changed rank yields the typed source-restriction error.
- Final head tested: 137bf41e982770ec2f098f8b5c222ff39a2cca2a. GitHub CI pending.

## Contract impact

- Public operation ID and request/result schemas are unchanged.
- [x] Derived source relation is established before exact-success aggregation.
- [x] Existing aggregate admission precedes authentication; no separate worker or deadline is introduced.
- [x] Exact output representation is unchanged.
- [x] Native/MCP rejection and serialized producer–consumer composition were tested.
- [x] Defining-invariant and adversarial regressions are covered.
- The unchecked `OrbitDistribution.from_ledger` convenience method is replaced by private kernel construction; no compatibility bypass is retained.

## Review closure

Primary and independent review are complete. The independent review identified the public constructor bypass; it was removed and the reviewer verified the final correction. No unresolved findings remain. Validation covers the final behavioral tree.

### Operation boundary

The finite-field orbit consumer owns recognition. It admits the complete ledger with the existing `_direction_rank_work` bound of 1,000,000, derives one restricted map/rank at a time through the maintained backend, and compares it before aggregation. Only one derived entry is retained at a time. The existing canonical ledger preserves the exact source and direction set; no new representation or generic verification layer is introduced. Result construction computes counts once without replaying source validation.
