### PR TITLE
fix(hypergraphs): binary threshold search for independence number

### DIFF
--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_independence_z3.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_independence_z3.py
@@ -148,7 +148,15 @@ def _solve_independence_number_kernel(
     source: FiniteHypergraph,
     resource_budget: HypergraphIndependenceBudget,
 ) -> HypergraphIndependenceResult:
-    """Search cardinality thresholds from a sound source-derived upper bound."""
+    """Refine cardinality thresholds by binary search on a monotone predicate.
+
+    ``exists independent set of size >= k`` is monotone decreasing in ``k``
+    (subsets of independent sets are independent), so one UNSAT at ``k``
+    proves every larger threshold infeasible while one SAT witness of size
+    ``m`` proves every threshold ``<= m`` feasible. The loop keeps a feasible
+    lower bound ``lo`` with its incumbent witness and a proved upper bound
+    ``hi``, querying ``mid = (lo + hi + 1) // 2`` until they coincide.
+    """
 
     import z3
 
@@ -191,7 +199,8 @@ def _solve_independence_number_kernel(
         )
 
     solver_calls = 0
-    for threshold in range(upper_bound, len(incumbent), -1):
+    lower_bound = len(incumbent)
+    while lower_bound < upper_bound:
         if solver_calls >= resource_budget.max_solver_calls:
             return _result(
                 source,
@@ -203,7 +212,7 @@ def _solve_independence_number_kernel(
                 solver_calls=solver_calls,
                 wall_budget_exhausted=False,
                 termination_reason="SOLVER_CALL_LIMIT",
-                detail="the descending threshold search exhausted its solver-call budget",
+                detail="the binary threshold search exhausted its solver-call budget",
             )
         if _remaining_ms(started, resource_budget.wall_seconds) <= 0:
             return _result(
@@ -219,6 +228,7 @@ def _solve_independence_number_kernel(
                 detail="the wall-clock budget expired before the next threshold query",
             )
 
+        threshold = (lower_bound + upper_bound + 1) // 2
         try:
             solver_calls += 1
             solver_status, candidate, reason = _check_threshold(
@@ -267,18 +277,12 @@ def _solve_independence_number_kernel(
                         f"the submitted threshold {threshold}"
                     ),
                 )
-            return _result(
-                source,
-                resource_budget,
-                status="EXACT",
-                independence_number=len(candidate),
-                incumbent=candidate,
-                upper_bound=len(candidate),
-                solver_calls=solver_calls,
-                wall_budget_exhausted=False,
-                termination_reason="OPTIMUM_ESTABLISHED",
-                detail="the exact backend established the first feasible descending threshold",
-            )
+            if len(candidate) > len(incumbent):
+                incumbent = candidate
+                lower_bound = max(lower_bound, len(candidate))
+            else:
+                lower_bound = max(lower_bound, threshold)
+            continue
 
         wall_expired = (
             _remaining_ms(started, resource_budget.wall_seconds) <= 0
@@ -310,7 +314,7 @@ def _solve_independence_number_kernel(
         solver_calls=solver_calls,
         wall_budget_exhausted=False,
         termination_reason="OPTIMUM_ESTABLISHED",
-        detail="all larger cardinality thresholds were proved unsatisfiable",
+        detail="the binary threshold search established coincident feasible and infeasible bounds",
     )
 
 

--- a/tests/math/combinatorics/finite_structures/hypergraphs/test_independence.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/test_independence.py
@@ -464,7 +464,10 @@ def test_solver_call_limit_returns_only_sound_partial_bounds() -> None:
     assert result.status == "UNKNOWN"
     assert result.independence_number is None
     assert len(result.incumbent_vertices) == result.lower_bound == 1
-    assert result.upper_bound == 3
+    # Binary search first queries mid=(1+4+1)//2=3; UNSAT proves 3..4
+    # infeasible by monotonicity, so one call tightens upper to 2
+    # (linear descent would only reach 3).
+    assert result.upper_bound == 2
     assert result.termination_reason == "SOLVER_CALL_LIMIT"
     assert result.solver_calls == 1
     assert not result.wall_budget_exhausted
@@ -790,13 +793,16 @@ def test_producer_projects_solver_error_when_witness_misses_threshold(
             "edges": [["ca", ["c", "a"]], ["cb", ["c", "b"]]],
         }
     )
-    assert thresholds == [3, 2]
+    # Binary search on (lo=1, hi=3) first queries mid=2, where the mocked
+    # backend returns a below-threshold witness, so the run stops after
+    # one call (linear descent would query 3 first, then 2).
+    assert thresholds == [2]
     assert result.status == "UNKNOWN"
     assert result.independence_number is None
     assert result.incumbent_vertices == ("c",)
     assert result.lower_bound == 1
     assert result.upper_bound == 3
-    assert result.solver_calls == 2
+    assert result.solver_calls == 1
     assert not result.wall_budget_exhausted
     assert result.termination_reason == "SOLVER_ERROR"
     assert HypergraphIndependenceResult.model_validate(result.model_dump(mode="json"))
@@ -815,6 +821,40 @@ def test_produced_exact_result_meets_the_queried_threshold() -> None:
     assert len(result.incumbent_vertices) >= 2
     brute_force = _brute_force_witness(result.hypergraph)
     assert result.independence_number == len(brute_force)
+
+
+def test_pair_edge_k25_establishes_exact_one_within_budget() -> None:
+    vertices = tuple(f"v{index:03}" for index in range(25))
+    source = FiniteHypergraph.model_validate(
+        {
+            "vertices": list(vertices),
+            "edges": [
+                [f"e{index}", edge]
+                for index, edge in enumerate(combinations(vertices, 2))
+            ],
+        }
+    )
+    result = _kernel_compute(source)
+    assert result.status == "EXACT"
+    assert result.independence_number == 1
+    assert result.lower_bound == result.upper_bound == 1
+    assert result.termination_reason == "OPTIMUM_ESTABLISHED"
+    assert result.solver_calls <= MAX_HYPERGRAPH_INDEPENDENCE_SOLVER_CALLS
+    assert result.solver_calls == 4
+
+
+def test_binary_search_refines_sat_lower_bound_to_exact() -> None:
+    source = FiniteHypergraph.model_validate(
+        {
+            "vertices": ["c", "a", "b", "d"],
+            "edges": [["ca", ["c", "a"]], ["cb", ["c", "b"]], ["cd", ["c", "d"]]],
+        }
+    )
+    result = _kernel_compute(source)
+    assert result.status == "EXACT"
+    assert result.independence_number == len(_brute_force_witness(source)) == 3
+    assert result.lower_bound == result.upper_bound == 3
+    assert result.termination_reason == "OPTIMUM_ESTABLISHED"
 
 
 def test_backend_witness_choice_is_repeatable() -> None:


### PR DESCRIPTION
Fixes #3186.

## Problem
hypergraph.independence_number.compute returned UNKNOWN on the K25 pair-edge hypergraph: the descending loop queries upper, upper-1, ... one solver call each, so 24 needed UNSATs exhausted the 16-call budget at upper=9. Honest incompleteness, but a wasteful schedule.

## Fix
Binary search on the monotone predicate (exists independent set >= k) in _solve_independence_number_kernel, reusing the incremental Z3 solver via push/pop:
- UNSAT(k) proves all larger thresholds infeasible (subset argument), hi = k-1.
- SAT(k) with validated witness W raises lo to |W| (constraint is >= k, model may exceed it); never promoted to optimum until lo == hi.
- Every _check_threshold still counts one solver call; wall budget checked before each query and around model extraction (unchanged helpers).
- SOLVER_ERROR paths keep returning source_upper_bound; call-limit/wall/unknown keep current hi; EXACT only at coincident bounds with OPTIMUM_ESTABLISHED.

K25 now: EXACT(1), 4 calls (13, 7, 4, 2), 0.27s. No new dependency, no cap change, no new operation.

## Tests
- Updated test_solver_call_limit... (binary first queries 3 not 4; same budget now proves upper 2, strictly tighter) and the mocked-threshold order test.
- New: K25 EXACT(1) in 4 calls within budget; star-hypergraph SAT-refinement to EXACT(3) vs brute force.
- 41/41 independence tests, 263 hypergraph+dispatch+catalog tests pass; ruff + mypy clean.