### PR TITLE
feat(matrix): complete rational PSD matrices on chordal patterns

### DIFF
--- a/src/jacobian/math/matrices/completion/__init__.py
+++ b/src/jacobian/math/matrices/completion/__init__.py
@@ -1,0 +1,13 @@
+"""Exact positive-semidefinite completion of chordal partial QQ matrices."""
+
+from jacobian.math.matrices.completion._models import (
+    ChordalPSDCompletionResult,
+    PartialSymmetricRationalMatrix,
+)
+from jacobian.math.matrices.completion.operations import complete_chordal_psd
+
+__all__ = [
+    "ChordalPSDCompletionResult",
+    "PartialSymmetricRationalMatrix",
+    "complete_chordal_psd",
+]

--- a/src/jacobian/math/matrices/completion/__init__.py
+++ b/src/jacobian/math/matrices/completion/__init__.py
@@ -2,12 +2,16 @@
 
 from jacobian.math.matrices.completion._models import (
     ChordalPSDCompletionResult,
+    CompletedChordalPSDCompletion,
+    InfeasibleChordalPSDCompletion,
     PartialSymmetricRationalMatrix,
 )
 from jacobian.math.matrices.completion.operations import complete_chordal_psd
 
 __all__ = [
     "ChordalPSDCompletionResult",
+    "CompletedChordalPSDCompletion",
+    "InfeasibleChordalPSDCompletion",
     "PartialSymmetricRationalMatrix",
     "complete_chordal_psd",
 ]

--- a/src/jacobian/math/matrices/completion/_models.py
+++ b/src/jacobian/math/matrices/completion/_models.py
@@ -42,14 +42,14 @@ class ChordalPSDCompletionRequest(StrictModel):
 class CompletedChordalPSDCompletion(StrictModel):
     """A completed rational PSD matrix on the retained source axes."""
 
-    status: Literal["COMPLETED"] = "COMPLETED"
+    status: Literal["COMPLETED"]
     completion: RationalMatrix
 
 
 class InfeasibleChordalPSDCompletion(StrictModel):
     """A specified non-PSD principal clique of the retained source pattern."""
 
-    status: Literal["INFEASIBLE"] = "INFEASIBLE"
+    status: Literal["INFEASIBLE"]
     obstruction_clique: tuple[int, ...] = Field(min_length=1, max_length=1024)
 
 

--- a/src/jacobian/math/matrices/completion/_models.py
+++ b/src/jacobian/math/matrices/completion/_models.py
@@ -1,5 +1,6 @@
 """Partial symmetric rational matrices and their chordal completions."""
 
+from itertools import combinations
 from typing import Literal, Self
 
 from pydantic import Field, model_validator
@@ -64,4 +65,12 @@ class ChordalPSDCompletionResult(StrictModel):
             raise ValueError("obstruction axes must be distinct and sorted")
         if any(not 0 <= i < n for i in self.obstruction_clique):
             raise ValueError("obstruction axes must belong to the source")
+        specified_edges = set(self.matrix.graph.edges)
+        if any(
+            (i, j) not in specified_edges
+            for i, j in combinations(self.obstruction_clique, 2)
+        ):
+            raise ValueError(
+                "obstruction axes must form a clique of specified graph edges"
+            )
         return self

--- a/src/jacobian/math/matrices/completion/_models.py
+++ b/src/jacobian/math/matrices/completion/_models.py
@@ -1,0 +1,67 @@
+"""Partial symmetric rational matrices and their chordal completions."""
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+from jacobian.math.matrices.values import RationalMatrix, SparseRationalMatrixEntry
+
+
+class PartialSymmetricRationalMatrix(StrictModel):
+    """A QQ partial matrix, with graph vertex i bound to matrix axis i.
+
+    Store each specified upper-triangular entry exactly once, in row-major
+    order, including every diagonal and every graph edge. Explicit zeros
+    are specified values; absent off-diagonal coordinates are unknown.
+    """
+
+    domain: Literal["QQ"] = "QQ"
+    graph: IndexedSimpleUndirectedGraph
+    specified_entries: tuple[SparseRationalMatrixEntry, ...] = Field(max_length=66560)
+
+    @model_validator(mode="after")
+    def require_specified_pattern(self) -> Self:
+        coordinates = tuple((e.row, e.column) for e in self.specified_entries)
+        expected = set(self.graph.edges) | {
+            (i, i) for i in range(self.graph.vertex_count)
+        }
+        if coordinates != tuple(sorted(expected)):
+            raise ValueError(
+                "specified entries must be row-major sorted diagonals and graph edges"
+            )
+        return self
+
+
+class ChordalPSDCompletionRequest(StrictModel):
+    matrix: PartialSymmetricRationalMatrix
+
+
+class ChordalPSDCompletionResult(StrictModel):
+    """One exact completion, or a specified non-PSD principal clique.
+
+    The retained source binds the completed axes and specified-entry relation.
+    Parsing checks shape, never replays positivity or completion mathematics.
+    """
+
+    matrix: PartialSymmetricRationalMatrix
+    outcome: Literal["COMPLETED", "INFEASIBLE"]
+    completion: RationalMatrix | None = None
+    obstruction_clique: tuple[int, ...] = Field(default=(), max_length=1024)
+
+    @model_validator(mode="after")
+    def require_result_shape(self) -> Self:
+        n = self.matrix.graph.vertex_count
+        if self.outcome == "COMPLETED":
+            if self.completion is None or self.obstruction_clique:
+                raise ValueError("COMPLETED requires only a completion")
+            if (self.completion.row_count, self.completion.column_count) != (n, n):
+                raise ValueError("completion must retain the source axes")
+        elif self.completion is not None or not self.obstruction_clique:
+            raise ValueError("INFEASIBLE requires only an obstruction clique")
+        if self.obstruction_clique != tuple(sorted(set(self.obstruction_clique))):
+            raise ValueError("obstruction axes must be distinct and sorted")
+        if any(not 0 <= i < n for i in self.obstruction_clique):
+            raise ValueError("obstruction axes must belong to the source")
+        return self

--- a/src/jacobian/math/matrices/completion/_models.py
+++ b/src/jacobian/math/matrices/completion/_models.py
@@ -1,7 +1,7 @@
 """Partial symmetric rational matrices and their chordal completions."""
 
 from itertools import combinations
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, model_validator
 
@@ -39,6 +39,26 @@ class ChordalPSDCompletionRequest(StrictModel):
     matrix: PartialSymmetricRationalMatrix
 
 
+class CompletedChordalPSDCompletion(StrictModel):
+    """A completed rational PSD matrix on the retained source axes."""
+
+    status: Literal["COMPLETED"] = "COMPLETED"
+    completion: RationalMatrix
+
+
+class InfeasibleChordalPSDCompletion(StrictModel):
+    """A specified non-PSD principal clique of the retained source pattern."""
+
+    status: Literal["INFEASIBLE"] = "INFEASIBLE"
+    obstruction_clique: tuple[int, ...] = Field(min_length=1, max_length=1024)
+
+
+ChordalPSDCompletionOutcome = Annotated[
+    CompletedChordalPSDCompletion | InfeasibleChordalPSDCompletion,
+    Field(discriminator="status"),
+]
+
+
 class ChordalPSDCompletionResult(StrictModel):
     """One exact completion, or a specified non-PSD principal clique.
 
@@ -47,29 +67,23 @@ class ChordalPSDCompletionResult(StrictModel):
     """
 
     matrix: PartialSymmetricRationalMatrix
-    outcome: Literal["COMPLETED", "INFEASIBLE"]
-    completion: RationalMatrix | None = None
-    obstruction_clique: tuple[int, ...] = Field(default=(), max_length=1024)
+    outcome: ChordalPSDCompletionOutcome
 
     @model_validator(mode="after")
     def require_result_shape(self) -> Self:
         n = self.matrix.graph.vertex_count
-        if self.outcome == "COMPLETED":
-            if self.completion is None or self.obstruction_clique:
-                raise ValueError("COMPLETED requires only a completion")
-            if (self.completion.row_count, self.completion.column_count) != (n, n):
+        if isinstance(self.outcome, CompletedChordalPSDCompletion):
+            completion = self.outcome.completion
+            if (completion.row_count, completion.column_count) != (n, n):
                 raise ValueError("completion must retain the source axes")
-        elif self.completion is not None or not self.obstruction_clique:
-            raise ValueError("INFEASIBLE requires only an obstruction clique")
-        if self.obstruction_clique != tuple(sorted(set(self.obstruction_clique))):
+            return self
+        clique = self.outcome.obstruction_clique
+        if clique != tuple(sorted(set(clique))):
             raise ValueError("obstruction axes must be distinct and sorted")
-        if any(not 0 <= i < n for i in self.obstruction_clique):
+        if any(not 0 <= i < n for i in clique):
             raise ValueError("obstruction axes must belong to the source")
         specified_edges = set(self.matrix.graph.edges)
-        if any(
-            (i, j) not in specified_edges
-            for i, j in combinations(self.obstruction_clique, 2)
-        ):
+        if any((i, j) not in specified_edges for i, j in combinations(clique, 2)):
             raise ValueError(
                 "obstruction axes must form a clique of specified graph edges"
             )

--- a/src/jacobian/math/matrices/completion/_tools.py
+++ b/src/jacobian/math/matrices/completion/_tools.py
@@ -1,0 +1,53 @@
+"""Exact chordal PSD completion declaration."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.matrices.completion._models import (
+    ChordalPSDCompletionRequest,
+    ChordalPSDCompletionResult,
+)
+from jacobian.math.matrices.completion.operations import complete_chordal_psd
+
+
+def _run(request: ChordalPSDCompletionRequest) -> ChordalPSDCompletionResult:
+    return complete_chordal_psd(request.matrix)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="matrix.chordal_psd_completion.compute",
+        title="Complete a chordal partial rational matrix to PSD",
+        description=(
+            "Construct one exact rational positive-semidefinite completion of a "
+            "partial symmetric matrix with chordal specified pattern and all "
+            "diagonals. Missing entries are distinct from specified zeros. "
+            "Singular separators are supported. Returns the completed QQ matrix "
+            "and its partial source, or a specified non-PSD principal clique. "
+            "Nonchordal patterns are unsupported, never a nonexistence verdict. "
+            "Deterministic MCS/RREF construction; no optimization is promised. "
+            "Admits recognition, clique solves, rational growth and dense output "
+            "(at most 65,536 entries) under a shared 30-second safety deadline."
+        ),
+        request_type=ChordalPSDCompletionRequest,
+        result_type=ChordalPSDCompletionResult,
+        run=_run,
+        tags=("matrix", "chordal", "positive-semidefinite", "completion", "exact"),
+        examples=(
+            OperationExample(
+                name="missing_path_entry",
+                description="Complete two correlated edges; the missing entry becomes 16/25.",
+                input={
+                    "matrix": {
+                        "graph": {"vertex_count": 3, "edges": [[0, 1], [1, 2]]},
+                        "specified_entries": [
+                            {"row": 0, "column": 0, "value": {"num": "1", "den": "1"}},
+                            {"row": 0, "column": 1, "value": {"num": "4", "den": "5"}},
+                            {"row": 1, "column": 1, "value": {"num": "1", "den": "1"}},
+                            {"row": 1, "column": 2, "value": {"num": "4", "den": "5"}},
+                            {"row": 2, "column": 2, "value": {"num": "1", "den": "1"}},
+                        ],
+                    }
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/matrices/completion/operations.py
+++ b/src/jacobian/math/matrices/completion/operations.py
@@ -81,9 +81,10 @@ def _component_budget(
     for q in values:
         checkpoint("during chordal completion denominator clearing")
         denominator = lcm(denominator, q.den)
-    h = max(
-        abs(q.num).bit_length() + (denominator // q.den).bit_length() for q in values
-    )
+    h = 1
+    for q in values:
+        checkpoint("during chordal completion denominator scaling")
+        h = max(h, abs(q.num).bit_length() + (denominator // q.den).bit_length())
     numerator_bits = max(abs(q.num).bit_length() for q in values)
     minors = [k * (h + k.bit_length()) for k in sizes if k]
     # The common output denominator divides D times the product of the

--- a/src/jacobian/math/matrices/completion/operations.py
+++ b/src/jacobian/math/matrices/completion/operations.py
@@ -31,6 +31,8 @@ from jacobian.math.matrices._flint import rational_rref
 from jacobian.math.matrices.analysis.operations import _symmetric_inertia
 from jacobian.math.matrices.completion._models import (
     ChordalPSDCompletionResult,
+    CompletedChordalPSDCompletion,
+    InfeasibleChordalPSDCompletion,
     PartialSymmetricRationalMatrix,
 )
 from jacobian.math.matrices.values import rational_matrix_from_fractions
@@ -194,7 +196,8 @@ def complete_chordal_psd(
         )
         if negative:
             obstruction = ChordalPSDCompletionResult(
-                matrix=matrix, outcome="INFEASIBLE", obstruction_clique=clique
+                matrix=matrix,
+                outcome=InfeasibleChordalPSDCompletion(obstruction_clique=clique),
             )
             checkpoint("after obstruction construction")
             return obstruction
@@ -233,7 +236,8 @@ def complete_chordal_psd(
     checkpoint("before completion serialization")
     completion = rational_matrix_from_fractions(result)
     answer = ChordalPSDCompletionResult(
-        matrix=matrix, outcome="COMPLETED", completion=completion
+        matrix=matrix,
+        outcome=CompletedChordalPSDCompletion(completion=completion),
     )
     checkpoint("after completion serialization")
     return answer

--- a/src/jacobian/math/matrices/completion/operations.py
+++ b/src/jacobian/math/matrices/completion/operations.py
@@ -1,0 +1,239 @@
+"""Exact clique gluing without inverses of singular separators.
+
+Vandenberghe--Andersen, Chordal Graphs and Semidefinite Optimization,
+sections 10.1 and 10.3: PSD specified cliques characterize completability.
+For a simplicial vertex v, solve C x = b on its later-neighbor separator.
+The row x^T A[S,:] extends the already completed remainder. Clique PSD
+ensures range membership and a nonnegative residual at v; any exact
+solution works, including the RREF solution with free coordinates zero.
+"""
+
+import time
+from fractions import Fraction
+from math import lcm
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.graphs.chordal.operations import (
+    _later_clique_failure,
+    _maximum_cardinality_ordering,
+)
+from jacobian.math.matrices._flint import rational_rref
+from jacobian.math.matrices.analysis.operations import _symmetric_inertia
+from jacobian.math.matrices.completion._models import (
+    ChordalPSDCompletionResult,
+    PartialSymmetricRationalMatrix,
+)
+from jacobian.math.matrices.values import rational_matrix_from_fractions
+
+__all__ = ["complete_chordal_psd"]
+
+
+def _reject(message: str) -> OperationDomainValidationError:
+    return OperationDomainValidationError(
+        location=("matrix",), code="matrix.chordal_completion.domain", message=message
+    )
+
+
+def _resource(message: str) -> OperationResourceAdmissionError:
+    return OperationResourceAdmissionError(
+        location=("matrix",), code="matrix.chordal_completion.budget", message=message
+    )
+
+
+def _numeric_components(matrix: PartialSymmetricRationalMatrix) -> list[int]:
+    parents = list(range(matrix.graph.vertex_count))
+
+    def root(v: int) -> int:
+        while parents[v] != v:
+            parents[v] = parents[parents[v]]
+            v = parents[v]
+        return v
+
+    for e in matrix.specified_entries:
+        if e.row != e.column and e.value.num:
+            parents[root(e.row)] = root(e.column)
+    return [root(v) for v in range(len(parents))]
+
+
+def _component_budget(
+    values: list[CanonicalRational], sizes: list[int]
+) -> tuple[int, int]:
+    # Clearing denominators is bounded by the admitted source component bits.
+    # For |B_ij| < 2**h every k-minor is below
+    # 2**(k*(h+ceil(log2(k)))); all RREF solution coefficients share one
+    # pivot-minor denominator, even when the separator is singular.
+    denominator = 1
+    for q in values:
+        denominator = lcm(denominator, q.den)
+    h = max(
+        abs(q.num).bit_length() + (denominator // q.den).bit_length() for q in values
+    )
+    numerator_bits = max(abs(q.num).bit_length() for q in values)
+    minors = [k * (h + k.bit_length()) for k in sizes if k]
+    # The common output denominator divides D times the product of the
+    # separator pivot minors. PSD bounds |A_ij| by the largest diagonal.
+    # Empty separators contribute no determinant and create no growth.
+    output_bits = denominator.bit_length() + sum(minors) + numerator_bits + 2
+    clique_minor = max(
+        ((k + 1) * (h + (k + 1).bit_length()) for k in sizes if k), default=0
+    )
+    # Inertia's Schur fractions are minor ratios; even unreduced 2x2
+    # updates use at most eight minor factors. Gluing partial sums use
+    # the current common denominator, one new pivot minor and log2(k).
+    arithmetic_bits = max(
+        8 * clique_minor,
+        output_bits + 2 * max(minors, default=0) + len(sizes).bit_length(),
+    )
+    work = sum((k + 1) ** 3 + len(sizes) * k for k in sizes)
+    if output_bits > 16000 or arithmetic_bits > 128000:
+        raise _resource("exact completion exceeds rational bit budget")
+    return len(sizes) ** 2 * 2 * output_bits, work * arithmetic_bits**2
+
+
+def _admit(
+    matrix: PartialSymmetricRationalMatrix,
+) -> tuple[tuple[int, ...], dict[int, tuple[int, ...]], list[int]]:
+    n = matrix.graph.vertex_count
+    neighbors: list[set[int]] = [set() for _ in range(n)]
+    for i, j in matrix.graph.edges:
+        neighbors[i].add(j)
+        neighbors[j].add(i)
+    if n * n + sum(len(s) ** 2 for s in neighbors) > 2_000_000:
+        raise _resource("chordal recognition exceeds 2,000,000 adjacency work units")
+    if n * n > 65536:
+        raise _resource("dense completion exceeds 65,536 output entries")
+    ordering = _maximum_cardinality_ordering(n, neighbors)
+    if _later_clique_failure(ordering, neighbors) is not None:
+        raise _reject("the specified pattern must be chordal; no fill-in is performed")
+    component = _numeric_components(matrix)
+    position = {v: i for i, v in enumerate(ordering)}
+    # Across numeric components all specified entries are zero. Choose zero
+    # also for missing cross entries. Restricting a PEO to each induced
+    # component remains a PEO, including extra zero-valued graph edges.
+    separators = {
+        v: tuple(
+            sorted(
+                w
+                for w in neighbors[v]
+                if position[w] > position[v] and component[w] == component[v]
+            )
+        )
+        for v in ordering
+    }
+    input_bits = sum(
+        abs(e.value.num).bit_length() + e.value.den.bit_length()
+        for e in matrix.specified_entries
+    )
+    if input_bits > 1_000_000:
+        raise _resource("source exceeds 1,000,000 rational component bits")
+    grouped: dict[int, list[CanonicalRational]] = {c: [] for c in component}
+    sizes: dict[int, list[int]] = {c: [] for c in component}
+    for e in matrix.specified_entries:
+        if component[e.row] == component[e.column]:
+            grouped[component[e.row]].append(e.value)
+    for v, separator in separators.items():
+        sizes[component[v]].append(len(separator))
+    budgets = [_component_budget(values, sizes[c]) for c, values in grouped.items()]
+    if n * n + sum(bits for bits, _ in budgets) > 64_000_000:
+        raise _resource("exact completion exceeds dense-output bit budget")
+    if sum(work for _, work in budgets) > 1_000_000_000_000:
+        raise _resource(
+            "exact clique solves and gluing exceed rational arithmetic budget"
+        )
+    return ordering, separators, component
+
+
+def complete_chordal_psd(
+    matrix: PartialSymmetricRationalMatrix,
+) -> ChordalPSDCompletionResult:
+    """Complete a chordal partial matrix over QQ, or return a non-PSD clique.
+
+    MCS ties use smallest vertex indices; each RREF solve sets free coordinates
+    to zero. No minimum-rank, norm, or determinant optimum is promised.
+    Nonchordal patterns are domain errors; resource excess is an execution rejection.
+    """
+    if not isinstance(matrix, PartialSymmetricRationalMatrix):
+        raise TypeError("complete_chordal_psd expects PartialSymmetricRationalMatrix")
+    execution = current_request_execution()
+    started = execution.started_at if execution is not None else time.monotonic()
+    deadline = started + 30.0
+    if execution is not None and execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+
+    def checkpoint(phase: str) -> None:
+        request_checkpoint(phase)
+        if time.monotonic() >= deadline:
+            raise OperationExecutionTimeoutError(f"completion deadline expired {phase}")
+
+    checkpoint("before admission")
+    ordering, separators, component = _admit(matrix)
+    checkpoint("after admission")
+    n = matrix.graph.vertex_count
+    source = {
+        (e.row, e.column): e.value.as_fraction() for e in matrix.specified_entries
+    }
+
+    def entry(i: int, j: int) -> Fraction:
+        return source[min(i, j), max(i, j)]
+
+    for v in ordering:
+        clique = tuple(sorted((v, *separators[v])))
+        _, negative, _ = _symmetric_inertia(
+            [[entry(i, j) for j in clique] for i in clique], checkpoint=checkpoint
+        )
+        if negative:
+            obstruction = ChordalPSDCompletionResult(
+                matrix=matrix, outcome="INFEASIBLE", obstruction_clique=clique
+            )
+            checkpoint("after obstruction construction")
+            return obstruction
+    result = [[Fraction() for _ in range(n)] for _ in range(n)]
+    processed: list[int] = []
+    for v in reversed(ordering):
+        checkpoint("during separator gluing")
+        separator = separators[v]
+        coefficients = [Fraction() for _ in separator]
+        if separator:
+            augmented = tuple(
+                (*(entry(i, j) for j in separator), entry(i, v)) for i in separator
+            )
+            reduced, rank = rational_rref(augmented)
+            checkpoint("after exact separator solve")
+            for row in reduced[:rank]:
+                pivot = next(i for i, value in enumerate(row) if value)
+                if pivot == len(separator):
+                    raise ArithmeticError(
+                        "PSD clique violated separator range condition"
+                    )
+                coefficients[pivot] = row[-1]
+        for j in processed:
+            if component[v] != component[j]:
+                continue
+            value = sum(
+                (
+                    x * result[s][j]
+                    for s, x in zip(separator, coefficients, strict=True)
+                ),
+                Fraction(),
+            )
+            result[v][j] = result[j][v] = value
+        result[v][v] = entry(v, v)
+        processed.append(v)
+    checkpoint("before completion serialization")
+    completion = rational_matrix_from_fractions(result)
+    answer = ChordalPSDCompletionResult(
+        matrix=matrix, outcome="COMPLETED", completion=completion
+    )
+    checkpoint("after completion serialization")
+    return answer

--- a/src/jacobian/math/matrices/completion/operations.py
+++ b/src/jacobian/math/matrices/completion/operations.py
@@ -9,6 +9,7 @@ solution works, including the RREF solution with free coordinates zero.
 """
 
 import time
+from collections.abc import Callable
 from fractions import Fraction
 from math import lcm
 
@@ -68,7 +69,9 @@ def _numeric_components(matrix: PartialSymmetricRationalMatrix) -> list[int]:
 
 
 def _component_budget(
-    values: list[CanonicalRational], sizes: list[int]
+    values: list[CanonicalRational],
+    sizes: list[int],
+    checkpoint: Callable[[str], None],
 ) -> tuple[int, int]:
     # Clearing denominators is bounded by the admitted source component bits.
     # For |B_ij| < 2**h every k-minor is below
@@ -76,6 +79,7 @@ def _component_budget(
     # pivot-minor denominator, even when the separator is singular.
     denominator = 1
     for q in values:
+        checkpoint("during chordal completion denominator clearing")
         denominator = lcm(denominator, q.den)
     h = max(
         abs(q.num).bit_length() + (denominator // q.den).bit_length() for q in values
@@ -145,7 +149,10 @@ def _admit(
             grouped[component[e.row]].append(e.value)
     for v, separator in separators.items():
         sizes[component[v]].append(len(separator))
-    budgets = [_component_budget(values, sizes[c]) for c, values in grouped.items()]
+    budgets = [
+        _component_budget(values, sizes[c], request_checkpoint)
+        for c, values in grouped.items()
+    ]
     if n * n + sum(bits for bits, _ in budgets) > 64_000_000:
         raise _resource("exact completion exceeds dense-output bit budget")
     if sum(work for _, work in budgets) > 1_000_000_000_000:
@@ -197,7 +204,9 @@ def complete_chordal_psd(
         if negative:
             obstruction = ChordalPSDCompletionResult(
                 matrix=matrix,
-                outcome=InfeasibleChordalPSDCompletion(obstruction_clique=clique),
+                outcome=InfeasibleChordalPSDCompletion(
+                    status="INFEASIBLE", obstruction_clique=clique
+                ),
             )
             checkpoint("after obstruction construction")
             return obstruction
@@ -237,7 +246,9 @@ def complete_chordal_psd(
     completion = rational_matrix_from_fractions(result)
     answer = ChordalPSDCompletionResult(
         matrix=matrix,
-        outcome=CompletedChordalPSDCompletion(completion=completion),
+        outcome=CompletedChordalPSDCompletion(
+            status="COMPLETED", completion=completion
+        ),
     )
     checkpoint("after completion serialization")
     return answer

--- a/tests/integration/catalog/test_chordal_psd_completion.py
+++ b/tests/integration/catalog/test_chordal_psd_completion.py
@@ -1,0 +1,30 @@
+"""Dispatch, canonical output and schema parity for exact completion."""
+
+import json
+
+from jsonschema import validate
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import invoke_operation
+from jacobian.math.matrices.completion import complete_chordal_psd
+from jacobian.math.matrices.completion._models import (
+    ChordalPSDCompletionRequest,
+    ChordalPSDCompletionResult,
+)
+from jacobian.math.matrices.completion._tools import TOOLS
+
+
+def test_public_completion_native_parity_and_matrix_composition() -> None:
+    payload = TOOLS[0].examples[0].input
+    validate(payload, ChordalPSDCompletionRequest.model_json_schema())
+    source = ChordalPSDCompletionRequest.model_validate_json(json.dumps(payload)).matrix
+    native = complete_chordal_psd(source).model_dump(mode="json")
+    catalog = Catalog.open()
+    wire = invoke_operation("matrix.chordal_psd_completion.compute", payload, catalog)
+    assert wire.output == native
+    validate(wire.output, ChordalPSDCompletionResult.model_json_schema())
+    inertia = invoke_operation(
+        "matrix.inertia.compute", {"matrix": wire.output["completion"]}, catalog
+    )
+    assert inertia.output["n_positive"] == 3
+    assert inertia.output["n_negative"] == 0

--- a/tests/integration/catalog/test_chordal_psd_completion.py
+++ b/tests/integration/catalog/test_chordal_psd_completion.py
@@ -24,7 +24,9 @@ def test_public_completion_native_parity_and_matrix_composition() -> None:
     assert wire.output == native
     validate(wire.output, ChordalPSDCompletionResult.model_json_schema())
     inertia = invoke_operation(
-        "matrix.inertia.compute", {"matrix": wire.output["completion"]}, catalog
+        "matrix.inertia.compute",
+        {"matrix": wire.output["outcome"]["completion"]},
+        catalog,
     )
     assert inertia.output["n_positive"] == 3
     assert inertia.output["n_negative"] == 0

--- a/tests/math/matrices/completion/test_completion.py
+++ b/tests/math/matrices/completion/test_completion.py
@@ -121,7 +121,14 @@ def test_degenerate_and_obstructed_patterns(rows: list[list[int | None]]) -> Non
         assert obstruction.is_positive_semidefinite is False
 
 
-def test_nonchordal_is_unsupported_not_infeasible() -> None:
+def test_authored_obstruction_must_be_a_specified_clique() -> None:
+    source = partial([[1, 1, None], [1, 1, 1], [None, 1, 1]])
+    with pytest.raises(ValidationError, match="specified graph edges"):
+        ChordalPSDCompletionResult(
+            matrix=source,
+            outcome="INFEASIBLE",
+            obstruction_clique=(0, 2),
+        )
     source = partial(
         [[1, 0, None, 0], [0, 1, 0, None], [None, 0, 1, 0], [0, None, 0, 1]]
     )

--- a/tests/math/matrices/completion/test_completion.py
+++ b/tests/math/matrices/completion/test_completion.py
@@ -12,6 +12,8 @@ from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices.completion import (
     ChordalPSDCompletionResult,
+    CompletedChordalPSDCompletion,
+    InfeasibleChordalPSDCompletion,
     PartialSymmetricRationalMatrix,
     complete_chordal_psd,
 )
@@ -46,10 +48,12 @@ def partial(
 
 
 def exact(result: ChordalPSDCompletionResult) -> Matrix:
-    assert result.outcome == "COMPLETED"
-    assert result.completion is not None
+    assert isinstance(result.outcome, CompletedChordalPSDCompletion)
     answer = Matrix(
-        [[Rational(q.num, q.den) for q in row] for row in result.completion.entries]
+        [
+            [Rational(q.num, q.den) for q in row]
+            for row in result.outcome.completion.entries
+        ]
     )
     for e in result.matrix.specified_entries:
         assert answer[e.row, e.column] == Rational(e.value.num, e.value.den)
@@ -69,8 +73,9 @@ def test_missing_path_entry_is_not_zero() -> None:
     assert completed.det() == Rational(81, 625)
     source_zero = partial([[1, q, 0], [q, 1, q], [0, q, 1]])
     rejected = complete_chordal_psd(source_zero)
-    assert rejected.outcome == "INFEASIBLE"
-    assert rejected.obstruction_clique == (0, 1, 2)
+    assert rejected.outcome.status == "INFEASIBLE"
+    assert isinstance(rejected.outcome, InfeasibleChordalPSDCompletion)
+    assert rejected.outcome.obstruction_clique == (0, 1, 2)
     for item in (source, source_zero):
         assert (
             PartialSymmetricRationalMatrix.model_validate_json(item.model_dump_json())
@@ -113,12 +118,21 @@ def test_singular_separator_all_axis_permutations() -> None:
 )
 def test_degenerate_and_obstructed_patterns(rows: list[list[int | None]]) -> None:
     result = complete_chordal_psd(partial(rows))
-    if result.outcome == "COMPLETED":
+    if isinstance(result.outcome, CompletedChordalPSDCompletion):
         exact(result)
     else:
-        axes = result.obstruction_clique
+        axes = result.outcome.obstruction_clique
         obstruction = Matrix([[rows[i][j] for j in axes] for i in axes])
         assert obstruction.is_positive_semidefinite is False
+
+
+def test_result_schema_rejects_completed_without_completion() -> None:
+    payload = {
+        "matrix": partial([[1]]).model_dump(mode="json"),
+        "outcome": {"status": "COMPLETED"},
+    }
+    with pytest.raises(ValidationError):
+        ChordalPSDCompletionResult.model_validate(payload)
 
 
 def test_authored_obstruction_must_be_a_specified_clique() -> None:
@@ -126,9 +140,11 @@ def test_authored_obstruction_must_be_a_specified_clique() -> None:
     with pytest.raises(ValidationError, match="specified graph edges"):
         ChordalPSDCompletionResult(
             matrix=source,
-            outcome="INFEASIBLE",
-            obstruction_clique=(0, 2),
+            outcome=InfeasibleChordalPSDCompletion(obstruction_clique=(0, 2)),
         )
+
+
+def test_nonchordal_is_unsupported_not_infeasible() -> None:
     source = partial(
         [[1, 0, None, 0], [0, 1, 0, None], [None, 0, 1, 0], [0, None, 0, 1]]
     )
@@ -165,9 +181,9 @@ def test_useful_sparse_path_scale() -> None:
         ]
     )
     result = complete_chordal_psd(source)
-    assert result.completion is not None
+    assert isinstance(result.outcome, CompletedChordalPSDCompletion)
     # This Toeplitz covariance has LDL pivots 1, 1-q², ..., 1-q².
-    for i, row in enumerate(result.completion.entries):
+    for i, row in enumerate(result.outcome.completion.entries):
         assert all(
             value.as_fraction() == q ** abs(i - j) for j, value in enumerate(row)
         )
@@ -195,8 +211,8 @@ def test_overlapping_gram_cliques_with_negative_correlations() -> None:
 def test_large_singleton_has_no_separator_growth() -> None:
     source = partial([[10**3000]])
     result = complete_chordal_psd(source)
-    assert result.completion is not None
-    assert result.completion.entries[0][0].num == 10**3000
+    assert isinstance(result.outcome, CompletedChordalPSDCompletion)
+    assert result.outcome.completion.entries[0][0].num == 10**3000
 
 
 def test_independent_diagonal_denominators_do_not_accumulate() -> None:
@@ -206,9 +222,10 @@ def test_independent_diagonal_denominators_do_not_accumulate() -> None:
         [[diagonal[i] if i == j else None for j in range(n)] for i in range(n)]
     )
     result = complete_chordal_psd(source)
-    assert result.completion is not None
+    assert isinstance(result.outcome, CompletedChordalPSDCompletion)
     assert all(
-        result.completion.entries[i][i].as_fraction() == diagonal[i] for i in range(n)
+        result.outcome.completion.entries[i][i].as_fraction() == diagonal[i]
+        for i in range(n)
     )
 
 

--- a/tests/math/matrices/completion/test_completion.py
+++ b/tests/math/matrices/completion/test_completion.py
@@ -135,12 +135,27 @@ def test_result_schema_rejects_completed_without_completion() -> None:
         ChordalPSDCompletionResult.model_validate(payload)
 
 
+def test_outcome_discriminator_is_required_in_schema() -> None:
+    completed = CompletedChordalPSDCompletion.model_json_schema()
+    infeasible = InfeasibleChordalPSDCompletion.model_json_schema()
+    assert "status" in completed.get("required", [])
+    assert "status" in infeasible.get("required", [])
+    payload = {
+        "matrix": partial([[1]]).model_dump(mode="json"),
+        "outcome": {"completion": partial([[1]]).model_dump(mode="json")},
+    }
+    with pytest.raises(ValidationError):
+        ChordalPSDCompletionResult.model_validate(payload)
+
+
 def test_authored_obstruction_must_be_a_specified_clique() -> None:
     source = partial([[1, 1, None], [1, 1, 1], [None, 1, 1]])
     with pytest.raises(ValidationError, match="specified graph edges"):
         ChordalPSDCompletionResult(
             matrix=source,
-            outcome=InfeasibleChordalPSDCompletion(obstruction_clique=(0, 2)),
+            outcome=InfeasibleChordalPSDCompletion(
+                status="INFEASIBLE", obstruction_clique=(0, 2)
+            ),
         )
 
 

--- a/tests/math/matrices/completion/test_completion.py
+++ b/tests/math/matrices/completion/test_completion.py
@@ -1,0 +1,213 @@
+"""Independent exact evidence for chordal PSD completion."""
+
+from collections.abc import Sequence
+from fractions import Fraction
+from itertools import combinations, permutations
+
+import pytest
+from pydantic import ValidationError
+from sympy import Matrix, Rational
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.matrices.completion import (
+    ChordalPSDCompletionResult,
+    PartialSymmetricRationalMatrix,
+    complete_chordal_psd,
+)
+
+
+def partial(
+    rows: Sequence[Sequence[int | Fraction | None]],
+) -> PartialSymmetricRationalMatrix:
+    return PartialSymmetricRationalMatrix.model_validate(
+        {
+            "graph": {
+                "vertex_count": len(rows),
+                "edges": [
+                    [i, j]
+                    for i in range(len(rows))
+                    for j in range(i + 1, len(rows))
+                    if rows[i][j] is not None
+                ],
+            },
+            "specified_entries": [
+                {
+                    "row": i,
+                    "column": j,
+                    "value": CanonicalRational.from_fraction(Fraction(str(rows[i][j]))),
+                }
+                for i in range(len(rows))
+                for j in range(i, len(rows))
+                if rows[i][j] is not None
+            ],
+        }
+    )
+
+
+def exact(result: ChordalPSDCompletionResult) -> Matrix:
+    assert result.outcome == "COMPLETED"
+    assert result.completion is not None
+    answer = Matrix(
+        [[Rational(q.num, q.den) for q in row] for row in result.completion.entries]
+    )
+    for e in result.matrix.specified_entries:
+        assert answer[e.row, e.column] == Rational(e.value.num, e.value.den)
+    assert answer == answer.T
+    # All principal minors, not merely leading minors, characterize PSD.
+    for size in range(1, answer.rows + 1):
+        for axes in combinations(range(answer.rows), size):
+            assert answer.extract(axes, axes).det() >= 0
+    return answer
+
+
+def test_missing_path_entry_is_not_zero() -> None:
+    q = Fraction(4, 5)
+    source = partial([[1, q, None], [q, 1, q], [None, q, 1]])
+    completed = exact(complete_chordal_psd(source))
+    assert completed[0, 2] == Rational(16, 25)
+    assert completed.det() == Rational(81, 625)
+    source_zero = partial([[1, q, 0], [q, 1, q], [0, q, 1]])
+    rejected = complete_chordal_psd(source_zero)
+    assert rejected.outcome == "INFEASIBLE"
+    assert rejected.obstruction_clique == (0, 1, 2)
+    for item in (source, source_zero):
+        assert (
+            PartialSymmetricRationalMatrix.model_validate_json(item.model_dump_json())
+            == item
+        )
+    assert source.model_dump_json() != source_zero.model_dump_json()
+
+
+def test_singular_separator_all_axis_permutations() -> None:
+    rows: list[list[int | None]] = [
+        [2, 1, 1, None],
+        [1, 1, 1, 2],
+        [1, 1, 1, 2],
+        [None, 2, 2, 5],
+    ]
+    for perm in permutations(range(4)):
+        source = partial([[rows[i][j] for j in perm] for i in perm])
+        result = complete_chordal_psd(source)
+        answer = exact(result)
+        assert answer[perm.index(0), perm.index(3)] == 2
+        assert answer.rank() == 3
+        assert (
+            ChordalPSDCompletionResult.model_validate_json(result.model_dump_json())
+            == result
+        )
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [],
+        [[0]],
+        [[-1]],
+        [[0, 1], [1, 0]],
+        [[1, 0, None], [0, 0, 0], [None, 0, 2]],
+        [[1, None, None], [None, 0, None], [None, None, 2]],
+        [[1, 1, None], [1, 1, None], [None, None, 0]],
+        [[1, 2, None], [2, 1, 0], [None, 0, 1]],
+    ],
+)
+def test_degenerate_and_obstructed_patterns(rows: list[list[int | None]]) -> None:
+    result = complete_chordal_psd(partial(rows))
+    if result.outcome == "COMPLETED":
+        exact(result)
+    else:
+        axes = result.obstruction_clique
+        obstruction = Matrix([[rows[i][j] for j in axes] for i in axes])
+        assert obstruction.is_positive_semidefinite is False
+
+
+def test_nonchordal_is_unsupported_not_infeasible() -> None:
+    source = partial(
+        [[1, 0, None, 0], [0, 1, 0, None], [None, 0, 1, 0], [0, None, 0, 1]]
+    )
+    with pytest.raises(OperationDomainValidationError, match="must be chordal"):
+        complete_chordal_psd(source)
+
+
+@pytest.mark.parametrize(
+    "mutation", ["missing_diagonal", "extra_entry", "duplicate", "ordering"]
+)
+def test_structural_pattern_rejects_malformed_source(mutation: str) -> None:
+    payload = partial([[1, None], [None, 1]]).model_dump(mode="json")
+    if mutation == "missing_diagonal":
+        payload["specified_entries"].pop()
+    elif mutation == "extra_entry":
+        payload["specified_entries"].insert(
+            1, {"row": 0, "column": 1, "value": {"num": "0", "den": "1"}}
+        )
+    elif mutation == "duplicate":
+        payload["specified_entries"].append(payload["specified_entries"][0])
+    else:
+        payload["elimination_ordering"] = [0, 1]
+    with pytest.raises(ValidationError):
+        PartialSymmetricRationalMatrix.model_validate(payload)
+
+
+def test_useful_sparse_path_scale() -> None:
+    n = 128
+    q = Fraction(4, 5)
+    source = partial(
+        [
+            [1 if i == j else q if abs(i - j) == 1 else None for j in range(n)]
+            for i in range(n)
+        ]
+    )
+    result = complete_chordal_psd(source)
+    assert result.completion is not None
+    # This Toeplitz covariance has LDL pivots 1, 1-q², ..., 1-q².
+    for i, row in enumerate(result.completion.entries):
+        assert all(
+            value.as_fraction() == q ** abs(i - j) for j, value in enumerate(row)
+        )
+
+
+def test_excessive_dense_output_rejected_before_expansion() -> None:
+    n = 257
+    source = partial([[1 if i == j else None for j in range(n)] for i in range(n)])
+    with pytest.raises(OperationDomainValidationError, match="output entries"):
+        complete_chordal_psd(source)
+
+
+def test_overlapping_gram_cliques_with_negative_correlations() -> None:
+    vectors = Matrix([[1, 2], [2, -1], [0, 1], [-1, 3], [2, 2]])
+    gram = vectors * vectors.T
+    source = partial(
+        [
+            [int(gram[i, j]) if abs(i - j) <= 2 else None for j in range(5)]
+            for i in range(5)
+        ]
+    )
+    exact(complete_chordal_psd(source))
+
+
+def test_large_singleton_has_no_separator_growth() -> None:
+    source = partial([[10**3000]])
+    result = complete_chordal_psd(source)
+    assert result.completion is not None
+    assert result.completion.entries[0][0].num == 10**3000
+
+
+def test_independent_diagonal_denominators_do_not_accumulate() -> None:
+    n = 128
+    diagonal = [Fraction(1, 2**128 - 1 + 2 * i) for i in range(n)]
+    source = partial(
+        [[diagonal[i] if i == j else None for j in range(n)] for i in range(n)]
+    )
+    result = complete_chordal_psd(source)
+    assert result.completion is not None
+    assert all(
+        result.completion.entries[i][i].as_fraction() == diagonal[i] for i in range(n)
+    )
+
+
+def test_coupled_rational_growth_rejection() -> None:
+    large = 10**3000
+    with pytest.raises(OperationDomainValidationError, match="bit budget"):
+        complete_chordal_psd(
+            partial([[large, 1, None], [1, large, 1], [None, 1, large]])
+        )

--- a/tests/mcp/test_chordal_psd_completion.py
+++ b/tests/mcp/test_chordal_psd_completion.py
@@ -1,0 +1,56 @@
+"""Completion resource errors and successful values through MCP."""
+
+import asyncio
+import json
+
+from mcp.types import TextContent
+
+from jacobian.math.matrices.completion._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_resource_rejection_and_completion_recovery() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        too_large = {
+            "matrix": {
+                "graph": {"vertex_count": 257, "edges": []},
+                "specified_entries": [
+                    {"row": i, "column": i, "value": {"num": "1", "den": "1"}}
+                    for i in range(257)
+                ],
+            }
+        }
+        async with Client(create_server(), raise_exceptions=False) as client:
+            rejected = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": too_large,
+                },
+            )
+            assert rejected.is_error
+            content = rejected.content[0]
+            assert isinstance(content, TextContent)
+            failure = json.loads(
+                content.text.removeprefix("Error executing tool math.run: ")
+            )
+            assert failure["code"] == "RESOURCE_ADMISSION_REJECTED"
+            assert failure["stage"] == "resource_admission"
+            result = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": payload,
+                },
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            assert result.structured_content["output"] == tool.run(request).model_dump(
+                mode="json"
+            )
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Closes #3460. Chordal recognition and fixed-matrix inertia do not construct the missing entries of a rational PSD-completable partial matrix. Zero filling the issue's path fixture is indefinite.

## Outcome

Publish `matrix.chordal_psd_completion.compute` and native `complete_chordal_psd`. The new `PartialSymmetricRationalMatrix` retains the indexed graph, all specified upper-triangular entries (including zeros), and the binding of graph vertex i to matrix axis i. Results retain that source and contain either an ordinary `RationalMatrix` completion or a non-PSD specified principal clique. Nonchordal patterns are unsupported domain inputs; resource excess is a distinct operational rejection.

The kernel reuses chordal MCS/PEO recognition, exact rational inertia, and the existing FLINT RREF adapter. Backward elimination solves `C x = b` on each separator and glues `x^T A[S,:]`, allowing singular C. Numeric components are independent; missing cross-component entries become zero. No existing contract is superseded, and no optimization objective is promised.

The mathematical reference is [Chordal Graphs and Semidefinite Optimization, sections 10.1 and 10.3](https://www.seas.ucla.edu/~vandenbe/publications/chordalsdp.pdf); the maintained backend is python-flint 0.9.0, using its [exact rational RREF](https://python-flint.readthedocs.io/en/latest/fmpq_mat.html).

## Validation

- `make affected AFFECTED_BASE=origin/main`: scoped lint/typecheck, mathematical owner, catalog, catalog integration, and MCP lanes.
- `uv run pytest tests/integration/catalog/test_public_operation_contract_conformance.py -m exhaustive -k chordal_psd_completion --timeout=120 -q`: 1 passed.
- Native/dispatch schema parity and serialized completion-to-inertia composition pass. The live MCP test verifies resource-admission rejection followed by successful recovery and native equality.
- Independent evidence checks every principal minor on small fixtures, all 24 permutations of the singular separator, exact specified-entry preservation, rank, and strict JSON round trips. The 128-vertex correlation path matches `(4/5)**abs(i-j)` entrywise (about 0.25 seconds locally).
- Final head SHA tested: 563a615fcf32c9af5a8658a0a9286d92b9e1a556
- Hosted CI: [required passed](https://github.com/morluto/jacobian/actions/runs/34169839298/job/101888279668) for the tested head.

## Contract impact

- [x] Structural parsing and generated schemas describe canonical values; cross-field shape constraints are enforced by structural validators.
- [x] Admission precedes rational matrix kernels and dense output expansion.
- [x] Exact results fit canonical rational matrix and scalar carriers, including the empty matrix.
- [x] Admission, kernels, and result construction share a 30-second cooperative safety deadline.
- [x] Native and MCP results agree; serialized producer-to-consumer composition and defining invariants are tested.

## Review closure

- [x] Substantive findings are repaired with accepted singleton/independent-component regressions and resource-recovery evidence.
- [x] Validation covers the final changed tree and the affected specialist lane.
- [x] Existing canonical values and private kernels are reused; no compatibility paths or unrelated changes.
- Hosted required CI passed for this head.

## Conditional detail

### Operation boundary

The matrix completion owner admits graph work, per-component denominator clearing, clique inertia and separator solves, intermediate rational height, and dense output. Limits are 2,000,000 graph-work units, 65,536 dense entries, 1,000,000 source component bits, 16,000 predicted bits per output rational component, 128,000 intermediate bits, 64,000,000 total output bits, and 10^12 bit-weighted rational work units. These are implementation resource ceilings, not mathematical nonexistence claims. The 30-second cooperative safety margin is over 100 times the measured 128-vertex path test; no caller-selectable algorithm or deadline parameter is added.

Denominator/minor bounds are computed independently per numeric component. RREF coefficients share a pivot-minor denominator; the completed common denominator divides the source denominator times the product of these determinants. PSD bounds completed magnitudes by source diagonals. Empty separators introduce no growth. Large singleton scalars and independent rational diagonals remain accepted; coupled growth and excessive dense output are rejected before kernels.

No authored ordering or clique-tree claim is accepted. Parsing and result construction check shape, never repeat positivity or solve mathematics. The producer establishes the completion relation; an inertia consumer independently admits and checks the returned matrix.

### Canonical value audit

- [x] Reuse `IndexedSimpleUndirectedGraph`, `SparseRationalMatrixEntry` coordinate triples, `CanonicalRational`, and `RationalMatrix`.
- [x] Partial matrices intentionally distinguish unspecified entries from numeric zeros; sparse matrices cannot carry that meaning.
- [x] Retain original axes, empty cases, specified entries, and exact QQ values through serialization.
- The zero-filled path is structurally valid but returns an `INFEASIBLE` clique. Nonchordal input produces a domain error. `COMPLETED` requires an n-by-n completion and no obstruction; `INFEASIBLE` requires a nonempty obstruction and no completion.

### Catalog admission

The independent reusable result is an exact rational PSD completion, or a local specified-clique obstruction, on admitted chordal partial matrices with all diagonals. Existing recognition and fixed-matrix analysis operations cannot supply the missing entries. The operation publishes one stable construction postcondition; algorithms remain private. Both issue fixtures succeed, including the singular separator. Dense output and rational arithmetic remain the limiting resources; this PR does not add graph fill-in or an SDP workflow.

Residual scope: none for #3460.
