### PR TITLE
fix(math): repair ten admitted-operation boundary defects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,8 +203,20 @@ representations, maintained specialist backends, and algorithms selected for
 the admitted input regime. A backend limitation must not masquerade as a
 mathematical domain restriction: accept large inputs when predicted work,
 intermediate growth, and exact output remain within budget. Use a fixed cap
-only as a documented conservative fallback when a sharper safe envelope has
-not yet been established.
+only as a documented conservative fallback after investigating how to scale
+the operation, not as a substitute for that work.
+
+**Scale first.** When a valid workload hits an admission limit, first try to
+make it executable: sharpen the estimate, preserve algebraic dependencies,
+reduce the problem exactly, improve its representation, or use a better
+algorithm or maintained backend. A pessimistic upper bound is not evidence
+that the workload is expensive. Probe the motivating rejected case in a
+bounded diagnostic run and check its defining invariant. If it is cheap,
+treat the rejection as an admission defect and retain the case as an accepted
+regression; do not declare the fix complete by adding a rejection test.
+Measurements guide the repair but do not replace a sound work/growth bound.
+If scaling remains unresolved, report the limitation and attempted approaches
+explicitly instead of presenting a narrower domain as the completed fix.
 
 Distinguish decision or first-witness operations from complete profiles and
 all-witness operations: they may inspect the same candidate family but have

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,13 @@ For mathematical changes, review three things before merging:
    as well as an excessive request that is rejected. Rejection tests alone do
    not establish that an operation remains usable.
 
+For an admission or scale defect, scale first: improve the estimate,
+representation, reduction, algorithm, or backend so the motivating valid
+request succeeds. Do not turn a cheaply executable request into a permanent
+rejection regression. Follow the
+[execution-envelope review](docs/reference/public-operation-admission.md#execution-envelope-review)
+before retaining a limit.
+
 Record the applicable evidence in the existing PR description; do not add a
 new review artifact or framework. The
 [operation review](docs/reference/domain-operation-library.md#operation-contract-review),

--- a/docs/reference/backend-known-defects.md
+++ b/docs/reference/backend-known-defects.md
@@ -16,6 +16,36 @@ entry must fail if the backend behavior changes in either direction.
 | Upstream defect | Affected operations | Adapter compensation | Guard tests |
 | --- | --- | --- | --- |
 | [SymPy #10666](https://github.com/sympy/sympy/issues/10666) — `resultant` returns `(-1)^(m*n)` times the true Sylvester determinant when `deg(left) < deg(right)` and both degrees are odd; the subresultant PRS swaps the inputs without recompensing the swap sign. Still present in SymPy 1.14. | `polynomial.multivariate.resultant.compute` (`SYLVESTER_DETERMINANT` convention) | `_sylvester_resultant_value` in `src/jacobian/math/polynomials/multivariate/_resultant.py` negates the backend value under exactly that degree condition. | `tests/math/polynomials/test_multivariate_polynomial.py`: `test_resultant_matches_sylvester_determinant_oracle` (independent determinant oracle), `test_resultant_sign_matches_sylvester_orientation`, `test_resultant_swap_law_with_degenerate_rows`. Remove the compensation when a SymPy release fixes #10666; the swap-law and oracle tests then hold with the compensation deleted. |
+| SymPy 1.14.0 exact simplex returns infeasible candidates: [Jacobian #3194](https://github.com/morluto/jacobian/issues/3194) and [#3192](https://github.com/morluto/jacobian/issues/3192) record the defect; these are local reports, not upstream issue IDs. Matrix `linprog` returns objective 1 at `(0,1)` for `min x+y`, `x+y>=1`, `x>=1`, `y>=1`, although the optimum is 2. Switching from symbolic `lpmin` to `linprog` does not repair the defect. | `optimization.linear.rational_optimum.compute` and `optimization.linear.rational_general_optimum.compute` | `_linear_basis.py` under `src/jacobian/math/optimization` replaces simplex with bounded basis enumeration and FLINT 0.9.0 exact elimination. `operations.py` checks primal/dual feasibility and objective equality, Farkas signs and pairing, or a feasible point and improving nonnegative ray before trusted result construction. Invalid candidates remain execution failures. | `tests/math/optimization/test_linear_certificates.py`: `test_pinned_sympy_matrix_lp_defect` records the exact bad backend answer and fails when it changes. `test_cover_row_order_preserves_exact_optimum`, `test_standard_cover_has_valid_objective_two_certificate`, and `test_pair_cover_original_and_trimmed_encodings` independently check the repaired public certificates. A backend upgrade warrants reassessment, not automatic restoration of the old solve path. |
+
+## Exact LP workload calibration
+
+The LP replacement uses the already-pinned FLINT binding. Maintained exact LP
+alternatives include [SoPlex](https://soplex.zib.de/) and
+[GMP cddlib through pycddlib](https://pycddlib.readthedocs.io/en/stable/);
+adopting either would require an additional native dependency. The finite basis
+families and conservative scalar-update/minor-height bounds are documented in
+`src/jacobian/math/optimization/_linear_basis.py` and exposed through inspection.
+They establish admission; timings do not.
+
+On 2026-09-05, Python 3.12.13 / FLINT 0.9.0 on x86-64 completed five runs of the
+#3192 pair cover at objective 2 in 0.0048–0.0054 seconds for ten source variables
+and 0.0060–0.0068 seconds for the original fifteen-variable encoding. These
+measurements include parsing, normalization, solving, source mapping, and JSON
+serialization. Both reserve 12,376 bases and 32,088,000 scalar updates after
+removing unused columns.
+
+A full-rank six-row, seventeen-column Vandermonde control with negative RHS
+forces all 12,376 original bases to fail feasibility before phase I. Its complete
+reservation is 18,564 bases and 49,909,832 updates, just below the 50,000,000
+update limit; it completed in 0.236 seconds with small coefficients. Replacing
+its nodes by `10**24+j+1` gives coefficients up to 121 digits and completed in
+0.430 seconds including serialization. The LP-specific 600-second safety
+deadline leaves over a thousandfold margin over these measurements for other
+admitted coefficient regimes and host variation. It is cooperative between
+bounded FLINT primitives, not a hard interruption inside a native matrix call.
+Normalization, both searches, certificate construction and dispatch projection
+share the original request deadline; no phase receives a fresh allowance.
 
 ## Adding an entry
 

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -681,6 +681,15 @@ kernel. Measurements show usefulness; the mathematical work and growth
 analysis remains the safety proof. Name each enforced budget in code and make
 rejections identify the controlling quantity that was exceeded.
 
+Scale first when an estimate rejects a motivating valid workload. Preserve
+relationships between intermediates, reduce the problem exactly, or improve
+the representation, algorithm, or backend before retaining the restriction.
+A sound but grossly pessimistic estimate can still be a product defect. Follow
+the [execution-envelope review](public-operation-admission.md#execution-envelope-review):
+a cheaply executable rejected case must become an accepted regression, not a
+new permanent rejection test. Report an unresolved scaling limitation as
+unfinished work rather than claiming that narrowing admission fixed it.
+
 ### Finite enumeration budgets
 
 Large finite enumeration is compatible with a bounded exact operation. Admit it

--- a/docs/reference/public-operation-admission.md
+++ b/docs/reference/public-operation-admission.md
@@ -64,7 +64,9 @@ global geometry or PDE workflow is not thereby defined.
 Keep the public mathematical postcondition as broad as its semantics permit.
 An implementation or backend limit describes the current admitted execution
 envelope; it does not redefine the mathematical objects to which the operation
-applies. Before adopting a small fixed input cap, complete this review:
+applies. **Scale first:** investigate how to execute the motivating valid
+workload before restricting admission. This applies to derived work, height,
+and storage estimates as well as fixed input caps. Complete this review:
 
 1. Identify the quantities that control work, intermediate growth, and exact
    output. Use quantities such as operand digits, coefficient height, degree,
@@ -93,9 +95,11 @@ applies. Before adopting a small fixed input cap, complete this review:
 6. Define request admission from the selected algorithm's work,
    intermediate, memory, and result bounds. Large scalar inputs should remain
    admissible when those derived quantities and the returned value are small.
-7. Document any remaining fixed ceiling as a conservative fallback. State
-   whether it is a mathematical, representation, backend, or currently
-   uninvestigated limit, and identify the evidence needed to raise it.
+7. Retain a restrictive ceiling only after investigating sharper bounds,
+   exact reductions, representations, algorithms, and maintained backends.
+   Document the remaining bottleneck, the approaches tried, and the evidence
+   needed to raise it. Calling a limit "conservative" or "uninvestigated"
+   does not discharge that investigation or complete a scale fix.
 8. Test accepted and rejected boundaries, algorithm or representation
    crossover points, and realistic source-backed cases. Exercise at least one
    motivating request through the final public boundary. Boundary-rejection
@@ -119,6 +123,22 @@ branches may also be too coarse for the intended workload even when it is
 mathematically valid. Improve the analysis, presolve, or algorithm when needed;
 a compact answer alone does not prove bounded runtime, and increasing a digit
 cap does not repair an estimate that grows needlessly at every step.
+
+When changing admission, freeze the motivating rejected input and compare the
+estimate with a bounded diagnostic execution of the selected kernel. Record
+the reduced problem, measured work or time, available intermediate/output
+sizes, and an independent defining-invariant check. Keep measurements distinct
+from proved bounds; a returned transform's size, for example, does not measure
+every intermediate used to obtain it. A cheap correct execution disproves the
+claim that rejection is a necessary practical limit, even though it does not
+prove a safe envelope for the whole domain.
+
+Such a case is an admission-precision regression: improve the analysis or
+kernel and require the final public operation to accept it. Do not special-case
+the fixture, raise constants without a justified analysis, or change the test
+to expect resource rejection. If no sound scalable repair is established,
+report the work as incomplete with the remaining limitation and attempted
+approaches; a safer rejection is not the requested scale improvement.
 
 A timeout, cancellation, resource exhaustion, or backend `UNKNOWN` result is
 an execution outcome, never a negative mathematical conclusion. If the public

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -395,6 +395,17 @@ with a source-backed accepted case even when its public dimensions are small.
 A compact request can still be the decisive scale fixture when private
 normalization, expansion, or backend representation makes it expensive.
 
+For an admission-precision defect, preserve the motivating valid request as an
+**accepted** public regression with a defining-invariant check. First compare
+the estimate against a bounded real-backend diagnostic; do not infer expense
+from the estimate being tested. If the computation is cheap, a test expecting
+resource rejection would freeze the defect rather than fix it. Exercise
+related sizes, nontrivial structures, and equivalent presentations so the
+repair scales a mathematical regime instead of recognizing one fixture.
+Keep timing measurements out of brittle unit-test thresholds and separate
+measured output sizes from proved intermediate bounds. See the
+[scale-first admission review](public-operation-admission.md#execution-envelope-review).
+
 Use a source-backed reference fixture when a standard example helps fix
 terminology, normalization, or another convention-sensitive output. Cite the
 specific theorem or example and record the convention the fixture depends on.

--- a/src/jacobian/math/algebra/__init__.py
+++ b/src/jacobian/math/algebra/__init__.py
@@ -1,0 +1,3 @@
+"""Exact algebra operation ownership and native subdomains."""
+
+__all__: list[str] = []

--- a/src/jacobian/math/analysis/orthogonal_polynomials/_jacobi.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/_jacobi.py
@@ -23,6 +23,114 @@ def _from_fraction(value: Fraction) -> CanonicalRational:
     return CanonicalRational.from_fraction(value)
 
 
+def require_three_term_identities(
+    family: OrthogonalPolynomialFamily,
+    alphas: list[Fraction],
+    betas: list[Fraction],
+) -> None:
+    """Establish the complete finite three-term identities of one family.
+
+    For every ``k`` with ``p_{k+1}`` supplied, ``x*p_k - p_{k+1}`` must equal
+    ``alpha_k*p_k + beta_k*p_{k-1}`` coefficient-wise (with ``p_{-1} = 0`` and
+    ``beta_0 = 0``). Checking only the ``x^k`` coefficient (which defines
+    ``alpha_k``) or only the norm ratios (which define ``beta_k``) accepts
+    families whose remaining coefficients contradict the emitted recurrence.
+    This finite prerequisite is shared by the recurrence and Jacobi consumers;
+    callers map the ``ValueError`` to their owner-local admission error.
+    """
+
+    polys = [
+        [coefficient.as_fraction() for coefficient in term.coefficients]
+        for term in family.polynomials
+    ]
+    n = len(polys)
+    if len(alphas) != max(n - 1, 0) or len(betas) < len(alphas):
+        raise ValueError("recurrence coefficient dimensions do not match the family")
+    if n >= 1 and len(betas) > 0 and betas[0] != Fraction(0):
+        raise ValueError("beta[0] must be the unused zero placeholder")
+    for k in range(len(alphas)):
+        p_k = polys[k]
+        p_next = polys[k + 1]
+        x_pk = [Fraction(0)] * (len(p_k) + 1)
+        for i, coefficient in enumerate(p_k):
+            x_pk[i + 1] = coefficient
+        width = max(len(x_pk), len(p_next))
+        lhs = [
+            (x_pk[i] if i < len(x_pk) else Fraction(0))
+            - (p_next[i] if i < len(p_next) else Fraction(0))
+            for i in range(width)
+        ]
+        alpha_k = alphas[k]
+        beta_k = betas[k]
+        rhs = [Fraction(0)] * width
+        for i, coefficient in enumerate(p_k):
+            if i < width:
+                rhs[i] += alpha_k * coefficient
+        if k > 0:
+            p_prev = polys[k - 1]
+            for i, coefficient in enumerate(p_prev):
+                if i < width:
+                    rhs[i] += beta_k * coefficient
+        if lhs != rhs:
+            raise ValueError(
+                f"family polynomials contradict the three-term recurrence at k={k}: "
+                "x*p_k - p_{k+1} differs from alpha_k*p_k + beta_k*p_{k-1}"
+            )
+
+
+def _derive_jacobi_coefficients(
+    family: OrthogonalPolynomialFamily,
+) -> tuple[list[Fraction], list[Fraction]]:
+    """Derive the exact alpha/beta lists emitted by the Jacobi kernel."""
+
+    polys = family.polynomials
+    n = len(polys)
+    alphas: list[Fraction] = []
+    betas: list[Fraction] = []
+    for k in range(n - 1):
+        p_k = [coefficient.as_fraction() for coefficient in polys[k].coefficients]
+        p_next = [
+            coefficient.as_fraction() for coefficient in polys[k + 1].coefficients
+        ]
+        if k == 0:
+            alphas.append(-p_next[0])
+            betas.append(Fraction(0))
+        else:
+            x_pk = [Fraction(0)] * (len(p_k) + 1)
+            for i, coefficient in enumerate(p_k):
+                x_pk[i + 1] = coefficient
+            residual = [
+                x_pk[i] - p_next[i] if i < len(p_next) else x_pk[i]
+                for i in range(len(x_pk))
+            ]
+            alphas.append(residual[k] if k < len(residual) else Fraction(0))
+            betas.append(
+                polys[k].squared_norm.as_fraction()
+                / polys[k - 1].squared_norm.as_fraction()
+            )
+    return alphas, betas
+
+
+def _require_compatible_or_raise(family: OrthogonalPolynomialFamily) -> None:
+    """Reject families whose coefficients contradict their norm ratios."""
+
+    if len(family.polynomials) < 2:
+        return
+    try:
+        alphas, betas = _derive_jacobi_coefficients(family)
+        require_three_term_identities(family, alphas, betas)
+    except ValueError as exc:
+        # Preserve zero-division diagnostics raised for vanishing norms;
+        # only compatibility failures are mapped here (admission already
+        # rejects undefined ratios above).
+        if "contradict" not in str(exc) and "dimensions" not in str(exc):
+            raise
+        raise JacobiMatrixAdmissionError(
+            "incompatible_family",
+            str(exc),
+        ) from None
+
+
 def require_jacobi_matrix_admission(family: OrthogonalPolynomialFamily) -> None:
     """Bound every exact entry emitted by the Jacobi-matrix kernel.
 
@@ -73,6 +181,7 @@ def require_jacobi_matrix_admission(family: OrthogonalPolynomialFamily) -> None:
                 "digit limit; supply a family whose squared norm ratios stay "
                 "representable",
             )
+    _require_compatible_or_raise(family)
 
 
 def jacobi_matrix_from_family(family: OrthogonalPolynomialFamily) -> JacobiMatrix:
@@ -110,7 +219,21 @@ def jacobi_matrix_from_family(family: OrthogonalPolynomialFamily) -> JacobiMatri
                 for i in range(len(x_pk))
             ]
             alphas.append(residual[k] if k < len(residual) else Fraction(0))
-            betas.append(squared_norm_k / squared_norm_prev)
+            try:
+                betas.append(squared_norm_k / squared_norm_prev)
+            except ZeroDivisionError:
+                raise JacobiMatrixAdmissionError(
+                    "norm_ratio",
+                    f"adjacent-norm ratio beta_{k} is undefined because squared "
+                    "norm h_{k-1} vanishes",
+                ) from None
+    try:
+        require_three_term_identities(family, alphas, betas)
+    except ValueError as exc:
+        raise JacobiMatrixAdmissionError(
+            "incompatible_family",
+            str(exc),
+        ) from None
 
     matrix_size = n - 1
     matrix = [[Fraction(0)] * matrix_size for _ in range(matrix_size)]

--- a/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
@@ -9,6 +9,7 @@ from jacobian.math._rational_height import RationalHeight
 from jacobian.math.analysis.orthogonal_polynomials._jacobi import (
     jacobi_matrix_from_family,
     require_jacobi_matrix_admission,
+    require_three_term_identities,
 )
 from jacobian.math.analysis.orthogonal_polynomials.values import (
     MAX_HANKEL_ORDER,
@@ -434,6 +435,13 @@ def recurrence_coefficients_from_family(
                 "recurrence coefficients exceed the canonical rational "
                 "digit limit for this family",
             )
+    try:
+        require_three_term_identities(family, alphas, betas)
+    except ValueError as exc:
+        raise MomentsOrthogonalAdmissionError(
+            "incompatible_family",
+            str(exc),
+        ) from None
     return ThreeTermRecurrence._from_kernel(
         alpha=tuple(_from_fraction(a) for a in alphas),
         beta=tuple(_from_fraction(b) for b in betas),

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_models.py
@@ -276,13 +276,17 @@ class HypergraphIndependenceRequest(StrictModel):
     """One finite hypergraph and its operation-owned exact-search budget.
 
     Hyperedges must be nonempty. The source carrier has its own representation
-    envelope; this operation independently admits only Boolean encodings of at
-    most 100 vertices and 10,000 incidences before invoking the private backend.
+    envelope. Sources whose singleton-forbidden vertices hit every edge are
+    solved directly throughout that envelope, including edgeless sources.
+    Other sources admit Boolean encodings of at most 100 vertices and 10,000
+    incidences before invoking the private backend.
     """
 
     hypergraph: FiniteHypergraph = Field(
         description=(
-            "Canonical finite hypergraph. The Z3 threshold search separately "
+            "Canonical finite hypergraph. Edgeless sources and sources whose "
+            "singleton-forbidden vertices hit every edge are solved directly "
+            "throughout the carrier envelope. The Z3 threshold search separately "
             f"admits at most {MAX_HYPERGRAPH_INDEPENDENCE_VERTICES} vertices "
             f"and {MAX_HYPERGRAPH_INDEPENDENCE_INCIDENCES} incidences."
         )

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/operations.py
@@ -50,7 +50,7 @@ __all__ = [
 ]
 
 
-def _admit_independence(hypergraph: FiniteHypergraph) -> None:
+def _admit_independence(hypergraph: FiniteHypergraph) -> tuple[str, ...] | None:
     if any(not members for _, members in hypergraph.edges):
         raise OperationDomainValidationError(
             location=("hypergraph",),
@@ -58,6 +58,18 @@ def _admit_independence(hypergraph: FiniteHypergraph) -> None:
             message="independence-number search does not admit empty edges",
         )
     total_incidences = sum(len(members) for _, members in hypergraph.edges)
+    # The canonical carrier bounds this linear scan by 256 vertices,
+    # 12,000 edges and 36,000 incidences. Singleton constraints force these
+    # exclusions; if they hit every edge, all remaining vertices attain the
+    # resulting upper bound. No greedy scan or solver encoding is needed.
+    forbidden = {members[0] for _, members in hypergraph.edges if len(members) == 1}
+    if all(
+        any(vertex in forbidden for vertex in members)
+        for _, members in hypergraph.edges
+    ):
+        return tuple(
+            vertex for vertex in hypergraph.vertices if vertex not in forbidden
+        )
     if len(hypergraph.vertices) > MAX_HYPERGRAPH_INDEPENDENCE_VERTICES:
         raise OperationDomainValidationError(
             location=("hypergraph",),
@@ -76,6 +88,7 @@ def _admit_independence(hypergraph: FiniteHypergraph) -> None:
                 f"{MAX_HYPERGRAPH_INDEPENDENCE_INCIDENCES}-incidence solver bound"
             ),
         )
+    return None
 
 
 def _admit_dual(hypergraph: FiniteHypergraph) -> None:
@@ -182,12 +195,26 @@ def independence_number(
 ) -> HypergraphIndependenceResult:
     """Return an exact optimum or source-bound incumbent and sound bounds."""
 
+    resource_budget = resource_budget or HypergraphIndependenceBudget()
+    trivial_witness = _admit_independence(hypergraph)
+    if trivial_witness is not None:
+        return HypergraphIndependenceResult._from_kernel(
+            hypergraph=hypergraph,
+            resource_budget=resource_budget,
+            status="EXACT",
+            independence_number=len(trivial_witness),
+            incumbent_vertices=trivial_witness,
+            upper_bound=len(trivial_witness),
+            solver_calls=0,
+            wall_budget_exhausted=False,
+            termination_reason="SPECIAL_CASE",
+            detail="singleton-forbidden vertices hit every edge; all other vertices form a maximum independent set",
+        )
+
     from jacobian.math.combinatorics.finite_structures.hypergraphs import (
         _independence_z3,
     )
 
-    resource_budget = resource_budget or HypergraphIndependenceBudget()
-    _admit_independence(hypergraph)
     return _independence_z3.solve_independence_number(hypergraph, resource_budget)
 
 

--- a/src/jacobian/math/combinatorics/posets/core/_models.py
+++ b/src/jacobian/math/combinatorics/posets/core/_models.py
@@ -10,8 +10,13 @@ from pydantic import Field, StrictInt, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._digest import Sha256Digest
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.canonical import canonicalize_json
+from jacobian.canonical import (
+    canonicalize_json,
+    format_canonical_integer,
+    parse_canonical_integer,
+)
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -533,7 +538,20 @@ class LinearExtensionRequest(StrictModel):
 
 
 class LinearExtensionCountResult(StrictModel):
-    count: StrictInt = Field(ge=1)
+    count: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_count(self) -> Self:
+        if parse_canonical_integer(self.count) < 1:
+            raise _validation_error(
+                "linear_extension_count_positive",
+                "linear-extension count must be positive",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(cls, count: int) -> Self:
+        return cls.model_construct(count=format_canonical_integer(count))
 
 
 class PosetInterval(StrictModel):

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -263,9 +263,7 @@ def linear_extension_count(poset: FinitePoset) -> LinearExtensionCountResult:
         )
         count = sum(counts[mask ^ (1 << index[element])] for element in removable)
         counts[mask] = count
-    return LinearExtensionCountResult(
-        count=counts[subset_count - 1],
-    )
+    return LinearExtensionCountResult._from_kernel(counts[subset_count - 1])
 
 
 def mobius_function(

--- a/src/jacobian/math/graphs/chip_firing/_hermite.py
+++ b/src/jacobian/math/graphs/chip_firing/_hermite.py
@@ -1,0 +1,135 @@
+"""Deterministic exact quotient preprocessing inside the supervised worker."""
+
+from __future__ import annotations
+
+import time
+
+from jacobian._execution import OperationExecutionTimeoutError, request_checkpoint
+
+
+def _column_hermite(matrix: list[list[int]], determinant: int) -> list[list[int]]:
+    """Lower column HNF via the pinned deterministic modular algorithm.
+
+    SymPy 1.14's hermite_normal_form(D=delta, check_rank=False) uses
+    Cohen Algorithm 2.4.8, not the unbounded randomized FLINT HNF dispatcher.
+    The source is nonsingular and delta is its determinant; unit elimination
+    preserves delta. Simultaneously reversing rows/columns changes SymPy's
+    upper column convention to the lower convention used by this adapter.
+
+    With B=max(delta, max|entry|), b=bit_length(B), the pinned algorithm has
+    <=n(n+1)/2 extended-gcd calls and O(n^3) scalar updates. Euclid takes
+    <=2b+1 quotient steps. A updates are reduced modulo R<=delta, so temporary
+    products are <=2B^2. W column reductions have at most n updates per column,
+    each multiplying its magnitude by <=1+delta: |W|<=delta*(1+delta)^n.
+    Thus 32*n^3+32*n^2*(b+1) integer-ring operations and
+    (n+2)*(b+1) bits per scalar conservatively cover this HNF, including
+    Euclidean arithmetic. The original graph determinant is <=50^48;
+    all subsequent matrices and reduced divisors have entries <=delta.
+    No randomized retries or estimated Smith branches enter this bound.
+
+    https://docs.sympy.org/latest/modules/matrices/normalforms.html
+    """
+    from sympy import Matrix
+    from sympy.matrices.normalforms import hermite_normal_form
+
+    n = len(matrix)
+    reverse = Matrix([row[::-1] for row in matrix[::-1]])
+    hnf = hermite_normal_form(reverse, D=determinant, check_rank=False)
+    request_checkpoint("after determinant-modular Hermite form")
+    return [[int(hnf[n - 1 - i, n - 1 - j]) for j in range(n)] for i in range(n)]
+
+
+def prepare_smith_coordinates(
+    matrix: list[list[int]], divisor: list[int], deadline: float
+) -> tuple[list[list[int]], list[int], int]:
+    """Compute each reduction once and admit only the remaining Smith work."""
+    from flint import fmpz_mat
+
+    from jacobian.math.graphs.chip_firing._smith_bounds import admit_smith_residual
+
+    request_checkpoint("before Hermite quotient preprocessing")
+    # Exact determinant, not a probabilistic estimate. The public owner
+    # established a connected graph, so this reduced Laplacian is nonsingular.
+    determinant = int(fmpz_mat(matrix).det())
+    request_checkpoint("after the reduced-Laplacian determinant")
+    hnf = _column_hermite(matrix, determinant)
+    residual, image = _reduce_hermite_units(hnf, divisor, determinant, deadline)
+    request_checkpoint("after Hermite quotient preprocessing")
+    admit_smith_residual(residual, determinant)
+    return residual, image, len(matrix) - len(residual)
+
+
+def _reduce_hermite_units(
+    matrix: list[list[int]], divisor: list[int], determinant: int, deadline: float
+) -> tuple[list[list[int]], list[int]]:
+    """Remove trivial quotient directions in both Hermite orientations.
+
+    Every repeated pass removes at least one coordinate, so an n-square
+    input uses at most 2n Hermite forms and n nonsingular rational solves.
+    The matrices entering each pass are column HNF, with entries <=delta,
+    and divisor entries are reduced modulo delta. Here delta<=50**48 for
+    admitted graphs. Row HNF R=U*C has the same entry bound. We transport
+    only the divisor, R*(C^-1*d), never materialize U. Fraction-free solve
+    stored entries are bounded minors of [C|d]: Hadamard gives
+    H=(sqrt(n)*delta)**n. Pre-division products are bounded by 2*H**2,
+    and the final product adds at most a factor n*delta to H.
+    Thus these bounded reductions scale with n and log(delta), not a
+    recursively inflated estimate for hypothetical Smith transformations.
+
+    SymPy owns determinant-modular HNF and FLINT owns fraction-free
+    elimination; the adapter only removes
+    unit blocks and carries their exact quotient maps. Backend domains:
+    https://python-flint.readthedocs.io/en/latest/fmpz_mat.html
+    https://python-flint.readthedocs.io/en/latest/fmpq_mat.html
+    """
+    from flint import fmpq_mat
+
+    while matrix:
+        request_checkpoint("during Hermite quotient reduction")
+        if time.monotonic() >= deadline:
+            raise OperationExecutionTimeoutError(
+                "request deadline expired during Hermite quotient reduction"
+            )
+        n = len(matrix)
+        units = [i for i in range(n) if matrix[i][i] == 1]
+        retained = [i for i in range(n) if matrix[i][i] != 1]
+        # In column HNF the unit rows are elementary: after simultaneous
+        # reordering C=[[I,0],[B,C1]], so d1=d_tail-B*d_head.
+        # delta*Z^n lies in C*Z^n by the adjugate identity.
+        residues = [value % determinant for value in divisor]
+        divisor = [
+            (residues[i] - sum(matrix[i][j] * residues[j] for j in units)) % determinant
+            for i in retained
+        ]
+        matrix = [[matrix[i][j] for j in retained] for i in retained]
+        n = len(matrix)
+        if n <= 1:
+            break
+
+        transposed = [list(row) for row in zip(*matrix, strict=True)]
+        row_hnf = [
+            list(row)
+            for row in zip(*_column_hermite(transposed, determinant), strict=True)
+        ]
+        request_checkpoint("after row-Hermite quotient reduction")
+        retained = [i for i in range(n) if row_hnf[i][i] != 1]
+        if len(retained) == n:
+            break
+        # Row HNF has elementary unit columns: R=[[I,B],[0,C1]].
+        # Column elimination of B leaves the transported d_tail unchanged.
+        solution = fmpq_mat(matrix).solve(  # type: ignore[call-arg]  # python-flint 0.9 stubs omit algorithm.
+            fmpq_mat([[v] for v in divisor]), algorithm="fflu"
+        )
+        transported = fmpq_mat(row_hnf) * solution
+        request_checkpoint("after transporting the Hermite divisor")
+        # R*C^-1 is unimodular, so every transported coordinate is integral.
+        if any(transported[i, 0].denominator != 1 for i in retained):
+            raise RuntimeError("Hermite quotient transport was not integral")
+        divisor = [int(transported[i, 0].numerator) % determinant for i in retained]
+        if not retained:
+            return [], []
+        smaller = [[row_hnf[i][j] for j in retained] for i in retained]
+        matrix = _column_hermite(smaller, determinant)
+        # The next pass has strictly fewer coordinates, not a retry of the
+        # same Smith request or a replay of a completed decomposition.
+    return matrix, divisor

--- a/src/jacobian/math/graphs/chip_firing/_models.py
+++ b/src/jacobian/math/graphs/chip_firing/_models.py
@@ -196,7 +196,7 @@ class SinkConfiguration(StrictModel):
 
 
 class StabilizeRequest(StrictModel):
-    """Stabilize a sink configuration."""
+    """Stabilize a sink configuration; every vertex must reach the sink."""
 
     configuration: SinkConfiguration
 
@@ -223,7 +223,7 @@ class ParallelStepResult(StrictModel):
 
 
 class QReducedRequest(StrictModel):
-    """Compute the q-reduced normal form of a divisor."""
+    """q-reduced form on a connected graph; coefficients have at most 1000 digits."""
 
     graph: _ChipFiringGraph
     divisor: tuple[int, ...] = Field(min_length=1)
@@ -295,7 +295,12 @@ class CriticalGroupResult(StrictModel):
 
 
 class AbelJacobiRequest(StrictModel):
-    """Map a degree-zero divisor into the critical group."""
+    """Connected-graph critical-group map; coefficients have at most 1000 digits.
+
+    The column-HNF residual must satisfy the conservative Smith transformation
+    work and intermediate-height envelope; graph order alone does not decide
+    resource admission.
+    """
 
     graph: _ChipFiringGraph
     divisor: tuple[int, ...] = Field(min_length=1)
@@ -317,7 +322,14 @@ class AbelJacobiRequest(StrictModel):
 
 
 class AbelJacobiResult(StrictModel):
-    """The critical-group coordinates of a degree-zero divisor."""
+    """Smith coordinates after successive Hermite unit reductions.
+
+    Column HNF preserves the column lattice; its unit block transports D
+    to D_tail-B*D_head. Row HNF R=U*C transports D to R*C^-1*D before
+    discarding unit coordinates. Retained indices keep their relative order.
+    Repeat only when dimension decreases, then use the pinned SymPy Smith
+    basis of the residual. Unit factors contribute no coordinates.
+    """
 
     sink: str
     nonsink_vertices: tuple[str, ...]

--- a/src/jacobian/math/graphs/chip_firing/_smith_bounds.py
+++ b/src/jacobian/math/graphs/chip_firing/_smith_bounds.py
@@ -1,0 +1,143 @@
+"""Preflight bounds for the pinned SymPy 1.14 Smith transformation kernel.
+
+HNF preprocessing and unit elimination are computed once and retained by the
+caller. These bounds inspect the residual; they do not simulate or replay SNF.
+"""
+
+from dataclasses import dataclass
+from itertools import pairwise
+
+from jacobian.catalog.models import OperationResourceAdmissionError
+
+# Separate arithmetic work, integer height, and live mathematical storage.
+# These conservative ceilings admit the full 50-vertex cycle/complete families
+# and large cyclic/two-generator residuals without claiming arbitrary Smith
+# transformations have the complexity of FLINT's diagonal-only algorithm.
+MAX_SMITH_WORK = 250_000_000
+MAX_SMITH_BITS = 4_000_000
+MAX_SMITH_STORAGE_BITS = 1 << 31
+
+
+@dataclass(frozen=True)
+class SmithEnvelope:
+    work: int
+    bits: int
+
+
+def _exceeded() -> SmithEnvelope:
+    return SmithEnvelope(MAX_SMITH_WORK + 1, MAX_SMITH_BITS + 1)
+
+
+def _two_by_two_bound(bits: int, determinant_bits: int) -> SmithEnvelope:
+    """Exploit nonsingularity to bound the last Euclidean block sharply.
+
+    Clearing the first column of [[a,b],[c,d]] gives [[g,t],[0,delta/g]],
+    where g=gcd(a,c) divides delta=det(A), |t|<=2*B**2, and the first
+    Bezout transform has entries <=B. Clearing that row either diagonalizes
+    it or gives [[g',0],[y*delta/g,-delta/g']], where |y|<=g/g'. Thus after
+    this first column/row pair every matrix entry is <=|delta|. Subsequent
+    column-clearing intermediates are <=2*delta**2 and each further pair
+    strictly reduces the pivot, allowing at most bit_length(delta) pairs.
+    Multiplying their transforms (and the final divisibility repair) gives
+    the deliberately loose 8*b + 16*d**2 bit bound below. Euclidean quotient
+    work is linear in operand bits, including the initial B-sized column.
+    """
+    return SmithEnvelope(
+        128 * (bits + 1 + (determinant_bits + 1) ** 2),
+        8 * (bits + 1) + 16 * (determinant_bits + 1) ** 2,
+    )
+
+
+def _recursive_bound(
+    n: int, bits: int, pivot_bits: int, determinant_bits: int
+) -> SmithEnvelope:
+    """Bound Euclidean clearing, recursive products, and divisibility repairs.
+
+    In SymPy 1.14 each elementary update has coefficients at most the
+    current maximum magnitude B (division or Bezout), and maps B to at most
+    2*B**2. Each pass has <=2(n-1) updates. A further pass strictly reduces
+    the positive pivot to a proper divisor, so <=pivot_bits passes suffice.
+    The recursive trailing matrix has the resulting entry bound. Embedding
+    and multiplying its transforms costs <=4*n**3 scalar operations; summing
+    products adds ceil(log2(n)) bits. At this level <=n-1 divisibility repairs
+    use three row and two column updates, with coefficients bounded by the
+    determinant: every partial diagonal factor divides its product.
+    """
+    if n <= 1:
+        return SmithEnvelope(1, max(1, bits))
+    if n == 2:
+        return _two_by_two_bound(bits, determinant_bits)
+    updates = 2 * (n - 1) * max(1, pivot_bits)
+    if updates >= MAX_SMITH_BITS.bit_length():
+        return _exceeded()
+    cleared = (bits + 1) * (1 << updates)
+    if cleared > MAX_SMITH_BITS:
+        return _exceeded()
+    child = _recursive_bound(n - 1, cleared, cleared, determinant_bits)
+    height = (
+        child.bits + cleared + n.bit_length() + 3 * (n - 1) * (determinant_bits + 2)
+    )
+    # Extended Euclid on b-bit operands needs O(b) quotient steps, each
+    # using a bounded number of integer-ring operations. Include those
+    # steps as well as matrix updates; this is not a bit-operation count.
+    work = child.work + 12 * updates * (n * n + cleared + 1) + 4 * n**3 + 30 * n * n
+    return SmithEnvelope(work, height)
+
+
+def admit_smith_residual(matrix: list[list[int]], determinant: int) -> SmithEnvelope:
+    """Admit a nonsingular lower column-HNF residual before SymPy expansion."""
+    n = len(matrix)
+    bits = max((abs(v).bit_length() for row in matrix for v in row), default=1)
+    det_bits = determinant.bit_length()
+    # For this visible triangular class, every column clears by exact
+    # division and the trailing matrix is unchanged. The only possible gcd
+    # updates are final diagonal divisibility repairs. There are <=n(n-1)/2
+    # repairs in the whole recursion, each with coefficients <=determinant.
+    # Unit triangular elimination has coefficient bound (1+n*B)**n.
+    divisible = all(
+        matrix[i][j] % matrix[j][j] == 0 for j in range(n) for i in range(j + 1, n)
+    )
+    if divisible:
+        diagonal = [matrix[i][i] for i in range(n)]
+        ordered = all(b % a == 0 for a, b in pairwise(diagonal))
+        repairs = 0 if ordered else n * (n - 1) // 2
+        # A diagonal matrix needs no clearing transforms at all; in
+        # particular a Smith diagonal keeps both transformations equal to I.
+        clearing_bits = (
+            (n + 1) * (bits + n.bit_length() + 2)
+            if any(matrix[i][j] for j in range(n) for i in range(j + 1, n))
+            else bits
+        )
+        envelope = SmithEnvelope(
+            20 * max(1, n) ** 4 + 12 * repairs * (det_bits + 1),
+            clearing_bits + 3 * repairs * (det_bits + 2),
+        )
+    else:
+        envelope = _recursive_bound(n, bits, matrix[0][0].bit_length(), det_bits)
+    # The worker also multiplies the left transform by a vector reduced
+    # modulo determinant. Reserve its products and accumulation explicitly.
+    envelope = SmithEnvelope(
+        envelope.work + 2 * n * n, envelope.bits + det_bits + n.bit_length() + 1
+    )
+    # Recursive sources, both transforms, embedded products, and temporaries
+    # occupy O(n^3) integer slots; 12*n^3 is a conservative retained-slot
+    # bound for this implementation. Include multiplication temporaries by
+    # doubling the entry bound. This is distinct from worker address space.
+    storage = 24 * max(1, n) ** 3 * envelope.bits
+    if (
+        envelope.bits > MAX_SMITH_BITS
+        or envelope.work > MAX_SMITH_WORK
+        or storage > MAX_SMITH_STORAGE_BITS
+    ):
+        raise OperationResourceAdmissionError(
+            location=("graph",),
+            code="chip_firing.smith_transform_bound",
+            message=(
+                "column-HNF residual exceeds the conservative Smith transformation bound "
+                f"(dimension={n}; work={envelope.work}/{MAX_SMITH_WORK}; "
+                f"intermediate_bits={envelope.bits}/{MAX_SMITH_BITS}; "
+                f"storage_bits={storage}/{MAX_SMITH_STORAGE_BITS}; "
+                "estimates saturate when excessive)"
+            ),
+        )
+    return envelope

--- a/src/jacobian/math/graphs/chip_firing/_snf_process.py
+++ b/src/jacobian/math/graphs/chip_firing/_snf_process.py
@@ -1,4 +1,4 @@
-"""Killable FLINT SNF process boundary for chip-firing critical groups."""
+"""Killable exact normal-form boundary for chip-firing critical groups."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import hashlib
 import math
 import sys
 import time
+from itertools import pairwise
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -14,6 +15,7 @@ from jacobian._execution import (
     OperationExecutionTimeoutError,
     bind_request_deadline,
     current_request_execution,
+    request_checkpoint,
 )
 from jacobian.canonical import (
     CanonicalizationError,
@@ -22,24 +24,60 @@ from jacobian.canonical import (
     loads_strict_json,
     parse_canonical_integer,
 )
+from jacobian.catalog.models import OperationResourceAdmissionError
 
 _SNF_WORKER = Path(__file__).resolve().with_name("_snf_worker.py")
 # Admitted reduced Laplacians satisfy dimension**3 <= 1_500_000. FLINT's
 # exact integer SNF on that envelope finishes well under a minute; keep a
 # generous killable ceiling so one stalled backend cannot outlive the request.
 _SNF_WALL_SECONDS = 120.0
+# HNF normalization, residue reduction, transformation admission, worker and
+# decoding share this one ceiling. It is a killable safety limit, not the
+# mathematical work bound (which lives in _smith_bounds).
+_COORDINATE_WALL_SECONDS = 600.0
 _SNF_STDERR_LIMIT = 64 * 1024
 _SNF_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
 _SNF_FILE_SIZE_BYTES = 1024 * 1024
+_SNF_DIAGNOSTIC_CHARS = 1024
 
 
 def smith_normal_form_diagonal(matrix: list[list[int]]) -> tuple[int, ...]:
     """Return the SNF diagonal through a deadline-bound killable FLINT worker."""
+    return _smith_projection(matrix, None)[0]
+
+
+def smith_coordinates(
+    matrix: list[list[int]], divisor: list[int]
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Compute the full exact quotient map inside one killable worker."""
+    deadline = _bind_deadline(_COORDINATE_WALL_SECONDS)
+    return _smith_projection(matrix, divisor, deadline=deadline)
+
+
+def _bind_deadline(wall_seconds: float) -> float:
+    execution = current_request_execution()
+    started = execution.started_at if execution is not None else time.monotonic()
+    deadline = started + wall_seconds
+    if execution is not None and execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before reduced-Laplacian Smith projection")
+    if time.monotonic() >= deadline:
+        raise OperationExecutionTimeoutError(
+            "request deadline expired before Smith projection"
+        )
+    return deadline
+
+
+def _smith_projection(
+    matrix: list[list[int]], divisor: list[int] | None, *, deadline: float | None = None
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
 
     rows = len(matrix)
     cols = len(matrix[0]) if matrix else 0
     if rows == 0 or cols == 0:
-        return ()
+        request_checkpoint("after empty chip-firing Smith projection")
+        return (), ()
 
     from jacobian.process import (
         ProcessResourceLimits,
@@ -47,21 +85,25 @@ def smith_normal_form_diagonal(matrix: list[list[int]]) -> tuple[int, ...]:
         worker_environment,
     )
 
-    execution = current_request_execution()
-    started = execution.started_at if execution is not None else time.monotonic()
-    deadline = started + _SNF_WALL_SECONDS
-    bind_request_deadline(deadline)
+    if deadline is None:
+        deadline = _bind_deadline(_SNF_WALL_SECONDS)
+    request_checkpoint("before reduced-Laplacian Smith projection")
     remaining = deadline - time.monotonic()
     if remaining <= 0:
         raise OperationExecutionTimeoutError(
             "request deadline expired before reduced-Laplacian SNF"
         )
 
+    request = {
+        "matrix": [[format_canonical_integer(value) for value in row] for row in matrix]
+    }
     payload = encode_strict_json(
-        {
-            "matrix": [
-                [format_canonical_integer(value) for value in row] for row in matrix
-            ]
+        request
+        if divisor is None
+        else {
+            **request,
+            "divisor": [format_canonical_integer(value) for value in divisor],
+            "deadline": repr(deadline),
         }
     )
     maximum_entry_digits = max(
@@ -83,8 +125,19 @@ def smith_normal_form_diagonal(matrix: list[list[int]]) -> tuple[int, ...]:
             },
         )
     )
+    if divisor is not None:
+        # Every residue is smaller than a Smith factor. Hadamard bounds
+        # their product (the determinant), hence each factor and residue.
+        stdout_limit += 32 + min(rows, cols) * (maximum_diagonal_digits + 4)
+        stdout_limit = max(stdout_limit, _SNF_DIAGNOSTIC_CHARS + 128)
     try:
         with TemporaryDirectory(prefix="jacobian-chip-firing-snf-") as worker_directory:
+            request_checkpoint("before launching reduced-Laplacian Smith worker")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise OperationExecutionTimeoutError(
+                    "request deadline expired before Smith worker launch"
+                )
             completed = run_bounded_process(
                 [sys.executable, str(_SNF_WORKER)],
                 input_bytes=payload,
@@ -93,7 +146,7 @@ def smith_normal_form_diagonal(matrix: list[list[int]]) -> tuple[int, ...]:
                 stdout_limit=stdout_limit,
                 stderr_limit=_SNF_STDERR_LIMIT,
                 resource_limits=ProcessResourceLimits(
-                    cpu_seconds=max(1, math.ceil(_SNF_WALL_SECONDS)),
+                    cpu_seconds=max(1, math.ceil(remaining)),
                     address_space_bytes=_SNF_ADDRESS_SPACE_BYTES,
                     file_size_bytes=_SNF_FILE_SIZE_BYTES,
                 ),
@@ -112,6 +165,11 @@ def smith_normal_form_diagonal(matrix: list[list[int]]) -> tuple[int, ...]:
         raise OperationExecutionTimeoutError(
             "request deadline expired during reduced-Laplacian SNF"
         )
+    request_checkpoint("after reduced-Laplacian Smith worker")
+    if time.monotonic() >= deadline:
+        raise OperationExecutionTimeoutError(
+            "request deadline expired after Smith worker"
+        )
     if (
         completed.stdout_exceeded
         or completed.stderr_exceeded
@@ -121,23 +179,73 @@ def smith_normal_form_diagonal(matrix: list[list[int]]) -> tuple[int, ...]:
             "bounded chip-firing SNF worker did not establish a diagonal"
         )
 
+    result = _decode_projection(
+        completed.stdout, payload, min(rows, cols), divisor is not None
+    )
+    request_checkpoint("after decoding chip-firing Smith projection")
+    if time.monotonic() >= deadline:
+        raise OperationExecutionTimeoutError(
+            "request deadline expired after Smith projection"
+        )
+    return result
+
+
+def _decode_projection(
+    content: bytes, payload: bytes, dimension: int, has_coordinates: bool
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
     try:
-        response = loads_strict_json(completed.stdout)
-        if not isinstance(response, dict) or set(response) != {
+        response = loads_strict_json(content)
+        if (
+            has_coordinates
+            and isinstance(response, dict)
+            and set(response) == {"request_digest", "resource_error"}
+        ):
+            diagnostic = response["resource_error"]
+            if (
+                response["request_digest"] != hashlib.sha256(payload).hexdigest()
+                or not isinstance(diagnostic, str)
+                or len(diagnostic) > _SNF_DIAGNOSTIC_CHARS
+            ):
+                raise ValueError("worker admission diagnostic is malformed")
+            raise OperationResourceAdmissionError(
+                location=("graph",),
+                code="chip_firing.smith_transform_bound",
+                message=diagnostic,
+            )
+        fields = {
             "diagonal",
             "request_digest",
-        }:
+        }
+        if has_coordinates:
+            fields.add("coordinates")
+        if not isinstance(response, dict) or set(response) != fields:
             raise ValueError("worker response has invalid fields")
         if response["request_digest"] != hashlib.sha256(payload).hexdigest():
             raise ValueError("worker response is not bound to its request")
         diagonal = response["diagonal"]
-        if not isinstance(diagonal, list) or len(diagonal) != min(rows, cols):
+        if not isinstance(diagonal, list) or len(diagonal) != dimension:
             raise ValueError("worker diagonal is malformed")
-        return tuple(parse_canonical_integer(value) for value in diagonal)
+        factors = tuple(parse_canonical_integer(value) for value in diagonal)
+        if any(d <= 0 for d in factors) or any(b % a for a, b in pairwise(factors)):
+            raise ValueError(
+                "worker factors must be positive and divide their successors"
+            )
+        coordinates: tuple[int, ...] = ()
+        if has_coordinates:
+            values = response["coordinates"]
+            nonunit = tuple(d for d in factors if d > 1)
+            if not isinstance(values, list) or len(values) != len(nonunit):
+                raise ValueError("worker coordinates are malformed")
+            coordinates = tuple(parse_canonical_integer(v) for v in values)
+            if any(not 0 <= c < d for c, d in zip(coordinates, nonunit, strict=True)):
+                raise ValueError("worker coordinate is outside its factor")
+        return factors, coordinates
+    except OperationResourceAdmissionError:
+        raise
     except (KeyError, TypeError, ValueError, CanonicalizationError) as exc:
         raise RuntimeError(
             "bounded chip-firing SNF worker returned malformed output"
         ) from exc
 
 
-__all__ = ["smith_normal_form_diagonal"]
+__all__ = ["smith_coordinates", "smith_normal_form_diagonal"]

--- a/src/jacobian/math/graphs/chip_firing/_snf_worker.py
+++ b/src/jacobian/math/graphs/chip_firing/_snf_worker.py
@@ -1,9 +1,10 @@
-"""One-shot FLINT Smith-normal-form worker for chip-firing critical groups."""
+"""One-shot exact normal-form worker for chip-firing critical groups."""
 
 from __future__ import annotations
 
 import hashlib
 import sys
+import time
 from typing import Any
 
 from jacobian.canonical import (
@@ -12,6 +13,7 @@ from jacobian.canonical import (
     loads_strict_json,
     parse_canonical_integer,
 )
+from jacobian.catalog.models import OperationResourceAdmissionError
 
 
 def _diagonal_snf(matrix: list[list[int]]) -> list[int]:
@@ -29,20 +31,71 @@ def _diagonal_snf(matrix: list[list[int]]) -> list[int]:
     return values
 
 
+def _coordinate_snf(
+    matrix: list[list[int]], divisor: list[int], deadline: float
+) -> tuple[list[int], list[int]]:
+    from sympy import ZZ, Matrix
+    from sympy.matrices.normalforms import smith_normal_decomp
+
+    from jacobian._execution import (
+        bind_request_deadline,
+        request_checkpoint,
+        request_execution,
+    )
+    from jacobian.math.graphs.chip_firing._hermite import prepare_smith_coordinates
+
+    with request_execution(started_at=time.monotonic()):
+        bind_request_deadline(deadline)
+        residual, image, units = prepare_smith_coordinates(matrix, divisor, deadline)
+        if not residual:
+            return [1] * units, []
+        # Admission follows exact reduction and precedes Smith expansion.
+        # Only final factors/residues leave the worker, never transforms.
+        diagonal, left, _ = smith_normal_decomp(Matrix(residual), domain=ZZ)
+        factors = [int(diagonal[i, i]) for i in range(len(residual))]
+        transported = left * Matrix(image)
+        coordinates = [int(transported[i]) % d for i, d in enumerate(factors) if d > 1]
+        request_checkpoint("after Smith coordinate projection")
+        return [1] * units + factors, coordinates
+
+
 def main() -> int:
     input_bytes = sys.stdin.buffer.read()
     payload: dict[str, Any] = loads_strict_json(input_bytes)
-    if set(payload) != {"matrix"} or not isinstance(payload["matrix"], list):
+    if set(payload) not in (
+        {"matrix"},
+        {"matrix", "divisor", "deadline"},
+    ) or not isinstance(payload["matrix"], list):
         raise ValueError("worker request has invalid fields")
     matrix = [
         [parse_canonical_integer(value) for value in row] for row in payload["matrix"]
     ]
+    if "divisor" in payload:
+        try:
+            factors, coordinates = _coordinate_snf(
+                matrix,
+                [parse_canonical_integer(v) for v in payload["divisor"]],
+                float(payload["deadline"]),
+            )
+        except OperationResourceAdmissionError as exc:
+            sys.stdout.buffer.write(
+                encode_strict_json(
+                    {
+                        "request_digest": hashlib.sha256(input_bytes).hexdigest(),
+                        "resource_error": str(exc),
+                    }
+                )
+            )
+            return 0
+    else:
+        factors = _diagonal_snf(matrix)
+        coordinates = []
     response = {
         "request_digest": hashlib.sha256(input_bytes).hexdigest(),
-        "diagonal": [
-            format_canonical_integer(value) for value in _diagonal_snf(matrix)
-        ],
+        "diagonal": [format_canonical_integer(value) for value in factors],
     }
+    if "divisor" in payload:
+        response["coordinates"] = [format_canonical_integer(v) for v in coordinates]
     sys.stdout.buffer.write(encode_strict_json(response, limits=None))
     return 0
 

--- a/src/jacobian/math/graphs/chip_firing/_tools.py
+++ b/src/jacobian/math/graphs/chip_firing/_tools.py
@@ -172,7 +172,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
     MathTool(
         operation_id="graph.chip_firing.stabilize.compute",
         title="Stabilize a sink configuration",
-        description="Stabilize a bounded sink configuration and return the unique "
+        description="Stabilize a bounded sink configuration on a connected graph and return the unique "
         "stable configuration, exact odometer (toppling-count) vector, "
         "and total firing count.",
         request_type=StabilizeRequest,
@@ -278,7 +278,10 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         title="Abel-Jacobi coordinates",
         description="Map a degree-zero graph divisor into the critical group via "
         "the Abel-Jacobi map, returning canonical class coordinates in "
-        "the cokernel of the reduced Laplacian.",
+        "the cokernel of the reduced Laplacian of a connected graph. "
+        "Coordinates use row/column Hermite unit reductions and the pinned "
+        "SymPy Smith basis, with unit factors omitted. The HNF residual must "
+        "fit the conservative transformation work and intermediate-height envelope.",
         request_type=AbelJacobiRequest,
         result_type=AbelJacobiResult,
         run=compute_abel_jacobi,

--- a/src/jacobian/math/graphs/chip_firing/operations.py
+++ b/src/jacobian/math/graphs/chip_firing/operations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import deque
 
+from jacobian._execution import request_checkpoint
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.chip_firing._models import (
     MAX_COEFFICIENT_DIGITS,
@@ -23,6 +24,24 @@ from jacobian.math.graphs.chip_firing._models import (
     StabilizeResult,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _admit_connected(graph: SimpleUndirectedGraph) -> None:
+    if not _is_connected(graph):
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="chip_firing.requires_connected_graph",
+            message="sink chip-firing requires a connected graph",
+        )
+
+
+def _admit_coefficient_height(divisor: tuple[int, ...]) -> None:
+    if any(abs(value) >= 10**MAX_COEFFICIENT_DIGITS for value in divisor):
+        raise OperationDomainValidationError(
+            location=("divisor",),
+            code="chip_firing.coefficient_bound",
+            message="divisor coefficients exceed the digit bound",
+        )
 
 
 def _admit_graph(graph: SimpleUndirectedGraph) -> None:
@@ -240,7 +259,14 @@ def _stabilize_configuration(
 ) -> tuple[list[int], list[int]]:
     """Stabilize via least-action / legal-firing algorithm.
 
-    Returns (stable_config, odometer).
+    Returns (stable_config, odometer). The owner admits a connected graph
+    and an effective nonsink configuration. If H=Lq^-1, the maximum
+    principle and effective resistance give 0 <= H_ij <= n-1: column j
+    is the voltage of a unit j-to-sink current, maximized at j, whose
+    resistance is at most a simple path length. Thus h=H*1 <= (n-1)^2.
+    The nonnegative potential h.T*eta drops by one per legal firing,
+    bounding all firings by sum(eta_nonsink)*(n-1)^2. A batch is a
+    sequence of legal firings at the same vertex, not a parallel firing.
     """
     n = len(config)
     eta = list(config)
@@ -252,14 +278,16 @@ def _stabilize_configuration(
             queue.append(i)
             in_queue[i] = True
     while queue:
+        request_checkpoint("during chip-firing stabilization")
         v = queue.popleft()
         in_queue[v] = False
         if eta[v] < degrees[v]:
             continue
-        eta[v] -= degrees[v]
-        odometer[v] += 1
+        count = eta[v] // degrees[v]
+        eta[v] -= count * degrees[v]
+        odometer[v] += count
         for nb in adj[v]:
-            eta[nb] += 1
+            eta[nb] += count
             if nb == sink_idx:
                 continue
             if eta[nb] >= degrees[nb] and not in_queue[nb]:
@@ -273,12 +301,15 @@ def stabilize(
 ) -> StabilizeResult:
     """Stabilize a sink configuration and return the odometer."""
     _admit_configuration(graph, sink, configuration)
+    _admit_connected(graph)
+    request_checkpoint("before chip-firing stabilization")
     vertices = graph.vertices
     sink_idx = vertices.index(sink)
     adj = _adjacency(graph)
     degrees = _degrees(graph)
     config = list(configuration)
     eta, odometer = _stabilize_configuration(config, adj, degrees, sink_idx)
+    request_checkpoint("after chip-firing stabilization")
     return StabilizeResult(
         stable=tuple(eta),
         odometer=tuple(odometer),
@@ -318,59 +349,81 @@ def q_reduced(
 ) -> QReducedResult:
     """Compute the q-reduced normal form via Dhar's algorithm.
 
-    After repeatedly firing unstable nonsink vertices (as in stabilization),
-    we then perform the reverse step: borrow from the sink to create a
-    non-negative configuration, and re-stabilize. This produces the unique
-    q-reduced representative.
+    First make the nonsink divisor effective by an exact rational solve,
+    then fire Dhar's unburned sets. Every update uses D' = D - L*f with
+    f(sink)=0. All subsets burning is exactly the q-reduced criterion.
     """
     _admit_divisor(graph, divisor)
     _admit_sink(graph, sink)
+    _admit_connected(graph)
+    _admit_coefficient_height(divisor)
+    request_checkpoint("before q-reduction")
     vertices = graph.vertices
     n = len(vertices)
     sink_idx = vertices.index(sink)
     adj = _adjacency(graph)
     degrees = _degrees(graph)
-    # Use Dhar's burning algorithm for q-reduction:
-    # 1. Start with divisor D.
-    # 2. Fire unstable vertices until stable (standard stabilization).
-    # 3. Use Dhar's reverse: check if any nonempty set can fire by
-    #    testing if the stable config is superstable.
-    #    If not superstable, borrow from sink and re-stabilize.
-    #
-    # The q-reduced form is: D - L*f where f is the firing vector.
-    # We compute f = odometer from stabilization + borrow rounds.
-
     config = list(divisor)
     total_firing = [0] * n
+    nonsink = [i for i in range(n) if i != sink_idx]
+    if nonsink:
+        from flint import fmpq_mat
 
-    # Stabilize first
-    eta, odo = _stabilize_configuration(config, adj, degrees, sink_idx)
-    config = eta
-    for i in range(n):
-        total_firing[i] += odo[i]
-
-    # Borrow from sink when needed
-    # A stable config is q-reduced iff it is non-negative on nonsink vertices.
-    # If some nonsink vertex is negative, we borrow from the sink:
-    # fire the sink (which gives chips to its neighbors) and re-stabilize.
-    max_rounds = n * n + 10
-    rounds = 0
-    while any(config[i] < 0 for i in range(n) if i != sink_idx):
-        rounds += 1
-        if rounds > max_rounds:
-            raise RuntimeError("q-reduction did not converge")
-        # Fire the sink: each neighbor of sink gains 1 chip.
-        # Firing the sink is D' = D - L * e_sink, so it counts in the
-        # firing vector to preserve D_reduced = D - L * f.
-        for nb in adj[sink_idx]:
-            config[nb] += 1
-        total_firing[sink_idx] += 1
-        # Now re-stabilize
-        eta, odo = _stabilize_configuration(config, adj, degrees, sink_idx)
-        config = eta
+        # FLINT solves a nonsingular integer reduced Laplacian over Q.
+        # At n<=50 and 1000-digit coefficients, fraction-free elimination
+        # has O(n^3) arithmetic steps; its minors have at most
+        # 1000 + O(n log n) digits by Hadamard (only the RHS is large).
+        # Put x=Lq^-1*(D-deg), f=floor(x), r=x-f in [0,1)^n.
+        # Then D-Lq*f=deg+Lq*r is >=0 and <2*deg coordinatewise.
+        reduced = [
+            [degrees[i] if i == j else -int(j in adj[i]) for j in nonsink]
+            for i in nonsink
+        ]
+        solution = fmpq_mat(reduced).solve(  # type: ignore[call-arg]  # python-flint 0.9 stubs omit documented algorithm.
+            fmpq_mat([[divisor[i] - degrees[i]] for i in nonsink]),
+            algorithm="fflu",
+        )
+        request_checkpoint("after q-reduction exact solve")
+        for j, i in enumerate(nonsink):
+            value = solution[j, 0]
+            total_firing[i] = int(value.numerator) // int(value.denominator)
         for i in range(n):
-            total_firing[i] += odo[i]
+            config[i] -= degrees[i] * total_firing[i] - sum(
+                total_firing[j] for j in adj[i]
+            )
 
+    # Initial nonsink mass < 2*sum(deg) <= 4m. The Green-function
+    # potential from stabilization bounds total vertex firings by
+    # 4m*(n-1)^2, including |S| for each Dhar set S. Thus this loop is
+    # independent of divisor magnitude. Each burn pass costs O(n+m).
+    while True:
+        config, odo = _stabilize_configuration(config, adj, degrees, sink_idx)
+        for i in nonsink:
+            total_firing[i] += odo[i]
+        request_checkpoint("during q-reduction Dhar burning")
+        burned = {sink_idx}
+        pending = deque([sink_idx])
+        outgoing = [0] * n
+        while pending:
+            v = pending.popleft()
+            for j in adj[v]:
+                outgoing[j] += 1
+                if j not in burned and config[j] < outgoing[j]:
+                    burned.add(j)
+                    pending.append(j)
+        unburned = [i for i in nonsink if i not in burned]
+        if not unburned:
+            break
+        # Only cut edges change a simultaneous subset firing. Vertices
+        # inside S have at least outdeg_S chips, so effectivity persists.
+        for i in unburned:
+            total_firing[i] += 1
+            for j in adj[i]:
+                if j in burned:
+                    config[i] -= 1
+                    config[j] += 1
+
+    request_checkpoint("after q-reduction")
     return QReducedResult(
         reduced_divisor=tuple(config),
         firing_vector=tuple(total_firing),
@@ -508,12 +561,17 @@ def abel_jacobi(
 ) -> AbelJacobiResult:
     """Map a degree-zero divisor into critical-group coordinates.
 
-    The coordinates are the remainder of the nonsink divisor coefficients
-    modulo the invariant factors of the critical group (the diagonal of
-    the SNF of the reduced Laplacian). Zero and unit factors are excluded.
+    Successive column and row Hermite forms eliminate trivial quotient
+    directions while transporting the divisor by each exact row map.
+    For pinned SymPy U*C*V=S on the remaining quotient, return the reduced
+    image transported by U modulo S, omitting unit factors. Relative axis
+    order is retained throughout. Admission uses the reduced problem.
     """
     _admit_divisor(graph, divisor)
     _admit_sink(graph, sink)
+    _admit_connected(graph)
+    _admit_coefficient_height(divisor)
+    request_checkpoint("before Abel-Jacobi coordinates")
     if sum(divisor) != 0:
         raise OperationDomainValidationError(
             location=("divisor",),
@@ -524,21 +582,14 @@ def abel_jacobi(
     n = len(vertices)
     sink_idx = vertices.index(sink)
     nonsink = [i for i in range(n) if i != sink_idx]
-    nonsink_labels, invariant = _critical_group_factors(graph, sink)
-    nonsink_div = [divisor[i] for i in nonsink]
-    # The coordinates: nonsink_div mod the invariant factors.
-    # Only non-unit, non-zero factors matter for the quotient group.
-    coords = []
-    j = 0
-    for d in invariant:
-        if d <= 1:
-            continue
-        idx = nonsink[j] if j < len(nonsink_div) else 0
-        coords.append(nonsink_div[idx] % d)
-        j += 1
+    from jacobian.math.graphs.chip_firing._snf_process import smith_coordinates
+
+    matrix = [list(row) for row in reduced_laplacian(graph, sink).reduced_laplacian]
+    invariant, coords = smith_coordinates(matrix, [divisor[i] for i in nonsink])
+    request_checkpoint("after Abel-Jacobi coordinates")
     return AbelJacobiResult(
         sink=sink,
-        nonsink_vertices=nonsink_labels,
+        nonsink_vertices=tuple(vertices[i] for i in nonsink),
         coordinates=tuple(coords),
         invariant_factors=invariant,
     )

--- a/src/jacobian/math/groups/cohomology/operations.py
+++ b/src/jacobian/math/groups/cohomology/operations.py
@@ -32,6 +32,12 @@ def _admitted_max_degree(order: int) -> int:
     return degree - 1
 
 
+def _schreier_sims_order(group: PermutationGroup) -> int:
+    """Return the exact group order via Schreier-Sims without enumeration."""
+    perms = [Permutation(list(g)) for g in group.generators]
+    return int(SympyPermutationGroup(perms).order())
+
+
 def _admit_request(
     group: PermutationGroup, prime: int, max_degree: int
 ) -> list[tuple[int, ...]]:
@@ -57,8 +63,7 @@ def _admit_request(
                 f"max_degree must be an integer between 0 and {MAX_COCHAIN_DEGREE}"
             ),
         )
-    elements = _enumerate_group_elements(group)
-    order = len(elements)
+    order = _schreier_sims_order(group)
     if order > MAX_GROUP_ORDER:
         raise OperationDomainValidationError(
             location=("group",),
@@ -67,6 +72,13 @@ def _admit_request(
                 f"enumerated group order {order} exceeds the bounded maximum "
                 f"{MAX_GROUP_ORDER}"
             ),
+        )
+    elements = _enumerate_group_elements(group)
+    if len(elements) != order:
+        raise OperationDomainValidationError(
+            location=("group",),
+            code="group_cohomology.group_enumeration_mismatch",
+            message="enumerated group elements do not match the Schreier-Sims order",
         )
     admitted_degree = _admitted_max_degree(order)
     if max_degree > admitted_degree:

--- a/src/jacobian/math/groups/root_systems/_models.py
+++ b/src/jacobian/math/groups/root_systems/_models.py
@@ -11,6 +11,7 @@ from jacobian._models import StrictModel
 
 MAX_RANK = 8
 MAX_REFLECTION_COORDINATE = ((1 << 53) - 1) // (1 + 3 * MAX_RANK)
+MAX_REFLECTION_REPRESENTABLE = (1 << 53) - 1
 MAX_POSITIVE_ROOTS = 120
 MAX_ROOT_COORDINATE = 6
 MAX_COXETER_NUMBER = 30
@@ -210,7 +211,7 @@ class SimpleReflectionRequest(StrictModel):
     vector: tuple[
         Annotated[
             int,
-            Field(ge=-MAX_REFLECTION_COORDINATE, le=MAX_REFLECTION_COORDINATE),
+            Field(ge=-MAX_REFLECTION_REPRESENTABLE, le=MAX_REFLECTION_REPRESENTABLE),
         ],
         ...,
     ] = Field(
@@ -218,8 +219,11 @@ class SimpleReflectionRequest(StrictModel):
         description=(
             "Root-lattice coordinates in the matrix's simple-root basis; "
             "length must equal the Cartan-matrix rank, and each coordinate "
-            f"must lie in [-{MAX_REFLECTION_COORDINATE}, "
-            f"{MAX_REFLECTION_COORDINATE}]."
+            f"must lie in [-{MAX_REFLECTION_REPRESENTABLE}, "
+            f"{MAX_REFLECTION_REPRESENTABLE}]. Inputs within "
+            f"[-{MAX_REFLECTION_COORDINATE}, {MAX_REFLECTION_COORDINATE}] "
+            "are guaranteed a representable image; larger representable "
+            "inputs are admitted when their exact reflection also fits."
         ),
     )
     simple_index: int = Field(
@@ -242,7 +246,7 @@ class SimpleReflectionResult(StrictModel):
     @model_validator(mode="after")
     def require_reflection_shape(self) -> Self:
         if len(self.reflected_vector) != len(self.vector) or any(
-            abs(coordinate) > MAX_REFLECTION_COORDINATE
+            abs(coordinate) > MAX_REFLECTION_REPRESENTABLE
             for coordinate in self.reflected_vector
         ):
             raise _validation_error(

--- a/src/jacobian/math/groups/root_systems/operations.py
+++ b/src/jacobian/math/groups/root_systems/operations.py
@@ -15,7 +15,7 @@ from jacobian.math.groups.root_systems._cartan import (
 from jacobian.math.groups.root_systems._models import (
     MAX_POSITIVE_ROOTS,
     MAX_RANK,
-    MAX_REFLECTION_COORDINATE,
+    MAX_REFLECTION_REPRESENTABLE,
     PositiveRootsResult,
     RootComponentData,
     RootSystemDataResult,
@@ -189,7 +189,7 @@ def simple_reflection(
             message="vector length must match rank",
         )
     if any(
-        type(coordinate) is not int or abs(coordinate) > MAX_REFLECTION_COORDINATE
+        type(coordinate) is not int or abs(coordinate) > MAX_REFLECTION_REPRESENTABLE
         for coordinate in vector
     ):
         raise OperationDomainValidationError(
@@ -204,6 +204,12 @@ def simple_reflection(
             simple_index,
         )
     )
+    if any(abs(coordinate) > MAX_REFLECTION_REPRESENTABLE for coordinate in reflected):
+        raise OperationDomainValidationError(
+            location=("reflected_vector",),
+            code="root_system.reflected_vector_out_of_range",
+            message="reflection image exceeds the interoperable root-lattice axis",
+        )
     return SimpleReflectionResult._from_kernel(matrix, vector, simple_index, reflected)
 
 

--- a/src/jacobian/math/lattices/_lattice_ops.py
+++ b/src/jacobian/math/lattices/_lattice_ops.py
@@ -120,8 +120,8 @@ def smith_invariant_factors(entries: list[list[int]]) -> list[int]:
 def dual_basis(entries: list[list[int]]) -> list[list[Fraction]]:
     """Return a rational dual basis of the lattice spanned by ``entries``.
 
-    For a full-row-rank basis ``B`` of rank ``r``, the dual basis is
-    ``L^* = B^T (B B^T)^{-1}``, i.e. ``B^* = B (B B^T)^{-1}`` so that
+    For a full-row-rank basis ``B`` of rank ``r``, the row dual basis is
+    ``B^* = (B B^T)^{-1} B`` so that
     ``B^* B^T = I_r``.
     """
     from sympy import Matrix, Rational
@@ -129,7 +129,7 @@ def dual_basis(entries: list[list[int]]) -> list[list[Fraction]]:
     basis = Matrix(entries)
     gram = basis * basis.T
     inverse = gram.inv()
-    dual = basis * inverse
+    dual = inverse * basis
     rows, cols = dual.rows, dual.cols
     result: list[list[Fraction]] = []
     for i in range(rows):
@@ -155,8 +155,6 @@ def saturate_lattice(
     form.  ``inclusion`` is the integer matrix ``C`` with ``B = C @ sat``.
     ``index`` is the finite index ``[sat(L) : L]``.
     """
-    from math import gcd
-
     from sympy import ZZ, Matrix
     from sympy.matrices.normalforms import hermite_normal_form
     from sympy.polys.matrices import DomainMatrix
@@ -197,18 +195,9 @@ def saturate_lattice(
             row.append(int(frac.numerator))
         inclusion_rows.append(row)
 
-    # Index = gcd of all r x r minors of B.
-    from itertools import combinations
-
-    rank = rows
-    if basis.cols < rank:
-        index = 1
-    else:
-        minors_gcd = 0
-        for cols in combinations(range(basis.cols), rank):
-            minor = int(basis[:, list(cols)].det())
-            minors_gcd = gcd(minors_gcd, abs(minor))
-        index = minors_gcd if minors_gcd > 0 else 1
+    # B = C @ sat identifies L with the full-rank row lattice of the
+    # square integer matrix C in ZZ^r, so [sat(L) : L] = |det C|.
+    index = abs(integer_determinant(inclusion_rows))
 
     return (
         _sympy_to_int_list(sat),

--- a/src/jacobian/math/lattices/operations.py
+++ b/src/jacobian/math/lattices/operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from math import isqrt
 from typing import Any
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
@@ -137,7 +138,7 @@ def compute_rank_gram(lattice: IntegerLattice) -> RankGramResult:
         ambient_dimension=lattice.ambient_dimension,
         gram_matrix=_integer_matrix(gram),
         squared_covolume=format_canonical_integer(det),
-        covolume_rational=bool(lattice.ambient_dimension != rank),
+        covolume_rational=isqrt(det) ** 2 == det,
     )
 
 

--- a/src/jacobian/math/matrices/finite_fields/linear_algebra.py
+++ b/src/jacobian/math/matrices/finite_fields/linear_algebra.py
@@ -79,10 +79,11 @@ def _domain_matrix(matrix: PrimeFieldMatrix) -> Any:
     import sympy
     from sympy.polys.matrices import DomainMatrix
 
+    field = sympy.GF(matrix.prime)
     return DomainMatrix(
-        [list(row) for row in matrix.entries],
+        [[field(value) for value in row] for row in matrix.entries],
         (len(matrix.entries), matrix.columns),
-        sympy.GF(matrix.prime),
+        field,
     )
 
 

--- a/src/jacobian/math/number_theory/algebraic_numbers/quadratic.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/quadratic.py
@@ -11,6 +11,10 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.number_theory.arithmetic._integer_predicates import is_square_free
 
 _MAX_RADICAND = 1_000_000
@@ -98,8 +102,10 @@ def _require_order_admission(
     """Validate the owner-local envelope of an exact order comparison."""
 
     if left.radicand != right.radicand:
-        raise _validation_error(
-            "radicand_mismatch", "comparison requires one shared radicand"
+        raise OperationDomainValidationError(
+            location=("right", "radicand"),
+            code="real_quadratic.radicand_mismatch",
+            message="comparison requires one shared radicand",
         )
     difference_components = (
         left.rational_part.as_fraction() - right.rational_part.as_fraction(),
@@ -111,9 +117,10 @@ def _require_order_admission(
         or len(format_canonical_integer(component.denominator)) > _MAX_DIGITS
         for component in difference_components
     ):
-        raise _validation_error(
-            "difference_bound_exceeded",
-            "exact quadratic difference exceeds the 256-digit result bound",
+        raise OperationResourceAdmissionError(
+            location=(),
+            code="real_quadratic.difference_bound_exceeded",
+            message="exact quadratic difference exceeds the 256-digit result bound",
         )
 
 

--- a/src/jacobian/math/number_theory/p_adic/_models.py
+++ b/src/jacobian/math/number_theory/p_adic/_models.py
@@ -7,8 +7,12 @@ from typing import Literal, Self
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.canonical import parse_canonical_integer
+from jacobian.canonical import (
+    format_canonical_integer,
+    parse_canonical_integer,
+)
 from jacobian.math.polynomials._models import IntegerPolynomial
 
 
@@ -52,11 +56,13 @@ class HenselRootResult(StrictModel):
 
     Retains the source polynomial and the original residue for downstream use.
     The producer establishes the Hensel-lift invariant; ordinary result parsing
-    checks only the serialized shape.
+    checks only the serialized shape. ``lifted_root`` uses the canonical
+    decimal-integer representation so residues above the interoperable JSON
+    integer range still cross the operation-result envelope exactly.
     """
 
     polynomial: IntegerPolynomial
-    lifted_root: int = Field(ge=0)
+    lifted_root: CanonicalInteger
     prime: int = Field(ge=2, le=MAX_PRIME)
     root_mod_p: int = Field(ge=0)
     precision: int = Field(ge=1, le=MAX_PRECISION)
@@ -68,7 +74,7 @@ class HenselRootResult(StrictModel):
             raise _validation_error(
                 "padic_arithmetic.root_out_of_range", "root_mod_p must be in 0..p-1"
             )
-        if self.lifted_root >= self.prime**self.precision:
+        if parse_canonical_integer(self.lifted_root) >= self.prime**self.precision:
             raise _validation_error(
                 "padic_arithmetic.lifted_root_out_of_range",
                 "lifted_root must be in 0..p^k - 1",
@@ -91,7 +97,7 @@ class HenselRootResult(StrictModel):
     ) -> Self:
         return cls.model_construct(
             polynomial=polynomial,
-            lifted_root=lifted_root,
+            lifted_root=format_canonical_integer(lifted_root),
             prime=prime,
             root_mod_p=root_mod_p,
             precision=precision,
@@ -135,8 +141,14 @@ class PAdicRootsRequest(StrictModel):
 class PAdicRootEntry(StrictModel):
     """One exact root of f mod p^k lifted from a simple root mod p."""
 
-    root: int = Field(ge=0)
+    root: CanonicalInteger
     root_type: Literal["SIMPLE"] = "SIMPLE"
+
+    @classmethod
+    def _from_kernel(cls, root: int) -> Self:
+        return cls.model_construct(
+            root=format_canonical_integer(root), root_type="SIMPLE"
+        )
 
 
 class PAdicRootsResult(StrictModel):
@@ -173,7 +185,7 @@ class PAdicRootsResult(StrictModel):
                 "multiple residues must lie in 0..p-1",
             )
         modulus = self.prime**self.precision
-        roots = tuple(entry.root for entry in self.roots)
+        roots = tuple(parse_canonical_integer(entry.root) for entry in self.roots)
         if any(root >= modulus for root in roots):
             raise _validation_error(
                 "padic_arithmetic.root_out_of_range", "roots must lie in 0..p^k - 1"

--- a/src/jacobian/math/number_theory/p_adic/operations.py
+++ b/src/jacobian/math/number_theory/p_adic/operations.py
@@ -424,7 +424,7 @@ def find_padic_roots(
             multiple_residues.append(r)
             continue
         lifted = _hensel_lift_root(coeffs, p, r, k)
-        lifted_roots.append(PAdicRootEntry(root=lifted, root_type="SIMPLE"))
+        lifted_roots.append(PAdicRootEntry._from_kernel(lifted))
 
     return PAdicRootsResult._from_kernel(
         polynomial, prime, precision, tuple(lifted_roots), tuple(multiple_residues)

--- a/src/jacobian/math/optimization/_general_linear_program.py
+++ b/src/jacobian/math/optimization/_general_linear_program.py
@@ -6,7 +6,7 @@ from fractions import Fraction
 from typing import NoReturn
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.canonical import format_canonical_integer
 from jacobian.math.optimization._arithmetic import rational_dot
 from jacobian.math.optimization._general_models import (
     MAX_GENERAL_RATIONAL_INPUT_DIGITS,
@@ -21,18 +21,21 @@ from jacobian.math.optimization._general_normalization import (
     _mapped_residual_digit_bound,
     admit_general_normalization,
 )
+from jacobian.math.optimization._linear_basis import (
+    admit_linear_program,
+    linear_execution,
+)
 from jacobian.math.optimization._models import RationalLinearProgramResult
 
 _INTERVAL_RESULT_DIGITS = 4 * MAX_GENERAL_RATIONAL_INPUT_DIGITS + 1
 
 
 def _wire(value: Fraction, *, max_digits: int) -> CanonicalRational | None:
-    if (
-        len(str(abs(value.numerator))) > max_digits
-        or len(str(value.denominator)) > max_digits
-    ):
+    numerator = format_canonical_integer(value.numerator)
+    denominator = format_canonical_integer(value.denominator)
+    if len(numerator.lstrip("-")) > max_digits or len(denominator) > max_digits:
         return None
-    return CanonicalRational.from_fraction(value)
+    return CanonicalRational(num=numerator, den=denominator)
 
 
 def _wire_vector(
@@ -714,33 +717,40 @@ def _box_program_result(
     )
 
 
-def general_linear_program(
+def _general_linear_program(
     program: GeneralFormRationalLinearProgram,
 ) -> GeneralRationalLinearProgramResult:
-    from jacobian.math.optimization.operations import linear_program
+    from jacobian.math.optimization.operations import _linear_program_admitted
 
     if (box_result := _box_program_result(program)) is not None:
         return box_result
     if (presolved := _one_variable_interval_result(program)) is not None:
         return presolved
 
-    try:
-        normalization = admit_general_normalization(program)
-    except ValueError as error:
-        raise OperationDomainValidationError(
-            location=("program",),
-            code="optimization.linear.general_normalization_admission",
-            message=str(error),
-        ) from error
-    standard_result = linear_program(normalization.standard_program)
+    normalization = admit_general_normalization(program)
+    admission = admit_linear_program(normalization.standard_program)
+    standard_result = _linear_program_admitted(
+        normalization.standard_program, admission
+    )
     return _map_standard_result(
         program,
         normalization,
         standard_result,
-        point_max_digits=_mapped_point_digit_bound(normalization),
-        residual_max_digits=_mapped_residual_digit_bound(normalization),
-        certificate_max_digits=_mapped_certificate_digit_bound(normalization),
+        point_max_digits=_mapped_point_digit_bound(admission.result_digits),
+        residual_max_digits=_mapped_residual_digit_bound(
+            normalization, admission.result_digits
+        ),
+        certificate_max_digits=_mapped_certificate_digit_bound(
+            normalization, admission.result_digits
+        ),
     )
+
+
+def general_linear_program(
+    program: GeneralFormRationalLinearProgram,
+) -> GeneralRationalLinearProgramResult:
+    with linear_execution():
+        return _general_linear_program(program)
 
 
 __all__ = ["general_linear_program"]

--- a/src/jacobian/math/optimization/_general_normalization.py
+++ b/src/jacobian/math/optimization/_general_normalization.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from fractions import Fraction
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.optimization._general_models import (
     MAX_GENERAL_LINEAR_PROGRAM_CONSTRAINTS,
     MAX_GENERAL_LINEAR_PROGRAM_VARIABLES,
@@ -14,7 +15,6 @@ from jacobian.math.optimization._general_models import (
 from jacobian.math.optimization._models import (
     MAX_RATIONAL_DIGITS,
     StandardFormRationalLinearProgram,
-    _result_digit_bound,
 )
 
 
@@ -72,6 +72,40 @@ def normalize_general_program(
     program: GeneralFormRationalLinearProgram,
 ) -> GeneralLinearNormalization:
     """Construct the bounded private standard-form source and exact ledger."""
+
+    normalized_columns = (
+        sum(
+            2 if v.lower_bound is None and v.upper_bound is None else 1
+            for v in program.variables
+        )
+        + sum(row.relation != "EQ" for row in program.constraints)
+        + sum(
+            v.lower_bound is not None and v.upper_bound is not None
+            for v in program.variables
+        )
+    )
+    normalized_rows = len(program.constraints) + sum(
+        v.lower_bound is not None and v.upper_bound is not None
+        for v in program.variables
+    )
+    for reason, count, limit in (
+        (
+            "normalized_columns",
+            normalized_columns,
+            MAX_GENERAL_LINEAR_PROGRAM_VARIABLES,
+        ),
+        ("normalized_rows", normalized_rows, MAX_GENERAL_LINEAR_PROGRAM_CONSTRAINTS),
+    ):
+        if count > limit:
+            raise OperationResourceAdmissionError(
+                location=("program",),
+                code=f"optimization.linear.{reason}",
+                message=(
+                    f"Exact LP {reason} exceeded: normalized_columns={normalized_columns}, "
+                    f"column_limit={MAX_GENERAL_LINEAR_PROGRAM_VARIABLES}, "
+                    f"normalized_rows={normalized_rows}, row_limit={MAX_GENERAL_LINEAR_PROGRAM_CONSTRAINTS}."
+                ),
+            )
 
     source_objective = tuple(
         value.as_fraction() for value in program.objective.coefficients
@@ -139,16 +173,6 @@ def normalize_general_program(
     for source_index, coefficient in enumerate(source_objective):
         for column, multiplier in columns[source_index]:
             objective[column] += sense_sign * coefficient * multiplier
-    if len(standard_names) > MAX_GENERAL_LINEAR_PROGRAM_VARIABLES:
-        raise ValueError(
-            "general linear-program normalized variables exceed the "
-            f"{MAX_GENERAL_LINEAR_PROGRAM_VARIABLES}-entry bound"
-        )
-    if len(rows) > MAX_GENERAL_LINEAR_PROGRAM_CONSTRAINTS:
-        raise ValueError(
-            "general linear-program normalized rows exceed the "
-            f"{MAX_GENERAL_LINEAR_PROGRAM_CONSTRAINTS}-entry bound"
-        )
     standard = StandardFormRationalLinearProgram.admit_derived_intermediate(
         {
             "variables": tuple(standard_names),
@@ -189,7 +213,7 @@ def _standard_intermediate_digit_bound(
 _MAPPED_RESULT_HEIGHT_SLACK = 16
 
 
-def _mapped_point_digit_bound(normalization: GeneralLinearNormalization) -> int:
+def _mapped_point_digit_bound(standard_digits: int) -> int:
     """Bound mapped coordinates, bound slacks, and mapped recession rays.
 
     A source coordinate adds its offset to at most two standard columns, and
@@ -198,14 +222,12 @@ def _mapped_point_digit_bound(normalization: GeneralLinearNormalization) -> int:
     before one chained difference.
     """
 
-    return (
-        2 * MAX_RATIONAL_DIGITS
-        + 2 * _result_digit_bound(normalization.standard_program)
-        + _MAPPED_RESULT_HEIGHT_SLACK
-    )
+    return 2 * MAX_RATIONAL_DIGITS + 2 * standard_digits + _MAPPED_RESULT_HEIGHT_SLACK
 
 
-def _mapped_residual_digit_bound(normalization: GeneralLinearNormalization) -> int:
+def _mapped_residual_digit_bound(
+    normalization: GeneralLinearNormalization, standard_digits: int
+) -> int:
     """Bound mapped objectives, residuals, and constraint slacks.
 
     These sums stack ``n`` coefficient-offset products and ``n``
@@ -219,11 +241,7 @@ def _mapped_residual_digit_bound(normalization: GeneralLinearNormalization) -> i
     variables = len(normalization.offsets)
     summed_terms = 2 * variables + 1
     return (
-        variables
-        * (
-            3 * MAX_RATIONAL_DIGITS
-            + _result_digit_bound(normalization.standard_program)
-        )
+        variables * (3 * MAX_RATIONAL_DIGITS + standard_digits)
         + MAX_RATIONAL_DIGITS
         + len(str(summed_terms))
         + 1
@@ -231,7 +249,9 @@ def _mapped_residual_digit_bound(normalization: GeneralLinearNormalization) -> i
     )
 
 
-def _mapped_certificate_digit_bound(normalization: GeneralLinearNormalization) -> int:
+def _mapped_certificate_digit_bound(
+    normalization: GeneralLinearNormalization, standard_digits: int
+) -> int:
     """Bound mapped dual, stationarity, and Farkas certificate values.
 
     Standard multipliers stay within ``_result_digit_bound`` of the private
@@ -245,7 +265,7 @@ def _mapped_certificate_digit_bound(normalization: GeneralLinearNormalization) -
 
     variables = len(normalization.offsets)
     return (
-        _result_digit_bound(normalization.standard_program)
+        standard_digits
         + (2 + 4 * variables) * MAX_RATIONAL_DIGITS
         + _MAPPED_RESULT_HEIGHT_SLACK
     )

--- a/src/jacobian/math/optimization/_linear_basis.py
+++ b/src/jacobian/math/optimization/_linear_basis.py
@@ -1,0 +1,207 @@
+"""Finite exact LP basis search, with FLINT 0.9 owning rational elimination.
+
+SymPy 1.14's lpmin AND linprog return infeasible points for the covering
+examples in #3194/#3192. No SymPy status is used here. SoPlex (exact mode),
+cddlib (GMP), and PPL offer maintained exact LP solvers, but require new native
+dependencies. For this bounded domain the installed FLINT binding suffices:
+enumerate bases, never implement simplex pivots or floating reconstruction.
+
+For full row rank r, every nonempty {x>=0: Ax=b} has a basic feasible point.
+A bounded optimum has a primal/dual feasible basis. An unbounded objective
+has a feasible basis with a nonnegative improving fundamental ray. If every
+original basis is infeasible, min t subject to Ax+b*t=b, x,t>=0 is feasible
+and bounded below. Its feasible bases must contain the artificial column b.
+An optimal basis has t>0 and dual y with A^T y<=0 and b^T y=t>0; -y is Farkas.
+Thus the two disjoint basis families total C(n+1,r), with no pivot cycles.
+Zero columns are removed reversibly; negative-cost zero columns supply rays
+only AFTER a feasible point has been established.
+
+Backend references: https://python-flint.readthedocs.io/en/latest/fmpq_mat.html
+https://soplex.zib.de/ and https://pycddlib.readthedocs.io/en/stable/
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from itertools import combinations
+from math import comb
+from time import monotonic
+from typing import Any
+
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.optimization._models import (
+    MAX_LINEAR_PROGRAM_BASES,
+    MAX_LINEAR_PROGRAM_SCALAR_UPDATES,
+    StandardFormRationalLinearProgram,
+    _active_equations,
+    _has_trivial_inconsistent_row,
+    _result_digit_bound,
+)
+
+LINEAR_PROGRAM_WALL_SECONDS = 600
+
+
+@contextmanager
+def linear_execution() -> Iterator[None]:
+    """One cooperative deadline from entry through normalization and mapping.
+
+    Dispatch retains this same envelope through serialization. Native callers get
+    an entry-local envelope. FLINT calls are bounded small matrix primitives;
+    checkpoints occur after elimination, between bases and before returning a
+    certificate. This safety deadline is not an admission proof or an LP status.
+    """
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(monotonic()), linear_execution():
+            yield
+        return
+    deadline = execution.started_at + LINEAR_PROGRAM_WALL_SECONDS
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("linear-program admission")
+    yield
+    request_checkpoint("linear-program result construction")
+
+
+@dataclass(frozen=True)
+class LinearAdmission:
+    columns: tuple[int, ...]
+    result_digits: int
+
+
+def basis_bounds(variables: int, equations: int) -> tuple[int, int]:
+    """Bound both searches without computing rank during admission.
+
+    Maximize over possible ranks. Per basis reserve cubic inversion, a full
+    tableau product, and linear scans/dot products. The preprocessing term covers
+    two rectangular row reductions, one inverse and source-row dependence checks.
+    All entries are ratios of source minors (including b and c); fraction-free
+    elimination and matrix products have finite intermediate height bounded by
+    (2*min(n,m)+4) times the conservative result-minor digit bound.
+    """
+    preprocessing = 8 * (equations + 1) ** 2 * (variables + equations + 2)
+    candidates = 1
+    updates = preprocessing
+    for rank in range(1, min(variables, equations) + 1):
+        count = comb(variables + 1, rank)
+        per_basis = (
+            4 * rank**3 + 2 * rank**2 * (variables + 2) + 4 * rank * (variables + 2)
+        )
+        candidates = max(candidates, count)
+        updates = max(updates, preprocessing + count * per_basis)
+    return candidates, updates
+
+
+def admit_linear_program(program: StandardFormRationalLinearProgram) -> LinearAdmission:
+    columns = tuple(
+        j
+        for j in range(len(program.variables))
+        if any(row[j].num != "0" for row in program.coefficients)
+    )
+    digits = _result_digit_bound(program)
+    rows = len(_active_equations(program))
+    candidates, work = (
+        (0, 0)
+        if _has_trivial_inconsistent_row(program)
+        else basis_bounds(len(columns), rows)
+    )
+    quantities = (
+        f"normalized_columns={len(program.variables)}, active_columns={len(columns)}, "
+        f"normalized_rows={len(program.rhs)}, active_rows={rows}, "
+        f"basis_estimate={candidates}, basis_limit={MAX_LINEAR_PROGRAM_BASES}, "
+        f"work_estimate={work}, work_limit={MAX_LINEAR_PROGRAM_SCALAR_UPDATES}, "
+        f"result_digits={digits}, result_digit_limit={MAX_CANONICAL_RATIONAL_DIGITS}"
+    )
+    for reason, measured, limit in (
+        ("result_height", digits, MAX_CANONICAL_RATIONAL_DIGITS),
+        ("basis_bound", candidates, MAX_LINEAR_PROGRAM_BASES),
+        ("work_bound", work, MAX_LINEAR_PROGRAM_SCALAR_UPDATES),
+    ):
+        if measured > limit:
+            raise OperationResourceAdmissionError(
+                location=("program",),
+                code=f"optimization.linear.{reason}",
+                message=f"Exact LP {reason} exceeded: {quantities}.",
+            )
+    return LinearAdmission(columns, digits)
+
+
+def independent_rows(a: Any, b: Any) -> tuple[tuple[int, ...], Any | None]:
+    """Select source rows, or produce a source-coordinate dependence witness."""
+    from flint import fmpq_mat
+
+    reduced, rank = a.transpose().rref()
+    request_checkpoint("linear-program row reduction")
+    indices = tuple(
+        next(j for j in range(a.nrows()) if reduced[i, j]) for i in range(rank)
+    )
+    selected = fmpq_mat([[a[i, j] for j in range(a.ncols())] for i in indices])
+    reduced_rows, _ = selected.rref()
+    pivots = tuple(
+        next(j for j in range(a.ncols()) if reduced_rows[i, j]) for i in range(rank)
+    )
+    square = fmpq_mat([[a[i, j] for j in pivots] for i in indices])
+    weights = (
+        fmpq_mat([[a[i, j] for j in pivots] for i in range(a.nrows())]) * square.inv()
+    )
+    residual = b - weights * fmpq_mat([[b[i, 0]] for i in indices])
+    request_checkpoint("linear-program row consistency")
+    for i in range(a.nrows()):
+        if residual[i, 0]:
+            witness = fmpq_mat(a.nrows(), 1)
+            sign = 1 if residual[i, 0] > 0 else -1
+            witness[i, 0] = -sign
+            for j, source in enumerate(indices):
+                witness[source, 0] += sign * weights[i, j]
+            return indices, witness
+    return indices, None
+
+
+def search_bases(
+    a: Any, b: Any, c: Any, *, artificial: bool = False
+) -> tuple[Any, Any, Any | None] | None:
+    """Return a primal/dual pair or a primal/ray pair from one finite family."""
+    from flint import fmpq_mat
+
+    rows, columns = a.nrows(), a.ncols()
+    family = (
+        ((*basis, columns - 1) for basis in combinations(range(columns - 1), rows - 1))
+        if artificial
+        else combinations(range(columns), rows)
+    )
+    for basis in family:
+        request_checkpoint("linear-program basis search")
+        square = fmpq_mat([[a[i, j] for j in basis] for i in range(rows)])
+        try:
+            inverse = square.inv()
+        except ZeroDivisionError:  # FLINT's documented singular-matrix outcome.
+            continue
+        basic_point = inverse * b
+        if any(basic_point[i, 0] < 0 for i in range(rows)):
+            continue
+        point = fmpq_mat(columns, 1)
+        for i, j in enumerate(basis):
+            point[j, 0] = basic_point[i, 0]
+        dual = fmpq_mat([[c[0, j] for j in basis]]) * inverse
+        slacks = c - dual * a
+        if all(slacks[0, j] >= 0 for j in range(columns)):
+            return point, dual.transpose(), None
+        if artificial:
+            continue  # min t >= 0 cannot be unbounded below.
+        tableau = inverse * a
+        for j in range(columns):
+            if slacks[0, j] < 0 and all(tableau[i, j] <= 0 for i in range(rows)):
+                ray = fmpq_mat(columns, 1)
+                ray[j, 0] = 1
+                for i, k in enumerate(basis):
+                    ray[k, 0] = -tableau[i, j]
+                return point, dual.transpose(), ray
+    return None

--- a/src/jacobian/math/optimization/_models.py
+++ b/src/jacobian/math/optimization/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from fractions import Fraction
-from math import comb, factorial
+from math import factorial
 from typing import Any, Literal, Self
 
 from pydantic import Field, ValidationInfo, model_validator
@@ -21,8 +21,8 @@ MAX_RATIONAL_DIGITS = 128
 MAX_LINEAR_PROGRAM_VARIABLES = 32
 MAX_LINEAR_PROGRAM_CONSTRAINTS = 64
 MAX_LINEAR_PROGRAM_VARIABLE_NAME_LENGTH = 64
-MAX_LINEAR_PROGRAM_SIMPLEX_BASES = 1_000_000
-MAX_LINEAR_PROGRAM_SIMPLEX_SCALAR_UPDATES = 50_000_000
+MAX_LINEAR_PROGRAM_BASES = 1_000_000
+MAX_LINEAR_PROGRAM_SCALAR_UPDATES = 50_000_000
 _INTERMEDIATE_SCALAR_DIGITS = "standard_intermediate_scalar_digits"
 
 
@@ -219,14 +219,15 @@ def _has_trivial_inconsistent_row(
 
 
 def _result_digit_bound(program: StandardFormRationalLinearProgram) -> int:
-    """Bound simplex tableaux, witnesses, and source-derived diagnostics.
+    """Conservatively bound basis witnesses and source-derived diagnostics.
 
     Clearing denominators row by row turns each exact LP used by the operation
-    into an integer tableau. Every basic coordinate, reduced cost, objective,
-    and normalized Farkas or recession coordinate is a ratio of minors. The
-    Leibniz bounds below include one additional row for a derived diagnostic.
-    Free dual/Farkas variables are represented as a difference of two
-    nonnegative basic variables; the final two digits cover that subtraction.
+    into an integer matrix. Every basic coordinate, reduced cost, objective,
+    and Farkas or recession coordinate is a ratio of minors. Both source-row
+    and transposed-row denominator clearings are covered below. Duplicated rows
+    and normalization rows deliberately overestimate the minors needed by the
+    single-artificial-column basis algorithm; the additional diagnostic rows
+    and final two digits cover exact dot products and differences.
     """
 
     if _has_trivial_inconsistent_row(program):
@@ -299,38 +300,6 @@ def _result_digit_bound(program: StandardFormRationalLinearProgram) -> int:
             ),
             variable_columns=2 * variables,
         ),
-    )
-
-
-def _simplex_candidate_and_update_bounds(
-    *,
-    variables: int,
-    equations: int,
-) -> tuple[int, int]:
-    """Bound Bland pivots by all possible bases in both simplex phases."""
-
-    def solve(rows: int, columns: int) -> tuple[int, int]:
-        # SymPy's pinned exact simplex uses Bland's rule. Each phase therefore
-        # visits no basis twice; the factor two covers feasibility and optimum.
-        candidates = 2 * comb(rows + columns, rows)
-        scalar_updates = candidates * (rows + 2) * (columns + 2)
-        return candidates, scalar_updates
-
-    # ``lpmin`` may introduce one shifted nonnegative auxiliary for each
-    # source variable whose univariate constraints form a finite interval.
-    primal = solve(2 * equations, 2 * variables)
-    dual = solve(variables, 2 * equations)
-    farkas = solve(variables + 2, 2 * equations)
-    feasible_point = primal
-    recession = solve(2 * (equations + 1), 2 * variables)
-    branches = (
-        (primal, dual),
-        (primal, farkas),
-        (primal, feasible_point, recession),
-    )
-    return (
-        max(sum(item[0] for item in branch) for branch in branches),
-        max(sum(item[1] for item in branch) for branch in branches),
     )
 
 
@@ -439,33 +408,6 @@ class StandardFormRationalLinearProgram(StrictModel):
                 "row_width", "every coefficient row must match the variable count"
             )
 
-        result_digits = _result_digit_bound(self)
-        if result_digits > MAX_CANONICAL_RATIONAL_DIGITS:
-            raise _validation_error(
-                "result_height",
-                "linear-program rational height can exceed the exact "
-                f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit result bound",
-            )
-        direct_certificate = _has_trivial_inconsistent_row(self)
-        active_equations = 0 if direct_certificate else len(_active_equations(self))
-        candidates, scalar_updates = (0, 0)
-        if not direct_certificate:
-            candidates, scalar_updates = _simplex_candidate_and_update_bounds(
-                variables=len(self.variables),
-                equations=active_equations,
-            )
-        if candidates > MAX_LINEAR_PROGRAM_SIMPLEX_BASES:
-            raise _validation_error(
-                "simplex_basis_bound",
-                "linear-program possible simplex bases exceed the "
-                f"{MAX_LINEAR_PROGRAM_SIMPLEX_BASES}-candidate bound",
-            )
-        if scalar_updates > MAX_LINEAR_PROGRAM_SIMPLEX_SCALAR_UPDATES:
-            raise _validation_error(
-                "simplex_work_bound",
-                "linear-program exact simplex pivot work exceeds the "
-                f"{MAX_LINEAR_PROGRAM_SIMPLEX_SCALAR_UPDATES}-scalar-update bound",
-            )
         return self
 
     @classmethod
@@ -475,7 +417,7 @@ class StandardFormRationalLinearProgram(StrictModel):
         Public requests keep the ``MAX_RATIONAL_DIGITS`` source-scalar cap.
         A normalization step that derives its intermediates from admitted
         inputs may pass the envelope its own derivation proves; every derived
-        result-height and simplex-work checks above still run unchanged.
+        shape checks above still run; execution owns resource admission.
         """
 
         return cls.model_validate(
@@ -632,8 +574,8 @@ def _require_result_shape(result: RationalLinearProgramResult) -> None:
 
 
 __all__ = [
-    "MAX_LINEAR_PROGRAM_SIMPLEX_BASES",
-    "MAX_LINEAR_PROGRAM_SIMPLEX_SCALAR_UPDATES",
+    "MAX_LINEAR_PROGRAM_BASES",
+    "MAX_LINEAR_PROGRAM_SCALAR_UPDATES",
     "RationalLinearProgramRequest",
     "RationalLinearProgramResult",
     "RationalLinearProgramStatus",

--- a/src/jacobian/math/optimization/_tools.py
+++ b/src/jacobian/math/optimization/_tools.py
@@ -7,10 +7,27 @@ from jacobian.math.optimization._general_models import (
     GeneralRationalLinearProgramResult,
 )
 from jacobian.math.optimization._models import (
+    MAX_LINEAR_PROGRAM_BASES,
+    MAX_LINEAR_PROGRAM_CONSTRAINTS,
+    MAX_LINEAR_PROGRAM_SCALAR_UPDATES,
+    MAX_LINEAR_PROGRAM_VARIABLES,
     RationalLinearProgramRequest,
     RationalLinearProgramResult,
 )
 from jacobian.math.optimization.operations import linear_program
+
+_BASIS_ENVELOPE = (
+    "Resource admission removes zero columns and zero equalities for work estimates. "
+    "For n remaining columns and m remaining rows, the basis estimate is "
+    "max C(n+1,r) over 0<=r<=min(n,m); the work estimate is "
+    "8(m+1)^2(n+m+2) + max C(n+1,r)[4r^3+2r^2(n+2)+4r(n+2)]. "
+    f"Limits are {MAX_LINEAR_PROGRAM_BASES} bases and "
+    f"{MAX_LINEAR_PROGRAM_SCALAR_UPDATES} scalar updates, plus source-derived "
+    "rational-minor height within the canonical rational digit limit. "
+    "Rejections report derived counts, estimates and limits; shape bounds alone "
+    "do not guarantee admission. Execution has one 600-second cooperative safety "
+    "deadline; expiration yields an execution error, never a mathematical conclusion."
+)
 
 
 def _linear_program_request(
@@ -30,11 +47,11 @@ RATIONAL_LINEAR_OPERATIONS: MathTools = (
         operation_id="optimization.linear.rational_optimum.compute",
         title="Solve a rational linear program",
         description=(
-            "Use exact SymPy simplex calls to return a source-bound standard-form "
-            "rational LP outcome. Optimal and feasible outcomes retain replayed "
+            "Return a source-bound standard-form rational LP outcome using exact "
+            "basis linear algebra. Optimal and feasible outcomes retain checked "
             "points; infeasible outcomes carry a Farkas witness; unbounded outcomes "
             "carry a feasible point and recession direction. Operational failure "
-            "uses the execution-error path."
+            "uses the execution-error path. " + _BASIS_ENVELOPE
         ),
         request_type=RationalLinearProgramRequest,
         result_type=RationalLinearProgramResult,
@@ -71,8 +88,14 @@ RATIONAL_LINEAR_OPERATIONS = (
         description=(
             "Solve a bounded exact rational LP with labeled LE, EQ, and GE rows, "
             "finite bounds, and free variables. Results retain the original source "
-            "coordinates and replayed optimality, Farkas, or recession evidence; "
-            "private slack and sign-split columns never appear on the wire."
+            "coordinates and checked optimality, Farkas, or recession evidence; "
+            "private slack and sign-split columns never appear on the wire. "
+            "Bound-only boxes and one-variable intervals have direct exact paths. "
+            "Other programs normalize each free variable to two columns and each "
+            "one-sided variable to one, plus one slack per inequality and one "
+            "row/slack per two-sided variable bound. Normalized limits are "
+            f"{MAX_LINEAR_PROGRAM_VARIABLES} columns and {MAX_LINEAR_PROGRAM_CONSTRAINTS} rows. "
+            + _BASIS_ENVELOPE
         ),
         request_type=GeneralRationalLinearProgramRequest,
         result_type=GeneralRationalLinearProgramResult,

--- a/src/jacobian/math/optimization/operations.py
+++ b/src/jacobian/math/optimization/operations.py
@@ -1,544 +1,216 @@
-"""Bounded rational optimization operations backed by SymPy."""
-
-from __future__ import annotations
+"""Bounded exact LP outcomes from FLINT basis linear algebra."""
 
 from fractions import Fraction
 from typing import Any, NoReturn
 
 from jacobian._exact import CanonicalRational
+from jacobian._execution import request_checkpoint
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.optimization._arithmetic import rational_dot
+from jacobian.math.optimization._linear_basis import (
+    LinearAdmission,
+    admit_linear_program,
+    independent_rows,
+    linear_execution,
+    search_bases,
+)
 from jacobian.math.optimization._models import (
     RationalLinearProgramResult,
     StandardFormRationalLinearProgram,
-    _active_equations,
     _dual_diagnostics,
     _primal_diagnostics,
-    _result_digit_bound,
+    _program_fractions,
 )
 
 
-def _rational(value: CanonicalRational) -> Any:
-    import sympy
-
-    return sympy.Rational(value.as_fraction())
+def _execution_failure() -> NoReturn:
+    raise RuntimeError("exact linear-program execution produced no mathematical result")
 
 
-def _linear(coefficients: tuple[Any, ...], symbols: tuple[Any, ...]) -> Any:
-    import sympy
-
-    return sum(
-        (
-            coefficient * symbol
-            for coefficient, symbol in zip(coefficients, symbols, strict=True)
-        ),
-        sympy.S.Zero,
-    )
-
-
-def _wire(value: Any, *, max_digits: int) -> CanonicalRational | None:
-    import sympy
-
-    try:
-        rational = sympy.Rational(value)
-        numerator = int(rational.p)
-        denominator = int(rational.q)
-    except (TypeError, ValueError, ZeroDivisionError):
-        return None
-    if len(str(abs(numerator))) > max_digits or len(str(denominator)) > max_digits:
-        return None
-    return CanonicalRational.from_integer_ratio(numerator, denominator)
-
-
-def _wire_fraction(
-    value: Fraction,
-    *,
-    max_digits: int,
-) -> CanonicalRational | None:
-    if (
-        len(str(abs(value.numerator))) > max_digits
-        or len(str(value.denominator)) > max_digits
-    ):
-        return None
-    return CanonicalRational.from_fraction(value)
-
-
-def _wire_solution(
-    solution: dict[Any, Any],
-    symbols: tuple[Any, ...],
-    *,
-    max_digits: int,
-) -> tuple[CanonicalRational, ...] | None:
-    import sympy
-
-    values: list[CanonicalRational] = []
-    for symbol in symbols:
-        value = _wire(solution.get(symbol, sympy.S.Zero), max_digits=max_digits)
-        if value is None:
-            return None
-        values.append(value)
-    return tuple(values)
-
-
-def _wire_difference_solution(
-    solution: dict[Any, Any],
-    positive_symbols: tuple[Any, ...],
-    negative_symbols: tuple[Any, ...],
-    *,
-    max_digits: int,
-) -> tuple[CanonicalRational, ...] | None:
-    import sympy
-
-    values: list[CanonicalRational] = []
-    for positive, negative in zip(positive_symbols, negative_symbols, strict=True):
-        value = _wire(
-            solution.get(positive, sympy.S.Zero) - solution.get(negative, sympy.S.Zero),
-            max_digits=max_digits,
-        )
-        if value is None:
-            return None
-        values.append(value)
-    return tuple(values)
-
-
-def _program_arrays(
-    program: StandardFormRationalLinearProgram,
-) -> tuple[tuple[Any, ...], tuple[tuple[Any, ...], ...], tuple[Any, ...]]:
-    return (
-        tuple(_rational(value) for value in program.objective),
-        tuple(tuple(_rational(value) for value in row) for row in program.coefficients),
-        tuple(_rational(value) for value in program.rhs),
-    )
-
-
-def _active_row_indices(program: StandardFormRationalLinearProgram) -> tuple[int, ...]:
-    """Return source rows that impose a nontrivial equality."""
-
+def _fractions(vector: Any) -> tuple[Fraction, ...]:
     return tuple(
-        index
-        for index, (row, rhs) in enumerate(
-            zip(program.coefficients, program.rhs, strict=True)
-        )
-        if any(value.num != "0" for value in row) or rhs.num != "0"
+        Fraction(int(v.numerator), int(v.denominator)) for v in vector.entries()
     )
 
 
-def _expand_active_row_values(
-    values: tuple[CanonicalRational, ...],
-    indices: tuple[int, ...],
-    *,
-    source_rows: int,
-) -> tuple[CanonicalRational, ...]:
-    """Embed an auxiliary-row vector back into the source row coordinates."""
+def _wire(values: tuple[Fraction, ...], digits: int) -> tuple[CanonicalRational, ...]:
+    result = []
+    for value in values:
+        numerator = format_canonical_integer(value.numerator)
+        denominator = format_canonical_integer(value.denominator)
+        if max(len(numerator.lstrip("-")), len(denominator)) > digits:
+            _execution_failure()
+        result.append(CanonicalRational(num=numerator, den=denominator))
+    return tuple(result)
 
-    zero = CanonicalRational.from_integer_ratio(0, 1)
-    expanded = [zero] * source_rows
+
+def _certify_infeasible(
+    program: StandardFormRationalLinearProgram,
+    witness: tuple[Fraction, ...],
+    digits: int,
+) -> RationalLinearProgramResult:
+    """Establish A^T y>=0 AND b^T y<0 before the trusted boundary."""
+    _, a, b = _program_fractions(program)
+    if (
+        len(witness) != len(b)
+        or rational_dot(b, witness) >= 0
+        or any(
+            sum((row[j] * y for row, y in zip(a, witness, strict=True)), Fraction()) < 0
+            for j in range(len(program.variables))
+        )
+    ):
+        _execution_failure()
+    return RationalLinearProgramResult._from_kernel(
+        program=program,
+        status="INFEASIBLE",
+        farkas_candidate=_wire(witness, digits),
+    )
+
+
+def _certify_point(
+    program: StandardFormRationalLinearProgram,
+    point: tuple[Fraction, ...],
+    dual: tuple[Fraction, ...],
+    ray: tuple[Fraction, ...] | None,
+    digits: int,
+) -> RationalLinearProgramResult:
+    objective, residuals = _primal_diagnostics(program, point)
+    if any(v < 0 for v in point) or any(residuals):
+        _execution_failure()
+    values: dict[str, Any] = {
+        "program": program,
+        "primal_candidate": _wire(point, digits),
+        "primal_objective": _wire((objective,), digits)[0],
+        "primal_residuals": _wire(residuals, digits),
+    }
+    if ray is not None:
+        c, a, _ = _program_fractions(program)
+        if (
+            any(v < 0 for v in ray)
+            or any(rational_dot(row, ray) for row in a)
+            or rational_dot(c, ray) >= 0
+        ):
+            _execution_failure()
+        return RationalLinearProgramResult._from_kernel(
+            **values,
+            status="UNBOUNDED",
+            recession_direction=_wire(ray, digits),
+        )
+    dual_objective, slacks = _dual_diagnostics(program, dual)
+    if any(v < 0 for v in slacks) or dual_objective != objective:
+        _execution_failure()
+    return RationalLinearProgramResult._from_kernel(
+        **values,
+        status="OPTIMAL",
+        dual_candidate=_wire(dual, digits),
+        dual_objective=_wire((dual_objective,), digits)[0],
+        dual_slacks=_wire(slacks, digits),
+    )
+
+
+def _expand_vector(
+    indices: tuple[int, ...], values: tuple[Fraction, ...], size: int
+) -> tuple[Fraction, ...]:
+    expanded = [Fraction()] * size
     for index, value in zip(indices, values, strict=True):
         expanded[index] = value
     return tuple(expanded)
 
 
-def _solve_primal(
+def _linear_program_admitted(
     program: StandardFormRationalLinearProgram,
-    objective: tuple[Any, ...],
-    *,
-    symbol_prefix: str,
-) -> tuple[tuple[Any, ...], dict[Any, Any]]:
-    import sympy
-    from sympy.solvers.simplex import InfeasibleLPError, lpmin
-
-    _, coefficients, rhs = _program_arrays(program)
-    symbols = tuple(sympy.symbols(f"{symbol_prefix}0:{len(program.variables)}"))
-    constraints = []
-    for row, expected in zip(coefficients, rhs, strict=True):
-        if any(row):
-            constraints.append(
-                sympy.Eq(_linear(row, symbols), expected, evaluate=False)
-            )
-        elif expected:
-            raise InfeasibleLPError("zero coefficient row has a nonzero rhs")
-    constraints.extend(
-        sympy.Ge(symbol, sympy.S.Zero, evaluate=False) for symbol in symbols
-    )
-    _, solution = lpmin(_linear(objective, symbols), constraints)
-    return symbols, solution
-
-
-def _solve_dual(
-    program: StandardFormRationalLinearProgram,
-) -> tuple[tuple[int, ...], tuple[Any, ...], dict[Any, Any]]:
-    import sympy
-    from sympy.solvers.simplex import lpmax
-
-    objective, all_coefficients, all_rhs = _program_arrays(program)
-    indices = _active_row_indices(program)
-    coefficients = tuple(all_coefficients[index] for index in indices)
-    rhs = tuple(all_rhs[index] for index in indices)
-    symbols = tuple(sympy.symbols(f"_lp_dual0:{len(rhs)}"))
-    constraints = [
-        sympy.Le(
-            _linear(
-                tuple(row[column] for row in coefficients),
-                symbols,
-            ),
-            objective[column],
-            evaluate=False,
-        )
-        for column in range(len(objective))
-    ]
-    _, solution = lpmax(_linear(rhs, symbols), constraints)
-    return indices, symbols, solution
-
-
-def _solve_farkas(
-    program: StandardFormRationalLinearProgram,
-) -> tuple[tuple[int, ...], tuple[Any, ...], tuple[Any, ...], dict[Any, Any]]:
-    import sympy
-    from sympy.solvers.simplex import InfeasibleLPError, lpmin
-
-    _, all_coefficients, all_rhs = _program_arrays(program)
-    indices = _active_row_indices(program)
-    coefficients = tuple(all_coefficients[index] for index in indices)
-    rhs = tuple(all_rhs[index] for index in indices)
-    if not any(rhs):
-        raise InfeasibleLPError("Farkas normalization requires a nonzero rhs")
-    positive = tuple(sympy.symbols(f"_lp_farkas_positive0:{len(rhs)}"))
-    negative = tuple(sympy.symbols(f"_lp_farkas_negative0:{len(rhs)}"))
-    symbols = tuple(
-        positive_value - negative_value
-        for positive_value, negative_value in zip(positive, negative, strict=True)
-    )
-    constraints = [
-        sympy.Ge(
-            _linear(
-                tuple(row[column] for row in coefficients),
-                symbols,
-            ),
-            sympy.S.Zero,
-            evaluate=False,
-        )
-        for column in range(len(program.variables))
-    ]
-    constraints.append(
-        sympy.Eq(
-            _linear(rhs, symbols),
-            -sympy.S.One,
-            evaluate=False,
-        )
-    )
-    constraints.extend(
-        sympy.Ge(symbol, sympy.S.Zero, evaluate=False)
-        for symbol in (*positive, *negative)
-    )
-    _, solution = lpmin(sum((*positive, *negative), sympy.S.Zero), constraints)
-    return indices, positive, negative, solution
-
-
-def _solve_recession_direction(
-    program: StandardFormRationalLinearProgram,
-) -> tuple[tuple[Any, ...], dict[Any, Any]]:
-    import sympy
-    from sympy.solvers.simplex import InfeasibleLPError, lpmin
-
-    objective, coefficients, _ = _program_arrays(program)
-    if not any(objective):
-        raise InfeasibleLPError("a zero objective has no decreasing direction")
-    symbols = tuple(sympy.symbols(f"_lp_ray0:{len(program.variables)}"))
-    constraints = [
-        sympy.Eq(_linear(row, symbols), sympy.S.Zero, evaluate=False)
-        for row in coefficients
-        if any(row)
-    ]
-    constraints.append(
-        sympy.Eq(
-            _linear(objective, symbols),
-            -sympy.S.One,
-            evaluate=False,
-        )
-    )
-    constraints.extend(
-        sympy.Ge(symbol, sympy.S.Zero, evaluate=False) for symbol in symbols
-    )
-    one_objective = tuple(sympy.S.One for _ in symbols)
-    _, solution = lpmin(_linear(one_objective, symbols), constraints)
-    return symbols, solution
-
-
-def _primal_data(
-    program: StandardFormRationalLinearProgram,
-    candidate: tuple[CanonicalRational, ...],
-    *,
-    max_digits: int,
-) -> tuple[CanonicalRational, tuple[CanonicalRational, ...]] | None:
-    values = tuple(value.as_fraction() for value in candidate)
-    objective, residuals = _primal_diagnostics(program, values)
-    # SymPy can return a symbolic/partial point for an infeasible model.  The
-    # diagnostics are already computed while converting that point; reject it
-    # here instead of constructing a result and replaying the whole claim.
-    if any(value < 0 for value in values) or any(residuals):
-        return None
-    wire_objective = _wire_fraction(objective, max_digits=max_digits)
-    wire_residuals = tuple(
-        _wire_fraction(value, max_digits=max_digits) for value in residuals
-    )
-    if wire_objective is None or any(value is None for value in wire_residuals):
-        return None
-    return wire_objective, tuple(value for value in wire_residuals if value is not None)
-
-
-def _dual_data(
-    program: StandardFormRationalLinearProgram,
-    candidate: tuple[CanonicalRational, ...],
-    *,
-    max_digits: int,
-) -> tuple[CanonicalRational, tuple[CanonicalRational, ...]] | None:
-    values = tuple(value.as_fraction() for value in candidate)
-    objective, slacks = _dual_diagnostics(program, values)
-    # A dual point with a negative slack is not an optimality certificate.
-    # This is an integration check on the backend output, not a second solve.
-    if any(value < 0 for value in slacks):
-        return None
-    wire_objective = _wire_fraction(objective, max_digits=max_digits)
-    wire_slacks = tuple(
-        _wire_fraction(value, max_digits=max_digits) for value in slacks
-    )
-    if wire_objective is None or any(value is None for value in wire_slacks):
-        return None
-    return wire_objective, tuple(value for value in wire_slacks if value is not None)
-
-
-def _execution_failure(
-    program: StandardFormRationalLinearProgram,
-) -> NoReturn:
-    raise RuntimeError("exact linear-program execution produced no mathematical result")
-
-
-def _trivial_infeasibility(
-    program: StandardFormRationalLinearProgram,
-) -> RationalLinearProgramResult | None:
-    zero = CanonicalRational.from_integer_ratio(0, 1)
-    for row_index, (row, rhs) in enumerate(
-        zip(program.coefficients, program.rhs, strict=True)
-    ):
-        if any(value.num != "0" for value in row) or rhs.num == "0":
-            continue
-        witness = [zero] * len(program.rhs)
-        witness[row_index] = CanonicalRational.from_integer_ratio(
-            1 if rhs.num.startswith("-") else -1,
-            1,
-        )
-        return RationalLinearProgramResult._from_kernel(
-            program=program,
-            status="INFEASIBLE",
-            farkas_candidate=tuple(witness),
-        )
-    return None
-
-
-def _certify_infeasible(
-    program: StandardFormRationalLinearProgram,
-    *,
-    result_digits: int,
+    admission: LinearAdmission,
 ) -> RationalLinearProgramResult:
-    from sympy.solvers.simplex import InfeasibleLPError, UnboundedLPError
+    from flint import fmpq, fmpq_mat
 
-    try:
-        active_rows, positive_symbols, negative_symbols, farkas_solution = (
-            _solve_farkas(program)
+    digits = admission.result_digits
+    width, height = len(program.variables), len(program.rhs)
+    zero = Fraction()
+    for i, (row, rhs) in enumerate(zip(program.coefficients, program.rhs, strict=True)):
+        if not any(v.num != "0" for v in row) and rhs.num != "0":
+            witness = [zero] * height
+            witness[i] = Fraction(1 if rhs.num.startswith("-") else -1)
+            return _certify_infeasible(program, tuple(witness), digits)
+    columns = admission.columns
+    active_rows = tuple(
+        i
+        for i, row in enumerate(program.coefficients)
+        if any(v.num != "0" for v in row)
+    )
+    zero_ray = next(
+        (
+            j
+            for j, c in enumerate(program.objective)
+            if j not in columns and c.num.startswith("-")
+        ),
+        None,
+    )
+    if not columns:
+        ray = None
+        if zero_ray is not None:
+            ray_values = [zero] * width
+            ray_values[zero_ray] = Fraction(1)
+            ray = tuple(ray_values)
+        return _certify_point(program, (zero,) * width, (zero,) * height, ray, digits)
+
+    def scalar(v: CanonicalRational) -> Any:
+        return fmpq(*v.as_integer_ratio())
+
+    a = fmpq_mat(
+        [[scalar(program.coefficients[i][j]) for j in columns] for i in active_rows]
+    )
+    b = fmpq_mat([[scalar(program.rhs[i])] for i in active_rows])
+    row_indices, inconsistent = independent_rows(a, b)
+    if inconsistent is not None:
+        witness = [zero] * height
+        for i, v in zip(active_rows, _fractions(inconsistent), strict=True):
+            witness[i] = v
+        return _certify_infeasible(program, tuple(witness), digits)
+    reduced_a = fmpq_mat([[a[i, j] for j in range(len(columns))] for i in row_indices])
+    reduced_b = fmpq_mat([[b[i, 0]] for i in row_indices])
+    c = fmpq_mat([[scalar(program.objective[j]) for j in columns]])
+    solved = search_bases(reduced_a, reduced_b, c)
+    if solved is None:
+        augmented = fmpq_mat(
+            [
+                [reduced_a[i, j] for j in range(len(columns))] + [reduced_b[i, 0]]
+                for i in range(len(row_indices))
+            ]
         )
-    except (
-        InfeasibleLPError,
-        UnboundedLPError,
-        AttributeError,
-        IndexError,
-        TypeError,
-        ValueError,
-        ZeroDivisionError,
-    ):
-        return _execution_failure(program)
-    active_farkas = _wire_difference_solution(
-        farkas_solution,
-        positive_symbols,
-        negative_symbols,
-        max_digits=result_digits,
-    )
-    if active_farkas is None:
-        return _execution_failure(program)
-    farkas = _expand_active_row_values(
-        active_farkas,
-        active_rows,
-        source_rows=len(program.rhs),
-    )
-    try:
-        return RationalLinearProgramResult._from_kernel(
-            program=program, status="INFEASIBLE", farkas_candidate=farkas
+        phase_one = search_bases(
+            augmented, reduced_b, fmpq_mat([[0] * len(columns) + [1]]), artificial=True
         )
-    except ValueError:
-        return _execution_failure(program)
+        if phase_one is None:
+            _execution_failure()
+        witness = [zero] * height
+        for i, v in zip(row_indices, _fractions(phase_one[1]), strict=True):
+            witness[active_rows[i]] = -v
+        return _certify_infeasible(program, tuple(witness), digits)
 
-
-def _certify_unbounded(
-    program: StandardFormRationalLinearProgram,
-    *,
-    result_digits: int,
-) -> RationalLinearProgramResult:
-    import sympy
-    from sympy.solvers.simplex import InfeasibleLPError, UnboundedLPError
-
-    feasibility_objective = tuple(sympy.S.One for _ in program.variables)
-    try:
-        feasible_symbols, feasible_solution = _solve_primal(
-            program,
-            feasibility_objective,
-            symbol_prefix="_lp_feasible",
-        )
-        ray_symbols, ray_solution = _solve_recession_direction(program)
-    except (
-        InfeasibleLPError,
-        UnboundedLPError,
-        AttributeError,
-        IndexError,
-        TypeError,
-        ValueError,
-        ZeroDivisionError,
-    ):
-        return _execution_failure(program)
-    feasible = _wire_solution(
-        feasible_solution,
-        feasible_symbols,
-        max_digits=result_digits,
+    basic_point, basic_dual, basic_ray = solved
+    point = _expand_vector(columns, _fractions(basic_point), width)
+    dual = _expand_vector(
+        tuple(active_rows[i] for i in row_indices), _fractions(basic_dual), height
     )
-    ray = _wire_solution(
-        ray_solution,
-        ray_symbols,
-        max_digits=result_digits,
-    )
-    if feasible is None or ray is None:
-        return _execution_failure(program)
-    primal_data = _primal_data(
-        program,
-        feasible,
-        max_digits=result_digits,
-    )
-    if primal_data is None:
-        return _execution_failure(program)
-    primal_objective, primal_residuals = primal_data
-    try:
-        return RationalLinearProgramResult._from_kernel(
-            program=program,
-            status="UNBOUNDED",
-            primal_candidate=feasible,
-            primal_objective=primal_objective,
-            primal_residuals=primal_residuals,
-            recession_direction=ray,
-        )
-    except ValueError:
-        return _execution_failure(program)
-
-
-def _positive_result(
-    program: StandardFormRationalLinearProgram,
-    primal_symbols: tuple[Any, ...],
-    primal_solution: dict[Any, Any],
-    *,
-    result_digits: int,
-) -> RationalLinearProgramResult:
-    from sympy.solvers.simplex import InfeasibleLPError, UnboundedLPError
-
-    primal = _wire_solution(
-        primal_solution,
-        primal_symbols,
-        max_digits=result_digits,
-    )
-    if primal is None:
-        return _certify_infeasible(program, result_digits=result_digits)
-    primal_data = _primal_data(program, primal, max_digits=result_digits)
-    if primal_data is None:
-        return _certify_infeasible(program, result_digits=result_digits)
-    primal_objective, primal_residuals = primal_data
-    primal_result = RationalLinearProgramResult._from_kernel(
-        program=program,
-        status="PRIMAL_FEASIBLE",
-        primal_candidate=primal,
-        primal_objective=primal_objective,
-        primal_residuals=primal_residuals,
-    )
-    if not _active_equations(program):
-        dual = tuple(CanonicalRational.from_integer_ratio(0, 1) for _ in program.rhs)
-    else:
-        try:
-            active_rows, dual_symbols, dual_solution = _solve_dual(program)
-        except (
-            InfeasibleLPError,
-            UnboundedLPError,
-            AttributeError,
-            IndexError,
-            TypeError,
-            ValueError,
-            ZeroDivisionError,
-        ):
-            return primal_result
-        converted_dual = _wire_solution(
-            dual_solution,
-            dual_symbols,
-            max_digits=result_digits,
-        )
-        if converted_dual is None:
-            return primal_result
-        dual = _expand_active_row_values(
-            converted_dual,
-            active_rows,
-            source_rows=len(program.rhs),
-        )
-    dual_data = _dual_data(program, dual, max_digits=result_digits)
-    if dual_data is None:
-        return primal_result
-    dual_objective, dual_slacks = dual_data
-    if dual_objective != primal_objective:
-        return primal_result
-    optimal_result = RationalLinearProgramResult._from_kernel(
-        program=program,
-        status="OPTIMAL",
-        primal_candidate=primal,
-        primal_objective=primal_objective,
-        primal_residuals=primal_residuals,
-        dual_candidate=dual,
-        dual_objective=dual_objective,
-        dual_slacks=dual_slacks,
-    )
-    return optimal_result
+    ray = None
+    if zero_ray is not None or basic_ray is not None:
+        ray_values = [zero] * width
+        if zero_ray is not None:
+            ray_values[zero_ray] = Fraction(1)
+        else:
+            for j, v in zip(columns, _fractions(basic_ray), strict=True):
+                ray_values[j] = v
+        ray = tuple(ray_values)
+    request_checkpoint("linear-program certificate construction")
+    return _certify_point(program, tuple(point), tuple(dual), ray, digits)
 
 
 def linear_program(
     program: StandardFormRationalLinearProgram,
 ) -> RationalLinearProgramResult:
-    import sympy
-    from sympy.solvers.simplex import InfeasibleLPError, UnboundedLPError
-
-    trivial_infeasibility = _trivial_infeasibility(program)
-    if trivial_infeasibility is not None:
-        return trivial_infeasibility
-    result_digits = _result_digit_bound(program)
-    objective, _, _ = _program_arrays(program)
-    backend_objective = (
-        objective if any(objective) else tuple(sympy.S.One for _ in program.variables)
-    )
-    try:
-        primal_symbols, primal_solution = _solve_primal(
-            program,
-            backend_objective,
-            symbol_prefix="_lp_primal",
-        )
-    except InfeasibleLPError:
-        return _certify_infeasible(program, result_digits=result_digits)
-    except UnboundedLPError:
-        return _certify_unbounded(program, result_digits=result_digits)
-    except (AttributeError, IndexError, TypeError, ValueError, ZeroDivisionError):
-        return _execution_failure(program)
-    return _positive_result(
-        program,
-        primal_symbols,
-        primal_solution,
-        result_digits=result_digits,
-    )
+    """Minimize c^T x over Ax=b, x>=0 with exact source certificates."""
+    with linear_execution():
+        return _linear_program_admitted(program, admit_linear_program(program))
 
 
 __all__ = ["linear_program"]

--- a/src/jacobian/math/polynomials/series/_models.py
+++ b/src/jacobian/math/polynomials/series/_models.py
@@ -10,6 +10,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
 from jacobian.math._rational_height import RationalHeight, sum_heights
 
 # ---------------------------------------------------------------------------
@@ -178,10 +179,11 @@ def _cleared_series(series: TruncatedSeries) -> tuple[int, tuple[int, ...]]:
     """
     denominator = 1
     for value in series.coefficients:
-        denominator = lcm(denominator, int(value.den))
+        denominator = lcm(denominator, parse_canonical_integer(value.den))
         _require_binary_height(0, denominator.bit_length(), "inverse")
     return denominator, tuple(
-        int(value.num) * (denominator // int(value.den))
+        parse_canonical_integer(value.num)
+        * (denominator // parse_canonical_integer(value.den))
         for value in series.coefficients
     )
 

--- a/src/jacobian/math/polynomials/series/_models.py
+++ b/src/jacobian/math/polynomials/series/_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from math import lcm
 from typing import Annotated, Literal, Self
 
 from pydantic import Field, StrictInt, StringConstraints, model_validator
@@ -131,13 +132,6 @@ def _max_height(values: tuple[CanonicalRational, ...]) -> RationalHeight:
     )
 
 
-def _merge_max(left: RationalHeight, right: RationalHeight) -> RationalHeight:
-    return RationalHeight(
-        max(left.numerator_digits, right.numerator_digits),
-        max(left.denominator_digits, right.denominator_digits),
-    )
-
-
 def _convolution_height(
     left: RationalHeight, right: RationalHeight, term_count: int
 ) -> RationalHeight:
@@ -169,17 +163,61 @@ def _require_zero_residual(
         )
 
 
-def _inverse_height(series: TruncatedSeries) -> RationalHeight:
-    source = _max_height(series.coefficients)
-    reciprocal = RationalHeight(1, 1).quotient(_height(series.coefficients[0]))
-    _require_height(reciprocal, "inverse")
-    result = reciprocal
-    for degree in range(1, series.truncation_order):
-        recurrence_sum = sum_heights(source.product(result) for _ in range(degree))
-        coefficient = reciprocal.product(recurrence_sum)
-        _require_height(coefficient, "inverse")
-        result = _merge_max(result, coefficient)
-    return result
+def _require_binary_height(numerator: int, denominator: int, operation: str) -> None:
+    # If |p| <= 2**b then p has at most floor(b / 3) + 1 decimal
+    # digits, since 2**3 < 10. No large power or floating log is needed.
+    _require_height(RationalHeight(numerator // 3 + 1, denominator // 3 + 1), operation)
+
+
+def _cleared_series(series: TruncatedSeries) -> tuple[int, tuple[int, ...]]:
+    """Bound denominator clearing before building P in A=P/D.
+
+    At most N lcms are formed. Each temporary integer adds at most one
+    admitted input denominator to the previous bounded lcm; no series
+    coefficients are computed during admission.
+    """
+    denominator = 1
+    for value in series.coefficients:
+        denominator = lcm(denominator, int(value.den))
+        _require_binary_height(0, denominator.bit_length(), "inverse")
+    return denominator, tuple(
+        int(value.num) * (denominator // int(value.den))
+        for value in series.coefficients
+    )
+
+
+def _inverse_height(series: TruncatedSeries) -> tuple[int, int, int, int]:
+    """Return shared numerator/denominator bit bounds and source norm bounds.
+
+    Write A=P/D, p=|P[0]|, C=p+sum_{i>0}|P[i]|. The finite geometric
+    expansion gives a common denominator p**N and numerator magnitude at
+    most D*C**(N-1) for every inverse coefficient. Indeed the degree-k
+    numerator over p**(k+1) is bounded by D*C**k by induction in the
+    triangular recurrence. Homogenizing to p**N preserves that bound.
+    Constant sources only need denominator p. This also bounds every
+    partial recurrence sum after multiplication by a source coefficient.
+
+    With N<=512 the existing kernel uses O(N**2) Fraction operations.
+    Reduced terms and partial sums fit the checked common-denominator
+    bounds; Fraction's unreduced cross-products have at most twice their
+    component bit bounds. Thus intermediates are bounded before execution.
+    """
+    denominator, coefficients = _cleared_series(series)
+    constant = abs(coefficients[0])
+    tail = sum(abs(value) for value in coefficients[1:])
+    order = series.truncation_order if tail else 1
+    source_norm = (constant + tail).bit_length()
+    source_denominator = denominator.bit_length()
+    numerator = source_denominator + (order - 1) * source_norm
+    inverse_denominator = order * (constant - 1).bit_length()
+    _require_binary_height(numerator, inverse_denominator, "inverse")
+    # Product residuals and partial recurrence sums share D*p**N.
+    _require_binary_height(
+        numerator + source_norm + 1,
+        inverse_denominator + source_denominator,
+        "inverse residual",
+    )
+    return numerator, inverse_denominator, source_norm, source_denominator
 
 
 Variable = Annotated[
@@ -330,13 +368,7 @@ def admit_native_inverse(series: TruncatedSeries) -> None:
         raise _validation_error(
             "inverse_zero_constant", "inverse requires a nonzero constant term"
         )
-    inverse = _inverse_height(series)
-    _require_height(
-        _convolution_height(
-            _max_height(series.coefficients), inverse, series.truncation_order
-        ),
-        "inverse residual",
-    )
+    _inverse_height(series)
 
 
 def admit_native_divide(
@@ -347,16 +379,20 @@ def admit_native_divide(
         raise _validation_error(
             "denominator_zero_constant", "denominator must have a nonzero constant term"
         )
-    inverse = _inverse_height(denominator)
-    quotient = _convolution_height(
-        _max_height(numerator.coefficients), inverse, numerator.truncation_order
-    )
-    _require_height(quotient, "division")
-    residual = _convolution_height(
-        _max_height(denominator.coefficients), quotient, numerator.truncation_order
-    )
-    _require_height(
-        sum_heights((residual, _max_height(numerator.coefficients))),
+    inv_num, inv_den, source_norm, source_den = _inverse_height(denominator)
+    common_denominator, coefficients = _cleared_series(numerator)
+    norm = sum(abs(value) for value in coefficients).bit_length()
+    common_den = common_denominator.bit_length()
+    # For numerator Q/E, all quotient partial sums have denominator
+    # E*p**N and numerator bounded by ||Q||_1 times the inverse bound.
+    quotient_num = norm + inv_num
+    quotient_den = common_den + inv_den
+    _require_binary_height(quotient_num, quotient_den, "division")
+    # B*(Q/B)-Q has common denominator D*E*p**N. Include both
+    # convolution partial sums and the final source subtraction.
+    _require_binary_height(
+        max(source_norm + quotient_num, norm + source_den + inv_den) + 1,
+        source_den + quotient_den,
         "division residual",
     )
 

--- a/src/jacobian/math/probability/graphical_models/operations.py
+++ b/src/jacobian/math/probability/graphical_models/operations.py
@@ -100,9 +100,37 @@ def variable_elimination(
         product = _multiply_all(relevant)
         working.append(factor_marginalize(product, variable))
     result = _multiply_all(working)
-    if result.variables != query_variables:
+    if set(result.variables) != set(query_variables):
         raise RuntimeError("variable elimination did not produce the bound query scope")
-    return result
+    return _reindex_factor(result, query_variables)
+
+
+def _reindex_factor(factor: Factor, target: tuple[int, ...]) -> Factor:
+    """Transport a factor into an exact target variable order.
+
+    Factor scopes are ordered; the table is lexicographic in that order.
+    A singleton product preserves its source order, so the final scope can
+    carry the right axes in a different valid order than the sorted query.
+    Reindexing permutes the table exactly instead of relabeling it.
+    """
+
+    if factor.variables == target:
+        return factor
+    assignment_for = _index_to_assignment
+    table: list[CanonicalRational] = []
+    for index in range(scope_size(target, factor.domain_sizes)):
+        assignment = assignment_for(index, target, factor.domain_sizes)
+        value_for = dict(zip(target, assignment, strict=True))
+        source_assignment = tuple(value_for[variable] for variable in factor.variables)
+        source_index = _assignment_to_index(
+            source_assignment, factor.variables, factor.domain_sizes
+        )
+        table.append(factor.table[source_index])
+    return Factor(
+        variables=target,
+        domain_sizes=factor.domain_sizes,
+        table=tuple(table),
+    )
 
 
 def d_separation(

--- a/src/jacobian/math/probability/markov_chains/operations.py
+++ b/src/jacobian/math/probability/markov_chains/operations.py
@@ -45,6 +45,38 @@ class MixingTimeSearchResult:
     max_total_variation_distance: Fraction
 
 
+def _admit_supplied_stationary(
+    matrix: TransitionMatrix,
+    stationary: tuple[Fraction, ...],
+) -> None:
+    dimension = len(matrix)
+    if len(stationary) != dimension:
+        _reject(
+            ("stationary",),
+            "mixing_stationary_length_mismatch",
+            "supplied stationary vector must have one entry per state",
+        )
+    if any(value < 0 for value in stationary) or sum(stationary) != 1:
+        _reject(
+            ("stationary",),
+            "mixing_stationary_not_probability",
+            "supplied stationary vector must be nonnegative and sum to one",
+        )
+    for target in range(dimension):
+        if (
+            sum(
+                stationary[source] * matrix[source][target]
+                for source in range(dimension)
+            )
+            != stationary[target]
+        ):
+            _reject(
+                ("stationary",),
+                "mixing_stationary_not_invariant",
+                "supplied vector is not stationary: pi P must equal pi",
+            )
+
+
 def mixing_time(
     matrix: TransitionMatrix,
     stationary: tuple[Fraction, ...],
@@ -52,6 +84,16 @@ def mixing_time(
     max_steps: int,
 ) -> MixingTimeSearchResult:
     """Return the first exact worst-case epsilon-mixing step within the bound."""
+    _admit_transition_matrix(matrix)
+    _admit_mixing(matrix, epsilon, max_steps)
+    _admit_supplied_stationary(matrix, stationary)
+    irreducible, aperiodic = _ergodic_properties(matrix)
+    if not (irreducible and aperiodic):
+        _reject(
+            ("matrix",),
+            "mixing_not_ergodic",
+            "mixing time requires an irreducible aperiodic chain",
+        )
     import sympy
 
     transition = sympy.Matrix(

--- a/src/jacobian/math/topology/cohomology/hochschild/operations.py
+++ b/src/jacobian/math/topology/cohomology/hochschild/operations.py
@@ -87,10 +87,11 @@ def _boundary_rank(
         import sympy
         from sympy.polys.matrices import DomainMatrix
 
+        field = sympy.GF(algebra.prime)
         domain_matrix = DomainMatrix(
-            [list(row) for row in entries],
+            [[field(value) for value in row] for row in entries],
             (len(entries), len(entries[0])),
-            sympy.GF(algebra.prime),
+            field,
         )
         return int(domain_matrix.rank())
 

--- a/src/jacobian/math/topology/cohomology/operations/operations.py
+++ b/src/jacobian/math/topology/cohomology/operations/operations.py
@@ -75,12 +75,10 @@ def _require_cocycle(
 
 
 def _validate_ambient_complex(
-    cochain_degree: int,
     support: tuple[tuple[int, ...], ...],
-    coefficients: tuple[int, ...],
     ambient: tuple[tuple[int, ...], ...],
 ) -> None:
-    """Verify ambient shape, support containment, closure, and cocyclicity."""
+    """Verify coefficient-independent ambient shape, support, and closure."""
 
     _validate_simplex_entries(ambient, "ambient simplex")
     if any(len(simplex) > MAX_AMBIENT_SIMPLEX_VERTICES for simplex in ambient):
@@ -97,7 +95,6 @@ def _validate_ambient_complex(
                 "cochain support must lie inside the ambient complex",
             )
     _require_downward_closed(ambient)
-    _require_cocycle(cochain_degree, support, coefficients, ambient)
 
 
 def _is_zero_mod2_cochain(
@@ -174,7 +171,8 @@ def _admit_steenrod_square(
                 "supply ambient_simplices or ambient_complex",
             )
         if effective_ambient:
-            _validate_ambient_complex(
+            _validate_ambient_complex(simplex_values, effective_ambient)
+            _require_cocycle(
                 cochain_degree,
                 simplex_values,
                 simplex_coefficients,
@@ -211,12 +209,8 @@ def _admit_bockstein(
             )
         effective_ambient = _effective_ambient(ambient_simplices, ambient_complex)
         if effective_ambient:
-            _validate_ambient_complex(
-                cochain_degree,
-                simplex_values,
-                simplex_coefficients,
-                effective_ambient,
-            )
+            # Zero modulo prime already establishes cocyclicity over Z/p.
+            _validate_ambient_complex(simplex_values, effective_ambient)
 
     _run_admission(admission)
 

--- a/src/jacobian/math/topology/finite/spaces/_tools.py
+++ b/src/jacobian/math/topology/finite/spaces/_tools.py
@@ -63,7 +63,7 @@ def _kolmogorov_quotient(
 
 
 # A Sierpinski space: points {a, b}, preorder rows: a -> {a}, b -> {a, b}
-# (a <= b in specialization order, so open sets are {}, {a}, {a,b}).
+# (a <= b in specialization order, so open sets are {}, {b}, {a,b}).
 _SPACE = {
     "points": ["a", "b"],
     "preorder": [[0], [0, 1]],
@@ -93,7 +93,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         operation_id="topology.finite.closure.compute",
         title="Compute the closure of a subset",
         description="Return the smallest closed set containing the subset. The closure "
-        "of x is the up-set of x in the specialization preorder.",
+        "of x is the down-set of x in the specialization preorder (the stored "
+        "preorder row).",
         request_type=SubsetRequest,
         result_type=ClosureResult,
         run=_closure,

--- a/src/jacobian/math/topology/finite/spaces/operations.py
+++ b/src/jacobian/math/topology/finite/spaces/operations.py
@@ -37,18 +37,23 @@ def minimal_neighbourhoods(
 ) -> tuple[tuple[int, ...], ...]:
     """Return the minimal open neighbourhood of each point.
 
-    In an Alexandrov space, the minimal open neighbourhood of x is {y : y <= x}
-    = the down-set of x in the specialization preorder.
+    The value stores ``preorder[y] = {x : x <= y}`` (the down-set, i.e. the
+    closure of {y}). The minimal open neighbourhood of x is the up-set
+    ``{y : x in preorder[y]}``.
     """
-    return space.preorder
+    count = len(space.points)
+    return tuple(
+        tuple(sorted(y for y in range(count) if x in space.preorder[y]))
+        for x in range(count)
+    )
 
 
 def interior(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[int]:
     """Return the interior of a subset (largest open set contained in it)."""
+    neighbourhoods = minimal_neighbourhoods(space)
     result: set[int] = set()
     for i in range(len(space.points)):
-        nbhd = set(space.preorder[i])
-        if nbhd.issubset(subset):
+        if set(neighbourhoods[i]).issubset(subset):
             result.add(i)
     return frozenset(result)
 
@@ -59,9 +64,7 @@ def closure(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[
     for i in subset:
         if not 0 <= i < len(space.points):
             raise ValueError("subset index out of range")
-        for j in range(len(space.points)):
-            if i in space.preorder[j]:
-                result.add(j)
+        result.update(space.preorder[i])
     return frozenset(result)
 
 

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -21,6 +21,7 @@ import math
 import os
 import signal
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -704,6 +705,9 @@ def run_bounded_process(
     never discovers executables.  *cancellation_event* overrides the context-bound cancellation
     event for explicit callers; when ``None`` the engine uses the
     context-bound event set by :func:`bounded_process_cancellation`.
+
+    Commands using ``sys.executable`` receive the loaded package's import root
+    when *environment* does not explicitly supply ``PYTHONPATH``.
     """
 
     if stdout_limit < 0 or stderr_limit < 0:
@@ -771,7 +775,7 @@ def run_bounded_process(
             stdin=stdin_file,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=environment,
+            env=_command_environment(command, environment),
             cwd=cwd,
             start_new_session=start_new_session,
             creationflags=creationflags,
@@ -889,6 +893,8 @@ def run_bounded_worker_dialogue[ValueT](
     launch admission, every read and write, child exit, stream drain, and
     cleanup. ``stdout_limit`` is cumulative across all frames; ``frame_limit``
     on :meth:`BoundedWorkerDialogue.read_until` bounds one unread frame.
+    Python commands use the same package import binding as
+    :func:`run_bounded_process`.
     """
 
     if stdout_limit < 0 or stderr_limit < 0:
@@ -920,7 +926,7 @@ def run_bounded_worker_dialogue[ValueT](
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             bufsize=0,
-            env=environment,
+            env=_command_environment(command, environment),
             cwd=cwd,
             start_new_session=False,
             creationflags=0,
@@ -960,6 +966,20 @@ def run_bounded_worker_dialogue[ValueT](
     state.deactivate()
     state.cleanup(kill=False)
     return BoundedWorkerDialogueCompleted(value=value, stdout_bytes=stdout_bytes)
+
+
+def _command_environment(
+    command: Sequence[str], environment: Mapping[str, str]
+) -> Mapping[str, str]:
+    # Bind only the host interpreter, before any prlimit wrapping. Do not infer
+    # Python from executable names or resolved symlinks: another virtualenv may
+    # share the binary while owning a different package environment.
+    if command and command[0] == sys.executable and "PYTHONPATH" not in environment:
+        return {
+            **environment,
+            "PYTHONPATH": str(Path(__file__).resolve().parent.parent),
+        }
+    return environment
 
 
 def worker_environment(

--- a/tests/dispatch/test_hypergraph_independence_dispatch.py
+++ b/tests/dispatch/test_hypergraph_independence_dispatch.py
@@ -18,3 +18,15 @@ def test_math_run_executes_independence_compute() -> None:
     assert result.output["status"] == "EXACT"
     assert result.output["independence_number"] == 2
     assert result.output["lower_bound"] == result.output["upper_bound"] == 2
+
+
+def test_math_run_admits_carrier_sized_edgeless_source() -> None:
+    vertices = [f"v{i:03}" for i in reversed(range(256))]
+    result = invoke_operation(
+        "hypergraph.independence_number.compute",
+        {"hypergraph": {"vertices": vertices, "edges": []}},
+        Catalog.open(),
+    )
+    assert result.output["independence_number"] == 256
+    assert result.output["incumbent_vertices"] == vertices
+    assert result.output["solver_calls"] == 0

--- a/tests/dispatch/test_root_system_dispatch.py
+++ b/tests/dispatch/test_root_system_dispatch.py
@@ -10,6 +10,7 @@ from jacobian.dispatch import invoke_operation
 from jacobian.math.groups.root_systems._models import (
     MAX_RANK,
     MAX_REFLECTION_COORDINATE,
+    MAX_REFLECTION_REPRESENTABLE,
 )
 
 
@@ -32,9 +33,10 @@ def test_simple_reflection_catalog_contract_matches_dispatch() -> None:
         in properties["vector"]["description"]
     )
     assert str(MAX_REFLECTION_COORDINATE) in properties["vector"]["description"]
+    assert str(MAX_REFLECTION_REPRESENTABLE) in properties["vector"]["description"]
     assert properties["vector"]["items"] == {
-        "maximum": MAX_REFLECTION_COORDINATE,
-        "minimum": -MAX_REFLECTION_COORDINATE,
+        "maximum": MAX_REFLECTION_REPRESENTABLE,
+        "minimum": -MAX_REFLECTION_REPRESENTABLE,
         "type": "integer",
     }
     assert (

--- a/tests/integration/linear/test_direct_linear_outcomes.py
+++ b/tests/integration/linear/test_direct_linear_outcomes.py
@@ -5,7 +5,6 @@ from fractions import Fraction
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from tests.integration.linear._support import linear_validation_error
 from tests.support.rationals import rational_payload as q
 
 from jacobian.math.matrices.rational_linear._models import (
@@ -197,8 +196,6 @@ def test_zero_coefficient_nonzero_rhs_has_a_direct_farkas_witness() -> None:
 
 
 def test_zero_equalities_are_pruned_from_farkas_backend_work() -> None:
-    from jacobian.math.optimization.operations import _solve_farkas
-
     program = RationalLinearProgramRequest.model_validate(
         {
             "program": {
@@ -210,10 +207,6 @@ def test_zero_equalities_are_pruned_from_farkas_backend_work() -> None:
             }
         }
     ).program
-
-    active_rows, positive, negative, _ = _solve_farkas(program)
-    assert active_rows == (0, 1)
-    assert len(positive) == len(negative) == 2
 
     result = _run_linear_program(program.model_dump(mode="json"))
     assert result.status == "INFEASIBLE"
@@ -319,49 +312,6 @@ def test_source_derived_result_height_exceeds_input_scalar_limit() -> None:
     )
 
 
-def test_missing_dual_evidence_remains_primal_feasible(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from sympy.solvers import simplex
-
-    def unavailable_dual(*_args: object, **_kwargs: object) -> None:
-        raise simplex.InfeasibleLPError("dual certificate unavailable")
-
-    monkeypatch.setattr(simplex, "lpmax", unavailable_dual)
-    result = _run_linear_program(
-        {
-            "variables": ["x"],
-            "objective": [q(1)],
-            "coefficients": [[q(1)]],
-            "rhs": [q(1)],
-        }
-    )
-
-    assert result.status == "PRIMAL_FEASIBLE"
-    assert result.primal_candidate is not None
-    assert result.dual_candidate is None
-
-
-def test_missing_negative_certificate_is_an_execution_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from sympy.solvers import simplex
-
-    def unavailable_simplex(*_args: object, **_kwargs: object) -> None:
-        raise simplex.InfeasibleLPError("certificate unavailable")
-
-    monkeypatch.setattr(simplex, "lpmin", unavailable_simplex)
-    with pytest.raises(RuntimeError, match="produced no mathematical result"):
-        _run_linear_program(
-            {
-                "variables": ["x"],
-                "objective": [q(0)],
-                "coefficients": [[q(1)], [q(1)]],
-                "rhs": [q(0), q(1)],
-            }
-        )
-
-
 @st.composite
 def _diagonal_linear_programs(
     draw: st.DrawFn,
@@ -437,11 +387,12 @@ def test_linear_program_admission_is_result_sensitive_but_bounds_all_bases() -> 
     }
     assert StandardFormRationalLinearProgram.model_validate(maximum_shape)
 
-    excessive_work = {
+    redundant = {
         "variables": [f"x{index}" for index in range(8)],
         "objective": [q(0)] * 8,
         "coefficients": [[q(1)] * 8 for _ in range(8)],
         "rhs": [q(0)] * 8,
     }
-    with linear_validation_error():
-        StandardFormRationalLinearProgram.model_validate(excessive_work)
+    # Rank deficiency does not remove all feasible vertices. The zero point
+    # is feasible, and the new basis path handles independent source rows.
+    assert _run_linear_program(redundant).status == "OPTIMAL"

--- a/tests/math/combinatorics/finite_structures/hypergraphs/test_independence.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/test_independence.py
@@ -9,7 +9,11 @@ from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_HYPERGRAPH_INDEPENDENCE_INCIDENCES,
     MAX_HYPERGRAPH_INDEPENDENCE_SOLVER_CALLS,
+    MAX_HYPERGRAPH_INDEPENDENCE_VERTICES,
+    MAX_VERTICES,
     FiniteHypergraph,
     HypergraphIndependenceRequest,
     HypergraphIndependenceResult,
@@ -221,12 +225,86 @@ def test_edge_free_hypergraph_returns_all_vertices() -> None:
     assert result.termination_reason == "SPECIAL_CASE"
 
 
+@pytest.mark.parametrize("order", [101, MAX_VERTICES])
+@pytest.mark.parametrize("forbidden", [False, True])
+def test_carrier_sized_trivial_sources_skip_worker(
+    order: int, forbidden: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jacobian.math.combinatorics.finite_structures.hypergraphs import (
+        _independence_z3,
+    )
+
+    def unexpected_worker(*args: object, **kwargs: object) -> None:
+        pytest.fail("source-trivial independence must not launch a worker")
+
+    monkeypatch.setattr(_independence_z3, "_run_independence_worker", unexpected_worker)
+    vertices = tuple(f"v{i:03}" for i in reversed(range(order)))
+    edges = (
+        (
+            ("forbid", (vertices[0],)),
+            ("duplicate", (vertices[0],)),
+            ("redundant", vertices),
+        )
+        if forbidden
+        else ()
+    )
+    source = FiniteHypergraph(vertices=vertices, edges=edges)
+    result = independence_number(source)
+    expected = vertices[1:] if forbidden else vertices
+    assert result.status == "EXACT"
+    assert (
+        result.independence_number
+        == result.lower_bound
+        == result.upper_bound
+        == len(expected)
+    )
+    assert result.incumbent_vertices == expected
+    assert result.hypergraph == source
+    assert result.solver_calls == 0
+    assert result.termination_reason == "SPECIAL_CASE"
+    assert (
+        HypergraphIndependenceResult.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
 def test_empty_hypergraph_returns_zero() -> None:
     result = _compute({"vertices": [], "edges": []})
     assert result.status == "EXACT"
     assert result.independence_number == 0
     assert result.incumbent_vertices == ()
     assert result.lower_bound == result.upper_bound == 0
+
+
+def test_singleton_only_at_carrier_edge_boundary() -> None:
+    vertices = tuple(f"v{i}" for i in range(MAX_VERTICES))
+    source = FiniteHypergraph(
+        vertices=vertices,
+        edges=tuple((f"e{i}", (vertices[i % 2],)) for i in range(MAX_EDGES)),
+    )
+    result = independence_number(source)
+    assert result.incumbent_vertices == vertices[2:]
+    assert result.independence_number == MAX_VERTICES - 2
+    assert result.solver_calls == 0
+
+
+@pytest.mark.parametrize("bound", ["vertex", "incidence"])
+def test_nontrivial_sources_still_require_solver_admission(bound: str) -> None:
+    order = MAX_HYPERGRAPH_INDEPENDENCE_VERTICES + 1 if bound == "vertex" else 2
+    vertices = tuple(f"v{i}" for i in range(order))
+    edge_count = (
+        1 if bound == "vertex" else MAX_HYPERGRAPH_INDEPENDENCE_INCIDENCES // 2 + 1
+    )
+    source = FiniteHypergraph(
+        vertices=vertices,
+        edges=tuple((f"e{i}", vertices[:2]) for i in range(edge_count)),
+    )
+    with pytest.raises(OperationDomainValidationError) as error:
+        independence_number(source)
+    assert (
+        error.value.errors()[0]["type"]
+        == f"hypergraph.independence_number.{bound}_bound"
+    )
 
 
 def test_singleton_edges_forbid_their_vertices() -> None:

--- a/tests/math/graphs/chip_firing/test_regressions.py
+++ b/tests/math/graphs/chip_firing/test_regressions.py
@@ -1,0 +1,344 @@
+"""Independent defining identities for issues 3206, 3207, and 3209."""
+
+from itertools import combinations, pairwise
+from random import Random
+
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.chip_firing import (
+    abel_jacobi,
+    parallel_step,
+    q_reduced,
+    stabilize,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def graph(n: int, edges: tuple[tuple[int, int], ...]) -> SimpleUndirectedGraph:
+    labels = tuple(str(i) for i in range(n))
+    return SimpleUndirectedGraph(
+        vertices=labels,
+        edges=tuple(
+            (min(labels[i], labels[j]), max(labels[i], labels[j])) for i, j in edges
+        ),
+    )
+
+
+EDGE = graph(2, ((0, 1),))
+TRIANGLE = graph(3, ((0, 1), (0, 2), (1, 2)))
+CYCLE = graph(4, ((0, 1), (1, 2), (2, 3), (0, 3)))
+COMPLETE = graph(4, tuple(combinations(range(4), 2)))
+PATH = graph(4, ((0, 1), (1, 2), (2, 3)))
+
+
+def transport(
+    g: SimpleUndirectedGraph, divisor: tuple[int, ...], f: tuple[int, ...]
+) -> tuple[int, ...]:
+    """Compute D-Lf edge by edge, independently of the production Laplacian."""
+    result = list(divisor)
+    for a, b in g.edges:
+        i, j = g.vertices.index(a), g.vertices.index(b)
+        result[i] -= f[i] - f[j]
+        result[j] += f[i] - f[j]
+    return tuple(result)
+
+
+def assert_reduced(
+    g: SimpleUndirectedGraph, divisor: tuple[int, ...], sink: str
+) -> None:
+    nonsink = set(g.vertices) - {sink}
+    assert all(divisor[g.vertices.index(v)] >= 0 for v in nonsink)
+    for size in range(1, len(nonsink) + 1):
+        for subset in combinations(sorted(nonsink), size):
+            assert any(
+                divisor[g.vertices.index(v)]
+                < sum(
+                    (a == v and b not in subset) or (b == v and a not in subset)
+                    for a, b in g.edges
+                )
+                for v in subset
+            ), (divisor, subset)
+
+
+@pytest.mark.parametrize("sink", EDGE.vertices)
+@pytest.mark.parametrize("chips", [2, 3, 1_000_000])
+def test_repeated_leaf_firing(sink: str, chips: int) -> None:
+    initial = tuple(0 if v == sink else chips for v in EDGE.vertices)
+    result = stabilize(EDGE, sink, initial)
+    assert result.stable == tuple(chips if v == sink else 0 for v in EDGE.vertices)
+    assert result.odometer == initial
+    assert result.total_firings == chips
+
+
+@pytest.mark.parametrize("g", [PATH, TRIANGLE, CYCLE, COMPLETE])
+def test_stabilization_matches_bounded_parallel_oracle(
+    g: SimpleUndirectedGraph,
+) -> None:
+    for sink in g.vertices:
+        initial = tuple(
+            0 if v == sink else 3 * (i + 1) for i, v in enumerate(g.vertices)
+        )
+        current = initial
+        odometer = [0] * len(initial)
+        for _ in range(sum(initial) * (len(initial) - 1) ** 2 + 1):
+            step = parallel_step(g, sink, current)
+            current = step.next_configuration
+            for v in step.fired_vertices:
+                odometer[g.vertices.index(v)] += 1
+            if not step.fired_vertices:
+                break
+        else:
+            pytest.fail("parallel oracle exceeded the Green-function firing bound")
+        result = stabilize(g, sink, initial)
+        assert result.stable == current
+        assert result.odometer == tuple(odometer)
+        assert transport(g, initial, result.odometer) == result.stable
+        assert stabilize(g, sink, result.stable).total_firings == 0
+
+
+@pytest.mark.parametrize(
+    ("divisor", "expected"), [((0, 1, 1), (2, 0, 0)), ((0, -1, 0), (-2, 0, 1))]
+)
+def test_triangle_reduction(
+    divisor: tuple[int, ...], expected: tuple[int, ...]
+) -> None:
+    result = q_reduced(TRIANGLE, divisor, "0")
+    assert result.reduced_divisor == expected
+    assert transport(TRIANGLE, divisor, result.firing_vector) == expected
+
+
+@pytest.mark.parametrize("g", [EDGE, PATH, TRIANGLE, CYCLE, COMPLETE])
+def test_reduction_subset_definition_and_equivalence(g: SimpleUndirectedGraph) -> None:
+    for sink in g.vertices:
+        divisor = tuple((-1) ** i * (i + 2) for i in range(len(g.vertices)))
+        result = q_reduced(g, divisor, sink)
+        assert_reduced(g, result.reduced_divisor, sink)
+        assert transport(g, divisor, result.firing_vector) == result.reduced_divisor
+        assert sum(result.reduced_divisor) == sum(divisor)
+        assert (
+            q_reduced(g, result.reduced_divisor, sink).reduced_divisor
+            == result.reduced_divisor
+        )
+        shifted = transport(g, divisor, tuple(10**30 * i for i in range(len(divisor))))
+        assert q_reduced(g, shifted, sink).reduced_divisor == result.reduced_divisor
+
+
+@pytest.mark.parametrize("g", [TRIANGLE, CYCLE, COMPLETE])
+def test_every_principal_generator_maps_to_zero(g: SimpleUndirectedGraph) -> None:
+    n = len(g.vertices)
+    for sink in g.vertices:
+        for j in range(n):
+            principal = transport(g, (0,) * n, tuple(int(i == j) for i in range(n)))
+            assert not any(abel_jacobi(g, principal, sink).coordinates)
+
+
+def test_abel_jacobi_separates_classes_and_preserves_addition() -> None:
+    for sink in TRIANGLE.vertices:
+        images = [abel_jacobi(TRIANGLE, (k, -k, 0), sink).coordinates for k in range(3)]
+        assert len(set(images)) == 3
+        assert images[2] == tuple(2 * c % 3 for c in images[1])
+        shifted = transport(TRIANGLE, (1, -1, 0), (7, -11, 23))
+        assert abel_jacobi(TRIANGLE, shifted, sink).coordinates == images[1]
+
+
+@pytest.mark.parametrize("g", [graph(3, ((1, 2),)), graph(2, ())])
+@pytest.mark.parametrize("chips", [0, 1])
+def test_disconnected_domain_is_specific_to_completion(
+    g: SimpleUndirectedGraph, chips: int
+) -> None:
+    configuration = (chips,) * len(g.vertices)
+    with pytest.raises(OperationDomainValidationError) as caught:
+        stabilize(g, "0", configuration)
+    assert caught.value.errors()[0]["type"] == "chip_firing.requires_connected_graph"
+    with pytest.raises(OperationDomainValidationError) as caught:
+        q_reduced(g, configuration, "0")
+    assert caught.value.errors()[0]["type"] == "chip_firing.requires_connected_graph"
+    with pytest.raises(OperationDomainValidationError) as caught:
+        abel_jacobi(g, (0,) * len(g.vertices), "0")
+    assert caught.value.errors()[0]["type"] == "chip_firing.requires_connected_graph"
+    assert len(parallel_step(g, "0", configuration).next_configuration) == len(
+        g.vertices
+    )
+
+
+def test_single_vertex_and_trivial_group() -> None:
+    singleton = graph(1, ())
+    assert stabilize(singleton, "0", (-10,)).stable == (-10,)
+    assert q_reduced(singleton, (-10,), "0").reduced_divisor == (-10,)
+    result = abel_jacobi(singleton, (0,), "0")
+    assert result.coordinates == result.invariant_factors == ()
+    assert result.nonsink_vertices == ()
+    assert abel_jacobi(PATH, (1, -1, 0, 0), "1").coordinates == ()
+
+
+def test_large_coefficient_reduction_and_rejected_height() -> None:
+    from jacobian.math.graphs.chip_firing._models import MAX_COEFFICIENT_DIGITS
+
+    large = 10 ** (MAX_COEFFICIENT_DIGITS - 1)
+    divisor = (-large, large, 0)
+    reduced = q_reduced(TRIANGLE, divisor, "0")
+    assert_reduced(TRIANGLE, reduced.reduced_divisor, "0")
+    assert (
+        transport(TRIANGLE, divisor, reduced.firing_vector) == reduced.reduced_divisor
+    )
+    assert (
+        abel_jacobi(TRIANGLE, divisor, "0").coordinates
+        == abel_jacobi(TRIANGLE, (-large % 3, -(-large % 3), 0), "0").coordinates
+    )
+    excessive = 10**MAX_COEFFICIENT_DIGITS
+    for operation in (q_reduced, abel_jacobi):
+        with pytest.raises(OperationDomainValidationError) as caught:
+            operation(TRIANGLE, (-excessive, excessive, 0), "0")
+        assert caught.value.errors()[0]["type"] == "chip_firing.coefficient_bound"
+
+
+def test_full_vertex_boundary_exact_cycle_coordinates() -> None:
+    from jacobian.math.graphs.chip_firing._models import MAX_VERTICES
+
+    labels = tuple(f"v{i:02d}" for i in range(MAX_VERTICES))
+    g = SimpleUndirectedGraph(
+        vertices=labels,
+        edges=(*pairwise(labels), (labels[0], labels[-1])),
+    )
+    principal = (2, -1) + (0,) * (MAX_VERTICES - 3) + (-1,)
+    result = abel_jacobi(g, principal, labels[-1])
+    assert result.invariant_factors == (1,) * (MAX_VERTICES - 2) + (MAX_VERTICES,)
+    assert result.coordinates == (0,)
+
+
+@pytest.mark.parametrize("complete", [False, True])
+def test_dense_fifty_vertex_column_quotient(complete: bool) -> None:
+    rng = Random(3209)
+    labels = tuple(f"v{i:02d}" for i in range(50))
+    edges = tuple(
+        (labels[i], labels[j])
+        for i in range(50)
+        for j in range(i + 1, 50)
+        if complete or j == i + 1 or rng.random() < 0.3
+    )
+    g = SimpleUndirectedGraph(vertices=labels, edges=edges)
+    divisor = (1, -1) + (0,) * 48
+    result = abel_jacobi(g, divisor, labels[0])
+    shifted = transport(g, divisor, tuple(10**30 * (i - 13) for i in range(50)))
+    assert abel_jacobi(g, shifted, labels[0]).coordinates == result.coordinates
+    principal = transport(g, (0,) * 50, tuple(int(i == 27) for i in range(50)))
+    assert not any(abel_jacobi(g, principal, labels[0]).coordinates)
+    if complete:
+        assert result.invariant_factors == (1,) + (50,) * 48
+
+
+def test_coupled_residual_and_interior_unit_axis() -> None:
+    cases = [
+        graph(5, ((0, 1), (0, 2), (1, 2), (1, 3), (2, 3), (3, 4))),
+        graph(
+            6,
+            (
+                (0, 1),
+                (0, 3),
+                (0, 4),
+                (0, 5),
+                (1, 2),
+                (1, 3),
+                (1, 4),
+                (1, 5),
+                (2, 3),
+                (3, 4),
+                (3, 5),
+                (4, 5),
+            ),
+        ),
+    ]
+    for g in cases:
+        n = len(g.vertices)
+        divisor = (1, -1) + (0,) * (n - 2)
+        result = abel_jacobi(g, divisor, "0")
+        shifted = transport(g, divisor, tuple(i * 17 for i in range(n)))
+        assert abel_jacobi(g, shifted, "0").coordinates == result.coordinates
+
+
+@pytest.mark.parametrize("sink", ["0", "3", "6"])
+@pytest.mark.parametrize("vertices", [7, 16, 50])
+def test_coupled_column_hnf_is_an_accepted_quotient(sink: str, vertices: int) -> None:
+    # Four coupled directions in column HNF need not be four nontrivial
+    # quotient generators. The group is cyclic of order 2520.
+    g = graph(
+        vertices,
+        (
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (0, 4),
+            (0, 5),
+            (1, 2),
+            (1, 4),
+            (1, 5),
+            (1, 6),
+            (2, 3),
+            (2, 5),
+            (3, 4),
+            (3, 5),
+            (3, 6),
+            (4, 5),
+            (5, 6),
+            *((i, i + 1) for i in range(6, vertices - 1)),
+        ),
+    )
+    # Attaching a tree changes presentation size but not the critical group.
+    divisor = (1, -1) + (0,) * (vertices - 2)
+    result = abel_jacobi(g, divisor, sink)
+    assert result.invariant_factors == (1,) * (vertices - 2) + (2520,)
+    assert any(result.coordinates)
+    shifted = transport(
+        g, divisor, tuple((-1) ** i * (2 * i + 3) for i in range(vertices))
+    )
+    assert abel_jacobi(g, shifted, sink).coordinates == result.coordinates
+    principal = transport(g, (0,) * vertices, (0, 1) + (0,) * (vertices - 2))
+    assert abel_jacobi(g, principal, sink).coordinates == (0,)
+    doubled = tuple(2 * value for value in divisor)
+    assert abel_jacobi(g, doubled, sink).coordinates == tuple(
+        2 * value % factor
+        for value, factor in zip(result.coordinates, (2520,), strict=True)
+    )
+
+
+def test_modular_hermite_kernel_work_matches_its_finite_loop_bound() -> None:
+    from cProfile import Profile
+    from math import prod
+
+    from sympy.polys.matrices import normalforms
+    from tests.fixtures.accounting import assert_charged_work_parity
+
+    from jacobian.math.graphs.chip_firing._hermite import _column_hermite
+
+    # K_50 has reduced Laplacian 50I-J and 50^48 spanning trees. This
+    # supplements the public quotient identities with real backend work,
+    # without replacing the kernel or its mathematical values.
+    n = 49
+    matrix = [[49 if i == j else -1 for j in range(n)] for i in range(n)]
+    with Profile() as profile:
+        hnf = _column_hermite(matrix, 50**48)
+    assert prod(hnf[i][i] for i in range(n)) == 50**48
+    names = {
+        "_gcdex": "gcd",
+        "add_columns_mod_R": "modular_column",
+        "add_columns": "hnf_column",
+    }
+    executed = dict.fromkeys(names.values(), 0)
+    for entry in profile.getstats():
+        code = entry.code
+        if (
+            not isinstance(code, str)
+            and code.co_filename == normalforms.__file__
+            and code.co_name in names
+        ):
+            executed[names[code.co_name]] += entry.callcount
+    assert all(count > 0 for count in executed.values())
+    assert_charged_work_parity(
+        charged={
+            "gcd": n * (n + 1) // 2,
+            "modular_column": n * (n - 1) // 2,
+            "hnf_column": n * (n - 1) // 2,
+        },
+        executed=executed,
+    )

--- a/tests/math/lattices/test_lattice_operations.py
+++ b/tests/math/lattices/test_lattice_operations.py
@@ -83,7 +83,7 @@ def test_rank_gram_of_identity_is_identity() -> None:
     assert result.rank == 2
     assert result.ambient_dimension == 2
     assert result.squared_covolume == "1"
-    assert result.covolume_rational is False
+    assert result.covolume_rational is True
     gram = result.gram_matrix.entries
     assert gram == (("1", "0"), ("0", "1"))
 
@@ -97,8 +97,7 @@ def test_rank_gram_of_scaled_lattice() -> None:
     assert result.squared_covolume == "36"
 
 
-def test_rank_gram_rank_deficient_reports_rational_covolume() -> None:
-    """A rank-1 lattice in ambient 2 has a rational (non-finite) covolume."""
+def test_rank_gram_rejects_dependent_basis_rows() -> None:
     with pytest.raises(ValueError, match="full row rank"):
         compute_rank_gram(_lattice(2, [[1, 0], [2, 0]]))
 
@@ -153,7 +152,7 @@ def test_dual_of_unimodular_is_itself() -> None:
 def test_dual_pairing_is_integer() -> None:
     """The dual basis times the basis transpose should be the identity."""
     result = compute_dual(_lattice(2, [[2, 0], [0, 3]]))
-    # B* = B (B B^T)^{-1}; B* B^T = I
+    # B* = (B B^T)^{-1} B; B* B^T = I
     # B B^T = diag(4, 9), so B* = diag(1/2, 1/3)
     dual = result.dual_basis.entries
     assert dual[0][0].num == "1" and dual[0][0].den == "2"

--- a/tests/math/lattices/test_lattice_structural_regressions.py
+++ b/tests/math/lattices/test_lattice_structural_regressions.py
@@ -1,0 +1,144 @@
+"""Defining identities and work regressions for issues #3196, #3198, #3199."""
+
+from cProfile import Profile
+from fractions import Fraction
+from itertools import combinations
+from math import gcd
+
+import pytest
+from sympy import Matrix
+from sympy.matrices.matrixbase import MatrixBase
+
+from jacobian.math.lattices import IntegerLattice
+from jacobian.math.lattices._lattice_tools import DUAL_OPERATION, RANK_GRAM_OPERATION
+from jacobian.math.lattices.operations import (
+    compute_dual,
+    compute_rank_gram,
+    compute_saturation,
+)
+from jacobian.math.matrices.values import MAX_MATRIX_DIMENSION
+
+
+def _lattice(rows: list[list[int]]) -> IntegerLattice:
+    return IntegerLattice.model_validate(
+        {
+            "ambient_dimension": len(rows[0]),
+            "basis": {"entries": [[str(value) for value in row] for row in rows]},
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [[[1, 1], [0, 2]], [[1, 0]], [[2, 2]], [[2, 1, 0], [0, 3, 1]]]
+    + [[[1, shear], [0, 2]] for shear in (-3, -1, 2, 4)],
+)
+def test_dual_exact_pairing_and_returned_gram(rows: list[list[int]]) -> None:
+    lattice = _lattice(rows)
+    result = compute_dual(lattice)
+    request = DUAL_OPERATION.request_type.model_validate_json(
+        '{"lattice":' + lattice.model_dump_json() + "}", strict=True
+    )
+    assert DUAL_OPERATION.run(request).model_dump_json() == result.model_dump_json()
+    dual = [
+        [Fraction(int(value.num), int(value.den)) for value in row]
+        for row in result.dual_basis.entries
+    ]
+    for i in range(len(rows)):
+        for j in range(len(rows)):
+            assert sum(a * b for a, b in zip(dual[i], rows[j], strict=True)) == int(
+                i == j
+            )
+            gram_entry = result.dual_gram.entries[i][j]
+            assert sum(
+                a * b for a, b in zip(dual[i], dual[j], strict=True)
+            ) == Fraction(int(gram_entry.num), int(gram_entry.den))
+    # Pairing alone permits an unwanted component outside the rational span.
+    assert Matrix(rows + dual).rank() == len(rows)
+
+
+@pytest.mark.parametrize(
+    ("rows", "squared_covolume", "rational"),
+    [
+        ([[1, 0], [0, 1]], 1, True),
+        ([[1, 1]], 2, False),
+        ([[1, 0]], 1, True),
+        ([[3, 4]], 25, True),
+        ([[6, 8]], 100, True),
+        ([[2, 2]], 8, False),
+        ([[1, 3], [0, 2]], 4, True),
+        ([[1, 1, 0], [0, 0, 1]], 2, False),
+        ([[1, 1, 3], [0, 0, 1]], 2, False),
+        ([[10**40, 1]], 10**80 + 1, False),
+    ],
+)
+def test_covolume_rationality(
+    rows: list[list[int]], squared_covolume: int, rational: bool
+) -> None:
+    lattice = _lattice(rows)
+    result = compute_rank_gram(lattice)
+    assert int(result.squared_covolume) == squared_covolume
+    assert result.covolume_rational is rational
+    request = RANK_GRAM_OPERATION.request_type.model_validate_json(
+        '{"lattice":' + lattice.model_dump_json() + "}", strict=True
+    )
+    assert (
+        RANK_GRAM_OPERATION.run(request).model_dump_json() == result.model_dump_json()
+    )
+
+
+@pytest.mark.parametrize("scale", [1, 2])
+def test_saturation_does_not_enumerate_determinants(scale: int) -> None:
+    """Count real determinant calls without replacing mathematical computations."""
+    rows = [[scale * int(i == j) for j in range(8)] for i in range(4)]
+    lattice = _lattice(rows)
+    with Profile() as profile:
+        result = compute_saturation(lattice)
+    determinant_calls = sum(
+        entry.callcount
+        for entry in profile.getstats()
+        if entry.code == MatrixBase.det.__code__
+    )
+    assert result.saturation_index == scale**4
+    assert determinant_calls <= 1
+
+
+@pytest.mark.parametrize("scale", [1, -2])
+def test_saturation_at_axis_boundary(scale: int) -> None:
+    rank = MAX_MATRIX_DIMENSION // 2
+    primitive = [
+        [int(i == j) for j in range(MAX_MATRIX_DIMENSION)] for i in range(rank)
+    ]
+    rows = [[scale * value for value in row] for row in primitive]
+    # An integer row shear preserves the lattice and defeats a diagonal-only fix.
+    rows[0] = [a + 3 * b for a, b in zip(rows[0], rows[1], strict=True)]
+    result = compute_saturation(_lattice(rows))
+    saturated = Matrix(
+        [[int(v) for v in row] for row in result.saturated_basis.entries]
+    )
+    inclusion = Matrix(
+        [[int(v) for v in row] for row in result.inclusion_transform.entries]
+    )
+    assert saturated == Matrix(primitive)
+    assert inclusion * saturated == Matrix(rows)
+    assert result.saturation_index == abs(scale) ** rank
+
+
+@pytest.mark.parametrize("rows", [[[2, 4, 6]], [[2, 1, 3], [0, -3, 3]]])
+def test_saturation_index_agrees_with_small_minor_oracle(rows: list[list[int]]) -> None:
+    basis = Matrix(rows)
+    result = compute_saturation(_lattice(rows))
+    saturated = Matrix(
+        [[int(v) for v in row] for row in result.saturated_basis.entries]
+    )
+    inclusion = Matrix(
+        [[int(v) for v in row] for row in result.inclusion_transform.entries]
+    )
+    assert inclusion * saturated == basis
+    assert basis.col_join(saturated).rank() == len(rows)
+    minors = combinations(range(basis.cols), basis.rows)
+    assert result.saturation_index == gcd(
+        *(int(basis[:, list(c)].det()) for c in minors)
+    )
+    sat_minors = combinations(range(saturated.cols), saturated.rows)
+    assert gcd(*(int(saturated[:, list(c)].det()) for c in sat_minors)) == 1

--- a/tests/math/number_theory/algebraic_numbers/test_real_quadratic.py
+++ b/tests/math/number_theory/algebraic_numbers/test_real_quadratic.py
@@ -9,7 +9,11 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import MathTool
+from jacobian.catalog.models import (
+    MathTool,
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.number_theory.algebraic_numbers.quadratic import (
     RealQuadraticEmbeddingProfile,
     RealQuadraticOrderValue,
@@ -38,8 +42,10 @@ def test_order_preflights_a_difference_that_cannot_be_returned() -> None:
         left=_value(maximum_component),
         right=_value(-maximum_component),
     )
-    with pytest.raises(ValueError, match="difference"):
+    with pytest.raises(OperationResourceAdmissionError, match="difference") as error:
         real_quadratic_order(request.left, request.right)
+    assert error.value.errors()[0]["type"] == "real_quadratic.difference_bound_exceeded"
+    assert error.value.errors()[0]["loc"] == ()
 
 
 def test_native_order_api_accepts_canonical_values_without_a_wire_request() -> None:
@@ -87,7 +93,9 @@ def test_order_result_rejects_forged_source_bound_fields(
 
 
 def test_native_order_api_retains_shared_field_admission() -> None:
-    with pytest.raises(ValueError, match="comparison requires one shared radicand"):
+    with pytest.raises(
+        OperationDomainValidationError, match="comparison requires one shared radicand"
+    ) as error:
         real_quadratic_order(
             _value(1),
             RealQuadraticValue(
@@ -96,6 +104,8 @@ def test_native_order_api_retains_shared_field_admission() -> None:
                 radicand=3,
             ),
         )
+    assert error.value.errors()[0]["type"] == "real_quadratic.radicand_mismatch"
+    assert error.value.errors()[0]["loc"] == ("right", "radicand")
 
 
 def test_declarations_project_wire_requests_to_native_kernels() -> None:

--- a/tests/math/number_theory/p_adic/test_padic.py
+++ b/tests/math/number_theory/p_adic/test_padic.py
@@ -7,7 +7,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.p_adic._models import (
     HenselFactorLiftRequest,
@@ -43,7 +43,9 @@ class TestHenselRootLifting:
 
     def test_native_surface_accepts_canonical_polynomial_value(self) -> None:
         poly = IntegerPolynomial(coefficients=("1", "0", "1"))
-        assert hensel_lift_root(poly, 5, 2, 3).lifted_root == 57
+        assert (
+            parse_canonical_integer(hensel_lift_root(poly, 5, 2, 3).lifted_root) == 57
+        )
         assert find_padic_roots(poly, 5, 3).root_count == 2
 
     def test_lift_simple_root(self) -> None:
@@ -53,7 +55,7 @@ class TestHenselRootLifting:
             HenselRootRequest(polynomial=poly, prime=5, root_mod_p=2, precision=3)
         )
         assert result.is_simple_root
-        assert (result.lifted_root**2 + 1) % 125 == 0
+        assert (parse_canonical_integer(result.lifted_root) ** 2 + 1) % 125 == 0
 
     def test_lift_mod_p_squared(self) -> None:
         """Lift root to mod p^2."""
@@ -62,7 +64,7 @@ class TestHenselRootLifting:
             HenselRootRequest(polynomial=poly, prime=5, root_mod_p=1, precision=2)
         )
         assert result.is_simple_root
-        assert (result.lifted_root**3 - 1) % 25 == 0
+        assert (parse_canonical_integer(result.lifted_root) ** 3 - 1) % 25 == 0
 
     def test_non_root_rejected(self) -> None:
         """A non-root mod p should be rejected."""
@@ -79,8 +81,9 @@ class TestHenselRootLifting:
         result = _hensel_lift_root(
             HenselRootRequest(polynomial=poly, prime=7, root_mod_p=2, precision=4)
         )
-        assert 0 <= result.lifted_root < 7**4
-        assert (result.lifted_root**2 + 3) % (7**4) == 0
+        lifted = parse_canonical_integer(result.lifted_root)
+        assert 0 <= lifted < 7**4
+        assert (lifted**2 + 3) % (7**4) == 0
 
 
 class TestPAdicRoots:
@@ -94,7 +97,7 @@ class TestPAdicRoots:
         )
         assert result.root_count >= 1
         for root in result.roots:
-            assert (root.root**3 - 1) % 25 == 0
+            assert (parse_canonical_integer(root.root) ** 3 - 1) % 25 == 0
 
     def test_find_roots_no_roots(self) -> None:
         """Find roots of x^2 + 1 mod 3 (no roots mod 3)."""
@@ -130,7 +133,7 @@ class TestPAdicRoots:
         )
         assert result.polynomial == poly
         assert result.root_mod_p == 2
-        assert result.lifted_root % 5 == 2
+        assert parse_canonical_integer(result.lifted_root) % 5 == 2
 
         roundtrip = HenselRootResult.model_validate(result.model_dump())
         assert roundtrip == result
@@ -152,7 +155,7 @@ class TestPAdicRoots:
             )
         )
         forged = result.model_dump()
-        forged["roots"][0]["root"] = 25
+        forged["roots"][0]["root"] = "25"
         with pytest.raises(ValidationError) as exc_info:
             PAdicRootsResult.model_validate(forged)
         assert (
@@ -175,7 +178,7 @@ class TestPAdicRoots:
             PAdicRootsRequest(polynomial=poly, prime=7, precision=3)
         )
         for root in result.roots:
-            assert (root.root**3 - 1) % (7**3) == 0
+            assert (parse_canonical_integer(root.root) ** 3 - 1) % (7**3) == 0
 
 
 def _wire_poly(*ascending: int) -> IntegerPolynomial:

--- a/tests/math/optimization/test_linear_admission.py
+++ b/tests/math/optimization/test_linear_admission.py
@@ -1,0 +1,88 @@
+"""Derived LP limits, useful boundaries, and one request deadline."""
+
+from time import monotonic
+
+import pytest
+from tests.support.rationals import rational_payload as q
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_execution,
+)
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.optimization import general_linear_program, linear_program
+from jacobian.math.optimization._general_models import GeneralFormRationalLinearProgram
+from jacobian.math.optimization._linear_basis import (
+    LINEAR_PROGRAM_WALL_SECONDS,
+    basis_bounds,
+)
+from jacobian.math.optimization._models import StandardFormRationalLinearProgram
+
+
+@pytest.mark.parametrize(
+    ("n", "m", "code"), [(18, 6, "work_bound"), (24, 12, "basis_bound")]
+)
+def test_standard_admission_reports_measured_costs(n: int, m: int, code: str) -> None:
+    program = StandardFormRationalLinearProgram.model_validate(
+        {
+            "variables": [f"x{i}" for i in range(n)],
+            "objective": [q(1)] * n,
+            "coefficients": [[q(int(i == j % m)) for j in range(n)] for i in range(m)],
+            "rhs": [q(1)] * m,
+        }
+    )
+    with pytest.raises(OperationResourceAdmissionError) as caught:
+        linear_program(program)
+    assert caught.value.errors()[0]["type"] == f"optimization.linear.{code}"
+    count, work = basis_bounds(n, m)
+    assert f"basis_estimate={count}" in str(caught.value)
+    assert f"work_estimate={work}" in str(caught.value)
+    assert "input_value" not in str(caught.value)
+
+
+def test_native_general_deadline_covers_normalization_and_respects_outer_deadline() -> (
+    None
+):
+    program = GeneralFormRationalLinearProgram.model_validate(
+        {
+            "variables": [
+                {"name": "x", "lower_bound": q(0)},
+                {"name": "y", "lower_bound": q(0)},
+            ],
+            "objective": {"sense": "MINIMIZE", "coefficients": [q(1), q(1)]},
+            "constraints": [
+                {
+                    "label": "sum",
+                    "relation": "GE",
+                    "coefficients": [q(1), q(1)],
+                    "rhs": q(1),
+                }
+            ],
+        }
+    )
+    start = monotonic()
+    with request_execution(start):
+        assert general_linear_program(program).status == "OPTIMAL"
+        execution = current_request_execution()
+        assert (
+            execution is not None
+            and execution.deadline == start + LINEAR_PROGRAM_WALL_SECONDS
+        )
+    with request_execution(start):
+        bind_request_deadline(start - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            general_linear_program(program)
+
+
+def test_rank_zero_maximum_shape_executes_without_empty_matrix_backend() -> None:
+    program = StandardFormRationalLinearProgram.model_validate(
+        {
+            "variables": [f"x{i}" for i in range(32)],
+            "objective": [q(0)] * 32,
+            "coefficients": [[q(0)] * 32 for _ in range(64)],
+            "rhs": [q(0)] * 64,
+        }
+    )
+    assert linear_program(program).status == "OPTIMAL"

--- a/tests/math/optimization/test_linear_certificates.py
+++ b/tests/math/optimization/test_linear_certificates.py
@@ -1,0 +1,290 @@
+"""Exact source certificates for the covering regressions #3194 and #3192."""
+
+from fractions import Fraction
+from itertools import combinations, permutations
+from random import Random
+
+import pytest
+from tests.support.rationals import rational_payload as q
+
+from jacobian.math.optimization import general_linear_program, linear_program
+from jacobian.math.optimization._general_models import (
+    GeneralFormRationalLinearProgram,
+    GeneralRationalLinearProgramResult,
+)
+from jacobian.math.optimization._models import StandardFormRationalLinearProgram
+
+
+def standard_program(
+    rows: list[list[int]], rhs: list[int], objective: list[int]
+) -> StandardFormRationalLinearProgram:
+    return StandardFormRationalLinearProgram.model_validate(
+        {
+            "variables": [f"x{i}" for i in range(len(objective))],
+            "objective": [q(v) for v in objective],
+            "coefficients": [[q(v) for v in row] for row in rows],
+            "rhs": [q(v) for v in rhs],
+        }
+    )
+
+
+def assert_standard_certificate(program: StandardFormRationalLinearProgram) -> str:
+    result = linear_program(program)
+    rows = [[v.as_fraction() for v in row] for row in program.coefficients]
+    rhs = [v.as_fraction() for v in program.rhs]
+    c = [v.as_fraction() for v in program.objective]
+    if result.status == "INFEASIBLE":
+        assert result.farkas_candidate is not None
+        y = [v.as_fraction() for v in result.farkas_candidate]
+        assert sum(a * b for a, b in zip(rhs, y, strict=True)) < 0
+        assert all(
+            sum(row[j] * v for row, v in zip(rows, y, strict=True)) >= 0
+            for j in range(len(c))
+        )
+        assert result.primal_candidate is None
+        return result.status
+    assert result.primal_candidate is not None
+    x = [v.as_fraction() for v in result.primal_candidate]
+    assert min(x) >= 0
+    assert [sum(a * b for a, b in zip(row, x, strict=True)) for row in rows] == rhs
+    objective = sum(a * b for a, b in zip(c, x, strict=True))
+    assert (
+        result.primal_objective is not None
+        and result.primal_objective.as_fraction() == objective
+    )
+    if result.status == "UNBOUNDED":
+        assert result.recession_direction is not None
+        ray = [v.as_fraction() for v in result.recession_direction]
+        assert min(ray) >= 0
+        assert all(
+            sum(a * b for a, b in zip(row, ray, strict=True)) == 0 for row in rows
+        )
+        assert sum(a * b for a, b in zip(c, ray, strict=True)) < 0
+    else:
+        assert result.status == "OPTIMAL" and result.dual_candidate is not None
+        y = [v.as_fraction() for v in result.dual_candidate]
+        assert all(
+            sum(row[j] * v for row, v in zip(rows, y, strict=True)) <= c[j]
+            for j in range(len(c))
+        )
+        assert sum(a * b for a, b in zip(rhs, y, strict=True)) == objective
+    return result.status
+
+
+def cover_program(rows: list[list[int]]) -> GeneralFormRationalLinearProgram:
+    return GeneralFormRationalLinearProgram.model_validate(
+        {
+            "variables": [
+                {"name": f"x{i}", "lower_bound": q(0)} for i in range(len(rows[0]))
+            ],
+            "objective": {"sense": "MINIMIZE", "coefficients": [q(1)] * len(rows[0])},
+            "constraints": [
+                {
+                    "label": f"row{i}",
+                    "coefficients": [q(a) for a in row],
+                    "relation": "GE",
+                    "rhs": q(1),
+                }
+                for i, row in enumerate(rows)
+            ],
+        }
+    )
+
+
+def assert_cover_certificate(result: GeneralRationalLinearProgramResult) -> None:
+    assert result.status == "OPTIMAL"
+    assert result.primal_candidate is not None
+    assert result.constraint_dual is not None
+    assert result.lower_bound_dual is not None
+    x = [v.as_fraction() for v in result.primal_candidate]
+    y = [v.as_fraction() for v in result.constraint_dual]
+    lower = [v.as_fraction() for v in result.lower_bound_dual]
+    rows = [
+        [v.as_fraction() for v in row.coefficients]
+        for row in result.program.constraints
+    ]
+    assert all(v >= 0 for v in (*x, *y, *lower))
+    assert all(sum(a * b for a, b in zip(row, x, strict=True)) >= 1 for row in rows)
+    assert all(
+        sum(row[j] * v for row, v in zip(rows, y, strict=True)) + lower[j] == 1
+        for j in range(len(x))
+    )
+    assert sum(x) == sum(y) == 2
+    assert (
+        result.primal_objective is not None
+        and result.primal_objective.as_fraction() == 2
+    )
+    assert result.dual_objective == result.primal_objective
+
+
+@pytest.mark.parametrize("order", list(permutations(range(3))))
+def test_cover_row_order_preserves_exact_optimum(order: tuple[int, ...]) -> None:
+    rows = [[1, 1], [1, 0], [0, 1]]
+    assert_cover_certificate(
+        general_linear_program(cover_program([rows[i] for i in order]))
+    )
+
+
+def test_standard_cover_has_valid_objective_two_certificate() -> None:
+    rows = [[-1, -1, 1, 0, 0], [-1, 0, 0, 1, 0], [0, -1, 0, 0, 1]]
+    program = StandardFormRationalLinearProgram.model_validate(
+        {
+            "variables": [f"x{i}" for i in range(5)],
+            "objective": [q(1), q(1), q(0), q(0), q(0)],
+            "coefficients": [[q(a) for a in row] for row in rows],
+            "rhs": [q(-1)] * 3,
+        }
+    )
+    result = linear_program(program)
+    assert result.status == "OPTIMAL"
+    assert result.primal_candidate is not None and result.dual_candidate is not None
+    x = [v.as_fraction() for v in result.primal_candidate]
+    y = [v.as_fraction() for v in result.dual_candidate]
+    assert min(x) >= 0
+    assert [sum(a * b for a, b in zip(row, x, strict=True)) for row in rows] == [-1] * 3
+    assert all(
+        sum(row[j] * v for row, v in zip(rows, y, strict=True)) <= int(j < 2)
+        for j in range(5)
+    )
+    assert x[0] + x[1] == -sum(y) == Fraction(2)
+
+
+def test_pinned_sympy_matrix_lp_defect() -> None:
+    """Notify backend upgrades when the documented 1.14.0 defect changes.
+
+    This is a defect sentinel, not evidence for Jacobian's mathematical answer.
+    The public regressions independently prove the objective-two certificates.
+    """
+    from sympy.solvers.simplex import linprog
+
+    objective, point = linprog([1, 1], [[-1, -1], [-1, 0], [0, -1]], [-1, -1, -1])
+    assert objective == 1 and point == [0, 1]
+    assert point[0] < 1  # Violates the second input row x >= 1.
+
+
+@pytest.mark.parametrize("unused", [False, True])
+def test_pair_cover_original_and_trimmed_encodings(unused: bool) -> None:
+    triples = [(0, 2, 3), (0, 2, 4), (0, 2, 5), (0, 3, 5), (1, 3, 5), (2, 3, 5)]
+    pairs = (
+        list(combinations(range(6), 2))
+        if unused
+        else sorted({p for t in triples for p in combinations(t, 2)})
+    )
+    rows = [[int(i in t and j in t) for i, j in pairs] for t in triples]
+    # Independent primal: pairs 02 and 35. Independent dual: triples 023 and
+    # 135 share no pair. Both have value two, proving the expected optimum.
+    assert_cover_certificate(general_linear_program(cover_program(rows)))
+
+
+@pytest.mark.parametrize(
+    ("rows", "rhs", "objective", "status"),
+    [
+        ([], [], [1, 0], "OPTIMAL"),
+        ([[0, 0]], [0], [1, -1], "UNBOUNDED"),
+        ([[0, 0]], [1], [1, -1], "INFEASIBLE"),
+        ([[1, 1], [2, 2], [0, 0]], [1, 2, 0], [1, 1], "OPTIMAL"),
+        ([[1, 1], [2, 2]], [1, 3], [1, 1], "INFEASIBLE"),
+        ([[1, 0], [2, 0]], [-1, -2], [0, -1], "INFEASIBLE"),
+        ([[1, -1], [2, -2]], [1, 2], [-1, 0], "UNBOUNDED"),
+        ([[1, 0], [2, 0]], [1, 2], [0, -1], "UNBOUNDED"),
+        ([[1, 1, 0], [0, 1, 1]], [-1, 1], [-1, 0, -1], "INFEASIBLE"),
+    ],
+)
+def test_rank_deficiency_and_negative_certificates(
+    rows: list[list[int]], rhs: list[int], objective: list[int], status: str
+) -> None:
+    assert assert_standard_certificate(standard_program(rows, rhs, objective)) == status
+
+
+def test_varied_exact_certificates_and_redundant_row_invariance() -> None:
+    random = Random(3194)
+    statuses = set()
+    for _ in range(80):
+        n, m = random.randint(1, 5), random.randint(1, 4)
+        rows = [[random.randint(-2, 2) for _ in range(n)] for _ in range(m)]
+        rhs = [random.randint(-2, 2) for _ in range(m)]
+        objective = [random.randint(-2, 2) for _ in range(n)]
+        status = assert_standard_certificate(standard_program(rows, rhs, objective))
+        statuses.add(status)
+        assert (
+            assert_standard_certificate(
+                standard_program(
+                    [*rows[::-1], rows[0]], [*rhs[::-1], rhs[0]], objective
+                )
+            )
+            == status
+        )
+    assert statuses == {"OPTIMAL", "INFEASIBLE", "UNBOUNDED"}
+
+
+def test_invalid_backend_negative_candidates_cannot_cross_trusted_boundary() -> None:
+    from jacobian.math.optimization.operations import (
+        _certify_infeasible,
+        _certify_point,
+    )
+
+    # The actual invalid Farkas candidate from #3194 has negative A^T y.
+    p = standard_program(
+        [[-1, -1, 1, 0, 0], [-1, 0, 0, 1, 0], [0, -1, 0, 0, 1]],
+        [-1, -1, -1],
+        [1, 1, 0, 0, 0],
+    )
+    with pytest.raises(RuntimeError, match="produced no mathematical result"):
+        _certify_infeasible(p, (Fraction(0), Fraction(1), Fraction(0)), 100)
+    # Nonnegative improving directions still need Ad=0; homogeneous improving
+    # vectors still need nonnegativity; and a ray alone needs a feasible point.
+    p = standard_program([[1, -1]], [1], [-1, 0])
+    for point, ray in [
+        ((1, 0), (1, 0)),
+        ((1, 0), (1, -1)),
+        ((0, 0), (1, 1)),
+        ((1, 0), (0, 0)),
+    ]:
+        with pytest.raises(RuntimeError, match="produced no mathematical result"):
+            _certify_point(
+                p, tuple(map(Fraction, point)), (), tuple(map(Fraction, ray)), 100
+            )
+
+
+def test_dense_full_rank_infeasibility_near_work_limit() -> None:
+    # Every six-column Vandermonde minor is nonsingular. Negative first RHS
+    # makes all C(17,6)=12376 original bases infeasible, forcing phase I.
+    # The complete conservative reservation is 49,909,832 < 50,000,000 updates.
+    rows = [[(j + 1) ** i for j in range(17)] for i in range(6)]
+    assert (
+        assert_standard_certificate(standard_program(rows, [-1] * 6, [1] * 17))
+        == "INFEASIBLE"
+    )
+
+
+def test_coupled_farkas_maps_upper_and_lower_signs() -> None:
+    program = GeneralFormRationalLinearProgram.model_validate(
+        {
+            "variables": [
+                {"name": name, "lower_bound": q(0), "upper_bound": q(1)}
+                for name in ("x", "y")
+            ],
+            "objective": {"sense": "MINIMIZE", "coefficients": [q(-1), q(-1)]},
+            "constraints": [
+                {
+                    "label": "sum",
+                    "coefficients": [q(1), q(1)],
+                    "relation": "GE",
+                    "rhs": q(3),
+                }
+            ],
+        }
+    )
+    result = general_linear_program(program)
+    assert result.status == "INFEASIBLE"
+    assert result.farkas_constraints is not None
+    assert (
+        result.farkas_lower_bounds is not None
+        and result.farkas_upper_bounds is not None
+    )
+    y = result.farkas_constraints[0].as_fraction()
+    lower = [v.as_fraction() for v in result.farkas_lower_bounds]
+    upper = [v.as_fraction() for v in result.farkas_upper_bounds]
+    assert y <= 0 and all(v <= 0 for v in lower) and all(v >= 0 for v in upper)
+    assert all(y + lo + hi == 0 for lo, hi in zip(lower, upper, strict=True))
+    assert 3 * y + sum(upper) < 0

--- a/tests/math/optimization/test_linear_large_rational_codecs.py
+++ b/tests/math/optimization/test_linear_large_rational_codecs.py
@@ -1,0 +1,154 @@
+"""Admitted exact LP values must not inherit Python's decimal-string ceiling."""
+
+import sys
+from collections.abc import Iterator
+from fractions import Fraction
+from random import Random
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.optimization import general_linear_program, linear_program
+from jacobian.math.optimization._general_models import (
+    GeneralFormRationalLinearProgram,
+    GeneralRationalLinearProgramResult,
+)
+from jacobian.math.optimization._models import (
+    RationalLinearProgramResult,
+    StandardFormRationalLinearProgram,
+)
+
+
+@pytest.fixture
+def default_integer_string_limit() -> Iterator[int]:
+    previous = sys.get_int_max_str_digits()
+    default = sys.int_info.default_max_str_digits
+    sys.set_int_max_str_digits(default)
+    try:
+        yield default
+        assert sys.get_int_max_str_digits() == default
+    finally:
+        sys.set_int_max_str_digits(previous)
+
+
+@pytest.mark.parametrize("general", [False, True])
+def test_exact_certificate_exceeds_interpreter_digit_limit(
+    default_integer_string_limit: int,
+    general: bool,
+) -> None:
+    random = Random(3194)
+    one = CanonicalRational.from_integer_ratio(1, 1)
+    rows = tuple(
+        tuple(
+            one
+            if i == j
+            else CanonicalRational.from_integer_ratio(
+                1, random.randrange(10**127, 10**128)
+            )
+            for j in range(7)
+        )
+        for i in range(7)
+    )
+    program = StandardFormRationalLinearProgram(
+        variables=tuple(f"x{i}" for i in range(7)),
+        objective=(one,) * 7,
+        coefficients=rows,
+        rhs=(one,) * 7,
+    )
+    result: RationalLinearProgramResult | GeneralRationalLinearProgramResult
+    if general:
+        general_program = GeneralFormRationalLinearProgram.model_validate(
+            {
+                "variables": [
+                    {
+                        "name": name,
+                        "lower_bound": CanonicalRational.from_integer_ratio(0, 1),
+                    }
+                    for name in program.variables
+                ],
+                "objective": {"sense": "MINIMIZE", "coefficients": program.objective},
+                "constraints": [
+                    {
+                        "label": f"row{i}",
+                        "relation": "EQ",
+                        "coefficients": row,
+                        "rhs": one,
+                    }
+                    for i, row in enumerate(rows)
+                ],
+            }
+        )
+        result = general_linear_program(general_program)
+        dual = result.constraint_dual
+    else:
+        result = linear_program(program)
+        dual = result.dual_candidate
+    assert result.status == "OPTIMAL"
+    assert result.primal_candidate is not None and dual is not None
+    assert (
+        max(len(v.num.lstrip("-")) for v in result.primal_candidate)
+        > default_integer_string_limit
+    )
+    x = tuple(v.as_fraction() for v in result.primal_candidate)
+    y = tuple(v.as_fraction() for v in dual)
+    assert all(v > 0 for v in (*x, *y))
+    assert all(
+        sum(a.as_fraction() * b for a, b in zip(row, x, strict=True)) == 1
+        for row in rows
+    )
+    assert all(
+        sum(rows[i][j].as_fraction() * y[i] for i in range(7)) == 1 for j in range(7)
+    )
+    assert sum(x) == sum(y)
+    assert (
+        result.primal_objective is not None
+        and result.primal_objective.as_fraction() == sum(x)
+    )
+    assert result.model_validate_json(result.model_dump_json()) == result
+
+
+def test_general_lp_normalized_rhs_and_source_point_exceed_interpreter_limit(
+    default_integer_string_limit: int,
+) -> None:
+    random = Random(3194)
+    lower = tuple(Fraction(1, random.randrange(10**127, 10**128)) for _ in range(20))
+    coefficients = tuple(
+        Fraction(1, random.randrange(10**127, 10**128)) for _ in range(20)
+    )
+    one = CanonicalRational.from_integer_ratio(1, 1)
+    wire_coefficients = tuple(CanonicalRational.from_fraction(c) for c in coefficients)
+    program = GeneralFormRationalLinearProgram.model_validate(
+        {
+            "variables": [
+                {"name": f"x{i}", "lower_bound": CanonicalRational.from_fraction(v)}
+                for i, v in enumerate(lower)
+            ],
+            "objective": {"sense": "MINIMIZE", "coefficients": wire_coefficients},
+            "constraints": [
+                {
+                    "label": "weighted_sum",
+                    "relation": "EQ",
+                    "coefficients": wire_coefficients,
+                    "rhs": one,
+                }
+            ],
+        }
+    )
+    # The affine shift produces 1 - sum(c_i*l_i), beyond Python's default
+    # decimal conversion limit even though every source component has <=128 digits.
+    shifted = CanonicalRational.from_fraction(
+        Fraction(1) - sum(c * v for c, v in zip(coefficients, lower, strict=True))
+    )
+    assert len(shifted.den) > default_integer_string_limit
+    result = general_linear_program(program)
+    assert result.status == "OPTIMAL" and result.primal_candidate is not None
+    assert (
+        max(len(v.num.lstrip("-")) for v in result.primal_candidate)
+        > default_integer_string_limit
+    )
+    x = tuple(v.as_fraction() for v in result.primal_candidate)
+    assert all(v >= bound for v, bound in zip(x, lower, strict=True))
+    assert sum(c * v for c, v in zip(coefficients, x, strict=True)) == 1
+    assert result.primal_objective == result.dual_objective == one
+    assert result.constraint_dual == (one,)
+    assert result.model_validate_json(result.model_dump_json()) == result

--- a/tests/math/polynomials/series/test_inverse_admission.py
+++ b/tests/math/polynomials/series/test_inverse_admission.py
@@ -1,0 +1,129 @@
+"""Useful inverse envelopes checked by independent finite convolution."""
+
+import json
+from fractions import Fraction
+from typing import Any, cast
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.catalog.models import MathTool, OperationDomainValidationError
+from jacobian.math.polynomials.series import divide, inverse
+from jacobian.math.polynomials.series._models import (
+    MAX_TRUNCATION_ORDER,
+    TruncatedSeries,
+)
+from jacobian.math.polynomials.series._tools import TOOLS
+
+
+def _series(values: list[Fraction]) -> TruncatedSeries:
+    return TruncatedSeries(
+        variable="x",
+        truncation_order=len(values),
+        coefficients=tuple(CanonicalRational.from_fraction(value) for value in values),
+    )
+
+
+def _product(left: TruncatedSeries, right: TruncatedSeries) -> list[Fraction]:
+    return [
+        sum(
+            (
+                left.coefficients[i].as_fraction()
+                * right.coefficients[k - i].as_fraction()
+                for i in range(k + 1)
+            ),
+            Fraction(),
+        )
+        for k in range(left.truncation_order)
+    ]
+
+
+@pytest.mark.parametrize("order", [5, 6, 7, 64, MAX_TRUNCATION_ORDER])
+@pytest.mark.parametrize("linear", [0, 1])
+def test_constant_and_geometric_inverse(order: int, linear: int) -> None:
+    source = _series([Fraction(1), Fraction(linear), *[Fraction()] * (order - 2)])
+    result = inverse(source)
+    assert [c.as_fraction() for c in result.result.coefficients] == [
+        (-linear) ** i for i in range(order)
+    ]
+    assert _product(source, result.result) == [1, *[0] * (order - 1)]
+    assert all(c.as_fraction() == 0 for c in result.residual_coefficients)
+
+
+def test_dense_rational_inverse_and_division() -> None:
+    order = 64
+    source = _series([Fraction((-1) ** i * (i + 1), 6) for i in range(order)])
+    numerator = _series([Fraction(i % 5 - 2, 7) for i in range(order)])
+    result = inverse(source)
+    assert _product(source, result.result) == [1, *[0] * (order - 1)]
+    quotient = divide(numerator, source)
+    assert _product(source, quotient.quotient) == [
+        c.as_fraction() for c in numerator.coefficients
+    ]
+    assert all(c.as_fraction() == 0 for c in quotient.residual_coefficients)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [Fraction(1, 2**700), *[Fraction(1)] * 7],
+        [Fraction(-2, 3), Fraction(3, 7), Fraction(-5, 11), *[Fraction(1, 13)] * 13],
+    ],
+)
+def test_nonunit_shared_denominators(values: list[Fraction]) -> None:
+    source = _series(values)
+    result = inverse(source)
+    assert _product(source, result.result) == [1, *[0] * (len(values) - 1)]
+    quotient = divide(source, source)
+    assert [c.as_fraction() for c in quotient.quotient.coefficients] == [
+        1,
+        *[0] * (len(values) - 1),
+    ]
+
+
+@pytest.mark.parametrize("operation", ["inverse", "divide"])
+def test_strict_json_execution_at_order_boundary(operation: str) -> None:
+    source = _series(
+        [Fraction(1), Fraction(1), *[Fraction()] * (MAX_TRUNCATION_ORDER - 2)]
+    )
+    tool = cast(
+        MathTool[Any, StrictModel],
+        next(
+            item
+            for item in TOOLS
+            if item.operation_id == f"formal_series.rational.{operation}.compute"
+        ),
+    )
+    if operation == "inverse":
+        payload = source.model_dump_json()
+        expected = inverse(source).model_dump()
+    else:
+        payload = json.dumps(
+            {
+                "left": source.model_dump(mode="json"),
+                "right": source.model_dump(mode="json"),
+            }
+        )
+        quotient = divide(source, source)
+        expected = quotient.model_dump()
+        assert [c.as_fraction() for c in quotient.quotient.coefficients] == [
+            1,
+            *[0] * (MAX_TRUNCATION_ORDER - 1),
+        ]
+    assert (
+        tool.run(tool.request_type.model_validate_json(payload)).model_dump()
+        == expected
+    )
+
+
+def test_growth_rejection_then_small_inverse_recovers() -> None:
+    source = _series([Fraction(1), Fraction(10**255), *[Fraction()] * 18])
+    with pytest.raises(OperationDomainValidationError) as error:
+        inverse(source)
+    assert (
+        error.value.errors()[0]["type"]
+        == "formal_power_series.inverse_coefficient_growth"
+    )
+    small = _series([Fraction(1), Fraction(1), *[Fraction()] * 4])
+    assert _product(small, inverse(small).result) == [1, 0, 0, 0, 0, 0]

--- a/tests/math/polynomials/series/test_result_height.py
+++ b/tests/math/polynomials/series/test_result_height.py
@@ -66,7 +66,9 @@ def test_power_propagates_binary_convolution_growth() -> None:
 
 
 def test_division_propagates_inverse_and_residual_growth() -> None:
-    order = 8
+    # The leading reciprocal contributes 2**700 at each recurrence degree;
+    # order 24 genuinely exceeds the result envelope (order 8 does not).
+    order = 24
     numerator = [_coefficient() for _ in range(order)]
     denominator = [_coefficient(den=str(2**700)), *[_coefficient()] * (order - 1)]
     request = SeriesDivideRequest.model_validate(

--- a/tests/math/topology/cohomology/operations/test_bockstein_ambient.py
+++ b/tests/math/topology/cohomology/operations/test_bockstein_ambient.py
@@ -1,0 +1,103 @@
+"""Zero Bocksteins retain their coefficient field with optional ambient data."""
+
+from itertools import combinations
+
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.topology.cohomology.operations import bockstein
+from jacobian.math.topology.cohomology.operations._models import (
+    BocksteinRequest,
+    BocksteinResult,
+)
+from jacobian.math.topology.cohomology.operations._tools import TOOLS
+from jacobian.math.topology.operations import canonicalize
+
+
+@pytest.mark.parametrize("prime", [2, 3, 5, 7])
+@pytest.mark.parametrize("degree", [0, 1])
+@pytest.mark.parametrize("representation", ["multiple", "duplicates", "normalized"])
+@pytest.mark.parametrize("ambient_kind", ["absent", "raw", "canonical"])
+def test_zero_bockstein_preserves_source_and_codomain(
+    prime: int, degree: int, representation: str, ambient_kind: str
+) -> None:
+    vertices = tuple(range(degree + 2))
+    ambient = tuple(
+        face
+        for size in range(1, len(vertices) + 1)
+        for face in combinations(vertices, size)
+    )
+    face = vertices[:-1]
+    values = (face, face) if representation == "duplicates" else (face,)
+    coefficients = {
+        "multiple": (prime,),
+        "duplicates": (1, prime - 1),
+        "normalized": (0,),
+    }[representation]
+    # The represented source is zero in GF(p); its zero lift has d(0)=0,
+    # so beta(0)=0 in degree n+1 for the same coefficient field.
+    assert sum(coefficients) % prime == 0
+    labels = tuple(str(vertex) for vertex in vertices)
+    complex_value = canonicalize(labels, (labels,)).complex
+    request = BocksteinRequest(
+        prime=prime,
+        cochain_degree=degree,
+        simplex_values=values,
+        simplex_coefficients=coefficients,
+        ambient_simplices=ambient if ambient_kind == "raw" else (),
+        ambient_complex=complex_value if ambient_kind == "canonical" else None,
+    )
+    native = bockstein(
+        prime,
+        degree,
+        values,
+        coefficients,
+        request.ambient_simplices,
+        request.ambient_complex,
+    )
+    tool = next(t for t in TOOLS if t.operation_id == "cohomology.bockstein.compute")
+    dispatched = tool.run(
+        BocksteinRequest.model_validate_json(request.model_dump_json(), strict=True)
+    )
+    for result in (native, dispatched):
+        assert result.prime == prime
+        assert result.cochain_degree == degree
+        assert result.simplex_values == values
+        assert result.simplex_coefficients == coefficients
+        assert result.ambient_simplices == request.ambient_simplices
+        assert result.ambient_complex == request.ambient_complex
+        assert result.result_degree == degree + 1
+        assert result.result_simplex_values == ()
+        assert result.result_simplex_coefficients == ()
+        assert result.is_zero
+        assert (
+            BocksteinResult.model_validate_json(result.model_dump_json(), strict=True)
+            == result
+        )
+
+
+@pytest.mark.parametrize(
+    ("ambient", "code"),
+    [
+        (((1,),), "support_outside_ambient"),
+        (((0,), (0, 1)), "ambient_not_downward_closed"),
+        (((0,), (1,), (1, 0)), "simplex_vertices_not_canonical"),
+    ],
+)
+def test_zero_bockstein_still_validates_ambient_and_recovers(
+    ambient: tuple[tuple[int, ...], ...], code: str
+) -> None:
+    with pytest.raises(OperationDomainValidationError) as excinfo:
+        bockstein(3, 0, ((0,),), (3,), ambient_simplices=ambient)
+    assert excinfo.value.errors()[0]["type"] == f"cohomology_operation.{code}"
+    assert bockstein(
+        3, 0, ((0,),), (3,), ambient_simplices=((0,), (1,), (0, 1))
+    ).is_zero
+
+
+def test_nonzero_mod_prime_is_rejected_even_when_zero_mod_two() -> None:
+    with pytest.raises(OperationDomainValidationError) as excinfo:
+        bockstein(3, 0, ((0,),), (2,), ambient_simplices=((0,),))
+    assert excinfo.value.errors()[0]["type"] == (
+        "cohomology_operation.nonzero_bockstein_unsupported"
+    )

--- a/tests/math/topology/finite/spaces/test_finite_topology_spaces.py
+++ b/tests/math/topology/finite/spaces/test_finite_topology_spaces.py
@@ -30,7 +30,7 @@ from jacobian.math.topology.finite.spaces._tools import (
 
 
 def _sierpinski() -> FiniteTopologicalSpace:
-    """Sierpinski space: points {a, b}, a <= b (open sets: {}, {a}, {a,b})."""
+    """Sierpinski space: points {a, b}, a <= b (open sets: {}, {b}, {a,b})."""
     return FiniteTopologicalSpace(
         points=("a", "b"),
         preorder=((0,), (0, 1)),
@@ -67,14 +67,14 @@ def test_catalog_contains_only_audited_agent_outcomes() -> None:
 
 class TestInterior:
     def test_sierpinski_interior_a(self) -> None:
-        # Interior of {a}: {a} is open, so interior = {a}.
+        # Interior of {a}: {a} is not open (minimal nbhd of a is {a,b}), so interior = {}.
         result = _interior(SubsetRequest(space=_sierpinski(), subset=(0,)))
-        assert result.interior == (0,)
+        assert result.interior == ()
 
     def test_sierpinski_interior_b(self) -> None:
-        # Interior of {b}: {b} is not open (its minimal nbhd is {a,b}), so interior = {}.
+        # Interior of {b}: {b} is open (minimal nbhd of b is {b}), so interior = {b}.
         result = _interior(SubsetRequest(space=_sierpinski(), subset=(1,)))
-        assert result.interior == ()
+        assert result.interior == (1,)
 
     def test_sierpinski_interior_ab(self) -> None:
         result = _interior(SubsetRequest(space=_sierpinski(), subset=(0, 1)))
@@ -88,13 +88,13 @@ class TestInterior:
 
 class TestClosure:
     def test_sierpinski_closure_a(self) -> None:
-        # Closure of {a}: up-set of a = {b} (since b >= a in specialization).
+        # Closure of {a}: down-set of a = {a} (preorder row).
         result = _closure(SubsetRequest(space=_sierpinski(), subset=(0,)))
-        assert result.closure == (0, 1)
+        assert result.closure == (0,)
 
     def test_sierpinski_closure_b(self) -> None:
         result = _closure(SubsetRequest(space=_sierpinski(), subset=(1,)))
-        assert result.closure == (1,)
+        assert result.closure == (0, 1)
 
 
 # ---------------------------------------------------------------------------
@@ -104,9 +104,9 @@ class TestClosure:
 
 class TestBoundary:
     def test_sierpinski_boundary_a(self) -> None:
-        # Closure({a}) = {a,b}, Interior({a}) = {a}. Boundary = {b}.
+        # Closure({a}) = {a}, Interior({a}) = {}. Boundary = {a}.
         result = _boundary(SubsetRequest(space=_sierpinski(), subset=(0,)))
-        assert result.boundary == (1,)
+        assert result.boundary == (0,)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp/test_chip_firing.py
+++ b/tests/mcp/test_chip_firing.py
@@ -1,0 +1,129 @@
+"""Live MCP projection of chip-firing defining regressions and rejection."""
+
+import asyncio
+
+from mcp.shared.exceptions import MCPError
+from mcp.types import INVALID_PARAMS
+
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_chip_firing_regressions_through_live_mcp() -> None:
+    async def scenario() -> None:
+        graph = {
+            "vertices": ["a", "b", "c"],
+            "edges": [["a", "b"], ["a", "c"], ["b", "c"]],
+        }
+        cases = [
+            (
+                "stabilize",
+                {
+                    "configuration": {
+                        "graph": {"vertices": ["a", "b"], "edges": [["a", "b"]]},
+                        "sink": "a",
+                        "configuration": [0, 3],
+                    }
+                },
+                "stable",
+                [3, 0],
+            ),
+            (
+                "q_reduced",
+                {"graph": graph, "sink": "a", "divisor": [0, 1, 1]},
+                "reduced_divisor",
+                [2, 0, 0],
+            ),
+            (
+                "q_reduced",
+                {"graph": graph, "sink": "a", "divisor": [0, -1, 0]},
+                "reduced_divisor",
+                [-2, 0, 1],
+            ),
+            (
+                "abel_jacobi",
+                {"graph": graph, "sink": "a", "divisor": [-1, 2, -1]},
+                "coordinates",
+                [0],
+            ),
+        ]
+        async with Client(create_server(), raise_exceptions=True) as client:
+            for name, payload, field, expected in cases:
+                result = await client.call_tool(
+                    "math.run",
+                    {
+                        "operation_id": f"graph.chip_firing.{name}.compute",
+                        "payload": payload,
+                    },
+                )
+                assert not result.is_error
+                assert result.structured_content["output"][field] == expected
+            # The formerly rejected coupled HNF is a successful public
+            # operation, not merely a fast private-backend diagnostic.
+            coupled = {
+                "vertices": [str(i) for i in range(7)],
+                "edges": [
+                    [str(i), str(j)]
+                    for i, j in (
+                        (0, 1),
+                        (0, 2),
+                        (0, 3),
+                        (0, 4),
+                        (0, 5),
+                        (1, 2),
+                        (1, 4),
+                        (1, 5),
+                        (1, 6),
+                        (2, 3),
+                        (2, 5),
+                        (3, 4),
+                        (3, 5),
+                        (3, 6),
+                        (4, 5),
+                        (5, 6),
+                    )
+                ],
+            }
+            for divisor, principal in (
+                ([-5, 1, 1, 1, 1, 1, 0], True),
+                ([1, -1, 0, 0, 0, 0, 0], False),
+            ):
+                result = await client.call_tool(
+                    "math.run",
+                    {
+                        "operation_id": "graph.chip_firing.abel_jacobi.compute",
+                        "payload": {"graph": coupled, "sink": "0", "divisor": divisor},
+                    },
+                )
+                assert not result.is_error
+                output = result.structured_content["output"]
+                assert output["invariant_factors"] == [1, 1, 1, 1, 1, 2520]
+                assert (output["coordinates"] == [0]) == principal
+            disconnected = {"vertices": ["a", "b", "c"], "edges": [["b", "c"]]}
+            # INVALID_PARAMS is a protocol exception, distinct from a
+            # successful mathematical result or an execution tool error.
+            for name in ("stabilize", "q_reduced"):
+                payload = {"graph": disconnected, "sink": "a"}
+                payload = (
+                    {"configuration": {**payload, "configuration": [0, 1, 1]}}
+                    if name == "stabilize"
+                    else {**payload, "divisor": [0, 1, 1]}
+                )
+                try:
+                    await client.call_tool(
+                        "math.run",
+                        {
+                            "operation_id": f"graph.chip_firing.{name}.compute",
+                            "payload": payload,
+                        },
+                    )
+                except MCPError as exc:
+                    assert exc.code == INVALID_PARAMS
+                    assert (
+                        exc.data["errors"][0]["code"]
+                        == "chip_firing.requires_connected_graph"
+                    )
+                else:
+                    raise AssertionError("MCP admitted a disconnected sink graph")
+
+    asyncio.run(scenario())

--- a/tests/mcp/test_formal_series_inverse.py
+++ b/tests/mcp/test_formal_series_inverse.py
@@ -1,0 +1,55 @@
+"""Live inverse admission and recovery through the MCP SDK boundary."""
+
+import asyncio
+
+import pytest
+from mcp.shared.exceptions import MCPError
+
+from jacobian.math.polynomials.series import inverse
+from jacobian.math.polynomials.series._models import TruncatedSeries
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_inverse_native_mcp_parity_after_growth_rejection() -> None:
+    async def scenario() -> None:
+        async with Client(create_server(), raise_exceptions=True) as client:
+            with pytest.raises(MCPError) as error:
+                await client.call_tool(
+                    "math.run",
+                    {
+                        "operation_id": "formal_series.rational.inverse.compute",
+                        "payload": {
+                            "variable": "x",
+                            "truncation_order": 20,
+                            "coefficients": [
+                                {"num": "1", "den": "1"},
+                                {"num": str(10**255), "den": "1"},
+                                *[{"num": "0", "den": "1"}] * 18,
+                            ],
+                        },
+                    },
+                )
+            assert error.value.code == -32602
+            source = TruncatedSeries.model_validate(
+                {
+                    "variable": "x",
+                    "truncation_order": 6,
+                    "coefficients": [{"num": "1", "den": "1"}] * 2
+                    + [{"num": "0", "den": "1"}] * 4,
+                }
+            )
+            result = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "formal_series.rational.inverse.compute",
+                    "payload": source.model_dump(mode="json"),
+                },
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            assert result.structured_content["output"] == inverse(source).model_dump(
+                mode="json"
+            )
+
+    asyncio.run(scenario())

--- a/tests/mcp/test_lattice_regressions.py
+++ b/tests/mcp/test_lattice_regressions.py
@@ -1,0 +1,38 @@
+"""Lattice corrections retain their exact values across live MCP."""
+
+import asyncio
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import invoke_operation
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_lattice_corrections_through_mcp() -> None:
+    cases = (
+        ("lattice.dual.compute", [[1, 1], [0, 2]]),
+        ("lattice.dual.compute", [[2, 2]]),
+        ("lattice.rank_gram.compute", [[1, 0], [0, 1]]),
+        ("lattice.rank_gram.compute", [[1, 1]]),
+        ("lattice.saturation.compute", [[2, 2]]),
+    )
+
+    async def scenario() -> None:
+        async with Client(create_server(), raise_exceptions=True) as client:
+            for operation_id, rows in cases:
+                lattice = {
+                    "ambient_dimension": len(rows[0]),
+                    "basis": {"entries": [[str(v) for v in row] for row in rows]},
+                }
+                payload = (
+                    lattice
+                    if operation_id == "lattice.saturation.compute"
+                    else {"lattice": lattice}
+                )
+                expected = invoke_operation(operation_id, payload, Catalog.open())
+                result = await client.call_tool(
+                    "math.run", {"operation_id": operation_id, "payload": payload}
+                )
+                assert result.structured_content["output"] == expected.output
+
+    asyncio.run(scenario())

--- a/tests/mcp/test_linear_program_admission.py
+++ b/tests/mcp/test_linear_program_admission.py
@@ -1,0 +1,88 @@
+"""LP-owned MCP inspection and derived admission recovery (#3191)."""
+
+import asyncio
+import json
+from itertools import combinations
+
+import pytest
+from mcp.shared.exceptions import MCPError
+from tests.support.rationals import rational_payload as q
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.math.optimization._tools import TOOLS
+from jacobian.mcp.runtime import AppState
+from jacobian.mcp.server import _build_server
+from mcp import Client
+
+OPERATION = "optimization.linear.rational_general_optimum.compute"
+
+
+@pytest.mark.parametrize(
+    ("n", "m", "relation", "code"),
+    [
+        (28, 24, "GE", "normalized_columns"),
+        (2, 64, "EQ", "normalized_rows"),
+        (18, 6, "EQ", "work_bound"),
+        (24, 12, "EQ", "basis_bound"),
+    ],
+)
+def test_lp_inspection_explains_derived_admission(
+    n: int, m: int, relation: str, code: str
+) -> None:
+    async def scenario() -> None:
+        server = _build_server(state=AppState(operation_catalog=Catalog(TOOLS)))
+        variables = [{"name": f"private_x{i}", "lower_bound": q(0)} for i in range(n)]
+        if code == "normalized_rows":
+            for variable in variables:
+                variable["upper_bound"] = q(1)
+        rows = [[int(i == j % m) for j in range(n)] for i in range(m)]
+        if code == "normalized_columns":
+            pairs = list(combinations(range(8), 2))
+            triples = [
+                t
+                for t in combinations(range(8), 3)
+                if not any(
+                    i // 4 == j // 4 and j - i == 1 for i, j in combinations(t, 2)
+                )
+            ]
+            rows = [[int(i in t and j in t) for i, j in pairs] for t in triples]
+        payload = {
+            "program": {
+                "variables": variables,
+                "objective": {"sense": "MINIMIZE", "coefficients": [q(1)] * n},
+                "constraints": [
+                    {
+                        "label": f"private_row{i}",
+                        "coefficients": [q(v) for v in row],
+                        "relation": relation,
+                        "rhs": q(1),
+                    }
+                    for i, row in enumerate(rows)
+                ],
+            }
+        }
+        async with Client(server, raise_exceptions=True) as client:
+            inspection = await client.call_tool(
+                "math.find", {"request": {"op": "inspect", "operation_id": OPERATION}}
+            )
+            text = json.dumps(inspection.structured_content)
+            assert "Normalized limits are 32 columns and 64 rows" in text
+            assert "C(n+1,r)" in text and "50000000" in text
+            with pytest.raises(MCPError) as caught:
+                await client.call_tool(
+                    "math.run", {"operation_id": OPERATION, "payload": payload}
+                )
+        diagnostic = caught.value.data
+        assert diagnostic["code"] == "RESOURCE_ADMISSION_REJECTED"
+        assert diagnostic["stage"] == "resource_admission"
+        assert diagnostic["errors"][0]["code"] == f"optimization.linear.{code}"
+        message = diagnostic["errors"][0]["message"]
+        assert "normalized_columns=" in message and "normalized_rows=" in message
+        assert "private_" not in message and "input_value" not in message
+        assert "correct the fields" not in diagnostic["hint"]
+        if code == "normalized_columns":
+            assert "normalized_columns=52" in message
+        if code == "normalized_rows":
+            assert "normalized_rows=66" in message
+
+    asyncio.run(scenario())

--- a/tests/mcp/test_real_quadratic_admission.py
+++ b/tests/mcp/test_real_quadratic_admission.py
@@ -1,0 +1,91 @@
+"""Real owner diagnostics survive native, dispatch, and live MCP calls."""
+
+import asyncio
+
+import pytest
+from mcp.shared.exceptions import MCPError
+from mcp.types import INVALID_PARAMS
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.dispatch import invoke_operation
+from jacobian.math.number_theory.algebraic_numbers.quadratic import real_quadratic_order
+from jacobian.math.number_theory.arithmetic._real_quadratic import (
+    RealQuadraticOrderRequest,
+)
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+@pytest.mark.parametrize(
+    "overflow", (False, True), ids=("shared-field", "difference-bound")
+)
+def test_real_quadratic_rejection_and_recovery(overflow: bool) -> None:
+    operation_id = "arithmetic.real_quadratic.order.compute"
+    payload = {
+        "left": {
+            "rational_part": {"num": "0", "den": "1"},
+            "radical_coefficient": {"num": "3", "den": "8"},
+            "radicand": 2,
+        },
+        "right": {
+            "rational_part": {"num": "1", "den": "2"},
+            "radical_coefficient": {"num": "1", "den": "20"},
+            "radicand": 3,
+        },
+    }
+    valid = RealQuadraticOrderRequest.model_validate(
+        {**payload, "left": {**payload["left"], "radicand": 3}}
+    )
+    if overflow:
+        payload = valid.model_dump(mode="json")
+        payload["left"]["rational_part"] = {"num": "9" * 256, "den": "1"}
+        payload["right"]["rational_part"] = {"num": "-" + "9" * 256, "den": "1"}
+    request = RealQuadraticOrderRequest.model_validate(payload)
+    with pytest.raises(OperationDomainValidationError) as native:
+        real_quadratic_order(request.left, request.right)
+    with pytest.raises(OperationDomainValidationError) as dispatch:
+        invoke_operation(operation_id, payload, Catalog.open())
+    assert dispatch.value.errors() == native.value.errors()
+
+    async def scenario() -> None:
+        async with Client(create_server(), raise_exceptions=True) as client:
+            with pytest.raises(MCPError) as rejected:
+                await client.call_tool(
+                    "math.run", {"operation_id": operation_id, "payload": payload}
+                )
+            assert rejected.value.code == INVALID_PARAMS
+            assert rejected.value.data["code"] == (
+                "RESOURCE_ADMISSION_REJECTED" if overflow else "INVALID_REQUEST"
+            )
+            assert rejected.value.data["stage"] == (
+                "resource_admission" if overflow else "operation_validation"
+            )
+            assert rejected.value.data["errors"] == [
+                {
+                    "location": list(error["loc"]),
+                    "code": error["type"],
+                    "message": error["msg"],
+                }
+                for error in native.value.errors()
+            ]
+            result = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": operation_id,
+                    "payload": valid.model_dump(mode="json"),
+                },
+            )
+            output = result.structured_content["output"]
+            assert output["order"] == "GT"
+            assert output["difference"]["rational_part"] == {"num": "-1", "den": "2"}
+            assert output["difference"]["radical_coefficient"] == {
+                "num": "13",
+                "den": "40",
+            }
+            assert output["sign_certificate"]["radical_part_squared"] == {
+                "num": "507",
+                "den": "1600",
+            }
+
+    asyncio.run(scenario())

--- a/tests/process/test_chip_firing.py
+++ b/tests/process/test_chip_firing.py
@@ -1,0 +1,260 @@
+"""Kill-isolated chip-firing rejection, cancellation and deadline regressions."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("operation", ["stabilize", "q_reduced"])
+@pytest.mark.parametrize("surface", ["native", "dispatch"])
+def test_unreachable_sink_rejects_in_isolation(operation: str, surface: str) -> None:
+    # A regression may restore a genuinely nonterminating loop. The test
+    # parent enforces the wall bound even if request checkpoints disappear.
+    script = """
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.dispatch import invoke_operation
+from jacobian.math.graphs.chip_firing import stabilize, q_reduced
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+import sys
+operation, surface = sys.argv[1:]
+g = SimpleUndirectedGraph(vertices=("a","b","c"), edges=(("b","c"),))
+try:
+    if surface == "native":
+        if operation == "stabilize":
+            stabilize(g, "a", (0,1,1))
+        else:
+            q_reduced(g, (0,1,1), "a")
+    else:
+        payload = {"graph": g.model_dump(mode="json"), "sink": "a"}
+        if operation == "stabilize":
+            payload = {"configuration": {**payload, "configuration": [0,1,1]}}
+        else:
+            payload["divisor"] = [0,1,1]
+        invoke_operation("graph.chip_firing." + operation + ".compute", payload, Catalog.open())
+except OperationDomainValidationError as exc:
+    assert exc.errors()[0]["type"] == "chip_firing.requires_connected_graph"
+else:
+    raise AssertionError("disconnected graph was accepted")
+edge = SimpleUndirectedGraph(vertices=("a","b"), edges=(("a","b"),))
+assert stabilize(edge, "a", (0,3)).stable == (3,0)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script, operation, surface],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src"),
+        },
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize("operation", ["stabilize", "q_reduced"])
+@pytest.mark.parametrize("interrupt", ["cancel", "deadline"])
+def test_interrupt_inside_real_iteration(operation: str, interrupt: str) -> None:
+    script = """
+import sys, time
+from jacobian._execution import (request_execution, request_cancellation,
+    bind_request_deadline, OperationExecutionCancelledError, OperationExecutionTimeoutError)
+from jacobian.math.graphs.chip_firing import stabilize, q_reduced
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+operation, interrupt = sys.argv[1:]
+labels = tuple(f"v{i:02d}" for i in range(50))
+g = SimpleUndirectedGraph(vertices=labels, edges=tuple(zip(labels, labels[1:])))
+class Signal:
+    checks = 0
+    def is_set(self):
+        self.checks += 1
+        if self.checks == 12:
+            if interrupt == "deadline":
+                bind_request_deadline(time.monotonic() - 1)
+            else:
+                return True
+        return False
+signal = Signal()
+expected = OperationExecutionCancelledError if interrupt == "cancel" else OperationExecutionTimeoutError
+with request_execution(started_at=time.monotonic()), request_cancellation(signal):
+    try:
+        if operation == "stabilize":
+            stabilize(g, labels[0], (0,) * 49 + (1_000_000,))
+        else:
+            q_reduced(g, (-100,) * 50, labels[0])
+    except expected as exc:
+        assert "during chip-firing stabilization" in str(exc), str(exc)
+    else:
+        raise AssertionError("iteration ignored interruption")
+assert signal.checks == 12
+assert stabilize(g, labels[0], (0,) * 50).total_firings == 0
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script, operation, interrupt],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_smith_preserves_inherited_deadline_and_empty_axis() -> None:
+    from time import monotonic
+
+    from jacobian._execution import (
+        OperationExecutionTimeoutError,
+        bind_request_deadline,
+        current_request_execution,
+        request_execution,
+    )
+    from jacobian.math.graphs.chip_firing._snf_process import smith_coordinates
+
+    assert smith_coordinates([], []) == ((), ())
+    with request_execution(started_at=monotonic()):
+        deadline = monotonic() - 1
+        bind_request_deadline(deadline)
+        with pytest.raises(OperationExecutionTimeoutError):
+            smith_coordinates([[2, -1], [-1, 2]], [2, -1])
+        execution = current_request_execution()
+        assert execution is not None and execution.deadline == deadline
+
+
+def test_smith_cancels_actual_worker_and_recovers() -> None:
+    from threading import Event, Timer
+
+    from jacobian._execution import (
+        OperationExecutionCancelledError,
+        request_cancellation,
+    )
+    from jacobian.math.graphs.chip_firing._snf_process import smith_coordinates
+
+    event = Event()
+    timer = Timer(0.05, event.set)
+    with request_cancellation(event):
+        timer.start()
+        try:
+            with pytest.raises(OperationExecutionCancelledError):
+                smith_coordinates([[2, -1], [-1, 2]], [2, -1])
+        finally:
+            timer.cancel()
+            timer.join()
+    assert smith_coordinates([[2, -1], [-1, 2]], [2, -1]) == ((1, 3), (0,))
+
+
+@pytest.mark.parametrize("factors", [["0", "3"], ["-1", "3"], ["2", "3"]])
+def test_smith_decoder_requires_positive_divisibility_chain(factors: list[str]) -> None:
+    import hashlib
+
+    from jacobian.canonical import encode_strict_json
+    from jacobian.math.graphs.chip_firing._snf_process import _decode_projection
+
+    request = b"admitted-source"
+    response = encode_strict_json(
+        {
+            "request_digest": hashlib.sha256(request).hexdigest(),
+            "diagonal": factors,
+            "coordinates": ["0"],
+        }
+    )
+    with pytest.raises(RuntimeError, match="malformed output") as caught:
+        _decode_projection(response, request, 2, True)
+    assert "positive" in str(caught.value.__cause__)
+
+
+def test_smith_bound_covers_adversarial_two_by_two_transforms() -> None:
+    # The near-unimodular matrix has huge entries but determinant one. A
+    # bound based only on determinant would miss its initial Bezout work.
+    script = """
+from sympy import Matrix, ZZ
+from sympy.matrices.normalforms import smith_normal_decomp
+from jacobian.math.graphs.chip_firing._smith_bounds import _two_by_two_bound
+for power in (1, 30, 1000):
+    n = 10**power
+    a = Matrix([[n,n-1],[n+1,n]])
+    envelope = _two_by_two_bound((n+1).bit_length(), 1)
+    s,u,v = smith_normal_decomp(a, domain=ZZ)
+    assert u*a*v == s
+    assert abs(u.det()) == abs(v.det()) == 1
+    assert max(abs(int(x)).bit_length() for m in (s,u,v) for x in m) <= envelope.bits
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_coordinate_worker_observes_cancellation_during_modular_hnf() -> None:
+    script = """
+import sys, time
+from threading import Event
+from jacobian._execution import request_cancellation, OperationExecutionCancelledError
+from jacobian.math.graphs.chip_firing._snf_worker import _coordinate_snf
+event = Event()
+entered = False
+def profile(frame, kind, argument):
+    global entered
+    if kind == "call" and frame.f_code.co_name == "_hermite_normal_form_modulo_D":
+        entered = True
+        event.set()
+with request_cancellation(event):
+    sys.setprofile(profile)
+    try:
+        _coordinate_snf([[2,-1],[-1,2]], [2,-1], time.monotonic()+10)
+    except OperationExecutionCancelledError as exc:
+        assert entered
+        assert "after determinant-modular Hermite form" in str(exc)
+    else:
+        raise AssertionError("Hermite preprocessing ignored cancellation")
+    finally:
+        sys.setprofile(None)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize("bound_source", [False, True])
+def test_worker_admission_diagnostic_is_bound_to_its_source(bound_source: bool) -> None:
+    import hashlib
+
+    from jacobian.canonical import encode_strict_json
+    from jacobian.catalog.models import OperationResourceAdmissionError
+    from jacobian.math.graphs.chip_firing._snf_process import _decode_projection
+
+    request = b"admitted-coordinate-source"
+    message = "residual work exceeds the Smith transformation bound"
+    response = encode_strict_json(
+        {
+            "request_digest": hashlib.sha256(
+                request if bound_source else b"other"
+            ).hexdigest(),
+            "resource_error": message,
+        }
+    )
+    if bound_source:
+        with pytest.raises(OperationResourceAdmissionError) as caught:
+            _decode_projection(response, request, 2, True)
+        assert caught.value.errors() == (
+            {
+                "loc": ("graph",),
+                "type": "chip_firing.smith_transform_bound",
+                "msg": message,
+            },
+        )
+    else:
+        with pytest.raises(RuntimeError, match="malformed output"):
+            _decode_projection(response, request, 2, True)

--- a/tests/process/test_environment.py
+++ b/tests/process/test_environment.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+
 import pytest
 
-from jacobian.process import worker_environment
+import jacobian
+from jacobian.process import (
+    run_bounded_process,
+    run_bounded_worker_dialogue,
+    worker_environment,
+)
 
 
 def test_worker_environment_does_not_forward_parent_secrets(
@@ -99,3 +110,89 @@ def test_locale_sets_lang_and_lc_all() -> None:
 
     assert environment["LANG"] == "C"
     assert environment["LC_ALL"] == "C"
+
+
+@pytest.mark.parametrize("dialogue", [False, True])
+def test_python_worker_imports_host_package_without_site_or_ambient_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, dialogue: bool
+) -> None:
+    # -S removes editable-install/site-packages assistance, exposing source-only
+    # startup failures even when pytest itself runs in an installed environment.
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path / "untrusted"))
+    monkeypatch.setenv("JACOBIAN_TEST_SECRET", "do-not-forward")
+    environment = worker_environment()
+    command = [
+        sys.executable,
+        "-S",
+        "-c",
+        "import json, os, jacobian; "
+        "print(json.dumps([jacobian.__file__, dict(os.environ)]), flush=True)",
+    ]
+    if dialogue:
+        completed = run_bounded_worker_dialogue(
+            command,
+            lambda child: child.read_until(b"\n", frame_limit=8192),
+            absolute_deadline=time.monotonic() + 10,
+            environment=environment,
+            stdout_limit=8192,
+            stderr_limit=8192,
+            cwd=str(tmp_path),
+        )
+        output = completed.value
+    else:
+        result = run_bounded_process(
+            command,
+            input_bytes=b"",
+            timeout_seconds=10,
+            environment=environment,
+            stdout_limit=8192,
+            stderr_limit=8192,
+            cwd=str(tmp_path),
+        )
+        assert result.returncode == 0, result.stderr
+        assert not result.timed_out
+        output = result.stdout
+    package_file, child_environment = json.loads(output)
+    assert Path(package_file).resolve() == Path(jacobian.__file__).resolve()
+    assert child_environment["PYTHONPATH"] == str(
+        Path(jacobian.__file__).resolve().parent.parent
+    )
+    assert "JACOBIAN_TEST_SECRET" not in child_environment
+    assert "HOME" not in child_environment
+    assert "PATH" not in child_environment
+    assert "PYTHONPATH" not in environment
+
+
+@pytest.mark.parametrize("pythonpath", ["", "/explicit/package/path"])
+def test_python_worker_preserves_explicit_pythonpath(pythonpath: str) -> None:
+    environment = worker_environment(overrides={"PYTHONPATH": pythonpath})
+    result = run_bounded_process(
+        [sys.executable, "-S", "-c", "import os; print(os.environ['PYTHONPATH'])"],
+        input_bytes=b"",
+        timeout_seconds=10,
+        environment=environment,
+        stdout_limit=8192,
+        stderr_limit=8192,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.decode().rstrip("\n") == pythonpath
+    assert environment["PYTHONPATH"] == pythonpath
+
+
+def test_non_python_command_does_not_receive_package_path() -> None:
+    executable = shutil.which("env")
+    if executable is None:
+        pytest.skip("env executable is unavailable")
+    environment = worker_environment()
+    result = run_bounded_process(
+        [executable],
+        input_bytes=b"",
+        timeout_seconds=10,
+        environment=environment,
+        stdout_limit=8192,
+        stderr_limit=8192,
+    )
+    assert result.returncode == 0, result.stderr
+    assert dict(line.split("=", 1) for line in result.stdout.decode().splitlines()) == (
+        environment
+    )


### PR DESCRIPTION
Fixes #3211, #3212, #3213, #3214, #3215, #3216, #3217, #3218, #3219, #3220.

## Problems and contracts

- #3211: affine-map word-collision operation omitted from packaged catalog because pkgutil skips namespace-package parent. Added missing algebra package initializer and lazy submodule entries; catalog now has 852 tools.
- #3220: 19-element antichain count admitted but rejected by OperationResult envelope. Changed LinearExtensionCountResult.count to CanonicalInteger string with _from_kernel formatting.
- #3219: Hensel roots exceed JSON integer range. Changed HenselRootResult.lifted_root and PAdicRootEntry.root to CanonicalInteger, preserving p/precision as numeric scalars.
- #3218: simple reflection returns vectors outside its own result/consumer bounds. Split representational bound (2^53-1) from conservative input estimate; request/result admit representable range with kernel output check, restoring involution composition.
- #3217: native mixing_time bypassed Markov admission. Added matrix/mixing/stationary admission plus ergodicity check; wrong stationary, negative/oversized horizons, nonstochastic matrices, and length mismatches now raise typed domain errors.
- #3216: preorder finite topology computed opposite topology. Fixed minimal_neighbourhoods to up-sets, closure to union of preorder rows, interior to up-set containment; corrected Sierpinski docs.
- #3215: variable_elimination rejected valid ordered factors. Added exact _reindex_factor transport to query order for singleton and final scopes.
- #3214: group cohomology enumerated entire group before 64-element limit. Added Schreier-Sims order guard before enumeration; S5/S8/S32 reject without materializing full groups.
- #3213: GF(p) DomainMatrix fallbacks used raw ints. Construct explicit field elements in both prime-field and Hochschild fallback adapters.
- #3212: orthogonal-family consumers accepted incompatible polynomials. Added shared require_three_term_identities full coefficient check used by recurrence and Jacobi admission/kernels; single-coefficient and norm mutations now raise incompatible_family.

## Compatibility

Breaking wire changes (pre-stable, per AGENTS.md): linear-extension count, Hensel lifted roots, and reflection vector bounds move from numeric ints to canonical string/representable envelopes. Updated native tests and dispatch contract tests accordingly.

## Validation

- Reproduced each issue on base revision before fix; verified envelope/involution/admission after fix with real owner MathTool.run, strict JSON, and OperationResult construction.
- make lint-scoped equivalent (ruff check/format) clean; mypy clean on touched models/operations.
- pytest ordinary lanes: math posets/padic/root_systems/topology/markov/graphical/cohomology/finite_fields/orthogonal (546 passed), dispatch (116 passed), catalog (105 passed), integration/catalog (883 passed), integration filtered (81 passed).
