### PR TITLE
fix(lattice): scale rectangular HNF with deterministic modular bounds

### DIFF
--- a/src/jacobian/math/lattices/_hnf.py
+++ b/src/jacobian/math/lattices/_hnf.py
@@ -10,8 +10,6 @@ from jacobian.math.lattices import hermite_normal_form
 from jacobian.math.lattices._models import (
     HermiteNormalFormRequest,
     HermiteNormalFormResult,
-    _require_lattice_matrix_envelope,
-    _run_admission,
 )
 from jacobian.math.matrices.values import IntegerMatrix
 
@@ -31,12 +29,6 @@ def _matrix(value: Any) -> IntegerMatrix:
 def compute_hermite_normal_form(
     request: HermiteNormalFormRequest,
 ) -> HermiteNormalFormResult:
-    _run_admission(
-        lambda: _require_lattice_matrix_envelope(
-            request.matrix, label="Hermite normal form input"
-        ),
-        location=("matrix",),
-    )
     integer_entries = [
         [parse_canonical_integer(value) for value in row]
         for row in request.matrix.entries

--- a/src/jacobian/math/lattices/_hnf.py
+++ b/src/jacobian/math/lattices/_hnf.py
@@ -1,4 +1,4 @@
-"""In-process Python-FLINT row-HNF producer owned by the lattice domain."""
+"""In-process deterministic modular row-HNF producer owned by the lattice domain."""
 
 from __future__ import annotations
 

--- a/src/jacobian/math/lattices/_hnf_backend.py
+++ b/src/jacobian/math/lattices/_hnf_backend.py
@@ -1,0 +1,77 @@
+"""Deterministic SymPy 1.14 modular row HNF with a unimodular lift.
+
+Use the public DomainMatrix FF_dense algorithm, rather than an automatic
+matrix-kernel selector, and the public HNF algorithm with an explicit modulus.
+Admission is derived from the pinned implementations in
+``sympy.polys.matrices.dense.ddm_irref_den`` and
+``sympy.polys.matrices.normalforms._hermite_normal_form_modulo_D``.
+Their loops and coefficient updates are bounded in ``_hnf_bounds``.
+"""
+
+from typing import Any
+
+from jacobian.math.lattices._hnf_bounds import HNFAdmission
+
+
+def modular_row_hnf(
+    entries: list[list[int]], admission: HNFAdmission
+) -> tuple[Any, Any]:
+    """Compute [H|U] from one elimination and one square modular HNF.
+
+    For G=[A|I], let B consist of the first independent columns of G.
+    Fraction-free Gauss-Jordan gives N/den=B^-1 G, with |den|=|det B|;
+    the identity suffix guarantees full row rank even for singular A.
+    SymPy 1.14 FF_dense performs no primitive-content cancellation, so
+    its last pivot denominator is the signed pivot minor, not just a
+    common denominator of the rational RREF.
+
+    If K is the row HNF of B, then K*N/den is the row HNF of G: pivot
+    columns are K, and each preceding nonpivot column depends only on
+    preceding pivots. Its suffix U=K*B^-1 is unimodular. The same product
+    establishes both H and U without a second solve or verification pass.
+    """
+    from flint import fmpz_mat
+    from sympy import ZZ
+    from sympy.polys.matrices import DomainMatrix
+    from sympy.polys.matrices.normalforms import hermite_normal_form
+
+    rows, columns = admission.rows, admission.columns
+    augmented = [
+        [ZZ(value) for value in row] + [ZZ(int(i == j)) for j in range(rows)]
+        for i, row in enumerate(entries)
+    ]
+    matrix = DomainMatrix(augmented, (rows, columns + rows), ZZ)
+    reduced, denominator, pivots = matrix.rref_den(method="FF_dense")
+    numerator = reduced.to_list()
+
+    # SymPy produces upper column HNF. Reverse-transpose before and after
+    # to obtain upper row HNF with positive pivots and reduced entries above.
+    pivot_transpose = [
+        [augmented[rows - 1 - j][pivots[rows - 1 - i]] for j in range(rows)]
+        for i in range(rows)
+    ]
+    column_hnf = hermite_normal_form(
+        DomainMatrix(pivot_transpose, (rows, rows), ZZ), D=abs(denominator)
+    ).to_list()
+    pivot_hnf = [
+        [column_hnf[rows - 1 - j][rows - 1 - i] for j in range(rows)]
+        for i in range(rows)
+    ]
+    # Scalar products fix the counted lift path; no automatic matrix product
+    # or inverse kernel can expand the admitted computation.
+    lifted = [
+        [
+            ZZ.exquo(
+                sum((pivot_hnf[i][k] * numerator[k][j] for k in range(rows)), ZZ.zero),
+                denominator,
+            )
+            for j in range(columns + rows)
+        ]
+        for i in range(rows)
+    ]
+    # Preserve the established native matrix return type. FLINT only stores
+    # these already computed entries; it runs no matrix algorithm here.
+    return (
+        fmpz_mat([row[:columns] for row in lifted]),
+        fmpz_mat([row[columns:] for row in lifted]),
+    )

--- a/src/jacobian/math/lattices/_hnf_bounds.py
+++ b/src/jacobian/math/lattices/_hnf_bounds.py
@@ -1,6 +1,11 @@
-"""Admission for the full-row-rank augmented HNF representation."""
+"""Bounds for fraction-free elimination, modular HNF, and exact lifting.
 
-from math import factorial
+The bounds follow the explicitly selected SymPy 1.14 algorithms documented
+in ``_hnf_backend``. Arithmetic counts and operand heights are independent;
+no time measurement or output-height proxy stands in for intermediate work.
+"""
+
+from dataclasses import dataclass
 
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices.values import (
@@ -9,25 +14,63 @@ from jacobian.math.matrices.values import (
 )
 
 MAX_HNF_INPUT_DIGITS = 256
-MAX_HNF_DIGIT_WORK = 100_000_000
+MAX_HNF_WORK_UNITS = 250_000_000
+MAX_HNF_INTERMEDIATE_BITS = 262_144
+MAX_HNF_COEFFICIENT_BITS = 12_000_000_000
 
 
-def admit_hermite_normal_form(entries: list[list[int]]) -> None:
-    """Admit [A | I_m], including the entire m by m transformation.
+@dataclass(frozen=True, slots=True)
+class HNFAdmission:
+    """One source-derived envelope for all mandatory mathematical phases."""
 
-    Every maximal minor of [A | I_m] is, up to sign, a minor of A of
-    order at most r=min(m,n). With d input digits, Leibniz bounds these
-    minors by r! * 10**(r*d). Full-row-rank row HNF entries are bounded
-    by the largest maximal minor. This applies to H and U together,
-    including singular, tall and wide A: the augmented matrix always
-    has rank m. No rank computation or HNF is replayed in admission.
+    rows: int
+    columns: int
+    minor_bits: int
+    intermediate_bits: int
+    work_units: int
+    coefficient_bits: int
 
-    Use m**2*(n+m) times the minor digit height as the conservative
-    admission cost estimate used by the existing invariant-form graph-HNF
-    envelope. This is a shape/height policy, not a count of FLINT's internal
-    arithmetic operations. The structural axes bound both H and U by 128
-    per axis and their combined cells by 32,768; no extra transport-size
-    cap is imposed here.
+
+def _reject(message: str) -> None:
+    raise OperationDomainValidationError(
+        location=("matrix",), code="lattice.budget_exceeded", message=message
+    )
+
+
+def admit_hermite_normal_form(entries: list[list[int]]) -> HNFAdmission:
+    """Bound every phase before constructing the augmented backend matrix.
+
+    Let P=2**b bound all minors of [A|I]. Each is a minor of A, so
+    Hadamard bounds it by the product of the largest min(m,n) row norms
+    of A (norms smaller than one are replaced by one). Squared row norms
+    give integer-only upper bounds on b, without rank or elimination.
+
+    SymPy's FF_dense Gauss-Jordan stores minors and forms differences of
+    two products before exact division: stored entries <=P, temporaries
+    <=2*P**2. There are at most m pivots and 6*m*m*(n+m) scalar operations,
+    including nonpivot-column updates and pivot searches.
+
+    The square modular HNF uses at most m*(m+1)/2 extended gcds on operands
+    <=P and 14*m**3 other scalar operations. Euclidean remainders halve
+    every two steps, so charge 16*b+24 abstract arithmetic units per gcd.
+    ZZ.gcdex uses the maintained scalar backend: this charge and its bounded
+    operands do not purport to count native instructions. Modular
+    column updates form products of operands <=P then reduce modulo R<=P.
+    Above-pivot reductions in W are not modular: a column undergoes at
+    most m reductions. If its current height is S>=1, one reduction has
+    height <=S+(S+1)*P <=(P+2)*S. Starting at P, (m+2)*(b+1)+2 bits bound
+    even the last pre-subtraction product. This separately accounts for
+    the intermediates that are larger than the final HNF.
+
+    Lifting multiplies the square HNF by the fraction-free RREF numerator,
+    then divides exactly by its denominator. At most 3*m*m*(n+m) scalar
+    operations suffice; partial dot products are <=m*P**2. The final [H|U]
+    is the full-row-rank HNF of [A|I], hence its entries are <=P.
+
+    Coefficient storage reserves four augmented arrays at elimination/lift
+    height and four square arrays at modular height, plus scalar scratch.
+    This bounds mathematical coefficient bits, not allocator or process RSS.
+    The loops, matrix cells, and operand heights are all bounded separately.
     """
     rows = len(entries)
     columns = len(entries[0]) if rows else 0
@@ -36,33 +79,64 @@ def admit_hermite_normal_form(entries: list[list[int]]) -> None:
         or not 1 <= columns <= MAX_INTEGER_MATRIX_ORDER
         or any(len(row) != columns for row in entries)
     ):
-        raise OperationDomainValidationError(
-            location=("matrix",),
-            code="lattice.budget_exceeded",
-            message=f"HNF requires a nonempty rectangular matrix with axes at most {MAX_INTEGER_MATRIX_ORDER}",
+        _reject(
+            "HNF requires a nonempty rectangular matrix with axes at most "
+            f"{MAX_INTEGER_MATRIX_ORDER}"
         )
     if any(type(value) is not int for row in entries for value in row):
         raise TypeError("Hermite normal form entries must be integers")
-    if any(abs(value) >= 10**MAX_HNF_INPUT_DIGITS for row in entries for value in row):
-        raise OperationDomainValidationError(
-            location=("matrix",),
-            code="lattice.budget_exceeded",
-            message=f"HNF input scalars are limited to {MAX_HNF_INPUT_DIGITS} decimal digits",
+    scalar_limit = 10**MAX_HNF_INPUT_DIGITS
+    if any(abs(value) >= scalar_limit for row in entries for value in row):
+        _reject(
+            f"HNF input scalars are limited to {MAX_HNF_INPUT_DIGITS} decimal digits"
         )
-    digits = max(len(str(abs(value))) for row in entries for value in row)
-    rank_bound = min(rows, columns)
-    minor_digits = rank_bound * digits + len(str(factorial(rank_bound)))
+
+    # A squared norm <2**k gives a norm <=2**ceil(k/2).
+    row_bits = sorted(
+        (
+            (sum(value * value for value in row).bit_length() + 1) // 2
+            for row in entries
+        ),
+        reverse=True,
+    )
+    minor_bits = max(1, sum(row_bits[: min(rows, columns)]))
+    minor_digits = minor_bits * 30_103 // 100_000 + 1
     if minor_digits > MAX_MATRIX_SCALAR_DIGITS:
-        raise OperationDomainValidationError(
-            location=("matrix",),
-            code="lattice.budget_exceeded",
-            message="HNF augmented minor height exceeds the canonical scalar envelope",
-        )
+        _reject("HNF augmented minor height exceeds the canonical scalar envelope")
+
     cells = rows * (columns + rows)
-    work = rows * cells * minor_digits
-    if work > MAX_HNF_DIGIT_WORK:
-        raise OperationDomainValidationError(
-            location=("matrix",),
-            code="lattice.budget_exceeded",
-            message=f"HNF augmented minor-height work {work:,} exceeds {MAX_HNF_DIGIT_WORK:,} digit-work units",
+    lift_bits = 2 * minor_bits + rows.bit_length() + 2
+    modular_bits = (rows + 2) * (minor_bits + 1) + 2
+    intermediate_bits = max(lift_bits, modular_bits)
+    if intermediate_bits > MAX_HNF_INTERMEDIATE_BITS:
+        _reject(
+            f"HNF intermediate height {intermediate_bits:,} exceeds "
+            f"{MAX_HNF_INTERMEDIATE_BITS:,} bits"
         )
+    gcd_calls = rows * (rows + 1) // 2
+    work = (
+        9 * rows * cells
+        + 14 * rows**3
+        + gcd_calls * (16 * minor_bits + 24)
+        + 2 * rows * columns  # squared norms in admission
+    )
+    if work > MAX_HNF_WORK_UNITS:
+        _reject(
+            f"HNF scalar-operation work {work:,} exceeds {MAX_HNF_WORK_UNITS:,} units"
+        )
+    coefficient_bits = (
+        4 * cells * lift_bits + 4 * rows * rows * modular_bits + 16 * intermediate_bits
+    )
+    if coefficient_bits > MAX_HNF_COEFFICIENT_BITS:
+        _reject(
+            f"HNF retained coefficient storage {coefficient_bits:,} exceeds "
+            f"{MAX_HNF_COEFFICIENT_BITS:,} bits"
+        )
+    return HNFAdmission(
+        rows=rows,
+        columns=columns,
+        minor_bits=minor_bits,
+        intermediate_bits=intermediate_bits,
+        work_units=work,
+        coefficient_bits=coefficient_bits,
+    )

--- a/src/jacobian/math/lattices/_hnf_bounds.py
+++ b/src/jacobian/math/lattices/_hnf_bounds.py
@@ -1,0 +1,68 @@
+"""Admission for the full-row-rank augmented HNF representation."""
+
+from math import factorial
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.matrices.values import (
+    MAX_INTEGER_MATRIX_ORDER,
+    MAX_MATRIX_SCALAR_DIGITS,
+)
+
+MAX_HNF_INPUT_DIGITS = 256
+MAX_HNF_DIGIT_WORK = 100_000_000
+
+
+def admit_hermite_normal_form(entries: list[list[int]]) -> None:
+    """Admit [A | I_m], including the entire m by m transformation.
+
+    Every maximal minor of [A | I_m] is, up to sign, a minor of A of
+    order at most r=min(m,n). With d input digits, Leibniz bounds these
+    minors by r! * 10**(r*d). Full-row-rank row HNF entries are bounded
+    by the largest maximal minor. This applies to H and U together,
+    including singular, tall and wide A: the augmented matrix always
+    has rank m. No rank computation or HNF is replayed in admission.
+
+    Use m**2*(n+m) times the minor digit height as the conservative
+    admission cost estimate used by the existing invariant-form graph-HNF
+    envelope. This is a shape/height policy, not a count of FLINT's internal
+    arithmetic operations. The structural axes bound both H and U by 128
+    per axis and their combined cells by 32,768; no extra transport-size
+    cap is imposed here.
+    """
+    rows = len(entries)
+    columns = len(entries[0]) if rows else 0
+    if (
+        not 1 <= rows <= MAX_INTEGER_MATRIX_ORDER
+        or not 1 <= columns <= MAX_INTEGER_MATRIX_ORDER
+        or any(len(row) != columns for row in entries)
+    ):
+        raise OperationDomainValidationError(
+            location=("matrix",),
+            code="lattice.budget_exceeded",
+            message=f"HNF requires a nonempty rectangular matrix with axes at most {MAX_INTEGER_MATRIX_ORDER}",
+        )
+    if any(type(value) is not int for row in entries for value in row):
+        raise TypeError("Hermite normal form entries must be integers")
+    if any(abs(value) >= 10**MAX_HNF_INPUT_DIGITS for row in entries for value in row):
+        raise OperationDomainValidationError(
+            location=("matrix",),
+            code="lattice.budget_exceeded",
+            message=f"HNF input scalars are limited to {MAX_HNF_INPUT_DIGITS} decimal digits",
+        )
+    digits = max(len(str(abs(value))) for row in entries for value in row)
+    rank_bound = min(rows, columns)
+    minor_digits = rank_bound * digits + len(str(factorial(rank_bound)))
+    if minor_digits > MAX_MATRIX_SCALAR_DIGITS:
+        raise OperationDomainValidationError(
+            location=("matrix",),
+            code="lattice.budget_exceeded",
+            message="HNF augmented minor height exceeds the canonical scalar envelope",
+        )
+    cells = rows * (columns + rows)
+    work = rows * cells * minor_digits
+    if work > MAX_HNF_DIGIT_WORK:
+        raise OperationDomainValidationError(
+            location=("matrix",),
+            code="lattice.budget_exceeded",
+            message=f"HNF augmented minor-height work {work:,} exceeds {MAX_HNF_DIGIT_WORK:,} digit-work units",
+        )

--- a/src/jacobian/math/lattices/_models.py
+++ b/src/jacobian/math/lattices/_models.py
@@ -68,9 +68,10 @@ class HermiteNormalFormRequest(StrictModel):
         description=(
             f"Nonempty integer matrix with axes at most {MAX_INTEGER_MATRIX_ORDER} "
             "and at most 256 digits per scalar. HNF admission bounds the "
-            "augmented matrix, including its square transformation, with "
-            "m*m*(n+m)*(r*d+digits(r!)) by 100,000,000, where "
-            "r=min(m,n) and d is the maximum input decimal width."
+            "fraction-free elimination, modular reduction and the square "
+            "transformation using row-norm minor bounds. At most 250,000,000 "
+            "scalar-operation units, 262,144 bits per intermediate and "
+            "12,000,000,000 retained coefficient bits are admitted."
         ),
     )
 

--- a/src/jacobian/math/lattices/_models.py
+++ b/src/jacobian/math/lattices/_models.py
@@ -11,6 +11,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices.values import (
+    MAX_INTEGER_MATRIX_ORDER,
     MAX_MATRIX_DIMENSION,
     IntegerMatrix,
     RationalMatrix,
@@ -57,24 +58,29 @@ def _run_admission(admission: Callable[[], None], *, location: tuple[str, ...]) 
 
 
 class HermiteNormalFormRequest(StrictModel):
-    """One bounded integer matrix for row Hermite normal form.
+    """An integer matrix for row HNF, with H = U A and unimodular U.
 
-    Row and column counts are at most ``MAX_MATRIX_DIMENSION``.
+    HNF-specific admission bounds the full augmented matrix [A | I],
+    including coefficient growth and the square transformation.
     """
 
-    matrix: Annotated[
-        IntegerMatrix,
-        WithJsonSchema(integer_matrix_axis_schema(MAX_MATRIX_DIMENSION)),
-    ] = Field(
+    matrix: IntegerMatrix = Field(
         description=(
-            "Integer matrix whose row and column counts are at most "
-            f"{MAX_MATRIX_DIMENSION}."
+            f"Nonempty integer matrix with axes at most {MAX_INTEGER_MATRIX_ORDER} "
+            "and at most 256 digits per scalar. HNF admission bounds the "
+            "augmented matrix, including its square transformation, with "
+            "m*m*(n+m)*(r*d+digits(r!)) by 100,000,000, where "
+            "r=min(m,n) and d is the maximum input decimal width."
         ),
     )
 
     @model_validator(mode="after")
-    def require_admitted_envelope(self) -> Self:
-        _require_lattice_matrix_envelope(self.matrix, label="Hermite normal form input")
+    def require_scalar_envelope(self) -> Self:
+        require_matrix_scalar_digits(
+            self.matrix.entries,
+            maximum=_MAX_LATTICE_INPUT_SCALAR_DIGITS,
+            label="Hermite normal form input",
+        )
         return self
 
 

--- a/src/jacobian/math/lattices/operations.py
+++ b/src/jacobian/math/lattices/operations.py
@@ -76,24 +76,11 @@ __all__ = [
 def hermite_normal_form(entries: list[list[int]]) -> tuple[Any, Any]:
     """Return the row Hermite normal form and its left transformation."""
 
-    import flint
-
+    from jacobian.math.lattices._hnf_backend import modular_row_hnf
     from jacobian.math.lattices._hnf_bounds import admit_hermite_normal_form
 
-    admit_hermite_normal_form(entries)
-    rows, columns = len(entries), len(entries[0])
-    # The canonical row HNF of [A | I] is [H | U]. Appending I makes
-    # the rows independent and bounds U by the same minors as H.
-    augmented = flint.fmpz_mat(
-        [row + [int(i == j) for j in range(rows)] for i, row in enumerate(entries)]
-    ).hnf()
-    normal_form = flint.fmpz_mat(
-        [[augmented[i, j] for j in range(columns)] for i in range(rows)]
-    )
-    transformation = flint.fmpz_mat(
-        [[augmented[i, columns + j] for j in range(rows)] for i in range(rows)]
-    )
-    return normal_form, transformation
+    admission = admit_hermite_normal_form(entries)
+    return modular_row_hnf(entries, admission)
 
 
 def reduce_basis(

--- a/src/jacobian/math/lattices/operations.py
+++ b/src/jacobian/math/lattices/operations.py
@@ -78,7 +78,22 @@ def hermite_normal_form(entries: list[list[int]]) -> tuple[Any, Any]:
 
     import flint
 
-    return flint.fmpz_mat(entries).hnf(True)
+    from jacobian.math.lattices._hnf_bounds import admit_hermite_normal_form
+
+    admit_hermite_normal_form(entries)
+    rows, columns = len(entries), len(entries[0])
+    # The canonical row HNF of [A | I] is [H | U]. Appending I makes
+    # the rows independent and bounds U by the same minors as H.
+    augmented = flint.fmpz_mat(
+        [row + [int(i == j) for j in range(rows)] for i, row in enumerate(entries)]
+    ).hnf()
+    normal_form = flint.fmpz_mat(
+        [[augmented[i, j] for j in range(columns)] for i in range(rows)]
+    )
+    transformation = flint.fmpz_mat(
+        [[augmented[i, columns + j] for j in range(rows)] for i in range(rows)]
+    )
+    return normal_form, transformation
 
 
 def reduce_basis(

--- a/tests/dispatch/test_lattice_dispatch.py
+++ b/tests/dispatch/test_lattice_dispatch.py
@@ -36,15 +36,30 @@ def test_lattice_reduction_admits_before_lll_backend() -> None:
 
 
 def test_hermite_admits_before_hnf_backend() -> None:
-    matrix = IntegerMatrix.model_validate(
-        {"entries": _identity_entries(MAX_MATRIX_DIMENSION + 1)}
-    )
+    entries = [
+        [str(10**255 + ((i + 1) * (j + 3) + j * j) % 101) for j in range(64)]
+        for i in range(64)
+    ]
+    matrix = IntegerMatrix.model_validate({"entries": entries})
     request = HermiteNormalFormRequest.model_construct(matrix=matrix)
     with pytest.raises(OperationDomainValidationError) as exc_info:
         compute_hermite_normal_form(request)
     error = exc_info.value.errors()[0]
     assert error["type"] == "lattice.budget_exceeded"
     assert error["loc"] == ("matrix",)
+    assert "intermediate height" in error["msg"]
+
+
+def test_dispatch_accepts_hnf_above_the_lll_axis() -> None:
+    entries = _identity_entries(MAX_MATRIX_DIMENSION + 1)
+    result = invoke_operation(
+        "lattice.hermite_normal_form.compute",
+        {"matrix": {"entries": entries}},
+        Catalog.open(),
+    )
+    expected = {"domain": "ZZ", "entries": entries}
+    assert result.output["normal_form"] == expected
+    assert result.output["transformation"] == expected
 
 
 def test_dispatch_rejects_lll_above_the_lattice_axis() -> None:

--- a/tests/math/lattices/test_lattice_operations.py
+++ b/tests/math/lattices/test_lattice_operations.py
@@ -363,12 +363,13 @@ def test_lattice_reduction_request_rejects_order_33_identity() -> None:
     assert exc_info.value.errors()[0]["type"] == "lattice.budget_exceeded"
 
 
-def test_hermite_request_rejects_order_33_identity() -> None:
-    with pytest.raises(ValidationError) as exc_info:
-        HermiteNormalFormRequest.model_validate(
-            {"matrix": {"entries": _identity_entries(MAX_MATRIX_DIMENSION + 1)}}
-        )
-    assert exc_info.value.errors()[0]["type"] == "lattice.budget_exceeded"
+def test_hermite_accepts_order_33_identity() -> None:
+    request = HermiteNormalFormRequest.model_validate(
+        {"matrix": {"entries": _identity_entries(MAX_MATRIX_DIMENSION + 1)}}
+    )
+    result = compute_hermite_normal_form(request)
+    assert result.normal_form == request.matrix
+    assert result.transformation == request.matrix
 
 
 def test_lattice_reduction_accepts_order_32_identity() -> None:

--- a/tests/math/lattices/test_rectangular_hnf.py
+++ b/tests/math/lattices/test_rectangular_hnf.py
@@ -1,0 +1,123 @@
+"""Row-HNF reconstruction and unimodularity beyond the LLL envelope."""
+
+from fractions import Fraction
+
+import pytest
+
+from jacobian.math.lattices._hnf import HERMITE_NORMAL_FORM_OPERATION
+
+
+def _determinant(entries: tuple[tuple[str, ...], ...]) -> Fraction:
+    """Independent rational elimination, without the HNF backend."""
+    a = [[Fraction(x) for x in row] for row in entries]
+    det = Fraction(1)
+    for j in range(len(a)):
+        pivot = next((i for i in range(j, len(a)) if a[i][j]), None)
+        if pivot is None:
+            return Fraction(0)
+        if pivot != j:
+            a[j], a[pivot] = a[pivot], a[j]
+            det = -det
+        p = a[j][j]
+        det *= p
+        for i in range(j + 1, len(a)):
+            q = a[i][j] / p
+            for k in range(j + 1, len(a)):
+                a[i][k] -= q * a[j][k]
+    return det
+
+
+@pytest.mark.parametrize("shape", [(61, 25), (25, 61), (33, 33)])
+def test_rectangular_coefficient_lattice(shape: tuple[int, int]) -> None:
+    rows, cols = shape
+    entries = [
+        [((i + 1) * (j + 3) + j * j) % 101 - 50 for j in range(cols)]
+        for i in range(rows)
+    ]
+    tool = HERMITE_NORMAL_FORM_OPERATION
+    request = tool.request_type.model_validate(
+        {"matrix": {"entries": [[str(x) for x in row] for row in entries]}}
+    )
+    result = tool.run(request)
+    h, u = result.normal_form.entries, result.transformation.entries
+    assert len(h) == rows and len(h[0]) == cols
+    assert len(u) == rows and len(u[0]) == rows
+    assert all(
+        sum(int(u[i][k]) * entries[k][j] for k in range(rows)) == int(h[i][j])
+        for i in range(rows)
+        for j in range(cols)
+    )
+    assert abs(_determinant(u)) == 1
+    # Positive increasing pivots; reduced entries above every pivot; zero rows last.
+    previous = -1
+    zero_seen = False
+    for i, row in enumerate(h):
+        pivot = next((j for j, x in enumerate(row) if int(x)), None)
+        if pivot is None:
+            zero_seen = True
+            continue
+        assert not zero_seen and pivot > previous
+        assert int(row[pivot]) > 0
+        assert all(0 <= int(h[k][pivot]) < int(row[pivot]) for k in range(i))
+        previous = pivot
+    assert type(result).model_validate_json(result.model_dump_json()) == result
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        [[0] for _ in range(128)],
+        [[i % 7, 2 * (i % 7)] for i in range(61)],
+        [[0, 0, 0]],
+        [[-7]],
+    ],
+)
+def test_degenerate_inputs_and_native_parity(entries: list[list[int]]) -> None:
+    from jacobian.math.lattices.operations import hermite_normal_form
+
+    tool = HERMITE_NORMAL_FORM_OPERATION
+    result = tool.run(
+        tool.request_type.model_validate(
+            {"matrix": {"entries": [[str(x) for x in row] for row in entries]}}
+        )
+    )
+    h, u = hermite_normal_form(entries)
+    assert result.normal_form.entries == tuple(
+        tuple(str(h[i, j]) for j in range(h.ncols())) for i in range(h.nrows())
+    )
+    assert abs(_determinant(result.transformation.entries)) == 1
+    assert all(
+        sum(int(u[i, k]) * entries[k][j] for k in range(len(entries))) == int(h[i, j])
+        for i in range(len(entries))
+        for j in range(len(entries[0]))
+    )
+
+
+@pytest.mark.parametrize(
+    ("rows", "columns", "value", "message"),
+    [
+        (64, 64, 10**255, "digit-work"),
+        (128, 128, 10**255, "minor height"),
+    ],
+)
+def test_hnf_specific_excessive_envelopes(
+    rows: int,
+    columns: int,
+    value: int,
+    message: str,
+) -> None:
+    from jacobian.catalog.models import OperationDomainValidationError
+    from jacobian.math.lattices.operations import hermite_normal_form
+
+    entries = [
+        [value + ((i + 1) * (j + 3) + j * j) % 101 for j in range(columns)]
+        for i in range(rows)
+    ]
+    tool = HERMITE_NORMAL_FORM_OPERATION
+    request = tool.request_type.model_validate(
+        {"matrix": {"entries": [[str(x) for x in row] for row in entries]}}
+    )
+    with pytest.raises(OperationDomainValidationError, match=message):
+        tool.run(request)
+    with pytest.raises(OperationDomainValidationError, match=message):
+        hermite_normal_form(entries)

--- a/tests/math/lattices/test_rectangular_hnf.py
+++ b/tests/math/lattices/test_rectangular_hnf.py
@@ -27,7 +27,9 @@ def _determinant(entries: tuple[tuple[str, ...], ...]) -> Fraction:
     return det
 
 
-@pytest.mark.parametrize("shape", [(61, 25), (25, 61), (33, 33)])
+@pytest.mark.parametrize(
+    "shape", [(61, 25), (25, 61), (33, 33), (64, 64), (128, 25), (128, 128)]
+)
 def test_rectangular_coefficient_lattice(shape: tuple[int, int]) -> None:
     rows, cols = shape
     entries = [
@@ -96,7 +98,7 @@ def test_degenerate_inputs_and_native_parity(entries: list[list[int]]) -> None:
 @pytest.mark.parametrize(
     ("rows", "columns", "value", "message"),
     [
-        (64, 64, 10**255, "digit-work"),
+        (64, 64, 10**255, "intermediate height"),
         (128, 128, 10**255, "minor height"),
     ],
 )
@@ -121,3 +123,82 @@ def test_hnf_specific_excessive_envelopes(
         tool.run(request)
     with pytest.raises(OperationDomainValidationError, match=message):
         hermite_normal_form(entries)
+
+
+@pytest.mark.parametrize("order", [2, 5, 9])
+def test_determinant_modulus_is_not_a_cancelled_rref_denominator(order: int) -> None:
+    # The rational RREF has denominator 2, but the square pivot determinant
+    # is 2**order. Passing 2 to modular HNF loses lattice index information.
+    entries = [[2 * int(i == j) for j in range(order)] for i in range(order)]
+    tool = HERMITE_NORMAL_FORM_OPERATION
+    result = tool.run(
+        tool.request_type.model_validate(
+            {"matrix": {"entries": [[str(x) for x in row] for row in entries]}}
+        )
+    )
+    assert result.normal_form.entries == tuple(
+        tuple(str(x) for x in row) for row in entries
+    )
+    assert result.transformation.entries == tuple(
+        tuple(str(int(i == j)) for j in range(order)) for i in range(order)
+    )
+
+
+def test_small_normal_form_retains_large_exact_transformation() -> None:
+    order, scale = 8, 10**50
+    # A=I+scale*N for the nilpotent upper shift. Its inverse has alternating
+    # powers of scale, even though its row HNF is the identity.
+    entries = [
+        [int(i == j) + scale * int(j == i + 1) for j in range(order)]
+        for i in range(order)
+    ]
+    tool = HERMITE_NORMAL_FORM_OPERATION
+    result = tool.run(
+        tool.request_type.model_validate(
+            {"matrix": {"entries": [[str(x) for x in row] for row in entries]}}
+        )
+    )
+    assert result.normal_form.entries == tuple(
+        tuple(str(int(i == j)) for j in range(order)) for i in range(order)
+    )
+    assert result.transformation.entries == tuple(
+        tuple(str((-scale) ** (j - i)) if j >= i else "0" for j in range(order))
+        for i in range(order)
+    )
+
+
+def test_seeded_rectangles_match_independent_reconstruction_and_flint_hnf() -> None:
+    from random import Random
+
+    from flint import fmpz_mat
+
+    from jacobian.math.lattices.operations import hermite_normal_form
+
+    rng = Random(3225)
+    for rows in range(1, 8):
+        for columns in range(1, 8):
+            entries = [
+                [rng.randrange(-9, 10) for _ in range(columns)] for _ in range(rows)
+            ]
+            # Some zero leading columns force nontrivial pivot selection.
+            if columns > 2 and rows % 2:
+                for row in entries:
+                    row[0] = 0
+            h, u = hermite_normal_form(entries)
+            assert h == fmpz_mat(entries).hnf()
+            assert (
+                abs(
+                    _determinant(
+                        tuple(
+                            tuple(str(u[i, j]) for j in range(rows))
+                            for i in range(rows)
+                        )
+                    )
+                )
+                == 1
+            )
+            assert all(
+                sum(int(u[i, k]) * entries[k][j] for k in range(rows)) == int(h[i, j])
+                for i in range(rows)
+                for j in range(columns)
+            )

--- a/tests/math/matrices/test_inverse.py
+++ b/tests/math/matrices/test_inverse.py
@@ -288,7 +288,7 @@ def test_inverse_reuses_canonical_integer_matrix() -> None:
     assert inverse == ((Fraction(1), Fraction(0)), (Fraction(0), Fraction(1)))
 
 
-def test_non_inverse_integer_requests_keep_order_32_envelope() -> None:
+def test_integer_requests_keep_operation_specific_envelopes() -> None:
     from pydantic import ValidationError
 
     from jacobian.math.lattices._hnf import compute_hermite_normal_form
@@ -322,17 +322,19 @@ def test_non_inverse_integer_requests_keep_order_32_envelope() -> None:
         LatticeReductionRequest.model_validate({"basis": {"entries": entries}})
     with pytest.raises(ValidationError):
         LatticeReductionRequest(basis=matrix)
-    with pytest.raises(ValidationError):
-        HermiteNormalFormRequest.model_validate({"matrix": {"entries": entries}})
-    with pytest.raises(ValidationError):
-        HermiteNormalFormRequest(matrix=matrix)
+    assert (
+        HermiteNormalFormRequest.model_validate({"matrix": {"entries": entries}}).matrix
+        == matrix
+    )
+    assert HermiteNormalFormRequest(matrix=matrix).matrix is matrix
 
     with pytest.raises(OperationDomainValidationError, match="32"):
         reduce_lattice_basis(LatticeReductionRequest.model_construct(basis=matrix))
-    with pytest.raises(OperationDomainValidationError, match="32"):
-        compute_hermite_normal_form(
-            HermiteNormalFormRequest.model_construct(matrix=matrix)
-        )
+    hermite = compute_hermite_normal_form(
+        HermiteNormalFormRequest.model_construct(matrix=matrix)
+    )
+    assert hermite.normal_form == matrix
+    assert hermite.transformation == matrix
 
     inverse_schema = _operation(
         "matrix.inverse.compute"
@@ -340,8 +342,10 @@ def test_non_inverse_integer_requests_keep_order_32_envelope() -> None:
     square_schema = SquareIntegerMatrixRequest.model_json_schema()
     integer_schema = IntegerMatrixRequest.model_json_schema()
     lattice_schema = LatticeReductionRequest.model_json_schema()
+    hermite_schema = HermiteNormalFormRequest.model_json_schema()
     assert _entry_axis_limit(inverse_schema, "matrix") == 128
     assert _entry_axis_limit(square_schema, "matrix") == 32
     assert _entry_axis_limit(integer_schema, "matrix") == MAX_EXACT_LINEAR_MATRIX_AXIS
     assert _entry_axis_limit(lattice_schema, "basis") == 32
+    assert _entry_axis_limit(hermite_schema, "matrix") == 128
     assert IntegerMatrix.model_json_schema()["properties"]["entries"]["maxItems"] == 128


### PR DESCRIPTION
## Problem

Fixes #3225. The shared 32-axis lattice limit rejects the reported 61-by-25 coefficient matrix. HNF needs an envelope that includes its square unimodular transformation and the computation's intermediate growth.

## Outcome

Admit rectangular HNF through a deterministic, explicitly selected modular algorithm. Preserve `H = U A`, unimodularity of U, canonical IntegerMatrix values, and the native matrix return types. Axes can reach 128 when all phase bounds fit; LLL retains its separate 32-axis limit.

For `G = [A | I]`, one fraction-free Gauss-Jordan elimination identifies the first independent columns B and returns `N/den = B^-1 G`. The pinned SymPy 1.14 `FF_dense` implementation retains the signed pivot determinant as den. A square HNF with explicit modulus `abs(den)` computes K, the row HNF of B. The exact product `K N / den = [H | U]` supplies both results. The identity suffix guarantees full row rank even for singular A. No rank computation, inverse, or solve is repeated in validation or result construction.

The adapter uses maintained [fraction-free elimination](https://github.com/sympy/sympy/blob/1.14.0/sympy/polys/matrices/dense.py) and [modular HNF](https://github.com/sympy/sympy/blob/1.14.0/sympy/polys/matrices/normalforms.py). FLINT stores the native results and supplies scalar arithmetic through SymPy; automatic FLINT matrix-algorithm dispatch is not used.

## Admission and contract impact

Admission runs once before backend matrix construction and covers elimination, modular reduction, lifting, and the complete H/U result:

- Hadamard row-norm bounds give `P = 2^b` bounding every minor of `[A | I]`. Elimination stores minors and forms temporaries at most `2 P²`.
- Modular column updates reduce modulo `R <= P`. The non-modular above-pivot reductions are bounded separately: each column undergoes at most m reductions, each increasing height S by at most `(P+2) S`. The bound includes pre-subtraction products.
- Explicit loop counts and operand heights replace the former dimension-times-digit estimate. The arithmetic allowance is `9 m²(n+m) + 14 m³ + m(m+1)/2 * (16b+24) + 2mn`; lifting partial sums are bounded by `m P²`.
- Enforced limits are 250,000,000 arithmetic units, 262,144 bits per intermediate, and 12,000,000,000 retained mathematical coefficient bits. Input scalars retain the 256-digit limit. Final coefficients must fit the canonical scalar envelope.

These are bounds on scalar calls and operand sizes, not CPU instruction counts, wall time, or allocator RSS. The extended-gcd allowance uses a Euclidean arithmetic bound; the maintained scalar backend may use faster algorithms. Large-height requests remain subject to conservative admission. The selected algorithms are tied to the pinned SymPy version and must be re-audited when that dependency changes.

## Validation

The original 61-by-25, wide 25-by-61, and 33-by-33 regressions failed on main with the old dimension rejection. The new 64-by-64, 128-by-25, and 128-by-128 scale regressions failed on the previous PR revision's work estimate and now pass.

Tests check reconstruction with integer multiplication, unimodularity with independent rational elimination, canonical HNF pivots, zero and dependent rows, native parity, and serialization. Additional regressions distinguish the determinant modulus from a cancelled RREF denominator (`2 I`) and retain a transformation with 350-digit entries when H is the identity. Seeded rectangles also agree with FLINT as an independent HNF oracle.

Complete operation timings below include request parsing and result JSON serialization, from one local Python 3.12 run. These establish feasibility, not performance guarantees.

| Matrix | Elapsed | Result bytes |
| --- | ---: | ---: |
| 61 × 25 | 0.510 s | 22,826 |
| 64 × 64 | 0.561 s | 83,305 |
| 128 × 25 | 2.432 s | 82,100 |
| 128 × 128 | 4.689 s | 395,624 |

The controlled route is slower than the previous direct FLINT call on 61 × 25 (0.066 s in the earlier run), while admitting larger cases with derived phase bounds.

- `uv run pytest tests/math/lattices/test_rectangular_hnf.py -q`: 17 passed.
- `make affected AFFECTED_BASE=origin/main`: scoped lint/types, 131 mathematical tests, 105 catalog tests, 890 catalog integration cases, and 117 dispatch tests passed.

## Review closure

No unresolved correctness findings remain in the final diff. Local validation covers the changed tree; hosted CI reports against the pushed revision.

Final tested revision: 1e83314bd. Superseded order-33 HNF rejection tests now check request/native/dispatch acceptance and the 128-axis schema; LLL retains its 32-axis rejection checks. The HNF pre-backend rejection test uses an excessive intermediate-height request.
