### PR TITLE
feat(geometry): partition finite subsets by subspace cosets

### DIFF
--- a/src/jacobian/math/geometry/finite/cosets/__init__.py
+++ b/src/jacobian/math/geometry/finite/cosets/__init__.py
@@ -1,0 +1,15 @@
+"""Finite subsets partitioned by affine cosets of a supplied subspace."""
+
+from jacobian.math.geometry.finite.cosets._models import (
+    CosetIntersection,
+    CosetIntersectionProfile,
+    CosetIntersectionSource,
+)
+from jacobian.math.geometry.finite.cosets.operations import coset_intersection_profile
+
+__all__ = [
+    "CosetIntersection",
+    "CosetIntersectionProfile",
+    "CosetIntersectionSource",
+    "coset_intersection_profile",
+]

--- a/src/jacobian/math/geometry/finite/cosets/_models.py
+++ b/src/jacobian/math/geometry/finite/cosets/_models.py
@@ -41,6 +41,8 @@ class CosetIntersection(StrictModel):
     def require_cardinality_matches_members(self) -> Self:
         if self.cardinality != len(self.members):
             raise ValueError("cardinality must equal the number of retained members")
+        if any(a >= b for a, b in zip(self.members, self.members[1:], strict=False)):
+            raise ValueError("members must be strictly lexicographically ordered")
         return self
 
 
@@ -59,4 +61,9 @@ class CosetIntersectionProfile(CosetIntersectionSource):
             _validate_vector(row.representative, self.space)
             for vector in row.members:
                 _validate_vector(vector, self.space)
+        collected = tuple(
+            sorted(member for row in self.rows for member in row.members)
+        )
+        if collected != self.subset:
+            raise ValueError("row members must be the complete retained subset")
         return self

--- a/src/jacobian/math/geometry/finite/cosets/_models.py
+++ b/src/jacobian/math/geometry/finite/cosets/_models.py
@@ -57,8 +57,14 @@ class CosetIntersectionProfile(CosetIntersectionSource):
 
     @model_validator(mode="after")
     def require_row_coordinates(self) -> Self:
+        previous: Vector | None = None
         for row in self.rows:
             _validate_vector(row.representative, self.space)
+            if previous is not None and row.representative <= previous:
+                raise ValueError(
+                    "occupied rows must be strictly lexicographically ordered by representative"
+                )
+            previous = row.representative
             for vector in row.members:
                 _validate_vector(vector, self.space)
         collected = tuple(sorted(member for row in self.rows for member in row.members))

--- a/src/jacobian/math/geometry/finite/cosets/_models.py
+++ b/src/jacobian/math/geometry/finite/cosets/_models.py
@@ -37,6 +37,12 @@ class CosetIntersection(StrictModel):
     members: Vectors = Field(min_length=1)
     cardinality: int = Field(ge=1, le=65_536)
 
+    @model_validator(mode="after")
+    def require_cardinality_matches_members(self) -> Self:
+        if self.cardinality != len(self.members):
+            raise ValueError("cardinality must equal the number of retained members")
+        return self
+
 
 class CosetIntersectionProfile(CosetIntersectionSource):
     """Complete partition with zero pivot coordinates in each representative.

--- a/src/jacobian/math/geometry/finite/cosets/_models.py
+++ b/src/jacobian/math/geometry/finite/cosets/_models.py
@@ -1,0 +1,56 @@
+"""Source-bound finite subsets and occupied affine-coset partitions."""
+
+from typing import Annotated, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.geometry.finite._models import LinearSubspace
+from jacobian.math.geometry.finite.values import PrimeFieldVectorSpace, _validate_vector
+
+Vector = Annotated[tuple[int, ...], Field(max_length=32)]
+Vectors = Annotated[tuple[Vector, ...], Field(max_length=65_536)]
+
+
+class CosetIntersectionSource(StrictModel):
+    """A lexicographically ordered finite subset and a supplied RREF subspace."""
+
+    space: PrimeFieldVectorSpace
+    subspace: LinearSubspace
+    subset: Vectors
+
+    @model_validator(mode="after")
+    def require_structure(self) -> Self:
+        if self.space != self.subspace.space:
+            raise ValueError("subspace must have the declared field and ordered axis")
+        for vector in self.subset:
+            _validate_vector(vector, self.space)
+        if any(a >= b for a, b in zip(self.subset, self.subset[1:], strict=False)):
+            raise ValueError("subset must be strictly lexicographically ordered")
+        return self
+
+
+class CosetIntersection(StrictModel):
+    """One occupied coset, with its complete source intersection."""
+
+    representative: Vector
+    members: Vectors = Field(min_length=1)
+    cardinality: int = Field(ge=1, le=65_536)
+
+
+class CosetIntersectionProfile(CosetIntersectionSource):
+    """Complete partition with zero pivot coordinates in each representative.
+
+    Parsing preserves source structure. The operation establishes the supplied
+    field and RREF claims, the coset relation, and completeness of the partition.
+    """
+
+    rows: tuple[CosetIntersection, ...] = Field(max_length=65_536)
+
+    @model_validator(mode="after")
+    def require_row_coordinates(self) -> Self:
+        for row in self.rows:
+            _validate_vector(row.representative, self.space)
+            for vector in row.members:
+                _validate_vector(vector, self.space)
+        return self

--- a/src/jacobian/math/geometry/finite/cosets/_models.py
+++ b/src/jacobian/math/geometry/finite/cosets/_models.py
@@ -61,9 +61,7 @@ class CosetIntersectionProfile(CosetIntersectionSource):
             _validate_vector(row.representative, self.space)
             for vector in row.members:
                 _validate_vector(vector, self.space)
-        collected = tuple(
-            sorted(member for row in self.rows for member in row.members)
-        )
+        collected = tuple(sorted(member for row in self.rows for member in row.members))
         if collected != self.subset:
             raise ValueError("row members must be the complete retained subset")
         return self

--- a/src/jacobian/math/geometry/finite/cosets/_tools.py
+++ b/src/jacobian/math/geometry/finite/cosets/_tools.py
@@ -1,0 +1,47 @@
+"""Public occupied affine-coset intersection profile."""
+
+from typing import Any
+
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.geometry.finite.cosets._models import (
+    CosetIntersectionProfile,
+    CosetIntersectionSource,
+)
+from jacobian.math.geometry.finite.cosets.operations import coset_intersection_profile
+
+
+def _compute(request: CosetIntersectionSource) -> CosetIntersectionProfile:
+    return coset_intersection_profile(request.space, request.subspace, request.subset)
+
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="finite_geometry.subspace.coset_intersection_profile.compute",
+        title="Partition a finite subset by subspace cosets",
+        description=(
+            "Return every occupied affine coset of a supplied prime-field RREF "
+            "subspace, its canonical quotient representative and complete sorted "
+            "intersection with the supplied finite subset. Retain the field, "
+            "ordered axes, subspace and subset. Representatives have zero pivot "
+            "coordinates; empty subsets give empty partitions."
+        ),
+        request_type=CosetIntersectionSource,
+        result_type=CosetIntersectionProfile,
+        run=_compute,
+        tags=("finite-geometry", "cosets", "subspace", "quotient", "exact"),
+        examples=(
+            OperationExample(
+                name="unequal_fibres",
+                description="Three points of F_2^3 meet two cosets of a line.",
+                input={
+                    "space": {"field_order": 2, "axis": ["x", "y", "z"]},
+                    "subspace": {
+                        "space": {"field_order": 2, "axis": ["x", "y", "z"]},
+                        "basis": [[1, 0, 0]],
+                    },
+                    "subset": [[0, 0, 0], [0, 1, 0], [1, 0, 0]],
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/geometry/finite/cosets/operations.py
+++ b/src/jacobian/math/geometry/finite/cosets/operations.py
@@ -1,0 +1,106 @@
+"""Exact occupied-coset partition by RREF quotient reduction."""
+
+import time
+from itertools import groupby
+from operator import itemgetter
+
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.geometry.finite._models import LinearSubspace
+from jacobian.math.geometry.finite.cosets._models import (
+    CosetIntersection,
+    CosetIntersectionProfile,
+    CosetIntersectionSource,
+)
+from jacobian.math.geometry.finite.operations import _admit_linear_subspace
+from jacobian.math.geometry.finite.values import PrimeFieldVectorSpace
+
+
+def coset_intersection_profile(
+    space: PrimeFieldVectorSpace,
+    subspace: LinearSubspace,
+    subset: tuple[tuple[int, ...], ...],
+) -> CosetIntersectionProfile:
+    """Partition a finite subset by cosets, retaining its ordered parent.
+
+    A representative has zero in every RREF pivot coordinate. Every reduction
+    subtracts a subspace vector, and these normal representatives are unique.
+    """
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return coset_intersection_profile(space, subspace, subset)
+    deadline = execution.started_at + 60.0
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before coset partition admission")
+    source = CosetIntersectionSource(space=space, subspace=subspace, subset=subset)
+    size, dimension, rank = len(subset), len(space.axis), len(subspace.basis)
+    # At most min(N, p**(n-r)) occupied cosets. Retained input, members and
+    # representatives are bounded separately, plus the retained RREF basis. Coordinates
+    # and modular intermediates fit 14 and 28 bits respectively (p <= 10000).
+    occupied = min(size, space.field_order ** max(0, dimension - rank))
+    coordinates = (2 * size + occupied + rank) * dimension
+    # RREF recognition, quotient reduction and comparison sorting of the
+    # representatives. Source canonical ordering already orders each fibre.
+    reduction_rank = rank if rank < dimension else 0
+    work = rank * rank * dimension + size * dimension * reduction_rank
+    if rank < dimension:
+        work += 2 * size * dimension * max(1, size.bit_length())
+    if coordinates > 1_048_576 or work > 67_108_864:
+        raise OperationResourceAdmissionError(
+            location=("subset",),
+            code="finite_geometry.coset_partition_budget",
+            message="coset partition exceeds coordinate allocation or reduction work",
+        )
+    # Supplied structural values need their mathematical claims recognized
+    # once, after admission; result parsing never repeats this computation.
+    basis = _admit_linear_subspace(subspace)
+    pivots = tuple(next(i for i, value in enumerate(row) if value) for row in basis)
+    modulus = space.field_order
+    rows: list[CosetIntersection] = []
+    if rank == dimension:
+        if subset:
+            rows.append(
+                CosetIntersection(
+                    representative=(0,) * dimension, members=subset, cardinality=size
+                )
+            )
+    else:
+        reductions = []
+        for index, vector in enumerate(subset):
+            if index % 256 == 0:
+                request_checkpoint("during coset quotient reduction")
+            word = list(vector)
+            for pivot, row in zip(pivots, basis, strict=True):
+                factor = word[pivot]
+                if factor:
+                    for j, value in enumerate(row):
+                        word[j] = (word[j] - factor * value) % modulus
+            reductions.append((tuple(word), vector))
+        # Comparison sorting supplies a deterministic worst-case work bound,
+        # independent of hash collisions. Stability preserves source ordering.
+        reductions.sort(key=itemgetter(0))
+        for representative, group in groupby(reductions, key=itemgetter(0)):
+            members = tuple(vector for _, vector in group)
+            rows.append(
+                CosetIntersection(
+                    representative=representative,
+                    members=members,
+                    cardinality=len(members),
+                )
+            )
+    result = CosetIntersectionProfile(
+        space=source.space,
+        subspace=source.subspace,
+        subset=source.subset,
+        rows=tuple(rows),
+    )
+    request_checkpoint("after coset partition construction")
+    return result

--- a/tests/math/geometry/test_coset_intersection_profile.py
+++ b/tests/math/geometry/test_coset_intersection_profile.py
@@ -16,6 +16,7 @@ from jacobian.math.geometry.finite import (
 )
 from jacobian.math.geometry.finite._models import LinearSubspace
 from jacobian.math.geometry.finite.cosets import (
+    CosetIntersection,
     CosetIntersectionProfile,
     coset_intersection_profile,
 )
@@ -134,6 +135,11 @@ def test_composite_field_is_rejected_even_when_subset_empty() -> None:
     space = PrimeFieldVectorSpace(field_order=9, axis=("x",))
     with pytest.raises(OperationDomainValidationError, match="prime"):
         coset_intersection_profile(space, LinearSubspace(space=space, basis=()), ())
+
+
+def test_intersection_row_rejects_cardinality_mismatch() -> None:
+    with pytest.raises(ValidationError, match="cardinality"):
+        CosetIntersection(representative=(0,), members=((0,),), cardinality=2)
 
 
 @pytest.mark.parametrize("subset", [((0,), (0,)), ((1,), (0,)), ((3,),), ((0, 0),)])

--- a/tests/math/geometry/test_coset_intersection_profile.py
+++ b/tests/math/geometry/test_coset_intersection_profile.py
@@ -142,6 +142,27 @@ def test_intersection_row_rejects_cardinality_mismatch() -> None:
         CosetIntersection(representative=(0,), members=((0,),), cardinality=2)
 
 
+def test_intersection_row_requires_canonical_member_order() -> None:
+    with pytest.raises(ValidationError, match="lexicographically"):
+        CosetIntersection(representative=(0,), members=((1,), (0,)), cardinality=2)
+    with pytest.raises(ValidationError, match="lexicographically"):
+        CosetIntersection(representative=(0,), members=((0,), (0,)), cardinality=2)
+
+
+def test_profile_rows_must_cover_the_retained_subset() -> None:
+    space = PrimeFieldVectorSpace(field_order=3, axis=("x",))
+    with pytest.raises(ValidationError, match="complete retained subset"):
+        CosetIntersectionProfile(
+            space=space,
+            subspace=LinearSubspace(space=space, basis=()),
+            subset=((0,), (1,)),
+            rows=(
+                CosetIntersection(representative=(0,), members=((0,),), cardinality=1),
+            ),
+        )
+
+
+
 @pytest.mark.parametrize("subset", [((0,), (0,)), ((1,), (0,)), ((3,),), ((0, 0),)])
 def test_noncanonical_subset_is_rejected(subset: tuple[tuple[int, ...], ...]) -> None:
     space = PrimeFieldVectorSpace(field_order=3, axis=("x",))

--- a/tests/math/geometry/test_coset_intersection_profile.py
+++ b/tests/math/geometry/test_coset_intersection_profile.py
@@ -162,7 +162,6 @@ def test_profile_rows_must_cover_the_retained_subset() -> None:
         )
 
 
-
 @pytest.mark.parametrize("subset", [((0,), (0,)), ((1,), (0,)), ((3,),), ((0, 0),)])
 def test_noncanonical_subset_is_rejected(subset: tuple[tuple[int, ...], ...]) -> None:
     space = PrimeFieldVectorSpace(field_order=3, axis=("x",))

--- a/tests/math/geometry/test_coset_intersection_profile.py
+++ b/tests/math/geometry/test_coset_intersection_profile.py
@@ -1,0 +1,184 @@
+"""Independent finite enumeration and serialized composition of coset fibres."""
+
+from itertools import combinations, product
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.geometry.finite import (
+    PrimeFieldVectorSpace,
+    subspace_compute,
+    subspace_membership,
+)
+from jacobian.math.geometry.finite._models import LinearSubspace
+from jacobian.math.geometry.finite.cosets import (
+    CosetIntersectionProfile,
+    coset_intersection_profile,
+)
+
+
+def _span_elements(subspace: LinearSubspace) -> set[tuple[int, ...]]:
+    return {
+        tuple(
+            sum(c * row[j] for c, row in zip(coefficients, subspace.basis, strict=True))
+            % subspace.space.field_order
+            for j in range(len(subspace.space.axis))
+        )
+        for coefficients in product(
+            range(subspace.space.field_order), repeat=subspace.dimension
+        )
+    }
+
+
+def _oracle(result: CosetIntersectionProfile) -> None:
+    space = result.space
+    elements = _span_elements(result.subspace)
+    remaining = set(result.subset)
+    expected = set()
+    while remaining:
+        a = min(remaining)
+        coset = {
+            tuple((x + y) % space.field_order for x, y in zip(a, h, strict=True))
+            for h in elements
+        }
+        members = remaining & coset
+        expected.add((min(coset), tuple(sorted(members))))
+        remaining -= members
+    assert {(r.representative, r.members) for r in result.rows} == expected
+    assert [r.representative for r in result.rows] == sorted(
+        r.representative for r in result.rows
+    )
+    assert all(r.cardinality == len(r.members) for r in result.rows)
+
+
+def test_all_subsets_of_binary_three_space_and_all_subspaces() -> None:
+    space = PrimeFieldVectorSpace(field_order=2, axis=("x", "y", "z"))
+    vectors = tuple(product(range(2), repeat=3))
+    bases = {
+        subspace_compute(space, generators).subspace.basis
+        for size in range(4)
+        for generators in combinations(vectors, size)
+    }
+    for basis in bases:
+        subspace = LinearSubspace(space=space, basis=basis)
+        for mask in range(256):
+            subset = tuple(v for i, v in enumerate(vectors) if mask & (1 << i))
+            _oracle(coset_intersection_profile(space, subspace, subset))
+
+
+def test_odd_field_noncoordinate_pivots_and_translation() -> None:
+    space = PrimeFieldVectorSpace(field_order=5, axis=("a", "b", "c", "d"))
+    subspace = subspace_compute(space, ((0, 2, 3, 1), (0, 0, 0, 4))).subspace
+    subset = ((0, 0, 0, 0), (0, 1, 4, 0), (0, 2, 3, 1), (1, 1, 1, 1))
+    result = coset_intersection_profile(space, subspace, subset)
+    _oracle(result)
+    translation = (2, 3, 4, 1)
+    shifted = tuple(
+        sorted(
+            tuple((a + b) % 5 for a, b in zip(vector, translation, strict=True))
+            for vector in subset
+        )
+    )
+    other = coset_intersection_profile(space, subspace, shifted)
+    _oracle(other)
+    assert sorted(r.cardinality for r in result.rows) == sorted(
+        r.cardinality for r in other.rows
+    )
+
+
+def test_serialized_span_to_partition_to_membership() -> None:
+    space = PrimeFieldVectorSpace(field_order=3, axis=("u", "v"))
+    produced = subspace_compute(space, ((2, 1),)).subspace
+    subspace = LinearSubspace.model_validate_json(produced.model_dump_json())
+    result = coset_intersection_profile(space, subspace, ((0, 0), (1, 2), (2, 1)))
+    restored = CosetIntersectionProfile.model_validate_json(result.model_dump_json())
+    for row in restored.rows:
+        for member in row.members:
+            difference = tuple(
+                (a - b) % 3 for a, b in zip(member, row.representative, strict=True)
+            )
+            assert subspace_membership(restored.subspace, difference).is_member
+    assert (
+        coset_intersection_profile(restored.space, restored.subspace, restored.subset)
+        == restored
+    )
+
+
+@pytest.mark.parametrize("subset", [(), ((),)])
+def test_zero_dimensional_parent(subset: tuple[tuple[int, ...], ...]) -> None:
+    space = PrimeFieldVectorSpace(field_order=9973, axis=())
+    result = coset_intersection_profile(
+        space, LinearSubspace(space=space, basis=()), subset
+    )
+    assert len(result.rows) == len(subset)
+    assert result.space == space
+
+
+@pytest.mark.parametrize(
+    "basis", [((0, 0),), ((2, 0),), ((0, 1), (1, 0)), ((1, 1), (0, 1))]
+)
+def test_authored_non_rref_claims_are_rejected_even_for_empty_subset(
+    basis: tuple[tuple[int, ...], ...],
+) -> None:
+    space = PrimeFieldVectorSpace(field_order=3, axis=("x", "y"))
+    authored = LinearSubspace(space=space, basis=basis)
+    with pytest.raises(OperationDomainValidationError, match="row echelon"):
+        coset_intersection_profile(space, authored, ())
+
+
+def test_composite_field_is_rejected_even_when_subset_empty() -> None:
+    space = PrimeFieldVectorSpace(field_order=9, axis=("x",))
+    with pytest.raises(OperationDomainValidationError, match="prime"):
+        coset_intersection_profile(space, LinearSubspace(space=space, basis=()), ())
+
+
+@pytest.mark.parametrize("subset", [((0,), (0,)), ((1,), (0,)), ((3,),), ((0, 0),)])
+def test_noncanonical_subset_is_rejected(subset: tuple[tuple[int, ...], ...]) -> None:
+    space = PrimeFieldVectorSpace(field_order=3, axis=("x",))
+    with pytest.raises(ValidationError):
+        coset_intersection_profile(space, LinearSubspace(space=space, basis=()), subset)
+
+
+def test_parent_mismatch() -> None:
+    space = PrimeFieldVectorSpace(field_order=3, axis=("x",))
+    other = PrimeFieldVectorSpace(field_order=3, axis=("y",))
+    with pytest.raises(ValidationError, match="ordered axis"):
+        coset_intersection_profile(space, LinearSubspace(space=other, basis=()), ())
+
+
+def test_many_occupied_cosets_in_large_ambient_space_are_accepted() -> None:
+    space = PrimeFieldVectorSpace(
+        field_order=9973, axis=tuple(f"x{i}" for i in range(32))
+    )
+    basis = ((1, *([0] * 31)),)
+    subset = tuple((0, i, *([0] * 30)) for i in range(8192))
+    result = coset_intersection_profile(
+        space, LinearSubspace(space=space, basis=basis), subset
+    )
+    assert tuple(r.representative for r in result.rows) == subset
+    assert all(r.members == (r.representative,) for r in result.rows)
+
+
+def test_excessive_coordinate_allocation_is_rejected() -> None:
+    space = PrimeFieldVectorSpace(field_order=2, axis=tuple(f"x{i}" for i in range(32)))
+    subset = tuple((*v, *([0] * 18)) for v in product(range(2), repeat=14))
+    with pytest.raises(OperationResourceAdmissionError, match="allocation"):
+        coset_intersection_profile(space, LinearSubspace(space=space, basis=()), subset)
+
+
+def test_full_space_uses_one_occupied_row_at_large_subset_boundary() -> None:
+    space = PrimeFieldVectorSpace(field_order=2, axis=tuple(f"x{i}" for i in range(32)))
+    subspace = LinearSubspace(
+        space=space,
+        basis=tuple(tuple(int(i == j) for j in range(32)) for i in range(32)),
+    )
+    subset = tuple((*v, *([0] * 18)) for v in product(range(2), repeat=14))[:16000]
+    result = coset_intersection_profile(space, subspace, subset)
+    assert len(result.rows) == 1
+    assert result.rows[0].representative == (0,) * 32
+    assert result.rows[0].members == subset
+    assert result.rows[0].cardinality == 16000

--- a/tests/mcp/test_coset_profile_boundary.py
+++ b/tests/mcp/test_coset_profile_boundary.py
@@ -1,0 +1,32 @@
+"""Native/MCP parity, authored-claim rejection, and recovery."""
+
+import asyncio
+import json
+
+from jacobian.math.geometry.finite.cosets._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_coset_profile_mcp_recovery_and_native_parity() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        invalid = request.model_dump(mode="json")
+        invalid["subspace"]["basis"] = [[0, 0, 0]]
+        async with Client(create_server(), raise_exceptions=False) as client:
+            failure = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": invalid}
+            )
+            assert failure.is_error
+            response = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not response.is_error
+            assert response.structured_content is not None
+            assert response.structured_content["output"] == tool.run(
+                request
+            ).model_dump(mode="json")
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Outcome

Closes #2900. Adds `finite_geometry.subspace.coset_intersection_profile.compute`: the complete partition of a canonical finite subset by affine cosets of a supplied prime-field subspace. The result retains the field, ordered axes, RREF subspace and subset; each occupied row has its unique representative with zero pivot coordinates, complete sorted members and cardinality. Empty subsets and zero-dimensional parents retain their exact meaning.

The existing subspace owner recognizes the supplied prime-field and RREF claims once after admission. RREF quotient reduction then subtracts only subspace vectors. Stable comparison sorting groups equal representatives without hash-dependent worst-case work. Result parsing checks structure and never replays reduction or membership. JSON output composes back into the partition operation, and its subspace is accepted unchanged by membership.

This is the finite coset-cover value used in the [PFR formalization](https://github.com/teorth/pfr); subspace selection and PFR conclusions remain caller-owned. The previous unmerged PR #3145 is superseded by this implementation. No published operation is superseded.

## Bounds and evidence

Admission uses subset cardinality, rank, dimension, at most `min(N,p^(n-r))` occupied rows, 1,048,576 retained coordinate entries and 67,108,864 reduction/comparison work units. Existing field/axis bounds keep coordinates within 14 bits and modular intermediates within 28 bits; bounded row and label counts also bound the complete JSON representation (below 16 million bytes). Full-space subspaces use the trivial one-coset quotient after recognition. All phases share the caller deadline and a 60-second owner backstop.

Independent tests compare every subset and every subspace of F₂³ with direct enumeration, plus odd fields, non-coordinate pivots, translations, authored invalid claims, parent mismatch, empty axes, accepted scale boundaries and excessive allocation rejection. On local Linux/Python 3.12, 8,192 occupied cosets in F₉₉₇₃³² took 0.121 seconds and returned 2,077,988 JSON bytes; 16,000 points in a full-space coset took 0.112 seconds and returned 2,114,707 bytes. These calibrate the deadline; the derived bounds govern admission.

## Validation

Final head: `d25b2d39b`.

- Independent exact-diff review complete, no unresolved findings; reviewer ran all 19 focused math/MCP cases.
- `make affected AFFECTED_BASE=origin/main`: all six commands passed (84 math, 156 catalog, 915 catalog integration and 72 MCP tests, plus scoped Ruff/mypy).
- `make architecture`: passed, 1,345 files checked.
- Scoped exhaustive public-operation conformance: 1 passed, 881 deselected.
- Public diff contains one operation and its owning source/partition values and native function. All required hosted CI checks passed on the final head.
