### PR TITLE
Keep algebraic root decoding structural

### DIFF
--- a/src/jacobian/math/number_theory/algebraic_numbers/complex.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/complex.py
@@ -13,6 +13,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalInteger, CanonicalRational
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import parse_canonical_integer
+from jacobian.catalog.models import OperationDomainValidationError
 
 MAX_COMPLEX_ALGEBRAIC_DEGREE = 8
 MAX_COMPLEX_ALGEBRAIC_COEFFICIENT_DIGITS = 1_000
@@ -206,13 +207,13 @@ class RationalComplexIsolatingRectangle(StrictModel):
 class _ComplexAlgebraicValueShape(StrictModel):
     """Canonical structural representation of an indexed nonreal root.
 
-    ``polynomial`` is primitive irreducible in ``ZZ[x]`` with positive leading
-    coefficient.  ``root_index`` uses the mathematical global order: all real
-    roots increasingly first; then conjugate pairs ordered lexicographically
-    by their positive-imaginary representative ``(Re(z), Im(z))``; and within
-    each pair the negative root precedes the positive root.  Thus the
-    polynomial and index, rather than any one of infinitely many valid
-    isolating rectangles, are the value's identity.
+    ``polynomial`` is a bounded canonical integer-coefficient spelling with
+    positive leading coefficient. ``root_index`` uses the mathematical global
+    order: all real roots increasingly first; then conjugate pairs ordered
+    lexicographically by their positive-imaginary representative ``(Re(z),
+    Im(z))``; and within each pair the negative root precedes the positive
+    root. Consumers establish primitivity, irreducibility, and nonreal-root
+    selection in their admitted computation.
 
     This structural view checks the bounded canonical representation. A public
     value constructor or mathematical consumer must additionally recognize
@@ -223,7 +224,7 @@ class _ComplexAlgebraicValueShape(StrictModel):
         min_length=2,
         max_length=MAX_COMPLEX_ALGEBRAIC_DEGREE + 1,
         description=(
-            "Primitive irreducible ZZ[x] coefficients in descending degree, "
+            "Bounded canonical ZZ[x] coefficient spelling in descending degree, "
             "with positive leading coefficient."
         ),
     )
@@ -268,15 +269,6 @@ class _ComplexAlgebraicValueShape(StrictModel):
                 "leading_sign",
                 "complex algebraic minimal polynomial must have positive leading coefficient",
             )
-        content = 0
-        for coefficient in coefficients:
-            content = gcd(content, abs(coefficient))
-        if content != 1:
-            raise _validation_error(
-                "not_primitive",
-                "complex algebraic minimal polynomial must be primitive over ZZ",
-            )
-
         if self.root_index >= len(self.polynomial) - 1:
             raise _validation_error(
                 "root_index",
@@ -303,6 +295,24 @@ class ComplexAlgebraicValue(_ComplexAlgebraicValueShape):
         """Construct after an owner has admitted the canonical polynomial/root."""
 
         return cls.model_construct(polynomial=polynomial, root_index=root_index)
+
+
+def require_primitive_complex_algebraic_value(
+    value: ComplexAlgebraicValue,
+    *,
+    location: tuple[str | int, ...] = ("value",),
+) -> None:
+    """Check the primitive-polynomial claim required by a complex-root consumer."""
+
+    content = 0
+    for coefficient in value.polynomial:
+        content = gcd(content, abs(parse_canonical_integer(coefficient)))
+    if content != 1:
+        raise OperationDomainValidationError(
+            location=location,
+            code="complex_algebraic.not_primitive",
+            message="complex algebraic minimal polynomial must be primitive over ZZ",
+        )
 
 
 def _unrecognized_complex_value_from_shape(
@@ -334,4 +344,5 @@ __all__ = [
     "algebraic_root_magnitude_numerator_bound",
     "algebraic_root_separation_denominator_bound",
     "complex_isolator_component_digit_bound",
+    "require_primitive_complex_algebraic_value",
 ]

--- a/src/jacobian/math/number_theory/algebraic_numbers/real.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/real.py
@@ -62,17 +62,18 @@ def _rational(value: SympyRational) -> CanonicalRational:
 class _RealAlgebraicValueShape(StrictModel):
     """Canonical structural representation of an indexed real root.
 
-    ``polynomial`` is the primitive irreducible polynomial in ``ZZ[x]`` with
-    positive leading coefficient, listed in descending degree.  The
-    zero-based ``real_root_index`` selects one of its real roots in increasing
-    order.  This pair uniquely determines the value and its real embedding.
+    ``polynomial`` is a bounded canonical integer-coefficient polynomial
+    spelling with positive leading coefficient, listed in descending degree.
+    The zero-based ``real_root_index`` selects one of its real roots in
+    increasing order.  Consumers establish primitivity, irreducibility, and
+    root existence in their admitted computation.
     """
 
     polynomial: tuple[CanonicalInteger, ...] = Field(
         min_length=2,
         max_length=MAX_REAL_ALGEBRAIC_DEGREE + 1,
         description=(
-            "Primitive irreducible ZZ[x] coefficients in descending degree, "
+            "Bounded canonical ZZ[x] coefficient spelling in descending degree, "
             "with positive leading coefficient and at most 1,000 digits each."
         ),
         examples=[["1", "0", "-2"]],
@@ -105,15 +106,6 @@ class _RealAlgebraicValueShape(StrictModel):
                 "leading_sign",
                 "real algebraic minimal polynomial must have positive leading coefficient",
             )
-        content = 0
-        for coefficient in coefficients:
-            content = gcd(content, abs(coefficient))
-        if content != 1:
-            raise _validation_error(
-                "not_primitive",
-                "real algebraic minimal polynomial must be primitive over ZZ",
-            )
-
         if self.real_root_index >= len(self.polynomial) - 1:
             raise _validation_error(
                 "root_index",
@@ -123,7 +115,7 @@ class _RealAlgebraicValueShape(StrictModel):
 
 
 class RealAlgebraicValue(_RealAlgebraicValueShape):
-    """One real algebraic number in canonical minimal-polynomial form.
+    """One structurally encoded real algebraic root identity.
 
     Parsing checks the canonical encoding. Consumers establish irreducibility
     and the selected real root within their admitted computation.
@@ -141,6 +133,24 @@ class RealAlgebraicValue(_RealAlgebraicValueShape):
         return cls.model_construct(
             polynomial=polynomial,
             real_root_index=real_root_index,
+        )
+
+
+def require_primitive_real_algebraic_value(
+    value: RealAlgebraicValue,
+    *,
+    location: tuple[str | int, ...] = ("value",),
+) -> None:
+    """Check the primitive-polynomial claim required by a real-root consumer."""
+
+    content = 0
+    for coefficient in value.polynomial:
+        content = gcd(content, abs(parse_canonical_integer(coefficient)))
+    if content != 1:
+        raise OperationDomainValidationError(
+            location=location,
+            code="real_algebraic.not_primitive",
+            message="real algebraic minimal polynomial must be primitive over ZZ",
         )
 
 
@@ -204,6 +214,7 @@ def _interval(lower: SympyRational, upper: SympyRational) -> RationalIsolatingIn
 
 
 def _admit_real_polynomial(value: RealAlgebraicValue) -> Poly:
+    require_primitive_real_algebraic_value(value)
     polynomial = _sympy_polynomial(value)
     if polynomial.is_irreducible is not True:
         raise OperationDomainValidationError(
@@ -434,4 +445,5 @@ __all__ = [
     "RealAlgebraicValue",
     "compare_real_algebraic",
     "isolate_real_algebraic",
+    "require_primitive_real_algebraic_value",
 ]

--- a/src/jacobian/math/number_theory/algebraic_numbers/root_isolation/_sympy.py
+++ b/src/jacobian/math/number_theory/algebraic_numbers/root_isolation/_sympy.py
@@ -50,7 +50,7 @@ def compute_root_isolation(request: UnivariatePolynomialRequest) -> RootIsolatio
         left_roots = int(owning_factor.count_roots(-sympy.oo, lower))
         if owning_factor.eval(lower) == 0:
             left_roots -= 1
-        algebraic_value = RealAlgebraicValue(
+        algebraic_value = RealAlgebraicValue._from_admitted_polynomial(
             polynomial=tuple(
                 format_canonical_integer(coefficient)
                 for coefficient in factor_coefficients

--- a/tests/integration/algebra/test_exact_operations.py
+++ b/tests/integration/algebra/test_exact_operations.py
@@ -9,6 +9,7 @@ from tests.integration.algebra._support import algebra_validation_error
 
 from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.number_theory.algebraic_numbers import real as real_algebraic
 from jacobian.math.number_theory.algebraic_numbers.root_isolation._models import (
     MAX_ROOT_ISOLATION_SOURCE_COEFFICIENT_DIGITS,
     AlgebraicCompareRequest,
@@ -82,6 +83,24 @@ def test_root_isolation_returns_source_bound_composable_identities() -> None:
         }
     )
     assert forged.roots[0].multiplicity == 2
+
+
+def test_root_isolation_uses_admitted_root_carriers_without_revalidation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_replayed(*_args: int) -> int:
+        raise AssertionError("root carrier gcd validation was replayed")
+
+    monkeypatch.setattr(real_algebraic, "gcd", fail_if_replayed)
+
+    result = compute_root_isolation(
+        UnivariatePolynomialRequest.model_validate(_isolation_payload(_quadratic("-2")))
+    )
+
+    assert tuple(root.algebraic_value.real_root_index for root in result.roots) == (
+        0,
+        1,
+    )
 
 
 def test_root_isolation_accepts_sympy_singleton_interval_for_a_rational_root() -> None:

--- a/tests/math/number_theory/algebraic_numbers/test_real_algebraic.py
+++ b/tests/math/number_theory/algebraic_numbers/test_real_algebraic.py
@@ -12,11 +12,13 @@ from tests.math.number_theory.algebraic_numbers._real_algebraic_support import (
 )
 
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.number_theory.algebraic_numbers import complex as complex_algebraic
 from jacobian.math.number_theory.algebraic_numbers.real import (
     RealAlgebraicValue,
     _compare_admitted_real_algebraic,
     compare_real_algebraic,
     isolate_real_algebraic,
+    require_primitive_real_algebraic_value,
 )
 from jacobian.math.number_theory.algebraic_numbers.root_isolation._models import (
     AlgebraicCompareRequest,
@@ -78,18 +80,54 @@ def test_order_within_one_degree_sixteen_polynomial_uses_root_indices() -> None:
     assert compare_real_algebraic(negative_root, positive_root).order == "LT"
 
 
-@pytest.mark.parametrize(
-    ("polynomial", "message"),
-    [
-        (("-1", "0", "2"), "positive leading"),
-        (("2", "0", "-4"), "primitive"),
-    ],
-)
-def test_noncanonical_minimal_polynomials_are_rejected(
-    polynomial: tuple[str, ...], message: str
+def test_negative_leading_polynomials_are_rejected_structurally() -> None:
+    with pytest.raises(ValidationError, match="positive leading"):
+        _value(("-1", "0", "2"), 0)
+
+
+def test_nonprimitive_real_root_claims_parse_without_gcd_proof(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with pytest.raises(ValidationError, match=message):
-        _value(polynomial, 0)
+    monkeypatch.setattr(
+        "jacobian.math.number_theory.algebraic_numbers.real.gcd",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("gcd was replayed")),
+    )
+
+    candidate = _value(("2", "0", "-4"), 0)
+    assert candidate.polynomial == ("2", "0", "-4")
+
+
+def test_nonprimitive_real_root_claims_are_rejected_by_consumers() -> None:
+    candidate = _value(("2", "0", "-4"), 0)
+
+    with pytest.raises(OperationDomainValidationError, match="primitive"):
+        require_primitive_real_algebraic_value(candidate)
+    with pytest.raises(OperationDomainValidationError, match="primitive"):
+        isolate_real_algebraic(candidate)
+
+
+def test_nonprimitive_complex_root_claims_parse_without_gcd_proof(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        complex_algebraic,
+        "gcd",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("gcd was replayed")),
+    )
+
+    candidate = complex_algebraic.ComplexAlgebraicValue.model_validate(
+        {"polynomial": ["2", "0", "-2"], "root_index": 0}
+    )
+    assert candidate.polynomial == ("2", "0", "-2")
+
+
+def test_nonprimitive_complex_root_claims_are_rejected_by_explicit_checker() -> None:
+    candidate = complex_algebraic.ComplexAlgebraicValue(
+        polynomial=("2", "0", "-2"), root_index=0
+    )
+
+    with pytest.raises(OperationDomainValidationError, match="primitive"):
+        complex_algebraic.require_primitive_complex_algebraic_value(candidate)
 
 
 def test_value_rejects_a_nonreal_or_missing_root() -> None:


### PR DESCRIPTION
## Summary / Problem

Issue #3280 identifies a contract-boundary problem in the real and complex algebraic-root carriers: parsing a bounded polynomial claim also computed its integer content with gcd. This made structural decoding prove primitivity before the consuming operation had admitted the polynomial.

## Changes

- Keep real and complex algebraic-root decoding structural: validate canonical coefficient spelling, positive leading sign, degree bounds, and root-index shape without computing polynomial content.
- Add explicit primitive-polynomial checkers for real and complex root consumers.
- Make real root comparison and isolation admit primitivity at the operation boundary before irreducibility and root selection.
- Construct root-isolation results through the admitted-polynomial kernel factory so the producer does not replay its own primitive claim during result construction.
- Add regression coverage for accepted nonprimitive structural claims, explicit consumer rejection, gcd-replay protection, and the root-isolation producer path.

## Tests

- `uv sync --locked --dev`
- Affected math lane — 47 passed
- Full integration lane — 165 passed
- Combined algebraic/root-isolation/integration regression run — 79 passed
- Ruff check, Ruff format check, and mypy for the changed algebraic-number paths — passed
- Full Ruff check and format check — passed
- An additional number-field embedding run reached 80 passed and one unrelated existing profiler assertion failure (`polytools.intervals` call count is 0 on this Windows/SymPy environment).

## Compatibility / Known limitations

Decoded root carriers now preserve bounded canonical claims without asserting primitivity. Consumers that require a primitive polynomial must call the explicit checker or perform the operation admission that owns that requirement. Native producers use admitted kernel construction for results whose invariants they already established.

## Issue

Closes #3280
