### PR TITLE
fix(catalog): surface edge-clique partition operations

### DIFF
--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_tools.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_tools.py
@@ -348,10 +348,18 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         description="Compute a maximum-weight family of pairwise-disjoint hyperedges "
         "(weighted set packing) with exact nonnegative per-edge weights: "
         "returns the optimum total weight and an attaining family in declared "
-        "edge order, ties broken toward the lexicographically smallest family.",
+        "edge order, ties broken toward the lexicographically smallest family. "
+        "For all nontrivial clique edge supports with weight |E(C)|-1, "
+        "the optimum equals |E(G)| minus the minimum edge-clique partition "
+        "number; uncovered edges contribute single-edge parts.",
         request_type=WeightedPackingRequest,
         result_type=WeightedPackingResult,
         run=_compute_maximum_weight_packing,
+        discovery_terms=(
+            "minimum edge clique partition number",
+            "edge-disjoint complete subgraphs integral partition optimization",
+            "clique edge savings weighted packing",
+        ),
         tags=("combinatorics", "hypergraph", "optimization", "exact"),
         examples=(
             OperationExample(

--- a/src/jacobian/math/graphs/clique_candidate_hypergraph/_tools.py
+++ b/src/jacobian/math/graphs/clique_candidate_hypergraph/_tools.py
@@ -30,12 +30,19 @@ TOOLS: MathTools = (
             "nontrivial clique (order at least two, including nonmaximal "
             "ones), each holding exactly its internal-edge resources. "
             "Retains the resource-to-edge and candidate-to-vertex-subset "
-            "maps for weighted selection and conflict analysis."
+            "maps for weighted selection and conflict analysis. These are the "
+            "complete candidate supports for integral and fractional "
+            "edge-clique partitions, including every clique size."
         ),
         request_type=AllCliqueCandidatesRequest,
         result_type=CliqueCandidateHypergraphResult,
         run=_compute_all_clique_candidates,
         tags=("graph", "hypergraph", "clique", "exact"),
+        discovery_terms=(
+            "edge clique partition all nontrivial cliques",
+            "edge-disjoint complete subgraphs every clique size",
+            "integral and fractional edge partition candidates",
+        ),
         examples=(
             OperationExample(
                 name="bowtie_candidates",

--- a/src/jacobian/math/graphs/clique_partition/_tools.py
+++ b/src/jacobian/math/graphs/clique_partition/_tools.py
@@ -36,6 +36,11 @@ TOOLS: MathTools = (
         result_type=EdgeCliquePartitionResult,
         run=_compute_edge_clique_partition,
         tags=("graph", "clique", "exact"),
+        discovery_terms=(
+            "integral edge clique partition certificate verification",
+            "partition graph edges exactly once complete subgraphs",
+            "clique partition number upper bound",
+        ),
         examples=(
             OperationExample(
                 name="diamond_valid_partition",

--- a/src/jacobian/math/graphs/signed_clique_weight/_tools.py
+++ b/src/jacobian/math/graphs/signed_clique_weight/_tools.py
@@ -30,12 +30,21 @@ TOOLS: MathTools = (
             "the graph and weights. Graphs without edges report a missing "
             "optimum explicitly; all-negative inputs may have a negative "
             "optimum. Maximal-clique-only tests are unsound for signed "
-            "weights."
+            "weights. For graphs with edges, fractional edge-clique partition "
+            "equality dual "
+            "feasibility of unrestricted-sign edge weights means this maximum "
+            "is at most one."
         ),
         request_type=SignedCliqueWeightRequest,
         result_type=SignedCliqueWeightResult,
         run=_compute_signed_clique_weight_maximum,
         tags=("graph", "clique", "exact"),
+        discovery_terms=(
+            "fractional edge clique partition dual",
+            "unrestricted-sign edge weights equality constraints",
+            "all nontrivial cliques nonmaximal cliques",
+            "complete subgraph signed edge sum certificate",
+        ),
         examples=(
             OperationExample(
                 name="signed_triangle",

--- a/tests/catalog/test_edge_clique_partition_discovery.py
+++ b/tests/catalog/test_edge_clique_partition_discovery.py
@@ -1,0 +1,72 @@
+"""Existing atomic operations for edge-clique partition mathematics."""
+
+import pytest
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationMatchRequest
+
+_CANDIDATES = "graph.clique_candidate_hypergraph.construct"
+_PACKING = "hypergraph.maximum_weight_packing.compute"
+_CHECK = "graph.edge_clique_partition.check"
+_SIGNED = "graph.signed_clique_weight.maximum.compute"
+_COLORING = "graph.coloring.chromatic_number.check"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "For the graph K5 minus one edge, compute the minimum edge clique partition "
+        "and the fractional edge clique partition with equality constraints, "
+        "allowing every clique size. Return an integral partition and exact "
+        "rational primal and unrestricted-sign dual certificates, and "
+        "independently verify the certificates.",
+        "Minimum edge-clique partition number: edge-disjoint cliques of all sizes, "
+        "an integral partition certificate and a fractional equality partition "
+        "dual with signed edge weights.",
+        "Partition graph edges exactly once into complete subgraphs; optimize "
+        "the number of parts and certify the fractional edge partition bound "
+        "with unrestricted-sign dual weights over all nontrivial cliques.",
+    ],
+)
+def test_edge_partition_operations_share_first_page(query: str) -> None:
+    matches = Catalog.open().match(OperationMatchRequest(need=query, limit=10)).matches
+    ids = [match.operation_id for match in matches]
+    relevant = {_CANDIDATES, _PACKING, _CHECK, _SIGNED}
+    assert relevant <= set(ids)
+    for unrelated in (_COLORING, "combinatorial_map.dual.compute"):
+        if unrelated in ids:
+            assert max(ids.index(item) for item in relevant) < ids.index(unrelated)
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        (
+            "unrestricted-sign edge weights fractional edge clique partition dual "
+            "constraints over every nontrivial clique, not just maximal cliques",
+            _SIGNED,
+        ),
+        (
+            "all nontrivial cliques including nonmaximal cliques as edge resources "
+            "for edge-disjoint clique partition",
+            _CANDIDATES,
+        ),
+        (
+            "verify an edge clique partition covers every graph edge exactly once",
+            _CHECK,
+        ),
+        ("check a graph vertex coloring chromatic number certificate", _COLORING),
+        (
+            "check vertex chromatic number using nonnegative fractional clique "
+            "vertex weights and a proper coloring",
+            _COLORING,
+        ),
+        (
+            "edge clique partition with disjoint parts, not an overlapping edge cover",
+            _PACKING,
+        ),
+    ],
+)
+def test_distinct_mathematical_needs_retain_routing(query: str, expected: str) -> None:
+    matches = Catalog.open().match(OperationMatchRequest(need=query, limit=10)).matches
+    assert matches[0].operation_id == expected


### PR DESCRIPTION
## Problem

Fixes #3227. The reported edge-clique partition request ranked vertex coloring first and omitted existing signed clique maximization and weighted packing operations from its first page. The exact ranking reproduced on the base checkout.

## Outcome

Add declarative mathematical relationships and discovery terms to the candidate, weighted packing, partition checker, and signed clique declarations. Weighted clique savings express the integral partition number; signed edge-weight maxima express the fractional equality-dual constraints. Metadata describes these identities without prescribing a workflow or introducing an aggregate solver.

The original query now retrieves all four operations ahead of vertex coloring and combinatorial-map duality. Regression tests require first-page relevance rather than an ordering among the four operations, and cover held-out paraphrases, nonmaximal clique candidates, unrestricted-sign edge duals, and actual vertex-coloring certificates.

## Validation

The three first-page retrieval tests failed on the base. `make affected AFFECTED_BASE=origin/main` runs scoped lint/types, the four mathematical owners, catalog tests and catalog integration examples.

## Contract impact

Discovery descriptions and aliases only. Operation membership, schemas, execution, and the generic relevance algorithm are unchanged.

## Review closure

The final diff is limited to four declarations and discovery regressions. Validation covers the final changed tree; hosted CI reports against the pushed revision.

Final tested revision: ef3dfe977. Affected validation passed: 202 owner tests, 114 catalog tests (including nine discovery cases), and 890 catalog integration cases; scoped lint and type checks passed.
