### PR TITLE
feat(matrices): decompose chordal PSD matrices into exact clique terms

### DIFF
--- a/src/jacobian/math/matrices/chordal_psd/__init__.py
+++ b/src/jacobian/math/matrices/chordal_psd/__init__.py
@@ -1,0 +1,9 @@
+"""Rational clique-supported decompositions of chordal sparse PSD matrices."""
+
+from jacobian.math.matrices.chordal_psd._models import (
+    ChordalPSDDecomposition,
+    CliquePSDTerm,
+)
+from jacobian.math.matrices.chordal_psd.operations import decompose_chordal_psd
+
+__all__ = ["ChordalPSDDecomposition", "CliquePSDTerm", "decompose_chordal_psd"]

--- a/src/jacobian/math/matrices/chordal_psd/_models.py
+++ b/src/jacobian/math/matrices/chordal_psd/_models.py
@@ -1,0 +1,64 @@
+"""Exact clique-supported sparse PSD decompositions."""
+
+from typing import Annotated, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+from jacobian.math.matrices.values import RationalMatrix
+
+
+class ChordalPSDRequest(StrictModel):
+    """A fully specified symmetric QQ matrix on graph vertices 0,...,n-1.
+
+    The graph must be chordal and cover all nonzero off-diagonal entries.
+    Extra graph edges are allowed; matrix zeros remain specified zeros.
+    """
+
+    matrix: RationalMatrix
+    graph: IndexedSimpleUndirectedGraph
+
+
+class CliquePSDTerm(StrictModel):
+    """Local matrix with ascending original-axis indices defining its inclusion.
+
+    PSD is established by the producing operation, not by structural parsing.
+    """
+
+    axes: tuple[Annotated[int, Field(ge=0, le=1023)], ...] = Field(
+        min_length=1, max_length=1024
+    )
+    matrix: RationalMatrix
+
+    @model_validator(mode="after")
+    def require_shape(self) -> Self:
+        if tuple(sorted(set(self.axes))) != self.axes or self.axes[0] < 0:
+            raise ValueError("axes must be distinct ascending nonnegative indices")
+        if self.matrix.row_count != len(self.axes) or self.matrix.column_count != len(
+            self.axes
+        ):
+            raise ValueError("local matrix dimensions must equal the axis count")
+        return self
+
+
+class ChordalPSDDecomposition(StrictModel):
+    """Sum of clique-supported PSD terms on the retained source axes.
+
+    Embedding and summing all local matrices reproduces matrix exactly. Terms
+    are in deterministic elimination order; zero pivots contribute no term.
+    The zero matrix (including order zero) has an empty tuple of terms.
+    """
+
+    matrix: RationalMatrix
+    graph: IndexedSimpleUndirectedGraph
+    terms: tuple[CliquePSDTerm, ...] = Field(max_length=1024)
+
+    @model_validator(mode="after")
+    def require_axes(self) -> Self:
+        n = self.graph.vertex_count
+        if self.matrix.row_count != n or self.matrix.column_count != n:
+            raise ValueError("source matrix dimensions must equal graph vertex count")
+        if any(axis >= n for term in self.terms for axis in term.axes):
+            raise ValueError("term axes must belong to the source matrix")
+        return self

--- a/src/jacobian/math/matrices/chordal_psd/_tools.py
+++ b/src/jacobian/math/matrices/chordal_psd/_tools.py
@@ -1,0 +1,52 @@
+"""Publication of exact chordal sparse PSD decomposition."""
+
+from typing import Any
+
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.matrices.chordal_psd._models import (
+    ChordalPSDDecomposition,
+    ChordalPSDRequest,
+)
+from jacobian.math.matrices.chordal_psd.operations import decompose_chordal_psd
+
+
+def _run(request: ChordalPSDRequest) -> ChordalPSDDecomposition:
+    return decompose_chordal_psd(request.matrix, request.graph)
+
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="matrix.chordal_psd.decompose",
+        title="Decompose a chordal sparse PSD matrix into rational clique terms",
+        description="Return rational PSD local matrices with original-axis inclusions whose embedded sum equals the supplied fully specified matrix. The graph must be chordal and cover every nonzero off-diagonal entry; extra zero-valued graph edges are allowed. Zero pivots emit no term, including an empty sum for the zero matrix. This constructs allocated clique summands, not a partial-matrix completion. Graph work, local output, and rational minor-height budgets bound execution.",
+        request_type=ChordalPSDRequest,
+        result_type=ChordalPSDDecomposition,
+        run=_run,
+        tags=(
+            "matrix",
+            "chordal",
+            "positive semidefinite",
+            "sparse",
+            "clique",
+            "decomposition",
+            "LDL",
+            "exact",
+        ),
+        examples=(
+            OperationExample(
+                name="path_psd_sum",
+                description="Decompose the singular path matrix into two edge-supported PSD terms; the symmetric PSD matrix must have zeros outside its chordal graph.",
+                input={
+                    "matrix": {
+                        "domain": "QQ",
+                        "entries": [
+                            [{"num": str(x), "den": "1"} for x in row]
+                            for row in ((1, 1, 0), (1, 2, 1), (0, 1, 1))
+                        ],
+                    },
+                    "graph": {"vertex_count": 3, "edges": [[0, 1], [1, 2]]},
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/matrices/chordal_psd/operations.py
+++ b/src/jacobian/math/matrices/chordal_psd/operations.py
@@ -35,6 +35,8 @@ from jacobian.math.matrices.values import RationalMatrix, rational_matrix_from_f
 _MAX_GRAPH_WORK = 16_777_216
 _MAX_OUTPUT_ENTRIES = 131_072
 _MAX_OUTPUT_BITS = 128_000_000
+_SOURCE_CELL_JSON_BITS = 192
+_RESULT_ENVELOPE_BITS = 8_192
 _MAX_ARITHMETIC_WORK = 1_000_000_000_000
 _MAX_SCALAR_BITS = 65_536
 _WALL_SECONDS = 60.0
@@ -169,7 +171,7 @@ def _admit(
         for v, support in zip(order, supports, strict=True)
     )
     n = matrix.row_count
-    source_bits = n * n * 160
+    source_bits = n * n * _SOURCE_CELL_JSON_BITS + n * 64 + _RESULT_ENVELOPE_BITS
     for row in matrix.entries:
         for value in row:
             source_bits += abs(value.num).bit_length() + value.den.bit_length()

--- a/src/jacobian/math/matrices/chordal_psd/operations.py
+++ b/src/jacobian/math/matrices/chordal_psd/operations.py
@@ -168,6 +168,13 @@ def _admit(
         2 * len(support) ** 2 * heights[component[v]]
         for v, support in zip(order, supports, strict=True)
     )
+    n = matrix.row_count
+    source_bits = n * n * 160
+    for row in matrix.entries:
+        for value in row:
+            source_bits += abs(value.num).bit_length() + value.den.bit_length()
+    graph_bits = 64 + 2 * len(graph.edges) * max(n.bit_length(), 1)
+    output_bits += source_bits + graph_bits
     arithmetic_work = sum(
         len(support) ** 2 * heights[component[v]] ** 2
         for v, support in zip(order, supports, strict=True)

--- a/src/jacobian/math/matrices/chordal_psd/operations.py
+++ b/src/jacobian/math/matrices/chordal_psd/operations.py
@@ -40,6 +40,14 @@ _RESULT_ENVELOPE_BITS = 8_192
 _MAX_ARITHMETIC_WORK = 1_000_000_000_000
 _MAX_SCALAR_BITS = 65_536
 _WALL_SECONDS = 60.0
+_JSON_HEIGHT_NUMERATOR = 12
+_JSON_HEIGHT_DENOMINATOR = 5
+
+
+def _json_scaled_bits(bits: int) -> int:
+    """Bound decimal JSON digits of a binary integer (log10(2) < 12/25, so 2.4 bits)."""
+
+    return (bits * _JSON_HEIGHT_NUMERATOR) // _JSON_HEIGHT_DENOMINATOR
 
 
 def _reject(code: str, message: str) -> OperationDomainValidationError:
@@ -167,14 +175,16 @@ def _admit(
             "output_bound", "total local matrix entries exceed the admitted bound"
         )
     output_bits = sum(
-        2 * len(support) ** 2 * heights[component[v]]
+        2 * len(support) ** 2 * _json_scaled_bits(heights[component[v]])
         for v, support in zip(order, supports, strict=True)
     )
     n = matrix.row_count
     source_bits = n * n * _SOURCE_CELL_JSON_BITS + n * 64 + _RESULT_ENVELOPE_BITS
     for row in matrix.entries:
         for value in row:
-            source_bits += abs(value.num).bit_length() + value.den.bit_length()
+            source_bits += _json_scaled_bits(
+                abs(value.num).bit_length()
+            ) + _json_scaled_bits(value.den.bit_length())
     graph_bits = 64 + 2 * len(graph.edges) * max(n.bit_length(), 1)
     output_bits += source_bits + graph_bits
     arithmetic_work = sum(

--- a/src/jacobian/math/matrices/chordal_psd/operations.py
+++ b/src/jacobian/math/matrices/chordal_psd/operations.py
@@ -1,0 +1,261 @@
+"""Sparse exact LDL elimination without irrational square roots.
+
+Vandenberghe and Andersen, Chordal Graphs and Semidefinite Optimization, §9.2.
+FLINT's rational matrix interface is dense and exposes no sparse LDL kernel;
+this sparse orchestration uses the standard library's exact Fraction arithmetic.
+"""
+
+from __future__ import annotations
+
+import time
+from fractions import Fraction
+from math import lcm
+
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.graphs.chordal.operations import (
+    _later_clique_failure,
+    _maximum_cardinality_ordering,
+)
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+from jacobian.math.matrices.chordal_psd._models import (
+    ChordalPSDDecomposition,
+    CliquePSDTerm,
+)
+from jacobian.math.matrices.values import RationalMatrix, rational_matrix_from_fractions
+
+_MAX_GRAPH_WORK = 16_777_216
+_MAX_OUTPUT_ENTRIES = 131_072
+_MAX_OUTPUT_BITS = 128_000_000
+_MAX_ARITHMETIC_WORK = 1_000_000_000_000
+_MAX_SCALAR_BITS = 65_536
+_WALL_SECONDS = 60.0
+
+
+def _reject(code: str, message: str) -> OperationDomainValidationError:
+    error_type = (
+        OperationResourceAdmissionError
+        if code.endswith("_bound")
+        else OperationDomainValidationError
+    )
+    return error_type(
+        location=("matrix",), code=f"matrix.chordal_psd.{code}", message=message
+    )
+
+
+def decompose_chordal_psd(
+    matrix: RationalMatrix, graph: IndexedSimpleUndirectedGraph
+) -> ChordalPSDDecomposition:
+    """Return at most n rational rank-one PSD clique terms summing to matrix.
+
+    Reject nonsymmetric, non-PSD, nonchordal, or uncovered support. No negative
+    mathematical conclusion is returned on resource exhaustion. All mandatory
+    phases share a 60-second cooperative request deadline.
+    """
+    if not isinstance(matrix, RationalMatrix) or not isinstance(
+        graph, IndexedSimpleUndirectedGraph
+    ):
+        raise TypeError("expected RationalMatrix and IndexedSimpleUndirectedGraph")
+    if current_request_execution() is None:
+        with request_execution(time.monotonic()):
+            return _decompose(matrix, graph)
+    return _decompose(matrix, graph)
+
+
+def _decompose(
+    matrix: RationalMatrix, graph: IndexedSimpleUndirectedGraph
+) -> ChordalPSDDecomposition:
+    execution = current_request_execution()
+    assert execution is not None
+    deadline = execution.started_at + _WALL_SECONDS
+    bind_request_deadline(
+        min(deadline, execution.deadline)
+        if execution.deadline is not None
+        else deadline
+    )
+    order, supports = _admit(matrix, graph)
+    residual = [
+        {j: value.as_fraction() for j, value in enumerate(row) if value.num != 0}
+        for row in matrix.entries
+    ]
+    terms: list[CliquePSDTerm] = []
+    for vertex, support in zip(order, supports, strict=True):
+        request_checkpoint("during sparse PSD elimination")
+        pivot = residual[vertex].get(vertex, Fraction(0))
+        if pivot < 0:
+            raise _reject("not_psd", "negative elimination pivot: matrix is not PSD")
+        if not pivot:
+            if any(residual[vertex].values()):
+                raise _reject(
+                    "not_psd",
+                    "zero diagonal with nonzero residual row: matrix is not PSD",
+                )
+            continue
+        row = [residual[vertex].get(axis, Fraction(0)) for axis in support]
+        local = (
+            [[pivot]]
+            if len(support) == 1
+            else [[left * right / pivot for right in row] for left in row]
+        )
+        for i, axis in enumerate(support):
+            for j, other in enumerate(support):
+                value = residual[axis].get(other, Fraction(0)) - local[i][j]
+                if value:
+                    residual[axis][other] = value
+                else:
+                    residual[axis].pop(other, None)
+        terms.append(
+            CliquePSDTerm(axes=support, matrix=rational_matrix_from_fractions(local))
+        )
+    request_checkpoint("before sparse PSD result construction")
+    result = ChordalPSDDecomposition(matrix=matrix, graph=graph, terms=tuple(terms))
+    request_checkpoint("after sparse PSD result construction")
+    return result
+
+
+def _admit(
+    matrix: RationalMatrix, graph: IndexedSimpleUndirectedGraph
+) -> tuple[tuple[int, ...], list[tuple[int, ...]]]:
+    n = graph.vertex_count
+    if matrix.row_count != n or matrix.column_count != n:
+        raise _reject("shape", "matrix must be square on the graph vertices")
+    neighbors: list[set[int]] = [set() for _ in range(n)]
+    for i, j in graph.edges:
+        neighbors[i].add(j)
+        neighbors[j].add(i)
+    if n * n + sum(len(row) ** 2 for row in neighbors) > _MAX_GRAPH_WORK:
+        raise _reject(
+            "graph_work_bound", "graph ordering work exceeds the admitted bound"
+        )
+    order = _maximum_cardinality_ordering(n, neighbors)
+    if _later_clique_failure(order, neighbors) is not None:
+        raise _reject("nonchordal", "the supplied graph must be chordal")
+    rank = {v: k for k, v in enumerate(order)}
+    component = _scan(matrix, neighbors)
+    heights = _component_heights(matrix, component)
+    # Numeric components are independent even when the supplied graph adds
+    # zero-valued edges between them. Restricting a PEO to each component
+    # remains a PEO of its induced chordal graph.
+    supports = [
+        tuple(
+            sorted(
+                (
+                    v,
+                    *(
+                        w
+                        for w in neighbors[v]
+                        if rank[w] > rank[v] and component[w] == component[v]
+                    ),
+                )
+            )
+        )
+        for v in order
+    ]
+    cells = sum(len(support) ** 2 for support in supports)
+    if cells > _MAX_OUTPUT_ENTRIES:
+        raise _reject(
+            "output_bound", "total local matrix entries exceed the admitted bound"
+        )
+    output_bits = sum(
+        2 * len(support) ** 2 * heights[component[v]]
+        for v, support in zip(order, supports, strict=True)
+    )
+    arithmetic_work = sum(
+        len(support) ** 2 * heights[component[v]] ** 2
+        for v, support in zip(order, supports, strict=True)
+    )
+    if output_bits > _MAX_OUTPUT_BITS:
+        raise _reject(
+            "output_bound",
+            "predicted exact local matrices exceed the output bit budget",
+        )
+    if arithmetic_work > _MAX_ARITHMETIC_WORK:
+        raise _reject(
+            "work_bound",
+            "support updates and coefficient height exceed the arithmetic budget",
+        )
+    return order, supports
+
+
+def _scan(matrix: RationalMatrix, neighbors: list[set[int]]) -> list[int]:
+    n = matrix.row_count
+    # Bound denominator clearing before building large integer intermediates.
+    # Each lcm multiplies operands of at most the scalar cap, so even
+    # the first rejected intermediate has at most twice that many bits.
+    component = list(range(n))
+
+    def root(v: int) -> int:
+        while component[v] != v:
+            component[v] = component[component[v]]
+            v = component[v]
+        return v
+
+    for i, row in enumerate(matrix.entries):
+        request_checkpoint("during sparse PSD admission")
+        for j, value in enumerate(row):
+            if value != matrix.entries[j][i]:
+                raise _reject("symmetry", "matrix must be symmetric")
+            q = value.as_fraction()
+            if i != j and q and j not in neighbors[i]:
+                raise _reject(
+                    "support", "graph must cover every nonzero off-diagonal entry"
+                )
+            if (
+                max(abs(q.numerator).bit_length(), q.denominator.bit_length())
+                > _MAX_SCALAR_BITS
+            ):
+                raise _reject(
+                    "height_bound",
+                    "input coefficient height exceeds the admitted bound",
+                )
+            if i != j and q:
+                component[root(i)] = root(j)
+    return [root(v) for v in range(n)]
+
+
+def _component_heights(matrix: RationalMatrix, component: list[int]) -> dict[int, int]:
+    """Admit each numeric block independently; singleton terms copy one scalar."""
+    denominators = dict.fromkeys(component, 1)
+    numerators = dict.fromkeys(component, 1)
+    sizes = dict.fromkeys(component, 0)
+    for i, row in enumerate(matrix.entries):
+        request_checkpoint("during component height admission")
+        c = component[i]
+        sizes[c] += 1
+        for q in row:
+            if not q.num:
+                continue
+            denominators[c] = lcm(denominators[c], q.den)
+            if denominators[c].bit_length() > _MAX_SCALAR_BITS:
+                raise _reject(
+                    "height_bound",
+                    "component common denominator exceeds the height bound",
+                )
+            numerators[c] = max(numerators[c], abs(q.num).bit_length())
+    heights: dict[int, int] = {}
+    for c, size in sizes.items():
+        d_bits = denominators[c].bit_length()
+        if size == 1:
+            heights[c] = max(numerators[c], d_bits)
+            continue
+        # For A=D*X, a k-minor is bounded by k! max|A_ij|^k.
+        # Schur entries are ratios of two minors with one D factor. Each
+        # r_i*r_j/p has at most three minor factors and two D factors.
+        # Four times (minor_bits+D_bits) bounds reduced numerator/denominator;
+        # unreduced arithmetic uses at most twice this many bits.
+        minor_bits = size * (numerators[c] + d_bits + size.bit_length()) + 1
+        heights[c] = 4 * (minor_bits + d_bits)
+        if heights[c] > _MAX_SCALAR_BITS:
+            raise _reject(
+                "height_bound",
+                "predicted rational coefficient height exceeds the admitted bound",
+            )
+    return heights

--- a/tests/math/matrices/chordal_psd/test_decomposition.py
+++ b/tests/math/matrices/chordal_psd/test_decomposition.py
@@ -147,6 +147,13 @@ def test_output_bound() -> None:
         decompose_chordal_psd(matrix, graph)
 
 
+def test_retained_source_counts_toward_output_bits() -> None:
+    n = 1024
+    matrix, graph = _case([[0] * n for _ in range(n)], ())
+    with pytest.raises(OperationDomainValidationError, match="output bit"):
+        decompose_chordal_psd(matrix, graph)
+
+
 def test_height_bound() -> None:
     # The nontrivial Schur denominator grows beyond 65,536 bits, although
     # each input scalar is below that limit.

--- a/tests/math/matrices/chordal_psd/test_decomposition.py
+++ b/tests/math/matrices/chordal_psd/test_decomposition.py
@@ -1,0 +1,180 @@
+"""Independent sum, clique, and principal-minor evidence."""
+
+import json
+from collections.abc import Sequence
+from fractions import Fraction
+from itertools import combinations
+
+import pytest
+import sympy
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+from jacobian.math.matrices.chordal_psd import (
+    ChordalPSDDecomposition,
+    decompose_chordal_psd,
+)
+from jacobian.math.matrices.chordal_psd._tools import TOOLS
+from jacobian.math.matrices.values import RationalMatrix, rational_matrix_from_fractions
+
+
+def _case(
+    rows: Sequence[Sequence[int | Fraction]], edges: Sequence[tuple[int, int]]
+) -> tuple[RationalMatrix, IndexedSimpleUndirectedGraph]:
+    return rational_matrix_from_fractions(
+        [[Fraction(x) for x in row] for row in rows]
+    ), IndexedSimpleUndirectedGraph(vertex_count=len(rows), edges=tuple(sorted(edges)))
+
+
+def _check(
+    matrix: RationalMatrix, graph: IndexedSimpleUndirectedGraph
+) -> ChordalPSDDecomposition:
+    result = decompose_chordal_psd(matrix, graph)
+    n = graph.vertex_count
+    total = [[Fraction(0) for _ in range(n)] for _ in range(n)]
+    for term in result.terms:
+        assert all((a, b) in graph.edges for a, b in combinations(term.axes, 2))
+        local = sympy.Matrix(
+            [[sympy.Rational(x.num, x.den) for x in row] for row in term.matrix.entries]
+        )
+        # Symmetric rank one with nonnegative diagonal independently proves PSD.
+        assert local == local.T
+        assert local.rank() == 1
+        assert all(x >= 0 for x in local.diagonal())
+        for i, a in enumerate(term.axes):
+            for j, b in enumerate(term.axes):
+                total[a][b] += term.matrix.entries[i][j].as_fraction()
+    assert total == [[x.as_fraction() for x in row] for row in matrix.entries]
+    assert (
+        ChordalPSDDecomposition.model_validate_json(result.model_dump_json()) == result
+    )
+    return result
+
+
+def test_path_allocates_separator() -> None:
+    result = _check(*_case([[1, 1, 0], [1, 2, 1], [0, 1, 1]], [(0, 1), (1, 2)]))
+    assert len(result.terms) == 2
+    assert all(
+        all(x.as_fraction() == 1 for row in term.matrix.entries for x in row)
+        for term in result.terms
+    )
+
+
+@pytest.mark.parametrize(
+    "rows,edges",
+    [
+        ([], []),
+        ([[0, 0], [0, 0]], [(0, 1)]),
+        ([[2, 0, 0], [0, 0, 0], [0, 0, 3]], []),
+        (
+            [[Fraction(2, 3), Fraction(1, 3)], [Fraction(1, 3), Fraction(1, 6)]],
+            [(0, 1)],
+        ),
+        ([[0, 0, 0], [0, 2, 1], [0, 1, 2]], [(0, 1), (1, 2)]),
+    ],
+)
+def test_degenerate_and_rational(
+    rows: list[list[int | Fraction]], edges: list[tuple[int, int]]
+) -> None:
+    _check(*_case(rows, edges))
+
+
+@pytest.mark.parametrize(
+    "rows,edges,code",
+    [
+        ([[1, 1], [0, 1]], [(0, 1)], "symmetry"),
+        ([[1, 1], [1, 1]], [], "support"),
+        ([[0, 1], [1, 0]], [(0, 1)], "not_psd"),
+        ([[1, 2], [2, 1]], [(0, 1)], "not_psd"),
+        (
+            [[int(i == j) for j in range(4)] for i in range(4)],
+            [(0, 1), (0, 3), (1, 2), (2, 3)],
+            "nonchordal",
+        ),
+    ],
+)
+def test_reject_invalid(
+    rows: list[list[int]], edges: list[tuple[int, int]], code: str
+) -> None:
+    with pytest.raises(OperationDomainValidationError) as error:
+        decompose_chordal_psd(*_case(rows, edges))
+    assert error.value.errors()[0]["type"].endswith(code)
+
+
+def test_native_wire_parity() -> None:
+    tool = TOOLS[0]
+    request = tool.request_type.model_validate_json(json.dumps(tool.examples[0].input))
+    assert tool.run(request) == decompose_chordal_psd(request.matrix, request.graph)
+
+
+def test_permuted_axes_remain_correct() -> None:
+    # Relabelling changes the owner's deterministic PEO; correctness is invariant.
+    rows = [[2, 1, 0, 0], [1, 3, 1, 1], [0, 1, 2, 0], [0, 1, 0, 1]]
+    for p in ((0, 1, 2, 3), (1, 3, 0, 2), (3, 2, 1, 0)):
+        permuted = [[rows[i][j] for j in p] for i in p]
+        edges = [(i, j) for i in range(4) for j in range(i + 1, 4) if permuted[i][j]]
+        _check(*_case(permuted, edges))
+
+
+def test_sparse_path_256() -> None:
+    n = 256
+    rows = [[0] * n for _ in range(n)]
+    for i in range(n - 1):
+        rows[i][i] += 1
+        rows[i + 1][i + 1] += 1
+        rows[i][i + 1] = rows[i + 1][i] = 1
+    result = _check(*_case(rows, [(i, i + 1) for i in range(n - 1)]))
+    assert len(result.terms) == n - 1
+
+
+def test_dense_clique_24() -> None:
+    n = 24
+    _check(
+        *_case(
+            [[2 if i == j else 1 for j in range(n)] for i in range(n)],
+            list(combinations(range(n), 2)),
+        )
+    )
+
+
+def test_output_bound() -> None:
+    n = 80
+    matrix, graph = _case(
+        [[2 if i == j else 1 for j in range(n)] for i in range(n)],
+        list(combinations(range(n), 2)),
+    )
+    with pytest.raises(OperationDomainValidationError, match="total local"):
+        decompose_chordal_psd(matrix, graph)
+
+
+def test_height_bound() -> None:
+    # The nontrivial Schur denominator grows beyond 65,536 bits, although
+    # each input scalar is below that limit.
+    matrix, graph = _case(
+        [[1, Fraction(1, 3**22000)], [Fraction(1, 3**22000), Fraction(1, 2**20000)]],
+        [(0, 1)],
+    )
+    with pytest.raises(OperationDomainValidationError, match="height"):
+        decompose_chordal_psd(matrix, graph)
+
+
+def test_large_singleton_and_independent_denominators() -> None:
+    _check(*_case([[Fraction(1, 2**20000)]], []))
+    n = 128
+    rows = [
+        [Fraction(1, 2**128 - 1 + 2 * i) if i == j else 0 for j in range(n)]
+        for i in range(n)
+    ]
+    result = _check(*_case(rows, []))
+    assert len(result.terms) == n
+
+
+def test_extra_zero_edges_do_not_inflate_diagonal_output() -> None:
+    n = 80
+    result = _check(
+        *_case(
+            [[int(i == j) for j in range(n)] for i in range(n)],
+            list(combinations(range(n), 2)),
+        )
+    )
+    assert all(len(term.axes) == 1 for term in result.terms)

--- a/tests/math/matrices/chordal_psd/test_decomposition.py
+++ b/tests/math/matrices/chordal_psd/test_decomposition.py
@@ -154,6 +154,13 @@ def test_retained_source_counts_toward_output_bits() -> None:
         decompose_chordal_psd(matrix, graph)
 
 
+def test_serialized_zero_matrix_scaffolding_is_bounded() -> None:
+    n = 875
+    matrix, graph = _case([[0] * n for _ in range(n)], ())
+    with pytest.raises(OperationDomainValidationError, match="output bit"):
+        decompose_chordal_psd(matrix, graph)
+
+
 def test_height_bound() -> None:
     # The nontrivial Schur denominator grows beyond 65,536 bits, although
     # each input scalar is below that limit.

--- a/tests/mcp/test_chordal_psd_decomposition.py
+++ b/tests/mcp/test_chordal_psd_decomposition.py
@@ -1,0 +1,55 @@
+"""Exact decomposition through the live MCP contract."""
+
+import asyncio
+import json
+
+from jacobian.math.matrices.chordal_psd._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_native_mcp_parity_and_non_psd_recovery() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        async with Client(create_server(), raise_exceptions=False) as client:
+            bad = dict(payload)
+            bad["matrix"] = {
+                "entries": [
+                    [
+                        {"num": "-1", "den": "1"}
+                        if i == j
+                        else {"num": "0", "den": "1"}
+                        for j in range(3)
+                    ]
+                    for i in range(3)
+                ]
+            }
+            rejected = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": bad}
+            )
+            assert rejected.is_error
+            result = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            assert result.structured_content["output"] == tool.run(request).model_dump(
+                mode="json"
+            )
+
+            local = result.structured_content["output"]["terms"][0]["matrix"]
+            inertia = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "matrix.inertia.compute",
+                    "payload": {"matrix": local},
+                },
+            )
+            assert not inertia.is_error
+            assert inertia.structured_content is not None
+            assert inertia.structured_content["output"]["n_positive"] == 1
+            assert inertia.structured_content["output"]["n_negative"] == 0
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Closes #3461. Existing chordal recognition and inertia operations do not allocate overlapping clique contributions of a fully specified sparse PSD matrix. For the path matrix `[[1,1,0],[1,2,1],[0,1,1]]`, summing principal clique blocks incorrectly doubles the central diagonal.

## Outcome

Adds `matrix.chordal_psd.decompose` and native `decompose_chordal_psd`: rational PSD local matrices with ascending original-axis inclusions whose embedded sum reconstructs the retained source exactly. The graph must be chordal and cover every nonzero off-diagonal entry; extra zero-valued edges are allowed. Singular zero pivots emit no term, isolated positive entries retain singleton terms, and zero matrices have an empty sum.

The construction uses rational sparse LDL elimination along a graph-owner perfect elimination ordering, following [Vandenberghe and Andersen, §9.2](https://www.seas.ucla.edu/~vandenbe/publications/chordalsdp.pdf). Positive pivots contribute rational rank-one matrices without square roots. Negative pivots or nonzero rows with zero diagonal reject the input. No partial result is returned. This is distinct from partial-matrix completion; no existing public contract is superseded.

## Validation

- `make affected AFFECTED_BASE=origin/main`: passed: scoped lint/types, 19 math, 156 catalog, 915 catalog/integration, and 72 MCP tests.
- Scoped exhaustive public-operation conformance: `uv run pytest -q -o addopts='' -m exhaustive tests/integration/catalog/test_public_operation_contract_conformance.py -k matrix.chordal_psd.decompose` — 1 passed, 881 deselected.
- Independent mathematical tests reconstruct the source, establish symmetry/rank-one/nonnegative diagonal for every summand, and cover singular/rational/empty cases, axis permutations, invalid support, nonchordal graphs, and accepted/rejected bounds.
- Live MCP tests compare native results, recover after a non-PSD request, and pass a serialized local matrix directly to `matrix.inertia.compute`.
- Native benchmark: 256-vertex nonconstant path, 0.202 seconds / 1,021 output entries; 24-vertex dense clique, 0.048 seconds / 4,900 entries. These measurements calibrate the 60-second shared safety deadline; the admission bounds provide the mathematical work guarantee.
- Final head: `543928d3a`.

## Contract impact

The canonical `RationalMatrix` and `IndexedSimpleUndirectedGraph` carry source and local values. `ChordalPSDDecomposition` retains the source/graph and `CliquePSDTerm` retains the local-axis inclusion. Parsing checks structural shape and axes; the native owner establishes chordality, support, PSD, and reconstruction. Serialization does not assert independently authored claims are PSD.

- [x] Native and MCP behavior agree; canonical output composes through serialization.
- [x] Defining invariant and invalid mathematical input are covered.
- [x] Admission precedes rational elimination; resource rejections remain distinct from mathematical domain errors.
- [x] All mandatory phases share one request deadline.

## Catalog admission

The stable postcondition is an exact clique-supported PSD sum, absent from recognition, principal-submatrix extraction, and fixed-matrix inertia. The implementation reuses graph-owner MCS/PEO kernels and standard-library exact rational arithmetic. The maintained FLINT rational matrix API is dense and does not expose sparse LDL; expanding into dense factorization would discard the active clique structure.

Admission bounds graph/order work, the sum of active clique squares, coefficient height through integer minor bounds, and exact output. Numeric components are admitted independently, and singleton terms copy their existing scalar. Consequently a 20,001-bit rational singleton and 128 unrelated rational diagonals remain accepted. Current caps are 16,777,216 graph work units, 131,072 local entries, 65,536 reduced scalar bits, 128,000,000 predicted output bits, and 10^12 squared-bit arithmetic units. Wider coupled/clique-heavy requests remain outside this execution envelope.

## Review closure

- [x] Substantive findings resolved with accepted large-singleton and independent-denominator regressions.
- [x] Final changed tree validated and public symbols compared with the intended operation.
- [Required CI passed](https://github.com/morluto/jacobian/actions/runs/34169784030/job/101888019571) for the final head.
