### PR TITLE
Preserve Dirichlet character claims during decoding

### DIFF
--- a/src/jacobian/math/number_theory/characters/_models.py
+++ b/src/jacobian/math/number_theory/characters/_models.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from typing import Annotated, Literal, Self
 
 from pydantic import (
@@ -80,26 +79,36 @@ class PrincipalDirichletCharacterValueResult(StrictModel):
     value: Literal[0, 1]
 
     @model_validator(mode="after")
-    def require_exact_source_bound_value(self) -> Self:
+    def require_source_bound_residue(self) -> Self:
+        """Validate only the inexpensive source-to-residue structural binding."""
+
         residue = int(self.integer) % self.character.modulus
         if self.canonical_residue != residue:
             raise _validation_error(
                 "canonical_residue_mismatch",
                 "canonical residue does not match the source integer",
             )
-        expected_is_unit = math.gcd(residue, self.character.modulus) == 1
-        if self.is_unit != expected_is_unit:
-            raise _validation_error(
-                "unit_status_mismatch",
-                "unit status does not match the source character modulus",
-            )
-        expected_value = self.character.values[residue]
-        if self.value != expected_value:
-            raise _validation_error(
-                "value_mismatch",
-                "value does not match the source principal-character table",
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        character: PrincipalDirichletCharacter,
+        integer: BoundedCanonicalInteger,
+        canonical_residue: StrictInt,
+        is_unit: StrictBool,
+        value: Literal[0, 1],
+    ) -> Self:
+        """Build a result after its producer has established the evaluation."""
+
+        return cls.model_construct(
+            character=character,
+            integer=integer,
+            canonical_residue=canonical_residue,
+            is_unit=is_unit,
+            value=value,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/number_theory/characters/_tools.py
+++ b/src/jacobian/math/number_theory/characters/_tools.py
@@ -31,7 +31,7 @@ def compute_principal_dirichlet_character_value(
         request.character, request.integer_value()
     )
     residue = request.integer_value() % request.character.modulus
-    return PrincipalDirichletCharacterValueResult(
+    return PrincipalDirichletCharacterValueResult._from_kernel(
         character=request.character,
         integer=request.integer,
         canonical_residue=residue,

--- a/src/jacobian/math/number_theory/characters/operations.py
+++ b/src/jacobian/math/number_theory/characters/operations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.characters._models import (
     PrincipalDirichletCharacterValueResult,
 )
@@ -31,16 +32,24 @@ def require_complete_principal_dirichlet_character(
         if math.gcd(residue, character.modulus) == 1
     )
     if character.unit_residues != expected_units:
-        raise ValueError(
-            "unit residues must be the complete canonical unit group modulo modulus"
+        raise OperationDomainValidationError(
+            location=("character", "unit_residues"),
+            code="dirichlet_character.unit_residues_mismatch",
+            message=(
+                "unit residues must be the complete canonical unit group modulo modulus"
+            ),
         )
     units = frozenset(expected_units)
     expected_values = tuple(
         1 if residue in units else 0 for residue in range(character.modulus)
     )
     if character.values != expected_values:
-        raise ValueError(
-            "values must be the complete extension-by-zero principal character table"
+        raise OperationDomainValidationError(
+            location=("character", "values"),
+            code="dirichlet_character.values_table_mismatch",
+            message=(
+                "values must be the complete extension-by-zero principal character table"
+            ),
         )
 
 

--- a/src/jacobian/math/number_theory/characters/operations.py
+++ b/src/jacobian/math/number_theory/characters/operations.py
@@ -4,12 +4,60 @@ from __future__ import annotations
 
 import math
 
+from jacobian.math.number_theory.characters._models import (
+    PrincipalDirichletCharacterValueResult,
+)
 from jacobian.math.number_theory.characters.values import (
     MAX_PRINCIPAL_CHARACTER_MODULUS,
     PrincipalDirichletCharacter,
 )
 
-__all__ = ["principal_dirichlet_character", "principal_dirichlet_character_value"]
+__all__ = [
+    "principal_dirichlet_character",
+    "principal_dirichlet_character_value",
+    "require_complete_principal_dirichlet_character",
+    "require_principal_dirichlet_character_value_result",
+]
+
+
+def require_complete_principal_dirichlet_character(
+    character: PrincipalDirichletCharacter,
+) -> None:
+    """Check the mathematical table claimed by a caller-supplied character."""
+
+    expected_units = tuple(
+        residue
+        for residue in range(character.modulus)
+        if math.gcd(residue, character.modulus) == 1
+    )
+    if character.unit_residues != expected_units:
+        raise ValueError(
+            "unit residues must be the complete canonical unit group modulo modulus"
+        )
+    units = frozenset(expected_units)
+    expected_values = tuple(
+        1 if residue in units else 0 for residue in range(character.modulus)
+    )
+    if character.values != expected_values:
+        raise ValueError(
+            "values must be the complete extension-by-zero principal character table"
+        )
+
+
+def require_principal_dirichlet_character_value_result(
+    result: PrincipalDirichletCharacterValueResult,
+) -> None:
+    """Check the character and source-evaluation relation of a claimed result."""
+
+    require_complete_principal_dirichlet_character(result.character)
+    residue = int(result.integer) % result.character.modulus
+    if result.canonical_residue != residue:
+        raise ValueError("canonical residue does not match the source integer")
+    expected_is_unit = math.gcd(residue, result.character.modulus) == 1
+    if result.is_unit != expected_is_unit:
+        raise ValueError("unit status does not match the source character modulus")
+    if result.value != result.character.values[residue]:
+        raise ValueError("value does not match the source principal-character table")
 
 
 def principal_dirichlet_character(modulus: int) -> PrincipalDirichletCharacter:
@@ -26,7 +74,7 @@ def principal_dirichlet_character(modulus: int) -> PrincipalDirichletCharacter:
         residue for residue in range(modulus) if math.gcd(residue, modulus) == 1
     )
     units = frozenset(unit_residues)
-    return PrincipalDirichletCharacter(
+    return PrincipalDirichletCharacter._from_kernel(
         modulus=modulus,
         unit_residues=unit_residues,
         values=tuple(1 if residue in units else 0 for residue in range(modulus)),
@@ -40,4 +88,5 @@ def principal_dirichlet_character_value(
 
     if type(integer) is not int:
         raise TypeError("principal-character input must be an integer")
+    require_complete_principal_dirichlet_character(character)
     return character.values[integer % character.modulus]

--- a/src/jacobian/math/number_theory/characters/values.py
+++ b/src/jacobian/math/number_theory/characters/values.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from typing import Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
@@ -36,27 +35,48 @@ class PrincipalDirichletCharacter(StrictModel):
     )
 
     @model_validator(mode="after")
-    def require_complete_canonical_principal_table(self) -> Self:
-        expected_units = tuple(
-            residue
-            for residue in range(self.modulus)
-            if math.gcd(residue, self.modulus) == 1
-        )
-        if self.unit_residues != expected_units:
+    def require_structural_shape(self) -> Self:
+        """Validate the bounded wire shape without proving the character."""
+
+        if len(self.unit_residues) > self.modulus:
             raise _validation_error(
-                "unit_residues_mismatch",
-                "unit residues must be the complete canonical unit group modulo modulus",
+                "unit_residues_length",
+                "unit residues cannot contain more entries than the modulus",
             )
-        units = frozenset(expected_units)
-        expected_values = tuple(
-            1 if residue in units else 0 for residue in range(self.modulus)
-        )
-        if self.values != expected_values:
+        if any(
+            residue < 0 or residue >= self.modulus for residue in self.unit_residues
+        ):
             raise _validation_error(
-                "values_table_mismatch",
-                "values must be the complete extension-by-zero principal character table",
+                "unit_residue_range",
+                "unit residues must be distinct canonical residues modulo modulus",
+            )
+        if self.unit_residues != tuple(sorted(set(self.unit_residues))):
+            raise _validation_error(
+                "unit_residue_order",
+                "unit residues must be strictly increasing canonical residues",
+            )
+        if len(self.values) != self.modulus:
+            raise _validation_error(
+                "values_table_length",
+                "values must contain exactly one entry for every canonical residue",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        modulus: int,
+        unit_residues: tuple[StrictInt, ...],
+        values: tuple[Literal[0, 1], ...],
+    ) -> Self:
+        """Build a character after its producer has established its table."""
+
+        return cls.model_construct(
+            modulus=modulus,
+            unit_residues=unit_residues,
+            values=values,
+        )
 
 
 __all__ = ["MAX_PRINCIPAL_CHARACTER_MODULUS", "PrincipalDirichletCharacter"]

--- a/tests/math/number_theory/characters/test_principal.py
+++ b/tests/math/number_theory/characters/test_principal.py
@@ -20,6 +20,10 @@ from jacobian.math.number_theory.characters._tools import (
     compute_principal_dirichlet_character,
     compute_principal_dirichlet_character_value,
 )
+from jacobian.math.number_theory.characters.operations import (
+    require_complete_principal_dirichlet_character,
+    require_principal_dirichlet_character_value_result,
+)
 from jacobian.math.number_theory.characters.values import (
     MAX_PRINCIPAL_CHARACTER_MODULUS,
     PrincipalDirichletCharacter,
@@ -67,28 +71,56 @@ def test_value_operation_is_bound_to_the_supplied_table(
     assert result.value == value
 
 
-def test_character_model_rejects_forged_unit_group_or_value_table() -> None:
-    with pytest.raises(ValidationError) as error:
-        PrincipalDirichletCharacter(
-            modulus=12,
-            unit_residues=(1, 5, 7),
-            values=(0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1),
-        )
-    assert (
-        error.value.errors()[0]["type"] == "dirichlet_character.unit_residues_mismatch"
-    )
-    with pytest.raises(ValidationError) as error:
-        PrincipalDirichletCharacter(
-            modulus=12,
-            unit_residues=(1, 5, 7, 11),
-            values=(0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1),
-        )
-    assert (
-        error.value.errors()[0]["type"] == "dirichlet_character.values_table_mismatch"
+def test_character_model_accepts_structural_claim_without_replaying_unit_group() -> (
+    None
+):
+    character = PrincipalDirichletCharacter.model_validate(
+        {
+            "modulus": 4,
+            "unit_residues": [1],
+            "values": [0, 1, 0, 0],
+        }
     )
 
+    assert character.modulus == 4
+    assert character.unit_residues == (1,)
+    assert character.values == (0, 1, 0, 0)
 
-def test_value_result_rejects_a_forged_residue_or_value() -> None:
+
+def test_character_model_rejects_structurally_invalid_tables() -> None:
+    with pytest.raises(ValidationError) as error:
+        PrincipalDirichletCharacter(
+            modulus=4,
+            unit_residues=(1,),
+            values=(0, 1, 0),
+        )
+    assert error.value.errors()[0]["type"] == "dirichlet_character.values_table_length"
+    with pytest.raises(ValidationError) as error:
+        PrincipalDirichletCharacter(
+            modulus=4,
+            unit_residues=(1, 4),
+            values=(0, 1, 0, 0),
+        )
+    assert error.value.errors()[0]["type"] == "dirichlet_character.unit_residue_range"
+
+
+def test_character_checker_rejects_a_structurally_valid_forged_claim() -> None:
+    character = PrincipalDirichletCharacter.model_validate(
+        {
+            "modulus": 4,
+            "unit_residues": [1],
+            "values": [0, 1, 0, 0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="complete canonical unit group"):
+        require_complete_principal_dirichlet_character(character)
+
+    with pytest.raises(ValueError, match="complete canonical unit group"):
+        principal_dirichlet_character_value(character, 1)
+
+
+def test_value_result_checks_only_structural_source_binding() -> None:
     character = principal_dirichlet_character(12)
     with pytest.raises(ValidationError) as error:
         PrincipalDirichletCharacterValueResult(
@@ -102,15 +134,30 @@ def test_value_result_rejects_a_forged_residue_or_value() -> None:
         error.value.errors()[0]["type"]
         == "dirichlet_character.canonical_residue_mismatch"
     )
-    with pytest.raises(ValidationError) as error:
-        PrincipalDirichletCharacterValueResult(
-            character=character,
-            integer="18",
-            canonical_residue=6,
-            is_unit=False,
-            value=1,
-        )
-    assert error.value.errors()[0]["type"] == "dirichlet_character.value_mismatch"
+
+    result = PrincipalDirichletCharacterValueResult(
+        character=character,
+        integer="18",
+        canonical_residue=6,
+        is_unit=True,
+        value=1,
+    )
+    with pytest.raises(ValueError, match="unit status"):
+        require_principal_dirichlet_character_value_result(result)
+
+
+def test_value_result_checker_rejects_a_forged_evaluation_claim() -> None:
+    character = principal_dirichlet_character(12)
+    result = PrincipalDirichletCharacterValueResult.model_construct(
+        character=character,
+        integer="18",
+        canonical_residue=6,
+        is_unit=False,
+        value=1,
+    )
+
+    with pytest.raises(ValueError, match="value does not match"):
+        require_principal_dirichlet_character_value_result(result)
 
 
 def test_value_request_rejects_noncanonical_negative_zero() -> None:

--- a/tests/math/number_theory/characters/test_principal.py
+++ b/tests/math/number_theory/characters/test_principal.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.dispatch import invoke_operation
 from jacobian.math.number_theory.characters import (
     principal_dirichlet_character,
     principal_dirichlet_character_value,
@@ -113,11 +116,41 @@ def test_character_checker_rejects_a_structurally_valid_forged_claim() -> None:
         }
     )
 
-    with pytest.raises(ValueError, match="complete canonical unit group"):
+    with pytest.raises(OperationDomainValidationError) as error:
         require_complete_principal_dirichlet_character(character)
+    assert error.value.errors()[0] == {
+        "loc": ("character", "unit_residues"),
+        "type": "dirichlet_character.unit_residues_mismatch",
+        "msg": (
+            "unit residues must be the complete canonical unit group modulo modulus"
+        ),
+    }
 
-    with pytest.raises(ValueError, match="complete canonical unit group"):
+    with pytest.raises(OperationDomainValidationError) as error:
         principal_dirichlet_character_value(character, 1)
+    assert error.value.errors()[0]["type"] == (
+        "dirichlet_character.unit_residues_mismatch"
+    )
+
+
+def test_dispatch_projects_forged_character_as_domain_validation_error() -> None:
+    with pytest.raises(OperationDomainValidationError) as error:
+        invoke_operation(
+            "dirichlet_character.principal.value.compute",
+            {
+                "character": {
+                    "modulus": 4,
+                    "unit_residues": [1],
+                    "values": [0, 1, 0, 0],
+                },
+                "integer": "1",
+            },
+            Catalog.open(),
+        )
+
+    assert error.value.errors()[0]["type"] == (
+        "dirichlet_character.unit_residues_mismatch"
+    )
 
 
 def test_value_result_checks_only_structural_source_binding() -> None:

--- a/tests/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/mcp/test_mcp_sdk_2_conformance.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+from mcp.shared.exceptions import MCPError
 from mcp.types import ContentBlock, TextContent, TextResourceContents
 from mcp.types.methods import serialize_server_result
 
@@ -187,6 +188,44 @@ def test_math_run_projects_unexpected_operation_failures() -> None:
         text = _content_text(result.content[0]) if result.content else ""
         assert text == "Error executing tool math.run: operation execution failed"
         assert "private backend failure" not in text
+
+    asyncio.run(scenario())
+
+
+def test_math_run_projects_forged_character_as_invalid_request() -> None:
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(create_server(), raise_exceptions=True) as client:
+            with pytest.raises(MCPError) as error:
+                await client.call_tool(
+                    "math.run",
+                    {
+                        "operation_id": "dirichlet_character.principal.value.compute",
+                        "payload": {
+                            "character": {
+                                "modulus": 4,
+                                "unit_residues": [1],
+                                "values": [0, 1, 0, 0],
+                            },
+                            "integer": "1",
+                        },
+                    },
+                )
+
+        assert error.value.code == -32602
+        assert error.value.message == "operation payload failed validation"
+        assert error.value.data["code"] == "INVALID_REQUEST"
+        assert error.value.data["stage"] == "operation_validation"
+        assert error.value.data["errors"] == [
+            {
+                "location": ["character", "unit_residues"],
+                "code": "dirichlet_character.unit_residues_mismatch",
+                "message": (
+                    "unit residues must be the complete canonical unit group modulo modulus"
+                ),
+            }
+        ]
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary / Problem

Issue #3281 identifies a contract-boundary problem in principal Dirichlet characters: deserializing a character or an evaluation result re-ran the mathematical unit-group and table computations. This rejected structurally valid claims before a caller could explicitly validate the mathematical relation.

## Changes

- Keep character decoding structural: validate bounded lengths, canonical residue shape, ordering, and table size without enumerating the unit group.
- Keep evaluation-result decoding structural: validate the source integer to canonical-residue binding without recomputing gcd status or table values.
- Add private kernel factories for native producers, which already establish the mathematical invariants they emit.
- Add explicit native checkers for complete principal-character tables and source-bound evaluation results; the native value consumer invokes the table checker before reading a supplied table.
- Preserve the existing top-level public API and add regression coverage for structural claims, malformed shapes, forged tables, and forged evaluation fields.

## Tests

- `uv sync --locked --dev`
- `uv run --locked pytest -n 1 --dist worksteal --timeout=120 tests/math/number_theory/characters` — 25 passed
- Math owner lane — 26 passed
- Catalog lane — 114 passed
- Ruff check, Ruff format check, and mypy for the changed character package — passed
- Full Ruff check and format check — passed
- The catalog integration lane reached 193 passed and 1 skipped before one unrelated Windows failure in the multivariate factor backend: no portable hard memory limit is available on this platform.
- Full mypy and the broad suite retain unrelated Windows baseline failures in POSIX-only process/locking APIs and the repository-hygiene fixture; none points to the changed files.

## Compatibility / Known limitations

Claims loaded from untrusted input remain structural until a consumer calls the explicit checker. Native producers and the native value consumer establish or verify the mathematical relation at their respective boundaries.

## Issue

Closes #3281
