### PR TITLE
feat(graph): add fixed-side Dulmage-Mendelsohn decomposition

### DIFF
--- a/src/jacobian/math/graphs/bipartite/__init__.py
+++ b/src/jacobian/math/graphs/bipartite/__init__.py
@@ -1,0 +1,15 @@
+"""Fixed-side bipartite graphs and Dulmage--Mendelsohn decomposition."""
+
+from jacobian.math.graphs.bipartite._models import DulmageMendelsohnDecomposition
+from jacobian.math.graphs.bipartite.operations import dulmage_mendelsohn
+from jacobian.math.graphs.bipartite.values import (
+    BipartiteVertexRegion,
+    FixedBipartiteGraph,
+)
+
+__all__ = [
+    "BipartiteVertexRegion",
+    "DulmageMendelsohnDecomposition",
+    "FixedBipartiteGraph",
+    "dulmage_mendelsohn",
+]

--- a/src/jacobian/math/graphs/bipartite/_models.py
+++ b/src/jacobian/math/graphs/bipartite/_models.py
@@ -1,0 +1,71 @@
+"""Dulmage--Mendelsohn decomposition contracts."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.bipartite.values import (
+    BipartiteVertexRegion,
+    FixedBipartiteGraph,
+    Vertex,
+)
+
+
+class DulmageMendelsohnRequest(StrictModel):
+    graph: FixedBipartiteGraph
+
+
+class DulmageMendelsohnDecomposition(StrictModel):
+    """Source-bound deficient regions and balanced elementary blocks.
+
+    Orient all edges left→right and matching edges also right→left.
+    left_excess is reachable from unmatched left vertices; right_excess
+    reaches unmatched right vertices. Balanced blocks are SCCs on the
+    remainder, labelled by earliest input-left position. Vertex tuples
+    retain their input-side order. condensation_edges contains every direct
+    inter-block arc, not transitive closure or a chosen topological order.
+    These structural sets and arcs are independent of the maximum matching.
+    """
+
+    graph: FixedBipartiteGraph
+    structural_rank: int = Field(ge=0, le=512)
+    left_excess: BipartiteVertexRegion
+    right_excess: BipartiteVertexRegion
+    balanced_blocks: tuple[BipartiteVertexRegion, ...] = Field(max_length=512)
+    condensation_edges: tuple[tuple[Vertex, Vertex], ...] = Field(max_length=65536)
+
+    @model_validator(mode="after")
+    def require_partition_shape(self) -> Self:
+        left = self.graph.left_vertices
+        right = self.graph.right_vertices
+        regions = (self.left_excess, self.right_excess, *self.balanced_blocks)
+        for source, field in ((left, "left_vertices"), (right, "right_vertices")):
+            positions = {v: i for i, v in enumerate(source)}
+            flat = tuple(v for region in regions for v in getattr(region, field))
+            if len(flat) != len(source) or set(flat) != set(source):
+                raise ValueError("regions must partition each original side")
+            for region in regions:
+                members = getattr(region, field)
+                if members != tuple(sorted(members, key=positions.__getitem__)):
+                    raise ValueError("region vertices must retain input-side order")
+        if any(
+            not block.left_vertices
+            or len(block.left_vertices) != len(block.right_vertices)
+            for block in self.balanced_blocks
+        ):
+            raise ValueError("balanced blocks must be nonempty with equal side sizes")
+        left_position = {v: i for i, v in enumerate(left)}
+        first = [
+            left_position[block.left_vertices[0]] for block in self.balanced_blocks
+        ]
+        if first != sorted(first):
+            raise ValueError("balanced blocks must be ordered by first left position")
+        if self.condensation_edges != tuple(sorted(set(self.condensation_edges))):
+            raise ValueError("condensation edges must be distinct and sorted")
+        k = len(self.balanced_blocks)
+        if any(a == b or a >= k or b >= k for a, b in self.condensation_edges):
+            raise ValueError("condensation edges must join distinct balanced blocks")
+        if self.structural_rank > min(len(left), len(right)):
+            raise ValueError("structural rank cannot exceed either side")
+        return self

--- a/src/jacobian/math/graphs/bipartite/_tools.py
+++ b/src/jacobian/math/graphs/bipartite/_tools.py
@@ -43,7 +43,7 @@ TOOLS: MathTools = (
         examples=(
             OperationExample(
                 name="triangular_pattern",
-                description="The 2-by-2 triangular pattern has two balanced blocks and the arc 0→1.",
+                description="Compute the Dulmage-Mendelsohn decomposition of the 2-by-2 triangular pattern, yielding two balanced blocks and the arc 0→1; the declared sides must partition every vertex and every edge must cross those sides.",
                 input={
                     "graph": {
                         "graph": {"vertex_count": 4, "edges": [[0, 2], [0, 3], [1, 3]]},

--- a/src/jacobian/math/graphs/bipartite/_tools.py
+++ b/src/jacobian/math/graphs/bipartite/_tools.py
@@ -1,0 +1,57 @@
+"""Publication of the source-bound Dulmage--Mendelsohn decomposition."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graphs.bipartite._models import (
+    DulmageMendelsohnDecomposition,
+    DulmageMendelsohnRequest,
+)
+from jacobian.math.graphs.bipartite.operations import dulmage_mendelsohn
+
+
+def _run(request: DulmageMendelsohnRequest) -> DulmageMendelsohnDecomposition:
+    return dulmage_mendelsohn(request.graph)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="graph.bipartite.dulmage_mendelsohn.compute",
+        title="Dulmage-Mendelsohn decomposition with fixed bipartite sides",
+        description=(
+            "Return left-excess and right-excess deficient regions, balanced "
+            "elementary blocks, structural rank and the direct condensation DAG "
+            "of a finite bipartite graph with explicit ordered sides. Retains "
+            "original indexed vertex identities, isolated vertices and empty "
+            "sides. Orient all edges left-to-right and matching edges also "
+            "right-to-left. Balanced SCC blocks are labelled by first input-left "
+            "position; inter-block arcs follow this orientation, without "
+            "transitive closure. Structural results are independent of the "
+            "chosen maximum matching. Matching/traversal/output work is admitted "
+            "before execution under one 30-second safety deadline."
+        ),
+        request_type=DulmageMendelsohnRequest,
+        result_type=DulmageMendelsohnDecomposition,
+        run=_run,
+        tags=(
+            "graph",
+            "bipartite",
+            "Dulmage-Mendelsohn",
+            "matching",
+            "structural rank",
+            "decomposition",
+            "exact",
+        ),
+        examples=(
+            OperationExample(
+                name="triangular_pattern",
+                description="The 2-by-2 triangular pattern has two balanced blocks and the arc 0→1.",
+                input={
+                    "graph": {
+                        "graph": {"vertex_count": 4, "edges": [[0, 2], [0, 3], [1, 3]]},
+                        "left_vertices": [0, 1],
+                        "right_vertices": [2, 3],
+                    }
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/graphs/bipartite/operations.py
+++ b/src/jacobian/math/graphs/bipartite/operations.py
@@ -1,0 +1,130 @@
+"""Dulmage--Mendelsohn regions via matching, alternating paths and SCCs."""
+
+import time
+
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.math.graphs.bipartite._models import DulmageMendelsohnDecomposition
+from jacobian.math.graphs.bipartite.values import (
+    BipartiteVertexRegion,
+    FixedBipartiteGraph,
+)
+
+__all__ = ["dulmage_mendelsohn"]
+
+
+def _reachable(seeds: set[int], adjacency: list[list[int]]) -> set[int]:
+    found = set(seeds)
+    pending = list(seeds)
+    while pending:
+        v = pending.pop()
+        for w in adjacency[v]:
+            if w not in found:
+                found.add(w)
+                pending.append(w)
+    return found
+
+
+def dulmage_mendelsohn(graph: FixedBipartiteGraph) -> DulmageMendelsohnDecomposition:
+    """Return maximum-matching-independent regions, balanced blocks and their DAG.
+
+    left_excess has more left vertices; right_excess has more right vertices.
+    Either region can be empty. For matrix patterns, left denotes rows and
+    right columns; condensation arcs point along block-upper-triangular order.
+    """
+    if not isinstance(graph, FixedBipartiteGraph):
+        raise TypeError("dulmage_mendelsohn expects FixedBipartiteGraph")
+    if current_request_execution() is None:
+        with request_execution(time.monotonic()):
+            return _decompose(graph)
+    return _decompose(graph)
+
+
+def _decompose(source: FixedBipartiteGraph) -> DulmageMendelsohnDecomposition:
+    import networkx as nx
+
+    execution = current_request_execution()
+    assert execution is not None
+    deadline = execution.started_at + 30.0
+    bind_request_deadline(
+        min(deadline, execution.deadline)
+        if execution.deadline is not None
+        else deadline
+    )
+    request_checkpoint("before Dulmage-Mendelsohn admission")
+    n = source.graph.vertex_count
+    # Admit the entire canonical 1024-vertex/65,536-edge envelope.
+    # Hopcroft--Karp has O((V+E)*sqrt(V)) work; the standard twice-ceil-sqrt
+    # phase estimate plus traversals and sorting is at most 6,100,000 units
+    # here: (V+E)*(2*(isqrt(V)+1)+bit_length(E+1)+8).
+    # SCC/output storage is O(V+E); there are at most E condensation arcs.
+    # The recursive matching DFS has at most min(|L|,|R|)+1 <=513 levels.
+    # No transitive closure, barrier certificate or matching enumeration runs.
+    graph: nx.Graph[int] = nx.Graph()
+    graph.add_nodes_from(range(n))
+    graph.add_edges_from(source.graph.edges)
+    # Reuse the maintained bipartite matching backend already used by
+    # poset owners. General matching's Tutte--Berge certificate and repeated
+    # vertex-deletion solves do not belong to this decomposition postcondition.
+    matching: dict[int, int] = nx.algorithms.bipartite.maximum_matching(
+        graph, top_nodes=source.left_vertices
+    )
+    request_checkpoint("after maximum bipartite matching")
+    left = set(source.left_vertices)
+    arcs: list[list[int]] = [[] for _ in range(n)]
+    reverse: list[list[int]] = [[] for _ in range(n)]
+    for a, b in source.graph.edges:
+        u, v = (a, b) if a in left else (b, a)
+        arcs[u].append(v)
+        reverse[v].append(u)
+        if matching.get(u) == v:
+            arcs[v].append(u)
+            reverse[u].append(v)
+    left_excess = _reachable(left - matching.keys(), arcs)
+    right_excess = _reachable(set(source.right_vertices) - matching.keys(), reverse)
+    balanced = set(range(n)) - left_excess - right_excess
+    request_checkpoint("after alternating reachability")
+    digraph: nx.DiGraph[int] = nx.DiGraph()
+    digraph.add_nodes_from(sorted(balanced))
+    digraph.add_edges_from((v, w) for v in balanced for w in arcs[v] if w in balanced)
+    components = list(nx.strongly_connected_components(digraph))
+    left_position = {v: i for i, v in enumerate(source.left_vertices)}
+    components.sort(
+        key=lambda component: min(left_position[v] for v in component if v in left)
+    )
+    component_of = {v: i for i, component in enumerate(components) for v in component}
+    edges = tuple(
+        sorted(
+            {
+                (component_of[v], component_of[w])
+                for v, w in digraph.edges
+                if component_of[v] != component_of[w]
+            }
+        )
+    )
+    request_checkpoint("after balanced SCC condensation")
+
+    right_position = {v: i for i, v in enumerate(source.right_vertices)}
+
+    def region(vertices: set[int]) -> BipartiteVertexRegion:
+        return BipartiteVertexRegion(
+            left_vertices=tuple(sorted(vertices & left, key=left_position.__getitem__)),
+            right_vertices=tuple(
+                sorted(vertices - left, key=right_position.__getitem__)
+            ),
+        )
+
+    result = DulmageMendelsohnDecomposition(
+        graph=source,
+        structural_rank=len(matching) // 2,
+        left_excess=region(left_excess),
+        right_excess=region(right_excess),
+        balanced_blocks=tuple(region(component) for component in components),
+        condensation_edges=edges,
+    )
+    request_checkpoint("after Dulmage-Mendelsohn result construction")
+    return result

--- a/src/jacobian/math/graphs/bipartite/values.py
+++ b/src/jacobian/math/graphs/bipartite/values.py
@@ -1,0 +1,42 @@
+"""Canonical indexed bipartite graphs with ordered, fixed sides."""
+
+from typing import Annotated, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+
+Vertex = Annotated[int, Field(ge=0, le=1023)]
+
+
+class FixedBipartiteGraph(StrictModel):
+    """An indexed graph with explicit ordered left and right vertex sets.
+
+    The sides partition 0..vertex_count-1. Every edge crosses sides; isolated
+    vertices and empty sides retain their chosen interpretation. Side order
+    is mathematical context and is never inferred by two-colouring.
+    """
+
+    graph: IndexedSimpleUndirectedGraph
+    left_vertices: tuple[Vertex, ...] = Field(max_length=1024)
+    right_vertices: tuple[Vertex, ...] = Field(max_length=1024)
+
+    @model_validator(mode="after")
+    def require_fixed_partition(self) -> Self:
+        vertices = (*self.left_vertices, *self.right_vertices)
+        if len(vertices) != self.graph.vertex_count or set(vertices) != set(
+            range(self.graph.vertex_count)
+        ):
+            raise ValueError("left and right must partition all graph vertices")
+        left = set(self.left_vertices)
+        if any((a in left) == (b in left) for a, b in self.graph.edges):
+            raise ValueError("every graph edge must cross the declared sides")
+        return self
+
+
+class BipartiteVertexRegion(StrictModel):
+    """Vertex subsets on fixed left/right sides; ambient graph is retained by the owner."""
+
+    left_vertices: tuple[Vertex, ...] = Field(max_length=1024)
+    right_vertices: tuple[Vertex, ...] = Field(max_length=1024)

--- a/tests/math/graphs/bipartite/test_dulmage_mendelsohn.py
+++ b/tests/math/graphs/bipartite/test_dulmage_mendelsohn.py
@@ -1,0 +1,220 @@
+"""DM evidence from enumeration of all maximum matchings, not a second solver."""
+
+import json
+from collections.abc import Sequence
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.bipartite import FixedBipartiteGraph, dulmage_mendelsohn
+from jacobian.math.graphs.bipartite._models import DulmageMendelsohnDecomposition
+from jacobian.math.graphs.bipartite._tools import TOOLS
+
+
+def source(p: int, q: int, edges: Sequence[tuple[int, int]]) -> FixedBipartiteGraph:
+    return FixedBipartiteGraph.model_validate(
+        {
+            "graph": {
+                "vertex_count": p + q,
+                "edges": tuple(sorted((i, p + j) for i, j in edges)),
+            },
+            "left_vertices": tuple(range(p)),
+            "right_vertices": tuple(range(p, p + q)),
+        }
+    )
+
+
+def all_maximum_matchings(
+    graph: FixedBipartiteGraph,
+) -> list[frozenset[tuple[int, int]]]:
+    neighbors: dict[int, list[int]] = {v: [] for v in graph.left_vertices}
+    for a, b in graph.graph.edges:
+        u, v = (a, b) if a in neighbors else (b, a)
+        neighbors[u].append(v)
+    matchings: list[frozenset[tuple[int, int]]] = []
+
+    def enumerate_at(k: int, chosen: list[tuple[int, int]], used: set[int]) -> None:
+        if k == len(graph.left_vertices):
+            matchings.append(frozenset(chosen))
+            return
+        u = graph.left_vertices[k]
+        enumerate_at(k + 1, chosen, used)
+        for v in neighbors[u]:
+            if v not in used:
+                enumerate_at(k + 1, [*chosen, (u, v)], used | {v})
+
+    enumerate_at(0, [], set())
+    rank = max(map(len, matchings))
+    return [matching for matching in matchings if len(matching) == rank]
+
+
+def check_oracle(graph: FixedBipartiteGraph) -> DulmageMendelsohnDecomposition:
+    matchings = all_maximum_matchings(graph)
+    result = dulmage_mendelsohn(graph)
+    assert result.structural_rank == len(matchings[0])
+    # A left vertex is in the left-excess region iff some maximum matching
+    # leaves it exposed. Its neighbors are exactly that region's right side.
+    exposed_left = set().union(
+        *(set(graph.left_vertices) - {u for u, _ in matching} for matching in matchings)
+    )
+    exposed_right = set().union(
+        *(
+            set(graph.right_vertices) - {v for _, v in matching}
+            for matching in matchings
+        )
+    )
+    left = set(graph.left_vertices)
+    oriented = [(a, b) if a in left else (b, a) for a, b in graph.graph.edges]
+    right_of_left = {v for u, v in oriented if u in exposed_left}
+    left_of_right = {u for u, v in oriented if v in exposed_right}
+    assert set(result.left_excess.left_vertices) == exposed_left
+    assert set(result.left_excess.right_vertices) == right_of_left
+    assert set(result.right_excess.left_vertices) == left_of_right
+    assert set(result.right_excess.right_vertices) == exposed_right
+    balanced = (
+        set(range(graph.graph.vertex_count))
+        - exposed_left
+        - exposed_right
+        - right_of_left
+        - left_of_right
+    )
+    allowed = set().union(*matchings)
+    # On the balanced part, connected components of edges appearing in
+    # ANY maximum matching are the elementary DM blocks. This oracle uses
+    # undirected union-find, not the production alternating SCC construction.
+    roots = {v: v for v in balanced}
+
+    def root(v: int) -> int:
+        while roots[v] != v:
+            v = roots[v]
+        return v
+
+    for u, v in allowed:
+        if u in balanced and v in balanced:
+            roots[root(u)] = root(v)
+    components = {
+        frozenset(v for v in balanced if root(v) == root(u)) for u in balanced
+    }
+    actual = [
+        set(block.left_vertices) | set(block.right_vertices)
+        for block in result.balanced_blocks
+    ]
+    assert {frozenset(block) for block in actual} == components
+    index = {v: i for i, block in enumerate(actual) for v in block}
+    expected_arcs = {
+        (index[u], index[v])
+        for u, v in oriented
+        if u in balanced and v in balanced and index[u] != index[v]
+    }
+    assert set(result.condensation_edges) == expected_arcs
+    assert (
+        DulmageMendelsohnDecomposition.model_validate_json(result.model_dump_json())
+        == result
+    )
+    return result
+
+
+def test_all_patterns_through_three_by_three() -> None:
+    for p in range(4):
+        for q in range(4):
+            possible = [(i, j) for i in range(p) for j in range(q)]
+            for mask in range(1 << len(possible)):
+                check_oracle(
+                    source(
+                        p, q, [edge for k, edge in enumerate(possible) if mask >> k & 1]
+                    )
+                )
+
+
+def test_triangular_order_and_complete_elementary_block() -> None:
+    triangular = check_oracle(source(2, 2, [(0, 0), (0, 1), (1, 1)]))
+    assert [block.left_vertices for block in triangular.balanced_blocks] == [(0,), (1,)]
+    assert triangular.condensation_edges == ((0, 1),)
+    complete = check_oracle(source(2, 2, [(i, j) for i in range(2) for j in range(2)]))
+    assert len(complete.balanced_blocks) == 1
+
+
+def test_union_of_opposite_deficiencies_balanced_and_isolates() -> None:
+    result = check_oracle(source(5, 5, [(0, 0), (1, 0), (2, 1), (2, 2), (3, 3)]))
+    assert result.left_excess.left_vertices == (0, 1, 4)
+    assert result.right_excess.right_vertices == (6, 7, 9)
+    assert result.balanced_blocks[0].left_vertices == (3,)
+
+
+def test_relabelled_and_reordered_sides_preserve_source_order() -> None:
+    original = source(3, 3, [(0, 0), (0, 1), (1, 0), (1, 1), (1, 2), (2, 2)])
+    perm = {0: 5, 1: 2, 2: 4, 3: 1, 4: 3, 5: 0}
+    relabelled = FixedBipartiteGraph.model_validate(
+        {
+            "graph": {
+                "vertex_count": 6,
+                "edges": tuple(
+                    sorted(
+                        tuple(sorted((perm[a], perm[b])))
+                        for a, b in original.graph.edges
+                    )
+                ),
+            },
+            "left_vertices": tuple(perm[v] for v in original.left_vertices),
+            "right_vertices": tuple(perm[v] for v in original.right_vertices),
+        }
+    )
+    first, second = check_oracle(original), check_oracle(relabelled)
+    assert second.condensation_edges == first.condensation_edges
+    for a, b in zip(first.balanced_blocks, second.balanced_blocks, strict=True):
+        assert b.left_vertices == tuple(perm[v] for v in a.left_vertices)
+        assert b.right_vertices == tuple(perm[v] for v in a.right_vertices)
+
+
+@pytest.mark.parametrize(
+    "left,right,edges",
+    [
+        ((0,), (0,), ()),
+        ((0,), (), ()),
+        ((0, 1), (), ((0, 1),)),
+        ((0, 0), (1,), ()),
+    ],
+)
+def test_invalid_sides_are_structural_errors(
+    left: tuple[int, ...], right: tuple[int, ...], edges: tuple[tuple[int, int], ...]
+) -> None:
+    with pytest.raises(ValidationError):
+        FixedBipartiteGraph.model_validate(
+            {
+                "graph": {"vertex_count": 2, "edges": edges},
+                "left_vertices": left,
+                "right_vertices": right,
+            }
+        )
+
+
+def test_native_wire_parity() -> None:
+    tool = TOOLS[0]
+    request = tool.request_type.model_validate_json(json.dumps(tool.examples[0].input))
+    assert tool.run(request) == dulmage_mendelsohn(request.graph)
+
+
+def test_sparse_1024_vertex_triangular_pattern() -> None:
+    n = 512
+    result = dulmage_mendelsohn(
+        source(n, n, [(i, i) for i in range(n)] + [(i, i + 1) for i in range(n - 1)])
+    )
+    assert result.structural_rank == n
+    assert len(result.balanced_blocks) == n
+    assert result.condensation_edges == tuple((i, i + 1) for i in range(n - 1))
+
+
+def test_sparse_carrier_boundary_rejection() -> None:
+    with pytest.raises(ValidationError):
+        source(513, 512, [(i, i) for i in range(512)])
+
+
+def test_sparse_and_dense_accepted_boundary() -> None:
+    # The full canonical edge envelope remains executable.
+    n = 256
+    result = dulmage_mendelsohn(
+        source(n, n, [(i, j) for i in range(n) for j in range(n)])
+    )
+    assert result.structural_rank == n
+    assert len(result.balanced_blocks) == 1
+    assert not result.condensation_edges

--- a/tests/mcp/test_dulmage_mendelsohn.py
+++ b/tests/mcp/test_dulmage_mendelsohn.py
@@ -1,0 +1,67 @@
+"""Source retention and native equivalence through the real MCP boundary."""
+
+import asyncio
+import json
+
+from jsonschema import validate
+
+from jacobian.math.graphs.bipartite._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_live_dulmage_mendelsohn_and_source_round_trip() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        validate(payload, tool.request_type.model_json_schema())
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        async with Client(create_server(), raise_exceptions=False) as client:
+            invalid = json.loads(json.dumps(payload))
+            invalid["graph"]["right_vertices"] = [1, 3]
+            rejected = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": invalid,
+                },
+            )
+            assert rejected.is_error
+            result = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            output = result.structured_content["output"]
+            validate(output, tool.result_type.model_json_schema())
+            assert output == tool.run(request).model_dump(mode="json")
+            reused = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": {"graph": output["graph"]},
+                },
+            )
+            assert not reused.is_error
+            assert reused.structured_content is not None
+            assert reused.structured_content["output"] == output
+            matching = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "graph.invariant.maximum_matching.compute",
+                    "payload": {
+                        "graph": {
+                            "vertices": ["l0", "l1", "r0", "r1"],
+                            "edges": [["l0", "r0"], ["l0", "r1"], ["l1", "r1"]],
+                        }
+                    },
+                },
+            )
+            assert not matching.is_error
+            assert matching.structured_content is not None
+            assert (
+                matching.structured_content["output"]["maximum_matching_cardinality"]
+                == output["structural_rank"]
+            )
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Closes #3457. A maximum matching or Hall witness does not describe the deficient regions and ordered balanced components of a bipartite graph. Fixed left/right sides are necessary to interpret rectangular patterns and isolated vertices.

## Outcome

Publish `graph.bipartite.dulmage_mendelsohn.compute` and native `dulmage_mendelsohn`. `FixedBipartiteGraph` retains the existing indexed graph carrier plus the caller's ordered left and right vertex partitions. The result retains that source, structural rank, both excess regions, balanced elementary blocks, and direct condensation arcs.

The convention is explicit: every edge points left-to-right; matching edges also point right-to-left. Left excess is reachable from unmatched left vertices, and right excess can reach unmatched right vertices. SCCs on the remainder give balanced blocks. Block indices follow earliest input-left position, while every vertex tuple follows its input-side order. Direct inter-block arcs describe the component partial order without materializing transitive closure. The triangular pattern `[[1,1],[0,1]]` therefore has two blocks and arc `0 -> 1`.

This matches the coarse/fine distinction described by [the dmperm reference](https://www.mathworks.com/help/matlab/ref/dmperm.html). It reuses the maintained NetworkX bipartite matching backend already used by the poset owners and the same SCC backend used by directed-graph operations; no matching solver is duplicated. No existing public contract is superseded.

## Validation

- `make affected AFFECTED_BASE=origin/main`: scoped lint/typecheck, mathematical owner, catalog, catalog integration, and full MCP lane.
- `uv run pytest tests/integration/catalog/test_public_operation_contract_conformance.py -m exhaustive -k dulmage_mendelsohn --timeout=120 -q`: 1 passed.
- The independent oracle enumerates **all maximum matchings** for all 689 patterns with each side of size 0 through 3. Exposable vertices determine deficient regions; undirected components of all allowed matching edges determine balanced blocks. Original inter-block edges independently determine the DAG.
- Fixtures cover opposite deficiencies, K2,2, triangular order, disconnected unions, isolated vertices, empty sides, relabeling, and nontrivial side order.
- The live MCP test checks malformed-side recovery, generated input/output schemas, native parity, retained-source round trip, and agreement with the existing maximum-matching operation's cardinality.
- Accepted scale: 1,024 vertices with 512 ordered singleton blocks and 511 arcs (about 0.01 seconds locally), and K256,256 at the full 65,536-edge carrier limit (about 0.16 seconds). A sparse source beyond 1,024 vertices is structurally rejected.
- Final head SHA tested: 81d23420e58af5beba452ca75ccd1f09473167db
- Hosted CI: [required passed](https://github.com/morluto/jacobian/actions/runs/34170651090/job/101890489412) for the tested head.

## Contract impact

- [x] Fixed sides partition the original indexed vertices and every edge crosses sides; malformed partitions are structural errors.
- [x] Empty sides and the null graph are representable, including an empty balanced condensation.
- [x] All mandatory computation phases share one 30-second cooperative request deadline.
- [x] Native/MCP values agree; source serialization and independent mathematical invariants are tested.
- [x] Parsing checks only encoding, side/region membership, ordering and result shape; no matching or SCC computation is replayed in validators.

## Review closure

- [x] Independent exact-diff review completed with no unresolved findings.
- [x] Final changed-tree validation and the relevant MCP lane are recorded above.
- [x] No compatibility path, new dependency, unrelated file changes, or shared runtime changes.
- Hosted required CI passed for this head.

## Conditional detail

### Operation boundary

The graph owner admits the complete existing canonical envelope of 1,024 vertices and 65,536 edges. Hopcroft-Karp matching costs `O((V+E)*sqrt(V))`; alternating reachability and SCCs are linear; canonical sorting costs at most `O((V+E)*log(V+E))`. The documented phase/traversal/sorting estimate is below 6.1 million units across this envelope. Matching DFS depth is at most `min(|L|,|R|)+1 <= 513`. Output contains each vertex once in its region/block and at most E condensation arcs. No transitive closure or matching enumeration is performed in production.

An initial narrower work ceiling rejected K256,256 despite a direct backend probe completing its matching in about 0.006 seconds. The final operation admits the full carrier, with the dense fixture retained as an accepted regression. Its 30-second safety deadline exceeds the complete measured dense test by over 100 times; measured timing supplements the structural work/output bounds.

### Canonical value audit

- [x] Reuse `IndexedSimpleUndirectedGraph`; fixed sides are an explicit additional mathematical structure, not an inferred coloring.
- [x] Source vertex identities and both side orders survive serialization, including empty/isolated cases.
- [x] Balanced blocks have equal nonzero side sizes; output regions partition the source exactly and condensation endpoints index the blocks.
- No caller-authored matching or decomposition claim is consumed. The producing matching and SCC kernels establish the mathematical structure once.

### Catalog admission

The reusable postcondition is the maximum-matching-independent Dulmage-Mendelsohn partition and balanced component order. Existing matching, covering and Hall-witness operations do not return this structure. Matching cardinality, deficient regions, elementary components and condensation belong to this one decomposition; permutations and numerical solves remain outside its scope. The whole canonical input envelope is admitted, bounded by graph size and direct output rather than enumerated matchings.

Residual scope: none for #3457.
