### PR TITLE
fix(finite-fields): match axis capacity to prime-field matrices

### DIFF
--- a/src/jacobian/math/finite_fields/values.py
+++ b/src/jacobian/math/finite_fields/values.py
@@ -294,7 +294,7 @@ class Axis(StrictModel):
             raise _validation_error(
                 "finite_field.axis_labels_nonempty", "axis labels must be nonempty"
             )
-        if len(self.labels) > _MAX_VALUE_AXIS_LABELS:
+        if len(self.labels) > MAX_PRIME_FIELD_MATRIX_AXIS:
             raise _validation_error(
                 "finite_field.axis_exceeds_supported_label_bound",
                 "axis exceeds the supported label bound",

--- a/tests/math/finite_fields/test_restriction_capacity.py
+++ b/tests/math/finite_fields/test_restriction_capacity.py
@@ -1,0 +1,66 @@
+"""Restriction output axes use the prime-field matrix capacity."""
+
+import pytest
+
+from jacobian.math.finite_fields import (
+    Axis,
+    AxisBoundMatrix,
+    FiniteDimensionalSubspace,
+    ProjectivePoint,
+    element,
+    finite_field,
+    linear_map_rank,
+    restrict_scalars,
+)
+
+
+def _source(
+    columns: int, modulus: tuple[int, ...]
+) -> tuple[FiniteDimensionalSubspace, ProjectivePoint]:
+    field = finite_field(2, modulus)
+    one = element(field, (1,) + (0,) * (field.degree - 1))
+    rows = Axis(name="rows", labels=("r",))
+    matrix = AxisBoundMatrix(
+        presentation=field,
+        row_axis=rows,
+        column_axis=Axis(name="columns", labels=tuple(f"c{i}" for i in range(columns))),
+        entries=((one,) * columns,),
+    )
+    subspace = FiniteDimensionalSubspace(
+        presentation=field,
+        basis_axis=Axis(name="basis", labels=("B",)),
+        basis=(matrix,),
+    )
+    direction = ProjectivePoint(presentation=field, axis=rows, coordinates=(one,))
+    return subspace, direction
+
+
+@pytest.mark.parametrize(
+    ("columns", "modulus"),
+    [(129, (1, 1, 1)), (128, (1, 1, 0, 1, 1, 0, 0, 0, 1))],
+)
+def test_restricted_axes_reach_the_matrix_capacity(
+    columns: int, modulus: tuple[int, ...]
+) -> None:
+    source, direction = _source(columns, modulus)
+    result = restrict_scalars(source, direction)
+    degree = source.presentation.degree
+    assert len(result.target_axis.labels) == columns * degree
+    assert result.matrix.entries == tuple(
+        (int(i % degree == 0),) for i in range(columns * degree)
+    )
+    assert type(result).model_validate_json(result.model_dump_json()) == result
+    ranked = linear_map_rank(source, direction)
+    assert ranked.rank == 1
+    assert ranked.linear_map == result
+    assert type(ranked).model_validate_json(ranked.model_dump_json()) == ranked
+
+
+def test_source_admission_rejects_expansion_beyond_matrix_capacity() -> None:
+    with pytest.raises(ValueError, match="matrix exceeds the supported axis bound"):
+        _source(129, (1, 1, 0, 1, 1, 0, 0, 0, 1))
+
+
+def test_larger_axis_does_not_expand_extension_matrix_source_capacity() -> None:
+    with pytest.raises(ValueError, match="matrix axes exceed"):
+        _source(257, (1, 1, 1))

--- a/tests/math/finite_fields/test_values.py
+++ b/tests/math/finite_fields/test_values.py
@@ -183,7 +183,7 @@ def test_presentation_rejects_oversized_modulus_length() -> None:
 
 def test_axis_rejects_oversized_label_set() -> None:
     with pytest.raises(ValueError, match="label bound"):
-        Axis(name="large", labels=tuple(f"x{i}" for i in range(257)))
+        Axis(name="large", labels=tuple(f"x{i}" for i in range(1025)))
 
 
 def test_subspace_rejects_oversized_rank_matrix_before_allocation() -> None:


### PR DESCRIPTION
## Problem

Restriction of scalars expands each extension-field coordinate into its prime-field basis coordinates. A valid one-basis matrix with 129 GF(4) columns therefore produces 258 target labels, but `Axis` rejected more than 256 labels during result construction. Native callers received a Pydantic validation failure; MCP returned an execution error.

## Outcome

Raise the shared axis capacity to the existing `MAX_PRIME_FIELD_MATRIX_AXIS` limit of 1,024. The production change is one line; no solver budget, algorithm, or new type is introduced.

Existing source validation already bounds `rows * columns * degree` by 1,024 through its prime-field basis matrix, which also bounds the restricted target's `columns * degree`. No additional operation guard is needed. Extension-matrix axes retain their independent 256-coordinate limit.

## Validation

- `make handoff-scoped LANE=math TESTS=tests/math/finite_fields PATHS="src/jacobian/math/finite_fields/values.py tests/math/finite_fields/test_values.py tests/math/finite_fields/test_restriction_capacity.py"`: Ruff, formatting, mypy, and 87 tests passed.
- `make test-catalog`: 105 passed.
- `make test-integration TESTS=tests/integration/catalog/`: 882 passed.
- Both 258- and 1,024-row output regressions fail against the base's 256-label cap. Final tests verify exact matrix coordinates, rank one, result/rank JSON round trips, the existing rejection of 1,032-coordinate source expansion, and the unchanged 256-column extension-matrix source cap.
- The original 129-column GF(4) request now succeeds through native and local MCP boundaries with all 258 expected zero coordinates.
- Final head tested: 6d922cb2de838983f39fa12afa9b7d36f5daaa3d. CI pending.

## Contract impact

- [x] Exact outputs fit the existing canonical prime-field matrix capacity.
- [x] Oversized source expansion remains rejected before restriction computation.
- [x] Native/MCP agreement and serialized result composition were tested.
- [x] Defining-invariant and boundary regressions are covered.
- `Axis` accepts up to 1,024 labels. Operation IDs, result shapes, backend execution, and deadline handling are unchanged. Specialized containers retain their own bounds.

## Review closure

Primary and independent review are complete. Review confirmed that the proposed additional guard duplicated existing source admission, so it was removed. No unresolved findings remain. Validation covers the final behavioral tree.

### Operation boundary

Canonical finite-field axis capacity now follows its prime-field matrix carrier. Source matrix/subspace admission remains responsible for mathematical work and expansion. The existing finite-field and prime-field kernels, result construction, and serialization are unchanged.
