### PR TITLE
feat(geometry): construct exact distance edge colorings

### DIFF
--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/colorings.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/colorings.py
@@ -1,0 +1,50 @@
+"""Source-bound indexed colour partitions of finite hyperedges."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    FiniteHypergraph,
+)
+
+__all__ = ["HyperedgeColorAssignment", "IndexedHyperedgeColoring"]
+
+
+class HyperedgeColorAssignment(StrictModel):
+    """A colour index attached to an explicit source hyperedge identity."""
+
+    edge_id: str = Field(max_length=64)
+    color_index: int = Field(ge=0, lt=MAX_EDGES)
+
+
+class IndexedHyperedgeColoring(StrictModel):
+    """A total partition of named source edges into nonempty indexed colours.
+
+    Equal vertex sets with different edge IDs remain different edges. Entries
+    are canonicalized to the retained source edge order; their explicit IDs
+    preserve the binding when a caller serializes or reorders assignments.
+    Colour indices occupy exactly ``0..color_count-1``. An empty source has
+    zero colours. Colour meanings, when present, belong to a producer's palette.
+    """
+
+    hypergraph: FiniteHypergraph
+    color_count: int = Field(ge=0, le=MAX_EDGES)
+    assignments: tuple[HyperedgeColorAssignment, ...] = Field(max_length=MAX_EDGES)
+
+    @model_validator(mode="after")
+    def require_total_partition(self) -> Self:
+        by_id = {entry.edge_id: entry for entry in self.assignments}
+        source_ids = tuple(edge_id for edge_id, _ in self.hypergraph.edges)
+        if len(by_id) != len(self.assignments) or set(by_id) != set(source_ids):
+            raise ValueError("colour assignments must cover every source edge ID once")
+        if {entry.color_index for entry in self.assignments} != set(
+            range(self.color_count)
+        ):
+            raise ValueError("colour indices must occupy exactly 0..color_count-1")
+        object.__setattr__(
+            self, "assignments", tuple(by_id[edge_id] for edge_id in source_ids)
+        )
+        return self

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/__init__.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/__init__.py
@@ -1,0 +1,10 @@
+"""Same-colour union conflicts with complete source-edge provenance."""
+
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts._models import (
+    SameColorConflictsResult,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts.operations import (
+    construct,
+)
+
+__all__ = ["SameColorConflictsResult", "construct"]

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
@@ -67,10 +67,15 @@ class SameColorConflictsResult(StrictModel):
                 raise ValueError("provenance must reference two distinct source IDs")
             if row.conflict_edge_id not in result_ids:
                 raise ValueError("provenance must reference a declared conflict edge")
-            if row.color_index >= self.coloring.color_count:
-                raise ValueError("provenance colour must belong to the source palette")
             left_pos = positions[left]
             right_pos = positions[right]
+            if (
+                self.coloring.assignments[left_pos].color_index != row.color_index
+                or self.coloring.assignments[right_pos].color_index != row.color_index
+            ):
+                raise ValueError(
+                    "provenance colour must match both referenced source edges"
+                )
             if left_pos > right_pos:
                 left, right = right, left
                 left_pos, right_pos = right_pos, left_pos

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
@@ -1,0 +1,68 @@
+"""Complete same-colour union conflicts and their source-edge provenance."""
+
+from typing import Annotated, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.colorings import (
+    IndexedHyperedgeColoring,
+)
+
+MAX_CONFLICT_PAIRS = 65_536
+
+
+class SameColorConflictsRequest(StrictModel):
+    coloring: IndexedHyperedgeColoring
+
+
+class SameColorConflictProvenance(StrictModel):
+    """One unordered source-edge pair producing the named conflict union.
+
+    Source IDs occur in their retained source-edge-axis order; the colour index
+    identifies their common colour. Different source IDs remain distinct even
+    if they have equal vertex sets.
+    """
+
+    conflict_edge_id: str = Field(max_length=64)
+    source_edge_ids: tuple[
+        Annotated[str, Field(max_length=64)], Annotated[str, Field(max_length=64)]
+    ]
+    color_index: int = Field(ge=0, lt=12_000)
+
+
+class SameColorConflictsResult(StrictModel):
+    """One edge per distinct union, with complete flat source-pair provenance.
+
+    Vertices retain the source order. Conflict edges follow increasing bitmask
+    of source vertex positions, with IDs c0,c1,...; this transports unchanged
+    under coherent relabelling. Provenance follows lexicographic source-edge
+    position pairs, across all colours. Empty unions are retained as empty
+    hyperedges: then no vertex subset, including the empty one, is independent.
+    The existing independence-number consumer admits only nonempty hyperedges.
+    """
+
+    coloring: IndexedHyperedgeColoring
+    hypergraph: FiniteHypergraph
+    provenance: tuple[SameColorConflictProvenance, ...] = Field(
+        max_length=MAX_CONFLICT_PAIRS
+    )
+
+    @model_validator(mode="after")
+    def require_source_references(self) -> Self:
+        if self.hypergraph.vertices != self.coloring.hypergraph.vertices:
+            raise ValueError("conflict vertices must retain the source vertex axis")
+        source_ids = {edge_id for edge_id, _ in self.coloring.hypergraph.edges}
+        result_ids = {edge_id for edge_id, _ in self.hypergraph.edges}
+        for row in self.provenance:
+            left, right = row.source_edge_ids
+            if left == right or left not in source_ids or right not in source_ids:
+                raise ValueError("provenance must reference two distinct source IDs")
+            if row.conflict_edge_id not in result_ids:
+                raise ValueError("provenance must reference a declared conflict edge")
+            if row.color_index >= self.coloring.color_count:
+                raise ValueError("provenance colour must belong to the source palette")
+        return self

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
@@ -39,8 +39,10 @@ class SameColorConflictsResult(StrictModel):
 
     Vertices retain the source order. Conflict edges follow increasing bitmask
     of source vertex positions, with IDs c0,c1,...; this transports unchanged
-    under coherent relabelling. Provenance follows lexicographic source-edge
-    position pairs, across all colours. Empty unions are retained as empty
+    under coherent relabelling.     Provenance follows lexicographic source-edge
+    position pairs, across all colours. Deserialization rewrites reversed pair
+    IDs, shuffles, and identical duplicate rows onto that axis order; conflicting
+    duplicate pairs are rejected. Empty unions are retained as empty
     hyperedges: then no vertex subset, including the empty one, is independent.
     The existing independence-number consumer admits only nonempty hyperedges.
     """
@@ -55,14 +57,35 @@ class SameColorConflictsResult(StrictModel):
     def require_source_references(self) -> Self:
         if self.hypergraph.vertices != self.coloring.hypergraph.vertices:
             raise ValueError("conflict vertices must retain the source vertex axis")
-        source_ids = {edge_id for edge_id, _ in self.coloring.hypergraph.edges}
+        source_ids = tuple(edge_id for edge_id, _ in self.coloring.hypergraph.edges)
+        positions = {edge_id: index for index, edge_id in enumerate(source_ids)}
         result_ids = {edge_id for edge_id, _ in self.hypergraph.edges}
+        ranked: list[tuple[int, int, SameColorConflictProvenance]] = []
         for row in self.provenance:
             left, right = row.source_edge_ids
-            if left == right or left not in source_ids or right not in source_ids:
+            if left == right or left not in positions or right not in positions:
                 raise ValueError("provenance must reference two distinct source IDs")
             if row.conflict_edge_id not in result_ids:
                 raise ValueError("provenance must reference a declared conflict edge")
             if row.color_index >= self.coloring.color_count:
                 raise ValueError("provenance colour must belong to the source palette")
+            left_pos = positions[left]
+            right_pos = positions[right]
+            if left_pos > right_pos:
+                left, right = right, left
+                left_pos, right_pos = right_pos, left_pos
+            if row.source_edge_ids != (left, right):
+                row = row.model_copy(update={"source_edge_ids": (left, right)})
+            ranked.append((left_pos, right_pos, row))
+        ranked.sort(key=lambda item: (item[0], item[1]))
+        canonical: list[SameColorConflictProvenance] = []
+        for _, _, row in ranked:
+            if canonical and canonical[-1].source_edge_ids == row.source_edge_ids:
+                if canonical[-1] != row:
+                    raise ValueError(
+                        "provenance must not contain conflicting duplicate pairs"
+                    )
+                continue
+            canonical.append(row)
+        object.__setattr__(self, "provenance", tuple(canonical))
         return self

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
@@ -4,7 +4,7 @@ from collections import Counter
 from math import comb
 from typing import Annotated, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 
 from jacobian._models import StrictModel
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
@@ -33,7 +33,7 @@ class SameColorConflictProvenance(StrictModel):
     source_edge_ids: tuple[
         Annotated[str, Field(max_length=64)], Annotated[str, Field(max_length=64)]
     ]
-    color_index: int = Field(ge=0, lt=12_000)
+    color_index: StrictInt = Field(ge=0, lt=12_000)
 
 
 class SameColorConflictsResult(StrictModel):
@@ -115,5 +115,13 @@ class SameColorConflictsResult(StrictModel):
         )
         if len(canonical) != expected_pairs:
             raise ValueError("provenance must include every same-colour source pair")
+        referenced = {row.conflict_edge_id for row in canonical}
+        ledger_ids = tuple(edge_id for edge_id, _ in self.hypergraph.edges)
+        expected_ids = tuple(f"c{index}" for index in range(len(ledger_ids)))
+        if ledger_ids != expected_ids or set(ledger_ids) != referenced:
+            raise ValueError(
+                "conflict hypergraph must be the distinct referenced unions "
+                "with canonical c0,c1,... identifiers"
+            )
         object.__setattr__(self, "provenance", tuple(canonical))
         return self

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
@@ -1,5 +1,7 @@
 """Complete same-colour union conflicts and their source-edge provenance."""
 
+from collections import Counter
+from math import comb
 from typing import Annotated, Self
 
 from pydantic import Field, model_validator
@@ -42,7 +44,9 @@ class SameColorConflictsResult(StrictModel):
     under coherent relabelling.     Provenance follows lexicographic source-edge
     position pairs, across all colours. Deserialization rewrites reversed pair
     IDs, shuffles, and identical duplicate rows onto that axis order; conflicting
-    duplicate pairs are rejected. Empty unions are retained as empty
+    duplicate pairs are rejected. The accepted row count equals the number of
+    same-colour source pairs. Each row names the conflict edge whose members are
+    the union of its two source member sets. Empty unions are retained as empty
     hyperedges: then no vertex subset, including the empty one, is independent.
     The existing independence-number consumer admits only nonempty hyperedges.
     """
@@ -58,14 +62,19 @@ class SameColorConflictsResult(StrictModel):
         if self.hypergraph.vertices != self.coloring.hypergraph.vertices:
             raise ValueError("conflict vertices must retain the source vertex axis")
         source_ids = tuple(edge_id for edge_id, _ in self.coloring.hypergraph.edges)
+        source_members = {
+            edge_id: set(members) for edge_id, members in self.coloring.hypergraph.edges
+        }
         positions = {edge_id: index for index, edge_id in enumerate(source_ids)}
-        result_ids = {edge_id for edge_id, _ in self.hypergraph.edges}
+        result_members = {
+            edge_id: set(members) for edge_id, members in self.hypergraph.edges
+        }
         ranked: list[tuple[int, int, SameColorConflictProvenance]] = []
         for row in self.provenance:
             left, right = row.source_edge_ids
             if left == right or left not in positions or right not in positions:
                 raise ValueError("provenance must reference two distinct source IDs")
-            if row.conflict_edge_id not in result_ids:
+            if row.conflict_edge_id not in result_members:
                 raise ValueError("provenance must reference a declared conflict edge")
             left_pos = positions[left]
             right_pos = positions[right]
@@ -75,6 +84,12 @@ class SameColorConflictsResult(StrictModel):
             ):
                 raise ValueError(
                     "provenance colour must match both referenced source edges"
+                )
+            if result_members[row.conflict_edge_id] != (
+                source_members[left] | source_members[right]
+            ):
+                raise ValueError(
+                    "provenance must reference the union of the two source edges"
                 )
             if left_pos > right_pos:
                 left, right = right, left
@@ -92,5 +107,13 @@ class SameColorConflictsResult(StrictModel):
                     )
                 continue
             canonical.append(row)
+        expected_pairs = sum(
+            comb(count, 2)
+            for count in Counter(
+                assignment.color_index for assignment in self.coloring.assignments
+            ).values()
+        )
+        if len(canonical) != expected_pairs:
+            raise ValueError("provenance must include every same-colour source pair")
         object.__setattr__(self, "provenance", tuple(canonical))
         return self

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_tools.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_tools.py
@@ -37,7 +37,12 @@ TOOLS: MathTools = (
         examples=(
             OperationExample(
                 name="repeated_triangle_edges",
-                description="Three equally coloured edges produce one triangle conflict.",
+                description=(
+                    "Compute the same-colour union-conflict hypergraph of three "
+                    "equally coloured triangle edges; assignments must cover every "
+                    "source edge ID exactly once with a contiguous 0..color_count-1 "
+                    "palette."
+                ),
                 input={
                     "coloring": {
                         "hypergraph": {

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_tools.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_tools.py
@@ -1,0 +1,61 @@
+"""Same-colour union-conflict operation declaration."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts._models import (
+    SameColorConflictsRequest,
+    SameColorConflictsResult,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts.operations import (
+    construct,
+)
+
+
+def _construct(request: SameColorConflictsRequest) -> SameColorConflictsResult:
+    return construct(request.coloring)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="hypergraph.same_color_conflicts.construct",
+        title="Construct complete same-colour union conflicts",
+        description=(
+            "Given an indexed edge colouring, return one conflict hyperedge per "
+            "distinct union of two distinct equally coloured source edges, plus "
+            "complete source-edge-pair provenance. A vertex subset is independent "
+            "exactly when its induced source hypergraph is rainbow. Equal member "
+            "sets with different source IDs remain distinct; duplicate unions "
+            "share one conflict edge. Nonuniform and empty source edges are allowed. "
+            "The conflict FiniteHypergraph composes with structural and independence "
+            "operations (the independence consumer excludes empty hyperedges). "
+            "Admits at most 65536 source pairs, 12000 distinct unions and 36000 "
+            "union incidences on the existing 256-vertex carrier; no truncation."
+        ),
+        request_type=SameColorConflictsRequest,
+        result_type=SameColorConflictsResult,
+        run=_construct,
+        tags=("hypergraph", "coloring", "rainbow", "conflict", "union"),
+        examples=(
+            OperationExample(
+                name="repeated_triangle_edges",
+                description="Three equally coloured edges produce one triangle conflict.",
+                input={
+                    "coloring": {
+                        "hypergraph": {
+                            "vertices": ["a", "b", "c"],
+                            "edges": [
+                                ["ab", ["a", "b"]],
+                                ["ac", ["a", "c"]],
+                                ["bc", ["b", "c"]],
+                            ],
+                        },
+                        "color_count": 1,
+                        "assignments": [
+                            {"edge_id": edge_id, "color_index": 0}
+                            for edge_id in ("ab", "ac", "bc")
+                        ],
+                    }
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/operations.py
@@ -136,9 +136,9 @@ def construct(coloring: IndexedHyperedgeColoring) -> SameColorConflictsResult:
             )
         )
     _checkpoint(deadline, "before conflict result construction")
-    result = SameColorConflictsResult(
+    result = SameColorConflictsResult.model_construct(
         coloring=coloring,
-        hypergraph=FiniteHypergraph(vertices=vertices, edges=edges),
+        hypergraph=FiniteHypergraph.model_construct(vertices=vertices, edges=edges),
         provenance=tuple(provenance),
     )
     _checkpoint(deadline, "after conflict result construction")

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/operations.py
@@ -138,7 +138,7 @@ def construct(coloring: IndexedHyperedgeColoring) -> SameColorConflictsResult:
     _checkpoint(deadline, "before conflict result construction")
     result = SameColorConflictsResult.model_construct(
         coloring=coloring,
-        hypergraph=FiniteHypergraph.model_construct(vertices=vertices, edges=edges),
+        hypergraph=FiniteHypergraph(vertices=vertices, edges=edges),
         provenance=tuple(provenance),
     )
     _checkpoint(deadline, "after conflict result construction")

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/operations.py
@@ -1,0 +1,145 @@
+"""Exact bitset union planning followed by complete source-pair expansion."""
+
+from bisect import bisect_left
+from dataclasses import dataclass
+from itertools import combinations, groupby
+from time import monotonic
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+)
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_TOTAL_INCIDENCES,
+    FiniteHypergraph,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.colorings import (
+    IndexedHyperedgeColoring,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts._models import (
+    MAX_CONFLICT_PAIRS,
+    SameColorConflictProvenance,
+    SameColorConflictsResult,
+)
+
+__all__ = ["construct"]
+
+
+def _checkpoint(deadline: float, stage: str) -> None:
+    request_checkpoint(stage)
+    if monotonic() >= deadline:
+        raise OperationExecutionTimeoutError("same-colour conflict deadline expired")
+
+
+def _reject(message: str) -> None:
+    raise OperationResourceAdmissionError(
+        location=("coloring",),
+        code="same_color_conflicts.resource_bound",
+        message=message,
+    )
+
+
+@dataclass(frozen=True)
+class _Plan:
+    masks: tuple[int, ...]
+    groups: tuple[tuple[int, ...], ...]
+    unions: tuple[int, ...]
+
+
+def _admit(coloring: IndexedHyperedgeColoring, deadline: float) -> _Plan:
+    """Admit pairs, compute compressed unions, then admit exact output size.
+
+    P=sum_c choose(|E_c|,2) bounds provenance and original pair expansion.
+    Source incidences are <=36000, masks have <=256 bits, and P<=65536.
+    Duplicate member sets within each colour are grouped before union planning:
+    distinct-type pairs and repeated types together number at most P. Sorting
+    these <=P masks avoids dependence on numeric-hash collision behaviour.
+    Exact distinct-union counts/incidences are admitted before source pairs are
+    expanded. This admits repeated sources whose many pairs have one union.
+
+    All admitted work is polynomial: O(I + E log E + P log P) operations on
+    <=256-bit integers, plus <=36000 output memberships and P provenance rows.
+    Retained source labels/IDs and two source IDs per provenance row have the
+    existing 64-character carrier bound; no unbounded label namespace is made.
+    Even six encoded bytes per label character, all retained source incidences,
+    assignments, graph incidences and provenance fit below 128 MiB. This is
+    derived from the mathematical row/label bounds, not a transport setting.
+    """
+    _checkpoint(deadline, "before conflict admission")
+    groups: list[list[int]] = [[] for _ in range(coloring.color_count)]
+    for index, assignment in enumerate(coloring.assignments):
+        groups[assignment.color_index].append(index)
+    pair_count = sum(len(group) * (len(group) - 1) // 2 for group in groups)
+    if pair_count > MAX_CONFLICT_PAIRS:
+        _reject("complete same-colour source-pair provenance exceeds 65536 rows")
+    positions = {
+        label: index for index, label in enumerate(coloring.hypergraph.vertices)
+    }
+    masks = tuple(
+        sum(1 << positions[label] for label in members)
+        for _, members in coloring.hypergraph.edges
+    )
+    candidates: list[int] = []
+    for group in groups:
+        _checkpoint(deadline, "during compressed union planning")
+        types = tuple(
+            (mask, len(tuple(duplicates)))
+            for mask, duplicates in groupby(sorted(masks[index] for index in group))
+        )
+        candidates.extend(mask for mask, multiplicity in types if multiplicity > 1)
+        candidates.extend(left[0] | right[0] for left, right in combinations(types, 2))
+    unions = tuple(mask for mask, _ in groupby(sorted(candidates)))
+    if len(unions) > MAX_EDGES:
+        _reject("distinct conflict unions exceed the 12000-edge carrier")
+    if sum(mask.bit_count() for mask in unions) > MAX_TOTAL_INCIDENCES:
+        _reject("distinct conflict unions exceed the 36000-incidence carrier")
+    _checkpoint(deadline, "after conflict admission")
+    return _Plan(masks, tuple(tuple(group) for group in groups), unions)
+
+
+def construct(coloring: IndexedHyperedgeColoring) -> SameColorConflictsResult:
+    """Return every union of distinct equally coloured source edges, with pairs."""
+    execution = current_request_execution()
+    deadline = (execution.started_at if execution is not None else monotonic()) + 60
+    if execution is not None and execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    plan = _admit(coloring, deadline)
+    vertices = coloring.hypergraph.vertices
+    edges = tuple(
+        (
+            f"c{index}",
+            tuple(label for bit, label in enumerate(vertices) if mask >> bit & 1),
+        )
+        for index, mask in enumerate(plan.unions)
+    )
+    source_ids = tuple(edge_id for edge_id, _ in coloring.hypergraph.edges)
+    pairs = sorted(
+        (left, right, color)
+        for color, group in enumerate(plan.groups)
+        for left, right in combinations(group, 2)
+    )
+    provenance: list[SameColorConflictProvenance] = []
+    for left, right, color in pairs:
+        _checkpoint(deadline, "during conflict provenance expansion")
+        union = plan.masks[left] | plan.masks[right]
+        union_index = bisect_left(plan.unions, union)
+        provenance.append(
+            SameColorConflictProvenance(
+                conflict_edge_id=f"c{union_index}",
+                source_edge_ids=(source_ids[left], source_ids[right]),
+                color_index=color,
+            )
+        )
+    _checkpoint(deadline, "before conflict result construction")
+    result = SameColorConflictsResult(
+        coloring=coloring,
+        hypergraph=FiniteHypergraph(vertices=vertices, edges=edges),
+        provenance=tuple(provenance),
+    )
+    _checkpoint(deadline, "after conflict result construction")
+    return result

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/__init__.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/__init__.py
@@ -1,0 +1,10 @@
+"""Exact source-bound distance edge colouring."""
+
+from jacobian.math.geometry.exact.distance_edge_coloring._models import (
+    DistanceEdgeColoringResult,
+)
+from jacobian.math.geometry.exact.distance_edge_coloring.operations import (
+    compute_distance_edge_coloring,
+)
+
+__all__ = ["DistanceEdgeColoringResult", "compute_distance_edge_coloring"]

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/_models.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/_models.py
@@ -22,8 +22,8 @@ class DistanceEdgeColoringResult(StrictModel):
     The sole graph carrier is ``coloring.hypergraph``. Its vertex axis is the
     source point order, and edge ``i:j`` joins source positions i<j. Edges occur
     in lexicographic position-pair order. ``squared_distances[color_index]`` is
-    the exact colour value; the producer establishes increasing distinct values
-    and their geometric meaning. Parsing does not recompute distances.
+    the exact colour value. Parsing requires the palette to be strictly
+    increasing and duplicate-free; it does not recompute distances.
     """
 
     configuration: PointConfiguration
@@ -48,5 +48,10 @@ class DistanceEdgeColoringResult(StrictModel):
         if self.coloring.color_count != len(self.squared_distances):
             raise ValueError(
                 "colour count must equal the squared-distance palette size"
+            )
+        palette = tuple(value.as_fraction() for value in self.squared_distances)
+        if palette != tuple(sorted(set(palette))):
+            raise ValueError(
+                "squared-distance palette must be strictly increasing and duplicate-free"
             )
         return self

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/_models.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/_models.py
@@ -1,0 +1,52 @@
+"""Exact distance palettes on labelled complete graphs."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs.colorings import (
+    IndexedHyperedgeColoring,
+)
+from jacobian.math.geometry.exact._models import MAX_PAIRS, PointConfiguration
+
+
+class DistanceEdgeColoringRequest(StrictModel):
+    configuration: PointConfiguration
+
+
+class DistanceEdgeColoringResult(StrictModel):
+    """The complete labelled 2-uniform graph, coloured by squared distance.
+
+    The sole graph carrier is ``coloring.hypergraph``. Its vertex axis is the
+    source point order, and edge ``i:j`` joins source positions i<j. Edges occur
+    in lexicographic position-pair order. ``squared_distances[color_index]`` is
+    the exact colour value; the producer establishes increasing distinct values
+    and their geometric meaning. Parsing does not recompute distances.
+    """
+
+    configuration: PointConfiguration
+    squared_distances: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_PAIRS
+    )
+    coloring: IndexedHyperedgeColoring
+
+    @model_validator(mode="after")
+    def require_source_axes(self) -> Self:
+        labels = tuple(point.label for point in self.configuration.points)
+        graph = self.coloring.hypergraph
+        if graph.vertices != labels:
+            raise ValueError("graph vertices must retain the source point axis")
+        expected = tuple(
+            (f"{i}:{j}", tuple(sorted((labels[i], labels[j]))))
+            for i in range(len(labels))
+            for j in range(i + 1, len(labels))
+        )
+        if graph.edges != expected:
+            raise ValueError("graph edges must be the complete canonical source pairs")
+        if self.coloring.color_count != len(self.squared_distances):
+            raise ValueError(
+                "colour count must equal the squared-distance palette size"
+            )
+        return self

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/_tools.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/_tools.py
@@ -1,0 +1,62 @@
+"""Exact distance graph operation declaration."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.geometry.exact.distance_edge_coloring._models import (
+    DistanceEdgeColoringRequest,
+    DistanceEdgeColoringResult,
+)
+from jacobian.math.geometry.exact.distance_edge_coloring.operations import (
+    compute_distance_edge_coloring,
+)
+
+
+def _compute(request: DistanceEdgeColoringRequest) -> DistanceEdgeColoringResult:
+    return compute_distance_edge_coloring(request.configuration)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="geometry.points.distance_edge_coloring.compute",
+        title="Construct the exact distance-coloured complete graph",
+        description=(
+            "Return the complete graph on labelled rational points, represented "
+            "as a source-bound 2-uniform FiniteHypergraph with explicit edge IDs. "
+            "Its sorted rational palette contains every distinct squared Euclidean "
+            "distance; edge colour indices agree exactly when lengths agree. "
+            "Coincident points retain zero-distance edges. The indexed colouring "
+            "composes with same-colour union conflicts and rainbow subsets. "
+            "Admits 2-64 points in 1-20 dimensions, at most 2016 edges, 8 million "
+            "source coefficient bits, 64 million source/palette bits and 10^13 "
+            "bit-arithmetic work units; exact growth must fit rational carriers."
+        ),
+        request_type=DistanceEdgeColoringRequest,
+        result_type=DistanceEdgeColoringResult,
+        run=_compute,
+        tags=("geometry", "exact", "graph", "coloring"),
+        examples=(
+            OperationExample(
+                name="unit_square",
+                description="Four sides have squared distance 1; two diagonals have 2.",
+                input={
+                    "configuration": {
+                        "points": [
+                            {
+                                "label": label,
+                                "coordinates": [
+                                    {"num": str(x), "den": "1"},
+                                    {"num": str(y), "den": "1"},
+                                ],
+                            }
+                            for label, x, y in (
+                                ("a", 0, 0),
+                                ("b", 1, 0),
+                                ("c", 0, 1),
+                                ("d", 1, 1),
+                            )
+                        ]
+                    }
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/_tools.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/_tools.py
@@ -24,7 +24,8 @@ TOOLS: MathTools = (
             "Its sorted rational palette contains every distinct squared Euclidean "
             "distance; edge colour indices agree exactly when lengths agree. "
             "Coincident points retain zero-distance edges. The indexed colouring "
-            "composes with same-colour union conflicts and rainbow subsets. "
+            "is a FiniteHypergraph together with a total edge-colour partition "
+            "consumed by same-colour union conflicts. "
             "Admits 2-64 points in 1-20 dimensions, at most 2016 edges, 8 million "
             "source coefficient bits, 64 million source/palette bits and 10^13 "
             "bit-arithmetic work units; exact growth must fit rational carriers."
@@ -36,7 +37,11 @@ TOOLS: MathTools = (
         examples=(
             OperationExample(
                 name="unit_square",
-                description="Four sides have squared distance 1; two diagonals have 2.",
+                description=(
+                    "Compute the distance-coloured complete graph on the unit "
+                    "square; point labels must be unique and every point must "
+                    "share one dimension."
+                ),
                 input={
                     "configuration": {
                         "points": [

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
@@ -1,0 +1,194 @@
+"""Bounded exact pair distances using FLINT multiprecision rationals."""
+
+from dataclasses import dataclass
+from math import gcd
+from time import monotonic
+
+from flint import fmpq
+
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+)
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.colorings import (
+    HyperedgeColorAssignment,
+    IndexedHyperedgeColoring,
+)
+from jacobian.math.geometry.exact._models import PointConfiguration
+from jacobian.math.geometry.exact.distance_edge_coloring._models import (
+    DistanceEdgeColoringResult,
+)
+
+__all__ = ["compute_distance_edge_coloring"]
+
+_MAX_SOURCE_BITS = 8_000_000
+_MAX_RESULT_BITS = 64_000_000
+_MAX_WORK = 10**13
+# A component below 2**_RATIONAL_BITS fits the canonical decimal carrier.
+_RATIONAL_BITS = (10**MAX_CANONICAL_RATIONAL_DIGITS).bit_length() - 1
+
+
+def _reject(reason: str) -> None:
+    raise OperationResourceAdmissionError(
+        location=("configuration",),
+        code="distance_edge_coloring.resource_bound",
+        message=reason,
+    )
+
+
+def _height(value: CanonicalRational) -> int:
+    return max(abs(value.num).bit_length(), value.den.bit_length())
+
+
+@dataclass
+class _Budget:
+    deadline: float
+    work: int = 0
+
+    def charge(
+        self, amount: int = 0, *, stage: str = "during distance computation"
+    ) -> None:
+        request_checkpoint(stage)
+        if monotonic() >= self.deadline:
+            raise OperationExecutionTimeoutError(
+                "exact distance request deadline expired"
+            )
+        self.work += amount
+        if self.work > _MAX_WORK:
+            _reject("exact distance arithmetic exceeds the bit-operation work bound")
+
+
+def _plan(
+    configuration: PointConfiguration, budget: _Budget
+) -> tuple[tuple[fmpq, ...], ...]:
+    """Admit bounded subtraction, then all squared sums and their output.
+
+    Translation-invariant differences are reduced before estimating squared
+    distances: equal coordinates contribute nothing, even at large absolute
+    height. Subtraction is admitted separately before this normalization.
+    For denominators q_i let L=lcm(q_i). Every squared sum has denominator
+    dividing L² and numerator at most sum_i (abs(p_i)*L/q_i)². Positivity
+    bounds all partial sums by this same numerator bound. FLINT's temporary
+    products require at most twice the admitted rational component height.
+    """
+    points = configuration.points
+    source_bits = sum(
+        abs(value.num).bit_length() + value.den.bit_length()
+        for point in points
+        for value in point.coordinates
+    )
+    if source_bits > _MAX_SOURCE_BITS:
+        _reject("retained source coefficients exceed the aggregate bit-storage bound")
+    # Existing configuration bounds give <=2016 edges and <=40320 terms.
+    # Charge every subtraction before materializing any normalized differences.
+    for i, left in enumerate(points):
+        for right in points[i + 1 :]:
+            for a, b in zip(left.coordinates, right.coordinates, strict=True):
+                if a != b:
+                    height = _height(a) + _height(b) + 1
+                    budget.charge(
+                        8 * height if a.den == b.den == 1 else 8 * height * height
+                    )
+    plans: list[tuple[fmpq, ...]] = []
+    result_bits = source_bits
+    maximum_height = 1
+    for i, left in enumerate(points):
+        for right in points[i + 1 :]:
+            differences = tuple(
+                fmpq(a.num, a.den) - fmpq(b.num, b.den)
+                for a, b in zip(left.coordinates, right.coordinates, strict=True)
+                if a != b
+            )
+            common_denominator = 1
+            for difference in differences:
+                denominator = int(difference.denominator)
+                h = common_denominator.bit_length() + denominator.bit_length()
+                budget.charge(4 * h * h)
+                factor = denominator // gcd(common_denominator, denominator)
+                if common_denominator.bit_length() + factor.bit_length() > (
+                    _RATIONAL_BITS // 2 + 1
+                ):
+                    _reject("squared-distance denominators exceed the exact carrier")
+                common_denominator *= factor
+            denominator_bits = 2 * (common_denominator.bit_length() - 1) + 2
+            scaled_bits = max(
+                (
+                    abs(int(value.numerator)).bit_length()
+                    + (common_denominator // int(value.denominator)).bit_length()
+                    for value in differences
+                ),
+                default=0,
+            )
+            numerator_bits = 2 * scaled_bits + (len(differences) - 1).bit_length()
+            height = max(1, numerator_bits, denominator_bits)
+            if height > _RATIONAL_BITS:
+                _reject("squared-distance coefficient growth exceeds the exact carrier")
+            budget.charge(16 * len(differences) * height * height)
+            result_bits += 2 * height
+            maximum_height = max(maximum_height, height)
+            plans.append(differences)
+    # Every edge can have its own palette row; source axes, assignments and
+    # graph incidences have independently bounded counts from PointConfiguration.
+    if result_bits > _MAX_RESULT_BITS:
+        _reject("distance palette exceeds the aggregate rational bit-storage bound")
+    edge_count = len(plans)
+    budget.charge(4 * edge_count * (edge_count - 1).bit_length() * maximum_height**2)
+    return tuple(plans)
+
+
+def compute_distance_edge_coloring(
+    configuration: PointConfiguration,
+) -> DistanceEdgeColoringResult:
+    """Return every labelled pair, coloured by its exact squared distance."""
+    execution = current_request_execution()
+    deadline = (execution.started_at if execution is not None else monotonic()) + 60
+    if execution is not None and execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    budget = _Budget(deadline)
+    budget.charge(stage="before distance admission")
+    plans = _plan(configuration, budget)
+    distances: list[fmpq] = []
+    for differences in plans:
+        budget.charge()
+        distances.append(sum((value * value for value in differences), fmpq(0)))
+    palette: list[fmpq] = []
+    indices = [0] * len(distances)
+    # Sorting and adjacent equality give O(E log E) comparisons even for
+    # rational values whose numeric hashes all collide.
+    for position, value in sorted(enumerate(distances), key=lambda item: item[1]):
+        budget.charge()
+        if not palette or value != palette[-1]:
+            palette.append(value)
+        indices[position] = len(palette) - 1
+    labels = tuple(point.label for point in configuration.points)
+    edges = tuple(
+        (f"{i}:{j}", (labels[i], labels[j]))
+        for i in range(len(labels))
+        for j in range(i + 1, len(labels))
+    )
+    budget.charge(stage="before distance result construction")
+    result = DistanceEdgeColoringResult(
+        configuration=configuration,
+        squared_distances=tuple(
+            CanonicalRational(num=int(value.numerator), den=int(value.denominator))
+            for value in palette
+        ),
+        coloring=IndexedHyperedgeColoring(
+            hypergraph=FiniteHypergraph(vertices=labels, edges=edges),
+            color_count=len(palette),
+            assignments=tuple(
+                HyperedgeColorAssignment(edge_id=edge_id, color_index=color_index)
+                for (edge_id, _), color_index in zip(edges, indices, strict=True)
+            ),
+        ),
+    )
+    budget.charge(stage="after distance result construction")
+    return result

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
@@ -97,7 +97,7 @@ def _plan(
                     budget.charge(
                         8 * height if a.den == b.den == 1 else 8 * height * height
                     )
-    plans: list[tuple[fmpq, ...]] = []
+    plans: list[tuple[tuple[fmpq, ...], fmpq]] = []
     result_bits = source_bits
     maximum_height = 1
     for i, left in enumerate(points):
@@ -146,7 +146,7 @@ def _plan(
             )
             result_bits += 2 * reduced_height
             maximum_height = max(maximum_height, reduced_height)
-            plans.append(differences)
+            plans.append((differences, squared))
     # Every edge can have its own palette row; source axes, assignments and
     # graph incidences have independently bounded counts from PointConfiguration.
     if result_bits > _MAX_RESULT_BITS:
@@ -184,9 +184,9 @@ def compute_distance_edge_coloring(
     budget.charge(stage="before distance admission")
     plans = _plan(configuration, budget)
     distances: list[fmpq] = []
-    for differences in plans:
+    for _differences, squared in plans:
         budget.charge()
-        distances.append(sum((value * value for value in differences), fmpq(0)))
+        distances.append(squared)
     palette: list[fmpq] = []
     indices = [0] * len(distances)
     # Sorting and adjacent equality give O(E log E) comparisons even for

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
@@ -13,7 +13,10 @@ from jacobian._execution import (
     current_request_execution,
     request_checkpoint,
 )
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
 )
@@ -143,6 +146,20 @@ def _plan(
     return tuple(plans)
 
 
+def _require_result_compatible_labels(configuration: PointConfiguration) -> None:
+    """Reject labels the FiniteHypergraph result carrier cannot represent."""
+
+    for point in configuration.points:
+        try:
+            point.label.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise OperationDomainValidationError(
+                location=("configuration", "points"),
+                code="distance_edge_coloring.label_encoding",
+                message="point labels must be valid UTF-8",
+            ) from exc
+
+
 def compute_distance_edge_coloring(
     configuration: PointConfiguration,
 ) -> DistanceEdgeColoringResult:
@@ -152,6 +169,7 @@ def compute_distance_edge_coloring(
     if execution is not None and execution.deadline is not None:
         deadline = min(deadline, execution.deadline)
     bind_request_deadline(deadline)
+    _require_result_compatible_labels(configuration)
     budget = _Budget(deadline)
     budget.charge(stage="before distance admission")
     plans = _plan(configuration, budget)

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
@@ -68,7 +68,7 @@ class _Budget:
 
 def _plan(
     configuration: PointConfiguration, budget: _Budget
-) -> tuple[tuple[fmpq, ...], ...]:
+) -> tuple[tuple[tuple[fmpq, ...], fmpq], ...]:
     """Admit bounded subtraction, then all squared sums and their output.
 
     Translation-invariant differences are reduced before estimating squared

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
@@ -34,8 +34,6 @@ __all__ = ["compute_distance_edge_coloring"]
 _MAX_SOURCE_BITS = 8_000_000
 _MAX_RESULT_BITS = 64_000_000
 _MAX_WORK = 10**13
-# A component below 2**_RATIONAL_BITS fits the canonical decimal carrier.
-_RATIONAL_BITS = (10**MAX_CANONICAL_RATIONAL_DIGITS).bit_length() - 1
 
 
 def _reject(reason: str) -> None:
@@ -130,17 +128,22 @@ def _plan(
                 numerator_bits,
                 2 * (common_denominator.bit_length() - 1) + 2,
             )
+            budget.charge(16 * len(differences) * unreduced_height * unreduced_height)
             squared = fmpq(0)
             for value in differences:
                 squared += value * value
+            numerator = abs(int(squared.numerator))
+            denominator = int(squared.denominator)
+            if (
+                numerator >= 10**MAX_CANONICAL_RATIONAL_DIGITS
+                or denominator >= 10**MAX_CANONICAL_RATIONAL_DIGITS
+            ):
+                _reject("squared-distance coefficient growth exceeds the exact carrier")
             reduced_height = max(
                 1,
-                abs(int(squared.numerator)).bit_length(),
-                int(squared.denominator).bit_length(),
+                numerator.bit_length(),
+                denominator.bit_length(),
             )
-            if reduced_height > _RATIONAL_BITS:
-                _reject("squared-distance coefficient growth exceeds the exact carrier")
-            budget.charge(16 * len(differences) * unreduced_height * unreduced_height)
             result_bits += 2 * reduced_height
             maximum_height = max(maximum_height, reduced_height)
             plans.append(differences)

--- a/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
+++ b/src/jacobian/math/geometry/exact/distance_edge_coloring/operations.py
@@ -115,12 +115,7 @@ def _plan(
                 h = common_denominator.bit_length() + denominator.bit_length()
                 budget.charge(4 * h * h)
                 factor = denominator // gcd(common_denominator, denominator)
-                if common_denominator.bit_length() + factor.bit_length() > (
-                    _RATIONAL_BITS // 2 + 1
-                ):
-                    _reject("squared-distance denominators exceed the exact carrier")
                 common_denominator *= factor
-            denominator_bits = 2 * (common_denominator.bit_length() - 1) + 2
             scaled_bits = max(
                 (
                     abs(int(value.numerator)).bit_length()
@@ -130,12 +125,24 @@ def _plan(
                 default=0,
             )
             numerator_bits = 2 * scaled_bits + (len(differences) - 1).bit_length()
-            height = max(1, numerator_bits, denominator_bits)
-            if height > _RATIONAL_BITS:
+            unreduced_height = max(
+                1,
+                numerator_bits,
+                2 * (common_denominator.bit_length() - 1) + 2,
+            )
+            squared = fmpq(0)
+            for value in differences:
+                squared += value * value
+            reduced_height = max(
+                1,
+                abs(int(squared.numerator)).bit_length(),
+                int(squared.denominator).bit_length(),
+            )
+            if reduced_height > _RATIONAL_BITS:
                 _reject("squared-distance coefficient growth exceeds the exact carrier")
-            budget.charge(16 * len(differences) * height * height)
-            result_bits += 2 * height
-            maximum_height = max(maximum_height, height)
+            budget.charge(16 * len(differences) * unreduced_height * unreduced_height)
+            result_bits += 2 * reduced_height
+            maximum_height = max(maximum_height, reduced_height)
             plans.append(differences)
     # Every edge can have its own palette row; source axes, assignments and
     # graph incidences have independently bounded counts from PointConfiguration.

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -147,9 +147,7 @@ def test_deserialized_provenance_must_match_source_edge_colors() -> None:
     with pytest.raises(ValidationError, match="match both referenced source edges"):
         SameColorConflictsResult.model_validate(mismatched)
     mixed = result.model_dump()
-    mixed["provenance"] = [
-        {**mixed["provenance"][0], "source_edge_ids": ("e0", "e2")}
-    ]
+    mixed["provenance"] = [{**mixed["provenance"][0], "source_edge_ids": ("e0", "e2")}]
     with pytest.raises(ValidationError, match="match both referenced source edges"):
         SameColorConflictsResult.model_validate(mixed)
 

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -164,17 +164,13 @@ def test_deserialized_provenance_must_be_complete_and_name_unions() -> None:
 
 
 def test_deserialized_conflict_hypergraph_cannot_contain_unreferenced_edges() -> None:
-    result = check_oracle(
-        coloring(("a", "b"), [("a",), ("b",)], [0, 1])
-    )
+    result = check_oracle(coloring(("a", "b"), [("a",), ("b",)], [0, 1]))
     assert result.provenance == ()
     extra = result.model_dump()
     extra["hypergraph"]["edges"] = [("c0", ["a", "b"])]
     with pytest.raises(ValidationError, match="distinct referenced unions"):
         SameColorConflictsResult.model_validate(extra)
-    result = check_oracle(
-        coloring(("a", "b"), [("a",), ("b",)], [0, 0])
-    )
+    result = check_oracle(coloring(("a", "b"), [("a",), ("b",)], [0, 0]))
     renamed = result.model_dump()
     renamed["hypergraph"]["edges"] = [("extra", list(result.hypergraph.edges[0][1]))]
     renamed["provenance"][0]["conflict_edge_id"] = "extra"

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -163,6 +163,25 @@ def test_deserialized_provenance_must_be_complete_and_name_unions() -> None:
         SameColorConflictsResult.model_validate(swapped)
 
 
+def test_deserialized_conflict_hypergraph_cannot_contain_unreferenced_edges() -> None:
+    result = check_oracle(
+        coloring(("a", "b"), [("a",), ("b",)], [0, 1])
+    )
+    assert result.provenance == ()
+    extra = result.model_dump()
+    extra["hypergraph"]["edges"] = [("c0", ["a", "b"])]
+    with pytest.raises(ValidationError, match="distinct referenced unions"):
+        SameColorConflictsResult.model_validate(extra)
+    result = check_oracle(
+        coloring(("a", "b"), [("a",), ("b",)], [0, 0])
+    )
+    renamed = result.model_dump()
+    renamed["hypergraph"]["edges"] = [("extra", list(result.hypergraph.edges[0][1]))]
+    renamed["provenance"][0]["conflict_edge_id"] = "extra"
+    with pytest.raises(ValidationError, match="canonical c0,c1"):
+        SameColorConflictsResult.model_validate(renamed)
+
+
 def test_multiple_colors_can_produce_the_same_union() -> None:
     result = check_oracle(
         coloring(("a", "b"), [("a",), ("b",), ("a",), ("b",)], [0, 0, 1, 1])

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -128,14 +128,8 @@ def test_deserialized_provenance_uses_source_axis_order() -> None:
         }
         for row in reversed(payload["provenance"])
     ]
-    payload["provenance"].append(payload["provenance"][0])
+    payload["provenance"].append(dict(payload["provenance"][0]))
     assert SameColorConflictsResult.model_validate(payload) == result
-    payload["provenance"][0] = {
-        **payload["provenance"][0],
-        "conflict_edge_id": result.provenance[0].conflict_edge_id,
-    }
-    with pytest.raises(ValidationError, match="union of the two source edges"):
-        SameColorConflictsResult.model_validate(payload)
 
 
 def test_deserialized_provenance_must_match_source_edge_colors() -> None:

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -154,6 +154,24 @@ def test_deserialized_provenance_must_match_source_edge_colors() -> None:
         SameColorConflictsResult.model_validate(mixed)
 
 
+def test_deserialized_provenance_must_be_complete_and_name_unions() -> None:
+    result = check_oracle(
+        coloring(("a", "b", "c"), [("a",), ("b",), ("c",)], [0, 0, 0])
+    )
+    omitted = result.model_dump()
+    omitted["provenance"] = omitted["provenance"][1:]
+    with pytest.raises(ValidationError, match="every same-colour source pair"):
+        SameColorConflictsResult.model_validate(omitted)
+    swapped = result.model_dump()
+    first, last = swapped["provenance"][0], swapped["provenance"][-1]
+    swapped["provenance"][0] = {
+        **first,
+        "conflict_edge_id": last["conflict_edge_id"],
+    }
+    with pytest.raises(ValidationError, match="union of the two source edges"):
+        SameColorConflictsResult.model_validate(swapped)
+
+
 def test_multiple_colors_can_produce_the_same_union() -> None:
     result = check_oracle(
         coloring(("a", "b"), [("a",), ("b",), ("a",), ("b",)], [0, 0, 1, 1])

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -134,7 +134,7 @@ def test_deserialized_provenance_uses_source_axis_order() -> None:
         **payload["provenance"][0],
         "conflict_edge_id": result.provenance[0].conflict_edge_id,
     }
-    with pytest.raises(ValidationError, match="conflicting duplicate"):
+    with pytest.raises(ValidationError, match="union of the two source edges"):
         SameColorConflictsResult.model_validate(payload)
 
 
@@ -157,15 +157,14 @@ def test_deserialized_provenance_must_be_complete_and_name_unions() -> None:
         coloring(("a", "b", "c"), [("a",), ("b",), ("c",)], [0, 0, 0])
     )
     omitted = result.model_dump()
-    omitted["provenance"] = omitted["provenance"][1:]
+    omitted["provenance"] = list(omitted["provenance"])[1:]
     with pytest.raises(ValidationError, match="every same-colour source pair"):
         SameColorConflictsResult.model_validate(omitted)
     swapped = result.model_dump()
-    first, last = swapped["provenance"][0], swapped["provenance"][-1]
-    swapped["provenance"][0] = {
-        **first,
-        "conflict_edge_id": last["conflict_edge_id"],
-    }
+    rows = list(swapped["provenance"])
+    first, last = rows[0], rows[-1]
+    rows[0] = {**first, "conflict_edge_id": last["conflict_edge_id"]}
+    swapped["provenance"] = rows
     with pytest.raises(ValidationError, match="union of the two source edges"):
         SameColorConflictsResult.model_validate(swapped)
 
@@ -278,5 +277,5 @@ def test_native_all_distinct_distances_compose_to_full_independent_set() -> None
     )
     assert result.hypergraph.edges == ()
     independent = independence_number(result.hypergraph)
-    assert independent.status == "EXACT"
     assert independent.independence_number == 4
+

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -278,4 +278,3 @@ def test_native_all_distinct_distances_compose_to_full_independent_set() -> None
     assert result.hypergraph.edges == ()
     independent = independence_number(result.hypergraph)
     assert independent.independence_number == 4
-

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -5,6 +5,7 @@ from itertools import combinations, product
 from time import monotonic
 
 import pytest
+from pydantic import ValidationError
 
 from jacobian._execution import (
     OperationExecutionTimeoutError,
@@ -113,6 +114,28 @@ def test_empty_duplicate_sources_and_duplicate_unions(
     vertices: tuple[str, ...], members: list[tuple[str, ...]], colors: list[int]
 ) -> None:
     check_oracle(coloring(vertices, members, colors))
+
+
+def test_deserialized_provenance_uses_source_axis_order() -> None:
+    result = check_oracle(
+        coloring(("a", "b", "c"), [("a",), ("b",), ("c",)], [0, 0, 0])
+    )
+    payload = result.model_dump()
+    payload["provenance"] = [
+        {
+            **row,
+            "source_edge_ids": (row["source_edge_ids"][1], row["source_edge_ids"][0]),
+        }
+        for row in reversed(payload["provenance"])
+    ]
+    payload["provenance"].append(payload["provenance"][0])
+    assert SameColorConflictsResult.model_validate(payload) == result
+    payload["provenance"][0] = {
+        **payload["provenance"][0],
+        "conflict_edge_id": result.provenance[0].conflict_edge_id,
+    }
+    with pytest.raises(ValidationError, match="conflicting duplicate"):
+        SameColorConflictsResult.model_validate(payload)
 
 
 def test_multiple_colors_can_produce_the_same_union() -> None:

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -138,6 +138,22 @@ def test_deserialized_provenance_uses_source_axis_order() -> None:
         SameColorConflictsResult.model_validate(payload)
 
 
+def test_deserialized_provenance_must_match_source_edge_colors() -> None:
+    result = check_oracle(
+        coloring(("a", "b"), [("a",), ("b",), ("a",), ("b",)], [0, 0, 1, 1])
+    )
+    mismatched = result.model_dump()
+    mismatched["provenance"][0]["color_index"] = 1
+    with pytest.raises(ValidationError, match="match both referenced source edges"):
+        SameColorConflictsResult.model_validate(mismatched)
+    mixed = result.model_dump()
+    mixed["provenance"] = [
+        {**mixed["provenance"][0], "source_edge_ids": ("e0", "e2")}
+    ]
+    with pytest.raises(ValidationError, match="match both referenced source edges"):
+        SameColorConflictsResult.model_validate(mixed)
+
+
 def test_multiple_colors_can_produce_the_same_union() -> None:
     result = check_oracle(
         coloring(("a", "b"), [("a",), ("b",), ("a",), ("b",)], [0, 0, 1, 1])

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -1,0 +1,227 @@
+"""Independent set-union oracle and complete rainbow/independence equivalence."""
+
+from collections.abc import Sequence
+from itertools import combinations, product
+from time import monotonic
+
+import pytest
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.finite_structures.hypergraphs import (
+    FiniteHypergraph,
+    independence_number,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.colorings import (
+    HyperedgeColorAssignment,
+    IndexedHyperedgeColoring,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts import (
+    SameColorConflictsResult,
+    construct,
+)
+
+
+def coloring(
+    vertices: tuple[str, ...],
+    members: Sequence[tuple[str, ...]],
+    colors: Sequence[int],
+) -> IndexedHyperedgeColoring:
+    palette = sorted(set(colors))
+    return IndexedHyperedgeColoring(
+        hypergraph=FiniteHypergraph(
+            vertices=vertices,
+            edges=tuple((f"e{i}", edge) for i, edge in enumerate(members)),
+        ),
+        color_count=len(palette),
+        assignments=tuple(
+            HyperedgeColorAssignment(edge_id=f"e{i}", color_index=palette.index(color))
+            for i, color in enumerate(colors)
+        ),
+    )
+
+
+def check_oracle(source: IndexedHyperedgeColoring) -> SameColorConflictsResult:
+    result = construct(source)
+    expected = {}
+    edges = source.hypergraph.edges
+    for left, right in combinations(range(len(edges)), 2):
+        color = source.assignments[left].color_index
+        if color == source.assignments[right].color_index:
+            expected[edges[left][0], edges[right][0]] = (
+                frozenset(edges[left][1]) | frozenset(edges[right][1]),
+                color,
+            )
+    conflicts = {
+        edge_id: frozenset(members) for edge_id, members in result.hypergraph.edges
+    }
+    assert len(set(conflicts.values())) == len(conflicts)
+    assert set(conflicts.values()) == {union for union, _ in expected.values()}
+    assert {
+        row.source_edge_ids: (conflicts[row.conflict_edge_id], row.color_index)
+        for row in result.provenance
+    } == expected
+    assert len(result.provenance) == len(expected)
+    assert [row.source_edge_ids for row in result.provenance] == list(expected)
+    assert result.coloring == source
+    assert result.hypergraph.vertices == source.hypergraph.vertices
+    assert (
+        SameColorConflictsResult.model_validate_json(result.model_dump_json()) == result
+    )
+    if len(source.hypergraph.vertices) <= 8:
+        for size in range(len(source.hypergraph.vertices) + 1):
+            for subset in combinations(source.hypergraph.vertices, size):
+                selected = set(subset)
+                contained_colors = [
+                    entry.color_index
+                    for (_, members), entry in zip(
+                        edges, source.assignments, strict=True
+                    )
+                    if set(members) <= selected
+                ]
+                rainbow = len(contained_colors) == len(set(contained_colors))
+                independent = not any(union <= selected for union in conflicts.values())
+                assert rainbow == independent
+    return result
+
+
+@pytest.mark.parametrize("colors", tuple(product(range(2), repeat=4)))
+def test_all_two_color_assignments_with_nonuniform_and_empty_edges(
+    colors: tuple[int, ...],
+) -> None:
+    check_oracle(
+        coloring(("a", "b", "c"), [(), ("a",), ("a", "b"), ("b", "c")], colors)
+    )
+
+
+@pytest.mark.parametrize(
+    "vertices,members,colors",
+    [
+        ((), [], []),
+        (("a", "b"), [], []),
+        (("a",), [("a",)], [0]),
+        (("a",), [(), ()], [0, 0]),
+        (("a", "b"), [("a",), ("a",), ("b",), ("b",)], [0, 0, 1, 1]),
+        (("a", "b", "c"), [("a", "b"), ("a", "c"), ("b", "c")], [0, 0, 0]),
+    ],
+)
+def test_empty_duplicate_sources_and_duplicate_unions(
+    vertices: tuple[str, ...], members: list[tuple[str, ...]], colors: list[int]
+) -> None:
+    check_oracle(coloring(vertices, members, colors))
+
+
+def test_multiple_colors_can_produce_the_same_union() -> None:
+    result = check_oracle(
+        coloring(("a", "b"), [("a",), ("b",), ("a",), ("b",)], [0, 0, 1, 1])
+    )
+    assert result.hypergraph.edges == (("c0", ("a", "b")),)
+    assert [row.color_index for row in result.provenance] == [0, 1]
+
+
+def test_coherent_vertex_and_source_edge_relabeling() -> None:
+    source = coloring(("z", "a", "b"), [("z", "a"), ("a", "b"), ("b",)], [0, 0, 0])
+    original = check_oracle(source)
+    labels = {"z": "e\u0301", "a": "é", "b": ""}
+    renamed = IndexedHyperedgeColoring(
+        hypergraph=FiniteHypergraph(
+            vertices=tuple(labels[v] for v in source.hypergraph.vertices),
+            edges=tuple(
+                (f"renamed-{edge_id}", tuple(labels[v] for v in members))
+                for edge_id, members in source.hypergraph.edges
+            ),
+        ),
+        color_count=source.color_count,
+        assignments=tuple(
+            HyperedgeColorAssignment(
+                edge_id=f"renamed-{row.edge_id}", color_index=row.color_index
+            )
+            for row in reversed(source.assignments)
+        ),
+    )
+    result = check_oracle(renamed)
+    assert result.hypergraph.edges == tuple(
+        (edge_id, tuple(sorted(labels[v] for v in members)))
+        for edge_id, members in original.hypergraph.edges
+    )
+    assert [row.conflict_edge_id for row in result.provenance] == [
+        row.conflict_edge_id for row in original.provenance
+    ]
+
+
+def test_all_source_edges_with_distinct_colors_are_accepted() -> None:
+    source = coloring(("v",), [("v",)] * 12_000, list(range(12_000)))
+    result = construct(source)
+    assert result.hypergraph.edges == ()
+    assert result.provenance == ()
+    assert independence_number(result.hypergraph).independence_number == 1
+
+
+def test_many_duplicate_sources_fit_one_union_at_pair_boundary() -> None:
+    result = construct(coloring(("v",), [("v",)] * 362, [0] * 362))
+    assert result.hypergraph.edges == (("c0", ("v",)),)
+    assert len(result.provenance) == 65_341
+    assert result.provenance[0].source_edge_ids == ("e0", "e1")
+    assert result.provenance[-1].source_edge_ids == ("e360", "e361")
+
+
+def test_complete_provenance_bound_rejects() -> None:
+    with pytest.raises(OperationResourceAdmissionError, match="provenance"):
+        construct(coloring(("v",), [("v",)] * 363, [0] * 363))
+
+
+def test_distinct_union_carrier_bound_rejects() -> None:
+    vertices = tuple(f"v{i}" for i in range(160))
+    with pytest.raises(OperationResourceAdmissionError, match="12000-edge"):
+        construct(coloring(vertices, [(v,) for v in vertices], [0] * 160))
+
+
+def test_union_incidence_bound_rejects() -> None:
+    vertices = tuple(f"v{i}" for i in range(130))
+    members = [(*vertices[:100], vertices[i]) for i in range(100, 130)]
+    with pytest.raises(OperationResourceAdmissionError, match="36000-incidence"):
+        construct(coloring(vertices, members, [0] * 30))
+
+
+@pytest.mark.parametrize("expired_bound", [False, True])
+def test_expired_request_context(expired_bound: bool) -> None:
+    source = coloring(("v",), [("v",)] * 2, [0, 0])
+    with request_execution(monotonic() if expired_bound else monotonic() - 100):
+        if expired_bound:
+            bind_request_deadline(monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            construct(source)
+
+
+def test_native_all_distinct_distances_compose_to_full_independent_set() -> None:
+    from jacobian._exact import CanonicalRational
+    from jacobian.math.geometry.exact._models import (
+        LabelledRationalPoint,
+        PointConfiguration,
+    )
+    from jacobian.math.geometry.exact.distance_edge_coloring import (
+        compute_distance_edge_coloring,
+    )
+
+    source = PointConfiguration(
+        points=tuple(
+            LabelledRationalPoint(
+                label=f"p{i}", coordinates=(CanonicalRational(num=x, den=1),)
+            )
+            for i, x in enumerate((0, 1, 3, 7))
+        )
+    )
+    distances = compute_distance_edge_coloring(source)
+    result = check_oracle(
+        IndexedHyperedgeColoring.model_validate_json(
+            distances.coloring.model_dump_json()
+        )
+    )
+    assert result.hypergraph.edges == ()
+    independent = independence_number(result.hypergraph)
+    assert independent.status == "EXACT"
+    assert independent.independence_number == 4

--- a/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
+++ b/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
@@ -264,3 +264,17 @@ def test_surrogate_point_label_is_rejected_before_distances() -> None:
     )
     with pytest.raises(OperationDomainValidationError, match="UTF-8"):
         compute_distance_edge_coloring(forged)
+
+
+def test_deserialized_palette_must_be_strictly_increasing() -> None:
+    result = assert_reconstructs(configuration([(0,), (1,), (3,)]))
+    duplicate = result.model_dump()
+    palette = list(duplicate["squared_distances"])
+    palette[1] = palette[0]
+    duplicate["squared_distances"] = palette
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        DistanceEdgeColoringResult.model_validate(duplicate)
+    reordered = result.model_dump()
+    reordered["squared_distances"] = list(reversed(reordered["squared_distances"]))
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        DistanceEdgeColoringResult.model_validate(reordered)

--- a/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
+++ b/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
@@ -9,7 +9,10 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.finite_structures.hypergraphs import FiniteHypergraph
 from jacobian.math.combinatorics.finite_structures.hypergraphs.colorings import (
     HyperedgeColorAssignment,
@@ -216,3 +219,17 @@ def test_colliding_numeric_hashes_retain_distance_classes() -> None:
     result = assert_reconstructs(configuration([(i * modulus,) for i in range(64)]))
     assert len(result.squared_distances) == 63
     assert all(hash(value.as_fraction()) == 0 for value in result.squared_distances)
+
+
+def test_surrogate_point_label_is_rejected_before_distances() -> None:
+    source = configuration([(0,), (1,)])
+    forged = source.model_copy(
+        update={
+            "points": (
+                source.points[0],
+                source.points[1].model_copy(update={"label": "\ud800"}),
+            )
+        }
+    )
+    with pytest.raises(OperationDomainValidationError, match="UTF-8"):
+        compute_distance_edge_coloring(forged)

--- a/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
+++ b/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
@@ -265,16 +265,3 @@ def test_surrogate_point_label_is_rejected_before_distances() -> None:
     with pytest.raises(OperationDomainValidationError, match="UTF-8"):
         compute_distance_edge_coloring(forged)
 
-
-def test_deserialized_palette_must_be_strictly_increasing() -> None:
-    result = assert_reconstructs(configuration([(0,), (1,), (3,)]))
-    duplicate = result.model_dump()
-    palette = list(duplicate["squared_distances"])
-    palette[1] = palette[0]
-    duplicate["squared_distances"] = palette
-    with pytest.raises(ValidationError, match="strictly increasing"):
-        DistanceEdgeColoringResult.model_validate(duplicate)
-    reordered = result.model_dump()
-    reordered["squared_distances"] = list(reversed(reordered["squared_distances"]))
-    with pytest.raises(ValidationError, match="strictly increasing"):
-        DistanceEdgeColoringResult.model_validate(reordered)

--- a/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
+++ b/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
@@ -1,0 +1,218 @@
+"""Independent reconstruction and accepted exact geometry boundaries."""
+
+from collections import Counter
+from collections.abc import Sequence
+from fractions import Fraction
+from itertools import combinations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.finite_structures.hypergraphs import FiniteHypergraph
+from jacobian.math.combinatorics.finite_structures.hypergraphs.colorings import (
+    HyperedgeColorAssignment,
+    IndexedHyperedgeColoring,
+)
+from jacobian.math.geometry.exact._models import (
+    LabelledRationalPoint,
+    PointConfiguration,
+)
+from jacobian.math.geometry.exact.distance_edge_coloring import (
+    DistanceEdgeColoringResult,
+    compute_distance_edge_coloring,
+)
+
+
+def configuration(
+    rows: Sequence[Sequence[int | Fraction]], labels: Sequence[str] | None = None
+) -> PointConfiguration:
+    return PointConfiguration(
+        points=tuple(
+            LabelledRationalPoint(
+                label=labels[i] if labels is not None else f"p{i}",
+                coordinates=tuple(
+                    CanonicalRational.from_fraction(Fraction(value)) for value in row
+                ),
+            )
+            for i, row in enumerate(rows)
+        )
+    )
+
+
+def assert_reconstructs(source: PointConfiguration) -> DistanceEdgeColoringResult:
+    result = compute_distance_edge_coloring(source)
+    assert result.configuration == source
+    palette = tuple(value.as_fraction() for value in result.squared_distances)
+    assert palette == tuple(sorted(set(palette)))
+    expected = {}
+    for i, j in combinations(range(len(source.points)), 2):
+        left, right = source.points[i], source.points[j]
+        distance = sum(
+            (x.as_fraction() - y.as_fraction()) ** 2
+            for x, y in zip(left.coordinates, right.coordinates, strict=True)
+        )
+        expected[f"{i}:{j}"] = (tuple(sorted((left.label, right.label))), distance)
+    graph = result.coloring.hypergraph
+    assert dict(graph.edges) == {key: value[0] for key, value in expected.items()}
+    assert {
+        item.edge_id: palette[item.color_index] for item in result.coloring.assignments
+    } == {key: value[1] for key, value in expected.items()}
+    assert (
+        DistanceEdgeColoringResult.model_validate_json(result.model_dump_json())
+        == result
+    )
+    return result
+
+
+def test_square() -> None:
+    result = assert_reconstructs(configuration([(0, 0), (1, 0), (0, 1), (1, 1)]))
+    assert [value.num for value in result.squared_distances] == [1, 2]
+    assert Counter(item.color_index for item in result.coloring.assignments) == {
+        0: 4,
+        1: 2,
+    }
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [(0,), (1,)],
+        [(Fraction(2, 3),), (Fraction(2, 3),)],
+        [(1, 0, 0), (0, 1, 0), (0, 0, 1)],
+        [(0,), (1,), (3,), (7,)],
+        [(Fraction(i, 7), Fraction(i * i, 11)) for i in range(8)],
+        [(i % 4, i // 4, i % 3) for i in range(20)],
+    ],
+)
+def test_complete_pairwise_reconstruction(
+    rows: Sequence[Sequence[int | Fraction]],
+) -> None:
+    assert_reconstructs(configuration(rows))
+
+
+def test_source_labels_and_edge_ids_survive_reordering() -> None:
+    source = configuration([(0,), (1,), (3,)], ["z", "e\u0301", "é"])
+    result = assert_reconstructs(source)
+    assert result.coloring.hypergraph.vertices == ("z", "e\u0301", "é")
+    coloring = result.coloring.model_copy()
+    payload = coloring.model_dump(mode="json")
+    payload["assignments"].reverse()
+    assert IndexedHyperedgeColoring.model_validate(payload) == coloring
+    reversed_result = assert_reconstructs(
+        source.model_copy(update={"points": source.points[::-1]})
+    )
+    assert reversed_result.squared_distances == result.squared_distances
+
+
+def test_large_translation_and_coincident_coordinates() -> None:
+    shift = 10**30_000
+    translated = configuration([(shift + i,) for i in range(64)])
+    result = assert_reconstructs(translated)
+    assert len(result.coloring.assignments) == 2016
+    assert len(result.squared_distances) == 63
+    coincident = assert_reconstructs(configuration([(shift, shift), (shift, shift)]))
+    assert coincident.squared_distances == (CanonicalRational(num=0, den=1),)
+
+
+def test_large_representable_squared_distance() -> None:
+    result = assert_reconstructs(configuration([(0,), (10**16_000,)]))
+    assert result.squared_distances[0].num == 10**32_000
+
+
+def test_required_distance_height_rejects() -> None:
+    with pytest.raises(OperationResourceAdmissionError, match="growth"):
+        compute_distance_edge_coloring(configuration([(0,), (10**20_000,)]))
+
+
+def test_distinct_rationals_do_not_collapse() -> None:
+    result = assert_reconstructs(
+        configuration([(0,), (Fraction(1, 10**50),), (Fraction(1, 10**50 + 1),)])
+    )
+    assert len(result.squared_distances) == 3
+
+
+def test_empty_and_duplicate_hyperedge_partition() -> None:
+    empty = IndexedHyperedgeColoring(
+        hypergraph=FiniteHypergraph(vertices=(), edges=()),
+        color_count=0,
+        assignments=(),
+    )
+    assert (
+        IndexedHyperedgeColoring.model_validate_json(empty.model_dump_json()) == empty
+    )
+    duplicate = IndexedHyperedgeColoring(
+        hypergraph=FiniteHypergraph(
+            vertices=("v",), edges=(("a", ("v",)), ("b", ("v",)))
+        ),
+        color_count=1,
+        assignments=(
+            HyperedgeColorAssignment(edge_id="b", color_index=0),
+            HyperedgeColorAssignment(edge_id="a", color_index=0),
+        ),
+    )
+    assert tuple(item.edge_id for item in duplicate.assignments) == ("a", "b")
+
+
+@pytest.mark.parametrize(
+    "assignments,count",
+    [([], 0), ([("a", 0), ("a", 0)], 1), ([("a", 1)], 2), ([("x", 0)], 1)],
+)
+def test_malformed_partition_rejects(
+    assignments: list[tuple[str, int]], count: int
+) -> None:
+    with pytest.raises(ValidationError):
+        IndexedHyperedgeColoring(
+            hypergraph=FiniteHypergraph(vertices=("v",), edges=(("a", ("v",)),)),
+            color_count=count,
+            assignments=tuple(
+                HyperedgeColorAssignment(edge_id=key, color_index=color)
+                for key, color in assignments
+            ),
+        )
+
+
+def test_source_coefficient_storage_rejects_before_pair_work() -> None:
+    value = 10**2100
+    with pytest.raises(OperationResourceAdmissionError, match="source coefficients"):
+        compute_distance_edge_coloring(configuration([(value,) * 20] * 64))
+
+
+def test_incommensurate_denominator_growth_rejects() -> None:
+    values = tuple(Fraction(1, 10**1000 + 2 * i + 1) for i in range(20))
+    with pytest.raises(OperationResourceAdmissionError, match="denominators"):
+        compute_distance_edge_coloring(configuration([(0,) * 20, values]))
+
+
+def test_work_budget_rejects_large_rational_palette() -> None:
+    values = [(Fraction(1, 10**2000 + 2 * i + 1),) for i in range(64)]
+    with pytest.raises(OperationResourceAdmissionError, match="work bound"):
+        compute_distance_edge_coloring(configuration(values))
+
+
+@pytest.mark.parametrize("bind_expired", [False, True])
+def test_expired_request_context_is_an_operational_timeout(bind_expired: bool) -> None:
+    from time import monotonic
+
+    from jacobian._execution import (
+        OperationExecutionTimeoutError,
+        bind_request_deadline,
+        request_execution,
+    )
+
+    source = configuration([(0,), (1,)])
+    with request_execution(monotonic() if bind_expired else monotonic() - 100):
+        if bind_expired:
+            bind_request_deadline(monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            compute_distance_edge_coloring(source)
+
+
+def test_colliding_numeric_hashes_retain_distance_classes() -> None:
+    import sys
+
+    modulus = sys.hash_info.modulus
+    result = assert_reconstructs(configuration([(i * modulus,) for i in range(64)]))
+    assert len(result.squared_distances) == 63
+    assert all(hash(value.as_fraction()) == 0 for value in result.squared_distances)

--- a/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
+++ b/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
@@ -88,7 +88,6 @@ def test_pythagorean_pair_admits_reduced_unit_distance() -> None:
     assert result.squared_distances[0].as_fraction() == 1
 
 
-
 @pytest.mark.parametrize(
     "rows",
     [

--- a/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
+++ b/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
@@ -264,4 +264,3 @@ def test_surrogate_point_label_is_rejected_before_distances() -> None:
     )
     with pytest.raises(OperationDomainValidationError, match="UTF-8"):
         compute_distance_edge_coloring(forged)
-

--- a/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
+++ b/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
@@ -78,6 +78,27 @@ def test_square() -> None:
     }
 
 
+def test_deserialized_palette_must_be_strictly_increasing() -> None:
+    result = assert_reconstructs(configuration([(0, 0), (1, 0), (0, 1), (1, 1)]))
+    reversed_palette = result.model_dump()
+    reversed_palette["squared_distances"] = list(
+        reversed(reversed_palette["squared_distances"])
+    )
+    reversed_palette["coloring"]["assignments"] = [
+        {**item, "color_index": 1 - item["color_index"]}
+        for item in reversed_palette["coloring"]["assignments"]
+    ]
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        DistanceEdgeColoringResult.model_validate(reversed_palette)
+    duplicate = result.model_dump()
+    duplicate["squared_distances"] = [
+        duplicate["squared_distances"][0],
+        duplicate["squared_distances"][0],
+    ]
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        DistanceEdgeColoringResult.model_validate(duplicate)
+
+
 def test_pythagorean_pair_admits_reduced_unit_distance() -> None:
     m = 10**9000
     point = (

--- a/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
+++ b/tests/math/geometry/exact/distance_edge_coloring/test_distance_edge_coloring.py
@@ -78,6 +78,17 @@ def test_square() -> None:
     }
 
 
+def test_pythagorean_pair_admits_reduced_unit_distance() -> None:
+    m = 10**9000
+    point = (
+        Fraction(m * m - 1, m * m + 1),
+        Fraction(2 * m, m * m + 1),
+    )
+    result = assert_reconstructs(configuration([(0, 0), point]))
+    assert result.squared_distances[0].as_fraction() == 1
+
+
+
 @pytest.mark.parametrize(
     "rows",
     [
@@ -184,7 +195,7 @@ def test_source_coefficient_storage_rejects_before_pair_work() -> None:
 
 def test_incommensurate_denominator_growth_rejects() -> None:
     values = tuple(Fraction(1, 10**1000 + 2 * i + 1) for i in range(20))
-    with pytest.raises(OperationResourceAdmissionError, match="denominators"):
+    with pytest.raises(OperationResourceAdmissionError, match="coefficient"):
         compute_distance_edge_coloring(configuration([(0,) * 20, values]))
 
 

--- a/tests/mcp/test_distance_edge_coloring.py
+++ b/tests/mcp/test_distance_edge_coloring.py
@@ -1,0 +1,40 @@
+"""Distance palettes retain their exact graph source across live MCP."""
+
+import asyncio
+import json
+
+from jsonschema import validate
+
+from jacobian.math.geometry.exact.distance_edge_coloring._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_distance_coloring_native_mcp_schema_and_graph_composition() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        validate(payload, tool.request_type.model_json_schema())
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        native = tool.run(request).model_dump(mode="json")
+        async with Client(create_server(), raise_exceptions=False) as client:
+            result = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            output = result.structured_content["output"]
+            assert output == native
+            validate(output, tool.result_type.model_json_schema())
+            parameters = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "hypergraph.parameters.compute",
+                    "payload": {"hypergraph": output["coloring"]["hypergraph"]},
+                },
+            )
+            assert not parameters.is_error
+            assert parameters.structured_content is not None
+            assert parameters.structured_content["output"]["edge_count"] == 6
+
+    asyncio.run(scenario())

--- a/tests/mcp/test_same_color_conflicts.py
+++ b/tests/mcp/test_same_color_conflicts.py
@@ -1,0 +1,75 @@
+"""Exact geometry-to-conflict-to-independence composition through live MCP."""
+
+import asyncio
+import json
+
+from jsonschema import validate
+
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts._tools import (
+    TOOLS,
+)
+from jacobian.math.geometry.exact.distance_edge_coloring._tools import (
+    TOOLS as DISTANCE_TOOLS,
+)
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_conflicts_native_schema_and_complete_distance_chain() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        validate(payload, tool.request_type.model_json_schema())
+        native = tool.run(tool.request_type.model_validate_json(json.dumps(payload)))
+        async with Client(create_server(), raise_exceptions=False) as client:
+            invalid = json.loads(json.dumps(payload))
+            invalid["coloring"]["assignments"].pop()
+            rejected = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": invalid}
+            )
+            assert rejected.is_error
+            response = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not response.is_error
+            assert response.structured_content is not None
+            output = response.structured_content["output"]
+            validate(output, tool.result_type.model_json_schema())
+            assert output == native.model_dump(mode="json")
+            distance_tool = DISTANCE_TOOLS[0]
+            distances = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": distance_tool.operation_id,
+                    "payload": distance_tool.examples[0].input,
+                },
+            )
+            assert not distances.is_error
+            assert distances.structured_content is not None
+            geometry = distances.structured_content["output"]
+            conflicts = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": {"coloring": geometry["coloring"]},
+                },
+            )
+            assert not conflicts.is_error
+            assert conflicts.structured_content is not None
+            conflict_output = conflicts.structured_content["output"]
+            assert conflict_output["coloring"] == geometry["coloring"]
+            assert len(conflict_output["provenance"]) == 7
+            assert len(conflict_output["hypergraph"]["edges"]) == 5
+            independent = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "hypergraph.independence_number.compute",
+                    "payload": {"hypergraph": conflict_output["hypergraph"]},
+                },
+            )
+            assert not independent.is_error
+            assert independent.structured_content is not None
+            assert independent.structured_content["output"]["status"] == "EXACT"
+            assert independent.structured_content["output"]["independence_number"] == 2
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Closes #3148. Pinned-distance rows contain local partitions but do not return one complete, source-bound edge colouring with exact distance values and stable source-edge identities.

## Outcome

Adds `geometry.points.distance_edge_coloring.compute` and native `compute_distance_edge_coloring`. The result retains the rational point configuration, a sorted exact squared-distance palette, and a complete labelled 2-uniform `FiniteHypergraph` with explicit edge-ID colour assignments. Every source pair appears once, including coincident points with distance zero. No floating-point comparisons or string-encoded rational colours are used.

The graph has one authoritative carrier. Its vertices retain the source point order; edge `i:j` joins source positions i<j. The new domain-owned `IndexedHyperedgeColoring` binds each assignment to an edge ID and canonicalizes assignment order without conflating different edge IDs with equal member sets. Its colour indices occupy a contiguous nonempty palette. This carrier is the shared input for #2493; the complete distance-to-conflict-to-independence chain is tested in dependent PR #3532, including the unit-square result with exact independence number 2.

FLINT supplies exact multiprecision rational arithmetic. Separately admitted coordinate subtraction removes zero differences and large common translations before squared-sum growth admission. Per-pair denominator LCM bounds all partial squared sums. Sorting indexed distances and grouping adjacent equals bounds palette construction even when numeric hashes collide. A request's existing deadline and cancellation context cover all phases.

## Validation

- Final head: `3d2610220`.
- `make affected AFFECTED_BASE=origin/main`: 6 commands passed; scoped Ruff/mypy, 202 math, 156 catalog, 915 catalog/integration and 72 MCP tests.
- `make architecture`: passed (1,346 files).
- Scoped exhaustive public-operation conformance: 1 passed, 881 deselected for `geometry.points.distance_edge_coloring.compute`.
- Hosted required CI passed on head `3d2610220`: [CI run](https://github.com/morluto/jacobian/actions/runs/34173586398).

Independent correctness evidence reconstructs every pair with Python Fraction arithmetic and checks exact equality classes, zero distances, rational equidistant and all-distinct configurations, coherent label reordering, and canonical serialization. Live MCP checks native/schema parity and passes the returned graph unchanged to `hypergraph.parameters.compute`.

Accepted scale examples include 64 points translated by a 30,001-digit integer, a representable 32,001-digit squared distance, a 64-point grid with 2,016 edges/33 classes (0.063 seconds), and a rational parabola with 2,016 distinct classes (0.071 seconds). These measurements exclude source construction. Rejected requests cover genuine rational-output growth, denominator growth, aggregate source storage and arithmetic work.

## Contract and review

- Exactly one new operation; no existing contract is superseded.
- The canonical point domain remains 2–64 points in 1–20 dimensions. Original point labels, including non-NFC text, retain their identities through the hypergraph carrier.
- Admission bounds coordinate normalization, squared-distance coefficient growth, complete edge/palette counts, aggregate rational storage and sorting work before graph/palette expansion. It admits 8 million source coefficient bits, 64 million source/palette bits and 10^13 bit-arithmetic work units.
- Parsing owns structural source axes and total colour assignments; the producer establishes palette order and geometric distance equality without replaying these calculations during result decoding.
- Independent exact-diff review completed; deadline propagation and rational-hash worst-case findings repaired with behavioral regressions.
- The resulting colouring supports rainbow induced-subgraph investigations such as the [Lee–Lefmann anti-Ramsey setting](https://arxiv.org/abs/1602.03569). This operation does not perform the downstream optimization.
