### PR TITLE
feat(hypergraphs): construct complete same-color union conflicts

### DIFF
--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/__init__.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/__init__.py
@@ -1,0 +1,10 @@
+"""Same-colour union conflicts with complete source-edge provenance."""
+
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts._models import (
+    SameColorConflictsResult,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts.operations import (
+    construct,
+)
+
+__all__ = ["SameColorConflictsResult", "construct"]

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_models.py
@@ -1,0 +1,68 @@
+"""Complete same-colour union conflicts and their source-edge provenance."""
+
+from typing import Annotated, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.colorings import (
+    IndexedHyperedgeColoring,
+)
+
+MAX_CONFLICT_PAIRS = 65_536
+
+
+class SameColorConflictsRequest(StrictModel):
+    coloring: IndexedHyperedgeColoring
+
+
+class SameColorConflictProvenance(StrictModel):
+    """One unordered source-edge pair producing the named conflict union.
+
+    Source IDs occur in their retained source-edge-axis order; the colour index
+    identifies their common colour. Different source IDs remain distinct even
+    if they have equal vertex sets.
+    """
+
+    conflict_edge_id: str = Field(max_length=64)
+    source_edge_ids: tuple[
+        Annotated[str, Field(max_length=64)], Annotated[str, Field(max_length=64)]
+    ]
+    color_index: int = Field(ge=0, lt=12_000)
+
+
+class SameColorConflictsResult(StrictModel):
+    """One edge per distinct union, with complete flat source-pair provenance.
+
+    Vertices retain the source order. Conflict edges follow increasing bitmask
+    of source vertex positions, with IDs c0,c1,...; this transports unchanged
+    under coherent relabelling. Provenance follows lexicographic source-edge
+    position pairs, across all colours. Empty unions are retained as empty
+    hyperedges: then no vertex subset, including the empty one, is independent.
+    The existing independence-number consumer admits only nonempty hyperedges.
+    """
+
+    coloring: IndexedHyperedgeColoring
+    hypergraph: FiniteHypergraph
+    provenance: tuple[SameColorConflictProvenance, ...] = Field(
+        max_length=MAX_CONFLICT_PAIRS
+    )
+
+    @model_validator(mode="after")
+    def require_source_references(self) -> Self:
+        if self.hypergraph.vertices != self.coloring.hypergraph.vertices:
+            raise ValueError("conflict vertices must retain the source vertex axis")
+        source_ids = {edge_id for edge_id, _ in self.coloring.hypergraph.edges}
+        result_ids = {edge_id for edge_id, _ in self.hypergraph.edges}
+        for row in self.provenance:
+            left, right = row.source_edge_ids
+            if left == right or left not in source_ids or right not in source_ids:
+                raise ValueError("provenance must reference two distinct source IDs")
+            if row.conflict_edge_id not in result_ids:
+                raise ValueError("provenance must reference a declared conflict edge")
+            if row.color_index >= self.coloring.color_count:
+                raise ValueError("provenance colour must belong to the source palette")
+        return self

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_tools.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/_tools.py
@@ -1,0 +1,61 @@
+"""Same-colour union-conflict operation declaration."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts._models import (
+    SameColorConflictsRequest,
+    SameColorConflictsResult,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts.operations import (
+    construct,
+)
+
+
+def _construct(request: SameColorConflictsRequest) -> SameColorConflictsResult:
+    return construct(request.coloring)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="hypergraph.same_color_conflicts.construct",
+        title="Construct complete same-colour union conflicts",
+        description=(
+            "Given an indexed edge colouring, return one conflict hyperedge per "
+            "distinct union of two distinct equally coloured source edges, plus "
+            "complete source-edge-pair provenance. A vertex subset is independent "
+            "exactly when its induced source hypergraph is rainbow. Equal member "
+            "sets with different source IDs remain distinct; duplicate unions "
+            "share one conflict edge. Nonuniform and empty source edges are allowed. "
+            "The conflict FiniteHypergraph composes with structural and independence "
+            "operations (the independence consumer excludes empty hyperedges). "
+            "Admits at most 65536 source pairs, 12000 distinct unions and 36000 "
+            "union incidences on the existing 256-vertex carrier; no truncation."
+        ),
+        request_type=SameColorConflictsRequest,
+        result_type=SameColorConflictsResult,
+        run=_construct,
+        tags=("hypergraph", "coloring", "rainbow", "conflict", "union"),
+        examples=(
+            OperationExample(
+                name="repeated_triangle_edges",
+                description="Three equally coloured edges produce one triangle conflict.",
+                input={
+                    "coloring": {
+                        "hypergraph": {
+                            "vertices": ["a", "b", "c"],
+                            "edges": [
+                                ["ab", ["a", "b"]],
+                                ["ac", ["a", "c"]],
+                                ["bc", ["b", "c"]],
+                            ],
+                        },
+                        "color_count": 1,
+                        "assignments": [
+                            {"edge_id": edge_id, "color_index": 0}
+                            for edge_id in ("ab", "ac", "bc")
+                        ],
+                    }
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/operations.py
@@ -1,0 +1,145 @@
+"""Exact bitset union planning followed by complete source-pair expansion."""
+
+from bisect import bisect_left
+from dataclasses import dataclass
+from itertools import combinations, groupby
+from time import monotonic
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+)
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_TOTAL_INCIDENCES,
+    FiniteHypergraph,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.colorings import (
+    IndexedHyperedgeColoring,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts._models import (
+    MAX_CONFLICT_PAIRS,
+    SameColorConflictProvenance,
+    SameColorConflictsResult,
+)
+
+__all__ = ["construct"]
+
+
+def _checkpoint(deadline: float, stage: str) -> None:
+    request_checkpoint(stage)
+    if monotonic() >= deadline:
+        raise OperationExecutionTimeoutError("same-colour conflict deadline expired")
+
+
+def _reject(message: str) -> None:
+    raise OperationResourceAdmissionError(
+        location=("coloring",),
+        code="same_color_conflicts.resource_bound",
+        message=message,
+    )
+
+
+@dataclass(frozen=True)
+class _Plan:
+    masks: tuple[int, ...]
+    groups: tuple[tuple[int, ...], ...]
+    unions: tuple[int, ...]
+
+
+def _admit(coloring: IndexedHyperedgeColoring, deadline: float) -> _Plan:
+    """Admit pairs, compute compressed unions, then admit exact output size.
+
+    P=sum_c choose(|E_c|,2) bounds provenance and original pair expansion.
+    Source incidences are <=36000, masks have <=256 bits, and P<=65536.
+    Duplicate member sets within each colour are grouped before union planning:
+    distinct-type pairs and repeated types together number at most P. Sorting
+    these <=P masks avoids dependence on numeric-hash collision behaviour.
+    Exact distinct-union counts/incidences are admitted before source pairs are
+    expanded. This admits repeated sources whose many pairs have one union.
+
+    All admitted work is polynomial: O(I + E log E + P log P) operations on
+    <=256-bit integers, plus <=36000 output memberships and P provenance rows.
+    Retained source labels/IDs and two source IDs per provenance row have the
+    existing 64-character carrier bound; no unbounded label namespace is made.
+    Even six encoded bytes per label character, all retained source incidences,
+    assignments, graph incidences and provenance fit below 128 MiB. This is
+    derived from the mathematical row/label bounds, not a transport setting.
+    """
+    _checkpoint(deadline, "before conflict admission")
+    groups: list[list[int]] = [[] for _ in range(coloring.color_count)]
+    for index, assignment in enumerate(coloring.assignments):
+        groups[assignment.color_index].append(index)
+    pair_count = sum(len(group) * (len(group) - 1) // 2 for group in groups)
+    if pair_count > MAX_CONFLICT_PAIRS:
+        _reject("complete same-colour source-pair provenance exceeds 65536 rows")
+    positions = {
+        label: index for index, label in enumerate(coloring.hypergraph.vertices)
+    }
+    masks = tuple(
+        sum(1 << positions[label] for label in members)
+        for _, members in coloring.hypergraph.edges
+    )
+    candidates: list[int] = []
+    for group in groups:
+        _checkpoint(deadline, "during compressed union planning")
+        types = tuple(
+            (mask, len(tuple(duplicates)))
+            for mask, duplicates in groupby(sorted(masks[index] for index in group))
+        )
+        candidates.extend(mask for mask, multiplicity in types if multiplicity > 1)
+        candidates.extend(left[0] | right[0] for left, right in combinations(types, 2))
+    unions = tuple(mask for mask, _ in groupby(sorted(candidates)))
+    if len(unions) > MAX_EDGES:
+        _reject("distinct conflict unions exceed the 12000-edge carrier")
+    if sum(mask.bit_count() for mask in unions) > MAX_TOTAL_INCIDENCES:
+        _reject("distinct conflict unions exceed the 36000-incidence carrier")
+    _checkpoint(deadline, "after conflict admission")
+    return _Plan(masks, tuple(tuple(group) for group in groups), unions)
+
+
+def construct(coloring: IndexedHyperedgeColoring) -> SameColorConflictsResult:
+    """Return every union of distinct equally coloured source edges, with pairs."""
+    execution = current_request_execution()
+    deadline = (execution.started_at if execution is not None else monotonic()) + 60
+    if execution is not None and execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    plan = _admit(coloring, deadline)
+    vertices = coloring.hypergraph.vertices
+    edges = tuple(
+        (
+            f"c{index}",
+            tuple(label for bit, label in enumerate(vertices) if mask >> bit & 1),
+        )
+        for index, mask in enumerate(plan.unions)
+    )
+    source_ids = tuple(edge_id for edge_id, _ in coloring.hypergraph.edges)
+    pairs = sorted(
+        (left, right, color)
+        for color, group in enumerate(plan.groups)
+        for left, right in combinations(group, 2)
+    )
+    provenance: list[SameColorConflictProvenance] = []
+    for left, right, color in pairs:
+        _checkpoint(deadline, "during conflict provenance expansion")
+        union = plan.masks[left] | plan.masks[right]
+        union_index = bisect_left(plan.unions, union)
+        provenance.append(
+            SameColorConflictProvenance(
+                conflict_edge_id=f"c{union_index}",
+                source_edge_ids=(source_ids[left], source_ids[right]),
+                color_index=color,
+            )
+        )
+    _checkpoint(deadline, "before conflict result construction")
+    result = SameColorConflictsResult(
+        coloring=coloring,
+        hypergraph=FiniteHypergraph(vertices=vertices, edges=edges),
+        provenance=tuple(provenance),
+    )
+    _checkpoint(deadline, "after conflict result construction")
+    return result

--- a/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/same_color_conflicts/test_conflicts.py
@@ -1,0 +1,227 @@
+"""Independent set-union oracle and complete rainbow/independence equivalence."""
+
+from collections.abc import Sequence
+from itertools import combinations, product
+from time import monotonic
+
+import pytest
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.finite_structures.hypergraphs import (
+    FiniteHypergraph,
+    independence_number,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.colorings import (
+    HyperedgeColorAssignment,
+    IndexedHyperedgeColoring,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts import (
+    SameColorConflictsResult,
+    construct,
+)
+
+
+def coloring(
+    vertices: tuple[str, ...],
+    members: Sequence[tuple[str, ...]],
+    colors: Sequence[int],
+) -> IndexedHyperedgeColoring:
+    palette = sorted(set(colors))
+    return IndexedHyperedgeColoring(
+        hypergraph=FiniteHypergraph(
+            vertices=vertices,
+            edges=tuple((f"e{i}", edge) for i, edge in enumerate(members)),
+        ),
+        color_count=len(palette),
+        assignments=tuple(
+            HyperedgeColorAssignment(edge_id=f"e{i}", color_index=palette.index(color))
+            for i, color in enumerate(colors)
+        ),
+    )
+
+
+def check_oracle(source: IndexedHyperedgeColoring) -> SameColorConflictsResult:
+    result = construct(source)
+    expected = {}
+    edges = source.hypergraph.edges
+    for left, right in combinations(range(len(edges)), 2):
+        color = source.assignments[left].color_index
+        if color == source.assignments[right].color_index:
+            expected[edges[left][0], edges[right][0]] = (
+                frozenset(edges[left][1]) | frozenset(edges[right][1]),
+                color,
+            )
+    conflicts = {
+        edge_id: frozenset(members) for edge_id, members in result.hypergraph.edges
+    }
+    assert len(set(conflicts.values())) == len(conflicts)
+    assert set(conflicts.values()) == {union for union, _ in expected.values()}
+    assert {
+        row.source_edge_ids: (conflicts[row.conflict_edge_id], row.color_index)
+        for row in result.provenance
+    } == expected
+    assert len(result.provenance) == len(expected)
+    assert [row.source_edge_ids for row in result.provenance] == list(expected)
+    assert result.coloring == source
+    assert result.hypergraph.vertices == source.hypergraph.vertices
+    assert (
+        SameColorConflictsResult.model_validate_json(result.model_dump_json()) == result
+    )
+    if len(source.hypergraph.vertices) <= 8:
+        for size in range(len(source.hypergraph.vertices) + 1):
+            for subset in combinations(source.hypergraph.vertices, size):
+                selected = set(subset)
+                contained_colors = [
+                    entry.color_index
+                    for (_, members), entry in zip(
+                        edges, source.assignments, strict=True
+                    )
+                    if set(members) <= selected
+                ]
+                rainbow = len(contained_colors) == len(set(contained_colors))
+                independent = not any(union <= selected for union in conflicts.values())
+                assert rainbow == independent
+    return result
+
+
+@pytest.mark.parametrize("colors", tuple(product(range(2), repeat=4)))
+def test_all_two_color_assignments_with_nonuniform_and_empty_edges(
+    colors: tuple[int, ...],
+) -> None:
+    check_oracle(
+        coloring(("a", "b", "c"), [(), ("a",), ("a", "b"), ("b", "c")], colors)
+    )
+
+
+@pytest.mark.parametrize(
+    "vertices,members,colors",
+    [
+        ((), [], []),
+        (("a", "b"), [], []),
+        (("a",), [("a",)], [0]),
+        (("a",), [(), ()], [0, 0]),
+        (("a", "b"), [("a",), ("a",), ("b",), ("b",)], [0, 0, 1, 1]),
+        (("a", "b", "c"), [("a", "b"), ("a", "c"), ("b", "c")], [0, 0, 0]),
+    ],
+)
+def test_empty_duplicate_sources_and_duplicate_unions(
+    vertices: tuple[str, ...], members: list[tuple[str, ...]], colors: list[int]
+) -> None:
+    check_oracle(coloring(vertices, members, colors))
+
+
+def test_multiple_colors_can_produce_the_same_union() -> None:
+    result = check_oracle(
+        coloring(("a", "b"), [("a",), ("b",), ("a",), ("b",)], [0, 0, 1, 1])
+    )
+    assert result.hypergraph.edges == (("c0", ("a", "b")),)
+    assert [row.color_index for row in result.provenance] == [0, 1]
+
+
+def test_coherent_vertex_and_source_edge_relabeling() -> None:
+    source = coloring(("z", "a", "b"), [("z", "a"), ("a", "b"), ("b",)], [0, 0, 0])
+    original = check_oracle(source)
+    labels = {"z": "e\u0301", "a": "é", "b": ""}
+    renamed = IndexedHyperedgeColoring(
+        hypergraph=FiniteHypergraph(
+            vertices=tuple(labels[v] for v in source.hypergraph.vertices),
+            edges=tuple(
+                (f"renamed-{edge_id}", tuple(labels[v] for v in members))
+                for edge_id, members in source.hypergraph.edges
+            ),
+        ),
+        color_count=source.color_count,
+        assignments=tuple(
+            HyperedgeColorAssignment(
+                edge_id=f"renamed-{row.edge_id}", color_index=row.color_index
+            )
+            for row in reversed(source.assignments)
+        ),
+    )
+    result = check_oracle(renamed)
+    assert result.hypergraph.edges == tuple(
+        (edge_id, tuple(sorted(labels[v] for v in members)))
+        for edge_id, members in original.hypergraph.edges
+    )
+    assert [row.conflict_edge_id for row in result.provenance] == [
+        row.conflict_edge_id for row in original.provenance
+    ]
+
+
+def test_all_source_edges_with_distinct_colors_are_accepted() -> None:
+    source = coloring(("v",), [("v",)] * 12_000, list(range(12_000)))
+    result = construct(source)
+    assert result.hypergraph.edges == ()
+    assert result.provenance == ()
+    assert independence_number(result.hypergraph).independence_number == 1
+
+
+def test_many_duplicate_sources_fit_one_union_at_pair_boundary() -> None:
+    result = construct(coloring(("v",), [("v",)] * 362, [0] * 362))
+    assert result.hypergraph.edges == (("c0", ("v",)),)
+    assert len(result.provenance) == 65_341
+    assert result.provenance[0].source_edge_ids == ("e0", "e1")
+    assert result.provenance[-1].source_edge_ids == ("e360", "e361")
+
+
+def test_complete_provenance_bound_rejects() -> None:
+    with pytest.raises(OperationResourceAdmissionError, match="provenance"):
+        construct(coloring(("v",), [("v",)] * 363, [0] * 363))
+
+
+def test_distinct_union_carrier_bound_rejects() -> None:
+    vertices = tuple(f"v{i}" for i in range(160))
+    with pytest.raises(OperationResourceAdmissionError, match="12000-edge"):
+        construct(coloring(vertices, [(v,) for v in vertices], [0] * 160))
+
+
+def test_union_incidence_bound_rejects() -> None:
+    vertices = tuple(f"v{i}" for i in range(130))
+    members = [(*vertices[:100], vertices[i]) for i in range(100, 130)]
+    with pytest.raises(OperationResourceAdmissionError, match="36000-incidence"):
+        construct(coloring(vertices, members, [0] * 30))
+
+
+@pytest.mark.parametrize("expired_bound", [False, True])
+def test_expired_request_context(expired_bound: bool) -> None:
+    source = coloring(("v",), [("v",)] * 2, [0, 0])
+    with request_execution(monotonic() if expired_bound else monotonic() - 100):
+        if expired_bound:
+            bind_request_deadline(monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            construct(source)
+
+
+def test_native_all_distinct_distances_compose_to_full_independent_set() -> None:
+    from jacobian._exact import CanonicalRational
+    from jacobian.math.geometry.exact._models import (
+        LabelledRationalPoint,
+        PointConfiguration,
+    )
+    from jacobian.math.geometry.exact.distance_edge_coloring import (
+        compute_distance_edge_coloring,
+    )
+
+    source = PointConfiguration(
+        points=tuple(
+            LabelledRationalPoint(
+                label=f"p{i}", coordinates=(CanonicalRational(num=x, den=1),)
+            )
+            for i, x in enumerate((0, 1, 3, 7))
+        )
+    )
+    distances = compute_distance_edge_coloring(source)
+    result = check_oracle(
+        IndexedHyperedgeColoring.model_validate_json(
+            distances.coloring.model_dump_json()
+        )
+    )
+    assert result.hypergraph.edges == ()
+    independent = independence_number(result.hypergraph)
+    assert independent.status == "EXACT"
+    assert independent.independence_number == 4

--- a/tests/mcp/test_same_color_conflicts.py
+++ b/tests/mcp/test_same_color_conflicts.py
@@ -1,0 +1,75 @@
+"""Exact geometry-to-conflict-to-independence composition through live MCP."""
+
+import asyncio
+import json
+
+from jsonschema import validate
+
+from jacobian.math.combinatorics.finite_structures.hypergraphs.same_color_conflicts._tools import (
+    TOOLS,
+)
+from jacobian.math.geometry.exact.distance_edge_coloring._tools import (
+    TOOLS as DISTANCE_TOOLS,
+)
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_conflicts_native_schema_and_complete_distance_chain() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        validate(payload, tool.request_type.model_json_schema())
+        native = tool.run(tool.request_type.model_validate_json(json.dumps(payload)))
+        async with Client(create_server(), raise_exceptions=False) as client:
+            invalid = json.loads(json.dumps(payload))
+            invalid["coloring"]["assignments"].pop()
+            rejected = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": invalid}
+            )
+            assert rejected.is_error
+            response = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not response.is_error
+            assert response.structured_content is not None
+            output = response.structured_content["output"]
+            validate(output, tool.result_type.model_json_schema())
+            assert output == native.model_dump(mode="json")
+            distance_tool = DISTANCE_TOOLS[0]
+            distances = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": distance_tool.operation_id,
+                    "payload": distance_tool.examples[0].input,
+                },
+            )
+            assert not distances.is_error
+            assert distances.structured_content is not None
+            geometry = distances.structured_content["output"]
+            conflicts = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": {"coloring": geometry["coloring"]},
+                },
+            )
+            assert not conflicts.is_error
+            assert conflicts.structured_content is not None
+            conflict_output = conflicts.structured_content["output"]
+            assert conflict_output["coloring"] == geometry["coloring"]
+            assert len(conflict_output["provenance"]) == 7
+            assert len(conflict_output["hypergraph"]["edges"]) == 5
+            independent = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "hypergraph.independence_number.compute",
+                    "payload": {"hypergraph": conflict_output["hypergraph"]},
+                },
+            )
+            assert not independent.is_error
+            assert independent.structured_content is not None
+            assert independent.structured_content["output"]["status"] == "EXACT"
+            assert independent.structured_content["output"]["independence_number"] == 2
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Closes #2493. A coloured finite hypergraph needs a complete union-conflict transform with source-edge provenance before its rainbow induced subsets can be studied through ordinary hypergraph independence.

## Outcome

Adds `hypergraph.same_color_conflicts.construct` and native `construct`. For every unordered pair of distinct equally coloured source edge IDs, it records the union and that pair. Equal unions share one conflict edge; equal source vertex sets with different edge IDs remain distinct sources. Flat provenance retains both source IDs and their common colour index.

This PR depends on #3530 and targets its branch. It reuses that PR's `IndexedHyperedgeColoring` unchanged; the diff contains only the conflict operation and its tests. No existing operation is superseded.

The output retains the source colouring and a directly consumable `FiniteHypergraph`. Conflict vertices retain the source axis, conflict edges follow increasing source-position bitmask with IDs `c0,c1,...`, and provenance follows source-edge position pairs. Coherent vertex/edge relabelling preserves these identities. Nonuniform and empty source edges are included. An empty conflict edge correctly means no independent vertex subset exists; the existing independence-number consumer excludes that case.

A subset is independent in the result exactly when the induced source hypergraph has no repeated edge colour. This is the union construction used in [Lee–Lefmann, Section 6, proof of Theorem 8](https://arxiv.org/pdf/1602.03569). The operation constructs the finite obstruction hypergraph; it does not optimize or prove an anti-Ramsey bound.

## Admission and implementation

The exact pair count `P = sum_c choose(|E_c|,2)` is admitted before original pair expansion. Source member sets become bounded bitmasks. Within each colour, duplicate member sets are grouped before union planning, allowing many source pairs to share one small output. Exact distinct-union counts and incidences are then admitted before emitting complete provenance.

The existing carrier allows 256 vertices, 12,000 source edges and 36,000 incidences. The operation admits at most 65,536 provenance pairs, 12,000 distinct unions and 36,000 union incidences. Sorting/grouping/binary search avoids numeric-hash assumptions. All phases retain the request's original start, existing deadline and cancellation context. Nothing is truncated.

## Validation

- Final head: `7997b43eb`.
- `make affected AFFECTED_BASE=3d2610220`: 6 commands passed; scoped Ruff/mypy, 32 math, 156 catalog, 916 catalog/integration and 73 MCP tests.
- `make architecture`: passed (1,350 files).
- Scoped exhaustive public-operation conformance: 1 passed, 882 deselected for `hypergraph.same_color_conflicts.construct`.
- Hosted CI passed on exact head `7997b43eb` and parent base `3d2610220`: [CI run](https://github.com/morluto/jacobian/actions/runs/34174393292). Static, math, catalog, catalog examples, MCP and the required aggregate passed. This stacked PR uses explicit dispatch because automatic PR CI targets main only.

- Independent set-union and exhaustive subset oracles cover every two-colour assignment on a small nonuniform family, duplicate sources/unions, multiple colours producing one union, and empty/degenerate inputs.
- Native all-distinct distance colouring serializes unchanged into conflicts and yields independence number 4.
- Live MCP checks invalid-input recovery, native/schema parity, and the full unit-square distance-colouring → conflict → independence chain: 7 source pairs, 5 distinct unions, exact independence number 2.
- Accepted scale: 362 repeated source edges produce 65,341 provenance rows and one union in 0.418 seconds; 12,000 independently coloured source edges produce no conflicts in 0.089 seconds. Timings exclude source construction.
- Rejection tests cover complete-provenance, distinct-union and incidence bounds; expired shared contexts raise operational timeouts.
- Result parsing checks structural source references without replaying union completeness or mathematical provenance.

## Review closure

Independent exact-diff review found no issues. The reviewer independently ran all 33 focused math/MCP tests and confirmed all three issue discovery queries rank the operation first. Inherited parent implementation was excluded from this focused review and is separately reviewed/tested in #3530.
