### PR TITLE
feat(matrices): compute Smith decomposition over QQ[t]

### DIFF
--- a/src/jacobian/math/matrices/certified_snf/__init__.py
+++ b/src/jacobian/math/matrices/certified_snf/__init__.py
@@ -1,15 +1,21 @@
-"""Transformation-certified Smith normal forms over the integers."""
+"""Smith decompositions with unimodular maps over ZZ and QQ[t]."""
 
 from jacobian.math.matrices.certified_snf.operations import (
     smith_normal_form_certificate,
     verify_smith_normal_form_certificate,
+)
+from jacobian.math.matrices.certified_snf.polynomial import (
+    PolynomialSmithDecomposition,
+    polynomial_smith_decomposition,
 )
 from jacobian.math.matrices.certified_snf.values import (
     SmithNormalFormCertificate,
 )
 
 __all__ = [
+    "PolynomialSmithDecomposition",
     "SmithNormalFormCertificate",
+    "polynomial_smith_decomposition",
     "smith_normal_form_certificate",
     "verify_smith_normal_form_certificate",
 ]

--- a/src/jacobian/math/matrices/certified_snf/_models.py
+++ b/src/jacobian/math/matrices/certified_snf/_models.py
@@ -12,7 +12,12 @@ from jacobian.math.matrices.certified_snf.values import (
     MAX_CERTIFIED_SNF_INPUT_DIMENSION,
     SmithNormalFormCertificate,
 )
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
 from jacobian.math.matrices.values import IntegerMatrix, SmithNormalForm
+
+
+class PolynomialSmithRequest(StrictModel):
+    matrix: RationalPolynomialMatrix
 
 
 def _certified_smith_input_schema() -> JsonSchemaValue:

--- a/src/jacobian/math/matrices/certified_snf/_polynomial_bounds.py
+++ b/src/jacobian/math/matrices/certified_snf/_polynomial_bounds.py
@@ -1,0 +1,225 @@
+"""Preflight for SymPy 1.14's full recursive polynomial Smith kernel.
+
+Heights below describe a polynomial as F/q with integer F and positive q;
+both the coefficient infinity norm and q are at most 2**height. They do
+not multiply unrelated rational denominators at every coefficient operation.
+All arithmetic here is on size metadata, before backend conversion.
+"""
+
+from dataclasses import dataclass
+
+from jacobian.catalog.models import OperationResourceAdmissionError
+
+_MAX_DEGREE = 4095
+_MAX_HEIGHT = 100_000
+_MAX_WORK = 20_000_000
+
+
+def _reject() -> None:
+    raise OperationResourceAdmissionError(
+        location=("matrix",),
+        code="matrix.polynomial_smith_budget",
+        message="polynomial Smith work, intermediate growth, or exact output exceeds the admitted envelope",
+    )
+
+
+@dataclass(frozen=True)
+class PolynomialSmithBound:
+    degree: int
+    height: int
+    work: int
+
+
+def _check(degree: int, height: int, work: int) -> PolynomialSmithBound:
+    if degree > _MAX_DEGREE or height > _MAX_HEIGHT or work > _MAX_WORK:
+        _reject()
+    return PolynomialSmithBound(degree, height, work)
+
+
+def _division_height(degree: int, height: int, *, constant: bool) -> int:
+    # Pseudo-division by an integer polynomial multiplies coefficient height
+    # by at most its leading coefficient and adds one product per step.
+    # At most degree+1 steps; restoring the two source denominators adds one
+    # further divisor-height term. Constant division is just scalar scaling.
+    return 2 * height if constant else (degree + 4) * (height + 1)
+
+
+def _bezout_height(degree: int, pivot_degree: int, height: int) -> int:
+    if pivot_degree == 1:
+        # The nondivisible branch with a linear pivot has one constant
+        # remainder. One long division, one scalar division, normalization,
+        # and reconstruction of the second Bezout coefficient suffice.
+        return (8 * degree + 32) * (height + 1)
+    # Extended Euclid first divides degree D by degree p, then the divisor
+    # degree strictly descends. Consecutive descending degrees maximize the
+    # product of the pseudo-division height factors: merging k degree drops
+    # replaces factors at least six by a factor growing only linearly in k.
+    # Track accumulator products too, not only the Euclidean remainders.
+    bound = height
+    dividend_degree = degree
+    for divisor_degree in range(pivot_degree, -1, -1):
+        quotient_height = (
+            2 * bound
+            if divisor_degree == 0
+            else bound + (dividend_degree - divisor_degree + 3) * (bound + 1)
+        )
+        bound = quotient_height + 2 * bound + (degree + 1).bit_length() + 1
+        dividend_degree = divisor_degree
+        if bound > _MAX_HEIGHT:
+            _reject()
+    # Monic normalization, t=(gcd-s*f)/g in SymPy's dup_gcdex, and
+    # exact division of both original operands by the resulting monic gcd.
+    return (2 * degree + 4) * (6 * bound + degree.bit_length() + 2)
+
+
+def _clear_pivot_bound(
+    rows: int,
+    columns: int,
+    degree: int,
+    height: int,
+    pivot_degree: int,
+) -> PolynomialSmithBound:
+    cells = rows * columns + rows * rows + columns * columns
+    # A single row or column is cleared in one pass: no opposite operation
+    # can reintroduce an entry along that pivot axis.
+    passes = 1 if min(rows, columns) == 1 else pivot_degree + 1
+    steps = (rows + columns - 2) * passes
+    if steps > _MAX_WORK:
+        _reject()
+    states = {(0, False): _check(degree, height, cells)}
+    completed: list[PolynomialSmithBound] = []
+    for step in range(steps):
+        next_states: dict[tuple[int, bool], PolynomialSmithBound] = {}
+        for (used, changed), state in states.items():
+            p = max(0, pivot_degree - used)
+            d, h = state.degree, state.height
+            for gcd_step in (False, True) if p else (False,):
+                coefficient_height = (
+                    _bezout_height(d, p, h)
+                    if gcd_step
+                    else _division_height(d, h, constant=p == 0)
+                )
+                # Two polynomial products and their sum cover every tracked
+                # matrix entry, including both transformation matrices.
+                new = _check(
+                    2 * d,
+                    2 * (coefficient_height + h + (d + 1).bit_length()) + 1,
+                    state.work + 100 * (d + 1) ** 3 + 8 * cells * (d + 1) ** 2,
+                )
+                key = used + int(gcd_step), changed or gcd_step
+                old = next_states.get(key)
+                next_states[key] = (
+                    new
+                    if old is None
+                    else _check(
+                        max(old.degree, new.degree),
+                        max(old.height, new.height),
+                        max(old.work, new.work),
+                    )
+                )
+        states = next_states
+        if (step + 1) % (rows + columns - 2) == 0:
+            completed.extend(states.values())
+            # A pass without a gcd has cleared both axes and must terminate.
+            # Continuing it would compound bounds along impossible paths.
+            states = {
+                (used, False): state
+                for (used, changed), state in states.items()
+                if changed
+            }
+            if not states:
+                break
+    return _check(
+        max(state.degree for state in completed),
+        max(state.height for state in completed),
+        max(state.work for state in completed),
+    )
+
+
+def polynomial_smith_bound(
+    rows: int,
+    columns: int,
+    degree: int,
+    height: int,
+    *,
+    pivot_degree: int,
+    diagonal: bool = False,
+) -> PolynomialSmithBound:
+    """Bound full transforms, recursive products and divisibility repairs.
+
+    Every nonexact gcd update strictly lowers the pivot degree. Each pass
+    without such an update finishes clearing the pivot, so there are at most
+    p+1 passes of r+c-2 updates. Keep alternatives by gcd count: exact
+    divisions after a constant pivot must not inherit polynomial-division
+    growth. Zero support is removed by the caller before this recurrence.
+    """
+    if not rows or not columns:
+        return _check(0, 1, rows * rows + columns * columns)
+    if degree == 0:
+        # Over QQ every nonzero pivot divides every entry. The maintained
+        # kernel is Gaussian elimination, with Schur entries and elementary
+        # factors ratios of source minors. Products of at most size factors
+        # bound accumulated transforms; there are no divisibility repairs.
+        size = max(rows, columns)
+        return _check(
+            0,
+            8 * size * size * (height + size.bit_length() + 2),
+            64 * size**4,
+        )
+    if rows == columns == 1:
+        return _check(degree, height, degree + 1)
+    cells = rows * columns + rows * rows + columns * columns
+    cleared = (
+        _check(degree, height, cells)
+        if diagonal
+        else _clear_pivot_bound(rows, columns, degree, height, pivot_degree)
+    )
+    if min(rows, columns) == 1:
+        return cleared
+    child = polynomial_smith_bound(
+        rows - 1,
+        columns - 1,
+        cleared.degree,
+        cleared.height,
+        pivot_degree=cleared.degree,
+        diagonal=diagonal,
+    )
+    size = max(rows, columns)
+    if diagonal:
+        # Before embedding the child, both outer transforms are identity.
+        # Their maintained matrix products add work, but no entry growth.
+        combined = _check(
+            max(degree, child.degree),
+            max(height, child.height),
+            child.work + 64 * size**4,
+        )
+    else:
+        combined = _check(
+            cleared.degree + child.degree,
+            size * (cleared.height + child.height + (cleared.degree + 1).bit_length())
+            + size.bit_length(),
+            cleared.work + child.work + 8 * size**3 * (cleared.degree + 1) ** 2,
+        )
+    # A constant pivot divides the entire child diagonal and requires no
+    # repair. Otherwise each adjacent repair uses one extended gcd and five
+    # elementary transform updates. Invariant-factor degrees are bounded by
+    # the degree of a maximal nonzero source minor.
+    if pivot_degree:
+        factor_degree = min(rows, columns) * degree
+        for repair in range(min(rows, columns) - 1):
+            repair_height = _bezout_height(
+                factor_degree,
+                min(pivot_degree, factor_degree) if repair == 0 else factor_degree,
+                combined.height,
+            )
+            combined = _check(
+                combined.degree + 5 * factor_degree,
+                32 * (combined.height + repair_height + factor_degree.bit_length() + 2),
+                combined.work
+                + 100 * (factor_degree + 1) ** 3
+                + 40 * cells * (combined.degree + factor_degree + 1) ** 2,
+            )
+    return combined
+
+
+__all__ = ["PolynomialSmithBound", "polynomial_smith_bound"]

--- a/src/jacobian/math/matrices/certified_snf/_tools.py
+++ b/src/jacobian/math/matrices/certified_snf/_tools.py
@@ -6,10 +6,19 @@ from jacobian.catalog.models import MathTool, MathTools, OperationExample
 from jacobian.math.matrices.certified_snf._models import (
     CertifiedSmithNormalFormRequest,
     CertifiedSmithNormalFormResult,
+    PolynomialSmithRequest,
 )
 from jacobian.math.matrices.certified_snf.operations import (
     smith_normal_form_certificate,
 )
+from jacobian.math.matrices.certified_snf.polynomial import (
+    PolynomialSmithDecomposition,
+    polynomial_smith_decomposition,
+)
+
+
+def _polynomial_smith(request: PolynomialSmithRequest) -> PolynomialSmithDecomposition:
+    return polynomial_smith_decomposition(request.matrix)
 
 
 def _certified_smith(
@@ -21,6 +30,62 @@ def _certified_smith(
 
 
 TOOLS: MathTools = (
+    MathTool(
+        operation_id="matrix.normal_form.smith.polynomial.compute",
+        title="Compute Smith decomposition over QQ[t] with unimodular maps",
+        description=(
+            "Return a monic divisibility diagonal D and polynomial unimodular "
+            "U,V with D=UAV for a rectangular matrix over QQ[t]. Retain the "
+            "polynomial ring, empty axes and nonzero rational units. Full "
+            "transform production is admitted by degree, rational-height, "
+            "Euclidean-work and exact-output bounds."
+        ),
+        request_type=PolynomialSmithRequest,
+        result_type=PolynomialSmithDecomposition,
+        run=_polynomial_smith,
+        discovery_terms=(
+            "polynomial presentation module decomposition",
+            "polynomial cokernel torsion invariant factors",
+            "polynomial unimodular source and target coordinates",
+            "rectangular polynomial Smith normal form",
+        ),
+        tags=(
+            "matrix",
+            "polynomial",
+            "smith-normal-form",
+            "unimodular-transformation",
+            "exact",
+            "bounded",
+        ),
+        examples=(
+            OperationExample(
+                name="polynomial_torsion",
+                description="The map t: QQ[t] to QQ[t] has cokernel QQ[t]/(t).",
+                input={
+                    "matrix": {
+                        "variables": ["t"],
+                        "row_count": 1,
+                        "column_count": 1,
+                        "entries": [
+                            [
+                                {
+                                    "variables": ["t"],
+                                    "polynomial": {
+                                        "terms": [
+                                            {
+                                                "coefficient": {"num": "1", "den": "1"},
+                                                "exponents": [1],
+                                            },
+                                        ]
+                                    },
+                                }
+                            ]
+                        ],
+                    }
+                },
+            ),
+        ),
+    ),
     MathTool(
         operation_id="matrix.normal_form.smith.certified.compute",
         title="Compute a transformation-certified Smith normal form",

--- a/src/jacobian/math/matrices/certified_snf/_tools.py
+++ b/src/jacobian/math/matrices/certified_snf/_tools.py
@@ -60,7 +60,11 @@ TOOLS: MathTools = (
         examples=(
             OperationExample(
                 name="polynomial_torsion",
-                description="The map t: QQ[t] to QQ[t] has cokernel QQ[t]/(t).",
+                description=(
+                    "Compute the Smith decomposition D=UAV of the 1-by-1 matrix "
+                    "[t] over QQ[t]; every entry must be univariate in the same "
+                    "declared ring variable."
+                ),
                 input={
                     "matrix": {
                         "variables": ["t"],

--- a/src/jacobian/math/matrices/certified_snf/polynomial.py
+++ b/src/jacobian/math/matrices/certified_snf/polynomial.py
@@ -15,7 +15,10 @@ from jacobian._execution import (
     request_execution,
 )
 from jacobian._models import StrictModel
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.matrices.certified_snf._polynomial_bounds import (
     polynomial_smith_bound,
 )
@@ -408,6 +411,31 @@ def _encode_polynomial(value: RationalPolynomial, plan: _SmithPlan, ring: Any) -
     )
 
 
+def _require_polynomial_matrix(matrix: object) -> RationalPolynomialMatrix:
+    """Revalidate a native carrier before trusting axes or entries.
+
+    ``model_copy(update=...)`` bypasses Pydantic validators, so class checks
+    alone do not establish the rectangular QQ[t] invariant.
+    """
+
+    if not isinstance(matrix, RationalPolynomialMatrix):
+        raise OperationDomainValidationError(
+            location=("matrix",),
+            code="matrix.polynomial_smith_domain",
+            message="polynomial Smith expects a RationalPolynomialMatrix",
+        )
+    try:
+        return RationalPolynomialMatrix.model_validate(
+            matrix.model_dump(warnings="none")
+        )
+    except Exception as exc:
+        raise OperationDomainValidationError(
+            location=("matrix",),
+            code="matrix.polynomial_smith_domain",
+            message="polynomial matrix carrier failed structural validation",
+        ) from exc
+
+
 def polynomial_smith_decomposition(
     matrix: RationalPolynomialMatrix,
 ) -> PolynomialSmithDecomposition:
@@ -421,6 +449,7 @@ def polynomial_smith_decomposition(
         deadline = min(deadline, execution.deadline)
     bind_request_deadline(deadline)
     request_checkpoint("before polynomial Smith admission")
+    matrix = _require_polynomial_matrix(matrix)
     plan = _admit(matrix)
     row_order, column_order, affine, shift = (
         plan.row_order,

--- a/src/jacobian/math/matrices/certified_snf/polynomial.py
+++ b/src/jacobian/math/matrices/certified_snf/polynomial.py
@@ -27,7 +27,9 @@ from jacobian.math.polynomials.values import (
 )
 
 _WALL_SECONDS = 60.0
-_MAX_SERIALIZED_BYTES = 8 * 1024 * 1024
+_MAX_MATRIX_CELLS = 16_384
+_MAX_TOTAL_TERMS = 16_384
+_MAX_COEFFICIENT_BITS = 8 * 1024 * 1024
 
 
 class PolynomialSmithDecomposition(StrictModel):
@@ -63,6 +65,19 @@ def _reject(message: str) -> None:
     raise OperationResourceAdmissionError(
         location=("matrix",), code="matrix.polynomial_smith_budget", message=message
     )
+
+
+def _admit_result_allocation(term_count: int, coefficient_bits: int) -> None:
+    """Bound polynomial objects and aggregate integer coefficient storage.
+
+    Numerator/denominator bit lengths measure mathematical integer payload,
+    independently of an encoder, field spelling, or transport byte allowance.
+    The separate matrix-cell and term counts bound container/object allocation.
+    """
+    if term_count > _MAX_TOTAL_TERMS or coefficient_bits > _MAX_COEFFICIENT_BITS:
+        _reject(
+            "Smith polynomial terms or aggregate coefficient storage exceed the allocation envelope"
+        )
 
 
 type _AffinePivot = tuple[bool, int, int, Fraction]
@@ -165,7 +180,6 @@ def _affine_pivot(
 def _admit_sparse_diagonal(
     matrix: RationalPolynomialMatrix,
     nonzero: list[tuple[int, int, int]],
-    cells: int,
 ) -> _SmithPlan:
     # A monomial weighted partial permutation is already Smith after
     # ordering its exponents and scaling rational units. The maintained
@@ -201,10 +215,11 @@ def _admit_sparse_diagonal(
                 + abs(lead.num).bit_length()
                 + lead.den.bit_length()
             )
-    if (
-        cells + extra_terms
-    ) * 512 + 2 * coefficient_bits + 1024 > _MAX_SERIALIZED_BYTES:
-        _reject("sparse Smith output exceeds the serialization envelope")
+    identity_terms = matrix.row_count + matrix.column_count
+    _admit_result_allocation(
+        len(nonzero) + extra_terms + identity_terms,
+        coefficient_bits + 2 * (len(nonzero) + identity_terms),
+    )
     ordered = sorted(nonzero)
     return _SmithPlan(tuple(i for _, i, _ in ordered), tuple(j for _, _, j in ordered))
 
@@ -214,7 +229,7 @@ def _admit(
 ) -> _SmithPlan:
     rows, columns = matrix.row_count, matrix.column_count
     cells = rows * columns + rows * rows + columns * columns
-    if cells > 16_384 or cells * 512 + 1024 > _MAX_SERIALIZED_BYTES:
+    if cells > _MAX_MATRIX_CELLS:
         _reject("dense source and full transformation output exceed the cell envelope")
     row_order = [
         i
@@ -238,7 +253,7 @@ def _admit(
         len(nonzero) == 1
         or all(len(matrix.entries[i][j].polynomial.terms) == 1 for _, i, j in nonzero)
     ):
-        return _admit_sparse_diagonal(matrix, nonzero, cells)
+        return _admit_sparse_diagonal(matrix, nonzero)
     pivot_degree, pivot_row, pivot_column = min(nonzero)
     # Permutations put a smallest-degree source entry first. This preserves
     # Smith semantics and allows constant pivots to use scalar-division bounds.
@@ -252,14 +267,14 @@ def _admit(
         row_order = [i for _, i, _ in ordered]
         column_order = [j for _, _, j in ordered]
     terms = [t for row in matrix.entries for p in row for t in p.polynomial.terms]
-    if len(terms) > 16_384:
+    if len(terms) > _MAX_TOTAL_TERMS:
         _reject("source polynomial support exceeds the term envelope")
     if (
         sum(
             abs(term.coefficient.num).bit_length() + term.coefficient.den.bit_length()
             for term in terms
         )
-        > _MAX_SERIALIZED_BYTES
+        > _MAX_COEFFICIENT_BITS
     ):
         _reject("source coefficient inspection exceeds the rational work envelope")
     denominator_bits = sum(
@@ -309,22 +324,24 @@ def _admit(
     )
     if output_bits > 100_000:
         _reject("monic normalization exceeds the rational coefficient envelope")
-    output_bytes = cells * (bound.degree + 1) * (2 * output_bits + 512) + 1024
+    result_terms = cells * (bound.degree + 1)
+    result_coefficient_bits = 2 * result_terms * output_bits
     if common_factor is not None:
-        factor_bytes = sum(
-            512
-            + abs(term.coefficient.num).bit_length()
-            + term.coefficient.den.bit_length()
+        factor_bits = sum(
+            abs(term.coefficient.num).bit_length() + term.coefficient.den.bit_length()
             for term in common_factor.polynomial.terms
         )
-        output_bytes = (
-            (rows * rows + columns * columns) * (2 * output_bits + 512)
-            + rows * columns * 512
-            + min(rows, columns) * factor_bytes
-            + 1024
+        # The retained factor appears only on D's nonzero diagonal; both
+        # transformation matrices are constant after rational elimination.
+        transform_terms = rows * rows + columns * columns
+        diagonal_count = min(rows, columns)
+        result_terms = transform_terms + diagonal_count * len(
+            common_factor.polynomial.terms
         )
-    if output_bytes > _MAX_SERIALIZED_BYTES:
-        _reject("serialized Smith matrices exceed the exact output envelope")
+        result_coefficient_bits = (
+            transform_terms * 2 * output_bits + diagonal_count * factor_bits
+        )
+    _admit_result_allocation(result_terms, result_coefficient_bits)
     return _SmithPlan(
         tuple(row_order), tuple(column_order), affine, shift, common_factor
     )

--- a/src/jacobian/math/matrices/certified_snf/polynomial.py
+++ b/src/jacobian/math/matrices/certified_snf/polynomial.py
@@ -1,0 +1,510 @@
+"""Smith decomposition over QQ[t] through the existing maintained PID kernel."""
+
+import time
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Any, Self
+
+from pydantic import model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian._models import StrictModel
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.matrices.certified_snf._polynomial_bounds import (
+    polynomial_smith_bound,
+)
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+_WALL_SECONDS = 60.0
+_MAX_SERIALIZED_BYTES = 8 * 1024 * 1024
+
+
+class PolynomialSmithDecomposition(StrictModel):
+    """D=UAV with monic divisibility diagonal and QQ[t]-unimodular U,V.
+
+    Parsing establishes shapes and rings. It does not establish an authored
+    transformation relation or replay the producer's mathematics.
+    """
+
+    diagonal: RationalPolynomialMatrix
+    left_transformation: RationalPolynomialMatrix
+    right_transformation: RationalPolynomialMatrix
+
+    @model_validator(mode="after")
+    def require_shapes_and_ring(self) -> Self:
+        rows, columns = self.diagonal.row_count, self.diagonal.column_count
+        for matrix, size in (
+            (self.left_transformation, rows),
+            (self.right_transformation, columns),
+        ):
+            if (matrix.row_count, matrix.column_count) != (size, size):
+                raise ValueError(
+                    "Smith transformations must be square on the respective axes"
+                )
+            if matrix.variables != self.diagonal.variables:
+                raise ValueError(
+                    "Smith matrices must belong to the same polynomial ring"
+                )
+        return self
+
+
+def _reject(message: str) -> None:
+    raise OperationResourceAdmissionError(
+        location=("matrix",), code="matrix.polynomial_smith_budget", message=message
+    )
+
+
+type _AffinePivot = tuple[bool, int, int, Fraction]
+
+
+@dataclass(frozen=True)
+class _SmithPlan:
+    row_order: tuple[int, ...]
+    column_order: tuple[int, ...]
+    affine: _AffinePivot | None = None
+    shift: int = 0
+    common_factor: RationalPolynomial | None = None
+
+
+def _proportional_factor(
+    matrix: RationalPolynomialMatrix,
+    nonzero: list[tuple[int, int, int]],
+) -> RationalPolynomial | None:
+    """Recognize A=p(t)B with B rational, retaining monic p unchanged.
+
+    Support and coefficient heights are admitted before these bounded
+    coefficient comparisons. No polynomial gcd or expanded arithmetic is used.
+    """
+    _, i, j = nonzero[0]
+    reference = matrix.entries[i][j].polynomial.terms
+    support = tuple(term.exponents for term in reference)
+    if any(
+        tuple(term.exponents for term in matrix.entries[i][j].polynomial.terms)
+        != support
+        for _, i, j in nonzero
+    ):
+        return None
+    leading = reference[0].coefficient.as_fraction()
+    coefficients = tuple(term.coefficient.as_fraction() / leading for term in reference)
+    for _, i, j in nonzero:
+        terms = matrix.entries[i][j].polynomial.terms
+        leading = terms[0].coefficient.as_fraction()
+        if any(
+            term.coefficient.as_fraction() != coefficient * leading
+            for term, coefficient in zip(terms, coefficients, strict=True)
+        ):
+            return None
+    if (
+        max(
+            max(abs(q.numerator).bit_length(), q.denominator.bit_length())
+            for q in coefficients
+        )
+        > 100_000
+    ):
+        _reject(
+            "proportional polynomial normalization exceeds the rational height envelope"
+        )
+    return RationalPolynomial(
+        variables=matrix.variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(coefficient),
+                    exponents=exponents,
+                )
+                for exponents, coefficient in zip(support, coefficients, strict=True)
+            )
+        ),
+    )
+
+
+def _affine_pivot(
+    matrix: RationalPolynomialMatrix,
+) -> tuple[_AffinePivot, int, int] | None:
+    """Retain one bounded rational elementary map exposing an affine unit.
+
+    The caller first bounds source support and coefficient height. This
+    two-by-two coefficient determinant comparison is not repeated at execution.
+    """
+    for by_rows in (True, False):
+        outer = matrix.column_count if by_rows else matrix.row_count
+        inner = matrix.row_count if by_rows else matrix.column_count
+        for fixed in range(outer):
+            first: tuple[int, Fraction, Fraction] | None = None
+            for index in range(inner):
+                i, j = (index, fixed) if by_rows else (fixed, index)
+                terms = matrix.entries[i][j].polynomial.terms
+                if not terms:
+                    continue
+                slope = terms[0].coefficient.as_fraction()
+                constant = (
+                    terms[1].coefficient.as_fraction()
+                    if len(terms) == 2
+                    else Fraction()
+                )
+                if first is None:
+                    first = index, slope, constant
+                    continue
+                source, source_slope, source_constant = first
+                if constant * source_slope != slope * source_constant:
+                    return (by_rows, source, index, slope / source_slope), i, j
+    return None
+
+
+def _admit_sparse_diagonal(
+    matrix: RationalPolynomialMatrix,
+    nonzero: list[tuple[int, int, int]],
+    cells: int,
+) -> _SmithPlan:
+    # A monomial weighted partial permutation is already Smith after
+    # ordering its exponents and scaling rational units. The maintained
+    # kernel performs no polynomial Euclid or divisibility repair here.
+    # Retain sparse high-degree entries without predicting dense support.
+    if 64 * len(nonzero) ** 4 > 20_000_000:
+        _reject("embedded monomial identity products exceed the work envelope")
+    coefficient_bits = sum(
+        abs(term.coefficient.num).bit_length() + term.coefficient.den.bit_length()
+        for _, i, j in nonzero
+        for term in matrix.entries[i][j].polynomial.terms
+    )
+    extra_terms = 0
+    if len(nonzero) == 1:
+        _, i, j = nonzero[0]
+        terms = matrix.entries[i][j].polynomial.terms
+        extra_terms = len(terms) - 1
+        if extra_terms:
+            lead = terms[0].coefficient
+            components = [
+                (
+                    abs(term.coefficient.num).bit_length() + lead.den.bit_length(),
+                    term.coefficient.den.bit_length() + abs(lead.num).bit_length(),
+                )
+                for term in terms
+            ]
+            if max(max(pair) for pair in components) > 100_000:
+                _reject(
+                    "sparse scalar monic normalization exceeds the rational height envelope"
+                )
+            coefficient_bits = (
+                sum(sum(pair) for pair in components)
+                + abs(lead.num).bit_length()
+                + lead.den.bit_length()
+            )
+    if (
+        cells + extra_terms
+    ) * 512 + 2 * coefficient_bits + 1024 > _MAX_SERIALIZED_BYTES:
+        _reject("sparse Smith output exceeds the serialization envelope")
+    ordered = sorted(nonzero)
+    return _SmithPlan(tuple(i for _, i, _ in ordered), tuple(j for _, _, j in ordered))
+
+
+def _admit(
+    matrix: RationalPolynomialMatrix,
+) -> _SmithPlan:
+    rows, columns = matrix.row_count, matrix.column_count
+    cells = rows * columns + rows * rows + columns * columns
+    if cells > 16_384 or cells * 512 + 1024 > _MAX_SERIALIZED_BYTES:
+        _reject("dense source and full transformation output exceed the cell envelope")
+    row_order = [
+        i
+        for i, row in enumerate(matrix.entries)
+        if any(p.polynomial.terms for p in row)
+    ]
+    column_order = [
+        j
+        for j in range(columns)
+        if any(matrix.entries[i][j].polynomial.terms for i in row_order)
+    ]
+    nonzero = [
+        (p.polynomial.terms[0].exponents[0], i, j)
+        for i, row in enumerate(matrix.entries)
+        for j, p in enumerate(row)
+        if p.polynomial.terms
+    ]
+    if not nonzero:
+        return _SmithPlan(tuple(row_order), tuple(column_order))
+    if len(nonzero) == len(row_order) == len(column_order) and (
+        len(nonzero) == 1
+        or all(len(matrix.entries[i][j].polynomial.terms) == 1 for _, i, j in nonzero)
+    ):
+        return _admit_sparse_diagonal(matrix, nonzero, cells)
+    pivot_degree, pivot_row, pivot_column = min(nonzero)
+    # Permutations put a smallest-degree source entry first. This preserves
+    # Smith semantics and allows constant pivots to use scalar-division bounds.
+    row_order.remove(pivot_row)
+    row_order.insert(0, pivot_row)
+    column_order.remove(pivot_column)
+    column_order.insert(0, pivot_column)
+    diagonal = len(nonzero) == len(row_order) == len(column_order)
+    if diagonal:
+        ordered = sorted(nonzero)
+        row_order = [i for _, i, _ in ordered]
+        column_order = [j for _, _, j in ordered]
+    terms = [t for row in matrix.entries for p in row for t in p.polynomial.terms]
+    if len(terms) > 16_384:
+        _reject("source polynomial support exceeds the term envelope")
+    if (
+        sum(
+            abs(term.coefficient.num).bit_length() + term.coefficient.den.bit_length()
+            for term in terms
+        )
+        > _MAX_SERIALIZED_BYTES
+    ):
+        _reject("source coefficient inspection exceeds the rational work envelope")
+    denominator_bits = sum(
+        (q - 1).bit_length() for q in {t.coefficient.den for t in terms} if q != 1
+    )
+    height = denominator_bits + max(abs(t.coefficient.num).bit_length() for t in terms)
+    if height > 100_000:
+        _reject("polynomial coefficient comparisons exceed the input height envelope")
+    original_degree = max(d for d, _, _ in nonzero)
+    common_factor = _proportional_factor(matrix, nonzero) if original_degree else None
+    # A common monomial factor translates support without changing either
+    # reconstruction map. Restore it on D after Smith reduction, preserving
+    # module torsion; it is never inverted in the public coefficient ring.
+    shift = min(term.exponents[0] for term in terms) if common_factor is None else 0
+    degree = original_degree - shift if common_factor is None else 0
+    pivot_degree = pivot_degree - shift if common_factor is None else 0
+    affine = None
+    input_height = height
+    if degree == pivot_degree == 1:
+        exposed = _affine_pivot(matrix)
+        if exposed is not None:
+            affine, pivot_row, pivot_column = exposed
+            row_order.remove(pivot_row)
+            row_order.insert(0, pivot_row)
+            column_order.remove(pivot_column)
+            column_order.insert(0, pivot_column)
+            pivot_degree = 0
+            # The scalar is a ratio of two slopes. Bound elementary
+            # subtraction, its retained map, and unreduced coefficient work.
+            height = 6 * height + 8
+    bound = polynomial_smith_bound(
+        len(row_order),
+        len(column_order),
+        degree,
+        height,
+        pivot_degree=pivot_degree,
+        diagonal=diagonal,
+    )
+    if bound.degree + shift > 32_768:
+        _reject("restored Smith diagonal exceeds the polynomial exponent envelope")
+    # Final monic normalization divides a D and U row by the same rational
+    # leading coefficient. The shared scalar type allows 32768 decimal digits.
+    output_bits = (
+        4 * bound.height + 4 * input_height + 4
+        if affine is not None
+        else 2 * bound.height + 1
+    )
+    if output_bits > 100_000:
+        _reject("monic normalization exceeds the rational coefficient envelope")
+    output_bytes = cells * (bound.degree + 1) * (2 * output_bits + 512) + 1024
+    if common_factor is not None:
+        factor_bytes = sum(
+            512
+            + abs(term.coefficient.num).bit_length()
+            + term.coefficient.den.bit_length()
+            for term in common_factor.polynomial.terms
+        )
+        output_bytes = (
+            (rows * rows + columns * columns) * (2 * output_bits + 512)
+            + rows * columns * 512
+            + min(rows, columns) * factor_bytes
+            + 1024
+        )
+    if output_bytes > _MAX_SERIALIZED_BYTES:
+        _reject("serialized Smith matrices exceed the exact output envelope")
+    return _SmithPlan(
+        tuple(row_order), tuple(column_order), affine, shift, common_factor
+    )
+
+
+def _apply_affine_presolve(
+    entries: list[list[Any]],
+    row_order: tuple[int, ...],
+    column_order: tuple[int, ...],
+    affine: _AffinePivot | None,
+) -> tuple[bool, int, int, Any] | None:
+    if affine is None:
+        return None
+    from sympy import QQ
+
+    by_rows, original_source, original_target, scalar = affine
+    order = row_order if by_rows else column_order
+    source, target = order.index(original_source), order.index(original_target)
+    q = QQ(scalar.numerator, scalar.denominator)
+    if by_rows:
+        entries[target] = [
+            a - b.mul_ground(q)
+            for a, b in zip(entries[target], entries[source], strict=True)
+        ]
+    else:
+        for row in entries:
+            row[target] -= row[source].mul_ground(q)
+    return by_rows, source, target, q
+
+
+def _compose_affine_maps(
+    left: list[list[Any]],
+    right: list[list[Any]],
+    affine: tuple[bool, int, int, Any] | None,
+) -> None:
+    if affine is None:
+        return
+    by_rows, source, target, q = affine
+    if by_rows:
+        for row in left:
+            row[source] -= row[target].mul_ground(q)
+    else:
+        right[source] = [
+            a - b.mul_ground(q)
+            for a, b in zip(right[source], right[target], strict=True)
+        ]
+
+
+def _encode_polynomial(value: RationalPolynomial, plan: _SmithPlan, ring: Any) -> Any:
+    from sympy import QQ
+
+    if plan.common_factor is not None:
+        if not value.polynomial.terms:
+            return ring.zero
+        leading = value.polynomial.terms[0].coefficient
+        return ring(QQ(leading.num, leading.den))
+    return ring.ring.from_dict(
+        {
+            (term.exponents[0] - plan.shift,): QQ(
+                term.coefficient.num, term.coefficient.den
+            )
+            for term in value.polynomial.terms
+        }
+    )
+
+
+def polynomial_smith_decomposition(
+    matrix: RationalPolynomialMatrix,
+) -> PolynomialSmithDecomposition:
+    """Return the monic Smith diagonal and polynomial reconstruction maps."""
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return polynomial_smith_decomposition(matrix)
+    deadline = execution.started_at + _WALL_SECONDS
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before polynomial Smith admission")
+    plan = _admit(matrix)
+    row_order, column_order, affine, shift = (
+        plan.row_order,
+        plan.column_order,
+        plan.affine,
+        plan.shift,
+    )
+    request_checkpoint("before polynomial Smith conversion")
+
+    from sympy import QQ, Symbol
+    from sympy.polys.matrices import DomainMatrix
+    from sympy.polys.matrices.normalforms import smith_normal_decomp
+
+    ring = QQ.poly_ring(Symbol(matrix.variables[0]))
+
+    active_rows, active_columns = len(row_order), len(column_order)
+    source_entries = [
+        [_encode_polynomial(matrix.entries[i][j], plan, ring) for j in column_order]
+        for i in row_order
+    ]
+    affine_indices = _apply_affine_presolve(
+        source_entries, row_order, column_order, affine
+    )
+    source = DomainMatrix(source_entries, (active_rows, active_columns), ring)
+    diagonal, left, right = smith_normal_decomp(source)
+    request_checkpoint("after polynomial Smith kernel")
+    d, u, v = diagonal.to_list(), left.to_list(), right.to_list()
+    _compose_affine_maps(u, v, affine_indices)
+    common_factor_backend = (
+        ring.ring.from_dict(
+            {
+                term.exponents: QQ(term.coefficient.num, term.coefficient.den)
+                for term in plan.common_factor.polynomial.terms
+            }
+        )
+        if plan.common_factor is not None
+        else ring.one
+    )
+    for i in range(min(active_rows, active_columns)):
+        if d[i][i]:
+            scale = QQ.one / d[i][i].LC
+            d[i][i] = d[i][i].mul_ground(scale)
+            d[i][i] *= common_factor_backend
+            if shift:
+                d[i][i] *= ring.gens[0] ** shift
+            u[i] = [entry.mul_ground(scale) for entry in u[i]]
+
+    rows, columns = matrix.row_count, matrix.column_count
+    full_d = [[ring.zero for _ in range(columns)] for _ in range(rows)]
+    full_u = [[ring.zero for _ in range(rows)] for _ in range(rows)]
+    full_v = [[ring.zero for _ in range(columns)] for _ in range(columns)]
+    for i in range(active_rows):
+        for j in range(active_columns):
+            full_d[i][j] = d[i][j]
+        for j, original in enumerate(row_order):
+            full_u[i][original] = u[i][j]
+    for i, original in enumerate(column_order):
+        for j in range(active_columns):
+            full_v[original][j] = v[i][j]
+    for i, original in enumerate(j for j in range(rows) if j not in row_order):
+        full_u[active_rows + i][original] = ring.one
+    for i, original in enumerate(j for j in range(columns) if j not in column_order):
+        full_v[original][active_columns + i] = ring.one
+
+    def decode(entries: list[list[Any]], n: int, m: int) -> RationalPolynomialMatrix:
+        return RationalPolynomialMatrix(
+            variables=matrix.variables,
+            row_count=n,
+            column_count=m,
+            entries=tuple(
+                tuple(
+                    RationalPolynomial(
+                        variables=matrix.variables,
+                        polynomial=SparseRationalPolynomial(
+                            terms=tuple(
+                                RationalPolynomialTerm(
+                                    coefficient=CanonicalRational(
+                                        num=int(coefficient.numerator),
+                                        den=int(coefficient.denominator),
+                                    ),
+                                    exponents=exponents,
+                                )
+                                for exponents, coefficient in sorted(
+                                    value.items(), reverse=True
+                                )
+                            )
+                        ),
+                    )
+                    for value in row
+                )
+                for row in entries
+            ),
+        )
+
+    result = PolynomialSmithDecomposition(
+        diagonal=decode(full_d, rows, columns),
+        left_transformation=decode(full_u, rows, rows),
+        right_transformation=decode(full_v, columns, columns),
+    )
+    request_checkpoint("after polynomial Smith result construction")
+    return result
+
+
+__all__ = ["PolynomialSmithDecomposition", "polynomial_smith_decomposition"]

--- a/src/jacobian/math/matrices/inertia_cells/__init__.py
+++ b/src/jacobian/math/matrices/inertia_cells/__init__.py
@@ -1,0 +1,17 @@
+"""Exact inertia partitions for symmetric matrices over QQ[t]."""
+
+from jacobian.math.matrices.inertia_cells._models import (
+    InertiaCellsResult,
+    InertiaOpenCell,
+    InertiaParameterBoundary,
+    InertiaPointCell,
+)
+from jacobian.math.matrices.inertia_cells.operations import compute_inertia_cells
+
+__all__ = [
+    "InertiaCellsResult",
+    "InertiaOpenCell",
+    "InertiaParameterBoundary",
+    "InertiaPointCell",
+    "compute_inertia_cells",
+]

--- a/src/jacobian/math/matrices/inertia_cells/_admission.py
+++ b/src/jacobian/math/matrices/inertia_cells/_admission.py
@@ -144,6 +144,13 @@ def admit(
             )
     if total_bits > 1_000_000:
         raise reject_budget("source coefficients exceed one million component bits")
+    total_terms = sum(
+        len(entry.polynomial.terms) for row in matrix.entries for entry in row
+    )
+    if total_terms > 65_536:
+        raise reject_budget(
+            "source polynomial terms exceed the echoed-matrix allocation envelope"
+        )
     working = (
         specialize(matrix, interval.lower.as_fraction())
         if interval.lower == interval.upper

--- a/src/jacobian/math/matrices/inertia_cells/_admission.py
+++ b/src/jacobian/math/matrices/inertia_cells/_admission.py
@@ -1,0 +1,247 @@
+"""Source-derived bounds before characteristic expansion or root isolation."""
+
+from collections import Counter
+from dataclasses import dataclass
+from math import lcm
+
+from jacobian._execution import request_checkpoint
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.matrices.inertia_cells._normalization import (
+    normalize_affine,
+    specialize,
+)
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.polynomials.values import RationalPolynomial
+
+Block = tuple[tuple[RationalPolynomial, ...], ...]
+
+
+@dataclass(frozen=True)
+class BlockPlan:
+    entries: Block
+    multiplicity: int
+    degree: int
+    coefficient_bits: int
+    denominator: int
+
+
+def reject_budget(message: str) -> OperationResourceAdmissionError:
+    return OperationResourceAdmissionError(
+        location=("matrix",), code="matrix.inertia_cells.budget", message=message
+    )
+
+
+def _blocks(matrix: RationalPolynomialMatrix) -> Counter[Block]:
+    n = matrix.row_count
+    unseen = set(range(n))
+    blocks: Counter[Block] = Counter()
+    while unseen:
+        pending = [min(unseen)]
+        unseen.remove(pending[0])
+        axes: list[int] = []
+        while pending:
+            v = pending.pop()
+            axes.append(v)
+            adjacent = [
+                w for w in sorted(unseen) if matrix.entries[v][w].polynomial.terms
+            ]
+            unseen.difference_update(adjacent)
+            pending.extend(adjacent)
+        axes.sort()
+        block = tuple(tuple(matrix.entries[i][j] for j in axes) for i in axes)
+        blocks[block] += 1
+    return blocks
+
+
+def _block_plan(
+    block: Block, multiplicity: int, interval: ClosedRationalInterval
+) -> BlockPlan:
+    if len(block) == 1 and all(
+        t.exponents[0] <= 1 for t in block[0][0].polynomial.terms
+    ):
+        block = ((normalize_affine(block[0][0], interval),),)
+    coefficients = [
+        term.coefficient
+        for row in block
+        for entry in row
+        for term in entry.polynomial.terms
+    ]
+    degree = max(
+        (
+            term.exponents[0]
+            for row in block
+            for entry in row
+            for term in entry.polynomial.terms
+        ),
+        default=0,
+    )
+    n = len(block)
+    if n * degree > 16:
+        raise reject_budget(
+            "a connected block's characteristic coefficient degree exceeds the degree-16 algebraic carrier"
+        )
+    denominator = 1
+    for q in coefficients:
+        denominator = lcm(denominator, q.den)
+    height = max(
+        (
+            abs(q.num).bit_length() + (denominator // q.den).bit_length()
+            for q in coefficients
+        ),
+        default=1,
+    )
+    # The kernel computes charpoly(D*A), with positive D. This preserves
+    # every specialization inertia and removes all rational denominators.
+    # Principal k-minor coefficients have at most k!*(degree+1)^k
+    # products; the characteristic coefficient sums at most 2^n minors.
+    # The same bound with slack bounds division-free Berkowitz products.
+    bits = n * (height + n.bit_length() + (degree + 1).bit_length() + 2)
+    if bits > (100000 if n == 1 and degree <= 1 else 65536):
+        raise reject_budget(
+            "characteristic expansion exceeds the coefficient bit bound"
+        )
+    if (
+        degree
+        and not (n == 1 and degree == 1)
+        and bits + n * degree + (n * degree + 1).bit_length() > 3300
+    ):
+        raise reject_budget(
+            "primitive factor coefficients would exceed the canonical algebraic carrier"
+        )
+    return BlockPlan(block, multiplicity, n * degree, bits, denominator)
+
+
+def admit(
+    matrix: RationalPolynomialMatrix, interval: ClosedRationalInterval
+) -> tuple[BlockPlan, ...]:
+    n = matrix.row_count
+    if matrix.column_count != n:
+        raise OperationDomainValidationError(
+            location=("matrix",),
+            code="matrix.inertia_cells.shape",
+            message="matrix must be square",
+        )
+    if n > 128:
+        raise reject_budget("source matrix exceeds 16,384 ordered entries")
+    total_bits = 0
+    for i, row in enumerate(matrix.entries):
+        request_checkpoint("during inertia-cell source admission")
+        for j, entry in enumerate(row):
+            if entry != matrix.entries[j][i]:
+                raise OperationDomainValidationError(
+                    location=("matrix",),
+                    code="matrix.inertia_cells.symmetry",
+                    message="matrix must be symmetric over QQ[t]",
+                )
+            total_bits += sum(
+                abs(term.coefficient.num).bit_length()
+                + term.coefficient.den.bit_length()
+                for term in entry.polynomial.terms
+            )
+    if total_bits > 1_000_000:
+        raise reject_budget("source coefficients exceed one million component bits")
+    working = (
+        specialize(matrix, interval.lower.as_fraction())
+        if interval.lower == interval.upper
+        else matrix
+    )
+    plans = tuple(
+        _block_plan(block, multiplicity, interval)
+        for block, multiplicity in _blocks(working).items()
+    )
+    characteristic_work = sum(
+        len(p.entries) ** 4 * (p.degree + 1) ** 2 * p.coefficient_bits**2 for p in plans
+    )
+    if characteristic_work > 1_000_000_000_000:
+        raise reject_budget(
+            "division-free characteristic coefficient work exceeds the admitted budget"
+        )
+    _admit_isolation(plans, interval)
+    return plans
+
+
+def _admit_isolation(
+    plans: tuple[BlockPlan, ...], interval: ClosedRationalInterval
+) -> None:
+    all_active = tuple(p for p in plans if p.degree)
+    nonconstant = tuple(
+        p for p in all_active if not (len(p.entries) == 1 and p.degree == 1)
+    )
+    linear = tuple(p for p in all_active if len(p.entries) == 1 and p.degree == 1)
+    # Affine roots are rational: sorting exact ratios requires no factorization.
+    if not nonconstant:
+        # Exact sorting and affine signs use rational cross-products only.
+        if (
+            4 * (len(linear) + 2) * sum(p.coefficient_bits**2 for p in linear)
+            > 100_000_000_000_000
+        ):
+            raise reject_budget(
+                "rational affine comparisons exceed the arithmetic budget"
+            )
+        if 12 * sum(p.coefficient_bits for p in linear) > 64_000_000:
+            raise reject_budget("rational cell boundaries exceed the output bit budget")
+        return
+    degree = sum(p.degree for p in nonconstant) + len(linear) + 2
+    if degree > 130:
+        raise reject_budget("transition union exceeds 128 candidate roots")
+    endpoint_bits = max(
+        abs(q.num).bit_length() + q.den.bit_length()
+        for q in (interval.lower, interval.upper)
+    )
+    # A primitive squarefree divisor obeys Landau-Mignotte's factor bound.
+    # Product coefficient height adds a convolution factor per source.
+    height = (
+        sum(
+            p.coefficient_bits + p.degree + 2 * (p.degree + 1).bit_length()
+            for p in nonconstant
+        )
+        + sum(p.coefficient_bits + 2 for p in linear)
+        + 2 * endpoint_bits
+        + 4
+    )
+    # Cauchy and Mignotte bounds admit separating rational endpoints with
+    # this bit length, also separating the two rational domain endpoints.
+    isolation_bits = 4 * degree * (height + degree.bit_length() + 2) + height + 8
+    if isolation_bits > 100_000:
+        raise reject_budget(
+            "root separation exceeds the canonical rational endpoint envelope"
+        )
+    if degree**4 * height**2 > 1_000_000_000_000:
+        raise reject_budget(
+            "transition root isolation exceeds the admitted arithmetic budget"
+        )
+    sign_work = 0
+    factor_degree = max(p.degree for p in nonconstant)
+    factor_bits = max(
+        p.coefficient_bits + p.degree + (p.degree + 1).bit_length() for p in nonconstant
+    )
+    # Each boundary appears in a point and at most two adjacent open cells:
+    # twelve rational numerator/denominator components plus three minimal
+    # polynomials. Counts and fixed schema fields have bounded constant size.
+    output_bits = degree * (12 * isolation_bits + 3 * (factor_degree + 1) * factor_bits)
+    if output_bits > 64_000_000:
+        raise reject_budget("exact cell boundary output exceeds the bit budget")
+    for p in all_active:
+        # Remainders modulo a factor have common denominator dividing the
+        # source denominator times a power of the factor leading coefficient.
+        # Isolating factor*remainder needs degree at most 2*d-1.
+        remainder_bits = 4 * (p.degree + 1) * (p.coefficient_bits + factor_bits + 2)
+        sign_work += (
+            (len(p.entries) + 1)
+            * degree
+            * (factor_degree + min(p.degree, factor_degree - 1) + 1) ** 4
+            * remainder_bits**2
+        )
+    if sign_work > 100_000_000_000_000:
+        raise reject_budget(
+            "algebraic coefficient sign work exceeds the admitted budget"
+        )
+    if (
+        degree * len(plans) * max(p.degree for p in nonconstant) * isolation_bits
+        > 100_000_000
+    ):
+        raise reject_budget("rational cell sampling exceeds the admitted work budget")

--- a/src/jacobian/math/matrices/inertia_cells/_models.py
+++ b/src/jacobian/math/matrices/inertia_cells/_models.py
@@ -1,0 +1,112 @@
+"""Source-bound exact inertia strata of a one-parameter polynomial matrix."""
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+    RealAlgebraicValue,
+)
+
+
+class InertiaParameterBoundary(StrictModel):
+    """Exact parameter value and a rational interval isolating that value.
+
+    Irrational values use their primitive irreducible polynomial and selected
+    real-root index. Rational values have singleton isolating intervals.
+    Parsing is structural; the producer establishes the isolation relation.
+    """
+
+    value: CanonicalRational | RealAlgebraicValue
+    isolating_interval: RationalIsolatingInterval
+
+
+class _InertiaCounts(StrictModel):
+    n_positive: int = Field(ge=0, le=128)
+    n_negative: int = Field(ge=0, le=128)
+    n_zero: int = Field(ge=0, le=128)
+
+
+class InertiaPointCell(_InertiaCounts):
+    """A singleton parameter cell, including both domain endpoints."""
+
+    cell_type: Literal["POINT"] = "POINT"
+    parameter: InertiaParameterBoundary
+
+
+class InertiaOpenCell(_InertiaCounts):
+    """The open interval between the two exact parameter boundaries."""
+
+    cell_type: Literal["OPEN"] = "OPEN"
+    lower: InertiaParameterBoundary
+    upper: InertiaParameterBoundary
+
+
+InertiaCell = Annotated[
+    InertiaPointCell | InertiaOpenCell, Field(discriminator="cell_type")
+]
+
+
+class InertiaCellsRequest(StrictModel):
+    """A square symmetric QQ[t] matrix on a closed rational interval."""
+
+    matrix: RationalPolynomialMatrix
+    interval: ClosedRationalInterval
+
+
+class InertiaCellsResult(StrictModel):
+    """Alternating point/open cells covering exactly the retained interval.
+
+    Every rank-drop value is retained. Deterministic refinements from separate
+    diagonal blocks are allowed; equal-inertia neighbors are not merged.
+    """
+
+    matrix: RationalPolynomialMatrix
+    interval: ClosedRationalInterval
+    cells: tuple[InertiaCell, ...] = Field(min_length=1, max_length=261)
+
+    @model_validator(mode="after")
+    def require_partition_shape(self) -> Self:
+        n = self.matrix.row_count
+        if self.matrix.column_count != n:
+            raise ValueError("source matrix must be square")
+        if len(self.cells) % 2 != 1:
+            raise ValueError("cells must alternate POINT and OPEN, ending at POINT")
+        for i, cell in enumerate(self.cells):
+            if cell.n_positive + cell.n_negative + cell.n_zero != n:
+                raise ValueError("cell inertia counts must sum to the matrix order")
+            if i % 2 == 0:
+                if not isinstance(cell, InertiaPointCell):
+                    raise ValueError("even cells must be points")
+            else:
+                previous, following = self.cells[i - 1], self.cells[i + 1]
+                if (
+                    not isinstance(cell, InertiaOpenCell)
+                    or not isinstance(previous, InertiaPointCell)
+                    or not isinstance(following, InertiaPointCell)
+                ):
+                    raise ValueError("open cells must lie between points")
+                if (
+                    cell.lower != previous.parameter
+                    or cell.upper != following.parameter
+                ):
+                    raise ValueError(
+                        "open boundaries must agree with adjacent point cells"
+                    )
+        first, last = self.cells[0], self.cells[-1]
+        assert isinstance(first, InertiaPointCell) and isinstance(
+            last, InertiaPointCell
+        )
+        if (
+            first.parameter.value != self.interval.lower
+            or last.parameter.value != self.interval.upper
+        ):
+            raise ValueError("point cells must retain the closed domain endpoints")
+        if self.interval.lower == self.interval.upper and len(self.cells) != 1:
+            raise ValueError("singleton domains have exactly one point cell")
+        return self

--- a/src/jacobian/math/matrices/inertia_cells/_normalization.py
+++ b/src/jacobian/math/matrices/inertia_cells/_normalization.py
@@ -1,0 +1,132 @@
+"""Bounded scalar and singleton-domain reductions before algebraic admission."""
+
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import request_checkpoint
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _budget(message: str) -> OperationResourceAdmissionError:
+    return OperationResourceAdmissionError(
+        location=("interval",),
+        code="matrix.inertia_cells.specialization_budget",
+        message=message,
+    )
+
+
+def _polynomial(
+    variables: tuple[str, ...], coefficients: tuple[Fraction, ...]
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(q), exponents=(i,)
+                )
+                for i, q in reversed(tuple(enumerate(coefficients)))
+                if q
+            )
+        ),
+    )
+
+
+def normalize_affine(
+    poly: RationalPolynomial, interval: ClosedRationalInterval
+) -> RationalPolynomial:
+    """Keep only sign when no root lies in the domain; otherwise primitive affine."""
+    coefficients = {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in poly.polynomial.terms
+    }
+    a, b = coefficients.get(1, Fraction()), coefficients.get(0, Fraction())
+    if a:
+        root = -b / a
+        if interval.lower.as_fraction() <= root <= interval.upper.as_fraction():
+            if (
+                max(abs(root.numerator).bit_length(), root.denominator.bit_length())
+                > 100000
+            ):
+                raise _budget("rational transition exceeds canonical endpoint height")
+            sign = 1 if a > 0 else -1
+            return _polynomial(
+                poly.variables,
+                (Fraction(-sign * root.numerator), Fraction(sign * root.denominator)),
+            )
+    value = a * interval.lower.as_fraction() + b
+    sign = 1 if value > 0 else -1 if value < 0 else 0
+    return _polynomial(poly.variables, (Fraction(sign),))
+
+
+def specialize(
+    matrix: RationalPolynomialMatrix, parameter: Fraction
+) -> RationalPolynomialMatrix:
+    """Evaluate sparse QQ[t] entries after bounding powers and rational sums.
+
+    At 0 only constant terms contribute; at ±1 powers have unit height.
+    No root isolation or algebraic carrier is involved in a singleton domain.
+    """
+    work = 0
+    for row in matrix.entries:
+        for polynomial in row:
+            terms = tuple(
+                t
+                for t in polynomial.polynomial.terms
+                if parameter or not t.exponents[0]
+            )
+            degree = max((t.exponents[0] for t in terms), default=0)
+            denominator_bits = sum(t.coefficient.den.bit_length() for t in terms)
+            numerator_bits = max(
+                (abs(t.coefficient.num).bit_length() for t in terms), default=1
+            )
+            power_bits = (
+                1
+                if parameter in (0, 1, -1)
+                else degree
+                * max(
+                    abs(parameter.numerator).bit_length(),
+                    parameter.denominator.bit_length(),
+                )
+            )
+            bits = (
+                denominator_bits
+                + numerator_bits
+                + 2 * power_bits
+                + (len(terms) + 1).bit_length()
+            )
+            if bits > 100000:
+                raise _budget(
+                    "singleton polynomial evaluation exceeds the rational height budget"
+                )
+            work += (len(terms) + degree.bit_length() + 1) * bits**2
+    if work > 1_000_000_000_000:
+        raise _budget("singleton polynomial evaluation exceeds the arithmetic budget")
+    entries = []
+    for row in matrix.entries:
+        request_checkpoint("during admitted singleton specialization")
+        values = []
+        for polynomial in row:
+            value = sum(
+                (
+                    t.coefficient.as_fraction() * parameter ** t.exponents[0]
+                    for t in polynomial.polynomial.terms
+                    if parameter or not t.exponents[0]
+                ),
+                Fraction(),
+            )
+            values.append(_polynomial(matrix.variables, (value,)))
+        entries.append(tuple(values))
+    return RationalPolynomialMatrix(
+        variables=matrix.variables,
+        row_count=matrix.row_count,
+        column_count=matrix.column_count,
+        entries=tuple(entries),
+    )

--- a/src/jacobian/math/matrices/inertia_cells/_tools.py
+++ b/src/jacobian/math/matrices/inertia_cells/_tools.py
@@ -1,0 +1,69 @@
+"""Publication of exact one-parameter polynomial matrix inertia cells."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.matrices.inertia_cells._models import (
+    InertiaCellsRequest,
+    InertiaCellsResult,
+)
+from jacobian.math.matrices.inertia_cells.operations import compute_inertia_cells
+
+
+def _run(request: InertiaCellsRequest) -> InertiaCellsResult:
+    return compute_inertia_cells(request.matrix, request.interval)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="matrix.polynomial.inertia_cells.compute",
+        title="Compute exact inertia cells of a symmetric polynomial matrix",
+        description="Partition a closed rational parameter interval into alternating exact point cells and open intervals on which a symmetric QQ[t] matrix has constant inertia. Retains every rank-drop specialization, including persistent nullspaces and tangencies. Algebraic boundaries retain canonical root identities and rational isolating intervals. Both endpoints are singleton cells; a singleton domain has one point cell. Connected support blocks are processed independently under characteristic-growth, root-isolation, sign-work and output bounds with a shared 60-second deadline.",
+        request_type=InertiaCellsRequest,
+        result_type=InertiaCellsResult,
+        run=_run,
+        tags=("matrix", "polynomial", "inertia", "parameter", "singular", "exact"),
+        examples=(
+            OperationExample(
+                name="persistent_nullspace",
+                description="Partition diag(t²-2,0) at both irrational singular parameters; the polynomial matrix must be symmetric and the rational interval closed.",
+                input={
+                    "matrix": {
+                        "variables": ["t"],
+                        "row_count": 2,
+                        "column_count": 2,
+                        "entries": [
+                            [
+                                {
+                                    "variables": ["t"],
+                                    "polynomial": {
+                                        "terms": [
+                                            {
+                                                "coefficient": {"num": "1", "den": "1"},
+                                                "exponents": [2],
+                                            },
+                                            {
+                                                "coefficient": {
+                                                    "num": "-2",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [0],
+                                            },
+                                        ]
+                                    },
+                                },
+                                {"variables": ["t"], "polynomial": {"terms": []}},
+                            ],
+                            [
+                                {"variables": ["t"], "polynomial": {"terms": []}},
+                                {"variables": ["t"], "polynomial": {"terms": []}},
+                            ],
+                        ],
+                    },
+                    "interval": {
+                        "lower": {"num": "-2", "den": "1"},
+                        "upper": {"num": "2", "den": "1"},
+                    },
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/matrices/inertia_cells/operations.py
+++ b/src/jacobian/math/matrices/inertia_cells/operations.py
@@ -19,6 +19,7 @@ from jacobian._execution import (
     request_checkpoint,
     request_execution,
 )
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math._root_isolation import strict_root_count
 from jacobian.math.analysis.intervals import ClosedRationalInterval
 from jacobian.math.matrices.inertia_cells._admission import BlockPlan, admit
@@ -196,6 +197,29 @@ def _inertia(
     return {"n_positive": counts[0], "n_negative": counts[1], "n_zero": counts[2]}
 
 
+def _require_inertia_inputs(
+    matrix: object, interval: object
+) -> tuple[RationalPolynomialMatrix, ClosedRationalInterval]:
+    if not isinstance(matrix, RationalPolynomialMatrix) or not isinstance(
+        interval, ClosedRationalInterval
+    ):
+        raise TypeError("expected RationalPolynomialMatrix and ClosedRationalInterval")
+    try:
+        validated_matrix = RationalPolynomialMatrix.model_validate(
+            matrix.model_dump(warnings="none")
+        )
+        validated_interval = ClosedRationalInterval.model_validate(
+            interval.model_dump(warnings="none")
+        )
+    except Exception as exc:
+        raise OperationDomainValidationError(
+            location=(),
+            code="matrix.inertia_cells_domain",
+            message="inertia cell carriers failed structural validation",
+        ) from exc
+    return validated_matrix, validated_interval
+
+
 def compute_inertia_cells(
     matrix: RationalPolynomialMatrix, interval: ClosedRationalInterval
 ) -> InertiaCellsResult:
@@ -206,14 +230,11 @@ def compute_inertia_cells(
     intervening interval. Point cells are evaluated exactly, including nullity
     increases without sign changes and identically singular matrix families.
     """
-    if not isinstance(matrix, RationalPolynomialMatrix) or not isinstance(
-        interval, ClosedRationalInterval
-    ):
-        raise TypeError("expected RationalPolynomialMatrix and ClosedRationalInterval")
+    validated_matrix, validated_interval = _require_inertia_inputs(matrix, interval)
     if current_request_execution() is None:
         with request_execution(time.monotonic()):
-            return _compute(matrix, interval)
-    return _compute(matrix, interval)
+            return _compute(validated_matrix, validated_interval)
+    return _compute(validated_matrix, validated_interval)
 
 
 def _compute(

--- a/src/jacobian/math/matrices/inertia_cells/operations.py
+++ b/src/jacobian/math/matrices/inertia_cells/operations.py
@@ -230,10 +230,16 @@ def compute_inertia_cells(
     intervening interval. Point cells are evaluated exactly, including nullity
     increases without sign changes and identically singular matrix families.
     """
-    validated_matrix, validated_interval = _require_inertia_inputs(matrix, interval)
-    if current_request_execution() is None:
+    execution = current_request_execution()
+    if execution is None:
         with request_execution(time.monotonic()):
-            return _compute(validated_matrix, validated_interval)
+            return compute_inertia_cells(matrix, interval)
+    deadline = execution.started_at + 60.0
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before inertia input revalidation")
+    validated_matrix, validated_interval = _require_inertia_inputs(matrix, interval)
     return _compute(validated_matrix, validated_interval)
 
 

--- a/src/jacobian/math/matrices/inertia_cells/operations.py
+++ b/src/jacobian/math/matrices/inertia_cells/operations.py
@@ -1,0 +1,259 @@
+"""Exact polynomial inertia through real-rooted characteristic coefficients.
+
+Schweighofer, Real Algebraic Geometry (2016/17), Theorem 1.5.14 and
+Example 1.5.15: Descartes sign variation counts positive eigenvalues exactly
+for the characteristic polynomial of a real symmetric matrix.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Any, TypedDict
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.math._root_isolation import strict_root_count
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.matrices.inertia_cells._admission import BlockPlan, admit
+from jacobian.math.matrices.inertia_cells._models import (
+    InertiaCell,
+    InertiaCellsResult,
+    InertiaOpenCell,
+    InertiaParameterBoundary,
+    InertiaPointCell,
+)
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+    RealAlgebraicValue,
+)
+from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
+
+
+class _Counts(TypedDict):
+    n_positive: int
+    n_negative: int
+    n_zero: int
+
+
+@dataclass(frozen=True)
+class _Boundary:
+    public: InertiaParameterBoundary
+    lower: Any
+    upper: Any
+    factor: Any | None = None
+    root_index: int = 0
+
+
+def _rational(q: Any) -> CanonicalRational:
+    return CanonicalRational(num=int(q.p), den=int(q.q))
+
+
+def _rational_boundary(q: Any) -> _Boundary:
+    value = _rational(q)
+    return _Boundary(
+        InertiaParameterBoundary(
+            value=value,
+            isolating_interval=RationalIsolatingInterval(
+                lower=value, upper=value, interval_type="SINGLETON"
+            ),
+        ),
+        q,
+        q,
+    )
+
+
+def _coefficients(plan: BlockPlan) -> list[Any]:
+    from sympy import QQ, Poly, Symbol
+    from sympy.polys.matrices import DomainMatrix
+
+    t = Symbol(plan.entries[0][0].variables[0])
+    ring = QQ.poly_ring(t)
+    rows = {
+        i: {
+            j: ring.from_sympy(
+                rational_polynomial_to_sympy(entry).as_expr() * plan.denominator
+            )
+            for j, entry in enumerate(row)
+            if entry.polynomial.terms
+        }
+        for i, row in enumerate(plan.entries)
+    }
+    charpoly = DomainMatrix(rows, (len(rows), len(rows)), ring).charpoly()
+    return [Poly(ring.to_sympy(coefficient), t, domain=QQ) for coefficient in charpoly]
+
+
+def _primitive(poly: Any) -> Any:
+    _, integer = poly.clear_denoms(convert=True)
+    _, primitive = integer.primitive()
+    return -primitive if primitive.LC() < 0 else primitive
+
+
+def _boundaries(
+    coefficients: list[list[Any]], lower: Any, upper: Any
+) -> list[_Boundary]:
+    from sympy import Poly
+
+    if lower == upper:
+        return [_rational_boundary(lower)]
+    transitions = [
+        next(c for c in reversed(block) if not c.is_zero) for block in coefficients
+    ]
+    active = [p for p in transitions if p.degree() > 0]
+    if not active:
+        return [_rational_boundary(lower), _rational_boundary(upper)]
+    if all(p.degree() == 1 for p in active):
+        roots = {-p.TC() / p.LC() for p in active}
+        return [
+            _rational_boundary(q)
+            for q in sorted({lower, upper, *(q for q in roots if lower <= q <= upper)})
+        ]
+    t = active[0].gens[0]
+    factors: dict[tuple[int, ...], Any] = {}
+    for polynomial in (*active, Poly(t - lower, t), Poly(t - upper, t)):
+        request_checkpoint("during transition factorization")
+        for factor, _ in _primitive(polynomial).factor_list()[1]:
+            factor = _primitive(factor)
+            factors[tuple(int(c) for c in factor.all_coeffs())] = factor
+    product = Poly(1, t)
+    for factor in factors.values():
+        product *= factor
+    root_indices = dict.fromkeys(factors, 0)
+    answer: list[_Boundary] = []
+    request_checkpoint("before transition root isolation")
+    for (lo, hi), _ in product.intervals():
+        request_checkpoint("during transition root isolation")
+        key = next(key for key, f in factors.items() if strict_root_count(f, lo, hi))
+        factor = factors[key]
+        index = root_indices[key]
+        root_indices[key] += 1
+        if factor.degree() == 1:
+            value = -factor.TC() / factor.LC()
+            if lower <= value <= upper:
+                answer.append(_rational_boundary(value))
+        elif lo >= lower and hi <= upper:
+            # Isolating open intervals may touch a different rational root.
+            # Refine away from every product root so midpoint samples are
+            # strictly inside their parameter cells, never at a point cell.
+            while product.eval(lo) == 0 or product.eval(hi) == 0:
+                request_checkpoint("during boundary separation")
+                lo, hi = factor.refine_root(lo, hi, steps=1)
+            algebraic = RealAlgebraicValue._from_admitted_polynomial(
+                polynomial=key, real_root_index=index
+            )
+            boundary = InertiaParameterBoundary(
+                value=algebraic,
+                isolating_interval=RationalIsolatingInterval(
+                    lower=_rational(lo), upper=_rational(hi), interval_type="OPEN"
+                ),
+            )
+            answer.append(_Boundary(boundary, lo, hi, factor, index))
+    return answer
+
+
+def _sign_at_root(polynomial: Any, boundary: _Boundary) -> int:
+    if boundary.factor is None or polynomial.degree() <= 0:
+        value = polynomial.eval(boundary.lower)
+        return 1 if value > 0 else -1 if value < 0 else 0
+    representative = polynomial.rem(boundary.factor)
+    if representative.is_zero:
+        return 0
+    # Same coprime-product isolation relation used by the exact real field
+    # owner: a reduced nonzero representative shares no root with the factor.
+    seen = 0
+    for (lo, hi), _ in (boundary.factor * representative).intervals():
+        if not strict_root_count(boundary.factor, lo, hi):
+            continue
+        if seen == boundary.root_index:
+            sample = lo if lo == hi else (lo + hi) / 2
+            value = representative.eval(sample)
+            return 1 if value > 0 else -1 if value < 0 else 0
+        seen += 1
+    raise ArithmeticError("exact coefficient sign isolation lost its defining root")
+
+
+def _inertia(
+    coefficients: list[list[Any]], plans: tuple[BlockPlan, ...], boundary: _Boundary
+) -> _Counts:
+    counts = [0, 0, 0]
+    for block, plan in zip(coefficients, plans, strict=True):
+        request_checkpoint("during exact inertia specialization")
+        signs = [_sign_at_root(c, boundary) for c in block]
+        positive = [s for s in signs if s]
+        negative = [s * (-1) ** i for i, s in enumerate(signs) if s]
+        p = sum(a != b for a, b in pairwise(positive))
+        m = sum(a != b for a, b in pairwise(negative))
+        counts[0] += plan.multiplicity * p
+        counts[1] += plan.multiplicity * m
+        counts[2] += plan.multiplicity * (len(plan.entries) - p - m)
+    return {"n_positive": counts[0], "n_negative": counts[1], "n_zero": counts[2]}
+
+
+def compute_inertia_cells(
+    matrix: RationalPolynomialMatrix, interval: ClosedRationalInterval
+) -> InertiaCellsResult:
+    """Partition a closed parameter interval into exact constant-inertia cells.
+
+    Rank is constant away from zeros of the lowest nonzero characteristic
+    coefficient. Eigenvalue continuity then makes inertia constant on each
+    intervening interval. Point cells are evaluated exactly, including nullity
+    increases without sign changes and identically singular matrix families.
+    """
+    if not isinstance(matrix, RationalPolynomialMatrix) or not isinstance(
+        interval, ClosedRationalInterval
+    ):
+        raise TypeError("expected RationalPolynomialMatrix and ClosedRationalInterval")
+    if current_request_execution() is None:
+        with request_execution(time.monotonic()):
+            return _compute(matrix, interval)
+    return _compute(matrix, interval)
+
+
+def _compute(
+    matrix: RationalPolynomialMatrix, interval: ClosedRationalInterval
+) -> InertiaCellsResult:
+    from sympy import Rational
+
+    execution = current_request_execution()
+    assert execution is not None
+    deadline = execution.started_at + 60.0
+    bind_request_deadline(
+        min(deadline, execution.deadline)
+        if execution.deadline is not None
+        else deadline
+    )
+    plans = admit(matrix, interval)
+    coefficients = []
+    for plan in plans:
+        request_checkpoint("before polynomial characteristic expansion")
+        coefficients.append(_coefficients(plan))
+    lower, upper = (Rational(q.num, q.den) for q in (interval.lower, interval.upper))
+    boundaries = _boundaries(coefficients, lower, upper)
+    cells: list[InertiaCell] = []
+    for i, boundary in enumerate(boundaries):
+        if i:
+            previous = boundaries[i - 1]
+            q = (previous.upper + boundary.lower) / 2
+            sample = _Boundary(previous.public, q, q)
+            cells.append(
+                InertiaOpenCell(
+                    lower=previous.public,
+                    upper=boundary.public,
+                    **_inertia(coefficients, plans, sample),
+                )
+            )
+        cells.append(
+            InertiaPointCell(
+                parameter=boundary.public, **_inertia(coefficients, plans, boundary)
+            )
+        )
+    result = InertiaCellsResult(matrix=matrix, interval=interval, cells=tuple(cells))
+    request_checkpoint("after inertia-cell result construction")
+    return result

--- a/src/jacobian/math/matrices/symbolic/__init__.py
+++ b/src/jacobian/math/matrices/symbolic/__init__.py
@@ -12,12 +12,14 @@ from jacobian.math.matrices.symbolic.values import (
     RationalFunctionMatrix,
     RationalFunctionVector,
     RationalFunctionVectorBasis,
+    RationalPolynomialMatrix,
 )
 
 __all__ = [
     "RationalFunctionMatrix",
     "RationalFunctionVector",
     "RationalFunctionVectorBasis",
+    "RationalPolynomialMatrix",
     "symbolic_characteristic_polynomial",
     "symbolic_determinant",
     "symbolic_linear_system_solve",

--- a/src/jacobian/math/matrices/symbolic/values.py
+++ b/src/jacobian/math/matrices/symbolic/values.py
@@ -1,4 +1,10 @@
-"""Canonical rational-function matrix and vector values."""
+"""Canonical polynomial-ring and rational-function matrix values."""
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
 
 # The operation request models remain in ``_models`` for the symbolic catalog,
 # while these names provide the stable value-owned import path for producers
@@ -8,9 +14,40 @@ from jacobian.math.matrices.symbolic._models import (
     RationalFunctionVector,
     RationalFunctionVectorBasis,
 )
+from jacobian.math.polynomials.values import PolynomialVariable, RationalPolynomial
+
+
+class RationalPolynomialMatrix(StrictModel):
+    """A rectangular matrix over QQ[t], including its empty ordered axes.
+
+    Entries reuse the polynomial owner's canonical values. This carrier never
+    silently embeds the coefficient ring in its field of fractions.
+    """
+
+    domain: Literal["QQ"] = "QQ"
+    variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=1)
+    row_count: int = Field(ge=0, le=8192)
+    column_count: int = Field(ge=0, le=8192)
+    entries: tuple[
+        Annotated[tuple[RationalPolynomial, ...], Field(max_length=8192)], ...
+    ] = Field(max_length=8192)
+
+    @model_validator(mode="after")
+    def require_shape_and_ring(self) -> Self:
+        if len(self.entries) != self.row_count or any(
+            len(row) != self.column_count for row in self.entries
+        ):
+            raise ValueError("polynomial entries must match the declared matrix axes")
+        if any(
+            entry.variables != self.variables for row in self.entries for entry in row
+        ):
+            raise ValueError("every polynomial must belong to the matrix's QQ[t] ring")
+        return self
+
 
 __all__ = [
     "RationalFunctionMatrix",
     "RationalFunctionVector",
     "RationalFunctionVectorBasis",
+    "RationalPolynomialMatrix",
 ]

--- a/tests/math/matrices/inertia_cells/test_inertia_cells.py
+++ b/tests/math/matrices/inertia_cells/test_inertia_cells.py
@@ -247,3 +247,16 @@ def test_singleton_specialization_of_high_degree_nondiagonal_matrix() -> None:
         result.cells[0].n_negative,
         result.cells[0].n_zero,
     ) == (1, 1, 0)
+
+
+def test_copied_inconsistent_inertia_carriers_are_rejected() -> None:
+    source = _source(sp.Matrix([[1]]))
+    forged_matrix = source.model_copy(update={"row_count": 0})
+    with pytest.raises(OperationDomainValidationError, match="structural"):
+        compute_inertia_cells(forged_matrix, _interval(0, 1))
+    reversed_interval = ClosedRationalInterval.model_construct(
+        lower=CanonicalRational(num=1, den=1),
+        upper=CanonicalRational(num=0, den=1),
+    )
+    with pytest.raises(OperationDomainValidationError, match="structural"):
+        compute_inertia_cells(source, reversed_interval)

--- a/tests/math/matrices/inertia_cells/test_inertia_cells.py
+++ b/tests/math/matrices/inertia_cells/test_inertia_cells.py
@@ -1,0 +1,249 @@
+"""Exact coverage, singular fibers and independent spectral evidence."""
+
+import json
+from fractions import Fraction
+from itertools import pairwise
+from typing import Any
+
+import pytest
+import sympy as sp
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.matrices.inertia_cells import (
+    InertiaCellsResult,
+    InertiaOpenCell,
+    InertiaPointCell,
+    compute_inertia_cells,
+)
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.polynomials._conversions import rational_polynomial_from_sympy
+
+T = sp.Symbol("t")
+
+
+def _source(matrix: Any) -> RationalPolynomialMatrix:
+    return RationalPolynomialMatrix(
+        variables=("t",),
+        row_count=matrix.rows,
+        column_count=matrix.cols,
+        entries=tuple(
+            tuple(
+                rational_polynomial_from_sympy(
+                    sp.Poly(matrix[i, j], T, domain=sp.QQ), ("t",)
+                )
+                for j in range(matrix.cols)
+            )
+            for i in range(matrix.rows)
+        ),
+    )
+
+
+def _interval(a: int | Fraction = -2, b: int | Fraction = 2) -> ClosedRationalInterval:
+    return ClosedRationalInterval(
+        lower=CanonicalRational.from_fraction(Fraction(a)),
+        upper=CanonicalRational.from_fraction(Fraction(b)),
+    )
+
+
+def _value(boundary: Any) -> Any:
+    value = boundary.value
+    if isinstance(value, CanonicalRational):
+        return sp.Rational(value.num, value.den)
+    return sp.CRootOf(sp.Poly.from_list(value.polynomial, T), value.real_root_index)
+
+
+def _counts(matrix: Any) -> tuple[int, int, int]:
+    positive = negative = zero = 0
+    for eigenvalue, multiplicity in matrix.eigenvals().items():
+        if eigenvalue == 0:
+            zero += multiplicity
+        elif eigenvalue.is_positive:
+            positive += multiplicity
+        else:
+            assert eigenvalue.is_negative
+            negative += multiplicity
+    return positive, negative, zero
+
+
+def _check(
+    matrix: Any, interval: ClosedRationalInterval | None = None
+) -> InertiaCellsResult:
+    interval = interval or _interval()
+    result = compute_inertia_cells(_source(matrix), interval)
+    points = [cell for cell in result.cells if isinstance(cell, InertiaPointCell)]
+    values = [_value(p.parameter) for p in points]
+    assert values[0] == sp.Rational(interval.lower.num, interval.lower.den)
+    assert values[-1] == sp.Rational(interval.upper.num, interval.upper.den)
+    assert all(a < b for a, b in pairwise(values))
+    for cell in result.cells:
+        if isinstance(cell, InertiaPointCell):
+            parameter = _value(cell.parameter)
+        else:
+            assert isinstance(cell, InertiaOpenCell)
+            lo = cell.lower.isolating_interval.upper.as_fraction()
+            hi = cell.upper.isolating_interval.lower.as_fraction()
+            parameter = sp.Rational((lo + hi) / 2)
+            assert _value(cell.lower) < parameter < _value(cell.upper)
+        expected = _counts(matrix.subs(T, parameter))
+        assert (cell.n_positive, cell.n_negative, cell.n_zero) == expected
+    assert InertiaCellsResult.model_validate_json(result.model_dump_json()) == result
+    return result
+
+
+def test_persistent_nullspace_and_irrational_rank_drops() -> None:
+    result = _check(sp.diag(T**2 - 2, 0))
+    assert len(result.cells) == 7
+    assert [c.n_zero for c in result.cells] == [1, 1, 2, 1, 2, 1, 1]
+
+
+def test_tangency_does_not_disappear() -> None:
+    result = _check(sp.diag(T**2, 1))
+    assert len(result.cells) == 5
+    assert result.cells[2].n_zero == 1
+    assert all(c.n_negative == 0 for c in result.cells)
+
+
+def test_indefinite_family_without_real_rank_drops() -> None:
+    result = _check(sp.Matrix([[T, 1], [1, -T]]))
+    assert len(result.cells) == 3
+    assert all(
+        (c.n_positive, c.n_negative, c.n_zero) == (1, 1, 0) for c in result.cells
+    )
+
+
+@pytest.mark.parametrize(
+    "matrix", [sp.zeros(0), sp.zeros(3), sp.diag(1, -1, 0), sp.Matrix([[0, 1], [1, 0]])]
+)
+def test_empty_zero_and_constant(matrix: Any) -> None:
+    _check(matrix)
+    _check(matrix, _interval(1, 1))
+
+
+def test_endpoint_singularities_and_singleton() -> None:
+    matrix = sp.diag(T * (T - 1), T)
+    assert len(_check(matrix, _interval(0, 1)).cells) == 3
+    assert _check(matrix, _interval(0, 0)).cells[0].n_zero == 2
+
+
+def test_repeated_roots_and_distinct_factor_union() -> None:
+    _check(sp.diag((T**2 - 2) ** 2, T**2 - 2, T**2 - 3))
+
+
+def test_congruence_preserves_cell_inertia() -> None:
+    transform = sp.Matrix([[1, 1, 0], [0, 1, 1], [1, 0, 1]])
+    diagonal = sp.diag(T, T - 1, 0)
+    source = transform.T * diagonal * transform
+    result = compute_inertia_cells(_source(source), _interval())
+    for cell in result.cells:
+        if isinstance(cell, InertiaPointCell):
+            value = _value(cell.parameter)
+        else:
+            value = sp.Rational(
+                (
+                    cell.lower.isolating_interval.upper.as_fraction()
+                    + cell.upper.isolating_interval.lower.as_fraction()
+                )
+                / 2
+            )
+        assert (cell.n_positive, cell.n_negative, cell.n_zero) == _counts(
+            diagonal.subs(T, value)
+        )
+
+
+def test_large_repeated_singular_blocks() -> None:
+    matrix = sp.diag(*([T**2 - 2] * 64), *([0] * 64))
+    result = compute_inertia_cells(_source(matrix), _interval())
+    assert len(result.cells) == 7
+    assert [c.n_zero for c in result.cells] == [64, 64, 128, 64, 128, 64, 64]
+
+
+def test_polynomial_symmetry_rejection() -> None:
+    with pytest.raises(OperationDomainValidationError, match="symmetric"):
+        compute_inertia_cells(_source(sp.Matrix([[T, 1], [0, T]])), _interval())
+
+
+def test_connected_algebraic_degree_rejection() -> None:
+    with pytest.raises(OperationResourceAdmissionError, match="degree-16"):
+        compute_inertia_cells(_source(sp.Matrix([[T**17 - T - 1]])), _interval())
+
+
+def test_excessive_coefficient_growth_rejection() -> None:
+    with pytest.raises(OperationResourceAdmissionError, match="carrier"):
+        compute_inertia_cells(
+            _source(sp.Matrix([[T**2 - (10**1000 + 7)]])),
+            _interval(-(10**501), 10**501),
+        )
+
+
+def test_structural_cell_contradiction_rejected() -> None:
+    result = compute_inertia_cells(_source(sp.diag(T)), _interval())
+    payload = result.model_dump(mode="json")
+    payload["cells"][1]["n_zero"] = 1
+    with pytest.raises(ValidationError, match="sum"):
+        InertiaCellsResult.model_validate_json(json.dumps(payload))
+
+
+def test_singular_endpoint_samples_stay_in_open_cells() -> None:
+    _check(sp.diag((T + 2) * (T**2 - 2), 0))
+    _check(sp.diag(T**2 - 2), _interval(Fraction(-3, 2), Fraction(-7, 5)))
+
+
+def test_algebraic_coefficient_sign_at_nonlinear_boundary() -> None:
+    transform = sp.Matrix([[1, 1], [1, 2]])
+    diagonal = sp.diag(T**3 - T - 1, T + 2)
+    source = transform.T * diagonal * transform
+    result = compute_inertia_cells(_source(source), _interval())
+    for cell in result.cells:
+        if isinstance(cell, InertiaPointCell):
+            value = _value(cell.parameter)
+        else:
+            value = sp.Rational(
+                (
+                    cell.lower.isolating_interval.upper.as_fraction()
+                    + cell.upper.isolating_interval.lower.as_fraction()
+                )
+                / 2
+            )
+        assert (cell.n_positive, cell.n_negative, cell.n_zero) == _counts(
+            diagonal.subs(T, value)
+        )
+
+
+def test_positive_denominator_scaling_preserves_profile() -> None:
+    transform = sp.Matrix([[1, 1], [1, 2]])
+    matrix = transform.T * sp.diag(T**2 - 2, 0) * transform
+    result = compute_inertia_cells(
+        _source(matrix / sp.Integer(2) ** 20000), _interval()
+    )
+    ordinary = compute_inertia_cells(_source(matrix), _interval())
+    assert result.cells == ordinary.cells
+
+
+def test_affine_large_coefficient_and_high_degree_singleton() -> None:
+    affine = _check(sp.Matrix([[T + 10**1000]]))
+    assert len(affine.cells) == 3
+    assert all(c.n_positive == 1 for c in affine.cells)
+    singleton = _check(sp.Matrix([[T**17]]), _interval(0, 0))
+    assert len(singleton.cells) == 1
+    assert singleton.cells[0].n_zero == 1
+
+
+def test_large_rational_affine_transition_inside_domain() -> None:
+    result = _check(sp.Matrix([[10**1000 * T - 1]]))
+    assert len(result.cells) == 5
+    assert result.cells[2].n_zero == 1
+
+
+def test_singleton_specialization_of_high_degree_nondiagonal_matrix() -> None:
+    result = _check(sp.Matrix([[T**17, 1], [1, -(T**17)]]), _interval(0, 0))
+    assert (
+        result.cells[0].n_positive,
+        result.cells[0].n_negative,
+        result.cells[0].n_zero,
+    ) == (1, 1, 0)

--- a/tests/math/matrices/test_polynomial_matrix_value.py
+++ b/tests/math/matrices/test_polynomial_matrix_value.py
@@ -1,0 +1,75 @@
+"""QQ[t] carrier ownership, scalar reuse and empty-axis serialization."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.matrices.symbolic import RationalPolynomialMatrix
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _polynomial(variable: str) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=(variable,),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(num=1, den=2), exponents=(2,)
+                ),
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize("rows,columns", [(0, 0), (0, 7), (4, 0)])
+def test_empty_axes_retain_the_polynomial_ring(rows: int, columns: int) -> None:
+    matrix = RationalPolynomialMatrix(
+        variables=("t",),
+        row_count=rows,
+        column_count=columns,
+        entries=tuple(() for _ in range(rows)),
+    )
+    assert (
+        RationalPolynomialMatrix.model_validate_json(matrix.model_dump_json()) == matrix
+    )
+
+
+def test_entries_reuse_the_canonical_polynomial_value() -> None:
+    entry = _polynomial("z")
+    matrix = RationalPolynomialMatrix(
+        variables=("z",),
+        row_count=1,
+        column_count=1,
+        entries=((entry,),),
+    )
+    restored = RationalPolynomialMatrix.model_validate_json(matrix.model_dump_json())
+    assert restored.entries[0][0] == entry
+    assert restored.entries[0][0].model_dump() == entry.model_dump()
+
+
+def test_ring_changes_and_ragged_rows_are_not_implicit_coercions() -> None:
+    with pytest.raises(ValidationError, match="ring"):
+        RationalPolynomialMatrix(
+            variables=("t",),
+            row_count=1,
+            column_count=1,
+            entries=((_polynomial("z"),),),
+        )
+    with pytest.raises(ValidationError, match="axes"):
+        RationalPolynomialMatrix(
+            variables=("t",),
+            row_count=1,
+            column_count=2,
+            entries=((_polynomial("t"),),),
+        )
+    with pytest.raises(ValidationError):
+        RationalPolynomialMatrix(
+            variables=("t", "z"),
+            row_count=0,
+            column_count=0,
+            entries=(),
+        )

--- a/tests/math/matrices/test_polynomial_smith.py
+++ b/tests/math/matrices/test_polynomial_smith.py
@@ -6,7 +6,10 @@ import pytest
 from sympy import QQ, Matrix, Poly, Rational, Symbol, gcd
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.matrices.certified_snf import polynomial_smith_decomposition
 from jacobian.math.matrices.certified_snf.polynomial import PolynomialSmithDecomposition
 from jacobian.math.matrices.symbolic import RationalPolynomialMatrix
@@ -245,3 +248,10 @@ def test_proportional_sparse_polynomial_entries_retain_the_common_factor() -> No
     )
     assert (u * _sympy(source) * v).applyfunc(lambda value: value.expand()) == d
     assert d == Matrix.diag(p, p)
+
+
+def test_copied_inconsistent_axes_are_rejected_before_admission() -> None:
+    source = _matrix([[t]])
+    forged = source.model_copy(update={"row_count": 0})
+    with pytest.raises(OperationDomainValidationError, match="structural"):
+        polynomial_smith_decomposition(forged)

--- a/tests/math/matrices/test_polynomial_smith.py
+++ b/tests/math/matrices/test_polynomial_smith.py
@@ -1,0 +1,217 @@
+"""Polynomial Smith identities and independently computed determinantal divisors."""
+
+from itertools import combinations, pairwise
+
+import pytest
+from sympy import QQ, Matrix, Poly, Rational, Symbol, gcd
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.matrices.certified_snf import polynomial_smith_decomposition
+from jacobian.math.matrices.certified_snf.polynomial import PolynomialSmithDecomposition
+from jacobian.math.matrices.symbolic import RationalPolynomialMatrix
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+t = Symbol("t")
+
+
+def _matrix(
+    rows: list[list[object]], *, columns: int | None = None
+) -> RationalPolynomialMatrix:
+    return RationalPolynomialMatrix(
+        variables=("t",),
+        row_count=len(rows),
+        column_count=len(rows[0]) if rows else (columns or 0),
+        entries=tuple(
+            tuple(
+                RationalPolynomial(
+                    variables=("t",),
+                    polynomial=SparseRationalPolynomial(
+                        terms=tuple(
+                            RationalPolynomialTerm(
+                                coefficient=CanonicalRational(
+                                    num=int(c.p), den=int(c.q)
+                                ),
+                                exponents=exponents,
+                            )
+                            for exponents, c in Poly(value, t, domain=QQ).terms()
+                            if c
+                        )
+                    ),
+                )
+                for value in row
+            )
+            for row in rows
+        ),
+    )
+
+
+def _sympy(matrix: RationalPolynomialMatrix) -> Matrix:
+    return Matrix(
+        matrix.row_count,
+        matrix.column_count,
+        [
+            sum(
+                Rational(term.coefficient.num, term.coefficient.den)
+                * t ** term.exponents[0]
+                for term in p.polynomial.terms
+            )
+            for row in matrix.entries
+            for p in row
+        ],
+    )
+
+
+def _identities(
+    source: RationalPolynomialMatrix, result: PolynomialSmithDecomposition
+) -> None:
+    a, d, u, v = map(
+        _sympy,
+        (
+            source,
+            result.diagonal,
+            result.left_transformation,
+            result.right_transformation,
+        ),
+    )
+    assert (u * a * v).applyfunc(lambda value: value.expand()) == d
+    for transformation in (u, v):
+        determinant = Poly(transformation.det(), t, domain=QQ)
+        assert determinant and determinant.degree() == 0
+    factors = [Poly(d[i, i], t, domain=QQ) for i in range(min(a.shape))]
+    nonzero = [factor for factor in factors if factor]
+    assert all(factor.LC() == 1 for factor in nonzero)
+    assert factors[: len(nonzero)] == nonzero
+    assert all(right.rem(left).is_zero for left, right in pairwise(nonzero))
+    assert all(d[i, j] == 0 for i in range(d.rows) for j in range(d.cols) if i != j)
+    product = Poly(1, t, domain=QQ)
+    for size, factor in enumerate(nonzero, 1):
+        divisor = Poly(0, t, domain=QQ)
+        for rows in combinations(range(a.rows), size):
+            for columns in combinations(range(a.cols), size):
+                divisor = gcd(
+                    divisor, Poly(a.extract(rows, columns).det(), t, domain=QQ)
+                )
+        product *= factor
+        assert divisor.monic() == product
+
+
+@pytest.mark.parametrize(
+    "rows,expected",
+    [
+        ([[t, 1], [0, t]], [1, t * t]),
+        ([[t, t * t, 0], [0, 0, 0]], [t, 0]),
+        ([[2 * t, Rational(1, 2)], [0, 3 * t]], [1, t * t]),
+        ([[0, 0], [t, t * t], [0, 0]], [t, 0]),
+        ([[t, t + 1]], [1]),
+        ([[t * t + 1, t]], [1]),
+        ([[t * t + 1, t * t + t]], [1]),
+        ([[1, 1 + t], [t, t * t]], [1, t]),
+        ([[t, t + 1], [t + 2, t + 3]], [1, 1]),
+        ([[t, t + 1], [2 * t, 2 * t + 2]], [1, 0]),
+        ([[t, t], [t, t]], [t, 0]),
+        ([[t * t, t * (t + 1)], [t * (t + 2), t * (t + 3)]], [t, t]),
+        ([[t + 1, 0], [0, t + 2]], [1, (t + 1) * (t + 2)]),
+        ([[t + 1, t + 1], [t + 1, t + 1]], [t + 1, 0]),
+    ],
+)
+def test_motivating_rectangular_and_rational_unit_cases(
+    rows: list[list[object]], expected: list[object]
+) -> None:
+    source = _matrix(rows)
+    result = polynomial_smith_decomposition(source)
+    _identities(source, result)
+    d = _sympy(result.diagonal)
+    assert [Poly(d[i, i], t) for i in range(min(d.shape))] == [
+        Poly(value, t) for value in expected
+    ]
+    assert (
+        PolynomialSmithDecomposition.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+@pytest.mark.parametrize(
+    "rows,columns", [([], 0), ([], 5), ([[], [], []], 0), ([[0, 0, 0], [0, 0, 0]], 3)]
+)
+def test_zero_and_empty_shapes(rows: list[list[object]], columns: int) -> None:
+    source = _matrix(rows, columns=columns)
+    result = polynomial_smith_decomposition(source)
+    _identities(source, result)
+    assert result.diagonal == source
+
+
+def test_rational_units_need_not_have_determinant_plus_or_minus_one() -> None:
+    source = _matrix([[Rational(2, 3) * t]])
+    result = polynomial_smith_decomposition(source)
+    _identities(source, result)
+    assert _sympy(result.left_transformation).det() == Rational(3, 2)
+
+
+def test_dense_constant_matrix_uses_field_elimination_bounds() -> None:
+    n = 8
+    source = _matrix([[1 + int(i == j) for j in range(n)] for i in range(n)])
+    result = polynomial_smith_decomposition(source)
+    a, d, u, v = map(
+        _sympy,
+        (
+            source,
+            result.diagonal,
+            result.left_transformation,
+            result.right_transformation,
+        ),
+    )
+    assert u * a * v == d == Matrix.eye(n)
+
+
+def test_excessive_dense_transforms_and_sparse_degree_are_rejected() -> None:
+    with pytest.raises(OperationResourceAdmissionError):
+        polynomial_smith_decomposition(_matrix([], columns=129))
+    with pytest.raises(OperationResourceAdmissionError):
+        polynomial_smith_decomposition(_matrix([[t**4096, t + 1]]))
+
+
+def test_high_degree_monomial_partial_permutation_keeps_sparse_support() -> None:
+    source = _matrix(
+        [[0, 3 * t**32768, 0], [0, 0, 0], [Rational(2, 7) * t**8192, 0, 0]]
+    )
+    result = polynomial_smith_decomposition(source)
+    d, u, v = map(
+        _sympy,
+        (result.diagonal, result.left_transformation, result.right_transformation),
+    )
+    assert (u * _sympy(source) * v).applyfunc(lambda value: value.expand()) == d
+    assert [d[i, i] for i in range(3)] == [t**8192, t**32768, 0]
+
+
+def test_sparse_scalar_polynomial_never_expands_missing_degrees() -> None:
+    source = _matrix([[Rational(2, 3) * t**32768 + Rational(3, 7)]])
+    result = polynomial_smith_decomposition(source)
+    assert _sympy(result.diagonal) == Matrix([[t**32768 + Rational(9, 14)]])
+    assert _sympy(result.left_transformation) == Matrix([[Rational(3, 2)]])
+
+
+def test_serialized_diagonal_is_an_unchanged_polynomial_matrix_input() -> None:
+    first = polynomial_smith_decomposition(_matrix([[t, 1], [0, t]]))
+    restored = RationalPolynomialMatrix.model_validate_json(
+        first.diagonal.model_dump_json()
+    )
+    second = polynomial_smith_decomposition(restored)
+    assert second.diagonal == first.diagonal
+    _identities(restored, second)
+
+
+def test_proportional_sparse_polynomial_entries_retain_the_common_factor() -> None:
+    p = t**32768 + 1
+    source = _matrix([[2 * p, p], [p, 3 * p]])
+    result = polynomial_smith_decomposition(source)
+    d, u, v = map(
+        _sympy,
+        (result.diagonal, result.left_transformation, result.right_transformation),
+    )
+    assert (u * _sympy(source) * v).applyfunc(lambda value: value.expand()) == d
+    assert d == Matrix.diag(p, p)

--- a/tests/math/matrices/test_polynomial_smith.py
+++ b/tests/math/matrices/test_polynomial_smith.py
@@ -205,6 +205,36 @@ def test_serialized_diagonal_is_an_unchanged_polynomial_matrix_input() -> None:
     _identities(restored, second)
 
 
+def test_empty_matrix_at_dense_cell_boundary_needs_only_identity_terms() -> None:
+    source = _matrix([], columns=128)
+    result = polynomial_smith_decomposition(source)
+    assert result.diagonal == source
+    assert _sympy(result.right_transformation) == Matrix.eye(128)
+
+
+def test_sparse_coefficients_exceeding_total_integer_storage_are_rejected() -> None:
+    coefficient = CanonicalRational(num=2**2200 + 1, den=1)
+    polynomial = RationalPolynomial(
+        variables=("t",),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(num=1, den=1), exponents=(4095,)
+                ),
+                *(
+                    RationalPolynomialTerm(coefficient=coefficient, exponents=(degree,))
+                    for degree in range(4094, -1, -1)
+                ),
+            )
+        ),
+    )
+    source = RationalPolynomialMatrix(
+        variables=("t",), row_count=1, column_count=1, entries=((polynomial,),)
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="coefficient storage"):
+        polynomial_smith_decomposition(source)
+
+
 def test_proportional_sparse_polynomial_entries_retain_the_common_factor() -> None:
     p = t**32768 + 1
     source = _matrix([[2 * p, p], [p, 3 * p]])

--- a/tests/math/matrices/test_symbolic_matrix.py
+++ b/tests/math/matrices/test_symbolic_matrix.py
@@ -1175,6 +1175,7 @@ def test_symbolic_native_api_exports_matrix_value_and_product() -> None:
         "RationalFunctionMatrix",
         "RationalFunctionVector",
         "RationalFunctionVectorBasis",
+        "RationalPolynomialMatrix",
         "symbolic_characteristic_polynomial",
         "symbolic_determinant",
         "symbolic_linear_system_solve",

--- a/tests/mcp/test_polynomial_inertia_cells.py
+++ b/tests/mcp/test_polynomial_inertia_cells.py
@@ -1,0 +1,42 @@
+"""Complete exact inertia partition through native and live MCP boundaries."""
+
+import asyncio
+import json
+
+from jsonschema import validate
+
+from jacobian.math.matrices.inertia_cells._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_inertia_cells_native_mcp_schema_parity() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        validate(payload, tool.request_type.model_json_schema())
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        native = tool.run(request).model_dump(mode="json")
+        async with Client(create_server(), raise_exceptions=False) as client:
+            result = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            output = result.structured_content["output"]
+            assert output == native
+            validate(output, tool.result_type.model_json_schema())
+            left = output["cells"][2]["parameter"]["value"]
+            right = output["cells"][4]["parameter"]["value"]
+            comparison = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "algebraic_number.compare",
+                    "payload": {"left": left, "right": right},
+                },
+            )
+            assert not comparison.is_error
+            assert comparison.structured_content is not None
+            assert comparison.structured_content["output"]["order"] == "LT"
+
+    asyncio.run(scenario())

--- a/tests/mcp/test_polynomial_smith.py
+++ b/tests/mcp/test_polynomial_smith.py
@@ -1,0 +1,66 @@
+"""QQ[t] Smith native/MCP parity and resource-rejection recovery."""
+
+import asyncio
+import json
+
+from jacobian.math.matrices.certified_snf._models import PolynomialSmithRequest
+from jacobian.math.matrices.certified_snf.polynomial import (
+    polynomial_smith_decomposition,
+)
+from jacobian.math.matrices.symbolic import RationalPolynomialMatrix
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_rectangular_torsion_native_mcp_parity_and_recovery() -> None:
+    async def scenario() -> None:
+        def entry(degree: int | None) -> dict[str, object]:
+            return {
+                "variables": ["t"],
+                "polynomial": {
+                    "terms": []
+                    if degree is None
+                    else [
+                        {
+                            "coefficient": {"num": "1", "den": "1"},
+                            "exponents": [degree],
+                        },
+                    ]
+                },
+            }
+
+        payload = {
+            "matrix": {
+                "variables": ["t"],
+                "row_count": 2,
+                "column_count": 3,
+                "entries": [[entry(1), entry(2), entry(None)], [entry(None)] * 3],
+            }
+        }
+        native = polynomial_smith_decomposition(
+            PolynomialSmithRequest.model_validate_json(json.dumps(payload)).matrix
+        )
+        async with Client(create_server(), raise_exceptions=False) as client:
+            invalid = RationalPolynomialMatrix(
+                variables=("t",), row_count=0, column_count=129, entries=()
+            )
+            rejected = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "matrix.normal_form.smith.polynomial.compute",
+                    "payload": {"matrix": invalid.model_dump(mode="json")},
+                },
+            )
+            assert rejected.is_error
+            result = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "matrix.normal_form.smith.polynomial.compute",
+                    "payload": payload,
+                },
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            assert result.structured_content["output"] == native.model_dump(mode="json")
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Closes #3459. Integer Smith operations cannot represent arbitrary rectangular presentations over `QQ[t]`; solving over `QQ(t)` loses polynomial-module divisibility and torsion.

## Outcome

Adds `matrix.normal_form.smith.polynomial.compute` and native `polynomial_smith_decomposition`. The result contains a monic divisibility diagonal `D` and polynomial unimodular maps `U,V` satisfying `D=UAV`, with zero factors last. The shared `RationalPolynomialMatrix` retains the named variable, coefficient ring, rectangular axes and empty shapes, and reuses canonical `RationalPolynomial` entries.

The implementation extends the existing Smith owner and uses the same maintained SymPy 1.14 PID decomposition kernel. A distinct polynomial-domain entry is appropriate because the existing integer certificate carrier requires integer matrices and determinant ±1. No existing operation is superseded. Polynomial transformations may have any nonzero rational constant determinant; final monic normalization rescales the corresponding `U` row.

## Validation

Original implementation validation ran at `47a43c191db07f22ecc66f4e87930dc93113746c`; the independently reviewed allocation repair is committed as `ded1391f5c6f94de0212d521b1a1526fefe46c3b`.

- `make affected AFFECTED_BASE=origin/main`: scoped Ruff/mypy passed; matrix lane had 699 passes and one existing public-export inventory assertion requiring the new carrier. That assertion was corrected and its owning test rerun successfully; scoped Ruff/mypy also passed for the updated file.
- Completed the remaining affected-plan stages explicitly: `make test-catalog` (156 passed), `make test-integration TESTS=tests/integration/catalog/` (915 passed), `make test-mcp` (72 passed).
- `uv run --locked pytest tests/integration/catalog/test_public_operation_contract_conformance.py -m exhaustive -k 'matrix.normal_form.smith.polynomial.compute' --timeout=120 -q`: 1 passed, 881 deselected.
- Exact reconstruction, nonzero constant determinants, monicity/divisibility, independently computed determinantal divisors, rational units, zero/empty and rank-deficient shapes, and serialized producer-to-consumer composition are covered. The motivating rectangular fixture also runs through a live MCP client with native-result parity and recovery after resource rejection.

- Allocation repair validation: `make architecture` (1,343 files), focused polynomial Smith math tests (27 passed), live MCP test (1 passed), scoped Ruff/mypy. The new accepted 0×128 regression was confirmed to fail on the previous commit; aggregate coefficient-storage rejection is also covered. These checks address the hosted architecture failure; all required hosted CI checks passed for the final repair head `ded1391f5c6f94de0212d521b1a1526fefe46c3b`.

## Contract impact

- New operation, native function, polynomial matrix carrier and decomposition value; no changes to integer Smith semantics.
- Structural parsing checks ring/axes. The native operation owns semantic resource admission, and MCP invokes that same path. Parsing an authored decomposition does not establish its transformation relation.
- The defining invariant is `U A V = D`, with `U,V` invertible over `QQ[t]` and canonical nonzero diagonal factors.
- No multivariate or rational-function Smith contract is introduced.

## Review closure

- Mathematical bounds, reconstruction maps and the final precision changes were independently reviewed; resulting fixes and accepted regressions are included.
- Final validation covers the changed tree. The corrected export assertion was rerun without repeating unrelated completed checks.
- All required hosted CI checks passed for the final publication head.

## Operation boundary and catalog admission

The stable result is a polynomial-module decomposition with concrete source/target coordinate maps. Neither integer Smith form nor the rational canonical form of a constant-field operator supplies this result for arbitrary polynomial presentations.

Admission accounts for dense source/full-transform cells, polynomial support, rational coefficient inspection, Euclidean degree descent, common-denominator coefficient height, recursive transformation growth, and exact value allocation. The general kernel uses a coefficient-operation work proxy capped at 20 million, a 100,000-bit height envelope and bounded dense intermediate support. This is not a bit-operation complexity or wall-time performance claim. Allocation admission separately caps matrix cells and polynomial terms at 16,384 each, and aggregate numerator/denominator coefficient capacity at 8,388,608 bits; transport encoding limits remain owned by the shared transport boundary. All phases share an operation-owned 60-second deadline, shortened by any earlier caller deadline. The retained 8×8 constant-matrix case took about 0.04 seconds in focused testing, providing substantial deadline margin without replacing the bounds.

Private regimes preserve mathematical structure before estimating growth: remove zero axes; retain common monomial factors; recognize proportional polynomial entries `A=p(t)B` with rational `B`; expose a constant pivot by a bounded rational affine subtraction; skip absent clearing for diagonal presentations; and retain sparse scalar/monomial support. Every removed factor is restored on `D`, and all elementary maps are composed into `U,V`. These choices admit both issue fixtures, generic affine 2×2 matrices, quadratic Bézout input, rational constant matrices, and sparse degree-32768 scalar/proportional presentations.

**Remaining limitation:** nonproportional higher-degree inputs outside these regimes can still be rejected by conservative recursive height/support estimates even when a particular backend execution would be cheap. This PR does not claim a general polynomial-time transformation algorithm or universal sparse-input admission.

Backend research used [SymPy's pinned PID implementation](https://github.com/sympy/sympy/blob/sympy-1.14.0/sympy/polys/matrices/normalforms.py) and evaluated [Sage's polynomial-matrix reference](https://doc.sagemath.org/html/en/reference/matrices/sage/matrix/matrix_polynomial_dense.html). The installed maintained SymPy kernel already returns both maps, so no second Smith implementation or backend dependency was added.
