### PR TITLE
fix(graph): admit signed clique searches by biconnected block

### DIFF
--- a/src/jacobian/math/graphs/signed_clique_weight/_bounds.py
+++ b/src/jacobian/math/graphs/signed_clique_weight/_bounds.py
@@ -5,22 +5,25 @@ from __future__ import annotations
 from dataclasses import dataclass
 from math import lcm
 
+import networkx as nx
+
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs._networkx import biconnected_components
 from jacobian.math.graphs.optimization._models import RationalWeightedGraph
 
-# A clique lies inside one connected component, so the Gray-code search runs
-# per component: 2**m subsets tracking the induced weight and the nonedge
+# A clique lies inside one biconnected block, so the Gray-code search runs
+# per block: 2**m subsets tracking the induced weight and the nonedge
 # count incrementally. One 20-vertex component is the exhaustive envelope.
 MAX_SIGNED_CLIQUE_VERTICES = 32
 MAX_SIGNED_CLIQUE_EDGES = 496
-MAX_SIGNED_CLIQUE_COMPONENT_VERTICES = 20
+MAX_SIGNED_CLIQUE_BLOCK_VERTICES = 20
 MAX_SIGNED_CLIQUE_WORK_UNITS = 25_000_000
 
 
 @dataclass(frozen=True, slots=True)
 class SignedCliqueComponent:
-    """One connected vertex set with its local dual-accumulator charge."""
+    """One biconnected vertex block with its local dual-accumulator charge."""
 
     vertices: tuple[int, ...]
     adjacency: tuple[tuple[tuple[int, int], ...], ...]
@@ -30,7 +33,7 @@ class SignedCliqueComponent:
 
 @dataclass(frozen=True, slots=True)
 class SignedCliqueWeightAdmission:
-    """One exact integer-scaled component-bounded clique-search plan."""
+    """One exact integer-scaled block-bounded clique-search plan."""
 
     denominator: int
     components: tuple[SignedCliqueComponent, ...]
@@ -46,35 +49,28 @@ def _decimal_digit_upper_bound(value: int) -> int:
     return (abs(value).bit_length() * 30_103) // 100_000 + 1
 
 
-def _connected_groups(
+def _block_groups(
     order: int,
     edges: tuple[tuple[int, int], ...],
 ) -> tuple[tuple[int, ...], ...]:
-    """Group vertex indices by graph connectivity via union-find."""
+    """Return blocks including bridges, in source-vertex order.
 
-    parent = list(range(order))
+    Every clique of order at least three is biconnected; every edge lies
+    in exactly one block. Isolated vertices cannot supply eligible cliques.
+    """
 
-    def find(index: int) -> int:
-        while parent[index] != index:
-            parent[index] = parent[parent[index]]
-            index = parent[index]
-        return index
-
-    for left, right in edges:
-        root_a, root_b = find(left), find(right)
-        if root_a != root_b:
-            parent[max(root_a, root_b)] = min(root_a, root_b)
-    groups: dict[int, list[int]] = {}
-    for index in range(order):
-        groups.setdefault(find(index), []).append(index)
-    ordered = sorted((min(group), tuple(group)) for group in groups.values() if group)
-    return tuple(group for _, group in ordered)
+    graph: nx.Graph[int] = nx.Graph()
+    graph.add_nodes_from(range(order))
+    graph.add_edges_from(edges)
+    return tuple(
+        sorted(tuple(sorted(block)) for block in biconnected_components(graph))
+    )
 
 
 def admit_signed_clique_weight(
     graph: RationalWeightedGraph,
 ) -> SignedCliqueWeightAdmission:
-    """Derive one bounded component-search plan shared by native and wire calls."""
+    """Derive one bounded block-search plan shared by native and wire calls."""
 
     if not isinstance(graph, RationalWeightedGraph):
         raise TypeError("signed_clique_weight_maximum expects a RationalWeightedGraph")
@@ -131,19 +127,20 @@ def admit_signed_clique_weight(
     )
     maximum_bits = max(denominator.bit_length(), scaled_absolute_sum.bit_length(), 1)
     integer_limbs = (maximum_bits + 63) // 64
-    presolve_work = len(graph.edges) + 2 * len(graph.edges)
+    # Decomposition is linear; constructing each local adjacency scans all edges.
+    presolve_work = order + 3 * len(graph.edges)
     components: list[SignedCliqueComponent] = []
     component_work = 0
-    for group in _connected_groups(order, pairs):
+    for group in _block_groups(order, pairs):
         if len(group) == 1:
             continue
-        if len(group) > MAX_SIGNED_CLIQUE_COMPONENT_VERTICES:
+        if len(group) > MAX_SIGNED_CLIQUE_BLOCK_VERTICES:
             raise OperationDomainValidationError(
                 location=("graph",),
                 code="graph.signed_clique_weight.work_budget",
                 message=(
-                    "a connected component exceeds the "
-                    f"{MAX_SIGNED_CLIQUE_COMPONENT_VERTICES}-vertex exhaustive "
+                    "a biconnected block exceeds the "
+                    f"{MAX_SIGNED_CLIQUE_BLOCK_VERTICES}-vertex exhaustive "
                     "search envelope"
                 ),
             )
@@ -160,7 +157,7 @@ def admit_signed_clique_weight(
             (size - 1) * (1 << (size - local - 1)) for local in range(size)
         )
         work = (1 << size) + edge_updates * integer_limbs
-        component_work += work
+        component_work += work + len(pairs)
         components.append(
             SignedCliqueComponent(
                 vertices=group,
@@ -175,7 +172,7 @@ def admit_signed_clique_weight(
             location=("graph",),
             code="graph.signed_clique_weight.work_budget",
             message=(
-                "the component-bounded clique-weight search requires "
+                "the block-bounded clique-weight search requires "
                 f"{work_units:,} candidate and integer-limb update work units, "
                 f"exceeding the {MAX_SIGNED_CLIQUE_WORK_UNITS:,}-unit bound"
             ),
@@ -189,7 +186,7 @@ def admit_signed_clique_weight(
 
 
 __all__ = [
-    "MAX_SIGNED_CLIQUE_COMPONENT_VERTICES",
+    "MAX_SIGNED_CLIQUE_BLOCK_VERTICES",
     "MAX_SIGNED_CLIQUE_EDGES",
     "MAX_SIGNED_CLIQUE_VERTICES",
     "MAX_SIGNED_CLIQUE_WORK_UNITS",

--- a/src/jacobian/math/graphs/signed_clique_weight/_models.py
+++ b/src/jacobian/math/graphs/signed_clique_weight/_models.py
@@ -11,7 +11,7 @@ from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.math.graphs.optimization._models import RationalWeightedGraph
 
-# A clique lies inside one connected component, so components are optimized
+# A clique lies inside one biconnected block, so blocks are optimized
 # independently and the best (value, witness) pair wins globally.
 
 

--- a/src/jacobian/math/graphs/signed_clique_weight/operations.py
+++ b/src/jacobian/math/graphs/signed_clique_weight/operations.py
@@ -91,8 +91,8 @@ def signed_clique_weight_maximum(
 ) -> SignedCliqueWeightResult:
     """Return the maximum signed edge-weight over cliques of order >= 2.
 
-    Every nontrivial clique lies inside one connected component, so each
-    component contributes its own optimum and the best (value, witness)
+    Every nontrivial clique lies inside one biconnected block, so each
+    block contributes its own optimum and the best (value, witness)
     pair wins globally. Graphs without edges report a missing optimum
     explicitly.
     """

--- a/tests/math/graphs/signed_clique_weight/test_signed_clique_weight.py
+++ b/tests/math/graphs/signed_clique_weight/test_signed_clique_weight.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from fractions import Fraction
 from itertools import combinations
 
@@ -21,22 +22,26 @@ from jacobian.math.graphs.signed_clique_weight.operations import (
 )
 
 
-def _edge(a: str, b: str, w: int) -> RationalWeightedEdge:
+def _edge(a: str, b: str, w: int | Fraction) -> RationalWeightedEdge:
     return RationalWeightedEdge(
         endpoints=(a, b) if a < b else (b, a),
         weight=CanonicalRational.from_fraction(Fraction(w)),
     )
 
 
-def _graph(vertices, specs) -> RationalWeightedGraph:
+def _graph(
+    vertices: Sequence[str], specs: Sequence[tuple[str, str, int | Fraction]]
+) -> RationalWeightedGraph:
     return RationalWeightedGraph(
         vertices=tuple(vertices),
         edges=tuple(_edge(a, b, w) for a, b, w in specs),
     )
 
 
-def _brute_force(graph: RationalWeightedGraph):
-    adjacency = {vertex: set() for vertex in graph.vertices}
+def _brute_force(
+    graph: RationalWeightedGraph,
+) -> tuple[Fraction | int, tuple[str, ...]] | None:
+    adjacency: dict[str, set[str]] = {vertex: set() for vertex in graph.vertices}
     weight_of = {}
     for edge in graph.edges:
         left, right = edge.endpoints
@@ -145,3 +150,51 @@ class TestSignedCliqueWeight:
                     "clique": ("a",),
                 }
             )
+
+
+def test_five_overlapping_blocks_public_operation() -> None:
+    from jacobian.math.graphs.signed_clique_weight._tools import TOOLS
+
+    vertices = ["z"]
+    specs: list[tuple[str, str, int | Fraction]] = []
+    for t in range(5):
+        block = ["z", f"a{t}", f"b{t}", f"u{t}", f"v{t}"]
+        vertices.extend(block[1:])
+        for i, j in combinations(range(5), 2):
+            if (i, j) != (3, 4):
+                specs.append((block[i], block[j], Fraction(2 if j >= 3 else -1, 3)))
+    graph = _graph(vertices, specs)
+    tool = TOOLS[0]
+    result = tool.run(tool.request_type.model_validate({"graph": graph.model_dump()}))
+    assert result.optimum_value.as_fraction() == 1
+    assert result.clique == ("a0", "b0", "u0")
+
+
+@pytest.mark.parametrize("weight", [-2, 0, 3])
+def test_overlapping_blocks_and_bridges_match_subsets(weight: int) -> None:
+    graph = _graph(
+        ["z", "b", "a", "e", "d", "c", "isolated"],
+        [
+            ("z", "a", weight),
+            ("a", "b", -1),
+            ("b", "z", 2),
+            ("b", "c", weight),
+            ("c", "d", -3),
+            ("d", "e", weight),
+            ("e", "c", -1),
+        ],
+    )
+    result = signed_clique_weight_maximum(graph)
+    assert result.optimum_value is not None
+    assert (result.optimum_value.as_fraction(), result.clique) == _brute_force(graph)
+
+
+def test_large_biconnected_block_rejected() -> None:
+    from jacobian.catalog.models import OperationDomainValidationError
+
+    vertices = [str(i) for i in range(21)]
+    graph = _graph(
+        vertices, [(vertices[i], vertices[(i + 1) % 21], 1) for i in range(21)]
+    )
+    with pytest.raises(OperationDomainValidationError, match="exhaustive"):
+        signed_clique_weight_maximum(graph)


### PR DESCRIPTION
## Problem

Fixes #3226. Five K5-minus-an-edge blocks sharing one vertex were rejected because their connected component has 21 vertices, although each clique lies in a five-vertex block.

## Outcome

Admit and search biconnected blocks, including bridges, through the existing NetworkX adapter. Preserve source-vertex ordering, lexicographic witness ties, negative optima, and the edgeless result. The motivating rational-weight graph now returns optimum 1 with witness `(a0, b0, u0)`.

The aggregate subset/integer-limb budget includes every block search and its edge scan. The existing 32-vertex, 496-edge, rational-height and 25-million-work ceilings remain; any block above 20 vertices is still rejected. This replaces connected-component admission without adding an operation or changing request/result types.

## Validation

The new public-operation regression failed on the base with the reported 20-vertex rejection. Focused tests cover independent subset enumeration, overlapping blocks, bridges, all-negative and edgeless graphs, witness ordering, result round trips, and excessive blocks.

- `uv run pytest tests/math/graphs/signed_clique_weight -q`: 12 passed.
- `make affected AFFECTED_BASE=origin/main`: scoped lint/types, mathematical owner, catalog conformance and catalog integration examples.

## Contract impact

The existing operation admits graphs whose biconnected blocks fit its aggregate envelope. Every clique of order at least three is biconnected and every edge belongs to a block, so block maxima establish the same global maximum. Native and declared operation execution share one admission path; result construction and serialization are unchanged.

## Review closure

The final diff has no unresolved correctness findings. Validation covers the final changed tree; hosted CI will report against the pushed revision.

Final tested revision: ac3b3206c. Affected validation passed: 12 owner tests, 105 catalog tests, and 890 catalog integration cases; scoped lint and type checks passed.
