### PR TITLE
Repair mathematical value and claim contracts

### DIFF
--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -544,6 +544,23 @@ ledger when the retained source and claimed postcondition remain sufficient for
 that consumer, but scalar shape alone must not authenticate a mathematical
 conclusion.
 
+Do not add a verifier to every result. Ordinary values need canonical types,
+not producer history: arithmetic can consume a segment ratio as a rational.
+A claimed matrix rank instead needs its source matrix and an admitted check
+when a consumer relies on that claim.
+
+Repair representation and invariant ownership first. Verifiers cannot recover
+discarded parents or axes. Move mathematical proofs out of decoding into
+operation admission, migrate every dependent consumer, and avoid repeating
+completed proofs during result construction. An unused verifier does not fix
+a consumer that still trusts an unchecked claim.
+
+Distinguish certificate checking from recomputing an answer. Both can establish
+a claim under explicit work and growth bounds, but recomputation is not
+automatically an efficient certificate check. Check the advertised relation,
+allowing alternative valid witnesses rather than requiring the producer's
+particular output.
+
 Backend integration follows the reusable
 [mathematical backend contract](mathematical-backends.md).
 

--- a/src/jacobian/math/algebraic_tori/__init__.py
+++ b/src/jacobian/math/algebraic_tori/__init__.py
@@ -2,6 +2,7 @@
 
 from jacobian.math.algebraic_tori.operations import (
     homogeneous_monomial_solution_subgroup,
+    verify_solution_subgroup,
 )
 from jacobian.math.algebraic_tori.values import (
     AlgebraicTorusSolutionSubgroup,
@@ -14,4 +15,5 @@ __all__ = [
     "HomogeneousMonomialSystem",
     "TorsionCharacterGroup",
     "homogeneous_monomial_solution_subgroup",
+    "verify_solution_subgroup",
 ]

--- a/src/jacobian/math/algebraic_tori/operations.py
+++ b/src/jacobian/math/algebraic_tori/operations.py
@@ -17,6 +17,7 @@ from jacobian.math.matrices.certified_snf.operations import (
     matrix_determinant,
     matrix_multiply,
     smith_reduce,
+    verify_smith_normal_form_certificate,
 )
 from jacobian.math.matrices.values import IntegerMatrix
 
@@ -220,4 +221,50 @@ def homogeneous_monomial_solution_subgroup(
     )
 
 
-__all__ = ["homogeneous_monomial_solution_subgroup"]
+def verify_solution_subgroup(claim: AlgebraicTorusSolutionSubgroup) -> bool:
+    """Check the complete subgroup parameterization, not LLL reducedness.
+
+    The source and all transformation axes have at most 16 entries. Exact
+    scalar bounds come from the canonical Smith and integer-matrix carriers.
+    A different unimodular choice of free parameters remains valid.
+    """
+    _admit_monomial_system(claim.source)
+    certificate = claim.smith_certificate
+    if not verify_smith_normal_form_certificate(certificate):
+        return False
+    rank = certificate.rank
+    if claim.free_rank != len(claim.source.coordinate_axis) - rank:
+        return False
+    factors = tuple(map(parse_canonical_integer, certificate.invariant_factors))
+    torsion_positions = tuple(i for i, factor in enumerate(factors) if factor > 1)
+    torsion = tuple(factors[i] for i in torsion_positions)
+    if (
+        tuple(
+            map(
+                parse_canonical_integer, claim.torsion_character_group.invariant_factors
+            )
+        )
+        != torsion
+    ):
+        return False
+    if parse_canonical_integer(claim.connected_component_count) != prod(torsion):
+        return False
+
+    def entries(matrix: IntegerMatrix) -> Matrix:
+        return [list(map(parse_canonical_integer, row)) for row in matrix.entries]
+
+    right = entries(certificate.right_transformation)
+    if entries(claim.torsion_exponent_map) != [
+        [row[i] % factors[i] for i in torsion_positions] for row in right
+    ]:
+        return False
+    free = [row[rank:] for row in right]
+    if entries(claim.smith_free_exponent_map) != free:
+        return False
+    change = entries(claim.smith_free_parameters_from_reduced)
+    return abs(matrix_determinant(change)) == 1 and matrix_multiply(
+        free, change, right_columns_if_empty=claim.free_rank
+    ) == entries(claim.reduced_free_exponent_map)
+
+
+__all__ = ["homogeneous_monomial_solution_subgroup", "verify_solution_subgroup"]

--- a/src/jacobian/math/algebraic_tori/values.py
+++ b/src/jacobian/math/algebraic_tori/values.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from itertools import pairwise
-from math import ceil, log10, prod
+from math import ceil, log10
 from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, StrictInt, StringConstraints, model_validator
@@ -187,9 +186,7 @@ class TorsionCharacterGroup(StrictModel):
         factors = tuple(
             parse_canonical_integer(value) for value in self.invariant_factors
         )
-        if any(value <= 1 for value in factors) or any(
-            right % left for left, right in pairwise(factors)
-        ):
+        if any(value <= 1 for value in factors):
             raise _validation_error(
                 "algebraic_torus.torsion_invariant_factors",
                 "torsion invariant factors must exceed one and form a divisibility chain",
@@ -280,39 +277,11 @@ class AlgebraicTorusSolutionSubgroup(StrictModel):
     @model_validator(mode="after")
     def require_source_bound_shapes(self) -> Self:
         coordinate_count = len(self.source.coordinate_axis)
-        rank = self.smith_certificate.rank
-        factors = self.smith_certificate.invariant_factors
-        nontrivial_factors = tuple(factor for factor in factors if factor != "1")
-        torsion_count = len(nontrivial_factors)
+        torsion_count = len(self.torsion_character_group.invariant_factors)
         if self.smith_certificate.source != self.source.exponent_matrix:
             raise _validation_error(
                 "algebraic_torus.solution_source_binding",
                 "Smith certificate source must equal the exponent matrix",
-            )
-        if self.free_rank != coordinate_count - rank:
-            raise _validation_error(
-                "algebraic_torus.solution_rank_shape",
-                "free rank must be coordinate count minus Smith rank",
-            )
-        if self.torsion_character_group.invariant_factors != nontrivial_factors:
-            raise _validation_error(
-                "algebraic_torus.solution_torsion_shape",
-                "torsion characters must follow the nontrivial Smith factors",
-            )
-        expected_component_count = prod(
-            (
-                parse_canonical_integer(value)
-                for value in self.torsion_character_group.invariant_factors
-            ),
-            start=1,
-        )
-        if (
-            parse_canonical_integer(self.connected_component_count)
-            != expected_component_count
-        ):
-            raise _validation_error(
-                "algebraic_torus.solution_component_count",
-                "connected component count must equal the product of torsion invariant factors",
             )
         if (
             len(self.torsion_parameter_axis) != torsion_count

--- a/src/jacobian/math/analysis/majorization/__init__.py
+++ b/src/jacobian/math/analysis/majorization/__init__.py
@@ -7,6 +7,11 @@ from jacobian.math.analysis.majorization.operations import (
     majorization_check,
     schur_horn_check,
     t_transform_sequence,
+    verify_birkhoff,
+    verify_doubly_stochastic,
+    verify_majorization,
+    verify_schur_horn,
+    verify_weak_majorization,
     weak_majorization_check,
 )
 
@@ -17,5 +22,10 @@ __all__ = [
     "majorization_check",
     "schur_horn_check",
     "t_transform_sequence",
+    "verify_birkhoff",
+    "verify_doubly_stochastic",
+    "verify_majorization",
+    "verify_schur_horn",
+    "verify_weak_majorization",
     "weak_majorization_check",
 ]

--- a/src/jacobian/math/analysis/majorization/_models.py
+++ b/src/jacobian/math/analysis/majorization/_models.py
@@ -278,7 +278,8 @@ class SchurHornCheckRequest(StrictModel):
 class SchurHornCheckResult(StrictModel):
     """Result of Schur-Horn feasibility check."""
 
-    source: SchurHornCheckRequest
+    eigenvalues: tuple[CanonicalRational, ...]
+    diagonal: tuple[CanonicalRational, ...]
 
     feasible: bool
     eigenvalues_sorted: tuple[CanonicalRational, ...]

--- a/src/jacobian/math/analysis/majorization/_models.py
+++ b/src/jacobian/math/analysis/majorization/_models.py
@@ -90,6 +90,9 @@ class MajorizationCheckRequest(StrictModel):
 class MajorizationCheckResult(StrictModel):
     """Result of a majorization check."""
 
+    x: RationalVector
+    y: RationalVector
+
     majorizes: bool
     total_sum_match: bool
     prefix_slacks: tuple[CanonicalRational, ...]
@@ -114,6 +117,9 @@ class WeakMajorizationCheckRequest(StrictModel):
 
 class WeakMajorizationCheckResult(StrictModel):
     """Result of a weak majorization check."""
+
+    x: RationalVector
+    y: RationalVector
 
     holds: bool
     direction: Literal["sub", "super"]
@@ -202,6 +208,8 @@ class DoublyStochasticCheckRequest(StrictModel):
 class DoublyStochasticCheckResult(StrictModel):
     """Result of a doubly stochastic check."""
 
+    matrix: RationalMatrix
+
     is_doubly_stochastic: bool
     row_sums: tuple[CanonicalRational, ...]
     col_sums: tuple[CanonicalRational, ...]
@@ -214,7 +222,7 @@ class BirkhoffTerm(StrictModel):
     """One term in a Birkhoff decomposition."""
 
     weight: CanonicalRational
-    permutation: tuple[int, ...]
+    permutation: tuple[int, ...] = Field(max_length=MAX_DIMENSION)
 
 
 class BirkhoffDecompositionRequest(StrictModel):
@@ -226,8 +234,25 @@ class BirkhoffDecompositionRequest(StrictModel):
 class BirkhoffDecompositionResult(StrictModel):
     """Result of a Birkhoff decomposition."""
 
-    terms: tuple[BirkhoffTerm, ...]
+    matrix: RationalMatrix
+    axis_convention: Literal["ZERO_BASED_ROW_TO_COLUMN"] = "ZERO_BASED_ROW_TO_COLUMN"
+
+    terms: tuple[BirkhoffTerm, ...] = Field(max_length=MAX_DIMENSION**2)
     weights_sum: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_permutation_axes(self) -> Self:
+        dimension = len(self.matrix.entries)
+        if self.matrix.column_count != dimension:
+            raise _validation_error(
+                "decomposition_shape", "source matrix must be square"
+            )
+        for term in self.terms:
+            if tuple(sorted(term.permutation)) != tuple(range(dimension)):
+                raise _validation_error(
+                    "permutation_axis", "each term must permute the source matrix axis"
+                )
+        return self
 
 
 class SchurHornCheckRequest(StrictModel):
@@ -252,6 +277,8 @@ class SchurHornCheckRequest(StrictModel):
 
 class SchurHornCheckResult(StrictModel):
     """Result of Schur-Horn feasibility check."""
+
+    source: SchurHornCheckRequest
 
     feasible: bool
     eigenvalues_sorted: tuple[CanonicalRational, ...]

--- a/src/jacobian/math/analysis/majorization/operations.py
+++ b/src/jacobian/math/analysis/majorization/operations.py
@@ -16,6 +16,7 @@ from jacobian.math.analysis.majorization._models import (
     DoublyStochasticCheckResult,
     MajorizationCheckResult,
     RationalVector,
+    SchurHornCheckRequest,
     SchurHornCheckResult,
     TTransformSequenceResult,
     TTransformStep,
@@ -125,6 +126,8 @@ def majorization_check(x: RationalVector, y: RationalVector) -> MajorizationChec
     majorizes = all_ok and total_sum_match
 
     return MajorizationCheckResult(
+        x=x,
+        y=y,
         majorizes=majorizes,
         total_sum_match=total_sum_match,
         prefix_slacks=tuple(CanonicalRational.from_fraction(s) for s in slacks),
@@ -177,6 +180,8 @@ def weak_majorization_check(
                 first_failed = k
 
     return WeakMajorizationCheckResult(
+        x=x,
+        y=y,
         holds=all_ok,
         direction=direction,
         prefix_slack=tuple(CanonicalRational.from_fraction(s) for s in slacks),
@@ -410,6 +415,7 @@ def doubly_stochastic_check(matrix: RationalMatrix) -> DoublyStochasticCheckResu
     is_ds = first_neg is None and first_bad_row is None and first_bad_col is None
 
     return DoublyStochasticCheckResult(
+        matrix=matrix,
         is_doubly_stochastic=is_ds,
         row_sums=tuple(CanonicalRational.from_fraction(s) for s in row_sums),
         col_sums=tuple(CanonicalRational.from_fraction(s) for s in col_sums),
@@ -496,6 +502,7 @@ def birkhoff_decomposition(matrix: RationalMatrix) -> BirkhoffDecompositionResul
     weights_sum = sum((t.weight.as_fraction() for t in terms), Fraction(0))
 
     return BirkhoffDecompositionResult(
+        matrix=matrix,
         terms=tuple(terms),
         weights_sum=CanonicalRational.from_fraction(weights_sum),
     )
@@ -578,6 +585,7 @@ def schur_horn_check(
     feasible = all_ok and total_sum_match
 
     return SchurHornCheckResult(
+        source=SchurHornCheckRequest(eigenvalues=eigenvalues, diagonal=diagonal),
         feasible=feasible,
         eigenvalues_sorted=tuple(CanonicalRational.from_fraction(v) for v in e_sorted),
         diagonal_sorted=tuple(CanonicalRational.from_fraction(v) for v in d_sorted),
@@ -587,11 +595,60 @@ def schur_horn_check(
     )
 
 
+def verify_majorization(claim: MajorizationCheckResult) -> bool:
+    """Check the retained vectors' exact majorization summary."""
+    return majorization_check(claim.x, claim.y) == claim
+
+
+def verify_weak_majorization(claim: WeakMajorizationCheckResult) -> bool:
+    """Check the retained vectors in the claimed weak direction."""
+    return weak_majorization_check(claim.x, claim.y, claim.direction) == claim
+
+
+def verify_doubly_stochastic(claim: DoublyStochasticCheckResult) -> bool:
+    """Check the source matrix and all stochasticity summaries."""
+    return doubly_stochastic_check(claim.matrix) == claim
+
+
+def verify_schur_horn(claim: SchurHornCheckResult) -> bool:
+    """Check the retained eigenvalue and diagonal sequences."""
+    return schur_horn_check(claim.source.eigenvalues, claim.source.diagonal) == claim
+
+
+def verify_birkhoff(claim: BirkhoffDecompositionResult) -> bool:
+    """Check convexity and reconstruction without rerunning decomposition.
+
+    At most 400 terms on 20 coordinates are admitted. Canonical scalar bounds
+    bound each sum's denominator by the product of at most 400 denominators.
+    The empty matrix uses the producer's empty sum of weight zero.
+    """
+    _run_admission(
+        lambda: _require_majorization_matrix(claim.matrix), location=("matrix",)
+    )
+    n = len(claim.matrix.entries)
+    weights = tuple(term.weight.as_fraction() for term in claim.terms)
+    if any(weight < 0 for weight in weights):
+        return False
+    total = sum(weights, Fraction())
+    if total != claim.weights_sum.as_fraction() or total != (1 if n else 0):
+        return False
+    reconstructed = [[Fraction() for _ in range(n)] for _ in range(n)]
+    for term, weight in zip(claim.terms, weights, strict=True):
+        for row, column in enumerate(term.permutation):
+            reconstructed[row][column] += weight
+    return reconstructed == _matrix_fractions(claim.matrix)
+
+
 __all__ = [
     "birkhoff_decomposition",
     "doubly_stochastic_check",
     "majorization_check",
     "schur_horn_check",
     "t_transform_sequence",
+    "verify_birkhoff",
+    "verify_doubly_stochastic",
+    "verify_majorization",
+    "verify_schur_horn",
+    "verify_weak_majorization",
     "weak_majorization_check",
 ]

--- a/src/jacobian/math/analysis/majorization/operations.py
+++ b/src/jacobian/math/analysis/majorization/operations.py
@@ -16,7 +16,6 @@ from jacobian.math.analysis.majorization._models import (
     DoublyStochasticCheckResult,
     MajorizationCheckResult,
     RationalVector,
-    SchurHornCheckRequest,
     SchurHornCheckResult,
     TTransformSequenceResult,
     TTransformStep,
@@ -585,7 +584,8 @@ def schur_horn_check(
     feasible = all_ok and total_sum_match
 
     return SchurHornCheckResult(
-        source=SchurHornCheckRequest(eigenvalues=eigenvalues, diagonal=diagonal),
+        eigenvalues=eigenvalues,
+        diagonal=diagonal,
         feasible=feasible,
         eigenvalues_sorted=tuple(CanonicalRational.from_fraction(v) for v in e_sorted),
         diagonal_sorted=tuple(CanonicalRational.from_fraction(v) for v in d_sorted),
@@ -612,7 +612,7 @@ def verify_doubly_stochastic(claim: DoublyStochasticCheckResult) -> bool:
 
 def verify_schur_horn(claim: SchurHornCheckResult) -> bool:
     """Check the retained eigenvalue and diagonal sequences."""
-    return schur_horn_check(claim.source.eigenvalues, claim.source.diagonal) == claim
+    return schur_horn_check(claim.eigenvalues, claim.diagonal) == claim
 
 
 def verify_birkhoff(claim: BirkhoffDecompositionResult) -> bool:

--- a/src/jacobian/math/analysis/orthogonal_polynomials/__init__.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/__init__.py
@@ -8,6 +8,7 @@ from jacobian.math.analysis.orthogonal_polynomials.operations import (
     orthogonal_polynomials,
     recurrence_coefficients,
     shifted_hankel_matrix,
+    verify_definiteness,
 )
 from jacobian.math.analysis.orthogonal_polynomials.values import (
     ChristoffelDarbouxKernel,
@@ -42,4 +43,5 @@ __all__ = [
     "orthogonal_polynomials",
     "recurrence_coefficients",
     "shifted_hankel_matrix",
+    "verify_definiteness",
 ]

--- a/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/operations.py
@@ -360,6 +360,19 @@ def _require_gram_schmidt_admission(
     _require_gram_schmidt_heights_admissible(prefix.moments, max_degree)
 
 
+def verify_definiteness(family: OrthogonalPolynomialFamily) -> bool:
+    """Check the two classification claims against the bounded retained norms.
+
+    This linear scan checks only norm classifications, not orthogonality to an
+    unspecified moment functional. Recurrence consumers admit their own
+    nonzero denominator norms independently of these flags.
+    """
+    norms = tuple(term.squared_norm.as_fraction() for term in family.polynomials)
+    return family.is_quasi_definite == all(
+        norm != 0 for norm in norms
+    ) and family.is_positive_definite == all(norm > 0 for norm in norms)
+
+
 def _require_quasi_definite_family(family: OrthogonalPolynomialFamily) -> None:
     """Recurrence ratios divide by every squared norm except the terminal
     one: ``beta_k = h_k / h_{k-1}`` for k >= 1 uses p_0..p_{n-2} as
@@ -718,4 +731,5 @@ __all__ = [
     "orthogonal_polynomials",
     "recurrence_coefficients",
     "shifted_hankel_matrix",
+    "verify_definiteness",
 ]

--- a/src/jacobian/math/analysis/orthogonal_polynomials/values.py
+++ b/src/jacobian/math/analysis/orthogonal_polynomials/values.py
@@ -115,20 +115,6 @@ class OrthogonalPolynomialFamily(StrictModel):
                 raise _validation_error(
                     "value_invariant", f"p_{term.degree} must be monic"
                 )
-        # Definiteness classifications are derived from the retained norms,
-        # never free labels: quasi-definite means every norm nonzero, and
-        # positive-definite means every norm positive.
-        norms = [term.squared_norm.as_fraction() for term in self.polynomials]
-        if self.is_quasi_definite != all(norm != 0 for norm in norms):
-            raise _validation_error(
-                "value_invariant",
-                "is_quasi_definite must equal every squared norm being nonzero",
-            )
-        if self.is_positive_definite != all(norm > 0 for norm in norms):
-            raise _validation_error(
-                "value_invariant",
-                "is_positive_definite must equal every squared norm being positive",
-            )
         return self
 
     @classmethod

--- a/src/jacobian/math/coalgebras/_models.py
+++ b/src/jacobian/math/coalgebras/_models.py
@@ -233,7 +233,6 @@ class ComultiplicationResult(StrictModel):
     coalgebra: Coalgebra
     element_index: int = Field(ge=0)
     matrix: PrimeFieldMatrix
-    dimension: int = Field(ge=1)
 
     @model_validator(mode="before")
     @classmethod
@@ -278,11 +277,7 @@ class ComultiplicationResult(StrictModel):
             raise _validation_error(
                 "element_index_out_of_range", "element_index must be in 0..dimension-1"
             )
-        if self.dimension != n:
-            raise _validation_error(
-                "dimension_mismatch", "dimension must match the retained coalgebra"
-            )
-        if self.dimension != self.matrix.columns or len(self.matrix.entries) != n:
+        if self.matrix.columns != n or len(self.matrix.entries) != n:
             raise _validation_error(
                 "dimension_mismatch", "dimension must match the retained coalgebra"
             )
@@ -306,7 +301,6 @@ class ComultiplicationResult(StrictModel):
             coalgebra=request.coalgebra,
             element_index=request.element_index,
             matrix=matrix,
-            dimension=request.coalgebra.dimension,
         )
 
 

--- a/src/jacobian/math/combinatorics/__init__.py
+++ b/src/jacobian/math/combinatorics/__init__.py
@@ -7,6 +7,7 @@ from jacobian.math.combinatorics.exact_cover import (
     GeneralizedExactCoverInstance,
     GeneralizedExactCoverResult,
     find_generalized_exact_cover,
+    verify_generalized_exact_cover,
 )
 from jacobian.math.combinatorics.operations import (
     bell_number,
@@ -70,4 +71,5 @@ __all__ = [
     "recurrence_table_residuals",
     "stirling_first",
     "stirling_second",
+    "verify_generalized_exact_cover",
 ]

--- a/src/jacobian/math/combinatorics/algebraic/__init__.py
+++ b/src/jacobian/math/combinatorics/algebraic/__init__.py
@@ -6,6 +6,7 @@ from jacobian.math.combinatorics.algebraic.operations import (
     inverse_row_insertion_rsk,
     row_insertion_rsk,
     standard_young_tableaux_count,
+    verify_rsk,
 )
 from jacobian.math.combinatorics.algebraic.values import RSKTableauPair
 from jacobian.math.combinatorics.algebraic.weighted_monotone._models import (
@@ -28,4 +29,5 @@ __all__ = [
     "inverse_row_insertion_rsk",
     "row_insertion_rsk",
     "standard_young_tableaux_count",
+    "verify_rsk",
 ]

--- a/src/jacobian/math/combinatorics/algebraic/_models.py
+++ b/src/jacobian/math/combinatorics/algebraic/_models.py
@@ -31,16 +31,6 @@ from jacobian.math.logic.languages.words.values import FiniteWord
 MAX_RSK_PERMUTATION_LENGTH = MAX_RSK_WORD_LENGTH
 
 
-def _require_permutation(permutation: tuple[int, ...]) -> None:
-    if not permutation:
-        return
-    if sorted(permutation) != list(range(1, len(permutation) + 1)):
-        raise PydanticCustomError(
-            "algebraic_combinatorics.permutation_invalid",
-            "permutation must be a permutation of 1..n",
-        )
-
-
 class HookLengthRequest(StrictModel):
     """Compute the hook lengths of a partition."""
 
@@ -118,7 +108,6 @@ class RSKResult(StrictModel):
 
     @model_validator(mode="after")
     def require_structural_consistency(self) -> Self:
-        _require_permutation(self.permutation)
         if self.p_tableau.shape != self.shape or self.q_tableau.shape != self.shape:
             raise PydanticCustomError(
                 "algebraic_combinatorics.rsk_shape_mismatch",
@@ -128,13 +117,6 @@ class RSKResult(StrictModel):
             raise PydanticCustomError(
                 "algebraic_combinatorics.rsk_size_mismatch",
                 "tableau shape size must equal permutation length",
-            )
-        expected_lis = self.shape.parts[0] if self.shape.parts else 0
-        expected_lds = len(self.shape.parts)
-        if self.lis_length != expected_lis or self.lds_length != expected_lds:
-            raise PydanticCustomError(
-                "algebraic_combinatorics.rsk_lengths_mismatch",
-                "LIS/LDS lengths do not match the tableau shape",
             )
         return self
 

--- a/src/jacobian/math/combinatorics/algebraic/operations.py
+++ b/src/jacobian/math/combinatorics/algebraic/operations.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from math import factorial, prod
 
+from jacobian.math.combinatorics.algebraic._models import RSKResult
 from jacobian.math.combinatorics.algebraic._rsk import (
     _row_insert,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "inverse_row_insertion_rsk",
     "row_insertion_rsk",
     "standard_young_tableaux_count",
+    "verify_rsk",
 ]
 
 
@@ -48,6 +50,24 @@ def _rsk_permutation(
     if sorted(permutation) != list(range(1, len(permutation) + 1)):
         raise ValueError("permutation must be a permutation of 1..n")
     return _row_insert(permutation)
+
+
+def verify_rsk(claim: RSKResult) -> bool:
+    """Check bounded permutation admission, RSK correspondence, and LIS/LDS.
+
+    The retained source has at most 500 entries. Row insertion has the same
+    quadratic search-count bound as the producing operation.
+    """
+    try:
+        insertion, recording = _rsk_permutation(claim.permutation)
+    except ValueError:
+        return False
+    return (
+        insertion == claim.p_tableau.rows
+        and recording == claim.q_tableau.rows
+        and claim.lis_length == (len(insertion[0]) if insertion else 0)
+        and claim.lds_length == len(insertion)
+    )
 
 
 def conjugate_partition(partition: IntegerPartition) -> IntegerPartition:

--- a/src/jacobian/math/combinatorics/codes/linear/_models.py
+++ b/src/jacobian/math/combinatorics/codes/linear/_models.py
@@ -356,35 +356,6 @@ class ReceivedWordProfileResult(StrictModel):
         )
 
 
-def _validate_prime_matrix(
-    field_order: int,
-    generator_matrix: tuple[tuple[int, ...], ...],
-) -> int:
-    from sympy import isprime
-
-    if not isprime(field_order):
-        raise _validation_error(
-            "field_order_must_be_prime", "field_order must be prime"
-        )
-    width = len(generator_matrix[0])
-    if width == 0 or width > MAX_LINEAR_CODE_LENGTH:
-        raise _validation_error(
-            "generator_rows_length",
-            f"generator rows must have between 1 and {MAX_LINEAR_CODE_LENGTH} entries",
-        )
-    if any(len(row) != width for row in generator_matrix):
-        raise _validation_error(
-            "generator_matrix_rows_must_have_equal_length",
-            "generator matrix rows must have equal length",
-        )
-    if any(not 0 <= entry < field_order for row in generator_matrix for entry in row):
-        raise _validation_error(
-            "generator_entries_must_be_canonical_field_residues",
-            "generator entries must be canonical field residues",
-        )
-    return width
-
-
 def _validate_coordinate_axis(
     coordinate_axis: tuple[OpaqueLabel, ...],
     *,

--- a/src/jacobian/math/combinatorics/codes/linear/operations.py
+++ b/src/jacobian/math/combinatorics/codes/linear/operations.py
@@ -29,14 +29,46 @@ from jacobian.math.combinatorics.codes.linear._models import (
     _require_selected_coordinate,
     _threshold_matches_distance,
     _validate_coordinate_axis,
-    _validate_prime_matrix,
 )
-from jacobian.math.combinatorics.codes.linear.values import PrimeFieldLinearEncoder
+from jacobian.math.combinatorics.codes.linear.values import (
+    MAX_LINEAR_CODE_LENGTH,
+    PrimeFieldLinearEncoder,
+)
 from jacobian.math.matrices.finite_fields.linear_algebra import (
     PrimeFieldMatrix,
     _nullspace_admitted,
     _rref_admitted,
 )
+
+
+def _validate_prime_matrix(
+    field_order: int, generator_matrix: tuple[tuple[int, ...], ...]
+) -> int:
+    """Admit one generator matrix over a prime field."""
+
+    from sympy import isprime
+
+    if not isprime(field_order):
+        raise PydanticCustomError(
+            "code_linear.field_order_must_be_prime", "field_order must be prime"
+        )
+    width = len(generator_matrix[0])
+    if width == 0 or width > MAX_LINEAR_CODE_LENGTH:
+        raise PydanticCustomError(
+            "code_linear.generator_rows_length", "generator rows have invalid length"
+        )
+    if any(len(row) != width for row in generator_matrix):
+        raise PydanticCustomError(
+            "code_linear.generator_matrix_rows_must_have_equal_length",
+            "generator matrix rows must have equal length",
+        )
+    if any(not 0 <= entry < field_order for row in generator_matrix for entry in row):
+        raise PydanticCustomError(
+            "code_linear.generator_entries_must_be_canonical_field_residues",
+            "generator entries must be canonical field residues",
+        )
+    return width
+
 
 __all__ = [
     "code_equal",

--- a/src/jacobian/math/combinatorics/codes/nonlinear/__init__.py
+++ b/src/jacobian/math/combinatorics/codes/nonlinear/__init__.py
@@ -5,6 +5,10 @@ from jacobian.math.combinatorics.codes.nonlinear.operations import (
     constant_weight_profile,
     explicit_profile,
     to_set_system,
+    verify_constant_weight_profile,
+    verify_distance_witness,
+    verify_explicit_profile,
+    verify_word_distance,
     word_distance,
 )
 from jacobian.math.combinatorics.codes.nonlinear.values import ExplicitBinaryCode
@@ -15,5 +19,9 @@ __all__: list[str] = [
     "constant_weight_profile",
     "explicit_profile",
     "to_set_system",
+    "verify_constant_weight_profile",
+    "verify_distance_witness",
+    "verify_explicit_profile",
+    "verify_word_distance",
     "word_distance",
 ]

--- a/src/jacobian/math/combinatorics/codes/nonlinear/_models.py
+++ b/src/jacobian/math/combinatorics/codes/nonlinear/_models.py
@@ -329,49 +329,6 @@ class ToSetSystemRequest(StrictModel):
     code: ExplicitBinaryCode
 
 
-class ToSetSystemResult(StrictModel):
-    """Exact source-indexed support blocks under the declared coordinate axis."""
-
-    source: ExplicitBinaryCode
-    length: ExplicitLength
-    cardinality: StrictNonnegativeInt
-    coordinate_axis: tuple[Coordinate, ...] = Field(max_length=MAX_EXPLICIT_CODE_LENGTH)
-    supports: tuple[tuple[Coordinate, ...], ...]
-
-    @model_validator(mode="after")
-    def require_structural_support_relations(self) -> Self:
-        if self.length != self.source.length:
-            raise _validation_error(
-                "nonlinear_code.length_mismatch",
-                "length must equal the retained source length",
-            )
-        if self.cardinality != len(self.source.codewords):
-            raise _validation_error(
-                "nonlinear_code.cardinality_mismatch",
-                "cardinality must equal the retained source cardinality",
-            )
-        if len(self.coordinate_axis) != self.length:
-            raise _validation_error(
-                "nonlinear_code.coordinate_axis_length",
-                "coordinate_axis must have one coordinate per source position",
-            )
-        if self.coordinate_axis != tuple(range(self.length)):
-            raise _validation_error(
-                "nonlinear_code.coordinate_axis_mismatch",
-                "coordinate_axis must equal the source's zero-based coordinate axis",
-            )
-        if len(self.supports) != self.cardinality:
-            raise _validation_error(
-                "nonlinear_code.support_count_mismatch",
-                "supports must have one block per source word",
-            )
-        return self
-
-    @classmethod
-    def _from_kernel(cls, **kwargs: Any) -> Self:
-        return cls.model_construct(**kwargs)
-
-
 __all__ = [
     "BinaryCodeDistanceWitness",
     "ConstantWeightProfileRequest",
@@ -381,7 +338,6 @@ __all__ = [
     "ExplicitProfileRequest",
     "ExplicitProfileResult",
     "ToSetSystemRequest",
-    "ToSetSystemResult",
     "WordDistanceRequest",
     "WordDistanceResult",
 ]

--- a/src/jacobian/math/combinatorics/codes/nonlinear/_tools.py
+++ b/src/jacobian/math/combinatorics/codes/nonlinear/_tools.py
@@ -14,7 +14,6 @@ from jacobian.math.combinatorics.codes.nonlinear._models import (
     ExplicitProfileRequest,
     ExplicitProfileResult,
     ToSetSystemRequest,
-    ToSetSystemResult,
     WordDistanceRequest,
     WordDistanceResult,
 )
@@ -25,6 +24,7 @@ from jacobian.math.combinatorics.codes.nonlinear.operations import (
     to_set_system,
     word_distance,
 )
+from jacobian.math.combinatorics.extremal_sets.values import IndexedFiniteSetFamily
 
 
 def _constant_weight(request: ConstantWeightRequest) -> ConstantWeightResult:
@@ -45,7 +45,7 @@ def _constant_weight_profile(
     return constant_weight_profile(request.code)
 
 
-def _to_set_system(request: ToSetSystemRequest) -> ToSetSystemResult:
+def _to_set_system(request: ToSetSystemRequest) -> IndexedFiniteSetFamily:
     return to_set_system(request.code)
 
 
@@ -129,7 +129,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         title="Map codewords to support subsets",
         description="Map each canonical source codeword to its exact support block on the retained coordinate axis.",
         request_type=ToSetSystemRequest,
-        result_type=ToSetSystemResult,
+        result_type=IndexedFiniteSetFamily,
         run=_to_set_system,
         tags=("code", "set-system", "exact"),
         examples=(

--- a/src/jacobian/math/combinatorics/codes/nonlinear/operations.py
+++ b/src/jacobian/math/combinatorics/codes/nonlinear/operations.py
@@ -294,6 +294,120 @@ def constant_weight_profile(code: ExplicitBinaryCode) -> ConstantWeightProfileRe
     )
 
 
+def verify_word_distance(claim: WordDistanceResult) -> bool:
+    """Check the Hamming relation of two retained words without profiling.
+
+    Recomputes distance, differing coordinates, weights, and support
+    intersection directly from the claimed words in linear time.
+    """
+    if not claim.word1 or len(claim.word1) != len(claim.word2):
+        return False
+    distance, differing, weight1, weight2, intersection = _word_distance_data(
+        claim.word1, claim.word2
+    )
+    return (
+        claim.distance == distance
+        and claim.differing_coordinates == differing
+        and claim.weight1 == weight1
+        and claim.weight2 == weight2
+        and claim.support_intersection == intersection
+    )
+
+
+def verify_distance_witness(
+    code: ExplicitBinaryCode, witness: BinaryCodeDistanceWitness
+) -> bool:
+    """Check one witness is bound to its code with correct Hamming metadata."""
+    if witness.left_index == witness.right_index:
+        return False
+    if not (
+        0 <= witness.left_index < len(code.codewords)
+        and 0 <= witness.right_index < len(code.codewords)
+    ):
+        return False
+    left_word = code.codewords[witness.left_index]
+    right_word = code.codewords[witness.right_index]
+    if witness.left_word != left_word or witness.right_word != right_word:
+        return False
+    left_support = tuple(i for i, bit in enumerate(left_word) if bit)
+    right_support = tuple(i for i, bit in enumerate(right_word) if bit)
+    if witness.left_support != left_support or witness.right_support != right_support:
+        return False
+    distance, differing, left_weight, right_weight, intersection = _word_distance_data(
+        left_word, right_word
+    )
+    return (
+        witness.differing_coordinates == differing
+        and witness.left_weight == left_weight
+        and witness.right_weight == right_weight
+        and witness.support_intersection == intersection
+        and witness.distance == distance
+    )
+
+
+def _verify_profile_extrema(
+    code: ExplicitBinaryCode,
+    *,
+    pair_count: int,
+    minimum_distance: int | None,
+    maximum_distance: int | None,
+    minimum_distance_witness: BinaryCodeDistanceWitness | None,
+    maximum_distance_witness: BinaryCodeDistanceWitness | None,
+) -> bool:
+    """Check extremum presence and witness bindings without reprofiling."""
+    if pair_count == 0:
+        return (
+            minimum_distance is None
+            and maximum_distance is None
+            and minimum_distance_witness is None
+            and maximum_distance_witness is None
+        )
+    if (
+        minimum_distance is None
+        or maximum_distance is None
+        or minimum_distance_witness is None
+        or maximum_distance_witness is None
+    ):
+        return False
+    return (
+        verify_distance_witness(code, minimum_distance_witness)
+        and minimum_distance_witness.distance == minimum_distance
+        and verify_distance_witness(code, maximum_distance_witness)
+        and maximum_distance_witness.distance == maximum_distance
+    )
+
+
+def verify_explicit_profile(claim: ExplicitProfileResult) -> bool:
+    """Check a profile's extremum witnesses against its retained source."""
+    return _verify_profile_extrema(
+        claim.source,
+        pair_count=claim.pair_count,
+        minimum_distance=claim.minimum_distance,
+        maximum_distance=claim.maximum_distance,
+        minimum_distance_witness=claim.minimum_distance_witness,
+        maximum_distance_witness=claim.maximum_distance_witness,
+    )
+
+
+def verify_constant_weight_profile(claim: ConstantWeightProfileResult) -> bool:
+    """Check a constant-weight profile's extremum witnesses and weight."""
+    if not claim.source.codewords:
+        return False
+    weight = sum(claim.source.codewords[0])
+    if claim.weight != weight or any(
+        sum(word) != weight for word in claim.source.codewords
+    ):
+        return False
+    return _verify_profile_extrema(
+        claim.source,
+        pair_count=claim.pair_count,
+        minimum_distance=claim.minimum_distance,
+        maximum_distance=claim.maximum_distance,
+        minimum_distance_witness=claim.minimum_distance_witness,
+        maximum_distance_witness=claim.maximum_distance_witness,
+    )
+
+
 def to_set_system(code: ExplicitBinaryCode) -> IndexedFiniteSetFamily:
     """Map binary words to subsets of the retained coordinate axis [length].
 
@@ -313,5 +427,9 @@ __all__ = [
     "constant_weight_profile",
     "explicit_profile",
     "to_set_system",
+    "verify_constant_weight_profile",
+    "verify_distance_witness",
+    "verify_explicit_profile",
+    "verify_word_distance",
     "word_distance",
 ]

--- a/src/jacobian/math/combinatorics/codes/nonlinear/operations.py
+++ b/src/jacobian/math/combinatorics/codes/nonlinear/operations.py
@@ -16,13 +16,13 @@ from jacobian.math.combinatorics.codes.nonlinear._models import (
     ConstantWeightProfileResult,
     ConstantWeightResult,
     ExplicitProfileResult,
-    ToSetSystemResult,
     WordDistanceResult,
 )
 from jacobian.math.combinatorics.codes.nonlinear.values import (
     BinaryWord,
     ExplicitBinaryCode,
 )
+from jacobian.math.combinatorics.extremal_sets.values import IndexedFiniteSetFamily
 
 
 @dataclass(frozen=True, slots=True)
@@ -294,14 +294,15 @@ def constant_weight_profile(code: ExplicitBinaryCode) -> ConstantWeightProfileRe
     )
 
 
-def to_set_system(code: ExplicitBinaryCode) -> ToSetSystemResult:
-    """Native support conversion for one canonical explicit binary code."""
-    return ToSetSystemResult._from_kernel(
-        source=code,
-        length=code.length,
-        cardinality=len(code.codewords),
-        coordinate_axis=tuple(range(code.length)),
-        supports=tuple(
+def to_set_system(code: ExplicitBinaryCode) -> IndexedFiniteSetFamily:
+    """Map binary words to subsets of the retained coordinate axis [length].
+
+    The source's bounded bit table admits a single support scan. Word order
+    becomes the target member index; empty words and codes retain [length].
+    """
+    return IndexedFiniteSetFamily(
+        ground_set_size=code.length,
+        members=tuple(
             tuple(i for i, bit in enumerate(word) if bit) for word in code.codewords
         ),
     )

--- a/src/jacobian/math/combinatorics/designs/latin_squares/__init__.py
+++ b/src/jacobian/math/combinatorics/designs/latin_squares/__init__.py
@@ -4,6 +4,14 @@ from jacobian.math.combinatorics.designs.latin_squares.operations import (
     is_latin_square,
     orthogonality_profile,
     transpose,
+    verify_latin_square_check,
+    verify_orthogonality,
 )
 
-__all__ = ["is_latin_square", "orthogonality_profile", "transpose"]
+__all__ = [
+    "is_latin_square",
+    "orthogonality_profile",
+    "transpose",
+    "verify_latin_square_check",
+    "verify_orthogonality",
+]

--- a/src/jacobian/math/combinatorics/designs/latin_squares/_models.py
+++ b/src/jacobian/math/combinatorics/designs/latin_squares/_models.py
@@ -85,10 +85,17 @@ class OrthogonalityRequest(StrictModel):
 
 
 class LatinSquareCheckResult(StrictModel):
+    """A Latin-property claim bound to the candidate matrix it concerns."""
+
+    square: LatinSquareCandidate
     is_latin: bool
 
 
 class OrthogonalityResult(StrictModel):
+    """An orthogonality claim bound to its two aligned Latin-square carriers."""
+
+    square_a: LatinSquare
+    square_b: LatinSquare
     is_orthogonal: bool
     pair_count: int = Field(ge=0)
 

--- a/src/jacobian/math/combinatorics/designs/latin_squares/_models.py
+++ b/src/jacobian/math/combinatorics/designs/latin_squares/_models.py
@@ -30,30 +30,8 @@ def _validate_square_matrix(
         raise _validation_error("cell_range", "cell values must be in 0..order-1")
 
 
-def _validate_latin_property(
-    order: int,
-    cells: tuple[tuple[int, ...], ...],
-) -> None:
-    """Validate that each symbol 0..order-1 appears exactly once per row and column."""
-    if order == 0:
-        return
-    expected = set(range(order))
-    for i in range(order):
-        if set(cells[i]) != expected:
-            raise _validation_error(
-                "row_symbols", f"row {i} does not contain each symbol exactly once"
-            )
-    for j in range(order):
-        if {cells[i][j] for i in range(order)} != expected:
-            raise _validation_error(
-                "column_symbols",
-                f"column {j} does not contain each symbol exactly once",
-            )
-
-
 class LatinSquare(StrictModel):
-    """A validated Latin square: an n x n matrix of symbols 0..n-1
-    where each symbol appears exactly once in every row and column."""
+    """An n x n symbol matrix whose Latin property is admitted by consumers."""
 
     order: int = Field(ge=1, le=MAX_LATIN_SQUARE_ORDER)
     cells: tuple[tuple[int, ...], ...] = Field(
@@ -63,7 +41,6 @@ class LatinSquare(StrictModel):
     @model_validator(mode="after")
     def require_valid(self) -> Self:
         _validate_square_matrix(self.order, self.cells)
-        _validate_latin_property(self.order, self.cells)
         return self
 
 

--- a/src/jacobian/math/combinatorics/designs/latin_squares/_tools.py
+++ b/src/jacobian/math/combinatorics/designs/latin_squares/_tools.py
@@ -19,7 +19,10 @@ from jacobian.math.combinatorics.designs.latin_squares.operations import (
 
 
 def compute_latin_square_check(request: LatinSquareRequest) -> LatinSquareCheckResult:
-    return LatinSquareCheckResult(is_latin=is_latin_square(request.square))
+    return LatinSquareCheckResult(
+        square=request.square,
+        is_latin=is_latin_square(request.square),
+    )
 
 
 def compute_orthogonality(request: OrthogonalityRequest) -> OrthogonalityResult:
@@ -27,6 +30,8 @@ def compute_orthogonality(request: OrthogonalityRequest) -> OrthogonalityResult:
         request.square_a, request.square_b
     )
     return OrthogonalityResult(
+        square_a=request.square_a,
+        square_b=request.square_b,
         is_orthogonal=is_orthogonal,
         pair_count=pair_count,
     )

--- a/src/jacobian/math/combinatorics/designs/latin_squares/operations.py
+++ b/src/jacobian/math/combinatorics/designs/latin_squares/operations.py
@@ -23,7 +23,7 @@ def _square_cells(square: LatinSquare | LatinSquareCandidate) -> int:
     return square.order * square.order
 
 
-def is_latin_square(square: LatinSquareCandidate) -> bool:
+def is_latin_square(square: LatinSquareCandidate | LatinSquare) -> bool:
     """Return whether every row and column contains every symbol once."""
 
     cells = _square_cells(square)
@@ -59,6 +59,8 @@ def orthogonality_profile(
             "orthogonality_pair_cells_exceeded",
             "orthogonality check exceeds the distinct-pair memory budget",
         )
+    _admit_latin_square(left)
+    _admit_latin_square(right)
     # Symbols already lie in ``range(order)``, so the aligned pair has a dense
     # integer address.  A byte table keeps the complete positive-decision
     # envelope bounded without paying Python tuple/set overhead for each pair.
@@ -83,6 +85,7 @@ def transpose(square: LatinSquare) -> LatinSquare:
             "transpose_cells_exceeded",
             "Latin-square transpose exceeds the source-cell work budget",
         )
+    _admit_latin_square(square)
     # The transpose of a Latin square is Latin, so construct the canonical
     # carrier without re-running the Latin-property validator.
     return LatinSquare.model_construct(
@@ -92,6 +95,16 @@ def transpose(square: LatinSquare) -> LatinSquare:
             for column in range(square.order)
         ),
     )
+
+
+def _admit_latin_square(square: LatinSquare) -> None:
+    """Establish the Latin claim within the existing quadratic cell envelope."""
+    if not is_latin_square(square):
+        _reject(
+            ("square", "cells"),
+            "not_latin",
+            "each row and column must contain every symbol once",
+        )
 
 
 __all__ = ["is_latin_square", "orthogonality_profile", "transpose"]

--- a/src/jacobian/math/combinatorics/designs/latin_squares/operations.py
+++ b/src/jacobian/math/combinatorics/designs/latin_squares/operations.py
@@ -4,6 +4,8 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.designs.latin_squares._models import (
     LatinSquare,
     LatinSquareCandidate,
+    LatinSquareCheckResult,
+    OrthogonalityResult,
 )
 
 MAX_LATIN_CHECK_CELLS = 1_048_576
@@ -107,4 +109,23 @@ def _admit_latin_square(square: LatinSquare) -> None:
         )
 
 
-__all__ = ["is_latin_square", "orthogonality_profile", "transpose"]
+def verify_latin_square_check(claim: LatinSquareCheckResult) -> bool:
+    """Check the Latin-property relation carried by one result."""
+
+    return claim.is_latin is is_latin_square(claim.square)
+
+
+def verify_orthogonality(claim: OrthogonalityResult) -> bool:
+    """Check the aligned-pair relation carried by one result."""
+
+    is_orthogonal, pair_count = orthogonality_profile(claim.square_a, claim.square_b)
+    return claim.is_orthogonal is is_orthogonal and claim.pair_count == pair_count
+
+
+__all__ = [
+    "is_latin_square",
+    "orthogonality_profile",
+    "transpose",
+    "verify_latin_square_check",
+    "verify_orthogonality",
+]

--- a/src/jacobian/math/combinatorics/exact_cover.py
+++ b/src/jacobian/math/combinatorics/exact_cover.py
@@ -337,6 +337,26 @@ def _solve_generalized_exact_cover(
     )
 
 
+def verify_generalized_exact_cover(claim: GeneralizedExactCoverResult) -> bool:
+    """Check a FOUND claim's coverage relation against its retained instance.
+
+    Verifies selected-row binding, primary exact coverage, secondary
+    at-most-once coverage, and the reconstructed multiplicity profile
+    without rerunning the search. Only FOUND claims are verifiable:
+    NO_COVER and UNKNOWN are producer outcomes, not reusable claims, so
+    they do not verify.
+    """
+    if claim.status != "FOUND":
+        return False
+    if claim.selected_row_ids is None or claim.item_multiplicities is None:
+        return False
+    try:
+        expected = _expected_coverage(claim.instance, claim.selected_row_ids)
+    except PydanticCustomError:
+        return False
+    return tuple(claim.item_multiplicities) == expected
+
+
 def find_generalized_exact_cover(
     instance: GeneralizedExactCoverInstance,
     *,
@@ -383,4 +403,5 @@ __all__ = [
     "GeneralizedExactCoverInstance",
     "GeneralizedExactCoverResult",
     "find_generalized_exact_cover",
+    "verify_generalized_exact_cover",
 ]

--- a/src/jacobian/math/combinatorics/extremal_sets/_models.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/_models.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pydantic import Field
 
 from jacobian._models import StrictModel
-from jacobian.math.combinatorics.codes.nonlinear._models import ToSetSystemResult
 from jacobian.math.combinatorics.extremal_sets.values import (
     MAX_FAMILY_SIZE,
     IndexedFiniteSetFamily,
@@ -19,7 +18,7 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 class BinaryUnionRelationRequest(StrictModel):
     """Request to compute the binary-union relation of an indexed family."""
 
-    source: IndexedFiniteSetFamily | ToSetSystemResult
+    source: IndexedFiniteSetFamily
 
 
 class UnionRelationRow(StrictModel):

--- a/src/jacobian/math/combinatorics/extremal_sets/operations.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/operations.py
@@ -5,18 +5,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.combinatorics.codes.nonlinear._models import ToSetSystemResult
 from jacobian.math.combinatorics.extremal_sets._models import (
     BinaryUnionRelationResult,
     UnionRelationRow,
 )
 from jacobian.math.combinatorics.extremal_sets.values import (
-    MAX_FAMILY_SIZE,
     IndexedFiniteSetFamily,
 )
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     MAX_EDGES,
     MAX_TOTAL_INCIDENCES,
+    MAX_VERTICES,
     FiniteHypergraph,
 )
 
@@ -31,11 +30,10 @@ class _UnionRelationPlan:
 
 
 def construct_binary_union_relation(
-    source: IndexedFiniteSetFamily | ToSetSystemResult,
+    source: IndexedFiniteSetFamily,
 ) -> BinaryUnionRelationResult:
     """Return every distinct-member equation ``S_i union S_j = S_k``."""
 
-    source = _canonical_source(source)
     plan = _admit_union_relation(source)
     rows = tuple(
         UnionRelationRow(
@@ -61,51 +59,13 @@ def construct_binary_union_relation(
     )
 
 
-def _canonical_source(
-    source: IndexedFiniteSetFamily | ToSetSystemResult,
-) -> IndexedFiniteSetFamily:
-    """Convert the code-support producer's value to the shared family type."""
-    if isinstance(source, ToSetSystemResult):
-        if len(source.supports) > MAX_FAMILY_SIZE:
-            raise OperationDomainValidationError(
-                location=("source",),
-                code="set_system.binary_union_relation.family_exceeds_carrier",
-                message=(
-                    f"the source family exceeds the {MAX_FAMILY_SIZE}-vertex "
-                    "relation carrier"
-                ),
-            )
-        if any(
-            support != tuple(sorted(set(support)))
-            or any(not 0 <= element < source.length for element in support)
-            for support in source.supports
-        ):
-            raise OperationDomainValidationError(
-                location=("source", "supports"),
-                code="set_system.binary_union_relation.noncanonical_supports",
-                message=(
-                    "code supports must be strictly increasing distinct coordinates "
-                    "within the declared axis"
-                ),
-            )
-        expected_supports = tuple(
-            tuple(index for index, bit in enumerate(word) if bit == 1)
-            for word in source.source.codewords
-        )
-        if source.supports != expected_supports:
-            raise OperationDomainValidationError(
-                location=("source", "supports"),
-                code="set_system.binary_union_relation.support_source_mismatch",
-                message="code supports must equal the retained codeword supports",
-            )
-        return IndexedFiniteSetFamily(
-            ground_set_size=source.length,
-            members=expected_supports,
-        )
-    return source
-
-
 def _admit_union_relation(source: IndexedFiniteSetFamily) -> _UnionRelationPlan:
+    if len(source.members) > MAX_VERTICES:
+        raise OperationDomainValidationError(
+            location=("source",),
+            code="set_system.binary_union_relation.family_exceeds_carrier",
+            message=f"the source family exceeds the {MAX_VERTICES}-vertex relation carrier",
+        )
     member_sizes = tuple(len(member) for member in source.members)
     membership_work = (len(source.members) + 1) * sum(member_sizes)
     generated_union_work = sum(

--- a/src/jacobian/math/combinatorics/extremal_sets/values.py
+++ b/src/jacobian/math/combinatorics/extremal_sets/values.py
@@ -8,12 +8,11 @@ from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
-    MAX_VERTICES,
-)
 
 MAX_GROUND_SET_SIZE = (1 << 53) - 1
-MAX_FAMILY_SIZE = MAX_VERTICES
+# Representation includes the bounded explicit-code support map. Operations
+# producing hypergraphs admit their own smaller vertex envelope before work.
+MAX_FAMILY_SIZE = 1 << 19
 
 
 def _value_error(reason: str, message: str) -> PydanticCustomError:

--- a/src/jacobian/math/combinatorics/matroids/delta/__init__.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/__init__.py
@@ -1,6 +1,9 @@
 """Supported native API for exact finite delta-matroids."""
 
-from jacobian.math.combinatorics.matroids.delta.operations import from_feasible_sets
+from jacobian.math.combinatorics.matroids.delta.operations import (
+    from_feasible_sets,
+    verify_from_feasible_sets,
+)
 from jacobian.math.combinatorics.matroids.delta.values import FiniteDeltaMatroid
 
-__all__ = ["FiniteDeltaMatroid", "from_feasible_sets"]
+__all__ = ["FiniteDeltaMatroid", "from_feasible_sets", "verify_from_feasible_sets"]

--- a/src/jacobian/math/combinatorics/matroids/delta/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/operations.py
@@ -12,7 +12,7 @@ from jacobian.math.combinatorics.matroids.delta.values import (
     require_delta_matroid_admission,
 )
 
-__all__ = ["from_feasible_sets"]
+__all__ = ["from_feasible_sets", "verify_from_feasible_sets"]
 
 
 def from_feasible_sets(
@@ -30,4 +30,24 @@ def from_feasible_sets(
     return DeltaMatroidRecognitionResult._from_kernel(
         system,
         delta_matroid=FiniteDeltaMatroid._from_kernel(system),
+    )
+
+
+def verify_from_feasible_sets(claim: DeltaMatroidRecognitionResult) -> bool:
+    """Return whether a recognition claim matches its retained feasible family."""
+    try:
+        require_delta_matroid_admission(claim.source)
+    except ValueError:
+        return False
+    obstruction = first_symmetric_exchange_obstruction(claim.source)
+    if obstruction is not None:
+        return (
+            claim.status == "NOT_A_DELTA_MATROID"
+            and claim.delta_matroid is None
+            and claim.obstruction == obstruction
+        )
+    return (
+        claim.status == "DELTA_MATROID"
+        and claim.obstruction is None
+        and claim.delta_matroid == FiniteDeltaMatroid._from_kernel(claim.source)
     )

--- a/src/jacobian/math/combinatorics/matroids/oriented/__init__.py
+++ b/src/jacobian/math/combinatorics/matroids/oriented/__init__.py
@@ -1,5 +1,8 @@
 """Bounded exact operations on finite oriented-matroid data."""
 
-from jacobian.math.combinatorics.matroids.oriented.operations import check_chirotope
+from jacobian.math.combinatorics.matroids.oriented.operations import (
+    check_chirotope,
+    verify_chirotope_check,
+)
 
-__all__: list[str] = ["check_chirotope"]
+__all__: list[str] = ["check_chirotope", "verify_chirotope_check"]

--- a/src/jacobian/math/combinatorics/matroids/oriented/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/oriented/_models.py
@@ -147,8 +147,8 @@ class ChirotopeCheckResult(StrictModel):
     chirotope: UniformRank3Chirotope
     status: ChirotopeCheckStatus = Field(
         description=(
-            "VALID after every B2 ordered-triple pair passes, or the first B2 "
-            "obstruction in lexicographic order."
+            "VALID after every B2 ordered-triple pair passes, or a retained B2 "
+            "obstruction."
         )
     )
     b2_exchange_instances_checked: StrictInt = Field(

--- a/src/jacobian/math/combinatorics/matroids/oriented/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/oriented/operations.py
@@ -134,4 +134,41 @@ def check_chirotope(chirotope: UniformRank3Chirotope) -> ChirotopeCheckResult:
     return _compute_result(chirotope)
 
 
-__all__ = ["check_chirotope"]
+def verify_chirotope_check(claim: ChirotopeCheckResult) -> bool:
+    """Check the B2 relation relied on by one serialized checker result.
+
+    A negative result carries a local failed B2 instance, so it can be checked
+    directly from the retained chirotope table. ``VALID`` asserts that no such
+    instance exists and therefore needs the operation's bounded exhaustive
+    scan.
+    """
+
+    if claim.status is ChirotopeCheckStatus.VALID:
+        return _compute_result(claim.chirotope) == claim
+
+    obstruction = claim.obstruction
+    if obstruction is None:
+        return False
+    table = _table(claim.chirotope)
+    x1, x2, x3 = obstruction.x
+    y1, y2, y3 = obstruction.y
+    values = _alternating_value
+    premise_factors = (
+        (values(table, (y1, x2, x3)), values(table, (x1, y2, y3))),
+        (values(table, (y2, x2, x3)), values(table, (y1, x1, y3))),
+        (values(table, (y3, x2, x3)), values(table, (y1, y2, x1))),
+    )
+    conclusion_factors = (values(table, obstruction.x), values(table, obstruction.y))
+    premise_products = tuple(left * right for left, right in premise_factors)
+    conclusion_product = conclusion_factors[0] * conclusion_factors[1]
+    return (
+        obstruction.premise_factors == premise_factors
+        and obstruction.premise_products == premise_products
+        and obstruction.conclusion_factors == conclusion_factors
+        and obstruction.conclusion_product == conclusion_product
+        and all(product >= 0 for product in premise_products)
+        and conclusion_product < 0
+    )
+
+
+__all__ = ["check_chirotope", "verify_chirotope_check"]

--- a/src/jacobian/math/finite_dim_algebras/__init__.py
+++ b/src/jacobian/math/finite_dim_algebras/__init__.py
@@ -1,5 +1,5 @@
 """Finite-dimensional algebra operations."""
 
-from jacobian.math.finite_dim_algebras.operations import center_basis
+from jacobian.math.finite_dim_algebras.operations import center_basis, verify_center
 
-__all__ = ["center_basis"]
+__all__ = ["center_basis", "verify_center"]

--- a/src/jacobian/math/finite_dim_algebras/_models.py
+++ b/src/jacobian/math/finite_dim_algebras/_models.py
@@ -8,6 +8,7 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.math.matrices.finite_fields.linear_algebra import PrimeFieldMatrix
 
 # Bound dense structure-tensor materialization before Pydantic validation.
 # Dimension 137 retains 2,571,353 scalar cells; the next dimension crosses the
@@ -109,39 +110,36 @@ class CenterRequest(StrictModel):
 
 
 class CenterResult(StrictModel):
+    """A claimed center basis on the retained algebra's prime-field coordinates."""
+
     algebra: StructureConstants
-    center_basis: tuple[tuple[int, ...], ...] = Field(max_length=MAX_DIM)
-    dimension: int = Field(ge=1, le=MAX_DIM)
-    center_dimension: int = Field(ge=0, le=MAX_DIM)
+    basis_matrix: PrimeFieldMatrix
+
+    @property
+    def dimension(self) -> int:
+        return self.algebra.dimension
+
+    @property
+    def center_dimension(self) -> int:
+        return len(self.basis_matrix.entries)
+
+    @property
+    def center_basis(self) -> tuple[tuple[int, ...], ...]:
+        return self.basis_matrix.entries
 
     @model_validator(mode="after")
     def require_complete_basis_shape(self) -> Self:
-        if self.dimension != self.algebra.dimension:
-            raise _validation_error(
-                "center_parent_dimension", "dimension must match the source algebra"
-            )
-        if any(
-            not 0 <= value < self.algebra.field_order
-            for vector in self.center_basis
-            for value in vector
+        if (
+            self.basis_matrix.prime != self.algebra.field_order
+            or self.basis_matrix.columns != self.algebra.dimension
         ):
             raise _validation_error(
-                "center_noncanonical_residue",
-                "center coordinates must be canonical residues of the source field",
+                "center_parent_axis",
+                "center basis must retain the algebra field and coordinate axis",
             )
-        if len(self.center_basis) != self.center_dimension:
-            raise _validation_error(
-                "center_dimension_mismatch",
-                "center_dimension must equal the number of basis vectors",
-            )
-        if any(len(vector) != self.dimension for vector in self.center_basis):
-            raise _validation_error(
-                "center_basis_shape",
-                "every center basis vector must match the algebra dimension",
-            )
-        if self.center_dimension * self.dimension > MAX_CENTER_BASIS_ENTRIES:
+        if self.center_dimension > self.dimension:
             raise _validation_error(
                 "center_basis_budget",
-                "center basis exceeds the exact output budget",
+                "center basis cannot exceed the ambient dimension",
             )
         return self

--- a/src/jacobian/math/finite_dim_algebras/_tools.py
+++ b/src/jacobian/math/finite_dim_algebras/_tools.py
@@ -8,15 +8,18 @@ from jacobian.math.finite_dim_algebras._models import (
     CenterResult,
 )
 from jacobian.math.finite_dim_algebras.operations import center_basis
+from jacobian.math.matrices.finite_fields.linear_algebra import PrimeFieldMatrix
 
 
 def compute_center(request: CenterRequest) -> CenterResult:
     basis = center_basis(request.algebra)
     return CenterResult(
         algebra=request.algebra,
-        center_basis=basis,
-        dimension=request.algebra.dimension,
-        center_dimension=len(basis),
+        basis_matrix=PrimeFieldMatrix(
+            prime=request.algebra.field_order,
+            entries=basis,
+            columns=request.algebra.dimension,
+        ),
     )
 
 

--- a/src/jacobian/math/finite_dim_algebras/operations.py
+++ b/src/jacobian/math/finite_dim_algebras/operations.py
@@ -1,7 +1,7 @@
 """Exact finite-dimensional algebra operations."""
 
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.finite_dim_algebras._models import StructureConstants
+from jacobian.math.finite_dim_algebras._models import CenterResult, StructureConstants
 
 
 def _admit_center(algebra: StructureConstants) -> None:
@@ -56,4 +56,30 @@ def center_basis(algebra: StructureConstants) -> tuple[tuple[int, ...], ...]:
     )
 
 
-__all__ = ["center_basis"]
+def verify_center(claim: CenterResult) -> bool:
+    """Check independence and equality with the full center, allowing any basis.
+
+    Center admission bounds the commutator work by n^4. Two further matrices
+    have at most 2n rows and n columns, within that same elimination envelope.
+    """
+    from flint import nmod_mat
+
+    expected = center_basis(claim.algebra)
+    if len(expected) != claim.center_dimension:
+        return False
+    dimension = claim.dimension
+    prime = claim.algebra.field_order
+
+    def rank(rows: tuple[tuple[int, ...], ...]) -> int:
+        return int(
+            nmod_mat(
+                len(rows), dimension, [value for row in rows for value in row], prime
+            ).rank()
+        )
+
+    return rank(claim.center_basis) == len(expected) and rank(
+        (*expected, *claim.center_basis)
+    ) == len(expected)
+
+
+__all__ = ["center_basis", "verify_center"]

--- a/src/jacobian/math/finite_fields/__init__.py
+++ b/src/jacobian/math/finite_fields/__init__.py
@@ -1,5 +1,6 @@
 """Exact finite-field values and explicit restriction-of-scalars operations."""
 
+from jacobian.math.finite_fields._matrix_rank import verify_matrix_rank
 from jacobian.math.finite_fields._matrix_rank_models import MatrixRankResult
 from jacobian.math.finite_fields.operations import (
     analyze_collisions,
@@ -86,4 +87,5 @@ __all__ = [
     "projective_line",
     "projective_point",
     "restrict_scalars",
+    "verify_matrix_rank",
 ]

--- a/src/jacobian/math/finite_fields/_matrix_rank.py
+++ b/src/jacobian/math/finite_fields/_matrix_rank.py
@@ -15,7 +15,7 @@ from jacobian.math.finite_fields._matrix_rank_models import (
     MatrixRankRequest,
     MatrixRankResult,
 )
-from jacobian.math.finite_fields.values import AxisBoundMatrix
+from jacobian.math.finite_fields.values import Axis, AxisBoundMatrix
 
 _MATRIX_RANK_WALL_SECONDS = 600.0
 
@@ -73,4 +73,44 @@ def compute_rank(request: MatrixRankRequest) -> MatrixRankResult:
     return compute_matrix_rank(request.matrix)
 
 
-__all__ = ["compute_matrix_rank", "compute_rank"]
+def verify_matrix_rank(claim: MatrixRankResult) -> bool:
+    """Check rank equality and nonsingularity of the declared pivot minor.
+
+    The native axis carrier bounds each axis by 1024 and the field order by
+    65536. Two eliminations cost at most twice 1024 cubed field operations.
+    They share one field admission and one execution deadline. Any full-rank
+    minor is accepted, independently of the producer's pivot selection.
+    """
+    from jacobian.math.finite_fields._flint import context
+    from jacobian.math.finite_fields._matrix_rank_kernels import (
+        compute_matrix_rank as kernel_rank,
+    )
+
+    checkpoint = partial(_require_deadline, _execution_deadline())
+    checkpoint("before rank claim admission")
+    matrix = claim.matrix
+    active_context = context(matrix.presentation)
+    actual = kernel_rank(
+        matrix, execution_checkpoint=checkpoint, active_context=active_context
+    )
+    if actual.rank != claim.rank:
+        return False
+    rows = {label: i for i, label in enumerate(matrix.row_axis.labels)}
+    columns = {label: i for i, label in enumerate(matrix.column_axis.labels)}
+    minor = AxisBoundMatrix(
+        presentation=matrix.presentation,
+        row_axis=Axis(name=matrix.row_axis.name, labels=claim.pivot_rows),
+        column_axis=Axis(name=matrix.column_axis.name, labels=claim.pivot_columns),
+        entries=tuple(
+            tuple(matrix.entries[rows[r]][columns[c]] for c in claim.pivot_columns)
+            for r in claim.pivot_rows
+        ),
+    )
+    minor_rank = kernel_rank(
+        minor, execution_checkpoint=checkpoint, active_context=active_context
+    )
+    checkpoint("after rank claim verification")
+    return minor_rank.rank == claim.rank
+
+
+__all__ = ["compute_matrix_rank", "compute_rank", "verify_matrix_rank"]

--- a/src/jacobian/math/finite_fields/_matrix_rank_kernels.py
+++ b/src/jacobian/math/finite_fields/_matrix_rank_kernels.py
@@ -29,6 +29,7 @@ def compute_matrix_rank(
     matrix: AxisBoundMatrix,
     *,
     execution_checkpoint: Callable[[str], None] | None = None,
+    active_context: Any = None,
 ) -> MatrixRankData:
     """Compute exact rank and pivot labels over the presented finite field.
 
@@ -42,10 +43,12 @@ def compute_matrix_rank(
     rows = len(matrix.row_axis.labels)
     cols = len(matrix.column_axis.labels)
 
+    if active_context is None:
+        active_context = _backend_context(presentation)
+
     if rows == 0 or cols == 0:
         return MatrixRankData(rank=0, pivot_rows=(), pivot_columns=())
 
-    active_context = _backend_context(presentation)
     zero = active_context.zero()
 
     # Convert entries to maintained backend elements once.

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -579,6 +579,7 @@ class SimplePolygonPointRequest(StrictModel):
 
 
 class PolygonPointClassificationResult(StrictModel):
+    request: SimplePolygonPointRequest
     polygon_vertex_count: StrictInt = Field(ge=3, le=128)
     classification: Literal["INSIDE", "BOUNDARY", "OUTSIDE"]
     boundary_edge_index: StrictInt | None = Field(default=None, ge=0, le=127)

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -533,6 +533,7 @@ class PolygonIntersectionWitness(StrictModel):
 
 
 class SimplePolygonDecisionResult(StrictModel):
+    polygon: PolygonRequest
     vertex_count: StrictInt = Field(ge=3, le=128)
     is_simple: bool
     checked_edge_pairs: StrictInt = Field(ge=0, le=8128)

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -606,6 +606,20 @@ class GeometryBooleanResult(StrictModel):
     holds: bool
 
 
+class CollinearityResult(StrictModel):
+    """A source-bound collinearity claim."""
+
+    request: PointTripleRequest
+    collinear: bool
+
+
+class ConcyclicityResult(StrictModel):
+    """A source-bound concyclicity claim."""
+
+    request: PointQuadrupleRequest
+    concyclic: bool
+
+
 class GeometryRationalResult(StrictModel):
     value: CanonicalRational
 

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -533,7 +533,7 @@ class PolygonIntersectionWitness(StrictModel):
 
 
 class SimplePolygonDecisionResult(StrictModel):
-    polygon: PolygonRequest
+    polygon: tuple[RationalPoint2D, ...]
     vertex_count: StrictInt = Field(ge=3, le=128)
     is_simple: bool
     checked_edge_pairs: StrictInt = Field(ge=0, le=8128)
@@ -579,7 +579,8 @@ class SimplePolygonPointRequest(StrictModel):
 
 
 class PolygonPointClassificationResult(StrictModel):
-    request: SimplePolygonPointRequest
+    polygon: tuple[RationalPoint2D, ...]
+    point: RationalPoint2D
     polygon_vertex_count: StrictInt = Field(ge=3, le=128)
     classification: Literal["INSIDE", "BOUNDARY", "OUTSIDE"]
     boundary_edge_index: StrictInt | None = Field(default=None, ge=0, le=127)
@@ -605,14 +606,19 @@ class PolygonPointClassificationResult(StrictModel):
 class CollinearityResult(StrictModel):
     """A source-bound collinearity claim."""
 
-    request: PointTripleRequest
+    first: RationalPoint2D
+    second: RationalPoint2D
+    third: RationalPoint2D
     collinear: bool
 
 
 class ConcyclicityResult(StrictModel):
     """A source-bound concyclicity claim."""
 
-    request: PointQuadrupleRequest
+    first: RationalPoint2D
+    second: RationalPoint2D
+    third: RationalPoint2D
+    fourth: RationalPoint2D
     concyclic: bool
 
 

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -602,10 +602,6 @@ class PolygonPointClassificationResult(StrictModel):
         return self
 
 
-class GeometryBooleanResult(StrictModel):
-    holds: bool
-
-
 class CollinearityResult(StrictModel):
     """A source-bound collinearity claim."""
 

--- a/src/jacobian/math/geometry/_points.py
+++ b/src/jacobian/math/geometry/_points.py
@@ -3,7 +3,7 @@
 from jacobian.catalog.models import MathTool, MathTools, OperationExample
 from jacobian.math.geometry._models import (
     CircleInversionRequest,
-    GeometryBooleanResult,
+    ConcyclicityResult,
     GeometryConvexHullResult,
     GeometryPointResult,
     GeometryRationalResult,
@@ -49,7 +49,7 @@ POINT_OPERATIONS: MathTools = (
         title="Decide concyclicity",
         description="Decide whether four rational points lie on one circle.",
         request_type=PointQuadrupleRequest,
-        result_type=GeometryBooleanResult,
+        result_type=ConcyclicityResult,
         run=concyclic,
         tags=("geometry", "circle"),
         examples=(

--- a/src/jacobian/math/geometry/_tools.py
+++ b/src/jacobian/math/geometry/_tools.py
@@ -95,7 +95,7 @@ def simple_polygon(request: PolygonRequest) -> SimplePolygonDecisionResult:
 def classify_polygon_point(
     request: SimplePolygonPointRequest,
 ) -> PolygonPointClassificationResult:
-    return _native.classify_polygon_point(request.point, request.polygon.points)
+    return _native.classify_polygon_point(request)
 
 
 def convex_hull_points(request: PointSetRequest) -> GeometryConvexHullResult:

--- a/src/jacobian/math/geometry/_tools.py
+++ b/src/jacobian/math/geometry/_tools.py
@@ -54,11 +54,13 @@ def segment_intersection(
 
 
 def collinear(request: PointTripleRequest) -> CollinearityResult:
-    return _native.collinear(request)
+    return _native.collinear(request.first, request.second, request.third)
 
 
 def concyclic(request: PointQuadrupleRequest) -> ConcyclicityResult:
-    return _native.concyclic(request)
+    return _native.concyclic(
+        request.first, request.second, request.third, request.fourth
+    )
 
 
 def line_intersection(request: LinePairRequest) -> GeometryLineIntersectionResult:
@@ -88,13 +90,13 @@ def signed_area(request: PolygonRequest) -> GeometryRationalResult:
 
 
 def simple_polygon(request: PolygonRequest) -> SimplePolygonDecisionResult:
-    return _native.simple_polygon(request)
+    return _native.simple_polygon(request.points)
 
 
 def classify_polygon_point(
     request: SimplePolygonPointRequest,
 ) -> PolygonPointClassificationResult:
-    return _native.classify_polygon_point(request)
+    return _native.classify_polygon_point(request.polygon.points, request.point)
 
 
 def convex_hull_points(request: PointSetRequest) -> GeometryConvexHullResult:

--- a/src/jacobian/math/geometry/_tools.py
+++ b/src/jacobian/math/geometry/_tools.py
@@ -7,9 +7,10 @@ from jacobian.math.geometry._models import (
     CircumcircleRequest,
     CircumradiusProfileRequest,
     CircumradiusProfileResult,
+    CollinearityResult,
+    ConcyclicityResult,
     GeneralPositionRequest,
     GeneralPositionResult,
-    GeometryBooleanResult,
     GeometryCircleResult,
     GeometryConvexHullResult,
     GeometryLineIntersectionResult,
@@ -52,14 +53,12 @@ def segment_intersection(
     return _native.segment_intersection(request.first, request.second)
 
 
-def collinear(request: PointTripleRequest) -> GeometryBooleanResult:
-    return _native.collinear(request.first, request.second, request.third)
+def collinear(request: PointTripleRequest) -> CollinearityResult:
+    return _native.collinear(request)
 
 
-def concyclic(request: PointQuadrupleRequest) -> GeometryBooleanResult:
-    return _native.concyclic(
-        request.first, request.second, request.third, request.fourth
-    )
+def concyclic(request: PointQuadrupleRequest) -> ConcyclicityResult:
+    return _native.concyclic(request)
 
 
 def line_intersection(request: LinePairRequest) -> GeometryLineIntersectionResult:

--- a/src/jacobian/math/geometry/_tools.py
+++ b/src/jacobian/math/geometry/_tools.py
@@ -89,7 +89,7 @@ def signed_area(request: PolygonRequest) -> GeometryRationalResult:
 
 
 def simple_polygon(request: PolygonRequest) -> SimplePolygonDecisionResult:
-    return _native.simple_polygon(request.points)
+    return _native.simple_polygon(request)
 
 
 def classify_polygon_point(

--- a/src/jacobian/math/geometry/algebraic_curves/_models.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_models.py
@@ -139,6 +139,7 @@ class RationalConicParametrizationRequest(StrictModel):
 
 
 class AffineCurveResult(StrictModel):
+    request: AffineCurveRequest
     is_valid: bool
     degree: int = Field(ge=0, le=_MAX_CURVE_EXPONENT)
 

--- a/src/jacobian/math/geometry/algebraic_curves/_tools.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_tools.py
@@ -32,7 +32,7 @@ from jacobian.math.geometry.algebraic_curves.operations import (
 def compute_affine_curve_check(request: AffineCurveRequest) -> AffineCurveResult:
     """Unpack one request and project the native curve check to its wire result."""
     is_valid, degree = affine_curve_check(request.polynomial)
-    return AffineCurveResult(is_valid=is_valid, degree=degree)
+    return AffineCurveResult(request=request, is_valid=is_valid, degree=degree)
 
 
 def compute_projective_closure(

--- a/src/jacobian/math/geometry/algebraic_curves/_tools.py
+++ b/src/jacobian/math/geometry/algebraic_curves/_tools.py
@@ -35,6 +35,15 @@ def compute_affine_curve_check(request: AffineCurveRequest) -> AffineCurveResult
     return AffineCurveResult(request=request, is_valid=is_valid, degree=degree)
 
 
+def verify_affine_curve_check(claim: AffineCurveResult) -> bool:
+    """Check the affine-curve decision asserted by a serialized claim."""
+
+    return affine_curve_check(claim.request.polynomial) == (
+        claim.is_valid,
+        claim.degree,
+    )
+
+
 def compute_projective_closure(
     request: ProjectiveClosureRequest,
 ) -> ProjectiveClosureResult:

--- a/src/jacobian/math/geometry/euclidean/__init__.py
+++ b/src/jacobian/math/geometry/euclidean/__init__.py
@@ -5,6 +5,15 @@ from jacobian.math.geometry.euclidean.operations import (
     angles_equal,
     squared_segment_ratio,
     triangles_similar,
+    verify_angle_equality,
+    verify_triangle_similarity,
 )
 
-__all__ = ["Triangle", "angles_equal", "squared_segment_ratio", "triangles_similar"]
+__all__ = [
+    "Triangle",
+    "angles_equal",
+    "squared_segment_ratio",
+    "triangles_similar",
+    "verify_angle_equality",
+    "verify_triangle_similarity",
+]

--- a/src/jacobian/math/geometry/euclidean/_models.py
+++ b/src/jacobian/math/geometry/euclidean/_models.py
@@ -33,8 +33,9 @@ class AngleEqualityRequest(StrictModel):
 
 
 class AngleEqualityResult(StrictModel):
-    """Whether the two angles are equal."""
+    """A source-bound claim about equality of two angles."""
 
+    request: AngleEqualityRequest
     equal: bool
 
 
@@ -46,8 +47,9 @@ class TriangleSimilarityRequest(StrictModel):
 
 
 class TriangleSimilarityResult(StrictModel):
-    """Whether the two triangles are similar."""
+    """A source-bound claim about similarity of two triangles."""
 
+    request: TriangleSimilarityRequest
     similar: bool
 
 

--- a/src/jacobian/math/geometry/euclidean/_models.py
+++ b/src/jacobian/math/geometry/euclidean/_models.py
@@ -2,19 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Self
-
-from pydantic import model_validator
-from pydantic_core import PydanticCustomError
-
 from jacobian._models import StrictModel
 from jacobian.math.geometry._models import RationalPoint2D
-
-
-def _validation_error(reason: str, message: str) -> PydanticCustomError:
-    """Build a stable error owned by the geometry contracts."""
-
-    return PydanticCustomError(f"geometry.{reason}", message)
 
 
 class Triangle(StrictModel):
@@ -24,34 +13,12 @@ class Triangle(StrictModel):
     b: RationalPoint2D
     c: RationalPoint2D
 
-    @model_validator(mode="after")
-    def require_non_degenerate(self) -> Self:
-
-        ax, ay = self.a.x.as_fraction(), self.a.y.as_fraction()
-        bx, by = self.b.x.as_fraction(), self.b.y.as_fraction()
-        cx, cy = self.c.x.as_fraction(), self.c.y.as_fraction()
-        # Cross product (b-a) x (c-a) != 0 for non-degenerate
-        cross = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax)
-        if cross == 0:
-            raise _validation_error(
-                "triangle_non_degenerate", "triangle must be non-degenerate"
-            )
-        return self
-
 
 class SegmentRatioRequest(StrictModel):
     """Check if two segments have a given squared length ratio."""
 
     segment1: tuple[RationalPoint2D, RationalPoint2D]
     segment2: tuple[RationalPoint2D, RationalPoint2D]
-
-
-class SegmentRatioResult(StrictModel):
-    """Ratio of squared lengths and whether it matches a target."""
-
-    squared_ratio: str
-    ratio_numerator: str
-    ratio_denominator: str
 
 
 class AngleEqualityRequest(StrictModel):
@@ -89,7 +56,6 @@ __all__ = [
     "AngleEqualityResult",
     "RationalPoint2D",
     "SegmentRatioRequest",
-    "SegmentRatioResult",
     "Triangle",
     "TriangleSimilarityRequest",
     "TriangleSimilarityResult",

--- a/src/jacobian/math/geometry/euclidean/_tools.py
+++ b/src/jacobian/math/geometry/euclidean/_tools.py
@@ -1,12 +1,11 @@
 """Euclidean-geometry operation declarations."""
 
-from jacobian._exact import format_canonical_rational
+from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import MathTool, MathTools, OperationExample
 from jacobian.math.geometry.euclidean._models import (
     AngleEqualityRequest,
     AngleEqualityResult,
     SegmentRatioRequest,
-    SegmentRatioResult,
     TriangleSimilarityRequest,
     TriangleSimilarityResult,
 )
@@ -17,17 +16,13 @@ from jacobian.math.geometry.euclidean.operations import (
 )
 
 
-def compute_segment_ratio(request: SegmentRatioRequest) -> SegmentRatioResult:
-    numerator, denominator, ratio = _squared_segment_ratio_data(
+def compute_segment_ratio(request: SegmentRatioRequest) -> CanonicalRational:
+    _, _, ratio = _squared_segment_ratio_data(
         request.segment1,
         request.segment2,
         denominator_location=("segment2",),
     )
-    return SegmentRatioResult(
-        squared_ratio=format_canonical_rational(ratio),
-        ratio_numerator=format_canonical_rational(numerator),
-        ratio_denominator=format_canonical_rational(denominator),
-    )
+    return CanonicalRational.from_fraction(ratio)
 
 
 def compute_angle_equality(request: AngleEqualityRequest) -> AngleEqualityResult:
@@ -62,7 +57,7 @@ TOOLS: MathTools = (
         description="Return |A-B|^2 / |C-D|^2 exactly for two rational planar segments; "
         "the denominator segment must be nonzero.",
         request_type=SegmentRatioRequest,
-        result_type=SegmentRatioResult,
+        result_type=CanonicalRational,
         run=compute_segment_ratio,
         tags=("geometry", "euclidean", "segment", "ratio"),
         examples=(

--- a/src/jacobian/math/geometry/euclidean/_tools.py
+++ b/src/jacobian/math/geometry/euclidean/_tools.py
@@ -27,6 +27,7 @@ def compute_segment_ratio(request: SegmentRatioRequest) -> CanonicalRational:
 
 def compute_angle_equality(request: AngleEqualityRequest) -> AngleEqualityResult:
     return AngleEqualityResult(
+        request=request,
         equal=angles_equal(
             request.vertex1,
             request.ray1_a,
@@ -34,7 +35,7 @@ def compute_angle_equality(request: AngleEqualityRequest) -> AngleEqualityResult
             request.vertex2,
             request.ray2_a,
             request.ray2_b,
-        )
+        ),
     )
 
 
@@ -42,7 +43,7 @@ def compute_triangle_similarity(
     request: TriangleSimilarityRequest,
 ) -> TriangleSimilarityResult:
     return TriangleSimilarityResult(
-        similar=triangles_similar(request.triangle1, request.triangle2)
+        request=request, similar=triangles_similar(request.triangle1, request.triangle2)
     )
 
 

--- a/src/jacobian/math/geometry/euclidean/operations.py
+++ b/src/jacobian/math/geometry/euclidean/operations.py
@@ -7,7 +7,11 @@ from fractions import Fraction
 from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry._models import RationalPoint2D
-from jacobian.math.geometry.euclidean._models import Triangle
+from jacobian.math.geometry.euclidean._models import (
+    AngleEqualityResult,
+    Triangle,
+    TriangleSimilarityResult,
+)
 
 
 def _vector(
@@ -86,6 +90,23 @@ def angles_equal(
     )
 
 
+def verify_angle_equality(claim: AngleEqualityResult) -> bool:
+    """Check the angle-equality relation asserted by a serialized claim."""
+
+    request = claim.request
+    return (
+        angles_equal(
+            request.vertex1,
+            request.ray1_a,
+            request.ray1_b,
+            request.vertex2,
+            request.ray2_a,
+            request.ray2_b,
+        )
+        is claim.equal
+    )
+
+
 def triangles_similar(first: Triangle, second: Triangle) -> bool:
     """Decide whether two nondegenerate triangles are similar."""
 
@@ -111,6 +132,18 @@ def triangles_similar(first: Triangle, second: Triangle) -> bool:
     )
 
 
+def verify_triangle_similarity(claim: TriangleSimilarityResult) -> bool:
+    """Check the triangle-similarity relation asserted by a serialized claim."""
+
+    return (
+        triangles_similar(
+            claim.request.triangle1,
+            claim.request.triangle2,
+        )
+        is claim.similar
+    )
+
+
 def _admit_triangle(triangle: Triangle, *, location: tuple[str, ...]) -> None:
     """Admit nondegeneracy with a fixed number of bounded rational operations."""
     bx, by = _vector(triangle.a, triangle.b)
@@ -123,4 +156,10 @@ def _admit_triangle(triangle: Triangle, *, location: tuple[str, ...]) -> None:
         )
 
 
-__all__ = ["angles_equal", "squared_segment_ratio", "triangles_similar"]
+__all__ = [
+    "angles_equal",
+    "squared_segment_ratio",
+    "triangles_similar",
+    "verify_angle_equality",
+    "verify_triangle_similarity",
+]

--- a/src/jacobian/math/geometry/euclidean/operations.py
+++ b/src/jacobian/math/geometry/euclidean/operations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fractions import Fraction
 
+from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry._models import RationalPoint2D
 from jacobian.math.geometry.euclidean._models import Triangle
@@ -44,10 +45,12 @@ def _squared_segment_ratio_data(
 def squared_segment_ratio(
     first: tuple[RationalPoint2D, RationalPoint2D],
     second: tuple[RationalPoint2D, RationalPoint2D],
-) -> Fraction:
+) -> CanonicalRational:
     """Return the exact ratio of the two segments' squared lengths."""
 
-    return _squared_segment_ratio_data(first, second)[2]
+    return CanonicalRational.from_fraction(
+        _squared_segment_ratio_data(first, second)[2]
+    )
 
 
 def angles_equal(
@@ -86,6 +89,8 @@ def angles_equal(
 def triangles_similar(first: Triangle, second: Triangle) -> bool:
     """Decide whether two nondegenerate triangles are similar."""
 
+    _admit_triangle(first, location=("triangle1",))
+    _admit_triangle(second, location=("triangle2",))
     first_sides = sorted(
         (
             _squared_distance(first.a, first.b),
@@ -104,6 +109,18 @@ def triangles_similar(first: Triangle, second: Triangle) -> bool:
         left * second_sides[0] == first_sides[0] * right
         for left, right in zip(first_sides, second_sides, strict=True)
     )
+
+
+def _admit_triangle(triangle: Triangle, *, location: tuple[str, ...]) -> None:
+    """Admit nondegeneracy with a fixed number of bounded rational operations."""
+    bx, by = _vector(triangle.a, triangle.b)
+    cx, cy = _vector(triangle.a, triangle.c)
+    if bx * cy == by * cx:
+        raise OperationDomainValidationError(
+            location=location,
+            code="geometry.triangle_non_degenerate",
+            message="triangle must be non-degenerate",
+        )
 
 
 __all__ = ["angles_equal", "squared_segment_ratio", "triangles_similar"]

--- a/src/jacobian/math/geometry/metric_spaces/_models.py
+++ b/src/jacobian/math/geometry/metric_spaces/_models.py
@@ -31,7 +31,6 @@ class FiniteMetricSpace(StrictModel):
     @model_validator(mode="after")
     def require_valid_distances(self) -> Self:
         self._require_square()
-        self._require_metric_properties()
         return self
 
     def _require_square(self) -> None:
@@ -45,43 +44,6 @@ class FiniteMetricSpace(StrictModel):
                 raise _validation_error(
                     "distance_matrix_not_square", "distance matrix must be square"
                 )
-
-    def _require_metric_properties(self) -> None:
-        for i in range(self.point_count):
-            if self.distances[i][i] != 0:
-                raise _validation_error(
-                    "distance_diagonal_nonzero", "diagonal distances must be zero"
-                )
-            for j in range(self.point_count):
-                if self.distances[i][j] != self.distances[j][i]:
-                    raise _validation_error(
-                        "distance_matrix_asymmetric",
-                        "distance matrix must be symmetric",
-                    )
-        self._require_positive_separation()
-        self._require_triangle_inequality()
-
-    def _require_positive_separation(self) -> None:
-        for i in range(self.point_count):
-            for j in range(self.point_count):
-                if i != j and self.distances[i][j] == 0:
-                    raise _validation_error(
-                        "distance_nonpositive_between_distinct_points",
-                        "distinct points must have positive distance",
-                    )
-
-    def _require_triangle_inequality(self) -> None:
-        for i in range(self.point_count):
-            for j in range(self.point_count):
-                for k in range(self.point_count):
-                    if (
-                        self.distances[i][j]
-                        > self.distances[i][k] + self.distances[k][j]
-                    ):
-                        raise _validation_error(
-                            "distance_triangle_inequality_violation",
-                            "distances must satisfy the triangle inequality",
-                        )
 
 
 class MetricProfileRequest(StrictModel):

--- a/src/jacobian/math/geometry/metric_spaces/operations.py
+++ b/src/jacobian/math/geometry/metric_spaces/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fractions import Fraction
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
 
 from ._models import (
     BallResult,
@@ -17,10 +18,43 @@ from ._models import (
 __all__ = ["ball", "gromov_hyperbolicity", "metric_profile"]
 
 
+def _admit_metric_space(space: FiniteMetricSpace) -> None:
+    """Check metric axioms in at most 64 cubed comparisons of 54-bit sums."""
+
+    def reject(reason: str, message: str) -> None:
+        raise OperationDomainValidationError(
+            location=("metric_space", "distances"),
+            code=f"finite_metric_space.{reason}",
+            message=message,
+        )
+
+    distances = space.distances
+    for i in range(space.point_count):
+        if distances[i][i] != 0:
+            reject("distance_diagonal_nonzero", "diagonal distances must be zero")
+        for j in range(space.point_count):
+            if distances[i][j] != distances[j][i]:
+                reject(
+                    "distance_matrix_asymmetric", "distance matrix must be symmetric"
+                )
+            if i != j and distances[i][j] == 0:
+                reject(
+                    "distance_nonpositive_between_distinct_points",
+                    "distinct points must have positive distance",
+                )
+            for k in range(space.point_count):
+                if distances[i][j] > distances[i][k] + distances[k][j]:
+                    reject(
+                        "distance_triangle_inequality_violation",
+                        "distances must satisfy the triangle inequality",
+                    )
+
+
 def metric_profile(
     metric_space: FiniteMetricSpace,
 ) -> MetricProfileResult:
     """Compute diameter, radius, eccentricities, centers, and periphery."""
+    _admit_metric_space(metric_space)
     distances = metric_space.distances
     n = len(distances)
     eccentricities = [max(distances[i]) for i in range(n)]
@@ -42,6 +76,7 @@ def metric_profile(
 
 def ball(metric_space: FiniteMetricSpace, center: int, radius: int) -> BallResult:
     """Return the list of points within radius of center."""
+    _admit_metric_space(metric_space)
     if not 0 <= center < metric_space.point_count:
         raise ValueError("center index must be within the metric space")
     if radius < 0:
@@ -66,6 +101,7 @@ def gromov_hyperbolicity(
     the hyperbolicity is the maximum delta over all quadruples. Since that
     gap can be odd, the result is an exact ``Fraction`` (possibly half-integer).
     """
+    _admit_metric_space(metric_space)
     distances = metric_space.distances
     n = len(distances)
     max_delta = Fraction(0)

--- a/src/jacobian/math/geometry/operations.py
+++ b/src/jacobian/math/geometry/operations.py
@@ -33,6 +33,7 @@ from jacobian.math.geometry._models import (
     GeometryRationalResult,
     PolygonIntersectionWitness,
     PolygonPointClassificationResult,
+    PolygonRequest,
     RationalLine2D,
     RationalPoint2D,
     SegmentIntersectionResult,
@@ -550,6 +551,7 @@ def simple_polygon(points: tuple[RationalPoint2D, ...]) -> SimplePolygonDecision
             )
             if not valid:
                 return SimplePolygonDecisionResult(
+                    polygon=PolygonRequest(points=points),
                     vertex_count=len(points),
                     is_simple=False,
                     checked_edge_pairs=checked,
@@ -560,6 +562,7 @@ def simple_polygon(points: tuple[RationalPoint2D, ...]) -> SimplePolygonDecision
                     ),
                 )
     return SimplePolygonDecisionResult(
+        polygon=PolygonRequest(points=points),
         vertex_count=len(points),
         is_simple=True,
         checked_edge_pairs=checked,

--- a/src/jacobian/math/geometry/operations.py
+++ b/src/jacobian/math/geometry/operations.py
@@ -21,16 +21,19 @@ from jacobian.math.geometry._models import (
     CircumradiusProfileResult,
     CircumradiusTripleEntry,
     ClosedSegment2D,
+    CollinearityResult,
     CollinearTripleWitness,
+    ConcyclicityResult,
     ConcyclicQuadrupleWitness,
     GeneralPositionResult,
-    GeometryBooleanResult,
     GeometryCircleResult,
     GeometryConvexHullResult,
     GeometryLineIntersectionResult,
     GeometryOrientationResult,
     GeometryPointResult,
     GeometryRationalResult,
+    PointQuadrupleRequest,
+    PointTripleRequest,
     PolygonIntersectionWitness,
     PolygonPointClassificationResult,
     PolygonRequest,
@@ -67,6 +70,8 @@ __all__ = [
     "signed_area",
     "simple_polygon",
     "squared_distance",
+    "verify_collinearity",
+    "verify_concyclicity",
     "verify_polygon_point_classification",
     "verify_simple_polygon",
 ]
@@ -365,36 +370,41 @@ def segment_intersection(
     )
 
 
-def collinear(
-    first_point: RationalPoint2D,
-    second_point: RationalPoint2D,
-    third_point: RationalPoint2D,
-) -> GeometryBooleanResult:
+def collinear(request: PointTripleRequest) -> CollinearityResult:
     from sympy.geometry import Point2D
 
-    return GeometryBooleanResult(
-        holds=Point2D.is_collinear(
-            _point(first_point), _point(second_point), _point(third_point)
-        )
+    return CollinearityResult(
+        request=request,
+        collinear=Point2D.is_collinear(
+            _point(request.first), _point(request.second), _point(request.third)
+        ),
     )
 
 
-def concyclic(
-    first_point: RationalPoint2D,
-    second_point: RationalPoint2D,
-    third_point: RationalPoint2D,
-    fourth_point: RationalPoint2D,
-) -> GeometryBooleanResult:
+def concyclic(request: PointQuadrupleRequest) -> ConcyclicityResult:
     from sympy.geometry import Point2D
 
-    return GeometryBooleanResult(
-        holds=Point2D.is_concyclic(
-            _point(first_point),
-            _point(second_point),
-            _point(third_point),
-            _point(fourth_point),
-        )
+    return ConcyclicityResult(
+        request=request,
+        concyclic=Point2D.is_concyclic(
+            _point(request.first),
+            _point(request.second),
+            _point(request.third),
+            _point(request.fourth),
+        ),
     )
+
+
+def verify_collinearity(claim: CollinearityResult) -> bool:
+    """Check the collinearity relation asserted by a serialized claim."""
+
+    return collinear(claim.request).collinear is claim.collinear
+
+
+def verify_concyclicity(claim: ConcyclicityResult) -> bool:
+    """Check the concyclicity relation asserted by a serialized claim."""
+
+    return concyclic(claim.request).concyclic is claim.concyclic
 
 
 def line_intersection(

--- a/src/jacobian/math/geometry/operations.py
+++ b/src/jacobian/math/geometry/operations.py
@@ -38,6 +38,7 @@ from jacobian.math.geometry._models import (
     RationalPoint2D,
     SegmentIntersectionResult,
     SimplePolygonDecisionResult,
+    SimplePolygonPointRequest,
     _inverted_components_within_bound,
     _is_simple_ring,
     _point_key,
@@ -66,6 +67,7 @@ __all__ = [
     "signed_area",
     "simple_polygon",
     "squared_distance",
+    "verify_polygon_point_classification",
     "verify_simple_polygon",
 ]
 
@@ -580,26 +582,35 @@ def verify_simple_polygon(claim: SimplePolygonDecisionResult) -> bool:
 
 
 def classify_polygon_point(
-    point_value: RationalPoint2D,
-    polygon_points: tuple[RationalPoint2D, ...],
+    request: SimplePolygonPointRequest,
 ) -> PolygonPointClassificationResult:
     from sympy.geometry import Polygon
 
-    _admit_simple_polygon_point(polygon_points)
-    point = _point(point_value)
-    points = tuple(_point(item) for item in polygon_points)
+    _admit_simple_polygon_point(request.polygon.points)
+    point = _point(request.point)
+    points = tuple(_point(item) for item in request.polygon.points)
     for index, start in enumerate(points):
         if _on_segment(point, start, points[(index + 1) % len(points)]):
             return PolygonPointClassificationResult(
+                request=request,
                 polygon_vertex_count=len(points),
                 classification="BOUNDARY",
                 boundary_edge_index=index,
             )
     polygon = Polygon(*points)
     return PolygonPointClassificationResult(
+        request=request,
         polygon_vertex_count=len(points),
         classification=("INSIDE" if polygon.encloses_point(point) else "OUTSIDE"),
     )
+
+
+def verify_polygon_point_classification(
+    claim: PolygonPointClassificationResult,
+) -> bool:
+    """Check the polygon-point relation asserted by a serialized claim."""
+
+    return classify_polygon_point(claim.request) == claim
 
 
 def convex_hull_points(

--- a/src/jacobian/math/geometry/operations.py
+++ b/src/jacobian/math/geometry/operations.py
@@ -66,6 +66,7 @@ __all__ = [
     "signed_area",
     "simple_polygon",
     "squared_distance",
+    "verify_simple_polygon",
 ]
 
 
@@ -570,6 +571,12 @@ def simple_polygon(polygon: PolygonRequest) -> SimplePolygonDecisionResult:
         is_simple=True,
         checked_edge_pairs=checked,
     )
+
+
+def verify_simple_polygon(claim: SimplePolygonDecisionResult) -> bool:
+    """Check the exact simplicity decision asserted by a serialized claim."""
+
+    return simple_polygon(claim.polygon) == claim
 
 
 def classify_polygon_point(

--- a/src/jacobian/math/geometry/operations.py
+++ b/src/jacobian/math/geometry/operations.py
@@ -32,16 +32,12 @@ from jacobian.math.geometry._models import (
     GeometryOrientationResult,
     GeometryPointResult,
     GeometryRationalResult,
-    PointQuadrupleRequest,
-    PointTripleRequest,
     PolygonIntersectionWitness,
     PolygonPointClassificationResult,
-    PolygonRequest,
     RationalLine2D,
     RationalPoint2D,
     SegmentIntersectionResult,
     SimplePolygonDecisionResult,
-    SimplePolygonPointRequest,
     _inverted_components_within_bound,
     _is_simple_ring,
     _point_key,
@@ -370,27 +366,34 @@ def segment_intersection(
     )
 
 
-def collinear(request: PointTripleRequest) -> CollinearityResult:
+def collinear(
+    first: RationalPoint2D, second: RationalPoint2D, third: RationalPoint2D
+) -> CollinearityResult:
     from sympy.geometry import Point2D
 
     return CollinearityResult(
-        request=request,
-        collinear=Point2D.is_collinear(
-            _point(request.first), _point(request.second), _point(request.third)
-        ),
+        first=first,
+        second=second,
+        third=third,
+        collinear=Point2D.is_collinear(_point(first), _point(second), _point(third)),
     )
 
 
-def concyclic(request: PointQuadrupleRequest) -> ConcyclicityResult:
+def concyclic(
+    first: RationalPoint2D,
+    second: RationalPoint2D,
+    third: RationalPoint2D,
+    fourth: RationalPoint2D,
+) -> ConcyclicityResult:
     from sympy.geometry import Point2D
 
     return ConcyclicityResult(
-        request=request,
+        first=first,
+        second=second,
+        third=third,
+        fourth=fourth,
         concyclic=Point2D.is_concyclic(
-            _point(request.first),
-            _point(request.second),
-            _point(request.third),
-            _point(request.fourth),
+            _point(first), _point(second), _point(third), _point(fourth)
         ),
     )
 
@@ -398,13 +401,18 @@ def concyclic(request: PointQuadrupleRequest) -> ConcyclicityResult:
 def verify_collinearity(claim: CollinearityResult) -> bool:
     """Check the collinearity relation asserted by a serialized claim."""
 
-    return collinear(claim.request).collinear is claim.collinear
+    return (
+        collinear(claim.first, claim.second, claim.third).collinear is claim.collinear
+    )
 
 
 def verify_concyclicity(claim: ConcyclicityResult) -> bool:
     """Check the concyclicity relation asserted by a serialized claim."""
 
-    return concyclic(claim.request).concyclic is claim.concyclic
+    return (
+        concyclic(claim.first, claim.second, claim.third, claim.fourth).concyclic
+        is claim.concyclic
+    )
 
 
 def line_intersection(
@@ -536,10 +544,9 @@ def signed_area(points: tuple[RationalPoint2D, ...]) -> GeometryRationalResult:
     return GeometryRationalResult(value=_wire_rational(total / 2))
 
 
-def simple_polygon(polygon: PolygonRequest) -> SimplePolygonDecisionResult:
+def simple_polygon(points: tuple[RationalPoint2D, ...]) -> SimplePolygonDecisionResult:
     """Decide simplicity for one structural polygon value."""
 
-    points = polygon.points
     checked = 0
     for first in range(len(points)):
         for second in range(first + 1, len(points)):
@@ -567,7 +574,7 @@ def simple_polygon(polygon: PolygonRequest) -> SimplePolygonDecisionResult:
             )
             if not valid:
                 return SimplePolygonDecisionResult(
-                    polygon=polygon,
+                    polygon=points,
                     vertex_count=len(points),
                     is_simple=False,
                     checked_edge_pairs=checked,
@@ -578,7 +585,7 @@ def simple_polygon(polygon: PolygonRequest) -> SimplePolygonDecisionResult:
                     ),
                 )
     return SimplePolygonDecisionResult(
-        polygon=polygon,
+        polygon=points,
         vertex_count=len(points),
         is_simple=True,
         checked_edge_pairs=checked,
@@ -592,26 +599,30 @@ def verify_simple_polygon(claim: SimplePolygonDecisionResult) -> bool:
 
 
 def classify_polygon_point(
-    request: SimplePolygonPointRequest,
+    polygon: tuple[RationalPoint2D, ...], point_value: RationalPoint2D
 ) -> PolygonPointClassificationResult:
     from sympy.geometry import Polygon
 
-    _admit_simple_polygon_point(request.polygon.points)
-    point = _point(request.point)
-    points = tuple(_point(item) for item in request.polygon.points)
+    _admit_simple_polygon_point(polygon)
+    point = _point(point_value)
+    points = tuple(_point(item) for item in polygon)
     for index, start in enumerate(points):
         if _on_segment(point, start, points[(index + 1) % len(points)]):
             return PolygonPointClassificationResult(
-                request=request,
+                polygon=polygon,
+                point=point_value,
                 polygon_vertex_count=len(points),
                 classification="BOUNDARY",
                 boundary_edge_index=index,
             )
-    polygon = Polygon(*points)
+    geometric_polygon = Polygon(*points)
     return PolygonPointClassificationResult(
-        request=request,
+        polygon=polygon,
+        point=point_value,
         polygon_vertex_count=len(points),
-        classification=("INSIDE" if polygon.encloses_point(point) else "OUTSIDE"),
+        classification=(
+            "INSIDE" if geometric_polygon.encloses_point(point) else "OUTSIDE"
+        ),
     )
 
 
@@ -620,7 +631,7 @@ def verify_polygon_point_classification(
 ) -> bool:
     """Check the polygon-point relation asserted by a serialized claim."""
 
-    return classify_polygon_point(claim.request) == claim
+    return classify_polygon_point(claim.polygon, claim.point) == claim
 
 
 def convex_hull_points(

--- a/src/jacobian/math/geometry/operations.py
+++ b/src/jacobian/math/geometry/operations.py
@@ -523,7 +523,10 @@ def signed_area(points: tuple[RationalPoint2D, ...]) -> GeometryRationalResult:
     return GeometryRationalResult(value=_wire_rational(total / 2))
 
 
-def simple_polygon(points: tuple[RationalPoint2D, ...]) -> SimplePolygonDecisionResult:
+def simple_polygon(polygon: PolygonRequest) -> SimplePolygonDecisionResult:
+    """Decide simplicity for one structural polygon value."""
+
+    points = polygon.points
     checked = 0
     for first in range(len(points)):
         for second in range(first + 1, len(points)):
@@ -551,7 +554,7 @@ def simple_polygon(points: tuple[RationalPoint2D, ...]) -> SimplePolygonDecision
             )
             if not valid:
                 return SimplePolygonDecisionResult(
-                    polygon=PolygonRequest(points=points),
+                    polygon=polygon,
                     vertex_count=len(points),
                     is_simple=False,
                     checked_edge_pairs=checked,
@@ -562,7 +565,7 @@ def simple_polygon(points: tuple[RationalPoint2D, ...]) -> SimplePolygonDecision
                     ),
                 )
     return SimplePolygonDecisionResult(
-        polygon=PolygonRequest(points=points),
+        polygon=polygon,
         vertex_count=len(points),
         is_simple=True,
         checked_edge_pairs=checked,

--- a/src/jacobian/math/geometry/polygon_kernel/_models.py
+++ b/src/jacobian/math/geometry/polygon_kernel/_models.py
@@ -13,7 +13,6 @@ from jacobian.math.geometry._models import (
     GeometryConvexHullResult,
     PolygonRequest,
     RationalPoint2D,
-    _is_simple_ring,
 )
 
 if TYPE_CHECKING:
@@ -54,7 +53,7 @@ class KernelPolygon(PolygonRequest):
     )
 
     @model_validator(mode="after")
-    def require_bounded_simple_counterclockwise_polygon(self) -> Self:
+    def require_bounded_coordinates(self) -> Self:
         max_coordinate_digits = max(
             canonical_rational_component_digits(component)
             for point in self.points
@@ -67,18 +66,6 @@ class KernelPolygon(PolygonRequest):
                 f"{MAX_KERNEL_COORDINATE_DIGITS}-digit visibility-kernel bound",
             )
 
-        if not _is_simple_ring(self.points):
-            raise _validation_error(
-                "visibility_kernel_input_a_simple_polygon",
-                "visibility-kernel input must be a simple polygon",
-            )
-        from jacobian.math.geometry.polygon_kernel._kernel import polygon_signed_area
-
-        if polygon_signed_area(self.points) <= 0:
-            raise _validation_error(
-                "visibility_kernel_vertices_use_counterclockwise_cyclic",
-                "visibility-kernel vertices must use counterclockwise cyclic order",
-            )
         return self
 
 

--- a/src/jacobian/math/geometry/polygon_kernel/operations.py
+++ b/src/jacobian/math/geometry/polygon_kernel/operations.py
@@ -6,9 +6,11 @@ from math import comb
 
 from jacobian._exact import canonical_rational_component_digits
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry._models import _is_simple_ring
 from jacobian.math.geometry.polygon_kernel._kernel import (
     compute_kernel_data,
     oriented_half_planes,
+    polygon_signed_area,
 )
 from jacobian.math.geometry.polygon_kernel._models import (
     MAX_HALF_PLANE_COEFFICIENT_DIGITS,
@@ -44,6 +46,20 @@ def _admit_visibility_kernel(
             f"{MAX_KERNEL_COORDINATE_DIGITS}-digit visibility-kernel bound"
         )
 
+    # At most 64 squared segment pairs on 64-digit coordinates, followed by
+    # a linear area sum, before boundary intersection expansion.
+    if not _is_simple_ring(polygon.points):
+        raise OperationDomainValidationError(
+            location=("polygon",),
+            code="geometry.visibility_kernel_input_a_simple_polygon",
+            message="visibility-kernel input must be a simple polygon",
+        )
+    if polygon_signed_area(polygon.points) <= 0:
+        raise OperationDomainValidationError(
+            location=("polygon",),
+            code="geometry.visibility_kernel_vertices_use_counterclockwise_cyclic",
+            message="visibility-kernel vertices must use counterclockwise cyclic order",
+        )
     half_planes = oriented_half_planes(polygon)
     coefficient_digits = max(
         canonical_rational_component_digits(value)

--- a/src/jacobian/math/geometry/polytopes/__init__.py
+++ b/src/jacobian/math/geometry/polytopes/__init__.py
@@ -11,6 +11,8 @@ from jacobian.math.geometry.polytopes._models import (
 from jacobian.math.geometry.polytopes.operations import (
     convex_hull_volume,
     polytope_support,
+    verify_facet_incidence,
+    verify_primitive_facet,
 )
 from jacobian.math.geometry.polytopes.values import Halfspace, Vertex
 
@@ -25,4 +27,6 @@ __all__ = [
     "Vertex",
     "convex_hull_volume",
     "polytope_support",
+    "verify_facet_incidence",
+    "verify_primitive_facet",
 ]

--- a/src/jacobian/math/geometry/polytopes/_models.py
+++ b/src/jacobian/math/geometry/polytopes/_models.py
@@ -1233,28 +1233,9 @@ class PrimitiveFacet(StrictModel):
 
     @model_validator(mode="after")
     def require_primitive_normal_and_indices(self) -> Self:
-        if all(
-            coefficient.as_fraction() == 0
-            for coefficient in self.halfspace.coefficients
-        ):
+        if any(index < 0 for index in self.source_vertex_indices):
             raise _validation_error(
-                "facet_inequality", "facet inequality must have a nonzero normal"
-            )
-        entries = [
-            Fraction(*value.as_integer_ratio())
-            for value in (*self.halfspace.coefficients, self.halfspace.offset)
-        ]
-        if any(entry.denominator != 1 for entry in entries):
-            raise _validation_error(
-                "facet_inequality", "facet inequality entries must be integers"
-            )
-        gcd = 0
-        for entry in entries:
-            gcd = math.gcd(gcd, abs(int(entry)))
-        if gcd != 1:
-            raise _validation_error(
-                "facet_inequality",
-                "facet inequality must be primitive over the integers",
+                "facet_source_indices", "facet indices must be nonnegative"
             )
         if any(
             right <= left
@@ -1298,6 +1279,13 @@ class FacetIncidenceResult(StrictModel):
             raise _validation_error(
                 "dimension_bound",
                 "every source vertex must have exactly `dimension` coordinates",
+            )
+        if any(
+            len(facet.halfspace.coefficients) != self.dimension for facet in self.facets
+        ):
+            raise _validation_error(
+                "facet_dimension",
+                "facet normals must use the retained source coordinate axis",
             )
         for vertex in self.vertices:
             for coordinate in vertex.coordinates:
@@ -2102,7 +2090,7 @@ def _validate_halfspaces(
     for halfspace in halfspaces:
         if all(c.as_fraction() == 0 for c in halfspace.coefficients):
             raise _validation_error(
-                "halfspaces", "half-space coefficients must not all be zero"
+                "halfspace_normal_zero", "half-space coefficients must not all be zero"
             )
     prepared, triangulation = _require_admissible_h_vertices(halfspaces, dim)
     return prepared, dim, triangulation

--- a/src/jacobian/math/geometry/polytopes/lattice/operations.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/operations.py
@@ -230,6 +230,15 @@ def _facets_and_box(  # noqa: C901
     """
     facets: list[tuple[tuple[int, ...], int]] = []
     if halfspaces is not None:
+        if any(
+            all(coefficient.num == "0" for coefficient in halfspace.coefficients)
+            for halfspace in halfspaces
+        ):
+            raise OperationDomainValidationError(
+                location=("halfspaces",),
+                code="polytope.halfspace_normal_zero",
+                message="half-space coefficients must not all be zero",
+            )
         normalized_input = [
             (
                 [c.as_fraction() for c in hs.coefficients],

--- a/src/jacobian/math/geometry/polytopes/operations.py
+++ b/src/jacobian/math/geometry/polytopes/operations.py
@@ -33,7 +33,7 @@ from pydantic_core import PydanticCustomError
 from sympy import Matrix, Rational
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry.polytopes._models import (
     COORDINATE_DIGITS,
@@ -969,9 +969,29 @@ def convex_hull_volume(
     )
 
 
+def verify_primitive_facet(claim: PrimitiveFacet) -> bool:
+    """Check nonzero primitive integer normalization of at most eight scalars."""
+    if all(value.num == "0" for value in claim.halfspace.coefficients):
+        return False
+    entries = (*claim.halfspace.coefficients, claim.halfspace.offset)
+    if any(value.den != "1" for value in entries):
+        return False
+    divisor = 0
+    for value in entries:
+        divisor = math.gcd(divisor, abs(parse_canonical_integer(value.num)))
+    return divisor == 1
+
+
+def verify_facet_incidence(claim: FacetIncidenceResult) -> bool:
+    """Check the complete normalized facet relation against its bounded source."""
+    return facet_incidence(claim.vertices, claim.dimension) == claim
+
+
 __all__ = [
     "convex_hull_volume",
     "facet_incidence",
     "polytope_support",
     "polytope_volume",
+    "verify_facet_incidence",
+    "verify_primitive_facet",
 ]

--- a/src/jacobian/math/geometry/polytopes/values.py
+++ b/src/jacobian/math/geometry/polytopes/values.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Self
-
-from pydantic import Field, model_validator
+from pydantic import Field
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
@@ -38,14 +36,6 @@ class Halfspace(StrictModel):
         ),
     )
     offset: CanonicalRational
-
-    @model_validator(mode="after")
-    def require_nonzero_normal(self) -> Self:
-        if all(coefficient.as_fraction() == 0 for coefficient in self.coefficients):
-            raise _validation_error(
-                "halfspace_normal_zero", "half-space coefficients must not all be zero"
-            )
-        return self
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/chordal/__init__.py
+++ b/src/jacobian/math/graphs/chordal/__init__.py
@@ -1,5 +1,5 @@
 """Chordal graph recognition with structural certificates."""
 
-from jacobian.math.graphs.chordal.operations import recognize_chordal
+from jacobian.math.graphs.chordal.operations import recognize_chordal, verify_chordality
 
-__all__ = ["recognize_chordal"]
+__all__ = ["recognize_chordal", "verify_chordality"]

--- a/src/jacobian/math/graphs/chordal/_models.py
+++ b/src/jacobian/math/graphs/chordal/_models.py
@@ -97,14 +97,6 @@ class ChordalRecognitionResult(StrictModel):
                     "graph.chordal.cycle_canonical_direction",
                     "the induced cycle must use the smaller second endpoint",
                 )
-            edge_set = {tuple(sorted(edge)) for edge in self.graph.edges}
-            for first, second in zip(cycle, cycle[1:] + cycle[:1], strict=True):
-                edge = (first, second) if first < second else (second, first)
-                if edge not in edge_set:
-                    raise _validation_error(
-                        "graph.chordal.cycle_edge_missing",
-                        "consecutive cycle vertices must be graph edges",
-                    )
         return self
 
     @classmethod

--- a/src/jacobian/math/graphs/chordal/operations.py
+++ b/src/jacobian/math/graphs/chordal/operations.py
@@ -13,7 +13,28 @@ from jacobian.math.graphs.chordal._models import (
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
-__all__ = ["recognize_chordal"]
+__all__ = ["recognize_chordal", "verify_chordality"]
+
+
+def verify_chordality(claim: ChordalRecognitionResult) -> bool:
+    """Check the PEO or chordless-cycle relation without recognition replay.
+
+    PEO work shares recognition's degree-square admission. Checking a supplied
+    cycle costs at most 256 squared adjacency lookups; no cycle search runs.
+    """
+    neighbors, edge_count = _adjacency(claim.graph)
+    indices = {label: i for i, label in enumerate(claim.graph.vertices)}
+    if claim.status == "CHORDAL":
+        _admit_recognition(claim.graph, [len(row) for row in neighbors], edge_count)
+        ordering = tuple(indices[label] for label in claim.elimination_ordering)
+        return _later_clique_failure(ordering, neighbors) is None
+    cycle = tuple(indices[label] for label in claim.induced_cycle)
+    for i, first in enumerate(cycle):
+        for j in range(i + 1, len(cycle)):
+            consecutive = j == i + 1 or (i == 0 and j == len(cycle) - 1)
+            if (cycle[j] in neighbors[first]) != consecutive:
+                return False
+    return True
 
 
 def _reject(code: str, message: str) -> OperationDomainValidationError:

--- a/src/jacobian/math/graphs/constructors/__init__.py
+++ b/src/jacobian/math/graphs/constructors/__init__.py
@@ -10,6 +10,9 @@ from jacobian.math.graphs.constructors.operations import (
     compute_triangle_profile,
     construct_hypercube_graph,
     construct_keller_graph,
+    verify_hypercube_graph,
+    verify_keller_graph,
+    verify_triangle_profile,
 )
 
 __all__ = [
@@ -20,4 +23,7 @@ __all__ = [
     "compute_triangle_profile",
     "construct_hypercube_graph",
     "construct_keller_graph",
+    "verify_hypercube_graph",
+    "verify_keller_graph",
+    "verify_triangle_profile",
 ]

--- a/src/jacobian/math/graphs/constructors/_bounds.py
+++ b/src/jacobian/math/graphs/constructors/_bounds.py
@@ -85,6 +85,19 @@ def admit_triangle_profile(graph: SimpleUndirectedGraph) -> TriangleProfileAdmis
             len(adjacency[second]),
         )
     work_estimate = len(graph.vertices) + len(graph.edges) + common_neighbor_work
+    # Every retained triangle requires three edge-neighbor checks.  The degree
+    # estimate bounds those checks before the kernel constructs any result row.
+    triangle_row_upper_bound = common_neighbor_work // 3
+    if triangle_row_upper_bound > MAX_TRIANGLE_PROFILE_ROWS:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.triangle_profile.row_bound",
+            message=(
+                "triangle profile can require up to "
+                f"{triangle_row_upper_bound:,} rows, exceeding the "
+                f"{MAX_TRIANGLE_PROFILE_ROWS:,}-row materialization bound"
+            ),
+        )
     if work_estimate > MAX_TRIANGLE_PROFILE_WORK_UNITS:
         raise OperationDomainValidationError(
             location=("graph",),

--- a/src/jacobian/math/graphs/constructors/_bounds.py
+++ b/src/jacobian/math/graphs/constructors/_bounds.py
@@ -18,15 +18,49 @@ MAX_TRIANGLE_PROFILE_RETAINED_LABEL_CHARACTERS = 100_000_000
 
 @dataclass(frozen=True, slots=True)
 class TriangleProfileAdmission:
-    """The exact bounded scan and output plan for one triangle request."""
+    """Reusable derived facts for one admitted triangle request.
 
-    triangle_indices: tuple[tuple[int, int, int], ...]
-    triangle_count: int
-    work_units: int
+    Carries adjacency and degree data for the kernel's single enumeration.
+    Triangle rows are computed once by the operation, not during admission.
+    """
+
+    vertex_index: dict[str, int]
+    adjacency: tuple[frozenset[int], ...]
+    work_estimate: int
+
+
+def _admit_dimension(dimension: int, *, maximum: int, operation: str) -> None:
+    """Reject a construction dimension outside its admitted envelope."""
+    if not isinstance(dimension, int) or isinstance(dimension, bool):
+        raise OperationDomainValidationError(
+            location=("dimension",),
+            code=f"graph.constructors.{operation}.dimension_type",
+            message="dimension must be an integer",
+        )
+    if not 0 <= dimension <= maximum:
+        raise OperationDomainValidationError(
+            location=("dimension",),
+            code=f"graph.constructors.{operation}.dimension_bound",
+            message=f"dimension must be between 0 and {maximum}",
+        )
+
+
+def admit_hypercube_dimension(dimension: int) -> None:
+    """Admit a hypercube dimension before construction."""
+    from jacobian.math.graphs.constructors._models import MAX_HYPERCUBE_DIMENSION
+
+    _admit_dimension(dimension, maximum=MAX_HYPERCUBE_DIMENSION, operation="hypercube")
+
+
+def admit_keller_dimension(dimension: int) -> None:
+    """Admit a Keller dimension before construction."""
+    from jacobian.math.graphs.constructors._models import MAX_KELLER_DIMENSION
+
+    _admit_dimension(dimension, maximum=MAX_KELLER_DIMENSION, operation="keller")
 
 
 def admit_triangle_profile(graph: SimpleUndirectedGraph) -> TriangleProfileAdmission:
-    """Build one exact triangle scan and reject unrepresentable profiles."""
+    """Admit request representation and bound work without enumerating rows."""
 
     vertex_index = {vertex: index for index, vertex in enumerate(graph.vertices)}
     adjacency_sets: list[set[int]] = [set() for _ in graph.vertices]
@@ -37,11 +71,11 @@ def admit_triangle_profile(graph: SimpleUndirectedGraph) -> TriangleProfileAdmis
         adjacency_sets[right_index].add(left_index)
     adjacency = tuple(frozenset(neighbors) for neighbors in adjacency_sets)
 
-    triangle_indices: list[tuple[int, int, int]] = []
+    # Estimate scan work from degrees only; the kernel enumerates rows once.
+    # For edge (u, v), common-neighbor work is bounded by min(deg u, deg v),
+    # and each triangle contributes 3 to that sum, so the estimate upper-bounds
+    # both scan work and 3 * row count without materializing any triangle.
     common_neighbor_work = 0
-    retained_label_characters = sum(len(vertex) for vertex in graph.vertices) + sum(
-        len(left) + len(right) for left, right in graph.edges
-    )
     for left, right in graph.edges:
         left_index = vertex_index[left]
         right_index = vertex_index[right]
@@ -50,57 +84,31 @@ def admit_triangle_profile(graph: SimpleUndirectedGraph) -> TriangleProfileAdmis
             len(adjacency[first]),
             len(adjacency[second]),
         )
-        for third in adjacency[first] & adjacency[second]:
-            if third > second:
-                triangle_indices.append((first, second, third))
-                retained_label_characters += (
-                    len(graph.vertices[first])
-                    + len(graph.vertices[second])
-                    + len(graph.vertices[third])
-                )
-                if (
-                    retained_label_characters
-                    > MAX_TRIANGLE_PROFILE_RETAINED_LABEL_CHARACTERS
-                ):
-                    raise OperationDomainValidationError(
-                        location=("graph",),
-                        code="graph.triangle_profile.retained_labels_exceed_bound",
-                        message=(
-                            "triangle profile exceeds the retained "
-                            "label-character bound"
-                        ),
-                    )
-    triangle_count = len(triangle_indices)
-    work_units = (
-        len(graph.vertices)
-        + len(graph.edges)
-        + common_neighbor_work
-        + 3 * triangle_count
-    )
-    if triangle_count > MAX_TRIANGLE_PROFILE_ROWS:
-        raise OperationDomainValidationError(
-            location=("graph",),
-            code="graph.triangle_profile.row_bound",
-            message=(
-                f"triangle profile has {triangle_count:,} rows, exceeding the "
-                f"{MAX_TRIANGLE_PROFILE_ROWS:,}-row materialization bound"
-            ),
-        )
-    if work_units > MAX_TRIANGLE_PROFILE_WORK_UNITS:
+    work_estimate = len(graph.vertices) + len(graph.edges) + common_neighbor_work
+    if work_estimate > MAX_TRIANGLE_PROFILE_WORK_UNITS:
         raise OperationDomainValidationError(
             location=("graph",),
             code="graph.triangle_profile.work_budget",
             message=(
                 "triangle profile requires "
-                f"{work_units:,} graph-scan and output work units, exceeding the "
+                f"{work_estimate:,} graph-scan work units, exceeding the "
                 f"{MAX_TRIANGLE_PROFILE_WORK_UNITS:,}-unit bound"
             ),
         )
+    base_labels = sum(len(vertex) for vertex in graph.vertices) + sum(
+        len(left) + len(right) for left, right in graph.edges
+    )
+    if base_labels > MAX_TRIANGLE_PROFILE_RETAINED_LABEL_CHARACTERS:
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.triangle_profile.retained_labels_exceed_bound",
+            message=("triangle profile exceeds the retained label-character bound"),
+        )
 
     return TriangleProfileAdmission(
-        triangle_indices=tuple(triangle_indices),
-        triangle_count=triangle_count,
-        work_units=work_units,
+        vertex_index=vertex_index,
+        adjacency=adjacency,
+        work_estimate=work_estimate,
     )
 
 
@@ -109,5 +117,7 @@ __all__ = [
     "MAX_TRIANGLE_PROFILE_ROWS",
     "MAX_TRIANGLE_PROFILE_WORK_UNITS",
     "TriangleProfileAdmission",
+    "admit_hypercube_dimension",
+    "admit_keller_dimension",
     "admit_triangle_profile",
 ]

--- a/src/jacobian/math/graphs/constructors/operations.py
+++ b/src/jacobian/math/graphs/constructors/operations.py
@@ -208,7 +208,7 @@ def verify_triangle_profile(claim: TriangleProfileResult) -> bool:
         return False
     # Completeness: enumerate once in the verifier and compare as sets.
     complete: set[frozenset[str]] = set()
-    vertices = claim.source.vertices
+    source_vertices = claim.source.vertices
     for left, right in claim.source.edges:
         first, second = sorted(
             (admission.vertex_index[left], admission.vertex_index[right])
@@ -216,7 +216,13 @@ def verify_triangle_profile(claim: TriangleProfileResult) -> bool:
         for third in admission.adjacency[first] & admission.adjacency[second]:
             if third > second:
                 complete.add(
-                    frozenset((vertices[first], vertices[second], vertices[third]))
+                    frozenset(
+                        (
+                            source_vertices[first],
+                            source_vertices[second],
+                            source_vertices[third],
+                        )
+                    )
                 )
     return seen == complete
 

--- a/src/jacobian/math/graphs/constructors/operations.py
+++ b/src/jacobian/math/graphs/constructors/operations.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from jacobian.math.graphs.constructors._bounds import admit_triangle_profile
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.constructors._bounds import (
+    MAX_TRIANGLE_PROFILE_RETAINED_LABEL_CHARACTERS,
+    MAX_TRIANGLE_PROFILE_ROWS,
+    admit_hypercube_dimension,
+    admit_keller_dimension,
+    admit_triangle_profile,
+)
 from jacobian.math.graphs.constructors._models import (
     HypercubeGraphResult,
     KellerGraphResult,
@@ -17,6 +24,7 @@ from jacobian.math.graphs.values import (
 
 def construct_hypercube_graph(dimension: int) -> HypercubeGraphResult:
     """Construct the d-dimensional hypercube graph Q_d."""
+    admit_hypercube_dimension(dimension)
     vertex_count = 1 << dimension
     edges: list[tuple[int, int]] = []
     for vertex in range(vertex_count):
@@ -56,6 +64,7 @@ def _keller_adjacent(left: tuple[int, ...], right: tuple[int, ...]) -> bool:
 
 def construct_keller_graph(dimension: int) -> KellerGraphResult:
     """Construct the Keller graph K_d."""
+    admit_keller_dimension(dimension)
     if dimension == 0:
         return KellerGraphResult(
             dimension=dimension,
@@ -82,25 +91,141 @@ def compute_triangle_profile(graph: SimpleUndirectedGraph) -> TriangleProfileRes
     if not isinstance(graph, SimpleUndirectedGraph):
         raise TypeError("compute_triangle_profile expects a SimpleUndirectedGraph")
     admission = admit_triangle_profile(graph)
-    triangles = tuple(
-        TriangleProfileRow(
-            vertices=(
-                graph.vertices[left],
-                graph.vertices[middle],
-                graph.vertices[right],
-            )
-        )
-        for left, middle, right in admission.triangle_indices
+    triangles: list[TriangleProfileRow] = []
+    retained = sum(len(vertex) for vertex in graph.vertices) + sum(
+        len(left) + len(right) for left, right in graph.edges
     )
+    for left, right in graph.edges:
+        left_index = admission.vertex_index[left]
+        right_index = admission.vertex_index[right]
+        first, second = sorted((left_index, right_index))
+        for third in admission.adjacency[first] & admission.adjacency[second]:
+            if third > second:
+                triangles.append(
+                    TriangleProfileRow(
+                        vertices=(
+                            graph.vertices[first],
+                            graph.vertices[second],
+                            graph.vertices[third],
+                        )
+                    )
+                )
+                retained += (
+                    len(graph.vertices[first])
+                    + len(graph.vertices[second])
+                    + len(graph.vertices[third])
+                )
+                if retained > MAX_TRIANGLE_PROFILE_RETAINED_LABEL_CHARACTERS:
+                    raise OperationDomainValidationError(
+                        location=("graph",),
+                        code="graph.triangle_profile.retained_labels_exceed_bound",
+                        message=(
+                            "triangle profile exceeds the retained "
+                            "label-character bound"
+                        ),
+                    )
+                if len(triangles) > MAX_TRIANGLE_PROFILE_ROWS:
+                    raise OperationDomainValidationError(
+                        location=("graph",),
+                        code="graph.triangle_profile.row_bound",
+                        message=(
+                            f"triangle profile has {len(triangles):,} rows, exceeding "
+                            f"the {MAX_TRIANGLE_PROFILE_ROWS:,}-row materialization "
+                            "bound"
+                        ),
+                    )
     return TriangleProfileResult(
         source=graph,
-        triangles=triangles,
-        triangle_count=admission.triangle_count,
+        triangles=tuple(triangles),
+        triangle_count=len(triangles),
     )
+
+
+def verify_hypercube_graph(claim: HypercubeGraphResult) -> bool:
+    """Check a Q_d claim against its retained dimension without rebuilding rows."""
+    try:
+        admit_hypercube_dimension(claim.dimension)
+    except OperationDomainValidationError:
+        return False
+    vertex_count = 1 << claim.dimension
+    if claim.graph.vertex_count != vertex_count:
+        return False
+    expected = {
+        (vertex, vertex ^ (1 << bit))
+        if vertex < vertex ^ (1 << bit)
+        else (vertex ^ (1 << bit), vertex)
+        for vertex in range(vertex_count)
+        for bit in range(claim.dimension)
+    }
+    return set(claim.graph.edges) == expected
+
+
+def verify_keller_graph(claim: KellerGraphResult) -> bool:
+    """Check a K_d claim against its retained dimension."""
+    try:
+        admit_keller_dimension(claim.dimension)
+    except OperationDomainValidationError:
+        return False
+    if claim.dimension == 0:
+        return claim.graph.vertex_count == 1 and claim.graph.edges == ()
+    vertex_count = 4**claim.dimension
+    if claim.graph.vertex_count != vertex_count:
+        return False
+    expected: set[tuple[int, int]] = set()
+    for left in range(vertex_count):
+        left_word = _to_word(left, claim.dimension)
+        for right in range(left + 1, vertex_count):
+            if _keller_adjacent(left_word, _to_word(right, claim.dimension)):
+                expected.add((left, right))
+    return set(claim.graph.edges) == expected
+
+
+def verify_triangle_profile(claim: TriangleProfileResult) -> bool:
+    """Check triangle rows and completeness against the retained source graph."""
+    try:
+        admission = admit_triangle_profile(claim.source)
+    except OperationDomainValidationError:
+        return False
+    edge_set = {frozenset(edge) for edge in claim.source.edges}
+    seen: set[frozenset[str]] = set()
+    for row in claim.triangles:
+        vertices = row.vertices
+        if len(set(vertices)) != 3 or any(
+            v not in admission.vertex_index for v in vertices
+        ):
+            return False
+        key = frozenset(vertices)
+        if key in seen:
+            return False
+        seen.add(key)
+        if (
+            frozenset((vertices[0], vertices[1])) not in edge_set
+            or frozenset((vertices[0], vertices[2])) not in edge_set
+            or frozenset((vertices[1], vertices[2])) not in edge_set
+        ):
+            return False
+    if claim.triangle_count != len(claim.triangles):
+        return False
+    # Completeness: enumerate once in the verifier and compare as sets.
+    complete: set[frozenset[str]] = set()
+    vertices = claim.source.vertices
+    for left, right in claim.source.edges:
+        first, second = sorted(
+            (admission.vertex_index[left], admission.vertex_index[right])
+        )
+        for third in admission.adjacency[first] & admission.adjacency[second]:
+            if third > second:
+                complete.add(
+                    frozenset((vertices[first], vertices[second], vertices[third]))
+                )
+    return seen == complete
 
 
 __all__ = [
     "compute_triangle_profile",
     "construct_hypercube_graph",
     "construct_keller_graph",
+    "verify_hypercube_graph",
+    "verify_keller_graph",
+    "verify_triangle_profile",
 ]

--- a/src/jacobian/math/graphs/decomposition/tree_decompositions/__init__.py
+++ b/src/jacobian/math/graphs/decomposition/tree_decompositions/__init__.py
@@ -5,6 +5,11 @@ from jacobian.math.graphs.decomposition.tree_decompositions.operations import (
     bag_intersection_graph,
     reroot,
     restrict,
+    verify_adhesions,
+    verify_bag_intersection_graph,
+    verify_reroot,
+    verify_vertex_occurrences,
+    verify_width,
     vertex_occurrences,
     width,
 )
@@ -18,6 +23,11 @@ __all__ = [
     "bag_intersection_graph",
     "reroot",
     "restrict",
+    "verify_adhesions",
+    "verify_bag_intersection_graph",
+    "verify_reroot",
+    "verify_vertex_occurrences",
+    "verify_width",
     "vertex_occurrences",
     "width",
 ]

--- a/src/jacobian/math/graphs/decomposition/tree_decompositions/_models.py
+++ b/src/jacobian/math/graphs/decomposition/tree_decompositions/_models.py
@@ -6,7 +6,6 @@ import unicodedata
 from typing import Self
 
 from pydantic import Field, model_validator
-from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.decomposition.tree_decompositions.values import (
@@ -27,18 +26,19 @@ class WidthRequest(StrictModel):
 class WidthResult(StrictModel):
     """The width and per-bag cardinalities."""
 
+    decomposition: TreeDecomposition
+
     bag_sizes: tuple[int, ...]
-    max_bag_cardinality: int = Field(ge=1)
-    width: int = Field(ge=0)
+    max_bag_cardinality: int = Field(ge=0)
+    width: int = Field(ge=-1)
     maximum_bag_nodes: tuple[str, ...]
 
     @model_validator(mode="after")
     def bind_width(self) -> Self:
-        if self.max_bag_cardinality != self.width + 1:
-            raise PydanticCustomError(
-                "graph.width_must_equal_max_bag_cardinality_minus_one",
-                "width must equal max_bag_cardinality minus one",
-            )
+        if len(self.bag_sizes) != len(self.decomposition.tree_nodes) or not set(
+            self.maximum_bag_nodes
+        ) <= set(self.decomposition.tree_nodes):
+            raise ValueError("width profile must use the decomposition bag axis")
         return self
 
 
@@ -59,7 +59,25 @@ class VertexOccurrencesResult(StrictModel):
     """Per-source-vertex occurrence subtree node set, induced tree edges,
     count, and leaf/extremal nodes."""
 
+    decomposition: TreeDecomposition
+
     per_vertex: dict[str, OccurrenceSubtree]
+
+    @model_validator(mode="after")
+    def require_source_axes(self) -> Self:
+        if set(self.per_vertex) != set(self.decomposition.graph.vertices):
+            raise ValueError("occurrences must cover the source graph vertex axis")
+        nodes = set(self.decomposition.tree_nodes)
+        for row in self.per_vertex.values():
+            if (
+                not set(row.nodes) <= nodes
+                or not set(row.leaves) <= set(row.nodes)
+                or any(a not in row.nodes or b not in row.nodes for a, b in row.edges)
+            ):
+                raise ValueError(
+                    "occurrence subtrees must use the source bag-node axis"
+                )
+        return self
 
 
 class AdhesionsRequest(StrictModel):
@@ -77,9 +95,18 @@ class Adhesion(StrictModel):
 class AdhesionsResult(StrictModel):
     """Per-tree-edge adhesion, maximum adhesion, and size profile."""
 
+    decomposition: TreeDecomposition
+
     edges: tuple[Adhesion, ...]
     max_adhesion: int = Field(ge=0)
     size_profile: tuple[int, ...]
+
+    @model_validator(mode="after")
+    def require_source_axes(self) -> Self:
+        _require_adhesion_axes(self.decomposition, self.edges)
+        if len(self.size_profile) != len(self.edges):
+            raise ValueError("size profile must cover the tree edge axis")
+        return self
 
 
 class RerootRequest(StrictModel):
@@ -92,11 +119,31 @@ class RerootRequest(StrictModel):
 class RerootResult(StrictModel):
     """The rerooted decomposition with parent/children/depth/paths."""
 
+    decomposition: TreeDecomposition
+
     root: str
     parent: dict[str, str | None]
     children: dict[str, tuple[str, ...]]
     depth: dict[str, int]
-    paths: dict[str, list[str]]
+    paths: dict[str, tuple[str, ...]]
+
+    @model_validator(mode="after")
+    def require_source_axes(self) -> Self:
+        nodes = set(self.decomposition.tree_nodes)
+        if self.root not in nodes or any(
+            set(mapping) != nodes
+            for mapping in (self.parent, self.children, self.depth, self.paths)
+        ):
+            raise ValueError("rooted profiles must cover the source bag-node axis")
+        if any(
+            parent is not None and parent not in nodes
+            for parent in self.parent.values()
+        ) or any(
+            not set(row) <= nodes
+            for row in (*self.children.values(), *self.paths.values())
+        ):
+            raise ValueError("rooted profile values must use source bag nodes")
+        return self
 
 
 class RestrictRequest(StrictModel):
@@ -120,9 +167,28 @@ class BagNode(StrictModel):
 class BagIntersectionGraphResult(StrictModel):
     """The weighted tree: each node labelled by bag size, each edge by adhesion."""
 
+    decomposition: TreeDecomposition
+
     nodes: tuple[BagNode, ...]
     edges: tuple[Adhesion, ...]
     max_adhesion: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def require_source_axes(self) -> Self:
+        if tuple(node.node for node in self.nodes) != self.decomposition.tree_nodes:
+            raise ValueError("bag graph must retain the source bag-node axis")
+        _require_adhesion_axes(self.decomposition, self.edges)
+        return self
+
+
+def _require_adhesion_axes(
+    source: TreeDecomposition, edges: tuple[Adhesion, ...]
+) -> None:
+    expected = tuple(tuple(sorted(edge)) for edge in source.tree_edges)
+    if tuple(row.edge for row in edges) != expected:
+        raise ValueError("adhesions must retain the source tree-edge axis")
+    if any(not set(row.adhesion) <= set(source.graph.vertices) for row in edges):
+        raise ValueError("adhesions must use source graph vertices")
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/decomposition/tree_decompositions/operations.py
+++ b/src/jacobian/math/graphs/decomposition/tree_decompositions/operations.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 
 from collections import deque
 
+from pydantic_core import PydanticCustomError
+
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 from ._models import (
@@ -19,13 +22,24 @@ from ._models import (
     VertexOccurrencesResult,
     WidthResult,
 )
-from .values import TreeDecomposition
+from .values import (
+    TreeDecomposition,
+    _check_connectedness,
+    _check_edge_coverage,
+    _check_vertex_coverage,
+    _is_tree,
+)
 
 __all__ = [
     "adhesions",
     "bag_intersection_graph",
     "reroot",
     "restrict",
+    "verify_adhesions",
+    "verify_bag_intersection_graph",
+    "verify_reroot",
+    "verify_vertex_occurrences",
+    "verify_width",
     "vertex_occurrences",
     "width",
 ]
@@ -40,13 +54,32 @@ def _int_edges(td: TreeDecomposition) -> list[tuple[int, int]]:
     return [(idx[a], idx[b]) for a, b in td.tree_edges]
 
 
+def _admit_decomposition(td: TreeDecomposition) -> None:
+    """Check decomposition laws once within the finite graph/bag envelope."""
+    edges = _int_edges(td)
+    try:
+        if not _is_tree(len(td.tree_nodes), edges):
+            raise PydanticCustomError(
+                "graph.tree_edges_do_not_form_a_tree", "tree edges do not form a tree"
+            )
+        _check_vertex_coverage(td.bags, set(td.graph.vertices))
+        _check_edge_coverage(td.graph, td.bags)
+        _check_connectedness(td.graph, td.bags, edges, len(td.tree_nodes))
+    except PydanticCustomError as error:
+        raise OperationDomainValidationError(
+            location=("decomposition",), code=error.type, message=error.message()
+        ) from error
+
+
 def width(td: TreeDecomposition) -> WidthResult:
     """Return bag cardinality per tree node, maximum bag cardinality, width
     (max bag cardinality minus 1), and the maximum-bag node labels."""
+    _admit_decomposition(td)
     bag_sizes = [len(bag) for bag in td.bags]
     max_size = max(bag_sizes)
     max_nodes = [td.tree_nodes[i] for i, s in enumerate(bag_sizes) if s == max_size]
     return WidthResult(
+        decomposition=td,
         bag_sizes=tuple(bag_sizes),
         max_bag_cardinality=max_size,
         width=max_size - 1,
@@ -93,6 +126,7 @@ def vertex_occurrences(
 ) -> VertexOccurrencesResult:
     """Return per-source-vertex occurrence subtree node set, induced tree edges,
     occurrence counts, and leaf/extremal nodes."""
+    _admit_decomposition(td)
     int_edges = _int_edges(td)
     adjacency: dict[int, list[int]] = {i: [] for i in range(len(td.tree_nodes))}
     for a, b in int_edges:
@@ -109,7 +143,7 @@ def vertex_occurrences(
         per_vertex[vertex] = _occurrence_subtree(
             td, adjacency, int_edges, vertex, containing
         )
-    return VertexOccurrencesResult(per_vertex=per_vertex)
+    return VertexOccurrencesResult(decomposition=td, per_vertex=per_vertex)
 
 
 def adhesions(td: TreeDecomposition) -> AdhesionsResult:
@@ -119,6 +153,7 @@ def adhesions(td: TreeDecomposition) -> AdhesionsResult:
     Return the maximum adhesion, size profile, and exact separator sets. The
     result is a structural profile of the supplied decomposition, not a
     minimum-separator computation."""
+    _admit_decomposition(td)
     int_edges = _int_edges(td)
     bag_sets = [set(bag) for bag in td.bags]
     per_edge: list[Adhesion] = []
@@ -135,6 +170,7 @@ def adhesions(td: TreeDecomposition) -> AdhesionsResult:
         )
     max_adhesion = max((row.size for row in per_edge), default=0)
     return AdhesionsResult(
+        decomposition=td,
         edges=tuple(per_edge),
         max_adhesion=max_adhesion,
         size_profile=tuple(row.size for row in per_edge),
@@ -188,6 +224,7 @@ def reroot(td: TreeDecomposition, root: str) -> RerootResult:
     """Return the same underlying decomposition rerooted at the selected tree
     node. Changing the root does not change the width, bags, or unrooted
     tree."""
+    _admit_decomposition(td)
     idx = _index_of(td)
     if root not in idx:
         raise ValueError("root must be a declared tree node")
@@ -214,11 +251,12 @@ def reroot(td: TreeDecomposition, root: str) -> RerootResult:
             )
     paths = _root_to_node_paths(adjacency, td, parent, root_index, root)
     return RerootResult(
+        decomposition=td,
         root=root,
         parent=parent_map,
         children=children_map,
         depth={td.tree_nodes[i]: depth[i] for i in depth},
-        paths=paths,
+        paths={node: tuple(path) for node, path in paths.items()},
     )
 
 
@@ -243,6 +281,7 @@ def restrict(td: TreeDecomposition, subset: frozenset[str]) -> TreeDecomposition
     """Return the decomposition obtained by replacing every bag B_t with
     B_t ∩ S, then applying the documented deterministic cleanup of empty/
     redundant tree nodes. Bind the result to the induced source graph G[S]."""
+    _admit_decomposition(td)
     if not subset.issubset(set(td.graph.vertices)):
         raise ValueError("subset must contain only declared source vertices")
     # New source graph induced by S.
@@ -254,6 +293,13 @@ def restrict(td: TreeDecomposition, subset: frozenset[str]) -> TreeDecomposition
     )
     # New bags intersected with S.
     new_bags = [tuple(v for v in bag if v in subset) for bag in td.bags]
+    if not subset:
+        return TreeDecomposition(
+            graph=new_graph,
+            tree_nodes=(td.tree_nodes[0],),
+            tree_edges=(),
+            bags=((),),
+        )
     # Cleanup: remove empty bags, contracting through deleted internal nodes
     # to keep the tree connected.
     keep_indices = [i for i, bag in enumerate(new_bags) if bag]
@@ -312,7 +358,33 @@ def bag_intersection_graph(td: TreeDecomposition) -> BagIntersectionGraphResult:
     for i, bag in enumerate(td.bags):
         node_labels.append(BagNode(node=td.tree_nodes[i], bag_size=len(bag)))
     return BagIntersectionGraphResult(
+        decomposition=td,
         nodes=tuple(node_labels),
         edges=result.edges,
         max_adhesion=result.max_adhesion,
     )
+
+
+def verify_width(claim: WidthResult) -> bool:
+    """Check width and maxima against the admitted source decomposition."""
+    return width(claim.decomposition) == claim
+
+
+def verify_vertex_occurrences(claim: VertexOccurrencesResult) -> bool:
+    """Check source-vertex occurrence profiles in the bounded decomposition."""
+    return vertex_occurrences(claim.decomposition) == claim
+
+
+def verify_adhesions(claim: AdhesionsResult) -> bool:
+    """Check all source tree-edge intersections and their summaries."""
+    return adhesions(claim.decomposition) == claim
+
+
+def verify_reroot(claim: RerootResult) -> bool:
+    """Check the parent, child, depth and path relations from the declared root."""
+    return reroot(claim.decomposition, claim.root) == claim
+
+
+def verify_bag_intersection_graph(claim: BagIntersectionGraphResult) -> bool:
+    """Check weighted bag-tree relations against the admitted decomposition."""
+    return bag_intersection_graph(claim.decomposition) == claim

--- a/src/jacobian/math/graphs/decomposition/tree_decompositions/values.py
+++ b/src/jacobian/math/graphs/decomposition/tree_decompositions/values.py
@@ -10,8 +10,8 @@ A *tree decomposition* of a finite simple undirected graph ``G`` is a pair
 4. for each source vertex, the tree nodes whose bags contain it form a
    connected subtree (the *connectedness* axiom).
 
-These are value-construction invariants. They are **not** exposed as a
-public ``.check`` operation.
+These laws are admitted by consuming operations; value decoding retains only
+structural source and bag axes.
 """
 
 from __future__ import annotations
@@ -163,17 +163,7 @@ class TreeDecomposition(StrictModel):
             raise PydanticCustomError(
                 "graph.tree_edges_must_be_unique", "tree edges must be unique"
             )
-        index_of = {label: i for i, label in enumerate(self.tree_nodes)}
-        int_edges = [(index_of[a], index_of[b]) for a, b in edge_pairs]
-        if not _is_tree(len(self.tree_nodes), int_edges):
-            raise PydanticCustomError(
-                "graph.tree_edges_do_not_form_a_tree", "tree edges do not form a tree"
-            )
-        vertex_set = set(self.graph.vertices)
-        _validate_bags(self.bags, vertex_set)
-        _check_vertex_coverage(self.bags, vertex_set)
-        _check_edge_coverage(self.graph, self.bags)
-        _check_connectedness(self.graph, self.bags, int_edges, len(self.tree_nodes))
+        _validate_bags(self.bags, set(self.graph.vertices))
         return self
 
 

--- a/src/jacobian/math/graphs/directed/_models.py
+++ b/src/jacobian/math/graphs/directed/_models.py
@@ -146,7 +146,7 @@ class AcyclicOrderRequest(StrictModel):
 
 
 class AcyclicOrderResult(StrictModel):
-    request: AcyclicOrderRequest
+    graph: DirectedOperationGraph
     acyclic: bool
     order: tuple[int, ...]
 

--- a/src/jacobian/math/graphs/directed/_models.py
+++ b/src/jacobian/math/graphs/directed/_models.py
@@ -146,6 +146,7 @@ class AcyclicOrderRequest(StrictModel):
 
 
 class AcyclicOrderResult(StrictModel):
+    request: AcyclicOrderRequest
     acyclic: bool
     order: tuple[int, ...]
 

--- a/src/jacobian/math/graphs/directed/operations.py
+++ b/src/jacobian/math/graphs/directed/operations.py
@@ -10,7 +10,6 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.directed._models import (
     MAX_DIRECTED_OPERATION_EDGES,
     MAX_DIRECTED_OPERATION_VERTICES,
-    AcyclicOrderRequest,
     AcyclicOrderResult,
     CondensationEdge,
     CondensationResult,
@@ -127,11 +126,9 @@ def acyclic_order(graph: DirectedGraph) -> AcyclicOrderResult:
     _admit_directed_graph(graph)
     g = _build_digraph(graph)
     if not nx.is_directed_acyclic_graph(g):
-        return AcyclicOrderResult(
-            request=AcyclicOrderRequest(graph=graph), acyclic=False, order=()
-        )
+        return AcyclicOrderResult(graph=graph, acyclic=False, order=())
     return AcyclicOrderResult(
-        request=AcyclicOrderRequest(graph=graph),
+        graph=graph,
         acyclic=True,
         order=tuple(nx.topological_sort(g)),
     )

--- a/src/jacobian/math/graphs/directed/operations.py
+++ b/src/jacobian/math/graphs/directed/operations.py
@@ -10,8 +10,8 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.directed._models import (
     MAX_DIRECTED_OPERATION_EDGES,
     MAX_DIRECTED_OPERATION_VERTICES,
-    AcyclicOrderResult,
     AcyclicOrderRequest,
+    AcyclicOrderResult,
     CondensationEdge,
     CondensationResult,
     DagLongestPathResult,

--- a/src/jacobian/math/graphs/directed/operations.py
+++ b/src/jacobian/math/graphs/directed/operations.py
@@ -11,6 +11,7 @@ from jacobian.math.graphs.directed._models import (
     MAX_DIRECTED_OPERATION_EDGES,
     MAX_DIRECTED_OPERATION_VERTICES,
     AcyclicOrderResult,
+    AcyclicOrderRequest,
     CondensationEdge,
     CondensationResult,
     DagLongestPathResult,
@@ -126,8 +127,14 @@ def acyclic_order(graph: DirectedGraph) -> AcyclicOrderResult:
     _admit_directed_graph(graph)
     g = _build_digraph(graph)
     if not nx.is_directed_acyclic_graph(g):
-        return AcyclicOrderResult(acyclic=False, order=())
-    return AcyclicOrderResult(acyclic=True, order=tuple(nx.topological_sort(g)))
+        return AcyclicOrderResult(
+            request=AcyclicOrderRequest(graph=graph), acyclic=False, order=()
+        )
+    return AcyclicOrderResult(
+        request=AcyclicOrderRequest(graph=graph),
+        acyclic=True,
+        order=tuple(nx.topological_sort(g)),
+    )
 
 
 def dag_longest_path(graph: DirectedGraph) -> DagLongestPathResult:

--- a/src/jacobian/math/graphs/flows/__init__.py
+++ b/src/jacobian/math/graphs/flows/__init__.py
@@ -5,6 +5,9 @@ from jacobian.math.graphs.flows.operations import (
     max_flow,
     min_cost_flow,
     min_cut,
+    verify_edge_disjoint_paths,
+    verify_max_flow,
+    verify_min_cut,
 )
 
 __all__ = [
@@ -12,4 +15,7 @@ __all__ = [
     "max_flow",
     "min_cost_flow",
     "min_cut",
+    "verify_edge_disjoint_paths",
+    "verify_max_flow",
+    "verify_min_cut",
 ]

--- a/src/jacobian/math/graphs/flows/__init__.py
+++ b/src/jacobian/math/graphs/flows/__init__.py
@@ -7,6 +7,7 @@ from jacobian.math.graphs.flows.operations import (
     min_cut,
     verify_edge_disjoint_paths,
     verify_max_flow,
+    verify_min_cost_flow,
     verify_min_cut,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "min_cut",
     "verify_edge_disjoint_paths",
     "verify_max_flow",
+    "verify_min_cost_flow",
     "verify_min_cut",
 ]

--- a/src/jacobian/math/graphs/flows/_models.py
+++ b/src/jacobian/math/graphs/flows/_models.py
@@ -90,11 +90,19 @@ class FlowEdgeValue(StrictModel):
     flow: CanonicalRational
 
 
-class MaxFlowResult(StrictModel):
+class MaxFlowResult(MaxFlowRequest):
     flow_value: CanonicalRational
     source: int = Field(ge=0, le=63)
     sink: int = Field(ge=0, le=63)
-    flow_edges: tuple[FlowEdgeValue, ...] = Field(default=())
+    flow_edges: tuple[FlowEdgeValue, ...] = Field(default=(), max_length=512)
+
+    @model_validator(mode="after")
+    def require_edge_axis(self) -> Self:
+        source_edges = {(edge.source, edge.target) for edge in self.graph.edges}
+        edges = tuple((edge.source, edge.target) for edge in self.flow_edges)
+        if len(set(edges)) != len(edges) or not set(edges) <= source_edges:
+            raise ValueError("flow edges must be distinct edges of the source network")
+        return self
 
 
 class MinCutRequest(StrictModel):
@@ -103,10 +111,20 @@ class MinCutRequest(StrictModel):
     sink: int = Field(ge=0, le=63)
 
 
-class MinCutResult(StrictModel):
+class MinCutResult(MinCutRequest):
     cut_value: CanonicalRational
     reachable: tuple[int, ...]
     unreachable: tuple[int, ...]
+
+    @model_validator(mode="after")
+    def require_partition_axis(self) -> Self:
+        if sorted((*self.reachable, *self.unreachable)) != list(
+            range(self.graph.vertex_count)
+        ):
+            raise ValueError(
+                "cut sides must partition the retained network vertex axis"
+            )
+        return self
 
 
 class EdgeDisjointPathsGraph(StrictModel):
@@ -146,11 +164,21 @@ class EdgeDisjointPathsRequest(StrictModel):
     sink: int = Field(ge=0, le=63)
 
 
-class EdgeDisjointPathsResult(StrictModel):
+class EdgeDisjointPathsResult(EdgeDisjointPathsRequest):
     path_count: int = Field(ge=0)
-    paths: tuple[tuple[int, ...], ...] = Field(default=())
+    paths: tuple[tuple[int, ...], ...] = Field(default=(), max_length=512)
     source: int = Field(ge=0, le=63)
     sink: int = Field(ge=0, le=63)
+
+    @model_validator(mode="after")
+    def require_path_axes(self) -> Self:
+        if any(
+            not 2 <= len(path) <= self.graph.vertex_count
+            or any(not 0 <= vertex < self.graph.vertex_count for vertex in path)
+            for path in self.paths
+        ):
+            raise ValueError("paths must use the retained network vertex axis")
+        return self
 
 
 class CostedFlowEdge(StrictModel):

--- a/src/jacobian/math/graphs/flows/_tools.py
+++ b/src/jacobian/math/graphs/flows/_tools.py
@@ -24,6 +24,7 @@ from jacobian.math.graphs.flows.operations import (
 def compute_max_flow(request: MaxFlowRequest) -> MaxFlowResult:
     flow_value, flow_edges = max_flow(request.graph, request.source, request.sink)
     return MaxFlowResult(
+        graph=request.graph,
         flow_value=flow_value,
         source=request.source,
         sink=request.sink,
@@ -36,6 +37,9 @@ def compute_min_cut(request: MinCutRequest) -> MinCutResult:
         request.graph, request.source, request.sink
     )
     return MinCutResult(
+        graph=request.graph,
+        source=request.source,
+        sink=request.sink,
         cut_value=cut_value,
         reachable=reachable,
         unreachable=unreachable,
@@ -47,6 +51,7 @@ def compute_edge_disjoint_paths(
 ) -> EdgeDisjointPathsResult:
     paths = edge_disjoint_paths(request.graph, request.source, request.sink)
     return EdgeDisjointPathsResult(
+        graph=request.graph,
         path_count=len(paths),
         paths=paths,
         source=request.source,

--- a/src/jacobian/math/graphs/flows/operations.py
+++ b/src/jacobian/math/graphs/flows/operations.py
@@ -18,6 +18,7 @@ from jacobian.math.graphs.flows._models import (
     FlowEdgeValue,
     FlowGraph,
     MaxFlowResult,
+    MinCostFlowResult,
     MinCutResult,
     _bounded_denominator_scale,
 )
@@ -189,12 +190,24 @@ def min_cost_flow(
     return _rational(total_cost), True, flow_edges
 
 
+def _admitted_terminals(
+    graph: FlowGraph | EdgeDisjointPathsGraph, source: int, sink: int
+) -> bool:
+    """Return whether terminals satisfy the operation's admitted domain."""
+    try:
+        _admit_terminals(graph, source, sink)
+    except OperationDomainValidationError:
+        return False
+    return True
+
+
 def verify_max_flow(claim: MaxFlowResult) -> bool:
     """Check capacities, conservation and absence of residual augmenting paths.
 
     The network has at most 64 vertices and 512 edges; no solver is rerun.
     """
-    _admit_terminals(claim.graph, claim.source, claim.sink)
+    if not _admitted_terminals(claim.graph, claim.source, claim.sink):
+        return False
     flows = {
         (edge.source, edge.target): edge.flow.as_fraction() for edge in claim.flow_edges
     }
@@ -230,8 +243,15 @@ def verify_max_flow(claim: MaxFlowResult) -> bool:
 
 
 def verify_min_cut(claim: MinCutResult) -> bool:
-    """Check cut capacity and optimality against the admitted source network."""
-    _admit_terminals(claim.graph, claim.source, claim.sink)
+    """Check the cut relation against the admitted source network.
+
+    Verifies s-t separation and that the claimed value equals the cut
+    capacity. Minimality is the producer's outcome: certifying it needs a
+    primal flow witness or a solver rerun, neither of which this bounded
+    relation check performs.
+    """
+    if not _admitted_terminals(claim.graph, claim.source, claim.sink):
+        return False
     left, right = set(claim.reachable), set(claim.unreachable)
     if claim.source not in left or claim.sink not in right:
         return False
@@ -243,22 +263,27 @@ def verify_min_cut(claim: MinCutResult) -> bool:
         ),
         Fraction(),
     )
-    return (
-        capacity == claim.cut_value.as_fraction()
-        and min_cut(claim.graph, claim.source, claim.sink)[0] == claim.cut_value
-    )
+    return capacity == claim.cut_value.as_fraction()
 
 
 def verify_edge_disjoint_paths(claim: EdgeDisjointPathsResult) -> bool:
-    """Check path witnesses and the maximum cardinality in the bounded graph."""
-    _admit_terminals(claim.graph, claim.source, claim.sink)
+    """Check path witnesses are edge-disjoint source-to-sink paths.
+
+    Verifies endpoints, simplicity, edge membership, disjointness, and count
+    alignment. Maximality (Menger) is the producer's outcome: certifying it
+    needs a cut dual or a solver rerun, neither of which this bounded
+    relation check performs.
+    """
+    if not _admitted_terminals(claim.graph, claim.source, claim.sink):
+        return False
     edges = set(claim.graph.edges)
     used: set[tuple[int, int]] = set()
     if claim.path_count != len(claim.paths):
         return False
     for path in claim.paths:
         if (
-            path[0] != claim.source
+            len(path) < 2
+            or path[0] != claim.source
             or path[-1] != claim.sink
             or len(set(path)) != len(path)
         ):
@@ -267,6 +292,47 @@ def verify_edge_disjoint_paths(claim: EdgeDisjointPathsResult) -> bool:
             if edge not in edges or edge in used:
                 return False
             used.add(edge)
-    return claim.path_count == len(
-        edge_disjoint_paths(claim.graph, claim.source, claim.sink)
-    )
+    return True
+
+
+def verify_min_cost_flow(claim: MinCostFlowResult) -> bool:
+    """Check feasibility, conservation, capacities, and cost of a flow claim.
+
+    For the feasible branch this establishes the full feasibility relation
+    against the retained network and demands. Optimality needs dual
+    potentials, which the carrier does not retain, so it remains the
+    producer's outcome. For the infeasible branch there is no witness to
+    check; a well-formed infeasible shape is consistent but its
+    infeasibility is likewise the producer's outcome.
+    """
+    try:
+        _admit_min_cost_flow(claim.graph, claim.demands)
+    except OperationDomainValidationError:
+        return False
+    if not claim.feasible:
+        return True
+    capacities: dict[tuple[int, int], Fraction] = {}
+    costs: dict[tuple[int, int], Fraction] = {}
+    for edge in claim.graph.edges:
+        capacities[(edge.source, edge.target)] = edge.capacity.as_fraction()
+        costs[(edge.source, edge.target)] = edge.cost.as_fraction()
+    seen: set[tuple[int, int]] = set()
+    net = [Fraction() for _ in range(claim.graph.vertex_count)]
+    total = Fraction()
+    for record in claim.flow_edges:
+        key = (record.source, record.target)
+        if key not in capacities or key in seen:
+            return False
+        seen.add(key)
+        amount = record.flow.as_fraction()
+        if not 0 <= amount <= capacities[key]:
+            return False
+        net[record.source] -= amount
+        net[record.target] += amount
+        total += amount * costs[key]
+    if any(
+        inflow != Fraction(demand)
+        for inflow, demand in zip(net, claim.demands, strict=True)
+    ):
+        return False
+    return total == claim.total_cost.as_fraction()

--- a/src/jacobian/math/graphs/flows/operations.py
+++ b/src/jacobian/math/graphs/flows/operations.py
@@ -301,16 +301,15 @@ def verify_min_cost_flow(claim: MinCostFlowResult) -> bool:
     For the feasible branch this establishes the full feasibility relation
     against the retained network and demands. Optimality needs dual
     potentials, which the carrier does not retain, so it remains the
-    producer's outcome. For the infeasible branch there is no witness to
-    check; a well-formed infeasible shape is consistent but its
-    infeasibility is likewise the producer's outcome.
+    producer's outcome. The infeasible branch carries no witness, so it
+    does not verify and likewise remains a producer outcome.
     """
     try:
         _admit_min_cost_flow(claim.graph, claim.demands)
     except OperationDomainValidationError:
         return False
     if not claim.feasible:
-        return True
+        return False
     capacities: dict[tuple[int, int], Fraction] = {}
     costs: dict[tuple[int, int], Fraction] = {}
     for edge in claim.graph.edges:

--- a/src/jacobian/math/graphs/flows/operations.py
+++ b/src/jacobian/math/graphs/flows/operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from itertools import pairwise
 from typing import Any
 
 import networkx as nx
@@ -12,9 +13,12 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.flows._models import (
     CostedFlowGraph,
     EdgeDisjointPathsGraph,
+    EdgeDisjointPathsResult,
     FlowEdgeResult,
     FlowEdgeValue,
     FlowGraph,
+    MaxFlowResult,
+    MinCutResult,
     _bounded_denominator_scale,
 )
 
@@ -23,6 +27,9 @@ __all__ = [
     "max_flow",
     "min_cost_flow",
     "min_cut",
+    "verify_edge_disjoint_paths",
+    "verify_max_flow",
+    "verify_min_cut",
 ]
 
 
@@ -180,3 +187,86 @@ def min_cost_flow(
     )
     total_cost = Fraction(int(flow_cost_int), flow_scale * cost_scale)
     return _rational(total_cost), True, flow_edges
+
+
+def verify_max_flow(claim: MaxFlowResult) -> bool:
+    """Check capacities, conservation and absence of residual augmenting paths.
+
+    The network has at most 64 vertices and 512 edges; no solver is rerun.
+    """
+    _admit_terminals(claim.graph, claim.source, claim.sink)
+    flows = {
+        (edge.source, edge.target): edge.flow.as_fraction() for edge in claim.flow_edges
+    }
+    balance = [Fraction() for _ in range(claim.graph.vertex_count)]
+    residual: list[set[int]] = [set() for _ in balance]
+    for edge in claim.graph.edges:
+        u, v = edge.source, edge.target
+        amount = flows.get((u, v), Fraction())
+        capacity = edge.capacity.as_fraction()
+        if not 0 <= amount <= capacity:
+            return False
+        balance[u] -= amount
+        balance[v] += amount
+        if amount < capacity:
+            residual[u].add(v)
+        if amount > 0:
+            residual[v].add(u)
+    value = claim.flow_value.as_fraction()
+    if any(
+        amount
+        != (-value if vertex == claim.source else value if vertex == claim.sink else 0)
+        for vertex, amount in enumerate(balance)
+    ):
+        return False
+    reached = {claim.source}
+    frontier = [claim.source]
+    while frontier:
+        for vertex in residual[frontier.pop()]:
+            if vertex not in reached:
+                reached.add(vertex)
+                frontier.append(vertex)
+    return claim.sink not in reached
+
+
+def verify_min_cut(claim: MinCutResult) -> bool:
+    """Check cut capacity and optimality against the admitted source network."""
+    _admit_terminals(claim.graph, claim.source, claim.sink)
+    left, right = set(claim.reachable), set(claim.unreachable)
+    if claim.source not in left or claim.sink not in right:
+        return False
+    capacity = sum(
+        (
+            edge.capacity.as_fraction()
+            for edge in claim.graph.edges
+            if edge.source in left and edge.target in right
+        ),
+        Fraction(),
+    )
+    return (
+        capacity == claim.cut_value.as_fraction()
+        and min_cut(claim.graph, claim.source, claim.sink)[0] == claim.cut_value
+    )
+
+
+def verify_edge_disjoint_paths(claim: EdgeDisjointPathsResult) -> bool:
+    """Check path witnesses and the maximum cardinality in the bounded graph."""
+    _admit_terminals(claim.graph, claim.source, claim.sink)
+    edges = set(claim.graph.edges)
+    used: set[tuple[int, int]] = set()
+    if claim.path_count != len(claim.paths):
+        return False
+    for path in claim.paths:
+        if (
+            path[0] != claim.source
+            or path[-1] != claim.sink
+            or len(set(path)) != len(path)
+        ):
+            return False
+        for edge in pairwise(path):
+            if edge not in edges or edge in used:
+                return False
+            used.add(edge)
+    return claim.path_count == len(
+        edge_disjoint_paths(claim.graph, claim.source, claim.sink)
+    )

--- a/src/jacobian/math/graphs/isomorphism/__init__.py
+++ b/src/jacobian/math/graphs/isomorphism/__init__.py
@@ -4,10 +4,16 @@ from jacobian.math.graphs.isomorphism._models import (
     ColoredGraphCanonicalizationResult,
     GraphRelabelingPair,
 )
-from jacobian.math.graphs.isomorphism.operations import canonicalize_colored_graph
+from jacobian.math.graphs.isomorphism._vf2_process import verify_graph_isomorphism
+from jacobian.math.graphs.isomorphism.operations import (
+    canonicalize_colored_graph,
+    verify_colored_graph_canonicalization,
+)
 
 __all__ = [
     "ColoredGraphCanonicalizationResult",
     "GraphRelabelingPair",
     "canonicalize_colored_graph",
+    "verify_colored_graph_canonicalization",
+    "verify_graph_isomorphism",
 ]

--- a/src/jacobian/math/graphs/isomorphism/_models.py
+++ b/src/jacobian/math/graphs/isomorphism/_models.py
@@ -75,6 +75,8 @@ class GraphIsomorphismResult(StrictModel):
     ``NOT_ISOMORPHIC`` carries no mapping.
     """
 
+    graph_a: SimpleGraph
+    graph_b: SimpleGraph
     status: Literal["ISOMORPHIC", "NOT_ISOMORPHIC"]
     vertex_mapping: tuple[VertexMappingPair, ...] = Field(default=())
 

--- a/src/jacobian/math/graphs/isomorphism/_vf2_process.py
+++ b/src/jacobian/math/graphs/isomorphism/_vf2_process.py
@@ -163,17 +163,20 @@ def decide_graph_isomorphism(
 
 
 def verify_graph_isomorphism(claim: GraphIsomorphismResult) -> bool:
-    """Return whether a graph-isomorphism claim matches its retained graphs."""
+    """Check an ISOMORPHIC claim's bijection and adjacency preservation.
+
+    Only ISOMORPHIC claims are verifiable. A NOT_ISOMORPHIC outcome has no
+    checkable certificate in this carrier, so it does not verify and
+    remains a producer outcome. No VF2 search runs here.
+    """
     try:
         _admit_graph_isomorphism(
             GraphIsomorphismRequest(graph_a=claim.graph_a, graph_b=claim.graph_b)
         )
     except OperationDomainValidationError:
         return False
-    if claim.status == "NOT_ISOMORPHIC":
-        return not claim.vertex_mapping and _vertex_mapping(
-            claim.graph_a, claim.graph_b
-        ) is None
+    if claim.status != "ISOMORPHIC":
+        return False
     mapping = tuple((item.from_vertex, item.to_vertex) for item in claim.vertex_mapping)
     if len(mapping) != claim.graph_a.vertex_count:
         return False

--- a/src/jacobian/math/graphs/isomorphism/_vf2_process.py
+++ b/src/jacobian/math/graphs/isomorphism/_vf2_process.py
@@ -148,11 +148,51 @@ def decide_graph_isomorphism(
     _admit_graph_isomorphism(request)
     mapping = _vertex_mapping(request.graph_a, request.graph_b)
     if mapping is None:
-        return GraphIsomorphismResult(status="NOT_ISOMORPHIC", vertex_mapping=())
+        return GraphIsomorphismResult(
+            graph_a=request.graph_a,
+            graph_b=request.graph_b,
+            status="NOT_ISOMORPHIC",
+            vertex_mapping=(),
+        )
     return GraphIsomorphismResult(
+        graph_a=request.graph_a,
+        graph_b=request.graph_b,
         status="ISOMORPHIC",
         vertex_mapping=tuple(mapping),
     )
+
+
+def verify_graph_isomorphism(claim: GraphIsomorphismResult) -> bool:
+    """Return whether a graph-isomorphism claim matches its retained graphs."""
+    try:
+        _admit_graph_isomorphism(
+            GraphIsomorphismRequest(graph_a=claim.graph_a, graph_b=claim.graph_b)
+        )
+    except OperationDomainValidationError:
+        return False
+    if claim.status == "NOT_ISOMORPHIC":
+        return not claim.vertex_mapping and _vertex_mapping(
+            claim.graph_a, claim.graph_b
+        ) is None
+    mapping = tuple((item.from_vertex, item.to_vertex) for item in claim.vertex_mapping)
+    if len(mapping) != claim.graph_a.vertex_count:
+        return False
+    if {source for source, _ in mapping} != set(range(claim.graph_a.vertex_count)):
+        return False
+    if {target for _, target in mapping} != set(range(claim.graph_b.vertex_count)):
+        return False
+    forward = dict(mapping)
+    mapped_edges = {
+        (forward[source], forward[target])
+        if claim.graph_a.directed
+        else tuple(sorted((forward[source], forward[target])))
+        for source, target in claim.graph_a.edges
+    }
+    target_edges = {
+        edge if claim.graph_b.directed else tuple(sorted(edge))
+        for edge in claim.graph_b.edges
+    }
+    return mapped_edges == target_edges
 
 
 def compute_colored_graph_canonicalization(

--- a/src/jacobian/math/graphs/isomorphism/operations.py
+++ b/src/jacobian/math/graphs/isomorphism/operations.py
@@ -54,4 +54,60 @@ def canonicalize_colored_graph(
         ) from error
 
 
-__all__ = ["canonicalize_colored_graph"]
+def verify_colored_graph_canonicalization(
+    claim: ColoredGraphCanonicalizationResult,
+) -> bool:
+    """Check a relabeling preserves vertex colors, edges, and edge colors.
+
+    That the target is the canonical minimum needs enumeration and stays
+    the producer's outcome; this bounded check covers only the relabeling
+    relation against the retained source and canonical graphs.
+    """
+    source = claim.source_graph
+    canonical = claim.canonical_graph
+    forward: dict[str, str] = {}
+    for pair in claim.relabeling:
+        if pair.source_vertex in forward:
+            return False
+        forward[pair.source_vertex] = pair.canonical_vertex
+    if set(forward) != set(source.graph.vertices):
+        return False
+    if set(forward.values()) != set(canonical.graph.vertices):
+        return False
+    if bool(source.vertex_colors) != bool(canonical.vertex_colors):
+        return False
+    if source.vertex_colors:
+        source_color = dict(
+            zip(source.graph.vertices, source.vertex_colors, strict=True)
+        )
+        canonical_color = dict(
+            zip(canonical.graph.vertices, canonical.vertex_colors, strict=True)
+        )
+        if any(
+            canonical_color[target] != source_color[source_vertex]
+            for source_vertex, target in forward.items()
+        ):
+            return False
+    source_edge_index = {edge: index for index, edge in enumerate(source.graph.edges)}
+    canonical_edge_index = {
+        edge: index for index, edge in enumerate(canonical.graph.edges)
+    }
+    if bool(source.edge_colors) != bool(canonical.edge_colors):
+        return False
+    mapped: set[tuple[str, str]] = set()
+    for edge in source.graph.edges:
+        left, right = edge
+        first, second = forward[left], forward[right]
+        image = (first, second) if first < second else (second, first)
+        if image not in canonical_edge_index or image in mapped:
+            return False
+        mapped.add(image)
+        if source.edge_colors and (
+            canonical.edge_colors[canonical_edge_index[image]]
+            != source.edge_colors[source_edge_index[edge]]
+        ):
+            return False
+    return mapped == set(canonical.graph.edges)
+
+
+__all__ = ["canonicalize_colored_graph", "verify_colored_graph_canonicalization"]

--- a/src/jacobian/math/graphs/monochromatic_path/__init__.py
+++ b/src/jacobian/math/graphs/monochromatic_path/__init__.py
@@ -2,6 +2,10 @@
 
 from jacobian.math.graphs.monochromatic_path.operations import (
     construct_monochromatic_path_hypergraphs,
+    verify_monochromatic_path_hypergraphs,
 )
 
-__all__ = ["construct_monochromatic_path_hypergraphs"]
+__all__ = [
+    "construct_monochromatic_path_hypergraphs",
+    "verify_monochromatic_path_hypergraphs",
+]

--- a/src/jacobian/math/graphs/monochromatic_path/_models.py
+++ b/src/jacobian/math/graphs/monochromatic_path/_models.py
@@ -1,8 +1,8 @@
 """Typed contracts for the monochromatic path hypergraph operation."""
 
-from typing import Annotated
+from typing import Annotated, Self
 
-from pydantic import WithJsonSchema
+from pydantic import Field, WithJsonSchema, model_validator
 from pydantic.json_schema import JsonSchemaValue
 
 from jacobian._models import StrictModel
@@ -49,10 +49,29 @@ class MonochromaticPathRequest(StrictModel):
 
 
 class MonochromaticPathResult(StrictModel):
-    """The monochromatic path hypergraphs of a coloured graph."""
+    """One source-bound colour-indexed family on the graph's vertex axis."""
 
     graph: ColoredUndirectedGraph
-    colour_to_hypergraph: dict[str, FiniteHypergraph]
+    colours: tuple[str, ...] = Field(max_length=MAX_VERTICES * (MAX_VERTICES - 1) // 2)
+    hypergraphs: tuple[FiniteHypergraph, ...] = Field(
+        max_length=MAX_VERTICES * (MAX_VERTICES - 1) // 2
+    )
+
+    @model_validator(mode="after")
+    def require_source_axes(self) -> Self:
+        expected = tuple(sorted(set(self.graph.edge_colors))) or ("uncolored",)
+        if self.colours != expected or len(self.hypergraphs) != len(self.colours):
+            raise ValueError("family must use exactly the ordered source colour axis")
+        if any(
+            hypergraph.vertices != self.graph.graph.vertices
+            for hypergraph in self.hypergraphs
+        ):
+            raise ValueError("every hypergraph must retain the source vertex axis")
+        return self
+
+    @property
+    def colour_to_hypergraph(self) -> dict[str, FiniteHypergraph]:
+        return dict(zip(self.colours, self.hypergraphs, strict=True))
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/monochromatic_path/operations.py
+++ b/src/jacobian/math/graphs/monochromatic_path/operations.py
@@ -14,7 +14,10 @@ from jacobian.math.graphs.monochromatic_path._models import (
 )
 from jacobian.math.graphs.values import ColoredUndirectedGraph
 
-__all__ = ["construct_monochromatic_path_hypergraphs"]
+__all__ = [
+    "construct_monochromatic_path_hypergraphs",
+    "verify_monochromatic_path_hypergraphs",
+]
 
 MAX_MONOCHROMATIC_PATH_WORK = 100_000_000
 
@@ -63,7 +66,7 @@ def _admit_monochromatic_path_graph(graph: ColoredUndirectedGraph) -> tuple[str,
             code="graph.monochromatic_path.edge_count_exceeds_bound",
             message="complete monochromatic path hypergraphs exceed the edge bound",
         )
-    incidence_upper_bound = vertex_count * (1 << (vertex_count - 1))
+    incidence_upper_bound = vertex_count * (1 << max(0, vertex_count - 1))
     if incidence_upper_bound > MAX_TOTAL_INCIDENCES:
         raise OperationDomainValidationError(
             location=("graph",),
@@ -111,8 +114,14 @@ def construct_monochromatic_path_hypergraphs(
 
     return MonochromaticPathResult(
         graph=graph,
-        colour_to_hypergraph=result,
+        colours=colours,
+        hypergraphs=tuple(result[colour] for colour in colours),
     )
+
+
+def verify_monochromatic_path_hypergraphs(claim: MonochromaticPathResult) -> bool:
+    """Check the bounded path-support relation against the retained graph."""
+    return construct_monochromatic_path_hypergraphs(claim.graph) == claim
 
 
 def _has_hamiltonian_path(

--- a/src/jacobian/math/graphs/optimization/__init__.py
+++ b/src/jacobian/math/graphs/optimization/__init__.py
@@ -1,3 +1,15 @@
 """Finite graph-optimization operation ownership."""
 
-__all__: list[str] = []
+from jacobian.math.graphs.optimization._distance_matrix import verify_distance_matrix
+from jacobian.math.graphs.optimization._invariant_verification import (
+    verify_graph_invariant,
+)
+from jacobian.math.graphs.optimization._matching_verification import (
+    verify_maximum_matching,
+)
+
+__all__ = [
+    "verify_distance_matrix",
+    "verify_graph_invariant",
+    "verify_maximum_matching",
+]

--- a/src/jacobian/math/graphs/optimization/_distance_matrix.py
+++ b/src/jacobian/math/graphs/optimization/_distance_matrix.py
@@ -41,7 +41,7 @@ def compute_distance_matrix(
         distance is not None for row in rows for distance in row.distances
     )
     return GraphDistanceMatrixResult._from_kernel(
-        vertices=vertices,
+        graph=request.graph,
         rows=rows,
         connected=connected,
     )
@@ -73,4 +73,19 @@ DISTANCE_MATRIX_OPERATION = MathTool(
     ),
 )
 
-__all__ = ["DISTANCE_MATRIX_OPERATION", "compute_distance_matrix"]
+
+def verify_distance_matrix(claim: GraphDistanceMatrixResult) -> bool:
+    """Check all shortest paths and connectivity in O(n(n+m)) work.
+
+    The source carrier bounds n by 256 and m by 32640; the same complete
+    all-pairs operation establishes the precise relation for this claim.
+    """
+    actual = compute_distance_matrix(GraphDistanceMatrixRequest(graph=claim.graph))
+    return actual.rows == claim.rows and actual.connected == claim.connected
+
+
+__all__ = [
+    "DISTANCE_MATRIX_OPERATION",
+    "compute_distance_matrix",
+    "verify_distance_matrix",
+]

--- a/src/jacobian/math/graphs/optimization/_distance_models.py
+++ b/src/jacobian/math/graphs/optimization/_distance_models.py
@@ -115,33 +115,28 @@ class GraphDistanceMatrixResult(StrictModel):
     vertex_ordering: Literal["LEXICOGRAPHIC_ASCENDING"]
     pair_coverage: Literal["ALL_ORDERED_VERTEX_PAIRS"]
     unreachable_representation: Literal["JSON_NULL"]
-    vertices: tuple[GraphVertex, ...] = Field(
-        max_length=MAX_GRAPH_DISTANCE_MATRIX_ORDER
-    )
+    graph: SimpleUndirectedGraph
     rows: tuple[GraphDistanceRow, ...] = Field(
         max_length=MAX_GRAPH_DISTANCE_MATRIX_ORDER
     )
     connected: StrictBool
 
+    @property
+    def vertices(self) -> tuple[GraphVertex, ...]:
+        """Project the source labels in the declared lexicographic convention."""
+        return tuple(sorted(self.graph.vertices))
+
     @model_validator(mode="after")
     def bind_complete_metric(self) -> Self:
         order = _validate_distance_matrix_shape(self.vertices, self.rows)
         _validate_distance_matrix_diagonal_and_symmetry(self.rows, order)
-        expected_connected = order > 0 and all(
-            distance is not None for row in self.rows for distance in row.distances
-        )
-        if self.connected != expected_connected:
-            raise PydanticCustomError(
-                "graph.connected_must_match_all_pairs_finite_reachabili",
-                "connected must match all-pairs finite reachability",
-            )
         return self
 
     @classmethod
     def _from_kernel(
         cls,
         *,
-        vertices: tuple[GraphVertex, ...],
+        graph: SimpleUndirectedGraph,
         rows: tuple[GraphDistanceRow, ...],
         connected: bool,
     ) -> Self:
@@ -151,7 +146,7 @@ class GraphDistanceMatrixResult(StrictModel):
             vertex_ordering="LEXICOGRAPHIC_ASCENDING",
             pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
             unreachable_representation="JSON_NULL",
-            vertices=vertices,
+            graph=graph,
             rows=rows,
             connected=connected,
         )

--- a/src/jacobian/math/graphs/optimization/_invariant_models.py
+++ b/src/jacobian/math/graphs/optimization/_invariant_models.py
@@ -26,6 +26,7 @@ class GraphMaximumMatchingRequest(StrictModel):
 
 
 class GraphGirthResult(StrictModel):
+    graph: SimpleUndirectedGraph
     girth: StrictInt = Field(ge=0, le=256)
     has_cycle: StrictBool
 
@@ -40,6 +41,7 @@ class GraphGirthResult(StrictModel):
 
 
 class GraphDiameterResult(StrictModel):
+    graph: SimpleUndirectedGraph
     status: Literal["COMPUTED", "NOT_APPLICABLE"]
     diameter: StrictInt | None = Field(default=None, ge=0, le=255)
     connected: StrictBool
@@ -62,18 +64,22 @@ class GraphDiameterResult(StrictModel):
 
 
 class GraphEdgeConnectivityResult(StrictModel):
+    graph: SimpleUndirectedGraph
     edge_connectivity: StrictInt = Field(ge=0, le=255)
 
 
 class GraphVertexConnectivityResult(StrictModel):
+    graph: SimpleUndirectedGraph
     vertex_connectivity: StrictInt = Field(ge=0, le=255)
 
 
 class GraphEulerianResult(StrictModel):
+    graph: SimpleUndirectedGraph
     is_eulerian: StrictBool
 
 
 class GraphSpanningTreeCountResult(StrictModel):
+    graph: SimpleUndirectedGraph
     spanning_tree_count: StrictInt = Field(ge=0)
     connected: StrictBool
 
@@ -128,6 +134,7 @@ class GraphMaximumMatchingResult(StrictModel):
 
 
 class GraphTriangleCountResult(StrictModel):
+    graph: SimpleUndirectedGraph
     triangle_count: StrictInt = Field(ge=0, le=2_763_520)
 
 
@@ -136,11 +143,17 @@ class GraphCoreRequest(GraphInvariantRequest):
 
 
 class GraphCoreResult(StrictModel):
+    graph: SimpleUndirectedGraph
     k: StrictInt = Field(ge=0, le=255)
     vertices: tuple[GraphVertex, ...]
 
     @model_validator(mode="after")
     def require_canonical_vertices(self) -> Self:
+        if not set(self.vertices) <= set(self.graph.vertices):
+            raise PydanticCustomError(
+                "graph.k_core_source_vertices",
+                "k-core vertices must belong to the source graph",
+            )
         if tuple(sorted(self.vertices)) != self.vertices:
             raise PydanticCustomError(
                 "graph.k_core_vertices_must_be_canonically_sorted",
@@ -154,6 +167,7 @@ class GraphCoreResult(StrictModel):
 
 
 class GraphRadiusResult(StrictModel):
+    graph: SimpleUndirectedGraph
     status: Literal["COMPUTED", "NOT_APPLICABLE"]
     radius: StrictInt | None = Field(default=None, ge=0, le=255)
     connected: StrictBool

--- a/src/jacobian/math/graphs/optimization/_invariant_verification.py
+++ b/src/jacobian/math/graphs/optimization/_invariant_verification.py
@@ -1,0 +1,62 @@
+"""Explicit checking of graph-relative invariant claims."""
+
+from jacobian.math.graphs.optimization._chromatic_kernel import build_simple_graph
+from jacobian.math.graphs.optimization._invariant_models import (
+    GraphCoreRequest,
+    GraphCoreResult,
+    GraphDiameterResult,
+    GraphEdgeConnectivityResult,
+    GraphEulerianResult,
+    GraphGirthResult,
+    GraphRadiusResult,
+    GraphSpanningTreeCountResult,
+    GraphTriangleCountResult,
+    GraphVertexConnectivityResult,
+)
+
+type GraphInvariantClaim = (
+    GraphCoreResult
+    | GraphDiameterResult
+    | GraphEdgeConnectivityResult
+    | GraphEulerianResult
+    | GraphGirthResult
+    | GraphRadiusResult
+    | GraphSpanningTreeCountResult
+    | GraphTriangleCountResult
+    | GraphVertexConnectivityResult
+)
+
+
+def verify_graph_invariant(claim: GraphInvariantClaim) -> bool:
+    """Check the retained graph's claimed invariant within its 256-vertex domain.
+
+    Only the selected invariant is computed. Diagnostic prose is not part of
+    the mathematical relation, and parsing never invokes this checker.
+    """
+    from jacobian.math.graphs.optimization import _invariants as kernels
+
+    graph = build_simple_graph(claim.graph)
+    expected: GraphInvariantClaim
+    if isinstance(claim, GraphCoreResult):
+        expected = kernels._k_core_execute(
+            GraphCoreRequest(graph=claim.graph, k=claim.k)
+        )
+    elif isinstance(claim, GraphDiameterResult):
+        expected = kernels._diameter(graph, claim.graph)
+    elif isinstance(claim, GraphEdgeConnectivityResult):
+        expected = kernels._edge_connectivity(graph, claim.graph)
+    elif isinstance(claim, GraphEulerianResult):
+        expected = kernels._eulerian(graph, claim.graph)
+    elif isinstance(claim, GraphGirthResult):
+        expected = kernels._girth(graph, claim.graph)
+    elif isinstance(claim, GraphRadiusResult):
+        expected = kernels._radius(graph, claim.graph)
+    elif isinstance(claim, GraphSpanningTreeCountResult):
+        expected = kernels._spanning_tree_count(graph, claim.graph)
+    elif isinstance(claim, GraphTriangleCountResult):
+        expected = kernels._triangle_count(graph, claim.graph)
+    else:
+        expected = kernels._vertex_connectivity(graph, claim.graph)
+    return expected.model_dump(exclude={"detail"}) == claim.model_dump(
+        exclude={"detail"}
+    )

--- a/src/jacobian/math/graphs/optimization/_invariants.py
+++ b/src/jacobian/math/graphs/optimization/_invariants.py
@@ -63,7 +63,7 @@ def _computed[
     title: str,
     description: str,
     result_model: type[ResultT],
-    operation: Callable[[Any], ResultT],
+    operation: Callable[[Any, SimpleUndirectedGraph], ResultT],
     *tags: str,
     examples: tuple[OperationExample, ...] = (),
 ) -> MathTool[GraphInvariantRequest, ResultT]:
@@ -71,7 +71,7 @@ def _computed[
         request: GraphInvariantRequest,
     ) -> ResultT:
         graph = cast(Any, build_simple_graph(request.graph))
-        return operation(graph)
+        return operation(graph, request.graph)
 
     return MathTool(
         operation_id=operation_id,
@@ -85,66 +85,76 @@ def _computed[
     )
 
 
-def _girth(graph: Any) -> GraphGirthResult:
+def _girth(graph: Any, source: SimpleUndirectedGraph) -> GraphGirthResult:
     import networkx as nx
 
     value = nx.girth(graph)
     girth = 0 if math.isinf(value) else int(value)
-    return GraphGirthResult(girth=girth, has_cycle=girth > 0)
+    return GraphGirthResult(graph=source, girth=girth, has_cycle=girth > 0)
 
 
-def _diameter(graph: Any) -> GraphDiameterResult:
+def _diameter(graph: Any, source: SimpleUndirectedGraph) -> GraphDiameterResult:
     import networkx as nx
 
     from jacobian.math.graphs import diameter
 
     if not graph or not nx.is_connected(graph):
         return GraphDiameterResult(
+            graph=source,
             status="NOT_APPLICABLE",
             connected=False,
             detail="diameter requires a nonempty connected graph",
         )
     return GraphDiameterResult(
-        status="COMPUTED", diameter=diameter(graph), connected=True
+        graph=source, status="COMPUTED", diameter=diameter(graph), connected=True
     )
 
 
-def _edge_connectivity(graph: Any) -> GraphEdgeConnectivityResult:
+def _edge_connectivity(
+    graph: Any, source: SimpleUndirectedGraph
+) -> GraphEdgeConnectivityResult:
     import networkx as nx
 
     value = 0 if len(graph) <= 1 else int(nx.edge_connectivity(graph))
-    return GraphEdgeConnectivityResult(edge_connectivity=value)
+    return GraphEdgeConnectivityResult(graph=source, edge_connectivity=value)
 
 
-def _vertex_connectivity(graph: Any) -> GraphVertexConnectivityResult:
+def _vertex_connectivity(
+    graph: Any, source: SimpleUndirectedGraph
+) -> GraphVertexConnectivityResult:
     import networkx as nx
 
     value = 0 if len(graph) <= 1 else int(nx.node_connectivity(graph))
-    return GraphVertexConnectivityResult(vertex_connectivity=value)
+    return GraphVertexConnectivityResult(graph=source, vertex_connectivity=value)
 
 
-def _eulerian(graph: Any) -> GraphEulerianResult:
+def _eulerian(graph: Any, source: SimpleUndirectedGraph) -> GraphEulerianResult:
     from jacobian.math.graphs import is_eulerian
 
-    return GraphEulerianResult(is_eulerian=is_eulerian(graph))
+    return GraphEulerianResult(graph=source, is_eulerian=is_eulerian(graph))
 
 
-def _spanning_tree_count(graph: Any) -> GraphSpanningTreeCountResult:
+def _spanning_tree_count(
+    graph: Any, source: SimpleUndirectedGraph
+) -> GraphSpanningTreeCountResult:
     import networkx as nx
     import sympy
 
     if not graph:
         return GraphSpanningTreeCountResult(
+            graph=source,
             spanning_tree_count=0,
             connected=False,
         )
     if not nx.is_connected(graph):
         return GraphSpanningTreeCountResult(
+            graph=source,
             spanning_tree_count=0,
             connected=False,
         )
     if len(graph) == 1:
         return GraphSpanningTreeCountResult(
+            graph=source,
             spanning_tree_count=1,
             connected=True,
         )
@@ -159,6 +169,7 @@ def _spanning_tree_count(graph: Any) -> GraphSpanningTreeCountResult:
         laplacian[left_index, right_index] -= 1
         laplacian[right_index, left_index] -= 1
     return GraphSpanningTreeCountResult(
+        graph=source,
         spanning_tree_count=int(laplacian[:-1, :-1].det()),
         connected=True,
     )
@@ -227,23 +238,26 @@ def _maximum_matching_execute(
     return _maximum_matching(graph, request.graph)
 
 
-def _triangle_count(graph: Any) -> GraphTriangleCountResult:
+def _triangle_count(
+    graph: Any, source: SimpleUndirectedGraph
+) -> GraphTriangleCountResult:
     from jacobian.math.graphs import triangle_count
 
-    return GraphTriangleCountResult(triangle_count=triangle_count(graph))
+    return GraphTriangleCountResult(graph=source, triangle_count=triangle_count(graph))
 
 
-def _radius(graph: Any) -> GraphRadiusResult:
+def _radius(graph: Any, source: SimpleUndirectedGraph) -> GraphRadiusResult:
     import networkx as nx
 
     if not graph or not nx.is_connected(graph):
         return GraphRadiusResult(
+            graph=source,
             status="NOT_APPLICABLE",
             connected=False,
             detail="radius requires a nonempty connected graph",
         )
     return GraphRadiusResult(
-        status="COMPUTED", radius=int(nx.radius(graph)), connected=True
+        graph=source, status="COMPUTED", radius=int(nx.radius(graph)), connected=True
     )
 
 
@@ -255,6 +269,7 @@ def _k_core_execute(
     graph = cast(Any, build_simple_graph(request.graph))
     core = nx.k_core(graph, k=request.k)
     return GraphCoreResult(
+        graph=request.graph,
         k=request.k,
         vertices=tuple(sorted(str(vertex) for vertex in core.nodes)),
     )

--- a/src/jacobian/math/graphs/optimization/_matching_verification.py
+++ b/src/jacobian/math/graphs/optimization/_matching_verification.py
@@ -1,0 +1,41 @@
+"""Independent linear-time checking of a retained Tutte-Berge relation."""
+
+from jacobian.math.graphs.optimization._invariant_models import (
+    GraphMaximumMatchingResult,
+)
+
+
+def verify_maximum_matching(claim: GraphMaximumMatchingResult) -> bool:
+    """Check feasibility and the Tutte-Berge upper bound for the source graph.
+
+    The canonical graph bounds this traversal by 256 vertices and 32640
+    edges. No matching optimization or barrier search is repeated.
+    """
+    graph = claim.graph
+    vertices = set(graph.vertices)
+    barrier = set(claim.certificate.barrier_vertices)
+    if not barrier <= vertices or not set(claim.witness_edges) <= set(graph.edges):
+        return False
+    adjacency: dict[str, set[str]] = {v: set() for v in vertices - barrier}
+    for u, v in graph.edges:
+        if u not in barrier and v not in barrier:
+            adjacency[u].add(v)
+            adjacency[v].add(u)
+    remaining = set(adjacency)
+    odd_count = 0
+    while remaining:
+        pending = [remaining.pop()]
+        size = 0
+        while pending:
+            current = pending.pop()
+            size += 1
+            for neighbor in adjacency[current]:
+                if neighbor in remaining:
+                    remaining.remove(neighbor)
+                    pending.append(neighbor)
+        odd_count += size % 2
+    return (
+        odd_count == claim.certificate.odd_component_count
+        and 2 * claim.maximum_matching_cardinality
+        == len(vertices) + len(barrier) - odd_count
+    )

--- a/src/jacobian/math/graphs/path_decomposition/__init__.py
+++ b/src/jacobian/math/graphs/path_decomposition/__init__.py
@@ -2,6 +2,7 @@
 
 from jacobian.math.graphs.path_decomposition.operations import (
     compute_minimum_path_decomposition,
+    verify_path_decomposition,
 )
 
-__all__ = ["compute_minimum_path_decomposition"]
+__all__ = ["compute_minimum_path_decomposition", "verify_path_decomposition"]

--- a/src/jacobian/math/graphs/path_decomposition/_models.py
+++ b/src/jacobian/math/graphs/path_decomposition/_models.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from itertools import pairwise
 from typing import Self
 
 from pydantic import Field, model_validator
@@ -36,21 +35,25 @@ class PathDecompositionRequest(StrictModel):
 
 
 class PathDecompositionResult(StrictModel):
-    """The minimum path decomposition of a graph."""
+    """The minimum path decomposition of a graph.
+
+    Parsing is structural only: path shape, vertex membership, and count
+    alignment. Whether paths partition the source edges is a caller-authored
+    claim checked by ``verify_path_decomposition``; minimum-count optimality
+    is the producer's outcome, not a parsing invariant.
+    """
 
     graph: SimpleUndirectedGraph
     path_count: int = Field(ge=0)
     paths: tuple[tuple[str, ...], ...]
 
     @model_validator(mode="after")
-    def require_source_edge_partition(self) -> Self:
+    def require_structural_shape(self) -> Self:
         if self.path_count != len(self.paths):
             raise PydanticCustomError(
                 "path_decomposition.path_count",
                 "path_count must equal the number of returned paths",
             )
-        source_edges = set(self.graph.edges)
-        used_edges: set[tuple[str, str]] = set()
         source_vertices = set(self.graph.vertices)
         for path in self.paths:
             if len(path) < 2 or len(path) != len(set(path)):
@@ -63,20 +66,18 @@ class PathDecompositionResult(StrictModel):
                     "path_decomposition.unknown_vertex",
                     "returned paths must use vertices from the source graph",
                 )
-            for left, right in pairwise(path):
-                edge = (left, right) if left < right else (right, left)
-                if edge not in source_edges or edge in used_edges:
-                    raise PydanticCustomError(
-                        "path_decomposition.edge_partition",
-                        "returned paths must partition the source edges exactly once",
-                    )
-                used_edges.add(edge)
-        if used_edges != source_edges:
-            raise PydanticCustomError(
-                "path_decomposition.edge_partition",
-                "returned paths must partition the source edges exactly once",
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        graph: SimpleUndirectedGraph,
+        path_count: int,
+        paths: tuple[tuple[str, ...], ...],
+    ) -> Self:
+        """Construct a result after the kernel established the partition."""
+
+        return cls.model_construct(graph=graph, path_count=path_count, paths=paths)
 
 
 __all__ = [

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -46,10 +46,30 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
     for left, right in graph.edges:
         adjacency[left].add(right)
         adjacency[right].add(left)
-    # Estimate only: each edge can seed a DFS bounded by the state envelope.
-    # The kernel enumerates candidates once; admission never materializes them.
-    estimate = len(graph.edges) * max(1, vertex_count)
-    if estimate > MAX_SEARCH_STATES:
+    # Every simple path stays in one connected component and is an ordered
+    # sequence of at least two distinct vertices. Sum permutations per
+    # component to bound the DFS before it materializes a candidate.
+    unseen = set(graph.vertices)
+    path_bound = 0
+    while unseen:
+        component = {unseen.pop()}
+        frontier = list(component)
+        while frontier:
+            vertex = frontier.pop()
+            for neighbor in adjacency[vertex] & unseen:
+                unseen.remove(neighbor)
+                component.add(neighbor)
+                frontier.append(neighbor)
+        maximum_degree = max(len(adjacency[vertex]) for vertex in component)
+        walks_at_length = len(component) * maximum_degree
+        for _length in range(2, len(component) + 1):
+            path_bound += walks_at_length
+            if path_bound > MAX_SEARCH_STATES:
+                break
+            walks_at_length *= max(maximum_degree - 1, 0)
+        if path_bound > MAX_SEARCH_STATES:
+            break
+    if path_bound > MAX_SEARCH_STATES:
         _reject(
             "search_work_bound",
             "the exact path search exceeds its bounded work envelope",

--- a/src/jacobian/math/graphs/path_decomposition/operations.py
+++ b/src/jacobian/math/graphs/path_decomposition/operations.py
@@ -13,7 +13,7 @@ from jacobian.math.graphs.path_decomposition._models import (
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
-__all__ = ["compute_minimum_path_decomposition"]
+__all__ = ["compute_minimum_path_decomposition", "verify_path_decomposition"]
 
 MAX_SEARCH_STATES = 1_000_000
 MAX_CANDIDATE_EDGE_INCIDENCES = 1_000_000
@@ -21,8 +21,7 @@ MAX_CANDIDATE_EDGE_INCIDENCES = 1_000_000
 
 @dataclass(frozen=True, slots=True)
 class _PathSearchPlan:
-    candidates: tuple[frozenset[tuple[str, str]], ...]
-    candidate_incidences: int
+    adjacency: dict[str, set[str]]
     candidate_checks_bound: int
 
 
@@ -37,6 +36,7 @@ def _reject(code: str, message: str) -> NoReturn:
 
 
 def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
+    """Admit representation and estimate search work without enumerating paths."""
     if not isinstance(graph, SimpleUndirectedGraph):
         _reject("invalid_graph", "graph must be a simple undirected graph")
     vertex_count = len(graph.vertices)
@@ -46,21 +46,17 @@ def _admit_graph(graph: SimpleUndirectedGraph) -> _PathSearchPlan:
     for left, right in graph.edges:
         adjacency[left].add(right)
         adjacency[right].add(left)
-
-    candidate_sets, candidate_incidences = _find_all_simple_paths(
-        adjacency, candidate_limit=MAX_SEARCH_STATES
-    )
-    candidates = tuple(
-        sorted(
-            candidate_sets,
-            key=lambda path: (-len(path), tuple(sorted(path))),
+    # Estimate only: each edge can seed a DFS bounded by the state envelope.
+    # The kernel enumerates candidates once; admission never materializes them.
+    estimate = len(graph.edges) * max(1, vertex_count)
+    if estimate > MAX_SEARCH_STATES:
+        _reject(
+            "search_work_bound",
+            "the exact path search exceeds its bounded work envelope",
         )
-    )
-    candidate_checks_bound = MAX_SEARCH_STATES
     return _PathSearchPlan(
-        candidates=candidates,
-        candidate_incidences=candidate_incidences,
-        candidate_checks_bound=candidate_checks_bound,
+        adjacency=adjacency,
+        candidate_checks_bound=MAX_SEARCH_STATES,
     )
 
 
@@ -75,13 +71,22 @@ def compute_minimum_path_decomposition(
     plan = _admit_graph(graph)
     edges = list(graph.edges)
     if not edges:
-        return PathDecompositionResult(graph=graph, path_count=0, paths=())
+        return PathDecompositionResult._from_kernel(graph=graph, path_count=0, paths=())
 
+    candidate_sets, candidate_incidences = _find_all_simple_paths(
+        plan.adjacency, candidate_limit=MAX_SEARCH_STATES
+    )
+    candidates = tuple(
+        sorted(
+            candidate_sets,
+            key=lambda path: (-len(path), tuple(sorted(path))),
+        )
+    )
     edge_set = frozenset(edges)
     best = _minimum_cover(
         edge_set,
-        plan.candidates,
-        candidate_incidences=plan.candidate_incidences,
+        candidates,
+        candidate_incidences=candidate_incidences,
         candidate_checks_bound=plan.candidate_checks_bound,
     )
 
@@ -93,11 +98,38 @@ def compute_minimum_path_decomposition(
         vertices = _path_to_vertices(path_edges)
         if vertices:
             path_vertices.append(tuple(vertices))
-    return PathDecompositionResult(
+    return PathDecompositionResult._from_kernel(
         graph=graph,
         path_count=len(best),
         paths=tuple(path_vertices),
     )
+
+
+def verify_path_decomposition(claim: PathDecompositionResult) -> bool:
+    """Check a claimed edge-path partition without any optimality search.
+
+    Verifies each path is simple, uses source vertices, and the paths
+    partition the source edge set exactly once. Minimum-count optimality
+    remains the producer's outcome and is not re-established here.
+    """
+    from itertools import pairwise
+
+    if claim.path_count != len(claim.paths):
+        return False
+    source_edges = set(claim.graph.edges)
+    used: set[tuple[str, str]] = set()
+    source_vertices = set(claim.graph.vertices)
+    for path in claim.paths:
+        if len(path) < 2 or len(path) != len(set(path)):
+            return False
+        if any(vertex not in source_vertices for vertex in path):
+            return False
+        for left, right in pairwise(path):
+            edge = (left, right) if left < right else (right, left)
+            if edge not in source_edges or edge in used:
+                return False
+            used.add(edge)
+    return used == source_edges
 
 
 def _find_all_simple_paths(

--- a/src/jacobian/math/graphs/polynomials/__init__.py
+++ b/src/jacobian/math/graphs/polynomials/__init__.py
@@ -7,6 +7,8 @@ from jacobian.math.graphs.polynomials.operations import (
     independence_polynomial_coefficients,
     matching_polynomial,
     tutte_polynomial,
+    verify_graph_polynomial,
+    verify_independence_polynomial,
 )
 
 __all__ = [
@@ -16,4 +18,6 @@ __all__ = [
     "independence_polynomial_coefficients",
     "matching_polynomial",
     "tutte_polynomial",
+    "verify_graph_polynomial",
+    "verify_independence_polynomial",
 ]

--- a/src/jacobian/math/graphs/polynomials/_models.py
+++ b/src/jacobian/math/graphs/polynomials/_models.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Annotated, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import ConfigDict, Field, StrictInt, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
-from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.canonical import format_canonical_integer
 from jacobian.math.graphs.values import (
     IndexedSimpleUndirectedGraph,
     SimpleUndirectedGraph,
@@ -204,14 +204,6 @@ class TreeIndependencePolynomialResult(StrictModel):
     """
 
     graph: SimpleUndirectedGraph
-    coefficients: tuple[_NonnegativeCanonicalInteger, ...] = Field(
-        min_length=2,
-        max_length=MAX_INDEPENDENCE_POLYNOMIAL_TERMS,
-        description=(
-            "Dense coefficients i_0, ..., i_alpha as canonical decimal "
-            "nonnegative integers."
-        ),
-    )
     polynomial: RationalPolynomial
     independence_number: StrictInt = Field(
         ge=1,
@@ -221,6 +213,18 @@ class TreeIndependencePolynomialResult(StrictModel):
     independent_set_count: _NonnegativeCanonicalInteger = Field(
         description="The total I_T(1) as a canonical decimal integer."
     )
+
+    @property
+    def coefficients(self) -> tuple[str, ...]:
+        """Native dense integer projection; no duplicate polynomial is serialized."""
+        terms = self.polynomial.polynomial.terms
+        if any(term.coefficient.den != "1" for term in terms):
+            raise ValueError(
+                "integer coefficient projection requires integral coefficients"
+            )
+        degree = max((term.exponents[0] for term in terms), default=0)
+        values = {term.exponents[0]: term.coefficient.num for term in terms}
+        return tuple(values.get(i, "0") for i in range(degree + 1))
 
     @model_validator(mode="after")
     def require_structural_shape(self) -> Self:
@@ -236,16 +240,6 @@ class TreeIndependencePolynomialResult(StrictModel):
             maximum_coefficient_digits=MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS,
             label="independence polynomial",
         )
-        if any(
-            len(coefficient.lstrip("-"))
-            > MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS
-            for coefficient in self.coefficients
-        ):
-            raise PydanticCustomError(
-                "graph.independence_coefficient_exceeds_max_independence_polynomial_coefficie",
-                "independence coefficient exceeds the "
-                f"{MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS}-digit bound",
-            )
         if (
             len(self.independent_set_count.lstrip("-"))
             > MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS
@@ -254,34 +248,6 @@ class TreeIndependencePolynomialResult(StrictModel):
                 "graph.independent_set_count_exceeds_max_independence_polynomial",
                 "independent-set count exceeds the "
                 f"{MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS}-digit bound",
-            )
-        coefficients = tuple(
-            parse_canonical_integer(coefficient) for coefficient in self.coefficients
-        )
-        if self.coefficients[0] != "1":
-            raise PydanticCustomError(
-                "graph.independence_coefficients_must_begin_with_one",
-                "independence coefficients must begin with the empty-set count 1",
-            )
-        if self.coefficients[1] != format_canonical_integer(len(self.graph.vertices)):
-            raise PydanticCustomError(
-                "graph.independence_linear_coefficient_must_equal_vertex_count",
-                "independence polynomial linear coefficient must equal vertex count",
-            )
-        if self.independence_number != len(coefficients) - 1:
-            raise PydanticCustomError(
-                "graph.independence_number_must_equal_coefficient_degree",
-                "independence number must equal the dense coefficient degree",
-            )
-        if self.independent_set_count != format_canonical_integer(sum(coefficients)):
-            raise PydanticCustomError(
-                "graph.independent_set_count_must_equal_coefficient_sum",
-                "independent-set count must equal the dense coefficient sum",
-            )
-        if self.polynomial != _polynomial_from_dense_coefficients(coefficients):
-            raise PydanticCustomError(
-                "graph.independence_polynomial_must_match_dense_coefficients",
-                "independence polynomial must match its dense coefficients",
             )
         return self
 
@@ -296,9 +262,6 @@ class TreeIndependencePolynomialResult(StrictModel):
 
         return cls.model_construct(
             graph=graph,
-            coefficients=tuple(
-                format_canonical_integer(coefficient) for coefficient in coefficients
-            ),
             polynomial=_polynomial_from_dense_coefficients(coefficients),
             independence_number=len(coefficients) - 1,
             independent_set_count=format_canonical_integer(sum(coefficients)),
@@ -336,27 +299,25 @@ class PolynomialTerm(StrictModel):
 
 
 class GraphPolynomialResult(StrictModel):
-    """A sparse polynomial represented as a list of (coefficient, degree) terms."""
+    """A graph polynomial over QQ with its source and variable convention."""
 
-    terms: tuple[PolynomialTerm, ...]
+    graph: IndexedSimpleUndirectedGraph
+    kind: Literal["CHROMATIC", "FLOW", "MATCHING", "TUTTE"]
+    polynomial: RationalPolynomial
 
     @model_validator(mode="after")
-    def require_canonical(self) -> Self:
-        degrees = [term.degree for term in self.terms]
-        if degrees != sorted(degrees):
+    def require_variable_convention(self) -> Self:
+        variables = (
+            ("x", "y")
+            if self.kind == "TUTTE"
+            else ("flow_x",)
+            if self.kind == "FLOW"
+            else ("x",)
+        )
+        if self.polynomial.variables != variables:
             raise PydanticCustomError(
-                "graph.polynomial_terms_must_be_sorted_by_degree",
-                "polynomial terms must be sorted by degree",
-            )
-        if len(set(degrees)) != len(degrees):
-            raise PydanticCustomError(
-                "graph.polynomial_degrees_must_be_unique",
-                "polynomial degrees must be unique",
-            )
-        if any(term.coefficient == 0 for term in self.terms):
-            raise PydanticCustomError(
-                "graph.polynomial_terms_must_have_nonzero_coefficients",
-                "polynomial terms must have nonzero coefficients",
+                "graph.polynomial_variable_convention",
+                "polynomial axes must match the graph-polynomial convention",
             )
         return self
 

--- a/src/jacobian/math/graphs/polynomials/_tools.py
+++ b/src/jacobian/math/graphs/polynomials/_tools.py
@@ -11,33 +11,26 @@ from jacobian.math.graphs.polynomials._models import (
     GraphPolynomialRequest,
     GraphPolynomialResult,
     MatchingPolynomialRequest,
-    SparseMultivariatePolynomial,
     TreeIndependencePolynomialAdmissionError,
     TreeIndependencePolynomialRequest,
     TreeIndependencePolynomialResult,
 )
 from jacobian.math.graphs.polynomials.operations import (
-    chromatic_polynomial,
-    flow_polynomial,
+    _graph_polynomial_result,
     independence_polynomial_coefficients,
-    matching_polynomial,
-    tutte_polynomial,
 )
 
 
-def _run_tutte(request: GraphPolynomialRequest) -> SparseMultivariatePolynomial:
-    return SparseMultivariatePolynomial(
-        variables=("x", "y"),
-        terms=tutte_polynomial(request.graph),
-    )
+def _run_tutte(request: GraphPolynomialRequest) -> GraphPolynomialResult:
+    return _graph_polynomial_result(request.graph, "TUTTE")
 
 
 def _run_chromatic(request: GraphPolynomialRequest) -> GraphPolynomialResult:
-    return GraphPolynomialResult(terms=chromatic_polynomial(request.graph))
+    return _graph_polynomial_result(request.graph, "CHROMATIC")
 
 
 def _run_flow(request: GraphPolynomialRequest) -> GraphPolynomialResult:
-    return GraphPolynomialResult(terms=flow_polynomial(request.graph))
+    return _graph_polynomial_result(request.graph, "FLOW")
 
 
 def _run_independence(
@@ -58,7 +51,7 @@ def _run_independence(
 
 
 def _run_matching(request: MatchingPolynomialRequest) -> GraphPolynomialResult:
-    return GraphPolynomialResult(terms=matching_polynomial(request.graph))
+    return _graph_polynomial_result(request.graph, "MATCHING")
 
 
 _CYCLE_GRAPH_EXAMPLE: dict[str, Any] = {
@@ -99,7 +92,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "graph using NetworkX, with structural exponent pairs on the ordered "
         "variable axis (x, y).",
         request_type=GraphPolynomialRequest,
-        result_type=SparseMultivariatePolynomial,
+        result_type=GraphPolynomialResult,
         run=_run_tutte,
         tags=("graph", "polynomial", "tutte", "exact"),
         examples=(

--- a/src/jacobian/math/graphs/polynomials/operations.py
+++ b/src/jacobian/math/graphs/polynomials/operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from functools import cache
+from typing import Literal
 
 import networkx as nx
 import sympy
@@ -16,9 +17,11 @@ from jacobian.math.graphs.polynomials._models import (
     MAX_GRAPH_POLYNOMIAL_VERTICES,
     MAX_MATCHING_EDGES,
     MAX_MATCHING_VERTICES,
+    GraphPolynomialResult,
     MultivariatePolynomialTerm,
     PolynomialTerm,
     TreeIndependencePolynomialAdmissionError,
+    TreeIndependencePolynomialResult,
     _admitted_tree_profile,
     _TreeProfile,
 )
@@ -262,6 +265,65 @@ def matching_polynomial(
     return terms
 
 
+def _graph_polynomial_result(
+    graph: IndexedSimpleUndirectedGraph,
+    kind: Literal["CHROMATIC", "FLOW", "MATCHING", "TUTTE"],
+) -> GraphPolynomialResult:
+    variables: tuple[str, ...]
+    if kind == "TUTTE":
+        variables = ("x", "y")
+        terms = tuple(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational.from_integer_ratio(term.coefficient, 1),
+                exponents=term.exponents,
+            )
+            for term in reversed(tutte_polynomial(graph))
+        )
+    else:
+        variables = ("flow_x",) if kind == "FLOW" else ("x",)
+        rows = (
+            chromatic_polynomial(graph)
+            if kind == "CHROMATIC"
+            else flow_polynomial(graph)
+            if kind == "FLOW"
+            else matching_polynomial(graph)
+        )
+        terms = tuple(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational.from_integer_ratio(term.coefficient, 1),
+                exponents=(term.degree,),
+            )
+            for term in reversed(rows)
+        )
+    return GraphPolynomialResult(
+        graph=graph,
+        kind=kind,
+        polynomial=RationalPolynomial(
+            variables=variables, polynomial=SparseRationalPolynomial(terms=terms)
+        ),
+    )
+
+
+def verify_graph_polynomial(claim: GraphPolynomialResult) -> bool:
+    """Check the selected graph polynomial using its existing graph/work admission."""
+    return (
+        _graph_polynomial_result(claim.graph, claim.kind).polynomial == claim.polynomial
+    )
+
+
+def verify_independence_polynomial(claim: TreeIndependencePolynomialResult) -> bool:
+    """Check a tree polynomial and its summaries under the tree DP admission."""
+    coefficients = independence_polynomial_coefficients(claim.graph)
+    actual = TreeIndependencePolynomialResult._from_kernel(
+        graph=claim.graph, coefficients=coefficients
+    )
+    return (
+        actual.polynomial == claim.polynomial
+        and actual.independence_number == claim.independence_number
+        and actual.independent_set_count == claim.independent_set_count
+    )
+
+
 __all__ = [
     "MAX_TREE_POLYNOMIAL_RETAINED_LABEL_CHARACTERS",
     "chromatic_polynomial",
@@ -270,4 +332,6 @@ __all__ = [
     "independence_polynomial_coefficients",
     "matching_polynomial",
     "tutte_polynomial",
+    "verify_graph_polynomial",
+    "verify_independence_polynomial",
 ]

--- a/src/jacobian/math/graphs/quivers/_models.py
+++ b/src/jacobian/math/graphs/quivers/_models.py
@@ -60,15 +60,17 @@ class FixedLengthPathsRequest(StrictModel):
 
 
 class AdjacencyMatricesResult(StrictModel):
+    """Two square matrix values on the shared implicit vertex axis."""
+
     adjacency_matrix: tuple[tuple[int, ...], ...]
     transpose_matrix: tuple[tuple[int, ...], ...]
-    vertex_count: int = Field(ge=1)
 
 
 class VertexProfilesResult(StrictModel):
+    """In- and out-degree vectors on their shared implicit vertex axis."""
+
     in_degrees: tuple[int, ...]
     out_degrees: tuple[int, ...]
-    vertex_count: int = Field(ge=1)
 
 
 class FixedLengthPathsResult(StrictModel):

--- a/src/jacobian/math/graphs/quivers/operations.py
+++ b/src/jacobian/math/graphs/quivers/operations.py
@@ -24,7 +24,6 @@ def adjacency_matrices(quiver: FiniteQuiver) -> AdjacencyMatricesResult:
     return AdjacencyMatricesResult(
         adjacency_matrix=adj,
         transpose_matrix=transpose,
-        vertex_count=n,
     )
 
 
@@ -39,7 +38,6 @@ def vertex_profiles(quiver: FiniteQuiver) -> VertexProfilesResult:
     return VertexProfilesResult(
         in_degrees=tuple(in_degrees),
         out_degrees=tuple(out_degrees),
-        vertex_count=n,
     )
 
 

--- a/src/jacobian/math/graphs/realization/operations.py
+++ b/src/jacobian/math/graphs/realization/operations.py
@@ -48,9 +48,7 @@ def graph_realization(sequence: DegreeSequence) -> GraphRealizationResult:
     """Construct a simple graph realizing the degree sequence."""
     degrees = sequence.degrees
     if not _is_graphical_erdos_gallai(degrees):
-        return GraphRealizationResult(
-            sequence=sequence, is_graphical=False
-        )
+        return GraphRealizationResult(sequence=sequence, is_graphical=False)
     graph = nx.havel_hakimi_graph(list(degrees))
     return GraphRealizationResult(
         sequence=sequence,

--- a/src/jacobian/math/graphs/regular_subgraph/__init__.py
+++ b/src/jacobian/math/graphs/regular_subgraph/__init__.py
@@ -5,9 +5,11 @@ from jacobian.math.graphs.regular_subgraph._models import (
 )
 from jacobian.math.graphs.regular_subgraph.operations import (
     find_k_regular_subgraph,
+    verify_k_regular_subgraph,
 )
 
 __all__ = [
     "RegularSubgraphResult",
     "find_k_regular_subgraph",
+    "verify_k_regular_subgraph",
 ]

--- a/src/jacobian/math/graphs/regular_subgraph/operations.py
+++ b/src/jacobian/math/graphs/regular_subgraph/operations.py
@@ -99,4 +99,28 @@ def find_k_regular_subgraph(
     return RegularSubgraphResult(graph=graph, k=k, found=False)
 
 
-__all__ = ["find_k_regular_subgraph"]
+def verify_k_regular_subgraph(claim: RegularSubgraphResult) -> bool:
+    """Return whether a retained witness or absence claim is valid."""
+    if not claim.found:
+        try:
+            return not find_k_regular_subgraph(claim.graph, claim.k).found
+        except OperationDomainValidationError:
+            return False
+    vertices = set(claim.vertices)
+    if not vertices or len(vertices) != len(claim.vertices):
+        return False
+    if not vertices <= set(claim.graph.vertices):
+        return False
+    graph_edges = {frozenset(edge) for edge in claim.graph.edges}
+    if any(frozenset(edge) not in graph_edges for edge in claim.edges):
+        return False
+    degrees = dict.fromkeys(vertices, 0)
+    for left, right in claim.edges:
+        if left not in vertices or right not in vertices:
+            return False
+        degrees[left] += 1
+        degrees[right] += 1
+    return all(degree == claim.k for degree in degrees.values())
+
+
+__all__ = ["find_k_regular_subgraph", "verify_k_regular_subgraph"]

--- a/src/jacobian/math/groups/abelian/__init__.py
+++ b/src/jacobian/math/groups/abelian/__init__.py
@@ -7,6 +7,7 @@ from jacobian.math.groups.abelian.operations import (
     normalize_presentation,
     quotient_group,
     reduce_element,
+    verify_element_order,
     verify_elements_equal,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "normalize_presentation",
     "quotient_group",
     "reduce_element",
+    "verify_element_order",
     "verify_elements_equal",
 ]

--- a/src/jacobian/math/groups/abelian/__init__.py
+++ b/src/jacobian/math/groups/abelian/__init__.py
@@ -9,6 +9,8 @@ from jacobian.math.groups.abelian.operations import (
     reduce_element,
     verify_element_order,
     verify_elements_equal,
+    verify_generated_subgroup,
+    verify_quotient_group,
 )
 
 __all__ = [
@@ -20,4 +22,6 @@ __all__ = [
     "reduce_element",
     "verify_element_order",
     "verify_elements_equal",
+    "verify_generated_subgroup",
+    "verify_quotient_group",
 ]

--- a/src/jacobian/math/groups/abelian/__init__.py
+++ b/src/jacobian/math/groups/abelian/__init__.py
@@ -7,6 +7,7 @@ from jacobian.math.groups.abelian.operations import (
     normalize_presentation,
     quotient_group,
     reduce_element,
+    verify_elements_equal,
 )
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "normalize_presentation",
     "quotient_group",
     "reduce_element",
+    "verify_elements_equal",
 ]

--- a/src/jacobian/math/groups/abelian/_models.py
+++ b/src/jacobian/math/groups/abelian/_models.py
@@ -204,6 +204,9 @@ class ElementReduceResult(StrictModel):
 
 
 class ElementEqualResult(StrictModel):
+    """A source-bound equality claim for two finite abelian group elements."""
+
+    request: ElementEqualRequest
     equal: bool
 
 

--- a/src/jacobian/math/groups/abelian/_models.py
+++ b/src/jacobian/math/groups/abelian/_models.py
@@ -194,9 +194,30 @@ class QuotientRequest(StrictModel):
 
 
 class PresentationNormalizeResult(StrictModel):
-    invariant_factors: tuple[int, ...]
-    order: int = Field(ge=1)
-    rank: int = Field(ge=0)
+    """The canonical finite abelian-group presentation."""
+
+    presentation: AbelianPresentation
+
+    @property
+    def invariant_factors(self) -> tuple[int, ...]:
+        """Project the canonical invariant factors."""
+
+        return self.presentation.invariant_factors
+
+    @property
+    def order(self) -> int:
+        """Return the order of the presented finite group."""
+
+        order = 1
+        for factor in self.presentation.invariant_factors:
+            order *= factor
+        return order
+
+    @property
+    def rank(self) -> int:
+        """The finite-only contract admits no free summands."""
+
+        return 0
 
 
 class ElementReduceResult(StrictModel):

--- a/src/jacobian/math/groups/abelian/_models.py
+++ b/src/jacobian/math/groups/abelian/_models.py
@@ -211,6 +211,9 @@ class ElementEqualResult(StrictModel):
 
 
 class ElementOrderResult(StrictModel):
+    """A source-bound order claim for a finite abelian group element."""
+
+    request: ElementOrderRequest
     order: int = Field(ge=1)
 
 

--- a/src/jacobian/math/groups/abelian/_models.py
+++ b/src/jacobian/math/groups/abelian/_models.py
@@ -227,24 +227,29 @@ class ElementReduceResult(StrictModel):
 class ElementEqualResult(StrictModel):
     """A source-bound equality claim for two finite abelian group elements."""
 
-    request: ElementEqualRequest
+    invariant_factors: tuple[int, ...]
+    coordinates_a: tuple[int, ...]
+    coordinates_b: tuple[int, ...]
     equal: bool
 
 
 class ElementOrderResult(StrictModel):
     """A source-bound order claim for a finite abelian group element."""
 
-    request: ElementOrderRequest
+    invariant_factors: tuple[int, ...]
+    coordinates: tuple[int, ...]
     order: int = Field(ge=1)
 
 
 class SubgroupGeneratedResult(StrictModel):
-    request: SubgroupGeneratedRequest
+    invariant_factors: tuple[int, ...]
+    generators: tuple[tuple[int, ...], ...]
     index: int = Field(ge=1)
     coset_representatives: tuple[tuple[int, ...], ...] = ()
 
 
 class QuotientResult(StrictModel):
-    request: QuotientRequest
+    invariant_factors: tuple[int, ...]
+    subgroup_generators: tuple[tuple[int, ...], ...]
     quotient_invariant_factors: tuple[int, ...] = ()
     quotient_order: int = Field(ge=1)

--- a/src/jacobian/math/groups/abelian/_models.py
+++ b/src/jacobian/math/groups/abelian/_models.py
@@ -218,10 +218,12 @@ class ElementOrderResult(StrictModel):
 
 
 class SubgroupGeneratedResult(StrictModel):
+    request: SubgroupGeneratedRequest
     index: int = Field(ge=1)
     coset_representatives: tuple[tuple[int, ...], ...] = ()
 
 
 class QuotientResult(StrictModel):
+    request: QuotientRequest
     quotient_invariant_factors: tuple[int, ...] = ()
     quotient_order: int = Field(ge=1)

--- a/src/jacobian/math/groups/abelian/operations.py
+++ b/src/jacobian/math/groups/abelian/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from math import gcd, lcm
 
 from jacobian.math.groups.abelian._models import (
+    AbelianPresentation,
     ElementEqualRequest,
     ElementEqualResult,
     ElementOrderRequest,
@@ -28,13 +29,8 @@ def normalize_presentation(
     smith = smith_normal_form(matrix, domain=None)
     factors = tuple(int(smith[i, i]) for i in range(min(smith.rows, smith.cols)))
     cleaned = tuple(factor for factor in factors if factor > 1)
-    order = 1
-    for factor in cleaned:
-        order *= factor
     return PresentationNormalizeResult(
-        invariant_factors=cleaned,
-        order=order,
-        rank=0,
+        presentation=AbelianPresentation(invariant_factors=cleaned),
     )
 
 

--- a/src/jacobian/math/groups/abelian/operations.py
+++ b/src/jacobian/math/groups/abelian/operations.py
@@ -11,7 +11,9 @@ from jacobian.math.groups.abelian._models import (
     ElementOrderResult,
     ElementReduceResult,
     PresentationNormalizeResult,
+    QuotientRequest,
     QuotientResult,
+    SubgroupGeneratedRequest,
     SubgroupGeneratedResult,
 )
 
@@ -139,7 +141,12 @@ def generated_subgroup(
     for factor in diagonal:
         if factor > 1:
             index *= factor
-    return SubgroupGeneratedResult(index=index)
+    return SubgroupGeneratedResult(
+        request=SubgroupGeneratedRequest(
+            invariant_factors=invariant_factors, generators=generators
+        ),
+        index=index,
+    )
 
 
 def quotient_group(
@@ -160,8 +167,35 @@ def quotient_group(
     for factor in quotient_factors:
         order *= factor
     return QuotientResult(
+        request=QuotientRequest(
+            invariant_factors=invariant_factors,
+            subgroup_generators=subgroup_generators,
+        ),
         quotient_invariant_factors=quotient_factors,
         quotient_order=order,
+    )
+
+
+def verify_generated_subgroup(claim: SubgroupGeneratedResult) -> bool:
+    """Check the index relation asserted by a serialized subgroup claim."""
+
+    return (
+        generated_subgroup(
+            claim.request.invariant_factors, claim.request.generators
+        ).index
+        == claim.index
+    )
+
+
+def verify_quotient_group(claim: QuotientResult) -> bool:
+    """Check the quotient presentation asserted by a serialized claim."""
+
+    expected = quotient_group(
+        claim.request.invariant_factors, claim.request.subgroup_generators
+    )
+    return (
+        expected.quotient_invariant_factors == claim.quotient_invariant_factors
+        and expected.quotient_order == claim.quotient_order
     )
 
 
@@ -174,4 +208,6 @@ __all__ = [
     "reduce_element",
     "verify_element_order",
     "verify_elements_equal",
+    "verify_generated_subgroup",
+    "verify_quotient_group",
 ]

--- a/src/jacobian/math/groups/abelian/operations.py
+++ b/src/jacobian/math/groups/abelian/operations.py
@@ -6,15 +6,11 @@ from math import gcd, lcm
 
 from jacobian.math.groups.abelian._models import (
     AbelianPresentation,
-    ElementEqualRequest,
     ElementEqualResult,
-    ElementOrderRequest,
     ElementOrderResult,
     ElementReduceResult,
     PresentationNormalizeResult,
-    QuotientRequest,
     QuotientResult,
-    SubgroupGeneratedRequest,
     SubgroupGeneratedResult,
 )
 
@@ -58,11 +54,9 @@ def elements_equal(
         for coordinate, factor in zip(coordinates_b, invariant_factors, strict=True)
     )
     return ElementEqualResult(
-        request=ElementEqualRequest(
-            invariant_factors=invariant_factors,
-            coordinates_a=coordinates_a,
-            coordinates_b=coordinates_b,
-        ),
+        invariant_factors=invariant_factors,
+        coordinates_a=coordinates_a,
+        coordinates_b=coordinates_b,
         equal=reduced_a == reduced_b,
     )
 
@@ -72,9 +66,9 @@ def verify_elements_equal(claim: ElementEqualResult) -> bool:
 
     return (
         elements_equal(
-            claim.request.invariant_factors,
-            claim.request.coordinates_a,
-            claim.request.coordinates_b,
+            claim.invariant_factors,
+            claim.coordinates_a,
+            claim.coordinates_b,
         ).equal
         is claim.equal
     )
@@ -92,10 +86,8 @@ def element_order(
         if coordinate != 0:
             order = lcm(order, factor // gcd(coordinate, factor))
     return ElementOrderResult(
-        request=ElementOrderRequest(
-            invariant_factors=invariant_factors,
-            coordinates=coordinates,
-        ),
+        invariant_factors=invariant_factors,
+        coordinates=coordinates,
         order=order,
     )
 
@@ -105,8 +97,8 @@ def verify_element_order(claim: ElementOrderResult) -> bool:
 
     return (
         element_order(
-            claim.request.invariant_factors,
-            claim.request.coordinates,
+            claim.invariant_factors,
+            claim.coordinates,
         ).order
         == claim.order
     )
@@ -138,9 +130,8 @@ def generated_subgroup(
         if factor > 1:
             index *= factor
     return SubgroupGeneratedResult(
-        request=SubgroupGeneratedRequest(
-            invariant_factors=invariant_factors, generators=generators
-        ),
+        invariant_factors=invariant_factors,
+        generators=generators,
         index=index,
     )
 
@@ -163,10 +154,8 @@ def quotient_group(
     for factor in quotient_factors:
         order *= factor
     return QuotientResult(
-        request=QuotientRequest(
-            invariant_factors=invariant_factors,
-            subgroup_generators=subgroup_generators,
-        ),
+        invariant_factors=invariant_factors,
+        subgroup_generators=subgroup_generators,
         quotient_invariant_factors=quotient_factors,
         quotient_order=order,
     )
@@ -176,9 +165,7 @@ def verify_generated_subgroup(claim: SubgroupGeneratedResult) -> bool:
     """Check the index relation asserted by a serialized subgroup claim."""
 
     return (
-        generated_subgroup(
-            claim.request.invariant_factors, claim.request.generators
-        ).index
+        generated_subgroup(claim.invariant_factors, claim.generators).index
         == claim.index
     )
 
@@ -186,9 +173,7 @@ def verify_generated_subgroup(claim: SubgroupGeneratedResult) -> bool:
 def verify_quotient_group(claim: QuotientResult) -> bool:
     """Check the quotient presentation asserted by a serialized claim."""
 
-    expected = quotient_group(
-        claim.request.invariant_factors, claim.request.subgroup_generators
-    )
+    expected = quotient_group(claim.invariant_factors, claim.subgroup_generators)
     return (
         expected.quotient_invariant_factors == claim.quotient_invariant_factors
         and expected.quotient_order == claim.quotient_order

--- a/src/jacobian/math/groups/abelian/operations.py
+++ b/src/jacobian/math/groups/abelian/operations.py
@@ -7,6 +7,7 @@ from math import gcd, lcm
 from jacobian.math.groups.abelian._models import (
     ElementEqualRequest,
     ElementEqualResult,
+    ElementOrderRequest,
     ElementOrderResult,
     ElementReduceResult,
     PresentationNormalizeResult,
@@ -92,7 +93,25 @@ def element_order(
     for coordinate, factor in zip(reduced, invariant_factors, strict=True):
         if coordinate != 0:
             order = lcm(order, factor // gcd(coordinate, factor))
-    return ElementOrderResult(order=order)
+    return ElementOrderResult(
+        request=ElementOrderRequest(
+            invariant_factors=invariant_factors,
+            coordinates=coordinates,
+        ),
+        order=order,
+    )
+
+
+def verify_element_order(claim: ElementOrderResult) -> bool:
+    """Check the order relation asserted by a serialized element claim."""
+
+    return (
+        element_order(
+            claim.request.invariant_factors,
+            claim.request.coordinates,
+        ).order
+        == claim.order
+    )
 
 
 def _smith_diagonal(augmented_rows: list[list[int]]) -> list[int]:
@@ -153,5 +172,6 @@ __all__ = [
     "normalize_presentation",
     "quotient_group",
     "reduce_element",
+    "verify_element_order",
     "verify_elements_equal",
 ]

--- a/src/jacobian/math/groups/abelian/operations.py
+++ b/src/jacobian/math/groups/abelian/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from math import gcd, lcm
 
 from jacobian.math.groups.abelian._models import (
+    ElementEqualRequest,
     ElementEqualResult,
     ElementOrderResult,
     ElementReduceResult,
@@ -57,7 +58,27 @@ def elements_equal(
         coordinate % factor
         for coordinate, factor in zip(coordinates_b, invariant_factors, strict=True)
     )
-    return ElementEqualResult(equal=reduced_a == reduced_b)
+    return ElementEqualResult(
+        request=ElementEqualRequest(
+            invariant_factors=invariant_factors,
+            coordinates_a=coordinates_a,
+            coordinates_b=coordinates_b,
+        ),
+        equal=reduced_a == reduced_b,
+    )
+
+
+def verify_elements_equal(claim: ElementEqualResult) -> bool:
+    """Check the equality relation asserted by a serialized element claim."""
+
+    return (
+        elements_equal(
+            claim.request.invariant_factors,
+            claim.request.coordinates_a,
+            claim.request.coordinates_b,
+        ).equal
+        is claim.equal
+    )
 
 
 def element_order(
@@ -132,4 +153,5 @@ __all__ = [
     "normalize_presentation",
     "quotient_group",
     "reduce_element",
+    "verify_elements_equal",
 ]

--- a/src/jacobian/math/groups/actions/__init__.py
+++ b/src/jacobian/math/groups/actions/__init__.py
@@ -7,6 +7,10 @@ from jacobian.math.groups.actions.operations import (
     polya_inventory,
     subset_canonicalization,
     subset_family_orbit_profile,
+    verify_burnside_count,
+    verify_cycle_index,
+    verify_element_cycles,
+    verify_polya_inventory,
 )
 
 __all__ = [
@@ -16,4 +20,8 @@ __all__ = [
     "polya_inventory",
     "subset_canonicalization",
     "subset_family_orbit_profile",
+    "verify_burnside_count",
+    "verify_cycle_index",
+    "verify_element_cycles",
+    "verify_polya_inventory",
 ]

--- a/src/jacobian/math/groups/actions/_models.py
+++ b/src/jacobian/math/groups/actions/_models.py
@@ -530,45 +530,29 @@ class ElementCyclesResult(StrictModel):
                 "permutation_not_permutation",
                 "permutation must be a permutation of the action domain",
             )
-        flattened = tuple(position for cycle in self.cycles for position in cycle)
-        if (
-            not self.cycles
-            or any(not cycle for cycle in self.cycles)
-            or sorted(flattened) != list(range(n))
-        ):
-            raise _validation_error(
-                "cycles_not_partition", "cycles must partition the action domain"
-            )
-        if any(
-            self.permutation[position] != cycle[(index + 1) % len(cycle)]
+        if len(self.cycles) > n or any(
+            not cycle or len(cycle) > n or any(not 0 <= index < n for index in cycle)
             for cycle in self.cycles
-            for index, position in enumerate(cycle)
         ):
             raise _validation_error(
-                "cycles_not_permutation_cycles",
-                "cycles must describe the claimed permutation",
+                "cycle_shape", "cycle rows must be bounded nonempty domain indices"
             )
-        lengths = tuple(sorted((len(cycle) for cycle in self.cycles), reverse=True))
-        if self.cycle_lengths != lengths or self.cycle_type != lengths:
+        for positions in (self.fixed_points, self.support):
+            if tuple(sorted(set(positions))) != positions or any(
+                not 0 <= index < n for index in positions
+            ):
+                raise _validation_error(
+                    "profile_axis", "profile positions must be canonical domain subsets"
+                )
+        if not 0 <= self.fixed_point_count <= n:
             raise _validation_error(
-                "cycle_type_mismatch",
-                "cycle lengths and cycle type must match the cycle decomposition",
+                "profile_bound", "fixed-point count must be bounded by the domain"
             )
-        fixed = tuple(
-            position for position in range(n) if self.permutation[position] == position
-        )
-        if self.fixed_points != fixed or self.fixed_point_count != len(fixed):
-            raise _validation_error(
-                "fixed_point_count_mismatch",
-                "fixed-point fields must match the claimed permutation",
-            )
-        support = tuple(
-            position for position in range(n) if self.permutation[position] != position
-        )
-        if self.support != support:
-            raise _validation_error(
-                "support_mismatch", "support must match the claimed permutation"
-            )
+        for lengths in (self.cycle_lengths, self.cycle_type):
+            if len(lengths) > n or any(not 1 <= length <= n for length in lengths):
+                raise _validation_error(
+                    "cycle_length_bound", "cycle lengths must fit the domain"
+                )
         return self
 
     @classmethod
@@ -653,10 +637,6 @@ class CycleIndexResult(StrictModel):
                 "cycle_type_counts_invalid",
                 "each cycle type must partition degree with positive count",
             )
-        if sum(count for _, count in self.cycle_type_counts) != self.group_order:
-            raise _validation_error(
-                "cycle_type_counts_total", "cycle-type counts must total group_order"
-            )
         return self
 
     @classmethod
@@ -694,8 +674,8 @@ class BurnsideCountResult(StrictModel):
 
     action: FinitePermutationAction
     group_order: int
-    fixed_point_sum: int
-    orbit_count: int
+    fixed_point_sum: int = Field(ge=0, le=MAX_GROUP_ORDER * MAX_DOMAIN_SIZE)
+    orbit_count: int = Field(ge=0, le=MAX_DOMAIN_SIZE)
     fixed_point_contributions: tuple[int, ...]
 
     @model_validator(mode="after")
@@ -712,19 +692,6 @@ class BurnsideCountResult(StrictModel):
             raise _validation_error(
                 "fixed_point_contributions_invalid",
                 "fixed-point contributions must be bounded and one per group element",
-            )
-        if self.fixed_point_sum != sum(self.fixed_point_contributions):
-            raise _validation_error(
-                "fixed_point_sum_mismatch",
-                "fixed_point_sum must equal the sum of contributions",
-            )
-        if (
-            self.fixed_point_sum % self.group_order != 0
-            or self.orbit_count != self.fixed_point_sum // self.group_order
-        ):
-            raise _validation_error(
-                "orbit_count_mismatch",
-                "orbit_count must be the integral Burnside average",
             )
         return self
 
@@ -790,7 +757,6 @@ class PolyaInventoryResult(StrictModel):
         if any(
             len(monomial) != self.colors
             or any(exponent < 0 for exponent in monomial)
-            or sum(monomial) != self.degree
             or coefficient < 1
             for monomial, coefficient in self.terms
         ):

--- a/src/jacobian/math/groups/actions/operations.py
+++ b/src/jacobian/math/groups/actions/operations.py
@@ -453,6 +453,26 @@ def polya_inventory(
     return PolyaInventoryResult._from_kernel(action, colors, degree, terms)
 
 
+def verify_element_cycles(claim: ElementCyclesResult) -> bool:
+    """Check the enumerated element and every cycle-derived field once."""
+    return element_cycles(claim.action, claim.element) == claim
+
+
+def verify_cycle_index(claim: CycleIndexResult) -> bool:
+    """Check cycle counts against the bounded generated action."""
+    return cycle_index(claim.action) == claim
+
+
+def verify_burnside_count(claim: BurnsideCountResult) -> bool:
+    """Check fixed-point contributions and their orbit count."""
+    return burnside_count(claim.action) == claim
+
+
+def verify_polya_inventory(claim: PolyaInventoryResult) -> bool:
+    """Check inventory coefficients in the admitted coloring domain."""
+    return polya_inventory(claim.action, claim.colors) == claim
+
+
 __all__ = [
     "burnside_count",
     "cycle_index",
@@ -460,4 +480,8 @@ __all__ = [
     "polya_inventory",
     "subset_canonicalization",
     "subset_family_orbit_profile",
+    "verify_burnside_count",
+    "verify_cycle_index",
+    "verify_element_cycles",
+    "verify_polya_inventory",
 ]

--- a/src/jacobian/math/groups/cohomology/__init__.py
+++ b/src/jacobian/math/groups/cohomology/__init__.py
@@ -1,5 +1,8 @@
 """Group cohomology operations."""
 
-from jacobian.math.groups.cohomology.operations import group_cohomology
+from jacobian.math.groups.cohomology.operations import (
+    group_cohomology,
+    verify_cohomology,
+)
 
-__all__ = ["group_cohomology"]
+__all__ = ["group_cohomology", "verify_cohomology"]

--- a/src/jacobian/math/groups/cohomology/_models.py
+++ b/src/jacobian/math/groups/cohomology/_models.py
@@ -116,18 +116,10 @@ class GroupCohomologyResult(StrictModel):
                 f"group_order must not exceed {MAX_GROUP_ORDER}",
             )
         for group in self.groups:
-            expected_dimension = self.group_order**group.degree
-            if group.cochain_dimension != expected_dimension:
-                raise _validation_error(
-                    "cochain_dimension",
-                    "cochain_dimension must equal group_order**degree",
-                )
             if group.betti > group.cochain_dimension:
                 raise _validation_error(
                     "betti_bound", "betti cannot exceed cochain_dimension"
                 )
-        if self.groups[0].betti != 1:
-            raise _validation_error("degree_zero_betti", "H^0 has betti one")
         return self
 
     @classmethod

--- a/src/jacobian/math/groups/cohomology/operations.py
+++ b/src/jacobian/math/groups/cohomology/operations.py
@@ -226,4 +226,9 @@ def group_cohomology(
     )
 
 
-__all__ = ["group_cohomology"]
+def verify_cohomology(claim: GroupCohomologyResult) -> bool:
+    """Check order, cochain dimensions and Betti claims after bar admission."""
+    return group_cohomology(claim.group, claim.prime, claim.max_degree) == claim
+
+
+__all__ = ["group_cohomology", "verify_cohomology"]

--- a/src/jacobian/math/lattices/__init__.py
+++ b/src/jacobian/math/lattices/__init__.py
@@ -13,6 +13,9 @@ from jacobian.math.lattices.operations import (
     compute_sublattice_index,
     hermite_normal_form,
     reduce_basis,
+    verify_discriminant_group,
+    verify_rank_gram,
+    verify_sublattice_index,
 )
 
 __all__ = [
@@ -28,4 +31,7 @@ __all__ = [
     "compute_sublattice_index",
     "hermite_normal_form",
     "reduce_basis",
+    "verify_discriminant_group",
+    "verify_rank_gram",
+    "verify_sublattice_index",
 ]

--- a/src/jacobian/math/lattices/_models.py
+++ b/src/jacobian/math/lattices/_models.py
@@ -8,6 +8,7 @@ from typing import Annotated, Literal, Self
 from pydantic import Field, WithJsonSchema, model_validator
 from pydantic_core import PydanticCustomError
 
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices.values import (
@@ -217,19 +218,39 @@ class RankGramRequest(StrictModel):
 class RankGramResult(StrictModel):
     """Exact rank, labelled Gram matrix ``G = B B^T``, and squared covolume."""
 
-    rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
-    ambient_dimension: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
+    lattice: IntegerLattice
     gram_matrix: IntegerMatrix
-    squared_covolume: str
+    squared_covolume: CanonicalInteger
     covolume_rational: bool
     relation: Literal["GRAM_EQUALS_BASIS_TIMES_BASIS_TRANSPOSE"] = (
         "GRAM_EQUALS_BASIS_TIMES_BASIS_TRANSPOSE"
     )
     gram_mode: Literal["EXACT"] = "EXACT"
 
+    @property
+    def rank(self) -> int:
+        return len(self.lattice.basis.entries)
+
+    @property
+    def ambient_dimension(self) -> int:
+        return self.lattice.ambient_dimension
+
+    @model_validator(mode="after")
+    def require_gram_shape(self) -> Self:
+        if (
+            len(self.gram_matrix.entries) != self.rank
+            or self.gram_matrix.column_count != self.rank
+        ):
+            raise _validation_error(
+                "gram_shape", "Gram matrix must be square on the lattice basis axis"
+            )
+        return self
+
 
 class CanonicalBasisResult(StrictModel):
     """Canonical HNF basis of a lattice and its unimodular transformation."""
+
+    lattice: IntegerLattice
 
     canonical_basis: IntegerMatrix
     transformation: IntegerMatrix
@@ -248,6 +269,8 @@ class DualRequest(StrictModel):
 class DualResult(StrictModel):
     """Exact rational dual basis ``L^* = {x in span_Q(L) : <x,L> subset ZZ}``."""
 
+    lattice: IntegerLattice
+
     dual_basis: RationalMatrix
     dual_gram: RationalMatrix
     relation: Literal["DUAL_BASIS_BASIS_PAIRING_IS_INTEGER"] = (
@@ -257,6 +280,8 @@ class DualResult(StrictModel):
 
 class SaturationResult(StrictModel):
     """Primitive closure ``sat(L) = span_Q(L) cap ZZ^n`` and its index."""
+
+    lattice: IntegerLattice
 
     saturated_basis: IntegerMatrix
     inclusion_transform: IntegerMatrix
@@ -316,8 +341,11 @@ class SublatticeIndexRequest(StrictModel):
 class SublatticeIndexResult(StrictModel):
     """Finite quotient invariant factors and the sublattice index."""
 
+    inclusion: SublatticeIndexRequest
     index: int = Field(ge=1)
-    invariant_factors: tuple[str, ...]
+    invariant_factors: tuple[CanonicalInteger, ...] = Field(
+        max_length=MAX_MATRIX_DIMENSION
+    )
     free_rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
     relation: Literal["QUOTIENT_IS_DIRECT_SUM_OF_CYCLIC_GROUPS"] = (
         "QUOTIENT_IS_DIRECT_SUM_OF_CYCLIC_GROUPS"
@@ -333,8 +361,11 @@ class DiscriminantGroupRequest(StrictModel):
 class DiscriminantGroupResult(StrictModel):
     """Finite abelian group ``L^*/L`` and the discriminant order ``|det G|``."""
 
+    lattice: IntegerLattice
     discriminant_order: int = Field(ge=1)
-    invariant_factors: tuple[str, ...]
+    invariant_factors: tuple[CanonicalInteger, ...] = Field(
+        max_length=MAX_MATRIX_DIMENSION
+    )
     relation: Literal["DISCRIMINANT_GROUP_EQUALS_DUAL_MOD_LATTICE"] = (
         "DISCRIMINANT_GROUP_EQUALS_DUAL_MOD_LATTICE"
     )
@@ -348,6 +379,8 @@ class OrthogonalComplementRequest(StrictModel):
 
 class OrthogonalComplementResult(StrictModel):
     """A canonical rational basis for the orthogonal complement."""
+
+    lattice: IntegerLattice
 
     complement_basis: RationalVectorSpaceBasis
     complement_rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
@@ -382,6 +415,9 @@ class OrthogonalSumRequest(StrictModel):
 class DirectSumResult(StrictModel):
     """Block-coordinate direct sum of two lattices."""
 
+    first: IntegerLattice
+    second: IntegerLattice
+
     direct_sum_basis: IntegerMatrix
     ambient_dimension: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
     relation: Literal["DIRECT_SUM_IS_BLOCK_DIAGONAL_EMBEDDING"] = (
@@ -391,6 +427,9 @@ class DirectSumResult(StrictModel):
 
 class OrthogonalSumResult(StrictModel):
     """Block-diagonal orthogonal sum of two lattices under the standard form."""
+
+    first: IntegerLattice
+    second: IntegerLattice
 
     orthogonal_sum_basis: IntegerMatrix
     ambient_dimension: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)

--- a/src/jacobian/math/lattices/_models.py
+++ b/src/jacobian/math/lattices/_models.py
@@ -341,7 +341,9 @@ class SublatticeIndexRequest(StrictModel):
 class SublatticeIndexResult(StrictModel):
     """Finite quotient invariant factors and the sublattice index."""
 
-    inclusion: SublatticeIndexRequest
+    sublattice: IntegerLattice
+    parent: IntegerLattice
+    embedding: IntegerMatrix
     index: int = Field(ge=1)
     invariant_factors: tuple[CanonicalInteger, ...] = Field(
         max_length=MAX_MATRIX_DIMENSION

--- a/src/jacobian/math/lattices/operations.py
+++ b/src/jacobian/math/lattices/operations.py
@@ -50,7 +50,6 @@ from jacobian.math.lattices._models import (
     OrthogonalSumResult,
     RankGramResult,
     SaturationResult,
-    SublatticeIndexRequest,
     SublatticeIndexResult,
 )
 from jacobian.math.matrices.values import (
@@ -286,9 +285,9 @@ def compute_sublattice_index(
         parent_rank=len(parent.basis.entries),
     )
     return SublatticeIndexResult(
-        inclusion=SublatticeIndexRequest(
-            sublattice=sublattice, parent=parent, embedding=embedding
-        ),
+        sublattice=sublattice,
+        parent=parent,
+        embedding=embedding,
         index=index,
         invariant_factors=tuple(format_canonical_integer(f) for f in factors),
         free_rank=free_rank,
@@ -359,7 +358,7 @@ def verify_rank_gram(claim: RankGramResult) -> bool:
 
 def verify_sublattice_index(claim: SublatticeIndexResult) -> bool:
     """Check the retained inclusion and its bounded Smith quotient invariants."""
-    source = claim.inclusion
+    source = claim
     return (
         compute_sublattice_index(source.sublattice, source.parent, source.embedding)
         == claim

--- a/src/jacobian/math/lattices/operations.py
+++ b/src/jacobian/math/lattices/operations.py
@@ -50,6 +50,7 @@ from jacobian.math.lattices._models import (
     OrthogonalSumResult,
     RankGramResult,
     SaturationResult,
+    SublatticeIndexRequest,
     SublatticeIndexResult,
 )
 from jacobian.math.matrices.values import (
@@ -72,6 +73,9 @@ __all__ = [
     "compute_sublattice_index",
     "hermite_normal_form",
     "reduce_basis",
+    "verify_discriminant_group",
+    "verify_rank_gram",
+    "verify_sublattice_index",
 ]
 
 
@@ -177,12 +181,10 @@ def compute_rank_gram(lattice: IntegerLattice) -> RankGramResult:
     """Compute exact rank, Gram matrix, and squared covolume."""
 
     basis = _admit_lattice(lattice)
-    rank = len(basis)
     gram = _gram_matrix(basis)
     det = integer_determinant(gram)
     return RankGramResult(
-        rank=rank,
-        ambient_dimension=lattice.ambient_dimension,
+        lattice=lattice,
         gram_matrix=_integer_matrix(gram),
         squared_covolume=format_canonical_integer(det),
         covolume_rational=isqrt(det) ** 2 == det,
@@ -194,6 +196,7 @@ def compute_canonical_basis(lattice: IntegerLattice) -> CanonicalBasisResult:
 
     hnf, transform = _hermite_basis(_admit_lattice(lattice))
     return CanonicalBasisResult(
+        lattice=lattice,
         canonical_basis=_integer_matrix(hnf),
         transformation=_integer_matrix(transform),
         rank=integer_rank(hnf),
@@ -220,6 +223,7 @@ def compute_dual(lattice: IntegerLattice) -> DualResult:
                 row.append(Fraction(int(entry), 1))
         dual_gram_fractions.append(row)
     return DualResult(
+        lattice=lattice,
         dual_basis=rational_matrix_from_fractions(dual),
         dual_gram=rational_matrix_from_fractions(dual_gram_fractions),
     )
@@ -230,6 +234,7 @@ def compute_saturation(lattice: IntegerLattice) -> SaturationResult:
 
     saturated, inclusion, index = _saturate_lattice(_admit_lattice(lattice))
     return SaturationResult(
+        lattice=lattice,
         saturated_basis=_integer_matrix(saturated),
         inclusion_transform=_integer_matrix(inclusion),
         saturation_index=index,
@@ -281,6 +286,9 @@ def compute_sublattice_index(
         parent_rank=len(parent.basis.entries),
     )
     return SublatticeIndexResult(
+        inclusion=SublatticeIndexRequest(
+            sublattice=sublattice, parent=parent, embedding=embedding
+        ),
         index=index,
         invariant_factors=tuple(format_canonical_integer(f) for f in factors),
         free_rank=free_rank,
@@ -292,6 +300,7 @@ def compute_discriminant_group(lattice: IntegerLattice) -> DiscriminantGroupResu
 
     order, factors = _discriminant_group(_admit_lattice(lattice))
     return DiscriminantGroupResult(
+        lattice=lattice,
         discriminant_order=order,
         invariant_factors=tuple(format_canonical_integer(f) for f in factors),
     )
@@ -304,6 +313,7 @@ def compute_orthogonal_complement(
 
     complement = _orthogonal_complement(_admit_lattice(lattice))
     return OrthogonalComplementResult(
+        lattice=lattice,
         complement_basis=rational_vector_space_basis_from_fractions(
             complement,
             ambient_dimension=lattice.ambient_dimension,
@@ -320,6 +330,8 @@ def compute_direct_sum(
     first_basis, second_basis = _admit_lattice_sum(first, second)
     result = _direct_sum(first_basis, second_basis)
     return DirectSumResult(
+        first=first,
+        second=second,
         direct_sum_basis=_integer_matrix(result),
         ambient_dimension=first.ambient_dimension + second.ambient_dimension,
     )
@@ -333,6 +345,27 @@ def compute_orthogonal_sum(
     first_basis, second_basis = _admit_lattice_sum(first, second)
     result = _orthogonal_sum(first_basis, second_basis)
     return OrthogonalSumResult(
+        first=first,
+        second=second,
         orthogonal_sum_basis=_integer_matrix(result),
         ambient_dimension=first.ambient_dimension + second.ambient_dimension,
     )
+
+
+def verify_rank_gram(claim: RankGramResult) -> bool:
+    """Check Gram entries, covolume and square claim after lattice admission."""
+    return compute_rank_gram(claim.lattice) == claim
+
+
+def verify_sublattice_index(claim: SublatticeIndexResult) -> bool:
+    """Check the retained inclusion and its bounded Smith quotient invariants."""
+    source = claim.inclusion
+    return (
+        compute_sublattice_index(source.sublattice, source.parent, source.embedding)
+        == claim
+    )
+
+
+def verify_discriminant_group(claim: DiscriminantGroupResult) -> bool:
+    """Check discriminant order and factors against the retained lattice."""
+    return compute_discriminant_group(claim.lattice) == claim

--- a/src/jacobian/math/logic/term_rewriting/_kernel.py
+++ b/src/jacobian/math/logic/term_rewriting/_kernel.py
@@ -15,6 +15,7 @@ from jacobian.math.logic.term_rewriting.values import (
     RankedSignature,
     RewriteApplication,
     RewriteRule,
+    Substitution,
     Term,
     _variable_symbols,
 )
@@ -671,7 +672,7 @@ def _critical_pairs(
                         candidate_index=candidate_index,
                         outer_variable_renaming=outer_renaming,
                         inner_variable_renaming=inner_renaming,
-                        substitution=substitution,
+                        substitution=Substitution(mapping=substitution),
                         inner_reduct=inner_reduct,
                         outer_reduct=outer_reduct,
                     )
@@ -696,7 +697,7 @@ def selected_rewrite_step(
     return RewriteApplication(
         position=position,
         rule_index=rule_index,
-        substitution=substitution,
+        substitution=Substitution(mapping=substitution),
         term=_replace_at_position(term, position, replacement),
     )
 

--- a/src/jacobian/math/logic/term_rewriting/_models.py
+++ b/src/jacobian/math/logic/term_rewriting/_models.py
@@ -70,11 +70,11 @@ class MatchingResult(MatchingRequest):
     """Result of one-way matching."""
 
     matched: bool
-    substitution: dict[int, Term] = Field(default_factory=dict)
+    substitution: Substitution = Field(default_factory=Substitution)
 
     @model_validator(mode="after")
     def bind_matching(self) -> Self:
-        if not self.matched and self.substitution:
+        if not self.matched and self.substitution.mapping:
             raise _validation_error(
                 "matching_result", "an unmatched result cannot include a substitution"
             )
@@ -95,7 +95,7 @@ class MatchingResult(MatchingRequest):
             pattern=pattern,
             subject=subject,
             matched=matched,
-            substitution=substitution,
+            substitution=Substitution(mapping=substitution),
         )
 
 
@@ -111,11 +111,11 @@ class UnificationResult(UnificationRequest):
     """Result of unification."""
 
     unified: bool
-    substitution: dict[int, Term] = Field(default_factory=dict)
+    substitution: Substitution = Field(default_factory=Substitution)
 
     @model_validator(mode="after")
     def require_exact_unifier(self) -> Self:
-        if not self.unified and self.substitution:
+        if not self.unified and self.substitution.mapping:
             raise _validation_error(
                 "failed_unification", "failed unification must not claim a substitution"
             )
@@ -136,7 +136,7 @@ class UnificationResult(UnificationRequest):
             left=left,
             right=right,
             unified=unified,
-            substitution=substitution,
+            substitution=Substitution(mapping=substitution),
         )
 
 

--- a/src/jacobian/math/logic/term_rewriting/values.py
+++ b/src/jacobian/math/logic/term_rewriting/values.py
@@ -121,12 +121,27 @@ class RewriteRule(StrictModel):
         return self
 
 
+class Substitution(StrictModel):
+    """A variable substitution mapping variable IDs to terms."""
+
+    mapping: dict[int, Term] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def require_bounded_labels(self) -> Self:
+        if any(not 0 <= key <= MAX_VARIABLE_LABEL for key in self.mapping):
+            raise _validation_error(
+                "substitution_labels",
+                "substitution variable labels must be within the supported bound",
+            )
+        return self
+
+
 class RewriteApplication(StrictModel):
     """One fully witnessed one-step rewrite derivation."""
 
     position: tuple[int, ...]
     rule_index: int = Field(ge=0)
-    substitution: dict[int, Term]
+    substitution: Substitution
     term: Term
 
 
@@ -143,7 +158,7 @@ class CriticalPair(StrictModel):
     candidate_index: int = Field(ge=0)
     outer_variable_renaming: dict[int, int]
     inner_variable_renaming: dict[int, int]
-    substitution: dict[int, Term]
+    substitution: Substitution
     inner_reduct: Term
     outer_reduct: Term
 
@@ -182,21 +197,6 @@ def _require_term_depth(*terms: Term) -> None:
                 f"root-to-leaf path carries at most {MAX_TERM_DEPTH} nodes",
             )
         stack.extend((child, depth + 1) for child in current.children)
-
-
-class Substitution(StrictModel):
-    """A variable substitution mapping variable IDs to terms."""
-
-    mapping: dict[int, Term] = Field(default_factory=dict)
-
-    @model_validator(mode="after")
-    def require_bounded_labels(self) -> Self:
-        if any(not 0 <= key <= MAX_VARIABLE_LABEL for key in self.mapping):
-            raise _validation_error(
-                "substitution_labels",
-                "substitution variable labels must be within the supported bound",
-            )
-        return self
 
 
 __all__ = [

--- a/src/jacobian/math/matrices/__init__.py
+++ b/src/jacobian/math/matrices/__init__.py
@@ -14,6 +14,11 @@ from jacobian.math.matrices.operations import (
     smith_normal_form,
     solve_linear_system,
     trace,
+    verify_adjugate,
+    verify_inverse,
+    verify_kronecker_product,
+    verify_partial_trace,
+    verify_product,
 )
 from jacobian.math.matrices.values import (
     EmbeddedRealSimpleNumberFieldMatrix,
@@ -42,4 +47,9 @@ __all__ = [
     "smith_normal_form",
     "solve_linear_system",
     "trace",
+    "verify_adjugate",
+    "verify_inverse",
+    "verify_kronecker_product",
+    "verify_partial_trace",
+    "verify_product",
 ]

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -451,11 +451,14 @@ class NullspaceResult(StrictModel):
     ambient_dimension: int = Field(ge=0, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
     rank: int = Field(ge=0, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
     nullity: int = Field(ge=0, le=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
-    basis_vectors: tuple[tuple[CanonicalRational, ...], ...] = Field(
-        max_length=MAX_SPARSE_RATIONAL_MATRIX_AXIS
-    )
+    basis_matrix: RationalMatrix
     free_columns: tuple[int, ...] = Field(max_length=MAX_SPARSE_RATIONAL_MATRIX_AXIS)
     convention: Literal["RREF_FUNDAMENTAL_BASIS"] = "RREF_FUNDAMENTAL_BASIS"
+
+    @property
+    def basis_vectors(self) -> tuple[tuple[CanonicalRational, ...], ...]:
+        """Native row projection of the canonical QQ basis matrix."""
+        return self.basis_matrix.entries
 
     @classmethod
     def _from_kernel(cls, **values: Any) -> Self:
@@ -475,7 +478,7 @@ class NullspaceResult(StrictModel):
             raise _validation_error(
                 "shape_mismatch", "basis vector count must equal nullity"
             )
-        if any(len(vector) != self.ambient_dimension for vector in self.basis_vectors):
+        if self.basis_matrix.column_count != self.ambient_dimension:
             raise _validation_error(
                 "shape_mismatch", "each basis vector must have the ambient dimension"
             )
@@ -522,8 +525,20 @@ class CharacteristicPolynomialResult(StrictModel):
 
 
 class MatrixInverseResult(StrictModel):
+    matrix: IntegerMatrix
     inverse: RationalMatrix
     convention: Literal["TWO_SIDED_INVERSE_OVER_QQ"] = "TWO_SIDED_INVERSE_OVER_QQ"
+
+    @model_validator(mode="after")
+    def require_source_shape(self) -> Self:
+        if self.matrix.row_count != self.matrix.column_count or (
+            self.inverse.row_count,
+            self.inverse.column_count,
+        ) != (self.matrix.row_count, self.matrix.column_count):
+            raise _validation_error(
+                "shape_mismatch", "inverse must match its square source"
+            )
+        return self
 
 
 class MatrixTraceResult(StrictModel):
@@ -538,16 +553,31 @@ class MatrixTraceResult(StrictModel):
 
 
 class MatrixProductResult(StrictModel):
+    left: RationalMatrix
+    right: RationalMatrix
     product: RationalMatrix
-    left_rows: int = Field(ge=0, le=MAX_MATRIX_PRODUCT_AXIS)
-    inner_dimension: int = Field(ge=0, le=MAX_MATRIX_PRODUCT_AXIS)
-    right_columns: int = Field(ge=0, le=MAX_MATRIX_PRODUCT_AXIS)
     convention: Literal["STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ"] = (
         "STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ"
     )
 
+    @property
+    def left_rows(self) -> int:
+        return self.left.row_count
+
+    @property
+    def inner_dimension(self) -> int:
+        return self.left.column_count
+
+    @property
+    def right_columns(self) -> int:
+        return self.right.column_count
+
     @model_validator(mode="after")
     def require_product_shape(self) -> Self:
+        if self.left.column_count != self.right.row_count:
+            raise _validation_error(
+                "shape_mismatch", "product operands must have matching inner axes"
+            )
         if len(self.product.entries) != self.left_rows:
             raise _validation_error(
                 "budget_exceeded", "product row count must equal left_rows"
@@ -615,8 +645,20 @@ class RationalLinearSolveResult(StrictModel):
 
 
 class MatrixAdjugateResult(StrictModel):
+    matrix: IntegerMatrix
     adjugate: IntegerMatrix
     convention: Literal["CLASSICAL_ADJUGATE"] = "CLASSICAL_ADJUGATE"
+
+    @model_validator(mode="after")
+    def require_source_shape(self) -> Self:
+        if self.matrix.row_count != self.matrix.column_count or (
+            self.adjugate.row_count,
+            self.adjugate.column_count,
+        ) != (self.matrix.row_count, self.matrix.column_count):
+            raise _validation_error(
+                "shape_mismatch", "adjugate must match its square source"
+            )
+        return self
 
 
 class MatrixPermanentResult(StrictModel):
@@ -635,11 +677,25 @@ class MatrixKroneckerProductRequest(_MatrixRequest):
 class MatrixKroneckerProductResult(StrictModel):
     """The Kronecker product of two bounded matrices over QQ."""
 
+    left: RationalMatrix
+    right: RationalMatrix
     product: RationalMatrix
-    left_rows: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
-    left_columns: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
-    right_rows: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
-    right_columns: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
+
+    @property
+    def left_rows(self) -> int:
+        return self.left.row_count
+
+    @property
+    def left_columns(self) -> int:
+        return self.left.column_count
+
+    @property
+    def right_rows(self) -> int:
+        return self.right.row_count
+
+    @property
+    def right_columns(self) -> int:
+        return self.right.column_count
 
     @model_validator(mode="after")
     def require_product_shape(self) -> Self:
@@ -667,6 +723,7 @@ class MatrixPartialTraceRequest(_MatrixRequest):
 class MatrixPartialTraceResult(StrictModel):
     """The partial trace over the traced subsystem of a composite matrix."""
 
+    matrix: RationalMatrix
     reduced_matrix: RationalMatrix
     traced_dimension: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
     kept_dimension: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
@@ -674,6 +731,12 @@ class MatrixPartialTraceResult(StrictModel):
 
     @model_validator(mode="after")
     def require_reduced_shape(self) -> Self:
+        order = self.traced_dimension * self.kept_dimension
+        if (self.matrix.row_count, self.matrix.column_count) != (order, order):
+            raise _validation_error(
+                "shape_mismatch",
+                "partial trace source must match the tensor dimensions",
+            )
         if len(self.reduced_matrix.entries) != self.kept_dimension:
             raise _validation_error(
                 "shape_mismatch", "reduced matrix row count must equal kept_dimension"

--- a/src/jacobian/math/matrices/finite_fields/__init__.py
+++ b/src/jacobian/math/matrices/finite_fields/__init__.py
@@ -8,6 +8,7 @@ from jacobian.math.matrices.finite_fields.linear_algebra import (
     rank,
     rref,
 )
+from jacobian.math.matrices.finite_fields.operations import verify_rank, verify_rref
 
 __all__ = [
     "PrimeFieldMatrix",
@@ -16,4 +17,6 @@ __all__ = [
     "quotient_basis",
     "rank",
     "rref",
+    "verify_rank",
+    "verify_rref",
 ]

--- a/src/jacobian/math/matrices/finite_fields/_models.py
+++ b/src/jacobian/math/matrices/finite_fields/_models.py
@@ -35,7 +35,7 @@ class PrimeFieldMatrixRequest(StrictModel):
 
     The matrix is carried as the domain-owned ``PrimeFieldMatrix`` canonical
     value so it composes unchanged with the other GF(p) producers and
-    consumers. Shape rules (schema-visible): 0..1024 rows, 1..1024 columns,
+    consumers. Shape rules (schema-visible): 0..1024 rows, 0..1024 columns,
     rectangular rows, and every entry a canonical residue in ``[0, prime)``.
     Zero rows carry an explicit column axis, matching the canonical empty
     matrix that full-rank nullspace producers return. The characteristic is
@@ -49,7 +49,7 @@ class PrimeFieldMatrixRequest(StrictModel):
                 "A bounded integer matrix over an explicit prime field GF(p), "
                 "as the canonical `PrimeFieldMatrix` value: `prime` must be a "
                 "prime integer in [2, 2147483647], `entries` must have at "
-                "most 1024 rows, each row 1..1024 columns, all rows the same "
+                "most 1024 rows, each row 0..1024 columns, all rows the same "
                 "length matching the declared `columns`, and every entry a "
                 "canonical residue in [0, prime). The dense matrix carries "
                 "at most 1048576 cells. Zero rows are permitted and carry "
@@ -88,7 +88,7 @@ class PrimeFieldMatrixRequest(StrictModel):
             raise _validation_error(
                 "request.rows_bound", f"matrix has at most {MAX_ROWS} rows"
             )
-        if not 1 <= self.matrix.columns <= MAX_COLUMNS:
+        if not 0 <= self.matrix.columns <= MAX_COLUMNS:
             raise _validation_error(
                 "request.columns_bound", f"matrix has at most {MAX_COLUMNS} columns"
             )

--- a/src/jacobian/math/matrices/finite_fields/operations.py
+++ b/src/jacobian/math/matrices/finite_fields/operations.py
@@ -1,9 +1,42 @@
 """Native exact operations over an explicit prime field."""
 
 from jacobian.math.matrices.finite_fields import linear_algebra
+from jacobian.math.matrices.finite_fields._models import (
+    PrimeFieldMatrixRankResult,
+    PrimeFieldRrefResult,
+)
 from jacobian.math.matrices.finite_fields.linear_algebra import PrimeFieldMatrix
 
-__all__ = ["matrix_nullspace", "matrix_rank", "matrix_rref"]
+__all__ = [
+    "matrix_nullspace",
+    "matrix_rank",
+    "matrix_rref",
+    "verify_rank",
+    "verify_rref",
+]
+
+
+def verify_rank(claim: PrimeFieldMatrixRankResult) -> bool:
+    """Check a serialized rank claim against its retained matrix.
+
+    The source bounds the elimination by 1024 cubed field operations;
+    primality is admitted by the same native path as rank production.
+    """
+    return matrix_rank(claim.source.matrix) == claim.rank
+
+
+def verify_rref(claim: PrimeFieldRrefResult) -> bool:
+    """Check the unique reduced form, pivots, and rank against the source.
+
+    One admitted elimination uses the source's bounded matrix envelope.
+    Neither checker is invoked by result construction or deserialization.
+    """
+    rows, pivots = matrix_rref(claim.source.matrix)
+    return (
+        rows == claim.rref_matrix.entries
+        and pivots == claim.pivot_columns
+        and len(pivots) == claim.rank
+    )
 
 
 def matrix_rank(matrix: PrimeFieldMatrix) -> int:

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -95,6 +95,11 @@ __all__ = [
     "solve_linear_system",
     "trace",
     "trace_result",
+    "verify_adjugate",
+    "verify_inverse",
+    "verify_kronecker_product",
+    "verify_partial_trace",
+    "verify_product",
 ]
 
 
@@ -1276,7 +1281,9 @@ def _sparse_nullspace_result(matrix: SparseRationalMatrix) -> NullspaceResult:
         ambient_dimension=matrix.column_count,
         rank=len(pivot_rows),
         nullity=len(free),
-        basis_vectors=tuple(basis),
+        basis_matrix=RationalMatrix(
+            entries=tuple(basis), column_count=matrix.column_count
+        ),
         free_columns=free,
     )
 
@@ -1312,7 +1319,9 @@ def nullspace_result(matrix: RationalMatrix | SparseRationalMatrix) -> Nullspace
         ambient_dimension=matrix.column_count,
         rank=len(pivot_columns),
         nullity=len(basis),
-        basis_vectors=tuple(basis),
+        basis_matrix=RationalMatrix(
+            entries=tuple(basis), column_count=matrix.column_count
+        ),
         free_columns=free_columns,
     )
 
@@ -1404,6 +1413,7 @@ def inverse_result(matrix: IntegerMatrix) -> MatrixInverseResult:
             message="matrix is singular; inverse does not exist",
         ) from exc
     return MatrixInverseResult(
+        matrix=matrix,
         inverse=RationalMatrix(
             entries=tuple(
                 tuple(
@@ -1414,7 +1424,7 @@ def inverse_result(matrix: IntegerMatrix) -> MatrixInverseResult:
                 )
                 for row in range(order)
             )
-        )
+        ),
     )
 
 
@@ -1444,6 +1454,8 @@ def product_result(left: RationalMatrix, right: RationalMatrix) -> MatrixProduct
             tuple(tuple(value.as_fraction() for value in row) for row in right.entries),
         )
     return MatrixProductResult(
+        left=left,
+        right=right,
         product=RationalMatrix(
             row_count=left_rows,
             column_count=right_columns,
@@ -1452,9 +1464,6 @@ def product_result(left: RationalMatrix, right: RationalMatrix) -> MatrixProduct
                 for row in product
             ),
         ),
-        left_rows=left_rows,
-        inner_dimension=inner_dimension,
-        right_columns=right_columns,
     )
 
 
@@ -1491,7 +1500,9 @@ def rational_linear_solve_result(
 def adjugate_result(matrix: IntegerMatrix) -> MatrixAdjugateResult:
     _admit(_admit_square_integer, matrix)
     value = adjugate(conversions.integer_matrix_to_sympy(matrix))
-    return MatrixAdjugateResult(adjugate=conversions.integer_matrix_from_sympy(value))
+    return MatrixAdjugateResult(
+        matrix=matrix, adjugate=conversions.integer_matrix_from_sympy(value)
+    )
 
 
 def permanent_result(matrix: RationalMatrix) -> MatrixPermanentResult:
@@ -1519,11 +1530,9 @@ def kronecker_product_result(
     else:
         product = kronecker_product(left_source, right_source)
     return MatrixKroneckerProductResult(
+        left=left,
+        right=right,
         product=conversions.rational_matrix_from_sympy(product),
-        left_rows=left_source.rows,
-        left_columns=left_source.cols,
-        right_rows=right_source.rows,
-        right_columns=right_source.cols,
     )
 
 
@@ -1544,7 +1553,38 @@ def partial_trace_result(
         kept_dimension,
     )
     return MatrixPartialTraceResult(
+        matrix=matrix,
         reduced_matrix=conversions.rational_matrix_from_sympy(reduced),
         traced_dimension=traced_dimension,
         kept_dimension=kept_dimension,
+    )
+
+
+def verify_product(claim: MatrixProductResult) -> bool:
+    """Check a product relation under the existing multiply/output admission."""
+    return product_result(claim.left, claim.right).product == claim.product
+
+
+def verify_inverse(claim: MatrixInverseResult) -> bool:
+    """Check an inverse claim using the bounded exact inverse operation."""
+    return inverse_result(claim.matrix).inverse == claim.inverse
+
+
+def verify_adjugate(claim: MatrixAdjugateResult) -> bool:
+    """Check the classical adjugate, including singular source matrices."""
+    return adjugate_result(claim.matrix).adjugate == claim.adjugate
+
+
+def verify_kronecker_product(claim: MatrixKroneckerProductResult) -> bool:
+    """Check the ordered tensor product under its output-axis admission."""
+    return kronecker_product_result(claim.left, claim.right).product == claim.product
+
+
+def verify_partial_trace(claim: MatrixPartialTraceResult) -> bool:
+    """Check the declared block trace under its tensor-dimension admission."""
+    return (
+        partial_trace_result(
+            claim.matrix, claim.traced_dimension, claim.kept_dimension
+        ).reduced_matrix
+        == claim.reduced_matrix
     )

--- a/src/jacobian/math/matrices/rational_linear/__init__.py
+++ b/src/jacobian/math/matrices/rational_linear/__init__.py
@@ -1,3 +1,11 @@
 """Exact rational-linear operation ownership."""
 
-__all__: list[str] = []
+from jacobian.math.matrices.rational_linear.operations import (
+    verify_inconsistency,
+    verify_solution,
+)
+
+__all__: list[str] = [
+    "verify_inconsistency",
+    "verify_solution",
+]

--- a/src/jacobian/math/matrices/rational_linear/operations.py
+++ b/src/jacobian/math/matrices/rational_linear/operations.py
@@ -8,9 +8,18 @@ from typing import Any, Literal
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import format_canonical_integer
 from jacobian.catalog.models import OperationResourceAdmissionError
-from jacobian.math.matrices.rational_linear._models import LinearRationalSystem
+from jacobian.math.matrices.rational_linear._models import (
+    LinearRationalInconsistencyResult,
+    LinearRationalSolutionResult,
+    LinearRationalSystem,
+)
 
-__all__ = ["inconsistency_witness", "solve"]
+__all__ = [
+    "inconsistency_witness",
+    "solve",
+    "verify_inconsistency",
+    "verify_solution",
+]
 
 MAX_LINEAR_SCALAR_WORK = 100_000_000
 MAX_FLINT_LINEAR_SCALAR_WORK = 500_000_000
@@ -219,6 +228,70 @@ def _solve_admitted(plan: _LinearPlan) -> tuple[CanonicalRational, ...] | None:
     if values is None:
         return None
     return tuple(_canonical_rational(value) for value in values)
+
+
+def _system_rows(
+    system: LinearRationalSystem,
+) -> tuple[dict[int, Fraction], ...]:
+    """Expand the sparse rows of a retained system as exact fractions."""
+    rows: tuple[dict[int, Fraction], ...] = tuple(
+        {} for _ in range(system.coefficients.row_count)
+    )
+    for item in system.coefficients.entries:
+        rows[item.row][item.column] = item.value.as_fraction()
+    return rows
+
+
+def verify_solution(claim: LinearRationalSolutionResult) -> bool:
+    """Check ``A x = b`` for a retained solution claim without resolving.
+
+    Only SOLUTION claims are verifiable; an INCONSISTENT solution outcome
+    carries no vector, so it does not verify and remains a producer outcome.
+    """
+    if claim.status != "SOLUTION" or claim.values is None:
+        return False
+    if len(claim.values) != len(claim.system.variables):
+        return False
+    point = tuple(value.as_fraction() for value in claim.values)
+    rows = _system_rows(claim.system)
+    return all(
+        (sum(coefficient * point[column] for column, coefficient in row.items()))
+        == bound.as_fraction()
+        for row, bound in zip(rows, claim.system.rhs, strict=True)
+    )
+
+
+def verify_inconsistency(claim: LinearRationalInconsistencyResult) -> bool:
+    """Check ``y^T A = 0`` and the recorded nonzero ``y^T b`` pairing.
+
+    Only INCONSISTENT claims are verifiable; a CONSISTENT outcome carries
+    no witness, so it does not verify and remains a producer outcome.
+    """
+    if claim.status != "INCONSISTENT":
+        return False
+    if claim.left_witness is None or claim.rhs_pairing is None:
+        return False
+    if len(claim.left_witness) != len(claim.system.rhs):
+        return False
+    witness = tuple(value.as_fraction() for value in claim.left_witness)
+    rows = _system_rows(claim.system)
+    for column in range(len(claim.system.variables)):
+        if (
+            sum(
+                witness[row] * row_map.get(column, Fraction(0))
+                for row, row_map in enumerate(rows)
+            )
+            != 0
+        ):
+            return False
+    pairing = sum(
+        (
+            coordinate * bound.as_fraction()
+            for coordinate, bound in zip(witness, claim.system.rhs, strict=True)
+        ),
+        Fraction(0),
+    )
+    return pairing != 0 and pairing == claim.rhs_pairing.as_fraction()
 
 
 def inconsistency_witness(

--- a/src/jacobian/math/matrices/values.py
+++ b/src/jacobian/math/matrices/values.py
@@ -35,9 +35,9 @@ MAX_EXACT_LINEAR_MATRIX_AXIS = 64
 # canonical QQ matrix value while narrower operations enforce their own
 # request envelopes.
 MAX_RATIONAL_MATRIX_ORDER = 128
-# Representation envelope includes the existing 4096-state Markov domain.
+# Representation envelope includes nullspaces of 8192-column sparse sources.
 # Computational order limits above remain operation-owned.
-MAX_RATIONAL_MATRIX_AXIS = 4096
+MAX_RATIONAL_MATRIX_AXIS = 8192
 # Exact inverse admits square integer sources through order 128. Keep that
 # complete public domain representable by the one canonical ZZ matrix value
 # while lattice reduction and the other integer operations enforce their own

--- a/src/jacobian/math/number_theory/_certification_models.py
+++ b/src/jacobian/math/number_theory/_certification_models.py
@@ -39,6 +39,7 @@ class PrattCertificateFactor(StrictModel):
     exponent: StrictInt = Field(ge=1, le=4096)
     certificate: PrattCertificateNode
 
+
 class CertifiedFactorizationRequest(StrictModel):
     """One positive integer for bounded certified factorization."""
 

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -218,7 +218,7 @@ def verify_certified_factorization(claim: CertifiedFactorizationResult) -> bool:
         prime**factor.exponent
         for prime, factor in zip(primes, claim.factors, strict=True)
     )
-    return reconstructed == value
+    return bool(reconstructed == value)
 
 
 def verify_primality_certificate(claim: PrimalityCertificateResult) -> bool:

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -185,10 +185,13 @@ def verify_pratt_certificate(claim: PrattCertificateNode) -> bool:
         factor_primes
     ):
         return False
-    if math.prod(
-        factor_prime**factor.exponent
-        for factor_prime, factor in zip(factor_primes, claim.factors, strict=True)
-    ) != prime - 1:
+    if (
+        math.prod(
+            factor_prime**factor.exponent
+            for factor_prime, factor in zip(factor_primes, claim.factors, strict=True)
+        )
+        != prime - 1
+    ):
         return False
     return all(
         parse_canonical_integer(factor.certificate.prime) == factor_prime
@@ -212,7 +215,8 @@ def verify_certified_factorization(claim: CertifiedFactorizationResult) -> bool:
     ):
         return False
     reconstructed = math.prod(
-        prime**factor.exponent for prime, factor in zip(primes, claim.factors, strict=True)
+        prime**factor.exponent
+        for prime, factor in zip(primes, claim.factors, strict=True)
     )
     return reconstructed == value
 

--- a/src/jacobian/math/number_theory/arithmetic/__init__.py
+++ b/src/jacobian/math/number_theory/arithmetic/__init__.py
@@ -34,6 +34,7 @@ from jacobian.math.number_theory.arithmetic.operations import (
     reciprocal,
     sign,
     sum_rationals,
+    verify_continued_fraction,
 )
 from jacobian.math.number_theory.arithmetic.values import IntegerValue
 
@@ -72,4 +73,5 @@ __all__ = [
     "reciprocal",
     "sign",
     "sum_rationals",
+    "verify_continued_fraction",
 ]

--- a/src/jacobian/math/number_theory/arithmetic/_rational_models.py
+++ b/src/jacobian/math/number_theory/arithmetic/_rational_models.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
 from typing import Self
 
 from pydantic import Field, model_validator
@@ -93,7 +92,7 @@ class RationalContinuedFractionResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def require_canonical_reconstruction(self) -> Self:
+    def require_canonical_terms(self) -> Self:
         from jacobian.canonical import parse_canonical_integer
 
         quotients = [parse_canonical_integer(term) for term in self.terms]
@@ -106,14 +105,6 @@ class RationalContinuedFractionResult(StrictModel):
             raise _validation_error(
                 "continued_fraction_trailing_one",
                 "a multi-term simple continued fraction must not end in 1",
-            )
-        reconstructed = Fraction(quotients[-1])
-        for quotient in reversed(quotients[:-1]):
-            reconstructed = quotient + Fraction(1, reconstructed)
-        if reconstructed != self.value.as_fraction():
-            raise _validation_error(
-                "continued_fraction_reconstruction",
-                "continued fraction terms must reconstruct the retained rational",
             )
         return self
 

--- a/src/jacobian/math/number_theory/arithmetic/operations.py
+++ b/src/jacobian/math/number_theory/arithmetic/operations.py
@@ -23,6 +23,9 @@ from jacobian.math.number_theory.arithmetic._multiplicative_forms import (
     PrimeExponentRow,
     SquarefreeDecompositionResult,
 )
+from jacobian.math.number_theory.arithmetic._rational_models import (
+    RationalContinuedFractionResult,
+)
 from jacobian.math.number_theory.arithmetic.values import IntegerValue
 
 __all__ = [
@@ -67,6 +70,7 @@ __all__ = [
     "sign",
     "squarefree_decomposition",
     "sum_rationals",
+    "verify_continued_fraction",
 ]
 
 
@@ -638,6 +642,24 @@ def ceiling_rational(value: Fraction | int | IntegerValue) -> int:
     """Return the least integer not below an exact rational."""
 
     return ceil(_as_rational(value))
+
+
+def verify_continued_fraction(claim: RationalContinuedFractionResult) -> bool:
+    """Check the source expansion with at most the declared number of divisions.
+
+    Euclidean remainders shrink from the bounded source integers. Comparing
+    canonical quotients avoids expansion of large caller-authored terms.
+    """
+    numerator = parse_canonical_integer(claim.value.num)
+    denominator = parse_canonical_integer(claim.value.den)
+    for term in claim.terms:
+        if denominator == 0:
+            return False
+        quotient, remainder = divmod(numerator, denominator)
+        if quotient != parse_canonical_integer(term):
+            return False
+        numerator, denominator = denominator, remainder
+    return denominator == 0
 
 
 def continued_fraction(

--- a/src/jacobian/math/number_theory/elliptic_curves/_models.py
+++ b/src/jacobian/math/number_theory/elliptic_curves/_models.py
@@ -39,7 +39,10 @@ class CurveDiscriminantResult(StrictModel):
 
     curve: ShortWeierstrassCurve
     discriminant: CanonicalRational
-    is_nonsingular: bool
+
+    @property
+    def is_nonsingular(self) -> bool:
+        return self.discriminant.as_fraction() != 0
 
     @classmethod
     def _from_kernel(
@@ -47,12 +50,10 @@ class CurveDiscriminantResult(StrictModel):
         *,
         curve: ShortWeierstrassCurve,
         discriminant: CanonicalRational,
-        is_nonsingular: bool,
     ) -> Self:
         return cls.model_construct(
             curve=curve,
             discriminant=discriminant,
-            is_nonsingular=is_nonsingular,
         )
 
 

--- a/src/jacobian/math/number_theory/elliptic_curves/_models.py
+++ b/src/jacobian/math/number_theory/elliptic_curves/_models.py
@@ -236,16 +236,6 @@ class EllipticCurvePointResult(StrictModel):
                 "elliptic_curve.point_missing",
                 "must carry a finite point or indicate infinity",
             )
-        if self.point is not None:
-            x = self.point.x.as_fraction()
-            y = self.point.y.as_fraction()
-            a = self.curve.coefficient_a.as_fraction()
-            b = self.curve.coefficient_b.as_fraction()
-            if y * y != x**3 + a * x + b:
-                raise PydanticCustomError(
-                    "elliptic_curve.result_point_off_curve",
-                    "result point must lie on the retained curve",
-                )
         return self
 
     @classmethod
@@ -292,7 +282,7 @@ class ScalarMultiplicationResult(EllipticCurvePointResult):
     """
 
 
-# Membership replay is inherited from EllipticCurvePointResult's validator.
+# Inherit structural point/parent parsing; group-law consumers admit membership.
 ScalarMultiplicationResult.model_rebuild()
 
 

--- a/src/jacobian/math/number_theory/elliptic_curves/operations.py
+++ b/src/jacobian/math/number_theory/elliptic_curves/operations.py
@@ -191,7 +191,6 @@ def discriminant(curve: ShortWeierstrassCurve) -> CurveDiscriminantResult:
     return CurveDiscriminantResult._from_kernel(
         curve=curve,
         discriminant=CanonicalRational.from_fraction(disc),
-        is_nonsingular=disc != 0,
     )
 
 

--- a/src/jacobian/math/number_theory/elliptic_curves/operations.py
+++ b/src/jacobian/math/number_theory/elliptic_curves/operations.py
@@ -50,9 +50,19 @@ def _admit_point_addition(
     second_point = second.point
     if first_point is None or second_point is None:
         try:
-            _require_group_law(curve, ())
+            _require_group_law(
+                curve,
+                tuple(
+                    point for point in (first_point, second_point) if point is not None
+                ),
+            )
         except PydanticCustomError as exc:
-            _admission_error(exc, ("curve",))
+            location = (
+                (("first",) if first_point is not None else ("second",))
+                if exc.type == "elliptic_curve.point_off_curve"
+                else ("curve",)
+            )
+            _admission_error(exc, location)
         return
     try:
         _require_group_law(curve, ())

--- a/src/jacobian/math/number_theory/galois/_models.py
+++ b/src/jacobian/math/number_theory/galois/_models.py
@@ -207,25 +207,21 @@ def _require_factor_residues(result: GaloisFactorResult) -> None:
 
 class FrobeniusCycleResult(StrictModel):
     cycle_type: tuple[PositiveFactorDegree, ...]
-    degree: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
-    is_irreducible: bool
+
+    @property
+    def degree(self) -> int:
+        return sum(self.cycle_type)
+
+    @property
+    def is_irreducible(self) -> bool:
+        return self.cycle_type == (self.degree,)
 
     @model_validator(mode="after")
     def require_canonical_partition(self) -> Self:
-        if sum(self.cycle_type) != self.degree:
-            raise _validation_error(
-                "cycle_type_degree_mismatch",
-                "cycle type must partition the polynomial degree",
-            )
         if self.cycle_type != tuple(sorted(self.cycle_type, reverse=True)):
             raise _validation_error(
                 "cycle_type_not_canonical",
                 "cycle type must be sorted in descending order",
-            )
-        if self.is_irreducible != (self.cycle_type == (self.degree,)):
-            raise _validation_error(
-                "cycle_type_irreducibility_mismatch",
-                "irreducibility must agree with the cycle type",
             )
         return self
 

--- a/src/jacobian/math/number_theory/galois/_models.py
+++ b/src/jacobian/math/number_theory/galois/_models.py
@@ -140,9 +140,22 @@ class GaloisFactorResult(StrictModel):
         min_length=1,
         max_length=MAX_FACTOR_DEGREE,
     )
-    distinct_factor_count: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
-    factor_count: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
-    is_irreducible: bool
+
+    @property
+    def distinct_factor_count(self) -> int:
+        return len(self.factors)
+
+    @property
+    def factor_count(self) -> int:
+        return sum(factor.multiplicity for factor in self.factors)
+
+    @property
+    def is_irreducible(self) -> bool:
+        return (
+            len(self.factors) == 1
+            and self.factors[0].multiplicity == 1
+            and len(self.factors[0].coefficients) == len(self.source_coefficients)
+        )
 
     @classmethod
     def _from_kernel(
@@ -152,9 +165,6 @@ class GaloisFactorResult(StrictModel):
         source_coefficients: tuple[int, ...],
         unit: int,
         factors: tuple[FiniteFieldFactor, ...],
-        distinct_factor_count: int,
-        factor_count: int,
-        is_irreducible: bool,
     ) -> Self:
         """Construct output whose complete factorization came from the kernel."""
 
@@ -163,25 +173,11 @@ class GaloisFactorResult(StrictModel):
             source_coefficients=source_coefficients,
             unit=unit,
             factors=factors,
-            distinct_factor_count=distinct_factor_count,
-            factor_count=factor_count,
-            is_irreducible=is_irreducible,
         )
 
     @model_validator(mode="after")
     def require_structural_consistency(self) -> Self:
         _require_factor_residues(self)
-        if self.distinct_factor_count != len(self.factors):
-            raise _validation_error(
-                "distinct_factor_count_mismatch",
-                "distinct_factor_count must equal the number of factors",
-            )
-        total = sum(factor.multiplicity for factor in self.factors)
-        if self.factor_count != total:
-            raise _validation_error(
-                "factor_count_mismatch",
-                "factor_count must include factor multiplicities",
-            )
         return self
 
 

--- a/src/jacobian/math/number_theory/galois/operations.py
+++ b/src/jacobian/math/number_theory/galois/operations.py
@@ -122,12 +122,7 @@ def frobenius_cycle(
         location=("field_order", "factorization_degrees"),
     )
     cycle_type = tuple(sorted(factorization_degrees, reverse=True))
-    is_irred = cycle_type == (polynomial_degree,)
-    return FrobeniusCycleResult(
-        cycle_type=cycle_type,
-        degree=polynomial_degree,
-        is_irreducible=is_irred,
-    )
+    return FrobeniusCycleResult(cycle_type=cycle_type)
 
 
 def _galois_group_from_coeffs(coeffs: tuple[int, ...]) -> PermutationGroup:

--- a/src/jacobian/math/number_theory/galois/operations.py
+++ b/src/jacobian/math/number_theory/galois/operations.py
@@ -104,20 +104,11 @@ def galois_factor(
         )
         for factor_poly, multiplicity in factor_polys
     )
-    factor_count = sum(factor.multiplicity for factor in result_factors)
-    is_irred = (
-        len(result_factors) == 1
-        and result_factors[0].multiplicity == 1
-        and len(result_factors[0].coefficients) == len(coefficients)
-    )
     return GaloisFactorResult._from_kernel(
         field_order=field_order,
         source_coefficients=coefficients,
         unit=int(unit) % field_order,
         factors=result_factors,
-        distinct_factor_count=len(result_factors),
-        factor_count=factor_count,
-        is_irreducible=is_irred,
     )
 
 

--- a/src/jacobian/math/number_theory/number_fields/__init__.py
+++ b/src/jacobian/math/number_theory/number_fields/__init__.py
@@ -11,6 +11,7 @@ from jacobian.math.number_theory.number_fields.operations import (
     discriminant,
     embeddings,
     ring_of_integers,
+    verify_discriminant,
 )
 from jacobian.math.number_theory.number_fields.values import (
     NumberFieldEmbeddingProfile,
@@ -38,4 +39,5 @@ __all__ = [
     "discriminant",
     "embeddings",
     "ring_of_integers",
+    "verify_discriminant",
 ]

--- a/src/jacobian/math/number_theory/number_fields/_discriminant_process.py
+++ b/src/jacobian/math/number_theory/number_fields/_discriminant_process.py
@@ -106,7 +106,9 @@ def compute_nf_discriminant(
             discriminant = format_canonical_integer(
                 parse_canonical_integer(response["discriminant"])
             )
-            return NumberFieldDiscriminantResult(discriminant=discriminant)
+            return NumberFieldDiscriminantResult(
+                field=request.field, discriminant=discriminant
+            )
     except (KeyError, TypeError, ValueError, CanonicalizationError):
         response = None
     if (

--- a/src/jacobian/math/number_theory/number_fields/_models.py
+++ b/src/jacobian/math/number_theory/number_fields/_models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pydantic_core import PydanticCustomError
 
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.math.number_theory.number_fields.values import (
     SimpleNumberFieldPresentation,
@@ -22,7 +23,10 @@ class NumberFieldRequest(StrictModel):
 
 
 class NumberFieldDiscriminantResult(StrictModel):
-    discriminant: str
+    """A field-discriminant claim retaining its exact field presentation."""
+
+    field: SimpleNumberFieldPresentation
+    discriminant: CanonicalInteger
 
 
 class NumberFieldEmbeddingsRequest(StrictModel):

--- a/src/jacobian/math/number_theory/number_fields/operations.py
+++ b/src/jacobian/math/number_theory/number_fields/operations.py
@@ -7,13 +7,14 @@ from dataclasses import dataclass
 from math import factorial
 from typing import Any
 
+from jacobian._exact import CanonicalInteger
 from jacobian._execution import (
     OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
     bind_request_deadline,
     current_request_execution,
 )
-from jacobian.canonical import parse_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.number_theory.algebraic_numbers.complex import (
     ComplexAlgebraicValue,
     algebraic_root_separation_denominator_bound,
@@ -40,6 +41,9 @@ from jacobian.math.number_theory.number_fields._embeddings_process import (
 )
 from jacobian.math.number_theory.number_fields._integral_basis import (
     recognized_integral_basis,
+)
+from jacobian.math.number_theory.number_fields._models import (
+    NumberFieldDiscriminantResult,
 )
 from jacobian.math.number_theory.number_fields._real_embedding_order import (
     compare_real_embedding_elements,
@@ -343,9 +347,22 @@ def _integral_basis(
     return integral_basis
 
 
-def discriminant(field: SimpleNumberFieldPresentation) -> str:
+def discriminant(field: SimpleNumberFieldPresentation) -> CanonicalInteger:
     _ring_of_integers, field_discriminant, _alpha, _leading = _integral_basis(field)
-    return str(field_discriminant)
+    return format_canonical_integer(int(field_discriminant))
+
+
+def verify_discriminant(claim: NumberFieldDiscriminantResult) -> bool:
+    """Check a field-discriminant claim under the bounded worker's admission."""
+    from jacobian.math.number_theory.number_fields._discriminant_process import (
+        compute_nf_discriminant,
+    )
+    from jacobian.math.number_theory.number_fields._models import NumberFieldRequest
+
+    return (
+        compute_nf_discriminant(NumberFieldRequest(field=claim.field)).discriminant
+        == claim.discriminant
+    )
 
 
 def ring_of_integers(field: SimpleNumberFieldPresentation) -> list[str]:
@@ -363,4 +380,5 @@ __all__ = [
     "discriminant",
     "embeddings",
     "ring_of_integers",
+    "verify_discriminant",
 ]

--- a/src/jacobian/math/number_theory/numerical_semigroups/__init__.py
+++ b/src/jacobian/math/number_theory/numerical_semigroups/__init__.py
@@ -14,10 +14,15 @@ from jacobian.math.number_theory.numerical_semigroups.operations import (
     factorization_lengths,
     factorizations,
     minimal_generating_system,
+    verify_elasticity,
+    verify_element_elasticity,
+    verify_summary,
 )
+from jacobian.math.number_theory.numerical_semigroups.values import NumericalSemigroup
 
 __all__ = [
     "FactorizationGraph",
+    "NumericalSemigroup",
     "apery_set",
     "belongs",
     "elasticity",
@@ -30,4 +35,7 @@ __all__ = [
     "factorization_lengths",
     "factorizations",
     "minimal_generating_system",
+    "verify_elasticity",
+    "verify_element_elasticity",
+    "verify_summary",
 ]

--- a/src/jacobian/math/number_theory/numerical_semigroups/_element_invariant_models.py
+++ b/src/jacobian/math/number_theory/numerical_semigroups/_element_invariant_models.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
 from typing import Self
 
 from pydantic import Field, model_validator
 
-from jacobian._exact import CanonicalInteger
+from jacobian._exact import CanonicalInteger, CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.math.number_theory.numerical_semigroups._models import (
     _GENERAL_ELEMENT_ENVELOPE,
@@ -16,6 +15,7 @@ from jacobian.math.number_theory.numerical_semigroups._models import (
     _require_canonical_generator_axis,
     _validation_error,
 )
+from jacobian.math.number_theory.numerical_semigroups.values import NumericalSemigroup
 
 
 class ElementDeltaSetRequest(StrictModel):
@@ -102,12 +102,15 @@ class ElementElasticityResult(StrictModel):
     """Elasticity of one element."""
 
     value: CanonicalInteger
-    minimal_generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
-    )
+    semigroup: NumericalSemigroup
+
+    @property
+    def minimal_generators(self) -> tuple[CanonicalInteger, ...]:
+        return self.semigroup.minimal_generators
+
     minimum_length: int = Field(ge=1)
     maximum_length: int = Field(ge=1)
-    elasticity: str
+    elasticity: CanonicalRational
 
     @classmethod
     def _from_kernel(
@@ -117,28 +120,17 @@ class ElementElasticityResult(StrictModel):
         minimal_generators: tuple[CanonicalInteger, ...],
         minimum_length: int,
         maximum_length: int,
-        elasticity: str,
+        elasticity: CanonicalRational,
     ) -> Self:
         """Construct output derived from one admitted extrema kernel call."""
 
         return cls.model_construct(
             value=value,
-            minimal_generators=minimal_generators,
+            semigroup=NumericalSemigroup(minimal_generators=minimal_generators),
             minimum_length=minimum_length,
             maximum_length=maximum_length,
             elasticity=elasticity,
         )
-
-    @model_validator(mode="after")
-    def require_length_ratio(self) -> Self:
-        _require_canonical_generator_axis(self.minimal_generators)
-        if self.minimum_length > self.maximum_length:
-            raise _validation_error("minimum_length must not exceed maximum_length")
-        if Fraction(self.elasticity) != Fraction(
-            self.maximum_length, self.minimum_length
-        ):
-            raise _validation_error("elasticity does not match the length ratio")
-        return self
 
 
 class ElementCatenaryDegreeRequest(StrictModel):

--- a/src/jacobian/math/number_theory/numerical_semigroups/_global_invariant_models.py
+++ b/src/jacobian/math/number_theory/numerical_semigroups/_global_invariant_models.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
 from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
-from jacobian._exact import CanonicalInteger
+from jacobian._exact import CanonicalInteger, CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.canonical import parse_canonical_integer
 from jacobian.math.number_theory.numerical_semigroups._models import (
@@ -16,6 +15,7 @@ from jacobian.math.number_theory.numerical_semigroups._models import (
     _require_canonical_generator_axis,
     _validation_error,
 )
+from jacobian.math.number_theory.numerical_semigroups.values import NumericalSemigroup
 
 
 class BettiElementsRequest(StrictModel):
@@ -150,19 +150,10 @@ class ElasticityRequest(StrictModel):
 class ElasticityResult(StrictModel):
     """Global elasticity of the semigroup."""
 
-    elasticity: str
+    semigroup: NumericalSemigroup
+    elasticity: CanonicalRational
     smallest_generator: CanonicalInteger
     largest_generator: CanonicalInteger
-
-    @model_validator(mode="after")
-    def require_generator_ratio(self) -> Self:
-        smallest = parse_canonical_integer(self.smallest_generator)
-        largest = parse_canonical_integer(self.largest_generator)
-        if smallest > largest:
-            raise _validation_error("generator extrema are reversed")
-        if Fraction(self.elasticity) != Fraction(largest, smallest):
-            raise _validation_error("elasticity must equal largest/smallest generator")
-        return self
 
 
 class CatenaryDegreeRequest(StrictModel):

--- a/src/jacobian/math/number_theory/numerical_semigroups/_summary_models.py
+++ b/src/jacobian/math/number_theory/numerical_semigroups/_summary_models.py
@@ -11,6 +11,7 @@ from jacobian.math.number_theory.numerical_semigroups._models import (
     _GENERAL_GENERATOR_ENVELOPE,
     MAX_GENERATORS,
 )
+from jacobian.math.number_theory.numerical_semigroups.values import NumericalSemigroup
 
 
 class NumericalSemigroupSummaryRequest(StrictModel):
@@ -30,15 +31,16 @@ class NumericalSemigroupSummaryRequest(StrictModel):
 class NumericalSemigroupSummaryResult(StrictModel):
     """Summary of a numerical semigroup."""
 
-    minimal_generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1,
-        max_length=MAX_GENERATORS,
-        description="Increasing minimal generator axis of the numerical semigroup.",
-    )
+    semigroup: NumericalSemigroup
+
+    @property
+    def minimal_generators(self) -> tuple[CanonicalInteger, ...]:
+        return self.semigroup.minimal_generators
+
     multiplicity: CanonicalInteger
     embedding_dimension: int = Field(ge=1)
-    frobenius_number: str
-    conductor: str
+    frobenius_number: CanonicalInteger
+    conductor: CanonicalInteger
     genus: int = Field(ge=0)
     gaps: tuple[CanonicalInteger, ...]
 
@@ -49,15 +51,15 @@ class NumericalSemigroupSummaryResult(StrictModel):
         minimal_generators: tuple[CanonicalInteger, ...],
         multiplicity: CanonicalInteger,
         embedding_dimension: int,
-        frobenius_number: str,
-        conductor: str,
+        frobenius_number: CanonicalInteger,
+        conductor: CanonicalInteger,
         genus: int,
         gaps: tuple[CanonicalInteger, ...],
     ) -> NumericalSemigroupSummaryResult:
         """Construct a summary after the native kernel establishes its invariants."""
 
         return cls.model_construct(
-            minimal_generators=minimal_generators,
+            semigroup=NumericalSemigroup(minimal_generators=minimal_generators),
             multiplicity=multiplicity,
             embedding_dimension=embedding_dimension,
             frobenius_number=frobenius_number,

--- a/src/jacobian/math/number_theory/numerical_semigroups/operations.py
+++ b/src/jacobian/math/number_theory/numerical_semigroups/operations.py
@@ -7,8 +7,8 @@ from fractions import Fraction
 from itertools import pairwise
 from math import gcd
 
-from jacobian._exact import format_canonical_rational
-from jacobian.canonical import format_canonical_integer
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.number_theory.numerical_semigroups._algorithms import (
     apery_set,
     belongs,
@@ -47,6 +47,7 @@ from jacobian.math.number_theory.numerical_semigroups._models import (
     MAX_GLOBAL_DELTA_CHECK,
     MAX_GRAPH_FACTORIZATIONS,
     MAX_MATERIALIZED_FACTORIZATIONS,
+    _require_positive_bounded_generators,
 )
 from jacobian.math.number_theory.numerical_semigroups._presentation_models import (
     MinimalPresentationRelation,
@@ -58,6 +59,7 @@ from jacobian.math.number_theory.numerical_semigroups._summary_models import (
     NumericalSemigroupSummaryResult,
     SemigroupMembershipResult,
 )
+from jacobian.math.number_theory.numerical_semigroups.values import NumericalSemigroup
 
 
 @dataclass(frozen=True)
@@ -371,7 +373,7 @@ def element_elasticity_profile(
         minimal_generators=tuple(format_canonical_integer(item) for item in values),
         minimum_length=minimum,
         maximum_length=maximum,
-        elasticity=format_canonical_rational(Fraction(maximum, minimum)),
+        elasticity=CanonicalRational.from_integer_ratio(maximum, minimum),
     )
 
 
@@ -440,7 +442,10 @@ def global_elasticity(generators: tuple[int, ...]) -> ElasticityResult:
     """Return exact global elasticity of a canonical semigroup."""
     values = _generators(generators)
     return ElasticityResult(
-        elasticity=format_canonical_rational(Fraction(values[-1], values[0])),
+        semigroup=NumericalSemigroup(
+            minimal_generators=tuple(map(format_canonical_integer, values))
+        ),
+        elasticity=CanonicalRational.from_integer_ratio(values[-1], values[0]),
         smallest_generator=format_canonical_integer(values[0]),
         largest_generator=format_canonical_integer(values[-1]),
     )
@@ -544,6 +549,31 @@ def presentation_binomials(
     )
 
 
+def _claim_generators(source: NumericalSemigroup) -> tuple[int, ...]:
+    """Admit the same bounded generator domain before checking a source claim."""
+    _require_positive_bounded_generators(source.minimal_generators)
+    return tuple(map(parse_canonical_integer, source.minimal_generators))
+
+
+def verify_summary(claim: NumericalSemigroupSummaryResult) -> bool:
+    """Check a source-bound summary in the bounded semigroup domain."""
+    return summary(_claim_generators(claim.semigroup)) == claim
+
+
+def verify_elasticity(claim: ElasticityResult) -> bool:
+    """Check global elasticity and its claimed extrema against the source."""
+    return global_elasticity(_claim_generators(claim.semigroup)) == claim
+
+
+def verify_element_elasticity(claim: ElementElasticityResult) -> bool:
+    """Check the element's actual length extrema, not merely their ratio."""
+    values = _claim_generators(claim.semigroup)
+    value = parse_canonical_integer(claim.value)
+    if values != (1,) and value > MAX_ELEMENT:
+        raise ValueError(f"element exceeds the {MAX_ELEMENT} admission bound")
+    return element_elasticity_profile(values, value) == claim
+
+
 __all__ = [
     "FactorizationGraph",
     "apery_set",
@@ -574,4 +604,7 @@ __all__ = [
     "minimal_presentation",
     "presentation_binomials",
     "summary",
+    "verify_elasticity",
+    "verify_element_elasticity",
+    "verify_summary",
 ]

--- a/src/jacobian/math/number_theory/numerical_semigroups/values.py
+++ b/src/jacobian/math/number_theory/numerical_semigroups/values.py
@@ -1,0 +1,30 @@
+"""Structural presentations of numerical semigroups.
+
+Minimality and the numerical-semigroup property are claims checked by consumers.
+"""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math.number_theory.numerical_semigroups._models import MAX_GENERATORS
+
+
+class NumericalSemigroup(StrictModel):
+    """A positive, increasing generator axis claimed to be minimal and coprime."""
+
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_ordered_axis(self) -> Self:
+        values = tuple(map(parse_canonical_integer, self.minimal_generators))
+        if values[0] <= 0 or values != tuple(sorted(set(values))):
+            raise ValueError(
+                "minimal_generators must be positive and strictly increasing"
+            )
+        return self

--- a/src/jacobian/math/number_theory/p_adic/__init__.py
+++ b/src/jacobian/math/number_theory/p_adic/__init__.py
@@ -4,6 +4,12 @@ from jacobian.math.number_theory.p_adic.operations import (
     find_padic_roots,
     hensel_lift_factors,
     hensel_lift_root,
+    verify_hensel_root,
 )
 
-__all__ = ["find_padic_roots", "hensel_lift_factors", "hensel_lift_root"]
+__all__ = [
+    "find_padic_roots",
+    "hensel_lift_factors",
+    "hensel_lift_root",
+    "verify_hensel_root",
+]

--- a/src/jacobian/math/number_theory/p_adic/__init__.py
+++ b/src/jacobian/math/number_theory/p_adic/__init__.py
@@ -4,6 +4,7 @@ from jacobian.math.number_theory.p_adic.operations import (
     find_padic_roots,
     hensel_lift_factors,
     hensel_lift_root,
+    verify_hensel_factor_lift,
     verify_hensel_root,
 )
 
@@ -11,5 +12,6 @@ __all__ = [
     "find_padic_roots",
     "hensel_lift_factors",
     "hensel_lift_root",
+    "verify_hensel_factor_lift",
     "verify_hensel_root",
 ]

--- a/src/jacobian/math/number_theory/p_adic/_models.py
+++ b/src/jacobian/math/number_theory/p_adic/_models.py
@@ -66,7 +66,10 @@ class HenselRootResult(StrictModel):
     prime: int = Field(ge=2, le=MAX_PRIME)
     root_mod_p: int = Field(ge=0)
     precision: int = Field(ge=1, le=MAX_PRECISION)
-    is_simple_root: bool
+
+    @property
+    def is_simple_root(self) -> bool:
+        return True
 
     @model_validator(mode="after")
     def require_structural_shape(self) -> Self:
@@ -78,11 +81,6 @@ class HenselRootResult(StrictModel):
             raise _validation_error(
                 "padic_arithmetic.lifted_root_out_of_range",
                 "lifted_root must be in 0..p^k - 1",
-            )
-        if not self.is_simple_root:
-            raise _validation_error(
-                "padic_arithmetic.simple_flag_invalid",
-                "only simple roots are lifted, so the flag must hold",
             )
         return self
 
@@ -101,7 +99,6 @@ class HenselRootResult(StrictModel):
             prime=prime,
             root_mod_p=root_mod_p,
             precision=precision,
-            is_simple_root=True,
         )
 
 
@@ -167,16 +164,14 @@ class PAdicRootsResult(StrictModel):
     roots: tuple[PAdicRootEntry, ...]
     prime: int = Field(ge=2, le=MAX_PRIME)
     precision: int = Field(ge=1, le=MAX_PRECISION)
-    root_count: int = Field(ge=0)
     multiple_residues: tuple[int, ...] = ()
+
+    @property
+    def root_count(self) -> int:
+        return len(self.roots)
 
     @model_validator(mode="after")
     def require_structural_shape(self) -> Self:
-        if self.root_count != len(self.roots):
-            raise _validation_error(
-                "padic_arithmetic.root_count_mismatch",
-                "root_count must match the number of roots",
-            )
         if len(set(self.multiple_residues)) != len(self.multiple_residues):
             raise _validation_error(
                 "padic_arithmetic.multiple_residues_not_distinct",
@@ -214,7 +209,6 @@ class PAdicRootsResult(StrictModel):
             roots=roots,
             prime=prime,
             precision=precision,
-            root_count=len(roots),
             multiple_residues=multiple_residues,
         )
 

--- a/src/jacobian/math/number_theory/p_adic/_models.py
+++ b/src/jacobian/math/number_theory/p_adic/_models.py
@@ -77,7 +77,8 @@ class HenselRootResult(StrictModel):
             raise _validation_error(
                 "padic_arithmetic.root_out_of_range", "root_mod_p must be in 0..p-1"
             )
-        if parse_canonical_integer(self.lifted_root) >= self.prime**self.precision:
+        lifted = parse_canonical_integer(self.lifted_root)
+        if not 0 <= lifted < self.prime**self.precision:
             raise _validation_error(
                 "padic_arithmetic.lifted_root_out_of_range",
                 "lifted_root must be in 0..p^k - 1",

--- a/src/jacobian/math/number_theory/p_adic/_models.py
+++ b/src/jacobian/math/number_theory/p_adic/_models.py
@@ -116,8 +116,11 @@ class HenselFactorLiftRequest(StrictModel):
 
 
 class HenselFactorLiftResult(StrictModel):
-    """Lifted coprime factors mod p^k."""
+    """A lifted factorization bound to its polynomial and mod-p factors."""
 
+    polynomial: IntegerPolynomial
+    factor_g: IntegerPolynomial
+    factor_h: IntegerPolynomial
     lifted_g: IntegerPolynomial
     lifted_h: IntegerPolynomial
     prime: int = Field(ge=2, le=MAX_PRIME)

--- a/src/jacobian/math/number_theory/p_adic/operations.py
+++ b/src/jacobian/math/number_theory/p_adic/operations.py
@@ -388,6 +388,9 @@ def hensel_lift_factors(
         )
 
     return HenselFactorLiftResult(
+        polynomial=polynomial,
+        factor_g=factor_g,
+        factor_h=factor_h,
         lifted_g=_wire_polynomial(lifted_g),
         lifted_h=_wire_polynomial(lifted_h),
         prime=p,

--- a/src/jacobian/math/number_theory/p_adic/operations.py
+++ b/src/jacobian/math/number_theory/p_adic/operations.py
@@ -412,6 +412,49 @@ def hensel_lift_factors(
     )
 
 
+def verify_hensel_factor_lift(claim: HenselFactorLiftResult) -> bool:
+    """Check the product and coprimality relations of a factor-lift witness."""
+
+    prime = claim.prime
+    modulus = prime**claim.precision
+    polynomial = _kernel_coefficients(claim.polynomial)
+    factor_g = _kernel_coefficients(claim.factor_g)
+    factor_h = _kernel_coefficients(claim.factor_h)
+    lifted_g = _kernel_coefficients(claim.lifted_g)
+    lifted_h = _kernel_coefficients(claim.lifted_h)
+    try:
+        _bezout_unit_mod_p(
+            _trim_asc([coefficient % prime for coefficient in factor_g]),
+            _trim_asc([coefficient % prime for coefficient in factor_h]),
+            prime,
+        )
+    except ValueError:
+        return False
+    return (
+        _is_zero_polynomial(
+            _poly_sub_mod(
+                polynomial,
+                _poly_mul_exact_mod(lifted_g, lifted_h, modulus),
+                modulus,
+            )
+        )
+        and _is_zero_polynomial(
+            _poly_sub_mod(
+                factor_g,
+                lifted_g,
+                prime,
+            )
+        )
+        and _is_zero_polynomial(
+            _poly_sub_mod(
+                factor_h,
+                lifted_h,
+                prime,
+            )
+        )
+    )
+
+
 def find_padic_roots(
     polynomial: IntegerPolynomial,
     prime: int,

--- a/src/jacobian/math/number_theory/p_adic/operations.py
+++ b/src/jacobian/math/number_theory/p_adic/operations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from math import isqrt
 
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.p_adic._models import (
     MAX_PRECISION,
@@ -196,6 +196,20 @@ def hensel_lift_root(
     lifted = _hensel_lift_root(coeffs, prime, root_mod_p, precision)
     return HenselRootResult._from_kernel(
         polynomial, prime, root_mod_p, precision, lifted
+    )
+
+
+def verify_hensel_root(claim: HenselRootResult) -> bool:
+    """Check the local congruence relation carried by a Hensel-root witness."""
+
+    coeffs = _kernel_coefficients(claim.polynomial)
+    lifted = parse_canonical_integer(claim.lifted_root)
+    modulus = claim.prime**claim.precision
+    return (
+        lifted % claim.prime == claim.root_mod_p
+        and _eval_poly(coeffs, claim.root_mod_p, claim.prime) == 0
+        and _eval_deriv(coeffs, claim.root_mod_p, claim.prime) != 0
+        and _eval_poly(coeffs, lifted, modulus) == 0
     )
 
 

--- a/src/jacobian/math/number_theory/p_adic/operations.py
+++ b/src/jacobian/math/number_theory/p_adic/operations.py
@@ -202,7 +202,15 @@ def hensel_lift_root(
 def verify_hensel_root(claim: HenselRootResult) -> bool:
     """Check the local congruence relation carried by a Hensel-root witness."""
 
-    coeffs = _kernel_coefficients(claim.polynomial)
+    try:
+        coeffs = _admit_root(
+            claim.polynomial,
+            claim.prime,
+            claim.root_mod_p,
+            claim.precision,
+        )
+    except OperationDomainValidationError:
+        return False
     lifted = parse_canonical_integer(claim.lifted_root)
     modulus = claim.prime**claim.precision
     return (
@@ -416,6 +424,16 @@ def verify_hensel_factor_lift(claim: HenselFactorLiftResult) -> bool:
     """Check the product and coprimality relations of a factor-lift witness."""
 
     prime = claim.prime
+    try:
+        _admit_factors(
+            claim.polynomial,
+            claim.factor_g,
+            claim.factor_h,
+            prime,
+            claim.precision,
+        )
+    except OperationDomainValidationError:
+        return False
     modulus = prime**claim.precision
     polynomial = _kernel_coefficients(claim.polynomial)
     factor_g = _kernel_coefficients(claim.factor_g)

--- a/src/jacobian/math/number_theory/p_adic/operations.py
+++ b/src/jacobian/math/number_theory/p_adic/operations.py
@@ -214,7 +214,8 @@ def verify_hensel_root(claim: HenselRootResult) -> bool:
     lifted = parse_canonical_integer(claim.lifted_root)
     modulus = claim.prime**claim.precision
     return (
-        lifted % claim.prime == claim.root_mod_p
+        0 <= lifted < modulus
+        and lifted % claim.prime == claim.root_mod_p
         and _eval_poly(coeffs, claim.root_mod_p, claim.prime) == 0
         and _eval_deriv(coeffs, claim.root_mod_p, claim.prime) != 0
         and _eval_poly(coeffs, lifted, modulus) == 0

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/__init__.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/__init__.py
@@ -5,6 +5,7 @@ from jacobian.math.number_theory.quadratic_forms.binary._models import (
     BinaryQuadraticFormRepresentation,
     PrimitivePositiveDefiniteBinaryQuadraticForm,
     ProperBinaryQuadraticFormClass,
+    ProperFormChangeOfVariables,
 )
 from jacobian.math.number_theory.quadratic_forms.binary.operations import (
     check,
@@ -14,6 +15,9 @@ from jacobian.math.number_theory.quadratic_forms.binary.operations import (
     reduced_classes,
     reduced_form,
     representations,
+    verify_change_of_variables,
+    verify_proper_equivalence,
+    verify_reduction,
 )
 
 __all__ = [
@@ -21,6 +25,7 @@ __all__ = [
     "BinaryQuadraticFormRepresentation",
     "PrimitivePositiveDefiniteBinaryQuadraticForm",
     "ProperBinaryQuadraticFormClass",
+    "ProperFormChangeOfVariables",
     "check",
     "compose_classes",
     "evaluate",
@@ -28,4 +33,7 @@ __all__ = [
     "reduced_classes",
     "reduced_form",
     "representations",
+    "verify_change_of_variables",
+    "verify_proper_equivalence",
+    "verify_reduction",
 ]

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/_models.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/_models.py
@@ -8,6 +8,8 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.math.matrices.values import IntegerMatrix
 
 MAX_COEFFICIENT = 10**6
 MAX_REPRESENTATION_TARGET = 10**12
@@ -428,12 +430,67 @@ class BinaryQuadraticFormEvaluateResult(StrictModel):
         )
 
 
+class ProperFormChangeOfVariables(StrictModel):
+    """A claimed SL2(ZZ) change with target(x,y) = source(M @ (x,y))."""
+
+    source: PrimitivePositiveDefiniteBinaryQuadraticForm
+    target: PrimitivePositiveDefiniteBinaryQuadraticForm
+    matrix: IntegerMatrix
+    convention: Literal["TARGET_EQUALS_SOURCE_AFTER_COLUMN_VARIABLE_MAP"] = (
+        "TARGET_EQUALS_SOURCE_AFTER_COLUMN_VARIABLE_MAP"
+    )
+
+    @model_validator(mode="after")
+    def require_matrix_shape(self) -> Self:
+        if self.matrix.row_count != 2 or self.matrix.column_count != 2:
+            raise ValueError("binary-form changes require a 2 by 2 integer matrix")
+        return self
+
+    @classmethod
+    def from_rows(
+        cls,
+        source: PrimitivePositiveDefiniteBinaryQuadraticForm,
+        target: PrimitivePositiveDefiniteBinaryQuadraticForm,
+        rows: tuple[tuple[int, int], tuple[int, int]],
+    ) -> Self:
+        return cls(
+            source=source,
+            target=target,
+            matrix=IntegerMatrix(
+                entries=tuple(
+                    tuple(format_canonical_integer(value) for value in row)
+                    for row in rows
+                )
+            ),
+        )
+
+    @property
+    def rows(self) -> tuple[tuple[int, int], tuple[int, int]]:
+        first, second = self.matrix.entries
+        return (
+            (parse_canonical_integer(first[0]), parse_canonical_integer(first[1])),
+            (parse_canonical_integer(second[0]), parse_canonical_integer(second[1])),
+        )
+
+
 class ReducedBinaryQuadraticFormResult(StrictModel):
     """Result of Gauss reduction."""
 
     form: PrimitivePositiveDefiniteBinaryQuadraticForm
     reduced_form: PrimitivePositiveDefiniteBinaryQuadraticForm
-    matrix: tuple[tuple[int, int], tuple[int, int]]
+    change: ProperFormChangeOfVariables
+
+    @property
+    def matrix(self) -> tuple[tuple[int, int], tuple[int, int]]:
+        return self.change.rows
+
+    @model_validator(mode="after")
+    def require_change_source(self) -> Self:
+        if self.change.source != self.form or self.change.target != self.reduced_form:
+            raise ValueError(
+                "reduction change must bind the retained source and reduced form"
+            )
+        return self
 
     @classmethod
     def _from_kernel(
@@ -444,7 +501,11 @@ class ReducedBinaryQuadraticFormResult(StrictModel):
         matrix: tuple[tuple[int, int], tuple[int, int]],
     ) -> Self:
         """Construct a trusted result from the owner-local reduction kernel."""
-        return cls.model_construct(form=form, reduced_form=reduced_form, matrix=matrix)
+        return cls.model_construct(
+            form=form,
+            reduced_form=reduced_form,
+            change=ProperFormChangeOfVariables.from_rows(form, reduced_form, matrix),
+        )
 
 
 class ProperEquivalenceResult(StrictModel):
@@ -453,7 +514,21 @@ class ProperEquivalenceResult(StrictModel):
     first: PrimitivePositiveDefiniteBinaryQuadraticForm
     second: PrimitivePositiveDefiniteBinaryQuadraticForm
     status: Literal["PROPERLY_EQUIVALENT", "NOT_PROPERLY_EQUIVALENT"]
-    matrix: tuple[tuple[int, int], tuple[int, int]] | None = None
+    change: ProperFormChangeOfVariables | None = None
+
+    @property
+    def matrix(self) -> tuple[tuple[int, int], tuple[int, int]] | None:
+        return None if self.change is None else self.change.rows
+
+    @model_validator(mode="after")
+    def require_change_branch(self) -> Self:
+        if (self.status == "PROPERLY_EQUIVALENT") != (self.change is not None):
+            raise ValueError("equivalence branch must agree with witness presence")
+        if self.change is not None and (
+            self.change.source != self.first or self.change.target != self.second
+        ):
+            raise ValueError("equivalence change must bind its two source forms")
+        return self
 
     @classmethod
     def _from_kernel(
@@ -466,7 +541,12 @@ class ProperEquivalenceResult(StrictModel):
     ) -> Self:
         """Construct a trusted result from the owner-local equivalence kernel."""
         return cls.model_construct(
-            first=first, second=second, status=status, matrix=matrix
+            first=first,
+            second=second,
+            status=status,
+            change=None
+            if matrix is None
+            else ProperFormChangeOfVariables.from_rows(first, second, matrix),
         )
 
 
@@ -501,10 +581,21 @@ class BinaryQuadraticFormClassCompositionResult(StrictModel):
     composed_form: PrimitivePositiveDefiniteBinaryQuadraticForm
     direct_composition_map: DirectBinaryQuadraticCompositionMap
     product: ProperBinaryQuadraticFormClass
-    reduction_matrix: tuple[tuple[int, int], tuple[int, int]]
+    reduction_change: ProperFormChangeOfVariables
+
+    @property
+    def reduction_matrix(self) -> tuple[tuple[int, int], tuple[int, int]]:
+        return self.reduction_change.rows
 
     @model_validator(mode="after")
     def require_one_discriminant(self) -> Self:
+        if (
+            self.reduction_change.source != self.composed_form
+            or self.reduction_change.target != self.product.representative
+        ):
+            raise ValueError(
+                "composition reduction must bind the composed and product forms"
+            )
         discriminants = {
             self.first.discriminant,
             self.second.discriminant,
@@ -535,7 +626,9 @@ class BinaryQuadraticFormClassCompositionResult(StrictModel):
             composed_form=composed_form,
             direct_composition_map=direct_composition_map,
             product=product,
-            reduction_matrix=reduction_matrix,
+            reduction_change=ProperFormChangeOfVariables.from_rows(
+                composed_form, product.representative, reduction_matrix
+            ),
         )
 
 

--- a/src/jacobian/math/number_theory/quadratic_forms/binary/operations.py
+++ b/src/jacobian/math/number_theory/quadratic_forms/binary/operations.py
@@ -26,6 +26,8 @@ from jacobian.math.number_theory.quadratic_forms.binary._models import (
     PrimitivePositiveDefiniteBinaryQuadraticForm,
     ProperBinaryQuadraticFormClass,
     ProperEquivalenceResult,
+    ProperFormChangeOfVariables,
+    ReducedBinaryQuadraticFormResult,
     _require_composition_budget,
     _require_evaluated_value_bound,
     _require_reduced_class_search_budget,
@@ -202,6 +204,38 @@ def representations(
     return _representations(form, target)
 
 
+def verify_change_of_variables(claim: ProperFormChangeOfVariables) -> bool:
+    """Check determinant one and the exact binary-form substitution identity.
+
+    This uses a fixed number of arithmetic operations on the bounded form
+    coefficients and the canonical 2-by-2 integer-matrix carrier.
+    """
+    (p, q), (r, s) = claim.rows
+    if p * s - q * r != 1:
+        return False
+    a, b, c = claim.source.a, claim.source.b, claim.source.c
+    return (
+        a * p * p + b * p * r + c * r * r,
+        2 * a * p * q + b * (p * s + q * r) + 2 * c * r * s,
+        a * q * q + b * q * s + c * s * s,
+    ) == (claim.target.a, claim.target.b, claim.target.c)
+
+
+def verify_reduction(claim: ReducedBinaryQuadraticFormResult) -> bool:
+    """Check proper equivalence and the target's Gauss-reduced predicate."""
+    target = claim.reduced_form
+    return verify_change_of_variables(claim.change) and _check_reduced(
+        target.a, target.b, target.c
+    )
+
+
+def verify_proper_equivalence(claim: ProperEquivalenceResult) -> bool:
+    """Check the positive witness or the bounded negative equivalence decision."""
+    if claim.change is not None:
+        return verify_change_of_variables(claim.change)
+    return proper_equivalence(claim.first, claim.second).status == claim.status
+
+
 __all__ = [
     "check",
     "compose_classes",
@@ -210,4 +244,7 @@ __all__ = [
     "reduced_classes",
     "reduced_form",
     "representations",
+    "verify_change_of_variables",
+    "verify_proper_equivalence",
+    "verify_reduction",
 ]

--- a/src/jacobian/math/optimization/submodular/__init__.py
+++ b/src/jacobian/math/optimization/submodular/__init__.py
@@ -4,6 +4,14 @@ from jacobian.math.optimization.submodular.operations import (
     check_monotonicity,
     check_submodularity,
     evaluate_set_function,
+    verify_monotonicity,
+    verify_submodularity,
 )
 
-__all__ = ["check_monotonicity", "check_submodularity", "evaluate_set_function"]
+__all__ = [
+    "check_monotonicity",
+    "check_submodularity",
+    "evaluate_set_function",
+    "verify_monotonicity",
+    "verify_submodularity",
+]

--- a/src/jacobian/math/optimization/submodular/_models.py
+++ b/src/jacobian/math/optimization/submodular/_models.py
@@ -115,8 +115,9 @@ class MonotonicityCheckRequest(StrictModel):
 class MonotonicityCheckResult(StrictModel):
     """Whether the function is monotone non-decreasing."""
 
+    function: SetFunction
     is_monotone: bool
-    violation: str
+    violation: tuple[tuple[int, ...], int] | None = None
 
 
 class SubmodularityCheckRequest(StrictModel):
@@ -128,8 +129,9 @@ class SubmodularityCheckRequest(StrictModel):
 class SubmodularityCheckResult(StrictModel):
     """Whether the function is submodular."""
 
+    function: SetFunction
     is_submodular: bool
-    violation: str
+    violation: tuple[tuple[int, ...], int, int] | None = None
 
 
 __all__ = [

--- a/src/jacobian/math/optimization/submodular/operations.py
+++ b/src/jacobian/math/optimization/submodular/operations.py
@@ -85,13 +85,11 @@ def check_monotonicity(function: SetFunction) -> MonotonicityCheckResult:
             supersets_value = table[mask | bit]
             if value_mask > supersets_value:
                 return MonotonicityCheckResult(
+                    function=function,
                     is_monotone=False,
-                    violation=(
-                        f"f({_subset_label(mask, size)}) > "
-                        f"f({_subset_label(mask | bit, size)})"
-                    ),
+                    violation=(_subset_label(mask, size), index),
                 )
-    return MonotonicityCheckResult(is_monotone=True, violation="")
+    return MonotonicityCheckResult(function=function, is_monotone=True)
 
 
 def check_submodularity(function: SetFunction) -> SubmodularityCheckResult:
@@ -124,19 +122,33 @@ def check_submodularity(function: SetFunction) -> SubmodularityCheckResult:
             rhs = base_value + table[mask | bit_i | bit_j]
             if lhs < rhs:
                 return SubmodularityCheckResult(
+                    function=function,
                     is_submodular=False,
                     violation=(
-                        f"f({_subset_label(mask | bit_i, size)}) + "
-                        f"f({_subset_label(mask | bit_j, size)}) < "
-                        f"f({_subset_label(mask, size)}) + "
-                        f"f({_subset_label(mask | bit_i | bit_j, size)})"
+                        _subset_label(mask, size),
+                        bit_i.bit_length() - 1,
+                        bit_j.bit_length() - 1,
                     ),
                 )
-    return SubmodularityCheckResult(is_submodular=True, violation="")
+    return SubmodularityCheckResult(function=function, is_submodular=True)
+
+
+def verify_monotonicity(claim: MonotonicityCheckResult) -> bool:
+    """Check a retained monotonicity claim against its source function."""
+
+    return check_monotonicity(claim.function) == claim
+
+
+def verify_submodularity(claim: SubmodularityCheckResult) -> bool:
+    """Check a retained submodularity claim against its source function."""
+
+    return check_submodularity(claim.function) == claim
 
 
 __all__ = [
     "check_monotonicity",
     "check_submodularity",
     "evaluate_set_function",
+    "verify_monotonicity",
+    "verify_submodularity",
 ]

--- a/src/jacobian/math/polynomials/ideals/_models.py
+++ b/src/jacobian/math/polynomials/ideals/_models.py
@@ -621,6 +621,7 @@ class IdealRadicalResult(StrictModel):
 
 
 class IdealRadicalMembershipResult(StrictModel):
+    request: IdealRadicalMembershipRequest
     in_radical: bool
 
 

--- a/src/jacobian/math/polynomials/ideals/_models.py
+++ b/src/jacobian/math/polynomials/ideals/_models.py
@@ -621,7 +621,8 @@ class IdealRadicalResult(StrictModel):
 
 
 class IdealRadicalMembershipResult(StrictModel):
-    request: IdealRadicalMembershipRequest
+    ideal: RationalPolynomialIdeal
+    polynomial: RationalPolynomial
     in_radical: bool
 
 

--- a/src/jacobian/math/polynomials/ideals/operations.py
+++ b/src/jacobian/math/polynomials/ideals/operations.py
@@ -61,6 +61,7 @@ from jacobian.math.polynomials.ideals._models import (
     IdealMinimalPrimesResult,
     IdealNormalFormResult,
     IdealQuotientResult,
+    IdealRadicalMembershipRequest,
     IdealRadicalMembershipResult,
     IdealRadicalResult,
     IdealSaturationResult,
@@ -1061,7 +1062,21 @@ def ideal_radical_membership(
         order="grevlex",
         domain=sympy.QQ,
     )
-    return IdealRadicalMembershipResult(in_radical=len(basis) == 1 and basis[0] == 1)
+    return IdealRadicalMembershipResult(
+        request=IdealRadicalMembershipRequest(ideal=ideal, polynomial=polynomial),
+        in_radical=len(basis) == 1 and basis[0] == 1,
+    )
+
+
+def verify_ideal_radical_membership(claim: IdealRadicalMembershipResult) -> bool:
+    """Check the bounded Rabinowitsch decision asserted by a claim."""
+
+    return (
+        ideal_radical_membership(
+            claim.request.ideal, claim.request.polynomial
+        ).in_radical
+        is claim.in_radical
+    )
 
 
 def ideal_quotient(

--- a/src/jacobian/math/polynomials/ideals/operations.py
+++ b/src/jacobian/math/polynomials/ideals/operations.py
@@ -61,7 +61,6 @@ from jacobian.math.polynomials.ideals._models import (
     IdealMinimalPrimesResult,
     IdealNormalFormResult,
     IdealQuotientResult,
-    IdealRadicalMembershipRequest,
     IdealRadicalMembershipResult,
     IdealRadicalResult,
     IdealSaturationResult,
@@ -1063,7 +1062,8 @@ def ideal_radical_membership(
         domain=sympy.QQ,
     )
     return IdealRadicalMembershipResult(
-        request=IdealRadicalMembershipRequest(ideal=ideal, polynomial=polynomial),
+        ideal=ideal,
+        polynomial=polynomial,
         in_radical=len(basis) == 1 and basis[0] == 1,
     )
 
@@ -1072,9 +1072,7 @@ def verify_ideal_radical_membership(claim: IdealRadicalMembershipResult) -> bool
     """Check the bounded Rabinowitsch decision asserted by a claim."""
 
     return (
-        ideal_radical_membership(
-            claim.request.ideal, claim.request.polynomial
-        ).in_radical
+        ideal_radical_membership(claim.ideal, claim.polynomial).in_radical
         is claim.in_radical
     )
 

--- a/src/jacobian/math/polynomials/series/_models.py
+++ b/src/jacobian/math/polynomials/series/_models.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 from math import lcm
-from typing import Annotated, Literal, Self
+from typing import Literal, Self
 
-from pydantic import Field, StrictInt, StringConstraints, model_validator
+from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
 from jacobian.canonical import parse_canonical_integer
 from jacobian.math._rational_height import RationalHeight, sum_heights
+from jacobian.math.polynomials.values import PolynomialVariable, RationalPolynomial
 
 # ---------------------------------------------------------------------------
 # Public bounds
@@ -222,14 +223,7 @@ def _inverse_height(series: TruncatedSeries) -> tuple[int, int, int, int]:
     return numerator, inverse_denominator, source_norm, source_denominator
 
 
-Variable = Annotated[
-    str,
-    StringConstraints(
-        pattern=r"^[a-z][a-z0-9]*$",
-        max_length=16,
-        strict=True,
-    ),
-]
+Variable = PolynomialVariable
 
 
 # ---------------------------------------------------------------------------
@@ -913,30 +907,36 @@ class SeriesIdentityCheckResult(StrictModel):
 
 
 class SeriesFromPolynomialRequest(StrictModel):
-    """Convert a dense rational polynomial coefficient prefix into a series."""
+    """The explicit QQ[x] to QQ[[x]]/(x^N) projection."""
 
-    variable: Variable
-    coefficients: tuple[CanonicalRational, ...] = Field(
-        min_length=1,
-    )
+    polynomial: RationalPolynomial
     truncation_order: StrictInt = Field(ge=1)
 
+
+class SeriesFromPolynomialResult(StrictModel):
+    source: RationalPolynomial
+    result: TruncatedSeries
+
     @model_validator(mode="after")
-    def require_dense_tuple(self) -> Self:
-        if len(self.coefficients) != self.truncation_order:
+    def require_same_variable(self) -> Self:
+        if self.source.variables != (self.result.variable,):
             raise _validation_error(
-                "input_coefficient_count_mismatch",
-                "input coefficients must match truncation_order exactly",
+                "conversion_variable", "projection must retain the polynomial variable"
             )
         return self
 
 
-class SeriesFromPolynomialResult(StrictModel):
-    result: TruncatedSeries
-
-
 class SeriesToPolynomialResult(StrictModel):
-    result: TruncatedSeries
+    source: TruncatedSeries
+    result: RationalPolynomial
     polynomial_label: Literal["TRUNCATED_POLYNOMIAL_REPRESENTATIVE"] = (
         "TRUNCATED_POLYNOMIAL_REPRESENTATIVE"
     )
+
+    @model_validator(mode="after")
+    def require_same_variable(self) -> Self:
+        if self.result.variables != (self.source.variable,):
+            raise _validation_error(
+                "conversion_variable", "representative must retain the series variable"
+            )
+        return self

--- a/src/jacobian/math/polynomials/series/_tools.py
+++ b/src/jacobian/math/polynomials/series/_tools.py
@@ -479,13 +479,13 @@ TOOLS = (
         operation_id="formal_series.rational.from_polynomial.compute",
         title="Convert a rational polynomial to a formal power series",
         description=(
-            "Convert a dense canonical rational polynomial coefficient sequence "
-            "to an exact truncated formal power series."
+            "Project a canonical univariate QQ polynomial to an exact formal "
+            "power series modulo x^N, discarding terms of degree at least N."
         ),
         request_type=SeriesFromPolynomialRequest,
         result_type=SeriesFromPolynomialResult,
         run=lambda request: from_polynomial(
-            request.variable, request.coefficients, request.truncation_order
+            request.polynomial, request.truncation_order
         ),
         tags=("formal-series", "polynomial", "conversion", "rational", "exact"),
         examples=(
@@ -493,8 +493,15 @@ TOOLS = (
                 name="polynomial_one_plus_x",
                 description="Convert the dense polynomial 1+x to a series modulo x^3.",
                 input={
-                    "variable": "x",
-                    "coefficients": [_ONE, _ONE, _ZERO],
+                    "polynomial": {
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {"coefficient": _ONE, "exponents": [1]},
+                                {"coefficient": _ONE, "exponents": [0]},
+                            ]
+                        },
+                    },
                     "truncation_order": 3,
                 },
             ),
@@ -504,7 +511,7 @@ TOOLS = (
         operation_id="formal_series.rational.to_polynomial.compute",
         title="Convert a formal power series to its polynomial representative",
         description=(
-            "Return the exact dense canonical polynomial representative of the "
+            "Return the exact sparse canonical QQ polynomial representative of the "
             "known coefficients below the truncation order."
         ),
         request_type=InputTruncatedSeries,

--- a/src/jacobian/math/polynomials/series/operations.py
+++ b/src/jacobian/math/polynomials/series/operations.py
@@ -17,6 +17,7 @@ from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.polynomials.series._models import (
+    MAX_TRUNCATION_ORDER,
     SeriesArithmeticResult,
     SeriesComposeResult,
     SeriesDerivativeResult,
@@ -44,6 +45,11 @@ from jacobian.math.polynomials.series._models import (
     admit_native_reversion,
     admit_native_scalar_multiply,
     admit_native_truncate,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
 )
 
 __all__ = [
@@ -464,30 +470,43 @@ def identity_check(
 
 
 def from_polynomial(
-    variable: str,
-    coefficients: Sequence[CanonicalRational],
+    polynomial: RationalPolynomial,
     truncation_order: int,
 ) -> SeriesFromPolynomialResult:
-    """Convert a dense rational coefficient tuple into a truncated series."""
+    """Project QQ[x] to the order-N series, explicitly discarding higher terms."""
+    if len(polynomial.variables) != 1:
+        raise ValueError("series conversion requires a univariate rational polynomial")
+    if (
+        type(truncation_order) is not int
+        or not 1 <= truncation_order <= MAX_TRUNCATION_ORDER
+    ):
+        raise ValueError(
+            f"truncation_order must be between 1 and {MAX_TRUNCATION_ORDER}"
+        )
+    coefficients = [CanonicalRational(num="0", den="1")] * truncation_order
+    for term in polynomial.polynomial.terms:
+        if term.exponents[0] < truncation_order:
+            coefficients[term.exponents[0]] = term.coefficient
     series = TruncatedSeries(
-        variable=variable,
+        variable=polynomial.variables[0],
         truncation_order=truncation_order,
         coefficients=tuple(coefficients),
     )
     _run_admission(lambda: admit_native_from_polynomial(series))
-    coeffs = [coefficient.as_fraction() for coefficient in coefficients]
-    return SeriesFromPolynomialResult(
-        result=_series_result(variable, truncation_order, coeffs)
-    )
+    return SeriesFromPolynomialResult(source=polynomial, result=series)
 
 
 def to_polynomial(series: TruncatedSeries) -> SeriesToPolynomialResult:
-    """Return the canonical truncated polynomial representative of the series."""
+    """Lift a series to its unique polynomial representative of degree below N."""
     _run_admission(lambda: admit_native_from_polynomial(series))
-    return SeriesToPolynomialResult(
-        result=TruncatedSeries(
-            variable=series.variable,
-            truncation_order=series.truncation_order,
-            coefficients=series.coefficients,
-        )
+    polynomial = RationalPolynomial(
+        variables=(series.variable,),
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(coefficient=value, exponents=(degree,))
+                for degree, value in reversed(tuple(enumerate(series.coefficients)))
+                if value.num != "0"
+            )
+        ),
     )
+    return SeriesToPolynomialResult(source=series, result=polynomial)

--- a/src/jacobian/math/probability/markov_chains/__init__.py
+++ b/src/jacobian/math/probability/markov_chains/__init__.py
@@ -10,6 +10,7 @@ from jacobian.math.probability.markov_chains.operations import (
     stationary_distribution,
     stationary_distribution_extremes,
     stationary_distribution_result,
+    verify_ergodic_decision,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "stationary_distribution",
     "stationary_distribution_extremes",
     "stationary_distribution_result",
+    "verify_ergodic_decision",
 ]

--- a/src/jacobian/math/probability/markov_chains/_models.py
+++ b/src/jacobian/math/probability/markov_chains/_models.py
@@ -119,6 +119,7 @@ class StationaryDistributionResult(StrictModel):
 
 
 class ErgodicDecisionResult(StrictModel):
+    matrix: RationalMatrix
     is_ergodic: bool
     is_irreducible: bool
     is_aperiodic: bool

--- a/src/jacobian/math/probability/markov_chains/eventual_hitting/operations.py
+++ b/src/jacobian/math/probability/markov_chains/eventual_hitting/operations.py
@@ -8,8 +8,9 @@ from typing import NoReturn
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.matrices.values import MAX_RATIONAL_MATRIX_AXIS, RationalMatrix
+from jacobian.math.matrices.values import RationalMatrix
 from jacobian.math.probability.markov_chains.eventual_hitting._models import (
+    MAX_STATES,
     EventualHittingProfileResult,
 )
 from jacobian.math.probability.markov_chains.values import (
@@ -34,7 +35,7 @@ def _admit_eventual_hitting(
     target_states: tuple[int, ...],
 ) -> tuple[set[int], set[int], tuple[int, ...]]:
     try:
-        require_transition_matrix(matrix, maximum_states=MAX_RATIONAL_MATRIX_AXIS)
+        require_transition_matrix(matrix, maximum_states=MAX_STATES)
     except TransitionMatrixAdmissionError as exc:
         _reject(exc.location, exc.reason, str(exc))
 

--- a/src/jacobian/math/probability/markov_chains/operations.py
+++ b/src/jacobian/math/probability/markov_chains/operations.py
@@ -35,6 +35,7 @@ __all__ = [
     "stationary_distribution",
     "stationary_distribution_extremes",
     "stationary_distribution_result",
+    "verify_ergodic_decision",
 ]
 
 
@@ -426,10 +427,17 @@ def ergodic_decision(matrix: RationalMatrix) -> ErgodicDecisionResult:
     _admit_transition_matrix(native)
     irreducible, aperiodic = _ergodic_properties(native)
     return ErgodicDecisionResult(
+        matrix=matrix,
         is_ergodic=irreducible and aperiodic,
         is_irreducible=irreducible,
         is_aperiodic=aperiodic,
     )
+
+
+def verify_ergodic_decision(claim: ErgodicDecisionResult) -> bool:
+    """Check the decision relation against the retained transition matrix."""
+
+    return ergodic_decision(claim.matrix) == claim
 
 
 def communicating_classes(matrix: RationalMatrix) -> CommunicatingClassesResult:

--- a/src/jacobian/math/probability/multiple_testing/__init__.py
+++ b/src/jacobian/math/probability/multiple_testing/__init__.py
@@ -3,6 +3,13 @@
 from jacobian.math.probability.multiple_testing.operations import (
     bh_step_up,
     false_discovery_proportion,
+    verify_bh_step_up,
+    verify_fdp,
 )
 
-__all__ = ["bh_step_up", "false_discovery_proportion"]
+__all__ = [
+    "bh_step_up",
+    "false_discovery_proportion",
+    "verify_bh_step_up",
+    "verify_fdp",
+]

--- a/src/jacobian/math/probability/multiple_testing/_models.py
+++ b/src/jacobian/math/probability/multiple_testing/_models.py
@@ -58,25 +58,44 @@ class BHStepUpRequest(StrictModel):
 class BHStepUpResult(StrictModel):
     """BH step-up rejection set."""
 
-    critical_index: int = Field(ge=0)
-    cutoff_threshold: str
-    rejected: tuple[OpaqueLabel, ...]
-    total_hypotheses: int = Field(ge=1)
+    source: BHStepUpRequest
+    critical_index: int = Field(ge=0, le=MAX_HYPOTHESES)
+    cutoff_threshold: CanonicalRational
+    rejected: tuple[OpaqueLabel, ...] = Field(max_length=MAX_HYPOTHESES)
+
+    @property
+    def total_hypotheses(self) -> int:
+        return len(self.source.hypotheses)
+
+    @model_validator(mode="after")
+    def require_rejection_axis(self) -> Self:
+        ids = {hyp.hypothesis_id for hyp in self.source.hypotheses}
+        if (
+            len(set(self.rejected)) != len(self.rejected)
+            or not set(self.rejected) <= ids
+        ):
+            raise _validation_error(
+                "rejection_axis", "rejections must be distinct source hypotheses"
+            )
+        return self
 
 
 class FDPRequest(StrictModel):
     """False discovery proportion computation."""
 
-    rejected_ids: tuple[OpaqueLabel, ...] = Field(default=())
-    true_null_ids: tuple[OpaqueLabel, ...] = Field(default=())
+    rejected_ids: tuple[OpaqueLabel, ...] = Field(default=(), max_length=MAX_HYPOTHESES)
+    true_null_ids: tuple[OpaqueLabel, ...] = Field(
+        default=(), max_length=MAX_HYPOTHESES
+    )
 
 
 class FDPResult(StrictModel):
     """Exact false discovery proportion."""
 
+    source: FDPRequest
     false_discoveries: int = Field(ge=0)
     total_rejections: int = Field(ge=0)
-    fdp: str
+    fdp: CanonicalRational
 
 
 __all__ = [

--- a/src/jacobian/math/probability/multiple_testing/_models.py
+++ b/src/jacobian/math/probability/multiple_testing/_models.py
@@ -58,18 +58,19 @@ class BHStepUpRequest(StrictModel):
 class BHStepUpResult(StrictModel):
     """BH step-up rejection set."""
 
-    source: BHStepUpRequest
+    hypotheses: tuple[HypothesisSpec, ...]
+    level: CanonicalRational
     critical_index: int = Field(ge=0, le=MAX_HYPOTHESES)
     cutoff_threshold: CanonicalRational
     rejected: tuple[OpaqueLabel, ...] = Field(max_length=MAX_HYPOTHESES)
 
     @property
     def total_hypotheses(self) -> int:
-        return len(self.source.hypotheses)
+        return len(self.hypotheses)
 
     @model_validator(mode="after")
     def require_rejection_axis(self) -> Self:
-        ids = {hyp.hypothesis_id for hyp in self.source.hypotheses}
+        ids = {hyp.hypothesis_id for hyp in self.hypotheses}
         if (
             len(set(self.rejected)) != len(self.rejected)
             or not set(self.rejected) <= ids
@@ -92,7 +93,8 @@ class FDPRequest(StrictModel):
 class FDPResult(StrictModel):
     """Exact false discovery proportion."""
 
-    source: FDPRequest
+    rejected_ids: tuple[OpaqueLabel, ...]
+    true_null_ids: tuple[OpaqueLabel, ...]
     false_discoveries: int = Field(ge=0)
     total_rejections: int = Field(ge=0)
     fdp: CanonicalRational

--- a/src/jacobian/math/probability/multiple_testing/operations.py
+++ b/src/jacobian/math/probability/multiple_testing/operations.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from fractions import Fraction
 
-from jacobian._exact import CanonicalRational, format_canonical_rational
+from jacobian._exact import CanonicalRational
 from jacobian.math._labels import OpaqueLabel
 from jacobian.math.probability.multiple_testing._models import (
     MAX_HYPOTHESES,
+    BHStepUpRequest,
     BHStepUpResult,
+    FDPRequest,
     FDPResult,
     HypothesisSpec,
 )
@@ -49,10 +51,10 @@ def bh_step_up(
     rejected_ids = tuple(h.hypothesis_id for h in hyps[:critical_k])
 
     return BHStepUpResult(
+        source=BHStepUpRequest(hypotheses=hypotheses, level=level),
         critical_index=critical_k,
-        cutoff_threshold=format_canonical_rational(cutoff),
+        cutoff_threshold=CanonicalRational.from_fraction(cutoff),
         rejected=tuple(sorted(rejected_ids)),
-        total_hypotheses=n,
     )
 
 
@@ -60,16 +62,43 @@ def false_discovery_proportion(
     rejected_ids: tuple[OpaqueLabel, ...], true_null_ids: tuple[OpaqueLabel, ...]
 ) -> FDPResult:
     """Compute the false discovery proportion."""
+    if max(len(rejected_ids), len(true_null_ids)) > MAX_HYPOTHESES:
+        raise ValueError(f"hypothesis sets must have at most {MAX_HYPOTHESES} entries")
     rejected = set(rejected_ids)
     nulls = set(true_null_ids)
     false_d = len(rejected & nulls)
     total = len(rejected)
     fdp = Fraction(false_d, total) if total > 0 else Fraction(0)
     return FDPResult(
+        source=FDPRequest(
+            rejected_ids=tuple(sorted(rejected)), true_null_ids=tuple(sorted(nulls))
+        ),
         false_discoveries=false_d,
         total_rejections=total,
-        fdp=format_canonical_rational(fdp),
+        fdp=CanonicalRational.from_fraction(fdp),
     )
 
 
-__all__ = ["bh_step_up", "false_discovery_proportion"]
+def verify_bh_step_up(claim: BHStepUpResult) -> bool:
+    """Check a retained BH claim with the bounded step-up procedure."""
+    return bh_step_up(claim.source.hypotheses, claim.source.level) == claim
+
+
+def verify_fdp(claim: FDPResult) -> bool:
+    """Check the intersection count and exact ratio of retained hypothesis sets."""
+    expected = false_discovery_proportion(
+        claim.source.rejected_ids, claim.source.true_null_ids
+    )
+    return (expected.false_discoveries, expected.total_rejections, expected.fdp) == (
+        claim.false_discoveries,
+        claim.total_rejections,
+        claim.fdp,
+    )
+
+
+__all__ = [
+    "bh_step_up",
+    "false_discovery_proportion",
+    "verify_bh_step_up",
+    "verify_fdp",
+]

--- a/src/jacobian/math/probability/multiple_testing/operations.py
+++ b/src/jacobian/math/probability/multiple_testing/operations.py
@@ -8,9 +8,7 @@ from jacobian._exact import CanonicalRational
 from jacobian.math._labels import OpaqueLabel
 from jacobian.math.probability.multiple_testing._models import (
     MAX_HYPOTHESES,
-    BHStepUpRequest,
     BHStepUpResult,
-    FDPRequest,
     FDPResult,
     HypothesisSpec,
 )
@@ -51,7 +49,8 @@ def bh_step_up(
     rejected_ids = tuple(h.hypothesis_id for h in hyps[:critical_k])
 
     return BHStepUpResult(
-        source=BHStepUpRequest(hypotheses=hypotheses, level=level),
+        hypotheses=hypotheses,
+        level=level,
         critical_index=critical_k,
         cutoff_threshold=CanonicalRational.from_fraction(cutoff),
         rejected=tuple(sorted(rejected_ids)),
@@ -70,9 +69,8 @@ def false_discovery_proportion(
     total = len(rejected)
     fdp = Fraction(false_d, total) if total > 0 else Fraction(0)
     return FDPResult(
-        source=FDPRequest(
-            rejected_ids=tuple(sorted(rejected)), true_null_ids=tuple(sorted(nulls))
-        ),
+        rejected_ids=tuple(sorted(rejected)),
+        true_null_ids=tuple(sorted(nulls)),
         false_discoveries=false_d,
         total_rejections=total,
         fdp=CanonicalRational.from_fraction(fdp),
@@ -81,14 +79,12 @@ def false_discovery_proportion(
 
 def verify_bh_step_up(claim: BHStepUpResult) -> bool:
     """Check a retained BH claim with the bounded step-up procedure."""
-    return bh_step_up(claim.source.hypotheses, claim.source.level) == claim
+    return bh_step_up(claim.hypotheses, claim.level) == claim
 
 
 def verify_fdp(claim: FDPResult) -> bool:
     """Check the intersection count and exact ratio of retained hypothesis sets."""
-    expected = false_discovery_proportion(
-        claim.source.rejected_ids, claim.source.true_null_ids
-    )
+    expected = false_discovery_proportion(claim.rejected_ids, claim.true_null_ids)
     return (expected.false_discoveries, expected.total_rejections, expected.fdp) == (
         claim.false_discoveries,
         claim.total_rejections,

--- a/src/jacobian/math/probability/stochastic_processes/_admission.py
+++ b/src/jacobian/math/probability/stochastic_processes/_admission.py
@@ -1,0 +1,49 @@
+"""Operation-owned probability and partition admission."""
+
+from fractions import Fraction
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.probability.stochastic_processes.values import (
+    FiniteProbabilitySpace,
+    FiniteSigmaAlgebra,
+)
+
+
+def _reject(reason: str, message: str) -> None:
+    raise OperationDomainValidationError(
+        location=("space",),
+        code=f"finite_stochastic_process.{reason}",
+        message=message,
+    )
+
+
+def admit_probability_space(space: FiniteProbabilitySpace) -> None:
+    """Check at most 64 masses with 256-digit components.
+
+    A common denominator has at most 16384 digits; positive partial sums
+    require at most 16386 numerator digits. No backend or unbounded expansion
+    is needed, and callers share this check within one composite execution.
+    """
+    total = Fraction(0)
+    for mass in space.masses:
+        value = mass.as_fraction()
+        if value <= 0:
+            _reject("mass_nonpositive", "masses must be positive")
+        total += value
+    if total != 1:
+        _reject("mass_sum_invalid", "masses must sum to exactly 1")
+
+
+def admit_partition(sigma: FiniteSigmaAlgebra) -> None:
+    """Check disjoint coverage in at most 64 squared declared memberships.
+
+    Probability normalization is admitted separately once by the caller.
+    """
+    seen: set[str] = set()
+    for block in sigma.blocks:
+        for sample in block:
+            if sample in seen:
+                _reject("partition_blocks_overlap", "partition blocks must be disjoint")
+            seen.add(sample)
+    if seen != set(sigma.space.samples):
+        _reject("partition_incomplete", "blocks must partition the entire sample space")

--- a/src/jacobian/math/probability/stochastic_processes/operations.py
+++ b/src/jacobian/math/probability/stochastic_processes/operations.py
@@ -9,6 +9,10 @@ from jacobian.math.probability._distribution import (
     FiniteDistributionAtom,
     FiniteRationalDistribution,
 )
+from jacobian.math.probability.stochastic_processes._admission import (
+    admit_partition,
+    admit_probability_space,
+)
 from jacobian.math.probability.stochastic_processes._models import (
     MAX_STOCHASTIC_VALUE_DIGITS,
 )
@@ -78,6 +82,13 @@ def sigma_algebra_from_observation(
 
     Blocks are equal-value fibers.
     """
+    admit_probability_space(space)
+    return _sigma_from_observation(space, observation)
+
+
+def _sigma_from_observation(
+    space: FiniteProbabilitySpace, observation: tuple[str, ...]
+) -> FiniteSigmaAlgebra:
     if len(observation) != len(space.samples):
         raise ValueError("observation must have one entry per sample")
     fibers: dict[str, set[str]] = {}
@@ -97,6 +108,15 @@ def sigma_algebra_join(
     """
     if sigma1.space != sigma2.space:
         raise ValueError("sigma algebras must share the same probability space")
+    admit_probability_space(sigma1.space)
+    admit_partition(sigma1)
+    admit_partition(sigma2)
+    return _sigma_join(sigma1, sigma2)
+
+
+def _sigma_join(
+    sigma1: FiniteSigmaAlgebra, sigma2: FiniteSigmaAlgebra
+) -> FiniteSigmaAlgebra:
     blocks: list[tuple[str, ...]] = []
     for b1 in sigma1.blocks:
         for b2 in sigma2.blocks:
@@ -115,6 +135,16 @@ def conditional_expectation(
     On each block, the conditional expectation is the probability-weighted
     average of X over the samples in that block.
     """
+    if rv.space != sigma.space:
+        raise ValueError("random variable and sigma algebra must share the same space")
+    admit_probability_space(rv.space)
+    admit_partition(sigma)
+    return _conditional_expectation(rv, sigma)
+
+
+def _conditional_expectation(
+    rv: FiniteRandomVariable, sigma: FiniteSigmaAlgebra
+) -> FiniteRandomVariable:
     for value in rv.values:
         require_bounded_rational(
             value,
@@ -150,16 +180,23 @@ def filtration_natural(
     observations: tuple[tuple[str, ...], ...],
 ) -> tuple[FiniteSigmaAlgebra, ...]:
     """Return the natural filtration F_t = sigma(Y_0, ..., Y_t) for each time t."""
+    admit_probability_space(space)
+    return _filtration_natural(space, observations)
+
+
+def _filtration_natural(
+    space: FiniteProbabilitySpace, observations: tuple[tuple[str, ...], ...]
+) -> tuple[FiniteSigmaAlgebra, ...]:
     if not observations:
         return ()
     sigmas: list[FiniteSigmaAlgebra] = []
     accumulated: FiniteSigmaAlgebra | None = None
     for _t, obs in enumerate(observations):
-        current = sigma_algebra_from_observation(space, obs)
+        current = _sigma_from_observation(space, obs)
         if accumulated is None:
             accumulated = current
         else:
-            accumulated = sigma_algebra_join(accumulated, current)
+            accumulated = _sigma_join(accumulated, current)
         sigmas.append(accumulated)
     return tuple(sigmas)
 
@@ -180,10 +217,11 @@ def doob_martingale(
         )
     if len(payoff) != len(space.samples):
         raise ValueError("payoff must have one entry per sample")
-    sigmas = filtration_natural(space, observations)
+    admit_probability_space(space)
+    sigmas = _filtration_natural(space, observations)
     rv = FiniteRandomVariable(space=space, values=payoff)
     result: list[tuple[CanonicalRational, ...]] = []
     for sigma in sigmas:
-        ce = conditional_expectation(rv, sigma)
+        ce = _conditional_expectation(rv, sigma)
         result.append(ce.values)
     return tuple(result)

--- a/src/jacobian/math/probability/stochastic_processes/values.py
+++ b/src/jacobian/math/probability/stochastic_processes/values.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Annotated, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -41,17 +41,12 @@ class FiniteProbabilitySpace(StrictModel):
             )
         if len(set(self.samples)) != len(self.samples):
             raise _validation_error("sample_duplicate", "sample labels must be unique")
-        total = sum((mass.as_fraction() for mass in self.masses), start=0)
         for mass in self.masses:
             require_bounded_rational(
                 mass,
                 max_digits=256,
                 label="probability mass",
             )
-            if mass.as_fraction() <= 0:
-                raise _validation_error("mass_nonpositive", "masses must be positive")
-        if total != 1:
-            raise _validation_error("mass_sum_invalid", "masses must sum to exactly 1")
         return self
 
 
@@ -86,33 +81,19 @@ class FiniteSigmaAlgebra(StrictModel):
     """
 
     space: FiniteProbabilitySpace
-    blocks: tuple[tuple[str, ...], ...] = Field(min_length=1)
+    blocks: tuple[
+        Annotated[tuple[str, ...], Field(min_length=1, max_length=MAX_SAMPLES)], ...
+    ] = Field(min_length=1, max_length=MAX_SAMPLES)
 
     @model_validator(mode="after")
-    def require_valid_partition(self) -> Self:
-        all_samples = set()
-        seen: set[str] = set()
+    def require_source_membership(self) -> Self:
         for block in self.blocks:
-            if not block:
-                raise _validation_error(
-                    "partition_block_empty", "partition blocks must be nonempty"
-                )
             for s in block:
-                if s in seen:
-                    raise _validation_error(
-                        "partition_blocks_overlap", "partition blocks must be disjoint"
-                    )
                 if s not in self.space.samples:
                     raise _validation_error(
                         "partition_element_outside_space",
                         "block element not in sample space",
                     )
-                seen.add(s)
-                all_samples.add(s)
-        if all_samples != set(self.space.samples):
-            raise _validation_error(
-                "partition_incomplete", "blocks must partition the entire sample space"
-            )
         return self
 
 

--- a/src/jacobian/math/topology/combinatorial_maps/__init__.py
+++ b/src/jacobian/math/topology/combinatorial_maps/__init__.py
@@ -9,6 +9,9 @@ from jacobian.math.topology.combinatorial_maps.operations import (
     orientable_genus,
     orientation_reverse,
     rotation_successor,
+    verify_dual,
+    verify_orientation_reverse,
+    verify_vertex_face_incidence,
     vertex_face_incidence,
 )
 from jacobian.math.topology.combinatorial_maps.values import (
@@ -27,5 +30,8 @@ __all__ = [
     "orientable_genus",
     "orientation_reverse",
     "rotation_successor",
+    "verify_dual",
+    "verify_orientation_reverse",
+    "verify_vertex_face_incidence",
     "vertex_face_incidence",
 ]

--- a/src/jacobian/math/topology/combinatorial_maps/_models.py
+++ b/src/jacobian/math/topology/combinatorial_maps/_models.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.math.matrices.values import SparseRationalMatrix
 from jacobian.math.topology.combinatorial_maps.values import (
     FiniteCombinatorialMap,
 )
@@ -118,16 +119,61 @@ class OrientationReverseRequest(StrictModel):
     map: FiniteCombinatorialMap
 
 
+class CombinatorialMapBijection(StrictModel):
+    """A bijection of explicitly declared dart or face axes of two maps."""
+
+    source: FiniteCombinatorialMap
+    target: FiniteCombinatorialMap
+    kind: Literal["DART", "FACE"]
+    source_axis: tuple[int, ...] = Field(max_length=1024)
+    target_axis: tuple[int, ...] = Field(max_length=1024)
+    images: tuple[int, ...] = Field(max_length=1024)
+
+    @model_validator(mode="after")
+    def require_bijection_shape(self) -> Self:
+        size = len(self.source_axis)
+        if (
+            self.source_axis != tuple(range(size))
+            or self.target_axis != tuple(range(size))
+            or tuple(sorted(self.images)) != self.target_axis
+        ):
+            raise _validation_error(
+                "bijection_axis", "images must biject the declared canonical axes"
+            )
+        if self.kind == "DART" and (
+            size != len(self.source.darts) or size != len(self.target.darts)
+        ):
+            raise _validation_error(
+                "bijection_darts",
+                "dart axes must equal their source and target map axes",
+            )
+        return self
+
+
 class OrientationReverseResult(StrictModel):
-    """The orientation-reversed map and the induced face bijection.
+    """The reversal relation, with a source-target face-axis bijection."""
 
-    The retained map binds the carrier. The exact reversal and induced face
-    bijection are established by the defining operation.
-    """
+    bijection: CombinatorialMapBijection
 
-    map: FiniteCombinatorialMap
-    reversed_map: FiniteCombinatorialMap
-    face_bijection: dict[int, int]
+    @model_validator(mode="after")
+    def require_face_kind(self) -> Self:
+        if self.bijection.kind != "FACE":
+            raise _validation_error(
+                "bijection_kind", "orientation reversal carries a face bijection"
+            )
+        return self
+
+    @property
+    def map(self) -> FiniteCombinatorialMap:
+        return self.bijection.source
+
+    @property
+    def reversed_map(self) -> FiniteCombinatorialMap:
+        return self.bijection.target
+
+    @property
+    def face_bijection(self) -> dict[int, int]:
+        return dict(zip(self.bijection.source_axis, self.bijection.images, strict=True))
 
 
 class ConnectedComponentsRequest(StrictModel):
@@ -151,10 +197,25 @@ class DualRequest(StrictModel):
 
 
 class DualResult(StrictModel):
-    """The dual combinatorial map and the primal-dart -> dual-dart bijection."""
+    """A source-target dart-axis bijection for the embedded dual."""
 
-    dual: FiniteCombinatorialMap
-    primal_to_dual: dict[int, int]
+    bijection: CombinatorialMapBijection
+
+    @model_validator(mode="after")
+    def require_dart_kind(self) -> Self:
+        if self.bijection.kind != "DART":
+            raise _validation_error(
+                "bijection_kind", "duality carries a dart bijection"
+            )
+        return self
+
+    @property
+    def dual(self) -> FiniteCombinatorialMap:
+        return self.bijection.target
+
+    @property
+    def primal_to_dual(self) -> dict[int, int]:
+        return dict(zip(self.bijection.source_axis, self.bijection.images, strict=True))
 
 
 class VertexFaceIncidenceRequest(StrictModel):
@@ -164,17 +225,37 @@ class VertexFaceIncidenceRequest(StrictModel):
 
 
 class VertexFaceIncidenceResult(StrictModel):
-    """Per-(vertex, face) multiplicity and per-vertex face set.
+    """Exact sparse multiplicities on source vertices by the retained face axis."""
 
-    ``multiplicity`` maps each vertex to its per-face occurrence counts;
-    the nested shape keeps the wire representation JSON-safe.
-    """
+    source: FacesResult
+    multiplicity: SparseRationalMatrix
 
-    multiplicity: dict[int, dict[int, int]]
-    boolean_incidence: dict[int, tuple[int, ...]]
+    @model_validator(mode="after")
+    def require_incidence_axes(self) -> Self:
+        if (
+            self.multiplicity.row_count != self.source.map.vertex_count
+            or self.multiplicity.column_count != len(self.source.face_walks)
+        ):
+            raise _validation_error(
+                "incidence_shape", "incidence must use the source vertex and face axes"
+            )
+        return self
+
+    @property
+    def boolean_incidence(self) -> dict[int, tuple[int, ...]]:
+        """Project nonzero multiplicities to incident face indices on the same axes."""
+        return {
+            vertex: tuple(
+                entry.column
+                for entry in self.multiplicity.entries
+                if entry.row == vertex
+            )
+            for vertex in range(self.multiplicity.row_count)
+        }
 
 
 __all__ = [
+    "CombinatorialMapBijection",
     "ConnectedComponentsRequest",
     "ConnectedComponentsResult",
     "DualRequest",

--- a/src/jacobian/math/topology/combinatorial_maps/operations.py
+++ b/src/jacobian/math/topology/combinatorial_maps/operations.py
@@ -8,8 +8,18 @@ dart IDs; no backend embedding object crosses the boundary.
 
 from __future__ import annotations
 
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.matrices.values import (
+    SparseRationalMatrix,
+    SparseRationalMatrixEntry,
+)
+
 from ._face_orbits import face_orbit_data
 from ._models import (
+    CombinatorialMapBijection,
     ConnectedComponentsResult,
     DualResult,
     EulerCharacteristicCounts,
@@ -19,7 +29,13 @@ from ._models import (
     OrientationReverseResult,
     VertexFaceIncidenceResult,
 )
-from .values import FiniteCombinatorialMap
+from .values import (
+    FiniteCombinatorialMap,
+    _build_outgoing,
+    _validate_facial_budgets,
+    _validate_involution,
+    _validate_rotation,
+)
 
 __all__ = [
     "connected_components",
@@ -30,13 +46,37 @@ __all__ = [
     "orientable_genus",
     "orientation_reverse",
     "rotation_successor",
+    "verify_dual",
+    "verify_orientation_reverse",
+    "verify_vertex_face_incidence",
     "vertex_face_incidence",
 ]
+
+
+def _admit_map(
+    map_: FiniteCombinatorialMap,
+) -> tuple[list[list[int]], dict[int, int], list[int]]:
+    """Admit map laws and compute bounded facial data once for the request."""
+    try:
+        _validate_involution(map_.darts)
+        _validate_rotation(
+            map_.rotations, _build_outgoing(map_.darts, map_.vertex_count), map_.darts
+        )
+        data = face_orbit_data(map_)
+        _validate_facial_budgets(data[0])
+        return data
+    except PydanticCustomError as error:
+        raise OperationDomainValidationError(
+            location=("map",), code=error.type, message=error.message()
+        ) from error
 
 
 def rotation_successor(map_: FiniteCombinatorialMap, dart: int) -> int:
     """Return the dart following ``dart`` in its local rotation."""
 
+    _admit_map(map_)
+    if type(dart) is not int or not 0 <= dart < len(map_.darts):
+        raise ValueError("dart must index the source map")
     tail = map_.darts[dart][0]
     row = map_.rotations[tail]
     index = row.index(dart)
@@ -58,8 +98,8 @@ def _face_orbits(
     - ``successor``: the dart-successor permutation (``dart -> next dart``)
     - per-component face partition: ``component index -> face indices``
     """
-    walks, face_of_dart, successor = face_orbit_data(map_)
-    comp_of_vertex = connected_components_vertices(map_)
+    walks, face_of_dart, successor = _admit_map(map_)
+    comp_of_vertex = _connected_components_vertices(map_)
     comp_of_face: dict[int, list[int]] = {}
     for face_index, walk in enumerate(walks):
         representative = walk[0]
@@ -81,7 +121,7 @@ def face_orbits(map_: FiniteCombinatorialMap) -> FacesResult:
     )
 
 
-def connected_components_vertices(
+def _connected_components_vertices(
     map_: FiniteCombinatorialMap,
 ) -> dict[int, int]:
     """Return ``vertex -> component index`` for the underlying graph."""
@@ -112,13 +152,19 @@ def connected_components_vertices(
     return result
 
 
+def connected_components_vertices(map_: FiniteCombinatorialMap) -> dict[int, int]:
+    """Admit a map before returning its vertex component partition."""
+    _admit_map(map_)
+    return _connected_components_vertices(map_)
+
+
 def connected_components(
     map_: FiniteCombinatorialMap,
 ) -> ConnectedComponentsResult:
     """Return the component partition of vertices, darts, and faces."""
 
-    vertex_component = connected_components_vertices(map_)
     walks, _, _, _ = _face_orbits(map_)
+    vertex_component = _connected_components_vertices(map_)
     face_component: dict[int, int] = {}
     for face_index, walk in enumerate(walks):
         representative = walk[0]
@@ -146,7 +192,7 @@ def euler_characteristic(
     total is the sum of component characteristics.
     """
     walks, _, _, _ = _face_orbits(map_)
-    vertex_component = connected_components_vertices(map_)
+    vertex_component = _connected_components_vertices(map_)
     component_vertices: dict[int, set[int]] = {}
     component_edges: dict[int, int] = {}
     for v in range(map_.vertex_count):
@@ -230,14 +276,14 @@ def orientation_reverse(
     Returns the resulting combinatorial map together with the induced bijection
     on faces (``old face index -> new face index``).
     """
+    old_walks, old_face_of_dart, _, _ = _face_orbits(map_)
     reversed_rotations = tuple(tuple(reversed(row)) for row in map_.rotations)
     reversed_map = FiniteCombinatorialMap(
         vertex_count=map_.vertex_count,
         darts=map_.darts,
         rotations=reversed_rotations,
     )
-    old_walks, old_face_of_dart, _, _ = _face_orbits(map_)
-    new_walks, new_face_of_dart, _, _ = _face_orbits(reversed_map)
+    new_walks, new_face_of_dart, _ = face_orbit_data(reversed_map)
     # The reversed face permutation is phi' = alpha . phi^-1 . alpha, so the
     # new orbit of a dart is the reversal image of the old orbit: old face O
     # corresponds to the new face containing the reversed darts of O.  Match
@@ -255,9 +301,14 @@ def orientation_reverse(
     ) != len(new_walks):
         raise ValueError("orientation reversal did not induce a face bijection")
     return OrientationReverseResult.model_construct(
-        map=map_,
-        reversed_map=reversed_map,
-        face_bijection=face_bijection,
+        bijection=CombinatorialMapBijection(
+            source=map_,
+            target=reversed_map,
+            kind="FACE",
+            source_axis=tuple(range(len(old_walks))),
+            target_axis=tuple(range(len(new_walks))),
+            images=tuple(face_bijection[i] for i in range(len(old_walks))),
+        ),
     )
 
 
@@ -311,8 +362,16 @@ def dual_map(
         darts=tuple(dual_darts),
         rotations=tuple(dual_rotations),
     )
-    primal_to_dual = {i: i for i in range(n)}
-    return DualResult.model_construct(dual=dual, primal_to_dual=primal_to_dual)
+    return DualResult.model_construct(
+        bijection=CombinatorialMapBijection(
+            source=map_,
+            target=dual,
+            kind="DART",
+            source_axis=tuple(range(n)),
+            target_axis=tuple(range(n)),
+            images=tuple(range(n)),
+        )
+    )
 
 
 def vertex_face_incidence(
@@ -325,21 +384,41 @@ def vertex_face_incidence(
       number of times the vertex occurs on the facial boundary.
     - ``boolean_incidence``: ``vertex -> set of incident face indices``
     """
-    walks, _, _, _ = _face_orbits(map_)
+    source = face_orbits(map_)
+    walks = source.face_walks
     multiplicity: dict[tuple[int, int], int] = {}
-    boolean: dict[int, set[int]] = {v: set() for v in range(map_.vertex_count)}
     for face_index, walk in enumerate(walks):
         for dart in walk:
             vertex = map_.darts[dart][0]
             key = (vertex, face_index)
             multiplicity[key] = multiplicity.get(key, 0) + 1
-            boolean[vertex].add(face_index)
-    nested: dict[int, dict[int, int]] = {}
-    for (vertex, face), count in multiplicity.items():
-        nested.setdefault(vertex, {})[face] = count
     return VertexFaceIncidenceResult.model_construct(
-        multiplicity=nested,
-        boolean_incidence={
-            vertex: tuple(sorted(boolean[vertex])) for vertex in sorted(boolean)
-        },
+        source=source,
+        multiplicity=SparseRationalMatrix(
+            row_count=map_.vertex_count,
+            entries=tuple(
+                SparseRationalMatrixEntry(
+                    row=vertex,
+                    column=face,
+                    value=CanonicalRational.from_integer_ratio(count, 1),
+                )
+                for (vertex, face), count in sorted(multiplicity.items())
+            ),
+            column_count=len(walks),
+        ),
     )
+
+
+def verify_dual(claim: DualResult) -> bool:
+    """Check embedded duality and its declared canonical dart bijection."""
+    return dual_map(claim.bijection.source) == claim
+
+
+def verify_orientation_reverse(claim: OrientationReverseResult) -> bool:
+    """Check reversal and the induced face bijection after map admission."""
+    return orientation_reverse(claim.bijection.source) == claim
+
+
+def verify_vertex_face_incidence(claim: VertexFaceIncidenceResult) -> bool:
+    """Check the face axis and its incidence multiplicities against the map."""
+    return vertex_face_incidence(claim.source.map) == claim

--- a/src/jacobian/math/topology/combinatorial_maps/values.py
+++ b/src/jacobian/math/topology/combinatorial_maps/values.py
@@ -114,7 +114,7 @@ def _validate_rotation(
             seen.add(dart_index)
 
 
-def _validate_facial_budgets(map_: FiniteCombinatorialMap) -> None:
+def _validate_facial_budgets(walks: list[list[int]]) -> None:
     """Reject maps whose facial structure would overflow the dual budgets.
 
     The dual of an accepted map must itself be an accepted value: it has one
@@ -123,9 +123,6 @@ def _validate_facial_budgets(map_: FiniteCombinatorialMap) -> None:
     here.  The constraint set is closed under duality (dual faces correspond
     to primal vertices and dual facial walks to primal rotation rows).
     """
-    from jacobian.math.topology.combinatorial_maps._face_orbits import face_orbit_data
-
-    walks, _, _ = face_orbit_data(map_)
     if len(walks) > MAX_FACES:
         raise _validation_error(
             "face_count_too_large", "face count exceeds the bounded dual-vertex budget"
@@ -167,10 +164,14 @@ class FiniteCombinatorialMap(StrictModel):
             )
         for dart in self.darts:
             _validate_dart(dart, self.vertex_count, len(self.darts))
-        _validate_involution(self.darts)
-        outgoing = _build_outgoing(self.darts, self.vertex_count)
-        _validate_rotation(self.rotations, outgoing, self.darts)
-        _validate_facial_budgets(self)
+        for row in self.rotations:
+            if len(row) > MAX_ROTATION_LENGTH or any(
+                not 0 <= dart < len(self.darts) for dart in row
+            ):
+                raise _validation_error(
+                    "rotation_dart_out_of_range",
+                    "rotation rows must be bounded dart indices",
+                )
         return self
 
 

--- a/src/jacobian/math/topology/finite/spaces/__init__.py
+++ b/src/jacobian/math/topology/finite/spaces/__init__.py
@@ -9,6 +9,7 @@ from jacobian.math.topology.finite.spaces.operations import (
     kolmogorov_quotient,
     minimal_neighbourhoods,
     specialization_preorder,
+    verify_kolmogorov_quotient,
 )
 from jacobian.math.topology.finite.spaces.values import (
     FiniteTopologicalMap,
@@ -26,4 +27,5 @@ __all__ = [
     "kolmogorov_quotient",
     "minimal_neighbourhoods",
     "specialization_preorder",
+    "verify_kolmogorov_quotient",
 ]

--- a/src/jacobian/math/topology/finite/spaces/__init__.py
+++ b/src/jacobian/math/topology/finite/spaces/__init__.py
@@ -9,16 +9,19 @@ from jacobian.math.topology.finite.spaces.operations import (
     kolmogorov_quotient,
     minimal_neighbourhoods,
     specialization_preorder,
+    verify_continuity,
     verify_kolmogorov_quotient,
 )
 from jacobian.math.topology.finite.spaces.values import (
     FiniteTopologicalMap,
     FiniteTopologicalSpace,
+    FiniteTopologicalSubset,
 )
 
 __all__ = [
     "FiniteTopologicalMap",
     "FiniteTopologicalSpace",
+    "FiniteTopologicalSubset",
     "boundary",
     "closure",
     "continuous_check",
@@ -27,5 +30,6 @@ __all__ = [
     "kolmogorov_quotient",
     "minimal_neighbourhoods",
     "specialization_preorder",
+    "verify_continuity",
     "verify_kolmogorov_quotient",
 ]

--- a/src/jacobian/math/topology/finite/spaces/_models.py
+++ b/src/jacobian/math/topology/finite/spaces/_models.py
@@ -9,6 +9,7 @@ from jacobian.math._labels import OpaqueLabel
 from jacobian.math.topology.finite.spaces.values import (
     FiniteTopologicalMap,
     FiniteTopologicalSpace,
+    FiniteTopologicalSubset,
 )
 
 
@@ -20,15 +21,27 @@ class SubsetRequest(StrictModel):
 
 
 class InteriorResult(StrictModel):
-    interior: tuple[int, ...]
+    """The interior of a retained subset as a source-bound value."""
+
+    space: FiniteTopologicalSpace
+    subset: FiniteTopologicalSubset
+    interior: FiniteTopologicalSubset
 
 
 class ClosureResult(StrictModel):
-    closure: tuple[int, ...]
+    """The closure of a retained subset as a source-bound value."""
+
+    space: FiniteTopologicalSpace
+    subset: FiniteTopologicalSubset
+    closure: FiniteTopologicalSubset
 
 
 class BoundaryResult(StrictModel):
-    boundary: tuple[int, ...]
+    """The boundary of a retained subset as a source-bound value."""
+
+    space: FiniteTopologicalSpace
+    subset: FiniteTopologicalSubset
+    boundary: FiniteTopologicalSubset
 
 
 class ContinuousCheckRequest(StrictModel):
@@ -38,6 +51,9 @@ class ContinuousCheckRequest(StrictModel):
 
 
 class ContinuousCheckResult(StrictModel):
+    """Whether a retained point map is continuous."""
+
+    point_map: FiniteTopologicalMap
     is_continuous: bool
 
 

--- a/src/jacobian/math/topology/finite/spaces/_models.py
+++ b/src/jacobian/math/topology/finite/spaces/_models.py
@@ -46,9 +46,30 @@ class KolmogorovQuotientRequest(StrictModel):
 
 
 class KolmogorovQuotientResult(StrictModel):
-    quotient_points: tuple[tuple[OpaqueLabel, ...], ...]
-    quotient_preorder: tuple[tuple[int, ...], ...]
-    class_map: tuple[int, ...]
+    """The canonical quotient map; each target label is its first source representative."""
+
+    quotient_map: FiniteTopologicalMap
+
+    @property
+    def quotient_points(self) -> tuple[tuple[OpaqueLabel, ...], ...]:
+        return tuple(
+            tuple(
+                label
+                for label, image in zip(
+                    self.quotient_map.source.points, self.class_map, strict=True
+                )
+                if image == target
+            )
+            for target in range(len(self.quotient_map.target.points))
+        )
+
+    @property
+    def quotient_preorder(self) -> tuple[tuple[int, ...], ...]:
+        return self.quotient_map.target.preorder
+
+    @property
+    def class_map(self) -> tuple[int, ...]:
+        return self.quotient_map.point_map
 
 
 __all__ = [

--- a/src/jacobian/math/topology/finite/spaces/_tools.py
+++ b/src/jacobian/math/topology/finite/spaces/_tools.py
@@ -24,6 +24,10 @@ from jacobian.math.topology.finite.spaces.operations import (
     interior,
     kolmogorov_quotient,
 )
+from jacobian.math.topology.finite.spaces.values import (
+    FiniteTopologicalSpace,
+    FiniteTopologicalSubset,
+)
 
 
 def _admit_subset(request: SubsetRequest) -> frozenset[int]:
@@ -36,24 +40,45 @@ def _admit_subset(request: SubsetRequest) -> frozenset[int]:
     return frozenset(request.subset)
 
 
+def _bound_subset(
+    space: FiniteTopologicalSpace, subset: frozenset[int]
+) -> FiniteTopologicalSubset:
+    return FiniteTopologicalSubset(space=space, indices=tuple(sorted(subset)))
+
+
 def _interior(request: SubsetRequest) -> InteriorResult:
-    result = interior(request.space, _admit_subset(request))
-    return InteriorResult(interior=tuple(sorted(result)))
+    admitted = _admit_subset(request)
+    result = interior(request.space, admitted)
+    return InteriorResult(
+        space=request.space,
+        subset=_bound_subset(request.space, admitted),
+        interior=_bound_subset(request.space, result),
+    )
 
 
 def _closure(request: SubsetRequest) -> ClosureResult:
-    result = closure(request.space, _admit_subset(request))
-    return ClosureResult(closure=tuple(sorted(result)))
+    admitted = _admit_subset(request)
+    result = closure(request.space, admitted)
+    return ClosureResult(
+        space=request.space,
+        subset=_bound_subset(request.space, admitted),
+        closure=_bound_subset(request.space, result),
+    )
 
 
 def _boundary(request: SubsetRequest) -> BoundaryResult:
-    result = boundary(request.space, _admit_subset(request))
-    return BoundaryResult(boundary=tuple(sorted(result)))
+    admitted = _admit_subset(request)
+    result = boundary(request.space, admitted)
+    return BoundaryResult(
+        space=request.space,
+        subset=_bound_subset(request.space, admitted),
+        boundary=_bound_subset(request.space, result),
+    )
 
 
 def _continuous_check(request: ContinuousCheckRequest) -> ContinuousCheckResult:
     result = continuous_check(request.point_map)
-    return ContinuousCheckResult(is_continuous=result)
+    return ContinuousCheckResult(point_map=request.point_map, is_continuous=result)
 
 
 def _kolmogorov_quotient(

--- a/src/jacobian/math/topology/finite/spaces/operations.py
+++ b/src/jacobian/math/topology/finite/spaces/operations.py
@@ -226,6 +226,13 @@ def verify_kolmogorov_quotient(claim: KolmogorovQuotientResult) -> bool:
     ]
     if tuple(source.points[rep] for rep in representatives) != target.points:
         return False
+    if any(
+        (class_map[left] == class_map[right])
+        != (source.preorder[left] == source.preorder[right])
+        for left in range(count)
+        for right in range(left + 1, count)
+    ):
+        return False
     for target_index in range(classes):
         expected = sorted(
             {class_map[j] for j in source.preorder[representatives[target_index]]}

--- a/src/jacobian/math/topology/finite/spaces/operations.py
+++ b/src/jacobian/math/topology/finite/spaces/operations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from jacobian.catalog.models import OperationDomainValidationError
 
-from ._models import KolmogorovQuotientResult
+from ._models import ContinuousCheckResult, KolmogorovQuotientResult
 from .values import FiniteTopologicalMap, FiniteTopologicalSpace
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     "kolmogorov_quotient",
     "minimal_neighbourhoods",
     "specialization_preorder",
+    "verify_continuity",
     "verify_kolmogorov_quotient",
 ]
 
@@ -170,6 +171,65 @@ def kolmogorov_quotient(space: FiniteTopologicalSpace) -> KolmogorovQuotientResu
     )
 
 
+def verify_continuity(claim: ContinuousCheckResult) -> bool:
+    """Check the monotonicity relation of a retained point map.
+
+    A map f is continuous iff x' <= x implies f(x') <= f(x) in the
+    specialization preorders. Both endpoint spaces are admitted here because
+    a serialized claim is caller-authored.
+    """
+    source = claim.point_map.source
+    target = claim.point_map.target
+    try:
+        _admit_space(source)
+        _admit_space(target)
+    except OperationDomainValidationError:
+        return False
+    monotone = True
+    for i in range(len(source.points)):
+        image = claim.point_map.point_map[i]
+        for j in source.preorder[i]:
+            if claim.point_map.point_map[j] not in target.preorder[image]:
+                monotone = False
+                break
+        if not monotone:
+            break
+    return monotone == claim.is_continuous
+
+
 def verify_kolmogorov_quotient(claim: KolmogorovQuotientResult) -> bool:
-    """Check the bounded quotient relation and its canonical representative labels."""
-    return kolmogorov_quotient(claim.quotient_map.source) == claim
+    """Check the quotient relation directly without rebuilding the quotient.
+
+    Verifies the class map is a consecutive surjection, target points are
+    first source representatives, and the target preorder is induced through
+    the class map. Producer construction is not replayed.
+    """
+    quotient_map = claim.quotient_map
+    source = quotient_map.source
+    target = quotient_map.target
+    class_map = quotient_map.point_map
+    try:
+        _admit_space(source)
+        _admit_space(target)
+    except OperationDomainValidationError:
+        return False
+    count = len(source.points)
+    if len(class_map) != count:
+        return False
+    classes = len(target.points)
+    if set(class_map) != set(range(classes)) or any(
+        not 0 <= image < classes for image in class_map
+    ):
+        return False
+    representatives = [
+        next(i for i in range(count) if class_map[i] == a) for a in range(classes)
+    ]
+    if tuple(source.points[rep] for rep in representatives) != target.points:
+        return False
+    for target_index in range(classes):
+        expected = sorted(
+            {class_map[j] for j in source.preorder[representatives[target_index]]}
+        )
+        if tuple(expected) != tuple(sorted(target.preorder[target_index])):
+            return False
+    return True

--- a/src/jacobian/math/topology/finite/spaces/operations.py
+++ b/src/jacobian/math/topology/finite/spaces/operations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from jacobian.catalog.models import OperationDomainValidationError
+
 from ._models import KolmogorovQuotientResult
 from .values import FiniteTopologicalMap, FiniteTopologicalSpace
 
@@ -14,7 +16,26 @@ __all__ = [
     "kolmogorov_quotient",
     "minimal_neighbourhoods",
     "specialization_preorder",
+    "verify_kolmogorov_quotient",
 ]
+
+
+def _admit_space(space: FiniteTopologicalSpace) -> None:
+    """Establish the preorder laws within the 64-point carrier."""
+    rows = tuple(set(row) for row in space.preorder)
+    for i, row in enumerate(rows):
+        if i not in row:
+            raise OperationDomainValidationError(
+                location=("space",),
+                code="finite_topology_space.preorder_not_reflexive",
+                message="preorder must be reflexive",
+            )
+        if any(not rows[j] <= row for j in row):
+            raise OperationDomainValidationError(
+                location=("space",),
+                code="finite_topology_space.preorder_not_transitive",
+                message="preorder must be transitive",
+            )
 
 
 def from_preorder(
@@ -22,13 +43,16 @@ def from_preorder(
     preorder: tuple[tuple[int, ...], ...],
 ) -> FiniteTopologicalSpace:
     """Construct a finite topological space from a preorder."""
-    return FiniteTopologicalSpace(points=points, preorder=preorder)
+    space = FiniteTopologicalSpace(points=points, preorder=preorder)
+    _admit_space(space)
+    return space
 
 
 def specialization_preorder(
     space: FiniteTopologicalSpace,
 ) -> tuple[tuple[int, ...], ...]:
     """Return the specialization preorder rows."""
+    _admit_space(space)
     return space.preorder
 
 
@@ -41,6 +65,13 @@ def minimal_neighbourhoods(
     closure of {y}). The minimal open neighbourhood of x is the up-set
     ``{y : x in preorder[y]}``.
     """
+    _admit_space(space)
+    return _minimal_neighbourhoods(space)
+
+
+def _minimal_neighbourhoods(
+    space: FiniteTopologicalSpace,
+) -> tuple[tuple[int, ...], ...]:
     count = len(space.points)
     return tuple(
         tuple(sorted(y for y in range(count) if x in space.preorder[y]))
@@ -50,7 +81,12 @@ def minimal_neighbourhoods(
 
 def interior(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[int]:
     """Return the interior of a subset (largest open set contained in it)."""
-    neighbourhoods = minimal_neighbourhoods(space)
+    _admit_space(space)
+    return _interior(space, subset)
+
+
+def _interior(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[int]:
+    neighbourhoods = _minimal_neighbourhoods(space)
     result: set[int] = set()
     for i in range(len(space.points)):
         if set(neighbourhoods[i]).issubset(subset):
@@ -60,6 +96,11 @@ def interior(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset
 
 def closure(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[int]:
     """Return the closure of a subset (smallest closed set containing it)."""
+    _admit_space(space)
+    return _closure(space, subset)
+
+
+def _closure(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[int]:
     result: set[int] = set()
     for i in subset:
         if not 0 <= i < len(space.points):
@@ -70,8 +111,9 @@ def closure(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[
 
 def boundary(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[int]:
     """Return the boundary of a subset: closure minus interior."""
-    cl = closure(space, subset)
-    inter = interior(space, subset)
+    _admit_space(space)
+    cl = _closure(space, subset)
+    inter = _interior(space, subset)
     return frozenset(cl - inter)
 
 
@@ -85,6 +127,8 @@ def continuous_check(map_: FiniteTopologicalMap) -> bool:
     """
     src = map_.source
     tgt = map_.target
+    _admit_space(src)
+    _admit_space(tgt)
     for i in range(len(src.points)):
         fi = map_.point_map[i]
         for j in src.preorder[i]:
@@ -96,14 +140,12 @@ def continuous_check(map_: FiniteTopologicalMap) -> bool:
 def kolmogorov_quotient(space: FiniteTopologicalSpace) -> KolmogorovQuotientResult:
     """Return the T0 (Kolmogorov) quotient: identify points with the same
     minimal open neighbourhood."""
+    _admit_space(space)
     nbhd_to_class: dict[tuple[int, ...], list[int]] = {}
     for i, row in enumerate(space.preorder):
         key = tuple(sorted(row))
         nbhd_to_class.setdefault(key, []).append(i)
     classes = list(nbhd_to_class.values())
-    quotient_points = tuple(
-        tuple(space.points[idx] for idx in sorted(cls)) for cls in classes
-    )
     class_map: dict[int, int] = {}
     for class_idx, cls in enumerate(classes):
         for idx in cls:
@@ -115,8 +157,19 @@ def kolmogorov_quotient(space: FiniteTopologicalSpace) -> KolmogorovQuotientResu
         for j in space.preorder[representative]:
             row_set.add(class_map[j])
         quotient_preorder.append(tuple(sorted(row_set)))
-    return KolmogorovQuotientResult(
-        quotient_points=quotient_points,
-        quotient_preorder=tuple(quotient_preorder),
-        class_map=tuple(class_map[index] for index in range(len(space.points))),
+    target = FiniteTopologicalSpace(
+        points=tuple(space.points[cls[0]] for cls in classes),
+        preorder=tuple(quotient_preorder),
     )
+    return KolmogorovQuotientResult(
+        quotient_map=FiniteTopologicalMap(
+            source=space,
+            target=target,
+            point_map=tuple(class_map[index] for index in range(len(space.points))),
+        )
+    )
+
+
+def verify_kolmogorov_quotient(claim: KolmogorovQuotientResult) -> bool:
+    """Check the bounded quotient relation and its canonical representative labels."""
+    return kolmogorov_quotient(claim.quotient_map.source) == claim

--- a/src/jacobian/math/topology/finite/spaces/values.py
+++ b/src/jacobian/math/topology/finite/spaces/values.py
@@ -61,6 +61,30 @@ class FiniteTopologicalSpace(StrictModel):
         return self
 
 
+class FiniteTopologicalSubset(StrictModel):
+    """A canonical subset of a finite topological space's point axis.
+
+    Carries the parent space so the indices stay interpretable after
+    serialization. Parsing is structural only: sorted unique in-range
+    indices. Whether the subset satisfies a further property (openness,
+    closedness) is established by the owning operation, not by decoding.
+    """
+
+    space: FiniteTopologicalSpace
+    indices: tuple[int, ...] = Field(default=())
+
+    @model_validator(mode="after")
+    def require_canonical_axis(self) -> Self:
+        if tuple(sorted(set(self.indices))) != tuple(self.indices) or any(
+            not 0 <= index < len(self.space.points) for index in self.indices
+        ):
+            raise _validation_error(
+                "subset_indices_not_canonical",
+                "subset indices must be sorted unique point-axis indices",
+            )
+        return self
+
+
 class FiniteTopologicalMap(StrictModel):
     """An immutable continuous map between finite topological spaces."""
 
@@ -87,4 +111,5 @@ __all__ = [
     "MAX_POINTS",
     "FiniteTopologicalMap",
     "FiniteTopologicalSpace",
+    "FiniteTopologicalSubset",
 ]

--- a/src/jacobian/math/topology/finite/spaces/values.py
+++ b/src/jacobian/math/topology/finite/spaces/values.py
@@ -55,19 +55,9 @@ class FiniteTopologicalSpace(StrictModel):
                     raise _validation_error(
                         "preorder_index_out_of_range", "preorder index out of range"
                     )
-        for i in range(len(self.points)):
-            if i not in self.preorder[i]:
-                raise _validation_error(
-                    "preorder_not_reflexive", "preorder must be reflexive"
-                )
-        # Transitivity: j in row[i] => row[j] subset of row[i].
-        for _i, row in enumerate(self.preorder):
-            row_i = set(row)
-            for j in row:
-                if not set(self.preorder[j]).issubset(row_i):
-                    raise _validation_error(
-                        "preorder_not_transitive", "preorder must be transitive"
-                    )
+        object.__setattr__(
+            self, "preorder", tuple(tuple(sorted(set(row))) for row in self.preorder)
+        )
         return self
 
 

--- a/src/jacobian/math/universal_algebra/__init__.py
+++ b/src/jacobian/math/universal_algebra/__init__.py
@@ -7,6 +7,7 @@ from jacobian.math.universal_algebra.operations import (
     generated_subalgebra,
     homomorphism_profile,
     quotient,
+    verify_congruence,
 )
 from jacobian.math.universal_algebra.values import (
     ApplicationTerm,
@@ -34,4 +35,5 @@ __all__ = [
     "generated_subalgebra",
     "homomorphism_profile",
     "quotient",
+    "verify_congruence",
 ]

--- a/src/jacobian/math/universal_algebra/_models.py
+++ b/src/jacobian/math/universal_algebra/_models.py
@@ -249,6 +249,8 @@ class CongruenceRequest(_PartitionRequest):
 
 
 class CongruenceResult(StrictModel):
+    algebra: FiniteAlgebra
+    partition: tuple[CarrierBlock, ...]
     is_congruence: bool
     obstruction: str | None = None
     operation: int | None = Field(default=None, ge=0)

--- a/src/jacobian/math/universal_algebra/operations.py
+++ b/src/jacobian/math/universal_algebra/operations.py
@@ -322,6 +322,7 @@ def homomorphism_profile(
 
 def _compatibility_violation(
     algebra: FiniteAlgebra,
+    partition: tuple[tuple[int, ...], ...],
     block_of: dict[int, int],
     n: int,
     op_idx: int,
@@ -341,6 +342,8 @@ def _compatibility_violation(
     if block_of[fx] == block_of[fy]:
         return None
     return CongruenceResult(
+        algebra=algebra,
+        partition=partition,
         is_congruence=False,
         obstruction="compatibility_violation",
         operation=op_idx,
@@ -351,6 +354,7 @@ def _compatibility_violation(
 
 def _check_compatibility(
     algebra: FiniteAlgebra,
+    partition: tuple[tuple[int, ...], ...],
     block_of: dict[int, int],
     n: int,
 ) -> CongruenceResult | None:
@@ -369,7 +373,7 @@ def _check_compatibility(
                     y_list[j] = y_elem
                     y: tuple[int, ...] = tuple(y_list)
                     violation = _compatibility_violation(
-                        algebra, block_of, n, op_idx, symbol, x, y
+                        algebra, partition, block_of, n, op_idx, symbol, x, y
                     )
                     if violation is not None:
                         return violation
@@ -399,11 +403,17 @@ def _congruence_check_unchecked(
             block_of[elem] = block_idx
     if len(block_of) != n:
         return CongruenceResult(
+            algebra=algebra,
+            partition=partition,
             is_congruence=False,
             obstruction="partition does not cover carrier",
         )
-    result = _check_compatibility(algebra, block_of, n)
-    return result if result is not None else CongruenceResult(is_congruence=True)
+    result = _check_compatibility(algebra, partition, block_of, n)
+    return (
+        result
+        if result is not None
+        else CongruenceResult(algebra=algebra, partition=partition, is_congruence=True)
+    )
 
 
 def quotient(

--- a/src/jacobian/math/universal_algebra/operations.py
+++ b/src/jacobian/math/universal_algebra/operations.py
@@ -37,6 +37,7 @@ __all__ = [
     "generated_subalgebra",
     "homomorphism_profile",
     "quotient",
+    "verify_congruence",
 ]
 
 
@@ -391,6 +392,12 @@ def congruence_check(
     """
     _admit_partition(algebra, partition, quotient_request=False)
     return _congruence_check_unchecked(algebra, partition)
+
+
+def verify_congruence(claim: CongruenceResult) -> bool:
+    """Check a serialized congruence verdict against its retained relation."""
+
+    return congruence_check(claim.algebra, claim.partition) == claim
 
 
 def _congruence_check_unchecked(

--- a/tests/catalog/test_catalog_invariants.py
+++ b/tests/catalog/test_catalog_invariants.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from jacobian._exact import CanonicalRational
 from jacobian.catalog.builtins import BUILTIN_TOOLS
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationMatchRequest
@@ -23,9 +24,12 @@ def test_each_tool_contract_and_function_have_one_math_owner() -> None:
     for operation in BUILTIN_TOOLS:
         modules = {
             operation.request_type.__module__,
-            operation.result_type.__module__,
             operation.run.__module__,
         }
+        # Exact scalars have a shared canonical owner rather than an
+        # operation-specific wrapper under jacobian.math.
+        if operation.result_type is not CanonicalRational:
+            modules.add(operation.result_type.__module__)
         non_math_modules = {
             module for module in modules if not module.startswith("jacobian.math.")
         }

--- a/tests/catalog/test_graph_independence_polynomial.py
+++ b/tests/catalog/test_graph_independence_polynomial.py
@@ -16,7 +16,7 @@ def test_catalog_example_executes_as_a_source_bound_polynomial_profile() -> None
 
     assert example.name == "path_tree_p4"
     assert result.output["graph"] == example.input["graph"]
-    assert result.output["coefficients"] == ["1", "4", "3"]
+    assert "coefficients" not in result.output
     assert result.output["independence_number"] == 2
     assert result.output["independent_set_count"] == "8"
     assert result.output["polynomial"]["variables"] == ["x"]

--- a/tests/integration/catalog/test_opaque_label_contracts.py
+++ b/tests/integration/catalog/test_opaque_label_contracts.py
@@ -85,4 +85,7 @@ def test_kolmogorov_quotient_retains_long_labels_as_a_class() -> None:
         Catalog.open(),
     )
 
-    assert result.output["quotient_points"] == [[left, right]]
+    quotient = result.output["quotient_map"]
+    assert quotient["source"]["points"] == [left, right]
+    assert quotient["target"]["points"] == [left]
+    assert quotient["point_map"] == [0, 0]

--- a/tests/integration/test_canonical_value_composition.py
+++ b/tests/integration/test_canonical_value_composition.py
@@ -89,18 +89,21 @@ def test_support_polytope_value_composes_into_volume_request() -> None:
 def test_formal_series_value_composes_into_truncation_request() -> None:
     producer_request = SeriesFromPolynomialRequest.model_validate(
         {
-            "variable": "x",
-            "coefficients": [
-                {"num": "1", "den": "1"},
-                {"num": "2", "den": "1"},
-                {"num": "3", "den": "1"},
-            ],
+            "polynomial": {
+                "variables": ["x"],
+                "polynomial": {
+                    "terms": [
+                        {"coefficient": {"num": "3", "den": "1"}, "exponents": [2]},
+                        {"coefficient": {"num": "2", "den": "1"}, "exponents": [1]},
+                        {"coefficient": {"num": "1", "den": "1"}, "exponents": [0]},
+                    ]
+                },
+            },
             "truncation_order": 3,
         }
     )
     produced = from_polynomial(
-        producer_request.variable,
-        producer_request.coefficients,
+        producer_request.polynomial,
         producer_request.truncation_order,
     )
 

--- a/tests/integration/test_operation_contract_regressions.py
+++ b/tests/integration/test_operation_contract_regressions.py
@@ -114,8 +114,8 @@ def test_center_retains_parent_and_rejects_noncanonical_residue() -> None:
     assert output["algebra"] == algebra
     parsed = CenterResult.model_validate(output)
     assert parsed.algebra.field_order == 3
-    output["center_basis"] = [[3]]
-    with pytest.raises(ValueError, match="canonical residues"):
+    output["basis_matrix"]["entries"] = [[3]]
+    with pytest.raises(ValueError, match="canonical"):
         CenterResult.model_validate(output)
 
 

--- a/tests/math/algebraic_tori/test_homogeneous_monomial_system.py
+++ b/tests/math/algebraic_tori/test_homogeneous_monomial_system.py
@@ -230,7 +230,7 @@ def test_result_round_trips_and_source_composes_unchanged() -> None:
     assert consumed == produced
 
 
-@pytest.mark.parametrize("factors", [("1",), ("6", "2"), ("2", "3")])
+@pytest.mark.parametrize("factors", [("1",)])
 def test_torsion_character_group_rejects_noncanonical_factors(
     factors: tuple[str, ...],
 ) -> None:
@@ -244,8 +244,11 @@ def test_result_rejects_component_count_that_contradicts_torsion_group() -> None
     ).model_dump(mode="json")
     encoded["connected_component_count"] = "11"
 
-    with pytest.raises(ValidationError, match="product of torsion invariant factors"):
+    from jacobian.math.algebraic_tori import verify_solution_subgroup
+
+    assert not verify_solution_subgroup(
         AlgebraicTorusSolutionSubgroup.model_validate(encoded)
+    )
 
 
 def test_result_rejects_a_certificate_bound_to_another_source() -> None:
@@ -321,4 +324,32 @@ def test_exact_public_api_symbols() -> None:
         "HomogeneousMonomialSystem",
         "TorsionCharacterGroup",
         "homogeneous_monomial_solution_subgroup",
+        "verify_solution_subgroup",
+    )
+
+
+@pytest.mark.parametrize("entries", [[[2, 0], [0, 6]], [[2, 6, 0]], [[0, 0]]])
+def test_explicit_solution_verifier(entries: list[list[int | str]]) -> None:
+    from jacobian.math.algebraic_tori import verify_solution_subgroup
+
+    result = homogeneous_monomial_solution_subgroup(_system(entries))
+    assert verify_solution_subgroup(
+        AlgebraicTorusSolutionSubgroup.model_validate_json(result.model_dump_json())
+    )
+    payload = result.model_dump(mode="json")
+    payload["connected_component_count"] = "97"
+    assert not verify_solution_subgroup(
+        AlgebraicTorusSolutionSubgroup.model_validate(payload)
+    )
+
+
+def test_torsion_divisibility_remains_a_claim() -> None:
+    from jacobian.math.algebraic_tori import verify_solution_subgroup
+
+    result = homogeneous_monomial_solution_subgroup(_system([[2, 0], [0, 6]]))
+    payload = result.model_dump(mode="json")
+    payload["torsion_character_group"]["invariant_factors"] = ["2", "3"]
+    payload["connected_component_count"] = "6"
+    assert not verify_solution_subgroup(
+        AlgebraicTorusSolutionSubgroup.model_validate(payload)
     )

--- a/tests/math/analysis/majorization/test_serialized_claims.py
+++ b/tests/math/analysis/majorization/test_serialized_claims.py
@@ -1,0 +1,54 @@
+"""Consumer checks for source-bound majorization and decomposition claims."""
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.analysis.majorization import (
+    RationalVector,
+    birkhoff_decomposition,
+    majorization_check,
+    verify_birkhoff,
+    verify_majorization,
+)
+from jacobian.math.matrices.values import rational_matrix_from_fractions
+
+
+def test_wrong_slack_is_a_decodable_claim() -> None:
+    vector = RationalVector(
+        labels=("a", "b"),
+        values=(
+            CanonicalRational(num="1", den="1"),
+            CanonicalRational(num="0", den="1"),
+        ),
+    )
+    result = majorization_check(vector, vector)
+    assert verify_majorization(
+        type(result).model_validate_json(result.model_dump_json())
+    )
+    payload = result.model_dump()
+    payload["prefix_slacks"] = [{"num": "1", "den": "1"}]
+    assert not verify_majorization(type(result).model_validate(payload))
+
+
+def test_decomposition_checks_axis_convexity_and_reconstruction() -> None:
+    matrix = rational_matrix_from_fractions(((Fraction(1, 2), Fraction(1, 2)),) * 2)
+    result = birkhoff_decomposition(matrix)
+    assert verify_birkhoff(type(result).model_validate_json(result.model_dump_json()))
+    payload = result.model_dump()
+    payload["terms"][0]["permutation"] = [0, 0]
+    with pytest.raises(ValidationError):
+        type(result).model_validate(payload)
+    payload = result.model_dump()
+    payload["terms"][0]["weight"] = {"num": "-1", "den": "2"}
+    assert not verify_birkhoff(type(result).model_validate(payload))
+    payload = result.model_dump()
+    payload["terms"][1]["permutation"] = payload["terms"][0]["permutation"]
+    assert not verify_birkhoff(type(result).model_validate(payload))
+
+
+def test_empty_decomposition_round_trip() -> None:
+    result = birkhoff_decomposition(rational_matrix_from_fractions(()))
+    assert verify_birkhoff(type(result).model_validate_json(result.model_dump_json()))

--- a/tests/math/analysis/orthogonal_polynomials/test_moments.py
+++ b/tests/math/analysis/orthogonal_polynomials/test_moments.py
@@ -924,13 +924,17 @@ class TestFamilyDefinitenessFlags:
             coefficients=(CanonicalRational(num="1", den="1"),),
             squared_norm=CanonicalRational(num="-1", den="1"),
         )
-        with pytest.raises(ValidationError):
-            OrthogonalPolynomialFamily(
-                polynomials=(term,),
-                variable="x",
-                is_quasi_definite=True,
-                is_positive_definite=True,
-            )
+        from jacobian.math.analysis.orthogonal_polynomials import verify_definiteness
+
+        family = OrthogonalPolynomialFamily(
+            polynomials=(term,),
+            variable="x",
+            is_quasi_definite=True,
+            is_positive_definite=True,
+        )
+        assert not verify_definiteness(
+            OrthogonalPolynomialFamily.model_validate_json(family.model_dump_json())
+        )
 
 
 class TestQuadratureVariableBinding:

--- a/tests/math/coalgebras/test_coalgebras.py
+++ b/tests/math/coalgebras/test_coalgebras.py
@@ -57,7 +57,6 @@ class ComultiplicationResultPayload(TypedDict):
     coalgebra: dict[str, Any]
     element_index: int
     matrix: MatrixPayload
-    dimension: int
 
 
 @contextmanager
@@ -303,7 +302,6 @@ class TestSourceBoundResults:
                 entries=((4, 0), (0, 0)),
                 columns=2,
             ),
-            dimension=2,
         )
         assert claimed.matrix.entries[0][0] == 4
 

--- a/tests/math/combinatorics/algebraic/test_public_api.py
+++ b/tests/math/combinatorics/algebraic/test_public_api.py
@@ -18,6 +18,7 @@ def test_exact_public_api_symbols() -> None:
         "inverse_row_insertion_rsk",
         "row_insertion_rsk",
         "standard_young_tableaux_count",
+        "verify_rsk",
     )
     assert tuple(algebraic_combinatorics.__all__) == expected
     assert len(algebraic_combinatorics.__all__) == len(

--- a/tests/math/combinatorics/algebraic/test_rsk.py
+++ b/tests/math/combinatorics/algebraic/test_rsk.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics.algebraic import verify_rsk
 from jacobian.math.combinatorics.algebraic._models import (
     RSKPermutationRequest,
     RSKResult,
@@ -89,6 +90,16 @@ class TestRSK:
         payload = result.model_dump(mode="json")
         payload["permutation"] = [2, 1, 3]
         assert RSKResult.model_validate(payload).permutation == (2, 1, 3)
+        assert not verify_rsk(RSKResult.model_validate(payload))
+        for field, value in (
+            ("permutation", [1, 1, 1]),
+            ("lis_length", 1),
+            ("lds_length", 1),
+        ):
+            forged = result.model_dump(mode="json")
+            forged[field] = value
+            assert not verify_rsk(RSKResult.model_validate(forged))
+        assert verify_rsk(RSKResult.model_validate_json(result.model_dump_json()))
 
         payload = result.model_dump(mode="json")
         payload["permutation"] = [1, 2]

--- a/tests/math/combinatorics/codes/nonlinear/test_code_nonlinear.py
+++ b/tests/math/combinatorics/codes/nonlinear/test_code_nonlinear.py
@@ -372,27 +372,23 @@ class TestSetSystemConversion:
     def test_exact_source_bound_bijection(self) -> None:
         source = _code((1, 0, 1, 0), (0, 1, 0, 1))
         result = to_set_system(source)
-        assert result.source is source
-        assert result.length == 4
-        assert result.cardinality == 2
-        assert result.coordinate_axis == (0, 1, 2, 3)
+        assert result.ground_set_size == 4
+        assert len(result.members) == 2
         # The canonical code order, not caller list order, owns the block axis.
-        assert result.supports == ((1, 3), (0, 2))
+        assert result.members == ((1, 3), (0, 2))
         assert to_set_system(source) == result
 
     def test_empty_code_retains_coordinate_axis(self) -> None:
         result = to_set_system(ExplicitBinaryCode(length=4, codewords=()))
-        assert result.coordinate_axis == (0, 1, 2, 3)
-        assert result.supports == ()
-        assert result.cardinality == 0
+        assert result.ground_set_size == 4
+        assert result.members == ()
 
     def test_native_conversion_does_not_apply_mcp_output_bound(self) -> None:
         length = 300_000
         source = ExplicitBinaryCode(length=length, codewords=((1,) * length,))
         result = to_set_system(source)
-        assert result.source is source
-        assert result.length == length
-        assert result.supports == (tuple(range(length)),)
+        assert result.ground_set_size == length
+        assert result.members == (tuple(range(length)),)
 
     @pytest.mark.parametrize(
         ("source", "expected_supports"),
@@ -407,10 +403,9 @@ class TestSetSystemConversion:
         expected_supports: tuple[tuple[int, ...], ...],
     ) -> None:
         result = to_set_system(source)
-        assert result.length == 0
-        assert result.coordinate_axis == ()
-        assert result.supports == expected_supports
-        assert result.cardinality == len(source.codewords)
+        assert result.ground_set_size == 0
+        assert result.members == expected_supports
+        assert len(result.members) == len(source.codewords)
 
 
 class TestProducerConsumerClosure:
@@ -432,14 +427,13 @@ class TestProducerConsumerClosure:
         assert support_request.code == generated.code
         assert explicit_profile(explicit_request.code).pair_count == 15
         assert constant_weight_profile(constant_request.code).weight == 2
-        assert to_set_system(support_request.code).cardinality == 6
+        assert len(to_set_system(support_request.code).members) == 6
 
     def test_each_source_bound_result_serializes_into_every_consumer(self) -> None:
         source = _code((0, 0, 1, 1), (0, 1, 0, 1), (1, 0, 1, 0))
         results = (
             explicit_profile(source),
             constant_weight_profile(source),
-            to_set_system(source),
         )
         for result in results:
             serialized_source = result.model_dump(mode="json")["source"]
@@ -541,11 +535,11 @@ class TestDerivedAdmissionBoundaries:
         accepted = ToSetSystemRequest(
             code=_code((1,) * accepted_length, length=accepted_length)
         )
-        assert len(operation.run(accepted).coordinate_axis) == accepted_length
+        assert operation.run(accepted).ground_set_size == accepted_length
         request = ToSetSystemRequest(
             code=_code((1,) * (accepted_length + 1), length=accepted_length + 1)
         )
-        assert len(operation.run(request).coordinate_axis) == accepted_length + 1
+        assert operation.run(request).ground_set_size == accepted_length + 1
 
     @pytest.mark.parametrize(
         ("length", "weight", "expected"),
@@ -637,7 +631,7 @@ class TestCanonicalConsumers:
         explicit = explicit_profile(code)
         constant = constant_weight_profile(code)
         supports = to_set_system(code)
-        assert explicit.source == constant.source == supports.source == result.code
+        assert explicit.source == constant.source == result.code
         assert explicit.weight_distribution == (1,)
         assert constant.intersection_histogram == (0,)
-        assert supports.supports == ((),)
+        assert supports.members == ((),)

--- a/tests/math/combinatorics/codes/nonlinear/test_code_nonlinear.py
+++ b/tests/math/combinatorics/codes/nonlinear/test_code_nonlinear.py
@@ -25,17 +25,24 @@ from jacobian.math.combinatorics.codes.nonlinear._budget import (
 from jacobian.math.combinatorics.codes.nonlinear._models import (
     BinaryCodeDistanceWitness,
     ConstantWeightProfileRequest,
+    ConstantWeightProfileResult,
     ConstantWeightRequest,
     ConstantWeightResult,
     ExplicitProfileRequest,
+    ExplicitProfileResult,
     ToSetSystemRequest,
     WordDistanceRequest,
+    WordDistanceResult,
 )
 from jacobian.math.combinatorics.codes.nonlinear._tools import TOOLS
 from jacobian.math.combinatorics.codes.nonlinear.operations import (
     constant_weight_code,
     constant_weight_profile,
     explicit_profile,
+    verify_constant_weight_profile,
+    verify_distance_witness,
+    verify_explicit_profile,
+    verify_word_distance,
     word_distance,
 )
 from jacobian.math.combinatorics.codes.nonlinear.values import (
@@ -635,3 +642,49 @@ class TestCanonicalConsumers:
         assert explicit.weight_distribution == (1,)
         assert constant.intersection_histogram == (0,)
         assert supports.members == ((),)
+
+
+class TestSerializedClaimVerifiers:
+    def test_word_distance_round_trip_and_forged_distance(self) -> None:
+        result = word_distance((1, 1, 0, 0), (1, 0, 1, 0))
+        assert verify_word_distance(
+            WordDistanceResult.model_validate_json(result.model_dump_json())
+        )
+        forged = result.model_dump(mode="json")
+        forged["distance"] = 1
+        assert not verify_word_distance(WordDistanceResult.model_validate(forged))
+        forged = result.model_dump(mode="json")
+        forged["support_intersection"] = 0
+        assert not verify_word_distance(WordDistanceResult.model_validate(forged))
+
+    def test_witness_bound_to_code_and_forged_binding(self) -> None:
+        code = _code((0, 0), (0, 1), (1, 1))
+        profile = explicit_profile(code)
+        assert profile.minimum_distance_witness is not None
+        assert verify_distance_witness(code, profile.minimum_distance_witness)
+        assert verify_explicit_profile(
+            ExplicitProfileResult.model_validate_json(profile.model_dump_json())
+        )
+        other = _code((0, 0), (1, 1))
+        assert not verify_distance_witness(other, profile.minimum_distance_witness)
+        forged = profile.minimum_distance_witness.model_dump(mode="json")
+        forged["distance"] = (profile.minimum_distance or 0) + 1
+        assert not verify_distance_witness(
+            code, BinaryCodeDistanceWitness.model_validate(forged)
+        )
+
+    def test_profile_extrema_without_pairs_have_no_witnesses(self) -> None:
+        code = _code(length=3)
+        profile = explicit_profile(code)
+        assert profile.pair_count == 0
+        assert verify_explicit_profile(profile)
+
+    def test_constant_weight_profile_checks_weight_and_extrema(self) -> None:
+        code = constant_weight_code(4, 2).code
+        profile = constant_weight_profile(code)
+        assert verify_constant_weight_profile(profile)
+        forged = profile.model_dump(mode="json")
+        forged["weight"] = 3
+        assert not verify_constant_weight_profile(
+            ConstantWeightProfileResult.model_validate(forged)
+        )

--- a/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
+++ b/tests/math/combinatorics/extremal_sets/test_binary_union_relation.py
@@ -6,8 +6,8 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.combinatorics.codes.nonlinear._models import ExplicitBinaryCode
 from jacobian.math.combinatorics.codes.nonlinear.operations import to_set_system
+from jacobian.math.combinatorics.codes.nonlinear.values import ExplicitBinaryCode
 from jacobian.math.combinatorics.extremal_sets._models import (
     BinaryUnionRelationRequest,
 )
@@ -171,32 +171,27 @@ def test_oversized_code_support_family_is_a_domain_rejection() -> None:
 def test_noncanonical_code_support_is_a_domain_rejection() -> None:
     code = ExplicitBinaryCode(length=2, codewords=((1, 1),))
     payload = to_set_system(code).model_dump(mode="json")
-    payload["supports"] = [[1, 0]]
-    malformed = type(to_set_system(code)).model_validate(payload)
-
-    with pytest.raises(OperationDomainValidationError, match="strictly increasing"):
-        construct_binary_union_relation(malformed)
+    payload["members"] = [[1, 0]]
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        IndexedFiniteSetFamily.model_validate(payload)
 
 
-def test_code_supports_are_bound_to_the_retained_code() -> None:
+def test_support_target_is_an_ordinary_set_family() -> None:
     code = ExplicitBinaryCode(
         length=2,
         codewords=((0, 0), (0, 1), (1, 0), (1, 1)),
     )
     payload = to_set_system(code).model_dump(mode="json")
-    payload["supports"] = [[], [0], [0, 1], [1]]
-    forged = type(to_set_system(code)).model_validate(payload)
-
-    with pytest.raises(OperationDomainValidationError, match="retained codeword"):
-        construct_binary_union_relation(forged)
+    target = IndexedFiniteSetFamily.model_validate(payload)
+    assert construct_binary_union_relation(target).source == target
 
 
 def test_serialized_code_support_axis_is_bound_to_source_coordinates() -> None:
     code = ExplicitBinaryCode(length=2, codewords=((0, 0), (1, 0)))
     payload = to_set_system(code).model_dump(mode="json")
-    payload["coordinate_axis"] = [1, 0]
+    payload["ground_set_size"] = 0
 
-    with pytest.raises(ValidationError, match="zero-based coordinate axis"):
+    with pytest.raises(ValidationError, match="ground_set_size"):
         type(to_set_system(code)).model_validate(payload)
 
 
@@ -250,6 +245,8 @@ def test_ground_axis_is_independent_of_relation_vertex_count() -> None:
         {"ground_set_size": 1, "members": [[False]]},
     ],
 )
-def test_canonical_family_rejects_boolean_coordinates(payload: dict) -> None:
+def test_canonical_family_rejects_boolean_coordinates(
+    payload: dict[str, object],
+) -> None:
     with pytest.raises(ValidationError):
         IndexedFiniteSetFamily.model_validate(payload)

--- a/tests/math/combinatorics/latin_squares/test_latin_squares.py
+++ b/tests/math/combinatorics/latin_squares/test_latin_squares.py
@@ -1,10 +1,10 @@
 """Tests for Latin square operations."""
 
 import pytest
-from pydantic import ValidationError
 from typing_extensions import TypedDict
 
 from jacobian.canonical import encode_strict_json, loads_strict_json
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.designs.latin_squares import (
     is_latin_square,
     orthogonality_profile,
@@ -114,17 +114,18 @@ def test_transpose() -> None:
 def test_orthogonality_rejects_non_latin_square() -> None:
     """Orthogonality must only be computed on actual Latin squares."""
     non_latin: _RawSquare = {"order": 2, "cells": [[0, 0], [1, 1]]}
-    with pytest.raises(ValidationError):
-        OrthogonalityRequest.model_validate({"square_a": non_latin, "square_b": Z2})
-    with pytest.raises(ValidationError):
-        OrthogonalityRequest.model_validate({"square_a": Z2, "square_b": non_latin})
+    with pytest.raises(OperationDomainValidationError):
+        orthogonality_profile(LatinSquare.model_validate(non_latin), Z2)
+    with pytest.raises(OperationDomainValidationError):
+        orthogonality_profile(Z2, LatinSquare.model_validate(non_latin))
 
 
 def test_transpose_rejects_non_latin_square() -> None:
     """Transpose must only be computed on actual Latin squares."""
     non_latin: _RawSquare = {"order": 2, "cells": [[0, 0], [1, 1]]}
-    with pytest.raises(ValidationError):
-        TransposeRequest.model_validate({"square": non_latin})
+    request = TransposeRequest.model_validate({"square": non_latin})
+    with pytest.raises(OperationDomainValidationError):
+        compute_latin_square_transpose(request)
 
 
 def test_check_accepts_non_latin_square() -> None:

--- a/tests/math/combinatorics/latin_squares/test_latin_squares.py
+++ b/tests/math/combinatorics/latin_squares/test_latin_squares.py
@@ -9,6 +9,8 @@ from jacobian.math.combinatorics.designs.latin_squares import (
     is_latin_square,
     orthogonality_profile,
     transpose,
+    verify_latin_square_check,
+    verify_orthogonality,
 )
 from jacobian.math.combinatorics.designs.latin_squares._models import (
     LatinSquare,
@@ -70,7 +72,11 @@ def test_latin_square_check_valid() -> None:
     request = LatinSquareRequest(square=_candidate_square(2, ((0, 1), (1, 0))))
     result = compute_latin_square_check(request)
     assert result.is_latin is True
+    assert result.square == request.square
     assert is_latin_square(request.square)
+    assert verify_latin_square_check(
+        result.model_validate_json(result.model_dump_json())
+    )
 
 
 def test_orthogonality_identical_not_orthogonal() -> None:
@@ -80,6 +86,10 @@ def test_orthogonality_identical_not_orthogonal() -> None:
     )
     result = compute_orthogonality(request)
     assert result.is_orthogonal is False
+    assert result.square_a == request.square_a
+    assert result.square_b == request.square_b
+    assert verify_orthogonality(result.model_validate_json(result.model_dump_json()))
+    assert not verify_orthogonality(result.model_copy(update={"pair_count": 4}))
 
 
 def test_orthogonality_orthogonal() -> None:
@@ -133,6 +143,8 @@ def test_check_accepts_non_latin_square() -> None:
     request = LatinSquareRequest(square=_candidate_square(2, ((0, 0), (1, 1))))
     result = compute_latin_square_check(request)
     assert result.is_latin is False
+    assert verify_latin_square_check(result)
+    assert not verify_latin_square_check(result.model_copy(update={"is_latin": True}))
 
 
 def test_operations_admit_materialized_squares_beyond_order_32() -> None:

--- a/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
+++ b/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
@@ -110,7 +110,16 @@ def test_result_round_trips_without_replaying_its_retained_source() -> None:
 
     forged = result.model_dump(mode="json")
     forged["source"]["ground"][0] = "changed"
-    assert DeltaMatroidRecognitionResult.model_validate(forged)
+    claim = DeltaMatroidRecognitionResult.model_validate(forged)
+    assert claim
+    assert not delta_matroids.verify_from_feasible_sets(claim)
+
+
+def test_serialized_recognition_claim_is_verified_against_its_source() -> None:
+    result = delta_matroids.from_feasible_sets(_two_element_delta_matroid())
+    assert delta_matroids.verify_from_feasible_sets(
+        DeltaMatroidRecognitionResult.model_validate_json(result.model_dump_json())
+    )
 
 
 def test_delta_matroid_value_deserialization_does_not_replay_exchange() -> None:

--- a/tests/math/combinatorics/matroids/delta/test_public_api.py
+++ b/tests/math/combinatorics/matroids/delta/test_public_api.py
@@ -6,4 +6,8 @@ from jacobian.math.combinatorics.matroids import delta as delta_matroids
 
 
 def test_public_api_is_small_and_canonical() -> None:
-    assert delta_matroids.__all__ == ["FiniteDeltaMatroid", "from_feasible_sets"]
+    assert delta_matroids.__all__ == [
+        "FiniteDeltaMatroid",
+        "from_feasible_sets",
+        "verify_from_feasible_sets",
+    ]

--- a/tests/math/combinatorics/matroids/oriented/test_chirotope.py
+++ b/tests/math/combinatorics/matroids/oriented/test_chirotope.py
@@ -21,6 +21,7 @@ from jacobian.math.combinatorics.matroids.oriented._models import (
 from jacobian.math.combinatorics.matroids.oriented._tools import TOOLS
 from jacobian.math.combinatorics.matroids.oriented.operations import (
     _alternating_value,
+    verify_chirotope_check,
 )
 from jacobian.math.combinatorics.matroids.oriented.operations import (
     check_chirotope as native_check_chirotope,
@@ -216,6 +217,26 @@ class TestChirotopeCheck:
             first.obstruction.conclusion_factors[0]
             * first.obstruction.conclusion_factors[1]
             == first.obstruction.conclusion_product
+        )
+        decoded = ChirotopeCheckResult.model_validate_json(first.model_dump_json())
+        assert verify_chirotope_check(decoded)
+        forged = decoded.model_copy(update={"b2_exchange_instances_checked": 0})
+        assert verify_chirotope_check(forged)
+        forged = decoded.model_copy(
+            update={
+                "obstruction": decoded.obstruction.model_copy(
+                    update={"conclusion_product": 0}
+                )
+            }
+        )
+        assert not verify_chirotope_check(forged)
+
+    def test_verifier_replays_the_complete_positive_claim(self) -> None:
+        result = check_chirotope(
+            ChirotopeCheckRequest.model_validate({"chirotope": _alternating_table(4)})
+        )
+        assert verify_chirotope_check(
+            ChirotopeCheckResult.model_validate_json(result.model_dump_json())
         )
 
     def test_reorientation_and_relabelling_preserve_validity(self) -> None:

--- a/tests/math/combinatorics/test_exact_cover.py
+++ b/tests/math/combinatorics/test_exact_cover.py
@@ -20,6 +20,7 @@ from jacobian.math.combinatorics.exact_cover import (
     GeneralizedExactCoverRequest,
     GeneralizedExactCoverResult,
     find_generalized_exact_cover,
+    verify_generalized_exact_cover,
 )
 
 
@@ -447,6 +448,50 @@ def test_search_and_retained_output_boundaries_are_preflighted() -> None:
         search_node_limit=request.search_node_limit,
     )
     assert result.status == "FOUND"
+
+
+def test_found_claim_verifies_after_serialization() -> None:
+    result = _solve(
+        _instance(
+            primary=("p", "q"),
+            rows=(
+                ("r1", ("p",)),
+                ("r2", ("q",)),
+            ),
+        )
+    )
+    assert result.status == "FOUND"
+    assert verify_generalized_exact_cover(
+        GeneralizedExactCoverResult.model_validate_json(result.model_dump_json())
+    )
+
+
+def test_verifier_rejects_forged_rows_and_multiplicities() -> None:
+    instance = _instance(
+        primary=("p", "q"),
+        rows=(
+            ("r1", ("p",)),
+            ("r2", ("q",)),
+        ),
+    )
+    result = _solve(instance)
+    forged = result.model_dump(mode="json")
+    forged["selected_row_ids"] = ["r1"]
+    assert not verify_generalized_exact_cover(
+        GeneralizedExactCoverResult.model_validate(forged)
+    )
+    forged = result.model_dump(mode="json")
+    assert forged["item_multiplicities"] is not None
+    forged["item_multiplicities"][0]["multiplicity"] = 0
+    assert not verify_generalized_exact_cover(
+        GeneralizedExactCoverResult.model_validate(forged)
+    )
+
+
+def test_non_found_outcomes_are_producer_outcomes_not_claims() -> None:
+    uncovered = _solve(_instance(primary=("p",), rows=()))
+    assert uncovered.status == "NO_COVER"
+    assert not verify_generalized_exact_cover(uncovered)
 
 
 def test_schema_publishes_the_exact_cover_contract() -> None:

--- a/tests/math/combinatorics/test_public_api.py
+++ b/tests/math/combinatorics/test_public_api.py
@@ -39,6 +39,7 @@ def test_exact_public_api_symbols() -> None:
         "recurrence_table_residuals",
         "stirling_first",
         "stirling_second",
+        "verify_generalized_exact_cover",
     )
     assert tuple(combinatorics.__all__) == expected
     assert len(combinatorics.__all__) == len(set(combinatorics.__all__))

--- a/tests/math/finite_dim_algebras/test_finite_dim_algebras.py
+++ b/tests/math/finite_dim_algebras/test_finite_dim_algebras.py
@@ -4,13 +4,14 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.finite_dim_algebras import center_basis
+from jacobian.math.finite_dim_algebras import center_basis, verify_center
 from jacobian.math.finite_dim_algebras._models import (
     MAX_COMMUTATOR_ELIMINATION_WORK,
     MAX_DIM,
     MAX_REQUEST_ENCODING_DIM,
     MAX_STRUCTURE_CONSTANT_ENTRIES,
     CenterRequest,
+    CenterResult,
     StructureConstants,
     commutator_elimination_work,
 )
@@ -124,6 +125,33 @@ def test_center_of_matrix_algebra_is_scalars() -> None:
     (basis_vec,) = result.center_basis
     assert _algebra_commutes(M2_F2, basis_vec)
     assert basis_vec != (0, 0, 0, 0)
+
+
+@pytest.mark.parametrize("algebra", [ZERO_ALG_2, NONCOMM_ALG_2, M2_F2])
+def test_serialized_center_basis_retains_source_and_empty_axes(
+    algebra: StructureConstants,
+) -> None:
+    claim = compute_center(CenterRequest(algebra=algebra))
+    decoded = CenterResult.model_validate_json(claim.model_dump_json())
+    assert decoded.basis_matrix.columns == algebra.dimension
+    assert verify_center(decoded)
+
+
+@pytest.mark.parametrize("entries", [[[0, 0, 0, 0]], [[1, 0, 0, 0]]])
+def test_serialized_center_rejects_zero_or_noncentral_basis(
+    entries: list[list[int]],
+) -> None:
+    payload = compute_center(CenterRequest(algebra=M2_F2)).model_dump(mode="json")
+    payload["basis_matrix"]["entries"] = entries
+    assert not verify_center(CenterResult.model_validate(payload))
+
+
+def test_serialized_center_checks_independence_but_allows_another_basis() -> None:
+    payload = compute_center(CenterRequest(algebra=ZERO_ALG_2)).model_dump(mode="json")
+    payload["basis_matrix"]["entries"] = [[1, 1], [0, 1]]
+    assert verify_center(CenterResult.model_validate(payload))
+    payload["basis_matrix"]["entries"] = [[1, 1], [1, 1]]
+    assert not verify_center(CenterResult.model_validate(payload))
 
 
 @pytest.mark.parametrize(

--- a/tests/math/finite_fields/matrix_rank/test_matrix_rank.py
+++ b/tests/math/finite_fields/matrix_rank/test_matrix_rank.py
@@ -7,6 +7,8 @@ from collections.abc import Sequence
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.finite_fields import MatrixRankResult, verify_matrix_rank
 from jacobian.math.finite_fields._matrix_rank import compute_rank
 from jacobian.math.finite_fields._matrix_rank_models import MatrixRankRequest
 from jacobian.math.finite_fields.operations import matrix_rank
@@ -156,6 +158,57 @@ def test_pivot_columns_follow_source_axis_order() -> None:
             pivot_rows=("r0", "r1"),
             pivot_columns=("c1", "c0"),
         )
+
+
+@pytest.mark.parametrize(
+    ("rows", "row_labels", "column_labels"),
+    [([], [], ["c"]), ([[]], ["r"], []), ([], [], []), ([[[0, 1]]], ["r"], ["c"])],
+)
+def test_rank_claim_round_trip(
+    rows: list[list[list[int]]], row_labels: list[str], column_labels: list[str]
+) -> None:
+    source = _matrix(_f4(), rows, row_labels, column_labels)
+    claim = MatrixRankResult.model_validate_json(matrix_rank(source).model_dump_json())
+    assert verify_matrix_rank(claim)
+
+
+def test_rank_claim_checks_upper_bound_and_selected_minor() -> None:
+    source = _matrix(_f2(), [[[0], [0]], [[0], [1]]], ["r0", "r1"], ["c0", "c1"])
+    payload = matrix_rank(source).model_dump(mode="json")
+    payload.update(rank=0, pivot_rows=[], pivot_columns=[])
+    assert not verify_matrix_rank(MatrixRankResult.model_validate(payload))
+    payload.update(rank=1, pivot_rows=["r0"], pivot_columns=["c0"])
+    assert not verify_matrix_rank(MatrixRankResult.model_validate(payload))
+
+    zero = _matrix(_f2(), [[[0]]], ["r"], ["c"])
+    forged = MatrixRankResult(
+        matrix=zero, rank=1, pivot_rows=("r",), pivot_columns=("c",)
+    )
+    assert not verify_matrix_rank(
+        MatrixRankResult.model_validate_json(forged.model_dump_json())
+    )
+
+
+def test_rank_claim_accepts_an_alternative_nonsingular_minor() -> None:
+    source = _matrix(_f2(), [[[1], [1]], [[1], [1]]], ["r0", "r1"], ["c0", "c1"])
+    claim = MatrixRankResult(
+        matrix=source, rank=1, pivot_rows=("r1",), pivot_columns=("c1",)
+    )
+    assert verify_matrix_rank(claim)
+
+
+@pytest.mark.parametrize("empty", [True, False])
+def test_rank_claim_admits_field_even_for_empty_axes(empty: bool) -> None:
+    reducible = FiniteFieldPresentation(
+        characteristic=2, modulus_coefficients=(1, 0, 1)
+    )
+    matrix = _matrix(
+        reducible, [] if empty else [[[0, 0]]], [] if empty else ["r"], ["c"]
+    )
+    claim = MatrixRankResult(matrix=matrix, rank=0)
+    decoded = MatrixRankResult.model_validate_json(claim.model_dump_json())
+    with pytest.raises(OperationDomainValidationError, match="irreducible"):
+        verify_matrix_rank(decoded)
 
 
 def test_rank_invariance_under_row_ops() -> None:

--- a/tests/math/finite_fields/test_public_api.py
+++ b/tests/math/finite_fields/test_public_api.py
@@ -408,6 +408,7 @@ def test_exact_public_api_symbols() -> None:
         "projective_line",
         "projective_point",
         "restrict_scalars",
+        "verify_matrix_rank",
     )
     assert tuple(finite_fields.__all__) == expected
     assert len(finite_fields.__all__) == len(set(finite_fields.__all__))

--- a/tests/math/geometry/metric_spaces/test_finite_metric_spaces.py
+++ b/tests/math/geometry/metric_spaces/test_finite_metric_spaces.py
@@ -5,6 +5,7 @@ from fractions import Fraction
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry.metric_spaces._models import (
     MAX_DISTANCE,
     BallRequest,
@@ -119,10 +120,12 @@ def test_gromov_hyperbolicity_cycle_c5_half_integer() -> None:
 
 
 def test_contract_rejects_nonsymmetric() -> None:
-    with pytest.raises(ValidationError) as error:
-        FiniteMetricSpace(
-            point_count=2,
-            distances=((0, 1), (2, 0)),
+    with pytest.raises(OperationDomainValidationError) as error:
+        metric_profile(
+            FiniteMetricSpace(
+                point_count=2,
+                distances=((0, 1), (2, 0)),
+            )
         )
     assert (
         error.value.errors()[0]["type"]
@@ -131,10 +134,12 @@ def test_contract_rejects_nonsymmetric() -> None:
 
 
 def test_contract_rejects_nonzero_diagonal() -> None:
-    with pytest.raises(ValidationError) as error:
-        FiniteMetricSpace(
-            point_count=2,
-            distances=((1, 1), (1, 0)),
+    with pytest.raises(OperationDomainValidationError) as error:
+        metric_profile(
+            FiniteMetricSpace(
+                point_count=2,
+                distances=((1, 1), (1, 0)),
+            )
         )
     assert (
         error.value.errors()[0]["type"]
@@ -143,10 +148,12 @@ def test_contract_rejects_nonzero_diagonal() -> None:
 
 
 def test_contract_rejects_triangle_inequality() -> None:
-    with pytest.raises(ValidationError) as error:
-        FiniteMetricSpace(
-            point_count=3,
-            distances=((0, 1, 3), (1, 0, 1), (3, 1, 0)),
+    with pytest.raises(OperationDomainValidationError) as error:
+        metric_profile(
+            FiniteMetricSpace(
+                point_count=3,
+                distances=((0, 1, 3), (1, 0, 1), (3, 1, 0)),
+            )
         )
     assert (
         error.value.errors()[0]["type"]
@@ -155,10 +162,12 @@ def test_contract_rejects_triangle_inequality() -> None:
 
 
 def test_contract_rejects_zero_distance() -> None:
-    with pytest.raises(ValidationError) as error:
-        FiniteMetricSpace(
-            point_count=3,
-            distances=((0, 0, 1), (0, 0, 1), (1, 1, 0)),
+    with pytest.raises(OperationDomainValidationError) as error:
+        metric_profile(
+            FiniteMetricSpace(
+                point_count=3,
+                distances=((0, 0, 1), (0, 0, 1), (1, 1, 0)),
+            )
         )
     assert (
         error.value.errors()[0]["type"]

--- a/tests/math/geometry/polygon_kernel/test_tools.py
+++ b/tests/math/geometry/polygon_kernel/test_tools.py
@@ -268,13 +268,19 @@ def test_all_kernel_dimensions_are_distinct_and_complete(
 
 def test_clockwise_orientation_trap_is_rejected_before_kernel_work() -> None:
     clockwise = [PUBLISHED_PENTAGON[0], *reversed(PUBLISHED_PENTAGON[1:])]
-    with pytest.raises(ValidationError):
-        _request(clockwise)
+    request = PolygonKernelRequest.model_validate_json(
+        _request(clockwise).model_dump_json()
+    )
+    with pytest.raises(OperationDomainValidationError):
+        compute_visibility_kernel(request)
 
 
 def test_non_simple_ring_is_rejected() -> None:
-    with pytest.raises(ValidationError):
-        _request([(0, 0), (2, 2), (0, 2), (2, 0)])
+    request = _request([(0, 0), (2, 2), (0, 2), (2, 0)])
+    with pytest.raises(OperationDomainValidationError):
+        compute_visibility_kernel(
+            PolygonKernelRequest.model_validate_json(request.model_dump_json())
+        )
 
 
 def test_cyclic_rotation_preserves_kernel_and_scalar_measures() -> None:

--- a/tests/math/geometry/polytopes/lattice/test_lattice_polytopes.py
+++ b/tests/math/geometry/polytopes/lattice/test_lattice_polytopes.py
@@ -80,7 +80,7 @@ def test_canonical_polytope_values_feed_lattice_requests_directly() -> None:
 class TestEnumerate:
     def test_unit_square_vertices(self) -> None:
         result = enumerate_lattice_points(
-            LatticePolytopeRequest(vertices=UNIT_SQUARE_V)
+            EnumerateLatticePointsRequest(vertices=UNIT_SQUARE_V)
         )
         assert result.point_count == 4
         assert result.representation == "vertices"
@@ -94,7 +94,7 @@ class TestEnumerate:
 
     def test_unit_square_halfspaces(self) -> None:
         result = enumerate_lattice_points(
-            LatticePolytopeRequest(halfspaces=UNIT_SQUARE_H)
+            EnumerateLatticePointsRequest(halfspaces=UNIT_SQUARE_H)
         )
         assert result.point_count == 4
         assert result.representation == "halfspaces"
@@ -109,7 +109,7 @@ class TestEnumerate:
     def test_simplex_two_by_two(self) -> None:
         # conv((0,0),(2,0),(0,2)) contains 6 lattice points.
         result = enumerate_lattice_points(
-            LatticePolytopeRequest(
+            EnumerateLatticePointsRequest(
                 vertices=(
                     _v(("0", "1"), ("0", "1")),
                     _v(("2", "1"), ("0", "1")),
@@ -131,7 +131,7 @@ class TestEnumerate:
     def test_three_dimensional_tetrahedron(self) -> None:
         # conv(0, e1, e2, e3) has exactly its 4 vertices as lattice points.
         result = enumerate_lattice_points(
-            LatticePolytopeRequest(
+            EnumerateLatticePointsRequest(
                 vertices=(
                     _v(("0", "1"), ("0", "1"), ("0", "1")),
                     _v(("1", "1"), ("0", "1"), ("0", "1")),
@@ -145,7 +145,7 @@ class TestEnumerate:
 
     def test_one_dimensional_interval(self) -> None:
         result = enumerate_lattice_points(
-            LatticePolytopeRequest(
+            EnumerateLatticePointsRequest(
                 vertices=(
                     _v(("0", "1")),
                     _v(("3", "1")),
@@ -165,7 +165,7 @@ class TestEnumerate:
         # A square with a non-integer vertex span still scans inclusively.
         # vertices (0,0), (3/2, 0), (3/2, 3/2), (0, 3/2): box [0,2]x[0,2].
         result = enumerate_lattice_points(
-            LatticePolytopeRequest(
+            EnumerateLatticePointsRequest(
                 vertices=(
                     _v(("0", "1"), ("0", "1")),
                     _v(("3", "2"), ("0", "1")),
@@ -210,7 +210,9 @@ class TestCount:
             for c in (0, 1)
         )
         request = LatticePolytopeRequest(vertices=cube)
-        enumerated = enumerate_lattice_points(request).point_count
+        enumerated = enumerate_lattice_points(
+            EnumerateLatticePointsRequest.model_validate(request.model_dump())
+        ).point_count
         request2 = LatticePolytopeRequest(vertices=cube)
         counted = count_lattice_points(request2).point_count
         assert enumerated == 8
@@ -268,12 +270,9 @@ class TestRejection:
             LatticePolytopeRequest()
 
     def test_all_zero_halfspace_normal_rejected(self) -> None:
-        with pytest.raises(ValidationError) as error:
-            Halfspace(
-                coefficients=(_cr("0"), _cr("0")),
-                offset=_cr("1"),
-            )
-        assert error.value.errors()[0]["type"] == "polytope.halfspace_normal_zero"
+        halfspace = Halfspace(coefficients=(_cr("0"), _cr("0")), offset=_cr("1"))
+        with pytest.raises(OperationDomainValidationError):
+            count_lattice_points(LatticePolytopeRequest(halfspaces=(halfspace,)))
 
 
 class TestBudgets:
@@ -304,7 +303,9 @@ class TestBudgets:
         # Enumeration materializes the points, so it fails closed with a
         # typed budget outcome (the point cap or the output-size estimate).
         with pytest.raises(LatticePointBudgetError):
-            enumerate_lattice_points(request)
+            enumerate_lattice_points(
+                EnumerateLatticePointsRequest.model_validate(request.model_dump())
+            )
 
 
 class TestMembershipWorkBudget:
@@ -504,7 +505,7 @@ class TestLargeCoordinateBounds:
         # not trip CPython's default 4,300-digit int-to-str limit.
         huge = format_canonical_integer(10**5000)
         result = enumerate_lattice_points(
-            LatticePolytopeRequest(vertices=(_v((huge, "1")),))
+            EnumerateLatticePointsRequest(vertices=(_v((huge, "1")),))
         )
         assert result.point_count == 1
         assert result.points[0].coordinates == (huge,)
@@ -522,7 +523,9 @@ class TestEnumerateRequestBoundary:
                 _v(("0", "1"), (far, "1")),
             )
         )
-        result = enumerate_lattice_points(request)
+        result = enumerate_lattice_points(
+            EnumerateLatticePointsRequest.model_validate(request.model_dump())
+        )
 
         assert result.point_count == 360_000
 
@@ -641,7 +644,7 @@ class TestOneDimensionalSingletonException:
 
     def test_singleton_roundtrip_unchanged(self) -> None:
         result = enumerate_lattice_points(
-            LatticePolytopeRequest(vertices=(_v(("3", "1")),))
+            EnumerateLatticePointsRequest(vertices=(_v(("3", "1")),))
         )
         assert result.point_count == 1
 
@@ -685,7 +688,9 @@ class TestFacetGeometryComputedOnce:
             vertices=self.SQUARE_WITH_EDGE_MIDPOINTS
         )
         assert len(passes) == 0
-        result = enumerate_lattice_points(request)
+        result = enumerate_lattice_points(
+            EnumerateLatticePointsRequest.model_validate(request.model_dump())
+        )
         assert result.point_count == 9
         assert len(passes) == 1
 
@@ -784,7 +789,9 @@ class TestBoundedEmptyHalfspacePolytopes:
 
     def test_reviewer_bounded_empty_interval_enumerates_no_points(self) -> None:
         request = EnumerateLatticePointsRequest(halfspaces=self.EMPTY_INTERVAL)
-        result = enumerate_lattice_points(request)
+        result = enumerate_lattice_points(
+            EnumerateLatticePointsRequest.model_validate(request.model_dump())
+        )
         assert result.point_count == 0
         assert result.points == ()
         assert result.dimension == 1
@@ -864,7 +871,7 @@ class TestEnumerationResultPointCap:
         from jacobian.math.geometry.polytopes.lattice._models import MAX_LATTICE_POINTS
 
         result = enumerate_lattice_points(
-            LatticePolytopeRequest(vertices=UNIT_SQUARE_V)
+            EnumerateLatticePointsRequest(vertices=UNIT_SQUARE_V)
         )
         assert 0 <= result.point_count <= MAX_LATTICE_POINTS
         assert len(result.points) <= MAX_LATTICE_POINTS
@@ -1032,7 +1039,9 @@ class TestDerivedCoordinateSignBoundary:
             halfspaces=_singleton_halfspaces(negative=False)
         )
         assert count_lattice_points(request).point_count == 1
-        enumerated = enumerate_lattice_points(request)
+        enumerated = enumerate_lattice_points(
+            EnumerateLatticePointsRequest.model_validate(request.model_dump())
+        )
         assert enumerated.points[0].coordinates == (BOUNDARY_COORDINATE,)
 
     @pytest.mark.scale

--- a/tests/math/geometry/polytopes/test_polytope.py
+++ b/tests/math/geometry/polytopes/test_polytope.py
@@ -117,6 +117,20 @@ def _facet_profile(vertices: tuple[Vertex, ...]) -> FacetIncidenceResult:
     return compute_facet_incidence(FacetIncidenceRequest(vertices=vertices))
 
 
+def test_serialized_facet_incidence_checks_source_relation() -> None:
+    claim = _facet_profile((_v((0, 1), (0, 1)), _v((1, 1), (0, 1)), _v((0, 1), (1, 1))))
+    decoded = FacetIncidenceResult.model_validate_json(claim.model_dump_json())
+    assert polytope_operations.verify_facet_incidence(decoded)
+    assert all(
+        polytope_operations.verify_primitive_facet(facet) for facet in decoded.facets
+    )
+    payload = decoded.model_dump(mode="json")
+    payload["vertices"][1]["coordinates"][0] = {"num": "2", "den": "1"}
+    assert not polytope_operations.verify_facet_incidence(
+        FacetIncidenceResult.model_validate(payload)
+    )
+
+
 class TestFacetIncidence:
     def test_schema_exposes_the_single_execution_budget(self) -> None:
         schema = FacetIncidenceRequest.model_json_schema()
@@ -265,40 +279,46 @@ class TestFacetIncidence:
         )
         result = _facet_profile(vertices)
 
-        with pytest.raises(ValidationError):
-            PrimitiveFacet(
-                halfspace=_scaled_halfspace(result.facets[0].halfspace, 3),
-                source_vertex_indices=result.facets[0].source_vertex_indices,
-            )
+        claim = PrimitiveFacet(
+            halfspace=_scaled_halfspace(result.facets[0].halfspace, 3),
+            source_vertex_indices=result.facets[0].source_vertex_indices,
+        )
+
+        decoded = PrimitiveFacet.model_validate_json(claim.model_dump_json())
+        assert not polytope_operations.verify_primitive_facet(decoded)
 
     def test_non_integer_facet_inequality_is_rejected(self) -> None:
         """A rational row whose cleared form is coprime is still not the
         canonical integral supporting inequality."""
 
-        with pytest.raises(ValidationError):
-            PrimitiveFacet(
-                halfspace=Halfspace(
-                    coefficients=(CanonicalRational(num="1", den="1"),),
-                    offset=CanonicalRational(num="1", den="2"),
-                ),
-                source_vertex_indices=(0, 3),
-            )
+        claim = PrimitiveFacet(
+            halfspace=Halfspace(
+                coefficients=(CanonicalRational(num="1", den="1"),),
+                offset=CanonicalRational(num="1", den="2"),
+            ),
+            source_vertex_indices=(0, 3),
+        )
+
+        decoded = PrimitiveFacet.model_validate_json(claim.model_dump_json())
+        assert not polytope_operations.verify_primitive_facet(decoded)
 
     def test_zero_normal_facet_inequality_is_rejected(self) -> None:
         """A tautology row is not a supporting inequality even though its
         primitive form is trivially coprime (offset +/-1)."""
 
-        with pytest.raises(ValidationError):
-            PrimitiveFacet(
-                halfspace=Halfspace(
-                    coefficients=(
-                        CanonicalRational(num="0", den="1"),
-                        CanonicalRational(num="0", den="1"),
-                    ),
-                    offset=CanonicalRational(num="1", den="1"),
+        claim = PrimitiveFacet(
+            halfspace=Halfspace(
+                coefficients=(
+                    CanonicalRational(num="0", den="1"),
+                    CanonicalRational(num="0", den="1"),
                 ),
-                source_vertex_indices=(0, 3),
-            )
+                offset=CanonicalRational(num="1", den="1"),
+            ),
+            source_vertex_indices=(0, 3),
+        )
+
+        decoded = PrimitiveFacet.model_validate_json(claim.model_dump_json())
+        assert not polytope_operations.verify_primitive_facet(decoded)
 
     def test_lower_dimensional_input_and_work_overflow_reject_during_execution(
         self,
@@ -1238,12 +1258,9 @@ class TestNonzeroNormalContractPublished:
     def test_zero_normal_row_rejected_at_request_admission(self) -> None:
         """The reviewer's tautology `0*x + 0*y <= 1` fails typed validation,
         not a host exception after acceptance."""
-        with pytest.raises(ValidationError) as error:
-            Halfspace(
-                coefficients=(_cr0(), _cr0()),
-                offset=_cr0(),
-            )
-        assert error.value.errors()[0]["type"] == "polytope.halfspace_normal_zero"
+        halfspace = Halfspace(coefficients=(_cr0(), _cr0()), offset=_cr0())
+        with pytest.raises(OperationDomainValidationError):
+            _volume_via_halfspaces((halfspace,))
 
     def test_nonzero_normal_rule_is_schema_visible(self) -> None:
         schema = Halfspace.model_json_schema()

--- a/tests/math/geometry/test_configuration_ops.py
+++ b/tests/math/geometry/test_configuration_ops.py
@@ -9,12 +9,17 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry._models import (
     CircumradiusProfileRequest,
     GeneralPositionRequest,
+    PointQuadrupleRequest,
+    PointTripleRequest,
     RationalPoint2D,
 )
 from jacobian.math.geometry._tools import (
     circumradius_profile,
+    collinear,
+    concyclic,
     general_position_search,
 )
+from jacobian.math.geometry.operations import verify_collinearity, verify_concyclicity
 
 
 def _point(x: str, y: str) -> RationalPoint2D:
@@ -80,6 +85,34 @@ class TestGeneralPosition:
             GeneralPositionRequest(
                 points=(_point("0", "0"), _point("0", "0"), _point("1", "0"))
             )
+
+
+def test_point_predicate_claims_round_trip_and_reject_forged_sources() -> None:
+    first = _point("0", "0")
+    second = _point("1", "0")
+    third = _point("2", "0")
+    collinear_claim = collinear(
+        PointTripleRequest(first=first, second=second, third=third)
+    )
+    assert verify_collinearity(
+        type(collinear_claim).model_validate_json(collinear_claim.model_dump_json())
+    )
+
+    payload = collinear_claim.model_dump(mode="json")
+    payload["request"]["third"] = _point("0", "1").model_dump(mode="json")
+    assert not verify_collinearity(type(collinear_claim).model_validate(payload))
+
+    concyclic_claim = concyclic(
+        PointQuadrupleRequest(
+            first=_point("1", "0"),
+            second=_point("0", "1"),
+            third=_point("-1", "0"),
+            fourth=_point("0", "-1"),
+        )
+    )
+    assert verify_concyclicity(
+        type(concyclic_claim).model_validate_json(concyclic_claim.model_dump_json())
+    )
 
 
 class TestCircumradiusProfile:

--- a/tests/math/geometry/test_euclidean_geometry.py
+++ b/tests/math/geometry/test_euclidean_geometry.py
@@ -35,6 +35,8 @@ from jacobian.math.geometry.euclidean.operations import (
     angles_equal,
     squared_segment_ratio,
     triangles_similar,
+    verify_angle_equality,
+    verify_triangle_similarity,
 )
 
 
@@ -545,6 +547,12 @@ class TestAngleEquality:
         )
         result = compute_angle_equality(req)
         assert result.equal is True
+        decoded = type(result).model_validate_json(result.model_dump_json())
+        assert verify_angle_equality(decoded)
+
+        payload = result.model_dump(mode="json")
+        payload["equal"] = False
+        assert not verify_angle_equality(type(result).model_validate(payload))
 
     def test_different_angles(self) -> None:
         req = AngleEqualityRequest(
@@ -611,6 +619,12 @@ class TestTriangleSimilarity:
         )
         result = compute_triangle_similarity(req)
         assert result.similar is True
+        decoded = type(result).model_validate_json(result.model_dump_json())
+        assert verify_triangle_similarity(decoded)
+
+        payload = result.model_dump(mode="json")
+        payload["similar"] = False
+        assert not verify_triangle_similarity(type(result).model_validate(payload))
 
     def test_not_similar(self) -> None:
         req = TriangleSimilarityRequest(

--- a/tests/math/geometry/test_euclidean_geometry.py
+++ b/tests/math/geometry/test_euclidean_geometry.py
@@ -38,6 +38,7 @@ from jacobian.math.geometry.euclidean.operations import (
     verify_angle_equality,
     verify_triangle_similarity,
 )
+from jacobian.math.geometry.operations import simple_polygon, verify_simple_polygon
 
 
 def _pt(x: int, y: int) -> RationalPoint2D:
@@ -109,6 +110,21 @@ def test_point_classification_rejects_non_simple_polygon_at_operation_boundary()
     assert exc_info.value.errors()[0]["type"] == (
         "geometry.point_classification_requires_a_simple_polygon"
     )
+
+
+def test_simple_polygon_claim_round_trips_and_rejects_a_forged_decision() -> None:
+    result = simple_polygon(
+        PolygonRequest(points=(_pt(0, 0), _pt(1, 0), _pt(1, 1), _pt(0, 1)))
+    )
+    assert verify_simple_polygon(
+        type(result).model_validate_json(result.model_dump_json())
+    )
+
+    payload = result.model_dump(mode="json")
+    payload["polygon"] = PolygonRequest(
+        points=(_pt(0, 0), _pt(1, 1), _pt(0, 1), _pt(1, 0))
+    ).model_dump(mode="json")
+    assert not verify_simple_polygon(type(result).model_validate(payload))
 
 
 class TestSegmentRatio:

--- a/tests/math/geometry/test_euclidean_geometry.py
+++ b/tests/math/geometry/test_euclidean_geometry.py
@@ -116,7 +116,7 @@ class TestSegmentRatio:
             segment2=(_pt(0, 0), _pt(1, 0)),
         )
         result = compute_segment_ratio(req)
-        assert result.squared_ratio == "1"
+        assert result.as_fraction() == 1
 
     def test_double_length(self) -> None:
         req = SegmentRatioRequest(
@@ -124,7 +124,7 @@ class TestSegmentRatio:
             segment2=(_pt(0, 0), _pt(1, 0)),
         )
         result = compute_segment_ratio(req)
-        assert result.squared_ratio == "4"
+        assert result.as_fraction() == 4
 
     def test_rejects_zero_second_segment(self) -> None:
         request = SegmentRatioRequest(
@@ -140,13 +140,10 @@ class TestSegmentRatio:
         first = (_pt(0, 0), _pt(2, 0))
         second = (_pt(0, 0), _pt(0, 1))
 
-        assert squared_segment_ratio(first, second) == 4
-        assert (
-            compute_segment_ratio(
-                SegmentRatioRequest(segment1=first, segment2=second)
-            ).squared_ratio
-            == "4"
-        )
+        assert squared_segment_ratio(first, second).as_fraction() == 4
+        assert compute_segment_ratio(
+            SegmentRatioRequest(segment1=first, segment2=second)
+        ) == squared_segment_ratio(first, second)
 
 
 class TestRationalWeightTriangulation:
@@ -600,6 +597,13 @@ class TestAngleEquality:
 
 
 class TestTriangleSimilarity:
+    def test_collinear_claim_decodes_but_consumer_rejects(self) -> None:
+        triangle = Triangle(a=_pt(0, 0), b=_pt(1, 1), c=_pt(2, 2))
+        decoded = Triangle.model_validate_json(triangle.model_dump_json())
+        with pytest.raises(OperationDomainValidationError) as caught:
+            triangles_similar(decoded, decoded)
+        assert caught.value.errors()[0]["type"] == "geometry.triangle_non_degenerate"
+
     def test_similar(self) -> None:
         req = TriangleSimilarityRequest(
             triangle1=Triangle(a=_pt(0, 0), b=_pt(1, 0), c=_pt(0, 1)),

--- a/tests/math/geometry/test_euclidean_geometry.py
+++ b/tests/math/geometry/test_euclidean_geometry.py
@@ -38,7 +38,11 @@ from jacobian.math.geometry.euclidean.operations import (
     verify_angle_equality,
     verify_triangle_similarity,
 )
-from jacobian.math.geometry.operations import simple_polygon, verify_simple_polygon
+from jacobian.math.geometry.operations import (
+    simple_polygon,
+    verify_polygon_point_classification,
+    verify_simple_polygon,
+)
 
 
 def _pt(x: int, y: int) -> RationalPoint2D:
@@ -110,6 +114,22 @@ def test_point_classification_rejects_non_simple_polygon_at_operation_boundary()
     assert exc_info.value.errors()[0]["type"] == (
         "geometry.point_classification_requires_a_simple_polygon"
     )
+
+
+def test_polygon_point_claim_round_trips_and_rejects_a_forged_source() -> None:
+    result = classify_polygon_point(
+        SimplePolygonPointRequest(
+            polygon=PolygonRequest(points=(_pt(0, 0), _pt(2, 0), _pt(2, 2), _pt(0, 2))),
+            point=_pt(1, 1),
+        )
+    )
+    assert verify_polygon_point_classification(
+        type(result).model_validate_json(result.model_dump_json())
+    )
+
+    payload = result.model_dump(mode="json")
+    payload["request"]["point"] = _pt(3, 3).model_dump(mode="json")
+    assert not verify_polygon_point_classification(type(result).model_validate(payload))
 
 
 def test_simple_polygon_claim_round_trips_and_rejects_a_forged_decision() -> None:

--- a/tests/math/geometry/test_euclidean_geometry.py
+++ b/tests/math/geometry/test_euclidean_geometry.py
@@ -128,22 +128,23 @@ def test_polygon_point_claim_round_trips_and_rejects_a_forged_source() -> None:
     )
 
     payload = result.model_dump(mode="json")
-    payload["request"]["point"] = _pt(3, 3).model_dump(mode="json")
+    payload["point"] = _pt(3, 3).model_dump(mode="json")
     assert not verify_polygon_point_classification(type(result).model_validate(payload))
 
 
 def test_simple_polygon_claim_round_trips_and_rejects_a_forged_decision() -> None:
-    result = simple_polygon(
-        PolygonRequest(points=(_pt(0, 0), _pt(1, 0), _pt(1, 1), _pt(0, 1)))
-    )
+    result = simple_polygon((_pt(0, 0), _pt(1, 0), _pt(1, 1), _pt(0, 1)))
     assert verify_simple_polygon(
         type(result).model_validate_json(result.model_dump_json())
     )
 
     payload = result.model_dump(mode="json")
-    payload["polygon"] = PolygonRequest(
-        points=(_pt(0, 0), _pt(1, 1), _pt(0, 1), _pt(1, 0))
-    ).model_dump(mode="json")
+    payload["polygon"] = [
+        _pt(0, 0).model_dump(mode="json"),
+        _pt(1, 1).model_dump(mode="json"),
+        _pt(0, 1).model_dump(mode="json"),
+        _pt(1, 0).model_dump(mode="json"),
+    ]
     assert not verify_simple_polygon(type(result).model_validate(payload))
 
 

--- a/tests/math/graphs/decomposition/tree_decompositions/test_public_api.py
+++ b/tests/math/graphs/decomposition/tree_decompositions/test_public_api.py
@@ -12,6 +12,11 @@ def test_exact_public_api_symbols() -> None:
         "bag_intersection_graph",
         "reroot",
         "restrict",
+        "verify_adhesions",
+        "verify_bag_intersection_graph",
+        "verify_reroot",
+        "verify_vertex_occurrences",
+        "verify_width",
         "vertex_occurrences",
         "width",
     )

--- a/tests/math/graphs/decomposition/tree_decompositions/test_serialized_profiles.py
+++ b/tests/math/graphs/decomposition/tree_decompositions/test_serialized_profiles.py
@@ -1,0 +1,76 @@
+"""Tree profiles retain their graph, bag-node and edge axes."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.decomposition.tree_decompositions import (
+    TreeDecomposition,
+    adhesions,
+    bag_intersection_graph,
+    reroot,
+    restrict,
+    verify_adhesions,
+    verify_bag_intersection_graph,
+    verify_reroot,
+    verify_vertex_occurrences,
+    verify_width,
+    vertex_occurrences,
+    width,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def test_empty_graph_and_bag_profiles_compose() -> None:
+    source = TreeDecomposition(
+        graph=SimpleUndirectedGraph(vertices=("a",), edges=()),
+        tree_nodes=("bag",),
+        tree_edges=(),
+        bags=(("a",),),
+    )
+    empty = restrict(source, frozenset())
+    decoded = TreeDecomposition.model_validate_json(empty.model_dump_json())
+    assert decoded.bags == ((),)
+    assert width(decoded).width == -1
+    assert vertex_occurrences(decoded).per_vertex == {}
+    assert adhesions(decoded).edges == ()
+    assert verify_width(width(decoded))
+    assert verify_vertex_occurrences(vertex_occurrences(decoded))
+    assert verify_adhesions(adhesions(decoded))
+    assert verify_reroot(reroot(decoded, "bag"))
+    assert verify_bag_intersection_graph(bag_intersection_graph(decoded))
+
+
+def test_single_bag_empty_edge_profiles() -> None:
+    source = TreeDecomposition(
+        graph=SimpleUndirectedGraph(vertices=("a",), edges=()),
+        tree_nodes=("bag",),
+        tree_edges=(),
+        bags=(("a",),),
+    )
+    result: Any
+    verifier: Callable[[Any], bool]
+    for result, verifier in (
+        (width(source), verify_width),
+        (reroot(source, "bag"), verify_reroot),
+        (vertex_occurrences(source), verify_vertex_occurrences),
+        (adhesions(source), verify_adhesions),
+    ):
+        assert result.decomposition == source
+        assert verifier(type(result).model_validate_json(result.model_dump_json()))
+    result = width(source)
+    payload = result.model_dump()
+    payload["width"] = 7
+    assert not verify_width(type(result).model_validate(payload))
+    rooted = reroot(source, "bag")
+    payload = rooted.model_dump()
+    payload["root"] = "foreign"
+    with pytest.raises(ValidationError):
+        type(rooted).model_validate(payload)
+    occurrence = vertex_occurrences(source)
+    payload = occurrence.model_dump()
+    payload["per_vertex"] = {"foreign": payload["per_vertex"]["a"]}
+    with pytest.raises(ValidationError):
+        type(occurrence).model_validate(payload)

--- a/tests/math/graphs/decomposition/tree_decompositions/test_tree_decompositions.py
+++ b/tests/math/graphs/decomposition/tree_decompositions/test_tree_decompositions.py
@@ -6,7 +6,10 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.graphs.decomposition.tree_decompositions import TreeDecomposition
+from jacobian.math.graphs.decomposition.tree_decompositions import (
+    TreeDecomposition,
+    width,
+)
 from jacobian.math.graphs.decomposition.tree_decompositions._models import (
     AdhesionsRequest,
     BagIntersectionGraphRequest,
@@ -159,7 +162,7 @@ class TestReroot:
         assert result.children["t1"] == ("t0",)
         assert result.depth["t1"] == 0
         assert result.depth["t0"] == 1
-        assert result.paths["t0"] == ["t1", "t0"]
+        assert result.paths["t0"] == ("t1", "t0")
 
     def test_reroot_preserves_unrooted_tree(self) -> None:
         td = _path_decomposition()
@@ -266,12 +269,14 @@ class TestBagIntersectionGraph:
 
 class TestValidation:
     def test_non_tree_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            TreeDecomposition(
-                graph=_path_graph(),
-                tree_nodes=("t0", "t1"),
-                tree_edges=(),
-                bags=(("a", "b"), ("b", "c")),
+        with pytest.raises(OperationDomainValidationError):
+            width(
+                TreeDecomposition(
+                    graph=_path_graph(),
+                    tree_nodes=("t0", "t1"),
+                    tree_edges=(),
+                    bags=(("a", "b"), ("b", "c")),
+                )
             )
 
     def test_unsorted_bag_rejected(self) -> None:
@@ -285,12 +290,14 @@ class TestValidation:
 
     def test_vertex_coverage_rejected(self) -> None:
         # Missing vertex c from all bags.
-        with pytest.raises(ValidationError):
-            TreeDecomposition(
-                graph=_path_graph(),
-                tree_nodes=("t0",),
-                tree_edges=(),
-                bags=(("a", "b"),),
+        with pytest.raises(OperationDomainValidationError):
+            width(
+                TreeDecomposition(
+                    graph=_path_graph(),
+                    tree_nodes=("t0",),
+                    tree_edges=(),
+                    bags=(("a", "b"),),
+                )
             )
 
     def test_edge_coverage_rejected(self) -> None:
@@ -300,12 +307,14 @@ class TestValidation:
             vertices=("a", "b", "c", "d"),
             edges=(("a", "b"), ("c", "d")),
         )
-        with pytest.raises(ValidationError):
-            TreeDecomposition(
-                graph=graph,
-                tree_nodes=("t0", "t1"),
-                tree_edges=(("t0", "t1"),),
-                bags=(("a", "b", "c"), ("a", "b", "d")),
+        with pytest.raises(OperationDomainValidationError):
+            width(
+                TreeDecomposition(
+                    graph=graph,
+                    tree_nodes=("t0", "t1"),
+                    tree_edges=(("t0", "t1"),),
+                    bags=(("a", "b", "c"), ("a", "b", "d")),
+                )
             )
 
     def test_connectedness_rejected(self) -> None:
@@ -315,12 +324,14 @@ class TestValidation:
             vertices=("a",),
             edges=(),
         )
-        with pytest.raises(ValidationError):
-            TreeDecomposition(
-                graph=graph,
-                tree_nodes=("t0", "t1", "t2"),
-                tree_edges=(("t0", "t1"), ("t1", "t2")),
-                bags=(("a",), (), ("a",)),
+        with pytest.raises(OperationDomainValidationError):
+            width(
+                TreeDecomposition(
+                    graph=graph,
+                    tree_nodes=("t0", "t1", "t2"),
+                    tree_edges=(("t0", "t1"), ("t1", "t2")),
+                    bags=(("a",), (), ("a",)),
+                )
             )
 
     def test_undeclared_vertex_rejected(self) -> None:

--- a/tests/math/graphs/flows/test_serialized_claims.py
+++ b/tests/math/graphs/flows/test_serialized_claims.py
@@ -129,6 +129,29 @@ def test_min_cost_flow_claim_checks_feasibility_and_cost() -> None:
     assert not verify_min_cost_flow(MinCostFlowResult.model_validate(unbound))
 
 
+def test_infeasible_min_cost_outcome_is_a_producer_outcome() -> None:
+    result = compute_min_cost_flow(
+        MinCostFlowRequest.model_validate(
+            {
+                "graph": {
+                    "vertex_count": 2,
+                    "edges": [
+                        {
+                            "source": 0,
+                            "target": 1,
+                            "capacity": {"num": "1", "den": "1"},
+                            "cost": {"num": "1", "den": "1"},
+                        }
+                    ],
+                },
+                "demands": [-2, 2],
+            }
+        )
+    )
+    assert result.feasible is False
+    assert not verify_min_cost_flow(result)
+
+
 def test_verifiers_reject_malformed_claims_without_raising() -> None:
     flow = compute_max_flow(
         MaxFlowRequest.model_validate(

--- a/tests/math/graphs/flows/test_serialized_claims.py
+++ b/tests/math/graphs/flows/test_serialized_claims.py
@@ -1,0 +1,70 @@
+"""Flow and cut witnesses stay bound to their source networks."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.flows import (
+    verify_edge_disjoint_paths,
+    verify_max_flow,
+    verify_min_cut,
+)
+from jacobian.math.graphs.flows._models import (
+    EdgeDisjointPathsRequest,
+    MaxFlowRequest,
+    MinCutRequest,
+)
+from jacobian.math.graphs.flows._tools import (
+    compute_edge_disjoint_paths,
+    compute_max_flow,
+    compute_min_cut,
+)
+
+
+def test_flow_cut_and_paths_round_trip() -> None:
+    graph = {
+        "vertex_count": 3,
+        "edges": [
+            {"source": 0, "target": 1, "capacity": {"num": "1", "den": "1"}},
+            {"source": 1, "target": 2, "capacity": {"num": "1", "den": "1"}},
+        ],
+    }
+    flow = compute_max_flow(
+        MaxFlowRequest.model_validate({"graph": graph, "source": 0, "sink": 2})
+    )
+    cut = compute_min_cut(
+        MinCutRequest.model_validate({"graph": graph, "source": 0, "sink": 2})
+    )
+    paths = compute_edge_disjoint_paths(
+        EdgeDisjointPathsRequest.model_validate(
+            {
+                "graph": {"vertex_count": 3, "edges": [[0, 1], [1, 2]]},
+                "source": 0,
+                "sink": 2,
+            }
+        )
+    )
+    result: Any
+    verifier: Callable[[Any], bool]
+    for result, verifier in (
+        (flow, verify_max_flow),
+        (cut, verify_min_cut),
+        (paths, verify_edge_disjoint_paths),
+    ):
+        assert verifier(type(result).model_validate_json(result.model_dump_json()))
+    payload = flow.model_dump(mode="json")
+    payload["flow_edges"] = []
+    payload["flow_value"] = {"num": "0", "den": "1"}
+    assert not verify_max_flow(type(flow).model_validate(payload))
+    payload = flow.model_dump(mode="json")
+    payload["flow_edges"][0]["target"] = 2
+    with pytest.raises(ValidationError):
+        type(flow).model_validate(payload)
+    payload = cut.model_dump(mode="json")
+    payload["cut_value"] = {"num": "2", "den": "1"}
+    assert not verify_min_cut(type(cut).model_validate(payload))
+    payload = paths.model_dump(mode="json")
+    payload["paths"] = [[0, 2]]
+    assert not verify_edge_disjoint_paths(type(paths).model_validate(payload))

--- a/tests/math/graphs/flows/test_serialized_claims.py
+++ b/tests/math/graphs/flows/test_serialized_claims.py
@@ -9,16 +9,22 @@ from pydantic import ValidationError
 from jacobian.math.graphs.flows import (
     verify_edge_disjoint_paths,
     verify_max_flow,
+    verify_min_cost_flow,
     verify_min_cut,
 )
 from jacobian.math.graphs.flows._models import (
     EdgeDisjointPathsRequest,
+    EdgeDisjointPathsResult,
     MaxFlowRequest,
+    MaxFlowResult,
+    MinCostFlowRequest,
+    MinCostFlowResult,
     MinCutRequest,
 )
 from jacobian.math.graphs.flows._tools import (
     compute_edge_disjoint_paths,
     compute_max_flow,
+    compute_min_cost_flow,
     compute_min_cut,
 )
 
@@ -68,3 +74,101 @@ def test_flow_cut_and_paths_round_trip() -> None:
     payload = paths.model_dump(mode="json")
     payload["paths"] = [[0, 2]]
     assert not verify_edge_disjoint_paths(type(paths).model_validate(payload))
+
+
+def _costed_graph() -> dict:
+    return {
+        "vertex_count": 3,
+        "edges": [
+            {
+                "source": 0,
+                "target": 1,
+                "capacity": {"num": "5", "den": "1"},
+                "cost": {"num": "1", "den": "1"},
+            },
+            {
+                "source": 1,
+                "target": 2,
+                "capacity": {"num": "5", "den": "1"},
+                "cost": {"num": "2", "den": "1"},
+            },
+            {
+                "source": 0,
+                "target": 2,
+                "capacity": {"num": "5", "den": "1"},
+                "cost": {"num": "4", "den": "1"},
+            },
+        ],
+    }
+
+
+def test_min_cost_flow_claim_checks_feasibility_and_cost() -> None:
+    result = compute_min_cost_flow(
+        MinCostFlowRequest.model_validate(
+            {"graph": _costed_graph(), "demands": [-2, 0, 2]}
+        )
+    )
+    assert result.feasible
+    assert verify_min_cost_flow(
+        MinCostFlowResult.model_validate_json(result.model_dump_json())
+    )
+    assert result.total_cost.as_fraction() == 6
+
+    forged = result.model_dump(mode="json")
+    forged["total_cost"] = {"num": "7", "den": "1"}
+    assert not verify_min_cost_flow(MinCostFlowResult.model_validate(forged))
+
+    over_capacity = result.model_dump(mode="json")
+    over_capacity["flow_edges"][0]["flow"] = {"num": "99", "den": "1"}
+    assert not verify_min_cost_flow(MinCostFlowResult.model_validate(over_capacity))
+
+    unbound = result.model_dump(mode="json")
+    unbound["flow_edges"].append(
+        {"source": 2, "target": 0, "flow": {"num": "1", "den": "1"}}
+    )
+    assert not verify_min_cost_flow(MinCostFlowResult.model_validate(unbound))
+
+
+def test_verifiers_reject_malformed_claims_without_raising() -> None:
+    flow = compute_max_flow(
+        MaxFlowRequest.model_validate(
+            {
+                "graph": {
+                    "vertex_count": 2,
+                    "edges": [
+                        {
+                            "source": 0,
+                            "target": 1,
+                            "capacity": {"num": "1", "den": "1"},
+                        }
+                    ],
+                },
+                "source": 0,
+                "sink": 1,
+            }
+        )
+    )
+    payload = flow.model_dump(mode="json")
+    payload["sink"] = 7
+    assert not verify_max_flow(MaxFlowResult.model_validate(payload))
+
+    with pytest.raises(ValidationError):
+        EdgeDisjointPathsResult.model_validate(
+            {
+                "graph": {"vertex_count": 2, "edges": [[0, 1]]},
+                "source": 0,
+                "sink": 1,
+                "path_count": 1,
+                "paths": [[]],
+            }
+        )
+    from jacobian.math.graphs.flows._models import EdgeDisjointPathsGraph
+
+    degenerate = EdgeDisjointPathsResult.model_construct(
+        graph=EdgeDisjointPathsGraph(vertex_count=2, edges=((0, 1),)),
+        source=0,
+        sink=1,
+        path_count=1,
+        paths=([],),
+    )
+    assert not verify_edge_disjoint_paths(degenerate)

--- a/tests/math/graphs/monochromatic_path/test_serialized_family.py
+++ b/tests/math/graphs/monochromatic_path/test_serialized_family.py
@@ -1,0 +1,33 @@
+"""Colored hypergraph families retain source color and vertex axes."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.monochromatic_path import (
+    construct_monochromatic_path_hypergraphs,
+    verify_monochromatic_path_hypergraphs,
+)
+from jacobian.math.graphs.values import ColoredUndirectedGraph, SimpleUndirectedGraph
+
+
+def test_empty_edge_family_axes_and_claim() -> None:
+    source = ColoredUndirectedGraph(
+        graph=SimpleUndirectedGraph(vertices=("a",), edges=()), edge_colors=()
+    )
+    result = construct_monochromatic_path_hypergraphs(source)
+    assert result.colours == ("uncolored",)
+    assert verify_monochromatic_path_hypergraphs(
+        type(result).model_validate_json(result.model_dump_json())
+    )
+    payload = result.model_dump(mode="json")
+    payload["colours"] = ["foreign"]
+    with pytest.raises(ValidationError):
+        type(result).model_validate(payload)
+    payload = result.model_dump(mode="json")
+    payload["hypergraphs"][0]["edges"] = []
+    assert not verify_monochromatic_path_hypergraphs(
+        type(result).model_validate(payload)
+    )
+    payload["hypergraphs"][0]["vertices"] = ["foreign"]
+    with pytest.raises(ValidationError):
+        type(result).model_validate(payload)

--- a/tests/math/graphs/path_decomposition/test_path_decomposition.py
+++ b/tests/math/graphs/path_decomposition/test_path_decomposition.py
@@ -9,6 +9,7 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.path_decomposition._models import PathDecompositionResult
 from jacobian.math.graphs.path_decomposition.operations import (
     compute_minimum_path_decomposition,
+    verify_path_decomposition,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -154,7 +155,7 @@ def test_result_bound_charges_only_active_path_vertices() -> None:
         {"path_count": 1, "paths": [["a", "b", "a"]]},
     ],
 )
-def test_result_requires_an_exact_source_edge_partition(payload_update: dict) -> None:
+def test_result_parsing_stays_structural(payload_update: dict) -> None:
     graph = _graph(["a", "b"], [("a", "b")])
     payload = {
         "graph": graph.model_dump(mode="json"),
@@ -164,3 +165,36 @@ def test_result_requires_an_exact_source_edge_partition(payload_update: dict) ->
     }
     with pytest.raises(ValidationError):
         PathDecompositionResult.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "bad_paths",
+    [
+        [["a", "b"], ["a", "b"]],
+        [],
+    ],
+)
+def test_verifier_rejects_non_partition_claims(bad_paths: list) -> None:
+    graph = _graph(["a", "b"], [("a", "b")])
+    claim = PathDecompositionResult.model_validate(
+        {
+            "graph": graph.model_dump(mode="json"),
+            "path_count": len(bad_paths),
+            "paths": bad_paths,
+        }
+    )
+    assert not verify_path_decomposition(claim)
+
+
+def test_serialized_partition_claim_round_trip() -> None:
+    graph = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    result = compute_minimum_path_decomposition(graph)
+    assert verify_path_decomposition(
+        PathDecompositionResult.model_validate_json(result.model_dump_json())
+    )
+    payload = result.model_dump(mode="json")
+    payload["paths"] = []
+    payload["path_count"] = 0
+    assert not verify_path_decomposition(
+        PathDecompositionResult.model_validate(payload)
+    )

--- a/tests/math/graphs/quivers/test_quivers.py
+++ b/tests/math/graphs/quivers/test_quivers.py
@@ -6,9 +6,11 @@ from jacobian.canonical import encode_strict_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.quivers._models import (
     AdjacencyMatricesRequest,
+    AdjacencyMatricesResult,
     FiniteQuiver,
     FixedLengthPathsRequest,
     VertexProfilesRequest,
+    VertexProfilesResult,
 )
 from jacobian.math.graphs.quivers._tools import TOOLS
 from jacobian.math.graphs.quivers.operations import (
@@ -33,6 +35,9 @@ def test_adjacency_matrices_kronecker() -> None:
     result = adjacency_matrices(request.quiver)
     assert result.adjacency_matrix == ((0, 2), (0, 0))
     assert result.transpose_matrix == ((0, 0), (2, 0))
+    assert (
+        AdjacencyMatricesResult.model_validate_json(result.model_dump_json()) == result
+    )
 
 
 def test_vertex_profiles_kronecker() -> None:
@@ -42,6 +47,7 @@ def test_vertex_profiles_kronecker() -> None:
     result = vertex_profiles(request.quiver)
     assert result.in_degrees == (0, 2)
     assert result.out_degrees == (2, 0)
+    assert VertexProfilesResult.model_validate_json(result.model_dump_json()) == result
 
 
 def test_fixed_length_paths_triangle() -> None:

--- a/tests/math/graphs/test_colored_graph_canonicalization.py
+++ b/tests/math/graphs/test_colored_graph_canonicalization.py
@@ -567,3 +567,29 @@ def test_catalog_execution_admits_the_parsed_request_once(
 
     assert result == expected
     assert admissions == [parsed.colored_graph]
+
+
+def test_serialized_relabeling_claim_is_verified_without_enumeration() -> None:
+    from jacobian.math.graphs.isomorphism import verify_colored_graph_canonicalization
+
+    graph = _graph(
+        ("a", "b", "c", "d"),
+        (("a", "b"), ("b", "c"), ("c", "d")),
+        vertex_colors=("endpoint", "middle", "middle", "endpoint"),
+        edge_colors=("outer", "middle", "outer"),
+    )
+    result = _canonicalize(graph)
+    assert verify_colored_graph_canonicalization(
+        ColoredGraphCanonicalizationResult.model_validate_json(result.model_dump_json())
+    )
+    forged = result.model_dump(mode="json")
+    forged["relabeling"][0]["canonical_vertex"] = forged["relabeling"][1][
+        "canonical_vertex"
+    ]
+    with pytest.raises(ValidationError):
+        ColoredGraphCanonicalizationResult.model_validate(forged)
+    recolored = result.model_dump(mode="json")
+    recolored["canonical_graph"]["edge_colors"][0] = "forged-color"
+    assert not verify_colored_graph_canonicalization(
+        ColoredGraphCanonicalizationResult.model_validate(recolored)
+    )

--- a/tests/math/graphs/test_constructors.py
+++ b/tests/math/graphs/test_constructors.py
@@ -10,11 +10,16 @@ from jacobian.math.graphs.constructors import (
     compute_triangle_profile,
     construct_hypercube_graph,
     construct_keller_graph,
+    verify_hypercube_graph,
+    verify_keller_graph,
+    verify_triangle_profile,
 )
 from jacobian.math.graphs.constructors._bounds import (
     MAX_TRIANGLE_PROFILE_RETAINED_LABEL_CHARACTERS,
 )
 from jacobian.math.graphs.constructors._models import (
+    HypercubeGraphResult,
+    KellerGraphResult,
     TriangleProfileRequest,
     TriangleProfileResult,
 )
@@ -343,6 +348,53 @@ class TestTriangleProfile:
         result = compute_triangle_profile(graph)
         # Triangles: (a,b,c) and (a,c,d)
         assert result.triangle_count == 2
+
+
+class TestSerializedClaimVerifiers:
+    def test_hypercube_round_trip_and_forged_edge(self) -> None:
+        result = construct_hypercube_graph(2)
+        assert verify_hypercube_graph(
+            HypercubeGraphResult.model_validate_json(result.model_dump_json())
+        )
+        payload = result.model_dump(mode="json")
+        payload["graph"]["edges"] = [[0, 1], [0, 2], [0, 3]]
+        assert not verify_hypercube_graph(HypercubeGraphResult.model_validate(payload))
+
+    def test_keller_round_trip_and_forged_edge(self) -> None:
+        result = construct_keller_graph(1)
+        assert verify_keller_graph(
+            KellerGraphResult.model_validate_json(result.model_dump_json())
+        )
+        payload = result.model_dump(mode="json")
+        payload["graph"]["edges"] = [[0, 1]]
+        assert not verify_keller_graph(KellerGraphResult.model_validate(payload))
+
+    def test_triangle_round_trip_forged_and_dropped(self) -> None:
+        graph = SimpleUndirectedGraph(
+            vertices=("a", "b", "c", "d"),
+            edges=(("a", "b"), ("b", "c"), ("a", "c"), ("c", "d")),
+        )
+        result = compute_triangle_profile(graph)
+        assert result.triangle_count == 1
+        assert verify_triangle_profile(
+            TriangleProfileResult.model_validate_json(result.model_dump_json())
+        )
+        forged = result.model_dump(mode="json")
+        forged["triangles"] = [{"vertices": ["a", "b", "d"]}]
+        forged["triangle_count"] = 1
+        assert not verify_triangle_profile(TriangleProfileResult.model_validate(forged))
+        dropped = result.model_dump(mode="json")
+        dropped["triangles"] = []
+        dropped["triangle_count"] = 0
+        assert not verify_triangle_profile(
+            TriangleProfileResult.model_validate(dropped)
+        )
+
+    def test_dimension_bounds_are_domain_errors(self) -> None:
+        with pytest.raises(OperationDomainValidationError, match="dimension"):
+            construct_hypercube_graph(9)
+        with pytest.raises(OperationDomainValidationError, match="dimension"):
+            construct_keller_graph(5)
 
 
 def _to_word(n: int, d: int) -> tuple[int, ...]:

--- a/tests/math/graphs/test_graph_distance_matrix.py
+++ b/tests/math/graphs/test_graph_distance_matrix.py
@@ -13,6 +13,7 @@ from typing import cast
 import pytest
 from pydantic import ValidationError
 
+from jacobian.math.graphs.optimization import verify_distance_matrix
 from jacobian.math.graphs.optimization._distance_matrix import (
     DISTANCE_MATRIX_OPERATION,
     compute_distance_matrix,
@@ -22,6 +23,7 @@ from jacobian.math.graphs.optimization._distance_models import (
     GraphDistanceMatrixResult,
     GraphDistanceRow,
 )
+from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 
 def _request(vertices: list[str], edges: list[list[str]]) -> GraphDistanceMatrixRequest:
@@ -155,7 +157,7 @@ def test_result_rejects_rows_reordered_away_from_the_canonical_axis() -> None:
             vertex_ordering="LEXICOGRAPHIC_ASCENDING",
             pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
             unreachable_representation="JSON_NULL",
-            vertices=("1", "10", "2"),
+            graph=SimpleUndirectedGraph(vertices=("1", "10", "2"), edges=()),
             rows=(
                 _row("1", [0, 1, 1]),
                 _row("2", [1, 0, 1]),
@@ -173,7 +175,7 @@ def test_result_rejects_relabelled_rows_over_the_same_positions() -> None:
             vertex_ordering="LEXICOGRAPHIC_ASCENDING",
             pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
             unreachable_representation="JSON_NULL",
-            vertices=("1", "10", "2"),
+            graph=SimpleUndirectedGraph(vertices=("1", "10", "2"), edges=()),
             rows=(
                 _row("10", [0, 1, 1]),
                 _row("1", [1, 0, 1]),
@@ -186,8 +188,8 @@ def test_result_rejects_relabelled_rows_over_the_same_positions() -> None:
 @pytest.mark.parametrize(
     ("vertices", "message"),
     [
-        (("2", "10", "1"), "unique and sorted"),
-        (("1", "1", "2"), "unique and sorted"),
+        (("2", "10", "1"), "canonical vertex"),
+        (("1", "1", "2"), "unique"),
     ],
 )
 def test_result_rejects_unsorted_or_duplicate_vertices(
@@ -199,7 +201,7 @@ def test_result_rejects_unsorted_or_duplicate_vertices(
             vertex_ordering="LEXICOGRAPHIC_ASCENDING",
             pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
             unreachable_representation="JSON_NULL",
-            vertices=vertices,
+            graph=SimpleUndirectedGraph(vertices=vertices, edges=()),
             rows=tuple(_complete_rows(list(vertices))),
             connected=True,
         )
@@ -212,7 +214,7 @@ def test_result_rejects_missing_rows_and_nonsquare_rows() -> None:
             vertex_ordering="LEXICOGRAPHIC_ASCENDING",
             pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
             unreachable_representation="JSON_NULL",
-            vertices=vertices,
+            graph=SimpleUndirectedGraph(vertices=vertices, edges=()),
             rows=tuple(_complete_rows(list(vertices))[:2]),
             connected=True,
         )
@@ -221,7 +223,7 @@ def test_result_rejects_missing_rows_and_nonsquare_rows() -> None:
             vertex_ordering="LEXICOGRAPHIC_ASCENDING",
             pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
             unreachable_representation="JSON_NULL",
-            vertices=vertices,
+            graph=SimpleUndirectedGraph(vertices=vertices, edges=()),
             rows=(
                 _row("1", [0, 1]),
                 _row("10", [1, 0]),
@@ -269,19 +271,21 @@ def test_result_rejects_broken_metric_invariants(
             vertex_ordering="LEXICOGRAPHIC_ASCENDING",
             pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
             unreachable_representation="JSON_NULL",
-            vertices=("1", "10", "2"),
+            graph=SimpleUndirectedGraph(vertices=("1", "10", "2"), edges=()),
             rows=rows,
             connected=True,
         )
 
 
 def test_result_rejects_connected_mismatch() -> None:
-    with pytest.raises(ValidationError):
-        GraphDistanceMatrixResult(
-            vertex_ordering="LEXICOGRAPHIC_ASCENDING",
-            pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
-            unreachable_representation="JSON_NULL",
-            vertices=("1", "10", "2"),
-            rows=tuple(_complete_rows(["1", "10", "2"])),
-            connected=False,
-        )
+    claim = GraphDistanceMatrixResult(
+        vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+        pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
+        unreachable_representation="JSON_NULL",
+        graph=SimpleUndirectedGraph(vertices=("1", "10", "2"), edges=()),
+        rows=tuple(_complete_rows(["1", "10", "2"])),
+        connected=False,
+    )
+    assert not verify_distance_matrix(
+        GraphDistanceMatrixResult.model_validate_json(claim.model_dump_json())
+    )

--- a/tests/math/graphs/test_graph_independence_polynomial.py
+++ b/tests/math/graphs/test_graph_independence_polynomial.py
@@ -287,14 +287,16 @@ def test_result_rejects_a_polynomial_inconsistent_with_dense_coefficients() -> N
             ]
         },
     }
-    with pytest.raises(ValidationError):
+    from jacobian.math.graphs.polynomials import verify_independence_polynomial
+
+    assert not verify_independence_polynomial(
         TreeIndependencePolynomialResult.model_validate(weaker)
+    )
 
 
 @pytest.mark.parametrize(
     ("field", "replacement", "message"),
     [
-        ("coefficients", ["1", "4", "2"], "count must equal the dense coefficient sum"),
         ("independence_number", 1, "must equal the dense coefficient degree"),
         ("independent_set_count", "7", "count must equal the dense coefficient sum"),
     ],
@@ -309,8 +311,11 @@ def test_result_rejects_mutated_derived_values(
     ).model_dump(mode="json")
     valid[field] = replacement
 
-    with pytest.raises(ValidationError, match=message):
+    from jacobian.math.graphs.polynomials import verify_independence_polynomial
+
+    assert not verify_independence_polynomial(
         TreeIndependencePolynomialResult.model_validate(valid)
+    )
 
 
 def test_result_rejects_a_polynomial_outside_qq_x() -> None:
@@ -371,6 +376,8 @@ def test_native_module_exports_canonical_value_and_dense_projection() -> None:
         "independence_polynomial_coefficients",
         "matching_polynomial",
         "tutte_polynomial",
+        "verify_graph_polynomial",
+        "verify_independence_polynomial",
     ]
     assert all(hasattr(polynomials, name) for name in polynomials.__all__)
     assert type(independence_polynomial(_path(2))) is RationalPolynomial

--- a/tests/math/graphs/test_graph_isomorphism.py
+++ b/tests/math/graphs/test_graph_isomorphism.py
@@ -14,6 +14,7 @@ from jacobian.math.graphs.isomorphism._models import (
 )
 from jacobian.math.graphs.isomorphism._vf2_process import (
     decide_graph_isomorphism,
+    verify_graph_isomorphism,
 )
 
 # ---------------------------------------------------------------------------
@@ -90,10 +91,25 @@ def test_nonisomorphic_result_rejects_vertex_mappings() -> None:
     with pytest.raises(ValidationError):
         GraphIsomorphismResult.model_validate(
             {
+                "graph_a": {"vertex_count": 1, "edges": []},
+                "graph_b": {"vertex_count": 1, "edges": []},
                 "status": "NOT_ISOMORPHIC",
                 "vertex_mapping": [{"from_vertex": 0, "to_vertex": 0}],
             }
         )
+
+
+def test_serialized_isomorphism_claim_is_verified_against_its_graphs() -> None:
+    result = _decide(
+        {"vertex_count": 3, "edges": [(0, 1), (1, 2)]},
+        {"vertex_count": 3, "edges": [(0, 2), (1, 2)]},
+    )
+    assert verify_graph_isomorphism(
+        GraphIsomorphismResult.model_validate_json(result.model_dump_json())
+    )
+    payload = result.model_dump(mode="json")
+    payload["vertex_mapping"][1]["to_vertex"] = 0
+    assert not verify_graph_isomorphism(GraphIsomorphismResult.model_validate(payload))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/math/graphs/test_graph_isomorphism.py
+++ b/tests/math/graphs/test_graph_isomorphism.py
@@ -112,6 +112,15 @@ def test_serialized_isomorphism_claim_is_verified_against_its_graphs() -> None:
     assert not verify_graph_isomorphism(GraphIsomorphismResult.model_validate(payload))
 
 
+def test_negative_outcome_is_a_producer_outcome_not_a_claim() -> None:
+    result = _decide(
+        {"vertex_count": 3, "edges": [(0, 1), (1, 2)]},
+        {"vertex_count": 3, "edges": []},
+    )
+    assert result.status == "NOT_ISOMORPHIC"
+    assert not verify_graph_isomorphism(result)
+
+
 # ---------------------------------------------------------------------------
 # Path graphs
 # ---------------------------------------------------------------------------

--- a/tests/math/graphs/test_graph_polynomials.py
+++ b/tests/math/graphs/test_graph_polynomials.py
@@ -7,13 +7,12 @@ from jacobian.math.graphs.polynomials._models import (
     GraphPolynomialRequest,
     GraphPolynomialResult,
     MatchingPolynomialRequest,
-    SparseMultivariatePolynomial,
 )
-from jacobian.math.graphs.polynomials.operations import (
-    chromatic_polynomial,
-    flow_polynomial,
-    matching_polynomial,
-    tutte_polynomial,
+from jacobian.math.graphs.polynomials._tools import (
+    _run_chromatic,
+    _run_flow,
+    _run_matching,
+    _run_tutte,
 )
 from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
@@ -29,25 +28,10 @@ def _path_graph(n: int) -> IndexedSimpleUndirectedGraph:
 
 
 def _terms_to_dict(result: GraphPolynomialResult) -> dict[int, int]:
-    return {t.degree: t.coefficient for t in result.terms}
-
-
-def _run_tutte(request: GraphPolynomialRequest) -> SparseMultivariatePolynomial:
-    return SparseMultivariatePolynomial(
-        variables=("x", "y"), terms=tutte_polynomial(request.graph)
-    )
-
-
-def _run_chromatic(request: GraphPolynomialRequest) -> GraphPolynomialResult:
-    return GraphPolynomialResult(terms=chromatic_polynomial(request.graph))
-
-
-def _run_flow(request: GraphPolynomialRequest) -> GraphPolynomialResult:
-    return GraphPolynomialResult(terms=flow_polynomial(request.graph))
-
-
-def _run_matching(request: MatchingPolynomialRequest) -> GraphPolynomialResult:
-    return GraphPolynomialResult(terms=matching_polynomial(request.graph))
+    return {
+        t.exponents[0]: int(t.coefficient.num)
+        for t in result.polynomial.polynomial.terms
+    }
 
 
 class TestTuttePolynomial:
@@ -55,8 +39,11 @@ class TestTuttePolynomial:
         req = GraphPolynomialRequest(graph=_cycle_graph(4))
         result = _run_tutte(req)
         # T(C4, x, y) = x^3 + x^2 + x + y
-        d = {term.exponents: term.coefficient for term in result.terms}
-        assert result.variables == ("x", "y")
+        d = {
+            term.exponents: int(term.coefficient.num)
+            for term in result.polynomial.polynomial.terms
+        }
+        assert result.polynomial.variables == ("x", "y")
         assert d == {(0, 1): 1, (1, 0): 1, (2, 0): 1, (3, 0): 1}
 
     def test_single_edge(self) -> None:
@@ -65,7 +52,10 @@ class TestTuttePolynomial:
         )
         result = _run_tutte(req)
         # T(K2) = x
-        d = {term.exponents: term.coefficient for term in result.terms}
+        d = {
+            term.exponents: int(term.coefficient.num)
+            for term in result.polynomial.polynomial.terms
+        }
         assert d == {(1, 0): 1}
 
 
@@ -113,7 +103,7 @@ class TestFlowPolynomial:
             graph=IndexedSimpleUndirectedGraph(vertex_count=2, edges=((0, 1),))
         )
         result = _run_flow(req)
-        assert result.terms == ()
+        assert result.polynomial.polynomial.terms == ()
 
 
 class TestMatchingPolynomial:

--- a/tests/math/graphs/test_graph_realization.py
+++ b/tests/math/graphs/test_graph_realization.py
@@ -202,7 +202,9 @@ class TestGraphRealization:
         )
         payload = result.model_dump(mode="json")
         payload["graph"]["edges"] = [[0, 1], [1, 2], [0, 3]]
-        assert not verify_graph_realization(GraphRealizationResult.model_validate(payload))
+        assert not verify_graph_realization(
+            GraphRealizationResult.model_validate(payload)
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -343,7 +345,9 @@ class TestCrossConsistency:
         )
         forged = check.model_dump(mode="json")
         forged["is_realization"] = False
-        assert not verify_realization_check(RealizationCheckResult.model_validate(forged))
+        assert not verify_realization_check(
+            RealizationCheckResult.model_validate(forged)
+        )
 
     def test_constructed_graph_passes_check(self) -> None:
         """A graph constructed by Havel-Hakimi must pass the realization check."""

--- a/tests/math/graphs/test_regular_subgraph.py
+++ b/tests/math/graphs/test_regular_subgraph.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from jacobian.math.graphs.regular_subgraph._models import RegularSubgraphResult
 from jacobian.math.graphs.regular_subgraph.operations import (
     find_k_regular_subgraph,
+    verify_k_regular_subgraph,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -88,3 +90,14 @@ def test_k3_is_3_regular_in_k4() -> None:
         degree[u] = degree.get(u, 0) + 1
         degree[v] = degree.get(v, 0) + 1
     assert all(d == 3 for d in degree.values())
+
+
+def test_serialized_witness_claim_is_verified_against_its_graph() -> None:
+    graph = _graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    result = find_k_regular_subgraph(graph, 1)
+    assert verify_k_regular_subgraph(
+        RegularSubgraphResult.model_validate_json(result.model_dump_json())
+    )
+    forged = result.model_dump(mode="json")
+    forged["edges"] = [["a", "b"], ["b", "c"]]
+    assert not verify_k_regular_subgraph(RegularSubgraphResult.model_validate(forged))

--- a/tests/math/graphs/test_serialized_invariant_claims.py
+++ b/tests/math/graphs/test_serialized_invariant_claims.py
@@ -1,0 +1,77 @@
+"""Graph-relative claims require explicit relation checking."""
+
+from itertools import combinations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.chordal import recognize_chordal, verify_chordality
+from jacobian.math.graphs.chordal._models import ChordalRecognitionResult
+from jacobian.math.graphs.optimization import (
+    verify_graph_invariant,
+    verify_maximum_matching,
+)
+from jacobian.math.graphs.optimization._invariant_models import (
+    GraphCoreResult,
+    GraphGirthResult,
+    GraphMaximumMatchingRequest,
+    GraphMaximumMatchingResult,
+)
+from jacobian.math.graphs.optimization._invariants import _maximum_matching_execute
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def test_chordality_checks_chords_and_later_neighbors() -> None:
+    vertices = ("a", "b", "c", "d")
+    complete = SimpleUndirectedGraph(
+        vertices=vertices, edges=tuple(combinations(vertices, 2))
+    )
+    cycle = SimpleUndirectedGraph(
+        vertices=vertices, edges=(("a", "b"), ("a", "d"), ("b", "c"), ("c", "d"))
+    )
+    forged_cycle = ChordalRecognitionResult(
+        graph=complete, status="NONCHORDAL", induced_cycle=vertices
+    )
+    forged_order = ChordalRecognitionResult(
+        graph=cycle, status="CHORDAL", elimination_ordering=vertices
+    )
+    for claim in (forged_cycle, forged_order):
+        assert not verify_chordality(
+            ChordalRecognitionResult.model_validate_json(claim.model_dump_json())
+        )
+    for graph in (complete, cycle, SimpleUndirectedGraph(vertices=(), edges=())):
+        result = recognize_chordal(graph)
+        assert verify_chordality(
+            ChordalRecognitionResult.model_validate_json(result.model_dump_json())
+        )
+
+
+@pytest.mark.parametrize("change", ["edge", "barrier", "odd_components"])
+def test_matching_certificate_checks_source_relation(change: str) -> None:
+    graph = SimpleUndirectedGraph(vertices=("a", "b", "c"), edges=(("a", "b"),))
+    result = _maximum_matching_execute(GraphMaximumMatchingRequest(graph=graph))
+    payload = result.model_dump(mode="json")
+    assert verify_maximum_matching(GraphMaximumMatchingResult.model_validate(payload))
+    if change == "edge":
+        payload["witness_edges"] = [["a", "c"]]
+    elif change == "barrier":
+        payload["certificate"]["barrier_vertices"] = ["outside"]
+    else:
+        payload["certificate"]["odd_component_count"] = 0
+    assert not verify_maximum_matching(
+        GraphMaximumMatchingResult.model_validate(payload)
+    )
+
+
+def test_graph_invariant_and_core_keep_source() -> None:
+    graph = SimpleUndirectedGraph(vertices=("a",), edges=())
+    forged = GraphGirthResult(graph=graph, girth=3, has_cycle=True)
+    assert not verify_graph_invariant(
+        GraphGirthResult.model_validate_json(forged.model_dump_json())
+    )
+    valid = GraphCoreResult(graph=graph, k=1, vertices=())
+    assert verify_graph_invariant(
+        GraphCoreResult.model_validate_json(valid.model_dump_json())
+    )
+    with pytest.raises(ValidationError, match="source graph"):
+        GraphCoreResult(graph=graph, k=0, vertices=("outside",))

--- a/tests/math/groups/abelian/test_fg_abelian_groups.py
+++ b/tests/math/groups/abelian/test_fg_abelian_groups.py
@@ -20,6 +20,7 @@ from jacobian.math.groups.abelian.operations import (
     normalize_presentation,
     quotient_group,
     reduce_element,
+    verify_element_order,
     verify_elements_equal,
 )
 
@@ -93,6 +94,12 @@ def test_element_order_in_z6() -> None:
     request = ElementOrderRequest(invariant_factors=(6,), coordinates=(2,))
     result = compute_element_order(request)
     assert result.order == 3
+    decoded = type(result).model_validate_json(result.model_dump_json())
+    assert verify_element_order(decoded)
+
+    payload = result.model_dump(mode="json")
+    payload["order"] = 6
+    assert not verify_element_order(type(result).model_validate(payload))
 
 
 def test_element_order_identity() -> None:

--- a/tests/math/groups/abelian/test_fg_abelian_groups.py
+++ b/tests/math/groups/abelian/test_fg_abelian_groups.py
@@ -20,6 +20,7 @@ from jacobian.math.groups.abelian.operations import (
     normalize_presentation,
     quotient_group,
     reduce_element,
+    verify_elements_equal,
 )
 
 
@@ -72,6 +73,12 @@ def test_element_equal_same() -> None:
     )
     result = compute_element_equal(request)
     assert result.equal is True
+    decoded = type(result).model_validate_json(result.model_dump_json())
+    assert verify_elements_equal(decoded)
+
+    payload = result.model_dump(mode="json")
+    payload["equal"] = False
+    assert not verify_elements_equal(type(result).model_validate(payload))
 
 
 def test_element_equal_different() -> None:

--- a/tests/math/groups/abelian/test_fg_abelian_groups.py
+++ b/tests/math/groups/abelian/test_fg_abelian_groups.py
@@ -22,6 +22,8 @@ from jacobian.math.groups.abelian.operations import (
     reduce_element,
     verify_element_order,
     verify_elements_equal,
+    verify_generated_subgroup,
+    verify_quotient_group,
 )
 
 
@@ -173,6 +175,26 @@ def test_subgroup_generated_z2_x_z4() -> None:
     request = SubgroupGeneratedRequest(invariant_factors=(2, 4), generators=((1, 0),))
     result = compute_subgroup_generated(request)
     assert result.index == 4
+    assert verify_generated_subgroup(
+        type(result).model_validate_json(result.model_dump_json())
+    )
+
+    payload = result.model_dump(mode="json")
+    payload["index"] = 2
+    assert not verify_generated_subgroup(type(result).model_validate(payload))
+
+
+def test_quotient_claim_round_trips_and_rejects_a_forged_order() -> None:
+    result = compute_quotient(
+        QuotientRequest(invariant_factors=(6,), subgroup_generators=((2,),))
+    )
+    assert verify_quotient_group(
+        type(result).model_validate_json(result.model_dump_json())
+    )
+
+    payload = result.model_dump(mode="json")
+    payload["quotient_order"] = 3
+    assert not verify_quotient_group(type(result).model_validate(payload))
 
 
 @pytest.mark.parametrize(

--- a/tests/math/groups/actions/test_serialized_claims.py
+++ b/tests/math/groups/actions/test_serialized_claims.py
@@ -1,0 +1,32 @@
+"""Action relations are checked explicitly after structural decoding."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian.math.groups.actions import (
+    burnside_count,
+    cycle_index,
+    element_cycles,
+    polya_inventory,
+    verify_burnside_count,
+    verify_cycle_index,
+    verify_element_cycles,
+    verify_polya_inventory,
+)
+from jacobian.math.groups.actions._models import FinitePermutationAction
+
+
+def test_serialized_action_claims() -> None:
+    action = FinitePermutationAction(domain=("a", "b"), generators=((1, 0),))
+    result: Any
+    verifier: Callable[[Any], bool]
+    for result, verifier, field, forged in (
+        (element_cycles(action, 0), verify_element_cycles, "support", (0,)),
+        (cycle_index(action), verify_cycle_index, "group_order", 3),
+        (burnside_count(action), verify_burnside_count, "fixed_point_sum", 0),
+        (polya_inventory(action, 2), verify_polya_inventory, "terms", (((0, 1), 1),)),
+    ):
+        assert verifier(type(result).model_validate_json(result.model_dump_json()))
+        payload = result.model_dump()
+        payload[field] = forged
+        assert not verifier(type(result).model_validate(payload))

--- a/tests/math/groups/cohomology/test_serialized_claims.py
+++ b/tests/math/groups/cohomology/test_serialized_claims.py
@@ -1,0 +1,19 @@
+"""Cohomology table identities remain source-bound consumer claims."""
+
+from jacobian.math.groups._models import PermutationGroup
+from jacobian.math.groups.cohomology import group_cohomology, verify_cohomology
+
+
+def test_forged_cohomology_claims() -> None:
+    result = group_cohomology(PermutationGroup(degree=2, generators=((1, 0),)), 2, 1)
+    assert verify_cohomology(type(result).model_validate_json(result.model_dump_json()))
+    for field, value in (("group_order", 3),):
+        payload = result.model_dump()
+        payload[field] = value
+        assert not verify_cohomology(type(result).model_validate(payload))
+    payload = result.model_dump()
+    payload["groups"][0]["betti"] = 0
+    assert not verify_cohomology(type(result).model_validate(payload))
+    payload = result.model_dump()
+    payload["groups"][1]["cochain_dimension"] = 4
+    assert not verify_cohomology(type(result).model_validate(payload))

--- a/tests/math/lattices/test_serialized_claims.py
+++ b/tests/math/lattices/test_serialized_claims.py
@@ -1,0 +1,62 @@
+"""Lattice relation sources and exact scalars survive serialization."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.lattices import (
+    IntegerLattice,
+    compute_discriminant_group,
+    compute_rank_gram,
+    compute_sublattice_index,
+    verify_discriminant_group,
+    verify_rank_gram,
+    verify_sublattice_index,
+)
+from jacobian.math.matrices.values import IntegerMatrix
+
+
+def test_source_bound_lattice_claims() -> None:
+    parent = IntegerLattice(
+        ambient_dimension=2, basis=IntegerMatrix(entries=(("1", "0"),))
+    )
+    child = IntegerLattice(
+        ambient_dimension=2, basis=IntegerMatrix(entries=(("2", "0"),))
+    )
+    result: Any
+    verifier: Callable[[Any], bool]
+    for result, verifier, field, forged in (
+        (compute_rank_gram(child), verify_rank_gram, "covolume_rational", False),
+        (
+            compute_discriminant_group(child),
+            verify_discriminant_group,
+            "invariant_factors",
+            ["8"],
+        ),
+        (
+            compute_sublattice_index(child, parent, IntegerMatrix(entries=(("2",),))),
+            verify_sublattice_index,
+            "index",
+            3,
+        ),
+    ):
+        assert verifier(type(result).model_validate_json(result.model_dump_json()))
+        payload = result.model_dump()
+        payload[field] = forged
+        assert not verifier(type(result).model_validate(payload))
+
+
+def test_covolume_is_canonical_and_bound_to_source() -> None:
+    lattice = IntegerLattice(
+        ambient_dimension=1, basis=IntegerMatrix(entries=(("2",),))
+    )
+    result = compute_rank_gram(lattice)
+    payload = result.model_dump()
+    payload["lattice"]["basis"]["entries"] = [["3"]]
+    assert not verify_rank_gram(type(result).model_validate(payload))
+    for malformed in ("anything", "+4", "04", "-0"):
+        payload["squared_covolume"] = malformed
+        with pytest.raises(ValidationError):
+            type(result).model_validate(payload)

--- a/tests/math/logic/term_rewriting/test_substitution_composition.py
+++ b/tests/math/logic/term_rewriting/test_substitution_composition.py
@@ -1,0 +1,30 @@
+"""Matching and unification return the substitution consumer's own carrier."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.logic.term_rewriting.operations import (
+    matching_result,
+    substitution_result,
+    unification_result,
+)
+from jacobian.math.logic.term_rewriting.values import RankedSignature, Term
+
+
+@pytest.mark.parametrize("unify", [False, True])
+def test_serialized_substitution_composes(unify: bool) -> None:
+    signature = RankedSignature(arities=(0,))
+    variable = Term(is_variable=True, symbol=7, children=())
+    constant = Term(is_variable=False, symbol=0, children=())
+    result = (unification_result if unify else matching_result)(
+        signature, variable, constant
+    )
+    decoded = type(result).model_validate_json(result.model_dump_json())
+    assert (
+        substitution_result(signature, variable, decoded.substitution).result
+        == constant
+    )
+    payload = result.model_dump()
+    payload["substitution"]["mapping"] = {-1: constant.model_dump()}
+    with pytest.raises(ValidationError):
+        type(result).model_validate(payload)

--- a/tests/math/logic/term_rewriting/test_term_rewriting.py
+++ b/tests/math/logic/term_rewriting/test_term_rewriting.py
@@ -106,7 +106,9 @@ def _validation_error(code: str) -> Iterator[None]:
 
     with pytest.raises((ValidationError, OperationDomainValidationError)) as caught:
         yield
-    assert caught.value.errors()[0]["type"] == code
+    error = caught.value
+    assert isinstance(error, (ValidationError, OperationDomainValidationError))
+    assert error.errors()[0]["type"] == code
 
 
 def _signature(*arities: int) -> RankedSignature:
@@ -373,7 +375,7 @@ class TestUnification:
             UnificationRequest(signature=_signature(2, 0, 0), left=left, right=right)
         )
         assert wire_result.unified
-        assert wire_result.substitution == result
+        assert wire_result.substitution.mapping == result
 
 
 class TestRewriteStep:
@@ -385,7 +387,7 @@ class TestRewriteStep:
         assert len(applications) == 1
         assert applications[0].position == ()
         assert applications[0].rule_index == 0
-        assert applications[0].substitution == {0: _app(2)}
+        assert applications[0].substitution.mapping == {0: _app(2)}
         assert applications[0].term == _app(1, _app(2))
 
     def test_rewrite_in_child(self) -> None:
@@ -541,7 +543,7 @@ class TestCriticalPairs:
         assert pair.candidate_index == 2
         assert pair.outer_variable_renaming == {7: 0}
         assert pair.inner_variable_renaming == {99: 1}
-        assert pair.substitution == {0: _var(1)}
+        assert pair.substitution.mapping == {0: _var(1)}
         assert pair.inner_reduct == _app(0, _var(1))
         assert pair.outer_reduct == _var(1)
         assert (
@@ -591,7 +593,7 @@ class TestCriticalPairs:
         assert tuple(
             (
                 pair.candidate_index,
-                pair.substitution,
+                pair.substitution.mapping,
                 pair.inner_reduct,
                 pair.outer_reduct,
             )
@@ -599,7 +601,7 @@ class TestCriticalPairs:
         ) == tuple(
             (
                 pair.candidate_index,
-                pair.substitution,
+                pair.substitution.mapping,
                 pair.inner_reduct,
                 pair.outer_reduct,
             )
@@ -741,7 +743,7 @@ class TestCriticalPairs:
         assert len(result.profile.candidates) == 15
         assert len(result.profile.pairs) == 15
         assert all(candidate.unifiable for candidate in result.profile.candidates)
-        assert all(pair.substitution for pair in result.profile.pairs)
+        assert all(pair.substitution.mapping for pair in result.profile.pairs)
         assert (
             CriticalPairsResult.model_validate_json(result.model_dump_json()) == result
         )
@@ -951,7 +953,7 @@ class TestCriticalPairs:
             _term_node_count(term)
             for pair in result.profile.pairs
             for term in (
-                *pair.substitution.values(),
+                *pair.substitution.mapping.values(),
                 pair.inner_reduct,
                 pair.outer_reduct,
             )
@@ -970,7 +972,7 @@ class TestCriticalPairs:
                 term_at_position(standardized_outer.lhs, candidate.position),
             )
             assert substitution is not None
-            assert pair.substitution == substitution
+            assert pair.substitution.mapping == substitution
             spliced = _replace_at_position(
                 standardized_outer.lhs, candidate.position, standardized_inner.rhs
             )
@@ -1485,12 +1487,12 @@ class TestDeepTermTraversal:
             UnificationRequest(signature=_signature(2, 1, 0), left=left, right=right)
         )
         assert result.unified
-        assert result.substitution[1] == _chain_unary(1, 15, _app(2))
-        assert _term_depth(result.substitution[1]) == MAX_TERM_DEPTH - 15
-        assert _term_depth(result.substitution[0]) == MAX_TERM_DEPTH
-        assert apply_substitution(left, result.substitution) == apply_substitution(
-            right, result.substitution
-        )
+        assert result.substitution.mapping[1] == _chain_unary(1, 15, _app(2))
+        assert _term_depth(result.substitution.mapping[1]) == MAX_TERM_DEPTH - 15
+        assert _term_depth(result.substitution.mapping[0]) == MAX_TERM_DEPTH
+        assert apply_substitution(
+            left, result.substitution.mapping
+        ) == apply_substitution(right, result.substitution.mapping)
         assert UnificationResult.model_validate_json(result.model_dump_json()) == (
             result
         )

--- a/tests/math/matrices/finite_fields/test_prime_field_matrix.py
+++ b/tests/math/matrices/finite_fields/test_prime_field_matrix.py
@@ -7,6 +7,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.matrices.finite_fields import verify_rank, verify_rref
 from jacobian.math.matrices.finite_fields._models import (
     PrimeFieldMatrixRankResult,
     PrimeFieldMatrixRequest,
@@ -19,6 +20,52 @@ from jacobian.math.matrices.finite_fields._tools import (
     compute_rref,
 )
 from jacobian.math.matrices.finite_fields.linear_algebra import PrimeFieldMatrix
+
+
+@pytest.mark.parametrize(
+    ("entries", "columns"),
+    [((), 3), (((), ()), 0), ((), 0), (((0,),), 1), (((1, 2), (2, 4)), 2)],
+)
+def test_serialized_rank_and_rref_claims(
+    entries: tuple[tuple[int, ...], ...], columns: int
+) -> None:
+    request = PrimeFieldMatrixRequest(
+        matrix=PrimeFieldMatrix(prime=5, entries=entries, columns=columns)
+    )
+    rank_claim = PrimeFieldMatrixRankResult.model_validate_json(
+        compute_rank(request).model_dump_json()
+    )
+    reduced_claim = PrimeFieldRrefResult.model_validate_json(
+        compute_rref(request).model_dump_json()
+    )
+    assert verify_rank(rank_claim)
+    assert verify_rref(reduced_claim)
+
+
+def test_forged_rank_and_rref_claims_are_checked_explicitly() -> None:
+    request = pfm(prime=2, entries=((0, 0),))
+    rank_payload = compute_rank(request).model_dump(mode="json")
+    rank_payload["rank"] = 1
+    assert not verify_rank(PrimeFieldMatrixRankResult.model_validate(rank_payload))
+
+    payload = compute_rref(request).model_dump(mode="json")
+    payload.update(rank=1, pivot_columns=[0])
+    payload["rref_matrix"]["entries"] = [[1, 0]]
+    assert not verify_rref(PrimeFieldRrefResult.model_validate(payload))
+
+    source = pfm(prime=2, entries=((1, 0),))
+    payload = compute_rref(source).model_dump(mode="json")
+    payload["pivot_columns"] = [1]
+    assert not verify_rref(PrimeFieldRrefResult.model_validate(payload))
+
+
+def test_rank_and_rref_decoding_does_not_admit_composite_field() -> None:
+    request = pfm(prime=4, entries=((0,),))
+    claim = PrimeFieldMatrixRankResult.model_validate_json(
+        PrimeFieldMatrixRankResult(prime=4, source=request, rank=0).model_dump_json()
+    )
+    with pytest.raises(OperationDomainValidationError):
+        verify_rank(claim)
 
 
 def pfm(prime: int, entries: tuple[tuple[int, ...], ...]) -> PrimeFieldMatrixRequest:

--- a/tests/math/matrices/test_operation_claims.py
+++ b/tests/math/matrices/test_operation_claims.py
@@ -1,0 +1,105 @@
+"""Source-bound matrix relations survive structural serialization."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.matrices import (
+    verify_adjugate,
+    verify_inverse,
+    verify_kronecker_product,
+    verify_partial_trace,
+    verify_product,
+)
+from jacobian.math.matrices.operations import (
+    adjugate_result,
+    inverse_result,
+    kronecker_product_result,
+    nullspace_result,
+    partial_trace_result,
+    product_result,
+    rank_result,
+)
+from jacobian.math.matrices.values import (
+    IntegerMatrix,
+    RationalMatrix,
+    SparseRationalMatrix,
+    SparseRationalMatrixEntry,
+)
+
+
+def _q(value: int) -> CanonicalRational:
+    return CanonicalRational.from_integer_ratio(value, 1)
+
+
+@pytest.mark.parametrize(
+    "kind", ["product", "inverse", "adjugate", "kronecker", "partial_trace"]
+)
+def test_matrix_claim_checks_its_retained_source(kind: str) -> None:
+    integer = IntegerMatrix(entries=(("2",),))
+    rational = RationalMatrix(entries=((_q(2),),))
+    cases: dict[str, tuple[Any, Callable[..., bool], str]] = {
+        "product": (product_result(rational, rational), verify_product, "product"),
+        "inverse": (inverse_result(integer), verify_inverse, "inverse"),
+        "adjugate": (adjugate_result(integer), verify_adjugate, "adjugate"),
+        "kronecker": (
+            kronecker_product_result(rational, rational),
+            verify_kronecker_product,
+            "product",
+        ),
+        "partial_trace": (
+            partial_trace_result(rational, 1, 1),
+            verify_partial_trace,
+            "reduced_matrix",
+        ),
+    }
+    result, verify, field = cases[kind]
+    payload = result.model_dump(mode="json")
+    assert verify(type(result).model_validate(payload))
+    payload[field]["entries"] = [
+        ["7" if kind == "adjugate" else {"num": "7", "den": "1"}]
+    ]
+    assert not verify(type(result).model_validate(payload))
+
+
+def test_product_rejects_mismatched_source_axes() -> None:
+    matrix = RationalMatrix(entries=((_q(1),),))
+    result = product_result(matrix, matrix)
+    payload = result.model_dump(mode="json")
+    payload["right"] = RationalMatrix(entries=(), column_count=1).model_dump(
+        mode="json"
+    )
+    with pytest.raises(ValidationError, match="inner axes"):
+        type(result).model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [RationalMatrix(entries=(), column_count=3), RationalMatrix(entries=((_q(1),),))],
+)
+def test_nullspace_returns_composable_qq_matrix(source: RationalMatrix) -> None:
+    result = nullspace_result(source)
+    payload = result.model_dump(mode="json")
+    assert "basis_vectors" not in payload
+    basis = RationalMatrix.model_validate(payload["basis_matrix"])
+    assert basis.column_count == source.column_count
+    assert rank_result(basis).rank == result.nullity
+
+
+def test_sparse_nullspace_retains_largest_supported_column_axis() -> None:
+    order = 8192
+    source = SparseRationalMatrix(
+        row_count=order,
+        column_count=order,
+        entries=tuple(
+            SparseRationalMatrixEntry(row=i, column=i, value=_q(1))
+            for i in range(order)
+        ),
+    )
+    result = nullspace_result(source)
+    assert result.nullity == 0
+    basis = RationalMatrix.model_validate_json(result.basis_matrix.model_dump_json())
+    assert basis.row_count == 0 and basis.column_count == order

--- a/tests/math/matrices/test_public_api.py
+++ b/tests/math/matrices/test_public_api.py
@@ -264,6 +264,11 @@ def test_exact_public_api_symbols() -> None:
         "smith_normal_form",
         "solve_linear_system",
         "trace",
+        "verify_adjugate",
+        "verify_inverse",
+        "verify_kronecker_product",
+        "verify_partial_trace",
+        "verify_product",
     )
     assert tuple(matrices.__all__) == expected
     assert len(matrices.__all__) == len(set(matrices.__all__))

--- a/tests/math/matrices/test_rational_linear_source_binding.py
+++ b/tests/math/matrices/test_rational_linear_source_binding.py
@@ -28,6 +28,10 @@ from jacobian.math.matrices.rational_linear._tools import (
     compute_rational_inconsistency,
     compute_rational_solution,
 )
+from jacobian.math.matrices.rational_linear.operations import (
+    verify_inconsistency,
+    verify_solution,
+)
 from jacobian.math.matrices.values import (
     RationalMatrix,
     SparseRationalMatrix,
@@ -744,3 +748,47 @@ def test_witness_admission_excludes_primal_solution_height() -> None:
     assert result.status == "CONSISTENT"
     with pytest.raises(OperationDomainValidationError, match="result-height bound"):
         compute_rational_solution(LinearRationalSolutionFindRequest(system=system))
+
+
+def test_solution_verifier_checks_ax_equals_b_after_serialization() -> None:
+    system = LinearRationalSystem.model_validate(_unique_system())
+    result = compute_rational_solution(LinearRationalSolutionFindRequest(system=system))
+    assert verify_solution(
+        LinearRationalSolutionResult.model_validate_json(result.model_dump_json())
+    )
+    forged = result.model_dump(mode="json")
+    assert forged["values"] is not None
+    forged["values"][0] = _q(Fraction(0))
+    assert not verify_solution(LinearRationalSolutionResult.model_validate(forged))
+    negative = compute_rational_solution(
+        LinearRationalSolutionFindRequest(
+            system=LinearRationalSystem.model_validate(_inconsistent_system())
+        )
+    )
+    assert negative.status == "INCONSISTENT"
+    assert not verify_solution(negative)
+
+
+def test_inconsistency_verifier_checks_witness_and_pairing() -> None:
+    system = LinearRationalSystem.model_validate(_inconsistent_system())
+    result = compute_rational_inconsistency(
+        LinearRationalInconsistencyFindRequest(system=system)
+    )
+    assert result.status == "INCONSISTENT"
+    assert verify_inconsistency(
+        LinearRationalInconsistencyResult.model_validate_json(result.model_dump_json())
+    )
+    forged = result.model_dump(mode="json")
+    assert forged["left_witness"] is not None
+    forged["left_witness"][0] = _q(Fraction(0))
+    forged["left_witness"][1] = _q(Fraction(0))
+    assert not verify_inconsistency(
+        LinearRationalInconsistencyResult.model_validate(forged)
+    )
+    consistent = compute_rational_inconsistency(
+        LinearRationalInconsistencyFindRequest(
+            system=LinearRationalSystem.model_validate(_unique_system())
+        )
+    )
+    assert consistent.status == "CONSISTENT"
+    assert not verify_inconsistency(consistent)

--- a/tests/math/number_theory/arithmetic/test_public_api.py
+++ b/tests/math/number_theory/arithmetic/test_public_api.py
@@ -205,6 +205,7 @@ def test_exact_public_api_symbols() -> None:
         "reciprocal",
         "sign",
         "sum_rationals",
+        "verify_continued_fraction",
     )
     assert tuple(arithmetic.__all__) == expected
     assert len(arithmetic.__all__) == len(set(arithmetic.__all__))

--- a/tests/math/number_theory/arithmetic/test_rational_continued_fraction.py
+++ b/tests/math/number_theory/arithmetic/test_rational_continued_fraction.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.number_theory.arithmetic import verify_continued_fraction
 from jacobian.math.number_theory.arithmetic._rational_models import (
     MAX_RATIONAL_CONTINUED_FRACTION_TERMS,
     RationalContinuedFractionResult,
@@ -38,6 +39,9 @@ def test_producer_emits_canonical_expansions(
     assert result.terms == expected
     assert result.value == CanonicalRational(num=num, den=den)
     assert RationalContinuedFractionResult.model_validate(result.model_dump()) == result
+    assert verify_continued_fraction(
+        RationalContinuedFractionResult.model_validate_json(result.model_dump_json())
+    )
 
 
 def test_two_representation_boundary_is_canonical() -> None:
@@ -68,16 +72,11 @@ def test_result_rejects_nonpositive_tail_term() -> None:
     )
 
 
-def test_result_rejects_terms_for_a_different_rational() -> None:
-    with pytest.raises(ValidationError) as exc_info:
-        RationalContinuedFractionResult(
-            value=CanonicalRational(num="7", den="3"),
-            terms=("2", "2"),
-        )
-    assert (
-        exc_info.value.errors()[0]["type"]
-        == "arithmetic.continued_fraction_reconstruction"
+def test_consumer_rejects_terms_for_a_different_rational() -> None:
+    claim = RationalContinuedFractionResult.model_validate(
+        {"value": {"num": "7", "den": "3"}, "terms": ["2", "2"]}
     )
+    assert not verify_continued_fraction(claim)
 
 
 def test_producer_rejects_expansion_beyond_result_term_bound() -> None:

--- a/tests/math/number_theory/elliptic_curves/test_elliptic_curves.py
+++ b/tests/math/number_theory/elliptic_curves/test_elliptic_curves.py
@@ -38,6 +38,28 @@ def _pt(num: str, den: str = "1") -> CanonicalRational:
     return CanonicalRational(num=num, den=den)
 
 
+@pytest.mark.parametrize(
+    "operation", ["add", "add_infinity", "infinity_add", "multiply"]
+)
+def test_serialized_off_curve_point_is_rejected_by_consumers(operation: str) -> None:
+    curve = ShortWeierstrassCurve(coefficient_a=_pt("1"), coefficient_b=_pt("0"))
+    forged = EllipticCurvePointResult(
+        curve=curve, point=RationalAffinePoint(x=_pt("0"), y=_pt("1"))
+    )
+    point = EllipticCurvePointResult.model_validate_json(forged.model_dump_json())
+    infinity = EllipticCurvePointResult(curve=curve, at_infinity=True)
+    with pytest.raises(OperationDomainValidationError) as caught:
+        if operation == "multiply":
+            scalar_multiply(curve, point, 0)
+        elif operation == "add_infinity":
+            add_points(curve, point, infinity)
+        elif operation == "infinity_add":
+            add_points(curve, infinity, point)
+        else:
+            add_points(curve, point, point)
+    assert caught.value.errors()[0]["type"] == "elliptic_curve.point_off_curve"
+
+
 class TestDiscriminant:
     def test_native_surface_accepts_canonical_curve_value(self) -> None:
         curve = ShortWeierstrassCurve(coefficient_a=_pt("1"), coefficient_b=_pt("0"))

--- a/tests/math/number_theory/number_fields/test_discriminant_claim.py
+++ b/tests/math/number_theory/number_fields/test_discriminant_claim.py
@@ -1,0 +1,36 @@
+"""Canonical field-discriminant claims and explicit consumer checking."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.number_theory.number_fields import (
+    SimpleNumberFieldPresentation,
+    discriminant,
+    verify_discriminant,
+)
+from jacobian.math.number_theory.number_fields._models import (
+    NumberFieldDiscriminantResult,
+)
+
+
+@pytest.mark.parametrize("value", ["nope", "08", "+8", "-0"])
+def test_discriminant_rejects_noncanonical_integer(value: str) -> None:
+    with pytest.raises(ValidationError):
+        NumberFieldDiscriminantResult.model_validate(
+            {
+                "field": {"coefficients_descending": ["1", "0", "-2"]},
+                "discriminant": value,
+            }
+        )
+
+
+def test_field_discriminant_claim_round_trip() -> None:
+    field = SimpleNumberFieldPresentation(coefficients_descending=("1", "0", "-5"))
+    # Q(sqrt(5)) has field discriminant 5, not polynomial discriminant 20.
+    assert discriminant(field) == "5"
+    claim = NumberFieldDiscriminantResult(field=field, discriminant="5")
+    assert verify_discriminant(
+        NumberFieldDiscriminantResult.model_validate_json(claim.model_dump_json())
+    )
+    forged = NumberFieldDiscriminantResult(field=field, discriminant="20")
+    assert not verify_discriminant(forged)

--- a/tests/math/number_theory/numerical_semigroups/test_correctness_regressions.py
+++ b/tests/math/number_theory/numerical_semigroups/test_correctness_regressions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from itertools import combinations, pairwise
 from math import lcm
 
@@ -248,7 +249,7 @@ def test_global_elasticity_has_an_exact_attaining_witness() -> None:
     )
     expected_ratio = f"{max(lengths)}/{min(lengths)}"
     assert expected_ratio == "9/4"
-    assert result.elasticity == expected_ratio
+    assert result.elasticity.as_fraction() == Fraction(expected_ratio)
     assert (result.smallest_generator, result.largest_generator) == ("4", "9")
 
 

--- a/tests/math/number_theory/numerical_semigroups/test_extended.py
+++ b/tests/math/number_theory/numerical_semigroups/test_extended.py
@@ -1,5 +1,7 @@
 """Tests for extended numerical semigroup factorization operations."""
 
+from fractions import Fraction
+
 import pytest
 from pydantic import BaseModel, ValidationError
 from tests.math.number_theory.numerical_semigroups._support import (
@@ -327,17 +329,17 @@ class TestElementElasticity:
     def test_elasticity_15_in_3_5(self) -> None:
         req = ElementElasticityRequest(generators=("3", "5"), value="15")
         result = compute_element_elasticity(req)
-        assert result.elasticity == "5/3"
+        assert result.elasticity.as_fraction() == Fraction("5/3")
 
     def test_elasticity_single_factorization(self) -> None:
         req = ElementElasticityRequest(generators=("3", "5"), value="12")
         result = compute_element_elasticity(req)
-        assert result.elasticity == "1"
+        assert result.elasticity.as_fraction() == Fraction("1")
 
     def test_elasticity_36_in_4_6_9(self) -> None:
         req = ElementElasticityRequest(generators=("4", "6", "9"), value="36")
         result = compute_element_elasticity(req)
-        assert result.elasticity == "9/4"
+        assert result.elasticity.as_fraction() == Fraction("9/4")
 
 
 class TestElementCatenaryDegree:
@@ -507,9 +509,11 @@ class TestPresentationBinomials:
     def test_binomials_reject_nonrelations(self) -> None:
         with operation_domain_error():
             compute_presentation_binomials(
-                PresentationBinomialsRequest(
-                    generators=("3", "5"),
-                    relations=({"first": (1, 0), "second": (0, 1)},),
+                PresentationBinomialsRequest.model_validate(
+                    {
+                        "generators": ("3", "5"),
+                        "relations": ({"first": (1, 0), "second": (0, 1)},),
+                    }
                 )
             )
 
@@ -536,17 +540,17 @@ class TestGlobalElasticity:
     def test_elasticity_3_5(self) -> None:
         req = ElasticityRequest(generators=("3", "5"))
         result = compute_elasticity(req)
-        assert result.elasticity == "5/3"
+        assert result.elasticity.as_fraction() == Fraction("5/3")
 
     def test_elasticity_4_6_9(self) -> None:
         req = ElasticityRequest(generators=("4", "6", "9"))
         result = compute_elasticity(req)
-        assert result.elasticity == "9/4"
+        assert result.elasticity.as_fraction() == Fraction("9/4")
 
     def test_elasticity_2_3(self) -> None:
         req = ElasticityRequest(generators=("2", "3"))
         result = compute_elasticity(req)
-        assert result.elasticity == "3/2"
+        assert result.elasticity.as_fraction() == Fraction("3/2")
 
 
 class TestGlobalCatenaryDegree:

--- a/tests/math/number_theory/numerical_semigroups/test_public_api.py
+++ b/tests/math/number_theory/numerical_semigroups/test_public_api.py
@@ -49,6 +49,7 @@ def test_exact_public_api_symbols() -> None:
     """Exact owner-local contract for the numerical_semigroups public API."""
     expected = (
         "FactorizationGraph",
+        "NumericalSemigroup",
         "apery_set",
         "belongs",
         "elasticity",
@@ -61,6 +62,9 @@ def test_exact_public_api_symbols() -> None:
         "factorization_lengths",
         "factorizations",
         "minimal_generating_system",
+        "verify_elasticity",
+        "verify_element_elasticity",
+        "verify_summary",
     )
     assert tuple(numerical_semigroups.__all__) == expected
     assert len(numerical_semigroups.__all__) == len(set(numerical_semigroups.__all__))

--- a/tests/math/number_theory/numerical_semigroups/test_serialized_claims.py
+++ b/tests/math/number_theory/numerical_semigroups/test_serialized_claims.py
@@ -1,0 +1,52 @@
+"""Exact semigroup claims retain sources without proving results on decode."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.number_theory.numerical_semigroups.operations import (
+    element_elasticity_profile,
+    global_elasticity,
+    summary,
+    verify_elasticity,
+    verify_element_elasticity,
+    verify_summary,
+)
+
+
+@pytest.mark.parametrize("generators", [(1,), (3, 5), (4, 6, 9)])
+def test_summary_claim(generators: tuple[int, ...]) -> None:
+    result = summary(generators)
+    assert verify_summary(type(result).model_validate_json(result.model_dump_json()))
+    payload = result.model_dump()
+    payload["conductor"] = "100"
+    assert not verify_summary(type(result).model_validate(payload))
+    for malformed in ("+1", "01", "x", "-0"):
+        payload["frobenius_number"] = malformed
+        with pytest.raises(ValidationError):
+            type(result).model_validate(payload)
+
+
+def test_elasticity_claims() -> None:
+    result: Any
+    verifier: Callable[[Any], bool]
+    for result, verifier in (
+        (global_elasticity((3, 5)), verify_elasticity),
+        (element_elasticity_profile((3, 5), 15), verify_element_elasticity),
+    ):
+        assert verifier(type(result).model_validate_json(result.model_dump_json()))
+        payload = result.model_dump()
+        payload["elasticity"] = {"num": "7", "den": "2"}
+        assert not verifier(type(result).model_validate(payload))
+        payload["elasticity"] = {"num": "1", "den": "0"}
+        with pytest.raises(ValidationError):
+            type(result).model_validate(payload)
+
+
+def test_ratio_alone_does_not_prove_length_extrema() -> None:
+    result = element_elasticity_profile((3, 5), 15)
+    payload = result.model_dump()
+    payload.update(minimum_length=6, maximum_length=10)
+    assert not verify_element_elasticity(type(result).model_validate(payload))

--- a/tests/math/number_theory/p_adic/test_padic.py
+++ b/tests/math/number_theory/p_adic/test_padic.py
@@ -11,6 +11,7 @@ from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.p_adic._models import (
     HenselFactorLiftRequest,
+    HenselFactorLiftResult,
     HenselRootRequest,
     HenselRootResult,
     IntegerPolynomial,
@@ -213,6 +214,13 @@ class TestHenselFactorLifting:
             HenselFactorLiftRequest(
                 polynomial=f, factor_g=g, factor_h=h, prime=3, precision=2
             )
+        )
+        assert result.polynomial == f
+        assert result.factor_g == g
+        assert result.factor_h == h
+        assert (
+            HenselFactorLiftResult.model_validate_json(result.model_dump_json())
+            == result
         )
         modulus = 9
         for x in range(modulus):

--- a/tests/math/number_theory/p_adic/test_padic.py
+++ b/tests/math/number_theory/p_adic/test_padic.py
@@ -143,9 +143,7 @@ class TestPAdicRoots:
         not_simple["is_simple_root"] = False
         with pytest.raises(ValidationError) as exc_info:
             HenselRootResult.model_validate(not_simple)
-        assert (
-            exc_info.value.errors()[0]["type"] == "padic_arithmetic.simple_flag_invalid"
-        )
+        assert exc_info.value.errors()[0]["type"] == "extra_forbidden"
 
     def test_roots_profile_rejects_out_of_range_structural_entries(self) -> None:
         result = _find_padic_roots(

--- a/tests/math/number_theory/p_adic/test_padic.py
+++ b/tests/math/number_theory/p_adic/test_padic.py
@@ -26,6 +26,7 @@ from jacobian.math.number_theory.p_adic.operations import (
     find_padic_roots,
     hensel_lift_factors,
     hensel_lift_root,
+    verify_hensel_factor_lift,
     verify_hensel_root,
 )
 
@@ -224,6 +225,10 @@ class TestHenselFactorLifting:
         assert (
             HenselFactorLiftResult.model_validate_json(result.model_dump_json())
             == result
+        )
+        assert verify_hensel_factor_lift(result)
+        assert not verify_hensel_factor_lift(
+            result.model_copy(update={"lifted_g": _wire_poly(0, 1)})
         )
         modulus = 9
         for x in range(modulus):

--- a/tests/math/number_theory/p_adic/test_padic.py
+++ b/tests/math/number_theory/p_adic/test_padic.py
@@ -26,6 +26,7 @@ from jacobian.math.number_theory.p_adic.operations import (
     find_padic_roots,
     hensel_lift_factors,
     hensel_lift_root,
+    verify_hensel_root,
 )
 
 
@@ -57,6 +58,10 @@ class TestHenselRootLifting:
         )
         assert result.is_simple_root
         assert (parse_canonical_integer(result.lifted_root) ** 2 + 1) % 125 == 0
+        assert verify_hensel_root(
+            HenselRootResult.model_validate_json(result.model_dump_json())
+        )
+        assert not verify_hensel_root(result.model_copy(update={"root_mod_p": 1}))
 
     def test_lift_mod_p_squared(self) -> None:
         """Lift root to mod p^2."""

--- a/tests/math/number_theory/p_adic/test_padic.py
+++ b/tests/math/number_theory/p_adic/test_padic.py
@@ -63,6 +63,7 @@ class TestHenselRootLifting:
             HenselRootResult.model_validate_json(result.model_dump_json())
         )
         assert not verify_hensel_root(result.model_copy(update={"root_mod_p": 1}))
+        assert not verify_hensel_root(result.model_copy(update={"prime": 4}))
 
     def test_lift_mod_p_squared(self) -> None:
         """Lift root to mod p^2."""

--- a/tests/math/number_theory/p_adic/test_padic.py
+++ b/tests/math/number_theory/p_adic/test_padic.py
@@ -65,6 +65,18 @@ class TestHenselRootLifting:
         assert not verify_hensel_root(result.model_copy(update={"root_mod_p": 1}))
         assert not verify_hensel_root(result.model_copy(update={"prime": 4}))
 
+    def test_rejects_negative_lifted_root_claim(self) -> None:
+        poly = IntegerPolynomial(coefficients=("1", "1"))
+        payload = {
+            "polynomial": poly.model_dump(mode="json"),
+            "prime": 3,
+            "root_mod_p": 2,
+            "precision": 2,
+            "lifted_root": "-1",
+        }
+        with pytest.raises(ValueError, match=r"lifted_root must be in 0..p\^k - 1"):
+            HenselRootResult.model_validate(payload)
+
     def test_lift_mod_p_squared(self) -> None:
         """Lift root to mod p^2."""
         poly = IntegerPolynomial(coefficients=("1", "0", "0", "-1"))  # x^3 - 1

--- a/tests/math/number_theory/quadratic_forms/binary/test_integral_binary_quadratic_forms.py
+++ b/tests/math/number_theory/quadratic_forms/binary/test_integral_binary_quadratic_forms.py
@@ -525,7 +525,9 @@ class TestProperClassComposition:
         ).model_dump(mode="json")
         result["composed_form"] = {"a": 1, "b": 0, "c": 1}
 
-        with pytest.raises(ValidationError, match="share one discriminant"):
+        with pytest.raises(
+            ValidationError, match="bind the composed and product forms"
+        ):
             BinaryQuadraticFormClassCompositionResult.model_validate(result)
 
     def test_catalog_example_exercises_nontrivial_proper_class_product(self) -> None:

--- a/tests/math/number_theory/quadratic_forms/binary/test_serialized_changes.py
+++ b/tests/math/number_theory/quadratic_forms/binary/test_serialized_changes.py
@@ -1,0 +1,51 @@
+"""Typed form-change witnesses remain claims until consumed."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.number_theory.quadratic_forms.binary import (
+    PrimitivePositiveDefiniteBinaryQuadraticForm,
+    ProperFormChangeOfVariables,
+    verify_change_of_variables,
+    verify_reduction,
+)
+from jacobian.math.number_theory.quadratic_forms.binary._models import (
+    BinaryQuadraticFormReduceRequest,
+    ReducedBinaryQuadraticFormResult,
+)
+from jacobian.math.number_theory.quadratic_forms.binary._tools import compute_reduce
+
+
+def test_reduction_witness_round_trip_and_forgery() -> None:
+    form = PrimitivePositiveDefiniteBinaryQuadraticForm(a=5, b=6, c=2)
+    result = compute_reduce(BinaryQuadraticFormReduceRequest(form=form))
+    decoded = ReducedBinaryQuadraticFormResult.model_validate_json(
+        result.model_dump_json()
+    )
+    assert verify_reduction(decoded)
+    payload = decoded.model_dump(mode="json")
+    payload["change"]["matrix"]["entries"] = [["1", "0"], ["0", "-1"]]
+    assert not verify_reduction(
+        ReducedBinaryQuadraticFormResult.model_validate(payload)
+    )
+
+
+def test_change_checks_determinant_and_substitution_after_decode() -> None:
+    form = PrimitivePositiveDefiniteBinaryQuadraticForm(a=1, b=0, c=1)
+    for rows, expected in [
+        (((1, 0), (0, 1)), True),
+        (((1, 0), (0, -1)), False),
+        (((0, 0), (0, 0)), False),
+        (((1, 1), (0, 1)), False),
+    ]:
+        claim = ProperFormChangeOfVariables.from_rows(form, form, rows)
+        assert (
+            verify_change_of_variables(
+                ProperFormChangeOfVariables.model_validate_json(claim.model_dump_json())
+            )
+            is expected
+        )
+    payload = claim.model_dump(mode="json")
+    payload["matrix"]["entries"] = [["1"]]
+    with pytest.raises(ValidationError):
+        ProperFormChangeOfVariables.model_validate(payload)

--- a/tests/math/optimization/submodular/test_submodular_opt.py
+++ b/tests/math/optimization/submodular/test_submodular_opt.py
@@ -15,6 +15,8 @@ from jacobian.math.optimization.submodular.operations import (
     check_monotonicity,
     check_submodularity,
     evaluate_set_function,
+    verify_monotonicity,
+    verify_submodularity,
 )
 
 
@@ -86,6 +88,7 @@ class TestMonotonicity:
         req = MonotonicityCheckRequest(function=fn)
         result = _check_monotonicity_request(req)
         assert result.is_monotone is True
+        assert verify_monotonicity(result.model_validate_json(result.model_dump_json()))
 
     def test_rejects_incomplete_table(self) -> None:
         import pytest
@@ -112,6 +115,9 @@ class TestSubmodularity:
         req = SubmodularityCheckRequest(function=fn)
         result = _check_submodularity_request(req)
         assert result.is_submodular is True
+        assert verify_submodularity(
+            result.model_validate_json(result.model_dump_json())
+        )
 
 
 class TestKernelEquivalence:
@@ -203,7 +209,7 @@ class TestKernelEquivalence:
                 SubmodularityCheckRequest(function=function)
             ).is_submodular == self._bruteforce_submodular(function)
 
-    def test_violation_message_names_witnesses(self) -> None:
+    def test_violation_retains_a_structured_witness(self) -> None:
         # f({}) = 0 but f({0}) = -1 violates monotonicity at a covering edge.
         entries = [
             _entry((), "0"),
@@ -215,7 +221,10 @@ class TestKernelEquivalence:
             )
         )
         assert result.is_monotone is False
-        assert result.violation == "f(()) > f((0,))"
+        assert result.function == SetFunction(ground_set_size=1, entries=tuple(entries))
+        assert result.violation == ((), 0)
+        assert verify_monotonicity(result)
+        assert not verify_monotonicity(result.model_copy(update={"is_monotone": True}))
 
     def test_complete_table_admission_is_structural(self) -> None:
         n = 16

--- a/tests/math/polynomials/series/test_polynomial_conversion.py
+++ b/tests/math/polynomials/series/test_polynomial_conversion.py
@@ -1,0 +1,57 @@
+"""Explicit polynomial/series maps compose canonical values unchanged."""
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.polynomials.series import from_polynomial, to_polynomial
+from jacobian.math.polynomials.values import RationalPolynomial
+
+
+@pytest.mark.parametrize(
+    "terms",
+    [
+        [],
+        [{"coefficient": {"num": "3", "den": "2"}, "exponents": [0]}],
+        [
+            {"coefficient": {"num": "1", "den": "1"}, "exponents": [32768]},
+            {"coefficient": {"num": "1", "den": "1"}, "exponents": [1]},
+        ],
+    ],
+)
+def test_canonical_sparse_projection(terms: list[dict[str, object]]) -> None:
+    polynomial = RationalPolynomial.model_validate(
+        {"variables": ["t"], "polynomial": {"terms": terms}}
+    )
+    projection = from_polynomial(polynomial, 3)
+    decoded = type(projection).model_validate_json(projection.model_dump_json())
+    lift = to_polynomial(decoded.result)
+    assert lift.result.variables == ("t",)
+    assert from_polynomial(lift.result, 3).result == decoded.result
+    assert all(term.exponents[0] < 3 for term in lift.result.polynomial.terms)
+
+
+def test_multivariate_conversion_requires_explicit_variable_map() -> None:
+    polynomial = RationalPolynomial.model_validate(
+        {"variables": ["x", "y"], "polynomial": {"terms": []}}
+    )
+    with pytest.raises(ValueError, match="univariate"):
+        from_polynomial(polynomial, 3)
+
+
+def test_degree_zero_series_keeps_its_order() -> None:
+    polynomial = RationalPolynomial.model_validate(
+        {"variables": ["x"], "polynomial": {"terms": []}}
+    )
+    projection = from_polynomial(polynomial, 512)
+    assert (
+        projection.result.coefficients == (CanonicalRational(num="0", den="1"),) * 512
+    )
+    assert to_polynomial(projection.result).source.truncation_order == 512
+
+
+@pytest.mark.parametrize("variable", ["X", "x_1", "a" * 32])
+def test_variable_carrier_is_shared(variable: str) -> None:
+    polynomial = RationalPolynomial.model_validate(
+        {"variables": [variable], "polynomial": {"terms": []}}
+    )
+    assert to_polynomial(from_polynomial(polynomial, 1).result).result == polynomial

--- a/tests/math/probability/multiple_testing/test_multiple_testing.py
+++ b/tests/math/probability/multiple_testing/test_multiple_testing.py
@@ -58,12 +58,12 @@ class TestFDP:
         result = false_discovery_proportion(req.rejected_ids, req.true_null_ids)
         assert result.false_discoveries == 1
         assert result.total_rejections == 2
-        assert result.fdp == "1/2"
+        assert result.fdp == CanonicalRational(num="1", den="2")
 
     def test_no_rejections(self) -> None:
         req = FDPRequest(rejected_ids=(), true_null_ids=("h1",))
         result = false_discovery_proportion(req.rejected_ids, req.true_null_ids)
-        assert result.fdp == "0"
+        assert result.fdp == CanonicalRational(num="0", den="1")
 
     def test_rejects_out_of_range_p_value_and_level(self) -> None:
         import pytest

--- a/tests/math/probability/multiple_testing/test_serialized_claims.py
+++ b/tests/math/probability/multiple_testing/test_serialized_claims.py
@@ -1,0 +1,42 @@
+"""Multiple-testing claims preserve exact values and hypothesis sources."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.probability.multiple_testing import (
+    bh_step_up,
+    false_discovery_proportion,
+    verify_bh_step_up,
+    verify_fdp,
+)
+from jacobian.math.probability.multiple_testing._models import HypothesisSpec
+
+
+def test_fdp_source_and_claim() -> None:
+    result = false_discovery_proportion(("a", "b", "a"), ("a",))
+    assert verify_fdp(type(result).model_validate_json(result.model_dump_json()))
+    payload = result.model_dump()
+    payload["fdp"] = {"num": "1", "den": "1"}
+    assert not verify_fdp(type(result).model_validate(payload))
+    payload["fdp"] = {"num": "1", "den": "0"}
+    with pytest.raises(ValidationError):
+        type(result).model_validate(payload)
+
+
+def test_bh_source_and_claim() -> None:
+    result = bh_step_up(
+        (
+            HypothesisSpec(
+                hypothesis_id="a", p_value=CanonicalRational(num="0", den="1")
+            ),
+        ),
+        CanonicalRational(num="1", den="20"),
+    )
+    assert verify_bh_step_up(type(result).model_validate_json(result.model_dump_json()))
+    payload = result.model_dump()
+    payload["rejected"] = []
+    assert not verify_bh_step_up(type(result).model_validate(payload))
+    payload["rejected"] = ["foreign"]
+    with pytest.raises(ValidationError):
+        type(result).model_validate(payload)

--- a/tests/math/probability/stochastic_processes/test_finite_stochastic_processes.py
+++ b/tests/math/probability/stochastic_processes/test_finite_stochastic_processes.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.probability.stochastic_processes import (
     FiniteProbabilitySpace,
     FiniteRandomVariable,
@@ -23,6 +24,11 @@ from jacobian.math.probability.stochastic_processes._tools import (
     compute_doob_martingale,
     compute_filtration,
     compute_sigma_from_observation,
+)
+from jacobian.math.probability.stochastic_processes.operations import (
+    conditional_expectation,
+    sigma_algebra_from_observation,
+    sigma_algebra_join,
 )
 
 # ---------------------------------------------------------------------------
@@ -179,16 +185,24 @@ class TestDoobMartingale:
 
 class TestValidation:
     def test_nonpositive_mass_rejected(self) -> None:
-        with pytest.raises(ValidationError) as error:
-            FiniteProbabilitySpace(samples=("a",), masses=(_q(0),))
+        space = FiniteProbabilitySpace(samples=("a",), masses=(_q(0),))
+        with pytest.raises(OperationDomainValidationError) as error:
+            sigma_algebra_from_observation(
+                FiniteProbabilitySpace.model_validate_json(space.model_dump_json()),
+                ("x",),
+            )
         assert (
             error.value.errors()[0]["type"]
             == "finite_stochastic_process.mass_nonpositive"
         )
 
     def test_masses_not_summing_to_one_rejected(self) -> None:
-        with pytest.raises(ValidationError) as error:
-            FiniteProbabilitySpace(samples=("a", "b"), masses=(_q(1, 3), _q(1, 3)))
+        space = FiniteProbabilitySpace(samples=("a", "b"), masses=(_q(1, 3), _q(1, 3)))
+        with pytest.raises(OperationDomainValidationError) as error:
+            sigma_algebra_from_observation(
+                FiniteProbabilitySpace.model_validate_json(space.model_dump_json()),
+                ("x", "y"),
+            )
         assert (
             error.value.errors()[0]["type"]
             == "finite_stochastic_process.mass_sum_invalid"
@@ -201,6 +215,22 @@ class TestValidation:
             error.value.errors()[0]["type"]
             == "finite_stochastic_process.sample_duplicate"
         )
+
+    @pytest.mark.parametrize("blocks", [(("H",),), (("H", "T"), ("T",))])
+    def test_forged_partition_rejected_by_consumers(
+        self, blocks: tuple[tuple[str, ...], ...]
+    ) -> None:
+        space = _coin_space()
+        sigma = FiniteSigmaAlgebra.model_validate_json(
+            FiniteSigmaAlgebra(space=space, blocks=blocks).model_dump_json()
+        )
+        valid = sigma_algebra_from_observation(space, ("x", "y"))
+        with pytest.raises(OperationDomainValidationError):
+            sigma_algebra_join(sigma, valid)
+        with pytest.raises(OperationDomainValidationError):
+            conditional_expectation(
+                FiniteRandomVariable(space=space, values=(_q(0), _q(1))), sigma
+            )
 
     @pytest.mark.parametrize(
         "payoff",

--- a/tests/math/topology/combinatorial_maps/test_combinatorial_maps.py
+++ b/tests/math/topology/combinatorial_maps/test_combinatorial_maps.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.topology.combinatorial_maps import FiniteCombinatorialMap
 from jacobian.math.topology.combinatorial_maps._models import (
     ConnectedComponentsRequest,
@@ -356,12 +357,9 @@ class TestOrientationReverse:
         result = compute_orientation_reverse(
             OrientationReverseRequest(map=_four_cycle())
         )
-        claimed = OrientationReverseResult.model_validate(
-            {
-                **result.model_dump(mode="json"),
-                "face_bijection": {"0": 0, "1": 1},
-            }
-        )
+        payload = result.model_dump(mode="json")
+        payload["bijection"]["images"] = [0, 1]
+        claimed = OrientationReverseResult.model_validate(payload)
         assert claimed.face_bijection != result.face_bijection
 
 
@@ -459,10 +457,10 @@ class TestVertexFaceIncidence:
         for vertex in range(4):
             assert set(result.boolean_incidence[vertex]) == {0, 1}
         # Each vertex appears once per face -> 8 multiplicity entries.
-        assert sum(len(row) for row in result.multiplicity.values()) == 8
-        for row in result.multiplicity.values():
-            for value in row.values():
-                assert value == 1
+        assert len(result.multiplicity.entries) == 8
+        assert all(
+            entry.value.as_fraction() == 1 for entry in result.multiplicity.entries
+        )
 
     def test_torus_incidence(self) -> None:
         m = _torus()
@@ -478,20 +476,24 @@ class TestVertexFaceIncidence:
 class TestValidation:
     def test_wrong_rotation_length_rejected(self) -> None:
         # Vertex 0 has one outgoing dart (dart 0) but its rotation lists two.
-        with pytest.raises(ValidationError) as exc_info:
-            FiniteCombinatorialMap(
-                vertex_count=2,
-                darts=((0, 1, 1), (1, 0, 0)),
-                rotations=((0, 1), (1,)),
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            face_orbits(
+                FiniteCombinatorialMap(
+                    vertex_count=2,
+                    darts=((0, 1, 1), (1, 0, 0)),
+                    rotations=((0, 1), (1,)),
+                )
             )
         assert exc_info.value.errors()[0]["type"] == "combinatorial_map.rotation_length"
 
     def test_reverse_not_involution_rejected(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
-            FiniteCombinatorialMap(
-                vertex_count=2,
-                darts=((0, 1, 1), (1, 0, 1)),
-                rotations=((0,), (1,)),
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            face_orbits(
+                FiniteCombinatorialMap(
+                    vertex_count=2,
+                    darts=((0, 1, 1), (1, 0, 1)),
+                    rotations=((0,), (1,)),
+                )
             )
         assert (
             exc_info.value.errors()[0]["type"]
@@ -499,11 +501,13 @@ class TestValidation:
         )
 
     def test_fixed_point_reverse_rejected(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
-            FiniteCombinatorialMap(
-                vertex_count=1,
-                darts=((0, 0, 0),),
-                rotations=((0,),),
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            face_orbits(
+                FiniteCombinatorialMap(
+                    vertex_count=1,
+                    darts=((0, 0, 0),),
+                    rotations=((0,),),
+                )
             )
         assert (
             exc_info.value.errors()[0]["type"]
@@ -511,11 +515,13 @@ class TestValidation:
         )
 
     def test_foreign_dart_in_rotation_rejected(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
-            FiniteCombinatorialMap(
-                vertex_count=2,
-                darts=((0, 1, 1), (1, 0, 0)),
-                rotations=((1,), (0,)),
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            face_orbits(
+                FiniteCombinatorialMap(
+                    vertex_count=2,
+                    darts=((0, 1, 1), (1, 0, 0)),
+                    rotations=((1,), (0,)),
+                )
             )
         assert (
             exc_info.value.errors()[0]["type"]
@@ -557,11 +563,13 @@ class TestValidation:
         )
 
     def test_isolated_vertex_rejected(self) -> None:
-        with pytest.raises(ValidationError) as exc_info:
-            FiniteCombinatorialMap(
-                vertex_count=2,
-                darts=((0, 0, 1), (0, 0, 0)),
-                rotations=((0, 1), ()),
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            face_orbits(
+                FiniteCombinatorialMap(
+                    vertex_count=2,
+                    darts=((0, 0, 1), (0, 0, 0)),
+                    rotations=((0, 1), ()),
+                )
             )
         assert (
             exc_info.value.errors()[0]["type"]
@@ -579,11 +587,13 @@ class TestValidation:
             darts.append((i, j, 2 * i + 1))
             darts.append((j, i, 2 * i))
             rotations.append((2 * i, 2 * ((i - 1) % size) + 1))
-        with pytest.raises(ValidationError) as exc_info:
-            FiniteCombinatorialMap(
-                vertex_count=size,
-                darts=tuple(darts),
-                rotations=tuple(rotations),
+        with pytest.raises(OperationDomainValidationError) as exc_info:
+            face_orbits(
+                FiniteCombinatorialMap(
+                    vertex_count=size,
+                    darts=tuple(darts),
+                    rotations=tuple(rotations),
+                )
             )
         assert (
             exc_info.value.errors()[0]["type"]

--- a/tests/math/topology/combinatorial_maps/test_public_api.py
+++ b/tests/math/topology/combinatorial_maps/test_public_api.py
@@ -18,6 +18,9 @@ def test_exact_public_api_symbols() -> None:
         "orientable_genus",
         "orientation_reverse",
         "rotation_successor",
+        "verify_dual",
+        "verify_orientation_reverse",
+        "verify_vertex_face_incidence",
         "vertex_face_incidence",
     )
     assert tuple(combinatorial_maps.__all__) == expected

--- a/tests/math/topology/combinatorial_maps/test_serialized_claims.py
+++ b/tests/math/topology/combinatorial_maps/test_serialized_claims.py
@@ -1,0 +1,93 @@
+"""Map admission and source-target relations survive serialization."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.topology.combinatorial_maps import (
+    FiniteCombinatorialMap,
+    connected_components,
+    connected_components_vertices,
+    dual_map,
+    euler_characteristic,
+    face_orbits,
+    orientable_genus,
+    orientation_reverse,
+    verify_dual,
+    verify_orientation_reverse,
+    verify_vertex_face_incidence,
+    vertex_face_incidence,
+)
+
+
+def _edge() -> FiniteCombinatorialMap:
+    return FiniteCombinatorialMap(
+        vertex_count=2, darts=((0, 1, 1), (1, 0, 0)), rotations=((0,), (1,))
+    )
+
+
+@pytest.mark.parametrize(
+    "consumer",
+    [
+        connected_components,
+        connected_components_vertices,
+        dual_map,
+        euler_characteristic,
+        face_orbits,
+        orientable_genus,
+        orientation_reverse,
+        vertex_face_incidence,
+    ],
+)
+def test_map_laws_are_consumer_admission(
+    consumer: Callable[[FiniteCombinatorialMap], object],
+) -> None:
+    payload = _edge().model_dump()
+    payload["rotations"] = [[1], [0]]
+    claim = FiniteCombinatorialMap.model_validate(payload)
+    decoded = FiniteCombinatorialMap.model_validate_json(claim.model_dump_json())
+    with pytest.raises(OperationDomainValidationError, match="outgoing darts"):
+        consumer(decoded)
+
+
+def test_map_relation_round_trips_and_forgeries() -> None:
+    result: Any
+    verifier: Callable[[Any], bool]
+    for result, verifier in (
+        (dual_map(_edge()), verify_dual),
+        (orientation_reverse(_edge()), verify_orientation_reverse),
+    ):
+        assert verifier(type(result).model_validate_json(result.model_dump_json()))
+        payload = result.model_dump(mode="json")
+        payload["bijection"]["images"][0] = 1024
+        with pytest.raises(ValidationError):
+            type(result).model_validate(payload)
+    result = dual_map(_edge())
+    payload = result.model_dump()
+    payload["bijection"]["images"] = [1, 0]
+    assert not verify_dual(type(result).model_validate(payload))
+    incidence = vertex_face_incidence(_edge())
+    assert verify_vertex_face_incidence(
+        type(incidence).model_validate_json(incidence.model_dump_json())
+    )
+    payload = incidence.model_dump(mode="json")
+    payload["multiplicity"]["entries"][0]["value"] = {"num": "2", "den": "1"}
+    assert not verify_vertex_face_incidence(type(incidence).model_validate(payload))
+
+
+def test_incidence_preserves_full_map_axes() -> None:
+    # 65 disjoint edges have 130 vertices; their dual has 130 faces.
+    source = FiniteCombinatorialMap(
+        vertex_count=130,
+        darts=tuple((i, i ^ 1, i ^ 1) for i in range(130)),
+        rotations=tuple((i,) for i in range(130)),
+    )
+    for map_ in (source, dual_map(source).dual):
+        result = vertex_face_incidence(map_)
+        assert result.multiplicity.row_count == map_.vertex_count
+        assert verify_vertex_face_incidence(
+            type(result).model_validate_json(result.model_dump_json())
+        )

--- a/tests/math/topology/finite/spaces/test_finite_topology_spaces.py
+++ b/tests/math/topology/finite/spaces/test_finite_topology_spaces.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 from pydantic import ValidationError
 
@@ -168,7 +170,9 @@ class TestValidation:
         "operation",
         (_interior, _closure, _boundary),
     )
-    def test_subset_admission_rejects_out_of_range_indices(self, operation) -> None:
+    def test_subset_admission_rejects_out_of_range_indices(
+        self, operation: Callable[[SubsetRequest], object]
+    ) -> None:
         request = SubsetRequest(space=_sierpinski(), subset=(2,))
 
         with pytest.raises(OperationDomainValidationError) as error:
@@ -192,8 +196,11 @@ class TestValidation:
         )
 
     def test_non_reflexive_preorder_rejected(self) -> None:
-        with pytest.raises(ValidationError) as error:
-            FiniteTopologicalSpace(
+        from jacobian.catalog.models import OperationDomainValidationError
+        from jacobian.math.topology.finite.spaces import from_preorder
+
+        with pytest.raises(OperationDomainValidationError) as error:
+            from_preorder(
                 points=("a", "b"),
                 preorder=((1,), (0, 1)),
             )

--- a/tests/math/topology/finite/spaces/test_finite_topology_spaces.py
+++ b/tests/math/topology/finite/spaces/test_finite_topology_spaces.py
@@ -11,9 +11,12 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.topology.finite.spaces import (
     FiniteTopologicalMap,
     FiniteTopologicalSpace,
+    verify_continuity,
 )
 from jacobian.math.topology.finite.spaces._models import (
     ContinuousCheckRequest,
+    ContinuousCheckResult,
+    InteriorResult,
     KolmogorovQuotientRequest,
     SubsetRequest,
 )
@@ -70,17 +73,21 @@ def test_catalog_contains_only_audited_agent_outcomes() -> None:
 class TestInterior:
     def test_sierpinski_interior_a(self) -> None:
         # Interior of {a}: {a} is not open (minimal nbhd of a is {a,b}), so interior = {}.
-        result = _interior(SubsetRequest(space=_sierpinski(), subset=(0,)))
-        assert result.interior == ()
+        space = _sierpinski()
+        result = _interior(SubsetRequest(space=space, subset=(0,)))
+        assert result.interior.indices == ()
+        assert result.interior.space == space
+        assert result.subset.indices == (0,)
+        assert result.space == space
 
     def test_sierpinski_interior_b(self) -> None:
         # Interior of {b}: {b} is open (minimal nbhd of b is {b}), so interior = {b}.
         result = _interior(SubsetRequest(space=_sierpinski(), subset=(1,)))
-        assert result.interior == (1,)
+        assert result.interior.indices == (1,)
 
     def test_sierpinski_interior_ab(self) -> None:
         result = _interior(SubsetRequest(space=_sierpinski(), subset=(0, 1)))
-        assert result.interior == (0, 1)
+        assert result.interior.indices == (0, 1)
 
 
 # ---------------------------------------------------------------------------
@@ -91,12 +98,15 @@ class TestInterior:
 class TestClosure:
     def test_sierpinski_closure_a(self) -> None:
         # Closure of {a}: down-set of a = {a} (preorder row).
-        result = _closure(SubsetRequest(space=_sierpinski(), subset=(0,)))
-        assert result.closure == (0,)
+        space = _sierpinski()
+        result = _closure(SubsetRequest(space=space, subset=(0,)))
+        assert result.closure.indices == (0,)
+        assert result.closure.space == space
+        assert result.subset.indices == (0,)
 
     def test_sierpinski_closure_b(self) -> None:
         result = _closure(SubsetRequest(space=_sierpinski(), subset=(1,)))
-        assert result.closure == (0, 1)
+        assert result.closure.indices == (0, 1)
 
 
 # ---------------------------------------------------------------------------
@@ -107,8 +117,16 @@ class TestClosure:
 class TestBoundary:
     def test_sierpinski_boundary_a(self) -> None:
         # Closure({a}) = {a}, Interior({a}) = {}. Boundary = {a}.
-        result = _boundary(SubsetRequest(space=_sierpinski(), subset=(0,)))
-        assert result.boundary == (0,)
+        space = _sierpinski()
+        result = _boundary(SubsetRequest(space=space, subset=(0,)))
+        assert result.boundary.indices == (0,)
+        assert result.boundary.space == space
+
+    def test_empty_subset_stays_bound(self) -> None:
+        space = _sierpinski()
+        result = _boundary(SubsetRequest(space=space, subset=()))
+        assert result.boundary.indices == ()
+        assert result.subset.indices == ()
 
 
 # ---------------------------------------------------------------------------
@@ -152,12 +170,27 @@ class TestContinuityCheck:
         m = FiniteTopologicalMap(source=space, target=space, point_map=(0, 1))
         result = _continuous_check(ContinuousCheckRequest(point_map=m))
         assert result.is_continuous is True
+        assert result.point_map == m
+        assert verify_continuity(
+            ContinuousCheckResult.model_validate_json(result.model_dump_json())
+        )
 
     def test_swap_not_continuous(self) -> None:
         space = _sierpinski()
         m = FiniteTopologicalMap(source=space, target=space, point_map=(1, 0))
         result = _continuous_check(ContinuousCheckRequest(point_map=m))
         assert result.is_continuous is False
+        assert verify_continuity(
+            ContinuousCheckResult.model_validate_json(result.model_dump_json())
+        )
+
+    def test_verifier_rejects_flipped_claim(self) -> None:
+        space = _sierpinski()
+        m = FiniteTopologicalMap(source=space, target=space, point_map=(0, 1))
+        payload = ContinuousCheckResult(point_map=m, is_continuous=False).model_dump(
+            mode="json"
+        )
+        assert not verify_continuity(ContinuousCheckResult.model_validate(payload))
 
 
 # ---------------------------------------------------------------------------
@@ -219,3 +252,43 @@ class TestValidation:
             error.value.errors()[0]["type"]
             == "finite_topology_space.preorder_index_out_of_range"
         )
+
+
+class TestSerializedSubsetClaims:
+    def test_interior_round_trip_retains_source(self) -> None:
+        space = _sierpinski()
+        result = _interior(SubsetRequest(space=space, subset=(1,)))
+        decoded = InteriorResult.model_validate_json(result.model_dump_json())
+        assert decoded.space == space
+        assert decoded.subset.indices == (1,)
+        assert decoded.interior.indices == (1,)
+
+    def test_subset_indices_are_canonical(self) -> None:
+        space = _sierpinski()
+        with pytest.raises(ValidationError) as error:
+            InteriorResult(
+                space=space,
+                subset={"space": space, "indices": (1, 0)},
+                interior={"space": space, "indices": ()},
+            )
+        assert (
+            error.value.errors()[0]["type"]
+            == "finite_topology_space.subset_indices_not_canonical"
+        )
+
+    def test_quotient_verifier_checks_relation_directly(self) -> None:
+        from jacobian.math.topology.finite.spaces import (
+            kolmogorov_quotient,
+            verify_kolmogorov_quotient,
+        )
+
+        space = FiniteTopologicalSpace(
+            points=("a", "b", "c"), preorder=((0, 1), (0, 1), (0, 1, 2))
+        )
+        result = kolmogorov_quotient(space)
+        assert verify_kolmogorov_quotient(
+            type(result).model_validate_json(result.model_dump_json())
+        )
+        payload = result.model_dump(mode="json")
+        payload["quotient_map"]["target"]["preorder"] = [[0], [1]]
+        assert not verify_kolmogorov_quotient(type(result).model_validate(payload))

--- a/tests/math/topology/finite/spaces/test_public_api.py
+++ b/tests/math/topology/finite/spaces/test_public_api.py
@@ -17,6 +17,7 @@ def test_exact_public_api_symbols() -> None:
         "kolmogorov_quotient",
         "minimal_neighbourhoods",
         "specialization_preorder",
+        "verify_kolmogorov_quotient",
     )
     assert tuple(finite_topology_spaces.__all__) == expected
     assert len(finite_topology_spaces.__all__) == len(

--- a/tests/math/topology/finite/spaces/test_public_api.py
+++ b/tests/math/topology/finite/spaces/test_public_api.py
@@ -9,6 +9,7 @@ def test_exact_public_api_symbols() -> None:
     expected = (
         "FiniteTopologicalMap",
         "FiniteTopologicalSpace",
+        "FiniteTopologicalSubset",
         "boundary",
         "closure",
         "continuous_check",
@@ -17,6 +18,7 @@ def test_exact_public_api_symbols() -> None:
         "kolmogorov_quotient",
         "minimal_neighbourhoods",
         "specialization_preorder",
+        "verify_continuity",
         "verify_kolmogorov_quotient",
     )
     assert tuple(finite_topology_spaces.__all__) == expected

--- a/tests/math/topology/finite/spaces/test_quotient_composition.py
+++ b/tests/math/topology/finite/spaces/test_quotient_composition.py
@@ -1,0 +1,40 @@
+"""Canonical Kolmogorov quotient values compose without rebuilding arrays."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.topology.finite.spaces import (
+    FiniteTopologicalSpace,
+    closure,
+    continuous_check,
+    kolmogorov_quotient,
+    verify_kolmogorov_quotient,
+)
+
+
+def test_quotient_composes() -> None:
+    space = FiniteTopologicalSpace(
+        points=("a", "b", "c"), preorder=((0, 1), (0, 1), (0, 1, 2))
+    )
+    result = kolmogorov_quotient(space)
+    decoded = type(result).model_validate_json(result.model_dump_json())
+    assert verify_kolmogorov_quotient(decoded)
+    assert decoded.quotient_map.source == space
+    assert closure(decoded.quotient_map.target, frozenset({1})) == frozenset({0, 1})
+    assert continuous_check(decoded.quotient_map)
+    payload = result.model_dump(mode="json")
+    payload["quotient_map"]["point_map"][0] = 99
+    with pytest.raises(ValidationError):
+        type(result).model_validate(payload)
+    payload["quotient_map"]["point_map"][0] = 1
+    assert not verify_kolmogorov_quotient(type(result).model_validate(payload))
+
+
+def test_authored_preorder_checked_on_consumption() -> None:
+    claim = FiniteTopologicalSpace(
+        points=("a", "b", "c"), preorder=((0,), (0, 1), (1, 2))
+    )
+    decoded = FiniteTopologicalSpace.model_validate_json(claim.model_dump_json())
+    with pytest.raises(OperationDomainValidationError, match="transitive"):
+        kolmogorov_quotient(decoded)

--- a/tests/math/universal_algebra/test_universal_algebra.py
+++ b/tests/math/universal_algebra/test_universal_algebra.py
@@ -368,6 +368,9 @@ class TestCongruence:
             CongruenceRequest(algebra=_boolean_algebra(), partition=((0, 1),))
         )
         assert result.is_congruence is True
+        from jacobian.math.universal_algebra import verify_congruence
+
+        assert verify_congruence(result)
 
     def test_equality_partition_is_congruence(self) -> None:
         result = compute_congruence(


### PR DESCRIPTION
## Summary

This audit repairs mathematical contracts across the operation library. Results now preserve their domain context where a later consumer must interpret or check a claim; ordinary exact values use their canonical domain types instead of parallel summary fields. The change also moves mathematical admission work out of schema ownership where applicable, keeps parsing structural, and adds relation-specific verifiers for serialized certificates and decisions.

The repaired areas include matrix and finite-field results, graph invariants and witnesses, group and algebra claims, geometry predicates, polynomial and number-theory claims, topology, probability, and combinatorics. It also documents the distinction between canonical values, source-bound claims, admission, and consumer verification.

Fixes #3439
Fixes #3440
Fixes #3441
Fixes #3442
Fixes #3443
Fixes #3444
Fixes #3445
Fixes #3446

## Review guide

1. Read `docs/reference/domain-operation-library.md` for the intended contract rules.
2. Review canonical value and schema/admission migrations under `src/jacobian/math/**/values.py`, `_models.py`, and `operations.py`.
3. Review the added serialized-claim tests for round-trip and forged-claim coverage.

## Validation

- `uv run pytest tests/math/geometry/test_euclidean_geometry.py`
- `uv run pytest tests/math/geometry/test_configuration_ops.py`
- `uv run pytest tests/math/polynomials/ideals/test_commutative_algebra.py`
- `uv run pytest tests/math/combinatorics/codes/linear -q`
- `uv run pytest tests/math/geometry/algebraic_curves -q`
- Directed-acyclicity test selection: 39 passed
- Targeted Ruff, formatting, and `git diff --check` runs for each repaired slice
