### PR TITLE
feat(math): construct deletion partition compatibility closures

### DIFF
--- a/src/jacobian/math/graphs/coloring/deletion_partition_closure/__init__.py
+++ b/src/jacobian/math/graphs/coloring/deletion_partition_closure/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility closure of a labelled vertex-deletion partition template."""
+
+from jacobian.math.graphs.coloring.deletion_partition_closure.operations import (
+    construct,
+)
+
+__all__ = ["construct"]

--- a/src/jacobian/math/graphs/coloring/deletion_partition_closure/_models.py
+++ b/src/jacobian/math/graphs/coloring/deletion_partition_closure/_models.py
@@ -1,0 +1,38 @@
+"""Source-bound values for deletion-partition compatibility closure."""
+
+from pydantic import Field
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.coloring.deletion_partition_closure.values import (
+    DeletionPartitionTemplate,
+    Label,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+class DeletionPartitionClosureRequest(StrictModel):
+    template: DeletionPartitionTemplate
+
+
+class DeletionPartitionBlocker(StrictModel):
+    """First source row co-classifying a nonedge, with its canonical block."""
+
+    pair_index: int = Field(ge=0, le=32639)
+    row_index: int = Field(ge=0, le=255)
+    block_index: int = Field(ge=0, le=254)
+
+
+class DeletionPartitionClosure(StrictModel):
+    """The largest graph making every source deletion partition proper.
+
+    The pair axis follows combinations of carrier positions; each pair's
+    endpoints are lexically oriented as required by SimpleUndirectedGraph.
+    Blockers follow pair-axis order. Each references the first source row
+    co-classifying its pair and the unique block in that row. These mathematical
+    relations are established by construct, not replayed during decoding.
+    """
+
+    template: DeletionPartitionTemplate
+    source_pair_axis: tuple[tuple[Label, Label], ...] = Field(max_length=32640)
+    graph: SimpleUndirectedGraph
+    nonedge_blockers: tuple[DeletionPartitionBlocker, ...] = Field(max_length=32640)

--- a/src/jacobian/math/graphs/coloring/deletion_partition_closure/_tools.py
+++ b/src/jacobian/math/graphs/coloring/deletion_partition_closure/_tools.py
@@ -1,0 +1,52 @@
+"""Deletion-partition compatibility closure operation declaration."""
+
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.graphs.coloring.deletion_partition_closure._models import (
+    DeletionPartitionClosure,
+    DeletionPartitionClosureRequest,
+)
+from jacobian.math.graphs.coloring.deletion_partition_closure.operations import (
+    construct,
+)
+
+
+def compute(request: DeletionPartitionClosureRequest) -> DeletionPartitionClosure:
+    return construct(request.template)
+
+
+TOOLS = (
+    MathTool(
+        operation_id="graph.coloring.deletion_partition_closure.construct",
+        title="Construct a vertex-deletion partition compatibility closure",
+        description=(
+            "Construct the largest simple graph for which every supplied partition "
+            "of V minus v is a proper coloring after deleting v. A pair is an edge "
+            "exactly when every applicable row separates its endpoints. Return the "
+            "canonical source template, complete pair axis and first-row/block "
+            "blocker for every nonedge. Accept up to 256 ordered labels of 64 UTF-8 "
+            "bytes, including empty carriers and vacuous two-vertex closures. "
+            "This does not decide chromatic number or vertex criticality."
+        ),
+        request_type=DeletionPartitionClosureRequest,
+        result_type=DeletionPartitionClosure,
+        run=compute,
+        tags=("graph", "coloring", "partition", "compatibility", "closure"),
+        examples=(
+            OperationExample(
+                name="one_block_deletion_rows",
+                description="Every pair in a three-vertex carrier has a blocking row.",
+                input={
+                    "template": {
+                        "vertices": ["a", "b", "c"],
+                        "block_bound": "1",
+                        "rows": [
+                            {"deleted_vertex": "a", "blocks": [["b", "c"]]},
+                            {"deleted_vertex": "b", "blocks": [["a", "c"]]},
+                            {"deleted_vertex": "c", "blocks": [["a", "b"]]},
+                        ],
+                    }
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/graphs/coloring/deletion_partition_closure/operations.py
+++ b/src/jacobian/math/graphs/coloring/deletion_partition_closure/operations.py
@@ -1,0 +1,65 @@
+"""Exact bitset union of forbidden pairs in deletion partition blocks."""
+
+from itertools import combinations
+
+from jacobian.math.graphs.coloring.deletion_partition_closure._models import (
+    DeletionPartitionBlocker,
+    DeletionPartitionClosure,
+)
+from jacobian.math.graphs.coloring.deletion_partition_closure.values import (
+    DeletionPartitionTemplate,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def construct(template: DeletionPartitionTemplate) -> DeletionPartitionClosure:
+    """Construct xy iff every deletion row other than x,y separates x and y.
+
+    The entire canonical envelope is admitted: n <= 256, at most n(n-1)
+    memberships, n(n-1)/2 output pairs and that many blockers. There are at
+    most n(n-1) bitset updates on n-bit integers; a forbidden pair is expanded
+    only once. Labels have at most 64 UTF-8 bytes, so even sixfold JSON escaping
+    bounds source plus complete output below 128 MiB (including 32,768 digits
+    for the retained block bound). No exponential coloring backend is needed.
+    """
+    vertices = template.vertices
+    positions = {vertex: index for index, vertex in enumerate(vertices)}
+    blocked = [0] * len(vertices)
+    witnesses: dict[tuple[int, int], tuple[int, int]] = {}
+    for row_index, row in enumerate(template.rows):
+        for block_index, block in enumerate(row.blocks):
+            indices = tuple(positions[vertex] for vertex in block)
+            mask = sum(1 << index for index in indices)
+            for left in indices:
+                new = mask & ~((1 << (left + 1)) - 1) & ~blocked[left]
+                while new:
+                    bit = new & -new
+                    right = bit.bit_length() - 1
+                    witnesses[left, right] = (row_index, block_index)
+                    new ^= bit
+                blocked[left] |= mask
+    axis: list[tuple[str, str]] = []
+    edges: list[tuple[str, str]] = []
+    blockers: list[DeletionPartitionBlocker] = []
+    for left, right in combinations(range(len(vertices)), 2):
+        pair = (
+            min(vertices[left], vertices[right]),
+            max(vertices[left], vertices[right]),
+        )
+        pair_index = len(axis)
+        axis.append(pair)
+        witness = witnesses.get((left, right))
+        if witness is None:
+            edges.append(pair)
+        else:
+            blockers.append(
+                DeletionPartitionBlocker(
+                    pair_index=pair_index, row_index=witness[0], block_index=witness[1]
+                )
+            )
+    return DeletionPartitionClosure(
+        template=template,
+        source_pair_axis=tuple(axis),
+        graph=SimpleUndirectedGraph(vertices=vertices, edges=tuple(edges)),
+        nonedge_blockers=tuple(blockers),
+    )

--- a/src/jacobian/math/graphs/coloring/deletion_partition_closure/values.py
+++ b/src/jacobian/math/graphs/coloring/deletion_partition_closure/values.py
@@ -1,0 +1,78 @@
+"""Canonical labelled vertex-deletion partition templates."""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Annotated, Self
+
+from pydantic import Field, StringConstraints, model_validator
+
+from jacobian._exact import ExactInteger
+from jacobian._models import StrictModel
+
+Label = Annotated[str, StringConstraints(strict=True, max_length=64)]
+Block = Annotated[tuple[Label, ...], Field(min_length=1, max_length=255)]
+
+
+class DeletionPartitionRow(StrictModel):
+    """Unordered nonempty blocks partitioning the carrier except one vertex."""
+
+    deleted_vertex: Label
+    blocks: tuple[Block, ...] = Field(max_length=255)
+
+
+class DeletionPartitionTemplate(StrictModel):
+    """One partition of V minus v for each v in the ordered labelled carrier.
+
+    Members and blocks are canonicalized by carrier position, and rows by
+    deleted-vertex position. The positive block bound is retained exactly.
+    Parsing checks partition structure only, without constructing a graph.
+    """
+
+    vertices: tuple[Label, ...] = Field(max_length=256)
+    block_bound: ExactInteger = Field(ge=1)
+    rows: tuple[DeletionPartitionRow, ...] = Field(max_length=256)
+
+    @model_validator(mode="after")
+    def canonicalize_partitions(self) -> Self:
+        if self.block_bound < 1:
+            raise ValueError("block bound must be positive")
+        positions = {vertex: index for index, vertex in enumerate(self.vertices)}
+        if len(positions) != len(self.vertices):
+            raise ValueError("carrier labels must be distinct")
+        for vertex in self.vertices:
+            if unicodedata.normalize("NFC", vertex) != vertex:
+                raise ValueError("carrier labels must be NFC normalized")
+            try:
+                encoded = vertex.encode("utf-8")
+            except UnicodeEncodeError as exc:
+                raise ValueError("carrier labels must be Unicode scalar text") from exc
+            if len(encoded) > 64:
+                raise ValueError("carrier labels must have at most 64 UTF-8 bytes")
+        if len(self.rows) != len(self.vertices):
+            raise ValueError("one deletion row is required per carrier vertex")
+        canonical: dict[str, DeletionPartitionRow] = {}
+        for row in self.rows:
+            if row.deleted_vertex not in positions or row.deleted_vertex in canonical:
+                raise ValueError("deleted vertices must enumerate the carrier once")
+            if len(row.blocks) > self.block_bound:
+                raise ValueError("partition exceeds its block bound")
+            members = [vertex for block in row.blocks for vertex in block]
+            if len(members) != len(set(members)) or set(members) != (
+                set(positions) - {row.deleted_vertex}
+            ):
+                raise ValueError("row blocks must partition exactly V minus its vertex")
+            blocks = tuple(
+                sorted(
+                    (
+                        tuple(sorted(block, key=positions.__getitem__))
+                        for block in row.blocks
+                    ),
+                    key=lambda block: positions[block[0]],
+                )
+            )
+            canonical[row.deleted_vertex] = DeletionPartitionRow(
+                deleted_vertex=row.deleted_vertex, blocks=blocks
+            )
+        object.__setattr__(self, "rows", tuple(canonical[v] for v in self.vertices))
+        return self

--- a/tests/math/graphs/coloring/deletion_partition_closure/test_closure.py
+++ b/tests/math/graphs/coloring/deletion_partition_closure/test_closure.py
@@ -1,0 +1,233 @@
+"""Independent pair-row oracle, normalization and full-envelope examples."""
+
+from itertools import combinations, product
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.coloring.deletion_partition_closure import construct
+from jacobian.math.graphs.coloring.deletion_partition_closure.values import (
+    DeletionPartitionRow,
+    DeletionPartitionTemplate,
+)
+
+
+def partitions(items: tuple[str, ...]) -> list[tuple[tuple[str, ...], ...]]:
+    if not items:
+        return [()]
+    first, rest = items[0], items[1:]
+    result = []
+    for partition in partitions(rest):
+        result.append(((first,), *partition))
+        for index in range(len(partition)):
+            result.append(
+                (
+                    *partition[:index],
+                    (first, *partition[index]),
+                    *partition[index + 1 :],
+                )
+            )
+    return result
+
+
+def check_oracle(template: DeletionPartitionTemplate) -> None:
+    result = construct(template)
+    expected_edges = set()
+    expected_blockers = []
+    axis = tuple(tuple(sorted(pair)) for pair in combinations(template.vertices, 2))
+    for pair_index, (left, right) in enumerate(axis):
+        blocking = [
+            (row_index, block_index)
+            for row_index, row in enumerate(template.rows)
+            if row.deleted_vertex not in (left, right)
+            for block_index, block in enumerate(row.blocks)
+            if left in block and right in block
+        ]
+        if blocking:
+            expected_blockers.append((pair_index, *min(blocking)))
+        else:
+            expected_edges.add((left, right))
+    assert result.template == template
+    assert result.source_pair_axis == axis
+    assert set(result.graph.edges) == expected_edges
+    assert [
+        (b.pair_index, b.row_index, b.block_index) for b in result.nonedge_blockers
+    ] == expected_blockers
+    # Replay every deletion coloring and each maximality obstruction.
+    for row in template.rows:
+        colors = {
+            vertex: index for index, block in enumerate(row.blocks) for vertex in block
+        }
+        assert all(
+            colors[left] != colors[right]
+            for left, right in result.graph.edges
+            if row.deleted_vertex not in (left, right)
+        )
+    for blocker in result.nonedge_blockers:
+        pair = axis[blocker.pair_index]
+        block = template.rows[blocker.row_index].blocks[blocker.block_index]
+        assert set(pair) <= set(block)
+
+
+@pytest.mark.parametrize("size", range(5))
+def test_all_partition_templates_through_four_vertices(size: int) -> None:
+    vertices = tuple("dcba"[:size])
+    row_options = [
+        partitions(tuple(v for v in vertices if v != deleted)) for deleted in vertices
+    ]
+    for rows in product(*row_options):
+        template = DeletionPartitionTemplate(
+            vertices=vertices,
+            block_bound=max(1, size - 1),
+            rows=tuple(
+                DeletionPartitionRow(deleted_vertex=v, blocks=blocks)
+                for v, blocks in zip(vertices, rows, strict=True)
+            ),
+        )
+        check_oracle(template)
+
+
+def cyclic_template(s: int) -> DeletionPartitionTemplate:
+    size = 3 * s + 1
+    vertices = tuple(f"v{index}" for index in range(size))
+    return DeletionPartitionTemplate(
+        vertices=vertices,
+        block_bound=3,
+        rows=tuple(
+            DeletionPartitionRow(
+                deleted_vertex=vertices[v],
+                blocks=tuple(
+                    tuple(vertices[(v + 1 + b * s + j) % size] for j in range(s))
+                    for b in range(3)
+                ),
+            )
+            for v in range(size)
+        ),
+    )
+
+
+def test_cyclic_interval_template() -> None:
+    check_oracle(cyclic_template(3))
+
+
+def test_full_256_vertex_cyclic_template() -> None:
+    template = cyclic_template(85)
+    result = construct(template)
+    assert len(result.source_pair_axis) == 32640
+    assert len(result.graph.edges) + len(result.nonedge_blockers) == 32640
+    # A pair survives precisely at cyclic distance at least s; all shorter
+    # distances share a length-s interval in some translated deletion row.
+    expected = {
+        tuple(sorted((template.vertices[i], template.vertices[j])))
+        for i, j in combinations(range(256), 2)
+        if min(j - i, 256 - (j - i)) >= 85
+    }
+    assert set(result.graph.edges) == expected
+
+
+def test_block_member_row_permutations_and_relabeling() -> None:
+    template = cyclic_template(2)
+    reordered = DeletionPartitionTemplate(
+        vertices=template.vertices,
+        block_bound=template.block_bound,
+        rows=tuple(
+            DeletionPartitionRow(
+                deleted_vertex=row.deleted_vertex,
+                blocks=tuple(tuple(reversed(block)) for block in reversed(row.blocks)),
+            )
+            for row in reversed(template.rows)
+        ),
+    )
+    assert reordered == template
+    assert construct(reordered) == construct(template)
+    mapping = {
+        v: f"x{len(template.vertices) - i}" for i, v in enumerate(template.vertices)
+    }
+    renamed = DeletionPartitionTemplate(
+        vertices=tuple(mapping[v] for v in template.vertices),
+        block_bound=3,
+        rows=tuple(
+            DeletionPartitionRow(
+                deleted_vertex=mapping[row.deleted_vertex],
+                blocks=tuple(tuple(mapping[v] for v in block) for block in row.blocks),
+            )
+            for row in template.rows
+        ),
+    )
+    original, transported = construct(template), construct(renamed)
+    assert transported.nonedge_blockers == original.nonedge_blockers
+    assert transported.graph.edges == tuple(
+        tuple(sorted((mapping[left], mapping[right])))
+        for left, right in original.graph.edges
+    )
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        (),
+        (("a", (("b",),)), ("a", (("b",),))),
+        (("a", (("a",),)), ("b", (("a",),))),
+        (("a", (("b",), ("b",))), ("b", (("a",),))),
+        (("a", ()), ("b", (("a",),))),
+        (("a", (("x",),)), ("b", (("a",),))),
+    ],
+)
+def test_malformed_rows_rejected(
+    rows: tuple[tuple[str, tuple[tuple[str, ...], ...]], ...],
+) -> None:
+    with pytest.raises(ValidationError):
+        DeletionPartitionTemplate(
+            vertices=("a", "b"),
+            block_bound=2,
+            rows=tuple(
+                DeletionPartitionRow(deleted_vertex=v, blocks=blocks)
+                for v, blocks in rows
+            ),
+        )
+
+
+def test_bound_and_empty_blocks_rejected() -> None:
+    with pytest.raises(ValidationError):
+        DeletionPartitionRow(deleted_vertex="a", blocks=((),))
+    template = cyclic_template(1)
+    with pytest.raises(ValidationError):
+        DeletionPartitionTemplate(
+            vertices=template.vertices, block_bound=2, rows=template.rows
+        )
+    with pytest.raises(ValidationError):
+        DeletionPartitionTemplate(vertices=(), block_bound=0, rows=())
+
+
+def test_large_bound_and_graph_compatible_labels() -> None:
+    vertices = ("", "\n", "é")
+    template = DeletionPartitionTemplate(
+        vertices=vertices,
+        block_bound=10**1000,
+        rows=tuple(
+            DeletionPartitionRow(
+                deleted_vertex=v, blocks=tuple((w,) for w in vertices if w != v)
+            )
+            for v in vertices
+        ),
+    )
+    check_oracle(template)
+    assert (
+        DeletionPartitionTemplate.model_validate_json(template.model_dump_json())
+        == template
+    )
+
+
+@pytest.mark.parametrize(
+    "vertices",
+    [
+        ("a", "a"),
+        ("e\u0301",),
+        ("é" * 33,),
+        ("\ud800",),
+        tuple(str(i) for i in range(257)),
+    ],
+)
+def test_invalid_carriers(vertices: tuple[str, ...]) -> None:
+    with pytest.raises(ValidationError):
+        DeletionPartitionTemplate(vertices=vertices, block_bound=1, rows=())

--- a/tests/mcp/test_deletion_partition_closure.py
+++ b/tests/mcp/test_deletion_partition_closure.py
@@ -1,0 +1,58 @@
+"""Real MCP parity, schema validation, rejection recovery and graph reuse."""
+
+import asyncio
+import json
+
+from jsonschema import validate
+
+from jacobian.math.graphs.coloring.deletion_partition_closure._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_live_closure() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        validate(payload, tool.request_type.model_json_schema())
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        async with Client(create_server(), raise_exceptions=False) as client:
+            invalid = json.loads(json.dumps(payload))
+            invalid["template"]["rows"].pop()
+            rejected = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": invalid}
+            )
+            assert rejected.is_error
+            response = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not response.is_error
+            assert response.structured_content is not None
+            output = response.structured_content["output"]
+            validate(output, tool.result_type.model_json_schema())
+            assert output == tool.run(request).model_dump(mode="json")
+            reused = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": {"template": output["template"]},
+                },
+            )
+            assert not reused.is_error
+            assert reused.structured_content is not None
+            assert reused.structured_content["output"] == output
+            matching = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "graph.invariant.maximum_matching.compute",
+                    "payload": {"graph": output["graph"]},
+                },
+            )
+            assert not matching.is_error
+            assert matching.structured_content is not None
+            assert (
+                matching.structured_content["output"]["maximum_matching_cardinality"]
+                == 0
+            )
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Closes #3151.

Adds `graph.coloring.deletion_partition_closure.construct`: given one partition of each vertex-deleted carrier, return the largest graph making every supplied deletion coloring proper. The result retains the normalized template and complete pair axis, with the first canonical row/block obstruction for every excluded pair. Rows, blocks and members normalize by the caller’s ordered carrier; the graph uses the existing `SimpleUndirectedGraph` value.

The bitset kernel admits the entire 256-vertex canonical envelope, including empty carriers, the vacuous two-vertex complete graph and arbitrarily large supported positive block bounds. Work is polynomial in source memberships and pair count, with a documented full-output bound. This implements the issue’s pairwise separation definition; it does not claim chromatic number or vertex criticality. No existing public operation is superseded. The motivating criticality context is described in [Skottova and Steiner](https://arxiv.org/abs/2508.08703).

Validation: independent exact-diff review passed. `make affected AFFECTED_BASE=origin/main` passed all six stages: Ruff/mypy, 21 mathematical tests, 156 catalog tests, 915 catalog integration/examples and 72 MCP tests. Scoped exhaustive catalog conformance passed. The mathematical tests enumerate every partition template through four vertices and check the complete 256-vertex cyclic fixture; live MCP checks schema parity, rejection recovery and canonical graph reuse. The cyclic fixture constructs all 32,640 pairs in approximately 0.34 seconds (2.2 MB JSON). [Hosted required CI passed](https://github.com/morluto/jacobian/actions/runs/34173525389/job/101898592606).

