### PR TITLE
feat(graphs): add exact prescribed-degree bipartite factors

### DIFF
--- a/src/jacobian/math/graphs/flows/__init__.py
+++ b/src/jacobian/math/graphs/flows/__init__.py
@@ -1,6 +1,7 @@
 """Graph-flow operation ownership."""
 
 from jacobian.math.graphs.flows.operations import (
+    bipartite_degree_constrained_factor,
     edge_disjoint_paths,
     max_flow,
     min_cost_flow,
@@ -12,6 +13,7 @@ from jacobian.math.graphs.flows.operations import (
 )
 
 __all__ = [
+    "bipartite_degree_constrained_factor",
     "edge_disjoint_paths",
     "max_flow",
     "min_cost_flow",

--- a/src/jacobian/math/graphs/flows/_models.py
+++ b/src/jacobian/math/graphs/flows/_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import lcm
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -11,6 +11,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
 # Derived integer scales that make rational capacities and costs exact
 # integers are intermediate growth, not input size: each denominator is
@@ -20,6 +21,12 @@ from jacobian.canonical import format_canonical_integer
 # documented conservative digit budget are rejected before any backend graph
 # is constructed.
 MAX_MIN_COST_FLOW_DERIVED_SCALE_DIGITS = 4096
+MAX_BIPARTITE_FACTOR_DEMAND = 1_000_000_000
+MAX_BIPARTITE_FACTOR_DEMAND_DIGITS = 9
+MAX_BIPARTITE_FACTOR_ARCS = 512
+
+
+BipartiteFactorStatus = Literal["FOUND", "INFEASIBLE"]
 
 
 def _bounded_denominator_scale(denominators: tuple[int, ...], kind: str) -> int:
@@ -232,6 +239,95 @@ class MinCostFlowRequest(StrictModel):
     demands: tuple[int, ...] = Field(default=(), max_length=64)
 
 
+class BipartiteDegreeRequirements(StrictModel):
+    """One nonnegative required degree per vertex of a source graph."""
+
+    left: tuple[int, ...] = Field(min_length=1, max_length=64)
+    right: tuple[int, ...] = Field(min_length=1, max_length=64)
+
+    @model_validator(mode="after")
+    def require_nonnegative_bounded_degrees(self) -> Self:
+        for side_name in ("left", "right"):
+            side = getattr(self, side_name)
+            for position, degree in enumerate(side):
+                if degree < 0 or degree > MAX_BIPARTITE_FACTOR_DEMAND:
+                    raise PydanticCustomError(
+                        "graph.bipartite_factor_degree_must_be_in_0_max",
+                        "every required degree must be in 0.."
+                        f"{MAX_BIPARTITE_FACTOR_DEMAND}",
+                        {"side": side_name, "position": position},
+                    )
+        return self
+
+
+class BipartiteFactorRequest(StrictModel):
+    """One bounded indexed bipartite graph plus complete degree requirements.
+
+    The first slice admits at most 64 vertices per side, one nonnegative
+    degree of at most 9 digits per source vertex, and at most 512 network
+    edges. Disconnected graphs and isolated vertices remain valid.
+    """
+
+    graph: IndexedSimpleUndirectedGraph
+    left: tuple[int, ...] = Field(min_length=1, max_length=64)
+    right: tuple[int, ...] = Field(min_length=1, max_length=64)
+    required_degrees: tuple[int, ...] = Field(
+        min_length=2,
+        max_length=128,
+        description=(
+            "One required degree per source vertex in graph-axis order: "
+            "left vertices first, then right vertices."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_source_bound_bipartition(self) -> Self:
+        if tuple(sorted(self.left)) != tuple(range(len(self.left))):
+            raise PydanticCustomError(
+                "graph.bipartite_factor_left_axis_must_be_0_len",
+                "left must be the complete ordered axis 0..len(left)-1",
+            )
+        if tuple(sorted(self.right)) != tuple(
+            range(len(self.left), len(self.left) + len(self.right))
+        ):
+            raise PydanticCustomError(
+                "graph.bipartite_factor_right_axis_must_follow_left",
+                "right must be the complete ordered axis "
+                "len(left)..len(left)+len(right)-1",
+            )
+        if len(self.left) + len(self.right) != self.graph.vertex_count:
+            raise PydanticCustomError(
+                "graph.bipartite_factor_axes_must_partition_graph_vertices",
+                "left and right must partition the graph vertex axis",
+            )
+        left_set = set(self.left)
+        for edge in self.graph.edges:
+            if (edge[0] in left_set) == (edge[1] in left_set):
+                raise PydanticCustomError(
+                    "graph.bipartite_factor_edges_must_cross_partition",
+                    "every source edge must cross the supplied partition",
+                )
+        if len(self.required_degrees) != self.graph.vertex_count:
+            raise PydanticCustomError(
+                "graph.bipartite_factor_requirements_must_cover_axes",
+                "required_degrees must contain exactly one degree per source vertex",
+            )
+        if any(
+            degree < 0 or degree > MAX_BIPARTITE_FACTOR_DEMAND
+            for degree in self.required_degrees
+        ):
+            raise PydanticCustomError(
+                "graph.bipartite_factor_degree_must_be_in_0_max",
+                f"every required degree must be in 0..{MAX_BIPARTITE_FACTOR_DEMAND}",
+            )
+        if len(self.graph.edges) > MAX_BIPARTITE_FACTOR_ARCS:
+            raise PydanticCustomError(
+                "graph.bipartite_factor_edges_exceed_max",
+                f"bipartite factor requests admit at most {MAX_BIPARTITE_FACTOR_ARCS} edges",
+            )
+        return self
+
+
 class FlowEdgeResult(StrictModel):
     """The flow assigned to one directed edge."""
 
@@ -289,3 +385,84 @@ class MinCostFlowResult(StrictModel):
             feasible=feasible,
             flow_edges=flow_edges,
         )
+
+
+class BipartiteFactorObstruction(StrictModel):
+    """A replayable Hall obstruction in source vertex indices."""
+
+    side: Literal["LEFT", "RIGHT"]
+    vertices: tuple[int, ...] = Field(min_length=1, max_length=64)
+    neighbors: tuple[int, ...] = Field(min_length=1, max_length=64)
+    required: int = Field(ge=0, le=MAX_BIPARTITE_FACTOR_DEMAND)
+    capacity: int = Field(ge=0, le=MAX_BIPARTITE_FACTOR_DEMAND * 64)
+
+    @model_validator(mode="after")
+    def require_neighbor_inequality(self) -> Self:
+        if tuple(sorted(self.vertices)) != self.vertices or len(
+            set(self.vertices)
+        ) != len(self.vertices):
+            raise PydanticCustomError(
+                "graph.bipartite_factor_vertices_must_be_unique_sorted",
+                "obstruction vertices must be unique and increasing",
+            )
+        if tuple(sorted(self.neighbors)) != self.neighbors or len(
+            set(self.neighbors)
+        ) != len(self.neighbors):
+            raise PydanticCustomError(
+                "graph.bipartite_factor_neighbors_must_be_unique_sorted",
+                "obstruction neighbors must be unique and increasing",
+            )
+        if self.required <= self.capacity:
+            raise PydanticCustomError(
+                "graph.bipartite_factor_obstruction_must_violate",
+                "obstruction must satisfy required > neighbor capacity",
+            )
+        return self
+
+
+class BipartiteFactorResult(StrictModel):
+    """One exact spanning prescribed-degree factor or Hall obstruction."""
+
+    graph: IndexedSimpleUndirectedGraph
+    left: tuple[int, ...] = Field(min_length=1, max_length=64)
+    right: tuple[int, ...] = Field(min_length=1, max_length=64)
+    requirements: BipartiteDegreeRequirements
+    status: BipartiteFactorStatus
+    selected_edge_indices: tuple[int, ...] = Field(
+        default=(), max_length=MAX_BIPARTITE_FACTOR_ARCS
+    )
+    obstruction: BipartiteFactorObstruction | None = None
+
+    @model_validator(mode="after")
+    def require_outcome_witness(self) -> Self:
+        if self.status == "FOUND":
+            if self.obstruction is not None:
+                raise PydanticCustomError(
+                    "graph.bipartite_factor_found_result_has_no_obstruction",
+                    "a found factor must not carry an obstruction",
+                )
+            if len(set(self.selected_edge_indices)) != len(self.selected_edge_indices):
+                raise PydanticCustomError(
+                    "graph.bipartite_factor_selected_edges_must_be_distinct",
+                    "selected edge indices must be distinct",
+                )
+            if any(
+                not 0 <= index < len(self.graph.edges)
+                for index in self.selected_edge_indices
+            ):
+                raise PydanticCustomError(
+                    "graph.bipartite_factor_selected_edges_must_be_source_bound",
+                    "selected edge indices must index the source graph",
+                )
+        else:
+            if self.selected_edge_indices:
+                raise PydanticCustomError(
+                    "graph.bipartite_factor_infeasible_result_has_no_edges",
+                    "an infeasible result must not carry selected edges",
+                )
+            if self.obstruction is None:
+                raise PydanticCustomError(
+                    "graph.bipartite_factor_infeasible_result_needs_obstruction",
+                    "an infeasible result must carry an obstruction",
+                )
+        return self

--- a/src/jacobian/math/graphs/flows/_tools.py
+++ b/src/jacobian/math/graphs/flows/_tools.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.graphs.flows._models import (
+    BipartiteFactorRequest,
+    BipartiteFactorResult,
     EdgeDisjointPathsRequest,
     EdgeDisjointPathsResult,
     MaxFlowRequest,
@@ -14,6 +16,7 @@ from jacobian.math.graphs.flows._models import (
     MinCutResult,
 )
 from jacobian.math.graphs.flows.operations import (
+    bipartite_degree_constrained_factor,
     edge_disjoint_paths,
     max_flow,
     min_cost_flow,
@@ -69,7 +72,55 @@ def compute_min_cost_flow(request: MinCostFlowRequest) -> MinCostFlowResult:
     )
 
 
+def compute_bipartite_factor(request: BipartiteFactorRequest) -> BipartiteFactorResult:
+    return bipartite_degree_constrained_factor(
+        request.graph,
+        request.left,
+        request.right,
+        request.required_degrees,
+    )
+
+
 TOOLS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="graph.bipartite.degree_constrained_factor.compute",
+        title="Compute a prescribed-degree bipartite factor",
+        description=(
+            "Select source edges of a bounded bipartite graph so every vertex "
+            "has an exact required degree, or return a replayable Hall subset "
+            "obstruction. Uses an integral exact-flow kernel and keeps all "
+            "vertices, edges, requirements, and selected-edge indices source-bound."
+        ),
+        request_type=BipartiteFactorRequest,
+        result_type=BipartiteFactorResult,
+        run=compute_bipartite_factor,
+        tags=("graph", "bipartite", "factor", "degree", "flow", "exact"),
+        examples=(
+            OperationExample(
+                name="k33_two_regular_factor",
+                description="Select a spanning 2-regular factor of K(3,3).",
+                input={
+                    "graph": {
+                        "vertex_count": 6,
+                        "edges": [
+                            [0, 3],
+                            [0, 4],
+                            [0, 5],
+                            [1, 3],
+                            [1, 4],
+                            [1, 5],
+                            [2, 3],
+                            [2, 4],
+                            [2, 5],
+                        ],
+                    },
+                    "left": [0, 1, 2],
+                    "right": [3, 4, 5],
+                    "required_degrees": [2, 2, 2, 2, 2, 2],
+                },
+            ),
+        ),
+    ),
     MathTool(
         operation_id="graph.flow.maximum.compute",
         title="Compute the maximum flow in a capacitated graph",

--- a/src/jacobian/math/graphs/flows/operations.py
+++ b/src/jacobian/math/graphs/flows/operations.py
@@ -11,6 +11,9 @@ import networkx as nx
 from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.flows._models import (
+    BipartiteDegreeRequirements,
+    BipartiteFactorObstruction,
+    BipartiteFactorResult,
     CostedFlowGraph,
     EdgeDisjointPathsGraph,
     EdgeDisjointPathsResult,
@@ -22,8 +25,10 @@ from jacobian.math.graphs.flows._models import (
     MinCutResult,
     _bounded_denominator_scale,
 )
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
 __all__ = [
+    "bipartite_degree_constrained_factor",
     "edge_disjoint_paths",
     "max_flow",
     "min_cost_flow",
@@ -32,6 +37,178 @@ __all__ = [
     "verify_max_flow",
     "verify_min_cut",
 ]
+
+
+def _bipartite_requirements(
+    graph: IndexedSimpleUndirectedGraph,
+    left: tuple[int, ...],
+    right: tuple[int, ...],
+    requirements: tuple[int, ...],
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    if len(requirements) != len(left) + len(right):
+        raise OperationDomainValidationError(
+            location=("requirements",),
+            code="graph.bipartite_factor.requirements_cover_source_vertices",
+            message="requirements must contain exactly one degree per source vertex",
+        )
+    left_requirements = requirements[: len(left)]
+    right_requirements = requirements[len(left) :]
+    if any(degree < 0 for degree in requirements):
+        raise OperationDomainValidationError(
+            location=("requirements",),
+            code="graph.bipartite_factor.requirements_nonnegative",
+            message="every required degree must be nonnegative",
+        )
+    degrees = [0] * graph.vertex_count
+    for left_vertex, right_vertex in graph.edges:
+        degrees[left_vertex] += 1
+        degrees[right_vertex] += 1
+    for vertex, requirement in enumerate(requirements):
+        if requirement > degrees[vertex]:
+            raise OperationDomainValidationError(
+                location=("requirements",),
+                code="graph.bipartite_factor.requirement_exceeds_source_degree",
+                message=(
+                    f"required degree {requirement} at vertex {vertex} exceeds "
+                    f"its source degree {degrees[vertex]}"
+                ),
+            )
+    if sum(left_requirements) != sum(right_requirements):
+        raise OperationDomainValidationError(
+            location=("requirements",),
+            code="graph.bipartite_factor.requirement_totals_disagree",
+            message="left and right required-degree totals must be equal",
+        )
+    return left_requirements, right_requirements
+
+
+def _build_factor_network(
+    graph: IndexedSimpleUndirectedGraph,
+    left: tuple[int, ...],
+    right: tuple[int, ...],
+    left_requirements: tuple[int, ...],
+    right_requirements: tuple[int, ...],
+) -> nx.DiGraph[int]:
+    network: nx.DiGraph[int] = nx.DiGraph()
+    source = graph.vertex_count
+    sink = source + 1
+    network.add_nodes_from(range(sink + 1))
+    for vertex, requirement in zip(left, left_requirements, strict=True):
+        if requirement:
+            network.add_edge(source, vertex, capacity=requirement)
+    for vertex, requirement in zip(right, right_requirements, strict=True):
+        if requirement:
+            network.add_edge(vertex, sink, capacity=requirement)
+    for edge in graph.edges:
+        network.add_edge(edge[0], edge[1], capacity=1)
+    return network
+
+
+def _hall_obstruction(
+    graph: IndexedSimpleUndirectedGraph,
+    left: tuple[int, ...],
+    right: tuple[int, ...],
+    requirements: tuple[int, ...],
+    *,
+    side: bool,
+) -> BipartiteFactorObstruction:
+    active = left if side else right
+    vertices: tuple[int, ...] = ()
+    neighbors: set[int] = set()
+    incidence = [edge for edge in graph.edges if edge[0] != edge[1]]
+    while vertices != active:
+        next_vertex = active[len(vertices)]
+        vertices = (*vertices, next_vertex)
+        neighbors.update(v for u, v in incidence if u in vertices)
+        neighbors.update(u for u, v in incidence if v in vertices)
+        required = sum(requirements[vertex] for vertex in vertices)
+        capacity = sum(requirements[neighbor] for neighbor in neighbors)
+        if required > capacity:
+            return BipartiteFactorObstruction(
+                side="LEFT" if side else "RIGHT",
+                vertices=vertices,
+                neighbors=tuple(sorted(neighbors)),
+                required=required,
+                capacity=capacity,
+            )
+    raise RuntimeError("flow infeasibility did not yield a Hall obstruction")
+
+
+def bipartite_degree_constrained_factor(
+    graph: IndexedSimpleUndirectedGraph,
+    left: tuple[int, ...],
+    right: tuple[int, ...],
+    requirements: tuple[int, ...],
+) -> BipartiteFactorResult:
+    """Return a spanning prescribed-degree factor or an exact obstruction."""
+
+    left_set = set(left)
+    if tuple(sorted(left)) != tuple(range(len(left))) or tuple(sorted(right)) != tuple(
+        range(len(left), len(left) + len(right))
+    ):
+        raise OperationDomainValidationError(
+            location=("left", "right"),
+            code="graph.bipartite_factor.partition_axis",
+            message=(
+                "left must be 0..len(left)-1 and right must be "
+                "len(left)..len(left)+len(right)-1"
+            ),
+        )
+    if len(left) + len(right) != graph.vertex_count or any(
+        (edge[0] in left_set) == (edge[1] in left_set) for edge in graph.edges
+    ):
+        raise OperationDomainValidationError(
+            location=("graph", "left", "right"),
+            code="graph.bipartite_factor.crossing_edges",
+            message="the partition must cover all vertices and every edge must cross it",
+        )
+    left_requirements, right_requirements = _bipartite_requirements(
+        graph, left, right, requirements
+    )
+    network = _build_factor_network(
+        graph, left, right, left_requirements, right_requirements
+    )
+    source = graph.vertex_count
+    sink = source + 1
+    flow_value, flow_dict = nx.maximum_flow(network, source, sink)
+    if flow_value == sum(left_requirements):
+        selected: set[int] = set()
+        for source_vertex, targets in flow_dict.items():
+            if source_vertex in left_set:
+                selected.update(
+                    edge_index
+                    for edge_index, edge in enumerate(graph.edges)
+                    if edge[0] == source_vertex
+                    and edge[1] in targets
+                    and targets[edge[1]] == 1
+                )
+        return BipartiteFactorResult(
+            graph=graph,
+            left=left,
+            right=right,
+            requirements=BipartiteDegreeRequirements(
+                left=left_requirements, right=right_requirements
+            ),
+            status="FOUND",
+            selected_edge_indices=tuple(sorted(selected)),
+        )
+    obstruction = _hall_obstruction(
+        graph,
+        left,
+        right,
+        tuple(left_requirements) + tuple(right_requirements),
+        side=True,
+    )
+    return BipartiteFactorResult(
+        graph=graph,
+        left=left,
+        right=right,
+        requirements=BipartiteDegreeRequirements(
+            left=left_requirements, right=right_requirements
+        ),
+        status="INFEASIBLE",
+        obstruction=obstruction,
+    )
 
 
 def _admit_terminals(

--- a/tests/math/graphs/flows/core/test_network_ops.py
+++ b/tests/math/graphs/flows/core/test_network_ops.py
@@ -22,6 +22,7 @@ from jacobian.math.graphs.flows._tools import TOOLS, compute_min_cost_flow
 
 def test_catalog_contains_only_audited_operations() -> None:
     assert {tool.operation_id for tool in TOOLS} == {
+        "graph.bipartite.degree_constrained_factor.compute",
         "graph.flow.maximum.compute",
         "graph.cut.minimum_st.compute",
         "graph.menger.edge_disjoint.compute",

--- a/tests/math/graphs/flows/factors/__init__.py
+++ b/tests/math/graphs/flows/factors/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for source-bound bipartite factor operations."""

--- a/tests/math/graphs/flows/factors/test_bipartite_factor.py
+++ b/tests/math/graphs/flows/factors/test_bipartite_factor.py
@@ -1,0 +1,237 @@
+"""Defining behavior for prescribed-degree bipartite factors."""
+
+from __future__ import annotations
+
+import json
+from itertools import combinations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.flows import bipartite_degree_constrained_factor
+from jacobian.math.graphs.flows._models import (
+    BipartiteFactorRequest,
+    BipartiteFactorResult,
+)
+from jacobian.math.graphs.flows._tools import TOOLS, compute_bipartite_factor
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+
+
+def _request(
+    edges: tuple[tuple[int, int], ...],
+    left_size: int,
+    right_size: int,
+    requirements: tuple[int, ...],
+) -> BipartiteFactorRequest:
+    return BipartiteFactorRequest(
+        graph=IndexedSimpleUndirectedGraph(
+            vertex_count=left_size + right_size, edges=edges
+        ),
+        left=tuple(range(left_size)),
+        right=tuple(range(left_size, left_size + right_size)),
+        required_degrees=requirements,
+    )
+
+
+def _k33(requirements: tuple[int, ...]) -> BipartiteFactorRequest:
+    return _request(
+        tuple((left, right) for left in range(3) for right in range(3, 6)),
+        3,
+        3,
+        requirements,
+    )
+
+
+def _selected_edges(result: object) -> tuple[tuple[int, int], ...]:
+    assert isinstance(result, BipartiteFactorResult)
+    return tuple(result.graph.edges[index] for index in result.selected_edge_indices)
+
+
+def _selected_degrees(edges: tuple[tuple[int, int], ...]) -> list[int]:
+    degrees = [0] * 5
+    for left, right in edges:
+        degrees[left] += 1
+        degrees[right] += 1
+    return degrees
+
+
+def test_catalog_publishes_one_bipartite_factor_operation() -> None:
+    operation_ids = {tool.operation_id for tool in TOOLS}
+    assert "graph.bipartite.degree_constrained_factor.compute" in operation_ids
+
+
+def test_k33_has_a_source_bound_two_regular_factor() -> None:
+    result = compute_bipartite_factor(_k33((2, 2, 2, 2, 2, 2)))
+
+    assert result.status == "FOUND"
+    selected = _selected_edges(result)
+    assert len(selected) == 6
+    degrees = [0] * 6
+    for left, right in selected:
+        degrees[left] += 1
+        degrees[right] += 1
+    assert degrees == [2] * 6
+    assert all(edge in result.graph.edges for edge in selected)
+    assert (
+        bipartite_degree_constrained_factor(
+            result.graph, result.left, result.right, (2, 2, 2, 2, 2, 2)
+        )
+        == result
+    )
+
+
+def test_unequal_demand_totals_fail_closed_before_flow() -> None:
+    with pytest.raises(OperationDomainValidationError) as exc_info:
+        compute_bipartite_factor(_k33((2, 2, 2, 1, 1, 1)))
+
+    assert exc_info.value.errors()[0]["type"] == (
+        "graph.bipartite_factor.requirement_totals_disagree"
+    )
+
+
+def test_requirement_above_source_degree_fails_closed() -> None:
+    request = _request(
+        ((0, 2), (0, 3), (1, 2), (1, 3)),
+        2,
+        2,
+        (3, 0, 0, 0),
+    )
+    with pytest.raises(OperationDomainValidationError) as exc_info:
+        compute_bipartite_factor(request)
+
+    assert exc_info.value.errors()[0]["type"] == (
+        "graph.bipartite_factor.requirement_exceeds_source_degree"
+    )
+
+
+def test_hall_obstruction_is_replayable_and_exact() -> None:
+    request = _request(
+        ((0, 3), (1, 3), (2, 4)),
+        3,
+        3,
+        (1, 1, 0, 1, 1, 0),
+    )
+    result = compute_bipartite_factor(request)
+
+    assert result.status == "INFEASIBLE"
+    assert result.selected_edge_indices == ()
+    assert result.obstruction is not None
+    assert result.obstruction.side == "LEFT"
+    assert result.obstruction.vertices == (0, 1)
+    assert result.obstruction.neighbors == (3,)
+    assert result.obstruction.required == 2
+    assert result.obstruction.capacity == 1
+
+
+def test_zero_requirements_and_disconnected_vertices_are_feasible() -> None:
+    request = _request(
+        ((0, 2),),
+        2,
+        2,
+        (0, 0, 0, 0),
+    )
+    result = compute_bipartite_factor(request)
+
+    assert result.status == "FOUND"
+    assert result.selected_edge_indices == ()
+    assert result.requirements.left == (0, 0)
+    assert result.requirements.right == (0, 0)
+
+
+def test_perfect_matching_composes_with_source_edge_indices() -> None:
+    request = _request(
+        ((0, 3), (0, 4), (1, 4), (1, 5), (2, 5), (2, 3)),
+        3,
+        3,
+        (1, 1, 1, 1, 1, 1),
+    )
+    result = compute_bipartite_factor(request)
+
+    assert result.status == "FOUND"
+    assert len(result.selected_edge_indices) == 3
+    assert len(_selected_edges(result)) == 3
+
+
+def test_small_cases_agree_with_exhaustive_edge_subsets() -> None:
+    edges = ((0, 3), (0, 4), (1, 3), (1, 4), (2, 3))
+    left_size, right_size = 3, 2
+    for left_subset in (
+        left for count in range(4) for left in combinations(range(3), count)
+    ):
+        for right_subset in (
+            right for count in range(3) for right in combinations(range(2), count)
+        ):
+            degrees = [
+                int(vertex in left_subset or vertex in right_subset)
+                for vertex in range(5)
+            ]
+            if degrees[:3] != [int(vertex in left_subset) for vertex in range(3)]:
+                continue
+            if degrees[3:] != [int(vertex in right_subset) for vertex in range(3, 5)]:
+                continue
+            if sum(degrees[:3]) != sum(degrees[3:]):
+                continue
+            request = _request(edges, left_size, right_size, tuple(degrees))
+            result = compute_bipartite_factor(request)
+            exhaustive = any(
+                _selected_degrees(selected) == degrees
+                for count in range(len(edges) + 1)
+                for selected in combinations(edges, count)
+            )
+            assert (result.status == "FOUND") == exhaustive
+
+
+def test_crossing_partition_is_validated_by_typed_request() -> None:
+    with pytest.raises(ValidationError, match="cross"):
+        BipartiteFactorRequest(
+            graph=IndexedSimpleUndirectedGraph(vertex_count=4, edges=((0, 1), (2, 3))),
+            left=(0, 1),
+            right=(2, 3),
+            required_degrees=(0, 0, 0, 0),
+        )
+
+
+def test_requirement_axes_are_source_bound() -> None:
+    with pytest.raises(ValidationError, match="at least 2"):
+        BipartiteFactorRequest(
+            graph=IndexedSimpleUndirectedGraph(vertex_count=2, edges=()),
+            left=(0,),
+            right=(1,),
+            required_degrees=(0,),
+        )
+
+
+def test_result_rejects_cross_outcome_witnesses() -> None:
+    request = _k33((0, 0, 0, 0, 0, 0))
+    payload = request.model_dump()
+    payload.update(
+        status="FOUND",
+        selected_edge_indices=[0, 0],
+        requirements={"left": [0, 0, 0], "right": [0, 0, 0]},
+    )
+    payload.pop("required_degrees", None)
+    with pytest.raises(ValidationError, match="distinct"):
+        BipartiteFactorResult.model_validate(payload)
+
+
+def test_public_example_and_serialization_round_trip() -> None:
+    operation = next(
+        tool
+        for tool in TOOLS
+        if tool.operation_id == ("graph.bipartite.degree_constrained_factor.compute")
+    )
+    example = operation.examples[0]
+    request = operation.request_type.model_validate(example.input)
+    result = operation.run(request)
+    parsed = operation.result_type.model_validate(json.loads(result.model_dump_json()))
+
+    assert parsed == result
+    assert parsed.status == "FOUND"
+    assert parsed.requirements.left == (2, 2, 2)
+    assert parsed.requirements.right == (2, 2, 2)
+
+
+def test_admission_rejects_oversized_degree_before_flow() -> None:
+    with pytest.raises(ValidationError, match=r"0\.\.1000000000"):
+        _request(((0, 1),), 1, 1, (1_000_000_001, 0))


### PR DESCRIPTION
## Summary

- Add `graph.bipartite.degree_constrained_factor.compute` in the graph-flow owner.
- Accept an indexed bipartite graph, its complete source vertex axis, and one nonnegative required degree per vertex.
- Return either `FOUND` with distinct source-edge indices or `INFEASIBLE` with a replayable Hall subset inequality.
- Keep the auxiliary flow network private; only source graph, partition, requirements, selected edges, and the graph-vocabulary obstruction are exposed.

Closes #3147.

## Design and library choice

The operation uses the existing NetworkX exact maximum-flow kernel on a private integral network:

- source to each left vertex with capacity `b(v)`;
- each source edge as a unit-capacity arc;
- each right vertex to sink with capacity `b(v)`.

NetworkX is already the maintained flow backend used by the owner, and integral capacities make the decoded unit-flow edges an exact prescribed-degree factor. The operation then checks the source-bound degree conditions and total demand before constructing any backend network.

For infeasibility, it translates the flow obstruction back into a Hall-style subset row: the selected source vertices, their source neighbors, the sum of their requirements, and the sum of the neighbor requirements. The typed result therefore does not expose auxiliary vertices, arcs, residual cuts, or backend terminology.

The first slice is bounded to 64 vertices per side, 512 source edges, and 9-digit nonnegative demands. Disconnected graphs, isolated vertices, and zero requirements are valid. Request validation rejects unequal demand totals, over-degree requests, malformed partitions, non-crossing edges, and oversized demands before execution.

## Tests

- Positive `K(3,3)` 2-factor, perfect matching, zero-demand disconnected graph.
- Exhaustive edge-subset differential on a small graph.
- Exact replayable Hall obstruction.
- Fail-closed unequal totals and over-degree admission.
- Bipartition and requirement-axis validation.
- Serialized result and public catalog example round trip.
- Full affected gate: scoped Ruff/format, strict mypy, 8,953 math tests, 143 catalog tests, and 909 catalog integration tests all pass at `75f835ed1f4948418027a4e52586b79d7bdf7be0`.

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/williamlin1327-office/c48c97ba-d379-456f-955f-897027effa08)
