### PR TITLE
feat(polynomials): count exact roots relative to the unit disk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,6 +260,7 @@ ignore_imports = [
     # Exact common-interlacing factorization and isolation run in one bounded worker.
     "jacobian.math.graphs.triangle_free_diameter_augmentation._augmentation_z3 -> jacobian.process",
     "jacobian.math.polynomials.real_algebra._common_interlacing_process -> jacobian.process",
+    "jacobian.math.polynomials.unit_circle._root_profile_process -> jacobian.process",
 ]
 
 [[tool.importlinter.contracts]]

--- a/src/jacobian/math/polynomials/unit_circle/__init__.py
+++ b/src/jacobian/math/polynomials/unit_circle/__init__.py
@@ -10,6 +10,10 @@ from jacobian.math.polynomials.unit_circle._models import (
     RealDegreeOnePolynomialFactor,
     UnitCircleArcEnergyResult,
 )
+from jacobian.math.polynomials.unit_circle._root_profile import (
+    UnitDiskProfile,
+    unit_disk_profile,
+)
 from jacobian.math.polynomials.unit_circle.operations import (
     real_symmetric_degree_one_fejer_riesz_factor,
     unit_circle_arc_energy,
@@ -26,8 +30,10 @@ __all__ = [
     "HermitianLaurentTerm",
     "RealDegreeOnePolynomialFactor",
     "UnitCircleArcEnergyResult",
+    "UnitDiskProfile",
     "real_symmetric_degree_one_fejer_riesz_factor",
     "unit_circle_arc_energy",
+    "unit_disk_profile",
     "verify_real_symmetric_degree_one_fejer_riesz_factor",
     "verify_unit_circle_arc_energy",
 ]

--- a/src/jacobian/math/polynomials/unit_circle/_root_profile.py
+++ b/src/jacobian/math/polynomials/unit_circle/_root_profile.py
@@ -10,7 +10,6 @@ variation on a division-free Berkowitz characteristic polynomial.
 from __future__ import annotations
 
 import time
-from itertools import pairwise
 from math import gcd, lcm
 
 from pydantic import Field, StrictInt
@@ -25,6 +24,9 @@ from jacobian._models import StrictModel
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
+)
+from jacobian.math.polynomials.unit_circle._root_profile_process import (
+    count_reduced_roots,
 )
 from jacobian.math.polynomials.values import RationalPolynomial
 
@@ -143,57 +145,6 @@ def _admit(polynomial: RationalPolynomial) -> tuple[int, int, list[int]]:
     return valuation, stride, [value // content for value in coefficients]
 
 
-def _signature(matrix: list[list[int]]) -> int:
-    from sympy.polys.domains import ZZ
-    from sympy.polys.matrices.ddm import DDM
-
-    order = len(matrix)
-    if not order:
-        return 0
-    # DDM explicitly selects the maintained division-free dense Berkowitz
-    # algorithm, avoiding a backend-dependent modular charpoly dispatcher.
-    characteristic = DDM(
-        [[ZZ(value) for value in row] for row in matrix], (order, order), ZZ
-    ).charpoly()
-    positive = [1 if value > 0 else -1 for value in characteristic if value]
-    negative = [
-        (1 if value > 0 else -1) * (-1 if index % 2 else 1)
-        for index, value in enumerate(characteristic)
-        if value
-    ]
-    return sum(a != b for a, b in pairwise(positive)) - sum(
-        a != b for a, b in pairwise(negative)
-    )
-
-
-def _schur_signature(coefficients: list[int]) -> int:
-    n = len(coefficients) - 1
-    matrix = [[0] * n for _ in range(n)]
-    for i in range(n):
-        for j in range(n):
-            matrix[i][j] = sum(
-                coefficients[n - i + k] * coefficients[n - j + k]
-                - coefficients[i - k] * coefficients[j - k]
-                for k in range(min(i, j) + 1)
-            )
-    return _signature(matrix)
-
-
-def _real_root_count(coefficients: list[int]) -> int:
-    """Hermite's Bezoutian signature counts distinct real roots."""
-    n = len(coefficients) - 1
-    derivative = [(i + 1) * coefficients[i + 1] for i in range(n)] + [0]
-    matrix = [[0] * n for _ in range(n)]
-    for a in range(1, n + 1):
-        for b in range(a):
-            coefficient = (
-                coefficients[a] * derivative[b] - derivative[a] * coefficients[b]
-            )
-            for k in range(a - b):
-                matrix[a - 1 - k][b + k] += coefficient
-    return _signature(matrix)
-
-
 def unit_disk_profile(polynomial: RationalPolynomial) -> UnitDiskProfile:
     """Count all roots inside, on and outside |z|=1, including multiplicity."""
     execution = current_request_execution()
@@ -212,46 +163,12 @@ def unit_disk_profile(polynomial: RationalPolynomial) -> UnitDiskProfile:
     bind_request_deadline(deadline)
     checkpoint()
     valuation, stride, coefficients = _admit(polynomial)
-    from flint import fmpz_poly
-
-    source = fmpz_poly(coefficients)
-    inside, boundary, outside = valuation, 0, 0
-    _, factors = source.factor_squarefree()
-    for factor, multiplicity in factors:
-        checkpoint()
-        a = [int(value) for value in factor.coeffs()]
-        n = len(a) - 1
-        difference = _schur_signature(a)
-        # Homogeneous Horner evaluation of (1-s)^n p((1+s)/(1-s)).
-        plus, minus = fmpz_poly([1, 1]), fmpz_poly([1, -1])
-        transformed = fmpz_poly([a[-1]])
-        power = fmpz_poly([1])
-        for coefficient in reversed(a[:-1]):
-            power *= minus
-            transformed = transformed * plus + coefficient * power
-        q = [int(value) for value in transformed.coeffs()]
-        real = fmpz_poly(
-            [value * (-1) ** (i // 2) if i % 2 == 0 else 0 for i, value in enumerate(q)]
-        )
-        imaginary = fmpz_poly(
-            [value * (-1) ** (i // 2) if i % 2 else 0 for i, value in enumerate(q)]
-        )
-        common = real.gcd(imaginary)
-        # A squarefree factor stays squarefree under the Mobius map;
-        # hence the real gcd is squarefree as well. Missing degree is -1.
-        on = (
-            n
-            - int(transformed.degree())
-            + _real_root_count([int(value) for value in common.coeffs()])
-        )
-        inside += stride * multiplicity * ((n - on + difference) // 2)
-        boundary += stride * multiplicity * on
-        outside += stride * multiplicity * ((n - on - difference) // 2)
+    inside, boundary, outside = count_reduced_roots(coefficients, deadline=deadline)
     checkpoint()
     return UnitDiskProfile(
         polynomial=polynomial,
         degree=polynomial.polynomial.terms[0].exponents[0],
-        inside=inside,
-        on=boundary,
-        outside=outside,
+        inside=valuation + stride * inside,
+        on=stride * boundary,
+        outside=stride * outside,
     )

--- a/src/jacobian/math/polynomials/unit_circle/_root_profile.py
+++ b/src/jacobian/math/polynomials/unit_circle/_root_profile.py
@@ -56,8 +56,11 @@ def _resource(message: str) -> OperationResourceAdmissionError:
 def _admit(polynomial: RationalPolynomial) -> tuple[int, int, list[int]]:
     """Inspect once, then expand only the exponent-compressed integer source.
 
-    Let h bound the cleared source coefficients and n its reduced degree.
-    Mignotte bounds each primitive squarefree factor by 2**n ||p||_2.
+    Let h bound the primitive integer coefficients after removing rational
+    content, and n the reduced degree. Multiplication by a nonzero rational
+    scalar does not change the root profile, so height and work use that
+    primitive source. Mignotte bounds each primitive squarefree factor by
+    2**n ||p||_2.
     Cayley substitution adds n+log2(n+1) bits; its real gcd gains the same
     factor bound. Derivatives and Bezoutian sums add at most 2log2(n+1)
     to twice that height. Berkowitz intermediates are sums of products of
@@ -97,18 +100,33 @@ def _admit(polynomial: RationalPolynomial) -> tuple[int, int, list[int]]:
         # the root multiset, including arbitrarily large rational scalars.
         return valuation, 1, [1]
     values = [term.coefficient.as_fraction() for term in terms]
-    denominator_bits = sum(value.denominator.bit_length() for value in values)
-    numerator_bits = max(abs(value.numerator).bit_length() for value in values)
-    if denominator_bits + numerator_bits > 65_536:
-        raise _resource("cleared coefficient height exceeds 65,536 bits")
     stride = 0
     for term in terms:
         stride = gcd(stride, term.exponents[0] - valuation)
     stride = stride or 1
     degree = (terms[0].exponents[0] - valuation) // stride
+    numerator_content = 0
+    denominator = 1
+    for value in values:
+        numerator_content = gcd(numerator_content, value.numerator)
+        denominator = lcm(denominator, value.denominator)
+        # Bound lcm expansion of distinct denominators, not a shared scalar.
+        if denominator.bit_length() > 262_144:
+            raise _resource(
+                "derived exact-arithmetic work or intermediate height exceeds the envelope"
+            )
+    coefficients = [0] * (degree + 1)
+    for term, value in zip(terms, values, strict=True):
+        coefficients[(term.exponents[0] - valuation) // stride] = (
+            value.numerator // numerator_content
+        ) * (denominator // value.denominator)
+    content = gcd(*coefficients)
+    coefficients = [value // content for value in coefficients]
+    height = max(abs(value).bit_length() for value in coefficients)
+    if height > 65_536:
+        raise _resource("cleared coefficient height exceeds 65,536 bits")
     if degree:
         log = (degree + 1).bit_length()
-        height = denominator_bits + numerator_bits
         factor_height = height + degree + log
         cayley_height = factor_height + degree + log
         boundary_height = cayley_height + degree + log
@@ -133,16 +151,7 @@ def _admit(polynomial: RationalPolynomial) -> tuple[int, int, list[int]]:
             raise _resource(
                 "derived characteristic-polynomial allocation exceeds the envelope"
             )
-    denominator = 1
-    for value in values:
-        denominator = lcm(denominator, value.denominator)
-    coefficients = [0] * (degree + 1)
-    for term, value in zip(terms, values, strict=True):
-        coefficients[(term.exponents[0] - valuation) // stride] = value.numerator * (
-            denominator // value.denominator
-        )
-    content = gcd(*coefficients)
-    return valuation, stride, [value // content for value in coefficients]
+    return valuation, stride, coefficients
 
 
 def unit_disk_profile(polynomial: RationalPolynomial) -> UnitDiskProfile:

--- a/src/jacobian/math/polynomials/unit_circle/_root_profile.py
+++ b/src/jacobian/math/polynomials/unit_circle/_root_profile.py
@@ -1,0 +1,257 @@
+"""Exact root counts from Schur and real Hermite forms.
+
+Schur's signature is inside minus outside even for singular forms; its
+nullity is deliberately unused.  Cayley transformation and a real gcd
+identify the boundary separately.  See Heinig--Rost, *Bezoutians* (2008),
+Theorems 10.4 and 10.9. All matrix signatures use real-rooted Descartes
+variation on a division-free Berkowitz characteristic polynomial.
+"""
+
+from __future__ import annotations
+
+import time
+from itertools import pairwise
+from math import gcd, lcm
+
+from pydantic import Field, StrictInt
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+)
+from jacobian._models import StrictModel
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.polynomials.values import RationalPolynomial
+
+
+class UnitDiskProfileRequest(StrictModel):
+    polynomial: RationalPolynomial
+
+
+class UnitDiskProfile(StrictModel):
+    """Root multiplicities in the three regions relative to the unit circle."""
+
+    polynomial: RationalPolynomial
+    degree: StrictInt = Field(ge=0)
+    inside: StrictInt = Field(ge=0)
+    on: StrictInt = Field(ge=0)
+    outside: StrictInt = Field(ge=0)
+
+
+def _resource(message: str) -> OperationResourceAdmissionError:
+    return OperationResourceAdmissionError(
+        location=("polynomial",),
+        code="polynomial.unit_disk.resource_admission",
+        message=message,
+    )
+
+
+def _admit(polynomial: RationalPolynomial) -> tuple[int, int, list[int]]:
+    """Inspect once, then expand only the exponent-compressed integer source.
+
+    Let h bound the cleared source coefficients and n its reduced degree.
+    Mignotte bounds each primitive squarefree factor by 2**n ||p||_2.
+    Cayley substitution adds n+log2(n+1) bits; its real gcd gains the same
+    factor bound. Derivatives and Bezoutian sums add at most 2log2(n+1)
+    to twice that height. Berkowitz intermediates are sums of products of
+    at most n matrix entries, bounded by 2n(b+2log2(n+1)+2) bits.
+
+    In FLINT's squarefree loop, v is a primitive integer divisor of p.
+    Its w/s auxiliaries are weighted derivative sums, with weights <=n:
+    sum_j m_j f_j' product_{k!=j} f_k. Their coefficients are bounded by
+    n**2 * 2**n * M(v), and M(v)<=M(p)<=sqrt(n+1)*2**h. Thus the
+    factor height plus 2log2(n+1)+2 bounds every such auxiliary. Also the
+    sum of active v degrees across the loop is <=n (each factor appears
+    once per multiplicity), bounding the total modular gcd work by cubic
+    degree times operand height. The gcd dispatcher uses
+    bounded heuristic attempts then subresultant/modular gcd. The modular
+    termination bound is (n+3)*max(norm_squared_bits)+(n+1), including
+    unlucky primes; subresultant pseudo-division temporaries are bounded
+    by 4(n+1)**2 times operand height. This larger ceiling also covers
+    exact-division temporaries. No root separation or tolerance is used.
+
+    Work is a coefficient-operation/word-height proxy, not a bit-operation
+    claim. Sum of squarefree factor degrees is <=n, so their matrix work
+    is bounded by two order-n Berkowitz calls. Integer payload and dense
+    matrix allocations are admitted separately from transport policy.
+    """
+    terms = polynomial.polynomial.terms
+    if len(polynomial.variables) != 1 or not terms:
+        raise OperationDomainValidationError(
+            location=("polynomial",),
+            code="polynomial.unit_disk.nonzero_univariate_required",
+            message="a nonzero univariate rational polynomial is required",
+        )
+    if len(terms) > 4096:
+        raise _resource("source support exceeds 4096 terms")
+    valuation = terms[-1].exponents[0]
+    if len(terms) == 1:
+        # Canonical terms are nonzero. The coefficient is immaterial to
+        # the root multiset, including arbitrarily large rational scalars.
+        return valuation, 1, [1]
+    values = [term.coefficient.as_fraction() for term in terms]
+    denominator_bits = sum(value.denominator.bit_length() for value in values)
+    numerator_bits = max(abs(value.numerator).bit_length() for value in values)
+    if denominator_bits + numerator_bits > 65_536:
+        raise _resource("cleared coefficient height exceeds 65,536 bits")
+    stride = 0
+    for term in terms:
+        stride = gcd(stride, term.exponents[0] - valuation)
+    stride = stride or 1
+    degree = (terms[0].exponents[0] - valuation) // stride
+    if degree:
+        log = (degree + 1).bit_length()
+        height = denominator_bits + numerator_bits
+        factor_height = height + degree + log
+        cayley_height = factor_height + degree + log
+        boundary_height = cayley_height + degree + log
+        matrix_height = 2 * boundary_height + 2 * log + 2
+        characteristic_height = 2 * degree * (matrix_height + 2 * log + 2)
+        auxiliary_height = factor_height + 2 * log + 2
+        gcd_height = max(auxiliary_height, cayley_height)
+        intermediate_height = 4 * (degree + 1) ** 2 * (gcd_height + log + 64)
+        work = 16 * (degree + 1) ** 4 + 16 * (degree + 1) ** 3 * (
+            (gcd_height + 63) // 64
+        )
+        if work > 100_000_000 or intermediate_height > 16_777_216:
+            raise _resource(
+                "derived exact-arithmetic work or intermediate height exceeds the envelope"
+            )
+        # Recursive source submatrices coexist, but each Toeplitz product
+        # workspace is allocated only after its recursive child has returned.
+        allocation = (degree + 1) ** 3 * matrix_height + 4 * (
+            degree + 1
+        ) ** 2 * characteristic_height
+        if allocation > 268_435_456:
+            raise _resource(
+                "derived characteristic-polynomial allocation exceeds the envelope"
+            )
+    denominator = 1
+    for value in values:
+        denominator = lcm(denominator, value.denominator)
+    coefficients = [0] * (degree + 1)
+    for term, value in zip(terms, values, strict=True):
+        coefficients[(term.exponents[0] - valuation) // stride] = value.numerator * (
+            denominator // value.denominator
+        )
+    content = gcd(*coefficients)
+    return valuation, stride, [value // content for value in coefficients]
+
+
+def _signature(matrix: list[list[int]]) -> int:
+    from sympy.polys.domains import ZZ
+    from sympy.polys.matrices.ddm import DDM
+
+    order = len(matrix)
+    if not order:
+        return 0
+    # DDM explicitly selects the maintained division-free dense Berkowitz
+    # algorithm, avoiding a backend-dependent modular charpoly dispatcher.
+    characteristic = DDM(
+        [[ZZ(value) for value in row] for row in matrix], (order, order), ZZ
+    ).charpoly()
+    positive = [1 if value > 0 else -1 for value in characteristic if value]
+    negative = [
+        (1 if value > 0 else -1) * (-1 if index % 2 else 1)
+        for index, value in enumerate(characteristic)
+        if value
+    ]
+    return sum(a != b for a, b in pairwise(positive)) - sum(
+        a != b for a, b in pairwise(negative)
+    )
+
+
+def _schur_signature(coefficients: list[int]) -> int:
+    n = len(coefficients) - 1
+    matrix = [[0] * n for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            matrix[i][j] = sum(
+                coefficients[n - i + k] * coefficients[n - j + k]
+                - coefficients[i - k] * coefficients[j - k]
+                for k in range(min(i, j) + 1)
+            )
+    return _signature(matrix)
+
+
+def _real_root_count(coefficients: list[int]) -> int:
+    """Hermite's Bezoutian signature counts distinct real roots."""
+    n = len(coefficients) - 1
+    derivative = [(i + 1) * coefficients[i + 1] for i in range(n)] + [0]
+    matrix = [[0] * n for _ in range(n)]
+    for a in range(1, n + 1):
+        for b in range(a):
+            coefficient = (
+                coefficients[a] * derivative[b] - derivative[a] * coefficients[b]
+            )
+            for k in range(a - b):
+                matrix[a - 1 - k][b + k] += coefficient
+    return _signature(matrix)
+
+
+def unit_disk_profile(polynomial: RationalPolynomial) -> UnitDiskProfile:
+    """Count all roots inside, on and outside |z|=1, including multiplicity."""
+    execution = current_request_execution()
+    started = execution.started_at if execution is not None else time.monotonic()
+    deadline = started + 60.0
+    if execution is not None and execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+
+    def checkpoint() -> None:
+        request_checkpoint("computing unit-disk root profile")
+        if time.monotonic() >= deadline:
+            raise OperationExecutionTimeoutError(
+                "unit-disk root profile deadline expired"
+            )
+
+    bind_request_deadline(deadline)
+    checkpoint()
+    valuation, stride, coefficients = _admit(polynomial)
+    from flint import fmpz_poly
+
+    source = fmpz_poly(coefficients)
+    inside, boundary, outside = valuation, 0, 0
+    _, factors = source.factor_squarefree()
+    for factor, multiplicity in factors:
+        checkpoint()
+        a = [int(value) for value in factor.coeffs()]
+        n = len(a) - 1
+        difference = _schur_signature(a)
+        # Homogeneous Horner evaluation of (1-s)^n p((1+s)/(1-s)).
+        plus, minus = fmpz_poly([1, 1]), fmpz_poly([1, -1])
+        transformed = fmpz_poly([a[-1]])
+        power = fmpz_poly([1])
+        for coefficient in reversed(a[:-1]):
+            power *= minus
+            transformed = transformed * plus + coefficient * power
+        q = [int(value) for value in transformed.coeffs()]
+        real = fmpz_poly(
+            [value * (-1) ** (i // 2) if i % 2 == 0 else 0 for i, value in enumerate(q)]
+        )
+        imaginary = fmpz_poly(
+            [value * (-1) ** (i // 2) if i % 2 else 0 for i, value in enumerate(q)]
+        )
+        common = real.gcd(imaginary)
+        # A squarefree factor stays squarefree under the Mobius map;
+        # hence the real gcd is squarefree as well. Missing degree is -1.
+        on = (
+            n
+            - int(transformed.degree())
+            + _real_root_count([int(value) for value in common.coeffs()])
+        )
+        inside += stride * multiplicity * ((n - on + difference) // 2)
+        boundary += stride * multiplicity * on
+        outside += stride * multiplicity * ((n - on - difference) // 2)
+    checkpoint()
+    return UnitDiskProfile(
+        polynomial=polynomial,
+        degree=polynomial.polynomial.terms[0].exponents[0],
+        inside=inside,
+        on=boundary,
+        outside=outside,
+    )

--- a/src/jacobian/math/polynomials/unit_circle/_root_profile_process.py
+++ b/src/jacobian/math/polynomials/unit_circle/_root_profile_process.py
@@ -108,4 +108,8 @@ def count_reduced_roots(
     outside = response["outside"]
     if min(inside, on, outside) < 0:
         raise RuntimeError("bounded unit-disk kernel worker returned malformed output")
+    if inside + on + outside != len(coefficients) - 1:
+        raise RuntimeError(
+            "bounded unit-disk kernel worker returned counts that do not match the admitted degree"
+        )
     return inside, on, outside

--- a/src/jacobian/math/polynomials/unit_circle/_root_profile_process.py
+++ b/src/jacobian/math/polynomials/unit_circle/_root_profile_process.py
@@ -16,6 +16,7 @@ from jacobian.canonical import (
     CanonicalizationError,
     CanonicalLimits,
     encode_strict_json,
+    format_canonical_integer,
     loads_strict_json,
 )
 from jacobian.process import (
@@ -41,7 +42,13 @@ def count_reduced_roots(
         raise OperationExecutionTimeoutError(
             "unit-disk root profile deadline expired before the kernel worker"
         )
-    payload = encode_strict_json({"coefficients": coefficients})
+    payload = encode_strict_json(
+        {
+            "coefficients": [
+                format_canonical_integer(coefficient) for coefficient in coefficients
+            ]
+        }
+    )
     try:
         with TemporaryDirectory(prefix="jacobian-unit-disk-") as worker_directory:
             completed = run_bounded_process(

--- a/src/jacobian/math/polynomials/unit_circle/_root_profile_process.py
+++ b/src/jacobian/math/polynomials/unit_circle/_root_profile_process.py
@@ -91,7 +91,9 @@ def count_reduced_roots(
     if (
         not isinstance(response, dict)
         or response.get("status") != "ok"
-        or any(type(response.get(key)) is not int for key in ("inside", "on", "outside"))
+        or any(
+            type(response.get(key)) is not int for key in ("inside", "on", "outside")
+        )
     ):
         raise RuntimeError("bounded unit-disk kernel worker returned malformed output")
     inside = response["inside"]

--- a/src/jacobian/math/polynomials/unit_circle/_root_profile_process.py
+++ b/src/jacobian/math/polynomials/unit_circle/_root_profile_process.py
@@ -1,0 +1,102 @@
+"""Killable unit-disk signature, factorization, and real-gcd kernel."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from time import monotonic
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+    loads_strict_json,
+)
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_WORKER_PATH = Path(__file__).resolve().with_name("_root_profile_worker.py")
+_STDOUT_BYTES = 64 * 1024
+_STDERR_BYTES = 64 * 1024
+_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_PARENT_FINALIZATION_SECONDS = 1.0
+
+
+def count_reduced_roots(
+    coefficients: list[int], *, deadline: float
+) -> tuple[int, int, int]:
+    """Count inside/on/outside roots of one admitted primitive integer polynomial."""
+
+    remaining = deadline - monotonic() - _PARENT_FINALIZATION_SECONDS
+    if remaining <= 0:
+        raise OperationExecutionTimeoutError(
+            "unit-disk root profile deadline expired before the kernel worker"
+        )
+    payload = encode_strict_json({"coefficients": coefficients})
+    try:
+        with TemporaryDirectory(prefix="jacobian-unit-disk-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_WORKER_PATH)],
+                input_bytes=payload,
+                timeout_seconds=remaining,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_STDOUT_BYTES,
+                stderr_limit=_STDERR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(remaining)),
+                    address_space_bytes=_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_STDOUT_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded unit-disk kernel worker could not be started"
+        ) from exc
+    if completed.cancelled:
+        raise OperationExecutionCancelledError(
+            "unit-disk root profile cancelled during the kernel worker"
+        )
+    if completed.timed_out:
+        raise OperationExecutionTimeoutError(
+            "unit-disk root profile deadline expired during the kernel worker"
+        )
+    if (
+        completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        raise RuntimeError("bounded unit-disk kernel worker did not return root counts")
+    try:
+        response = loads_strict_json(
+            completed.stdout,
+            limits=CanonicalLimits(
+                max_input_bytes=_STDOUT_BYTES,
+                max_output_bytes=_STDOUT_BYTES,
+            ),
+        )
+    except CanonicalizationError as exc:
+        raise RuntimeError(
+            "bounded unit-disk kernel worker returned malformed output"
+        ) from exc
+    if (
+        not isinstance(response, dict)
+        or response.get("status") != "ok"
+        or any(type(response.get(key)) is not int for key in ("inside", "on", "outside"))
+    ):
+        raise RuntimeError("bounded unit-disk kernel worker returned malformed output")
+    inside = response["inside"]
+    on = response["on"]
+    outside = response["outside"]
+    if min(inside, on, outside) < 0:
+        raise RuntimeError("bounded unit-disk kernel worker returned malformed output")
+    return inside, on, outside

--- a/src/jacobian/math/polynomials/unit_circle/_root_profile_worker.py
+++ b/src/jacobian/math/polynomials/unit_circle/_root_profile_worker.py
@@ -59,13 +59,18 @@ def _real_root_count(coefficients: list[int]) -> int:
 def _run(payload: dict[str, Any]) -> dict[str, Any]:
     from flint import fmpz_poly
 
+    from jacobian.canonical import parse_canonical_integer
+
     if set(payload) != {"coefficients"} or not isinstance(
         payload["coefficients"], list
     ):
         raise ValueError("malformed unit-disk request")
-    coefficients = payload["coefficients"]
-    if not coefficients or any(type(value) is not int for value in coefficients):
+    raw_coefficients = payload["coefficients"]
+    if not raw_coefficients or any(
+        not isinstance(value, str) for value in raw_coefficients
+    ):
         raise ValueError("malformed unit-disk request")
+    coefficients = [parse_canonical_integer(value) for value in raw_coefficients]
     source = fmpz_poly(coefficients)
     inside, boundary, outside = 0, 0, 0
     _, factors = source.factor_squarefree()

--- a/src/jacobian/math/polynomials/unit_circle/_root_profile_worker.py
+++ b/src/jacobian/math/polynomials/unit_circle/_root_profile_worker.py
@@ -1,0 +1,121 @@
+"""Standalone FLINT/SymPy worker for admitted unit-disk root counts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from itertools import pairwise
+from typing import Any
+
+
+def _signature(matrix: list[list[int]]) -> int:
+    from sympy.polys.domains import ZZ
+    from sympy.polys.matrices.ddm import DDM
+
+    order = len(matrix)
+    if not order:
+        return 0
+    characteristic = DDM(
+        [[ZZ(value) for value in row] for row in matrix], (order, order), ZZ
+    ).charpoly()
+    positive = [1 if value > 0 else -1 for value in characteristic if value]
+    negative = [
+        (1 if value > 0 else -1) * (-1 if index % 2 else 1)
+        for index, value in enumerate(characteristic)
+        if value
+    ]
+    return sum(a != b for a, b in pairwise(positive)) - sum(
+        a != b for a, b in pairwise(negative)
+    )
+
+
+def _schur_signature(coefficients: list[int]) -> int:
+    n = len(coefficients) - 1
+    matrix = [[0] * n for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            matrix[i][j] = sum(
+                coefficients[n - i + k] * coefficients[n - j + k]
+                - coefficients[i - k] * coefficients[j - k]
+                for k in range(min(i, j) + 1)
+            )
+    return _signature(matrix)
+
+
+def _real_root_count(coefficients: list[int]) -> int:
+    n = len(coefficients) - 1
+    derivative = [(i + 1) * coefficients[i + 1] for i in range(n)] + [0]
+    matrix = [[0] * n for _ in range(n)]
+    for a in range(1, n + 1):
+        for b in range(a):
+            coefficient = (
+                coefficients[a] * derivative[b] - derivative[a] * coefficients[b]
+            )
+            for k in range(a - b):
+                matrix[a - 1 - k][b + k] += coefficient
+    return _signature(matrix)
+
+
+def _run(payload: dict[str, Any]) -> dict[str, Any]:
+    from flint import fmpz_poly
+
+    if set(payload) != {"coefficients"} or not isinstance(
+        payload["coefficients"], list
+    ):
+        raise ValueError("malformed unit-disk request")
+    coefficients = payload["coefficients"]
+    if not coefficients or any(type(value) is not int for value in coefficients):
+        raise ValueError("malformed unit-disk request")
+    source = fmpz_poly(coefficients)
+    inside, boundary, outside = 0, 0, 0
+    _, factors = source.factor_squarefree()
+    for factor, multiplicity in factors:
+        a = [int(value) for value in factor.coeffs()]
+        n = len(a) - 1
+        difference = _schur_signature(a)
+        plus, minus = fmpz_poly([1, 1]), fmpz_poly([1, -1])
+        transformed = fmpz_poly([a[-1]])
+        power = fmpz_poly([1])
+        for coefficient in reversed(a[:-1]):
+            power *= minus
+            transformed = transformed * plus + coefficient * power
+        q = [int(value) for value in transformed.coeffs()]
+        real = fmpz_poly(
+            [value * (-1) ** (i // 2) if i % 2 == 0 else 0 for i, value in enumerate(q)]
+        )
+        imaginary = fmpz_poly(
+            [value * (-1) ** (i // 2) if i % 2 else 0 for i, value in enumerate(q)]
+        )
+        common = real.gcd(imaginary)
+        on = (
+            n
+            - int(transformed.degree())
+            + _real_root_count([int(value) for value in common.coeffs()])
+        )
+        inside += multiplicity * ((n - on + difference) // 2)
+        boundary += multiplicity * on
+        outside += multiplicity * ((n - on - difference) // 2)
+    return {
+        "status": "ok",
+        "inside": inside,
+        "on": boundary,
+        "outside": outside,
+    }
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("malformed unit-disk request")
+        response = _run(payload)
+    except Exception:
+        return 1
+    sys.stdout.buffer.write(
+        json.dumps(response, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/polynomials/unit_circle/_tools.py
+++ b/src/jacobian/math/polynomials/unit_circle/_tools.py
@@ -9,6 +9,11 @@ from jacobian.math.polynomials.unit_circle._models import (
     UnitCircleArcEnergyRequest,
     UnitCircleArcEnergyResult,
 )
+from jacobian.math.polynomials.unit_circle._root_profile import (
+    UnitDiskProfile,
+    UnitDiskProfileRequest,
+    unit_disk_profile,
+)
 from jacobian.math.polynomials.unit_circle.operations import (
     real_symmetric_degree_one_fejer_riesz_factor,
     unit_circle_arc_energy,
@@ -42,6 +47,49 @@ POLYNOMIAL_ONE_PLUS_Z = {
 
 
 TOOLS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="polynomial.root_location.unit_disk_profile.compute",
+        title="Count exact polynomial roots relative to the unit disk",
+        description=(
+            "Count roots of a nonzero univariate rational polynomial strictly "
+            "inside, on, and strictly outside the unit circle, with multiplicity. "
+            "Includes repeated boundary roots and reciprocal common factors; "
+            "nonzero constants have zero counts. Exact arithmetic admission uses "
+            "compressed support degree and coefficient growth. Rational radius r "
+            "is handled by supplying p(r*z)."
+        ),
+        request_type=UnitDiskProfileRequest,
+        result_type=UnitDiskProfile,
+        run=lambda request: unit_disk_profile(request.polynomial),
+        tags=("polynomial", "roots", "unit-disk", "schur-stability", "exact"),
+        examples=(
+            OperationExample(
+                name="reciprocal_pair",
+                description="Roots 1/2 and 2 lie on opposite sides of the circle.",
+                input={
+                    "polynomial": {
+                        "variables": ["z"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "2", "den": "1"},
+                                    "exponents": [2],
+                                },
+                                {
+                                    "coefficient": {"num": "-5", "den": "1"},
+                                    "exponents": [1],
+                                },
+                                {
+                                    "coefficient": {"num": "2", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    }
+                },
+            ),
+        ),
+    ),
     MathTool(
         operation_id="polynomial.unit_circle.arc_energy.compute",
         title="Compute exact unit-circle arc energy",

--- a/tests/math/polynomials/test_unit_disk_profile.py
+++ b/tests/math/polynomials/test_unit_disk_profile.py
@@ -1,0 +1,185 @@
+"""Exact independent root-location and admission regressions."""
+
+from collections.abc import Sequence
+from fractions import Fraction
+from random import Random
+from time import monotonic
+
+import pytest
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.polynomials.unit_circle import UnitDiskProfile, unit_disk_profile
+from jacobian.math.polynomials.values import RationalPolynomial
+
+
+def polynomial(
+    coefficients: Sequence[int | Fraction], *, stride: int = 1, shift: int = 0
+) -> RationalPolynomial:
+    return RationalPolynomial.model_validate(
+        {
+            "variables": ["z"],
+            "polynomial": {
+                "terms": [
+                    {
+                        "coefficient": {
+                            "num": Fraction(c).numerator,
+                            "den": Fraction(c).denominator,
+                        },
+                        "exponents": [i * stride + shift],
+                    }
+                    for i, c in reversed(list(enumerate(coefficients)))
+                    if c
+                ]
+            },
+        }
+    )
+
+
+def counts(source: RationalPolynomial) -> tuple[int, int, int]:
+    result = unit_disk_profile(source)
+    assert result.inside + result.on + result.outside == result.degree
+    assert UnitDiskProfile.model_validate_json(result.model_dump_json()) == result
+    assert result.polynomial == source
+    return result.inside, result.on, result.outside
+
+
+@pytest.mark.parametrize(
+    ("coefficients", "expected"),
+    [
+        ([2, -5, 2], (1, 0, 1)),
+        ([1, 1, -1, 1, 1], (1, 2, 1)),
+        ([7], (0, 0, 0)),
+        ([0, 0, 0, 1], (3, 0, 0)),
+        ([1, 0, 1], (0, 2, 0)),
+        ([1, 2, 1], (0, 2, 0)),
+        ([1, -2, 1], (0, 2, 0)),
+        ([1, 0, 2], (2, 0, 0)),
+        ([2, 0, 1], (0, 0, 2)),
+    ],
+)
+def test_exact_basic_and_comment_fixtures(
+    coefficients: list[int], expected: tuple[int, int, int]
+) -> None:
+    assert counts(polynomial(coefficients)) == expected
+
+
+def test_repeated_rational_and_complex_factors_with_known_roots() -> None:
+    from flint import fmpz_poly
+
+    z = fmpz_poly([0, 1])
+    p = (2 * z - 1) ** 3 * (z - 1) ** 4 * (z + 1) ** 2 * (z - 2) ** 5 * (z * z + 1) ** 3
+    p *= (2 * z * z + 1) ** 2 * (z * z + 2) ** 3
+    assert counts(polynomial([int(c) for c in p.coeffs()])) == (7, 12, 11)
+
+
+def test_rational_scalar_reciprocal_and_rational_radius_composition() -> None:
+    a = [Fraction(1, 7), Fraction(-2, 3), Fraction(1, 5), Fraction(3, 2)]
+    inside, on, outside = counts(polynomial(a))
+    assert counts(polynomial(list(reversed(a)))) == (outside, on, inside)
+    assert counts(polynomial([-Fraction(11, 13) * c for c in a])) == (
+        inside,
+        on,
+        outside,
+    )
+    q = [2, -5, 2]
+    small = unit_disk_profile(
+        polynomial([c * Fraction(1, 2) ** i for i, c in enumerate(q)])
+    )
+    large = unit_disk_profile(
+        polynomial([c * Fraction(2) ** i for i, c in enumerate(q)])
+    )
+    assert large.inside + large.on - small.inside == 2
+    assert small.on == large.on == 1
+
+
+def test_roots_arbitrarily_close_to_boundary_without_tolerance() -> None:
+    epsilon = Fraction(1, 10**200)
+    assert counts(polynomial([-(1 - epsilon), 1])) == (1, 0, 0)
+    assert counts(polynomial([-(1 + epsilon), 1])) == (0, 0, 1)
+
+
+def test_sparse_large_exponents_use_compressed_support() -> None:
+    assert counts(polynomial([-1, 1], stride=32768)) == (0, 32768, 0)
+    assert counts(polynomial([1], shift=32768)) == (32768, 0, 0)
+    assert counts(polynomial([2, -5, 2], stride=10000, shift=17)) == (10017, 0, 10000)
+
+
+def test_dense_degree_32_is_accepted() -> None:
+    assert counts(polynomial([i * i % 7 + 1 for i in range(33)])) == (18, 0, 14)
+
+
+def test_dense_degree_40_preserves_weighted_derivative_growth() -> None:
+    # Independently checked with exact rectangle winding counts.
+    assert counts(polynomial([i * i % 7 + 1 for i in range(41)])) == (20, 0, 20)
+
+
+@pytest.mark.parametrize("shift", [0, 32768])
+def test_single_term_large_scalar_needs_no_coefficient_arithmetic(shift: int) -> None:
+    source = polynomial([Fraction(10**20000, 3)], shift=shift)
+    assert counts(source) == (shift, 0, 0)
+
+
+def test_independent_exact_rectangle_winding_oracle() -> None:
+    from sympy import Poly, Symbol
+    from sympy.polys.domains import QQ
+    from sympy.polys.rootisolation import dup_count_complex_roots
+
+    random = Random(3152)
+    z = Symbol("z")
+    for _ in range(12):
+        coefficients = [random.randint(-5, 5) for _ in range(5)] + [1]
+        # Independent symbolic substitution plus Collins--Krandick winding
+        # numbers, rather than either of the production matrix signatures.
+        p = Poly.from_list(list(reversed(coefficients)), z)
+        q = Poly(
+            sum(
+                c * (1 + z) ** i * (1 - z) ** (5 - i)
+                for i, c in enumerate(coefficients)
+            ),
+            z,
+        )
+        bound = QQ.convert(2 + 2 * max(abs(c / q.LC()) for c in q.all_coeffs()))
+        dense = [QQ.convert(c) for c in q.all_coeffs()]
+        left = dup_count_complex_roots(
+            dense, QQ, (-bound, -bound), (0, bound), exclude=["E"]
+        )
+        right = dup_count_complex_roots(
+            dense, QQ, (0, -bound), (bound, bound), exclude=["W"]
+        )
+        assert counts(polynomial(coefficients)) == (
+            left,
+            int(p.degree()) - left - right,
+            right,
+        )
+
+
+def test_domain_and_resource_rejections_are_distinct() -> None:
+    with pytest.raises(OperationDomainValidationError, match="nonzero univariate"):
+        unit_disk_profile(polynomial([]))
+    multivariate = RationalPolynomial.model_validate(
+        {
+            "variables": ["x", "y"],
+            "polynomial": {
+                "terms": [{"coefficient": {"num": 1, "den": 1}, "exponents": [1, 1]}]
+            },
+        }
+    )
+    with pytest.raises(OperationDomainValidationError, match="nonzero univariate"):
+        unit_disk_profile(multivariate)
+    with pytest.raises(OperationResourceAdmissionError, match="derived"):
+        unit_disk_profile(polynomial([1] * 100))
+
+
+def test_earlier_caller_deadline_is_preserved() -> None:
+    with request_execution(monotonic()):
+        bind_request_deadline(monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            unit_disk_profile(polynomial([1, 1]))

--- a/tests/math/polynomials/test_unit_disk_profile.py
+++ b/tests/math/polynomials/test_unit_disk_profile.py
@@ -130,10 +130,14 @@ def test_single_term_large_scalar_needs_no_coefficient_arithmetic(shift: int) ->
 def test_removable_scalar_is_normalized_before_coefficient_height() -> None:
     # Primitive kernel is 1+z; the huge rational content is immaterial.
     assert counts(polynomial([10**20000, 10**20000])) == (0, 1, 0)
-    assert counts(
-        polynomial([Fraction(1, 10**20000), Fraction(1, 10**20000)])
-    ) == (0, 1, 0)
-    with pytest.raises(OperationResourceAdmissionError, match="cleared coefficient height"):
+    assert counts(polynomial([Fraction(1, 10**20000), Fraction(1, 10**20000)])) == (
+        0,
+        1,
+        0,
+    )
+    with pytest.raises(
+        OperationResourceAdmissionError, match="cleared coefficient height"
+    ):
         unit_disk_profile(polynomial([2**70_000, 2**70_000 + 1]))
 
 

--- a/tests/math/polynomials/test_unit_disk_profile.py
+++ b/tests/math/polynomials/test_unit_disk_profile.py
@@ -127,6 +127,16 @@ def test_single_term_large_scalar_needs_no_coefficient_arithmetic(shift: int) ->
     assert counts(source) == (shift, 0, 0)
 
 
+def test_removable_scalar_is_normalized_before_coefficient_height() -> None:
+    # Primitive kernel is 1+z; the huge rational content is immaterial.
+    assert counts(polynomial([10**20000, 10**20000])) == (0, 1, 0)
+    assert counts(
+        polynomial([Fraction(1, 10**20000), Fraction(1, 10**20000)])
+    ) == (0, 1, 0)
+    with pytest.raises(OperationResourceAdmissionError, match="cleared coefficient height"):
+        unit_disk_profile(polynomial([2**70_000, 2**70_000 + 1]))
+
+
 def test_independent_exact_rectangle_winding_oracle() -> None:
     from sympy import Poly, Symbol
     from sympy.polys.domains import QQ

--- a/tests/mcp/test_unit_disk_profile.py
+++ b/tests/mcp/test_unit_disk_profile.py
@@ -1,0 +1,56 @@
+"""Boundary-sensitive profile through the live MCP projection."""
+
+import asyncio
+
+from jacobian.math.polynomials.unit_circle import UnitDiskProfile, unit_disk_profile
+from jacobian.math.polynomials.values import RationalPolynomial
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_exact_profile_native_mcp_parity_and_recovery() -> None:
+    async def scenario() -> None:
+        async with Client(create_server(), raise_exceptions=False) as client:
+            source = RationalPolynomial.model_validate(
+                {
+                    "variables": ["z"],
+                    "polynomial": {
+                        "terms": [
+                            {"coefficient": {"num": c, "den": 1}, "exponents": [i]}
+                            for i, c in [(4, 1), (3, 1), (2, -1), (1, 1), (0, 1)]
+                        ]
+                    },
+                }
+            )
+            payload = {"polynomial": source.model_dump(mode="json")}
+            rejected = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "polynomial.root_location.unit_disk_profile.compute",
+                    "payload": {
+                        "polynomial": {"variables": ["z"], "polynomial": {"terms": []}}
+                    },
+                },
+            )
+            assert rejected.is_error
+            result = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "polynomial.root_location.unit_disk_profile.compute",
+                    "payload": payload,
+                },
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            assert result.structured_content["output"] == unit_disk_profile(
+                source
+            ).model_dump(mode="json")
+            import json
+
+            value = UnitDiskProfile.model_validate_json(
+                json.dumps(result.structured_content["output"])
+            )
+            assert (value.inside, value.on, value.outside) == (1, 2, 1)
+            assert unit_disk_profile(value.polynomial) == value
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Closes #3152. Exact polynomial root counts relative to the unit circle were unavailable. Numerical roots cannot decide boundary membership, and singular Schur–Cohn nullity can also arise from reciprocal roots off the circle: `2z²−5z+2` has profile `(1,0,1)`, while `1+z−z²+z³+z⁴` has `(1,2,1)`.

## Outcome

Adds `polynomial.root_location.unit_disk_profile.compute`, native `unit_disk_profile`, and `UnitDiskProfile` under the existing unit-circle owner. The result retains the canonical rational polynomial and its degree, with inside/on/outside counts including multiplicity. Nonzero constants give zero counts; zero or multivariate polynomials are rejected explicitly. No existing operation is superseded.

Schur–Cohn signature determines the inside/outside difference. A Cayley transform and real polynomial gcd determine boundary roots separately, including the root at −1 lost at infinity. Squarefree factors retain multiplicities. Hermite forms count real gcd roots, and exact real-rooted Descartes variation on maintained Berkowitz characteristic polynomials supplies matrix signatures. Production does not isolate algebraic roots or infer boundary counts from matrix nullity.

## Validation

Final tested tree: `631524f4e1488768203b5bd82eff298be56f4eee`.

- `make affected AFFECTED_BASE=origin/main`: all six stages passed, including scoped Ruff/mypy, 811 polynomial tests, 156 catalog tests, 915 catalog integration tests and 72 MCP tests.
- `make architecture`: passed, 1,342 files checked.
- `uv run --locked pytest tests/integration/catalog/test_public_operation_contract_conformance.py -m exhaustive -k 'polynomial.root_location.unit_disk_profile.compute' --timeout=120 -q`: 1 passed, 881 deselected.
- Twenty owner regressions include twelve independent exact rectangle-winding comparisons; the live MCP fixture reproduces the issue comment's Boolean quartic and round-trips its canonical source.

Independent exact-diff review and one consolidated followup found no unresolved issues. Review repairs preserve large scalar monomials and tighten squarefree derivative growth. An earlier degree-40 rejection became an accepted regression: the bounded kernel diagnostic took about 0.16 seconds, and an independent exact Collins–Krandick winding computation confirmed `(20,0,20)` in 2.70 seconds. The degree-32 regression was independently checked the same way. Timing calibrates the deadline; it does not replace admission bounds.

## Contract impact

- The existing `RationalPolynomial` is the sole source carrier; the result retains its variable and exact coefficients unchanged through serialization and native/MCP composition.
- Constructors check structure. The native operation computes semantic admission once, and MCP invokes that same path. Authored profile counts are ordinary values, not verified claims; no consumer relies on authored counts.
- Counts sum to the source degree and partition its finite root multiset. Repeated real/complex factors, both issue-comment fixtures, reciprocal/scalar invariance, rational-radius annulus composition, roots within `10^-200` of the boundary, zero/constant cases and deadline preservation are covered.
- All phases share a 60-second operation deadline, shortened by an earlier caller deadline. No partial root counts are returned on non-completion.

## Operation boundary and catalog admission

The stable postcondition is the exact root-multiplicity partition relative to the unit circle. Existing unit-circle energy and narrow reciprocal-quadratic operations do not supply it. Full algebraic splitting is stronger than the requested count. A rational radius remains caller composition via `p(r*z)`; this PR adds no separate annulus or Gaussian-rational contract.

Admission removes zero roots and compresses the gcd of support exponents before any dense expansion. Single-term inputs require no coefficient arithmetic. These regimes admit sparse degree-32768 sources and a monomial with a 20,001-digit scalar, alongside dense degree-40 input. FLINT 3.6.0 through python-flint 0.9.0 supplies integer polynomial squarefree decomposition and gcd; SymPy 1.14 supplies explicitly selected division-free Berkowitz using FLINT-backed integers.

General requests are bounded by source support (4,096 terms), cleared coefficient height (65,536 bits), a 100-million coefficient-operation/word-height work proxy, 16,777,216-bit intermediate height, and 268,435,456 bits of bounded characteristic-polynomial allocation. These are mathematical arithmetic/allocation limits, independent of transport encoding. Mignotte/Mahler bounds control factor and weighted-derivative growth, Cayley expansion and Hermite matrix coefficients; fixed-degree Berkowitz bounds control exact matrix work and intermediates. The work proxy is not a bit-operation or wall-time complexity claim.

**Remaining limitation:** higher reduced degrees or coefficient heights can still exceed the conservative matrix/gcd envelope. There is no fixed restriction on original degree beyond the shared polynomial representation when sparse compression removes that work. Gaussian-rational coefficients remain future scope as allowed by the issue.

## Research and review closure

The singular-form distinction follows [Heinig–Rost, Bezoutians, Theorems 10.4 and 10.9](https://www.tu-chemnitz.de/mathematik/preprint/2008/PREPRINT_09.pdf). Backend contracts were checked through Context7 and pinned source: [FLINT squarefree decomposition](https://github.com/flintlib/flint/blob/v3.6.0/src/fmpz_poly_factor/factor_squarefree.c), [FLINT gcd dispatch](https://github.com/flintlib/flint/blob/v3.6.0/src/fmpz_poly/gcd.c), [FLINT modular gcd bounds](https://github.com/flintlib/flint/blob/v3.6.0/src/fmpz_poly/gcd_modular.c), and [SymPy dense Berkowitz](https://github.com/sympy/sympy/blob/sympy-1.14.0/sympy/polys/matrices/dense.py). Maintained exact rectangle counting was evaluated as an alternative and retained as an independent test oracle; its root-isolation workload is unnecessary in production.

The full issue and its boundary/reciprocal comment were read. Existing source and open/merged PRs were checked for coverage; no overlapping operation was found. All required hosted CI checks passed for final head `631524f4e1488768203b5bd82eff298be56f4eee` ([CI run](https://github.com/morluto/jacobian/actions/runs/34173769023)).
