### PR TITLE
fix: preserve MCP contracts and exact-value composition

### DIFF
--- a/benchmarks/tooling/codex_telemetry.py
+++ b/benchmarks/tooling/codex_telemetry.py
@@ -336,9 +336,17 @@ def _record_describe_and_attempt(
     direct_operation_ids: Set[str],
 ) -> None:
     if tool == "math.find":
-        request = arguments.get("request") if isinstance(arguments, Mapping) else None
-        if isinstance(request, Mapping) and request.get("op") == "inspect":
-            requested_operation_id = request.get("operation_id")
+        wrapped_request = (
+            arguments.get("request") if isinstance(arguments, Mapping) else None
+        )
+        if isinstance(wrapped_request, Mapping):
+            discovery_request = wrapped_request
+            is_inspection = wrapped_request.get("op") == "inspect"
+        else:
+            discovery_request = arguments if isinstance(arguments, Mapping) else {}
+            is_inspection = isinstance(discovery_request.get("operation_id"), str)
+        if is_inspection:
+            requested_operation_id = discovery_request.get("operation_id")
             inspected_operation = (
                 response.get("operation") if isinstance(response, Mapping) else None
             )
@@ -550,15 +558,16 @@ def _build_operation_description(
     cards = None
     if isinstance(response, Mapping):
         cards = response.get("matches", response.get("operations"))
-    request = arguments.get("request")
-    request = request if isinstance(request, Mapping) else {}
+    wrapped_request = arguments.get("request")
+    request = wrapped_request if isinstance(wrapped_request, Mapping) else arguments
+    query = request.get("need", request.get("query"))
     return {
         "kind": (
             response.get("kind")
             if isinstance(response, Mapping) and isinstance(response.get("kind"), str)
             else None
         ),
-        "need": (request.get("need") if isinstance(request.get("need"), str) else None),
+        "need": query if isinstance(query, str) else None,
         "namespace": (
             request.get("namespace")
             if isinstance(request.get("namespace"), str)

--- a/benchmarks/tooling/mcp_catalog_evaluation.py
+++ b/benchmarks/tooling/mcp_catalog_evaluation.py
@@ -257,15 +257,14 @@ async def _run_discovery(
     cursor: str | None = None
     while len(match_ids) < limit:
         request: dict[str, Any] = {
-            "op": "match",
-            "need": query,
+            "query": query,
             "limit": min(10, limit - len(match_ids)),
         }
         if namespace is not None:
             request["namespace"] = namespace
         if cursor is not None:
             request["cursor"] = cursor
-        result = await client.call_tool("math.find", {"request": request})
+        result = await client.call_tool("math.find", request)
         payload = result.structured_content
         if not isinstance(payload, dict):
             raise RuntimeError("math.find omitted structured discovery output")

--- a/benchmarks/validation/test_direct_mcp_catalog_evaluation.py
+++ b/benchmarks/validation/test_direct_mcp_catalog_evaluation.py
@@ -240,10 +240,8 @@ def test_discovery_probe_paginates_to_its_declared_limit() -> None:
             self, name: str, arguments: dict[str, object]
         ) -> SimpleNamespace:
             assert name == "math.find"
-            request = arguments["request"]
-            assert isinstance(request, dict)
-            self.requests.append(request)
-            start = 0 if "cursor" not in request else 10
+            self.requests.append(arguments)
+            start = 0 if "cursor" not in arguments else 10
             payload: dict[str, object] = {
                 "matches": [
                     {"operation_id": f"example.operation.{index:02d}"}

--- a/deploy/smoke_remote.py
+++ b/deploy/smoke_remote.py
@@ -182,7 +182,7 @@ async def inspect(
             )
         discovery_result = await client.call_tool(
             "math.find",
-            {"request": {"op": "match", "need": need, "limit": 5}},
+            {"query": need, "limit": 5},
         )
         if discovery_result.is_error:
             failures.append("deployed operation discovery returned an MCP error")

--- a/deploy/smoke_stdio.py
+++ b/deploy/smoke_stdio.py
@@ -38,12 +38,7 @@ async def inspect(server: Path, *, timeout_seconds: float) -> None:
         described = await asyncio.wait_for(
             client.call_tool(
                 "math.find",
-                {
-                    "request": {
-                        "op": "inspect",
-                        "operation_id": "integer.compute.extended_gcd",
-                    }
-                },
+                {"operation_id": "integer.compute.extended_gcd"},
             ),
             timeout_seconds,
         )

--- a/docs/how-to/invoke-domain-operations.md
+++ b/docs/how-to/invoke-domain-operations.md
@@ -20,11 +20,11 @@ For example, search for a small number of matrix operations, then inspect an
 exact candidate:
 
 ```json
-{"request":{"op":"match","need":"exact determinant of a rational matrix","namespace":"matrix","limit":3}}
+{"query":"exact determinant of a rational matrix","namespace":"matrix","limit":3}
 ```
 
 ```json
-{"request":{"op":"inspect","operation_id":"matrix.determinant.compute"}}
+{"operation_id":"matrix.determinant.compute"}
 ```
 
 The optional `namespace` filter matches only the first segment of an operation

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -274,7 +274,8 @@ structurally invalid payload raises `OperationRequestValidationError`. A
 structurally valid payload rejected by native mathematical admission raises
 `OperationDomainValidationError`; where practical, assert that
 native and dispatch calls preserve the same structured owner error code. MCP
-projects both validation classes as `INVALID_PARAMS`. Timeout, cancellation,
+projects both validation classes through the model-visible tool-error channel
+with bounded structured diagnostics. Timeout, cancellation,
 host or worker failure, and unexpected backend failures remain
 operational errors and project as agent-visible tool failures. Test that these
 paths establish no mathematical result and do not become invalid-parameter

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -56,7 +56,8 @@ operational failure, not a mathematical conclusion.
 ## Execution non-completion and recovery
 
 MCP distinguishes an invalid request from a valid call that could not complete.
-Structural or mathematical admission failures use `INVALID_PARAMS`. Timeout,
+Structural or mathematical admission failures use the model-visible tool error
+channel with a bounded structured diagnostic. Timeout,
 cancellation, configured worker or host capacity exhaustion, backend failure,
 and delivery failure return an agent-visible tool error (`is_error=true`). The
 error is not a mathematical result and must not be interpreted as `False`,
@@ -69,11 +70,11 @@ An agent can retry with a smaller request, a more compact representation,
 another backend, or a deployment with more capacity. Diagnostics may name the
 exhausted boundary, but exact results are never truncated.
 
-Use `math.find` with `request.op="match"` and a short description of the local
-result needed. Its compact matches retain `catalog_resource` as an explicit
-pointer to the bulk catalog export. Then call `math.find` with
-`request.op="inspect"` to obtain the selected operation's exact input/output
-schemas and valid examples.
+Use `math.find` with `query` and a short description of the local result needed.
+Its compact matches retain `catalog_resource` as an explicit pointer to the bulk
+catalog export. Then call `math.find` with `operation_id` to obtain the selected
+operation's exact input/output schemas and valid examples. Provide exactly one of
+`query` and `operation_id`; `namespace`, `limit`, and `cursor` are search-only.
 
 ## Form a payload from an inspected contract
 
@@ -81,7 +82,7 @@ Inspect an operation before constructing an unfamiliar payload. Start from one
 of its valid examples, when it has one, and adapt it to the mathematical input.
 Otherwise form the payload from the input schema and field descriptions. They
 state the required representation, including units, bounds, and canonical
-encodings or ordering where they matter. An `INVALID_PARAMS` response from
+encodings or ordering where they matter. An invalid-request tool error from
 `math.run` means either that the payload was structurally malformed or that the
 operation's mathematical admission rejected an otherwise well-formed request.
 Use its structured diagnostic to make the smallest correction before drawing a

--- a/docs/reference/value-interoperability.md
+++ b/docs/reference/value-interoperability.md
@@ -30,6 +30,14 @@ Use these rules when designing or repairing an operation:
    the characteristic polynomial of A,” it must establish that additional
    relation under its own admission.
 
+Graph transforms return the same `IndexedSimpleUndirectedGraph` value that
+indexed graph operations consume, including the null graph and canonical
+`(left, right)` edge pairs with `left < right`. Its encoding envelope allows
+1,024 vertices and 65,536 edges so existing line-graph outputs remain
+representable. This is not a computational admission promise: each consumer
+retains its own work and size limits. Label-based `SimpleUndirectedGraph`
+values retain their separate 256-vertex envelope.
+
 ## Values, witnesses, and source binding
 
 | Need | Appropriate result |

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_models.py
@@ -21,7 +21,7 @@ from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import encode_strict_json
 from jacobian.math.graphs.values import (
     MAX_GRAPH_LABEL_BYTES,
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
 
@@ -654,14 +654,14 @@ class EdgeIntersectionGraphRequest(StrictModel):
     are adjacent if and only if the corresponding hyperedges have nonempty
     intersection.  Because the result is a canonical
     :class:`SimpleUndirectedGraph`, the operation admits at most
-    ``MAX_INDEXED_SIMPLE_GRAPH_VERTICES`` edge IDs; every ID must be nonempty,
+    ``MAX_SIMPLE_GRAPH_VERTICES`` edge IDs; every ID must be nonempty,
     NFC-normalized, and at most ``MAX_GRAPH_LABEL_BYTES`` UTF-8 bytes.
     """
 
     hypergraph: FiniteHypergraph = Field(
         description=(
             "Canonical finite hypergraph with at most "
-            f"{MAX_INDEXED_SIMPLE_GRAPH_VERTICES} edges. For the graph carrier, "
+            f"{MAX_SIMPLE_GRAPH_VERTICES} edges. For the graph carrier, "
             "every edge ID must be nonempty, Unicode NFC-normalized, and at most "
             f"{MAX_GRAPH_LABEL_BYTES} UTF-8 bytes."
         ),
@@ -669,7 +669,7 @@ class EdgeIntersectionGraphRequest(StrictModel):
             "edge_id_nfc": True,
             "edge_id_nonempty": True,
             "edge_id_utf8_bytes_bound": MAX_GRAPH_LABEL_BYTES,
-            "graph_vertex_count_bound": MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+            "graph_vertex_count_bound": MAX_SIMPLE_GRAPH_VERTICES,
         },
     )
 

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/operations.py
@@ -38,7 +38,7 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 )
 from jacobian.math.graphs.values import (
     MAX_GRAPH_LABEL_BYTES,
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
 
@@ -149,13 +149,13 @@ def _admit_edge_intersection_graph(
             )
     # The edge-intersection graph maps each hyperedge to a graph vertex, so
     # the number of hyperedges must fit the SimpleUndirectedGraph carrier.
-    if len(hypergraph.edges) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
+    if len(hypergraph.edges) > MAX_SIMPLE_GRAPH_VERTICES:
         raise OperationDomainValidationError(
             location=("hypergraph",),
             code="hypergraph.edge_intersection_graph.carrier_vertex_bound",
             message=(
                 "edge-intersection graph exceeds the "
-                f"{MAX_INDEXED_SIMPLE_GRAPH_VERTICES}-vertex graph carrier bound"
+                f"{MAX_SIMPLE_GRAPH_VERTICES}-vertex graph carrier bound"
             ),
         )
     # Vertex labels of the target graph are the edge IDs of the source

--- a/src/jacobian/math/combinatorics/operations.py
+++ b/src/jacobian/math/combinatorics/operations.py
@@ -163,7 +163,13 @@ def _falling_factorial_digit_bound(n: int, k: int) -> int:
 def _bind_counting_deadline() -> None:
     execution = current_request_execution()
     started = execution.started_at if execution is not None else time.monotonic()
-    bind_request_deadline(started + 120.0)
+    owner_deadline = started + 120.0
+    deadline = (
+        min(execution.deadline, owner_deadline)
+        if execution is not None and execution.deadline is not None
+        else owner_deadline
+    )
+    bind_request_deadline(deadline)
 
 
 def _canonical_count(operation: str, n: int, k: int) -> int:

--- a/src/jacobian/math/geometry/algebraic_curves/operations.py
+++ b/src/jacobian/math/geometry/algebraic_curves/operations.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import sympy
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.geometry.algebraic_curves._conic import (
     ConicParametrizationData,
     derive_rational_conic_parametrization,
@@ -251,7 +254,9 @@ def verify_projective_plane_curve_singularity_profile(
 
     try:
         return singularity_profile(claim.source_polynomial) == claim
-    except (OperationDomainValidationError, ValueError, TypeError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError, TypeError):
         return False
 
 

--- a/src/jacobian/math/geometry/differential/operations.py
+++ b/src/jacobian/math/geometry/differential/operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.geometry.differential._bounds import (
     build_lie_derivative_plan,
 )
@@ -68,7 +69,9 @@ def verify_lie_derivative(claim: RationalLieDerivativeProfile) -> bool:
     try:
         expected = lie_derivative(claim.vector_field, claim.source)
         return expected.lie_derivative == claim.lie_derivative
-    except (ValueError, TypeError, ArithmeticError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (ValueError, TypeError, ArithmeticError):
         return False
 
 

--- a/src/jacobian/math/geometry/exact/operations.py
+++ b/src/jacobian/math/geometry/exact/operations.py
@@ -9,7 +9,10 @@ from itertools import combinations, permutations
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.geometry.exact._line_arithmetic import (
     canonical_line_coefficients,
     squared_point_line_distance,
@@ -98,7 +101,9 @@ def verify_distance_profile(claim: DistanceProfileResult) -> bool:
     """Verify a serialized distance profile against its retained source."""
     try:
         return distance_profile(claim.configuration) == claim
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False
 
 
@@ -108,7 +113,9 @@ def verify_distance_graph(claim: DistanceGraphResult) -> bool:
         return (
             distance_graph(claim.configuration, claim.target_squared_distance) == claim
         )
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False
 
 
@@ -191,7 +198,9 @@ def verify_euclidean_orbit_profile(claim: EuclideanOrbitProfileResult) -> bool:
     """Verify canonical orbit forms and relabelings against their source."""
     try:
         return euclidean_orbit_profile(claim.configuration) == claim
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False
 
 
@@ -267,7 +276,9 @@ def verify_pinned_line_distance_profile(claim: PinnedLineDistanceResult) -> bool
     """Verify the pinned line profile against its retained source and anchor."""
     try:
         return pinned_line_distance_profile(claim.configuration, claim.anchor) == claim
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False
 
 

--- a/src/jacobian/math/geometry/exact/pinned_distance/operations.py
+++ b/src/jacobian/math/geometry/exact/pinned_distance/operations.py
@@ -9,7 +9,10 @@ from typing import NoReturn
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.geometry.exact._models import PointConfiguration
 from jacobian.math.geometry.exact.pinned_distance._models import (
     DistanceClass,
@@ -126,7 +129,9 @@ def verify_pinned_distance_support_profile(
     """Verify a serialized support profile against its retained configuration."""
     try:
         return compute_pinned_distance_support_profile(claim.configuration) == claim
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False
 
 

--- a/src/jacobian/math/geometry/exact/spanned_line_profile/operations.py
+++ b/src/jacobian/math/geometry/exact/spanned_line_profile/operations.py
@@ -9,7 +9,10 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.geometry.exact._models import PointConfiguration
 from jacobian.math.geometry.exact.spanned_line_profile._models import (
     SpannedLineEntry,
@@ -101,7 +104,9 @@ def verify_spanned_line_profile(claim: SpannedLineProfileResult) -> bool:
     """Verify a serialized line profile against its retained configuration."""
     try:
         return compute_spanned_line_profile(claim.configuration) == claim
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False
 
 

--- a/src/jacobian/math/geometry/exact/triangle_area_profile/operations.py
+++ b/src/jacobian/math/geometry/exact/triangle_area_profile/operations.py
@@ -9,7 +9,10 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.geometry.exact._models import PointConfiguration
 from jacobian.math.geometry.exact.triangle_area_profile._models import (
     TriangleAreaEntry,
@@ -141,5 +144,7 @@ def verify_triangle_area_profile(claim: TriangleAreaProfileResult) -> bool:
     """Verify a serialized triangle-area profile against its source."""
     try:
         return compute_triangle_area_profile(claim.configuration) == claim
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False

--- a/src/jacobian/math/geometry/framework/operations.py
+++ b/src/jacobian/math/geometry/framework/operations.py
@@ -9,7 +9,10 @@ from typing import NoReturn
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.geometry.exact._models import PointConfiguration
 from jacobian.math.geometry.framework._bounds import (
     MAX_FRAMEWORK_COORDINATE_WORK,
@@ -211,7 +214,9 @@ def verify_planar_rigidity_profile(claim: PlanarRigidityProfile) -> bool:
             and claim.maximal_infinitesimal_rigidity_rank == maximal_rank
             and claim.is_infinitesimally_rigid == (expected_rank.rank == maximal_rank)
         )
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False
 
 

--- a/src/jacobian/math/graphs/chordal/_models.py
+++ b/src/jacobian/math/graphs/chordal/_models.py
@@ -9,7 +9,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
 
@@ -76,7 +76,7 @@ class ChordalRecognitionResult(StrictModel):
                     "graph.chordal.cycle_shape",
                     "the induced cycle needs at least four distinct vertices",
                 )
-            if len(cycle) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
+            if len(cycle) > MAX_SIMPLE_GRAPH_VERTICES:
                 raise _validation_error(
                     "graph.chordal.cycle_shape",
                     "the induced cycle cannot exceed the graph vertex bound",

--- a/src/jacobian/math/graphs/clique_partition/_models.py
+++ b/src/jacobian/math/graphs/clique_partition/_models.py
@@ -10,8 +10,8 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_EDGES,
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_EDGES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     GraphVertexLabel,
     SimpleUndirectedGraph,
 )
@@ -19,12 +19,12 @@ from jacobian.math.graphs.values import (
 # Candidate parts are vertex subsets; pair work per part is quadratic in its
 # size. Both the part count and the aggregate pair checks are bounded before
 # any adjacency expansion.
-MAX_PARTITION_VERTEX_REFERENCES = 2 * MAX_INDEXED_SIMPLE_GRAPH_EDGES
+MAX_PARTITION_VERTEX_REFERENCES = 2 * MAX_SIMPLE_GRAPH_EDGES
 MAX_PARTITION_PARTS = MAX_PARTITION_VERTEX_REFERENCES // 2
 MAX_PARTITION_PAIR_WORK = 1_000_000
 PartitionPart = Annotated[
     tuple[GraphVertexLabel, ...],
-    Field(min_length=2, max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES),
+    Field(min_length=2, max_length=MAX_SIMPLE_GRAPH_VERTICES),
 ]
 
 
@@ -64,7 +64,7 @@ class EdgeCliquePartitionRequest(StrictModel):
                 references = 0
                 for part in parts:
                     if isinstance(part, (list, tuple)):
-                        if len(part) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
+                        if len(part) > MAX_SIMPLE_GRAPH_VERTICES:
                             raise _validation_error(
                                 "graph.clique_partition.part_too_large",
                                 "partition parts cannot exceed the graph vertex bound",
@@ -119,7 +119,7 @@ def _require_well_formed_parts(
                 "graph.clique_partition.part_vertex_unknown",
                 "every partition part must use declared graph vertices",
             )
-        if len(part) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
+        if len(part) > MAX_SIMPLE_GRAPH_VERTICES:
             raise _validation_error(
                 "graph.clique_partition.part_too_large",
                 "partition parts cannot exceed the graph vertex bound",

--- a/src/jacobian/math/graphs/coloring/_models.py
+++ b/src/jacobian/math/graphs/coloring/_models.py
@@ -11,7 +11,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel
 from jacobian.math._labels import OpaqueLabel
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     IndexedSimpleUndirectedGraph,
     SimpleUndirectedGraph,
 )
@@ -20,7 +20,7 @@ from jacobian.math.graphs.values import (
 # most C(64, 2) edge variables.  Retain that formula/output envelope rather
 # than treating 64 vertices as the mathematical domain: sparse graphs on the
 # shared 256-vertex axis are no more expensive in the vertex-coloring formula.
-MAX_COLORING_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+MAX_COLORING_VERTICES = MAX_SIMPLE_GRAPH_VERTICES
 _DENSE_COLORING_REFERENCE_ORDER = 64
 MAX_COLORING_COLORS = _DENSE_COLORING_REFERENCE_ORDER
 MAX_EDGE_COLORING_EDGES = (
@@ -47,6 +47,11 @@ MAX_SOLVER_CONFLICT_BUDGET = 1_000_000
 
 
 def _require_indexed_coloring_graph(graph: IndexedSimpleUndirectedGraph) -> None:
+    if graph.vertex_count > MAX_COLORING_VERTICES:
+        raise PydanticCustomError(
+            "graph.coloring_vertex_count_exceeds_formula_bound",
+            f"coloring operations support at most {MAX_COLORING_VERTICES} vertices",
+        )
     if len(graph.edges) > MAX_EDGE_COLORING_EDGES:
         raise PydanticCustomError(
             "graph.coloring_edge_count_exceeds_formula_bound",

--- a/src/jacobian/math/graphs/cycle_length_profile/_models.py
+++ b/src/jacobian/math/graphs/cycle_length_profile/_models.py
@@ -9,11 +9,11 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
 
-MAX_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+MAX_VERTICES = MAX_SIMPLE_GRAPH_VERTICES
 
 
 class CycleLengthProfileRequest(StrictModel):

--- a/src/jacobian/math/graphs/decomposition/tree_decompositions/_models.py
+++ b/src/jacobian/math/graphs/decomposition/tree_decompositions/_models.py
@@ -13,7 +13,7 @@ from jacobian.math.graphs.decomposition.tree_decompositions.values import (
     MAX_TREE_NODES,
     TreeDecomposition,
 )
-from jacobian.math.graphs.values import MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+from jacobian.math.graphs.values import MAX_SIMPLE_GRAPH_VERTICES
 
 
 def _normalized_tree_nodes(decomposition: TreeDecomposition) -> list[str]:
@@ -68,7 +68,7 @@ class VertexOccurrencesResult(StrictModel):
     decomposition: TreeDecomposition
 
     occurrences: tuple[OccurrenceSubtree, ...] = Field(
-        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+        max_length=MAX_SIMPLE_GRAPH_VERTICES
     )
 
     @model_validator(mode="after")

--- a/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
+++ b/src/jacobian/math/graphs/edge_coloring_arrowing/_models.py
@@ -10,16 +10,16 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel
 from jacobian.math.graphs.coloring._models import EdgeColoringAssignment
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_EDGES,
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_EDGES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
 
 # The graph value already bounds the carrier at 256 vertices.  Arrowing
 # admission is otherwise controlled by the derived coloring/embedding work.
-MAX_HOST_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
-MAX_HOST_EDGES = MAX_INDEXED_SIMPLE_GRAPH_EDGES
-MAX_TARGET_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+MAX_HOST_VERTICES = MAX_SIMPLE_GRAPH_VERTICES
+MAX_HOST_EDGES = MAX_SIMPLE_GRAPH_EDGES
+MAX_TARGET_VERTICES = MAX_SIMPLE_GRAPH_VERTICES
 MAX_TARGET_COUNT = 8
 MAX_ARROWING_WORK = 20_000_000
 

--- a/src/jacobian/math/graphs/edge_deletion_profile/_models.py
+++ b/src/jacobian/math/graphs/edge_deletion_profile/_models.py
@@ -9,11 +9,11 @@ from pydantic.json_schema import JsonSchemaValue
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_EDGES,
+    MAX_SIMPLE_GRAPH_EDGES,
     SimpleUndirectedGraph,
 )
 
-MAX_DELETION_ORDER = MAX_INDEXED_SIMPLE_GRAPH_EDGES
+MAX_DELETION_ORDER = MAX_SIMPLE_GRAPH_EDGES
 
 
 def _edge_deletion_graph_schema() -> JsonSchemaValue:

--- a/src/jacobian/math/graphs/monochromatic_clique/_models.py
+++ b/src/jacobian/math/graphs/monochromatic_clique/_models.py
@@ -9,11 +9,11 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
 )
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     ColoredUndirectedGraph,
 )
 
-MAX_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+MAX_VERTICES = MAX_SIMPLE_GRAPH_VERTICES
 MAX_CLIQUE_ORDER = MAX_VERTICES
 
 

--- a/src/jacobian/math/graphs/neighborhood/_bounds.py
+++ b/src/jacobian/math/graphs/neighborhood/_bounds.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
 
@@ -30,13 +30,13 @@ def admit_open_neighborhood(
         not isinstance(vertex, str) for vertex in selected_vertices
     ):
         raise TypeError("selected_vertices must be a tuple of strings")
-    if len(selected_vertices) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
+    if len(selected_vertices) > MAX_SIMPLE_GRAPH_VERTICES:
         raise OperationDomainValidationError(
             location=("selected_vertices",),
             code="graph.open_neighborhood.selected_vertices_bound",
             message=(
                 "open-neighbourhood selection supports at most "
-                f"{MAX_INDEXED_SIMPLE_GRAPH_VERTICES} raw vertices"
+                f"{MAX_SIMPLE_GRAPH_VERTICES} raw vertices"
             ),
         )
 

--- a/src/jacobian/math/graphs/neighborhood/_models.py
+++ b/src/jacobian/math/graphs/neighborhood/_models.py
@@ -7,7 +7,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
 
@@ -16,9 +16,7 @@ class NeighborhoodRequest(StrictModel):
     """Compute the exact open neighbourhood of a selected vertex set."""
 
     graph: SimpleUndirectedGraph
-    selected_vertices: tuple[str, ...] = Field(
-        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
-    )
+    selected_vertices: tuple[str, ...] = Field(max_length=MAX_SIMPLE_GRAPH_VERTICES)
 
     @model_validator(mode="before")
     @classmethod
@@ -27,7 +25,7 @@ class NeighborhoodRequest(StrictModel):
             selected = value.get("selected_vertices")
             if (
                 isinstance(selected, (list, tuple))
-                and len(selected) > MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+                and len(selected) > MAX_SIMPLE_GRAPH_VERTICES
             ):
                 raise PydanticCustomError(
                     "graph.selected_vertices_bound",

--- a/src/jacobian/math/graphs/patterns/_models.py
+++ b/src/jacobian/math/graphs/patterns/_models.py
@@ -12,8 +12,8 @@ from jacobian._exact import DecimalIntegerEncoding, ExactInteger
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_EDGES,
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_EDGES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
 
@@ -117,8 +117,8 @@ class InducedVertexSubsetPatternCountRequest(StrictModel):
                 "Count vertex subsets S of the canonical host for which host[S] "
                 "is isomorphic to the canonical pattern. Graphs use the shared "
                 f"SimpleUndirectedGraph bounds (at most "
-                f"{MAX_INDEXED_SIMPLE_GRAPH_VERTICES:,} vertices and "
-                f"{MAX_INDEXED_SIMPLE_GRAPH_EDGES:,} edges). Admission "
+                f"{MAX_SIMPLE_GRAPH_VERTICES:,} vertices and "
+                f"{MAX_SIMPLE_GRAPH_EDGES:,} edges). Admission "
                 "preflights the exact candidate count "
                 "C(|V(host)|, |V(pattern)|), graph records, and explicit candidate construction from "
                 "C(|V(pattern)|, 2) direct host-edge probes per subset, local "

--- a/src/jacobian/math/graphs/rainbow_embedding/_models.py
+++ b/src/jacobian/math/graphs/rainbow_embedding/_models.py
@@ -7,13 +7,13 @@ from pydantic.json_schema import JsonSchemaValue
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     ColoredUndirectedGraph,
     SimpleUndirectedGraph,
 )
 
-MAX_HOST_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
-MAX_PATTERN_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+MAX_HOST_VERTICES = MAX_SIMPLE_GRAPH_VERTICES
+MAX_PATTERN_VERTICES = MAX_SIMPLE_GRAPH_VERTICES
 
 
 def _bounded_graph_schema(

--- a/src/jacobian/math/graphs/rooted_trees/values.py
+++ b/src/jacobian/math/graphs/rooted_trees/values.py
@@ -11,12 +11,12 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel
 from jacobian.math.graphs.values import (
     MAX_GRAPH_LABEL_BYTES,
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     GraphVertexLabel,
     SimpleUndirectedGraph,
 )
 
-_MAX_TREE_EDGES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1
+_MAX_TREE_EDGES = MAX_SIMPLE_GRAPH_VERTICES - 1
 type _Edge = tuple[str, str]
 
 
@@ -77,13 +77,13 @@ class RootedTreeShrub(StrictModel):
     side of every boundary seed.
     """
 
-    index: StrictInt = Field(ge=0, le=MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1)
+    index: StrictInt = Field(ge=0, le=MAX_SIMPLE_GRAPH_VERTICES - 1)
     vertices: tuple[GraphVertexLabel, ...] = Field(
-        min_length=1, max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1
+        min_length=1, max_length=MAX_SIMPLE_GRAPH_VERTICES - 1
     )
     edges: tuple[_Edge, ...] = Field(max_length=_MAX_TREE_EDGES)
     boundary_seeds: tuple[GraphVertexLabel, ...] = Field(
-        min_length=1, max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
+        min_length=1, max_length=MAX_SIMPLE_GRAPH_VERTICES
     )
     boundary_edges: tuple[_Edge, ...] = Field(min_length=1, max_length=_MAX_TREE_EDGES)
     upper_seed: GraphVertexLabel
@@ -113,15 +113,11 @@ class RootedTreeFinePartitionConstructed(StrictModel):
     """The constructed seed sides and all source-bound shrubs."""
 
     status: Literal["CONSTRUCTED"] = "CONSTRUCTED"
-    seeds_x: tuple[GraphVertexLabel, ...] = Field(
-        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
-    )
-    seeds_y: tuple[GraphVertexLabel, ...] = Field(
-        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES
-    )
+    seeds_x: tuple[GraphVertexLabel, ...] = Field(max_length=MAX_SIMPLE_GRAPH_VERTICES)
+    seeds_y: tuple[GraphVertexLabel, ...] = Field(max_length=MAX_SIMPLE_GRAPH_VERTICES)
     seed_edges: tuple[_Edge, ...] = Field(max_length=_MAX_TREE_EDGES)
     shrubs: tuple[RootedTreeShrub, ...] = Field(
-        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1
+        max_length=MAX_SIMPLE_GRAPH_VERTICES - 1
     )
 
     @model_validator(mode="after")
@@ -148,7 +144,7 @@ class RootedTreeNotATree(StrictModel):
     status: Literal["NOT_A_TREE"] = "NOT_A_TREE"
     connected: StrictBool
     has_cycle: StrictBool
-    component_count: StrictInt = Field(ge=1, le=MAX_INDEXED_SIMPLE_GRAPH_VERTICES)
+    component_count: StrictInt = Field(ge=1, le=MAX_SIMPLE_GRAPH_VERTICES)
 
 
 RootedTreeFinePartitionOutcome = Annotated[
@@ -175,9 +171,7 @@ class RootedTreeFinePartition(StrictModel):
 
     graph: SimpleUndirectedGraph
     root: GraphVertexLabel
-    component_size_limit: StrictInt = Field(
-        ge=1, le=MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1
-    )
+    component_size_limit: StrictInt = Field(ge=1, le=MAX_SIMPLE_GRAPH_VERTICES - 1)
     outcome: RootedTreeFinePartitionOutcome
 
     @classmethod

--- a/src/jacobian/math/graphs/symmetry/operations.py
+++ b/src/jacobian/math/graphs/symmetry/operations.py
@@ -162,6 +162,8 @@ def verify_graph_symmetry_orbits(claim: GraphSymmetryOrbitResult) -> bool:
         expected_vertex_members, expected_edge_members = _declared_orbit_partitions(
             graph, source.generators
         )
+    except OperationResourceAdmissionError:
+        raise
     except (OperationDomainValidationError, PydanticCustomError, KeyError):
         return False
 

--- a/src/jacobian/math/graphs/transforms/_models.py
+++ b/src/jacobian/math/graphs/transforms/_models.py
@@ -12,50 +12,19 @@ from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
 # Input graph bounds.
 MAX_VERTICES = 64
-MAX_EDGES = 1024
-
-# Result bounds derived from the worst-case transforms over the accepted
-# input domain. A line graph reindexes one vertex per input edge, so its
-# vertices reach the input edge bound (0..MAX_EDGES-1) rather than the input
-# vertex bound; every other transform keeps the input vertex set and stays
-# within MAX_VERTICES.
-MAX_RESULT_VERTICES = MAX_EDGES
-MAX_RESULT_EDGE_ENDPOINT = MAX_EDGES - 1
-
-# |E(L(G))| = sum_v C(deg(v), 2) <= (max_deg - 1) * |E(G)|
-#           <= (MAX_VERTICES - 2) * MAX_EDGES.
-# Complement, square, and induced subgraph produce at most C(MAX_VERTICES, 2)
-# = 2016 edges, so this line-graph bound covers every transform result.
-MAX_RESULT_EDGES = MAX_EDGES * (MAX_VERTICES - 2)
-
-
-class ResultGraphEdge(StrictModel):
-    """One undirected edge of a transformed graph.
-
-    Line graph vertices are reindexed input edges, so result endpoints may
-    reach the input edge bound, not just the input vertex bound.
-    """
-
-    source: int = Field(ge=0, le=MAX_RESULT_EDGE_ENDPOINT)
-    target: int = Field(ge=0, le=MAX_RESULT_EDGE_ENDPOINT)
-
-    @model_validator(mode="after")
-    def require_distinct(self) -> Self:
-        if self.source == self.target:
-            raise PydanticCustomError(
-                "graph.edge_endpoints_must_be_distinct",
-                "edge endpoints must be distinct",
-            )
-        return self
+MAX_EDGES = MAX_VERTICES * (MAX_VERTICES - 1) // 2
+# A line graph has one vertex per input edge and at most
+# (MAX_VERTICES - 2) * MAX_LINE_GRAPH_EDGES = 63,488 edges.
+MAX_LINE_GRAPH_EDGES = 1024
 
 
 def _require_transform_input_graph(
     graph: IndexedSimpleUndirectedGraph,
 ) -> IndexedSimpleUndirectedGraph:
-    if not 1 <= graph.vertex_count <= MAX_VERTICES:
+    if not 0 <= graph.vertex_count <= MAX_VERTICES:
         raise PydanticCustomError(
             "graph.transform_vertex_bound",
-            f"graph transforms require between 1 and {MAX_VERTICES} vertices",
+            f"graph transforms require between 0 and {MAX_VERTICES} vertices",
         )
     if len(graph.edges) > MAX_EDGES:
         raise PydanticCustomError(
@@ -68,6 +37,7 @@ def _require_transform_input_graph(
 _TransformInputGraph = Annotated[
     IndexedSimpleUndirectedGraph,
     AfterValidator(_require_transform_input_graph),
+    Field(description="Canonical graph with 0..64 vertices and at most 2016 edges."),
 ]
 
 
@@ -77,14 +47,21 @@ class GraphTransformRequest(StrictModel):
     graph: _TransformInputGraph
 
 
-class GraphResult(StrictModel):
-    """The result graph of a transform."""
+class LineGraphRequest(GraphTransformRequest):
+    """A line graph whose expanded output fits the canonical graph envelope."""
 
-    vertex_count: int = Field(ge=0, le=MAX_RESULT_VERTICES)
-    edges: tuple[ResultGraphEdge, ...] = Field(
-        default=(),
-        max_length=MAX_RESULT_EDGES,
+    graph: _TransformInputGraph = Field(
+        description="Canonical graph with 0..64 vertices and at most 1024 edges.",
     )
+
+    @model_validator(mode="after")
+    def require_line_graph_output_bound(self) -> Self:
+        if len(self.graph.edges) > MAX_LINE_GRAPH_EDGES:
+            raise PydanticCustomError(
+                "graph.line_graph_edge_bound",
+                f"line graphs support at most {MAX_LINE_GRAPH_EDGES} input edges",
+            )
+        return self
 
 
 class SubgraphRequest(StrictModel):

--- a/src/jacobian/math/graphs/transforms/_tools.py
+++ b/src/jacobian/math/graphs/transforms/_tools.py
@@ -9,9 +9,8 @@ from jacobian.math.graphs.transforms import (
     path_profile,
 )
 from jacobian.math.graphs.transforms._models import (
-    GraphResult,
     GraphTransformRequest,
-    ResultGraphEdge,
+    LineGraphRequest,
     SubgraphRequest,
 )
 from jacobian.math.graphs.transforms._path_profile_models import (
@@ -27,28 +26,30 @@ def _edges(graph: IndexedSimpleUndirectedGraph) -> list[tuple[int, int]]:
     return list(graph.edges)
 
 
-def _result(vertex_count: int, edges: list[tuple[int, int]]) -> GraphResult:
-    return GraphResult(
+def _result(
+    vertex_count: int, edges: list[tuple[int, int]]
+) -> IndexedSimpleUndirectedGraph:
+    return IndexedSimpleUndirectedGraph(
         vertex_count=vertex_count,
         edges=tuple(
-            ResultGraphEdge(source=source, target=target) for source, target in edges
+            (min(source, target), max(source, target)) for source, target in edges
         ),
     )
 
 
-def compute_complement(request: GraphTransformRequest) -> GraphResult:
+def compute_complement(request: GraphTransformRequest) -> IndexedSimpleUndirectedGraph:
     graph = request.graph
     vertex_count, edges = complement(graph.vertex_count, _edges(graph))
     return _result(vertex_count, edges)
 
 
-def compute_line_graph(request: GraphTransformRequest) -> GraphResult:
+def compute_line_graph(request: LineGraphRequest) -> IndexedSimpleUndirectedGraph:
     graph = request.graph
     vertex_count, edges = line_graph(graph.vertex_count, _edges(graph))
     return _result(vertex_count, edges)
 
 
-def compute_graph_power(request: GraphTransformRequest) -> GraphResult:
+def compute_graph_power(request: GraphTransformRequest) -> IndexedSimpleUndirectedGraph:
     graph = request.graph
     vertex_count, edges = graph_power(
         graph.vertex_count,
@@ -58,7 +59,7 @@ def compute_graph_power(request: GraphTransformRequest) -> GraphResult:
     return _result(vertex_count, edges)
 
 
-def compute_induced_subgraph(request: SubgraphRequest) -> GraphResult:
+def compute_induced_subgraph(request: SubgraphRequest) -> IndexedSimpleUndirectedGraph:
     graph = request.graph
     vertex_count, edges = induced_subgraph(
         graph.vertex_count,
@@ -89,7 +90,7 @@ TOOLS: MathTools = (
         title="Compute the complement of a graph",
         description="Compute the exact complement of a simple undirected graph. The complement has the same vertex set, with edges exactly where the original has no edge.",
         request_type=GraphTransformRequest,
-        result_type=GraphResult,
+        result_type=IndexedSimpleUndirectedGraph,
         run=compute_complement,
         tags=("graph", "complement", "exact"),
         examples=(
@@ -104,8 +105,8 @@ TOOLS: MathTools = (
         operation_id="graph.line_graph.compute",
         title="Compute the line graph of a graph",
         description="Compute the exact line graph L(G), whose vertices are edges of G and whose edges join pairs of incident edges.",
-        request_type=GraphTransformRequest,
-        result_type=GraphResult,
+        request_type=LineGraphRequest,
+        result_type=IndexedSimpleUndirectedGraph,
         run=compute_line_graph,
         tags=("graph", "line-graph", "exact"),
         examples=(
@@ -121,7 +122,7 @@ TOOLS: MathTools = (
         title="Compute the graph square",
         description="Compute the exact square G^2 of a simple undirected graph, joining vertices at distance at most two.",
         request_type=GraphTransformRequest,
-        result_type=GraphResult,
+        result_type=IndexedSimpleUndirectedGraph,
         run=compute_graph_power,
         tags=("graph", "graph-power", "exact"),
         examples=(
@@ -137,7 +138,7 @@ TOOLS: MathTools = (
         title="Extract an induced subgraph on a vertex subset",
         description="Compute the exact induced subgraph G[V'] and reindex its selected vertices from zero.",
         request_type=SubgraphRequest,
-        result_type=GraphResult,
+        result_type=IndexedSimpleUndirectedGraph,
         run=compute_induced_subgraph,
         tags=("graph", "induced-subgraph", "exact"),
         examples=(

--- a/src/jacobian/math/graphs/uniform_subset_intersection/_models.py
+++ b/src/jacobian/math/graphs/uniform_subset_intersection/_models.py
@@ -11,8 +11,8 @@ from pydantic import Field, StrictInt
 from jacobian._models import StrictModel
 from jacobian.math.graphs.values import (
     MAX_GRAPH_LABEL_BYTES,
-    MAX_INDEXED_SIMPLE_GRAPH_EDGES,
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_EDGES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
 
@@ -104,12 +104,12 @@ def _admit_uniform_subset_intersection(
     vertex_count = _combination_at_most(
         ground_set_size,
         subset_cardinality,
-        MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+        MAX_SIMPLE_GRAPH_VERTICES,
     )
-    if vertex_count > MAX_INDEXED_SIMPLE_GRAPH_VERTICES:
+    if vertex_count > MAX_SIMPLE_GRAPH_VERTICES:
         raise ValueError(
             "the uniform subset family exceeds the "
-            f"{MAX_INDEXED_SIMPLE_GRAPH_VERTICES}-vertex graph bound"
+            f"{MAX_SIMPLE_GRAPH_VERTICES}-vertex graph bound"
         )
     if (
         _largest_subset_label_bytes(ground_set_size, subset_cardinality)
@@ -122,10 +122,10 @@ def _admit_uniform_subset_intersection(
     edge_count = _intersection_pair_count(
         ground_set_size, subset_cardinality, threshold, relation
     )
-    if edge_count > MAX_INDEXED_SIMPLE_GRAPH_EDGES:
+    if edge_count > MAX_SIMPLE_GRAPH_EDGES:
         raise ValueError(
             "the selected intersection relation exceeds the "
-            f"{MAX_INDEXED_SIMPLE_GRAPH_EDGES}-edge graph bound"
+            f"{MAX_SIMPLE_GRAPH_EDGES}-edge graph bound"
         )
     return _UniformSubsetIntersectionPlan(
         vertex_count=vertex_count,

--- a/src/jacobian/math/graphs/values.py
+++ b/src/jacobian/math/graphs/values.py
@@ -19,10 +19,14 @@ GraphCompositionOperation = Literal[
 
 MAX_GRAPH_LABEL_BYTES = 64
 MAX_GRAPH_COLOR_BYTES = 64
-MAX_INDEXED_SIMPLE_GRAPH_VERTICES = 256
-MAX_INDEXED_SIMPLE_GRAPH_EDGES = (
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES * (MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1) // 2
+MAX_SIMPLE_GRAPH_VERTICES = 256
+MAX_SIMPLE_GRAPH_EDGES = (
+    MAX_SIMPLE_GRAPH_VERTICES * (MAX_SIMPLE_GRAPH_VERTICES - 1) // 2
 )
+# Indexed values also carry line graphs. Computational admission belongs to
+# each consumer, not to the producer-independent value's encoding envelope.
+MAX_INDEXED_SIMPLE_GRAPH_VERTICES = 1024
+MAX_INDEXED_SIMPLE_GRAPH_EDGES = 65_536
 
 GraphVertexLabel = Annotated[
     str,
@@ -67,14 +71,14 @@ class SimpleUndirectedGraph(StrictModel):
     """Immutable canonical value for a finite simple undirected graph."""
 
     vertices: tuple[str, ...] = Field(
-        max_length=MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+        max_length=MAX_SIMPLE_GRAPH_VERTICES,
         description=(
             "Unique Unicode NFC vertex labels containing valid Unicode scalar "
             "values. Vertex list order is preserved and need not be sorted."
         ),
     )
     edges: tuple[tuple[str, str], ...] = Field(
-        max_length=MAX_INDEXED_SIMPLE_GRAPH_EDGES,
+        max_length=MAX_SIMPLE_GRAPH_EDGES,
         description=(
             "Unique pairs of distinct declared vertices. Each pair must have "
             "left < right in lexicographic label order (Unicode code points, "

--- a/src/jacobian/math/groups/operations.py
+++ b/src/jacobian/math/groups/operations.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.groups._models import (
     MAX_GROUP_DEGREE,
     GroupConjugacyClassesResult,
@@ -371,5 +374,7 @@ def subgroup_lattice(group: PermutationGroup) -> list[SubgroupEntry]:
 def verify_subgroup_lattice(claim: GroupSubgroupLatticeResult) -> bool:
     try:
         return tuple(subgroup_lattice(claim.source)) == claim.subgroups
-    except (OperationDomainValidationError, RuntimeError, TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, TypeError, ValueError):
         return False

--- a/src/jacobian/math/logic/_sat.py
+++ b/src/jacobian/math/logic/_sat.py
@@ -18,6 +18,10 @@ from pydantic import (
 )
 from pydantic_core import PydanticCustomError
 
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
 from jacobian._models import StrictModel
 from jacobian.math.logic._cnf import (
     _MAX_VARIABLES,
@@ -28,7 +32,9 @@ from jacobian.math.logic._cnf import (
 from jacobian.math.logic._smt import (
     _EXHAUSTION_DETAILS,
     _classify_exhaustion,
+    _execution_deadline,
     _project_unknown,
+    _require_execution_deadline,
     _solver_settings,
     _UnknownResource,
 )
@@ -72,23 +78,13 @@ class SatSolveResult(StrictModel):
                 "logic.sat_assignment_outcome",
                 "only a SAT result may carry an assignment",
             )
-        if self.assignment is not None:
-            if len(self.assignment) != len(self.source.cnf.variables):
-                raise _validation_error(
-                    "logic.sat_assignment_length",
-                    "a SAT assignment must cover the source CNF variable axis",
-                )
-            if not all(
-                any(
-                    self.assignment[abs(literal) - 1] == (literal > 0)
-                    for literal in clause
-                )
-                for clause in self.source.cnf.clauses
-            ):
-                raise _validation_error(
-                    "logic.sat_assignment_unsatisfied",
-                    "a SAT assignment must satisfy every source CNF clause",
-                )
+        if self.assignment is not None and len(self.assignment) != len(
+            self.source.cnf.variables
+        ):
+            raise _validation_error(
+                "logic.sat_assignment_length",
+                "a SAT assignment must cover the source CNF variable axis",
+            )
         if self.exhausted is not None and self.outcome != "UNKNOWN":
             raise _validation_error(
                 "logic.unknown_exhaustion",
@@ -129,19 +125,6 @@ def _solve_sat_kernel(*, cnf: CanonicalCnf, timeout_ms: int) -> dict[str, object
                 z3.is_true(model.eval(variable, model_completion=True))
                 for variable in variables
             )
-            checked_assignment = check_sat_assignment(
-                SatAssignmentCheckRequest(cnf=cnf, assignment=assignment)
-            )
-            if not checked_assignment.satisfies:
-                return {
-                    "outcome": "UNKNOWN",
-                    "assignment": None,
-                    "exhausted": None,
-                    "detail": (
-                        "the Z3 backend returned a model that does not satisfy the "
-                        "canonical CNF"
-                    ),
-                }
             return {
                 "outcome": "SAT",
                 "assignment": list(assignment),
@@ -200,12 +183,14 @@ def _time_exhausted_result(request: SatSolveRequest) -> SatSolveResult:
 def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
     """Project one killable SAT worker invocation onto the public result."""
 
-    deadline = time.monotonic() + (request.timeout_ms / 1_000)
+    deadline = _execution_deadline(request.timeout_ms, "before SAT worker")
     try:
         with tempfile.TemporaryDirectory(prefix="jacobian-sat-") as worker_directory:
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
-                return _time_exhausted_result(request)
+                raise OperationExecutionTimeoutError(
+                    "request deadline expired before SAT worker"
+                )
             completed = run_bounded_process(
                 [sys.executable, str(_SAT_WORKER)],
                 input_bytes=json.dumps(
@@ -222,18 +207,21 @@ def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
                 ),
                 cwd=worker_directory,
             )
+    except (OperationExecutionCancelledError, OperationExecutionTimeoutError):
+        raise
     except OSError:
+        _require_execution_deadline(deadline, "after SAT worker startup")
         return _result(
             request,
             outcome="UNKNOWN",
             detail="the bounded Z3 worker could not be started",
         )
     if completed.timed_out:
-        return _time_exhausted_result(request)
-    if completed.cancelled:
-        return _result(
-            request, outcome="UNKNOWN", detail="the bounded Z3 worker was cancelled"
+        raise OperationExecutionTimeoutError(
+            "request deadline expired during SAT worker"
         )
+    if completed.cancelled:
+        raise OperationExecutionCancelledError("request cancelled during SAT worker")
     if completed.stdout_exceeded or completed.stderr_exceeded:
         return _result(
             request,
@@ -246,18 +234,30 @@ def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
             outcome="UNKNOWN",
             detail="the bounded Z3 worker failed before returning a result",
         )
-    if time.monotonic() >= deadline:
-        return _time_exhausted_result(request)
+    _require_execution_deadline(deadline, "after SAT worker")
     try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+        if not isinstance(response, dict) or "source" in response:
+            raise TypeError("worker response must not replace the retained source")
         result = SatSolveResult.model_validate(
-            {
-                "source": request.model_dump(mode="json"),
-                **json.loads(completed.stdout.decode("utf-8")),
-            }
+            {"source": request.model_dump(mode="json"), **response}
         )
-        return (
-            result if time.monotonic() < deadline else _time_exhausted_result(request)
-        )
+        if (
+            result.assignment is not None
+            and not check_sat_assignment(
+                SatAssignmentCheckRequest(cnf=request.cnf, assignment=result.assignment)
+            ).satisfies
+        ):
+            return _result(
+                request,
+                outcome="UNKNOWN",
+                detail=(
+                    "the Z3 worker returned an assignment that does not satisfy "
+                    "the canonical CNF"
+                ),
+            )
+        _require_execution_deadline(deadline, "after SAT result projection")
+        return result
     except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
         return _result(
             request,

--- a/src/jacobian/math/logic/_smt.py
+++ b/src/jacobian/math/logic/_smt.py
@@ -10,7 +10,7 @@ import time
 from enum import StrEnum
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Literal, NamedTuple, Self
+from typing import Any, Literal, NamedTuple, Self
 
 from pydantic import (
     Field,
@@ -19,7 +19,15 @@ from pydantic import (
 )
 from pydantic_core import PydanticCustomError
 
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+)
 from jacobian._models import StrictModel
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.process import (
     ProcessResourceLimits,
     run_bounded_process,
@@ -39,6 +47,11 @@ _MAX_SMTLIB_DEPTH = 512
 _MAX_SMTLIB_TERMS = 32_768
 _MAX_SMTLIB_DECLARATIONS = 4_096
 _MAX_SMTLIB_NUMERAL_DIGITS = 4_096
+# Parsed closed arithmetic may grow beyond one literal (a product of two
+# admitted literals is roughly twice as wide), but repeated DAG multiplication
+# must not be allowed to expand without an owner-level envelope.
+_MAX_SMTLIB_ARITHMETIC_BITS = _MAX_SMTLIB_NUMERAL_DIGITS * 16
+_MAX_SMTLIB_ARITHMETIC_WORK = _MAX_SMTLIB_NUMERAL_DIGITS**2 * 64
 # Request-scoped solver budgets beyond wall time. Z3 rlimit is a deterministic
 # work measure: identical requests cut off identically regardless of host load
 # or speed. The ceiling is orders of magnitude above admitted easy queries
@@ -62,7 +75,31 @@ _SMT_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 _SUPPORTED_SMTLIB_COMMANDS = frozenset(
     {"set-logic", "declare-const", "declare-fun", "assert", "check-sat"}
 )
+_SUPPORTED_SMTLIB_COMMANDS_DESCRIPTION = (
+    "set-logic, declare-const, declare-fun, assert, and check-sat"
+)
 _UnknownResource = Literal["time", "work", "memory"]
+
+
+def _execution_deadline(timeout_ms: int, stage: str) -> float:
+    now = time.monotonic()
+    execution = current_request_execution()
+    started_at = execution.started_at if execution is not None else now
+    owner_deadline = started_at + (timeout_ms / 1_000)
+    deadline = (
+        min(owner_deadline, execution.deadline)
+        if execution is not None and execution.deadline is not None
+        else owner_deadline
+    )
+    bind_request_deadline(deadline)
+    _require_execution_deadline(deadline, stage)
+    return deadline
+
+
+def _require_execution_deadline(deadline: float, stage: str) -> None:
+    request_checkpoint(stage)
+    if time.monotonic() >= deadline:
+        raise OperationExecutionTimeoutError(f"request deadline expired {stage}")
 
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
@@ -73,6 +110,156 @@ class SmtLogic(StrEnum):
     QF_UF = "QF_UF"
     QF_LIA = "QF_LIA"
     QF_LRA = "QF_LRA"
+
+
+class _ArithmeticBound(NamedTuple):
+    numerator_bits: int
+    denominator_bits: int
+
+
+def _saturating_add(*values: int) -> int:
+    return min(_MAX_SMTLIB_ARITHMETIC_BITS + 1, sum(values))
+
+
+def _saturating_work_add(total: int, amount: int) -> int:
+    return min(_MAX_SMTLIB_ARITHMETIC_WORK + 1, total + amount)
+
+
+def _check_arithmetic_bound(bound: _ArithmeticBound) -> None:
+    if (
+        bound.numerator_bits > _MAX_SMTLIB_ARITHMETIC_BITS
+        or bound.denominator_bits > _MAX_SMTLIB_ARITHMETIC_BITS
+    ):
+        raise ValueError("SMT closed arithmetic exceeds the admitted growth bound")
+
+
+def _literal_arithmetic_bound(expression: Any, z3: Any) -> _ArithmeticBound | None:
+    if z3.is_int_value(expression):
+        return _ArithmeticBound(max(1, abs(expression.as_long()).bit_length()), 1)
+    if z3.is_rational_value(expression):
+        value = expression.as_fraction()
+        return _ArithmeticBound(
+            max(1, abs(value.numerator).bit_length()),
+            max(1, value.denominator.bit_length()),
+        )
+    return None
+
+
+def _sum_arithmetic_bounds(
+    bounds: tuple[_ArithmeticBound, ...], *, extra_terms: int = 0
+) -> _ArithmeticBound:
+    denominator_bits = _saturating_add(*(bound.denominator_bits for bound in bounds))
+    numerator_bits = _saturating_add(
+        max(
+            bound.numerator_bits + denominator_bits - bound.denominator_bits
+            for bound in bounds
+        ),
+        max(1, extra_terms.bit_length()),
+    )
+    return _ArithmeticBound(numerator_bits, denominator_bits)
+
+
+def _multiply_arithmetic_bounds(
+    bounds: tuple[_ArithmeticBound, ...],
+) -> _ArithmeticBound:
+    return _ArithmeticBound(
+        _saturating_add(*(bound.numerator_bits for bound in bounds)),
+        _saturating_add(*(bound.denominator_bits for bound in bounds)),
+    )
+
+
+def _arithmetic_node_bound(
+    expression: Any, bounds: tuple[_ArithmeticBound, ...], z3: Any
+) -> _ArithmeticBound:
+    """Bound coefficient height, treating variables as unit formal terms.
+
+    Addition and multiplication bound the common denominator and the sum of
+    absolute numerator coefficients. The same bound therefore covers closed
+    constants, affine expressions, and mixtures of the two without evaluating
+    them. The fragment probe still owns linearity and theory membership.
+    """
+
+    kind = expression.decl().kind()
+    if kind in (z3.Z3_OP_ADD, z3.Z3_OP_SUB):
+        return _sum_arithmetic_bounds(bounds, extra_terms=len(bounds))
+    if kind == z3.Z3_OP_MUL:
+        return _multiply_arithmetic_bounds(bounds)
+    if kind == z3.Z3_OP_DIV:
+        left, right = bounds
+        return _ArithmeticBound(
+            _saturating_add(left.numerator_bits, right.denominator_bits),
+            _saturating_add(left.denominator_bits, right.numerator_bits),
+        )
+    if kind in (z3.Z3_OP_IDIV, z3.Z3_OP_MOD, z3.Z3_OP_REM):
+        # Integer quotient and signed remainder do not have rational quotient
+        # heights. In particular, mod(-1, b) can be b-1, not a small numerator
+        # over a large denominator. Retain both operand heights conservatively.
+        return _ArithmeticBound(
+            _saturating_add(max(bound.numerator_bits for bound in bounds), 1), 1
+        )
+    if kind == z3.Z3_OP_TO_INT:
+        return _ArithmeticBound(_saturating_add(bounds[0].numerator_bits, 1), 1)
+    if kind in (z3.Z3_OP_TO_REAL, z3.Z3_OP_UMINUS):
+        return bounds[0]
+    if kind == z3.Z3_OP_ITE:
+        return _ArithmeticBound(
+            max(bound.numerator_bits for bound in bounds),
+            max(bound.denominator_bits for bound in bounds),
+        )
+    raise ValueError("unsupported arithmetic operator in SMT fragment")
+
+
+def _require_closed_arithmetic_growth(assertions: tuple[Any, ...], z3: Any) -> None:
+    """Bound parsed arithmetic before simplification, without expanding its DAG."""
+
+    memo: dict[int, _ArithmeticBound | None] = {}
+    pending: list[tuple[Any, bool]] = [(assertion, False) for assertion in assertions]
+    work = 0
+    while pending:
+        expression, expanded = pending.pop()
+        expression_id = expression.get_id()
+        if expression_id in memo:
+            continue
+        literal = _literal_arithmetic_bound(expression, z3)
+        if literal is not None:
+            _check_arithmetic_bound(literal)
+            memo[expression_id] = literal
+            continue
+        children = expression.children()
+        if not expanded and children:
+            pending.append((expression, True))
+            pending.extend(
+                (child, False) for child in children if child.get_id() not in memo
+            )
+            continue
+        if not z3.is_arith(expression):
+            memo[expression_id] = None
+            continue
+        if not children:
+            memo[expression_id] = _ArithmeticBound(1, 1)
+            continue
+        # The condition of a numeric ite is Boolean, not an arithmetic operand.
+        operands = children[1:] if z3.is_app_of(expression, z3.Z3_OP_ITE) else children
+        bounds = tuple(memo[child.get_id()] for child in operands)
+        if any(bound is None for bound in bounds):
+            raise ValueError("unsupported arithmetic operand in SMT fragment")
+        numeric_bounds = tuple(bound for bound in bounds if bound is not None)
+        bound = _arithmetic_node_bound(expression, numeric_bounds, z3)
+        _check_arithmetic_bound(bound)
+        # A sum of operand widths squared bounds schoolbook cross-products,
+        # products and quotient work for this parsed arithmetic node. Reused
+        # children are visited once but counted at every parent occurrence.
+        work = _saturating_work_add(
+            work,
+            sum(
+                value.numerator_bits + value.denominator_bits
+                for value in numeric_bounds
+            )
+            ** 2,
+        )
+        if work > _MAX_SMTLIB_ARITHMETIC_WORK:
+            raise ValueError("SMT arithmetic exceeds the admitted work bound")
+        memo[expression_id] = bound
 
 
 def _consume_smtlib_string(source: str, position: int) -> int:
@@ -265,8 +452,14 @@ class SmtSolveRequest(StrictModel):
             f"{_MAX_SMTLIB_DEPTH}, compound terms at most {_MAX_SMTLIB_TERMS}, declared "
             f"symbols at most {_MAX_SMTLIB_DECLARATIONS}, and any one numeral, decimal, "
             f"or indexed bit-vector spelling at most {_MAX_SMTLIB_NUMERAL_DIGITS} digits. "
+            "Closed arithmetic and coefficient-only linear scaling are also bounded "
+            f"at {_MAX_SMTLIB_ARITHMETIC_BITS} bits per numerator or denominator and "
+            f"{_MAX_SMTLIB_ARITHMETIC_WORK:,} units of aggregate arithmetic work. "
             "The source is structurally admitted before execution; Z3 parsing and "
-            "solving occur within the operation's bounded execution envelope."
+            "solving occur within the operation's bounded execution envelope. "
+            "The only accepted top-level commands are "
+            f"{_SUPPORTED_SMTLIB_COMMANDS_DESCRIPTION}; definitions such as "
+            "define-fun are not accepted."
         ),
         examples=[
             "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)"
@@ -335,7 +528,9 @@ class SmtSolveRequest(StrictModel):
         for command in commands:
             if command and command[0] not in _SUPPORTED_SMTLIB_COMMANDS:
                 raise _validation_error(
-                    "logic.smtlib_command", f"unsupported SMT-LIB command: {command[0]}"
+                    "logic.smtlib_command",
+                    f"unsupported SMT-LIB command: {command[0]}; supported commands are "
+                    f"{_SUPPORTED_SMTLIB_COMMANDS_DESCRIPTION}",
                 )
         return self
 
@@ -424,6 +619,98 @@ def _solver_settings(timeout_ms: int) -> dict[str, int]:
     }
 
 
+def _require_supported_fragment_nodes(
+    assertions: tuple[Any, ...], logic: str, z3: Any
+) -> None:
+    """Reject theory sorts and applications outside the advertised fragment."""
+
+    if logic == SmtLogic.QF_UF.value:
+        allowed_sort_kinds = frozenset({z3.Z3_BOOL_SORT, z3.Z3_UNINTERPRETED_SORT})
+    elif logic == SmtLogic.QF_LIA.value:
+        allowed_sort_kinds = frozenset({z3.Z3_BOOL_SORT, z3.Z3_INT_SORT})
+    else:
+        allowed_sort_kinds = frozenset({z3.Z3_BOOL_SORT, z3.Z3_REAL_SORT})
+
+    stack = list(assertions)
+    seen: set[int] = set()
+    while stack:
+        expression = stack.pop()
+        expression_id = expression.get_id()
+        if expression_id in seen:
+            continue
+        seen.add(expression_id)
+        if expression.sort().kind() not in allowed_sort_kinds:
+            raise ValueError(f"SMT terms must belong to the declared {logic} fragment")
+        if (
+            logic != SmtLogic.QF_UF.value
+            and z3.is_app(expression)
+            and expression.decl().kind() == z3.Z3_OP_UNINTERPRETED
+            and expression.decl().arity() != 0
+        ):
+            raise ValueError(f"SMT terms must belong to the declared {logic} fragment")
+        stack.extend(expression.children())
+
+
+def _probe_declared_logic(
+    assertions: Any, logic: str, z3: Any, *, simplify_arithmetic: bool = True
+) -> None:
+    """Reject parsed assertions outside the advertised quantifier-free fragment."""
+
+    assertion_tuple = tuple(assertions)
+    if not assertion_tuple:
+        return
+    _require_supported_fragment_nodes(assertion_tuple, logic, z3)
+    if logic in (SmtLogic.QF_LIA.value, SmtLogic.QF_LRA.value):
+        _require_closed_arithmetic_growth(assertion_tuple, z3)
+    if logic == SmtLogic.QF_UF.value:
+        allowed_kinds = frozenset(
+            {
+                z3.Z3_OP_TRUE,
+                z3.Z3_OP_FALSE,
+                z3.Z3_OP_EQ,
+                z3.Z3_OP_DISTINCT,
+                z3.Z3_OP_ITE,
+                z3.Z3_OP_AND,
+                z3.Z3_OP_OR,
+                z3.Z3_OP_XOR,
+                z3.Z3_OP_NOT,
+                z3.Z3_OP_IMPLIES,
+                z3.Z3_OP_UNINTERPRETED,
+            }
+        )
+        stack = list(assertion_tuple)
+        seen: set[int] = set()
+        while stack:
+            expression = stack.pop()
+            if expression.get_id() in seen:
+                continue
+            seen.add(expression.get_id())
+            if (
+                not z3.is_app(expression)
+                or not z3.is_bool(expression)
+                or expression.decl().kind() not in allowed_kinds
+            ):
+                raise ValueError("SMT terms must belong to the declared QF_UF fragment")
+            stack.extend(expression.children())
+        return
+
+    raw_goal = z3.Goal(ctx=assertion_tuple[0].ctx)
+    raw_goal.add(*assertion_tuple)
+    has_quantifiers = float(
+        z3.Probe("has-quantifiers", ctx=assertion_tuple[0].ctx)(raw_goal)
+    )
+    goal = z3.Goal(ctx=assertion_tuple[0].ctx)
+    goal.add(
+        *(z3.simplify(assertion) for assertion in assertion_tuple)
+        if simplify_arithmetic
+        else assertion_tuple
+    )
+    probe_name = "is-lia" if logic == SmtLogic.QF_LIA.value else "is-lra"
+    belongs_to_fragment = float(z3.Probe(probe_name, ctx=assertion_tuple[0].ctx)(goal))
+    if has_quantifiers != 0.0 or belongs_to_fragment != 1.0:
+        raise ValueError(f"SMT terms must belong to the declared {logic} fragment")
+
+
 def _result(request: SmtSolveRequest, **values: object) -> SmtSolveResult:
     """Bind every projected worker outcome to its exact admitted source."""
 
@@ -460,6 +747,10 @@ def _solve_smt_kernel(
 
     try:
         assertions = z3.parse_smt2_string(smtlib)
+        try:
+            _probe_declared_logic(assertions, logic, z3)
+        except ValueError as exc:
+            return {"kind": "invalid", "detail": str(exc)[:1_024]}
         solver = z3.SolverFor(logic)
         solver.add(assertions)
         solver.set(**_solver_settings(timeout_ms))
@@ -501,6 +792,11 @@ def _solve_smt_kernel(
                 "detail": None,
             }
     except (OSError, z3.Z3Exception) as exc:
+        if isinstance(exc, z3.Z3Exception) and _is_smtlib_source_diagnostic(exc):
+            return {
+                "kind": "invalid",
+                "detail": "SMT-LIB source could not be parsed as SMT-LIB",
+            }
         exhausted = _classify_exhaustion(str(exc))
         if exhausted is not None:
             return {
@@ -528,7 +824,7 @@ def _solve_smt_kernel(
 def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
     """Project one killable worker invocation onto the public typed result."""
 
-    deadline = time.monotonic() + (request.timeout_ms / 1_000)
+    deadline = _execution_deadline(request.timeout_ms, "before SMT worker")
     try:
         # The isolated worker has no reason to inherit the checkout as its
         # current directory.  Its input arrives only through stdin and its
@@ -536,7 +832,9 @@ def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
         with TemporaryDirectory(prefix="jacobian-smt-") as worker_directory:
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
-                return _time_exhausted_result(request)
+                raise OperationExecutionTimeoutError(
+                    "request deadline expired before SMT worker"
+                )
             completed = run_bounded_process(
                 [sys.executable, str(_SMT_WORKER)],
                 input_bytes=json.dumps(
@@ -558,18 +856,21 @@ def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
                 ),
                 cwd=worker_directory,
             )
+    except (OperationExecutionCancelledError, OperationExecutionTimeoutError):
+        raise
     except OSError:
+        _require_execution_deadline(deadline, "after SMT worker startup")
         return _result(
             request,
             outcome="UNKNOWN",
             detail="the bounded Z3 worker could not be started",
         )
     if completed.timed_out:
-        return _time_exhausted_result(request)
-    if completed.cancelled:
-        return _result(
-            request, outcome="UNKNOWN", detail="the bounded Z3 worker was cancelled"
+        raise OperationExecutionTimeoutError(
+            "request deadline expired during SMT worker"
         )
+    if completed.cancelled:
+        raise OperationExecutionCancelledError("request cancelled during SMT worker")
     if completed.stdout_exceeded or completed.stderr_exceeded:
         return _result(
             request,
@@ -582,16 +883,31 @@ def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
             outcome="UNKNOWN",
             detail="the bounded Z3 worker failed before returning a result",
         )
-    if time.monotonic() >= deadline:
-        return _time_exhausted_result(request)
+    _require_execution_deadline(deadline, "after SMT worker")
     try:
         response = json.loads(completed.stdout.decode("utf-8"))
+        if not isinstance(response, dict):
+            raise TypeError("worker response must be an object")
+        if "source" in response:
+            raise TypeError("worker response must not replace the retained source")
+        if (
+            set(response) == {"kind", "detail"}
+            and response.get("kind") == "invalid"
+            and isinstance(response.get("detail"), str)
+            and 0 < len(response["detail"]) <= 1_024
+        ):
+            raise OperationDomainValidationError(
+                location=("smtlib",),
+                code="logic.smtlib_source",
+                message=response["detail"],
+            )
         result = SmtSolveResult.model_validate(
             {"source": request.model_dump(mode="json"), **response}
         )
-        return (
-            result if time.monotonic() < deadline else _time_exhausted_result(request)
-        )
+        _require_execution_deadline(deadline, "after SMT result projection")
+        return result
+    except OperationDomainValidationError:
+        raise
     except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
         return _result(
             request,
@@ -613,8 +929,10 @@ __all__ = [
     "SmtSolveResult",
     "_UnknownResource",
     "_classify_exhaustion",
+    "_execution_deadline",
     "_is_smtlib_source_diagnostic",
     "_project_unknown",
+    "_require_execution_deadline",
     "_run_smt_worker",
     "_solve_smt_kernel",
     "_solver_settings",

--- a/src/jacobian/math/logic/_tools.py
+++ b/src/jacobian/math/logic/_tools.py
@@ -69,12 +69,19 @@ TOOLS: MathTools = (
     ),
     MathTool(
         operation_id="smt.solve",
-        title="Solve a bounded SMT-LIB query",
-        description="Run the maintained Z3 Python binding on one QF SMT-LIB query.",
+        title="Find a model or decide a bounded SMT-LIB query",
+        description=(
+            "Decide one bounded quantifier-free SMT-LIB query and return SAT, "
+            "UNSAT, or UNKNOWN; SAT includes a satisfying model projection."
+        ),
         request_type=SmtSolveRequest,
         result_type=SmtSolveResult,
         run=solve_smt,
         tags=("smt", "solve", "smtlib", "z3"),
+        discovery_terms=(
+            "satisfying model",
+            "quantifier-free linear integer constraints",
+        ),
         examples=(
             OperationExample(
                 name="positive_integer",

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -24,9 +24,11 @@ from jacobian.catalog.models import (
     OperationExample,
 )
 from jacobian.math.logic._smt import (
+    _MAX_SMTLIB_BYTES,
     SmtLogic,
     SmtSolveRequest,
     _is_smtlib_source_diagnostic,
+    _probe_declared_logic,
     _tokenize_smtlib,
     _top_level_smtlib_commands,
 )
@@ -186,6 +188,26 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
                 }
             ]
         }
+    )
+
+    smtlib: str = Field(
+        min_length=1,
+        max_length=_MAX_SMTLIB_BYTES,
+        description=(
+            "ASCII SMT-LIB using set-logic, declare-const, declare-fun, assert, "
+            "and check-sat; the source must end with exactly one check-sat. "
+            "For UNSAT-core requests, the effective limits are at most 32,768 "
+            "tokens, nesting depth 256, 512 source assertions, 4,096 declared "
+            "symbols, and 256 digits per numeral or normalized coefficient. "
+            "Definitions such as define-fun are not accepted."
+        ),
+        examples=[
+            "(set-logic QF_LIA)\n"
+            "(declare-const x Int)\n"
+            "(assert (>= x 1))\n"
+            "(assert (<= x 0))\n"
+            "(check-sat)"
+        ],
     )
 
     logic: SmtLogic = Field(
@@ -411,24 +433,14 @@ def _require_declared_logic(
 
     try:
         if logic is SmtLogic.QF_UF:
-            if not _is_boolean_uninterpreted_fragment(assertions):
-                raise _logic_error(
-                    "SMT core terms must belong to the declared QF_UF fragment"
-                )
+            _probe_declared_logic(assertions, logic.value, z3)
             return
-
         classified_assertions = _normalize_closed_coefficients(assertions)
-        goal = z3.Goal(ctx=assertions[0].ctx)
-        goal.add(*classified_assertions)
-        probe_name = "is-lia" if logic is SmtLogic.QF_LIA else "is-lra"
-        has_quantifiers = float(
-            z3.Probe("has-quantifiers", ctx=assertions[0].ctx)(goal)
+        _probe_declared_logic(
+            classified_assertions, logic.value, z3, simplify_arithmetic=False
         )
-        belongs_to_fragment = float(z3.Probe(probe_name, ctx=assertions[0].ctx)(goal))
-        if has_quantifiers != 0.0 or belongs_to_fragment != 1.0:
-            raise _logic_error(
-                f"SMT core terms must belong to the declared {logic.value} fragment"
-            )
+    except ValueError as exc:
+        raise _logic_error(str(exc)) from exc
     except z3.Z3Exception as exc:
         raise _logic_error(
             f"SMT core terms could not be classified as {logic.value}"
@@ -1460,6 +1472,10 @@ SMT_UNSAT_CORE_OPERATION = MathTool(
     result_type=SmtUnsatCoreResult,
     run=compute_smt_unsat_core,
     tags=("smt", "unsat", "core", "constraints", "z3"),
+    discovery_terms=(
+        "unsatisfiable core",
+        "contradictory constraints",
+    ),
     examples=(
         OperationExample(
             name="contradictory_integer_bounds",

--- a/src/jacobian/math/logic/games/finite/operations.py
+++ b/src/jacobian/math/logic/games/finite/operations.py
@@ -12,7 +12,10 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.logic.games.finite._models import (
     MAX_EXACT_EQUILIBRIUM_WORK,
     BestResponseResult,
@@ -399,7 +402,9 @@ def verify_best_response(claim: BestResponseResult) -> bool:
 def verify_nash_equilibrium(claim: NashEquilibriumResult) -> bool:
     try:
         return nash_equilibrium(claim.payoff_matrix) == claim
-    except (OperationDomainValidationError, TypeError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, TypeError, ValueError):
         return False
 
 

--- a/src/jacobian/math/logic/languages/context_free/operations.py
+++ b/src/jacobian/math/logic/languages/context_free/operations.py
@@ -1,5 +1,6 @@
 """Exact operations on finite context-free grammars."""
 
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.logic.languages.context_free._models import (
     DependencyGraphResult,
     FiniteCFGO,
@@ -83,7 +84,9 @@ def verify_symbol_profiles(claim: SymbolProfilesResult) -> bool:
         return tuple(nullable_nonterminals(claim.grammar)) == claim.nullable and len(
             claim.nullable
         ) == len(claim.grammar.nonterminals)
-    except (TypeError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (TypeError, ValueError):
         return False
 
 
@@ -91,7 +94,9 @@ def verify_dependency_graph(claim: DependencyGraphResult) -> bool:
     """Verify dependency edges against the retained grammar."""
     try:
         return dependency_edges(claim.grammar) == claim.edges
-    except (TypeError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (TypeError, ValueError):
         return False
 
 
@@ -99,7 +104,9 @@ def verify_first_sets(claim: FirstSetsResult) -> bool:
     """Verify FIRST sets against the retained grammar and terminal axis."""
     try:
         return first_sets(claim.grammar) == claim.first_sets
-    except (TypeError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (TypeError, ValueError):
         return False
 
 

--- a/src/jacobian/math/logic/languages/regular/operations.py
+++ b/src/jacobian/math/logic/languages/regular/operations.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.logic.languages.regular._models import CountResult, RunResult
 from jacobian.math.logic.languages.regular._profile_admission import (
     TransitionParikhAdmissionPlan,
@@ -341,5 +344,7 @@ def verify_transition_parikh_profile(claim: TransitionParikhProfile) -> bool:
             )
             == claim
         )
-    except (OperationDomainValidationError, ValueError, TypeError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError, TypeError):
         return False

--- a/src/jacobian/math/matrices/cyclic_linear/operations.py
+++ b/src/jacobian/math/matrices/cyclic_linear/operations.py
@@ -933,11 +933,8 @@ def cyclic_rational_rank_kernel_profile(
 def verify_cyclic_rational_rank_kernel_profile(
     claim: CyclicRationalRankKernelProfile,
 ) -> bool:
-    """Verify a serialized profile by recomputing its retained source claim."""
-    try:
-        return cyclic_rational_rank_kernel_profile(claim.symbol) == claim
-    except (CyclicRankKernelAdmissionError, ValueError, RuntimeError, TimeoutError):
-        return False
+    """Compare a claim with its recomputation; non-completion propagates."""
+    return cyclic_rational_rank_kernel_profile(claim.symbol) == claim
 
 
 def _cyclic_rational_rank_kernel_profile_in_request(

--- a/src/jacobian/math/matrices/quadratic_spectral/operations.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/operations.py
@@ -8,7 +8,10 @@ from math import gcd
 from typing import TYPE_CHECKING, Literal
 
 from jacobian._flint import flint_workprec
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math._root_isolation import strict_root_count
 from jacobian.math.matrices.quadratic_spectral._bounds import (
     annihilating_coefficients,
@@ -614,7 +617,9 @@ def verify_symmetric_spectrum(claim: RealQuadraticSpectrum) -> bool:
         return False
     try:
         return symmetric_spectrum(claim.matrix) == claim
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False
 
 
@@ -624,7 +629,9 @@ def verify_singular_spectrum(claim: RealQuadraticSpectrum) -> bool:
         return False
     try:
         return singular_spectrum(claim.matrix) == claim
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False
 
 
@@ -632,7 +639,9 @@ def verify_inertia(claim: RealQuadraticInertia) -> bool:
     """Verify serialized inertia counts and definiteness against the source."""
     try:
         return inertia(claim.matrix) == claim
-    except (OperationDomainValidationError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError):
         return False
 
 

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -14,6 +14,10 @@ from typing import Literal
 from jacobian._execution import (
     OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
 )
 from jacobian.canonical import (
     CanonicalizationError,
@@ -270,6 +274,19 @@ def factorize_certified(
 ) -> CertifiedFactorizationResult:
     """Factor through a killable worker; a stop establishes no factor claim."""
 
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(monotonic()):
+            return factorize_certified(request)
+    owner_deadline = execution.started_at + _FACTORIZATION_WORKER_TIMEOUT_SECONDS
+    deadline = (
+        min(execution.deadline, owner_deadline)
+        if execution.deadline is not None
+        else owner_deadline
+    )
+    bind_request_deadline(deadline)
+    request_checkpoint("before certified factorization preparation")
+
     from jacobian.process import (
         ProcessResourceLimits,
         run_bounded_process,
@@ -298,7 +315,9 @@ def factorize_certified(
                 cwd=worker_directory,
             )
     except OSError as exc:
+        request_checkpoint("during certified factorization worker startup")
         raise RuntimeError("bounded factorization worker could not be started") from exc
+    request_checkpoint("after certified factorization worker")
     if completed.cancelled:
         raise OperationExecutionCancelledError("factorization worker was cancelled")
     if completed.timed_out:
@@ -322,10 +341,13 @@ def factorize_certified(
             raise ValueError("worker failure")
         if response["request_digest"] != hashlib.sha256(input_bytes).hexdigest():
             raise ValueError("worker response is not bound to its request")
-        return CertifiedFactorizationResult.model_validate_json(
+        result = CertifiedFactorizationResult.model_validate_json(
             encode_strict_json(response["result"]), strict=True
         )
+        request_checkpoint("after certified factorization result construction")
+        return result
     except (KeyError, TypeError, ValueError, CanonicalizationError) as exc:
+        request_checkpoint("during certified factorization response validation")
         raise RuntimeError(
             "bounded factorization worker returned malformed output"
         ) from exc

--- a/src/jacobian/math/number_theory/number_fields/_discriminant_process.py
+++ b/src/jacobian/math/number_theory/number_fields/_discriminant_process.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import hashlib
 import math
 import sys
+import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from jacobian._execution import (
     OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
 )
 from jacobian.canonical import (
     CanonicalizationError,
@@ -35,6 +40,19 @@ _WORKER_STDERR_BYTES = 64 * 1024
 def compute_nf_discriminant(
     request: NumberFieldRequest,
 ) -> NumberFieldDiscriminantResult:
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return compute_nf_discriminant(request)
+    owner_deadline = execution.started_at + _WORKER_TIMEOUT_SECONDS
+    deadline = (
+        min(execution.deadline, owner_deadline)
+        if execution.deadline is not None
+        else owner_deadline
+    )
+    bind_request_deadline(deadline)
+    request_checkpoint("before number-field discriminant preparation")
+
     from jacobian.process import (
         ProcessResourceLimits,
         run_bounded_process,
@@ -77,7 +95,9 @@ def compute_nf_discriminant(
                 cwd=worker_directory,
             )
     except OSError as exc:
+        request_checkpoint("during number-field worker startup")
         raise RuntimeError("bounded number-field worker could not be started") from exc
+    request_checkpoint("after number-field discriminant worker")
     if completed.cancelled:
         raise OperationExecutionCancelledError(
             "number-field discriminant computation cancelled"
@@ -105,10 +125,13 @@ def compute_nf_discriminant(
             if set(response) != {"kind", "discriminant", "request_digest"}:
                 raise ValueError("complete worker response has invalid fields")
             discriminant = parse_canonical_integer(response["discriminant"])
-            return NumberFieldDiscriminantResult(
+            result = NumberFieldDiscriminantResult(
                 field=request.field, discriminant=discriminant
             )
+            request_checkpoint("after number-field discriminant result construction")
+            return result
     except (KeyError, TypeError, ValueError, CanonicalizationError):
+        request_checkpoint("during number-field discriminant response validation")
         response = None
     if (
         isinstance(response, dict)

--- a/src/jacobian/math/number_theory/sequences/recurrence_solving/operations.py
+++ b/src/jacobian/math/number_theory/sequences/recurrence_solving/operations.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.number_theory.sequences.recurrence_solving._models import (
     _MAX_FIELD_PRIME,
     _MAX_FIELD_SEQUENCE_LENGTH,
@@ -170,6 +171,8 @@ def verify_recurrence(claim: RecurrenceFindResult) -> bool:
     """Verify a fitted rational recurrence against its retained sequence."""
     try:
         expected = find_recurrence(claim.sequence)
+    except OperationResourceAdmissionError:
+        raise
     except (TypeError, ValueError):
         return False
     return (
@@ -183,7 +186,9 @@ def verify_closed_form(claim: ClosedFormResult) -> bool:
     """Verify the displayed closed form against its retained recurrence source."""
     try:
         expected = closed_form(claim.characteristic_coefficients, claim.initial_values)
-    except (TypeError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (TypeError, ValueError):
         return False
     return claim.expression.value == expected.expression
 
@@ -192,7 +197,9 @@ def verify_prime_field_recurrence(claim: PrimeFieldRecurrenceFindResult) -> bool
     """Verify a prime-field recurrence against its retained source sequence."""
     try:
         expected = berlekamp_massey(list(claim.sequence), claim.recurrence.prime)
-    except (TypeError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (TypeError, ValueError):
         return False
     return claim.recurrence == expected
 

--- a/src/jacobian/math/optimization/_optimality.py
+++ b/src/jacobian/math/optimization/_optimality.py
@@ -68,6 +68,7 @@ class RationalLinearOptimalityCandidate(StrictModel):
                 prepared.get(field),
                 maximum_length=limit,
                 label=field,
+                maximum_digits=MAX_CANONICAL_RATIONAL_DIGITS,
             )
         return canonicalize_json_containers(prepared)
 

--- a/src/jacobian/math/polynomials/ideals/operations.py
+++ b/src/jacobian/math/polynomials/ideals/operations.py
@@ -1324,7 +1324,9 @@ def verify_ideal_membership_certificate(
                 rational_polynomial_to_sympy(generator).as_expr()
             )
         return bool(sympy.expand(identity - claim.multiplier * target) == 0)
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except (AttributeError, KeyError, TypeError, ValueError, sympy.SympifyError):
         return False
 
 
@@ -1347,7 +1349,11 @@ def verify_groebner_basis(claim: GroebnerBasisResult) -> bool:
             ],
         }
         return bool(_run_sympy_kernel(payload, 10).get("equal", False))
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except _ResultLimitExceededError:
+        raise
+    except (AttributeError, KeyError, TypeError, ValueError, sympy.SympifyError):
         return False
 
 

--- a/src/jacobian/math/polynomials/real_algebra/operations.py
+++ b/src/jacobian/math/polynomials/real_algebra/operations.py
@@ -8,7 +8,10 @@ from typing import Any
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials.real_algebra._common_interlacing import (
     common_interlacing_profile as _common_interlacing_profile,
 )
@@ -80,7 +83,9 @@ def verify_common_interlacing_profile(claim: CommonInterlacingProfile) -> bool:
 
     try:
         return common_interlacing_profile(claim.family) == claim
-    except (OperationDomainValidationError, ValueError, TypeError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError, TypeError):
         return False
 
 
@@ -378,7 +383,9 @@ def verify_strict_sublevel_measure(claim: StrictSublevelMeasureResult) -> bool:
             )
             == claim
         )
-    except (OperationDomainValidationError, ValueError, TypeError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError, TypeError):
         return False
 
 
@@ -393,5 +400,7 @@ def verify_plane_component_profile(claim: PlaneComponentProfileResult) -> bool:
             )
             == claim
         )
-    except (OperationDomainValidationError, ValueError, TypeError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (OperationDomainValidationError, ValueError, TypeError):
         return False

--- a/src/jacobian/math/polynomials/unit_circle/operations.py
+++ b/src/jacobian/math/polynomials/unit_circle/operations.py
@@ -434,12 +434,13 @@ def verify_unit_circle_arc_energy(claim: UnitCircleArcEnergyResult) -> bool:
             value.as_fraction() for value in binding.element.coefficients_ascending
         )
         return actual == expected
+    except OperationResourceAdmissionError:
+        raise
     except (
         AttributeError,
         TypeError,
         OperationDomainValidationError,
         ValueError,
-        RuntimeError,
     ):
         return False
 
@@ -592,6 +593,8 @@ def verify_real_symmetric_degree_one_fejer_riesz_factor(
             and field_element_sign(q0, recognized) > 0
             and field_element_sign(outer_difference, recognized) >= 0
         )
+    except OperationResourceAdmissionError:
+        raise
     except (
         AttributeError,
         EmbeddedNumberFieldRecognitionError,
@@ -599,6 +602,5 @@ def verify_real_symmetric_degree_one_fejer_riesz_factor(
         OperationDomainValidationError,
         TypeError,
         ValueError,
-        RuntimeError,
     ):
         return False

--- a/src/jacobian/math/topology/cubical_complexes/operations.py
+++ b/src/jacobian/math/topology/cubical_complexes/operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.topology.cubical_complexes._models import (
     CubicalCell,
     CubicalComplex,
@@ -96,7 +97,9 @@ def verify_f_vector(claim: FVectorResult) -> bool:
     """Verify f-vector and Euler claims against retained source cells."""
     try:
         return f_vector(claim.source_cells) == claim
-    except (TypeError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (TypeError, ValueError):
         return False
 
 
@@ -104,7 +107,9 @@ def verify_face_closure(claim: FaceClosureResult) -> bool:
     """Verify the canonical face closure and count summary."""
     try:
         return face_closure(claim.source_cells) == claim
-    except (TypeError, ValueError, RuntimeError):
+    except OperationResourceAdmissionError:
+        raise
+    except (TypeError, ValueError):
         return False
 
 

--- a/src/jacobian/mcp/guidance.py
+++ b/src/jacobian/mcp/guidance.py
@@ -20,14 +20,15 @@ MATH_FIND_DESCRIPTION = """\
 Find or inspect public Jacobian MCP operations.
 
 Forms:
-- `request.op="match"`: describe one local mathematical need in ordinary language.
+- `query`: describe one local mathematical need in ordinary language. `namespace`,
+  `limit`, and `cursor` are optional search controls.
   Preserve established mathematical names from the task, the supplied objects and
   constraints, the requested computation or decision, the full scalar, batch, or
   exhaustive scope, and whether the requested result is a value, witness,
   certificate, obstruction, profile, or complete enumeration. Do not replace a
   supplied named property only with its expanded definition, translate the need into
   catalog tags, or submit the surrounding proof goal.
-- `request.op="inspect"`: pass one exact `operation_id` to receive its authoritative
+- `operation_id`: pass one exact operation ID to receive its authoritative
   input and output schemas, operator-authored examples, and current optional
   backend availability. Matches expose static `runtime_requirements`; inspection
   checks these runtimes in the server environment.
@@ -40,8 +41,8 @@ applicability claims; inspect a promising operation before math.run. Read
 `operation://catalog` only when the complete bulk catalog is genuinely needed.
 
 Examples:
-- `{"request":{"op":"match","need":"exact determinant of a rational matrix","namespace":"matrix","limit":3}}`
-- `{"request":{"op":"inspect","operation_id":"polynomial.compute.gcd"}}`
+- `{"query":"exact determinant of a rational matrix","namespace":"matrix","limit":3}`
+- `{"operation_id":"polynomial.compute.gcd"}`
 """
 
 MATH_RUN_DESCRIPTION = """\

--- a/src/jacobian/mcp/models.py
+++ b/src/jacobian/mcp/models.py
@@ -75,25 +75,6 @@ OperationFindOperationId = Annotated[
 ]
 
 
-class OperationMatchRequest(StrictModel):
-    op: Literal["match"]
-    need: OperationNeed
-    namespace: OperationNamespace = None
-    limit: OperationMatchLimit = 10
-    cursor: OperationCursor = None
-
-
-class OperationInspectRequest(StrictModel):
-    op: Literal["inspect"]
-    operation_id: OperationId
-
-
-OperationFindRequest = Annotated[
-    OperationMatchRequest | OperationInspectRequest,
-    Field(discriminator="op"),
-]
-
-
 class OperationDiscoveryErrorDetail(StrictModel):
     code: Literal["INVALID_CURSOR", "UNKNOWN_OPERATION"]
     stage: Literal["operation_discovery", "operation_resolution"]
@@ -183,14 +164,11 @@ __all__ = [
     "OperationDiscoveryError",
     "OperationDiscoveryErrorDetail",
     "OperationFindOperationId",
-    "OperationFindRequest",
     "OperationFindResponse",
     "OperationFindResult",
-    "OperationInspectRequest",
     "OperationInspectionResult",
     "OperationInvalidRequestData",
     "OperationMatchLimit",
-    "OperationMatchRequest",
     "OperationNamespace",
     "OperationNeed",
     "OperationResourceAdmissionData",

--- a/src/jacobian/mcp/models.py
+++ b/src/jacobian/mcp/models.py
@@ -64,6 +64,16 @@ OperationCursor = Annotated[
     ),
 ]
 
+OperationFindOperationId = Annotated[
+    OperationId,
+    Field(
+        description=(
+            "Exact public operation ID returned by a prior math.find match or "
+            "listed in operation://catalog."
+        )
+    ),
+]
+
 
 class OperationMatchRequest(StrictModel):
     op: Literal["match"]
@@ -172,6 +182,7 @@ __all__ = [
     "OperationCursor",
     "OperationDiscoveryError",
     "OperationDiscoveryErrorDetail",
+    "OperationFindOperationId",
     "OperationFindRequest",
     "OperationFindResponse",
     "OperationFindResult",

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -14,7 +14,6 @@ from typing import Any
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.shared.exceptions import MCPError
-from mcp.types import INVALID_PARAMS
 
 from jacobian._execution import (
     OperationExecutionCancelledError,
@@ -34,13 +33,16 @@ from jacobian.dispatch import (
     execute_operation,
 )
 from jacobian.mcp.models import (
+    OperationCursor,
     OperationDiscoveryError,
     OperationDiscoveryErrorDetail,
-    OperationFindRequest,
+    OperationFindOperationId,
     OperationFindResponse,
     OperationInspectionResult,
     OperationInvalidRequestData,
-    OperationMatchRequest,
+    OperationMatchLimit,
+    OperationNamespace,
+    OperationNeed,
     OperationResourceAdmissionData,
     OperationValidationIssue,
 )
@@ -60,29 +62,73 @@ _FIND_QUERY_LOG_KEY = secrets.token_bytes(32)
 logger = logging.getLogger(__name__)
 
 
+def _find_invalid_request_error(
+    message: str, *, hint: str, locations: tuple[str, ...]
+) -> ToolError:
+    diagnostic = {
+        "code": "INVALID_REQUEST",
+        "stage": "operation_discovery",
+        "errors": [
+            {
+                "location": list(locations),
+                "code": "invalid_request",
+                "message": message,
+            }
+        ],
+        "hint": hint,
+        "message": message,
+    }
+    return ToolError(json.dumps(diagnostic, separators=(",", ":")))
+
+
 def math_find(
-    request: OperationFindRequest,
+    query: OperationNeed | None = None,
+    operation_id: OperationFindOperationId | None = None,
+    namespace: OperationNamespace = None,
+    limit: OperationMatchLimit | None = None,
+    cursor: OperationCursor = None,
     *,
     ctx: Context[AppState, Any],
 ) -> OperationFindResponse:
+    if query is None and operation_id is None:
+        raise _find_invalid_request_error(
+            "Provide exactly one of query or operation_id.",
+            hint="Use query to search, or operation_id to inspect one operation.",
+            locations=("query", "operation_id"),
+        )
+    if query is not None and operation_id is not None:
+        raise _find_invalid_request_error(
+            "Provide exactly one of query or operation_id, not both.",
+            hint="Remove operation_id for a search, or remove query for inspection.",
+            locations=("query", "operation_id"),
+        )
+    if operation_id is not None and (
+        namespace is not None or limit is not None or cursor is not None
+    ):
+        raise _find_invalid_request_error(
+            "namespace, limit, and cursor are only valid with query.",
+            hint="Remove search options when inspecting an operation_id.",
+            locations=("namespace", "limit", "cursor"),
+        )
+
     active_catalog = _catalog(ctx)
-    if isinstance(request, OperationMatchRequest):
+    if query is not None:
         # The process-local HMAC key prevents log readers from recovering a
         # short caller need through an offline digest lookup.
         need_hash = hmac.new(
-            _FIND_QUERY_LOG_KEY, request.need.encode("utf-8"), hashlib.sha256
+            _FIND_QUERY_LOG_KEY, query.encode("utf-8"), hashlib.sha256
         ).hexdigest()[:_FIND_QUERY_HASH_HEX_LENGTH]
         logger.info("math.find query_hash=%s", need_hash)
         match_response = _operation_match_response(
             active_catalog,
-            need=request.need,
-            namespace=request.namespace,
-            limit=request.limit,
-            cursor=request.cursor,
+            need=query,
+            namespace=namespace,
+            limit=limit if limit is not None else 10,
+            cursor=cursor,
         )
         return OperationFindResponse(root=match_response)
 
-    operation_id = request.operation_id
+    assert operation_id is not None
     descriptor = active_catalog.inspect(operation_id)
     if descriptor is None:
         hint = (
@@ -159,7 +205,7 @@ def math_run(
 def _invalid_request_error(
     operation_id: OperationId,
     error: OperationRequestValidationError | OperationDomainValidationError,
-) -> MCPError:
+) -> ToolError:
     """Project one owner-bound rejection without reflecting caller values."""
 
     issues = _bounded_validation_issues(error.errors())
@@ -171,11 +217,9 @@ def _invalid_request_error(
     else:
         data = OperationInvalidRequestData(operation_id=operation_id, errors=issues)
         message = "operation payload failed validation"
-    return MCPError(
-        code=INVALID_PARAMS,
-        message=message,
-        data=data.model_dump(mode="json"),
-    )
+    diagnostic = data.model_dump(mode="json")
+    diagnostic["message"] = message
+    return ToolError(json.dumps(diagnostic, separators=(",", ":"), sort_keys=True))
 
 
 def _backend_unavailable_error(

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -35,6 +35,7 @@ from typing import BinaryIO, Never, cast
 from jacobian._execution import (
     RequestCancellationSignal,
     current_request_cancellation,
+    current_request_execution,
     request_cancellation,
 )
 
@@ -715,12 +716,32 @@ def run_bounded_process(
     if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
         raise ValueError("subprocess timeout must be positive")
 
+    if cancellation_event is None:
+        cancellation_event = current_request_cancellation()
+    execution = current_request_execution()
+
     # This envelope includes input spooling, process setup, execution, result
     # capture, and reaping.  Keep a finite portion for teardown so a timeout
     # cannot acquire a second, fresh cleanup clock after the admitted lifetime.
     started = time.monotonic()
     absolute_deadline = started + timeout_seconds
-    cleanup_allowance = min(_PIPE_DRAIN_GRACE_SECONDS, timeout_seconds / 100)
+    if execution is not None and execution.deadline is not None:
+        absolute_deadline = min(absolute_deadline, execution.deadline)
+    effective_timeout = absolute_deadline - started
+    cancelled_before_start = (
+        cancellation_event is not None and cancellation_event.is_set()
+    )
+    if cancelled_before_start or effective_timeout <= 0:
+        return BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=not cancelled_before_start,
+            cancelled=cancelled_before_start,
+        )
+    cleanup_allowance = min(_PIPE_DRAIN_GRACE_SECONDS, effective_timeout / 100)
     execution_deadline = absolute_deadline - cleanup_allowance
 
     start_new_session = os.name == "posix"
@@ -734,9 +755,6 @@ def run_bounded_process(
     stderr = bytearray()
     stdout_exceeded = threading.Event()
     stderr_exceeded = threading.Event()
-    if cancellation_event is None:
-        cancellation_event = current_request_cancellation()
-
     prlimit_executable = (
         platform_tools.prlimit_executable if platform_tools is not None else None
     )

--- a/tests/catalog/test_search.py
+++ b/tests/catalog/test_search.py
@@ -66,6 +66,19 @@ def test_determinant_need_ranks_determinants_before_charpolys() -> None:
     )
 
 
+def test_smt_model_query_discovers_the_solver_operation() -> None:
+    result = Catalog.open().match(
+        OperationMatchRequest(
+            need="Find a satisfying model for quantifier-free linear integer constraints.",
+            namespace="smt",
+            limit=5,
+        )
+    )
+
+    assert result.matches
+    assert result.matches[0].operation_id == "smt.solve"
+
+
 @pytest.mark.parametrize(
     "query",
     (

--- a/tests/math/combinatorics/test_counting_execution.py
+++ b/tests/math/combinatorics/test_counting_execution.py
@@ -1,5 +1,6 @@
 """Counting control outcomes use the public operation execution errors."""
 
+import time
 from threading import Event
 
 import pytest
@@ -7,10 +8,13 @@ import pytest
 from jacobian._execution import (
     OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
     request_cancellation,
     request_execution,
 )
 from jacobian.math.combinatorics import _counting_process
+from jacobian.math.combinatorics.operations import canonical_binomial
 from jacobian.process import BoundedProcessResult
 
 
@@ -52,7 +56,7 @@ def test_counting_worker_control_outcomes(
 def test_expired_counting_request_before_startup(
     monkeypatch: pytest.MonkeyPatch, now: float
 ) -> None:
-    monkeypatch.setattr(_counting_process.time, "monotonic", lambda: now)
+    monkeypatch.setattr(time, "monotonic", lambda: now)
     started = now - _counting_process._COUNTING_WALL_SECONDS - 1
     with request_execution(started), pytest.raises(OperationExecutionTimeoutError):
         _counting_process.evaluate_count("comb", 4, 2)
@@ -63,3 +67,23 @@ def test_cancelled_counting_request_before_startup() -> None:
     event.set()
     with request_cancellation(event), pytest.raises(OperationExecutionCancelledError):
         _counting_process.evaluate_count("comb", 4, 2)
+
+
+def test_counting_preserves_a_shorter_caller_deadline() -> None:
+    started = time.monotonic()
+    caller_deadline = started + 10.0
+    with request_execution(started):
+        bind_request_deadline(caller_deadline)
+        assert canonical_binomial(4, 2) == 6
+        execution = current_request_execution()
+
+    assert execution is not None
+    assert execution.deadline == caller_deadline
+
+
+def test_expired_caller_deadline_is_not_replaced_by_counting_owner_limit() -> None:
+    started = time.monotonic()
+    with request_execution(started):
+        bind_request_deadline(started - 1.0)
+        with pytest.raises(OperationExecutionTimeoutError):
+            canonical_binomial(4, 2)

--- a/tests/math/graphs/neighborhood/test_open_neighborhood.py
+++ b/tests/math/graphs/neighborhood/test_open_neighborhood.py
@@ -15,7 +15,7 @@ from jacobian.math.graphs.neighborhood.operations import (
     verify_open_neighborhood,
 )
 from jacobian.math.graphs.values import (
-    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    MAX_SIMPLE_GRAPH_VERTICES,
     SimpleUndirectedGraph,
 )
 
@@ -138,9 +138,9 @@ def test_native_operation_rejects_an_oversized_raw_selection_before_hashing() ->
     g = _graph(["a"], ())
     with pytest.raises(
         OperationDomainValidationError,
-        match=(f"at most {MAX_INDEXED_SIMPLE_GRAPH_VERTICES} raw vertices"),
+        match=(f"at most {MAX_SIMPLE_GRAPH_VERTICES} raw vertices"),
     ):
-        open_neighborhood(g, ("a",) * (MAX_INDEXED_SIMPLE_GRAPH_VERTICES + 1))
+        open_neighborhood(g, ("a",) * (MAX_SIMPLE_GRAPH_VERTICES + 1))
 
 
 def test_catalog_request_rejects_an_oversized_raw_selection() -> None:
@@ -148,7 +148,7 @@ def test_catalog_request_rejects_an_oversized_raw_selection() -> None:
     with pytest.raises(ValueError, match="raw tuple-length bound"):
         NeighborhoodRequest(
             graph=g,
-            selected_vertices=("a",) * (MAX_INDEXED_SIMPLE_GRAPH_VERTICES + 1),
+            selected_vertices=("a",) * (MAX_SIMPLE_GRAPH_VERTICES + 1),
         )
 
 

--- a/tests/math/graphs/spectra/test_graph_characteristic_polynomial.py
+++ b/tests/math/graphs/spectra/test_graph_characteristic_polynomial.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.spectra import _tools as spectral_operations
 from jacobian.math.graphs.spectra import (
     adjacency_characteristic_polynomial,
@@ -281,8 +282,19 @@ def test_maximal_path_round_trips_through_serialization() -> None:
 def test_characteristic_polynomial_request_rejects_above_graph_carrier() -> None:
     with pytest.raises(ValidationError):
         GraphCharacteristicPolynomialRequest.model_validate(
-            {"graph": {"vertex_count": 257, "edges": []}}
+            {"graph": {"vertex_count": 1025, "edges": []}}
         )
+
+
+def test_characteristic_polynomial_native_admission_stays_below_carrier() -> None:
+    request = GraphCharacteristicPolynomialRequest.model_validate(
+        {"graph": {"vertex_count": 257, "edges": []}}
+    )
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="characteristic-polynomial operations support at most 256 vertices",
+    ):
+        adjacency_characteristic_polynomial(request.graph)
 
 
 def test_native_adjacency_returns_canonical_polynomial() -> None:

--- a/tests/math/graphs/test_claim_verifiers.py
+++ b/tests/math/graphs/test_claim_verifiers.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+from itertools import combinations
+
+import pytest
 
 from jacobian.math.graphs.coloring import (
     verify_k_colorability,
@@ -33,8 +36,12 @@ from jacobian.math.graphs.symmetry import (
     graph_symmetry_orbits,
     verify_graph_symmetry_orbits,
 )
-from jacobian.math.graphs.symmetry._models import GraphSymmetryOrbitRequest
+from jacobian.math.graphs.symmetry._models import (
+    GraphAutomorphismGenerator,
+    GraphSymmetryOrbitRequest,
+)
 from jacobian.math.graphs.values import (
+    ColoredUndirectedGraph,
     IndexedSimpleUndirectedGraph,
     SimpleUndirectedGraph,
 )
@@ -112,6 +119,33 @@ def test_symmetry_verifier_rejects_arbitrary_complete_partition() -> None:
     assert not verify_graph_symmetry_orbits(
         type(result).model_validate_json(forged.model_dump_json())
     )
+
+
+def test_symmetry_verifier_propagates_action_resource_admission() -> None:
+    vertices = tuple(sorted(str(index) for index in range(100)))
+    graph = ColoredUndirectedGraph(
+        graph=SimpleUndirectedGraph(
+            vertices=vertices,
+            edges=tuple(combinations(vertices, 2)),
+        )
+    )
+    generators = tuple(
+        GraphAutomorphismGenerator(
+            generator_id=f"g{index}",
+            mapping=tuple((vertex, vertex) for vertex in graph.graph.vertices),
+        )
+        for index in range(64)
+    )
+    source = GraphSymmetryOrbitRequest(graph=graph, generators=generators)
+    base = graph_symmetry_orbits(
+        GraphSymmetryOrbitRequest(graph=graph, generators=()).graph, ()
+    )
+    claim = base.model_copy(update={"source": source})
+
+    from jacobian.catalog.models import OperationResourceAdmissionError
+
+    with pytest.raises(OperationResourceAdmissionError, match="action entries"):
+        verify_graph_symmetry_orbits(claim)
 
 
 def test_multigraph_flow_checker_diagnoses_invalid_candidate_and_verifies_roundtrip() -> (

--- a/tests/math/graphs/test_graph_transforms.py
+++ b/tests/math/graphs/test_graph_transforms.py
@@ -4,9 +4,8 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.graphs.transforms._models import (
-    GraphResult,
     GraphTransformRequest,
-    ResultGraphEdge,
+    LineGraphRequest,
     SubgraphRequest,
 )
 from jacobian.math.graphs.transforms._tools import (
@@ -25,11 +24,8 @@ def _graph(vc: int, edges: list[tuple[int, int]]) -> IndexedSimpleUndirectedGrap
     )
 
 
-def _result_edges(result: GraphResult) -> frozenset[tuple[int, int]]:
-    return frozenset(
-        (e.source, e.target) if e.source < e.target else (e.target, e.source)
-        for e in result.edges
-    )
+def _result_edges(result: IndexedSimpleUndirectedGraph) -> frozenset[tuple[int, int]]:
+    return frozenset(result.edges)
 
 
 def test_complement_of_path_3() -> None:
@@ -51,7 +47,7 @@ def test_complement_of_complete_graph_is_empty() -> None:
 def test_line_graph_of_path() -> None:
     """Line graph of path 0-1-2 is a single edge between the two edges."""
     g = _graph(3, [(0, 1), (1, 2)])
-    result = compute_line_graph(GraphTransformRequest(graph=g))
+    result = compute_line_graph(LineGraphRequest(graph=g))
     assert result.vertex_count == 2  # two edges in original
     assert len(result.edges) == 1  # they share a vertex
 
@@ -59,7 +55,7 @@ def test_line_graph_of_path() -> None:
 def test_line_graph_of_triangle_is_triangle() -> None:
     """Line graph of K3 (triangle) is K3."""
     g = _graph(3, [(0, 1), (1, 2), (0, 2)])
-    result = compute_line_graph(GraphTransformRequest(graph=g))
+    result = compute_line_graph(LineGraphRequest(graph=g))
     assert result.vertex_count == 3
     assert len(result.edges) == 3
 
@@ -107,7 +103,7 @@ def test_complement_of_edgeless_graph_within_output_bounds() -> None:
 def test_line_graph_of_edgeless_graph_is_empty() -> None:
     """Line graph of an edgeless graph has zero vertices (empty result allowed)."""
     g = _graph(3, [])
-    result = compute_line_graph(GraphTransformRequest(graph=g))
+    result = compute_line_graph(LineGraphRequest(graph=g))
     assert result.vertex_count == 0
     assert len(result.edges) == 0
 
@@ -132,11 +128,9 @@ def test_line_graph_reindexes_endpoints_above_input_vertex_bound() -> None:
     """A line graph of more than 64 input edges reindexes endpoints above 63."""
     edges = [(0, i) for i in range(1, 64)] + [(1, 2), (1, 3)]
     g = _graph(64, edges)
-    result = compute_line_graph(GraphTransformRequest(graph=g))
+    result = compute_line_graph(LineGraphRequest(graph=g))
     assert result.vertex_count == 65
-    endpoints = {
-        endpoint for edge in result.edges for endpoint in (edge.source, edge.target)
-    }
+    endpoints = {endpoint for edge in result.edges for endpoint in edge}
     assert max(endpoints) >= 64
 
 
@@ -145,12 +139,48 @@ def test_input_edge_rejects_endpoint_at_or_above_vertex_bound() -> None:
         _graph(64, [(0, 64)])
 
 
-def test_result_edge_allows_endpoint_up_to_input_edge_bound() -> None:
-    edge = ResultGraphEdge(source=1023, target=1022)
-    assert edge.source == 1023
-    assert edge.target == 1022
+def test_line_graph_retains_maximum_input_edge_boundary() -> None:
+    edges = [(left, right) for left in range(32) for right in range(32, 64)]
+    result = compute_line_graph(LineGraphRequest(graph=_graph(64, edges)))
+    assert type(result) is IndexedSimpleUndirectedGraph
+    assert result.vertex_count == 1024
+    assert len(result.edges) == 32 * 32 * 62 // 2
+    assert (
+        IndexedSimpleUndirectedGraph.model_validate_json(result.model_dump_json())
+        == result
+    )
 
 
-def test_result_edge_rejects_endpoint_above_input_edge_bound() -> None:
-    with pytest.raises(ValidationError):
-        ResultGraphEdge(source=1024, target=0)
+def test_line_graph_preserves_its_expansion_admission() -> None:
+    edges = [(left, right) for left in range(32) for right in range(32, 64)]
+    edges.append((0, 1))
+    with pytest.raises(ValidationError, match="1024 input edges"):
+        LineGraphRequest(graph=_graph(64, edges))
+
+
+def test_reversed_induced_selection_has_canonical_edges() -> None:
+    result = compute_induced_subgraph(
+        SubgraphRequest(graph=_graph(2, [(0, 1)]), vertices=(1, 0))
+    )
+    assert result.edges == ((0, 1),)
+    assert (
+        IndexedSimpleUndirectedGraph.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+def test_dense_complement_round_trip_needs_no_representation_adapter() -> None:
+    original = _graph(64, [])
+    complete = compute_complement(GraphTransformRequest(graph=original))
+    request = GraphTransformRequest.model_validate_json(
+        '{"graph":' + complete.model_dump_json() + "}"
+    )
+    assert compute_complement(request) == original
+
+
+def test_empty_transform_results_compose_unchanged() -> None:
+    empty = _graph(0, [])
+    assert compute_complement(GraphTransformRequest(graph=empty)) == empty
+    assert compute_graph_power(GraphTransformRequest(graph=empty)) == empty
+    assert compute_line_graph(LineGraphRequest(graph=empty)) == empty
+    assert compute_induced_subgraph(SubgraphRequest(graph=empty, vertices=())) == empty

--- a/tests/math/graphs/test_indexed_graph_admission.py
+++ b/tests/math/graphs/test_indexed_graph_admission.py
@@ -1,0 +1,37 @@
+"""Boundary separation between indexed and label-based graph carriers."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.coloring._models import _require_indexed_coloring_graph
+from jacobian.math.graphs.values import (
+    IndexedSimpleUndirectedGraph,
+    SimpleUndirectedGraph,
+)
+
+
+def test_indexed_graph_accepts_line_graph_vertex_bound() -> None:
+    graph = IndexedSimpleUndirectedGraph(vertex_count=1024, edges=())
+
+    assert graph.vertex_count == 1024
+
+
+def test_indexed_graph_rejects_vertices_above_line_graph_bound() -> None:
+    with pytest.raises(ValidationError):
+        IndexedSimpleUndirectedGraph(vertex_count=1025, edges=())
+
+
+def test_simple_graph_retains_256_vertex_bound() -> None:
+    SimpleUndirectedGraph(vertices=tuple(str(i) for i in range(256)), edges=())
+
+    with pytest.raises(ValidationError):
+        SimpleUndirectedGraph(vertices=tuple(str(i) for i in range(257)), edges=())
+
+
+def test_coloring_admission_retains_256_vertex_bound() -> None:
+    graph = IndexedSimpleUndirectedGraph(vertex_count=257, edges=())
+
+    with pytest.raises(ValueError, match="at most 256 vertices"):
+        _require_indexed_coloring_graph(graph)

--- a/tests/math/logic/test_smt_arithmetic_composition.py
+++ b/tests/math/logic/test_smt_arithmetic_composition.py
@@ -1,0 +1,48 @@
+"""Arithmetic admission survives constants mixed with variables and conditionals."""
+
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.logic._smt import SmtLogic, SmtSolveRequest, solve_smt
+
+
+@pytest.mark.parametrize("base", ["(+ x 1)", "(ite p x 1)", "(- x 1)"])
+def test_mixed_arithmetic_cannot_drop_its_growth_bound(base: str) -> None:
+    expression = base
+    for _ in range(24):
+        expression = f"(* {'9' * 1000} {expression})"
+    request = SmtSolveRequest(
+        logic=SmtLogic.QF_LIA,
+        smtlib=(
+            "(set-logic QF_LIA)(declare-const x Int)(declare-const p Bool)"
+            f"(assert (= {expression} 1))(check-sat)"
+        ),
+    )
+    with pytest.raises(OperationDomainValidationError, match=r"growth|work"):
+        solve_smt(request)
+
+
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        ("(ite true 1 2)", 1),
+        ("(ite p 1 2)", 1),
+        ("(+ (ite p x 1) 1)", 2),
+        ("(mod (- 1) 100000)", 99999),
+        ("(div (- 7) 3)", -3),
+    ],
+)
+def test_small_conditional_and_signed_arithmetic_remains_accepted(
+    expression: str, expected: int
+) -> None:
+    value = f"(- {-expected})" if expected < 0 else str(expected)
+    result = solve_smt(
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib=(
+                "(set-logic QF_LIA)(declare-const x Int)(declare-const p Bool)"
+                f"(assert (= {expression} {value}))(check-sat)"
+            ),
+        )
+    )
+    assert result.outcome == "SAT"

--- a/tests/math/logic/test_smt_fragment_sorts.py
+++ b/tests/math/logic/test_smt_fragment_sorts.py
@@ -1,0 +1,138 @@
+"""Public SMT fragment sort-admission regressions."""
+
+from __future__ import annotations
+
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.logic._smt import SmtLogic, SmtSolveRequest, solve_smt
+from jacobian.math.logic._unsat_core import (
+    SmtUnsatCoreRequest,
+    compute_smt_unsat_core,
+)
+
+
+def test_qf_lia_retains_closed_integer_arithmetic() -> None:
+    result = solve_smt(
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib="(set-logic QF_LIA)\n(assert (= (* 7 6) 42))\n(check-sat)",
+        )
+    )
+    assert result.outcome == "SAT"
+
+
+def test_qf_lra_retains_closed_real_arithmetic() -> None:
+    result = solve_smt(
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LRA,
+            smtlib="(set-logic QF_LRA)\n(assert (= (* (/ 1.0 3.0) 3.0) 1.0))\n(check-sat)",
+        )
+    )
+    assert result.outcome == "SAT"
+
+
+def test_qf_uf_retains_boolean_uninterpreted_constants() -> None:
+    result = solve_smt(
+        SmtSolveRequest(
+            logic=SmtLogic.QF_UF,
+            smtlib="(set-logic QF_UF)\n(declare-const p Bool)\n(assert p)\n(check-sat)",
+        )
+    )
+    assert result.outcome == "SAT"
+
+
+@pytest.mark.parametrize("logic", (SmtLogic.QF_LIA, SmtLogic.QF_LRA, SmtLogic.QF_UF))
+def test_advertised_fragments_reject_bitvector_terms(
+    logic: SmtLogic,
+) -> None:
+    with pytest.raises(OperationDomainValidationError, match="declared"):
+        solve_smt(
+            SmtSolveRequest(
+                logic=logic,
+                smtlib=(
+                    f"(set-logic {logic.value})\n"
+                    "(assert (= (_ bv1 1000) (_ bv1 1000)))\n"
+                    "(check-sat)"
+                ),
+            )
+        )
+
+
+def test_qf_lia_accepts_a_safe_large_closed_product() -> None:
+    literal = "9" * 4_096
+    result = solve_smt(
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib=(
+                "(set-logic QF_LIA)\n"
+                f"(assert (= (* {literal} {literal}) (* {literal} {literal})))\n"
+                "(check-sat)"
+            ),
+        )
+    )
+    assert result.outcome == "SAT"
+
+
+def test_qf_lia_rejects_bounded_let_expansion_before_solving() -> None:
+    expression = "9" * 100
+    for _ in range(8):
+        expression = f"(let ((a {expression})) (* a a))"
+    with pytest.raises(OperationDomainValidationError, match=r"growth|work"):
+        solve_smt(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib=f"(set-logic QF_LIA)\n(assert (= {expression} 0))\n(check-sat)",
+            )
+        )
+
+
+def test_qf_lia_rejects_repeated_closed_coefficient_scaling() -> None:
+    expression = "x"
+    literal = "9" * 1_000
+    for index in range(32):
+        expression = f"(let ((a{index} {literal})) (* a{index} {expression}))"
+    with pytest.raises(OperationDomainValidationError, match=r"growth|work"):
+        solve_smt(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib=(
+                    "(set-logic QF_LIA)\n"
+                    "(declare-const x Int)\n"
+                    f"(assert (= {expression} 0))\n(check-sat)"
+                ),
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "assertion",
+    (
+        "(declare-const a (Array Int Int))\n(assert (= (select a 0) 0))",
+        "(declare-const x Int)\n(declare-fun f (Int) Int)\n(assert (= (f x) x))",
+    ),
+)
+def test_qf_lia_rejects_array_and_nonconstant_uf(assertion: str) -> None:
+    with pytest.raises(OperationDomainValidationError, match="declared"):
+        solve_smt(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib=f"(set-logic QF_LIA)\n{assertion}\n(check-sat)",
+            )
+        )
+
+
+def test_unsat_core_reuses_sort_and_operator_admission() -> None:
+    with pytest.raises(OperationDomainValidationError, match="declared"):
+        compute_smt_unsat_core(
+            SmtUnsatCoreRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib=(
+                    "(set-logic QF_LIA)\n"
+                    "(declare-const x Int)\n"
+                    "(declare-fun f (Int) Int)\n"
+                    "(assert (= (f x) x))\n"
+                    "(check-sat)"
+                ),
+            )
+        )

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 import sys
+import threading
+import time
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -10,6 +13,13 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    request_cancellation,
+    request_execution,
+)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.logic import _sat as sat
 from jacobian.math.logic import _smt as smt
 from jacobian.math.logic._cnf import (
@@ -122,6 +132,58 @@ def test_logic_bundle_exposes_only_atomic_inline_operations() -> None:
     )
 
 
+def test_smt_schema_publishes_commands_and_unsat_core_limits() -> None:
+    tools_by_id = {operation.operation_id: operation for operation in TOOLS}
+    solve_schema = tools_by_id["smt.solve"].request_type.model_json_schema()
+    core_schema = tools_by_id["smt.unsat_core"].request_type.model_json_schema()
+
+    solve_description = solve_schema["properties"]["smtlib"]["description"]
+    core_description = core_schema["properties"]["smtlib"]["description"]
+    assert (
+        "set-logic, declare-const, declare-fun, assert, and check-sat"
+        in solve_description
+    )
+    assert "define-fun are not accepted" in solve_description
+    assert "nesting depth 256" in core_description
+    assert "512 source assertions" in core_description
+    assert "256 digits" in core_description
+
+
+@pytest.mark.parametrize("clauses, outcome", (((), "SAT"), (((),), "UNSAT")))
+def test_sat_solver_preserves_empty_formula_semantics(
+    clauses: tuple[tuple[int, ...], ...], outcome: str
+) -> None:
+    result = solve_sat(SatSolveRequest(cnf=CanonicalCnf(variables=(), clauses=clauses)))
+    assert result.outcome == outcome
+    assert result.assignment == (() if outcome == "SAT" else None)
+
+
+def test_sat_solver_checks_assignment_once_at_parent_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.logic._cnf import (
+        SatAssignmentCheckResult,
+    )
+    from jacobian.math.logic._cnf import check_sat_assignment as original_check
+
+    checks = 0
+
+    def counting_check(request: SatAssignmentCheckRequest) -> SatAssignmentCheckResult:
+        nonlocal checks
+        checks += 1
+        return original_check(request)
+
+    monkeypatch.setattr(sat, "check_sat_assignment", counting_check)
+    request = SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
+    candidate = sat._solve_sat_kernel(cnf=request.cnf, timeout_ms=request.timeout_ms)
+    assert candidate["outcome"] == "SAT"
+    assert checks == 0
+    result = solve_sat(request)
+    assert result.outcome == "SAT"
+    assert result.assignment == (True,)
+    assert checks == 1
+
+
 def test_canonical_cnf_can_be_passed_directly_to_assignment_and_solver() -> None:
     canonical = canonicalize_cnf(
         CnfCanonicalizeRequest(
@@ -143,14 +205,19 @@ def test_canonical_cnf_can_be_passed_directly_to_assignment_and_solver() -> None
     ).satisfies
 
 
-def test_sat_result_rejects_a_witness_or_source_mutation() -> None:
+def test_sat_result_keeps_witness_validation_at_the_worker_boundary() -> None:
     positive = SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
     negative = SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((-1,),)))
 
+    assert SatSolveResult(
+        source=positive, outcome="SAT", assignment=(False,)
+    ).assignment == (False,)
+    assert SatSolveResult(
+        source=negative, outcome="SAT", assignment=(True,)
+    ).assignment == (True,)
+
     with raises_logic_validation():
-        SatSolveResult(source=positive, outcome="SAT", assignment=(False,))
-    with raises_logic_validation():
-        SatSolveResult(source=negative, outcome="SAT", assignment=(True,))
+        SatSolveResult(source=positive, outcome="SAT", assignment=())
 
 
 def test_tautological_cnf_is_a_typed_invalid_request() -> None:
@@ -198,15 +265,22 @@ def test_sat_solver_does_not_promote_a_malformed_backend_model(
             return SimpleNamespace(eval=lambda _variable, **_kwargs: z3.BoolVal(False))
 
     monkeypatch.setattr(z3, "Solver", MisreportingSolver)
+    monkeypatch.setattr(
+        sat,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: _sat_worker_result(
+            stdout=b'{"outcome":"SAT","assignment":[false],"exhausted":null,"detail":null}'
+        ),
+    )
 
-    result = _solve_sat_kernel(
+    result = solve_sat(
         SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
     )
 
     assert result.outcome == "UNKNOWN"
     assert result.assignment is None
     assert result.detail == (
-        "the Z3 backend returned a model that does not satisfy the canonical CNF"
+        "the Z3 worker returned an assignment that does not satisfy the canonical CNF"
     )
 
 
@@ -544,22 +618,37 @@ def test_smt_request_rejects_an_indexed_bit_vector_value_beyond_the_digit_budget
         )
 
 
-def test_smt_request_structurally_admits_an_ill_sorted_expression() -> None:
-    """Well-sortedness is a bounded execution concern, not model validation."""
+@pytest.mark.parametrize(
+    ("logic", "declarations", "assertion"),
+    (
+        ("QF_LIA", "(declare-const x Int)", "(assert (= (* x x) 2))"),
+        ("QF_UF", "(declare-const x Int)", "(assert (= x x))"),
+        ("QF_LIA", "", "(assert (forall ((x Int)) (= x x)))"),
+    ),
+)
+def test_smt_solver_rejects_terms_outside_declared_fragment(
+    logic: str, declarations: str, assertion: str
+) -> None:
+    source = "\n".join((f"(set-logic {logic})", declarations, assertion, "(check-sat)"))
 
+    with pytest.raises(OperationDomainValidationError, match="declared"):
+        solve_smt(SmtSolveRequest(logic=SmtLogic(logic), smtlib=source))
+
+
+def test_smt_solver_accepts_exact_closed_linear_coefficients() -> None:
     result = solve_smt(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib=(
                 "(set-logic QF_LIA)\n"
                 "(declare-const x Int)\n"
-                f"(assert (= x (_ bv{'9' * 4_096} 8)))\n"
+                "(assert (= (* 12345678901234567890 x) "
+                "12345678901234567890))\n"
                 "(check-sat)\n"
             ),
         )
     )
-
-    assert result.outcome == "UNKNOWN"
+    assert result.outcome == "SAT"
 
 
 def test_smt_request_admits_a_bv_named_symbol_outside_index_context_and_solves() -> (
@@ -771,14 +860,12 @@ def test_worker_response_conversion_cannot_outlive_request_deadline(
         module, "run_bounded_process", lambda *_args, **_kwargs: response
     )
 
-    result = (
-        module.solve_smt(solve_request)
-        if module is smt
-        else module.solve_sat(solve_request)
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted == "time"
+    with pytest.raises(OperationExecutionTimeoutError, match="deadline expired"):
+        (
+            module.solve_smt(solve_request)
+            if module is smt
+            else module.solve_sat(solve_request)
+        )
 
 
 @pytest.mark.parametrize(
@@ -787,6 +874,12 @@ def test_worker_response_conversion_cannot_outlive_request_deadline(
         (_sat_worker_result(cancelled=True, returncode=None), "was cancelled"),
         (_sat_worker_result(stdout_exceeded=True, returncode=None), "output limit"),
         (_sat_worker_result(stdout=b"not JSON"), "malformed output"),
+        (
+            _sat_worker_result(
+                stdout=b'{"source":{},"outcome":"UNSAT","assignment":null,"exhausted":null,"detail":null}'
+            ),
+            "malformed output",
+        ),
     ),
 )
 def test_sat_worker_never_projects_transport_failure_as_a_math_verdict(
@@ -796,13 +889,18 @@ def test_sat_worker_never_projects_transport_failure_as_a_math_verdict(
 ) -> None:
     monkeypatch.setattr(sat, "run_bounded_process", lambda *_args, **_kwargs: completed)
 
-    result = solve_sat(
-        SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted is None
-    assert detail in (result.detail or "")
+    if completed.cancelled:
+        with pytest.raises(OperationExecutionCancelledError, match="cancelled"):
+            solve_sat(
+                SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
+            )
+    else:
+        result = solve_sat(
+            SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
+        )
+        assert result.outcome == "UNKNOWN"
+        assert result.exhausted is None
+        assert detail in (result.detail or "")
 
 
 def test_sat_worker_start_failure_is_a_typed_unknown(
@@ -828,6 +926,12 @@ def test_sat_worker_start_failure_is_a_typed_unknown(
         (_worker_result(cancelled=True, returncode=None), "was cancelled"),
         (_worker_result(stdout_exceeded=True, returncode=None), "output limit"),
         (_worker_result(stdout=b"not JSON"), "malformed output"),
+        (
+            _worker_result(
+                stdout=b'{"source":{},"outcome":"UNSAT","model_smtlib":null,"exhausted":null,"detail":null}'
+            ),
+            "malformed output",
+        ),
     ),
 )
 def test_smt_worker_never_projects_transport_failure_as_a_math_verdict(
@@ -837,16 +941,24 @@ def test_smt_worker_never_projects_transport_failure_as_a_math_verdict(
 ) -> None:
     monkeypatch.setattr(smt, "run_bounded_process", lambda *_args, **_kwargs: completed)
 
-    result = solve_smt(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+    if completed.cancelled:
+        with pytest.raises(OperationExecutionCancelledError, match="cancelled"):
+            solve_smt(
+                SmtSolveRequest(
+                    logic=SmtLogic.QF_LIA,
+                    smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+                )
+            )
+    else:
+        result = solve_smt(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+            )
         )
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted is None
-    assert detail in (result.detail or "")
+        assert result.outcome == "UNKNOWN"
+        assert result.exhausted is None
+        assert detail in (result.detail or "")
 
 
 def test_smt_worker_start_failure_is_a_typed_unknown(
@@ -879,17 +991,46 @@ def test_smt_parse_stage_expiry_is_a_typed_unknown(
         "run_bounded_process",
         lambda *_args, **_kwargs: _worker_result(timed_out=True, returncode=None),
     )
-    result = solve_smt(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
-            timeout_ms=1,
+    with pytest.raises(OperationExecutionTimeoutError, match="deadline expired"):
+        solve_smt(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+                timeout_ms=1,
+            )
         )
-    )
 
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted == "time"
-    assert result.detail == smt._EXHAUSTION_DETAILS["time"]
+
+def test_native_sat_caller_does_not_restart_an_expired_request_deadline() -> None:
+    request = SatSolveRequest(
+        cnf=CanonicalCnf(variables=("x",), clauses=((1,),)), timeout_ms=1_000
+    )
+    with (
+        request_execution(time.monotonic() - 2.0),
+        pytest.raises(OperationExecutionTimeoutError, match="deadline expired"),
+    ):
+        solve_sat(request)
+
+
+def test_native_smt_caller_cancellation_stops_before_worker_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event = threading.Event()
+    event.set()
+    monkeypatch.setattr(
+        smt,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: pytest.fail("cancelled request launched worker"),
+    )
+    request = SmtSolveRequest(
+        logic=SmtLogic.QF_LIA,
+        smtlib="(set-logic QF_LIA)\n(check-sat)",
+    )
+    with (
+        request_cancellation(event),
+        pytest.raises(OperationExecutionCancelledError, match="cancelled"),
+    ):
+        solve_smt(request)
 
 
 def test_smt_solver_projects_exhausted_work_budget_as_typed_unknown(
@@ -1219,22 +1360,20 @@ def test_smt_request_does_not_parse_before_execution(
 def test_smt_execution_reports_undeclared_identifiers_without_resource_claims(
     identifier: str,
 ) -> None:
-    """Located parser diagnostics never fabricate an exhausted-resource claim."""
+    """Located parser diagnostics become source-domain errors, never exhaustion."""
 
-    result = solve_smt(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib=(
-                "(set-logic QF_LIA)\n"
-                "(declare-const x Int)\n"
-                f"(assert (> {identifier} 0))\n"
-                "(check-sat)"
-            ),
+    with pytest.raises(OperationDomainValidationError, match="could not be parsed"):
+        solve_smt(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib=(
+                    "(set-logic QF_LIA)\n"
+                    "(declare-const x Int)\n"
+                    f"(assert (> {identifier} 0))\n"
+                    "(check-sat)"
+                ),
+            )
         )
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted is None
 
 
 def test_smt_solver_types_parse_stage_backend_failures_as_unknown(
@@ -1280,11 +1419,14 @@ def test_smt_solver_never_classifies_located_source_text_as_exhaustion(
     )
     monkeypatch.setattr(z3, "parse_smt2_string", diagnosing_parser)
 
-    result = _solve_smt_kernel(admitted)
+    result = smt._solve_smt_kernel(
+        logic=admitted.logic.value,
+        smtlib=admitted.smtlib,
+        timeout_ms=admitted.timeout_ms,
+    )
 
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted is None
-    assert result.detail is not None and "bounded solve" in result.detail
+    assert result["kind"] == "invalid"
+    assert result["detail"] == "SMT-LIB source could not be parsed as SMT-LIB"
 
 
 def test_smt_execution_projects_located_parser_diagnostics(
@@ -1298,20 +1440,53 @@ def test_smt_execution_projects_located_parser_diagnostics(
         raise z3.Z3Exception(b'(error "line 2 column 11: unknown constant y")\n')
 
     monkeypatch.setattr(z3, "parse_smt2_string", diagnosing_parser)
-    result = _solve_smt_kernel(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib=(
-                "(set-logic QF_LIA)\n"
-                "(declare-const x Int)\n"
-                "(assert (> y 0))\n"
-                "(check-sat)"
-            ),
-        )
+    request = SmtSolveRequest(
+        logic=SmtLogic.QF_LIA,
+        smtlib=(
+            "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> y 0))\n(check-sat)"
+        ),
     )
 
+    result = smt._solve_smt_kernel(
+        logic=request.logic.value,
+        smtlib=request.smtlib,
+        timeout_ms=request.timeout_ms,
+    )
+
+    assert result["kind"] == "invalid"
+    assert result["detail"] == "SMT-LIB source could not be parsed as SMT-LIB"
+
+
+@pytest.mark.parametrize(
+    "response",
+    (
+        {"kind": "invalid"},
+        {"kind": "invalid", "detail": 123},
+        {
+            "kind": "invalid",
+            "detail": "SMT-LIB source could not be parsed as SMT-LIB",
+            "outcome": "SAT",
+        },
+    ),
+)
+def test_smt_rejects_malformed_invalid_worker_envelopes_as_unknown(
+    monkeypatch: pytest.MonkeyPatch, response: dict[str, object]
+) -> None:
+    monkeypatch.setattr(
+        smt,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: _worker_result(
+            stdout=json.dumps(response).encode("utf-8")
+        ),
+    )
+    result = solve_smt(
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib="(set-logic QF_LIA)\n(check-sat)",
+        )
+    )
     assert result.outcome == "UNKNOWN"
-    assert result.exhausted is None
+    assert result.detail == "the bounded Z3 worker returned malformed output"
 
 
 def test_smt_request_admission_defers_parse_stage_os_errors(

--- a/tests/math/matrices/cyclic_linear/test_rank_kernel_profile.py
+++ b/tests/math/matrices/cyclic_linear/test_rank_kernel_profile.py
@@ -154,6 +154,30 @@ def test_serialized_profile_verifier_rejects_forged_crt_claim() -> None:
     assert not verify_cyclic_rational_rank_kernel_profile(forged)
 
 
+def test_profile_verifier_propagates_expired_request() -> None:
+    claim = cyclic_rational_rank_kernel_profile(_symbol(period=1, entries=()))
+    started = time.monotonic()
+    with request_execution(started):
+        bind_request_deadline(started - 1)
+        with pytest.raises(OperationExecutionTimeoutError, match="deadline expired"):
+            verify_cyclic_rational_rank_kernel_profile(claim)
+
+
+def test_profile_verifier_propagates_backend_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.matrices.cyclic_linear import _kernel_process
+
+    claim = cyclic_rational_rank_kernel_profile(_symbol(period=1, entries=()))
+
+    def unavailable_worker(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("cyclic worker unavailable")
+
+    monkeypatch.setattr(_kernel_process, "run_cyclotomic_kernels", unavailable_worker)
+    with pytest.raises(RuntimeError, match="cyclic worker unavailable"):
+        verify_cyclic_rational_rank_kernel_profile(claim)
+
+
 def _rational_rowspace(
     vectors: tuple[tuple[Fraction, ...], ...],
 ) -> tuple[tuple[Fraction, ...], ...]:

--- a/tests/math/optimization/test_supplied_optimality.py
+++ b/tests/math/optimization/test_supplied_optimality.py
@@ -6,6 +6,7 @@ from fractions import Fraction
 import pytest
 from pydantic import ValidationError
 
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
 from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.optimization import check_linear_optimality, general_linear_program
 from jacobian.math.optimization._general_models import GeneralFormRationalLinearProgram
@@ -204,9 +205,66 @@ def test_large_shared_denominators_do_not_pay_independent_growth() -> None:
     assert check_linear_optimality(
         RationalLinearOptimalityCandidate.model_validate(payload)
     ).is_optimal
-    payload["primal_candidate"] = [{"num": "1" * 129, "den": "1"}]
-    with pytest.raises(ValidationError, match="128-digit"):
+    payload["primal_candidate"] = [
+        {"num": "1" * (MAX_CANONICAL_RATIONAL_DIGITS + 1), "den": "1"}
+    ]
+    with pytest.raises(ValidationError, match=f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit"):
         RationalLinearOptimalityCandidate.model_validate(payload)
+
+
+@pytest.mark.parametrize("serialized", [False, True])
+def test_solver_candidates_above_source_digit_limit_compose(serialized: bool) -> None:
+    coefficient = 10**100
+    program = GeneralFormRationalLinearProgram.model_validate(
+        {
+            "variables": [
+                {"name": name, "lower_bound": None, "upper_bound": None}
+                for name in ("x", "y")
+            ],
+            "objective": {"sense": "MINIMIZE", "coefficients": [_r(0), _r(0)]},
+            "constraints": [
+                {
+                    "label": "first",
+                    "coefficients": [_r(coefficient), _r(1)],
+                    "relation": "EQ",
+                    "rhs": _r(0),
+                },
+                {
+                    "label": "second",
+                    "coefficients": [_r(0), _r(coefficient)],
+                    "relation": "EQ",
+                    "rhs": _r(1),
+                },
+            ],
+        }
+    )
+    solved = general_linear_program(program)
+    assert solved.primal_candidate is not None
+    assert solved.primal_candidate[0].as_fraction() == Fraction(-1, coefficient**2)
+    fields = (
+        "program",
+        "primal_candidate",
+        "constraint_dual",
+        "lower_bound_dual",
+        "upper_bound_dual",
+    )
+    payload = (
+        {name: solved.model_dump(mode="json")[name] for name in fields}
+        if serialized
+        else {name: getattr(solved, name) for name in fields}
+    )
+    candidate = (
+        RationalLinearOptimalityCandidate.model_validate_json(json.dumps(payload))
+        if serialized
+        else RationalLinearOptimalityCandidate.model_validate(payload)
+    )
+    checked = check_linear_optimality(candidate)
+    assert checked.is_optimal
+    assert checked.stationarity_residuals == solved.stationarity_residuals
+    assert (
+        RationalLinearOptimalityResult.model_validate_json(checked.model_dump_json())
+        == checked
+    )
 
 
 @pytest.mark.parametrize("shared", [False, True])

--- a/tests/math/polynomials/ideals/test_groebner_basis.py
+++ b/tests/math/polynomials/ideals/test_groebner_basis.py
@@ -23,6 +23,8 @@ from jacobian.math.polynomials.ideals._singular import (
     run_bounded_stdin_python_kernel,
 )
 from jacobian.math.polynomials.ideals.operations import (
+    _ResultLimitExceededError,
+    _SympyKernelCancelledError,
     _SympyKernelError,
     _SympyKernelTimeoutError,
     elimination_ideal,
@@ -352,6 +354,32 @@ class TestKernelFailures:
         g = _poly(("x", "y"), (1, 1, (2, 0)), (-1, 1, (0, 2)))
         with pytest.raises(RuntimeError, match="worker crashed"):
             _run_groebner(GroebnerBasisRequest(ideal=_ideal(("x", "y"), (g,))))
+
+    @pytest.mark.parametrize(
+        "failure",
+        (
+            _SympyKernelTimeoutError,
+            _SympyKernelCancelledError,
+            _SympyKernelError,
+            _ResultLimitExceededError,
+        ),
+    )
+    def test_verifier_propagates_kernel_noncompletion(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        failure: type[Exception],
+    ) -> None:
+        g = _poly(("x",), (1, 1, (1,)))
+        result = _run_groebner(
+            GroebnerBasisRequest(ideal=_ideal(("x",), (g,)), monomial_order="lex")
+        )
+
+        def failing_kernel(*args: object, **kwargs: object) -> NoReturn:
+            raise failure("worker did not produce a result")
+
+        monkeypatch.setattr(operations, "_run_sympy_kernel", failing_kernel)
+        with pytest.raises(failure, match="worker did not produce a result"):
+            verify_groebner_basis(result)
 
 
 class TestKillableWorkerContract:

--- a/tests/math/polynomials/ideals/test_ideal_membership_certificate.py
+++ b/tests/math/polynomials/ideals/test_ideal_membership_certificate.py
@@ -17,7 +17,10 @@ from jacobian.math.polynomials.ideals._models import (
     IdealMembershipCertificateRequest,
     IdealMembershipCertificateResult,
 )
-from jacobian.math.polynomials.ideals.operations import ideal_membership_certificate
+from jacobian.math.polynomials.ideals.operations import (
+    ideal_membership_certificate,
+    verify_ideal_membership_certificate,
+)
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
     RationalPolynomialIdeal,
@@ -183,3 +186,26 @@ def test_generated_linear_work_is_rejected_at_the_certificate_boundary() -> None
 
     assert error.value.errors()[0]["loc"] == ("cofactor_degree_bound",)
     assert "linear" in error.value.errors()[0]["type"]
+
+
+def test_membership_verifier_propagates_source_resource_admission() -> None:
+    result = ideal_membership_certificate(
+        _request(
+            (_polynomial(("x",), ((1, (1,)),)),), _polynomial(("x",), ()), 0
+        ).ideal,
+        _polynomial(("x",), ()),
+        0,
+    )
+    variables = tuple(f"x{index}" for index in range(8))
+    zero = _polynomial(variables, ())
+    oversized_ideal = RationalPolynomialIdeal(variables=variables, generators=(zero,))
+    claim = result.model_copy(
+        update={
+            "ideal": oversized_ideal,
+            "polynomial": zero,
+            "cofactor_degree_bound": 16,
+        }
+    )
+
+    with pytest.raises(OperationResourceAdmissionError, match="column"):
+        verify_ideal_membership_certificate(claim)

--- a/tests/math/polynomials/test_fejer_riesz_factor.py
+++ b/tests/math/polynomials/test_fejer_riesz_factor.py
@@ -8,6 +8,7 @@ from fractions import Fraction
 import pytest
 from pydantic import ValidationError
 
+import jacobian.math.polynomials.unit_circle.operations as unit_circle_operations
 from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import (
     OperationDomainValidationError,
@@ -116,7 +117,7 @@ def test_operation_admits_only_real_symmetric_sources() -> None:
 def test_verifier_rejects_reciprocal_and_source_forgeries() -> None:
     result = real_symmetric_degree_one_fejer_riesz_factor(laurent(3, -1))
     assert not verify_real_symmetric_degree_one_fejer_riesz_factor(
-        result.model_copy(update={"source": None})  # type: ignore[arg-type]
+        result.model_copy(update={"source": None})
     )
     payload = json.loads(result.model_dump_json())
     coefficients = payload["conclusion"]["factor"]["coefficients_ascending"]
@@ -177,3 +178,29 @@ def test_every_admitted_factor_remains_inside_the_verifier_envelope() -> None:
     )
     with pytest.raises(OperationResourceAdmissionError, match="32-digit"):
         real_symmetric_degree_one_fejer_riesz_factor(outside)
+
+
+def test_fejer_riesz_verifier_propagates_operational_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = real_symmetric_degree_one_fejer_riesz_factor(laurent(2, -1))
+
+    def fail(_value: object) -> object:
+        raise RuntimeError("embedding backend failed")
+
+    monkeypatch.setattr(
+        unit_circle_operations,
+        "recognize_real_simple_number_field",
+        fail,
+    )
+    with pytest.raises(RuntimeError, match="embedding backend failed"):
+        verify_real_symmetric_degree_one_fejer_riesz_factor(result)
+
+
+def test_fejer_riesz_verifier_propagates_source_resource_admission() -> None:
+    result = real_symmetric_degree_one_fejer_riesz_factor(laurent(2, -1))
+    oversized_source = laurent(2 * 10**32, -(10**32))
+    claim = result.model_copy(update={"source": oversized_source})
+
+    with pytest.raises(OperationResourceAdmissionError, match="32-digit"):
+        verify_real_symmetric_degree_one_fejer_riesz_factor(claim)

--- a/tests/math/test_verifier_failure_channels.py
+++ b/tests/math/test_verifier_failure_channels.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.geometry.differential import operations as differential
+from jacobian.math.geometry.exact import operations as exact_geometry
+from jacobian.math.matrices.quadratic_spectral import operations as quadratic_spectral
+from jacobian.math.number_theory.sequences.recurrence_solving import (
+    operations as recurrence,
+)
+from jacobian.math.polynomials.real_algebra import operations as real_algebra
+
+
+@pytest.mark.parametrize(
+    ("module", "recompute", "claim"),
+    [
+        (
+            differential,
+            "lie_derivative",
+            SimpleNamespace(vector_field=None, source=None, lie_derivative=None),
+        ),
+        (
+            real_algebra,
+            "common_interlacing_profile",
+            SimpleNamespace(family=None),
+        ),
+        (
+            quadratic_spectral,
+            "inertia",
+            SimpleNamespace(matrix=None),
+        ),
+        (exact_geometry, "distance_profile", SimpleNamespace(configuration=None)),
+        (
+            recurrence,
+            "closed_form",
+            SimpleNamespace(characteristic_coefficients=None, initial_values=None),
+        ),
+    ],
+)
+def test_verifiers_propagate_operational_runtime_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    module: object,
+    recompute: str,
+    claim: object,
+) -> None:
+    def fail(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("backend failed")
+
+    monkeypatch.setattr(module, recompute, fail)
+    verifier = getattr(module, f"verify_{recompute}")
+
+    with pytest.raises(RuntimeError, match="backend failed"):
+        verifier(claim)
+
+
+@pytest.mark.parametrize(
+    ("module", "recompute", "claim"),
+    [
+        (
+            differential,
+            "lie_derivative",
+            SimpleNamespace(vector_field=None, source=None, lie_derivative=None),
+        ),
+        (real_algebra, "common_interlacing_profile", SimpleNamespace(family=None)),
+        (quadratic_spectral, "inertia", SimpleNamespace(matrix=None)),
+        (exact_geometry, "distance_profile", SimpleNamespace(configuration=None)),
+        (
+            recurrence,
+            "closed_form",
+            SimpleNamespace(characteristic_coefficients=None, initial_values=None),
+        ),
+    ],
+)
+def test_verifiers_propagate_resource_admission_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    module: object,
+    recompute: str,
+    claim: object,
+) -> None:
+    def reject(*_args: object, **_kwargs: object) -> object:
+        raise OperationResourceAdmissionError(
+            location=("source",),
+            code="test.resource_bound",
+            message="resource bound exceeded",
+        )
+
+    monkeypatch.setattr(module, recompute, reject)
+    verifier = getattr(module, f"verify_{recompute}")
+
+    with pytest.raises(OperationResourceAdmissionError, match="resource bound"):
+        verifier(claim)

--- a/tests/mcp/test_backend_requirements.py
+++ b/tests/mcp/test_backend_requirements.py
@@ -50,10 +50,7 @@ def test_missing_singular_is_inspectable_and_actionable(
             inspection = await client.call_tool(
                 "math.find",
                 {
-                    "request": {
-                        "op": "inspect",
-                        "operation_id": operation_id,
-                    }
+                    "operation_id": operation_id,
                 },
             )
             assert inspection.structured_content is not None

--- a/tests/mcp/test_catalog_isolation.py
+++ b/tests/mcp/test_catalog_isolation.py
@@ -11,7 +11,6 @@ import pytest
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationMatchResult
 from jacobian.mcp import tools
-from jacobian.mcp.models import OperationInspectRequest, OperationMatchRequest
 from jacobian.mcp.runtime import AppState
 from jacobian.mcp.tools import math_find
 
@@ -35,9 +34,7 @@ def test_math_find_does_not_acquire_an_execution_runtime() -> None:
     context = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=state))
 
     result = math_find(
-        OperationMatchRequest(
-            op="match", need="compute an exact greatest common divisor"
-        ),
+        query="compute an exact greatest common divisor",
         ctx=cast(Any, context),
     )
 
@@ -54,9 +51,7 @@ def test_math_find_inspection_does_not_log_a_query_or_acquire_a_runtime(
 
     with caplog.at_level(logging.INFO, logger="jacobian.mcp.tools"):
         result = math_find(
-            OperationInspectRequest(
-                op="inspect", operation_id="integer.compute.unknown"
-            ),
+            operation_id="integer.compute.unknown",
             ctx=cast(Any, context),
         )
 
@@ -77,10 +72,7 @@ def test_math_find_logs_a_hashed_match_query(
 
     with caplog.at_level(logging.INFO, logger="jacobian.mcp.tools"):
         math_find(
-            OperationMatchRequest(
-                op="match",
-                need=need,
-            ),
+            query=need,
             ctx=cast(Any, context),
         )
 

--- a/tests/mcp/test_chip_firing.py
+++ b/tests/mcp/test_chip_firing.py
@@ -1,12 +1,17 @@
 """Live MCP projection of chip-firing defining regressions and rejection."""
 
 import asyncio
+import json
 
-from mcp.shared.exceptions import MCPError
-from mcp.types import INVALID_PARAMS
+from mcp.types import ContentBlock, TextContent
 
 from jacobian.mcp.server import create_server
 from mcp import Client
+
+
+def _content_text(block: ContentBlock) -> str:
+    assert isinstance(block, TextContent)
+    return block.text
 
 
 def test_chip_firing_regressions_through_live_mcp() -> None:
@@ -47,7 +52,7 @@ def test_chip_firing_regressions_through_live_mcp() -> None:
                 [0],
             ),
         ]
-        async with Client(create_server(), raise_exceptions=True) as client:
+        async with Client(create_server(), raise_exceptions=False) as client:
             for name, payload, field, expected in cases:
                 result = await client.call_tool(
                     "math.run",
@@ -100,8 +105,8 @@ def test_chip_firing_regressions_through_live_mcp() -> None:
                 assert output["invariant_factors"] == [1, 1, 1, 1, 1, 2520]
                 assert (output["coordinates"] == [0]) == principal
             disconnected = {"vertices": ["a", "b", "c"], "edges": [["b", "c"]]}
-            # INVALID_PARAMS is a protocol exception, distinct from a
-            # successful mathematical result or an execution tool error.
+            # Invalid owner requests are model-visible tool errors, distinct
+            # from a successful mathematical result or execution failure.
             for name in ("stabilize", "q_reduced"):
                 payload = {"graph": disconnected, "sink": "a"}
                 payload = (
@@ -109,21 +114,21 @@ def test_chip_firing_regressions_through_live_mcp() -> None:
                     if name == "stabilize"
                     else {**payload, "divisor": [0, 1, 1]}
                 )
-                try:
-                    await client.call_tool(
-                        "math.run",
-                        {
-                            "operation_id": f"graph.chip_firing.{name}.compute",
-                            "payload": payload,
-                        },
+                result = await client.call_tool(
+                    "math.run",
+                    {
+                        "operation_id": f"graph.chip_firing.{name}.compute",
+                        "payload": payload,
+                    },
+                )
+                diagnostic = json.loads(
+                    _content_text(result.content[0]).removeprefix(
+                        "Error executing tool math.run: "
                     )
-                except MCPError as exc:
-                    assert exc.code == INVALID_PARAMS
-                    assert (
-                        exc.data["errors"][0]["code"]
-                        == "chip_firing.requires_connected_graph"
-                    )
-                else:
-                    raise AssertionError("MCP admitted a disconnected sink graph")
+                )
+                assert (
+                    diagnostic["errors"][0]["code"]
+                    == "chip_firing.requires_connected_graph"
+                )
 
     asyncio.run(scenario())

--- a/tests/mcp/test_direct_operations.py
+++ b/tests/mcp/test_direct_operations.py
@@ -8,8 +8,7 @@ import json
 from typing import Any, Self, cast
 
 import pytest
-from mcp.shared.exceptions import MCPError
-from mcp.types import INVALID_PARAMS, TextContent
+from mcp.types import ContentBlock, TextContent
 from pydantic import model_validator
 
 from jacobian._execution import (
@@ -34,6 +33,11 @@ from jacobian.mcp.server import _build_server, create_server
 from jacobian.mcp.tools import _invalid_request_error
 
 _FIXED_TOOLS = {"math.find", "math.run"}
+
+
+def _content_text(block: ContentBlock) -> str:
+    assert isinstance(block, TextContent)
+    return block.text
 
 
 def _operations(*operation_ids: str) -> tuple[MathTool[Any, Any], ...]:
@@ -279,56 +283,55 @@ def test_direct_calls_preserve_strict_and_domain_invalid_params() -> None:
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(_server(*operation_ids), raise_exceptions=True) as client:
-            try:
-                await client.call_tool(
-                    "integer.compute.extended_gcd",
-                    {"left": "84", "right": "30", "private": secret},
+        async with Client(_server(*operation_ids), raise_exceptions=False) as client:
+            invalid = await client.call_tool(
+                "integer.compute.extended_gcd",
+                {"left": "84", "right": "30", "private": secret},
+            )
+            invalid_data = json.loads(
+                _content_text(invalid.content[0]).removeprefix(
+                    "Error executing tool integer.compute.extended_gcd: "
                 )
-            except MCPError as invalid:
-                assert invalid.code == INVALID_PARAMS
-                assert invalid.data["errors"] == [
-                    {
-                        "location": ["private"],
-                        "code": "extra_forbidden",
-                        "message": "Extra inputs are not permitted",
-                    }
-                ]
-                assert secret not in invalid.message
-                assert secret not in str(invalid.data)
-            else:  # pragma: no cover - regression assertion
-                raise AssertionError("extra direct argument was accepted")
+            )
+            assert invalid_data["errors"] == [
+                {
+                    "location": ["private"],
+                    "code": "extra_forbidden",
+                    "message": "Extra inputs are not permitted",
+                }
+            ]
+            assert secret not in _content_text(invalid.content[0])
 
-            try:
-                await client.call_tool(
-                    "integer.compute.extended_gcd",
-                    {"left": 1.5, "right": "30"},
+            noncanonical = await client.call_tool(
+                "integer.compute.extended_gcd",
+                {"left": 1.5, "right": "30"},
+            )
+            noncanonical_data = json.loads(
+                _content_text(noncanonical.content[0]).removeprefix(
+                    "Error executing tool integer.compute.extended_gcd: "
                 )
-            except MCPError as noncanonical:
-                assert noncanonical.code == INVALID_PARAMS
-                assert noncanonical.data["errors"] == [
-                    {
-                        "location": [],
-                        "code": "canonicalization_error",
-                        "message": "JSON floating-point numbers are not allowed",
-                    }
-                ]
-            else:  # pragma: no cover - regression assertion
-                raise AssertionError("floating-point direct argument was accepted")
+            )
+            assert noncanonical_data["errors"] == [
+                {
+                    "location": [],
+                    "code": "canonicalization_error",
+                    "message": "JSON floating-point numbers are not allowed",
+                }
+            ]
 
-            try:
-                await client.call_tool(universal.operation_id, invalid_domain)
-            except MCPError as domain:
-                assert domain.code == INVALID_PARAMS
-                assert domain.data["errors"] == [
-                    {
-                        "location": ["assignment"],
-                        "code": "universal_algebra.assignment_coverage",
-                        "message": "assignment must cover exactly the referenced variables",
-                    }
-                ]
-            else:  # pragma: no cover - regression assertion
-                raise AssertionError("domain-invalid direct argument was accepted")
+            domain = await client.call_tool(universal.operation_id, invalid_domain)
+            domain_data = json.loads(
+                _content_text(domain.content[0]).removeprefix(
+                    f"Error executing tool {universal.operation_id}: "
+                )
+            )
+            assert domain_data["errors"] == [
+                {
+                    "location": ["assignment"],
+                    "code": "universal_algebra.assignment_coverage",
+                    "message": "assignment must cover exactly the referenced variables",
+                }
+            ]
 
     asyncio.run(scenario())
 
@@ -362,10 +365,10 @@ def test_direct_calls_do_not_expose_unexpected_owner_failures() -> None:
         assert result.is_error is True
         assert result.structured_content is None
         assert result.content and isinstance(result.content[0], TextContent)
-        assert result.content[0].text == (
+        assert _content_text(result.content[0]) == (
             "Error executing tool test.direct.crash: operation execution failed"
         )
-        assert "private backend value" not in result.content[0].text
+        assert "private backend value" not in _content_text(result.content[0])
 
     asyncio.run(scenario())
 
@@ -399,11 +402,11 @@ def test_direct_calls_preserve_owner_cancellation_diagnosis() -> None:
         assert result.is_error is True
         assert result.structured_content is None
         assert result.content and isinstance(result.content[0], TextContent)
-        assert result.content[0].text == (
+        assert _content_text(result.content[0]) == (
             "Error executing tool test.direct.cancel: operation cancelled"
         )
-        assert "private cancellation detail" not in result.content[0].text
-        assert "operation execution failed" not in result.content[0].text
+        assert "private cancellation detail" not in _content_text(result.content[0])
+        assert "operation execution failed" not in _content_text(result.content[0])
 
     asyncio.run(scenario())
 
@@ -453,14 +456,16 @@ def test_math_run_preserves_bounded_operation_failure_context(
         assert result.is_error is True
         assert result.content and isinstance(result.content[0], TextContent)
         diagnostic = json.loads(
-            result.content[0].text.removeprefix("Error executing tool math.run: ")
+            _content_text(result.content[0]).removeprefix(
+                "Error executing tool math.run: "
+            )
         )
         assert diagnostic == {
             "code": code,
             "operation_id": operation.operation_id,
             "stage": "operation_execution",
         }
-        assert "private" not in result.content[0].text
+        assert "private" not in _content_text(result.content[0])
 
     asyncio.run(scenario())
 
@@ -492,19 +497,22 @@ def test_math_run_reports_resource_admission_separately_from_invalid_payload() -
         from mcp import Client
 
         async with Client(
-            _direct_server(Catalog((operation,))), raise_exceptions=True
+            _direct_server(Catalog((operation,))), raise_exceptions=False
         ) as client:
-            with pytest.raises(MCPError) as error:
-                await client.call_tool(
-                    "math.run",
-                    {"operation_id": operation.operation_id, "payload": {"value": 1}},
-                )
+            error = await client.call_tool(
+                "math.run",
+                {"operation_id": operation.operation_id, "payload": {"value": 1}},
+            )
 
-        assert error.value.code == INVALID_PARAMS
-        assert error.value.data["code"] == "RESOURCE_ADMISSION_REJECTED"
-        assert error.value.data["stage"] == "resource_admission"
-        assert error.value.data["operation_id"] == operation.operation_id
-        assert "correct the fields" not in error.value.data["hint"]
+        diagnostic = json.loads(
+            _content_text(error.content[0]).removeprefix(
+                "Error executing tool math.run: "
+            )
+        )
+        assert diagnostic["code"] == "RESOURCE_ADMISSION_REJECTED"
+        assert diagnostic["stage"] == "resource_admission"
+        assert diagnostic["operation_id"] == operation.operation_id
+        assert "correct the fields" not in diagnostic["hint"]
 
     asyncio.run(scenario())
 
@@ -518,7 +526,7 @@ def test_budget_named_mathematical_precondition_remains_invalid_payload() -> Non
 
     projected = _invalid_request_error("matrix.determinant.compute", error)
 
-    assert projected.data["code"] == "INVALID_REQUEST"
+    assert json.loads(str(projected))["code"] == "INVALID_REQUEST"
 
 
 @pytest.mark.parametrize("direct", [False, True])

--- a/tests/mcp/test_formal_series_inverse.py
+++ b/tests/mcp/test_formal_series_inverse.py
@@ -2,9 +2,6 @@
 
 import asyncio
 
-import pytest
-from mcp.shared.exceptions import MCPError
-
 from jacobian.math.polynomials.series import inverse
 from jacobian.math.polynomials.series._models import TruncatedSeries
 from jacobian.mcp.server import create_server
@@ -13,24 +10,23 @@ from mcp import Client
 
 def test_inverse_native_mcp_parity_after_growth_rejection() -> None:
     async def scenario() -> None:
-        async with Client(create_server(), raise_exceptions=True) as client:
-            with pytest.raises(MCPError) as error:
-                await client.call_tool(
-                    "math.run",
-                    {
-                        "operation_id": "formal_series.rational.inverse.compute",
-                        "payload": {
-                            "variable": "x",
-                            "truncation_order": 20,
-                            "coefficients": [
-                                {"num": "1", "den": "1"},
-                                {"num": str(10**255), "den": "1"},
-                                *[{"num": "0", "den": "1"}] * 18,
-                            ],
-                        },
+        async with Client(create_server(), raise_exceptions=False) as client:
+            error = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "formal_series.rational.inverse.compute",
+                    "payload": {
+                        "variable": "x",
+                        "truncation_order": 20,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": str(10**255), "den": "1"},
+                            *[{"num": "0", "den": "1"}] * 18,
+                        ],
                     },
-                )
-            assert error.value.code == -32602
+                },
+            )
+            assert error.is_error is True
             source = TruncatedSeries.model_validate(
                 {
                     "variable": "x",

--- a/tests/mcp/test_graph_edge_order_guidance.py
+++ b/tests/mcp/test_graph_edge_order_guidance.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
-import pytest
-from mcp.shared.exceptions import MCPError
+from mcp.types import ContentBlock, TextContent
 
 from jacobian.mcp.server import create_server
 from mcp import Client
+
+
+def _content_text(block: ContentBlock) -> str:
+    assert isinstance(block, TextContent)
+    return block.text
 
 
 def test_graph_inspection_and_error_explain_endpoint_order_before_recovery() -> None:
@@ -34,10 +39,10 @@ def test_graph_inspection_and_error_explain_endpoint_order_before_recovery() -> 
             "vertices": ["x", "y", "z", "r", "u", "v", "w"],
             "edges": edges,
         }
-        async with Client(create_server(), raise_exceptions=True) as client:
+        async with Client(create_server(), raise_exceptions=False) as client:
             inspected = await client.call_tool(
                 "math.find",
-                {"request": {"op": "inspect", "operation_id": operation_id}},
+                {"operation_id": operation_id},
             )
             contract = inspected.structured_content["operation"]
             schema = contract["input_schema"]["$defs"]["SimpleUndirectedGraph"]
@@ -51,12 +56,15 @@ def test_graph_inspection_and_error_explain_endpoint_order_before_recovery() -> 
             )
             assert example_result.structured_content["output"]["clique_count"] == 2
 
-            with pytest.raises(MCPError) as rejected:
-                await client.call_tool(
-                    "math.run",
-                    {"operation_id": operation_id, "payload": {"graph": graph}},
+            rejected = await client.call_tool(
+                "math.run",
+                {"operation_id": operation_id, "payload": {"graph": graph}},
+            )
+            error = json.loads(
+                _content_text(rejected.content[0]).removeprefix(
+                    "Error executing tool math.run: "
                 )
-            error = rejected.value.data["errors"][0]
+            )["errors"][0]
             assert error["location"] == ["graph"]
             assert "lexicographic label order" in error["message"]
             assert "not positions in vertices" in error["message"]

--- a/tests/mcp/test_linear_program_admission.py
+++ b/tests/mcp/test_linear_program_admission.py
@@ -5,7 +5,7 @@ import json
 from itertools import combinations
 
 import pytest
-from mcp.shared.exceptions import MCPError
+from mcp.types import ContentBlock, TextContent
 from tests.support.rationals import rational_payload as q
 
 from jacobian.catalog.catalog import Catalog
@@ -16,6 +16,12 @@ from jacobian.math.optimization._tools import TOOLS
 from jacobian.mcp.runtime import AppState
 from jacobian.mcp.server import _build_server
 from mcp import Client
+
+
+def _content_text(block: ContentBlock) -> str:
+    assert isinstance(block, TextContent)
+    return block.text
+
 
 OPERATION = "optimization.linear.rational_general_optimum.compute"
 
@@ -64,18 +70,17 @@ def test_lp_inspection_explains_derived_admission(
                 ],
             }
         }
-        async with Client(server, raise_exceptions=True) as client:
+        async with Client(server, raise_exceptions=False) as client:
             inspection = await client.call_tool(
-                "math.find", {"request": {"op": "inspect", "operation_id": OPERATION}}
+                "math.find", {"operation_id": OPERATION}
             )
             text = json.dumps(inspection.structured_content)
             assert "Normalized limits are 32 columns and 64 rows" in text
             assert "C(n+1,r)" in text and "50000000" in text
             if expect_rejection:
-                with pytest.raises(MCPError) as caught:
-                    await client.call_tool(
-                        "math.run", {"operation_id": OPERATION, "payload": payload}
-                    )
+                caught = await client.call_tool(
+                    "math.run", {"operation_id": OPERATION, "payload": payload}
+                )
             else:
                 result = await client.call_tool(
                     "math.run", {"operation_id": OPERATION, "payload": payload}
@@ -89,7 +94,11 @@ def test_lp_inspection_explains_derived_admission(
                 assert parsed.primal_objective is not None
                 assert parsed.primal_objective.as_fraction() == m
                 return
-        diagnostic = caught.value.data
+        diagnostic = json.loads(
+            _content_text(caught.content[0]).removeprefix(
+                "Error executing tool math.run: "
+            )
+        )
         assert diagnostic["code"] == "RESOURCE_ADMISSION_REJECTED"
         assert diagnostic["stage"] == "resource_admission"
         assert diagnostic["errors"][0]["code"] == f"optimization.linear.{code}"

--- a/tests/mcp/test_mcp_catalog_and_policy.py
+++ b/tests/mcp/test_mcp_catalog_and_policy.py
@@ -60,12 +60,7 @@ def test_mcp_compact_operation_matches_are_paginated() -> None:
 
             listed = await client.call_tool(
                 "math.find",
-                {
-                    "request": {
-                        "op": "match",
-                        "need": "exact mathematical computation",
-                    }
-                },
+                {"query": "exact mathematical computation"},
             )
             assert isinstance(listed.structured_content, dict)
             index = listed.structured_content
@@ -84,12 +79,9 @@ def test_mcp_compact_operation_matches_are_paginated() -> None:
                 next_page = await client.call_tool(
                     "math.find",
                     {
-                        "request": {
-                            "op": "match",
-                            "need": "exact mathematical computation",
-                            "cursor": cursor,
-                            "limit": 10,
-                        }
+                        "query": "exact mathematical computation",
+                        "cursor": cursor,
+                        "limit": 10,
                     },
                 )
                 assert isinstance(next_page.structured_content, dict)
@@ -108,11 +100,8 @@ def test_mcp_compact_operation_matches_are_paginated() -> None:
             first_page = await client.call_tool(
                 "math.find",
                 {
-                    "request": {
-                        "op": "match",
-                        "need": "exact mathematical computation",
-                        "limit": 10,
-                    }
+                    "query": "exact mathematical computation",
+                    "limit": 10,
                 },
             )
             assert isinstance(first_page.structured_content, dict)
@@ -122,12 +111,9 @@ def test_mcp_compact_operation_matches_are_paginated() -> None:
             second_page = await client.call_tool(
                 "math.find",
                 {
-                    "request": {
-                        "op": "match",
-                        "need": "exact mathematical computation",
-                        "cursor": first["next_cursor"],
-                        "limit": 10,
-                    }
+                    "query": "exact mathematical computation",
+                    "cursor": first["next_cursor"],
+                    "limit": 10,
                 },
             )
             assert isinstance(second_page.structured_content, dict)
@@ -139,12 +125,9 @@ def test_mcp_compact_operation_matches_are_paginated() -> None:
             changed_limit = await client.call_tool(
                 "math.find",
                 {
-                    "request": {
-                        "op": "match",
-                        "need": "exact mathematical computation",
-                        "cursor": first["next_cursor"],
-                        "limit": 20,
-                    }
+                    "query": "exact mathematical computation",
+                    "cursor": first["next_cursor"],
+                    "limit": 20,
                 },
             )
             assert changed_limit.structured_content["kind"] == "matches"
@@ -152,11 +135,8 @@ def test_mcp_compact_operation_matches_are_paginated() -> None:
             changed_need = await client.call_tool(
                 "math.find",
                 {
-                    "request": {
-                        "op": "match",
-                        "need": "exact integer greatest common divisor",
-                        "cursor": first["next_cursor"],
-                    }
+                    "query": "exact integer greatest common divisor",
+                    "cursor": first["next_cursor"],
                 },
             )
             assert changed_need.structured_content["error"]["code"] == "INVALID_CURSOR"
@@ -164,11 +144,8 @@ def test_mcp_compact_operation_matches_are_paginated() -> None:
             wider_page = await client.call_tool(
                 "math.find",
                 {
-                    "request": {
-                        "op": "match",
-                        "need": "exact mathematical computation",
-                        "limit": 20,
-                    }
+                    "query": "exact mathematical computation",
+                    "limit": 20,
                 },
             )
             assert isinstance(wider_page.structured_content, dict)
@@ -177,16 +154,13 @@ def test_mcp_compact_operation_matches_are_paginated() -> None:
             invalid_cursor = await client.call_tool(
                 "math.find",
                 {
-                    "request": {
-                        "op": "match",
-                        # Keep the cursor invalid for this filtered result. The
-                        # catalog contains many descriptions mentioning "operation",
-                        # so that word is not a stable no-match fixture as the
-                        # library grows.
-                        "need": "zqx",
-                        "cursor": "integer.compute.unknown",
-                        "limit": 10,
-                    }
+                    # Keep the cursor invalid for this filtered result. The
+                    # catalog contains many descriptions mentioning "operation",
+                    # so that word is not a stable no-match fixture as the
+                    # library grows.
+                    "query": "zqx",
+                    "cursor": "integer.compute.unknown",
+                    "limit": 10,
                 },
             )
             invalid = json.loads(_content_text(invalid_cursor.content[0]))

--- a/tests/mcp/test_mcp_invocation_journey.py
+++ b/tests/mcp/test_mcp_invocation_journey.py
@@ -11,7 +11,6 @@ import json
 import threading
 
 import pytest
-from mcp.shared.exceptions import MCPError
 from mcp.types import ContentBlock, TextContent
 
 from jacobian.mcp.server import create_server
@@ -97,14 +96,11 @@ def test_mcp_describes_and_invokes_operations() -> None:
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(), raise_exceptions=True) as client:
+        async with Client(create_server(), raise_exceptions=False) as client:
             described = await client.call_tool(
                 "math.find",
                 {
-                    "request": {
-                        "op": "inspect",
-                        "operation_id": "integer.compute.extended_gcd",
-                    }
+                    "operation_id": "integer.compute.extended_gcd",
                 },
             )
             assert isinstance(described.structured_content, dict)
@@ -165,21 +161,23 @@ def test_mcp_describes_and_invokes_operations() -> None:
                 "first_unsatisfied_clause": None,
             }
 
-            with pytest.raises(MCPError) as invalid_error:
-                await client.call_tool(
-                    "math.run",
-                    {
-                        "operation_id": "integer.compute.extended_gcd",
-                        "payload": {
-                            "left": "84",
-                            "right": "30",
-                            "private": "reject-this-private-value",
-                        },
+            invalid_error = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "integer.compute.extended_gcd",
+                    "payload": {
+                        "left": "84",
+                        "right": "30",
+                        "private": "reject-this-private-value",
                     },
+                },
+            )
+            invalid_data = json.loads(
+                _text_content(invalid_error.content[0]).removeprefix(
+                    "Error executing tool math.run: "
                 )
-            assert invalid_error.value.code == -32602
-            assert invalid_error.value.message == "operation payload failed validation"
-            assert invalid_error.value.data == {
+            )
+            assert invalid_data == {
                 "code": "INVALID_REQUEST",
                 "stage": "operation_validation",
                 "operation_id": "integer.compute.extended_gcd",
@@ -194,19 +192,25 @@ def test_mcp_describes_and_invokes_operations() -> None:
                     "Inspect the operation with math.find and correct the fields at "
                     "the reported locations before retrying."
                 ),
+                "message": "operation payload failed validation",
             }
-            assert "reject-this-private-value" not in invalid_error.value.message
+            assert "reject-this-private-value" not in _text_content(
+                invalid_error.content[0]
+            )
 
-            with pytest.raises(MCPError) as noncanonical_error:
-                await client.call_tool(
-                    "math.run",
-                    {
-                        "operation_id": "integer.compute.extended_gcd",
-                        "payload": {"left": 1.5, "right": "30"},
-                    },
+            noncanonical_error = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "integer.compute.extended_gcd",
+                    "payload": {"left": 1.5, "right": "30"},
+                },
+            )
+            noncanonical_data = json.loads(
+                _text_content(noncanonical_error.content[0]).removeprefix(
+                    "Error executing tool math.run: "
                 )
-            assert noncanonical_error.value.code == -32602
-            assert noncanonical_error.value.data["errors"] == [
+            )
+            assert noncanonical_data["errors"] == [
                 {
                     "location": [],
                     "code": "canonicalization_error",
@@ -214,35 +218,38 @@ def test_mcp_describes_and_invokes_operations() -> None:
                 }
             ]
 
-            with pytest.raises(MCPError) as semantic_error:
-                await client.call_tool(
-                    "math.run",
-                    {
-                        "operation_id": "universal_algebra.term.evaluate.compute",
-                        "payload": {
-                            "algebra": {
-                                "carrier": ["0", "1"],
-                                "operations": [{"operation_id": "and", "arity": 2}],
-                                "tables": [[0, 0, 0, 1]],
-                            },
-                            "term": {
-                                "nodes": [
-                                    {"kind": "variable", "variable_id": 0},
-                                    {"kind": "variable", "variable_id": 1},
-                                    {
-                                        "kind": "application",
-                                        "operation": 0,
-                                        "children": [0, 1],
-                                    },
-                                ],
-                                "root": 2,
-                            },
-                            "assignment": [0],
+            semantic_error = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "universal_algebra.term.evaluate.compute",
+                    "payload": {
+                        "algebra": {
+                            "carrier": ["0", "1"],
+                            "operations": [{"operation_id": "and", "arity": 2}],
+                            "tables": [[0, 0, 0, 1]],
                         },
+                        "term": {
+                            "nodes": [
+                                {"kind": "variable", "variable_id": 0},
+                                {"kind": "variable", "variable_id": 1},
+                                {
+                                    "kind": "application",
+                                    "operation": 0,
+                                    "children": [0, 1],
+                                },
+                            ],
+                            "root": 2,
+                        },
+                        "assignment": [0],
                     },
+                },
+            )
+            semantic_data = json.loads(
+                _text_content(semantic_error.content[0]).removeprefix(
+                    "Error executing tool math.run: "
                 )
-            assert semantic_error.value.code == -32602
-            assert semantic_error.value.data["errors"] == [
+            )
+            assert semantic_data["errors"] == [
                 {
                     "location": ["assignment"],
                     "code": "universal_algebra.assignment_coverage",
@@ -250,41 +257,46 @@ def test_mcp_describes_and_invokes_operations() -> None:
                 }
             ]
 
-            with pytest.raises(MCPError) as oversized_error:
-                await client.call_tool(
-                    "math.run",
-                    {
-                        "operation_id": "universal_algebra.term.evaluate.compute",
-                        "payload": {
-                            "term": {
-                                "nodes": [{"kind": "x" * 4_096}],
-                                "root": 0,
-                            }
-                        },
+            oversized_error = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "universal_algebra.term.evaluate.compute",
+                    "payload": {
+                        "term": {
+                            "nodes": [{"kind": "x" * 4_096}],
+                            "root": 0,
+                        }
                     },
+                },
+            )
+            oversized_data = json.loads(
+                _text_content(oversized_error.content[0]).removeprefix(
+                    "Error executing tool math.run: "
                 )
-            assert oversized_error.value.code == -32602
+            )
             assert all(
-                len(issue["message"]) <= 1_024
-                for issue in oversized_error.value.data["errors"]
+                len(issue["message"]) <= 1_024 for issue in oversized_data["errors"]
             )
 
             oversized_fields = {
                 f"{'x' * 4_096}{index}": "y" * 2_000 for index in range(64)
             }
-            with pytest.raises(MCPError) as bounded_locations_error:
-                await client.call_tool(
-                    "math.run",
-                    {
-                        "operation_id": "integer.compute.extended_gcd",
-                        "payload": {
-                            "left": "84",
-                            "right": "30",
-                            **oversized_fields,
-                        },
+            bounded_locations_error = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "integer.compute.extended_gcd",
+                    "payload": {
+                        "left": "84",
+                        "right": "30",
+                        **oversized_fields,
                     },
+                },
+            )
+            bounded_data = json.loads(
+                _text_content(bounded_locations_error.content[0]).removeprefix(
+                    "Error executing tool math.run: "
                 )
-            bounded_data = bounded_locations_error.value.data
+            )
             assert all(
                 len(component) <= 128
                 for issue in bounded_data["errors"]
@@ -292,25 +304,26 @@ def test_mcp_describes_and_invokes_operations() -> None:
                 if isinstance(component, str)
             )
 
-            with pytest.raises(MCPError) as multiple_errors:
-                await client.call_tool(
-                    "math.run",
-                    {
-                        "operation_id": "integer.compute.extended_gcd",
-                        "payload": {"left": "01", "right": "not-an-integer"},
-                    },
-                )
+            multiple_errors = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "integer.compute.extended_gcd",
+                    "payload": {"left": "01", "right": "not-an-integer"},
+                },
+            )
             assert [
-                error["location"] for error in multiple_errors.value.data["errors"]
+                error["location"]
+                for error in json.loads(
+                    _text_content(multiple_errors.content[0]).removeprefix(
+                        "Error executing tool math.run: "
+                    )
+                )["errors"]
             ] == [["left"], ["right"]]
 
             matching_description = await client.call_tool(
                 "math.find",
                 {
-                    "request": {
-                        "op": "inspect",
-                        "operation_id": ("graph.invariant.maximum_matching.compute"),
-                    }
+                    "operation_id": "graph.invariant.maximum_matching.compute",
                 },
             )
             assert isinstance(matching_description.structured_content, dict)

--- a/tests/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/mcp/test_mcp_sdk_2_conformance.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import inspect
+import json
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from mcp.shared.exceptions import MCPError
 from mcp.types import ContentBlock, TextContent, TextResourceContents
 from mcp.types.methods import serialize_server_result
 
@@ -196,28 +196,31 @@ def test_math_run_projects_forged_character_as_invalid_request() -> None:
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(), raise_exceptions=True) as client:
-            with pytest.raises(MCPError) as error:
-                await client.call_tool(
-                    "math.run",
-                    {
-                        "operation_id": "dirichlet_character.principal.value.compute",
-                        "payload": {
-                            "character": {
-                                "modulus": 4,
-                                "unit_residues": [1],
-                                "values": [0, 1, 0, 0],
-                            },
-                            "integer": "1",
+        async with Client(create_server(), raise_exceptions=False) as client:
+            error = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "dirichlet_character.principal.value.compute",
+                    "payload": {
+                        "character": {
+                            "modulus": 4,
+                            "unit_residues": [1],
+                            "values": [0, 1, 0, 0],
                         },
+                        "integer": "1",
                     },
-                )
+                },
+            )
 
-        assert error.value.code == -32602
-        assert error.value.message == "operation payload failed validation"
-        assert error.value.data["code"] == "INVALID_REQUEST"
-        assert error.value.data["stage"] == "operation_validation"
-        assert error.value.data["errors"] == [
+        assert error.is_error is True
+        diagnostic = json.loads(
+            _content_text(error.content[0]).removeprefix(
+                "Error executing tool math.run: "
+            )
+        )
+        assert diagnostic["code"] == "INVALID_REQUEST"
+        assert diagnostic["stage"] == "operation_validation"
+        assert diagnostic["errors"] == [
             {
                 "location": ["character", "unit_residues"],
                 "code": "dirichlet_character.unit_residues_mismatch",
@@ -257,26 +260,27 @@ def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources() -> None
             assert find.annotations is not None
             assert find.annotations.read_only_hint is True
             assert find.annotations.idempotent_hint is True
-            assert set(find.input_schema["properties"]) == {"request"}
-            assert find.input_schema["properties"]["request"]["discriminator"] == {
-                "mapping": {
-                    "inspect": "#/$defs/OperationInspectRequest",
-                    "match": "#/$defs/OperationMatchRequest",
-                },
-                "propertyName": "op",
+            assert set(find.input_schema["properties"]) == {
+                "query",
+                "operation_id",
+                "namespace",
+                "limit",
+                "cursor",
             }
-            assert find.input_schema["required"] == ["request"]
-            need_description = find.input_schema["$defs"]["OperationMatchRequest"][
-                "properties"
-            ]["need"]["description"]
+            assert not find.input_schema.get("required")
+            query_schema = find.input_schema["properties"]["query"]
+            need_description = query_schema["anyOf"][0]["description"]
             assert "established mathematical names" in need_description
             assert "full scalar, batch, or exhaustive scope" in need_description
             assert "requested result" in need_description
-            limit_schema = find.input_schema["$defs"]["OperationMatchRequest"][
-                "properties"
-            ]["limit"]
-            assert limit_schema["default"] == 10
-            assert limit_schema["maximum"] == 20
+            operation_id_schema = find.input_schema["properties"]["operation_id"]
+            assert (
+                "Exact public operation ID"
+                in operation_id_schema["anyOf"][0]["description"]
+            )
+            limit_schema = find.input_schema["properties"]["limit"]
+            assert limit_schema["default"] is None
+            assert any(item.get("maximum") == 20 for item in limit_schema["anyOf"])
             assert find.output_schema is not None
             assert find.output_schema["type"] == "object"
 
@@ -293,14 +297,21 @@ def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources() -> None
             assert invalid_request.is_error is True
             assert invalid_request.content, "error responses must carry diagnostic text"
             assert any(
-                "request" in item.text
+                "query or operation_id" in item.text
                 for item in invalid_request.content
                 if isinstance(item, TextContent)
-            ), "error text must identify the missing request field"
+            ), "error text must identify the required discovery selector"
 
-            blank_need = await client.call_tool(
-                "math.find", {"request": {"op": "match", "need": "   "}}
+            flat_query = await client.call_tool(
+                "math.find",
+                {"query": "polynomial symbolic expand", "limit": 2},
             )
+            assert flat_query.is_error is False
+            assert isinstance(flat_query.structured_content, dict)
+            assert flat_query.structured_content["kind"] == "matches"
+            assert len(flat_query.structured_content["matches"]) <= 2
+
+            blank_need = await client.call_tool("math.find", {"query": "   "})
             assert blank_need.is_error is True
             assert any(
                 "non-whitespace" in item.text
@@ -308,13 +319,46 @@ def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources() -> None
                 if isinstance(item, TextContent)
             )
 
-            contract_result = await client.call_tool(
+            both_selectors = await client.call_tool(
+                "math.find",
+                {
+                    "query": "exact determinant",
+                    "operation_id": "matrix.determinant.compute",
+                },
+            )
+            assert both_selectors.is_error is True
+            assert any(
+                "exactly one" in item.text
+                for item in both_selectors.content
+                if isinstance(item, TextContent)
+            )
+
+            inspect_with_search_option = await client.call_tool(
+                "math.find",
+                {"operation_id": "matrix.determinant.compute", "limit": 2},
+            )
+            assert inspect_with_search_option.is_error is True
+            assert any(
+                "only valid with query" in item.text
+                for item in inspect_with_search_option.content
+                if isinstance(item, TextContent)
+            )
+
+            legacy_wrapper = await client.call_tool(
                 "math.find",
                 {
                     "request": {
                         "op": "inspect",
                         "operation_id": "matrix.determinant.compute",
                     }
+                },
+            )
+            assert legacy_wrapper.is_error is True
+
+            contract_result = await client.call_tool(
+                "math.find",
+                {
+                    "operation_id": "matrix.determinant.compute",
                 },
             )
             assert isinstance(contract_result.structured_content, dict)

--- a/tests/mcp/test_real_quadratic_admission.py
+++ b/tests/mcp/test_real_quadratic_admission.py
@@ -4,8 +4,7 @@ import asyncio
 import json
 
 import pytest
-from mcp.shared.exceptions import MCPError
-from mcp.types import INVALID_PARAMS
+from mcp.types import ContentBlock, TextContent
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationDomainValidationError
@@ -16,6 +15,11 @@ from jacobian.math.number_theory.arithmetic._real_quadratic import (
 )
 from jacobian.mcp.server import create_server
 from mcp import Client
+
+
+def _content_text(block: ContentBlock) -> str:
+    assert isinstance(block, TextContent)
+    return block.text
 
 
 @pytest.mark.parametrize(
@@ -50,19 +54,22 @@ def test_real_quadratic_rejection_and_recovery(overflow: bool) -> None:
     assert dispatch.value.errors() == native.value.errors()
 
     async def scenario() -> None:
-        async with Client(create_server(), raise_exceptions=True) as client:
-            with pytest.raises(MCPError) as rejected:
-                await client.call_tool(
-                    "math.run", {"operation_id": operation_id, "payload": payload}
+        async with Client(create_server(), raise_exceptions=False) as client:
+            rejected = await client.call_tool(
+                "math.run", {"operation_id": operation_id, "payload": payload}
+            )
+            diagnostic = json.loads(
+                _content_text(rejected.content[0]).removeprefix(
+                    "Error executing tool math.run: "
                 )
-            assert rejected.value.code == INVALID_PARAMS
-            assert rejected.value.data["code"] == (
+            )
+            assert diagnostic["code"] == (
                 "RESOURCE_ADMISSION_REJECTED" if overflow else "INVALID_REQUEST"
             )
-            assert rejected.value.data["stage"] == (
+            assert diagnostic["stage"] == (
                 "resource_admission" if overflow else "operation_validation"
             )
-            assert rejected.value.data["errors"] == [
+            assert diagnostic["errors"] == [
                 {
                     "location": list(error["loc"]),
                     "code": error["type"],

--- a/tests/process/test_bounded_process.py
+++ b/tests/process/test_bounded_process.py
@@ -13,6 +13,11 @@ from typing import Never
 
 import pytest
 
+from jacobian._execution import (
+    bind_request_deadline,
+    request_cancellation,
+    request_execution,
+)
 from jacobian.process import (
     ProcessPlatformTools,
     ProcessResourceLimits,
@@ -43,6 +48,74 @@ def test_expired_input_spooling_does_not_launch_a_worker(
 
     assert completed.timed_out
     assert not completed.cancelled
+    assert completed.returncode is None
+
+
+def test_expired_request_envelope_does_not_launch_a_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_to_launch(*_args: object, **_kwargs: object) -> Never:
+        raise AssertionError("expired request must not launch a worker")
+
+    monkeypatch.setattr("jacobian.process.subprocess.Popen", fail_to_launch)
+
+    with request_execution(0.0):
+        bind_request_deadline(0.0)
+        completed = run_bounded_process(
+            [sys.executable, "-c", "raise SystemExit(0)"],
+            input_bytes=b"input",
+            timeout_seconds=30,
+            environment=dict(os.environ),
+            stdout_limit=4096,
+            stderr_limit=4096,
+        )
+
+    assert completed.timed_out
+    assert not completed.cancelled
+    assert completed.returncode is None
+
+
+def test_request_envelope_caps_worker_wall_time() -> None:
+    started = time.monotonic()
+    with request_execution(started):
+        bind_request_deadline(started + 0.2)
+        completed = run_bounded_process(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            input_bytes=b"",
+            timeout_seconds=30,
+            environment=dict(os.environ),
+            stdout_limit=4096,
+            stderr_limit=4096,
+        )
+
+    assert completed.timed_out
+    assert not completed.cancelled
+    assert completed.returncode is not None
+    assert time.monotonic() - started < 3
+
+
+def test_cancelled_request_envelope_does_not_launch_a_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_to_launch(*_args: object, **_kwargs: object) -> Never:
+        raise AssertionError("cancelled request must not launch a worker")
+
+    monkeypatch.setattr("jacobian.process.subprocess.Popen", fail_to_launch)
+    cancellation_event = threading.Event()
+    cancellation_event.set()
+
+    with request_cancellation(cancellation_event):
+        completed = run_bounded_process(
+            [sys.executable, "-c", "raise SystemExit(0)"],
+            input_bytes=b"input",
+            timeout_seconds=30,
+            environment=dict(os.environ),
+            stdout_limit=4096,
+            stderr_limit=4096,
+        )
+
+    assert completed.cancelled
+    assert not completed.timed_out
     assert completed.returncode is None
 
 

--- a/tests/process/test_factorization_workers.py
+++ b/tests/process/test_factorization_workers.py
@@ -1,8 +1,11 @@
 """Process-boundary behavior for integer-factorization workers."""
 
+import time
+
 import pytest
 
 from jacobian import process as process_runtime
+from jacobian._execution import OperationExecutionTimeoutError, request_execution
 from jacobian.math.number_theory._certification_models import (
     CertifiedFactorizationRequest,
 )
@@ -28,6 +31,15 @@ def _timed_out_worker(*_args: object, **_kwargs: object) -> BoundedProcessResult
         stderr_exceeded=False,
         timed_out=True,
     )
+
+
+def test_certified_factorization_budget_includes_prior_request_work() -> None:
+    request = CertifiedFactorizationRequest(value=2)
+    with (
+        request_execution(time.monotonic() - 61),
+        pytest.raises(OperationExecutionTimeoutError, match="deadline expired"),
+    ):
+        factorize_certified(request)
 
 
 def test_timed_out_certified_factorization_raises_timeout(

--- a/tests/process/test_number_field_discriminant_worker.py
+++ b/tests/process/test_number_field_discriminant_worker.py
@@ -1,10 +1,12 @@
 """Process-boundary behavior for number-field discriminant workers."""
 
 import hashlib
+import time
 
 import pytest
 
 from jacobian import process as process_runtime
+from jacobian._execution import OperationExecutionTimeoutError, request_execution
 from jacobian.math.number_theory.number_fields import (
     SimpleNumberFieldPresentation,
 )
@@ -22,6 +24,15 @@ def _number_field(*coefficients: str) -> SimpleNumberFieldPresentation:
     return SimpleNumberFieldPresentation(
         coefficients_descending=tuple(int(coefficient) for coefficient in coefficients)
     )
+
+
+def test_number_field_budget_includes_prior_request_work() -> None:
+    request = NumberFieldRequest(field=_number_field("1", "0", "-2"))
+    with (
+        request_execution(time.monotonic() - 61),
+        pytest.raises(OperationExecutionTimeoutError, match="deadline expired"),
+    ):
+        compute_nf_discriminant(request)
 
 
 def test_timed_out_number_field_worker_is_an_operational_failure(

--- a/tests/tooling/evaluations/test_codex_telemetry.py
+++ b/tests/tooling/evaluations/test_codex_telemetry.py
@@ -202,6 +202,55 @@ def test_agent_telemetry_does_not_count_unknown_exact_inspection(
     assert telemetry["operation_descriptions"] == []
 
 
+def test_agent_telemetry_recognizes_flat_discovery_and_inspection(
+    tmp_path: Path,
+) -> None:
+    events = [
+        _tool_event(
+            "math.find",
+            {"query": "polynomial symbolic expand", "limit": 2},
+            {
+                "kind": "matches",
+                "matches": [{"operation_id": "polynomial.expand.compute"}],
+            },
+        ),
+        _tool_event(
+            "math.find",
+            {"operation_id": "polynomial.expand.compute"},
+            {
+                "kind": "operation",
+                "operation": {"operation_id": "polynomial.expand.compute"},
+            },
+        ),
+    ]
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+
+    telemetry = parse_agent_transcript(transcript)
+
+    assert telemetry["operation_describe_index_calls"] == 1
+    assert telemetry["operation_describe_exact_calls"] == 1
+    assert telemetry["operation_descriptions"] == [
+        {
+            "kind": "matches",
+            "need": "polynomial symbolic expand",
+            "namespace": None,
+            "operation_id": None,
+            "match_ids": ["polynomial.expand.compute"],
+        },
+        {
+            "kind": "operation",
+            "need": None,
+            "namespace": None,
+            "operation_id": "polynomial.expand.compute",
+            "match_ids": [],
+        },
+    ]
+
+
 def test_agent_telemetry_records_current_inline_math_run_result(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Problem

Discovery calls using a top-level query fail before reaching the catalog, operational failures can be mistaken for malformed requests or negative mathematical verdicts, and some exact results cannot be consumed unchanged by related operations. Parsed SMT expressions also admit unsupported assertion sorts and arithmetic growth not captured by lexical limits.

## Outcome

- Flatten `math.find`: search with `query` and inspect with `operation_id`. Migrate guidance, callers, and evaluations; retain historical transcript decoding only in telemetry.
- Return recoverable operation errors through MCP tool-error results. Preserve timeout, cancellation, resource-admission, and backend failures instead of turning them into false verifier verdicts. Share request deadlines across worker execution and result decoding.
- Publish the SMT command allowlist, validate assertion fragments, and bound parsed arithmetic before simplification. One iterative DAG walk handles constants, variables, and conditional expressions without evaluating their arithmetic. Retain 4,096-digit products and the existing nesting boundary. Keep SAT assignment recognition at the worker adapter rather than replaying it during result construction.
- Return canonical indexed graph values from all graph transforms, normalize edge orientation, and admit null graphs and dense 64-vertex complement round trips. Preserve operation-owned computational limits while allowing existing 1,024-vertex line-graph outputs to use the shared value.
- Let LP optimality candidates use the canonical rational encoding limit, not the smaller source-program limit. Existing arithmetic admission remains in force; solver-produced 201-digit denominators now compose through native and JSON inputs.

Review order follows the three commits: MCP/execution contracts, graph values and dependent admissions, then LP candidate composition. This follows up on #3475 without reopening its completed issue scope. No operation IDs are added or removed.

## Validation

Evidence covers the working tree committed as `8f3e7b286b4224a215517cbe3f86803307a8037e`; PR preparation changed no code.

- `make affected AFFECTED_BASE=origin/main`: scoped Ruff, formatting, and mypy passed. The full math lane completed with 9,004 passing tests and one stale graph-carrier boundary assertion. That assertion was corrected, a native-admission regression was added, and the owning spectra tests passed: 27 tests. The unchanged full math lane was not repeated.
- Focused logic, SMT-growth, and unsat-core tests: 222 passed. Graph-transform and carrier tests: 23 passed. Neighborhood tests: 22 passed. LP optimality tests: 20 passed.
- Remaining selected lanes were completed successfully with:

```sh
make test-catalog
make test-integration TESTS=tests/integration/catalog
make test-cli test-dispatch test-integration test-tooling test-mcp test-process test-singular test-qepcad
make docs-linkcheck
git diff --check
```

- The final spectra test edit also passed scoped Ruff, formatting, and mypy.
- Hosted CI is pending. Installed-wheel validation remains CI-only; no merged-main validation is claimed.

## Contract impact

- `math.find` replaces the wrapped `request`/`op`/`need` input with top-level `query` or `operation_id`; no compatibility aliases are introduced. Existing MCP connections must reconnect to load the new schema.
- Graph transform results replace operation-specific edge objects with `IndexedSimpleUndirectedGraph` canonical edge pairs. Indexed values permit 1,024 vertices and 65,536 edges; labeled values remain at 256 vertices. Coloring and characteristic-polynomial computation retain their 256-vertex admission limits.
- Complement, square, and induced-subgraph inputs allow 0..64 vertices and up to 2,016 edges. Line-graph inputs retain their 1,024-edge cap, bounding output edges by 63,488.
- SMT arithmetic admission limits numerator/denominator heights to 65,536 bits and aggregate parsed arithmetic work to 1,073,741,824 units before simplification. This is not a universal solver-complexity guarantee. Sort checks apply to parsed assertions, not unused declarations before parsing.
- LP source coefficients retain their 128-digit limit; candidate encoding uses the existing 32,768-digit canonical rational limit and remains subject to tighter operation-specific arithmetic/output admission.

## Review closure

- Behavioral regressions cover serialized producer-consumer composition, empty values, accepted large inputs, forged claims, and operational failure propagation.
- Existing value types and owner-local admission were reused; no compatibility layer or generic verification framework was added.
- `main` currently contains one newer, non-overlapping flow-operation commit. This branch does not rewrite or revert it.
- Open PR #3486 also touches coloring models. This PR preserves the existing coloring envelope; coordinate that shared-file change when merging.
- Review threads are not applicable yet; CI evidence will attach to this PR head.