### PR TITLE
feat(matrices): reduce rational semidefinite exposed faces

### DIFF
--- a/src/jacobian/math/matrices/semidefinite/__init__.py
+++ b/src/jacobian/math/matrices/semidefinite/__init__.py
@@ -1,0 +1,13 @@
+"""Exact rational semidefinite systems and exposed-face reduction."""
+
+from jacobian.math.matrices.semidefinite.operations import reduce_exposed_face
+from jacobian.math.matrices.semidefinite.values import (
+    RationalSemidefiniteSystem,
+    SemidefiniteFaceReduction,
+)
+
+__all__ = [
+    "RationalSemidefiniteSystem",
+    "SemidefiniteFaceReduction",
+    "reduce_exposed_face",
+]

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -9,6 +9,71 @@ from jacobian.math.matrices.semidefinite.values import (
     RationalSemidefiniteSystem,
 )
 
+_MAX_SOURCE_DIGITS = 8_000_000
+
+
+def _raw_component_digits(component: object) -> int:
+    if isinstance(component, str):
+        return len(component.lstrip("-") or "0")
+    if type(component) is int:
+        return len(str(abs(component)))
+    return 0
+
+
+def _raw_rational_digits(value: object) -> int:
+    if isinstance(value, dict):
+        return _raw_component_digits(value.get("num")) + _raw_component_digits(
+            value.get("den")
+        )
+    if hasattr(value, "num") and hasattr(value, "den"):
+        return _raw_component_digits(value.num) + _raw_component_digits(value.den)
+    return 0
+
+
+def _scan_matrix_entries(matrices: object) -> tuple[int, int]:
+    if not isinstance(matrices, (list, tuple)):
+        return 0, 0
+    cells = 0
+    digits = 0
+    for matrix in matrices:
+        entries = matrix.get("entries") if isinstance(matrix, dict) else None
+        if entries is None and hasattr(matrix, "entries"):
+            entries = matrix.entries
+        if not isinstance(entries, (list, tuple)):
+            continue
+        for row in entries:
+            if isinstance(row, (list, tuple)):
+                cells += len(row)
+                digits += sum(_raw_rational_digits(entry) for entry in row)
+            else:
+                cells += 1
+                digits += _raw_rational_digits(row)
+    return cells, digits
+
+
+def _count_raw_cells_and_digits(data: dict[str, object]) -> tuple[int, int, int]:
+    system = data.get("system")
+    if not isinstance(system, dict):
+        return 0, 0, 0
+    order = system.get("order")
+    matrices = system.get("matrices")
+    cells, digits = _scan_matrix_entries(matrices)
+    rhs = system.get("rhs")
+    if isinstance(rhs, (list, tuple)):
+        digits += sum(_raw_rational_digits(value) for value in rhs)
+    multipliers = data.get("multipliers")
+    if isinstance(multipliers, (list, tuple)):
+        digits += sum(_raw_rational_digits(value) for value in multipliers)
+    declared = 0
+    if type(order) is int:
+        if order < 0:
+            raise ValueError(
+                "source and reduced matrices exceed the dense cell envelope"
+            )
+        if isinstance(matrices, (list, tuple)):
+            declared = len(matrices) * order * order
+    return cells, declared, digits
+
 
 class SemidefiniteFaceReductionRequest(StrictModel):
     system: RationalSemidefiniteSystem
@@ -22,39 +87,14 @@ class SemidefiniteFaceReductionRequest(StrictModel):
     def require_aggregate_cells(cls, data: object) -> object:
         """Reject over-budget dense systems before nested matrix parsing."""
 
-        data = canonicalize_json_containers(data)
-        if not isinstance(data, dict):
-            return data
-        system = data.get("system")
-        if not isinstance(system, dict):
-            return data
-        order = system.get("order")
-        matrices = system.get("matrices")
-        if not isinstance(matrices, (list, tuple)):
-            return data
-        cells = 0
-        for matrix in matrices:
-            entries = None
-            if isinstance(matrix, dict):
-                entries = matrix.get("entries")
-            elif hasattr(matrix, "entries"):
-                entries = matrix.entries
-            if not isinstance(entries, (list, tuple)):
-                continue
-            for row in entries:
-                if isinstance(row, (list, tuple)):
-                    cells += len(row)
-                else:
-                    cells += 1
-        declared = 0
-        if type(order) is int:
-            if order < 0:
+        if isinstance(data, dict):
+            cells, declared, digits = _count_raw_cells_and_digits(data)
+            if cells > MAX_SEMIDEFINITE_CELLS or declared > MAX_SEMIDEFINITE_CELLS:
                 raise ValueError(
                     "source and reduced matrices exceed the dense cell envelope"
                 )
-            declared = len(matrices) * order * order
-        if cells > MAX_SEMIDEFINITE_CELLS or declared > MAX_SEMIDEFINITE_CELLS:
-            raise ValueError(
-                "source and reduced matrices exceed the dense cell envelope"
-            )
-        return data
+            if digits > _MAX_SOURCE_DIGITS:
+                raise ValueError(
+                    "source rationals exceed the admitted aggregate digit envelope"
+                )
+        return canonicalize_json_containers(data)

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -48,39 +48,27 @@ def _materialize_sequence(value: object, *, limit: int) -> list[object] | None:
     return None
 
 
-def _install_sequence(
-    container: dict[str, object], key: str, *, limit: int
-) -> list[object] | None:
-    value = container.get(key)
-    materialized = _materialize_sequence(value, limit=limit)
-    if materialized is not None and not isinstance(value, Sequence):
-        container[key] = materialized
-    return materialized
+def _scan_row(row: object, *, limit: int) -> tuple[object, int, int, bool]:
+    """Count cells in one row and materialize a generated row up to ``limit``."""
 
-
-def _scan_matrix_entries(matrices: object) -> tuple[int, int]:
-    matrix_list = _materialize_sequence(matrices, limit=MAX_SEMIDEFINITE_CELLS)
-    if matrix_list is None:
-        return 0, 0
-    cells = 0
-    digits = 0
-    for matrix in matrix_list:
-        entries = matrix.get("entries") if isinstance(matrix, dict) else None
-        if entries is None and hasattr(matrix, "entries"):
-            entries = matrix.entries
-        row_list = _materialize_sequence(entries, limit=MAX_SEMIDEFINITE_CELLS)
-        if row_list is None:
-            continue
-        for row in row_list:
-            if isinstance(row, (list, tuple)):
-                cells += len(row)
-                digits += sum(_raw_rational_digits(entry) for entry in row)
-            else:
-                cells += 1
-                digits += _raw_rational_digits(row)
-            if cells > MAX_SEMIDEFINITE_CELLS:
-                return cells, digits
-    return cells, digits
+    if isinstance(row, (str, bytes, bytearray, Mapping)):
+        return row, 1, _raw_rational_digits(row), False
+    if isinstance(row, Sequence):
+        return (
+            row,
+            len(row),
+            sum(_raw_rational_digits(entry) for entry in row),
+            False,
+        )
+    materialized = _materialize_sequence(row, limit=limit)
+    if materialized is None:
+        return row, 1, _raw_rational_digits(row), False
+    return (
+        materialized,
+        len(materialized),
+        sum(_raw_rational_digits(entry) for entry in materialized),
+        True,
+    )
 
 
 def _preflight_raw_payload(
@@ -93,28 +81,59 @@ def _preflight_raw_payload(
     system = dict(system)
     payload["system"] = system
     matrices_value = system.get("matrices")
-    matrix_list = _materialize_sequence(matrices_value, limit=MAX_SEMIDEFINITE_CELLS)
+    remaining_rows = MAX_SEMIDEFINITE_CELLS
+    matrix_list = _materialize_sequence(matrices_value, limit=remaining_rows)
     installed_matrices: list[object] | None = None
+    cells = 0
+    digits = 0
     if matrix_list is not None:
         installed_matrices = []
         needs_install = not isinstance(matrices_value, Sequence)
         for matrix in matrix_list:
-            if isinstance(matrix, dict):
-                matrix_payload = dict(matrix)
-                entries = matrix_payload.get("entries")
-                row_list = _install_sequence(
-                    matrix_payload, "entries", limit=MAX_SEMIDEFINITE_CELLS
+            if cells > MAX_SEMIDEFINITE_CELLS:
+                break
+            if not isinstance(matrix, dict):
+                entries = matrix.entries if hasattr(matrix, "entries") else None
+                row_list = _materialize_sequence(
+                    entries, limit=MAX_SEMIDEFINITE_CELLS - cells
                 )
-                if row_list is not None and not isinstance(entries, Sequence):
-                    needs_install = True
-                installed_matrices.append(matrix_payload)
-            else:
+                if row_list is not None:
+                    for row in row_list:
+                        _installed, row_cells, row_digits, _replaced = _scan_row(
+                            row, limit=MAX_SEMIDEFINITE_CELLS - cells
+                        )
+                        cells += row_cells
+                        digits += row_digits
+                        if cells > MAX_SEMIDEFINITE_CELLS:
+                            break
                 installed_matrices.append(matrix)
+                continue
+            matrix_payload = dict(matrix)
+            entries = matrix_payload.get("entries")
+            row_list = _materialize_sequence(
+                entries, limit=MAX_SEMIDEFINITE_CELLS - cells
+            )
+            if row_list is None:
+                installed_matrices.append(matrix_payload)
+                continue
+            installed_rows: list[object] = []
+            replace_entries = not isinstance(entries, Sequence)
+            for row in row_list:
+                installed_row, row_cells, row_digits, replaced = _scan_row(
+                    row, limit=MAX_SEMIDEFINITE_CELLS - cells
+                )
+                installed_rows.append(installed_row)
+                replace_entries = replace_entries or replaced
+                cells += row_cells
+                digits += row_digits
+                if cells > MAX_SEMIDEFINITE_CELLS:
+                    break
+            if replace_entries:
+                matrix_payload["entries"] = installed_rows
+                needs_install = True
+            installed_matrices.append(matrix_payload)
         if needs_install:
             system["matrices"] = installed_matrices
-    cells, digits = _scan_matrix_entries(
-        installed_matrices if installed_matrices is not None else system.get("matrices")
-    )
     rhs = system.get("rhs")
     if isinstance(rhs, (list, tuple)):
         digits += sum(_raw_rational_digits(value) for value in rhs)

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -13,6 +13,7 @@ from jacobian.math.matrices.semidefinite.values import (
 )
 
 _MAX_SOURCE_DIGITS = 8_000_000
+_MAX_EQUALITIES = 8192
 
 
 def _raw_component_digits(component: object) -> int:
@@ -36,16 +37,14 @@ def _raw_rational_digits(value: object) -> int:
 def _materialize_sequence(value: object, *, limit: int) -> list[object] | None:
     if isinstance(value, (str, bytes, bytearray, Mapping)):
         return None
-    if isinstance(value, Sequence):
-        return list(value)
-    if isinstance(value, Iterable):
-        collected: list[object] = []
-        for item in value:
-            collected.append(item)
-            if len(collected) > limit:
-                break
-        return collected
-    return None
+    if not isinstance(value, Iterable):
+        return None
+    collected: list[object] = []
+    for item in value:
+        collected.append(item)
+        if len(collected) > limit:
+            break
+    return collected
 
 
 def _scan_row(row: object, *, limit: int) -> tuple[object, int, int, bool]:
@@ -54,12 +53,16 @@ def _scan_row(row: object, *, limit: int) -> tuple[object, int, int, bool]:
     if isinstance(row, (str, bytes, bytearray, Mapping)):
         return row, 1, _raw_rational_digits(row), False
     if isinstance(row, Sequence):
-        return (
-            row,
-            len(row),
-            sum(_raw_rational_digits(entry) for entry in row),
-            False,
-        )
+        row_length = len(row)
+        if row_length > limit:
+            return row, row_length, 0, False
+        if isinstance(row, (list, tuple)):
+            return (
+                row,
+                row_length,
+                sum(_raw_rational_digits(entry) for entry in row),
+                False,
+            )
     materialized = _materialize_sequence(row, limit=limit)
     if materialized is None:
         return row, 1, _raw_rational_digits(row), False
@@ -71,24 +74,52 @@ def _scan_row(row: object, *, limit: int) -> tuple[object, int, int, bool]:
     )
 
 
+def _scan_and_install_scalars(
+    container: dict[str, object],
+    key: str,
+    *,
+    digits: int,
+) -> int:
+    value = container.get(key)
+    if isinstance(value, (str, bytes, bytearray, Mapping)) or value is None:
+        return digits
+    if not isinstance(value, Iterable):
+        return digits
+    collected: list[object] = []
+    extra = 0
+    remaining = _MAX_SOURCE_DIGITS - digits
+    for item in value:
+        collected.append(item)
+        extra += _raw_rational_digits(item)
+        if extra > remaining or len(collected) > _MAX_EQUALITIES:
+            break
+    if not isinstance(value, (list, tuple)):
+        container[key] = collected
+    return digits + extra
+
+
 def _preflight_raw_payload(
     data: dict[str, object],
 ) -> tuple[dict[str, object], int, int, int]:
     payload = dict(data)
     system = payload.get("system")
     if not isinstance(system, dict):
-        return payload, 0, 0, 0
+        digits = _scan_and_install_scalars(payload, "multipliers", digits=0)
+        return payload, 0, 0, digits
     system = dict(system)
     payload["system"] = system
     matrices_value = system.get("matrices")
-    remaining_rows = MAX_SEMIDEFINITE_CELLS
-    matrix_list = _materialize_sequence(matrices_value, limit=remaining_rows)
+    matrix_list = _materialize_sequence(
+        matrices_value, limit=MAX_SEMIDEFINITE_CELLS
+    )
     installed_matrices: list[object] | None = None
     cells = 0
     digits = 0
     if matrix_list is not None:
         installed_matrices = []
-        needs_install = not isinstance(matrices_value, Sequence)
+        needs_install = not isinstance(matrices_value, (list, tuple))
+        if len(matrix_list) > MAX_SEMIDEFINITE_CELLS:
+            cells = MAX_SEMIDEFINITE_CELLS + 1
         for matrix in matrix_list:
             if cells > MAX_SEMIDEFINITE_CELLS:
                 break
@@ -117,7 +148,7 @@ def _preflight_raw_payload(
                 installed_matrices.append(matrix_payload)
                 continue
             installed_rows: list[object] = []
-            replace_entries = not isinstance(entries, Sequence)
+            replace_entries = not isinstance(entries, (list, tuple))
             for row in row_list:
                 installed_row, row_cells, row_digits, replaced = _scan_row(
                     row, limit=MAX_SEMIDEFINITE_CELLS - cells
@@ -134,12 +165,8 @@ def _preflight_raw_payload(
             installed_matrices.append(matrix_payload)
         if needs_install:
             system["matrices"] = installed_matrices
-    rhs = system.get("rhs")
-    if isinstance(rhs, (list, tuple)):
-        digits += sum(_raw_rational_digits(value) for value in rhs)
-    multipliers = payload.get("multipliers")
-    if isinstance(multipliers, (list, tuple)):
-        digits += sum(_raw_rational_digits(value) for value in multipliers)
+    digits = _scan_and_install_scalars(system, "rhs", digits=digits)
+    digits = _scan_and_install_scalars(payload, "multipliers", digits=digits)
     declared = 0
     order = system.get("order")
     if type(order) is int:

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -1,10 +1,13 @@
 """Requests for a single rational exposed-face reduction."""
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from jacobian._exact import CanonicalRational
-from jacobian._models import StrictModel
-from jacobian.math.matrices.semidefinite.values import RationalSemidefiniteSystem
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.matrices.semidefinite.values import (
+    MAX_SEMIDEFINITE_CELLS,
+    RationalSemidefiniteSystem,
+)
 
 
 class SemidefiniteFaceReductionRequest(StrictModel):
@@ -13,3 +16,24 @@ class SemidefiniteFaceReductionRequest(StrictModel):
         max_length=8192,
         description="Supplied y with nonzero PSD sum y_i A_i and sum y_i b_i = 0.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_aggregate_cells(cls, data: object) -> object:
+        """Reject over-budget dense systems before nested matrix parsing."""
+
+        data = canonicalize_json_containers(data)
+        if not isinstance(data, dict):
+            return data
+        system = data.get("system")
+        if not isinstance(system, dict):
+            return data
+        order = system.get("order")
+        matrices = system.get("matrices")
+        if type(order) is not int or not isinstance(matrices, (list, tuple)):
+            return data
+        if order < 0 or len(matrices) * max(order, 0) ** 2 > MAX_SEMIDEFINITE_CELLS:
+            raise ValueError(
+                "source and reduced matrices exceed the dense cell envelope"
+            )
+        return data

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -25,7 +25,7 @@ def _raw_component_digits(component: object) -> int:
 
 
 def _raw_rational_digits(value: object) -> int:
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         return _raw_component_digits(value.get("num")) + _raw_component_digits(
             value.get("den")
         )
@@ -74,6 +74,28 @@ def _scan_row(row: object, *, limit: int) -> tuple[object, int, int, bool]:
     )
 
 
+def _scan_entries(
+    entries: object, *, cells: int
+) -> tuple[list[object] | None, int, int, bool]:
+    row_list = _materialize_sequence(entries, limit=MAX_SEMIDEFINITE_CELLS - cells)
+    if row_list is None:
+        return None, cells, 0, False
+    installed_rows: list[object] = []
+    replace_entries = not isinstance(entries, (list, tuple))
+    digits = 0
+    for row in row_list:
+        installed_row, row_cells, row_digits, replaced = _scan_row(
+            row, limit=MAX_SEMIDEFINITE_CELLS - cells
+        )
+        installed_rows.append(installed_row)
+        replace_entries = replace_entries or replaced
+        cells += row_cells
+        digits += row_digits
+        if cells > MAX_SEMIDEFINITE_CELLS:
+            break
+    return installed_rows, cells, digits, replace_entries
+
+
 def _scan_and_install_scalars(
     container: dict[str, object],
     key: str,
@@ -99,19 +121,17 @@ def _scan_and_install_scalars(
 
 
 def _preflight_raw_payload(
-    data: dict[str, object],
+    data: Mapping[str, object],
 ) -> tuple[dict[str, object], int, int, int]:
     payload = dict(data)
     system = payload.get("system")
-    if not isinstance(system, dict):
+    if not isinstance(system, Mapping):
         digits = _scan_and_install_scalars(payload, "multipliers", digits=0)
         return payload, 0, 0, digits
     system = dict(system)
     payload["system"] = system
     matrices_value = system.get("matrices")
-    matrix_list = _materialize_sequence(
-        matrices_value, limit=MAX_SEMIDEFINITE_CELLS
-    )
+    matrix_list = _materialize_sequence(matrices_value, limit=MAX_SEMIDEFINITE_CELLS)
     installed_matrices: list[object] | None = None
     cells = 0
     digits = 0
@@ -123,43 +143,22 @@ def _preflight_raw_payload(
         for matrix in matrix_list:
             if cells > MAX_SEMIDEFINITE_CELLS:
                 break
-            if not isinstance(matrix, dict):
+            if not isinstance(matrix, Mapping):
                 entries = matrix.entries if hasattr(matrix, "entries") else None
-                row_list = _materialize_sequence(
-                    entries, limit=MAX_SEMIDEFINITE_CELLS - cells
+                _rows, cells, row_digits, _replaced = _scan_entries(
+                    entries, cells=cells
                 )
-                if row_list is not None:
-                    for row in row_list:
-                        _installed, row_cells, row_digits, _replaced = _scan_row(
-                            row, limit=MAX_SEMIDEFINITE_CELLS - cells
-                        )
-                        cells += row_cells
-                        digits += row_digits
-                        if cells > MAX_SEMIDEFINITE_CELLS:
-                            break
+                digits += row_digits
                 installed_matrices.append(matrix)
                 continue
             matrix_payload = dict(matrix)
-            entries = matrix_payload.get("entries")
-            row_list = _materialize_sequence(
-                entries, limit=MAX_SEMIDEFINITE_CELLS - cells
+            if not isinstance(matrix, dict):
+                needs_install = True
+            installed_rows, cells, row_digits, replace_entries = _scan_entries(
+                matrix_payload.get("entries"), cells=cells
             )
-            if row_list is None:
-                installed_matrices.append(matrix_payload)
-                continue
-            installed_rows: list[object] = []
-            replace_entries = not isinstance(entries, (list, tuple))
-            for row in row_list:
-                installed_row, row_cells, row_digits, replaced = _scan_row(
-                    row, limit=MAX_SEMIDEFINITE_CELLS - cells
-                )
-                installed_rows.append(installed_row)
-                replace_entries = replace_entries or replaced
-                cells += row_cells
-                digits += row_digits
-                if cells > MAX_SEMIDEFINITE_CELLS:
-                    break
-            if replace_entries:
+            digits += row_digits
+            if replace_entries and installed_rows is not None:
                 matrix_payload["entries"] = installed_rows
                 needs_install = True
             installed_matrices.append(matrix_payload)
@@ -196,7 +195,7 @@ class SemidefiniteFaceReductionRequest(StrictModel):
     def require_aggregate_cells(cls, data: object) -> object:
         """Reject over-budget dense systems before nested matrix parsing."""
 
-        if isinstance(data, dict):
+        if isinstance(data, Mapping):
             data, cells, declared, digits = _preflight_raw_payload(data)
             if cells > MAX_SEMIDEFINITE_CELLS or declared > MAX_SEMIDEFINITE_CELLS:
                 raise ValueError(

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -4,6 +4,7 @@ from pydantic import Field, model_validator
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.canonical import format_canonical_integer
 from jacobian.math.matrices.semidefinite.values import (
     MAX_SEMIDEFINITE_CELLS,
     RationalSemidefiniteSystem,
@@ -16,7 +17,7 @@ def _raw_component_digits(component: object) -> int:
     if isinstance(component, str):
         return len(component.lstrip("-") or "0")
     if type(component) is int:
-        return len(str(abs(component)))
+        return len(format_canonical_integer(abs(component)))
     return 0
 
 

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -30,9 +30,30 @@ class SemidefiniteFaceReductionRequest(StrictModel):
             return data
         order = system.get("order")
         matrices = system.get("matrices")
-        if type(order) is not int or not isinstance(matrices, (list, tuple)):
+        if not isinstance(matrices, (list, tuple)):
             return data
-        if order < 0 or len(matrices) * max(order, 0) ** 2 > MAX_SEMIDEFINITE_CELLS:
+        cells = 0
+        for matrix in matrices:
+            entries = None
+            if isinstance(matrix, dict):
+                entries = matrix.get("entries")
+            elif hasattr(matrix, "entries"):
+                entries = matrix.entries
+            if not isinstance(entries, (list, tuple)):
+                continue
+            for row in entries:
+                if isinstance(row, (list, tuple)):
+                    cells += len(row)
+                else:
+                    cells += 1
+        declared = 0
+        if type(order) is int:
+            if order < 0:
+                raise ValueError(
+                    "source and reduced matrices exceed the dense cell envelope"
+                )
+            declared = len(matrices) * order * order
+        if cells > MAX_SEMIDEFINITE_CELLS or declared > MAX_SEMIDEFINITE_CELLS:
             raise ValueError(
                 "source and reduced matrices exceed the dense cell envelope"
             )

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -48,6 +48,16 @@ def _materialize_sequence(value: object, *, limit: int) -> list[object] | None:
     return None
 
 
+def _install_sequence(
+    container: dict[str, object], key: str, *, limit: int
+) -> list[object] | None:
+    value = container.get(key)
+    materialized = _materialize_sequence(value, limit=limit)
+    if materialized is not None and not isinstance(value, Sequence):
+        container[key] = materialized
+    return materialized
+
+
 def _scan_matrix_entries(matrices: object) -> tuple[int, int]:
     matrix_list = _materialize_sequence(matrices, limit=MAX_SEMIDEFINITE_CELLS)
     if matrix_list is None:
@@ -73,29 +83,59 @@ def _scan_matrix_entries(matrices: object) -> tuple[int, int]:
     return cells, digits
 
 
-def _count_raw_cells_and_digits(data: dict[str, object]) -> tuple[int, int, int]:
-    system = data.get("system")
+def _preflight_raw_payload(
+    data: dict[str, object],
+) -> tuple[dict[str, object], int, int, int]:
+    payload = dict(data)
+    system = payload.get("system")
     if not isinstance(system, dict):
-        return 0, 0, 0
-    order = system.get("order")
-    matrices = system.get("matrices")
-    cells, digits = _scan_matrix_entries(matrices)
+        return payload, 0, 0, 0
+    system = dict(system)
+    payload["system"] = system
+    matrices_value = system.get("matrices")
+    matrix_list = _materialize_sequence(matrices_value, limit=MAX_SEMIDEFINITE_CELLS)
+    installed_matrices: list[object] | None = None
+    if matrix_list is not None:
+        installed_matrices = []
+        needs_install = not isinstance(matrices_value, Sequence)
+        for matrix in matrix_list:
+            if isinstance(matrix, dict):
+                matrix_payload = dict(matrix)
+                entries = matrix_payload.get("entries")
+                row_list = _install_sequence(
+                    matrix_payload, "entries", limit=MAX_SEMIDEFINITE_CELLS
+                )
+                if row_list is not None and not isinstance(entries, Sequence):
+                    needs_install = True
+                installed_matrices.append(matrix_payload)
+            else:
+                installed_matrices.append(matrix)
+        if needs_install:
+            system["matrices"] = installed_matrices
+    cells, digits = _scan_matrix_entries(
+        installed_matrices if installed_matrices is not None else system.get("matrices")
+    )
     rhs = system.get("rhs")
     if isinstance(rhs, (list, tuple)):
         digits += sum(_raw_rational_digits(value) for value in rhs)
-    multipliers = data.get("multipliers")
+    multipliers = payload.get("multipliers")
     if isinstance(multipliers, (list, tuple)):
         digits += sum(_raw_rational_digits(value) for value in multipliers)
     declared = 0
+    order = system.get("order")
     if type(order) is int:
         if order < 0:
             raise ValueError(
                 "source and reduced matrices exceed the dense cell envelope"
             )
-        matrix_list = _materialize_sequence(matrices, limit=8192)
-        if matrix_list is not None:
-            declared = len(matrix_list) * order * order
-    return cells, declared, digits
+        declared_matrices = (
+            installed_matrices
+            if installed_matrices is not None
+            else _materialize_sequence(system.get("matrices"), limit=8192)
+        )
+        if declared_matrices is not None:
+            declared = len(declared_matrices) * order * order
+    return payload, cells, declared, digits
 
 
 class SemidefiniteFaceReductionRequest(StrictModel):
@@ -111,7 +151,7 @@ class SemidefiniteFaceReductionRequest(StrictModel):
         """Reject over-budget dense systems before nested matrix parsing."""
 
         if isinstance(data, dict):
-            cells, declared, digits = _count_raw_cells_and_digits(data)
+            data, cells, declared, digits = _preflight_raw_payload(data)
             if cells > MAX_SEMIDEFINITE_CELLS or declared > MAX_SEMIDEFINITE_CELLS:
                 raise ValueError(
                     "source and reduced matrices exceed the dense cell envelope"

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -1,0 +1,15 @@
+"""Requests for a single rational exposed-face reduction."""
+
+from pydantic import Field
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.math.matrices.semidefinite.values import RationalSemidefiniteSystem
+
+
+class SemidefiniteFaceReductionRequest(StrictModel):
+    system: RationalSemidefiniteSystem
+    multipliers: tuple[CanonicalRational, ...] = Field(
+        max_length=8192,
+        description="Supplied y with nonzero PSD sum y_i A_i and sum y_i b_i = 0.",
+    )

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -1,5 +1,7 @@
 """Requests for a single rational exposed-face reduction."""
 
+from collections.abc import Iterable, Mapping, Sequence
+
 from pydantic import Field, model_validator
 
 from jacobian._exact import CanonicalRational
@@ -31,24 +33,43 @@ def _raw_rational_digits(value: object) -> int:
     return 0
 
 
+def _materialize_sequence(value: object, *, limit: int) -> list[object] | None:
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        return None
+    if isinstance(value, Sequence):
+        return list(value)
+    if isinstance(value, Iterable):
+        collected: list[object] = []
+        for item in value:
+            collected.append(item)
+            if len(collected) > limit:
+                break
+        return collected
+    return None
+
+
 def _scan_matrix_entries(matrices: object) -> tuple[int, int]:
-    if not isinstance(matrices, (list, tuple)):
+    matrix_list = _materialize_sequence(matrices, limit=MAX_SEMIDEFINITE_CELLS)
+    if matrix_list is None:
         return 0, 0
     cells = 0
     digits = 0
-    for matrix in matrices:
+    for matrix in matrix_list:
         entries = matrix.get("entries") if isinstance(matrix, dict) else None
         if entries is None and hasattr(matrix, "entries"):
             entries = matrix.entries
-        if not isinstance(entries, (list, tuple)):
+        row_list = _materialize_sequence(entries, limit=MAX_SEMIDEFINITE_CELLS)
+        if row_list is None:
             continue
-        for row in entries:
+        for row in row_list:
             if isinstance(row, (list, tuple)):
                 cells += len(row)
                 digits += sum(_raw_rational_digits(entry) for entry in row)
             else:
                 cells += 1
                 digits += _raw_rational_digits(row)
+            if cells > MAX_SEMIDEFINITE_CELLS:
+                return cells, digits
     return cells, digits
 
 
@@ -71,8 +92,9 @@ def _count_raw_cells_and_digits(data: dict[str, object]) -> tuple[int, int, int]
             raise ValueError(
                 "source and reduced matrices exceed the dense cell envelope"
             )
-        if isinstance(matrices, (list, tuple)):
-            declared = len(matrices) * order * order
+        matrix_list = _materialize_sequence(matrices, limit=8192)
+        if matrix_list is not None:
+            declared = len(matrix_list) * order * order
     return cells, declared, digits
 
 

--- a/src/jacobian/math/matrices/semidefinite/_tools.py
+++ b/src/jacobian/math/matrices/semidefinite/_tools.py
@@ -1,0 +1,64 @@
+"""One supplied-relation semidefinite reduction."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.matrices.semidefinite._models import SemidefiniteFaceReductionRequest
+from jacobian.math.matrices.semidefinite.operations import reduce_exposed_face
+from jacobian.math.matrices.semidefinite.values import SemidefiniteFaceReduction
+
+
+def compute_face_reduction(
+    request: SemidefiniteFaceReductionRequest,
+) -> SemidefiniteFaceReduction:
+    return reduce_exposed_face(request.system, request.multipliers)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="matrix.semidefinite.exposed_face.reduce",
+        title="Reduce a rational semidefinite system to one exposed face",
+        description=(
+            "Given tr(A_i X)=b_i, X PSD and supplied rational y, recognize that "
+            "W=sum y_i A_i is nonzero PSD and y^T b=0. Return equivalent equalities "
+            "on ker(W) with the rational embedding X=VYV^T, retaining all equalities "
+            "including contradictions and zero-dimensional faces. Bounded by "
+            "dense cells, rational growth, output digits and elimination bit-work."
+        ),
+        request_type=SemidefiniteFaceReductionRequest,
+        result_type=SemidefiniteFaceReduction,
+        run=compute_face_reduction,
+        tags=("matrix", "semidefinite", "facial-reduction", "exact"),
+        discovery_terms=(
+            "exposed face",
+            "SDP reduction",
+            "exposing relation",
+            "Gram matrix face",
+        ),
+        examples=(
+            OperationExample(
+                name="one_dimensional_face",
+                description="The relation X_00=0 forces the first PSD row and column to vanish.",
+                input={
+                    "system": {
+                        "order": 2,
+                        "matrices": [
+                            {
+                                "entries": [
+                                    [
+                                        {"num": "1", "den": "1"},
+                                        {"num": "0", "den": "1"},
+                                    ],
+                                    [
+                                        {"num": "0", "den": "1"},
+                                        {"num": "0", "den": "1"},
+                                    ],
+                                ]
+                            },
+                        ],
+                        "rhs": [{"num": "0", "den": "1"}],
+                    },
+                    "multipliers": [{"num": "1", "den": "1"}],
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/matrices/semidefinite/_tools.py
+++ b/src/jacobian/math/matrices/semidefinite/_tools.py
@@ -36,7 +36,12 @@ TOOLS: MathTools = (
         examples=(
             OperationExample(
                 name="one_dimensional_face",
-                description="The relation X_00=0 forces the first PSD row and column to vanish.",
+                description=(
+                    "Reduce the exposed face of a 2-by-2 system whose one "
+                    "constraint is the symmetric matrix diag(1,0) with rhs 0 and "
+                    "multiplier 1; matrix count must match rhs, and every matrix "
+                    "must be symmetric of the declared order."
+                ),
                 input={
                     "system": {
                         "order": 2,

--- a/src/jacobian/math/matrices/semidefinite/operations.py
+++ b/src/jacobian/math/matrices/semidefinite/operations.py
@@ -17,12 +17,13 @@ from jacobian.catalog.models import (
 from jacobian.math.matrices._flint import rational_matrix_product, rational_rref
 from jacobian.math.matrices.analysis.operations import _symmetric_inertia
 from jacobian.math.matrices.semidefinite.values import (
+    MAX_SEMIDEFINITE_CELLS,
     RationalSemidefiniteSystem,
     SemidefiniteFaceReduction,
 )
 from jacobian.math.matrices.values import rational_matrix_from_fractions
 
-_MAX_CELLS = 131_072
+_MAX_CELLS = MAX_SEMIDEFINITE_CELLS
 _MAX_BIT_WORK = 2_000_000_000
 _MAX_OUTPUT_DIGITS = 8_000_000
 _WALL_SECONDS = 3600.0
@@ -106,27 +107,51 @@ def _admit(
             output_digits=output_digits,
         )
         return True
-    # Clear all input denominators by one common Q. Its bit length is bounded
-    # without constructing Q. Repeated denominators are counted once.
+    active = tuple(
+        (multiplier, matrix)
+        for multiplier, matrix in zip(multipliers, system.matrices, strict=True)
+        if multiplier.num
+    )
+    exposing_scalars = (
+        *(
+            entry
+            for _, matrix in active
+            for row in matrix.entries
+            for entry in row
+        ),
+        *(multiplier for multiplier, _ in active),
+        *(
+            rhs
+            for multiplier, rhs in zip(multipliers, system.rhs, strict=True)
+            if multiplier.num
+        ),
+    )
     denominator_bits = sum(
-        (den - 1).bit_length() for den in {q.den for q in scalars} if den != 1
+        (den - 1).bit_length() for den in {q.den for q in exposing_scalars} if den != 1
     )
     input_bits = (
         denominator_bits
-        + max((abs(q.num).bit_length() for q in scalars), default=1)
+        + max((abs(q.num).bit_length() for q in exposing_scalars), default=1)
         + 1
     )
-    # Q^2 W is integral: each entry sums m products of Q-scaled inputs.
-    exposing_bits = 2 * input_bits + max(1, m.bit_length())
-    # Hadamard bounds every minor of Q^2 W. RREF coordinates have a common
-    # pivot-minor denominator and numerators bounded by these same minors.
-    # A nullspace basis adds identity coordinates. All compression products
-    # therefore share Q * pivot_minor^2 as a denominator, rather than a
-    # product of unrelated denominators for each summand.
+    exposing_bits = 2 * input_bits + max(1, max(len(active), 1).bit_length())
     minor_bits = max(1, n * (exposing_bits + n.bit_length()))
-    result_bits = input_bits + 2 * minor_bits + 2 * n.bit_length() + 2
-    # Congruence Schur entries are ratios of bordered minors; factor four
-    # covers unreduced multiply/add operands in 1x1 and 2x2 pivot updates.
+    matrix_bits = [
+        max(
+            (
+                abs(entry.num).bit_length() + entry.den.bit_length()
+                for row in matrix.entries
+                for entry in row
+            ),
+            default=1,
+        )
+        + 2 * minor_bits
+        for matrix in system.matrices
+    ]
+    result_bits = max(
+        input_bits + 2 * minor_bits + 2 * n.bit_length() + 2,
+        max(matrix_bits, default=1),
+    )
     intermediate_bits = 4 * max(result_bits, minor_bits)
     work = (2 * m + 4) * n**3 + m * n * n + m
     _check_budgets(cells, result_bits, intermediate_bits, work)

--- a/src/jacobian/math/matrices/semidefinite/operations.py
+++ b/src/jacobian/math/matrices/semidefinite/operations.py
@@ -143,7 +143,7 @@ def _admit(
             ),
             default=1,
         )
-        denominator_growth = aggregate_denominators if multiplier.num else 0
+        denominator_growth = aggregate_denominators
         matrix_bits.append(
             entry_bits + denominator_growth + 2 * minor_bits + (n * n).bit_length()
         )

--- a/src/jacobian/math/matrices/semidefinite/operations.py
+++ b/src/jacobian/math/matrices/semidefinite/operations.py
@@ -167,7 +167,7 @@ def _admit(
         _component_digits(abs(component).bit_length())
         for q in retained_scalars
         for component in (q.num, q.den)
-    ) + 2 * n * n * _component_digits(result_bits)
+    ) + 2 * m * n * n * _component_digits(result_bits)
     _check_budgets(
         cells, result_bits, intermediate_bits, work, output_digits=output_digits
     )

--- a/src/jacobian/math/matrices/semidefinite/operations.py
+++ b/src/jacobian/math/matrices/semidefinite/operations.py
@@ -132,11 +132,9 @@ def _admit(
     exposing_bits = 2 * input_bits + max(1, max(len(active), 1).bit_length())
     minor_bits = max(1, n * (exposing_bits + n.bit_length()))
     matrix_bits = []
-    for matrix in system.matrices:
+    for matrix, multiplier in zip(system.matrices, multipliers, strict=True):
         dens = {entry.den for row in matrix.entries for entry in row}
-        aggregate_denominators = sum(
-            (den - 1).bit_length() for den in dens if den != 1
-        )
+        aggregate_denominators = sum((den - 1).bit_length() for den in dens if den != 1)
         entry_bits = max(
             (
                 abs(entry.num).bit_length() + entry.den.bit_length()
@@ -145,10 +143,9 @@ def _admit(
             ),
             default=1,
         )
+        denominator_growth = aggregate_denominators if multiplier.num else 0
         matrix_bits.append(
-            max(entry_bits, aggregate_denominators)
-            + 2 * minor_bits
-            + (n * n).bit_length()
+            entry_bits + denominator_growth + 2 * minor_bits + (n * n).bit_length()
         )
     result_bits = max(
         input_bits + 2 * minor_bits + 2 * n.bit_length() + 2,

--- a/src/jacobian/math/matrices/semidefinite/operations.py
+++ b/src/jacobian/math/matrices/semidefinite/operations.py
@@ -113,12 +113,7 @@ def _admit(
         if multiplier.num
     )
     exposing_scalars = (
-        *(
-            entry
-            for _, matrix in active
-            for row in matrix.entries
-            for entry in row
-        ),
+        *(entry for _, matrix in active for row in matrix.entries for entry in row),
         *(multiplier for multiplier, _ in active),
         *(
             rhs

--- a/src/jacobian/math/matrices/semidefinite/operations.py
+++ b/src/jacobian/math/matrices/semidefinite/operations.py
@@ -36,7 +36,7 @@ def _reject(message: str) -> None:
 
 def _admit(
     system: RationalSemidefiniteSystem, multipliers: tuple[CanonicalRational, ...]
-) -> None:
+) -> bool:
     n, m = system.order, len(system.matrices)
     if len(multipliers) != m:
         raise OperationDomainValidationError(
@@ -58,6 +58,54 @@ def _admit(
         *system.rhs,
         *multipliers,
     )
+    diagonal = all(
+        not entry.num
+        for matrix in system.matrices
+        for i, row in enumerate(matrix.entries)
+        for j, entry in enumerate(row)
+        if i != j
+    )
+    if diagonal:
+        # A diagonal exposing matrix selects coordinate axes: no elimination,
+        # division or matrix products are needed. Charge only the scalar dot
+        # products and retained source/selected submatrices, including y^T b.
+        exposing_bounds = tuple(
+            _dot_product_bits(
+                tuple(
+                    (y, matrix.entries[i][i])
+                    for y, matrix in zip(multipliers, system.matrices, strict=True)
+                )
+            )
+            for i in range(n)
+        )
+        result_bits = max(
+            max(
+                (max(abs(q.num).bit_length(), q.den.bit_length()) for q in scalars),
+                default=1,
+            ),
+            _dot_product_bits(tuple(zip(multipliers, system.rhs, strict=True))),
+            max(exposing_bounds, default=1),
+        )
+        # Copies keep their own scalar heights; a single large diagonal does
+        # not enlarge the many zero entries in the retained dense matrices.
+        copied_digits = 2 * sum(
+            _component_digits(abs(component).bit_length())
+            for q in scalars
+            for component in (q.num, q.den)
+        )
+        output_digits = (
+            copied_digits
+            + 4 * n * n
+            + sum(2 * _component_digits(bits) for bits in exposing_bounds)
+        )
+        _check_budgets(
+            cells,
+            result_bits,
+            4 * result_bits,
+            cells + m * (n + 1),
+            output_digits=output_digits,
+        )
+        return True
     # Clear all input denominators by one common Q. Its bit length is bounded
     # without constructing Q. Repeated denominators are counted once.
     denominator_bits = sum(
@@ -80,12 +128,48 @@ def _admit(
     # Congruence Schur entries are ratios of bordered minors; factor four
     # covers unreduced multiply/add operands in 1x1 and 2x2 pivot updates.
     intermediate_bits = 4 * max(result_bits, minor_bits)
-    digits = (result_bits * 30103 + 99999) // 100000 + 1
+    work = (2 * m + 4) * n**3 + m * n * n + m
+    _check_budgets(cells, result_bits, intermediate_bits, work)
+    return False
+
+
+def _dot_product_bits(
+    pairs: tuple[tuple[CanonicalRational, CanonicalRational], ...],
+) -> int:
+    active = tuple((a, b) for a, b in pairs if a.num and b.num)
+    if not active:
+        return 1
+    # The product of every operand denominator is a common denominator for
+    # every partial sum. Each scaled numerator is bounded by that denominator
+    # times the largest numerator product; summing k terms adds ceil(log2 k).
+    denominator_bits = sum(
+        (a.den - 1).bit_length() + (b.den - 1).bit_length() for a, b in active
+    )
+    numerator_bits = max(
+        abs(a.num).bit_length() + abs(b.num).bit_length() for a, b in active
+    )
+    return denominator_bits + numerator_bits + (len(active) - 1).bit_length() + 1
+
+
+def _component_digits(bits: int) -> int:
+    return max(1, (bits * 30103 + 99999) // 100000)
+
+
+def _check_budgets(
+    cells: int,
+    result_bits: int,
+    intermediate_bits: int,
+    work: int,
+    *,
+    output_digits: int | None = None,
+) -> None:
+    digits = _component_digits(result_bits)
     if digits > MAX_CANONICAL_RATIONAL_DIGITS:
         _reject("exact compression exceeds the canonical rational height envelope")
-    if cells * 2 * digits > _MAX_OUTPUT_DIGITS:
+    if (
+        cells * 2 * digits if output_digits is None else output_digits
+    ) > _MAX_OUTPUT_DIGITS:
         _reject("source-bound reduction exceeds the exact output digit envelope")
-    work = (2 * m + 4) * n**3 + m * n * n + m
     if work * intermediate_bits > _MAX_BIT_WORK:
         _reject("rational elimination and compression exceed the bit-work envelope")
 
@@ -121,7 +205,7 @@ def reduce_exposed_face(
             )
 
     checkpoint("before face reduction admission")
-    _admit(system, multipliers)
+    diagonal = _admit(system, multipliers)
     checkpoint("after face reduction admission")
     n = system.order
     y = tuple(q.as_fraction() for q in multipliers)
@@ -135,7 +219,9 @@ def reduce_exposed_face(
     )
     exposing = tuple(
         tuple(
-            sum(
+            Fraction()
+            if diagonal and i != j
+            else sum(
                 (a * matrix[i][j] for a, matrix in zip(y, matrices, strict=True)),
                 Fraction(),
             )
@@ -146,17 +232,26 @@ def reduce_exposed_face(
     checkpoint("after exposing matrix construction")
     if not any(entry for row in exposing for entry in row):
         _invalid_relation("the exposing matrix must be nonzero")
-    _, negative, _ = _symmetric_inertia(
-        [list(row) for row in exposing], checkpoint=checkpoint
-    )
-    if negative:
-        _invalid_relation("the exposing matrix must be positive semidefinite")
-    reduced_rows, rank = rational_rref(exposing)
-    checkpoint("after exposing kernel elimination")
-    pivots = tuple(
-        next(j for j, q in enumerate(row) if q) for row in reduced_rows[:rank]
-    )
-    free = tuple(j for j in range(n) if j not in pivots)
+    pivots: tuple[int, ...]
+    reduced_rows: tuple[tuple[Fraction, ...], ...]
+    if diagonal:
+        if any(exposing[i][i] < 0 for i in range(n)):
+            _invalid_relation("the exposing matrix must be positive semidefinite")
+        free = tuple(i for i in range(n) if not exposing[i][i])
+        pivots = ()
+        reduced_rows = ()
+    else:
+        _, negative, _ = _symmetric_inertia(
+            [list(row) for row in exposing], checkpoint=checkpoint
+        )
+        if negative:
+            _invalid_relation("the exposing matrix must be positive semidefinite")
+        reduced_rows, rank = rational_rref(exposing)
+        pivots = tuple(
+            next(j for j, q in enumerate(row) if q) for row in reduced_rows[:rank]
+        )
+        free = tuple(j for j in range(n) if j not in pivots)
+    checkpoint("after exposing kernel computation")
     width = len(free)
     basis = [[Fraction(int(i == j)) for j in free] for i in range(n)]
     for row, pivot in enumerate(pivots):
@@ -167,11 +262,15 @@ def reduce_exposed_face(
     for matrix in matrices:
         checkpoint("before equality compression")
         entries = (
-            rational_matrix_product(
-                rational_matrix_product(transposed, matrix), embedding_entries
+            tuple(tuple(matrix[i][j] for j in free) for i in free)
+            if diagonal
+            else (
+                rational_matrix_product(
+                    rational_matrix_product(transposed, matrix), embedding_entries
+                )
+                if width
+                else ()
             )
-            if width
-            else ()
         )
         compressed.append(rational_matrix_from_fractions(entries, column_count=width))
     checkpoint("before face reduction result construction")

--- a/src/jacobian/math/matrices/semidefinite/operations.py
+++ b/src/jacobian/math/matrices/semidefinite/operations.py
@@ -132,7 +132,7 @@ def _admit(
     exposing_bits = 2 * input_bits + max(1, max(len(active), 1).bit_length())
     minor_bits = max(1, n * (exposing_bits + n.bit_length()))
     matrix_bits = []
-    for matrix, multiplier in zip(system.matrices, multipliers, strict=True):
+    for matrix in system.matrices:
         dens = {entry.den for row in matrix.entries for entry in row}
         aggregate_denominators = sum((den - 1).bit_length() for den in dens if den != 1)
         entry_bits = max(

--- a/src/jacobian/math/matrices/semidefinite/operations.py
+++ b/src/jacobian/math/matrices/semidefinite/operations.py
@@ -1,0 +1,191 @@
+"""One exact facial reduction, using the matrix owner's rational kernels."""
+
+import time
+from fractions import Fraction
+
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.matrices._flint import rational_matrix_product, rational_rref
+from jacobian.math.matrices.analysis.operations import _symmetric_inertia
+from jacobian.math.matrices.semidefinite.values import (
+    RationalSemidefiniteSystem,
+    SemidefiniteFaceReduction,
+)
+from jacobian.math.matrices.values import rational_matrix_from_fractions
+
+_MAX_CELLS = 131_072
+_MAX_BIT_WORK = 2_000_000_000
+_MAX_OUTPUT_DIGITS = 8_000_000
+_WALL_SECONDS = 3600.0
+
+
+def _reject(message: str) -> None:
+    raise OperationResourceAdmissionError(
+        location=("system",), code="matrix.face_reduction_budget", message=message
+    )
+
+
+def _admit(
+    system: RationalSemidefiniteSystem, multipliers: tuple[CanonicalRational, ...]
+) -> None:
+    n, m = system.order, len(system.matrices)
+    if len(multipliers) != m:
+        raise OperationDomainValidationError(
+            location=("multipliers",),
+            code="matrix.shape_mismatch",
+            message="multipliers must index every equality",
+        )
+    # Dense source inspection, exposing matrix, basis and compressed output.
+    cells = (2 * m + 3) * n * n + 2 * m
+    if cells > _MAX_CELLS:
+        _reject("source and reduced matrices exceed the dense cell envelope")
+    scalars = (
+        *(
+            entry
+            for matrix in system.matrices
+            for row in matrix.entries
+            for entry in row
+        ),
+        *system.rhs,
+        *multipliers,
+    )
+    # Clear all input denominators by one common Q. Its bit length is bounded
+    # without constructing Q. Repeated denominators are counted once.
+    denominator_bits = sum(
+        (den - 1).bit_length() for den in {q.den for q in scalars} if den != 1
+    )
+    input_bits = (
+        denominator_bits
+        + max((abs(q.num).bit_length() for q in scalars), default=1)
+        + 1
+    )
+    # Q^2 W is integral: each entry sums m products of Q-scaled inputs.
+    exposing_bits = 2 * input_bits + max(1, m.bit_length())
+    # Hadamard bounds every minor of Q^2 W. RREF coordinates have a common
+    # pivot-minor denominator and numerators bounded by these same minors.
+    # A nullspace basis adds identity coordinates. All compression products
+    # therefore share Q * pivot_minor^2 as a denominator, rather than a
+    # product of unrelated denominators for each summand.
+    minor_bits = max(1, n * (exposing_bits + n.bit_length()))
+    result_bits = input_bits + 2 * minor_bits + 2 * n.bit_length() + 2
+    # Congruence Schur entries are ratios of bordered minors; factor four
+    # covers unreduced multiply/add operands in 1x1 and 2x2 pivot updates.
+    intermediate_bits = 4 * max(result_bits, minor_bits)
+    digits = (result_bits * 30103 + 99999) // 100000 + 1
+    if digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        _reject("exact compression exceeds the canonical rational height envelope")
+    if cells * 2 * digits > _MAX_OUTPUT_DIGITS:
+        _reject("source-bound reduction exceeds the exact output digit envelope")
+    work = (2 * m + 4) * n**3 + m * n * n + m
+    if work * intermediate_bits > _MAX_BIT_WORK:
+        _reject("rational elimination and compression exceed the bit-work envelope")
+
+
+def _invalid_relation(message: str) -> None:
+    raise OperationDomainValidationError(
+        location=("multipliers",),
+        code="matrix.invalid_exposing_relation",
+        message=message,
+    )
+
+
+def reduce_exposed_face(
+    system: RationalSemidefiniteSystem, multipliers: tuple[CanonicalRational, ...]
+) -> SemidefiniteFaceReduction:
+    """Recognize y and return equivalent PSD equalities on ker(sum y_i A_i).
+
+    The embedding uses the RREF fundamental kernel basis, with free columns
+    in source-axis order. No minimal face or feasibility claim is made.
+    """
+    execution = current_request_execution()
+    started = execution.started_at if execution is not None else time.monotonic()
+    deadline = started + _WALL_SECONDS
+    if execution is not None and execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+
+    def checkpoint(phase: str) -> None:
+        request_checkpoint(phase)
+        if time.monotonic() >= deadline:
+            raise OperationExecutionTimeoutError(
+                "semidefinite face reduction timed out"
+            )
+
+    checkpoint("before face reduction admission")
+    _admit(system, multipliers)
+    checkpoint("after face reduction admission")
+    n = system.order
+    y = tuple(q.as_fraction() for q in multipliers)
+    if sum(
+        (a * b.as_fraction() for a, b in zip(y, system.rhs, strict=True)), Fraction()
+    ):
+        _invalid_relation("the exposing relation must satisfy y^T b = 0")
+    matrices = tuple(
+        tuple(tuple(q.as_fraction() for q in row) for row in matrix.entries)
+        for matrix in system.matrices
+    )
+    exposing = tuple(
+        tuple(
+            sum(
+                (a * matrix[i][j] for a, matrix in zip(y, matrices, strict=True)),
+                Fraction(),
+            )
+            for j in range(n)
+        )
+        for i in range(n)
+    )
+    checkpoint("after exposing matrix construction")
+    if not any(entry for row in exposing for entry in row):
+        _invalid_relation("the exposing matrix must be nonzero")
+    _, negative, _ = _symmetric_inertia(
+        [list(row) for row in exposing], checkpoint=checkpoint
+    )
+    if negative:
+        _invalid_relation("the exposing matrix must be positive semidefinite")
+    reduced_rows, rank = rational_rref(exposing)
+    checkpoint("after exposing kernel elimination")
+    pivots = tuple(
+        next(j for j, q in enumerate(row) if q) for row in reduced_rows[:rank]
+    )
+    free = tuple(j for j in range(n) if j not in pivots)
+    width = len(free)
+    basis = [[Fraction(int(i == j)) for j in free] for i in range(n)]
+    for row, pivot in enumerate(pivots):
+        basis[pivot] = [-reduced_rows[row][j] for j in free]
+    embedding_entries = tuple(tuple(row) for row in basis)
+    transposed = tuple(tuple(basis[i][j] for i in range(n)) for j in range(width))
+    compressed = []
+    for matrix in matrices:
+        checkpoint("before equality compression")
+        entries = (
+            rational_matrix_product(
+                rational_matrix_product(transposed, matrix), embedding_entries
+            )
+            if width
+            else ()
+        )
+        compressed.append(rational_matrix_from_fractions(entries, column_count=width))
+    checkpoint("before face reduction result construction")
+    result = SemidefiniteFaceReduction(
+        source=system,
+        multipliers=multipliers,
+        exposing_matrix=rational_matrix_from_fractions(exposing),
+        embedding=rational_matrix_from_fractions(embedding_entries, column_count=width),
+        reduced=RationalSemidefiniteSystem(
+            order=width, matrices=tuple(compressed), rhs=system.rhs
+        ),
+    )
+    checkpoint("after face reduction result construction")
+    return result
+
+
+__all__ = ["reduce_exposed_face"]

--- a/src/jacobian/math/matrices/semidefinite/operations.py
+++ b/src/jacobian/math/matrices/semidefinite/operations.py
@@ -131,8 +131,13 @@ def _admit(
     )
     exposing_bits = 2 * input_bits + max(1, max(len(active), 1).bit_length())
     minor_bits = max(1, n * (exposing_bits + n.bit_length()))
-    matrix_bits = [
-        max(
+    matrix_bits = []
+    for matrix in system.matrices:
+        dens = {entry.den for row in matrix.entries for entry in row}
+        aggregate_denominators = sum(
+            (den - 1).bit_length() for den in dens if den != 1
+        )
+        entry_bits = max(
             (
                 abs(entry.num).bit_length() + entry.den.bit_length()
                 for row in matrix.entries
@@ -140,16 +145,35 @@ def _admit(
             ),
             default=1,
         )
-        + 2 * minor_bits
-        for matrix in system.matrices
-    ]
+        matrix_bits.append(
+            max(entry_bits, aggregate_denominators)
+            + 2 * minor_bits
+            + (n * n).bit_length()
+        )
     result_bits = max(
         input_bits + 2 * minor_bits + 2 * n.bit_length() + 2,
         max(matrix_bits, default=1),
     )
     intermediate_bits = 4 * max(result_bits, minor_bits)
     work = (2 * m + 4) * n**3 + m * n * n + m
-    _check_budgets(cells, result_bits, intermediate_bits, work)
+    retained_scalars = (
+        *(
+            entry
+            for matrix in system.matrices
+            for row in matrix.entries
+            for entry in row
+        ),
+        *system.rhs,
+        *multipliers,
+    )
+    output_digits = 2 * sum(
+        _component_digits(abs(component).bit_length())
+        for q in retained_scalars
+        for component in (q.num, q.den)
+    ) + 2 * n * n * _component_digits(result_bits)
+    _check_budgets(
+        cells, result_bits, intermediate_bits, work, output_digits=output_digits
+    )
     return False
 
 

--- a/src/jacobian/math/matrices/semidefinite/values.py
+++ b/src/jacobian/math/matrices/semidefinite/values.py
@@ -8,13 +8,32 @@ from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.math.matrices.values import RationalMatrix
 
+MAX_SEMIDEFINITE_CELLS = 131_072
+
 
 class RationalSemidefiniteSystem(StrictModel):
-    """The equalities tr(A_i X)=b_i with X PSD in the ordered matrix axes."""
+    """The equalities tr(A_i X)=b_i with X PSD in the ordered matrix axes.
 
-    order: int = Field(ge=0, le=8192)
-    matrices: tuple[RationalMatrix, ...] = Field(max_length=8192)
-    rhs: tuple[CanonicalRational, ...] = Field(max_length=8192)
+    ``matrices`` and ``rhs`` must have the same length. Every matrix must be
+    symmetric and exactly ``order`` by ``order``.
+    """
+
+    order: int = Field(
+        ge=0,
+        le=8192,
+        description="Common axis length; every constraint matrix is order-by-order.",
+    )
+    matrices: tuple[RationalMatrix, ...] = Field(
+        max_length=8192,
+        description=(
+            "Symmetric order-by-order QQ constraint matrices, one per equality "
+            "and in the same order as rhs."
+        ),
+    )
+    rhs: tuple[CanonicalRational, ...] = Field(
+        max_length=8192,
+        description="Right-hand sides; length must match matrices.",
+    )
 
     @model_validator(mode="after")
     def require_symmetric_equalities(self) -> Self:

--- a/src/jacobian/math/matrices/semidefinite/values.py
+++ b/src/jacobian/math/matrices/semidefinite/values.py
@@ -1,0 +1,68 @@
+"""Rational affine sections of a positive-semidefinite cone."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.math.matrices.values import RationalMatrix
+
+
+class RationalSemidefiniteSystem(StrictModel):
+    """The equalities tr(A_i X)=b_i with X PSD in the ordered matrix axes."""
+
+    order: int = Field(ge=0, le=8192)
+    matrices: tuple[RationalMatrix, ...] = Field(max_length=8192)
+    rhs: tuple[CanonicalRational, ...] = Field(max_length=8192)
+
+    @model_validator(mode="after")
+    def require_symmetric_equalities(self) -> Self:
+        if len(self.matrices) != len(self.rhs):
+            raise ValueError("one right-hand side is required per equality")
+        for matrix in self.matrices:
+            if matrix.row_count != self.order or matrix.column_count != self.order:
+                raise ValueError("constraint matrices must have the declared order")
+            if any(
+                matrix.entries[i][j] != matrix.entries[j][i]
+                for i in range(self.order)
+                for j in range(i)
+            ):
+                raise ValueError("constraint matrices must be symmetric")
+        return self
+
+
+class SemidefiniteFaceReduction(StrictModel):
+    """Equivalent PSD equalities under X = embedding Y embedding^T.
+
+    Parsing checks dimensions only. A consumer relying on an authored exposing
+    relation must recognize it by calling reduce_exposed_face on source and
+    multipliers; structural parsing does not establish feasible-set equivalence.
+    """
+
+    source: RationalSemidefiniteSystem
+    multipliers: tuple[CanonicalRational, ...] = Field(max_length=8192)
+    exposing_matrix: RationalMatrix
+    embedding: RationalMatrix
+    reduced: RationalSemidefiniteSystem
+
+    @model_validator(mode="after")
+    def require_shapes(self) -> Self:
+        n = self.source.order
+        if len(self.multipliers) != len(self.source.matrices):
+            raise ValueError("multipliers must index source equalities")
+        if (self.exposing_matrix.row_count, self.exposing_matrix.column_count) != (
+            n,
+            n,
+        ):
+            raise ValueError("exposing matrix must use the source axes")
+        if (self.embedding.row_count, self.embedding.column_count) != (
+            n,
+            self.reduced.order,
+        ):
+            raise ValueError("embedding must map reduced axes into source axes")
+        if self.reduced.order >= n:
+            raise ValueError("a proper exposed face has strictly smaller order")
+        if self.reduced.rhs != self.source.rhs:
+            raise ValueError("face reduction preserves every right-hand side")
+        return self

--- a/tests/dispatch/test_semidefinite_face_dispatch.py
+++ b/tests/dispatch/test_semidefinite_face_dispatch.py
@@ -1,0 +1,33 @@
+"""Dispatch boundaries for exposed-face reduction of rational SDP systems."""
+
+from __future__ import annotations
+
+import json
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import invoke_operation, parse_operation_input
+from jacobian.math.matrices.semidefinite import (
+    SemidefiniteFaceReduction,
+    reduce_exposed_face,
+)
+from jacobian.math.matrices.semidefinite._models import SemidefiniteFaceReductionRequest
+from jacobian.math.matrices.semidefinite._tools import TOOLS
+
+
+def test_native_dispatch_and_serialized_result_parity() -> None:
+    tool = TOOLS[0]
+    parsed = parse_operation_input(
+        SemidefiniteFaceReductionRequest, tool.examples[0].input
+    )
+    assert isinstance(parsed, SemidefiniteFaceReductionRequest)
+    dispatched = invoke_operation(
+        tool.operation_id, tool.examples[0].input, Catalog.open()
+    )
+    result = SemidefiniteFaceReduction.model_validate_json(
+        json.dumps(dispatched.output)
+    )
+    assert result == reduce_exposed_face(parsed.system, parsed.multipliers)
+    assert (
+        SemidefiniteFaceReduction.model_validate_json(result.model_dump_json())
+        == result
+    )

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -1,0 +1,226 @@
+"""Defining feasible-set and reconstruction identities for exposed faces."""
+
+import json
+from collections.abc import Sequence
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+from sympy import Matrix, Rational, zeros
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.dispatch import invoke_operation, parse_operation_input
+from jacobian.math.matrices.semidefinite import (
+    RationalSemidefiniteSystem,
+    SemidefiniteFaceReduction,
+    reduce_exposed_face,
+)
+from jacobian.math.matrices.semidefinite._models import SemidefiniteFaceReductionRequest
+from jacobian.math.matrices.semidefinite._tools import TOOLS
+from jacobian.math.matrices.values import RationalMatrix, rational_matrix_from_fractions
+
+
+def _q(value: int | Fraction) -> CanonicalRational:
+    return CanonicalRational.from_fraction(Fraction(value))
+
+
+def _matrix(rows: Sequence[Sequence[int | Fraction]]) -> RationalMatrix:
+    return rational_matrix_from_fractions([[Fraction(q) for q in row] for row in rows])
+
+
+def _sympy(matrix: RationalMatrix) -> Matrix:
+    return Matrix(
+        matrix.row_count,
+        matrix.column_count,
+        [Rational(q.num, q.den) for row in matrix.entries for q in row],
+    )
+
+
+def _system(
+    matrices: tuple[RationalMatrix, ...], rhs: tuple[int, ...]
+) -> RationalSemidefiniteSystem:
+    return RationalSemidefiniteSystem(
+        order=matrices[0].row_count, matrices=matrices, rhs=tuple(map(_q, rhs))
+    )
+
+
+def _identities(result: SemidefiniteFaceReduction) -> None:
+    w, v = _sympy(result.exposing_matrix), _sympy(result.embedding)
+    source = result.source
+    assert w == sum(
+        (
+            _qv.as_fraction() * _sympy(a)
+            for _qv, a in zip(result.multipliers, source.matrices, strict=True)
+        ),
+        zeros(source.order),
+    )
+    assert w * v == zeros(source.order, v.cols)
+    assert v.rank() == v.cols == source.order - w.rank()
+    assert w.is_positive_semidefinite
+    for a, compressed in zip(source.matrices, result.reduced.matrices, strict=True):
+        assert v.T * _sympy(a) * v == _sympy(compressed)
+    assert result.reduced.rhs == source.rhs
+
+
+def test_issue_fixture_and_psd_lift() -> None:
+    system = _system((_matrix([[1, 0], [0, 0]]), _matrix([[1, 0], [0, 1]])), (0, 1))
+    result = reduce_exposed_face(system, (_q(1), _q(0)))
+    _identities(result)
+    assert _sympy(result.embedding) == Matrix([[0], [1]])
+    assert [_sympy(a) for a in result.reduced.matrices] == [
+        Matrix([[0]]),
+        Matrix([[1]]),
+    ]
+    assert _sympy(result.embedding) * _sympy(result.embedding).T == Matrix(
+        [[0, 0], [0, 1]]
+    )
+
+
+def test_noncoordinate_kernel_preserves_all_feasible_psd_matrices() -> None:
+    # W annihilates (-2,1,0) and (0,0,1); rational nonorthonormal V is enough.
+    system = _system(
+        (
+            _matrix([[1, 2, 0], [2, 4, 0], [0, 0, 0]]),
+            _matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+        ),
+        (0, 5),
+    )
+    result = reduce_exposed_face(system, (_q(1), _q(0)))
+    _identities(result)
+    v = _sympy(result.embedding)
+    for a, b in [(0, 0), (1, 0), (0, 2), (2, -1)]:
+        z = Matrix([a, b])
+        y = z * z.T
+        x = v * y * v.T
+        assert x.is_positive_semidefinite
+        assert (_sympy(result.exposing_matrix) * x).trace() == 0
+        for original, reduced in zip(
+            system.matrices, result.reduced.matrices, strict=True
+        ):
+            assert (_sympy(original) * x).trace() == (_sympy(reduced) * y).trace()
+        # The left inverse recovers the unique reduced PSD coordinate matrix.
+        left_inverse = (v.T * v).inv() * v.T
+        assert left_inverse * x * left_inverse.T == y
+
+
+def test_full_rank_face_retains_contradictory_equalities_and_empty_axes() -> None:
+    system = _system((_matrix([[1, 0], [0, 1]]), _matrix([[0, 0], [0, 0]])), (0, 1))
+    result = reduce_exposed_face(system, (_q(1), _q(0)))
+    _identities(result)
+    assert result.reduced.order == 0
+    assert result.reduced.rhs == (_q(0), _q(1))
+    assert (result.embedding.row_count, result.embedding.column_count) == (2, 0)
+    assert (
+        SemidefiniteFaceReduction.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+def test_serialized_reduced_system_supports_another_supplied_step() -> None:
+    system = _system(
+        (
+            _matrix([[1, 0, 0], [0, 0, 0], [0, 0, 0]]),
+            _matrix([[0, 0, 0], [0, 1, 0], [0, 0, 0]]),
+        ),
+        (0, 0),
+    )
+    first = reduce_exposed_face(system, (_q(1), _q(0)))
+    reduced = RationalSemidefiniteSystem.model_validate_json(
+        first.reduced.model_dump_json()
+    )
+    second = reduce_exposed_face(reduced, (_q(0), _q(1)))
+    _identities(second)
+    assert _sympy(first.embedding) * _sympy(second.embedding) == Matrix([[0], [0], [1]])
+
+
+@pytest.mark.parametrize(
+    "matrix,rhs,y",
+    [
+        ([[1, 0], [0, -1]], 0, 1),
+        ([[0, 1], [1, 0]], 0, 1),
+        ([[0, 0], [0, 0]], 0, 1),
+        ([[1, 0], [0, 1]], 1, 1),
+        ([[1, 0], [0, 1]], 0, -1),
+    ],
+)
+def test_false_exposing_relations_are_rejected(
+    matrix: list[list[int]], rhs: int, y: int
+) -> None:
+    with pytest.raises(OperationDomainValidationError, match=r"expos|positive|nonzero"):
+        reduce_exposed_face(_system((_matrix(matrix),), (rhs,)), (_q(y),))
+
+
+def test_multipliers_may_have_negative_entries_when_the_relation_is_valid() -> None:
+    system = _system((_matrix([[2, 0], [0, 1]]), _matrix([[1, 0], [0, 1]])), (3, 3))
+    result = reduce_exposed_face(system, (_q(1), _q(-1)))
+    _identities(result)
+    assert result.reduced.order == 1
+
+
+def test_rational_inputs_and_nonunit_pivot() -> None:
+    system = _system(
+        (
+            _matrix(
+                [[Fraction(2, 3), Fraction(1, 3)], [Fraction(1, 3), Fraction(1, 6)]]
+            ),
+        ),
+        (0,),
+    )
+    result = reduce_exposed_face(system, (_q(Fraction(3, 7)),))
+    _identities(result)
+    assert _sympy(result.embedding) == Matrix([[Rational(-1, 2)], [1]])
+
+
+def test_dense_rank_one_exposure_at_useful_order() -> None:
+    n = 32
+    system = _system((_matrix([[1 for _ in range(n)] for _ in range(n)]),), (0,))
+    result = reduce_exposed_face(system, (_q(1),))
+    assert result.reduced.order == 31
+    v = _sympy(result.embedding)
+    assert v.rank() == 31
+    assert _sympy(result.exposing_matrix) * v == zeros(n, 31)
+
+
+def test_excessive_height_and_dense_output_are_rejected() -> None:
+    huge = _matrix([[Fraction(1, 10**16000 + 1)]])
+    with pytest.raises(OperationResourceAdmissionError):
+        reduce_exposed_face(_system((huge,), (0,)), (_q(1),))
+    n = 164
+    dense = _matrix([[int(i == j) for j in range(n)] for i in range(n)])
+    with pytest.raises(OperationResourceAdmissionError):
+        reduce_exposed_face(_system((dense,), (0,)), (_q(1),))
+
+
+def test_shape_validation_and_zero_cone_has_no_proper_exposure() -> None:
+    with pytest.raises(ValidationError, match="symmetric"):
+        _system((_matrix([[0, 1], [0, 0]]),), (0,))
+    with pytest.raises(OperationDomainValidationError):
+        reduce_exposed_face(
+            RationalSemidefiniteSystem(order=0, matrices=(), rhs=()), ()
+        )
+    with pytest.raises(OperationDomainValidationError, match="index"):
+        reduce_exposed_face(_system((_matrix([[1]]),), (0,)), ())
+
+
+def test_native_dispatch_and_serialized_result_parity() -> None:
+    tool = TOOLS[0]
+    parsed = parse_operation_input(
+        SemidefiniteFaceReductionRequest, tool.examples[0].input
+    )
+    assert isinstance(parsed, SemidefiniteFaceReductionRequest)
+    dispatched = invoke_operation(
+        tool.operation_id, tool.examples[0].input, Catalog.open()
+    )
+    result = SemidefiniteFaceReduction.model_validate_json(
+        json.dumps(dispatched.output)
+    )
+    assert result == reduce_exposed_face(parsed.system, parsed.multipliers)
+    assert (
+        SemidefiniteFaceReduction.model_validate_json(result.model_dump_json())
+        == result
+    )

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -187,13 +187,47 @@ def test_dense_rank_one_exposure_at_useful_order() -> None:
 
 
 def test_excessive_height_and_dense_output_are_rejected() -> None:
-    huge = _matrix([[Fraction(1, 10**16000 + 1)]])
+    # The exposing entry itself would have 40,001 digits, beyond the scalar
+    # codomain. Rejection is necessary, rather than an inflated minor bound.
+    large = 10**20000 + 1
+    huge = _matrix([[large]])
     with pytest.raises(OperationResourceAdmissionError):
-        reduce_exposed_face(_system((huge,), (0,)), (_q(1),))
+        reduce_exposed_face(_system((huge,), (0,)), (_q(large),))
     n = 164
     dense = _matrix([[int(i == j) for j in range(n)] for i in range(n)])
     with pytest.raises(OperationResourceAdmissionError):
         reduce_exposed_face(_system((dense,), (0,)), (_q(1),))
+
+
+def test_large_scalar_exposure_needs_no_elimination_growth() -> None:
+    matrix = _matrix([[Fraction(1, 10**20000 + 1)]])
+    system = _system((matrix,), (0,))
+    result = reduce_exposed_face(system, (_q(1),))
+    assert result.exposing_matrix == matrix
+    assert result.embedding.row_count == 1
+    assert result.embedding.column_count == result.reduced.order == 0
+    assert (
+        SemidefiniteFaceReduction.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+def test_diagonal_exposure_has_coordinate_kernel_and_independent_denominators() -> None:
+    n = 128
+    diagonal = [Fraction(1, 2**128 + i + 1) if i % 2 else Fraction() for i in range(n)]
+    matrix = _matrix(
+        [[diagonal[i] if i == j else 0 for j in range(n)] for i in range(n)]
+    )
+    result = reduce_exposed_face(_system((matrix,), (0,)), (_q(1),))
+    assert result.exposing_matrix == matrix
+    assert result.reduced.order == n // 2
+    assert all(
+        not q.num for a in result.reduced.matrices for row in a.entries for q in row
+    )
+    for i, row in enumerate(result.embedding.entries):
+        assert [q.as_fraction() for q in row] == [
+            Fraction(int(i == 2 * j)) for j in range(n // 2)
+        ]
 
 
 def test_shape_validation_and_zero_cone_has_no_proper_exposure() -> None:

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -303,5 +303,3 @@ def test_coprime_constraint_denominators_are_bounded_in_compression() -> None:
         reduce_exposed_face(system, (_q(1), _q(1)))
     with pytest.raises(OperationResourceAdmissionError, match="canonical rational"):
         reduce_exposed_face(system, (_q(1), _q(0)))
-
-

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -285,9 +285,9 @@ def test_python_mode_generators_reduce_the_issue_fixture_face() -> None:
                         {"entries": ((_q(1), _q(0)), (_q(0), _q(1)))},
                     )
                 ),
-                "rhs": (_q(0), _q(1)),
+                "rhs": (value for value in (_q(0), _q(1))),
             },
-            "multipliers": (_q(1), _q(0)),
+            "multipliers": (value for value in (_q(1), _q(0))),
         }
     )
     result = reduce_exposed_face(request.system, request.multipliers)
@@ -310,6 +310,61 @@ def test_raw_request_preflight_rejects_over_budget_generated_cells() -> None:
                     "rhs": [{"num": "0", "den": "1"}] * 9,
                 },
                 "multipliers": [{"num": "1", "den": "1"}] * 9,
+            }
+        )
+
+
+def test_raw_request_preflight_bounds_range_sequences() -> None:
+    with pytest.raises(ValidationError, match="dense cell envelope"):
+        SemidefiniteFaceReductionRequest.model_validate(
+            {
+                "system": {
+                    "order": 1,
+                    "matrices": range(10**9),
+                    "rhs": [{"num": "0", "den": "1"}],
+                },
+                "multipliers": [{"num": "1", "den": "1"}],
+            }
+        )
+    with pytest.raises(ValidationError, match="dense cell envelope"):
+        SemidefiniteFaceReductionRequest.model_validate(
+            {
+                "system": {
+                    "order": 1,
+                    "matrices": [{"entries": range(10**9)}],
+                    "rhs": [{"num": "0", "den": "1"}],
+                },
+                "multipliers": [{"num": "1", "den": "1"}],
+            }
+        )
+
+
+def test_raw_request_preflight_scans_generated_rhs_and_multipliers() -> None:
+    huge = {"num": "1" + "0" * 40_000, "den": "1"}
+    with pytest.raises(ValidationError, match="aggregate digit envelope"):
+        SemidefiniteFaceReductionRequest.model_validate(
+            {
+                "system": {
+                    "order": 1,
+                    "matrices": [
+                        {"entries": [[{"num": "1", "den": "1"}]]},
+                    ],
+                    "rhs": (huge for _ in range(8192)),
+                },
+                "multipliers": [{"num": "1", "den": "1"}],
+            }
+        )
+    with pytest.raises(ValidationError, match="aggregate digit envelope"):
+        SemidefiniteFaceReductionRequest.model_validate(
+            {
+                "system": {
+                    "order": 1,
+                    "matrices": [
+                        {"entries": [[{"num": "1", "den": "1"}]]},
+                    ],
+                    "rhs": [{"num": "0", "den": "1"}],
+                },
+                "multipliers": (huge for _ in range(8192)),
             }
         )
 

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -276,7 +276,12 @@ def test_python_mode_generators_reduce_the_issue_fixture_face() -> None:
                 "matrices": (
                     matrix
                     for matrix in (
-                        {"entries": (row for row in ((_q(1), _q(0)), (_q(0), _q(0))))},
+                        {
+                            "entries": (
+                                (entry for entry in row)
+                                for row in ((_q(1), _q(0)), (_q(0), _q(0)))
+                            )
+                        },
                         {"entries": ((_q(1), _q(0)), (_q(0), _q(1)))},
                     )
                 ),
@@ -305,6 +310,28 @@ def test_raw_request_preflight_rejects_over_budget_generated_cells() -> None:
                     "rhs": [{"num": "0", "den": "1"}] * 9,
                 },
                 "multipliers": [{"num": "1", "den": "1"}] * 9,
+            }
+        )
+
+
+def test_raw_request_preflight_counts_generated_row_cells() -> None:
+    zero = {"num": "0", "den": "1"}
+
+    def generated_row() -> object:
+        return (zero for _ in range(8192))
+
+    with pytest.raises(ValidationError, match="dense cell envelope"):
+        SemidefiniteFaceReductionRequest.model_validate(
+            {
+                "system": {
+                    "order": 1,
+                    "matrices": [
+                        {"entries": (generated_row() for _ in range(8192))}
+                        for _ in range(16)
+                    ],
+                    "rhs": [zero] * 16,
+                },
+                "multipliers": [{"num": "1", "den": "1"}] * 16,
             }
         )
 

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -266,6 +266,49 @@ def test_raw_request_preflight_counts_actual_nested_cells() -> None:
         )
 
 
+def test_python_mode_generators_reduce_the_issue_fixture_face() -> None:
+    # Nested generators are the motivating Python-mode payload: preflight must
+    # install them before Pydantic sees an empty matrices or entries sequence.
+    request = SemidefiniteFaceReductionRequest.model_validate(
+        {
+            "system": {
+                "order": 2,
+                "matrices": (
+                    matrix
+                    for matrix in (
+                        {"entries": (row for row in ((_q(1), _q(0)), (_q(0), _q(0))))},
+                        {"entries": ((_q(1), _q(0)), (_q(0), _q(1)))},
+                    )
+                ),
+                "rhs": (_q(0), _q(1)),
+            },
+            "multipliers": (_q(1), _q(0)),
+        }
+    )
+    result = reduce_exposed_face(request.system, request.multipliers)
+    _identities(result)
+    assert _sympy(result.embedding) == Matrix([[0], [1]])
+    assert [_sympy(a) for a in result.reduced.matrices] == [
+        Matrix([[0]]),
+        Matrix([[1]]),
+    ]
+
+
+def test_raw_request_preflight_rejects_over_budget_generated_cells() -> None:
+    row = [{"num": "0", "den": "1"}] * 128
+    with pytest.raises(ValidationError, match="dense cell envelope"):
+        SemidefiniteFaceReductionRequest.model_validate(
+            {
+                "system": {
+                    "order": 1,
+                    "matrices": ({"entries": [row] * 128} for _ in range(9)),
+                    "rhs": [{"num": "0", "den": "1"}] * 9,
+                },
+                "multipliers": [{"num": "1", "den": "1"}] * 9,
+            }
+        )
+
+
 def test_inactive_constraint_denominators_are_charged_during_compression() -> None:
     huge = Fraction(1, 10**20_001)
     system = _system(

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -281,6 +281,32 @@ def test_inactive_large_denominator_does_not_block_exposing_matrix() -> None:
     assert result.reduced.matrices[1].entries[0][0].as_fraction() == huge
 
 
+def test_inactive_rhs_heights_count_toward_output() -> None:
+    huge = Fraction(10**32_000)
+    matrices = (_matrix([[1, 1], [1, 1]]),) + tuple(
+        _matrix([[0, 0], [0, 0]]) for _ in range(200)
+    )
+    rhs = (0,) + tuple(huge for _ in range(200))
+    system = RationalSemidefiniteSystem(
+        order=2, matrices=matrices, rhs=tuple(_q(value) for value in rhs)
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="output digit"):
+        reduce_exposed_face(system, (_q(1),) + tuple(_q(0) for _ in range(200)))
+
+
+def test_coprime_constraint_denominators_are_bounded_in_compression() -> None:
+    primes = [10**12_000 + 2 * i + 1 for i in range(3)]
+    dense = _matrix(
+        [
+            [Fraction(1, primes[0]), Fraction(1, primes[1])],
+            [Fraction(1, primes[1]), Fraction(1, primes[2])],
+        ]
+    )
+    system = _system((_matrix([[0, 1], [1, 0]]), dense), (0, 0))
+    with pytest.raises(OperationResourceAdmissionError, match="canonical rational"):
+        reduce_exposed_face(system, (_q(1), _q(1)))
+
+
 def test_native_dispatch_and_serialized_result_parity() -> None:
     tool = TOOLS[0]
     parsed = parse_operation_input(

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -1,5 +1,6 @@
 """Defining feasible-set and reconstruction identities for exposed faces."""
 
+from collections import UserDict
 from collections.abc import Sequence
 from fractions import Fraction
 
@@ -249,6 +250,43 @@ def test_raw_request_preflight_rejects_over_budget_cells() -> None:
                 "multipliers": [{"num": "1", "den": "1"}] * 128,
             }
         )
+
+
+def test_raw_request_preflight_scans_mapping_wrapped_system() -> None:
+    payload = UserDict(
+        {
+            "system": UserDict(
+                {
+                    "order": 128,
+                    "matrices": [{}] * 128,
+                    "rhs": [{"num": "0", "den": "1"}] * 128,
+                }
+            ),
+            "multipliers": [{"num": "1", "den": "1"}] * 128,
+        }
+    )
+    with pytest.raises(ValidationError, match="dense cell envelope"):
+        SemidefiniteFaceReductionRequest.model_validate(payload)
+    request = SemidefiniteFaceReductionRequest.model_validate(
+        UserDict(
+            {
+                "system": UserDict(
+                    {
+                        "order": 2,
+                        "matrices": [
+                            UserDict({"entries": ((_q(1), _q(0)), (_q(0), _q(0)))}),
+                            UserDict({"entries": ((_q(1), _q(0)), (_q(0), _q(1)))}),
+                        ],
+                        "rhs": (_q(0), _q(1)),
+                    }
+                ),
+                "multipliers": (_q(1), _q(0)),
+            }
+        )
+    )
+    result = reduce_exposed_face(request.system, request.multipliers)
+    _identities(result)
+    assert _sympy(result.embedding) == Matrix([[0], [1]])
 
 
 def test_raw_request_preflight_counts_actual_nested_cells() -> None:

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -255,6 +255,21 @@ def test_raw_request_preflight_rejects_over_budget_cells() -> None:
         )
 
 
+def test_raw_request_preflight_counts_actual_nested_cells() -> None:
+    row = [{"num": "0", "den": "1"}] * 128
+    with pytest.raises(ValidationError, match="dense cell envelope"):
+        SemidefiniteFaceReductionRequest.model_validate(
+            {
+                "system": {
+                    "order": 1,
+                    "matrices": [{"entries": [row] * 128}] * 9,
+                    "rhs": [{"num": "0", "den": "1"}] * 9,
+                },
+                "multipliers": [{"num": "1", "den": "1"}] * 9,
+            }
+        )
+
+
 def test_inactive_large_denominator_does_not_block_exposing_matrix() -> None:
     huge = Fraction(1, 10**20_001)
     system = _system(

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -241,6 +241,31 @@ def test_shape_validation_and_zero_cone_has_no_proper_exposure() -> None:
         reduce_exposed_face(_system((_matrix([[1]]),), (0,)), ())
 
 
+def test_raw_request_preflight_rejects_over_budget_cells() -> None:
+    with pytest.raises(ValidationError, match="dense cell envelope"):
+        SemidefiniteFaceReductionRequest.model_validate(
+            {
+                "system": {
+                    "order": 128,
+                    "matrices": [{}] * 128,
+                    "rhs": [{"num": "0", "den": "1"}] * 128,
+                },
+                "multipliers": [{"num": "1", "den": "1"}] * 128,
+            }
+        )
+
+
+def test_inactive_large_denominator_does_not_block_exposing_matrix() -> None:
+    huge = Fraction(1, 10**20_001)
+    system = _system(
+        (_matrix([[1, 1], [1, 1]]), _matrix([[huge, 0], [0, 0]])),
+        (0, 0),
+    )
+    result = reduce_exposed_face(system, (_q(1), _q(0)))
+    _identities(result)
+    assert result.reduced.matrices[1].entries[0][0].as_fraction() == huge
+
+
 def test_native_dispatch_and_serialized_result_parity() -> None:
     tool = TOOLS[0]
     parsed = parse_operation_input(

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -270,15 +270,14 @@ def test_raw_request_preflight_counts_actual_nested_cells() -> None:
         )
 
 
-def test_inactive_large_denominator_does_not_block_exposing_matrix() -> None:
+def test_inactive_constraint_denominators_are_charged_during_compression() -> None:
     huge = Fraction(1, 10**20_001)
     system = _system(
         (_matrix([[1, 1], [1, 1]]), _matrix([[huge, 0], [0, 0]])),
         (0, 0),
     )
-    result = reduce_exposed_face(system, (_q(1), _q(0)))
-    _identities(result)
-    assert result.reduced.matrices[1].entries[0][0].as_fraction() == huge
+    with pytest.raises(OperationResourceAdmissionError, match="canonical rational"):
+        reduce_exposed_face(system, (_q(1), _q(0)))
 
 
 def test_inactive_rhs_heights_count_toward_output() -> None:
@@ -305,6 +304,8 @@ def test_coprime_constraint_denominators_are_bounded_in_compression() -> None:
     system = _system((_matrix([[0, 1], [1, 0]]), dense), (0, 0))
     with pytest.raises(OperationResourceAdmissionError, match="canonical rational"):
         reduce_exposed_face(system, (_q(1), _q(1)))
+    with pytest.raises(OperationResourceAdmissionError, match="canonical rational"):
+        reduce_exposed_face(system, (_q(1), _q(0)))
 
 
 def test_native_dispatch_and_serialized_result_parity() -> None:

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -1,6 +1,5 @@
 """Defining feasible-set and reconstruction identities for exposed faces."""
 
-import json
 from collections.abc import Sequence
 from fractions import Fraction
 
@@ -9,19 +8,16 @@ from pydantic import ValidationError
 from sympy import Matrix, Rational, zeros
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
 )
-from jacobian.dispatch import invoke_operation, parse_operation_input
 from jacobian.math.matrices.semidefinite import (
     RationalSemidefiniteSystem,
     SemidefiniteFaceReduction,
     reduce_exposed_face,
 )
 from jacobian.math.matrices.semidefinite._models import SemidefiniteFaceReductionRequest
-from jacobian.math.matrices.semidefinite._tools import TOOLS
 from jacobian.math.matrices.values import RationalMatrix, rational_matrix_from_fractions
 
 
@@ -282,15 +278,16 @@ def test_inactive_constraint_denominators_are_charged_during_compression() -> No
 
 def test_inactive_rhs_heights_count_toward_output() -> None:
     huge = Fraction(10**32_000)
-    matrices = (_matrix([[1, 1], [1, 1]]),) + tuple(
-        _matrix([[0, 0], [0, 0]]) for _ in range(200)
+    matrices = (
+        _matrix([[1, 1], [1, 1]]),
+        *(_matrix([[0, 0], [0, 0]]) for _ in range(200)),
     )
-    rhs = (0,) + tuple(huge for _ in range(200))
+    rhs = (0, *(huge for _ in range(200)))
     system = RationalSemidefiniteSystem(
         order=2, matrices=matrices, rhs=tuple(_q(value) for value in rhs)
     )
     with pytest.raises(OperationResourceAdmissionError, match="output digit"):
-        reduce_exposed_face(system, (_q(1),) + tuple(_q(0) for _ in range(200)))
+        reduce_exposed_face(system, (_q(1), *(_q(0) for _ in range(200))))
 
 
 def test_coprime_constraint_denominators_are_bounded_in_compression() -> None:
@@ -308,20 +305,3 @@ def test_coprime_constraint_denominators_are_bounded_in_compression() -> None:
         reduce_exposed_face(system, (_q(1), _q(0)))
 
 
-def test_native_dispatch_and_serialized_result_parity() -> None:
-    tool = TOOLS[0]
-    parsed = parse_operation_input(
-        SemidefiniteFaceReductionRequest, tool.examples[0].input
-    )
-    assert isinstance(parsed, SemidefiniteFaceReductionRequest)
-    dispatched = invoke_operation(
-        tool.operation_id, tool.examples[0].input, Catalog.open()
-    )
-    result = SemidefiniteFaceReduction.model_validate_json(
-        json.dumps(dispatched.output)
-    )
-    assert result == reduce_exposed_face(parsed.system, parsed.multipliers)
-    assert (
-        SemidefiniteFaceReduction.model_validate_json(result.model_dump_json())
-        == result
-    )

--- a/tests/mcp/test_semidefinite_face.py
+++ b/tests/mcp/test_semidefinite_face.py
@@ -4,8 +4,11 @@ import asyncio
 import json
 from copy import deepcopy
 
+from jacobian._exact import CanonicalRational
+from jacobian.math.matrices.semidefinite import RationalSemidefiniteSystem
 from jacobian.math.matrices.semidefinite._models import SemidefiniteFaceReductionRequest
 from jacobian.math.matrices.semidefinite._tools import TOOLS, compute_face_reduction
+from jacobian.math.matrices.values import RationalMatrix
 from jacobian.mcp.server import create_server
 from mcp import Client
 
@@ -38,5 +41,29 @@ def test_exposed_face_native_mcp_parity_and_invalid_relation_recovery() -> None:
             assert not result.is_error
             assert result.structured_content is not None
             assert result.structured_content["output"] == native.model_dump(mode="json")
+            large = SemidefiniteFaceReductionRequest(
+                system=RationalSemidefiniteSystem(
+                    order=1,
+                    matrices=(
+                        RationalMatrix(
+                            entries=((CanonicalRational(num=1, den=10**20000 + 1),),)
+                        ),
+                    ),
+                    rhs=(CanonicalRational(num=0, den=1),),
+                ),
+                multipliers=(CanonicalRational(num=1, den=1),),
+            )
+            large_result = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": large.model_dump(mode="json"),
+                },
+            )
+            assert not large_result.is_error
+            assert large_result.structured_content is not None
+            assert large_result.structured_content["output"] == compute_face_reduction(
+                large
+            ).model_dump(mode="json")
 
     asyncio.run(scenario())

--- a/tests/mcp/test_semidefinite_face.py
+++ b/tests/mcp/test_semidefinite_face.py
@@ -1,0 +1,42 @@
+"""Live SDK result validation and recovery for a supplied exposing relation."""
+
+import asyncio
+import json
+from copy import deepcopy
+
+from jacobian.math.matrices.semidefinite._models import SemidefiniteFaceReductionRequest
+from jacobian.math.matrices.semidefinite._tools import TOOLS, compute_face_reduction
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_exposed_face_native_mcp_parity_and_invalid_relation_recovery() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        native = compute_face_reduction(
+            SemidefiniteFaceReductionRequest.model_validate_json(json.dumps(payload))
+        )
+        async with Client(create_server(), raise_exceptions=False) as client:
+            invalid = deepcopy(payload)
+            invalid["multipliers"] = [{"num": "-1", "den": "1"}]
+            error = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": invalid,
+                },
+            )
+            assert error.is_error
+            result = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": payload,
+                },
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            assert result.structured_content["output"] == native.model_dump(mode="json")
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Exact semidefinite equality systems can have feasible matrices confined to a proper face. Existing matrix arithmetic does not bind a supplied exposing relation to an equivalent reduced system. Closes #3458.

## Outcome

Adds `matrix.semidefinite.exposed_face.reduce` and native `reduce_exposed_face`. Given `tr(A_i X)=b_i`, it recognizes `W=sum y_i A_i` as nonzero PSD and checks `y^T b=0`, then returns the complete reduced equalities `tr(V^T A_i V Y)=b_i` and rational embedding `X=VYV^T`. The RREF fundamental basis spans `ker(W)` without introducing irrational orthonormal coordinates.

For `A_1=diag(1,0), b_1=0; A_2=I, b_2=1`, the result has embedding `(0,1)^T` and equalities `0=0, Y=1`. Positive-definite exposing matrices produce a zero-dimensional cone with every equality retained, including contradictions. Reduction makes no feasibility or minimal-face claim.

Diagonal systems use scalar dot-product bounds, sign recognition and coordinate selection; their reduced matrices are copied submatrices. This admits a scalar exposure with a 20,001-digit denominator and a 128-axis diagonal system with unrelated denominators, without charging nonexistent elimination growth.

The mathematical relation follows the exposed-face construction described in [Reid et al.](https://arxiv.org/abs/1504.00931). Implementation reuses the matrix owner's exact congruence-inertia kernel and FLINT-backed RREF and rational products.

## Validation

Final revision: `716dd726a`.

- `make affected AFFECTED_BASE=origin/main`: all six planned commands passed, including Ruff/mypy, 687 matrix tests, 156 catalog tests, 915 catalog integration tests and 72 live MCP tests.
- `uv run pytest -n 0 --timeout=120 tests/integration/catalog/test_public_operation_contract_conformance.py -k matrix.semidefinite.exposed_face.reduce`: 1 passed.
- Focused mathematical tests independently establish `WV=0`, complete kernel span, full column rank, every compression identity and unique PSD lift coordinates. Tests include rational pivots, non-coordinate kernels, false exposing relations, negative multipliers with a valid relation, empty reduced axes and serialized repeated reduction.
- Native 32×32 dense rank-one exposure returned a 31-dimensional face in 0.02761 seconds with 88,751 JSON bytes on the local Linux/Python 3.12 environment. The 128-axis diagonal example took 0.23893 seconds and returned 997,442 JSON bytes. The large scalar case took 0.00115 seconds and returned 40,486 bytes; the preceding implementation was reproduced rejecting it. These are calibration examples, not worst-case runtime bounds.

## Contract impact

New domain-owned `RationalSemidefiniteSystem` and `SemidefiniteFaceReduction` use unchanged canonical `RationalMatrix` and rational scalars. Ordered row/column coordinates are retained, including an `n×0` embedding and `0×0` compressed equalities. Parsing checks structure; the operation recognizes the caller's exposing relation under admission. A consumer cannot infer mathematical correctness from a parsed result alone.

- [x] Generated request/result schemas and runtime conformance checked
- [x] Native and live MCP parity, including rejection followed by recovery
- [x] Producer → JSON → reduced-system consumer tested
- [x] All mandatory phases share one deadline
- [x] Defining identities and adversarial inputs covered

### Catalog admission

The reusable result is equivalence of entire PSD feasible sets under a recognized supplied relation. There is no existing semidefinite-system carrier or exposed-face owner; loose matrix operations do not establish that bound relation.

Admission bounds dense source/result cells, input common-denominator growth, Hadamard minor bounds for kernel coordinates and Schur entries, compressed rational height and output digits. The envelope is 131,072 cells, 8,000,000 estimated scalar digits and 2,000,000 weighted scalar-work units (operation count times intermediate bit height, not a claim of exact bit-operation complexity). It is computed once before elimination. The 3,600-second owner deadline is an occupancy backstop shared with the caller's earlier deadline; mathematical rejection never derives from timeout. Output-size and coefficient-height limits remain explicit limits of this implementation.

## Review closure

- [x] Independent exact-diff contract review completed; no unresolved correctness findings
- [x] Final changed tree passed affected validation and scoped catalog conformance
- [x] Public-symbol diff is limited to one operation and its owning native values/function

No existing operation is superseded. Hosted required CI passed on the final revision, including static checks, matrix tests, catalog examples and MCP boundaries.
