### PR TITLE
feat(matrices): compute exact polynomial inertia cells

### DIFF
--- a/src/jacobian/math/matrices/inertia_cells/__init__.py
+++ b/src/jacobian/math/matrices/inertia_cells/__init__.py
@@ -1,0 +1,17 @@
+"""Exact inertia partitions for symmetric matrices over QQ[t]."""
+
+from jacobian.math.matrices.inertia_cells._models import (
+    InertiaCellsResult,
+    InertiaOpenCell,
+    InertiaParameterBoundary,
+    InertiaPointCell,
+)
+from jacobian.math.matrices.inertia_cells.operations import compute_inertia_cells
+
+__all__ = [
+    "InertiaCellsResult",
+    "InertiaOpenCell",
+    "InertiaParameterBoundary",
+    "InertiaPointCell",
+    "compute_inertia_cells",
+]

--- a/src/jacobian/math/matrices/inertia_cells/_admission.py
+++ b/src/jacobian/math/matrices/inertia_cells/_admission.py
@@ -1,0 +1,247 @@
+"""Source-derived bounds before characteristic expansion or root isolation."""
+
+from collections import Counter
+from dataclasses import dataclass
+from math import lcm
+
+from jacobian._execution import request_checkpoint
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.matrices.inertia_cells._normalization import (
+    normalize_affine,
+    specialize,
+)
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.polynomials.values import RationalPolynomial
+
+Block = tuple[tuple[RationalPolynomial, ...], ...]
+
+
+@dataclass(frozen=True)
+class BlockPlan:
+    entries: Block
+    multiplicity: int
+    degree: int
+    coefficient_bits: int
+    denominator: int
+
+
+def reject_budget(message: str) -> OperationResourceAdmissionError:
+    return OperationResourceAdmissionError(
+        location=("matrix",), code="matrix.inertia_cells.budget", message=message
+    )
+
+
+def _blocks(matrix: RationalPolynomialMatrix) -> Counter[Block]:
+    n = matrix.row_count
+    unseen = set(range(n))
+    blocks: Counter[Block] = Counter()
+    while unseen:
+        pending = [min(unseen)]
+        unseen.remove(pending[0])
+        axes: list[int] = []
+        while pending:
+            v = pending.pop()
+            axes.append(v)
+            adjacent = [
+                w for w in sorted(unseen) if matrix.entries[v][w].polynomial.terms
+            ]
+            unseen.difference_update(adjacent)
+            pending.extend(adjacent)
+        axes.sort()
+        block = tuple(tuple(matrix.entries[i][j] for j in axes) for i in axes)
+        blocks[block] += 1
+    return blocks
+
+
+def _block_plan(
+    block: Block, multiplicity: int, interval: ClosedRationalInterval
+) -> BlockPlan:
+    if len(block) == 1 and all(
+        t.exponents[0] <= 1 for t in block[0][0].polynomial.terms
+    ):
+        block = ((normalize_affine(block[0][0], interval),),)
+    coefficients = [
+        term.coefficient
+        for row in block
+        for entry in row
+        for term in entry.polynomial.terms
+    ]
+    degree = max(
+        (
+            term.exponents[0]
+            for row in block
+            for entry in row
+            for term in entry.polynomial.terms
+        ),
+        default=0,
+    )
+    n = len(block)
+    if n * degree > 16:
+        raise reject_budget(
+            "a connected block's characteristic coefficient degree exceeds the degree-16 algebraic carrier"
+        )
+    denominator = 1
+    for q in coefficients:
+        denominator = lcm(denominator, q.den)
+    height = max(
+        (
+            abs(q.num).bit_length() + (denominator // q.den).bit_length()
+            for q in coefficients
+        ),
+        default=1,
+    )
+    # The kernel computes charpoly(D*A), with positive D. This preserves
+    # every specialization inertia and removes all rational denominators.
+    # Principal k-minor coefficients have at most k!*(degree+1)^k
+    # products; the characteristic coefficient sums at most 2^n minors.
+    # The same bound with slack bounds division-free Berkowitz products.
+    bits = n * (height + n.bit_length() + (degree + 1).bit_length() + 2)
+    if bits > (100000 if n == 1 and degree <= 1 else 65536):
+        raise reject_budget(
+            "characteristic expansion exceeds the coefficient bit bound"
+        )
+    if (
+        degree
+        and not (n == 1 and degree == 1)
+        and bits + n * degree + (n * degree + 1).bit_length() > 3300
+    ):
+        raise reject_budget(
+            "primitive factor coefficients would exceed the canonical algebraic carrier"
+        )
+    return BlockPlan(block, multiplicity, n * degree, bits, denominator)
+
+
+def admit(
+    matrix: RationalPolynomialMatrix, interval: ClosedRationalInterval
+) -> tuple[BlockPlan, ...]:
+    n = matrix.row_count
+    if matrix.column_count != n:
+        raise OperationDomainValidationError(
+            location=("matrix",),
+            code="matrix.inertia_cells.shape",
+            message="matrix must be square",
+        )
+    if n > 128:
+        raise reject_budget("source matrix exceeds 16,384 ordered entries")
+    total_bits = 0
+    for i, row in enumerate(matrix.entries):
+        request_checkpoint("during inertia-cell source admission")
+        for j, entry in enumerate(row):
+            if entry != matrix.entries[j][i]:
+                raise OperationDomainValidationError(
+                    location=("matrix",),
+                    code="matrix.inertia_cells.symmetry",
+                    message="matrix must be symmetric over QQ[t]",
+                )
+            total_bits += sum(
+                abs(term.coefficient.num).bit_length()
+                + term.coefficient.den.bit_length()
+                for term in entry.polynomial.terms
+            )
+    if total_bits > 1_000_000:
+        raise reject_budget("source coefficients exceed one million component bits")
+    working = (
+        specialize(matrix, interval.lower.as_fraction())
+        if interval.lower == interval.upper
+        else matrix
+    )
+    plans = tuple(
+        _block_plan(block, multiplicity, interval)
+        for block, multiplicity in _blocks(working).items()
+    )
+    characteristic_work = sum(
+        len(p.entries) ** 4 * (p.degree + 1) ** 2 * p.coefficient_bits**2 for p in plans
+    )
+    if characteristic_work > 1_000_000_000_000:
+        raise reject_budget(
+            "division-free characteristic coefficient work exceeds the admitted budget"
+        )
+    _admit_isolation(plans, interval)
+    return plans
+
+
+def _admit_isolation(
+    plans: tuple[BlockPlan, ...], interval: ClosedRationalInterval
+) -> None:
+    all_active = tuple(p for p in plans if p.degree)
+    nonconstant = tuple(
+        p for p in all_active if not (len(p.entries) == 1 and p.degree == 1)
+    )
+    linear = tuple(p for p in all_active if len(p.entries) == 1 and p.degree == 1)
+    # Affine roots are rational: sorting exact ratios requires no factorization.
+    if not nonconstant:
+        # Exact sorting and affine signs use rational cross-products only.
+        if (
+            4 * (len(linear) + 2) * sum(p.coefficient_bits**2 for p in linear)
+            > 100_000_000_000_000
+        ):
+            raise reject_budget(
+                "rational affine comparisons exceed the arithmetic budget"
+            )
+        if 12 * sum(p.coefficient_bits for p in linear) > 64_000_000:
+            raise reject_budget("rational cell boundaries exceed the output bit budget")
+        return
+    degree = sum(p.degree for p in nonconstant) + len(linear) + 2
+    if degree > 130:
+        raise reject_budget("transition union exceeds 128 candidate roots")
+    endpoint_bits = max(
+        abs(q.num).bit_length() + q.den.bit_length()
+        for q in (interval.lower, interval.upper)
+    )
+    # A primitive squarefree divisor obeys Landau-Mignotte's factor bound.
+    # Product coefficient height adds a convolution factor per source.
+    height = (
+        sum(
+            p.coefficient_bits + p.degree + 2 * (p.degree + 1).bit_length()
+            for p in nonconstant
+        )
+        + sum(p.coefficient_bits + 2 for p in linear)
+        + 2 * endpoint_bits
+        + 4
+    )
+    # Cauchy and Mignotte bounds admit separating rational endpoints with
+    # this bit length, also separating the two rational domain endpoints.
+    isolation_bits = 4 * degree * (height + degree.bit_length() + 2) + height + 8
+    if isolation_bits > 100_000:
+        raise reject_budget(
+            "root separation exceeds the canonical rational endpoint envelope"
+        )
+    if degree**4 * height**2 > 1_000_000_000_000:
+        raise reject_budget(
+            "transition root isolation exceeds the admitted arithmetic budget"
+        )
+    sign_work = 0
+    factor_degree = max(p.degree for p in nonconstant)
+    factor_bits = max(
+        p.coefficient_bits + p.degree + (p.degree + 1).bit_length() for p in nonconstant
+    )
+    # Each boundary appears in a point and at most two adjacent open cells:
+    # twelve rational numerator/denominator components plus three minimal
+    # polynomials. Counts and fixed schema fields have bounded constant size.
+    output_bits = degree * (12 * isolation_bits + 3 * (factor_degree + 1) * factor_bits)
+    if output_bits > 64_000_000:
+        raise reject_budget("exact cell boundary output exceeds the bit budget")
+    for p in all_active:
+        # Remainders modulo a factor have common denominator dividing the
+        # source denominator times a power of the factor leading coefficient.
+        # Isolating factor*remainder needs degree at most 2*d-1.
+        remainder_bits = 4 * (p.degree + 1) * (p.coefficient_bits + factor_bits + 2)
+        sign_work += (
+            (len(p.entries) + 1)
+            * degree
+            * (factor_degree + min(p.degree, factor_degree - 1) + 1) ** 4
+            * remainder_bits**2
+        )
+    if sign_work > 100_000_000_000_000:
+        raise reject_budget(
+            "algebraic coefficient sign work exceeds the admitted budget"
+        )
+    if (
+        degree * len(plans) * max(p.degree for p in nonconstant) * isolation_bits
+        > 100_000_000
+    ):
+        raise reject_budget("rational cell sampling exceeds the admitted work budget")

--- a/src/jacobian/math/matrices/inertia_cells/_models.py
+++ b/src/jacobian/math/matrices/inertia_cells/_models.py
@@ -1,0 +1,112 @@
+"""Source-bound exact inertia strata of a one-parameter polynomial matrix."""
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+    RealAlgebraicValue,
+)
+
+
+class InertiaParameterBoundary(StrictModel):
+    """Exact parameter value and a rational interval isolating that value.
+
+    Irrational values use their primitive irreducible polynomial and selected
+    real-root index. Rational values have singleton isolating intervals.
+    Parsing is structural; the producer establishes the isolation relation.
+    """
+
+    value: CanonicalRational | RealAlgebraicValue
+    isolating_interval: RationalIsolatingInterval
+
+
+class _InertiaCounts(StrictModel):
+    n_positive: int = Field(ge=0, le=128)
+    n_negative: int = Field(ge=0, le=128)
+    n_zero: int = Field(ge=0, le=128)
+
+
+class InertiaPointCell(_InertiaCounts):
+    """A singleton parameter cell, including both domain endpoints."""
+
+    cell_type: Literal["POINT"] = "POINT"
+    parameter: InertiaParameterBoundary
+
+
+class InertiaOpenCell(_InertiaCounts):
+    """The open interval between the two exact parameter boundaries."""
+
+    cell_type: Literal["OPEN"] = "OPEN"
+    lower: InertiaParameterBoundary
+    upper: InertiaParameterBoundary
+
+
+InertiaCell = Annotated[
+    InertiaPointCell | InertiaOpenCell, Field(discriminator="cell_type")
+]
+
+
+class InertiaCellsRequest(StrictModel):
+    """A square symmetric QQ[t] matrix on a closed rational interval."""
+
+    matrix: RationalPolynomialMatrix
+    interval: ClosedRationalInterval
+
+
+class InertiaCellsResult(StrictModel):
+    """Alternating point/open cells covering exactly the retained interval.
+
+    Every rank-drop value is retained. Deterministic refinements from separate
+    diagonal blocks are allowed; equal-inertia neighbors are not merged.
+    """
+
+    matrix: RationalPolynomialMatrix
+    interval: ClosedRationalInterval
+    cells: tuple[InertiaCell, ...] = Field(min_length=1, max_length=261)
+
+    @model_validator(mode="after")
+    def require_partition_shape(self) -> Self:
+        n = self.matrix.row_count
+        if self.matrix.column_count != n:
+            raise ValueError("source matrix must be square")
+        if len(self.cells) % 2 != 1:
+            raise ValueError("cells must alternate POINT and OPEN, ending at POINT")
+        for i, cell in enumerate(self.cells):
+            if cell.n_positive + cell.n_negative + cell.n_zero != n:
+                raise ValueError("cell inertia counts must sum to the matrix order")
+            if i % 2 == 0:
+                if not isinstance(cell, InertiaPointCell):
+                    raise ValueError("even cells must be points")
+            else:
+                previous, following = self.cells[i - 1], self.cells[i + 1]
+                if (
+                    not isinstance(cell, InertiaOpenCell)
+                    or not isinstance(previous, InertiaPointCell)
+                    or not isinstance(following, InertiaPointCell)
+                ):
+                    raise ValueError("open cells must lie between points")
+                if (
+                    cell.lower != previous.parameter
+                    or cell.upper != following.parameter
+                ):
+                    raise ValueError(
+                        "open boundaries must agree with adjacent point cells"
+                    )
+        first, last = self.cells[0], self.cells[-1]
+        assert isinstance(first, InertiaPointCell) and isinstance(
+            last, InertiaPointCell
+        )
+        if (
+            first.parameter.value != self.interval.lower
+            or last.parameter.value != self.interval.upper
+        ):
+            raise ValueError("point cells must retain the closed domain endpoints")
+        if self.interval.lower == self.interval.upper and len(self.cells) != 1:
+            raise ValueError("singleton domains have exactly one point cell")
+        return self

--- a/src/jacobian/math/matrices/inertia_cells/_normalization.py
+++ b/src/jacobian/math/matrices/inertia_cells/_normalization.py
@@ -1,0 +1,132 @@
+"""Bounded scalar and singleton-domain reductions before algebraic admission."""
+
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import request_checkpoint
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _budget(message: str) -> OperationResourceAdmissionError:
+    return OperationResourceAdmissionError(
+        location=("interval",),
+        code="matrix.inertia_cells.specialization_budget",
+        message=message,
+    )
+
+
+def _polynomial(
+    variables: tuple[str, ...], coefficients: tuple[Fraction, ...]
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(q), exponents=(i,)
+                )
+                for i, q in reversed(tuple(enumerate(coefficients)))
+                if q
+            )
+        ),
+    )
+
+
+def normalize_affine(
+    poly: RationalPolynomial, interval: ClosedRationalInterval
+) -> RationalPolynomial:
+    """Keep only sign when no root lies in the domain; otherwise primitive affine."""
+    coefficients = {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in poly.polynomial.terms
+    }
+    a, b = coefficients.get(1, Fraction()), coefficients.get(0, Fraction())
+    if a:
+        root = -b / a
+        if interval.lower.as_fraction() <= root <= interval.upper.as_fraction():
+            if (
+                max(abs(root.numerator).bit_length(), root.denominator.bit_length())
+                > 100000
+            ):
+                raise _budget("rational transition exceeds canonical endpoint height")
+            sign = 1 if a > 0 else -1
+            return _polynomial(
+                poly.variables,
+                (Fraction(-sign * root.numerator), Fraction(sign * root.denominator)),
+            )
+    value = a * interval.lower.as_fraction() + b
+    sign = 1 if value > 0 else -1 if value < 0 else 0
+    return _polynomial(poly.variables, (Fraction(sign),))
+
+
+def specialize(
+    matrix: RationalPolynomialMatrix, parameter: Fraction
+) -> RationalPolynomialMatrix:
+    """Evaluate sparse QQ[t] entries after bounding powers and rational sums.
+
+    At 0 only constant terms contribute; at ±1 powers have unit height.
+    No root isolation or algebraic carrier is involved in a singleton domain.
+    """
+    work = 0
+    for row in matrix.entries:
+        for polynomial in row:
+            terms = tuple(
+                t
+                for t in polynomial.polynomial.terms
+                if parameter or not t.exponents[0]
+            )
+            degree = max((t.exponents[0] for t in terms), default=0)
+            denominator_bits = sum(t.coefficient.den.bit_length() for t in terms)
+            numerator_bits = max(
+                (abs(t.coefficient.num).bit_length() for t in terms), default=1
+            )
+            power_bits = (
+                1
+                if parameter in (0, 1, -1)
+                else degree
+                * max(
+                    abs(parameter.numerator).bit_length(),
+                    parameter.denominator.bit_length(),
+                )
+            )
+            bits = (
+                denominator_bits
+                + numerator_bits
+                + 2 * power_bits
+                + (len(terms) + 1).bit_length()
+            )
+            if bits > 100000:
+                raise _budget(
+                    "singleton polynomial evaluation exceeds the rational height budget"
+                )
+            work += (len(terms) + degree.bit_length() + 1) * bits**2
+    if work > 1_000_000_000_000:
+        raise _budget("singleton polynomial evaluation exceeds the arithmetic budget")
+    entries = []
+    for row in matrix.entries:
+        request_checkpoint("during admitted singleton specialization")
+        values = []
+        for polynomial in row:
+            value = sum(
+                (
+                    t.coefficient.as_fraction() * parameter ** t.exponents[0]
+                    for t in polynomial.polynomial.terms
+                    if parameter or not t.exponents[0]
+                ),
+                Fraction(),
+            )
+            values.append(_polynomial(matrix.variables, (value,)))
+        entries.append(tuple(values))
+    return RationalPolynomialMatrix(
+        variables=matrix.variables,
+        row_count=matrix.row_count,
+        column_count=matrix.column_count,
+        entries=tuple(entries),
+    )

--- a/src/jacobian/math/matrices/inertia_cells/_tools.py
+++ b/src/jacobian/math/matrices/inertia_cells/_tools.py
@@ -1,0 +1,69 @@
+"""Publication of exact one-parameter polynomial matrix inertia cells."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.matrices.inertia_cells._models import (
+    InertiaCellsRequest,
+    InertiaCellsResult,
+)
+from jacobian.math.matrices.inertia_cells.operations import compute_inertia_cells
+
+
+def _run(request: InertiaCellsRequest) -> InertiaCellsResult:
+    return compute_inertia_cells(request.matrix, request.interval)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="matrix.polynomial.inertia_cells.compute",
+        title="Compute exact inertia cells of a symmetric polynomial matrix",
+        description="Partition a closed rational parameter interval into alternating exact point cells and open intervals on which a symmetric QQ[t] matrix has constant inertia. Retains every rank-drop specialization, including persistent nullspaces and tangencies. Algebraic boundaries retain canonical root identities and rational isolating intervals. Both endpoints are singleton cells; a singleton domain has one point cell. Connected support blocks are processed independently under characteristic-growth, root-isolation, sign-work and output bounds with a shared 60-second deadline.",
+        request_type=InertiaCellsRequest,
+        result_type=InertiaCellsResult,
+        run=_run,
+        tags=("matrix", "polynomial", "inertia", "parameter", "singular", "exact"),
+        examples=(
+            OperationExample(
+                name="persistent_nullspace",
+                description="Partition diag(t²-2,0) at both irrational singular parameters; the polynomial matrix must be symmetric and the rational interval closed.",
+                input={
+                    "matrix": {
+                        "variables": ["t"],
+                        "row_count": 2,
+                        "column_count": 2,
+                        "entries": [
+                            [
+                                {
+                                    "variables": ["t"],
+                                    "polynomial": {
+                                        "terms": [
+                                            {
+                                                "coefficient": {"num": "1", "den": "1"},
+                                                "exponents": [2],
+                                            },
+                                            {
+                                                "coefficient": {
+                                                    "num": "-2",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [0],
+                                            },
+                                        ]
+                                    },
+                                },
+                                {"variables": ["t"], "polynomial": {"terms": []}},
+                            ],
+                            [
+                                {"variables": ["t"], "polynomial": {"terms": []}},
+                                {"variables": ["t"], "polynomial": {"terms": []}},
+                            ],
+                        ],
+                    },
+                    "interval": {
+                        "lower": {"num": "-2", "den": "1"},
+                        "upper": {"num": "2", "den": "1"},
+                    },
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/matrices/inertia_cells/operations.py
+++ b/src/jacobian/math/matrices/inertia_cells/operations.py
@@ -1,0 +1,259 @@
+"""Exact polynomial inertia through real-rooted characteristic coefficients.
+
+Schweighofer, Real Algebraic Geometry (2016/17), Theorem 1.5.14 and
+Example 1.5.15: Descartes sign variation counts positive eigenvalues exactly
+for the characteristic polynomial of a real symmetric matrix.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Any, TypedDict
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.math._root_isolation import strict_root_count
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.matrices.inertia_cells._admission import BlockPlan, admit
+from jacobian.math.matrices.inertia_cells._models import (
+    InertiaCell,
+    InertiaCellsResult,
+    InertiaOpenCell,
+    InertiaParameterBoundary,
+    InertiaPointCell,
+)
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+    RealAlgebraicValue,
+)
+from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
+
+
+class _Counts(TypedDict):
+    n_positive: int
+    n_negative: int
+    n_zero: int
+
+
+@dataclass(frozen=True)
+class _Boundary:
+    public: InertiaParameterBoundary
+    lower: Any
+    upper: Any
+    factor: Any | None = None
+    root_index: int = 0
+
+
+def _rational(q: Any) -> CanonicalRational:
+    return CanonicalRational(num=int(q.p), den=int(q.q))
+
+
+def _rational_boundary(q: Any) -> _Boundary:
+    value = _rational(q)
+    return _Boundary(
+        InertiaParameterBoundary(
+            value=value,
+            isolating_interval=RationalIsolatingInterval(
+                lower=value, upper=value, interval_type="SINGLETON"
+            ),
+        ),
+        q,
+        q,
+    )
+
+
+def _coefficients(plan: BlockPlan) -> list[Any]:
+    from sympy import QQ, Poly, Symbol
+    from sympy.polys.matrices import DomainMatrix
+
+    t = Symbol(plan.entries[0][0].variables[0])
+    ring = QQ.poly_ring(t)
+    rows = {
+        i: {
+            j: ring.from_sympy(
+                rational_polynomial_to_sympy(entry).as_expr() * plan.denominator
+            )
+            for j, entry in enumerate(row)
+            if entry.polynomial.terms
+        }
+        for i, row in enumerate(plan.entries)
+    }
+    charpoly = DomainMatrix(rows, (len(rows), len(rows)), ring).charpoly()
+    return [Poly(ring.to_sympy(coefficient), t, domain=QQ) for coefficient in charpoly]
+
+
+def _primitive(poly: Any) -> Any:
+    _, integer = poly.clear_denoms(convert=True)
+    _, primitive = integer.primitive()
+    return -primitive if primitive.LC() < 0 else primitive
+
+
+def _boundaries(
+    coefficients: list[list[Any]], lower: Any, upper: Any
+) -> list[_Boundary]:
+    from sympy import Poly
+
+    if lower == upper:
+        return [_rational_boundary(lower)]
+    transitions = [
+        next(c for c in reversed(block) if not c.is_zero) for block in coefficients
+    ]
+    active = [p for p in transitions if p.degree() > 0]
+    if not active:
+        return [_rational_boundary(lower), _rational_boundary(upper)]
+    if all(p.degree() == 1 for p in active):
+        roots = {-p.TC() / p.LC() for p in active}
+        return [
+            _rational_boundary(q)
+            for q in sorted({lower, upper, *(q for q in roots if lower <= q <= upper)})
+        ]
+    t = active[0].gens[0]
+    factors: dict[tuple[int, ...], Any] = {}
+    for polynomial in (*active, Poly(t - lower, t), Poly(t - upper, t)):
+        request_checkpoint("during transition factorization")
+        for factor, _ in _primitive(polynomial).factor_list()[1]:
+            factor = _primitive(factor)
+            factors[tuple(int(c) for c in factor.all_coeffs())] = factor
+    product = Poly(1, t)
+    for factor in factors.values():
+        product *= factor
+    root_indices = dict.fromkeys(factors, 0)
+    answer: list[_Boundary] = []
+    request_checkpoint("before transition root isolation")
+    for (lo, hi), _ in product.intervals():
+        request_checkpoint("during transition root isolation")
+        key = next(key for key, f in factors.items() if strict_root_count(f, lo, hi))
+        factor = factors[key]
+        index = root_indices[key]
+        root_indices[key] += 1
+        if factor.degree() == 1:
+            value = -factor.TC() / factor.LC()
+            if lower <= value <= upper:
+                answer.append(_rational_boundary(value))
+        elif lo >= lower and hi <= upper:
+            # Isolating open intervals may touch a different rational root.
+            # Refine away from every product root so midpoint samples are
+            # strictly inside their parameter cells, never at a point cell.
+            while product.eval(lo) == 0 or product.eval(hi) == 0:
+                request_checkpoint("during boundary separation")
+                lo, hi = factor.refine_root(lo, hi, steps=1)
+            algebraic = RealAlgebraicValue._from_admitted_polynomial(
+                polynomial=key, real_root_index=index
+            )
+            boundary = InertiaParameterBoundary(
+                value=algebraic,
+                isolating_interval=RationalIsolatingInterval(
+                    lower=_rational(lo), upper=_rational(hi), interval_type="OPEN"
+                ),
+            )
+            answer.append(_Boundary(boundary, lo, hi, factor, index))
+    return answer
+
+
+def _sign_at_root(polynomial: Any, boundary: _Boundary) -> int:
+    if boundary.factor is None or polynomial.degree() <= 0:
+        value = polynomial.eval(boundary.lower)
+        return 1 if value > 0 else -1 if value < 0 else 0
+    representative = polynomial.rem(boundary.factor)
+    if representative.is_zero:
+        return 0
+    # Same coprime-product isolation relation used by the exact real field
+    # owner: a reduced nonzero representative shares no root with the factor.
+    seen = 0
+    for (lo, hi), _ in (boundary.factor * representative).intervals():
+        if not strict_root_count(boundary.factor, lo, hi):
+            continue
+        if seen == boundary.root_index:
+            sample = lo if lo == hi else (lo + hi) / 2
+            value = representative.eval(sample)
+            return 1 if value > 0 else -1 if value < 0 else 0
+        seen += 1
+    raise ArithmeticError("exact coefficient sign isolation lost its defining root")
+
+
+def _inertia(
+    coefficients: list[list[Any]], plans: tuple[BlockPlan, ...], boundary: _Boundary
+) -> _Counts:
+    counts = [0, 0, 0]
+    for block, plan in zip(coefficients, plans, strict=True):
+        request_checkpoint("during exact inertia specialization")
+        signs = [_sign_at_root(c, boundary) for c in block]
+        positive = [s for s in signs if s]
+        negative = [s * (-1) ** i for i, s in enumerate(signs) if s]
+        p = sum(a != b for a, b in pairwise(positive))
+        m = sum(a != b for a, b in pairwise(negative))
+        counts[0] += plan.multiplicity * p
+        counts[1] += plan.multiplicity * m
+        counts[2] += plan.multiplicity * (len(plan.entries) - p - m)
+    return {"n_positive": counts[0], "n_negative": counts[1], "n_zero": counts[2]}
+
+
+def compute_inertia_cells(
+    matrix: RationalPolynomialMatrix, interval: ClosedRationalInterval
+) -> InertiaCellsResult:
+    """Partition a closed parameter interval into exact constant-inertia cells.
+
+    Rank is constant away from zeros of the lowest nonzero characteristic
+    coefficient. Eigenvalue continuity then makes inertia constant on each
+    intervening interval. Point cells are evaluated exactly, including nullity
+    increases without sign changes and identically singular matrix families.
+    """
+    if not isinstance(matrix, RationalPolynomialMatrix) or not isinstance(
+        interval, ClosedRationalInterval
+    ):
+        raise TypeError("expected RationalPolynomialMatrix and ClosedRationalInterval")
+    if current_request_execution() is None:
+        with request_execution(time.monotonic()):
+            return _compute(matrix, interval)
+    return _compute(matrix, interval)
+
+
+def _compute(
+    matrix: RationalPolynomialMatrix, interval: ClosedRationalInterval
+) -> InertiaCellsResult:
+    from sympy import Rational
+
+    execution = current_request_execution()
+    assert execution is not None
+    deadline = execution.started_at + 60.0
+    bind_request_deadline(
+        min(deadline, execution.deadline)
+        if execution.deadline is not None
+        else deadline
+    )
+    plans = admit(matrix, interval)
+    coefficients = []
+    for plan in plans:
+        request_checkpoint("before polynomial characteristic expansion")
+        coefficients.append(_coefficients(plan))
+    lower, upper = (Rational(q.num, q.den) for q in (interval.lower, interval.upper))
+    boundaries = _boundaries(coefficients, lower, upper)
+    cells: list[InertiaCell] = []
+    for i, boundary in enumerate(boundaries):
+        if i:
+            previous = boundaries[i - 1]
+            q = (previous.upper + boundary.lower) / 2
+            sample = _Boundary(previous.public, q, q)
+            cells.append(
+                InertiaOpenCell(
+                    lower=previous.public,
+                    upper=boundary.public,
+                    **_inertia(coefficients, plans, sample),
+                )
+            )
+        cells.append(
+            InertiaPointCell(
+                parameter=boundary.public, **_inertia(coefficients, plans, boundary)
+            )
+        )
+    result = InertiaCellsResult(matrix=matrix, interval=interval, cells=tuple(cells))
+    request_checkpoint("after inertia-cell result construction")
+    return result

--- a/tests/math/matrices/inertia_cells/test_inertia_cells.py
+++ b/tests/math/matrices/inertia_cells/test_inertia_cells.py
@@ -1,0 +1,249 @@
+"""Exact coverage, singular fibers and independent spectral evidence."""
+
+import json
+from fractions import Fraction
+from itertools import pairwise
+from typing import Any
+
+import pytest
+import sympy as sp
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.matrices.inertia_cells import (
+    InertiaCellsResult,
+    InertiaOpenCell,
+    InertiaPointCell,
+    compute_inertia_cells,
+)
+from jacobian.math.matrices.symbolic.values import RationalPolynomialMatrix
+from jacobian.math.polynomials._conversions import rational_polynomial_from_sympy
+
+T = sp.Symbol("t")
+
+
+def _source(matrix: Any) -> RationalPolynomialMatrix:
+    return RationalPolynomialMatrix(
+        variables=("t",),
+        row_count=matrix.rows,
+        column_count=matrix.cols,
+        entries=tuple(
+            tuple(
+                rational_polynomial_from_sympy(
+                    sp.Poly(matrix[i, j], T, domain=sp.QQ), ("t",)
+                )
+                for j in range(matrix.cols)
+            )
+            for i in range(matrix.rows)
+        ),
+    )
+
+
+def _interval(a: int | Fraction = -2, b: int | Fraction = 2) -> ClosedRationalInterval:
+    return ClosedRationalInterval(
+        lower=CanonicalRational.from_fraction(Fraction(a)),
+        upper=CanonicalRational.from_fraction(Fraction(b)),
+    )
+
+
+def _value(boundary: Any) -> Any:
+    value = boundary.value
+    if isinstance(value, CanonicalRational):
+        return sp.Rational(value.num, value.den)
+    return sp.CRootOf(sp.Poly.from_list(value.polynomial, T), value.real_root_index)
+
+
+def _counts(matrix: Any) -> tuple[int, int, int]:
+    positive = negative = zero = 0
+    for eigenvalue, multiplicity in matrix.eigenvals().items():
+        if eigenvalue == 0:
+            zero += multiplicity
+        elif eigenvalue.is_positive:
+            positive += multiplicity
+        else:
+            assert eigenvalue.is_negative
+            negative += multiplicity
+    return positive, negative, zero
+
+
+def _check(
+    matrix: Any, interval: ClosedRationalInterval | None = None
+) -> InertiaCellsResult:
+    interval = interval or _interval()
+    result = compute_inertia_cells(_source(matrix), interval)
+    points = [cell for cell in result.cells if isinstance(cell, InertiaPointCell)]
+    values = [_value(p.parameter) for p in points]
+    assert values[0] == sp.Rational(interval.lower.num, interval.lower.den)
+    assert values[-1] == sp.Rational(interval.upper.num, interval.upper.den)
+    assert all(a < b for a, b in pairwise(values))
+    for cell in result.cells:
+        if isinstance(cell, InertiaPointCell):
+            parameter = _value(cell.parameter)
+        else:
+            assert isinstance(cell, InertiaOpenCell)
+            lo = cell.lower.isolating_interval.upper.as_fraction()
+            hi = cell.upper.isolating_interval.lower.as_fraction()
+            parameter = sp.Rational((lo + hi) / 2)
+            assert _value(cell.lower) < parameter < _value(cell.upper)
+        expected = _counts(matrix.subs(T, parameter))
+        assert (cell.n_positive, cell.n_negative, cell.n_zero) == expected
+    assert InertiaCellsResult.model_validate_json(result.model_dump_json()) == result
+    return result
+
+
+def test_persistent_nullspace_and_irrational_rank_drops() -> None:
+    result = _check(sp.diag(T**2 - 2, 0))
+    assert len(result.cells) == 7
+    assert [c.n_zero for c in result.cells] == [1, 1, 2, 1, 2, 1, 1]
+
+
+def test_tangency_does_not_disappear() -> None:
+    result = _check(sp.diag(T**2, 1))
+    assert len(result.cells) == 5
+    assert result.cells[2].n_zero == 1
+    assert all(c.n_negative == 0 for c in result.cells)
+
+
+def test_indefinite_family_without_real_rank_drops() -> None:
+    result = _check(sp.Matrix([[T, 1], [1, -T]]))
+    assert len(result.cells) == 3
+    assert all(
+        (c.n_positive, c.n_negative, c.n_zero) == (1, 1, 0) for c in result.cells
+    )
+
+
+@pytest.mark.parametrize(
+    "matrix", [sp.zeros(0), sp.zeros(3), sp.diag(1, -1, 0), sp.Matrix([[0, 1], [1, 0]])]
+)
+def test_empty_zero_and_constant(matrix: Any) -> None:
+    _check(matrix)
+    _check(matrix, _interval(1, 1))
+
+
+def test_endpoint_singularities_and_singleton() -> None:
+    matrix = sp.diag(T * (T - 1), T)
+    assert len(_check(matrix, _interval(0, 1)).cells) == 3
+    assert _check(matrix, _interval(0, 0)).cells[0].n_zero == 2
+
+
+def test_repeated_roots_and_distinct_factor_union() -> None:
+    _check(sp.diag((T**2 - 2) ** 2, T**2 - 2, T**2 - 3))
+
+
+def test_congruence_preserves_cell_inertia() -> None:
+    transform = sp.Matrix([[1, 1, 0], [0, 1, 1], [1, 0, 1]])
+    diagonal = sp.diag(T, T - 1, 0)
+    source = transform.T * diagonal * transform
+    result = compute_inertia_cells(_source(source), _interval())
+    for cell in result.cells:
+        if isinstance(cell, InertiaPointCell):
+            value = _value(cell.parameter)
+        else:
+            value = sp.Rational(
+                (
+                    cell.lower.isolating_interval.upper.as_fraction()
+                    + cell.upper.isolating_interval.lower.as_fraction()
+                )
+                / 2
+            )
+        assert (cell.n_positive, cell.n_negative, cell.n_zero) == _counts(
+            diagonal.subs(T, value)
+        )
+
+
+def test_large_repeated_singular_blocks() -> None:
+    matrix = sp.diag(*([T**2 - 2] * 64), *([0] * 64))
+    result = compute_inertia_cells(_source(matrix), _interval())
+    assert len(result.cells) == 7
+    assert [c.n_zero for c in result.cells] == [64, 64, 128, 64, 128, 64, 64]
+
+
+def test_polynomial_symmetry_rejection() -> None:
+    with pytest.raises(OperationDomainValidationError, match="symmetric"):
+        compute_inertia_cells(_source(sp.Matrix([[T, 1], [0, T]])), _interval())
+
+
+def test_connected_algebraic_degree_rejection() -> None:
+    with pytest.raises(OperationResourceAdmissionError, match="degree-16"):
+        compute_inertia_cells(_source(sp.Matrix([[T**17 - T - 1]])), _interval())
+
+
+def test_excessive_coefficient_growth_rejection() -> None:
+    with pytest.raises(OperationResourceAdmissionError, match="carrier"):
+        compute_inertia_cells(
+            _source(sp.Matrix([[T**2 - (10**1000 + 7)]])),
+            _interval(-(10**501), 10**501),
+        )
+
+
+def test_structural_cell_contradiction_rejected() -> None:
+    result = compute_inertia_cells(_source(sp.diag(T)), _interval())
+    payload = result.model_dump(mode="json")
+    payload["cells"][1]["n_zero"] = 1
+    with pytest.raises(ValidationError, match="sum"):
+        InertiaCellsResult.model_validate_json(json.dumps(payload))
+
+
+def test_singular_endpoint_samples_stay_in_open_cells() -> None:
+    _check(sp.diag((T + 2) * (T**2 - 2), 0))
+    _check(sp.diag(T**2 - 2), _interval(Fraction(-3, 2), Fraction(-7, 5)))
+
+
+def test_algebraic_coefficient_sign_at_nonlinear_boundary() -> None:
+    transform = sp.Matrix([[1, 1], [1, 2]])
+    diagonal = sp.diag(T**3 - T - 1, T + 2)
+    source = transform.T * diagonal * transform
+    result = compute_inertia_cells(_source(source), _interval())
+    for cell in result.cells:
+        if isinstance(cell, InertiaPointCell):
+            value = _value(cell.parameter)
+        else:
+            value = sp.Rational(
+                (
+                    cell.lower.isolating_interval.upper.as_fraction()
+                    + cell.upper.isolating_interval.lower.as_fraction()
+                )
+                / 2
+            )
+        assert (cell.n_positive, cell.n_negative, cell.n_zero) == _counts(
+            diagonal.subs(T, value)
+        )
+
+
+def test_positive_denominator_scaling_preserves_profile() -> None:
+    transform = sp.Matrix([[1, 1], [1, 2]])
+    matrix = transform.T * sp.diag(T**2 - 2, 0) * transform
+    result = compute_inertia_cells(
+        _source(matrix / sp.Integer(2) ** 20000), _interval()
+    )
+    ordinary = compute_inertia_cells(_source(matrix), _interval())
+    assert result.cells == ordinary.cells
+
+
+def test_affine_large_coefficient_and_high_degree_singleton() -> None:
+    affine = _check(sp.Matrix([[T + 10**1000]]))
+    assert len(affine.cells) == 3
+    assert all(c.n_positive == 1 for c in affine.cells)
+    singleton = _check(sp.Matrix([[T**17]]), _interval(0, 0))
+    assert len(singleton.cells) == 1
+    assert singleton.cells[0].n_zero == 1
+
+
+def test_large_rational_affine_transition_inside_domain() -> None:
+    result = _check(sp.Matrix([[10**1000 * T - 1]]))
+    assert len(result.cells) == 5
+    assert result.cells[2].n_zero == 1
+
+
+def test_singleton_specialization_of_high_degree_nondiagonal_matrix() -> None:
+    result = _check(sp.Matrix([[T**17, 1], [1, -(T**17)]]), _interval(0, 0))
+    assert (
+        result.cells[0].n_positive,
+        result.cells[0].n_negative,
+        result.cells[0].n_zero,
+    ) == (1, 1, 0)

--- a/tests/mcp/test_polynomial_inertia_cells.py
+++ b/tests/mcp/test_polynomial_inertia_cells.py
@@ -1,0 +1,42 @@
+"""Complete exact inertia partition through native and live MCP boundaries."""
+
+import asyncio
+import json
+
+from jsonschema import validate
+
+from jacobian.math.matrices.inertia_cells._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_inertia_cells_native_mcp_schema_parity() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        validate(payload, tool.request_type.model_json_schema())
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        native = tool.run(request).model_dump(mode="json")
+        async with Client(create_server(), raise_exceptions=False) as client:
+            result = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            output = result.structured_content["output"]
+            assert output == native
+            validate(output, tool.result_type.model_json_schema())
+            left = output["cells"][2]["parameter"]["value"]
+            right = output["cells"][4]["parameter"]["value"]
+            comparison = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "algebraic_number.compare",
+                    "payload": {"left": left, "right": right},
+                },
+            )
+            assert not comparison.is_error
+            assert comparison.structured_content is not None
+            assert comparison.structured_content["output"]["order"] == "LT"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Closes #3456. Fixed-matrix inertia and determinant-root sampling do not provide a complete parameter profile: `diag(t²-2,0)` has an identically zero determinant but changes inertia at both irrational roots of `t²-2`.

## Outcome

Adds `matrix.polynomial.inertia_cells.compute` and native `compute_inertia_cells`. The result retains the symmetric QQ[t] source, closed rational domain, and alternating point/open cells with exact inertia. Every rank-drop specialization is included, both endpoints are point cells, and singleton domains return one point. Irrational boundaries retain canonical real-algebraic identities and rational isolating intervals.

This PR depends on the shared `RationalPolynomialMatrix` carrier in #3526 and targets that branch so the diff contains only the inertia operation and its tests. No existing operation is superseded.

The kernel processes nonzero-support components independently, reuses identical blocks, and computes characteristic polynomials after positive denominator clearing. Roots of the lowest nonzero characteristic coefficient locate all possible rank drops, including persistent nullspaces. Between them, eigenvalue continuity fixes inertia. At point cells, exact coefficient signs and [Descartes' theorem for real-rooted polynomials, Theorem 1.5.14 and Example 1.5.15](https://www.math.uni-konstanz.de/~schweigh/17/real-alg-geo-16-17.pdf) count positive and negative eigenvalues. SymPy supplies division-free characteristic coefficients, factorization and rational root isolation; no numerical eigenvalues are used.

## Validation

- `make affected AFFECTED_BASE=b79ea149d`: passed: scoped lint/types, 21 math, 156 catalog, 915 catalog/integration, and 72 MCP tests.
- Scoped exhaustive public-operation conformance: `uv run pytest -q -o addopts='' -m exhaustive tests/integration/catalog/test_public_operation_contract_conformance.py -k matrix.polynomial.inertia_cells.compute` — 1 passed, 881 deselected.
- Independent tests cover exact cell coverage, all singular fixtures, tangencies, endpoint singularities, rational/irrational transitions, congruence invariance, zero/constant/empty shapes, and singleton domains.
- Live MCP checks native/result-schema parity and passes serialized algebraic boundaries unchanged to `algebraic_number.compare`.
- Native calibration: a 128-axis repeated singular family takes 0.034 seconds and returns 7 cells; a connected 4-axis singular family takes 0.008 seconds and returns 9 cells. The shared 60-second deadline is a safety limit; source-derived bounds admit the mathematical work.
- Final head: `138fbe297`. The repaired parent was merged additively; the focused operation diff is unchanged. The gate covers operation commit `f73f49a18`; the subsequent shared-carrier test-only merge additionally passed the exact symbolic native-export test (1 passed, 71 deselected), Ruff and mypy. The operation diff is unchanged.

## Contract impact

`RationalPolynomialMatrix`, `ClosedRationalInterval`, `CanonicalRational`, `RealAlgebraicValue`, and `RationalIsolatingInterval` remain their existing canonical carriers. Cell parsing checks structural alternation, shared boundaries, domain endpoints and inertia count sums. The producing operation establishes actual isolation, ordered coverage and inertia; deserializing a claim does not recompute these relations.

- [x] Native/MCP behavior and canonical producer-to-consumer serialization are covered.
- [x] Non-symmetric inputs and resource excess have distinct typed rejections.
- [x] Admission precedes characteristic expansion and isolation; singleton normalization has its own admitted power/sum bound.
- [x] All phases share one request deadline.

## Catalog admission and execution envelope

The reusable result is the complete constant-inertia partition, absent from fixed-fiber inertia and symbolic matrix operations. General algebraic processing admits at most 128 matrix axes and 128 candidate transitions, with connected-block characteristic degree at most 16 and factor height fitting the canonical algebraic carrier. Principal-minor/Berkowitz bounds cover coefficient growth; factor, separation, coefficient-sign, rational-sample and boundary-output budgets cover subsequent work and representation.

Singleton domains specialize before algebraic admission. Scalar affine blocks use direct rational roots, or a constant sign when their root lies outside the domain. Consequently `t**17` at zero, `t + 10**1000` on `[-2,2]`, a large rational affine transition inside the domain, and positive denominator scaling remain accepted. Rejections include a required degree-17 algebraic transition and an in-domain irreducible quadratic whose defining coefficient exceeds the 1,000-digit carrier. More expensive connected families remain outside the admitted envelope.

## Review closure

- [x] Admission-precision findings repaired with accepted singleton/affine regressions.
- [x] Focused public symbols and dependency boundary checked.
- Hosted CI passed on final head `138fbe297` with explicit repaired-parent base `ded1391f5`: [CI run](https://github.com/morluto/jacobian/actions/runs/34172437493). Static, math, catalog, catalog examples, MCP, and the required aggregate passed. An explicit dispatch was used because automatic pull-request CI only targets main.
