### PR TITLE
fix(math): preserve native contracts and admit tractable exact workloads

### DIFF
--- a/docs/reference/value-interoperability.md
+++ b/docs/reference/value-interoperability.md
@@ -38,6 +38,18 @@ representable. This is not a computational admission promise: each consumer
 retains its own work and size limits. Label-based `SimpleUndirectedGraph`
 values retain their separate 256-vertex envelope.
 
+Frame operations share `VectorFamily`, whose required `dimension` retains the
+standard Euclidean ambient space even when `vectors` is empty. Coordinates are
+integers. Gram computation accepts empty families in any admitted dimension;
+frame potential and coherence additionally require spanning. The empty family
+spans dimension zero, with potential and squared coherence zero and no
+maximizing pair. Coherence rejects any zero vector.
+
+Cubical face closure separates its source-cell envelope from its exact result
+envelope. A full cube at the largest supported ambient dimension remains
+representable; distinct generated faces share one bounded admission set, so
+repeated source cubes do not multiply the output estimate.
+
 ## Values, witnesses, and source binding
 
 | Need | Appropriate result |

--- a/src/jacobian/canonical.py
+++ b/src/jacobian/canonical.py
@@ -71,6 +71,16 @@ def _reject_constant(_value: str) -> NoReturn:
     raise CanonicalizationError("non-finite JSON value is not allowed")
 
 
+def _parse_json_integer(value: str) -> int:
+    if len(value.lstrip("-")) > 16:
+        raise CanonicalizationError(
+            "JSON integers outside the interoperable range must be encoded as strings"
+        )
+    integer = int(value)
+    _validate_json_integer(integer)
+    return integer
+
+
 def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:
@@ -90,7 +100,10 @@ def loads_strict_json(
     """Parse JSON while rejecting duplicate keys, floats, and oversized input."""
 
     active_limits = limits or CanonicalLimits()
-    raw = value.encode("utf-8") if isinstance(value, str) else bytes(value)
+    try:
+        raw = value.encode("utf-8") if isinstance(value, str) else bytes(value)
+    except UnicodeEncodeError as exc:
+        raise CanonicalizationError("JSON input must be valid UTF-8") from exc
     if len(raw) > active_limits.max_input_bytes:
         raise CanonicalizationError("JSON input exceeds the configured size limit")
     try:
@@ -100,9 +113,10 @@ def loads_strict_json(
     if text.startswith("\ufeff"):
         raise CanonicalizationError("JSON input must not contain a UTF-8 BOM")
     try:
-        return json.loads(
+        parsed = json.loads(
             text,
             object_pairs_hook=_unique_object,
+            parse_int=_parse_json_integer,
             parse_float=_reject_float,
             parse_constant=_reject_constant,
         )
@@ -110,6 +124,8 @@ def loads_strict_json(
         raise
     except (json.JSONDecodeError, RecursionError) as exc:
         raise CanonicalizationError("invalid or excessively nested JSON") from exc
+    _validate_json_value(parsed, limits=active_limits, depth=0)
+    return parsed
 
 
 def _normalize_rational(

--- a/src/jacobian/cli.py
+++ b/src/jacobian/cli.py
@@ -10,7 +10,11 @@ import typer
 from typer import _click
 from typer.core import TyperGroup
 
-from jacobian.canonical import loads_strict_json
+from jacobian.canonical import CanonicalizationError, loads_strict_json
+
+
+class _InvalidArgumentError(ValueError):
+    """An invalid CLI argument or payload source."""
 
 
 class JacobianGroup(TyperGroup):
@@ -22,9 +26,30 @@ class JacobianGroup(TyperGroup):
         except (_click.ClickException, typer.Abort, typer.Exit):
             raise
         except Exception as exc:
-            code = (
-                "INVALID_ARGUMENT" if isinstance(exc, ValueError) else "COMMAND_FAILED"
+            from jacobian.catalog.models import (
+                OperationDomainValidationError,
+                OperationResourceAdmissionError,
             )
+            from jacobian.dispatch import (
+                OperationRequestValidationError,
+                _OperationResolutionError,
+            )
+
+            if isinstance(exc, OperationResourceAdmissionError):
+                code = "RESOURCE_NOT_ADMITTED"
+            elif isinstance(
+                exc,
+                (
+                    _InvalidArgumentError,
+                    CanonicalizationError,
+                    OperationRequestValidationError,
+                    OperationDomainValidationError,
+                    _OperationResolutionError,
+                ),
+            ):
+                code = "INVALID_ARGUMENT"
+            else:
+                code = "COMMAND_FAILED"
             typer.echo(
                 json.dumps(
                     {
@@ -57,7 +82,7 @@ def inspect_operation(operation_id: str) -> None:
 
     descriptor = Catalog.open().inspect(operation_id)
     if descriptor is None:
-        raise ValueError(f"operation {operation_id!r} is not installed")
+        raise _InvalidArgumentError(f"operation {operation_id!r} is not installed")
     _emit(descriptor.model_dump(mode="json"))
 
 
@@ -75,16 +100,17 @@ def run_operation(
     """Run one installed operation with one parsed JSON payload."""
 
     if (json_payload is None) == (file is None):
-        raise ValueError("pass exactly one of --json or --file")
+        raise _InvalidArgumentError("pass exactly one of --json or --file")
+    source: str | bytes
     if json_payload is not None:
-        source = json_payload.encode("utf-8")
+        source = json_payload
     elif file is not None:
         source = file.read_bytes()
     else:
-        raise ValueError("pass exactly one of --json or --file")
+        raise _InvalidArgumentError("pass exactly one of --json or --file")
     payload = loads_strict_json(source)
     if not isinstance(payload, dict):
-        raise ValueError("operation payload must be a JSON object")
+        raise _InvalidArgumentError("operation payload must be a JSON object")
     from jacobian.catalog.catalog import Catalog
     from jacobian.dispatch import invoke_operation
 

--- a/src/jacobian/math/algebra/affine_map_word_collision/operations.py
+++ b/src/jacobian/math/algebra/affine_map_word_collision/operations.py
@@ -7,7 +7,10 @@ from dataclasses import dataclass
 from fractions import Fraction
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math._rational_height import RationalHeight, sum_heights
 from jacobian.math.algebra.affine_map_word_collision._models import (
     MAX_COMPOSITION_WORK,
@@ -315,6 +318,8 @@ def _composed_words(
 def verify_word_collision_profile(claim: WordCollisionProfileResult) -> bool:
     """Verify composed maps and complete collision multiplicities from the family."""
 
+    if not isinstance(claim, WordCollisionProfileResult):
+        return False
     try:
         generators = tuple(
             (item.slope.as_fraction(), item.intercept.as_fraction())
@@ -322,7 +327,9 @@ def verify_word_collision_profile(claim: WordCollisionProfileResult) -> bool:
         )
         expected = compute_word_collision_profile(generators, claim.depth)
         return expected.rows == claim.rows
-    except (ArithmeticError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/analysis/approximation/operations.py
+++ b/src/jacobian/math/analysis/approximation/operations.py
@@ -8,7 +8,10 @@ from fractions import Fraction
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.analysis.approximation._models import (
     LagrangeBasisPolynomial,
     LagrangeBasisResult,
@@ -170,6 +173,8 @@ def lagrange_basis(nodes: RationalNodeSet) -> LagrangeBasisResult:
 def verify_lagrange_basis(claim: LagrangeBasisResult) -> bool:
     """Verify basis polynomials, cardinality, partition, and weights."""
 
+    if not isinstance(claim, LagrangeBasisResult):
+        return False
     try:
         expected = lagrange_basis(claim.nodes)
         if expected != claim:
@@ -186,13 +191,17 @@ def verify_lagrange_basis(claim: LagrangeBasisResult) -> bool:
             == 1
             for point in points
         )
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_lagrange_interpolation(claim: LagrangeInterpolationResult) -> bool:
     """Verify an interpolant against its retained node and value axes."""
 
+    if not isinstance(claim, LagrangeInterpolationResult):
+        return False
     try:
         if lagrange_interpolation(claim.source) != claim:
             return False
@@ -203,7 +212,9 @@ def verify_lagrange_interpolation(claim: LagrangeInterpolationResult) -> bool:
                 claim.source.nodes.nodes, claim.source.values, strict=True
             )
         )
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/analysis/boolean/_models.py
+++ b/src/jacobian/math/analysis/boolean/_models.py
@@ -63,6 +63,8 @@ class BooleanWalshTransformResult(StrictModel):
     using the fast Walsh-Hadamard transform in Hadamard (natural) order.
     """
 
+    source: BooleanTruthTable
+
     spectrum: tuple[ExactInteger, ...] = Field(
         min_length=1,
         max_length=MAX_TRUTH_TABLE_LENGTH,
@@ -73,6 +75,11 @@ class BooleanWalshTransformResult(StrictModel):
 
     @model_validator(mode="after")
     def require_spectrum_shape(self) -> Self:
+        if self.variable_count != self.source.variable_count:
+            raise _validation_error(
+                "source_dimension_mismatch",
+                "source and spectrum must retain the same Boolean cube",
+            )
         if len(self.spectrum) != 1 << self.variable_count:
             raise _validation_error(
                 "spectrum_length_mismatch",

--- a/src/jacobian/math/analysis/boolean/_tools.py
+++ b/src/jacobian/math/analysis/boolean/_tools.py
@@ -1,7 +1,9 @@
 """Exact Boolean operation declarations."""
 
+from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.analysis.boolean._models import (
+    BooleanTruthTable,
     BooleanTruthTableRequest,
     BooleanWalshTransformResult,
 )
@@ -13,6 +15,11 @@ def _walsh_hadamard_transform(
 ) -> BooleanWalshTransformResult:
     spectrum = walsh_hadamard_transform(request.truth_table)
     return BooleanWalshTransformResult(
+        source=BooleanTruthTable(
+            values=tuple(
+                CanonicalRational(num=value, den=1) for value in request.truth_table
+            )
+        ),
         spectrum=tuple(spectrum),
         variable_count=len(request.truth_table).bit_length() - 1,
     )

--- a/src/jacobian/math/analysis/boolean/fourier/operations.py
+++ b/src/jacobian/math/analysis/boolean/fourier/operations.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from fractions import Fraction
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.analysis.boolean._models import (
     MAX_WALSH_VARIABLES,
     BooleanRationalVector,
@@ -161,30 +164,42 @@ def erasure_noise(
 def verify_fourier_spectrum(claim: FourierSpectrumResult) -> bool:
     """Verify a Fourier spectrum against its retained Boolean function."""
 
+    if not isinstance(claim, FourierSpectrumResult):
+        return False
     try:
         return fourier_spectrum(claim.source.values) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_multilinear_extension(claim: MultilinearExtensionResult) -> bool:
     """Verify multilinear coefficients against their retained truth table."""
 
+    if not isinstance(claim, MultilinearExtensionResult):
+        return False
     try:
         return multilinear_extension(claim.source.values) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_erasure_noise(claim: ErasureNoiseResult) -> bool:
     """Verify the exact noise expectation against source and base assignment."""
 
+    if not isinstance(claim, ErasureNoiseResult):
+        return False
     try:
         return (
             erasure_noise(claim.source.values, claim.probability, claim.base_input)
             == claim
         )
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/analysis/boolean/operations.py
+++ b/src/jacobian/math/analysis/boolean/operations.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.analysis.boolean.fourier._models import FourierSpectrumResult
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.analysis.boolean._models import BooleanWalshTransformResult
 
 
 def walsh_hadamard_transform(truth_table: Sequence[int]) -> list[int]:
@@ -50,18 +53,20 @@ def walsh_hadamard_transform(truth_table: Sequence[int]) -> list[int]:
 
 
 def verify_walsh_transform(
-    claim: FourierSpectrumResult,
+    claim: BooleanWalshTransformResult,
 ) -> bool:
     """Verify a Walsh spectrum against its retained Boolean truth table."""
 
+    if not isinstance(claim, BooleanWalshTransformResult):
+        return False
     try:
         truth = [int(value.as_fraction()) for value in claim.source.values]
         expected = walsh_hadamard_transform(truth)
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
-    return tuple(expected) == tuple(
-        int(value.as_fraction()) for value in claim.spectrum.values
-    )
+    return tuple(expected) == claim.spectrum
 
 
 __all__ = ["verify_walsh_transform", "walsh_hadamard_transform"]

--- a/src/jacobian/math/analysis/convex/operations.py
+++ b/src/jacobian/math/analysis/convex/operations.py
@@ -6,7 +6,10 @@ from fractions import Fraction
 from typing import Any
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.analysis.convex._models import (
     AffinePiece,
     MaxAffineEvalResult,
@@ -102,9 +105,13 @@ def max_affine_subdifferential(
 def verify_max_affine_evaluation(claim: MaxAffineEvalResult) -> bool:
     """Verify value, active-piece IDs, and per-piece values against the source."""
 
+    if not isinstance(claim, MaxAffineEvalResult):
+        return False
     try:
         return max_affine_evaluation(claim.function, claim.point) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -113,9 +120,13 @@ def verify_max_affine_subdifferential(
 ) -> bool:
     """Verify active gradients against the retained function and point."""
 
+    if not isinstance(claim, MaxAffineSubdifferentialResult):
+        return False
     try:
         return max_affine_subdifferential(claim.function, claim.point) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/combinatorics/additive/cyclic_sumset_profile/operations.py
+++ b/src/jacobian/math/combinatorics/additive/cyclic_sumset_profile/operations.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.additive.cyclic_sumset_profile._models import (
     MAX_CYCLIC_SUMSET_PAIRS,
     CyclicSumsetEntry,
@@ -25,7 +28,7 @@ def compute_cyclic_sumset_profile(
             message="cyclic sumset modulus must be positive",
         )
     if len(left) * len(right) > MAX_CYCLIC_SUMSET_PAIRS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("left", "right"),
             code="cyclic_sumset.pair_work_exceeded",
             message="cyclic sumset exceeds the 100000-pair work bound",
@@ -63,6 +66,8 @@ def compute_cyclic_sumset_profile(
 
 def verify_cyclic_sumset_profile(result: CyclicSumsetResult) -> bool:
     """Verify cyclic representation counts against modulus and source sets."""
+    if not isinstance(result, CyclicSumsetResult):
+        return False
     try:
         expected = compute_cyclic_sumset_profile(
             result.modulus, result.left, result.right
@@ -71,5 +76,7 @@ def verify_cyclic_sumset_profile(result: CyclicSumsetResult) -> bool:
             expected.entries == result.entries
             and expected.support_cardinality == result.support_cardinality
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/combinatorics/additive/gowers_cube_profile/operations.py
+++ b/src/jacobian/math/combinatorics/additive/gowers_cube_profile/operations.py
@@ -6,7 +6,10 @@ from fractions import Fraction
 from itertools import product
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.additive.gowers_cube_profile._models import (
     MAX_GOWERS_CUBE_ORDER,
     MAX_GOWERS_CUBE_VERTEX_CHECKS,
@@ -51,7 +54,7 @@ def compute_gowers_cube_profile(
         len(subset) > 1
         and gowers_cube_work(modulus, order) > MAX_GOWERS_CUBE_VERTEX_CHECKS
     ):
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("modulus", "order"),
             code="gowers_cube.work_exceeded",
             message="Gowers cube enumeration exceeds the 2000000-vertex-check bound",
@@ -115,6 +118,8 @@ def compute_gowers_cube_profile(
 
 def verify_gowers_cube_profile(result: GowersCubeResult) -> bool:
     """Verify cube counts and normalization against the retained source."""
+    if not isinstance(result, GowersCubeResult):
+        return False
     try:
         expected = compute_gowers_cube_profile(
             result.modulus, result.subset, result.order
@@ -123,5 +128,7 @@ def verify_gowers_cube_profile(result: GowersCubeResult) -> bool:
             expected.cube_count == result.cube_count
             and expected.normalized_count == result.normalized_count
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/combinatorics/additive/operations.py
+++ b/src/jacobian/math/combinatorics/additive/operations.py
@@ -12,7 +12,10 @@ from jacobian.canonical import (
     CanonicalLimits,
     format_canonical_integer,
 )
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.additive import _multiset_sum
 from jacobian.math.combinatorics.additive._models import (
     _MAX_COORDINATE_DIGITS,
@@ -80,7 +83,7 @@ def _parse_set(spec: FiniteIntegerSet) -> frozenset[int]:
         abs(element) >= 10 ** CanonicalLimits().max_integer_digits
         for element in spec.elements
     ):
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("left", "right"),
             code="additive_combinatorics.integer_digit_bound",
             message="finite-set operands exceed the canonical integer digit bound",
@@ -112,7 +115,7 @@ def _admit_direct_sum(
             ),
         )
     if modulus > MAX_DIRECT_SUM_DIAGNOSTIC_ENTRIES:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("modulus",),
             code="additive_combinatorics.direct_sum.result_cardinality_exceeded",
             message=(
@@ -123,7 +126,7 @@ def _admit_direct_sum(
     try:
         _require_bounded_cartesian_product(left, right)
     except PydanticCustomError as exc:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("left", "right"), code=exc.type, message=exc.message()
         ) from None
 
@@ -136,7 +139,7 @@ def representation_profile(
     try:
         _require_bounded_cartesian_product(left, right)
     except PydanticCustomError as exc:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("left", "right"), code=exc.type, message=exc.message()
         ) from None
     counts = _representation_function(_parse_set(left), _parse_set(right))
@@ -206,7 +209,12 @@ def additive_energy(
     left: FiniteIntegerSet, right: FiniteIntegerSet
 ) -> AdditiveEnergyResult:
     """Compute ``E(A, B) = sum_x r_{A+B}(x)^2``."""
-    _require_bounded_cartesian_product(left, right)
+    try:
+        _require_bounded_cartesian_product(left, right)
+    except PydanticCustomError as exc:
+        raise OperationResourceAdmissionError(
+            location=("left", "right"), code=exc.type, message=exc.message()
+        ) from exc
     counts = _representation_function(_parse_set(left), _parse_set(right))
     decomposition = tuple(
         RepresentationProfileEntry(sum=value, multiplicity=counts[value])
@@ -224,13 +232,18 @@ def sumset_cardinality(
     left: FiniteIntegerSet, right: FiniteIntegerSet
 ) -> SumsetCardinalityResult:
     """Compute ``|A + B|`` (the support cardinality of ``r_{A+B}``)."""
-    _require_bounded_cartesian_product(left, right)
+    try:
+        _require_bounded_cartesian_product(left, right)
+    except PydanticCustomError as exc:
+        raise OperationResourceAdmissionError(
+            location=("left", "right"), code=exc.type, message=exc.message()
+        ) from exc
     counts = _representation_function(_parse_set(left), _parse_set(right))
     support_values = _sorted_sums(counts)
     try:
         support = FiniteIntegerSet(elements=tuple(support_values))
     except ValidationError as exc:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("left", "right"),
             code="additive_combinatorics.sumset_support_not_composable",
             message="the produced support exceeds the canonical finite-set envelope",
@@ -269,43 +282,59 @@ def direct_sum_predicate(
 
 def verify_representation_profile(result: RepresentationProfileResult) -> bool:
     """Verify a serialized representation profile against its source sets."""
+    if not isinstance(result, RepresentationProfileResult):
+        return False
     try:
         expected = representation_profile(result.left, result.right)
         return expected.entries == result.entries
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_additive_energy(result: AdditiveEnergyResult) -> bool:
     """Verify additive energy and its decomposition against source sets."""
+    if not isinstance(result, AdditiveEnergyResult):
+        return False
     try:
         expected = additive_energy(result.left, result.right)
         return (
             expected.energy == result.energy
             and expected.decomposition == result.decomposition
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_sumset_cardinality(result: SumsetCardinalityResult) -> bool:
     """Verify sumset support and cardinality against source sets."""
+    if not isinstance(result, SumsetCardinalityResult):
+        return False
     try:
         expected = sumset_cardinality(result.left, result.right)
         return (
             expected.cardinality == result.cardinality
             and expected.support == result.support
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_direct_sum_predicate(result: DirectSumPredicateResult) -> bool:
     """Verify direct-sum diagnostics and conclusion against source sets."""
+    if not isinstance(result, DirectSumPredicateResult):
+        return False
     try:
         expected = direct_sum_predicate(result.modulus, result.left, result.right)
         return expected == result
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -318,7 +347,7 @@ def ordered_difference_profile(
     ordered_pairs = set_size * (set_size - 1)
     coordinate_work = ordered_pairs * dimension
     if coordinate_work > MAX_ORDERED_DIFFERENCE_COORDINATE_WORK:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("vectors",),
             code="additive_combinatorics.ordered_difference_work_exceeded",
             message=(
@@ -328,7 +357,7 @@ def ordered_difference_profile(
         )
     output_cells = set_size * dimension + ordered_pairs * (dimension + 2)
     if output_cells > MAX_ORDERED_DIFFERENCE_OUTPUT_CELLS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("vectors",),
             code="additive_combinatorics.ordered_difference_output_exceeded",
             message=(
@@ -542,7 +571,7 @@ def _admit_ordered_difference_claim(
     ordered_pairs = set_size * (set_size - 1)
     coordinate_work = ordered_pairs * dimension
     if coordinate_work > MAX_ORDERED_DIFFERENCE_COORDINATE_WORK:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("claim", "vectors"),
             code="additive_combinatorics.ordered_difference_work_exceeded",
             message=(
@@ -552,7 +581,7 @@ def _admit_ordered_difference_claim(
         )
     output_cells = set_size * dimension + ordered_pairs * (dimension + 2)
     if output_cells > MAX_ORDERED_DIFFERENCE_OUTPUT_CELLS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("claim",),
             code="additive_combinatorics.ordered_difference_output_exceeded",
             message=(
@@ -617,7 +646,7 @@ def _admit_ordered_difference_claim(
         for entry in claim.entries
     )
     if claimed_cells > MAX_ORDERED_DIFFERENCE_OUTPUT_CELLS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("claim", "entries"),
             code="additive_combinatorics.ordered_difference_output_exceeded",
             message=(
@@ -693,7 +722,9 @@ def verify_ordered_difference_profile(
             and claim.first_collision == expected_collision
             and total == set_size * (set_size - 1)
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/combinatorics/additive/product_representation/operations.py
+++ b/src/jacobian/math/combinatorics/additive/product_representation/operations.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.additive.product_representation._models import (
     ProductRepresentationResult,
     RepresentationEntry,
@@ -29,7 +32,7 @@ def _admit_product_representation(
 ) -> None:
     pair_count = len(left.elements) * len(right.elements)
     if pair_count > MAX_PRODUCT_REPRESENTATION_PAIRS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("left", "right"),
             code="additive.product_representation_pair_work_exceeded",
             message=(
@@ -50,7 +53,7 @@ def _admit_product_representation(
     # any caller-supplied value into a Python integer.
     digit_work = pair_count * maximum_product_digits**2
     if digit_work > MAX_PRODUCT_REPRESENTATION_DIGIT_WORK:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("left", "right"),
             code="additive.product_representation_digit_work_exceeded",
             message=(
@@ -90,11 +93,15 @@ def compute_product_representation_profile(
 
 def verify_product_representation_profile(result: ProductRepresentationResult) -> bool:
     """Verify every product multiplicity against the retained source sets."""
+    if not isinstance(result, ProductRepresentationResult):
+        return False
     try:
         expected = compute_product_representation_profile(result.left, result.right)
         return (
             expected.entries == result.entries
             and expected.support_cardinality == result.support_cardinality
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_fixed_arity/operations.py
@@ -9,7 +9,10 @@ from math import gcd
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.additive.rational_fixed_arity._models import (
     RationalFixedAritySumResult,
     SumProfileRow,
@@ -32,7 +35,17 @@ class _AdmissionPlan:
 
 
 def _reject(location: tuple[str | int, ...], code: str, message: str) -> None:
-    raise OperationDomainValidationError(location=location, code=code, message=message)
+    error_type = (
+        OperationResourceAdmissionError
+        if code
+        in {
+            "rational_fixed_arity.work_bound",
+            "rational_fixed_arity.rational_growth",
+            "rational_fixed_arity.arity_json_range",
+        }
+        else OperationDomainValidationError
+    )
+    raise error_type(location=location, code=code, message=message)
 
 
 def _common_denominator_digits(fractions: tuple[Fraction, ...]) -> int:
@@ -418,8 +431,12 @@ def verify_rational_fixed_arity_sum_profile(
     result: RationalFixedAritySumResult,
 ) -> bool:
     """Verify fixed-arity sums and multiplicities against source values."""
+    if not isinstance(result, RationalFixedAritySumResult):
+        return False
     try:
         expected = compute_rational_fixed_arity_sum_profile(result.values, result.arity)
         return expected.rows == result.rows
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
+++ b/src/jacobian/math/combinatorics/additive/rational_subset_sum/operations.py
@@ -11,7 +11,10 @@ from jacobian._exact import (
     MAX_CANONICAL_RATIONAL_DIGITS,
     CanonicalRational,
 )
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.additive.rational_subset_sum._models import (
     MAX_SEQUENCE_LENGTH,
     RationalSubsetSumResult,
@@ -30,7 +33,12 @@ class _RationalSubsetSumPlan:
 
 
 def _reject(code: str, message: str) -> NoReturn:
-    raise OperationDomainValidationError(
+    error_type = (
+        OperationDomainValidationError
+        if code == "invalid_values"
+        else OperationResourceAdmissionError
+    )
+    raise error_type(
         location=("values",), code=f"rational_subset_sum.{code}", message=message
     )
 
@@ -190,8 +198,12 @@ def compute_rational_subset_sum_profile(
 
 def verify_rational_subset_sum_profile(result: RationalSubsetSumResult) -> bool:
     """Verify the complete subset-sum profile against its retained sequence."""
+    if not isinstance(result, RationalSubsetSumResult):
+        return False
     try:
         expected = compute_rational_subset_sum_profile(result.values)
         return expected.rows == result.rows
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/combinatorics/additive/zero_sum_atoms/operations.py
+++ b/src/jacobian/math/combinatorics/additive/zero_sum_atoms/operations.py
@@ -12,7 +12,10 @@ from jacobian._execution import (
     request_checkpoint,
     request_execution,
 )
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.additive.zero_sum_atoms._models import (
     MAX_ATOM_EDGES,
     MAX_ATOM_INCIDENCES,
@@ -35,7 +38,12 @@ _OWNER_DEADLINE_SECONDS = 3600.0
 
 
 def _reject(location: tuple[str | int, ...], code: str, message: str) -> None:
-    raise OperationDomainValidationError(location=location, code=code, message=message)
+    error_type = (
+        OperationDomainValidationError
+        if code == "zero_sum_atom.source_domain"
+        else OperationResourceAdmissionError
+    )
+    raise error_type(location=location, code=code, message=message)
 
 
 def _add(
@@ -192,6 +200,8 @@ def verify_zero_sum_atom_hypergraph(
     result: ZeroSumAtomHypergraphResult,
 ) -> bool:
     """Verify atom zero-sum, minimality, and completeness for the source."""
+    if not isinstance(result, ZeroSumAtomHypergraphResult):
+        return False
     try:
         expected = construct_zero_sum_atom_hypergraph(result.source)
         return (
@@ -200,7 +210,9 @@ def verify_zero_sum_atom_hypergraph(
             and expected.atom_count == result.atom_count
             and expected.total_incidences == result.total_incidences
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -235,5 +247,7 @@ def verify_zero_sum_atom(
                 if subset_sum == zero:
                     return False
         return True
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/combinatorics/arithmetic_progression_hypergraph/operations.py
+++ b/src/jacobian/math/combinatorics/arithmetic_progression_hypergraph/operations.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.arithmetic_progression_hypergraph._models import (
     ArithmeticProgressionHypergraphResult,
     _admission_error,
@@ -30,7 +33,12 @@ def construct_arithmetic_progression_hypergraph(
     failure = _admission_error(lower, upper, k)
     if failure is not None:
         field, code, message = failure
-        raise OperationDomainValidationError(
+        error_type = (
+            OperationDomainValidationError
+            if code in {"invalid_integer", "empty_interval", "invalid_arity"}
+            else OperationResourceAdmissionError
+        )
+        raise error_type(
             location=(field,),
             code=f"hypergraph.arithmetic_progression.{code}",
             message=message,
@@ -62,12 +70,16 @@ def verify_arithmetic_progression_hypergraph(
 ) -> bool:
     """Verify interval vertices and every ``(a, d)`` progression edge."""
 
+    if not isinstance(claim, ArithmeticProgressionHypergraphResult):
+        return False
     try:
         expected = construct_arithmetic_progression_hypergraph(
             claim.lower, claim.upper, claim.k
         )
         return claim.hypergraph == expected.hypergraph
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/combinatorics/codes/general/operations.py
+++ b/src/jacobian/math/combinatorics/codes/general/operations.py
@@ -8,7 +8,10 @@ from itertools import product
 
 from sympy import isprime
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.codes.general._models import (
     EXACT_ENUMERATION_PASSES,
     MAX_COVERING_RADIUS_STATES_PER_PASS,
@@ -79,7 +82,7 @@ def _admit_enumeration(generator_matrix: GeneratorMatrix, field_order: int) -> N
         EXACT_ENUMERATION_PASSES * field_order ** len(generator_matrix)
         > MAX_EXACT_CODEWORD_EVALUATIONS
     ):
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("generator_matrix",),
             code="code_theory.enumeration_work_exceeded",
             message="generator matrix exceeds the exact enumeration bound",
@@ -114,12 +117,6 @@ def _admit_encoder(encoder: PrimeFieldLinearEncoder) -> GeneratorMatrix:
                 location=("encoder", "field_order"),
                 code="code_theory.field_order_not_prime",
                 message="field_order must be prime for this prime-field operation",
-            )
-        if not encoder.coordinate_axis:
-            raise OperationDomainValidationError(
-                location=("encoder", "coordinate_axis"),
-                code="code_theory.generator_width_out_of_bounds",
-                message="generator rows must have between one and 256 entries",
             )
         return generator_matrix
     _admit_prime_field_matrix(encoder.field_order, generator_matrix)
@@ -235,7 +232,7 @@ def covering_radius(encoder: PrimeFieldLinearEncoder) -> int:
     rank = _matrix_rank_mod_prime(generator_matrix, field_order)
     state_count = field_order ** (width - rank)
     if state_count > MAX_COVERING_RADIUS_STATES_PER_PASS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("generator_matrix",),
             code="code_theory.syndrome_state_bound_exceeded",
             message="syndrome space exceeds the exact state bound",
@@ -245,7 +242,7 @@ def covering_radius(encoder: PrimeFieldLinearEncoder) -> int:
         SYNDROME_BFS_PASSES * state_count * move_count_bound
         > MAX_COVERING_RADIUS_TRANSITIONS
     ):
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("generator_matrix",),
             code="code_theory.syndrome_transition_bound_exceeded",
             message="syndrome graph exceeds the exact transition bound",
@@ -297,25 +294,37 @@ def covering_radius(encoder: PrimeFieldLinearEncoder) -> int:
 def verify_minimum_distance(claim: MinimumDistanceResult) -> bool:
     """Verify a serialized minimum-distance claim against its encoder."""
 
+    if not isinstance(claim, MinimumDistanceResult):
+        return False
     try:
         return claim.minimum_distance == minimum_distance(claim.request.encoder)
-    except (ArithmeticError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_weight_distribution(claim: WeightDistributionResult) -> bool:
     """Verify a serialized weight profile against its encoder."""
 
+    if not isinstance(claim, WeightDistributionResult):
+        return False
     try:
         return claim.weights == tuple(weight_distribution(claim.request.encoder))
-    except (ArithmeticError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_covering_radius(claim: CoveringRadiusResult) -> bool:
     """Verify a serialized covering-radius claim against its encoder."""
 
+    if not isinstance(claim, CoveringRadiusResult):
+        return False
     try:
         return claim.covering_radius == covering_radius(claim.request.encoder)
-    except (ArithmeticError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/combinatorics/discrepancy/_tools.py
+++ b/src/jacobian/math/combinatorics/discrepancy/_tools.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.catalog.models import (
+    MathTool,
+    OperationDomainValidationError,
+    OperationExample,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.discrepancy._models import (
     DiscrepancyEvalRequest,
     DiscrepancyEvalResult,
@@ -40,14 +45,13 @@ def compute_discrepancy(request: DiscrepancyEvalRequest) -> DiscrepancyEvalResul
 
 
 def verify_discrepancy(claim: DiscrepancyEvalResult) -> bool:
+    if not isinstance(claim, DiscrepancyEvalResult):
+        return False
     try:
-        expected = compute_discrepancy(
-            DiscrepancyEvalRequest(
-                set_system=claim.set_system,
-                coloring=claim.coloring,
-            )
-        )
-    except Exception:
+        expected = _compute_discrepancy_native(claim.set_system, claim.coloring)
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
     return (
         claim.signed_sums == expected.signed_sums

--- a/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/axis_aligned_square_grid/operations.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.finite_structures.axis_aligned_square_grid._models import (
     MAX_SIDE_LENGTH,
     AxisAlignedSquareGridResult,
@@ -36,13 +39,13 @@ def _admit_side_length(side_length: int) -> int:
     edge_count = n * (n - 1) * (2 * n - 1) // 6
     incidence_count = 4 * edge_count
     if edge_count > MAX_EDGES:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("side_length",),
             code="square_grid.edge_bound",
             message=f"the grid would contain {edge_count} edges, over the {MAX_EDGES}-edge bound",
         )
     if incidence_count > MAX_TOTAL_INCIDENCES:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("side_length",),
             code="square_grid.incidence_bound",
             message=(
@@ -98,8 +101,12 @@ def construct_axis_aligned_square_grid(
 def verify_axis_aligned_square_grid(claim: AxisAlignedSquareGridResult) -> bool:
     """Verify the complete square-grid vertex and edge construction claim."""
 
+    if not isinstance(claim, AxisAlignedSquareGridResult):
+        return False
     try:
         expected = construct_axis_aligned_square_grid(claim.side_length)
         return claim.hypergraph == expected.hypergraph
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/combinatorics/finite_structures/divisibility_sum_triples/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/divisibility_sum_triples/operations.py
@@ -8,7 +8,10 @@ from math import comb
 
 from pydantic_core import PydanticCustomError
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.finite_structures.divisibility_sum_triples._models import (
     MAX_INTERVAL_SIZE,
     DivisibilitySumTriplesResult,
@@ -47,14 +50,14 @@ def _admit_divisibility_sum_triples(
 
     interval_size = upper_bound - lower_bound + 1
     if interval_size > MAX_INTERVAL_SIZE:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=(),
             code="divisibility_sum.interval_too_large",
             message=f"interval size must not exceed {MAX_INTERVAL_SIZE}",
         )
     vertices = tuple(str(value) for value in range(lower_bound, upper_bound + 1))
     if any(len(vertex) > MAX_LABEL_LENGTH for vertex in vertices):
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=(),
             code="divisibility_sum.vertex_label_too_long",
             message=f"interval vertices must be at most {MAX_LABEL_LENGTH} characters",
@@ -68,7 +71,7 @@ def _admit_divisibility_sum_triples(
         0 if sparse_no_edges else comb(interval_size, 3) if interval_size >= 3 else 0
     )
     if candidate_count > MAX_TRIPLE_ENUMERATION:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=(),
             code="divisibility_sum.enumeration_work_exceeded",
             message=(
@@ -88,7 +91,7 @@ def _admit_divisibility_sum_triples(
                     (f"edge_{edge_index}", tuple(str(value) for value in triple))
                 )
                 if len(edges) > 12_000 or 3 * len(edges) > 36_000:
-                    raise OperationDomainValidationError(
+                    raise OperationResourceAdmissionError(
                         location=(),
                         code="divisibility_sum.output_too_large",
                         message="the exact triple family exceeds the hypergraph envelope",
@@ -121,10 +124,14 @@ def construct_divisibility_sum_triples_hypergraph(
 def verify_divisibility_sum_triples(claim: DivisibilitySumTriplesResult) -> bool:
     """Verify the complete interval-bound divisibility-triple claim."""
 
+    if not isinstance(claim, DivisibilitySumTriplesResult):
+        return False
     try:
         expected = construct_divisibility_sum_triples_hypergraph(
             claim.lower_bound, claim.upper_bound
         )
         return claim.hypergraph == expected.hypergraph
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/_models.py
@@ -34,10 +34,8 @@ class _ColoringAdmission:
     work_budget: int
 
 
-def _validate_coloring_envelope(
-    hypergraph: FiniteHypergraph, palette_size: int
-) -> _ColoringAdmission:
-    """Validate the complete request and retained-result envelope."""
+def _validate_coloring_source(hypergraph: FiniteHypergraph, palette_size: int) -> None:
+    """Validate source structure and bounded retained axes, without search work."""
     vertex_count = len(hypergraph.vertices)
     edge_count = len(hypergraph.edges)
     if not isinstance(palette_size, int) or isinstance(palette_size, bool):
@@ -59,6 +57,15 @@ def _validate_coloring_envelope(
             "hypergraph_coloring.too_many_edges",
             f"at most {MAX_EDGE_COUNT} edges are supported",
         )
+
+
+def _validate_coloring_envelope(
+    hypergraph: FiniteHypergraph, palette_size: int
+) -> _ColoringAdmission:
+    """Admit the decision search after checking its bounded source."""
+    _validate_coloring_source(hypergraph, palette_size)
+    vertex_count = len(hypergraph.vertices)
+    edge_count = len(hypergraph.edges)
     has_forced_failure = any(len(members) <= 1 for _, members in hypergraph.edges)
     has_injective_witness = not has_forced_failure and palette_size >= vertex_count
     work = (

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/operations.py
@@ -12,11 +12,15 @@ from jacobian._execution import (
     bind_request_deadline,
     current_request_execution,
 )
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.finite_structures.hypergraph_coloring._models import (
     ColoringWitness,
     NonmonochromaticColoringResult,
     _validate_coloring_envelope,
+    _validate_coloring_source,
 )
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
@@ -28,6 +32,21 @@ __all__ = [
     "verify_non_colorable",
     "verify_nonmonochromatic_coloring",
 ]
+
+
+def _coloring_admission_error(
+    error: PydanticCustomError,
+) -> OperationDomainValidationError:
+    error_type = (
+        OperationDomainValidationError
+        if error.type
+        in {
+            "hypergraph_coloring.palette_type",
+            "hypergraph_coloring.palette_out_of_range",
+        }
+        else OperationResourceAdmissionError
+    )
+    return error_type(location=(), code=error.type, message=str(error))
 
 
 def decide_nonmonochromatic_coloring(
@@ -42,9 +61,7 @@ def decide_nonmonochromatic_coloring(
     try:
         admission = _validate_coloring_envelope(hypergraph, palette_size)
     except PydanticCustomError as error:
-        raise OperationDomainValidationError(
-            location=(), code=error.type, message=str(error)
-        ) from error
+        raise _coloring_admission_error(error) from error
 
     # Establish the operation-owned deadline before any presolve return so
     # native and dispatched calls cover result construction on every path.
@@ -142,8 +159,11 @@ def verify_coloring_witness(claim: NonmonochromaticColoringResult) -> bool:
     if claim.outcome != "COLORABLE" or claim.witness is None:
         return False
     try:
-        _validate_coloring_envelope(claim.hypergraph, claim.palette_size)
-    except (PydanticCustomError, TypeError, ValueError):
+        _validate_coloring_source(claim.hypergraph, claim.palette_size)
+    except PydanticCustomError as error:
+        failure = _coloring_admission_error(error)
+        if isinstance(failure, OperationResourceAdmissionError):
+            raise failure from error
         return False
     vertices = tuple(claim.hypergraph.vertices)
     assignments = claim.witness.assignments
@@ -177,7 +197,9 @@ def verify_non_colorable(claim: NonmonochromaticColoringResult) -> bool:
             ).outcome
             == "NOT_COLORABLE"
         )
-    except (OperationDomainValidationError, TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/operations.py
@@ -5,7 +5,10 @@ from fractions import Fraction
 from math import lcm
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     MAX_HYPERGRAPH_INDEPENDENCE_INCIDENCES,
     MAX_HYPERGRAPH_INDEPENDENCE_VERTICES,
@@ -84,7 +87,7 @@ def _admit_independence(hypergraph: FiniteHypergraph) -> tuple[str, ...] | None:
             vertex for vertex in hypergraph.vertices if vertex not in forbidden
         )
     if len(hypergraph.vertices) > MAX_HYPERGRAPH_INDEPENDENCE_VERTICES:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("hypergraph",),
             code="hypergraph.independence_number.vertex_bound",
             message=(
@@ -93,7 +96,7 @@ def _admit_independence(hypergraph: FiniteHypergraph) -> tuple[str, ...] | None:
             ),
         )
     if total_incidences > MAX_HYPERGRAPH_INDEPENDENCE_INCIDENCES:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("hypergraph",),
             code="hypergraph.independence_number.incidence_bound",
             message=(
@@ -261,7 +264,7 @@ def _admit_maximum_edge_matching(
     plan = _matching_search_plan(hypergraph)
     _, _, components, search_work = plan
     if any(len(component) > MAX_MATCHING_EDGES for component in components):
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("hypergraph",),
             code="hypergraph.maximum_edge_matching.search_bound",
             message=(
@@ -270,7 +273,7 @@ def _admit_maximum_edge_matching(
             ),
         )
     if search_work > MAX_MATCHING_SEARCH_WORK:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("hypergraph",),
             code="hypergraph.maximum_edge_matching.search_bound",
             message=(
@@ -332,15 +335,25 @@ def verify_independence_number(claim: HypergraphIndependenceResult) -> bool:
         if claim.status == "UNKNOWN":
             return False
 
-        expected = independence_number(claim.hypergraph, claim.resource_budget)
-        return (
-            expected.status == "EXACT"
-            and claim.independence_number == expected.independence_number
-            and claim.lower_bound == expected.lower_bound
-            and claim.upper_bound == expected.upper_bound
-        )
-    except Exception:
+    except (AttributeError, TypeError):
         return False
+    try:
+        expected = independence_number(claim.hypergraph, claim.resource_budget)
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
+        return False
+    if expected.status != "EXACT":
+        raise OperationResourceAdmissionError(
+            location=("claim",),
+            code="hypergraph.independence_number.verification_incomplete",
+            message="verification could not establish the claimed independence optimum",
+        )
+    return (
+        claim.independence_number == expected.independence_number
+        and claim.lower_bound == expected.lower_bound
+        and claim.upper_bound == expected.upper_bound
+    )
 
 
 def _canonical_edges(
@@ -742,7 +755,7 @@ def _admit_minimum_transversal(
         )
     plan = _minimum_transversal_search_plan(hypergraph)
     if plan.search_work > MAX_TRANSVERSAL_SEARCH_WORK:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("hypergraph",),
             code="hypergraph.minimum_transversal.search_bound",
             message=(
@@ -785,10 +798,15 @@ def verify_minimum_transversal(claim: MinimumTransversalResult) -> bool:
             )
         ):
             return False
-        expected = minimum_transversal(claim.hypergraph)
-        return claim.cardinality == expected.cardinality
-    except Exception:
+    except (AttributeError, TypeError):
         return False
+    try:
+        expected = minimum_transversal(claim.hypergraph)
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
+        return False
+    return claim.cardinality == expected.cardinality
 
 
 def _maximum_component_matching(
@@ -888,10 +906,15 @@ def verify_maximum_edge_matching(claim: MaximumEdgeMatchingResult) -> bool:
             for right in range(left + 1, len(member_sets))
         ):
             return False
-        expected = maximum_edge_matching(claim.hypergraph)
-        return claim.count == expected.count
-    except Exception:
+    except (AttributeError, TypeError):
         return False
+    try:
+        expected = maximum_edge_matching(claim.hypergraph)
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
+        return False
+    return claim.count == expected.count
 
 
 def _weighted_packing_plan(
@@ -1028,7 +1051,7 @@ def maximum_weight_packing(
     for entry in weights:
         denominator = lcm(denominator, entry.weight.den)
         if denominator.bit_length() > 96_000:
-            raise OperationDomainValidationError(
+            raise OperationResourceAdmissionError(
                 location=("weights",),
                 code="hypergraph.weighted_packing.growth",
                 message="packing weight common denominator exceeds the exact height envelope",
@@ -1042,7 +1065,7 @@ def maximum_weight_packing(
         default=1,
     )
     if numerator_bits + max(1, len(weights)).bit_length() > 96_000:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("weights",),
             code="hypergraph.weighted_packing.growth",
             message="packing weight sums exceed the exact height envelope",
@@ -1054,7 +1077,7 @@ def maximum_weight_packing(
         len(component) > MAX_MATCHING_EDGES and axis is None
         for component, axis in zip(components, resources, strict=True)
     ):
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("hypergraph",),
             code="hypergraph.weighted_packing.search_bound",
             message=(
@@ -1063,7 +1086,7 @@ def maximum_weight_packing(
             ),
         )
     if search_work > MAX_WEIGHTED_PACKING_SEARCH_WORK:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("hypergraph",),
             code="hypergraph.weighted_packing.search_bound",
             message=(
@@ -1127,7 +1150,12 @@ def verify_weighted_packing(claim: WeightedPackingResult) -> bool:
         )
         if claim.total_weight.as_fraction() != selected_weight:
             return False
-        expected = maximum_weight_packing(claim.hypergraph, claim.weights)
-        return claim == expected
-    except Exception:
+    except (AttributeError, TypeError):
         return False
+    try:
+        expected = maximum_weight_packing(claim.hypergraph, claim.weights)
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
+        return False
+    return claim == expected

--- a/src/jacobian/math/combinatorics/operations.py
+++ b/src/jacobian/math/combinatorics/operations.py
@@ -11,7 +11,10 @@ from typing import Literal, NoReturn
 
 from jacobian._exact import CanonicalRational
 from jacobian._execution import bind_request_deadline, current_request_execution
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics._counting_process import evaluate_count
 from jacobian.math.combinatorics._progression_hypergraph_models import (
     MAX_GROUP_ORDER,
@@ -812,7 +815,11 @@ def verify_rational_generating_function_coefficients(
             _rational_series_work_units(len(denominator) - 1, order)
             > MAX_RATIONAL_SERIES_WORK_UNITS
         ):
-            return False
+            raise OperationResourceAdmissionError(
+                location=("claim",),
+                code="combinatorics.generating_function_verification_work_bound",
+                message="coefficient-relation verification exceeds its work bound",
+            )
         coefficients = _canonical_fractions(
             series.coefficients,
             MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS,
@@ -828,6 +835,8 @@ def verify_rational_generating_function_coefficients(
             == (numerator[degree] if degree < len(numerator) else Fraction())
             for degree in range(order)
         )
+    except OperationResourceAdmissionError:
+        raise
     except (ArithmeticError, AttributeError, IndexError, TypeError, ValueError):
         return False
 

--- a/src/jacobian/math/crossed_products/_budget.py
+++ b/src/jacobian/math/crossed_products/_budget.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.crossed_products.values import (
     MAX_EXPONENT_DIGITS,
     FiniteCosetCrossedProductElement,
@@ -13,8 +16,8 @@ MAX_MULTIPLICATION_SCALAR_WORK = 80_000
 MAX_COEFFICIENT_INTERMEDIATE_DIGITS = 19
 
 
-def _reject(*, location: tuple[str, ...], code: str, message: str) -> None:
-    raise OperationDomainValidationError(
+def _reject_resource(*, location: tuple[str, ...], code: str, message: str) -> None:
+    raise OperationResourceAdmissionError(
         location=location,
         code=f"crossed_product.{code}",
         message=message,
@@ -32,15 +35,15 @@ def require_multiplication_budget(
     """Preflight all work, intermediate, support, exponent, and output bounds."""
 
     if left.presentation != right.presentation:
-        _reject(
+        raise OperationDomainValidationError(
             location=("left", "right"),
-            code="presentation_mismatch",
+            code="crossed_product.presentation_mismatch",
             message="crossed-product operands must have the same presentation",
         )
 
     pair_count = len(left.terms) * len(right.terms)
     if pair_count > MAX_CONVOLUTION_PAIRS:
-        _reject(
+        _reject_resource(
             location=("left", "right"),
             code="convolution_work_bound",
             message=(
@@ -52,7 +55,7 @@ def require_multiplication_budget(
     dimension = left.presentation.lattice_rank
     scalar_work = pair_count * (dimension**2 + 3 * dimension + 1)
     if scalar_work > MAX_MULTIPLICATION_SCALAR_WORK:
-        _reject(
+        _reject_resource(
             location=("left", "right"),
             code="scalar_work_bound",
             message="crossed-product multiplication exceeds its scalar-work budget",
@@ -61,7 +64,7 @@ def require_multiplication_budget(
     characteristic = left.presentation.characteristic
     coefficient_intermediate = (characteristic - 1) ** 2 + characteristic - 1
     if coefficient_intermediate >= 10**MAX_COEFFICIENT_INTERMEDIATE_DIGITS:
-        _reject(
+        _reject_resource(
             location=("left", "right"),
             code="coefficient_growth_bound",
             message="coefficient accumulation exceeds its exact-integer bound",
@@ -96,7 +99,7 @@ def require_multiplication_budget(
             left_height + dimension * action_height * right_height + cocycle_height
         )
         if exponent_height >= 10**MAX_EXPONENT_DIGITS:
-            _reject(
+            _reject_resource(
                 location=("left", "right"),
                 code="exponent_growth_bound",
                 message=(

--- a/src/jacobian/math/crossed_products/operations.py
+++ b/src/jacobian/math/crossed_products/operations.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.crossed_products._budget import require_multiplication_budget
 from jacobian.math.crossed_products._models import CrossedProductMultiplyResult
 from jacobian.math.crossed_products.values import (
@@ -107,6 +110,8 @@ def verify_multiply(claim: CrossedProductMultiplyResult) -> bool:
         ):
             return False
         return multiply(claim.left, claim.right) == claim.product
+    except OperationResourceAdmissionError:
+        raise
     except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
         return False
 

--- a/src/jacobian/math/dynamics/arithmetic/_models.py
+++ b/src/jacobian/math/dynamics/arithmetic/_models.py
@@ -27,6 +27,14 @@ MAX_FIELD_PRIME = 10_000
 CoefficientHeight = RationalHeight | None
 
 
+class _ArithmeticInputError(ValueError):
+    """A native caller violates an explicit mathematical input condition."""
+
+
+class _ArithmeticResourceError(_ArithmeticInputError):
+    """Admitted exact computation exceeds a bounded execution envelope."""
+
+
 _VALIDATION_CODES = {
     "iterate output degree exceeds bound": "iterate_degree_exceeds_bound",
     f"iterate coefficient growth exceeds the {MAX_POLYNOMIAL_OUTPUT_DIGITS}-digit output bound": "iterate_coefficient_growth_exceeds_bound",
@@ -151,7 +159,7 @@ def _require_polynomial_height(
         height is not None and height.exceeds(MAX_POLYNOMIAL_OUTPUT_DIGITS)
         for height in coefficients
     ):
-        raise ValueError(
+        raise _ArithmeticResourceError(
             f"{operation} coefficient growth exceeds the "
             f"{MAX_POLYNOMIAL_OUTPUT_DIGITS}-digit output bound"
         )

--- a/src/jacobian/math/dynamics/arithmetic/_tools.py
+++ b/src/jacobian/math/dynamics/arithmetic/_tools.py
@@ -2,11 +2,14 @@
 
 from typing import Any, NoReturn
 
+from pydantic import ValidationError
+
 from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
     OperationExample,
+    OperationResourceAdmissionError,
 )
 from jacobian.math.dynamics.arithmetic._models import (
     MAX_DEGREE,
@@ -21,6 +24,8 @@ from jacobian.math.dynamics.arithmetic._models import (
     OrbitPrefixRequest,
     OrbitPrefixResult,
     OrbitRepeatEvidence,
+    _ArithmeticInputError,
+    _ArithmeticResourceError,
     _validation_code,
 )
 from jacobian.math.dynamics.arithmetic.operations import (
@@ -44,7 +49,12 @@ from jacobian.math.finite_fields.values import (
 def _translate_value_error(
     exc: ValueError, location: tuple[str | int, ...]
 ) -> NoReturn:
-    raise OperationDomainValidationError(
+    error_type = (
+        OperationResourceAdmissionError
+        if isinstance(exc, _ArithmeticResourceError)
+        else OperationDomainValidationError
+    )
+    raise error_type(
         location=location,
         code=f"arithmetic_dynamics.{_validation_code(str(exc))}",
         message=str(exc),
@@ -75,7 +85,7 @@ def _finite_map_example(prime: int, coefficients: tuple[int, ...]) -> dict[str, 
 def compute_map_iterate(request: MapIterateRequest) -> MapIterateResult:
     try:
         result = iterate_polynomial(request.polynomial, request.n)
-    except ValueError as exc:
+    except _ArithmeticInputError as exc:
         location = ("polynomial",) if "polynomial" in str(exc) else ("n",)
         _translate_value_error(exc, location)
     return MapIterateResult._from_kernel(
@@ -91,7 +101,7 @@ def compute_map_iterate(request: MapIterateRequest) -> MapIterateResult:
 def compute_orbit_prefix(request: OrbitPrefixRequest) -> OrbitPrefixResult:
     try:
         result = orbit_prefix(request.polynomial, request.start, request.max_steps)
-    except ValueError as exc:
+    except _ArithmeticInputError as exc:
         location = ("start",) if "orbit start" in str(exc) else ("polynomial",)
         _translate_value_error(exc, location)
     repeat = (
@@ -119,7 +129,7 @@ def compute_dynatomic_polynomial(
 ) -> DynatomicPolynomialResult:
     try:
         result = dynatomic_polynomial(request.polynomial, request.n)
-    except ValueError as exc:
+    except _ArithmeticInputError as exc:
         location = ("polynomial",) if "polynomial" in str(exc) else ("n",)
         _translate_value_error(exc, location)
     return DynatomicPolynomialResult._from_kernel(
@@ -137,7 +147,7 @@ def compute_cycle_multiplier(
 ) -> CycleMultiplierResult:
     try:
         multiplier = cycle_multiplier(request.polynomial, request.cycle)
-    except ValueError as exc:
+    except _ArithmeticInputError as exc:
         location = ("cycle",) if "cycle" in str(exc) else ("polynomial",)
         _translate_value_error(exc, location)
     return CycleMultiplierResult._from_kernel(
@@ -170,7 +180,7 @@ def compute_finite_field_map(request: FiniteFieldMapRequest) -> FiniteFieldMapRe
         graph = finite_field_functional_graph(
             tuple(values), polynomial_map.domain.characteristic
         )
-    except ValueError as exc:
+    except _ArithmeticInputError as exc:
         _translate_value_error(exc, ("polynomial_map",))
     return FiniteFieldMapResult._from_kernel(
         polynomial_map=polynomial_map,
@@ -185,7 +195,9 @@ def verify_finite_field_map(claim: FiniteFieldMapResult) -> bool:
         expected = compute_finite_field_map(
             FiniteFieldMapRequest(polynomial_map=claim.polynomial_map)
         )
-    except (TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except (ValidationError, OperationDomainValidationError):
         return False
     return claim == expected
 
@@ -195,7 +207,9 @@ def verify_map_iterate(claim: MapIterateResult) -> bool:
         expected = compute_map_iterate(
             MapIterateRequest(polynomial=claim.source_polynomial, n=claim.n)
         )
-    except (TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except (ValidationError, OperationDomainValidationError):
         return False
     return claim == expected
 
@@ -209,7 +223,9 @@ def verify_orbit_prefix(claim: OrbitPrefixResult) -> bool:
                 max_steps=claim.requested_steps,
             )
         )
-    except (TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except (ValidationError, OperationDomainValidationError):
         return False
     return claim == expected
 
@@ -219,7 +235,9 @@ def verify_dynatomic_polynomial(claim: DynatomicPolynomialResult) -> bool:
         expected = compute_dynatomic_polynomial(
             DynatomicPolynomialRequest(polynomial=claim.source_polynomial, n=claim.n)
         )
-    except (TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except (ValidationError, OperationDomainValidationError):
         return False
     return claim == expected
 
@@ -231,7 +249,9 @@ def verify_cycle_multiplier(claim: CycleMultiplierResult) -> bool:
                 polynomial=claim.source_polynomial, cycle=claim.cycle
             )
         )
-    except (TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except (ValidationError, OperationDomainValidationError):
         return False
     return claim == expected
 

--- a/src/jacobian/math/dynamics/arithmetic/operations.py
+++ b/src/jacobian/math/dynamics/arithmetic/operations.py
@@ -22,6 +22,8 @@ from jacobian.math.dynamics.arithmetic._models import (
     MAX_POLYNOMIAL_OUTPUT_DIGITS,
     CoefficientHeight,
     _add_heights,
+    _ArithmeticInputError,
+    _ArithmeticResourceError,
     _divide_height_polynomials,
     _fraction_height,
     _iterate_heights,
@@ -79,15 +81,17 @@ def polynomial_from_coefficients(
     coefficients: Sequence[Fraction | int],
 ) -> RationalPolynomial:
     """Build a canonical univariate ``QQ`` polynomial from low-to-high values."""
-    values = tuple(Fraction(value) for value in coefficients)
-    if not 1 <= len(values) <= MAX_DEGREE + 1:
-        raise ValueError(
+    if not 1 <= len(coefficients) <= MAX_DEGREE + 1:
+        raise _ArithmeticInputError(
             f"polynomial must have between 1 and {MAX_DEGREE + 1} coefficients"
         )
+    values = tuple(Fraction(value) for value in coefficients)
     if any(_fraction_digits(value) > MAX_COEFFICIENT_DIGITS for value in values):
-        raise ValueError("polynomial coefficient exceeds the input digit bound")
+        raise _ArithmeticInputError(
+            "polynomial coefficient exceeds the input digit bound"
+        )
     if len(values) > 1 and values[-1] == 0:
-        raise ValueError("polynomial coefficients must omit trailing zeros")
+        raise _ArithmeticInputError("polynomial coefficients must omit trailing zeros")
     return _canonical_polynomial(values)
 
 
@@ -101,7 +105,7 @@ def polynomial_coefficients(polynomial: RationalPolynomial) -> tuple[Fraction, .
     }
     degree = max(exponents, default=0)
     if degree > MAX_ITERATE_DEGREE:
-        raise ValueError("polynomial degree exceeds the extraction bound")
+        raise _ArithmeticInputError("polynomial degree exceeds the extraction bound")
     values = tuple(exponents.get(index, Fraction(0)) for index in range(degree + 1))
     _require_bounded_output_coefficients(values)
     if not polynomial.polynomial.terms:
@@ -115,12 +119,14 @@ def iterate_polynomial(polynomial: RationalPolynomial, n: int) -> RationalPolyno
     import sympy
 
     if not 0 <= n <= MAX_ITERATE:
-        raise ValueError(f"iterate count must be between 0 and {MAX_ITERATE}")
+        raise _ArithmeticInputError(
+            f"iterate count must be between 0 and {MAX_ITERATE}"
+        )
     source_coefficients = polynomial_coefficients(polynomial)
     source_degree = 0 if len(source_coefficients) == 1 else len(source_coefficients) - 1
     output_degree = 1 if n == 0 else source_degree**n
     if output_degree > MAX_ITERATE_DEGREE:
-        raise ValueError("iterate output degree exceeds bound")
+        raise _ArithmeticResourceError("iterate output degree exceeds bound")
     _require_polynomial_height(
         _iterate_heights(
             tuple(_fraction_height(value) for value in source_coefficients), n
@@ -141,7 +147,7 @@ def fixed_point_equation(polynomial: RationalPolynomial, n: int) -> RationalPoly
 
     source = _require_input_polynomial(polynomial)
     if n < 1:
-        raise ValueError("fixed-point iterate must be positive")
+        raise _ArithmeticInputError("fixed-point iterate must be positive")
     identity = sympy.Poly(source.gens[0], source.gens[0], domain=sympy.QQ)
     result = _to_sympy(iterate_polynomial(polynomial, n)) - identity
     _require_bounded_output_coefficients(result)
@@ -153,14 +159,18 @@ def dynatomic_polynomial(polynomial: RationalPolynomial, n: int) -> RationalPoly
 
     import sympy
 
-    if n < 1:
-        raise ValueError("dynatomic index must be positive")
+    if not 1 <= n <= MAX_ITERATE:
+        raise _ArithmeticInputError(
+            f"dynatomic index must be between 1 and {MAX_ITERATE}"
+        )
     source_coefficients = polynomial_coefficients(polynomial)
     source_degree = 0 if len(source_coefficients) == 1 else len(source_coefficients) - 1
     if source_degree < 2:
-        raise ValueError("dynatomic polynomial requires map degree at least two")
+        raise _ArithmeticInputError(
+            "dynatomic polynomial requires map degree at least two"
+        )
     if source_degree**n > MAX_DYNATOMIC_DEGREE:
-        raise ValueError("dynatomic output degree exceeds bound")
+        raise _ArithmeticResourceError("dynatomic output degree exceeds bound")
     source_heights = tuple(_fraction_height(value) for value in source_coefficients)
     numerator_heights: tuple[CoefficientHeight, ...] = (RationalHeight(1, 1),)
     denominator_heights: tuple[CoefficientHeight, ...] = (RationalHeight(1, 1),)
@@ -209,12 +219,14 @@ def orbit_prefix(
 
     source = _require_input_polynomial(polynomial)
     if not 0 <= max_steps <= MAX_ORBIT_STEPS:
-        raise ValueError(f"orbit step bound must be between 0 and {MAX_ORBIT_STEPS}")
+        raise _ArithmeticInputError(
+            f"orbit step bound must be between 0 and {MAX_ORBIT_STEPS}"
+        )
     if max_value_digits < 1:
-        raise ValueError("orbit value digit bound must be positive")
+        raise _ArithmeticInputError("orbit value digit bound must be positive")
     initial = start.as_fraction()
     if _fraction_digits(initial) > MAX_COEFFICIENT_DIGITS:
-        raise ValueError("orbit start exceeds the input digit bound")
+        raise _ArithmeticInputError("orbit start exceeds the input digit bound")
     values = [initial]
     seen = {values[0]: 0}
     for step in range(1, max_steps + 1):
@@ -255,16 +267,25 @@ def validate_cycle(
     """Reject a sequence that is not one exact ordered periodic cycle."""
 
     source = _require_input_polynomial(polynomial)
+    _validate_cycle_points(source, cycle)
+
+
+def _validate_cycle_points(
+    source: Any, cycle: Sequence[CanonicalRational]
+) -> tuple[Fraction, ...]:
+    if not 1 <= len(cycle) <= MAX_ORBIT_STEPS:
+        raise _ArithmeticInputError(
+            f"cycle must contain between 1 and {MAX_ORBIT_STEPS} points"
+        )
     points = tuple(point.as_fraction() for point in cycle)
-    if not 1 <= len(points) <= MAX_ORBIT_STEPS:
-        raise ValueError(f"cycle must contain between 1 and {MAX_ORBIT_STEPS} points")
     if any(_fraction_digits(point) > MAX_COEFFICIENT_DIGITS for point in points):
-        raise ValueError("cycle point exceeds the input digit bound")
+        raise _ArithmeticInputError("cycle point exceeds the input digit bound")
     if len(set(points)) != len(points):
-        raise ValueError("cycle must contain distinct points")
+        raise _ArithmeticInputError("cycle must contain distinct points")
     for index, point in enumerate(points):
         if Fraction(source.eval(point)) != points[(index + 1) % len(points)]:
-            raise ValueError("cycle points do not follow the polynomial map")
+            raise _ArithmeticInputError("cycle points do not follow the polynomial map")
+    return points
 
 
 def cycle_multiplier(
@@ -273,14 +294,15 @@ def cycle_multiplier(
     """Return the exact derivative product around a validated periodic cycle."""
 
     source = _require_input_polynomial(polynomial)
-    points = tuple(point.as_fraction() for point in cycle)
-    validate_cycle(polynomial, cycle)
+    points = _validate_cycle_points(source, cycle)
     derivative = source.diff()
     multiplier = Fraction(1)
     for point in points:
         multiplier *= Fraction(derivative.eval(point))
         if _fraction_digits(multiplier) > MAX_POLYNOMIAL_OUTPUT_DIGITS:
-            raise ValueError("cycle multiplier exceeds the output digit bound")
+            raise _ArithmeticResourceError(
+                "cycle multiplier exceeds the output digit bound"
+            )
     return CanonicalRational.from_fraction(multiplier)
 
 
@@ -293,19 +315,23 @@ def finite_field_functional_graph(
     import sympy
 
     if not 2 <= prime <= MAX_FIELD_PRIME or not sympy.isprime(prime):
-        raise ValueError(
+        raise _ArithmeticInputError(
             f"prime must be a prime number between 2 and {MAX_FIELD_PRIME}"
         )
-    values = tuple(int(value) for value in coefficients)
-    if not 1 <= len(values) <= MAX_DEGREE + 1:
-        raise ValueError(
+    if not 1 <= len(coefficients) <= MAX_DEGREE + 1:
+        raise _ArithmeticInputError(
             f"polynomial must have between 1 and {MAX_DEGREE + 1} coefficients"
         )
+    values = tuple(int(value) for value in coefficients)
     if any(abs(value) >= 10**MAX_COEFFICIENT_DIGITS for value in values):
-        raise ValueError("polynomial coefficient exceeds the input digit bound")
+        raise _ArithmeticInputError(
+            "polynomial coefficient exceeds the input digit bound"
+        )
     normalized = tuple(value % prime for value in values)
     if len(normalized) > 1 and normalized[-1] == 0:
-        raise ValueError("polynomial coefficients must omit trailing zeros modulo p")
+        raise _ArithmeticInputError(
+            "polynomial coefficients must omit trailing zeros modulo p"
+        )
 
     def evaluate(point: int) -> int:
         value = 0
@@ -369,7 +395,9 @@ def _tail_lengths(
 
 def _require_polynomial(polynomial: RationalPolynomial) -> RationalPolynomial:
     if polynomial.domain != "QQ" or polynomial.variables != ("x",):
-        raise ValueError("polynomial must be univariate over QQ in variable x")
+        raise _ArithmeticInputError(
+            "polynomial must be univariate over QQ in variable x"
+        )
     return polynomial
 
 
@@ -385,15 +413,16 @@ def _from_sympy(polynomial: Any, maximum_terms: int) -> RationalPolynomial:
 
 def _require_input_polynomial(polynomial: RationalPolynomial) -> Any:
     _require_polynomial(polynomial)
-    source = _to_sympy(polynomial)
-    if not source.is_zero and source.degree() > MAX_DEGREE:
-        raise ValueError("polynomial degree exceeds the input bound")
+    if any(term.exponents[0] > MAX_DEGREE for term in polynomial.polynomial.terms):
+        raise _ArithmeticInputError("polynomial degree exceeds the input bound")
     if any(
-        _fraction_digits(Fraction(coefficient)) > MAX_COEFFICIENT_DIGITS
-        for coefficient in source.all_coeffs()
+        _fraction_digits(term.coefficient.as_fraction()) > MAX_COEFFICIENT_DIGITS
+        for term in polynomial.polynomial.terms
     ):
-        raise ValueError("polynomial coefficient exceeds the input digit bound")
-    return source
+        raise _ArithmeticInputError(
+            "polynomial coefficient exceeds the input digit bound"
+        )
+    return _to_sympy(polynomial)
 
 
 def _fraction_digits(value: Fraction) -> int:
@@ -414,7 +443,9 @@ def _require_bounded_output_coefficients(polynomial: Any) -> None:
         _fraction_digits(Fraction(coefficient)) > MAX_POLYNOMIAL_OUTPUT_DIGITS
         for coefficient in coefficients
     ):
-        raise ValueError("polynomial coefficient exceeds the output digit bound")
+        raise _ArithmeticResourceError(
+            "polynomial coefficient exceeds the output digit bound"
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/geometry/arrangements/operations.py
+++ b/src/jacobian/math/geometry/arrangements/operations.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.geometry.arrangements._models import (
     MAX_GENERIC_FORMULA_INDEX,
     ChamberCountResult,
@@ -15,7 +18,12 @@ MAX_GENERIC_FORMULA_WORK = 100_000
 
 
 def _reject(location: tuple[str | int, ...], code: str, message: str) -> None:
-    raise OperationDomainValidationError(
+    error_type = (
+        OperationResourceAdmissionError
+        if code.endswith("work_exceeded")
+        else OperationDomainValidationError
+    )
+    raise error_type(
         location=location,
         code=f"hyperplane_arrangement.{code}",
         message=message,
@@ -246,12 +254,16 @@ def chamber_count(ambient_dimension: int, hyperplane_count: int) -> ChamberCount
 def verify_arrangement(claim: HyperplaneArrangementResult) -> bool:
     """Verify centrality against the retained hyperplane arrangement."""
 
+    if not isinstance(claim, HyperplaneArrangementResult):
+        return False
     try:
         return (
             arrangement(claim.ambient_dimension, claim.hyperplanes).is_central
             == claim.is_central
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -260,21 +272,29 @@ def verify_characteristic_polynomial(
 ) -> bool:
     """Verify generic characteristic coefficients against their source axes."""
 
+    if not isinstance(claim, CharacteristicPolynomialResult):
+        return False
     try:
         return (
             characteristic_polynomial(claim.ambient_dimension, claim.hyperplane_count)
             == claim
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_chamber_count(claim: ChamberCountResult) -> bool:
     """Verify a generic chamber count against its source axes."""
 
+    if not isinstance(claim, ChamberCountResult):
+        return False
     try:
         return chamber_count(claim.ambient_dimension, claim.hyperplane_count) == claim
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/geometry/differential/operations.py
+++ b/src/jacobian/math/geometry/differential/operations.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.geometry.differential._bounds import (
     build_lie_derivative_plan,
 )
@@ -66,12 +69,14 @@ def lie_derivative(
 def verify_lie_derivative(claim: RationalLieDerivativeProfile) -> bool:
     """Verify the retained source-field Lie derivative relation."""
 
+    if not isinstance(claim, RationalLieDerivativeProfile):
+        return False
     try:
         expected = lie_derivative(claim.vector_field, claim.source)
         return expected.lie_derivative == claim.lie_derivative
     except OperationResourceAdmissionError:
         raise
-    except (ValueError, TypeError, ArithmeticError):
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/geometry/exact/operations.py
+++ b/src/jacobian/math/geometry/exact/operations.py
@@ -99,23 +99,27 @@ def distance_graph(
 
 def verify_distance_profile(claim: DistanceProfileResult) -> bool:
     """Verify a serialized distance profile against its retained source."""
+    if not isinstance(claim, DistanceProfileResult):
+        return False
     try:
         return distance_profile(claim.configuration) == claim
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 
 def verify_distance_graph(claim: DistanceGraphResult) -> bool:
     """Verify a serialized distance graph against its source and target."""
+    if not isinstance(claim, DistanceGraphResult):
+        return False
     try:
         return (
             distance_graph(claim.configuration, claim.target_squared_distance) == claim
         )
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 
@@ -196,11 +200,13 @@ def euclidean_orbit_profile(
 
 def verify_euclidean_orbit_profile(claim: EuclideanOrbitProfileResult) -> bool:
     """Verify canonical orbit forms and relabelings against their source."""
+    if not isinstance(claim, EuclideanOrbitProfileResult):
+        return False
     try:
         return euclidean_orbit_profile(claim.configuration) == claim
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 
@@ -274,11 +280,13 @@ def pinned_line_distance_profile(
 
 def verify_pinned_line_distance_profile(claim: PinnedLineDistanceResult) -> bool:
     """Verify the pinned line profile against its retained source and anchor."""
+    if not isinstance(claim, PinnedLineDistanceResult):
+        return False
     try:
         return pinned_line_distance_profile(claim.configuration, claim.anchor) == claim
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/geometry/exact/pinned_distance/operations.py
+++ b/src/jacobian/math/geometry/exact/pinned_distance/operations.py
@@ -41,7 +41,12 @@ class _EntryPlan:
 
 
 def _reject(code: str, message: str) -> NoReturn:
-    raise OperationDomainValidationError(
+    error_type = (
+        OperationDomainValidationError
+        if code == "invalid_configuration"
+        else OperationResourceAdmissionError
+    )
+    raise error_type(
         location=("configuration",),
         code=f"pinned_distance.{code}",
         message=message,
@@ -127,11 +132,13 @@ def verify_pinned_distance_support_profile(
     claim: PinnedDistanceSupportProfileResult,
 ) -> bool:
     """Verify a serialized support profile against its retained configuration."""
+    if not isinstance(claim, PinnedDistanceSupportProfileResult):
+        return False
     try:
         return compute_pinned_distance_support_profile(claim.configuration) == claim
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/geometry/exact/spanned_line_profile/operations.py
+++ b/src/jacobian/math/geometry/exact/spanned_line_profile/operations.py
@@ -23,9 +23,11 @@ from jacobian.math.geometry.exact.spanned_line_profile._models import (
 __all__ = ["compute_spanned_line_profile", "verify_spanned_line_profile"]
 
 
-def _admit_line_key_growth(configuration: PointConfiguration) -> None:
+def _admit_line_key_growth(
+    configuration: PointConfiguration, varying_axes: tuple[int, ...]
+) -> None:
     points = configuration.points
-    dimension = len(points[0].coordinates) if points else 0
+    dimension = len(varying_axes)
     maximum_coordinate_digits = max(
         (
             max(
@@ -33,13 +35,14 @@ def _admit_line_key_growth(configuration: PointConfiguration) -> None:
                 len(format_canonical_integer(coordinate.den)),
             )
             for point in points
-            for coordinate in point.coordinates
+            for axis in varying_axes
+            for coordinate in (point.coordinates[axis],)
         ),
         default=1,
     )
     derived_digits = dimension * (2 * maximum_coordinate_digits + 2)
     if derived_digits > MAX_CANONICAL_RATIONAL_DIGITS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("configuration",),
             code="geometry.spanned_line_profile.result_bound",
             message="spanned-line keys exceed the canonical rational digit bound",
@@ -56,12 +59,41 @@ def compute_spanned_line_profile(
         raise OperationDomainValidationError(
             location=("configuration",), code=exc.type, message=exc.message()
         ) from exc
-    _admit_line_key_growth(configuration)
     points = configuration.points
     n = len(points)
-
+    # Two distinct points determine one line. More generally, if only one
+    # coordinate axis varies, all source pairs determine that same axis line.
+    # Neither case needs the private normalized-direction/anchor keys; the
+    # complete result has at most C(64, 2) source pairs by the source carrier.
+    varying_axes = (
+        tuple(
+            axis
+            for axis in range(len(points[0].coordinates))
+            if any(
+                point.coordinates[axis] != points[0].coordinates[axis]
+                for point in points[1:]
+            )
+        )
+        if n > 2
+        else ()
+    )
+    if n == 2 or len(varying_axes) <= 1:
+        return SpannedLineProfileResult(
+            configuration=configuration,
+            lines=(
+                SpannedLineEntry(
+                    source_pairs=tuple(combinations(range(n), 2)), point_count=n
+                ),
+            ),
+            line_count=1,
+        )
+    # Removing coordinates common to every point is an affine bijection onto
+    # the projected source span, so it preserves exactly which pairs span
+    # the same line. Keys are private; results retain the full source axes.
+    _admit_line_key_growth(configuration, varying_axes)
     point_coords = tuple(
-        tuple(c.as_fraction() for c in point.coordinates) for point in points
+        tuple(point.coordinates[axis].as_fraction() for axis in varying_axes)
+        for point in points
     )
 
     line_to_pairs: dict[
@@ -102,11 +134,13 @@ def compute_spanned_line_profile(
 
 def verify_spanned_line_profile(claim: SpannedLineProfileResult) -> bool:
     """Verify a serialized line profile against its retained configuration."""
+    if not isinstance(claim, SpannedLineProfileResult):
+        return False
     try:
         return compute_spanned_line_profile(claim.configuration) == claim
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/geometry/exact/triangle_area_profile/operations.py
+++ b/src/jacobian/math/geometry/exact/triangle_area_profile/operations.py
@@ -45,7 +45,7 @@ def _admit_triangle_area_result(configuration: PointConfiguration) -> None:
     # digits. Reserve that complete factor product before enumeration.
     derived_digits = sum(coordinate_widths[:6], 0) + 2
     if derived_digits > MAX_CANONICAL_RATIONAL_DIGITS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("configuration",),
             code="geometry.triangle_area_result_bound",
             message=(
@@ -105,7 +105,7 @@ def compute_triangle_area_profile(
             len(numerator.lstrip("-")) > MAX_CANONICAL_RATIONAL_DIGITS
             or len(denominator) > MAX_CANONICAL_RATIONAL_DIGITS
         ):
-            raise OperationDomainValidationError(
+            raise OperationResourceAdmissionError(
                 location=("configuration",),
                 code="geometry.triangle_area_result_bound",
                 message=(
@@ -142,9 +142,11 @@ def compute_triangle_area_profile(
 
 def verify_triangle_area_profile(claim: TriangleAreaProfileResult) -> bool:
     """Verify a serialized triangle-area profile against its source."""
+    if not isinstance(claim, TriangleAreaProfileResult):
+        return False
     try:
         return compute_triangle_area_profile(claim.configuration) == claim
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/geometry/framework/operations.py
+++ b/src/jacobian/math/geometry/framework/operations.py
@@ -44,7 +44,17 @@ class _FrameworkAdmission:
 
 
 def _reject(location: tuple[str | int, ...], code: str, message: str) -> NoReturn:
-    raise OperationDomainValidationError(
+    error_type = (
+        OperationResourceAdmissionError
+        if code
+        in {
+            "coordinate_work_exceeds_bound",
+            "rigidity_matrix_scalar_exceeds_rank_bound",
+            "rigidity_matrix_rank_admission_failed",
+        }
+        else OperationDomainValidationError
+    )
+    raise error_type(
         location=location,
         code=(
             code
@@ -202,6 +212,8 @@ def planar_rigidity_profile(
 
 def verify_planar_rigidity_profile(claim: PlanarRigidityProfile) -> bool:
     """Verify the canonical rigidity matrix and rank claim for a framework."""
+    if not isinstance(claim, PlanarRigidityProfile):
+        return False
     try:
         admission = _admit_framework(claim.configuration, claim.graph)
         matrix = _rigidity_matrix(admission)
@@ -216,7 +228,7 @@ def verify_planar_rigidity_profile(claim: PlanarRigidityProfile) -> bool:
         )
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/geometry/polytopes/_rational_geometry.py
+++ b/src/jacobian/math/geometry/polytopes/_rational_geometry.py
@@ -152,8 +152,10 @@ def vertices_from_halfspaces(
             if matrix.det() == 0:
                 continue
             solution = matrix.solve(rhs)
-        except (NonInvertibleMatrixError, ValueError):
+        except NonInvertibleMatrixError:
             continue
+        except ValueError as exc:
+            raise RuntimeError("exact vertex enumeration computation failed") from exc
         point = tuple(Rational(solution[axis, 0]) for axis in range(dimension))
         if all(
             sum(

--- a/src/jacobian/math/graphs/decomposition/tree_decompositions/operations.py
+++ b/src/jacobian/math/graphs/decomposition/tree_decompositions/operations.py
@@ -9,7 +9,10 @@ from collections import deque
 
 from pydantic_core import PydanticCustomError
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 from ._models import (
@@ -229,7 +232,11 @@ def reroot(td: TreeDecomposition, root: str) -> RerootResult:
     _admit_decomposition(td)
     idx = _index_of(td)
     if root not in idx:
-        raise ValueError("root must be a declared tree node")
+        raise OperationDomainValidationError(
+            location=("root",),
+            code="graph.tree_decomposition.root_not_declared",
+            message="root must be a declared tree node",
+        )
     int_edges = _int_edges(td)
     adjacency: dict[int, list[int]] = {i: [] for i in range(len(td.tree_nodes))}
     for a, b in int_edges:
@@ -379,15 +386,9 @@ def verify_width(claim: WidthResult) -> bool:
         if not isinstance(claim, WidthResult):
             return False
         return width(claim.decomposition) == claim
-    except (
-        AttributeError,
-        IndexError,
-        KeyError,
-        OperationDomainValidationError,
-        RuntimeError,
-        TypeError,
-        ValueError,
-    ):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -397,15 +398,9 @@ def verify_vertex_occurrences(claim: VertexOccurrencesResult) -> bool:
         if not isinstance(claim, VertexOccurrencesResult):
             return False
         return vertex_occurrences(claim.decomposition) == claim
-    except (
-        AttributeError,
-        IndexError,
-        KeyError,
-        OperationDomainValidationError,
-        RuntimeError,
-        TypeError,
-        ValueError,
-    ):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -415,15 +410,9 @@ def verify_adhesions(claim: AdhesionsResult) -> bool:
         if not isinstance(claim, AdhesionsResult):
             return False
         return adhesions(claim.decomposition) == claim
-    except (
-        AttributeError,
-        IndexError,
-        KeyError,
-        OperationDomainValidationError,
-        RuntimeError,
-        TypeError,
-        ValueError,
-    ):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -433,15 +422,9 @@ def verify_reroot(claim: RerootResult) -> bool:
         if not isinstance(claim, RerootResult):
             return False
         return reroot(claim.decomposition, claim.root) == claim
-    except (
-        AttributeError,
-        IndexError,
-        KeyError,
-        OperationDomainValidationError,
-        RuntimeError,
-        TypeError,
-        ValueError,
-    ):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -451,13 +434,7 @@ def verify_bag_intersection_graph(claim: BagIntersectionGraphResult) -> bool:
         if not isinstance(claim, BagIntersectionGraphResult):
             return False
         return bag_intersection_graph(claim.decomposition) == claim
-    except (
-        AttributeError,
-        IndexError,
-        KeyError,
-        OperationDomainValidationError,
-        RuntimeError,
-        TypeError,
-        ValueError,
-    ):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/graphs/triangle_free_diameter_augmentation/_augmentation_z3.py
+++ b/src/jacobian/math/graphs/triangle_free_diameter_augmentation/_augmentation_z3.py
@@ -62,10 +62,7 @@ def _is_triangle_free(graph: SimpleUndirectedGraph) -> bool:
     import networkx as nx
 
     g = _graph_from_value(graph)
-    try:
-        tri = sum(nx.triangles(g).values()) // 3  # type: ignore[union-attr]
-    except Exception:
-        return False
+    tri = sum(nx.triangles(g).values()) // 3  # type: ignore[union-attr]
     return tri == 0
 
 

--- a/src/jacobian/math/groups/finite_abelian.py
+++ b/src/jacobian/math/groups/finite_abelian.py
@@ -27,7 +27,10 @@ from jacobian._execution import (
 )
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 
 if TYPE_CHECKING:
     from sympy import Poly, Symbol
@@ -876,6 +879,8 @@ class FiniteAbelianCharacterSumIntervalProfileResult(StrictModel):
 @dataclass(frozen=True, slots=True)
 class _CharacterSumIntervalProfileWork:
     group_exponent: int
+    squarefree_exponent: int
+    inflation: int
     cyclotomic_degree: int
     cells: int
     total_visits: int
@@ -884,6 +889,35 @@ class _CharacterSumIntervalProfileWork:
     cyclotomic_coefficient_bits: int
     cyclotomic_intermediate_bits: int
     remainder_coefficient_bits: int
+
+
+def _character_sum_conductor(exponent: int) -> tuple[int, int, int]:
+    """Admit the output degree and retain squarefree conductor and inflation."""
+    # phi(N)^2 >= N/2: in its prime-factor product only p=2, a=1
+    # contributes less than one. This bounds trial division before factoring.
+    if exponent > 2 * MAX_CHARACTER_SUM_CYCLOTOMIC_DEGREE**2:
+        raise ValueError(
+            "character-sum cyclotomic degree exceeds the exact reduction bound"
+        )
+    remaining = exponent
+    radical = 1
+    degree = exponent
+    prime = 2
+    while prime * prime <= remaining:
+        if remaining % prime == 0:
+            radical *= prime
+            degree -= degree // prime
+            while remaining % prime == 0:
+                remaining //= prime
+        prime += 1
+    if remaining > 1:
+        radical *= remaining
+        degree -= degree // remaining
+    if degree > MAX_CHARACTER_SUM_CYCLOTOMIC_DEGREE:
+        raise ValueError(
+            "character-sum cyclotomic degree exceeds the exact reduction bound"
+        )
+    return radical, degree, exponent // radical
 
 
 def _character_sum_interval_profile_work(
@@ -912,8 +946,13 @@ def _character_sum_interval_profile_work(
         raise ValueError("character-sum interval count exceeds its bound")
 
     exponent = source.group.exponent
-    cyclotomic_dense_ops = 10 * exponent.bit_length() * (exponent + 1) * (exponent + 1)
-    cyclotomic_intermediate_bits = 2 * exponent + (exponent + 1).bit_length() + 1
+    radical, degree, inflation = _character_sum_conductor(exponent)
+    base_degree = degree // inflation
+    # Phi_N(x) = Phi_rad(N)(x^(N/rad(N))). Construct only the squarefree
+    # polynomial; reduction below treats each residue class modulo inflation
+    # independently. Coefficient heights and elimination chains use rad(N).
+    cyclotomic_dense_ops = 10 * radical.bit_length() * (radical + 1) ** 2
+    cyclotomic_intermediate_bits = 2 * radical + (radical + 1).bit_length() + 1
     if cyclotomic_dense_ops > MAX_CHARACTER_SUM_CYCLOTOMIC_DENSE_OPS:
         raise ValueError(
             "character-sum cyclotomic construction work exceeds its dense-op bound"
@@ -922,13 +961,7 @@ def _character_sum_interval_profile_work(
         raise ValueError(
             "character-sum cyclotomic construction intermediate exceeds its bit bound"
         )
-
-    degree = _euler_totient(exponent)
-    if degree > MAX_CHARACTER_SUM_CYCLOTOMIC_DEGREE:
-        raise ValueError(
-            "character-sum cyclotomic degree exceeds the exact reduction bound"
-        )
-    if degree > MAX_CHARACTER_SUM_CYCLOTOMIC_COEFFICIENT_BITS - 1:
+    if base_degree + 1 > MAX_CHARACTER_SUM_CYCLOTOMIC_COEFFICIENT_BITS:
         raise ValueError("character-sum cyclotomic coefficient exceeds its bit bound")
 
     cells = frequency_count * interval_count
@@ -949,25 +982,30 @@ def _character_sum_interval_profile_work(
     retained_source_work = rank * (sequence_length + frequency_count)
     if retained_source_work > MAX_CHARACTER_SUM_PREFIX_WORK:
         raise ValueError("character-sum retained source coordinates exceed their bound")
-    prefix_work = frequency_count * sequence_length * rank + cells * degree
+    reduction_work = cells * inflation * (radical - base_degree) * base_degree
+    prefix_work = (
+        frequency_count * sequence_length * rank + cells * degree + reduction_work
+    )
     if prefix_work > MAX_CHARACTER_SUM_PREFIX_WORK:
         raise ValueError("character-sum prefix-table work exceeds its bound")
 
     max_interval_length = max((b - a for a, b in source.intervals), default=0)
-    remainder_coefficient_bits = max_interval_length.bit_length() + (degree + 1) * (
-        exponent - degree
-    )
+    remainder_coefficient_bits = max_interval_length.bit_length() + (
+        base_degree + 1
+    ) * (radical - base_degree)
     if remainder_coefficient_bits > MAX_CHARACTER_SUM_REMAINDER_COEFFICIENT_BITS:
         raise ValueError("character-sum remainder intermediate exceeds its bit bound")
 
     return _CharacterSumIntervalProfileWork(
         group_exponent=exponent,
+        squarefree_exponent=radical,
+        inflation=inflation,
         cyclotomic_degree=degree,
         cells=cells,
         total_visits=total_visits,
         prefix_work=prefix_work,
         cyclotomic_dense_ops=cyclotomic_dense_ops,
-        cyclotomic_coefficient_bits=degree + 1,
+        cyclotomic_coefficient_bits=base_degree + 1,
         cyclotomic_intermediate_bits=cyclotomic_intermediate_bits,
         remainder_coefficient_bits=remainder_coefficient_bits,
     )
@@ -994,7 +1032,14 @@ def _finite_abelian_character_sum_interval_profile_data(
     """Compute all exact interval remainders after admission."""
 
     request_checkpoint("before character-sum admission")
-    work = _character_sum_interval_profile_work(source)
+    try:
+        work = _character_sum_interval_profile_work(source)
+    except ValueError as exc:
+        raise OperationResourceAdmissionError(
+            location=("source",),
+            code="finite_abelian_group.character_sum_not_admitted",
+            message=str(exc),
+        ) from exc
     request_checkpoint("after character-sum admission")
     degree = work.cyclotomic_degree
     exponent = work.group_exponent
@@ -1005,9 +1050,13 @@ def _finite_abelian_character_sum_interval_profile_data(
     generator = Symbol("_finite_abelian_character")
     cyclotomic = cast(
         "Poly",
-        cyclotomic_poly(exponent, generator, polys=True),
+        cyclotomic_poly(work.squarefree_exponent, generator, polys=True),
     )
-    if cyclotomic.domain != ZZ or cyclotomic.LC() != 1 or cyclotomic.degree() != degree:
+    if (
+        cyclotomic.domain != ZZ
+        or cyclotomic.LC() != 1
+        or cyclotomic.degree() != degree // work.inflation
+    ):
         raise RuntimeError("SymPy returned an incompatible cyclotomic polynomial")
 
     # Precompute powers of zeta_N for each frequency across the labelled sequence.
@@ -1041,16 +1090,26 @@ def _finite_abelian_character_sum_interval_profile_data(
             if not interval_powers:
                 coefficients = (0,) * degree
             else:
-                counts: Counter[int] = Counter(interval_powers)
-                polynomial = Poly.from_dict(
-                    {(int(power),): int(coeff) for power, coeff in counts.items()},
-                    generator,
-                    domain=ZZ,
-                )
-                remainder = polynomial.rem(cyclotomic, auto=False)
-                coefficients = tuple(
-                    int(remainder.nth(power)) for power in range(degree)
-                )
+                residue_counts: dict[int, Counter[int]] = {}
+                for power in interval_powers:
+                    quotient, residue = divmod(power, work.inflation)
+                    residue_counts.setdefault(residue, Counter())[quotient] += 1
+                reduced = [0] * degree
+                for residue, counts in residue_counts.items():
+                    polynomial = Poly.from_dict(
+                        {
+                            (power,): coefficient
+                            for power, coefficient in counts.items()
+                        },
+                        generator,
+                        domain=ZZ,
+                    )
+                    remainder = polynomial.rem(cyclotomic, auto=False)
+                    for power in range(degree // work.inflation):
+                        reduced[residue + work.inflation * power] = int(
+                            remainder.nth(power)
+                        )
+                coefficients = tuple(reduced)
             cells.append(
                 FiniteAbelianCharacterSumCell(
                     frequency=frequency,
@@ -1072,14 +1131,7 @@ def compute_finite_abelian_character_sum_interval_profile(
             return compute_finite_abelian_character_sum_interval_profile(source)
 
     _character_sum_execution_deadline()
-    try:
-        work, cells = _finite_abelian_character_sum_interval_profile_data(source)
-    except ValueError as exc:
-        raise OperationDomainValidationError(
-            location=("source",),
-            code="finite_abelian_group.character_sum_not_admitted",
-            message=str(exc),
-        ) from exc
+    work, cells = _finite_abelian_character_sum_interval_profile_data(source)
     request_checkpoint("after character-sum result")
     return FiniteAbelianCharacterSumIntervalProfileResult._from_kernel(
         source,

--- a/src/jacobian/math/lattices/_hnf.py
+++ b/src/jacobian/math/lattices/_hnf.py
@@ -28,6 +28,7 @@ def compute_hermite_normal_form(
     integer_entries = [list(row) for row in request.matrix.entries]
     normal_form, transformation = hermite_normal_form(integer_entries)
     return HermiteNormalFormResult(
+        matrix=request.matrix,
         normal_form=_matrix(normal_form),
         transformation=_matrix(transformation),
     )

--- a/src/jacobian/math/lattices/_lattice.py
+++ b/src/jacobian/math/lattices/_lattice.py
@@ -10,8 +10,6 @@ from jacobian.math.lattices import reduce_basis
 from jacobian.math.lattices._models import (
     LatticeReductionRequest,
     LatticeReductionResult,
-    _require_lattice_matrix_envelope,
-    _run_admission,
 )
 from jacobian.math.matrices.values import (
     MAX_MATRIX_SCALAR_DIGITS,
@@ -36,13 +34,10 @@ def _wire(matrix: Any) -> IntegerMatrix:
 def reduce_lattice_basis(
     request: LatticeReductionRequest,
 ) -> LatticeReductionResult:
-    _run_admission(
-        lambda: _require_lattice_matrix_envelope(request.basis, label="basis input"),
-        location=("basis",),
-    )
     entries = [list(row) for row in request.basis.entries]
     reduced, transformation, rank = reduce_basis(entries)
     return LatticeReductionResult(
+        basis=request.basis,
         reduced_basis=_wire(reduced),
         transformation=_wire(transformation),
         rank=rank,

--- a/src/jacobian/math/lattices/_models.py
+++ b/src/jacobian/math/lattices/_models.py
@@ -97,6 +97,7 @@ class HermiteNormalFormRequest(StrictModel):
 class HermiteNormalFormResult(StrictModel):
     """Exact row HNF and its left unimodular transformation."""
 
+    matrix: IntegerMatrix
     normal_form: IntegerMatrix
     transformation: IntegerMatrix
     relation: Literal["NORMAL_FORM_EQUALS_TRANSFORMATION_TIMES_MATRIX"] = (
@@ -106,6 +107,14 @@ class HermiteNormalFormResult(StrictModel):
     @model_validator(mode="after")
     def require_compatible_shapes(self) -> Self:
         rows = len(self.normal_form.entries)
+        if (
+            self.matrix.row_count != rows
+            or self.matrix.column_count != self.normal_form.column_count
+        ):
+            raise _validation_error(
+                "hnf_source_shape",
+                "normal form must retain the source matrix dimensions",
+            )
         if len(self.transformation.entries) != rows:
             raise _validation_error(
                 "hnf_transformation_rows",
@@ -143,6 +152,7 @@ class LatticeReductionRequest(StrictModel):
 class LatticeReductionResult(StrictModel):
     """An exact reduced basis and its left transformation."""
 
+    basis: IntegerMatrix
     reduced_basis: IntegerMatrix
     transformation: IntegerMatrix
     rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
@@ -157,6 +167,14 @@ class LatticeReductionResult(StrictModel):
     @model_validator(mode="after")
     def require_transformation_shape(self) -> Self:
         rows = len(self.reduced_basis.entries)
+        if (
+            self.basis.row_count != rows
+            or self.basis.column_count != self.reduced_basis.column_count
+        ):
+            raise _validation_error(
+                "lll_source_shape",
+                "reduced basis must retain the source basis dimensions",
+            )
         if len(self.transformation.entries) != rows:
             raise _validation_error(
                 "lll_transformation_rows",

--- a/src/jacobian/math/lattices/operations.py
+++ b/src/jacobian/math/lattices/operations.py
@@ -50,6 +50,8 @@ from jacobian.math.lattices._models import (
     RankGramResult,
     SaturationResult,
     SublatticeIndexResult,
+    _require_lattice_matrix_envelope,
+    _run_admission,
 )
 from jacobian.math.matrices.values import (
     MAX_MATRIX_DIMENSION,
@@ -101,6 +103,11 @@ def reduce_basis(
     transformation.
     """
 
+    basis = IntegerMatrix(entries=tuple(tuple(row) for row in entries))
+    _run_admission(
+        lambda: _require_lattice_matrix_envelope(basis, label="basis input"),
+        location=("basis",),
+    )
     import flint
 
     source = flint.fmpz_mat(entries)

--- a/src/jacobian/math/logic/automata/petri_nets/_tools.py
+++ b/src/jacobian/math/logic/automata/petri_nets/_tools.py
@@ -4,11 +4,9 @@ from typing import Any
 
 from jacobian.catalog.models import (
     MathTool,
-    OperationDomainValidationError,
     OperationExample,
 )
 from jacobian.math.logic.automata.petri_nets._models import (
-    MAX_SIPHON_TRAP_PLACES,
     EnabledTransitionsRequest,
     EnabledTransitionsResult,
     FireTransitionRequest,
@@ -44,32 +42,11 @@ def compute_incidence(request: IncidenceMatrixRequest) -> IncidenceMatrixResult:
 
 
 def compute_reachability(request: ReachabilityRequest) -> ReachabilityResult:
-    try:
-        return reachability_graph(
-            request.net, request.initial_marking, request.max_states
-        )
-    except ValueError as error:
-        raise OperationDomainValidationError(
-            location=("net", "max_states"),
-            code="petri_net.reachability_bound",
-            message=str(error),
-        ) from error
+    return reachability_graph(request.net, request.initial_marking, request.max_states)
 
 
 def compute_siphon_trap(request: SiphonTrapRequest) -> SiphonTrapResult:
-    try:
-        return siphon_trap(request.net)
-    except ValueError as error:
-        code = (
-            "petri_net.siphon_trap_place_bound"
-            if request.net.place_count > MAX_SIPHON_TRAP_PLACES
-            else "petri_net.siphon_trap_work_bound"
-        )
-        raise OperationDomainValidationError(
-            location=("net",),
-            code=code,
-            message=str(error),
-        ) from error
+    return siphon_trap(request.net)
 
 
 # Simple net: 2 places, 2 transitions

--- a/src/jacobian/math/logic/automata/petri_nets/operations.py
+++ b/src/jacobian/math/logic/automata/petri_nets/operations.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from collections import deque
 
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.logic.automata.petri_nets._models import (
     MAX_SIPHON_TRAP_PLACES,
     MAX_SIPHON_TRAP_WORK,
@@ -44,7 +48,11 @@ def _require_marking_size(net: PetriNet, marking: Marking) -> None:
     """Require one token count for each place in the net."""
 
     if len(marking.tokens) != net.place_count:
-        raise ValueError("marking length must match place_count")
+        raise OperationDomainValidationError(
+            location=("marking",),
+            code="petri_net.marking_axis",
+            message="marking length must match place_count",
+        )
 
 
 def _enabled_transition_indices(net: PetriNet, marking: Marking) -> list[int]:
@@ -81,7 +89,11 @@ def _fire_transition_tokens(
 
     _require_marking_size(net, marking)
     if not 0 <= transition < net.transition_count:
-        raise ValueError("transition index out of range")
+        raise OperationDomainValidationError(
+            location=("transition",),
+            code="petri_net.transition_axis",
+            message="transition index out of range",
+        )
     for p in range(net.place_count):
         if marking.tokens[p] < net.pre[p][transition]:
             return (False, marking.tokens)
@@ -223,6 +235,8 @@ def find_minimal_siphons(net: PetriNet) -> list[frozenset[int]]:
     from itertools import combinations
 
     n = net.place_count
+    if net.transition_count == 0:
+        return [frozenset((place,)) for place in range(n)]
     if n == 0:
         return []
 
@@ -262,6 +276,8 @@ def find_minimal_traps(net: PetriNet) -> list[frozenset[int]]:
     from itertools import combinations
 
     n = net.place_count
+    if net.transition_count == 0:
+        return [frozenset((place,)) for place in range(n)]
     if n == 0:
         return []
 
@@ -290,16 +306,27 @@ def find_minimal_traps(net: PetriNet) -> list[frozenset[int]]:
 def siphon_trap(net: PetriNet) -> SiphonTrapResult:
     """Return all inclusion-minimal siphons and traps within the exact bound."""
 
+    if net.transition_count == 0:
+        # Every nonempty subset satisfies both implications vacuously; its
+        # inclusion-minimal members are precisely the singletons.
+        singletons = tuple(
+            PetriPlaceSubset(places=(place,)) for place in range(net.place_count)
+        )
+        return SiphonTrapResult(net=net, siphons=singletons, traps=singletons)
     if net.place_count > MAX_SIPHON_TRAP_PLACES:
-        raise ValueError(
-            "siphon/trap check supports at most "
-            f"{MAX_SIPHON_TRAP_PLACES} places for exact enumeration"
+        raise OperationResourceAdmissionError(
+            location=("net",),
+            code="petri_net.siphon_trap_place_bound",
+            message="siphon/trap check supports at most "
+            f"{MAX_SIPHON_TRAP_PLACES} places for exact enumeration",
         )
     candidates = (1 << net.place_count) - 1
     work = 2 * candidates * (net.transition_count + net.place_count)
     if work > MAX_SIPHON_TRAP_WORK:
-        raise ValueError(
-            "siphon/trap candidate and transition-scan work exceeds the admitted bound"
+        raise OperationResourceAdmissionError(
+            location=("net",),
+            code="petri_net.siphon_trap_work_bound",
+            message="siphon/trap candidate and transition-scan work exceeds the admitted bound",
         )
     return SiphonTrapResult(
         net=net,
@@ -317,7 +344,9 @@ def verify_enabled_transitions(claim: EnabledTransitionsResult) -> bool:
 
     try:
         return enabled_transitions(claim.net, claim.marking) == claim
-    except (TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -326,7 +355,9 @@ def verify_fire_transition(claim: FireTransitionResult) -> bool:
 
     try:
         return fire_transition(claim.net, claim.marking, claim.transition) == claim
-    except (TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -335,7 +366,9 @@ def verify_incidence_matrix(claim: IncidenceMatrixResult) -> bool:
 
     try:
         return compute_incidence_matrix(claim.net) == claim
-    except (TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -347,7 +380,9 @@ def verify_reachability_graph(claim: ReachabilityResult) -> bool:
             reachability_graph(claim.net, claim.initial_marking, claim.max_states)
             == claim
         )
-    except (TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -356,5 +391,7 @@ def verify_siphon_trap(claim: SiphonTrapResult) -> bool:
 
     try:
         return siphon_trap(claim.net) == claim
-    except (TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/logic/automata/petri_nets/values.py
+++ b/src/jacobian/math/logic/automata/petri_nets/values.py
@@ -8,6 +8,10 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 
 MAX_PETRI_PLACES = 64
 MAX_PETRI_TRANSITIONS = 64
@@ -144,15 +148,33 @@ class FiringSequence(StrictModel):
 
 def require_reachability_bounds(net: PetriNet, max_states: int) -> None:
     """Admit BFS work jointly with state, place, and transition dimensions."""
+    if type(max_states) is not int or not 1 <= max_states <= MAX_REACHABILITY_STATES:
+        raise OperationDomainValidationError(
+            location=("max_states",),
+            code="petri_net.reachability_states",
+            message="max_states must be within 1..100000",
+        )
     state_cells = max_states * net.place_count
     firing_records = max_states * net.transition_count
     exploration_work = 2 * firing_records * net.place_count
     if state_cells > MAX_REACHABILITY_STATE_TOKEN_CELLS:
-        raise ValueError("reachability state-token cells exceed the work bound")
+        raise OperationResourceAdmissionError(
+            location=("net", "max_states"),
+            code="petri_net.reachability_bound",
+            message="reachability state-token cells exceed the work bound",
+        )
     if firing_records > MAX_REACHABILITY_FIRING_RECORDS:
-        raise ValueError("reachability firing records exceed the work bound")
+        raise OperationResourceAdmissionError(
+            location=("net", "max_states"),
+            code="petri_net.reachability_bound",
+            message="reachability firing records exceed the work bound",
+        )
     if exploration_work > MAX_REACHABILITY_EXPLORATION_WORK:
-        raise ValueError("reachability exploration exceeds the work bound")
+        raise OperationResourceAdmissionError(
+            location=("net", "max_states"),
+            code="petri_net.reachability_bound",
+            message="reachability exploration exceeds the work bound",
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/logic/automata/tree/_tools.py
+++ b/src/jacobian/math/logic/automata/tree/_tools.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from jacobian.catalog.models import (
     MathTool,
-    OperationDomainValidationError,
     OperationExample,
 )
 from jacobian.math.logic.automata.tree._models import (
@@ -15,8 +14,8 @@ from jacobian.math.logic.automata.tree._models import (
     TreeRunResult,
 )
 from jacobian.math.logic.automata.tree.operations import (
+    _accepted_tree_count_admitted,
     _tree_state_chart_unchecked,
-    accepted_tree_count,
     reachable_state_profile,
 )
 from jacobian.math.logic.automata.tree.values import (
@@ -28,14 +27,7 @@ from jacobian.math.logic.automata.tree.values import (
 
 
 def compute_tree_run(request: TreeRunRequest) -> TreeRunResult:
-    try:
-        node_count = validate_ranked_tree(request.automaton, request.tree)
-    except ValueError as exc:
-        raise OperationDomainValidationError(
-            location=("tree",),
-            code="tree_automata.ranked_tree_domain",
-            message=str(exc),
-        ) from exc
+    node_count = validate_ranked_tree(request.automaton, request.tree)
     chart = _tree_state_chart_unchecked(request.automaton, request.tree)
     states = set(chart[-1][1])
     accepting = set(states) & set(request.automaton.final_states)
@@ -54,19 +46,12 @@ def compute_tree_run(request: TreeRunRequest) -> TreeRunResult:
 def compute_accepted_tree_count(
     request: AcceptedTreeCountRequest,
 ) -> AcceptedTreeCountResult:
-    try:
-        estimated_work_bound = accepted_tree_count_work_bound(
-            request.automaton, request.tree_size
-        )
-    except ValueError as exc:
-        raise OperationDomainValidationError(
-            location=("tree_size",),
-            code="tree_automata.accepted_tree_count_work_bound",
-            message=str(exc),
-        ) from exc
+    estimated_work_bound = accepted_tree_count_work_bound(
+        request.automaton, request.tree_size
+    )
     return AcceptedTreeCountResult._from_kernel(
         request,
-        count=accepted_tree_count(request.automaton, request.tree_size),
+        count=_accepted_tree_count_admitted(request.automaton, request.tree_size),
         estimated_work_bound=estimated_work_bound,
     )
 

--- a/src/jacobian/math/logic/automata/tree/operations.py
+++ b/src/jacobian/math/logic/automata/tree/operations.py
@@ -7,6 +7,10 @@ from collections.abc import Iterator
 from itertools import product
 from math import prod
 
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.logic.automata.tree._models import (
     AcceptedTreeCountResult,
     TreeRunResult,
@@ -18,6 +22,7 @@ from jacobian.math.logic.automata.tree.values import (
     TreeAutomatonTransition,
     TreeStateChartEntry,
     _build_reachable_state_profile,
+    _reject_tree,
     accepted_tree_count_work_bound,
     validate_ranked_tree,
 )
@@ -97,9 +102,29 @@ def accepted_tree_count(
 ) -> int:
     """Count distinct accepted ranked trees, not accepting runs."""
 
+    if type(tree_size) is not int:
+        _reject_tree("tree size must be an integer", resource=False)
     if tree_size < 1:
         return 0
     accepted_tree_count_work_bound(automaton, tree_size)
+    return _accepted_tree_count_admitted(automaton, tree_size)
+
+
+def _accepted_tree_count_admitted(
+    automaton: BottomUpTreeAutomaton, tree_size: int
+) -> int:
+    if not any(transition.child_states for transition in automaton.transitions):
+        # Only leaves can have a run. Count symbols, not nondeterministic runs.
+        if tree_size != 1:
+            return 0
+        finals = set(automaton.final_states)
+        return len(
+            {
+                transition.symbol
+                for transition in automaton.transitions
+                if transition.target_state in finals
+            }
+        )
     transitions_by_symbol = {
         symbol: tuple(
             transition
@@ -197,7 +222,9 @@ def verify_tree_run(claim: TreeRunResult) -> bool:
             and claim.accepted == accepted
             and claim.node_count == len(chart)
         )
-    except (TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -206,7 +233,9 @@ def verify_reachable_state_profile(claim: ReachableStateProfile) -> bool:
 
     try:
         return reachable_state_profile(claim.automaton) == claim
-    except (TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -215,5 +244,7 @@ def verify_accepted_tree_count(claim: AcceptedTreeCountResult) -> bool:
 
     try:
         return accepted_tree_count(claim.automaton, claim.tree_size) == claim.count
-    except (TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/logic/automata/tree/values.py
+++ b/src/jacobian/math/logic/automata/tree/values.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass
 from math import comb
-from typing import Annotated, Self
+from typing import Annotated, NoReturn, Self
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 
 MAX_TA_STATES = 64
 MAX_TA_SYMBOLS = 32
@@ -140,6 +144,15 @@ class BottomUpTreeAutomaton(StrictModel):
                 raise ValueError("final state out of range")
 
 
+def _reject_tree(message: str, *, resource: bool = True) -> NoReturn:
+    error_type = (
+        OperationResourceAdmissionError if resource else OperationDomainValidationError
+    )
+    raise error_type(
+        location=("automaton", "tree"), code="tree_automata.admission", message=message
+    )
+
+
 def validate_ranked_tree(
     automaton: BottomUpTreeAutomaton,
     tree: RankedTree,
@@ -152,19 +165,19 @@ def validate_ranked_tree(
         node, depth = stack.pop()
         node_count += 1
         if node_count > MAX_RUN_TREE_NODES:
-            raise ValueError("tree node count exceeds bound")
+            _reject_tree("tree node count exceeds bound")
         if depth > MAX_RUN_TREE_DEPTH:
-            raise ValueError("tree depth exceeds bound")
+            _reject_tree("tree depth exceeds bound")
         if node.symbol >= len(automaton.arity):
-            raise ValueError("tree symbol out of ranked alphabet")
+            _reject_tree("tree symbol out of ranked alphabet", resource=False)
         if len(node.children) != automaton.arity[node.symbol]:
-            raise ValueError("every tree node must match its symbol arity")
+            _reject_tree("every tree node must match its symbol arity", resource=False)
         stack.extend((child, depth + 1) for child in node.children)
 
     arity_factor = max(1, max(automaton.arity))
     estimated_work = node_count * max(1, len(automaton.transitions)) * arity_factor
     if estimated_work > MAX_TREE_AUTOMATON_WORK:
-        raise ValueError("tree run work bound exceeded")
+        _reject_tree("tree run work bound exceeded")
     return node_count
 
 
@@ -177,9 +190,9 @@ def ranked_tree_node_count(tree: RankedTree) -> int:
         node, depth = stack.pop()
         node_count += 1
         if node_count > MAX_RUN_TREE_NODES:
-            raise ValueError("tree node count exceeds bound")
+            _reject_tree("tree node count exceeds bound")
         if depth > MAX_RUN_TREE_DEPTH:
-            raise ValueError("tree depth exceeds bound")
+            _reject_tree("tree depth exceeds bound")
         stack.extend((child, depth + 1) for child in node.children)
     return node_count
 
@@ -344,7 +357,7 @@ def _build_reachable_state_profile(
     if sort_work + scan_rounds * per_scan_work + 3 * MAX_REACHABILITY_WITNESS_NODES > (
         MAX_TREE_AUTOMATON_REACHABILITY_WORK
     ):
-        raise ValueError("tree automaton reachability work bound exceeded")
+        _reject_tree("tree automaton reachability work bound exceeded")
     reachable_choices = tuple(
         (state, choice) for state, choice in enumerate(choices) if choice is not None
     )
@@ -352,7 +365,7 @@ def _build_reachable_state_profile(
     if sum(choice.node_count for _, choice in reachable_choices) > (
         MAX_REACHABILITY_WITNESS_NODES
     ):
-        raise ValueError("reachable-state witness output exceeds the node bound")
+        _reject_tree("reachable-state witness output exceeds the node bound")
     return ReachableStateProfile._from_kernel(
         automaton,
         reachable_states=reachable_states,
@@ -448,6 +461,12 @@ def accepted_tree_count_work_bound(
 ) -> int:
     """Return a conservative bound for subset-DP transition checks."""
 
+    if type(tree_size) is not int:
+        _reject_tree("tree size must be an integer", resource=False)
+    if not any(transition.child_states for transition in automaton.transitions):
+        return len(automaton.transitions)
+    if not 0 <= tree_size <= 100:
+        _reject_tree("tree size exceeds the supported 0..100 bound")
     transition_counts = Counter(
         transition.symbol for transition in automaton.transitions
     )
@@ -461,7 +480,7 @@ def accepted_tree_count_work_bound(
             compositions = comb(tree_size - 1, arity)
             work += compositions * subset_count**arity * transition_count
         if work > MAX_TREE_AUTOMATON_WORK:
-            raise ValueError("accepted-tree count work bound exceeded")
+            _reject_tree("accepted-tree count work bound exceeded")
     return work
 
 

--- a/src/jacobian/math/logic/games/finite/operations.py
+++ b/src/jacobian/math/logic/games/finite/operations.py
@@ -313,7 +313,7 @@ def nash_equilibrium(payoff_matrix: PayoffMatrix) -> NashEquilibriumResult:
     elimination_dimension = max(matrix_value.n_rows, matrix_value.n_cols) + 2
     work = elimination_dimension * (denominator_digits + numerator_digits)
     if work > MAX_EXACT_EQUILIBRIUM_WORK:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("payoff_matrix",),
             code="finite_game.exact_equilibrium_budget",
             message="payoffs exceed the published exact-equilibrium work bound",
@@ -393,19 +393,56 @@ def nash_equilibrium(payoff_matrix: PayoffMatrix) -> NashEquilibriumResult:
 
 
 def verify_best_response(claim: BestResponseResult) -> bool:
-    try:
-        return best_response(claim.payoff_matrix) == claim
-    except (OperationDomainValidationError, TypeError, ValueError):
+    """Check a maximizing row, including any row tied for the maximin value."""
+    if not 0 <= claim.best_row < claim.payoff_matrix.n_rows:
         return False
+    matrix = _payoff_matrix(claim.payoff_matrix)
+    row_values = tuple(min(row) for row in matrix)
+    value = claim.value.as_fraction()
+    return row_values[claim.best_row] == value == max(row_values)
 
 
 def verify_nash_equilibrium(claim: NashEquilibriumResult) -> bool:
-    try:
-        return nash_equilibrium(claim.payoff_matrix) == claim
-    except OperationResourceAdmissionError:
-        raise
-    except (OperationDomainValidationError, TypeError, ValueError):
+    """Check the authored simplex strategies and saddle inequalities directly."""
+    payoffs = claim.payoff_matrix
+    if (
+        len(claim.row_strategy) != payoffs.n_rows
+        or len(claim.col_strategy) != payoffs.n_cols
+    ):
         return False
+    scalars = (*payoffs.entries, *claim.row_strategy, *claim.col_strategy, claim.value)
+    # Every checked dot product is a sum of at most max(rows, columns)
+    # pair products. Total input height bounds the common denominator and
+    # numerator growth; multiply by the scalar-work count before arithmetic.
+    height = sum(
+        abs(value.num).bit_length() + value.den.bit_length() for value in scalars
+    )
+    work = (
+        2 * payoffs.n_rows * payoffs.n_cols + payoffs.n_rows + payoffs.n_cols
+    ) * max(1, height)
+    if work > MAX_EXACT_EQUILIBRIUM_WORK * 16:
+        raise OperationResourceAdmissionError(
+            location=("claim",),
+            code="finite_game.equilibrium_check_budget",
+            message="equilibrium relation exceeds its exact arithmetic work bound",
+        )
+    rows = tuple(value.as_fraction() for value in claim.row_strategy)
+    columns = tuple(value.as_fraction() for value in claim.col_strategy)
+    if (
+        any(weight < 0 for weight in (*rows, *columns))
+        or sum(rows) != 1
+        or sum(columns) != 1
+    ):
+        return False
+    value = claim.value.as_fraction()
+    matrix = _payoff_matrix(payoffs)
+    return all(
+        sum(rows[i] * matrix[i][j] for i in range(payoffs.n_rows)) >= value
+        for j in range(payoffs.n_cols)
+    ) and all(
+        sum(matrix[i][j] * columns[j] for j in range(payoffs.n_cols)) <= value
+        for i in range(payoffs.n_rows)
+    )
 
 
 __all__ = [

--- a/src/jacobian/math/logic/languages/context_free/_models.py
+++ b/src/jacobian/math/logic/languages/context_free/_models.py
@@ -29,7 +29,7 @@ class FiniteCFGO(StrictModel):
 
     nonterminals: tuple[str, ...] = Field(min_length=1, max_length=MAX_NONTERMINALS)
     terminals: tuple[str, ...] = Field(min_length=0, max_length=MAX_NONTERMINALS)
-    rules: tuple[GrammarRule, ...] = Field(min_length=1, max_length=MAX_RULES)
+    rules: tuple[GrammarRule, ...] = Field(min_length=0, max_length=MAX_RULES)
     start_symbol: str = Field(min_length=1, max_length=64)
 
     @model_validator(mode="after")
@@ -40,6 +40,12 @@ class FiniteCFGO(StrictModel):
             )
         nonterminal_set = set(self.nonterminals)
         terminal_set = set(self.terminals)
+        if len(nonterminal_set) != len(self.nonterminals) or len(terminal_set) != len(
+            self.terminals
+        ):
+            raise _validation_error(
+                "duplicate_symbols", "grammar symbol axes must be unique"
+            )
         disjoint = nonterminal_set & terminal_set
         if disjoint:
             raise _validation_error(

--- a/src/jacobian/math/logic/languages/context_free/operations.py
+++ b/src/jacobian/math/logic/languages/context_free/operations.py
@@ -1,6 +1,5 @@
 """Exact operations on finite context-free grammars."""
 
-from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.logic.languages.context_free._models import (
     DependencyGraphResult,
     FiniteCFGO,
@@ -80,34 +79,19 @@ def first_sets(grammar: FiniteCFGO) -> tuple[tuple[str, ...], ...]:
 
 def verify_symbol_profiles(claim: SymbolProfilesResult) -> bool:
     """Verify nullable flags against the retained grammar and symbol axis."""
-    try:
-        return tuple(nullable_nonterminals(claim.grammar)) == claim.nullable and len(
-            claim.nullable
-        ) == len(claim.grammar.nonterminals)
-    except OperationResourceAdmissionError:
-        raise
-    except (TypeError, ValueError):
-        return False
+    return tuple(nullable_nonterminals(claim.grammar)) == claim.nullable and len(
+        claim.nullable
+    ) == len(claim.grammar.nonterminals)
 
 
 def verify_dependency_graph(claim: DependencyGraphResult) -> bool:
     """Verify dependency edges against the retained grammar."""
-    try:
-        return dependency_edges(claim.grammar) == claim.edges
-    except OperationResourceAdmissionError:
-        raise
-    except (TypeError, ValueError):
-        return False
+    return dependency_edges(claim.grammar) == claim.edges
 
 
 def verify_first_sets(claim: FirstSetsResult) -> bool:
     """Verify FIRST sets against the retained grammar and terminal axis."""
-    try:
-        return first_sets(claim.grammar) == claim.first_sets
-    except OperationResourceAdmissionError:
-        raise
-    except (TypeError, ValueError):
-        return False
+    return first_sets(claim.grammar) == claim.first_sets
 
 
 __all__ = [

--- a/src/jacobian/math/logic/languages/regular/_profile_admission.py
+++ b/src/jacobian/math/logic/languages/regular/_profile_admission.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import NoReturn
 
 from jacobian.canonical import format_canonical_integer
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.logic.languages.regular.values import (
     MAX_TRANSITION_PROFILE_COUNT_DIGITS,
     MAX_TRANSITION_PROFILE_ENTRIES,
@@ -12,6 +17,18 @@ from jacobian.math.logic.languages.regular.values import (
     AutomatonTransition,
     FiniteLabeledAutomaton,
 )
+
+
+def _reject(message: str, *, resource: bool = True) -> NoReturn:
+    error_type = (
+        OperationResourceAdmissionError if resource else OperationDomainValidationError
+    )
+    raise error_type(
+        location=("automaton", "source_state", "target_state", "path_length"),
+        code="regular_language.transition_profile_not_admitted",
+        message=message,
+    )
+
 
 _MAX_DP_UPDATES = 2_000_000
 _MAX_VECTOR_UPDATE_WORK = 20_000_000
@@ -140,7 +157,7 @@ def _path_count_and_walk_bound(
                     next_counts.get(transition.target, 0) + multiplicity
                 )
         if updates > _MAX_DP_UPDATES and composition_updates > _MAX_DP_UPDATES:
-            raise ValueError(
+            _reject(
                 "transition-Parikh DP transition-update bound exceeded; reduce the "
                 "path length or transition branching"
             )
@@ -160,15 +177,13 @@ def admit_transition_profile(
     """Admit one exact transition-profile computation and retain its plan."""
 
     if not 0 <= source_state < automaton.state_count:
-        raise ValueError("source_state must be in 0..state_count-1")
+        _reject("source_state must be in 0..state_count-1", resource=False)
     if not 0 <= target_state < automaton.state_count:
-        raise ValueError("target_state must be in 0..state_count-1")
+        _reject("target_state must be in 0..state_count-1", resource=False)
     if path_length < 0:
-        raise ValueError("path_length must be nonnegative")
+        _reject("path_length must be nonnegative", resource=False)
     if path_length > MAX_TRANSITION_PROFILE_PATH_LENGTH:
-        raise ValueError(
-            "path_length exceeds the transition-Parikh preflight length bound"
-        )
+        _reject("path_length exceeds the transition-Parikh preflight length bound")
     transition_count = len(automaton.transitions)
     outgoing = _relevant_outgoing(automaton, source_state, target_state)
     active_transition_count = sum(map(len, outgoing))
@@ -184,18 +199,18 @@ def admit_transition_profile(
     )
     updates = min(walk_updates, composition_updates)
     if updates > _MAX_DP_UPDATES:
-        raise ValueError(
+        _reject(
             "transition-Parikh DP transition-update bound exceeded; reduce the "
             "path length or transition branching"
         )
     profile_cells = min(target_count, composition_cells)
     if profile_cells > MAX_TRANSITION_PROFILE_ENTRIES:
-        raise ValueError(
+        _reject(
             "transition-Parikh profile-cell bound exceeded; reduce the path length "
             "or transition dimension"
         )
     if updates * transition_count > _MAX_VECTOR_UPDATE_WORK:
-        raise ValueError(
+        _reject(
             "transition-Parikh dense-vector update-work bound exceeded; reduce "
             "the transition axis or path branching"
         )
@@ -205,13 +220,13 @@ def admit_transition_profile(
         updates + 1,
     )
     if layer_cells * transition_count > _MAX_VECTOR_COORDINATES:
-        raise ValueError(
+        _reject(
             "transition-Parikh intermediate vector-coordinate bound exceeded; "
             "reduce the transition axis or path branching"
         )
     count_digits = len(format_canonical_integer(max(1, target_count)))
     if count_digits > MAX_TRANSITION_PROFILE_COUNT_DIGITS:
-        raise ValueError(
+        _reject(
             "transition-Parikh multiplicity digit bound exceeded; reduce the path "
             "length or transition branching"
         )

--- a/src/jacobian/math/logic/languages/regular/_tools.py
+++ b/src/jacobian/math/logic/languages/regular/_tools.py
@@ -63,19 +63,12 @@ def compute_complement(request: ComplementRequest) -> ComplementResult:
 def compute_transition_parikh_profile(
     request: TransitionParikhProfileRequest,
 ) -> TransitionParikhProfile:
-    try:
-        return transition_parikh_profile(
-            request.automaton,
-            request.source_state,
-            request.target_state,
-            request.path_length,
-        )
-    except ValueError as exc:
-        raise OperationDomainValidationError(
-            location=("automaton", "source_state", "target_state", "path_length"),
-            code="regular_language.transition_profile_not_admitted",
-            message=str(exc),
-        ) from exc
+    return transition_parikh_profile(
+        request.automaton,
+        request.source_state,
+        request.target_state,
+        request.path_length,
+    )
 
 
 _DFA_EXAMPLE = {

--- a/src/jacobian/math/logic/languages/regular/operations.py
+++ b/src/jacobian/math/logic/languages/regular/operations.py
@@ -77,7 +77,7 @@ def count_accepted_words(dfa: DFA, word_length: int) -> int:
         result_cap,
     )
     if selected_count >= result_cap:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("dfa", "word_length"),
             code="regular_language.count_result_bound",
             message="accepted-word count exceeds the canonical result digit bound",
@@ -85,7 +85,7 @@ def count_accepted_words(dfa: DFA, word_length: int) -> int:
     if max_intermediate >= result_cap:
         # FLINT powers the full matrix. Unused entries can explode while the
         # selected count stays tiny; do not cap that growth at the result limit.
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("dfa", "word_length"),
             code="regular_language.count_intermediate_bound",
             message="DFA matrix-power intermediates exceed the canonical digit bound",
@@ -99,7 +99,7 @@ def count_accepted_words(dfa: DFA, word_length: int) -> int:
         * max(1, coefficient_bound.bit_length())
     )
     if matrix_bit_work > MAX_COUNT_MATRIX_BIT_WORK:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("dfa", "word_length"),
             code="regular_language.count_work_bound",
             message="DFA matrix powering exceeds the exact work bound",
@@ -324,7 +324,9 @@ def verify_accepted_word_count(claim: CountResult) -> bool:
 
     try:
         return count_accepted_words(claim.dfa, claim.word_length) == claim.count
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -343,5 +345,5 @@ def verify_transition_parikh_profile(claim: TransitionParikhProfile) -> bool:
         )
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/logic/languages/words/_fixed_point_admission.py
+++ b/src/jacobian/math/logic/languages/words/_fixed_point_admission.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pydantic_core import PydanticCustomError
+
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.logic.languages.words.values import (
     MAX_MORPHISM_OUTPUT_LENGTH,
     ProlongableSubstitution,
@@ -18,12 +21,17 @@ def require_fixed_point_prefix_budget(
     """Admit a fixed-point prefix before any iterate is materialized."""
 
     if not 0 <= prefix_length <= MAX_MORPHISM_OUTPUT_LENGTH:
-        raise ValueError(f"prefix length must be in 0..{MAX_MORPHISM_OUTPUT_LENGTH}")
+        raise PydanticCustomError(
+            "word.prefix_length",
+            f"prefix length must be in 0..{MAX_MORPHISM_OUTPUT_LENGTH}",
+        )
     _require_prolongable_source_occurrence_bound(source)
     _require_growing_seed(source)
     generation_work = 4 * prefix_length * prefix_length
     if generation_work > MAX_FIXED_POINT_GENERATION_WORK:
-        raise ValueError(
-            "fixed-point generation exceeds the work bound "
-            f"({generation_work} > {MAX_FIXED_POINT_GENERATION_WORK})"
+        raise OperationResourceAdmissionError(
+            location=("prefix_length",),
+            code="words.fixed_point_generation_budget",
+            message="fixed-point generation exceeds the work bound "
+            f"({generation_work} > {MAX_FIXED_POINT_GENERATION_WORK})",
         )

--- a/src/jacobian/math/logic/languages/words/_tools.py
+++ b/src/jacobian/math/logic/languages/words/_tools.py
@@ -3,6 +3,8 @@
 from collections.abc import Callable
 from typing import Any
 
+from pydantic_core import PydanticCustomError
+
 from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
@@ -40,7 +42,7 @@ def _admit[T](
 ) -> T:
     try:
         return admission()
-    except ValueError as exc:
+    except PydanticCustomError as exc:
         raise OperationDomainValidationError(
             location=location,
             code=code,

--- a/src/jacobian/math/logic/languages/words/operations.py
+++ b/src/jacobian/math/logic/languages/words/operations.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
+from pydantic_core import PydanticCustomError
+
 from jacobian.math.logic.languages.words._fixed_point_admission import (
     require_fixed_point_prefix_budget,
 )
@@ -65,7 +67,10 @@ class PrimitivityAnalysis:
 
 def factors_of_length(word: FiniteWord, factor_length: int) -> FactorAnalysis:
     if not 0 <= factor_length <= len(word.letters):
-        raise ValueError("factor length must be between zero and the word length")
+        raise PydanticCustomError(
+            "word.factor_length_out_of_range",
+            "factor length must be between zero and the word length",
+        )
     positions: dict[tuple[str, ...], list[int]] = {}
     for start in range(len(word.letters) - factor_length + 1):
         factor = word.letters[start : start + factor_length]
@@ -166,12 +171,15 @@ def compose_morphisms(first: WordMorphism, second: WordMorphism) -> WordMorphism
     if first.target_alphabet != second.source_alphabet:
         raise ValueError("first target alphabet must equal second source alphabet")
     second_map = dict(zip(second.source_alphabet, second.images, strict=True))
+    if any(
+        sum(len(second_map[letter]) for letter in image) > MAX_MORPHISM_OUTPUT_LENGTH
+        for image in first.images
+    ):
+        raise ValueError("composed morphism image exceeds the length bound")
     images = tuple(
         tuple(output for letter in image for output in second_map[letter])
         for image in first.images
     )
-    if any(len(image) > MAX_MORPHISM_OUTPUT_LENGTH for image in images):
-        raise ValueError("composed morphism image exceeds the length bound")
     return WordMorphism(
         source_alphabet=first.source_alphabet,
         target_alphabet=second.target_alphabet,
@@ -269,6 +277,18 @@ def substitution_primitivity_profile(
     import networkx as nx
 
     alphabet = dependency_graph.substitution.morphism.source_alphabet
+    images = dependency_graph.substitution.morphism.images
+    expected_support = {
+        (source, target)
+        for source, image in zip(alphabet, images, strict=True)
+        for target in image
+    }
+    actual_support = {(edge.source, edge.target) for edge in dependency_graph.edges}
+    if actual_support != expected_support:
+        raise PydanticCustomError(
+            "word.dependency_support_mismatch",
+            "dependency graph support must match the retained substitution",
+        )
     index = {symbol: position for position, symbol in enumerate(alphabet)}
     graph: nx.DiGraph[str] = nx.DiGraph()
     graph.add_nodes_from(alphabet)
@@ -365,7 +385,7 @@ def verify_factors_length(claim: FactorsLengthResult) -> bool:
             == tuple(positions[0] for positions in analysis.occurrences)
             and claim.distinct_count == len(analysis.factors)
         )
-    except (TypeError, ValueError, IndexError):
+    except PydanticCustomError:
         return False
 
 
@@ -379,7 +399,7 @@ def verify_periods(claim: PeriodsResult) -> bool:
             and claim.least_period == analysis.least_period
             and claim.is_primitive == analysis.primitive
         )
-    except (TypeError, ValueError):
+    except PydanticCustomError:
         return False
 
 
@@ -388,7 +408,7 @@ def verify_incidence_matrix(claim: IncidenceMatrixResult) -> bool:
 
     try:
         return claim.matrix == incidence_matrix(claim.morphism)
-    except (TypeError, ValueError):
+    except PydanticCustomError:
         return False
 
 
@@ -399,7 +419,7 @@ def verify_substitution_dependency_graph(
 
     try:
         return claim.graph == substitution_dependency_graph(claim.substitution)
-    except (TypeError, ValueError):
+    except PydanticCustomError:
         return False
 
 
@@ -409,14 +429,6 @@ def verify_substitution_primitivity_profile(
     """Verify a substitution primitivity claim against its dependency graph."""
 
     try:
-        # The profile is mathematically a property of the substitution's
-        # dependency graph.  Verify that retained graph before trusting its
-        # edges; a structurally valid graph may omit an occurrence edge.
-        expected_graph = substitution_dependency_graph(
-            claim.dependency_graph.substitution
-        )
-        if expected_graph != claim.dependency_graph:
-            return False
         analysis = substitution_primitivity_profile(claim.dependency_graph)
         return (
             claim.strongly_connected_components
@@ -428,7 +440,7 @@ def verify_substitution_primitivity_profile(
             and claim.exponent_upper_bound == analysis.exponent_upper_bound
             and claim.obstruction == analysis.obstruction
         )
-    except (TypeError, ValueError):
+    except PydanticCustomError:
         return False
 
 
@@ -444,5 +456,5 @@ def verify_substitution_fixed_point_prefix(
             and claim.least_iterate_depth == analysis.least_iterate_depth
             and claim.retained_prefix_lengths == analysis.retained_prefix_lengths
         )
-    except (TypeError, ValueError):
+    except PydanticCustomError:
         return False

--- a/src/jacobian/math/logic/languages/words/values.py
+++ b/src/jacobian/math/logic/languages/words/values.py
@@ -9,6 +9,7 @@ from pydantic import AfterValidator, Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.catalog.models import OperationResourceAdmissionError
 
 MAX_WORD_LENGTH = 500
 MAX_ALPHABET_SIZE = 50
@@ -126,9 +127,11 @@ class Substitution(StrictModel):
 def _require_dependency_occurrence_bound(substitution: Substitution) -> None:
     occurrence_count = sum(len(image) for image in substitution.morphism.images)
     if occurrence_count > MAX_SUBSTITUTION_DEPENDENCY_OCCURRENCES:
-        raise ValueError(
-            "dependency occurrence output exceeds the aggregate bound "
-            f"({occurrence_count} > {MAX_SUBSTITUTION_DEPENDENCY_OCCURRENCES})"
+        raise OperationResourceAdmissionError(
+            location=("substitution",),
+            code="words.dependency_occurrence_budget",
+            message="dependency occurrence output exceeds the aggregate bound "
+            f"({occurrence_count} > {MAX_SUBSTITUTION_DEPENDENCY_OCCURRENCES})",
         )
 
 

--- a/src/jacobian/math/matrices/analysis/operations.py
+++ b/src/jacobian/math/matrices/analysis/operations.py
@@ -25,7 +25,10 @@ from jacobian._execution import (
     request_checkpoint,
 )
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.matrices._number_field import (
     EmbeddedNumberFieldRecognitionError,
     RecognizedRealSimpleNumberField,
@@ -858,9 +861,13 @@ def _compute_inertia(
 
 def verify_inertia(claim: InertiaResult) -> bool:
     """Verify a serialized exact-real inertia claim against its source matrix."""
+    if not isinstance(claim, InertiaResult):
+        return False
     try:
         return compute_inertia(claim.matrix) == claim
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/matrices/canonical_forms/operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/operations.py
@@ -10,7 +10,10 @@ from typing import Any
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.matrices.canonical_forms._models import (
     MATRIX_POLYNOMIAL_EVALUATION_PASSES,
     MAX_CANONICAL_FORM_DIMENSION,
@@ -251,9 +254,8 @@ def minimal_polynomial(entries: RationalEntries) -> CoefficientList:
     Returns the monic minimal polynomial as coefficient list [a_0, ..., a_n].
     """
 
-    from sympy import Matrix, Poly, Symbol, eye
+    from sympy import Matrix, eye
 
-    x = Symbol("x")
     n = _square_dimension(entries)
     matrix = _sympy_matrix(entries)
 
@@ -264,23 +266,19 @@ def minimal_polynomial(entries: RationalEntries) -> CoefficientList:
     rows = [[mat[i, j] for i in range(n) for j in range(n)] for mat in powers]
     stacked = Matrix(rows).T
 
-    _reduced, pivots = stacked.rref()
+    reduced, pivots = stacked.rref()
     degree = next((index for index in range(n + 1) if index not in pivots), None)
     if degree is None:
         raise ArithmeticError("Krylov subspace exceeded the Cayley-Hamilton bound")
     if degree == 0:
         return (Fraction(1),)
 
-    submatrix = stacked[:, : degree + 1]
-    null_vectors = submatrix.nullspace()
-    if not null_vectors:
-        raise ArithmeticError(
-            "Krylov subspace produced no minimal polynomial dependency"
-        )
-
-    coefficients = null_vectors[0]
-    dependency = sum(coefficients[index] * x**index for index in range(degree + 1))
-    return _coefficients(Poly(dependency, x).monic())
+    # All earlier power columns are pivots. The first free column gives the
+    # unique monic dependence directly in the already-reduced Krylov matrix.
+    return (
+        *(Fraction(-reduced[index, degree]) for index in range(degree)),
+        Fraction(1),
+    )
 
 
 def invariant_factors(entries: RationalEntries) -> tuple[CoefficientList, ...]:
@@ -543,6 +541,8 @@ def _primary_decomposition_components(
 def verify_minimal_polynomial(claim: MinimalPolynomialResult) -> bool:
     """Verify minimal and characteristic polynomials against the matrix."""
 
+    if not isinstance(claim, MinimalPolynomialResult):
+        return False
     try:
         minimal, characteristic = _minimal_polynomial_components(claim.matrix)
         expected = MinimalPolynomialResult._from_kernel(
@@ -551,13 +551,17 @@ def verify_minimal_polynomial(claim: MinimalPolynomialResult) -> bool:
             characteristic_polynomial=characteristic,
         )
         return expected == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_rational_canonical_form(claim: RationalCanonicalFormResult) -> bool:
     """Verify invariant factors and derived polynomials against the matrix."""
 
+    if not isinstance(claim, RationalCanonicalFormResult):
+        return False
     try:
         factors, characteristic, minimal = _rational_canonical_components(claim.matrix)
         expected = RationalCanonicalFormResult._from_kernel(
@@ -567,13 +571,17 @@ def verify_rational_canonical_form(claim: RationalCanonicalFormResult) -> bool:
             minimal_polynomial=minimal,
         )
         return expected == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_primary_decomposition(claim: PrimaryDecompositionResult) -> bool:
     """Verify primary components and their product against the matrix."""
 
+    if not isinstance(claim, PrimaryDecompositionResult):
+        return False
     try:
         components, minimal = _primary_decomposition_components(claim.matrix)
         expected = PrimaryDecompositionResult._from_kernel(
@@ -582,5 +590,7 @@ def verify_primary_decomposition(claim: PrimaryDecompositionResult) -> bool:
             minimal_polynomial=minimal,
         )
         return expected == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/matrices/certified_snf/operations.py
+++ b/src/jacobian/math/matrices/certified_snf/operations.py
@@ -172,7 +172,7 @@ def inverse_unimodular(matrix: Matrix) -> Matrix:
     if size == 0:
         return []
 
-    from sympy import ZZ, eye
+    from sympy import ZZ
     from sympy.polys.matrices import DomainMatrix
     from sympy.polys.matrices.exceptions import DMNonInvertibleMatrixError
 
@@ -184,8 +184,6 @@ def inverse_unimodular(matrix: Matrix) -> Matrix:
     numerator, denominator = numerator.cancel_denom(denominator)
     if denominator != ZZ.one:
         raise ValueError("matrix is not unimodular")
-    if domain.matmul(numerator).to_Matrix() != eye(size):
-        raise ArithmeticError("unimodular inverse does not recover the identity")
     return [[int(value) for value in row] for row in numerator.to_Matrix().tolist()]
 
 
@@ -343,18 +341,15 @@ def verify_smith_normal_form_certificate(
     diagonal = [list(row) for row in certificate.diagonal.entries]
     left = [list(row) for row in certificate.left_transformation.entries]
     right = [list(row) for row in certificate.right_transformation.entries]
-    try:
-        if matrix_multiply(matrix_multiply(left, source), right) != diagonal:
-            return False
-        return all(
-            matrix_determinant(transformation) == int(determinant)
-            for transformation, determinant in (
-                (left, certificate.left_determinant),
-                (right, certificate.right_determinant),
-            )
-        )
-    except (ArithmeticError, ValueError):
+    if matrix_multiply(matrix_multiply(left, source), right) != diagonal:
         return False
+    return all(
+        matrix_determinant(transformation) == int(determinant)
+        for transformation, determinant in (
+            (left, certificate.left_determinant),
+            (right, certificate.right_determinant),
+        )
+    )
 
 
 __all__ = [

--- a/src/jacobian/math/matrices/operations.py
+++ b/src/jacobian/math/matrices/operations.py
@@ -18,7 +18,10 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.matrices import _conversions as conversions
 from jacobian.math.matrices._operation_models import (
     MAX_CHARACTERISTIC_POLYNOMIAL_ORDER,
@@ -1334,6 +1337,8 @@ def nullspace_result(matrix: RationalMatrix | SparseRationalMatrix) -> Nullspace
 
 def verify_nullspace(claim: NullspaceResult) -> bool:
     """Check a serialized fundamental nullspace claim against its source."""
+    if not isinstance(claim, NullspaceResult):
+        return False
     try:
         source_rank = rank_result(claim.matrix)
         if source_rank.rank != claim.rank:
@@ -1377,7 +1382,9 @@ def verify_nullspace(claim: NullspaceResult) -> bool:
             ):
                 return False
         return True
-    except (AttributeError, IndexError, OperationDomainValidationError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/matrices/quadratic_spectral/operations.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/operations.py
@@ -613,35 +613,41 @@ def inertia(matrix: RealQuadraticMatrix) -> RealQuadraticInertia:
 
 def verify_symmetric_spectrum(claim: RealQuadraticSpectrum) -> bool:
     """Verify a serialized exact symmetric spectrum against its source."""
+    if not isinstance(claim, RealQuadraticSpectrum):
+        return False
     if claim.spectrum_kind != "SYMMETRIC_EIGENVALUES":
         return False
     try:
         return symmetric_spectrum(claim.matrix) == claim
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 
 def verify_singular_spectrum(claim: RealQuadraticSpectrum) -> bool:
     """Verify a serialized exact singular spectrum against its source."""
+    if not isinstance(claim, RealQuadraticSpectrum):
+        return False
     if claim.spectrum_kind != "SINGULAR_VALUES":
         return False
     try:
         return singular_spectrum(claim.matrix) == claim
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 
 def verify_inertia(claim: RealQuadraticInertia) -> bool:
     """Verify serialized inertia counts and definiteness against the source."""
+    if not isinstance(claim, RealQuadraticInertia):
+        return False
     try:
         return inertia(claim.matrix) == claim
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/matrices/subsystems/operations.py
+++ b/src/jacobian/math/matrices/subsystems/operations.py
@@ -8,7 +8,10 @@ from fractions import Fraction
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math._exact_linear_algebra import symmetric_inertia
 from jacobian.math.matrices.subsystems._models import (
     MAX_KRONECKER_RESULT_COMPONENT_DIGITS,
@@ -130,28 +133,40 @@ def verify_subsystem_kronecker_product(
     claim: SubsystemKroneckerProductResult,
 ) -> bool:
     """Verify a source-bound Kronecker product claim."""
+    if not isinstance(claim, SubsystemKroneckerProductResult):
+        return False
     try:
         return kronecker_product(claim.left, claim.right) == claim.product
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_partial_trace(claim: SubsystemPartialTraceResult) -> bool:
     """Verify a source-bound partial-trace contraction claim."""
+    if not isinstance(claim, SubsystemPartialTraceResult):
+        return False
     try:
         return (
             partial_trace(claim.source_matrix, claim.traced_factor_labels)
             == claim.reduced_matrix
         )
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_psd_order(claim: PsdOrderResult) -> bool:
     """Verify a source-bound PSD-order decision and witness."""
+    if not isinstance(claim, PsdOrderResult):
+        return False
     try:
         return psd_order(claim.left, claim.right) == claim
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/matrices/symbolic/operations.py
+++ b/src/jacobian/math/matrices/symbolic/operations.py
@@ -10,9 +10,13 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Literal
 
+from pydantic import ValidationError
 from pydantic_core import PydanticCustomError
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.matrices.symbolic._models import (
     RationalFunctionMatrix,
     RationalFunctionVector,
@@ -51,7 +55,7 @@ def _validate_matrix_carrier(value: object) -> RationalFunctionMatrix:
         raise ValueError("symbolic matrix must be a RationalFunctionMatrix carrier")
     try:
         return RationalFunctionMatrix.model_validate(value.model_dump(warnings="none"))
-    except Exception as exc:
+    except ValidationError as exc:
         raise ValueError(
             "symbolic matrix carrier failed structural validation"
         ) from exc
@@ -224,11 +228,16 @@ def verify_symbolic_eigenvalues(claim: SymbolicEigenvaluesResult) -> bool:
             return False
         normalized = SymbolicEigenvaluesResult.model_validate(claim.model_dump())
         matrix = _validate_matrix_carrier(normalized.matrix)
+    except (AttributeError, TypeError, ValueError):
+        return False
+    try:
         degree, coefficients = symbolic_characteristic_polynomial(
             matrix.entries,
             matrix.variables,
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
     return (
         degree == normalized.degree

--- a/src/jacobian/math/number_theory/p_adic/operations.py
+++ b/src/jacobian/math/number_theory/p_adic/operations.py
@@ -313,10 +313,12 @@ def hensel_lift_factors(
 ) -> HenselFactorLiftResult:
     """Lift a coprime factorization f ≡ g*h (mod p) to f ≡ g*h (mod p^k).
 
-    Standard quadratic Hensel lifting: every step derives both factor
-    corrections from the fixed Bézout relation ``s*g + t*h ≡ 1 (mod p)``,
-    preserving the product congruence exactly. The reconstructed product
-    is validated against ``f`` modulo ``p^k`` before returning.
+    Each step lifts one p-adic digit using the fixed Bézout relation
+    ``s*g + t*h ≡ 1 (mod p)``. The corrections satisfy
+    ``sigma*h + tau*g = (f-g*h)/p^r (mod p)``; their cross term is
+    divisible by ``p^(r+1)``. Thus induction from the admitted source
+    congruence establishes the final product without replaying it.
+    Consumers of an authored lift use ``verify_hensel_factor_lift``.
     """
     _admit_factors(polynomial, factor_g, factor_h, prime, precision)
     f_asc = _kernel_coefficients(polynomial)
@@ -388,14 +390,6 @@ def hensel_lift_factors(
 
     lifted_g = _trim_asc([coefficient % modulus for coefficient in g])
     lifted_h = _trim_asc([coefficient % modulus for coefficient in h])
-    reconstruction = _poly_mul_exact_mod(lifted_g, lifted_h, modulus)
-    residue = _poly_sub_mod(f_asc, reconstruction, modulus)
-    if not _is_zero_polynomial(residue):
-        raise ValueError(
-            "Hensel lifting failed to reproduce the polynomial "
-            f"mod {modulus}; supply factors admitting a coprime lift"
-        )
-
     return HenselFactorLiftResult(
         polynomial=polynomial,
         factor_g=factor_g,

--- a/src/jacobian/math/polynomials/_jacobian_syzygy.py
+++ b/src/jacobian/math/polynomials/_jacobian_syzygy.py
@@ -293,7 +293,7 @@ def _compute_graded_jacobian_syzygy(
             multiplier_degree,
             source_degree,
         )
-        _, pivot_columns = matrix.rref()
+        reduced, pivot_columns = matrix.rref()
         rank = len(pivot_columns)
         rank_minor: GradedJacobianRankMinor | None = None
         if rank:
@@ -346,7 +346,14 @@ def _compute_graded_jacobian_syzygy(
         )
         if nullity:
             first_degree = multiplier_degree
-            vector = _primitive_kernel(matrix.nullspace()[0])
+            free_column = next(
+                index for index in range(matrix.cols) if index not in pivot_columns
+            )
+            dependence = [Fraction(0)] * matrix.cols
+            dependence[free_column] = Fraction(1)
+            for row, pivot in enumerate(pivot_columns):
+                dependence[pivot] = Fraction(-reduced[row, free_column])
+            vector = _primitive_kernel(dependence)
             block_size = len(source_basis)
             multipliers = tuple(
                 _multiplier_polynomial(

--- a/src/jacobian/math/polynomials/bernstein/operations.py
+++ b/src/jacobian/math/polynomials/bernstein/operations.py
@@ -15,7 +15,10 @@ from jacobian._execution import (
     request_checkpoint,
 )
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.analysis.intervals import RationalBox
 from jacobian.math.polynomials.bernstein.values import (
     Multidegree,
@@ -327,12 +330,16 @@ def bernstein_coefficients(
 
 def verify_bernstein_coefficients(claim: RationalBernsteinPolynomial) -> bool:
     """Verify tensor coefficients against the retained polynomial and box."""
+    if not isinstance(claim, RationalBernsteinPolynomial):
+        return False
     try:
         expected = bernstein_coefficients(
             claim.polynomial, claim.box, claim.multidegree
         )
         return expected.coefficients == claim.coefficients
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -519,6 +526,10 @@ def verify_bernstein_restriction(
     claim: RationalBernsteinPolynomial,
 ) -> bool:
     """Verify a serialized child tensor is the exact restriction of its parent."""
+    if not isinstance(parent, RationalBernsteinPolynomial) or not isinstance(
+        claim, RationalBernsteinPolynomial
+    ):
+        return False
     try:
         if (
             parent.polynomial != claim.polynomial
@@ -529,7 +540,9 @@ def verify_bernstein_restriction(
             return False
         expected = _restrict_trusted(parent, claim.box)
         return expected.coefficients == claim.coefficients
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/polynomials/ideals/operations.py
+++ b/src/jacobian/math/polynomials/ideals/operations.py
@@ -1300,21 +1300,21 @@ def verify_ideal_membership_certificate(
 ) -> bool:
     """Verify a serialized ideal-membership identity against its sources."""
 
+    if claim.status == "NO_CERTIFICATE_WITHIN_BOUND":
+        return (
+            ideal_membership_certificate(
+                claim.ideal,
+                claim.polynomial,
+                claim.cofactor_degree_bound,
+            )
+            == claim
+        )
     try:
         _admit_membership_certificate(
             claim.ideal,
             claim.polynomial,
             claim.cofactor_degree_bound,
         )
-        if claim.status == "NO_CERTIFICATE_WITHIN_BOUND":
-            return (
-                ideal_membership_certificate(
-                    claim.ideal,
-                    claim.polynomial,
-                    claim.cofactor_degree_bound,
-                )
-                == claim
-            )
         if claim.multiplier is None or claim.cofactors is None:
             return False
         cofactor_terms = 0
@@ -1341,19 +1341,19 @@ def verify_ideal_membership_certificate(
             for term in cofactor.polynomial.terms
         ):
             return False
-        target = rational_polynomial_to_sympy(claim.polynomial).as_expr()
-        identity = sympy.Integer(0)
-        for cofactor, generator in zip(
-            claim.cofactors, claim.ideal.generators, strict=True
-        ):
-            identity += rational_polynomial_to_sympy(cofactor).as_expr() * (
-                rational_polynomial_to_sympy(generator).as_expr()
-            )
-        return bool(sympy.expand(identity - claim.multiplier * target) == 0)
     except OperationResourceAdmissionError:
         raise
     except (AttributeError, KeyError, TypeError, ValueError, sympy.SympifyError):
         return False
+    target = rational_polynomial_to_sympy(claim.polynomial).as_expr()
+    identity = sympy.Integer(0)
+    for cofactor, generator in zip(
+        claim.cofactors, claim.ideal.generators, strict=True
+    ):
+        identity += rational_polynomial_to_sympy(cofactor).as_expr() * (
+            rational_polynomial_to_sympy(generator).as_expr()
+        )
+    return bool(sympy.expand(identity - claim.multiplier * target) == 0)
 
 
 def verify_groebner_basis(claim: GroebnerBasisResult) -> bool:
@@ -1374,13 +1374,19 @@ def verify_groebner_basis(claim: GroebnerBasisResult) -> bool:
                 for generator in claim.basis.generators
             ],
         }
-        return bool(_run_sympy_kernel(payload, 10).get("equal", False))
     except OperationResourceAdmissionError:
         raise
     except _ResultLimitExceededError:
         raise
     except (AttributeError, KeyError, TypeError, ValueError, sympy.SympifyError):
         return False
+
+    equal = _run_sympy_kernel(payload, 10).get("equal")
+    if type(equal) is not bool:
+        raise RuntimeError(
+            "the Groebner verification worker omitted its Boolean result"
+        )
+    return equal
 
 
 def verify_ideal_normal_form(claim: IdealNormalFormResult) -> bool:
@@ -1395,7 +1401,9 @@ def verify_ideal_normal_form(claim: IdealNormalFormResult) -> bool:
             )
             == claim
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -1411,7 +1419,9 @@ def verify_ideal_containment(claim: IdealContainmentResult) -> bool:
             )
             == claim
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -1427,7 +1437,9 @@ def verify_ideal_equality(claim: IdealEqualityResult) -> bool:
             )
             == claim
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/polynomials/interpolation/operations.py
+++ b/src/jacobian/math/polynomials/interpolation/operations.py
@@ -9,7 +9,10 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials.interpolation._kernel import (
     divided_difference_coefficients,
     evaluate_newton_form,
@@ -122,27 +125,39 @@ def evaluate_newton(
 def verify_divided_differences(claim: DividedDifferencesResult) -> bool:
     """Verify divided-difference coefficients against retained samples."""
 
+    if not isinstance(claim, DividedDifferencesResult):
+        return False
     try:
         return divided_differences(claim.samples) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_newton_evaluation(claim: NewtonEvaluateResult) -> bool:
     """Verify a Newton evaluation against its retained form and point."""
 
+    if not isinstance(claim, NewtonEvaluateResult):
+        return False
     try:
         return evaluate_newton(claim.newton_form, claim.evaluation_point) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_hermite_interpolation(claim: HermiteInterpolationResult) -> bool:
     """Verify all Hermite polynomial, degree, leading, and replay claims."""
 
+    if not isinstance(claim, HermiteInterpolationResult):
+        return False
     try:
         return hermite_interpolation(claim.source) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/polynomials/intervals/_tools.py
+++ b/src/jacobian/math/polynomials/intervals/_tools.py
@@ -2,7 +2,13 @@
 
 from typing import Any
 
-from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.catalog.models import (
+    MathTool,
+    MathTools,
+    OperationDomainValidationError,
+    OperationExample,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials.intervals._models import (
     BOX_ENCLOSURE_ADMISSION_SUMMARY,
     PolynomialBoxEnclosureRequest,
@@ -30,7 +36,9 @@ def verify_polynomial_box_enclosure(
                 box=claim.box,
             )
         )
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
     return claim.enclosure == expected.enclosure
 

--- a/src/jacobian/math/polynomials/maps/operations.py
+++ b/src/jacobian/math/polynomials/maps/operations.py
@@ -14,7 +14,10 @@ from jacobian._execution import (
 )
 from jacobian.backends import BackendUnavailableError
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials._conversions import (
     rational_from_sympy,
     rational_function_to_sympy,
@@ -361,9 +364,13 @@ def jacobian_matrix(polynomial_map: RationalPolynomialMap) -> JacobianResult:
 def verify_jacobian(claim: JacobianResult) -> bool:
     """Verify Jacobian entries against the retained polynomial map source."""
 
+    if not isinstance(claim, JacobianResult):
+        return False
     try:
         return jacobian_matrix(claim.source) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/polynomials/multivariate/operations.py
+++ b/src/jacobian/math/polynomials/multivariate/operations.py
@@ -11,7 +11,10 @@ from jacobian._execution import (
     OperationExecutionTimeoutError,
 )
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials._conversions import (
     rational_polynomial_from_sympy,
     rational_polynomial_to_sympy,
@@ -517,12 +520,16 @@ def verify_multivariate_gcd(claim: MultivariateGcdResult) -> bool:
             claim.left.variables,
         )
         return expected == claim.gcd
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_multivariate_division(claim: MultivariateDivisionResult) -> bool:
     """Verify the canonical quotient and remainder under the retained order."""
+    if not isinstance(claim, MultivariateDivisionResult):
+        return False
     try:
         _admit_division(claim.left, claim.right)
         expected = multivariate_division(claim.left, claim.right, claim.monomial_order)
@@ -530,20 +537,21 @@ def verify_multivariate_division(claim: MultivariateDivisionResult) -> bool:
             expected.quotient == claim.quotient
             and expected.remainder == claim.remainder
         )
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_multivariate_factor(claim: MultivariateFactorResult) -> bool:
     """Verify the complete canonical factorization for the retained source."""
+    if not isinstance(claim, MultivariateFactorResult):
+        return False
     try:
         return multivariate_factor(claim.polynomial) == claim
-    except (
-        AttributeError,
-        TypeError,
-        ValueError,
-        OperationDomainValidationError,
-    ):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -557,7 +565,9 @@ def verify_multivariate_resultant(claim: MultivariateResultantResult) -> bool:
             )
             == claim.resultant
         )
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -565,10 +575,14 @@ def verify_multivariate_subresultant_sequence(
     claim: MultivariateSubresultantSequenceResult,
 ) -> bool:
     """Verify the complete Brown PRS and ledgers against retained sources."""
+    if not isinstance(claim, MultivariateSubresultantSequenceResult):
+        return False
     try:
         expected = multivariate_subresultant_sequence(
             claim.left, claim.right, claim.main_variable
         )
         return expected == claim
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/polynomials/operations.py
+++ b/src/jacobian/math/polynomials/operations.py
@@ -10,7 +10,10 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials._conversions import (
     rational_from_sympy,
     rational_polynomial_from_sympy,
@@ -657,30 +660,42 @@ def polynomial_factorization(
 def verify_polynomial_gcd(claim: PolynomialGcdResult) -> bool:
     """Verify a GCD and Bézout identity against both retained operands."""
 
+    if not isinstance(claim, PolynomialGcdResult):
+        return False
     try:
         return polynomial_gcd(claim.left, claim.right) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_polynomial_resultant(claim: PolynomialResultantResult) -> bool:
     """Verify a resultant against its retained operands and elimination variable."""
 
+    if not isinstance(claim, PolynomialResultantResult):
+        return False
     try:
         return (
             polynomial_resultant(claim.left, claim.right, claim.elimination_variable)
             == claim
         )
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_polynomial_discriminant(claim: PolynomialDiscriminantResult) -> bool:
     """Verify a discriminant against its retained polynomial and variable."""
 
+    if not isinstance(claim, PolynomialDiscriminantResult):
+        return False
     try:
         return polynomial_discriminant(claim.polynomial, claim.variable) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -689,18 +704,26 @@ def verify_polynomial_square_free_decomposition(
 ) -> bool:
     """Verify square-free factors and reconstruction against their source."""
 
+    if not isinstance(claim, PolynomialSquareFreeDecompositionResult):
+        return False
     try:
         return polynomial_square_free_decomposition(claim.polynomial) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_polynomial_factorization(claim: PolynomialFactorizationResult) -> bool:
     """Verify factorization claims against their retained source polynomial."""
 
+    if not isinstance(claim, PolynomialFactorizationResult):
+        return False
     try:
         return polynomial_factorization(claim.polynomial) == claim
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/polynomials/rational_functions/_models.py
+++ b/src/jacobian/math/polynomials/rational_functions/_models.py
@@ -8,6 +8,7 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.polynomials.values import (
     RationalFunction,
     require_canonical_rational_function,
@@ -30,25 +31,42 @@ def require_hermite_reduction_budget(function: RationalFunction) -> None:
 
     if len(function.variables) != 1:
         raise _validation_error("Hermite reduction requires exactly one variable")
-    require_sparse_polynomial_budget(
-        function.numerator,
-        maximum_terms=MAX_HERMITE_NUMERATOR_DEGREE + 1,
-        maximum_exponent=MAX_HERMITE_NUMERATOR_DEGREE,
-        maximum_coefficient_digits=MAX_HERMITE_COEFFICIENT_DIGITS,
-        label="Hermite-reduction numerator",
+    polynomial_source = all(
+        not any(term.exponents) for term in function.denominator.terms
     )
-    require_sparse_polynomial_budget(
-        function.denominator,
-        maximum_terms=MAX_HERMITE_DENOMINATOR_DEGREE + 1,
-        maximum_exponent=MAX_HERMITE_DENOMINATOR_DEGREE,
-        maximum_coefficient_digits=MAX_HERMITE_COEFFICIENT_DIGITS,
-        label="Hermite-reduction denominator",
+    coefficient_digits = (
+        MAX_HERMITE_RESULT_COEFFICIENT_DIGITS - 1
+        if polynomial_source
+        else MAX_HERMITE_COEFFICIENT_DIGITS
     )
+    # Integrating a degree-six polynomial only divides coefficients by 1..7;
+    # one extra denominator digit bounds its degree-seven primitive.
+    try:
+        require_sparse_polynomial_budget(
+            function.numerator,
+            maximum_terms=MAX_HERMITE_NUMERATOR_DEGREE + 1,
+            maximum_exponent=MAX_HERMITE_NUMERATOR_DEGREE,
+            maximum_coefficient_digits=coefficient_digits,
+            label="Hermite-reduction numerator",
+        )
+        require_sparse_polynomial_budget(
+            function.denominator,
+            maximum_terms=MAX_HERMITE_DENOMINATOR_DEGREE + 1,
+            maximum_exponent=MAX_HERMITE_DENOMINATOR_DEGREE,
+            maximum_coefficient_digits=coefficient_digits,
+            label="Hermite-reduction denominator",
+        )
+    except ValueError as exc:
+        raise OperationResourceAdmissionError(
+            location=("function",),
+            code="polynomial.hermite_reduction_budget",
+            message=str(exc),
+        ) from exc
     require_canonical_rational_function(
         function,
         maximum_terms=MAX_HERMITE_NUMERATOR_DEGREE + 1,
         maximum_exponent=MAX_HERMITE_NUMERATOR_DEGREE,
-        maximum_coefficient_digits=MAX_HERMITE_COEFFICIENT_DIGITS,
+        maximum_coefficient_digits=coefficient_digits,
         label="Hermite-reduction function",
     )
 
@@ -60,14 +78,15 @@ def _require_hermite_result_budget(
     """Bound the retained exact Hermite-reduction result.
 
     A degree-six numerator over a degree-three denominator yields a
-    zero-constant rational part with numerator degree at most six and
-    denominator degree at most two.  The square-free residual denominator has
+    zero-constant rational part with numerator degree at most seven and
+    denominator degree at most two. The degree-seven case integrates a
+    polynomial source and has at most seven nonzero terms. The square-free residual denominator has
     degree at most three and its numerator is proper.  These derived limits
     keep every retained result within the operation's exact envelope.
     """
 
     for label, polynomial, maximum_terms, maximum_exponent in (
-        ("Hermite rational-part numerator", rational_part.numerator, 7, 6),
+        ("Hermite rational-part numerator", rational_part.numerator, 7, 7),
         ("Hermite rational-part denominator", rational_part.denominator, 3, 2),
         ("Hermite remainder numerator", remainder.numerator, 3, 2),
         ("Hermite remainder denominator", remainder.denominator, 4, 3),
@@ -86,8 +105,9 @@ class HermiteReductionRequest(StrictModel):
 
     The present envelope bounds polynomial division, denominator GCD, and a
     three-variable Horowitz--Ostrogradsky linear system before backend
-    expansion. Two-digit rational components keep the exact Cramer/factor
-    coefficient-height bound inside the canonical 128-digit result carrier.
+    expansion. Polynomial sources permit 127-digit components, reserving one
+    digit for integration denominators. For other rational functions, two-digit
+    components bound the Cramer/factor growth inside the 128-digit result carrier.
     This is a scale limit, not a restriction on the mathematical domain.
     """
 
@@ -95,7 +115,7 @@ class HermiteReductionRequest(StrictModel):
         description=(
             "A canonical univariate QQ(x) value with numerator degree at most 6, "
             "denominator degree at most 3, at most 7/4 respective terms, and "
-            "at most two decimal digits in each rational coefficient component."
+            "127-digit rational components for polynomial inputs, otherwise two-digit components."
         )
     )
 

--- a/src/jacobian/math/polynomials/rational_functions/_tools.py
+++ b/src/jacobian/math/polynomials/rational_functions/_tools.py
@@ -2,35 +2,21 @@
 
 from __future__ import annotations
 
-from pydantic_core import PydanticCustomError
-
 from jacobian.catalog.models import (
     MathTool,
-    OperationDomainValidationError,
     OperationExample,
 )
 from jacobian.math.polynomials.rational_functions import operations as native
 from jacobian.math.polynomials.rational_functions._models import (
     HermiteReductionRequest,
     HermiteReductionResult,
-    require_hermite_reduction_budget,
 )
 
 
 def compute_hermite_reduction(
     request: HermiteReductionRequest,
 ) -> HermiteReductionResult:
-    try:
-        require_hermite_reduction_budget(request.function)
-    except PydanticCustomError as exc:
-        raise OperationDomainValidationError(
-            location=(), code=exc.type, message=exc.message()
-        ) from exc
-    except ValueError as exc:
-        raise OperationDomainValidationError(
-            location=(), code="polynomial.rational_function_admission", message=str(exc)
-        ) from exc
-    rational_part, remainder = native._hermite_reduction_admitted(request.function)
+    rational_part, remainder = native.hermite_reduction(request.function)
     return HermiteReductionResult._from_kernel(
         function=request.function,
         rational_part=rational_part,
@@ -48,7 +34,8 @@ TOOLS = (
             "completely decides whether f has a rational primitive; a nonzero "
             "H does not rule out a formal primitive involving logarithms. The "
             "current conservative envelope admits numerator degree 6, denominator "
-            "degree 3, and two-digit rational coefficient components."
+            "degree 3, and 127-digit rational components for polynomial inputs "
+            "or two-digit components for other rational functions."
         ),
         request_type=HermiteReductionRequest,
         result_type=HermiteReductionResult,
@@ -57,11 +44,7 @@ TOOLS = (
         examples=(
             OperationExample(
                 name="simple_and_repeated_poles",
-                description="Separate the derivative of a repeated pole from a simple-pole "
-                "remainder; the function must be canonical univariate QQ(x) in "
-                "one variable x, with numerator degree at most 6, denominator "
-                "degree at most 3, and two-digit rational coefficient "
-                "components.",
+                description="Use canonical univariate QQ(x), one variable x, numerator degree at most 6 and denominator degree at most 3. Polynomial inputs allow 127-digit rational coefficient components; other inputs require two-digit rational coefficient components.",
                 input={
                     "function": {
                         "variables": ["x"],

--- a/src/jacobian/math/polynomials/rational_functions/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/operations.py
@@ -6,6 +6,10 @@ from typing import Any
 
 from pydantic_core import PydanticCustomError
 
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials._conversions import (
     rational_function_from_sympy,
     rational_function_to_sympy,
@@ -53,12 +57,23 @@ def hermite_reduction(
     """Compute canonical ``f = R' + H`` over the admitted subset of ``QQ(x)``.
 
     The current native envelope matches the catalog operation: numerator degree
-    at most 6, denominator degree at most 3, and at most two decimal digits in
-    each rational coefficient component. ``H`` is proper with square-free
+    at most 6 and denominator degree at most 3. Polynomial inputs allow
+    127-digit rational components; other inputs allow two-digit components. ``H`` is proper with square-free
     denominator. ``R`` has zero additive constant, so the pair is unique.
     """
 
-    require_hermite_reduction_budget(function)
+    try:
+        require_hermite_reduction_budget(function)
+    except OperationResourceAdmissionError:
+        raise
+    except PydanticCustomError as exc:
+        raise OperationDomainValidationError(
+            location=(), code=exc.type, message=exc.message()
+        ) from exc
+    except ValueError as exc:
+        raise OperationDomainValidationError(
+            location=(), code="polynomial.rational_function_admission", message=str(exc)
+        ) from exc
     return _hermite_reduction_admitted(function)
 
 
@@ -86,7 +101,9 @@ def verify_hermite_reduction(claim: HermiteReductionResult) -> bool:
             == ("RATIONAL_PRIMITIVE" if has_primitive else "NO_RATIONAL_PRIMITIVE")
             and claim.rational_primitive == (rational_part if has_primitive else None)
         )
-    except (AttributeError, TypeError, ValueError, PydanticCustomError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/polynomials/real_algebra/_common_interlacing_process.py
+++ b/src/jacobian/math/polynomials/real_algebra/_common_interlacing_process.py
@@ -108,20 +108,6 @@ def _preflight_family_size(
                 )
 
 
-def _multiply_integer_polynomials(
-    left: tuple[int, ...], right: tuple[int, ...]
-) -> tuple[int, ...]:
-    """Multiply two dense integer polynomials (leading coefficient first)."""
-
-    if not left or not right:
-        return ()
-    product = [0] * (len(left) + len(right) - 1)
-    for i, lc in enumerate(left):
-        for j, rc in enumerate(right):
-            product[i + j] += lc * rc
-    return tuple(product)
-
-
 def _source_to_dense_int(
     source: LabelledRationalPolynomial,
 ) -> tuple[int, ...]:
@@ -153,16 +139,15 @@ def _source_to_dense_int(
     return tuple(dense_int)
 
 
-def _verify_declared_factors(  # noqa: C901
+def _require_declared_factor_structure(  # noqa: C901
     source: LabelledRationalPolynomial,
     declared_factors: list[Any],
 ) -> None:
-    """Verify the worker's declared factors reconstruct the retained source.
+    """Check bounded factor structure from the admitted, trusted worker.
 
-    Each declared factor is a [coefficients, multiplicity] pair.  Multiplies
-    each factor raised to its multiplicity and checks the product equals the
-    source polynomial.  Uses only integer polynomial arithmetic, not SymPy,
-    so no kernel work is replayed in the parent.
+    The worker establishes source factorization. Decoding retains coefficient,
+    multiplicity, canonical-form, and total-degree bounds without multiplying
+    the factors to repeat that computation.
     """
 
     if not declared_factors:
@@ -176,7 +161,6 @@ def _verify_declared_factors(  # noqa: C901
     factor_digit_bound = _factor_digit_bound(source_degree, source_height_digits)
     if len(declared_factors) > source_degree:
         raise ValueError("worker declared more factors than source degree")
-    product: tuple[int, ...] = (1,)
     seen_factor_coefficients: set[tuple[int, ...]] = set()
     aggregate_degree = 0
     for entry in declared_factors:
@@ -222,10 +206,8 @@ def _verify_declared_factors(  # noqa: C901
         if factor_dense in seen_factor_coefficients:
             raise ValueError("worker declared a duplicate source factor")
         seen_factor_coefficients.add(factor_dense)
-        for _ in range(multiplicity):
-            product = _multiply_integer_polynomials(product, factor_dense)
-    if product != source_dense:
-        raise ValueError("declared factors do not reconstruct the source polynomial")
+    if aggregate_degree != source_degree:
+        raise ValueError("worker factor degrees differ from source degree")
 
 
 def _root_profile_from_worker(  # noqa: C901
@@ -262,16 +244,18 @@ def _root_profile_from_worker(  # noqa: C901
     factor_multiplicities: dict[tuple[int, ...], int] = {}
     factor_row_counts: dict[tuple[int, ...], int] = {}
     factor_root_indices: dict[tuple[int, ...], set[int]] = {}
-    squarefree_product: tuple[int, ...] = (1,)
-    for entry in declared_factors:
-        factor = tuple(parse_canonical_integer(c) for c in entry[0])
-        squarefree_product = _multiply_integer_polynomials(squarefree_product, factor)
+    # The product's coefficient norm is bounded by the product of factor
+    # L1 norms. Each factor with k coefficients and height h has L1 norm
+    # below 10**(h + ceil(log10(k))); adding these exponents bounds the
+    # square-free product height without reconstructing that polynomial.
+    squarefree_degree = sum(len(factor) - 1 for factor in declared_factor_set)
+    squarefree_height_bound = sum(
+        max(len(format_canonical_integer(c).lstrip("-")) for c in factor)
+        + len(str(len(factor) - 1))
+        for factor in declared_factor_set
+    )
     endpoint_digit_bound = _isolation_endpoint_digit_bound(
-        len(squarefree_product) - 1,
-        max(
-            len(format_canonical_integer(coefficient).lstrip("-"))
-            for coefficient in squarefree_product
-        ),
+        squarefree_degree, squarefree_height_bound
     )
     for raw_root in value["roots"]:
         if not isinstance(raw_root, dict):
@@ -411,7 +395,7 @@ def _profile_from_worker(
         raise ValueError("worker source factor declarations are missing or malformed")
     for source_index, source in enumerate(family):
         declared = raw_source_factors[source_index]
-        _verify_declared_factors(source, declared)
+        _require_declared_factor_structure(source, declared)
 
     # Require factor-root-count projection aligned one-for-one with family.
     if not isinstance(raw_factor_root_counts, list) or len(

--- a/src/jacobian/math/polynomials/real_algebra/operations.py
+++ b/src/jacobian/math/polynomials/real_algebra/operations.py
@@ -82,11 +82,13 @@ def common_interlacing_profile(
 def verify_common_interlacing_profile(claim: CommonInterlacingProfile) -> bool:
     """Verify retained roots and the complete common-interlacing outcome."""
 
+    if not isinstance(claim, CommonInterlacingProfile):
+        return False
     try:
         return common_interlacing_profile(claim.family) == claim
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationDomainValidationError:
         return False
 
 
@@ -358,19 +360,27 @@ def compute_root_count(
 
 def verify_sturm_chain(claim: SturmChainResult) -> bool:
     """Verify a serialized Sturm chain against its retained source polynomial."""
+    if not isinstance(claim, SturmChainResult):
+        return False
     try:
         expected = compute_sturm_chain(claim.source_polynomial)
         return expected.chain == claim.chain and expected.degree == claim.degree
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_root_count(claim: RootCountResult) -> bool:
     """Verify a serialized distinct-root count against its source interval."""
+    if not isinstance(claim, RootCountResult):
+        return False
     try:
         expected = compute_root_count(claim.source_polynomial, claim.lower, claim.upper)
         return expected.root_count == claim.root_count
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -395,6 +405,8 @@ def compute_strict_sublevel_measure(
 def verify_strict_sublevel_measure(claim: StrictSublevelMeasureResult) -> bool:
     """Verify strict-sublevel components and exact measure against the source."""
 
+    if not isinstance(claim, StrictSublevelMeasureResult):
+        return False
     try:
         return (
             compute_strict_sublevel_measure(
@@ -407,7 +419,7 @@ def verify_strict_sublevel_measure(claim: StrictSublevelMeasureResult) -> bool:
         )
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationDomainValidationError:
         return False
 
 
@@ -424,5 +436,5 @@ def verify_plane_component_profile(claim: PlaneComponentProfileResult) -> bool:
         )
     except OperationResourceAdmissionError:
         raise
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationDomainValidationError:
         return False

--- a/src/jacobian/math/polynomials/root_boxes/operations.py
+++ b/src/jacobian/math/polynomials/root_boxes/operations.py
@@ -9,7 +9,10 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.analysis.intervals import ClosedRationalInterval, RationalBox
 from jacobian.math.matrices.values import rational_matrix_from_fractions
 from jacobian.math.polynomials.intervals._kernel import natural_interval_extension
@@ -498,7 +501,9 @@ def verify_real_root_box(claim: PolynomialSystemRootBoxResult) -> bool:
 
     try:
         expected = certify_real_root_box(claim.polynomial_map, claim.box)
-    except Exception:
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
     return claim.conclusion == expected.conclusion
 

--- a/src/jacobian/math/polynomials/series/_models.py
+++ b/src/jacobian/math/polynomials/series/_models.py
@@ -10,6 +10,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math._rational_height import RationalHeight, sum_heights
 from jacobian.math.polynomials.values import PolynomialVariable, RationalPolynomial
 
@@ -42,6 +43,18 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"formal_power_series.{reason}", message)
 
 
+def _resource_error(reason: str, message: str) -> OperationResourceAdmissionError:
+    return OperationResourceAdmissionError(
+        location=(), code=f"formal_power_series.{reason}", message=message
+    )
+
+
+def _has_degree_at_most(series: TruncatedSeries, degree: int) -> bool:
+    return series.truncation_order <= MAX_TRUNCATE_SOURCE_ORDER and not any(
+        value.num for value in series.coefficients[degree + 1 :]
+    )
+
+
 def _height(value: CanonicalRational) -> RationalHeight:
     return RationalHeight.from_canonical(value)
 
@@ -71,7 +84,7 @@ def _require_height_vector(
         height is not None and height.exceeds(MAX_RESULT_RATIONAL_DIGITS)
         for height in coefficients
     ):
-        raise _validation_error(
+        raise _resource_error(
             f"{operation}_coefficient_growth",
             f"{operation} coefficient growth exceeds the "
             f"{MAX_RESULT_RATIONAL_DIGITS}-digit result bound",
@@ -142,7 +155,7 @@ def _convolution_height(
 
 def _require_height(height: RationalHeight, operation: str) -> None:
     if height.exceeds(MAX_RESULT_RATIONAL_DIGITS):
-        raise _validation_error(
+        raise _resource_error(
             f"{operation}_coefficient_growth",
             f"{operation} coefficient growth exceeds the "
             f"{MAX_RESULT_RATIONAL_DIGITS}-digit result bound",
@@ -266,20 +279,30 @@ def _require_native_scalar(value: int, label: str) -> None:
         raise _validation_error(f"{label}_type", f"{label} must be an integer scalar")
 
 
-def _require_native_input_series(series: TruncatedSeries) -> None:
-    if series.truncation_order > MAX_TRUNCATION_ORDER:
-        raise _validation_error(
-            "input_order", f"truncation order exceeds {MAX_TRUNCATION_ORDER}"
+def _require_native_input_series(
+    series: TruncatedSeries, *, maximum_order: int = MAX_TRUNCATION_ORDER
+) -> None:
+    if series.truncation_order > maximum_order:
+        raise _resource_error(
+            "input_order", f"truncation order exceeds {maximum_order}"
         )
-    for value in series.coefficients:
-        require_bounded_rational(
-            value, max_digits=MAX_RATIONAL_DIGITS, label="input coefficient"
-        )
+    try:
+        for value in series.coefficients:
+            require_bounded_rational(
+                value, max_digits=MAX_RATIONAL_DIGITS, label="input coefficient"
+            )
+    except ValueError as exc:
+        raise _resource_error("input_coefficient", str(exc)) from exc
 
 
-def _require_native_pair(left: TruncatedSeries, right: TruncatedSeries) -> None:
-    _require_native_input_series(left)
-    _require_native_input_series(right)
+def _require_native_pair(
+    left: TruncatedSeries,
+    right: TruncatedSeries,
+    *,
+    maximum_order: int = MAX_TRUNCATION_ORDER,
+) -> None:
+    _require_native_input_series(left, maximum_order=maximum_order)
+    _require_native_input_series(right, maximum_order=maximum_order)
     if left.variable != right.variable:
         raise _validation_error(
             "operand_variable_mismatch", "operands must share the same variable"
@@ -340,22 +363,38 @@ def admit_native_power(series: TruncatedSeries, exponent: int) -> None:
 
 
 def admit_native_inverse(series: TruncatedSeries) -> None:
-    _require_native_input_series(series)
+    constant = _has_degree_at_most(series, 0)
+    _require_native_input_series(
+        series,
+        maximum_order=MAX_TRUNCATE_SOURCE_ORDER if constant else MAX_TRUNCATION_ORDER,
+    )
     if series.coefficients[0].as_fraction() == 0:
         raise _validation_error(
             "inverse_zero_constant", "inverse requires a nonzero constant term"
         )
-    _inverse_height(series)
+    if not constant:
+        _inverse_height(series)
 
 
 def admit_native_divide(
     numerator: TruncatedSeries, denominator: TruncatedSeries
 ) -> None:
-    _require_native_pair(numerator, denominator)
+    constant = _has_degree_at_most(denominator, 0)
+    _require_native_pair(
+        numerator,
+        denominator,
+        maximum_order=MAX_TRUNCATE_SOURCE_ORDER if constant else MAX_TRUNCATION_ORDER,
+    )
     if denominator.coefficients[0].as_fraction() == 0:
         raise _validation_error(
             "denominator_zero_constant", "denominator must have a nonzero constant term"
         )
+    if constant:
+        # A coefficient quotient has at most twice the input component bound.
+        _require_height(
+            RationalHeight(2 * MAX_RATIONAL_DIGITS, 2 * MAX_RATIONAL_DIGITS), "division"
+        )
+        return
     inv_num, inv_den, source_norm, source_den = _inverse_height(denominator)
     common_denominator, coefficients = _cleared_series(numerator)
     norm = sum(abs(value) for value in coefficients).bit_length()
@@ -390,7 +429,13 @@ def admit_native_compose(outer: TruncatedSeries, inner: TruncatedSeries) -> None
 
 
 def admit_native_reversion(series: TruncatedSeries) -> None:
-    _require_native_input_series(series)
+    linear_source = _has_degree_at_most(series, 1)
+    _require_native_input_series(
+        series,
+        maximum_order=MAX_TRUNCATE_SOURCE_ORDER
+        if linear_source
+        else MAX_TRUNCATION_ORDER,
+    )
     if series.truncation_order < 2:
         raise _validation_error(
             "reversion_order", "reversion requires truncation order >= 2"
@@ -404,6 +449,8 @@ def admit_native_reversion(series: TruncatedSeries) -> None:
             "reversion_zero_linear_coefficient",
             "reversion requires nonzero linear coefficient",
         )
+    if linear_source:
+        return
     source = _height_vector(series.coefficients)
     linear = _height(series.coefficients[1])
     result: list[CoefficientHeight] = [None, RationalHeight(1, 1).quotient(linear)]

--- a/src/jacobian/math/polynomials/series/operations.py
+++ b/src/jacobian/math/polynomials/series/operations.py
@@ -14,7 +14,10 @@ from fractions import Fraction
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials.series._models import (
     MAX_TRUNCATION_ORDER,
     SeriesArithmeticResult,
@@ -32,6 +35,7 @@ from jacobian.math.polynomials.series._models import (
     SeriesToPolynomialResult,
     SeriesTruncateResult,
     TruncatedSeries,
+    _has_degree_at_most,
     admit_native_add_subtract,
     admit_native_compose,
     admit_native_divide,
@@ -119,6 +123,10 @@ def _cauchy_convolve(
     a: Sequence[Fraction], b: Sequence[Fraction], n: int
 ) -> list[Fraction]:
     """c_k = sum_{i=0}^{k} a_i * b_{k-i} for 0 <= k < n."""
+    if n and not any(a[1:n]):
+        return [a[0] * b[k] for k in range(n)]
+    if n and not any(b[1:n]):
+        return [b[0] * a[k] for k in range(n)]
     return [
         sum((a[i] * b[k - i] for i in range(k + 1)), start=Fraction()) for k in range(n)
     ]
@@ -222,6 +230,8 @@ def _inverse_coefficients(series: TruncatedSeries) -> list[Fraction]:
         raise ValueError("series with zero constant term is not a unit")
     inverse = [Fraction(0)] * n
     inverse[0] = Fraction(1) / a[0]
+    if not any(a[1:]):
+        return inverse
     for degree in range(1, n):
         recurrence_sum = sum(
             (a[index] * inverse[degree - index] for index in range(1, degree + 1)),
@@ -255,23 +265,25 @@ def verify_inverse(claim: SeriesInverseResult) -> bool:
     """Verify an inverse claim, including its serialized residual ledger."""
     try:
         admit_native_inverse(claim.source)
-        if (
-            claim.source.variable != claim.result.variable
-            or claim.source.truncation_order != claim.result.truncation_order
-        ):
-            return False
-        product = _cauchy_convolve(
-            _series_fractions(claim.source),
-            _series_fractions(claim.result),
-            claim.source.truncation_order,
-        )
-        product[0] -= Fraction(1)
-        return (
-            all(value == 0 for value in product)
-            and tuple(_wire(value) for value in product) == claim.residual_coefficients
-        )
+    except OperationResourceAdmissionError:
+        raise
     except (TypeError, ValueError):
         return False
+    if (
+        claim.source.variable != claim.result.variable
+        or claim.source.truncation_order != claim.result.truncation_order
+    ):
+        return False
+    product = _cauchy_convolve(
+        _series_fractions(claim.source),
+        _series_fractions(claim.result),
+        claim.source.truncation_order,
+    )
+    product[0] -= Fraction(1)
+    return (
+        all(value == 0 for value in product)
+        and tuple(_wire(value) for value in product) == claim.residual_coefficients
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -304,31 +316,32 @@ def verify_divide(claim: SeriesDivideResult) -> bool:
     """Verify a quotient claim, including its serialized residual ledger."""
     try:
         admit_native_divide(claim.numerator, claim.denominator)
-        if not (
-            claim.numerator.variable
-            == claim.denominator.variable
-            == claim.quotient.variable
-            and claim.numerator.truncation_order
-            == claim.denominator.truncation_order
-            == claim.quotient.truncation_order
-        ):
-            return False
-        residual = _cauchy_convolve(
-            _series_fractions(claim.denominator),
-            _series_fractions(claim.quotient),
-            claim.numerator.truncation_order,
-        )
-        numerator = _series_fractions(claim.numerator)
-        differences = tuple(
-            left - right for left, right in zip(residual, numerator, strict=True)
-        )
-        return (
-            all(value == 0 for value in differences)
-            and tuple(_wire(value) for value in differences)
-            == claim.residual_coefficients
-        )
+    except OperationResourceAdmissionError:
+        raise
     except (TypeError, ValueError):
         return False
+    if not (
+        claim.numerator.variable
+        == claim.denominator.variable
+        == claim.quotient.variable
+        and claim.numerator.truncation_order
+        == claim.denominator.truncation_order
+        == claim.quotient.truncation_order
+    ):
+        return False
+    residual = _cauchy_convolve(
+        _series_fractions(claim.denominator),
+        _series_fractions(claim.quotient),
+        claim.numerator.truncation_order,
+    )
+    numerator = _series_fractions(claim.numerator)
+    differences = tuple(
+        left - right for left, right in zip(residual, numerator, strict=True)
+    )
+    return (
+        all(value == 0 for value in differences)
+        and tuple(_wire(value) for value in differences) == claim.residual_coefficients
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -343,6 +356,11 @@ def _compose_coefficients(
     n = outer.truncation_order
     outer_coefficients = _series_fractions(outer)
     inner_coefficients = _series_fractions(inner)
+    if not any(outer_coefficients[2:]):
+        slope = outer_coefficients[1] if n > 1 else Fraction(0)
+        result = [slope * value for value in inner_coefficients]
+        result[0] += outer_coefficients[0]
+        return result
     inner_power = [Fraction(1)] + [Fraction(0)] * (n - 1)
     result = [outer_coefficients[0] * value for value in inner_power]
     for outer_degree in range(1, n):
@@ -392,7 +410,7 @@ def reversion(series: TruncatedSeries) -> SeriesReversionResult:
     g = [Fraction(0)] * n
     g[1] = Fraction(1) / f[1]
     # Compute G powers up to N-1 and solve for g_k one at a time
-    for k in range(2, n):
+    for k in range(2, n if any(f[2:]) else 2):
         target = Fraction(0)
         # For j = 2 to k:
         #   compute G^j using g_0..g_{k-1} and read off coefficient of x^k
@@ -438,30 +456,43 @@ def verify_reversion(claim: SeriesReversionResult) -> bool:
     """Verify both composition identities and their serialized ledgers."""
     try:
         admit_native_reversion(claim.source)
-        if (
-            claim.source.variable != claim.result.variable
-            or claim.source.truncation_order != claim.result.truncation_order
-        ):
-            return False
-        order = claim.source.truncation_order
-        left = _compose_coefficients(claim.source, claim.result)
-        right = _compose_coefficients(claim.result, claim.source)
-        target = [Fraction(1) if index == 1 else Fraction(0) for index in range(order)]
-        left_differences = tuple(
-            value - expected for value, expected in zip(left, target, strict=True)
-        )
-        right_differences = tuple(
-            value - expected for value, expected in zip(right, target, strict=True)
-        )
-        return (
-            all(value == 0 for value in left_differences)
-            and all(value == 0 for value in right_differences)
-            and tuple(_wire(value) for value in left_differences) == claim.left_residual
-            and tuple(_wire(value) for value in right_differences)
-            == claim.right_residual
-        )
+    except OperationResourceAdmissionError:
+        raise
     except (TypeError, ValueError):
         return False
+    if (
+        claim.source.variable != claim.result.variable
+        or claim.source.truncation_order != claim.result.truncation_order
+    ):
+        return False
+    order = claim.source.truncation_order
+    if _has_degree_at_most(claim.source, 1):
+        return (
+            claim.result.coefficients[0].num == 0
+            and all(value.num == 0 for value in claim.result.coefficients[2:])
+            and claim.source.coefficients[1].as_fraction()
+            * claim.result.coefficients[1].as_fraction()
+            == 1
+            and all(
+                value.num == 0
+                for value in (*claim.left_residual, *claim.right_residual)
+            )
+        )
+    left = _compose_coefficients(claim.source, claim.result)
+    right = _compose_coefficients(claim.result, claim.source)
+    target = [Fraction(1) if index == 1 else Fraction(0) for index in range(order)]
+    left_differences = tuple(
+        value - expected for value, expected in zip(left, target, strict=True)
+    )
+    right_differences = tuple(
+        value - expected for value, expected in zip(right, target, strict=True)
+    )
+    return (
+        all(value == 0 for value in left_differences)
+        and all(value == 0 for value in right_differences)
+        and tuple(_wire(value) for value in left_differences) == claim.left_residual
+        and tuple(_wire(value) for value in right_differences) == claim.right_residual
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/jacobian/math/polynomials/unit_circle/operations.py
+++ b/src/jacobian/math/polynomials/unit_circle/operations.py
@@ -397,6 +397,10 @@ def unit_circle_arc_energy(
 
 def verify_unit_circle_arc_energy(claim: UnitCircleArcEnergyResult) -> bool:
     """Verify the exact arc-energy identity against its retained source."""
+    if not isinstance(claim, UnitCircleArcEnergyResult) or not isinstance(
+        claim.pi_inverse_coefficient, SimpleNumberFieldRealEmbeddingBinding
+    ):
+        return False
     try:
         coefficients, _degree, width, conductor = _admit_arc(
             claim.polynomial, claim.start_turn, claim.end_turn
@@ -436,12 +440,7 @@ def verify_unit_circle_arc_energy(claim: UnitCircleArcEnergyResult) -> bool:
         return actual == expected
     except OperationResourceAdmissionError:
         raise
-    except (
-        AttributeError,
-        TypeError,
-        OperationDomainValidationError,
-        ValueError,
-    ):
+    except OperationDomainValidationError:
         return False
 
 
@@ -554,6 +553,10 @@ def verify_real_symmetric_degree_one_fejer_riesz_factor(
     claim: FejerRieszFactorResult,
 ) -> bool:
     """Independently verify the conclusion against its retained Laurent source."""
+    if not isinstance(claim, FejerRieszFactorResult) or not isinstance(
+        claim.source, HermitianLaurentPolynomial
+    ):
+        return False
     try:
         coefficients = _laurent_coefficients(claim.source)
         c0 = coefficients.get(0, Fraction(0))
@@ -596,11 +599,8 @@ def verify_real_symmetric_degree_one_fejer_riesz_factor(
     except OperationResourceAdmissionError:
         raise
     except (
-        AttributeError,
         EmbeddedNumberFieldRecognitionError,
         NumberFieldRealEmbeddingOrderError,
         OperationDomainValidationError,
-        TypeError,
-        ValueError,
     ):
         return False

--- a/src/jacobian/math/polynomials/vector_calculus/operations.py
+++ b/src/jacobian/math/polynomials/vector_calculus/operations.py
@@ -8,7 +8,10 @@ import sympy
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials._conversions import (
     rational_polynomial_from_sympy,
     rational_polynomial_to_sympy,
@@ -208,47 +211,67 @@ def directional_derivative(
 
 
 def verify_gradient(claim: VectorResult) -> bool:
+    if not isinstance(claim, VectorResult):
+        return False
     try:
         if claim.source_polynomial is None:
             return False
         return gradient(claim.source_polynomial) == claim
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_divergence(claim: ScalarResult) -> bool:
+    if not isinstance(claim, ScalarResult):
+        return False
     try:
         if claim.source_components is None:
             return False
         return divergence(claim.source_components) == claim
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_curl(claim: VectorResult) -> bool:
+    if not isinstance(claim, VectorResult):
+        return False
     try:
         if claim.source_components is None:
             return False
         return curl(claim.source_components) == claim
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_laplacian(claim: ScalarResult) -> bool:
+    if not isinstance(claim, ScalarResult):
+        return False
     try:
         if claim.source_polynomial is None:
             return False
         return laplacian(claim.source_polynomial) == claim
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
 def verify_directional_derivative(claim: ScalarResult) -> bool:
+    if not isinstance(claim, ScalarResult):
+        return False
     try:
         if claim.source_polynomial is None or claim.direction is None:
             return False
         return directional_derivative(claim.source_polynomial, claim.direction) == claim
-    except (AttributeError, TypeError, ValueError, OperationDomainValidationError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/topology/cubical_complexes/_models.py
+++ b/src/jacobian/math/topology/cubical_complexes/_models.py
@@ -11,6 +11,8 @@ from jacobian._models import StrictModel
 
 MAX_DIM = 10
 MAX_CELLS = 5000
+MAX_FACE_CELLS = 3**MAX_DIM
+"""Enough distinct faces for a full cube at every supported ambient dimension."""
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -59,7 +61,7 @@ class CubicalComplex(StrictModel):
     """
 
     ambient_dimension: int = Field(ge=1, le=MAX_DIM)
-    cells: tuple[CubicalCell, ...] = Field(min_length=1, max_length=MAX_CELLS)
+    cells: tuple[CubicalCell, ...] = Field(min_length=1, max_length=MAX_FACE_CELLS)
 
     @model_validator(mode="after")
     def require_structural_cells(self) -> Self:

--- a/src/jacobian/math/topology/cubical_complexes/_tools.py
+++ b/src/jacobian/math/topology/cubical_complexes/_tools.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from jacobian.catalog.models import (
     MathTool,
-    OperationDomainValidationError,
     OperationExample,
 )
 from jacobian.math.topology.cubical_complexes._models import (
@@ -20,25 +19,11 @@ from jacobian.math.topology.cubical_complexes.operations import (
 
 
 def _f_vector(request: CubicalComplexRequest) -> FVectorResult:
-    try:
-        return f_vector(request.cells)
-    except ValueError as exc:
-        raise OperationDomainValidationError(
-            location=("cells",),
-            code="cubical_complex.invalid_ambient_axis",
-            message=str(exc),
-        ) from exc
+    return f_vector(request.cells)
 
 
 def _face_closure(request: FaceClosureRequest) -> FaceClosureResult:
-    try:
-        return face_closure(request.cells)
-    except ValueError as exc:
-        raise OperationDomainValidationError(
-            location=("cells",),
-            code="cubical_complex.invalid_ambient_axis",
-            message=str(exc),
-        ) from exc
+    return face_closure(request.cells)
 
 
 # A single 2D square: [(0,1),(0,1)] + [(0,1),(1,2)] + [(1,2),(0,1)] + [(1,2),(1,2)]

--- a/src/jacobian/math/topology/cubical_complexes/operations.py
+++ b/src/jacobian/math/topology/cubical_complexes/operations.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.topology.cubical_complexes._models import (
+    MAX_CELLS,
+    MAX_FACE_CELLS,
     CubicalCell,
     CubicalComplex,
     FaceClosureResult,
@@ -19,6 +24,12 @@ def _face_cells(cells: tuple[CubicalCell, ...]) -> tuple[CubicalCell, ...]:
     def add_faces(intervals: tuple[tuple[int, int], ...]) -> None:
         if intervals in all_cells:
             return
+        if len(all_cells) >= MAX_FACE_CELLS:
+            raise OperationResourceAdmissionError(
+                location=("cells",),
+                code="cubical_complex.face_output_budget",
+                message="cubical face closure exceeds the cell output bound",
+            )
         all_cells.add(intervals)
         for i, (a, b) in enumerate(intervals):
             if b > a:
@@ -36,10 +47,24 @@ def _canonical_complex(
     cells: tuple[CubicalCell, ...],
 ) -> tuple[CubicalComplex, tuple[CubicalCell, ...]]:
     if not cells:
-        raise ValueError("at least one cell is required")
+        raise OperationDomainValidationError(
+            location=("cells",),
+            code="cubical_complex.invalid_ambient_axis",
+            message="at least one cell is required",
+        )
     ambient_dimension = len(cells[0].intervals)
     if any(len(cell.intervals) != ambient_dimension for cell in cells):
-        raise ValueError("all cells must use one ambient coordinate axis")
+        raise OperationDomainValidationError(
+            location=("cells",),
+            code="cubical_complex.invalid_ambient_axis",
+            message="all cells must use one ambient coordinate axis",
+        )
+    if len(cells) > MAX_CELLS:
+        raise OperationResourceAdmissionError(
+            location=("cells",),
+            code="cubical_complex.source_cell_budget",
+            message="cubical source exceeds the cell input bound",
+        )
     source_cells = tuple(sorted(set(cells), key=lambda cell: cell.intervals))
     closed_cells = _face_cells(source_cells)
     return (
@@ -99,7 +124,7 @@ def verify_f_vector(claim: FVectorResult) -> bool:
         return f_vector(claim.source_cells) == claim
     except OperationResourceAdmissionError:
         raise
-    except (TypeError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 
@@ -109,7 +134,7 @@ def verify_face_closure(claim: FaceClosureResult) -> bool:
         return face_closure(claim.source_cells) == claim
     except OperationResourceAdmissionError:
         raise
-    except (TypeError, ValueError):
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/topology/edge_paths/_models.py
+++ b/src/jacobian/math/topology/edge_paths/_models.py
@@ -25,18 +25,18 @@ class OrientedEdge(StrictModel):
 class EdgePathWordRequest(StrictModel):
     """Compute the free group word for an edge path."""
 
-    vertex_count: int = Field(ge=2)
-    edges: tuple[tuple[int, int], ...] = Field(min_length=1, max_length=MAX_EDGES)
+    vertex_count: int = Field(ge=1)
+    edges: tuple[tuple[int, int], ...] = Field(max_length=MAX_EDGES)
     start_vertex: int = Field(ge=0)
-    path: tuple[OrientedEdge, ...] = Field(min_length=1, max_length=MAX_WORD)
+    path: tuple[OrientedEdge, ...] = Field(max_length=MAX_WORD)
 
 
 class EdgePathConcatenateRequest(StrictModel):
     """Concatenate two edge paths."""
 
-    vertex_count: int = Field(ge=2)
-    path_a: tuple[int, ...] = Field(min_length=2, max_length=MAX_WORD)
-    path_b: tuple[int, ...] = Field(min_length=2, max_length=MAX_WORD)
+    vertex_count: int = Field(ge=1)
+    path_a: tuple[int, ...] = Field(min_length=1, max_length=MAX_WORD)
+    path_b: tuple[int, ...] = Field(min_length=1, max_length=MAX_WORD)
 
 
 # Results
@@ -45,8 +45,8 @@ class EdgePathConcatenateRequest(StrictModel):
 class EdgeGraph(StrictModel):
     """A bounded graph with an explicit vertex axis for edge paths."""
 
-    vertex_count: int = Field(ge=2)
-    edges: tuple[tuple[int, int], ...] = Field(min_length=1, max_length=MAX_EDGES)
+    vertex_count: int = Field(ge=1)
+    edges: tuple[tuple[int, int], ...] = Field(max_length=MAX_EDGES)
 
     @classmethod
     def from_request(
@@ -58,14 +58,14 @@ class EdgeGraph(StrictModel):
 class EdgePathWordResult(StrictModel):
     graph: EdgeGraph
     start_vertex: int
-    path: tuple[OrientedEdge, ...] = Field(min_length=1, max_length=MAX_WORD)
+    path: tuple[OrientedEdge, ...] = Field(max_length=MAX_WORD)
     word: tuple[str, ...]
     length: int = Field(ge=0)
 
 
 class EdgePathConcatenateResult(StrictModel):
-    vertex_count: int = Field(ge=2)
-    path_a: tuple[int, ...] = Field(min_length=2, max_length=MAX_WORD)
-    path_b: tuple[int, ...] = Field(min_length=2, max_length=MAX_WORD)
+    vertex_count: int = Field(ge=1)
+    path_a: tuple[int, ...] = Field(min_length=1, max_length=MAX_WORD)
+    path_b: tuple[int, ...] = Field(min_length=1, max_length=MAX_WORD)
     path: tuple[int, ...]
     length: int = Field(ge=0)

--- a/src/jacobian/math/topology/edge_paths/operations.py
+++ b/src/jacobian/math/topology/edge_paths/operations.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.topology.edge_paths._models import (
+    MAX_EDGES,
+    MAX_WORD,
     EdgeGraph,
     EdgePathConcatenateResult,
     EdgePathWordResult,
@@ -25,6 +30,12 @@ def _admit_edge_path_word(
     start_vertex: int,
     path: tuple[OrientedEdge, ...],
 ) -> None:
+    if len(edges) > MAX_EDGES or len(path) > MAX_WORD:
+        raise OperationResourceAdmissionError(
+            location=("path",),
+            code="topology.edge_path.source_budget",
+            message="edge path exceeds the source edge or word bound",
+        )
     for u, v in edges:
         if not (0 <= u < vertex_count and 0 <= v < vertex_count):
             _reject(
@@ -62,6 +73,18 @@ def _admit_edge_path_concatenation(
     path_a: tuple[int, ...],
     path_b: tuple[int, ...],
 ) -> None:
+    if not path_a or not path_b:
+        _reject(
+            location=("path_a", "path_b"),
+            code="missing_endpoint",
+            message="each path must retain at least its endpoint vertex",
+        )
+    if len(path_a) > MAX_WORD or len(path_b) > MAX_WORD:
+        raise OperationResourceAdmissionError(
+            location=("path_a", "path_b"),
+            code="topology.edge_path.source_budget",
+            message="edge path exceeds the source word bound",
+        )
     if any(not 0 <= v < vertex_count for v in path_a):
         _reject(
             location=("path_a",),
@@ -118,12 +141,7 @@ def concatenate_edge_paths(
     the concatenation is path_a + path_b[1:], removing the duplicate.
     """
     _admit_edge_path_concatenation(vertex_count, path_a, path_b)
-    first = list(path_a)
-    second = list(path_b)
-    if first and second and first[-1] == second[0]:
-        result = first + second[1:]
-    else:
-        result = first + second
+    result = path_a + path_b[1:]
     return EdgePathConcatenateResult(
         vertex_count=vertex_count,
         path_a=path_a,
@@ -145,7 +163,9 @@ def verify_edge_path_word(claim: EdgePathWordResult) -> bool:
             )
             == claim
         )
-    except (OperationDomainValidationError, TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 
@@ -156,7 +176,9 @@ def verify_edge_path_concatenation(claim: EdgePathConcatenateResult) -> bool:
             concatenate_edge_paths(claim.vertex_count, claim.path_a, claim.path_b)
             == claim
         )
-    except (OperationDomainValidationError, TypeError, ValueError):
+    except OperationResourceAdmissionError:
+        raise
+    except OperationDomainValidationError:
         return False
 
 

--- a/src/jacobian/math/topology/finite/spaces/operations.py
+++ b/src/jacobian/math/topology/finite/spaces/operations.py
@@ -89,9 +89,19 @@ def _minimal_neighbourhoods(
     )
 
 
+def _admit_subset(space: FiniteTopologicalSpace, subset: frozenset[int]) -> None:
+    if any(not 0 <= point < len(space.points) for point in subset):
+        raise OperationDomainValidationError(
+            location=("subset",),
+            code="finite_topology_space.subset_index_range",
+            message="subset index out of range",
+        )
+
+
 def interior(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[int]:
     """Return the interior of a subset (largest open set contained in it)."""
     _admit_space(space)
+    _admit_subset(space, subset)
     return _interior(space, subset)
 
 
@@ -107,14 +117,13 @@ def _interior(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozense
 def closure(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[int]:
     """Return the closure of a subset (smallest closed set containing it)."""
     _admit_space(space)
+    _admit_subset(space, subset)
     return _closure(space, subset)
 
 
 def _closure(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[int]:
     result: set[int] = set()
     for i in subset:
-        if not 0 <= i < len(space.points):
-            raise ValueError("subset index out of range")
         result.update(space.preorder[i])
     return frozenset(result)
 
@@ -122,6 +131,7 @@ def _closure(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset
 def boundary(space: FiniteTopologicalSpace, subset: frozenset[int]) -> frozenset[int]:
     """Return the boundary of a subset: closure minus interior."""
     _admit_space(space)
+    _admit_subset(space, subset)
     cl = _closure(space, subset)
     inter = _interior(space, subset)
     return frozenset(cl - inter)
@@ -208,45 +218,39 @@ def verify_continuity(claim: ContinuousCheckResult) -> bool:
 
 def verify_interior(claim: InteriorResult) -> bool:
     """Verify an interior claim against its retained finite space and subset."""
+    if claim.subset.space != claim.space or claim.interior.space != claim.space:
+        return False
     try:
         _admit_space(claim.space)
         expected = _interior(claim.space, frozenset(claim.subset.indices))
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationDomainValidationError:
         return False
-    return (
-        claim.subset.space == claim.space
-        and claim.interior.space == claim.space
-        and tuple(sorted(expected)) == claim.interior.indices
-    )
+    return tuple(sorted(expected)) == claim.interior.indices
 
 
 def verify_closure(claim: ClosureResult) -> bool:
     """Verify a closure claim against its retained finite space and subset."""
+    if claim.subset.space != claim.space or claim.closure.space != claim.space:
+        return False
     try:
         _admit_space(claim.space)
         expected = _closure(claim.space, frozenset(claim.subset.indices))
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationDomainValidationError:
         return False
-    return (
-        claim.subset.space == claim.space
-        and claim.closure.space == claim.space
-        and tuple(sorted(expected)) == claim.closure.indices
-    )
+    return tuple(sorted(expected)) == claim.closure.indices
 
 
 def verify_boundary(claim: BoundaryResult) -> bool:
     """Verify a boundary claim against its retained finite space and subset."""
+    if claim.subset.space != claim.space or claim.boundary.space != claim.space:
+        return False
     try:
         _admit_space(claim.space)
         subset = frozenset(claim.subset.indices)
         expected = _closure(claim.space, subset) - _interior(claim.space, subset)
-    except (OperationDomainValidationError, ValueError, TypeError):
+    except OperationDomainValidationError:
         return False
-    return (
-        claim.subset.space == claim.space
-        and claim.boundary.space == claim.space
-        and tuple(sorted(expected)) == claim.boundary.indices
-    )
+    return tuple(sorted(expected)) == claim.boundary.indices
 
 
 def verify_kolmogorov_quotient(claim: KolmogorovQuotientResult) -> bool:

--- a/src/jacobian/math/topology/frames/_flint.py
+++ b/src/jacobian/math/topology/frames/_flint.py
@@ -36,6 +36,8 @@ def integer_gram(
 
 def integer_gram_and_rank(
     vectors: tuple[tuple[int, ...], ...],
+    *,
+    dimension: int,
 ) -> tuple[int, tuple[tuple[int, ...], ...] | None]:
     """Return rank and, only when admitted, the Gram matrix from one source."""
 
@@ -43,7 +45,7 @@ def integer_gram_and_rank(
 
     source = fmpz_mat(vectors)
     rank = int(source.rank())
-    if rank != len(vectors[0]):
+    if rank != dimension:
         return rank, None
     return rank, _canonical_rows(source * source.transpose())
 

--- a/src/jacobian/math/topology/frames/_models.py
+++ b/src/jacobian/math/topology/frames/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import Field, model_validator
+from pydantic import model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, ExactInteger
@@ -16,28 +16,13 @@ from jacobian.math.topology.frames.values import (
 )
 
 
-class VectorFamilyRequest(VectorFamily):
-    """A bounded family in the standard ordered coordinate space."""
-
-
-class FiniteFrameRequest(VectorFamilyRequest):
-    """Wire request for an operation whose input must span its ambient space."""
-
-
-class CoherenceRequest(FiniteFrameRequest):
-    """Wire request for the normalized pairwise coherence operation."""
-
-
-class GramResult(VectorFamilyRequest):
+class GramResult(VectorFamily):
     gram: IntegerMatrix
-    dimension: int = Field(ge=1)
 
     @model_validator(mode="after")
     def require_source_shape(self) -> Self:
-        if (
-            self.gram.row_count != len(self.vectors)
-            or self.gram.column_count != len(self.vectors)
-            or self.dimension != len(self.vectors[0])
+        if self.gram.row_count != len(self.vectors) or self.gram.column_count != len(
+            self.vectors
         ):
             raise PydanticCustomError(
                 "frames.gram_shape",
@@ -50,16 +35,17 @@ class GramResult(VectorFamilyRequest):
         cls,
         *,
         vectors: tuple[tuple[int, ...], ...],
+        dimension: int,
         gram: IntegerMatrix,
     ) -> Self:
         return cls.model_construct(
             vectors=vectors,
             gram=gram,
-            dimension=len(vectors[0]),
+            dimension=dimension,
         )
 
 
-class CoherenceResult(CoherenceRequest):
+class CoherenceResult(VectorFamily):
     coherence_squared: CanonicalRational
     maximizing_pair: tuple[int, int] | None
 
@@ -68,25 +54,32 @@ class CoherenceResult(CoherenceRequest):
         cls,
         *,
         vectors: tuple[tuple[int, ...], ...],
+        dimension: int,
         coherence_squared: CanonicalRational,
         maximizing_pair: tuple[int, int] | None,
     ) -> Self:
         return cls.model_construct(
             vectors=vectors,
+            dimension=dimension,
             coherence_squared=coherence_squared,
             maximizing_pair=maximizing_pair,
         )
 
 
-class FramePotentialResult(FiniteFrameRequest):
+class FramePotentialResult(VectorFamily):
     potential: ExactInteger
 
     @classmethod
     def _from_kernel(
-        cls, *, vectors: tuple[tuple[int, ...], ...], potential: ExactInteger
+        cls,
+        *,
+        vectors: tuple[tuple[int, ...], ...],
+        dimension: int,
+        potential: ExactInteger,
     ) -> Self:
         return cls.model_construct(
             vectors=vectors,
+            dimension=dimension,
             potential=potential,
         )
 
@@ -94,10 +87,7 @@ class FramePotentialResult(FiniteFrameRequest):
 __all__ = [
     "MAX_DIM",
     "MAX_VECTOR_CELLS",
-    "CoherenceRequest",
     "CoherenceResult",
-    "FiniteFrameRequest",
     "FramePotentialResult",
     "GramResult",
-    "VectorFamilyRequest",
 ]

--- a/src/jacobian/math/topology/frames/_tools.py
+++ b/src/jacobian/math/topology/frames/_tools.py
@@ -2,33 +2,31 @@
 
 from jacobian.catalog.models import MathTool, MathTools, OperationExample
 from jacobian.math.topology.frames._models import (
-    CoherenceRequest,
     CoherenceResult,
-    FiniteFrameRequest,
     FramePotentialResult,
     GramResult,
-    VectorFamilyRequest,
 )
 from jacobian.math.topology.frames.operations import (
     coherence,
     frame_potential,
     gram,
 )
+from jacobian.math.topology.frames.values import VectorFamily
 
 
-def _gram(request: VectorFamilyRequest) -> GramResult:
+def _gram(request: VectorFamily) -> GramResult:
     return gram(request)
 
 
-def _coherence(request: CoherenceRequest) -> CoherenceResult:
+def _coherence(request: VectorFamily) -> CoherenceResult:
     return coherence(request)
 
 
-def _frame_potential(request: FiniteFrameRequest) -> FramePotentialResult:
+def _frame_potential(request: VectorFamily) -> FramePotentialResult:
     return frame_potential(request)
 
 
-_ORTHONORMAL = {"vectors": [[1, 0], [0, 1]]}
+_ORTHONORMAL = {"dimension": 2, "vectors": [[1, 0], [0, 1]]}
 
 TOOLS: MathTools = (
     MathTool(
@@ -36,7 +34,7 @@ TOOLS: MathTools = (
         title="Compute the Gram matrix of a vector family",
         description="Compute the exact Gram matrix G with G_ij = <v_i, v_j> "
         "for a finite family of integer vectors.",
-        request_type=VectorFamilyRequest,
+        request_type=VectorFamily,
         result_type=GramResult,
         run=_gram,
         tags=("topology", "frame", "gram", "exact"),
@@ -53,7 +51,7 @@ TOOLS: MathTools = (
         title="Compute the coherence of a frame",
         description="Compute the maximum normalized off-diagonal Gram entry "
         "after checking that the family spans the ambient space.",
-        request_type=CoherenceRequest,
+        request_type=VectorFamily,
         result_type=CoherenceResult,
         run=_coherence,
         tags=("topology", "frame", "coherence", "exact"),
@@ -70,7 +68,7 @@ TOOLS: MathTools = (
         title="Compute the frame potential",
         description="Compute the exact frame potential sum_{i,j} |<v_i, v_j>|^2 "
         "after checking that the family spans the ambient space.",
-        request_type=FiniteFrameRequest,
+        request_type=VectorFamily,
         result_type=FramePotentialResult,
         run=_frame_potential,
         tags=("topology", "frame", "potential", "exact"),

--- a/src/jacobian/math/topology/frames/operations.py
+++ b/src/jacobian/math/topology/frames/operations.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from fractions import Fraction
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.matrices.values import IntegerMatrix
 from jacobian.math.topology.frames._flint import integer_gram, integer_gram_and_rank
 from jacobian.math.topology.frames._models import (
@@ -22,22 +25,18 @@ MAX_FRAME_GRAM_ENTRIES = 2_097_152
 MAX_FRAME_GRAM_MULTIPLY_ADDS = 536_870_912
 
 
-def _coefficient_height(value: VectorFamily) -> int:
-    return max(abs(entry) for vector in value.vectors for entry in vector)
-
-
 def _require_gram_work_budget(value: VectorFamily) -> None:
     vector_count = len(value.vectors)
-    dimension = len(value.vectors[0])
+    dimension = value.dimension
     gram_entries = vector_count**2
     if gram_entries > MAX_FRAME_GRAM_ENTRIES:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("vectors",),
             code="frames.gram_intermediate_budget",
             message="frame Gram intermediate exceeds its entry budget",
         )
     if gram_entries * dimension > MAX_FRAME_GRAM_MULTIPLY_ADDS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("vectors",),
             code="frames.gram_work_budget",
             message="frame Gram computation exceeds its multiply-add work budget",
@@ -48,6 +47,7 @@ def _gram_result(value: VectorFamily) -> GramResult:
     matrix = integer_gram(value.vectors)
     return GramResult._from_kernel(
         vectors=value.vectors,
+        dimension=value.dimension,
         gram=IntegerMatrix(
             row_count=len(matrix),
             column_count=len(matrix[0]) if matrix else len(value.vectors),
@@ -57,7 +57,7 @@ def _gram_result(value: VectorFamily) -> GramResult:
 
 
 def _admit_frame(value: VectorFamily, *, rank: int) -> None:
-    if rank != len(value.vectors[0]):
+    if rank != value.dimension:
         raise OperationDomainValidationError(
             location=("vectors",),
             code="frames.frame_does_not_span",
@@ -66,7 +66,7 @@ def _admit_frame(value: VectorFamily, *, rank: int) -> None:
 
 
 def _admit_frame_shape(value: VectorFamily) -> None:
-    if len(value.vectors) < len(value.vectors[0]):
+    if len(value.vectors) < value.dimension:
         raise OperationDomainValidationError(
             location=("vectors",),
             code="frames.frame_does_not_span",
@@ -86,20 +86,13 @@ def verify_gram(claim: GramResult) -> bool:
         if (
             claim.gram.row_count != len(claim.vectors)
             or claim.gram.column_count != len(claim.vectors)
-            or claim.dimension != len(claim.vectors[0])
+            or any(len(vector) != claim.dimension for vector in claim.vectors)
         ):
             return False
-        _require_gram_work_budget(claim)
-        expected = integer_gram(claim.vectors)
-        return claim.gram.entries == expected
-    except (
-        AttributeError,
-        IndexError,
-        TypeError,
-        ValueError,
-        OperationDomainValidationError,
-    ):
+    except (AttributeError, IndexError, TypeError):
         return False
+    _require_gram_work_budget(claim)
+    return claim.gram.entries == integer_gram(claim.vectors)
 
 
 def coherence(value: VectorFamily) -> CoherenceResult:
@@ -112,7 +105,7 @@ def coherence(value: VectorFamily) -> CoherenceResult:
             message="coherence requires every vector to be nonzero",
         )
     _admit_frame_shape(value)
-    rank, matrix = integer_gram_and_rank(value.vectors)
+    rank, matrix = integer_gram_and_rank(value.vectors, dimension=value.dimension)
     _admit_frame(value, rank=rank)
     assert matrix is not None
     maximum_numerator = 0
@@ -135,6 +128,7 @@ def coherence(value: VectorFamily) -> CoherenceResult:
                 pair = candidate_pair
     return CoherenceResult._from_kernel(
         vectors=value.vectors,
+        dimension=value.dimension,
         coherence_squared=CanonicalRational.from_fraction(
             Fraction(maximum_numerator, maximum_denominator)
         ),
@@ -146,8 +140,10 @@ def frame_potential(value: VectorFamily) -> FramePotentialResult:
     """Compute the exact frame potential of a finite frame."""
     _require_gram_work_budget(value)
     _admit_frame_shape(value)
-    rank, matrix = integer_gram_and_rank(value.vectors)
+    rank, matrix = integer_gram_and_rank(value.vectors, dimension=value.dimension)
     _admit_frame(value, rank=rank)
     assert matrix is not None
     total = sum(entry**2 for row in matrix for entry in row)
-    return FramePotentialResult._from_kernel(vectors=value.vectors, potential=total)
+    return FramePotentialResult._from_kernel(
+        vectors=value.vectors, dimension=value.dimension, potential=total
+    )

--- a/src/jacobian/math/topology/frames/values.py
+++ b/src/jacobian/math/topology/frames/values.py
@@ -19,14 +19,15 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 
 
 class VectorFamily(StrictModel):
-    """A bounded family in the standard ordered coordinate space.
+    """A bounded family of integer vectors in Euclidean coordinate space.
 
     Spanning and nonzero-vector requirements are operation-specific admission
     decisions made by the native kernels.
     """
 
+    dimension: int = Field(ge=0, le=MAX_DIM)
     vectors: tuple[tuple[int, ...], ...] = Field(
-        min_length=1,
+        max_length=MAX_VECTOR_CELLS,
         description=(
             "Ordered vectors with len(vectors) * dimension <= "
             f"{MAX_VECTOR_CELLS} materialized cells."
@@ -35,12 +36,7 @@ class VectorFamily(StrictModel):
 
     @model_validator(mode="after")
     def require_rectangular_family(self) -> Self:
-        dimension = len(self.vectors[0])
-        if not 1 <= dimension <= MAX_DIM:
-            raise _validation_error(
-                "vector_dimension_out_of_range",
-                f"vector dimension must be between 1 and {MAX_DIM}",
-            )
+        dimension = self.dimension
         if any(len(vector) != dimension for vector in self.vectors):
             raise _validation_error(
                 "vector_dimension_mismatch", "all vectors must have equal dimension"

--- a/src/jacobian/math/universal_algebra/operations.py
+++ b/src/jacobian/math/universal_algebra/operations.py
@@ -66,7 +66,7 @@ def _admit_evaluate(
             message="assignment must cover exactly the referenced variables",
         )
     size = len(algebra.carrier)
-    if any(not 0 <= value < size for value in assignment):
+    if any(type(value) is not int or not 0 <= value < size for value in assignment):
         _reject(
             location=("assignment",),
             code="assignment_carrier_range",
@@ -194,6 +194,14 @@ def evaluate_term(
 
     Return the exact carrier value ``t^A(alpha)``.
     """
+    if any(type(key) is not int for key in assignment) or set(assignment) != set(
+        range(term.variable_count)
+    ):
+        _reject(
+            location=("assignment",),
+            code="assignment_variable_axis",
+            message="assignment keys must cover exactly the term variable axis 0..variable_count-1",
+        )
     _admit_evaluate(algebra, term, tuple(assignment.values()))
     return _evaluate_term_unchecked(algebra, term, assignment)
 

--- a/src/jacobian/mcp/direct_tools.py
+++ b/src/jacobian/mcp/direct_tools.py
@@ -28,6 +28,7 @@ from jacobian.dispatch import (
 from jacobian.mcp.runtime import AppState, _authorize
 from jacobian.mcp.tools import (
     _backend_unavailable_error,
+    _execution_tool_error,
     _invalid_request_error,
     _request_cancellation,
 )
@@ -96,9 +97,13 @@ def _direct_operation_tool(
         except (OperationRequestValidationError, OperationDomainValidationError) as exc:
             raise _invalid_request_error(operation_id, exc) from exc
         except OperationExecutionTimeoutError as exc:
-            raise ToolError("operation execution deadline expired") from exc
+            raise _execution_tool_error(
+                code="OPERATION_TIMEOUT", operation_id=operation_id, stage=exc.stage
+            ) from exc
         except OperationExecutionCancelledError as exc:
-            raise ToolError("operation cancelled") from exc
+            raise _execution_tool_error(
+                code="OPERATION_CANCELLED", operation_id=operation_id, stage=exc.stage
+            ) from exc
         except BackendUnavailableError as exc:
             raise _backend_unavailable_error(operation_id, exc) from exc
         except (MCPError, ToolError):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -65,3 +65,35 @@ def test_cli_run_requires_exactly_one_payload_source(
     error = json.loads(result.stderr)["error"]
     assert error["code"] == "INVALID_ARGUMENT"
     assert error["message"] == ("pass exactly one of --json or --file")
+
+
+def test_cli_backend_value_error_is_command_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jacobian.dispatch as dispatch
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise ValueError("backend failed")
+
+    monkeypatch.setattr(dispatch, "invoke_operation", fail)
+    result = CliRunner().invoke(
+        app, ["run", "integer.compute.extended_gcd", "--json", "{}"]
+    )
+    assert result.exit_code == 1
+    assert json.loads(result.stderr)["error"]["code"] == "COMMAND_FAILED"
+
+
+def test_cli_resource_refusal_is_not_invalid_argument() -> None:
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "cubical.face_closure.compute",
+            "--json",
+            json.dumps(
+                {"cells": [{"intervals": [[0, 1]] * 10}, {"intervals": [[3, 4]] * 10}]}
+            ),
+        ],
+    )
+    assert result.exit_code == 1
+    assert json.loads(result.stderr)["error"]["code"] == "RESOURCE_NOT_ADMITTED"

--- a/tests/dispatch/test_owner_semantic_validation.py
+++ b/tests/dispatch/test_owner_semantic_validation.py
@@ -27,8 +27,8 @@ def test_universal_algebra_assignment_admission_is_typed() -> None:
     assert caught.value.errors() == (
         {
             "loc": ("assignment",),
-            "type": "universal_algebra.assignment_coverage",
-            "msg": "assignment must cover exactly the referenced variables",
+            "type": "universal_algebra.assignment_variable_axis",
+            "msg": "assignment keys must cover exactly the term variable axis 0..variable_count-1",
         },
     )
 

--- a/tests/integration/test_algebra_function_verification_failures.py
+++ b/tests/integration/test_algebra_function_verification_failures.py
@@ -1,0 +1,609 @@
+"""Operational failure at a native claim consumer never refutes its claim."""
+
+import importlib
+import json
+from typing import Any
+
+import pytest
+
+from jacobian._execution import OperationExecutionTimeoutError
+from jacobian.catalog.builtins import BUILTIN_TOOLS
+from jacobian.catalog.models import OperationResourceAdmissionError
+
+CASES = (
+    (
+        "matrix.symbolic.eigenvalues.compute",
+        "matrices.symbolic.operations",
+        "verify_symbolic_eigenvalues",
+        "_symbolic_characteristic_polynomial_kernel",
+    ),
+    (
+        "polynomial.ideal.normal_form.compute",
+        "polynomials.ideals.operations",
+        "verify_ideal_normal_form",
+        "ideal_normal_form",
+    ),
+    (
+        "polynomial.ideal.containment.decide",
+        "polynomials.ideals.operations",
+        "verify_ideal_containment",
+        "ideal_containment",
+    ),
+    (
+        "polynomial.ideal.equality.decide",
+        "polynomials.ideals.operations",
+        "verify_ideal_equality",
+        "ideal_equality",
+    ),
+    (
+        "polynomial.system.real_root_box.certify",
+        "polynomials.root_boxes.operations",
+        "verify_real_root_box",
+        "certify_real_root_box",
+    ),
+    (
+        "polynomial.box.enclosure.compute",
+        "polynomials.intervals._tools",
+        "verify_polynomial_box_enclosure",
+        "polynomial_box_enclosure",
+    ),
+)
+
+
+@pytest.mark.parametrize("operation_id,module_name,verifier_name,boundary", CASES)
+@pytest.mark.parametrize(
+    "failure",
+    (
+        RuntimeError,
+        ValueError,
+        OperationExecutionTimeoutError,
+        MemoryError,
+        OperationResourceAdmissionError,
+    ),
+)
+def test_verifier_preserves_operational_noncompletion(
+    monkeypatch: pytest.MonkeyPatch,
+    operation_id: str,
+    module_name: str,
+    verifier_name: str,
+    boundary: str,
+    failure: type[Exception],
+) -> None:
+    tool = next(tool for tool in BUILTIN_TOOLS if tool.operation_id == operation_id)
+    payload = json.loads(json.dumps(tool.examples[0].input))
+    if (
+        operation_id == "formal_series.rational.reversion.compute"
+        and boundary == "_compose_coefficients"
+    ):
+        payload["coefficients"][2] = {"num": "1", "den": "1"}
+    result = tool.run(tool.request_type.model_validate_json(json.dumps(payload)))
+    claim = tool.result_type.model_validate_json(result.model_dump_json())
+    module = importlib.import_module("jacobian.math." + module_name)
+    verifier = getattr(module, verifier_name)
+    assert verifier(claim)
+    error = (
+        OperationResourceAdmissionError(
+            location=(), code="test.resource", message="injected noncompletion"
+        )
+        if failure is OperationResourceAdmissionError
+        else failure("injected noncompletion")
+    )
+
+    def fail(*args: Any, **kwargs: Any) -> Any:
+        raise error
+
+    monkeypatch.setattr(module, boundary, fail)
+    with pytest.raises(failure, match="injected noncompletion"):
+        verifier(claim)
+
+
+@pytest.mark.parametrize("restriction", (False, True))
+@pytest.mark.parametrize("failure", (ValueError, OperationResourceAdmissionError))
+def test_bernstein_verifier_preserves_operational_noncompletion(
+    monkeypatch: pytest.MonkeyPatch,
+    restriction: bool,
+    failure: type[Exception],
+) -> None:
+    from jacobian.math.polynomials.bernstein import operations
+    from jacobian.math.polynomials.bernstein.values import RationalBernsteinPolynomial
+
+    tool = next(
+        t
+        for t in BUILTIN_TOOLS
+        if t.operation_id == "polynomial.bernstein.coefficients.compute"
+    )
+    result = tool.run(
+        tool.request_type.model_validate_json(json.dumps(tool.examples[0].input))
+    )
+    claim = RationalBernsteinPolynomial.model_validate_json(result.model_dump_json())
+    error = (
+        OperationResourceAdmissionError(
+            location=(), code="test.resource", message="injected noncompletion"
+        )
+        if failure is OperationResourceAdmissionError
+        else failure("injected noncompletion")
+    )
+
+    def fail(*args: Any, **kwargs: Any) -> Any:
+        raise error
+
+    monkeypatch.setattr(operations, "bernstein_coefficients", fail)
+    with pytest.raises(failure, match="injected noncompletion"):
+        if restriction:
+            operations.verify_bernstein_restriction(claim, claim)
+        else:
+            operations.verify_bernstein_coefficients(claim)
+
+
+EXPANDED_CASES: tuple[tuple[str, str, str, str], ...] = (
+    (
+        "algebra.affine_map.word_collision_profile.compute",
+        "algebra.affine_map_word_collision.operations",
+        "verify_word_collision_profile",
+        "compute_word_collision_profile",
+    ),
+    (
+        "convex.max_affine.evaluate",
+        "analysis.convex.operations",
+        "verify_max_affine_evaluation",
+        "max_affine_evaluation",
+    ),
+    (
+        "convex.max_affine.subdifferential",
+        "analysis.convex.operations",
+        "verify_max_affine_subdifferential",
+        "max_affine_subdifferential",
+    ),
+    (
+        "approximation.lagrange.basis.compute",
+        "analysis.approximation.operations",
+        "verify_lagrange_basis",
+        "lagrange_basis",
+    ),
+    (
+        "approximation.lagrange.interpolate.compute",
+        "analysis.approximation.operations",
+        "verify_lagrange_interpolation",
+        "lagrange_interpolation",
+    ),
+    (
+        "boolean.fourier_spectrum.compute",
+        "analysis.boolean.fourier.operations",
+        "verify_fourier_spectrum",
+        "fourier_spectrum",
+    ),
+    (
+        "boolean.multilinear_extension.compute",
+        "analysis.boolean.fourier.operations",
+        "verify_multilinear_extension",
+        "multilinear_extension",
+    ),
+    (
+        "boolean.erasure_noise.compute",
+        "analysis.boolean.fourier.operations",
+        "verify_erasure_noise",
+        "erasure_noise",
+    ),
+    (
+        "matrix.nullspace.compute",
+        "matrices.operations",
+        "verify_nullspace",
+        "rank_result",
+    ),
+    (
+        "matrix.minimal_polynomial.compute",
+        "matrices.canonical_forms.operations",
+        "verify_minimal_polynomial",
+        "_minimal_polynomial_components",
+    ),
+    (
+        "matrix.rational_canonical_form.compute",
+        "matrices.canonical_forms.operations",
+        "verify_rational_canonical_form",
+        "_rational_canonical_components",
+    ),
+    (
+        "matrix.primary_decomposition.compute",
+        "matrices.canonical_forms.operations",
+        "verify_primary_decomposition",
+        "_primary_decomposition_components",
+    ),
+    (
+        "matrix.real_quadratic.symmetric_spectrum.compute",
+        "matrices.quadratic_spectral.operations",
+        "verify_symmetric_spectrum",
+        "symmetric_spectrum",
+    ),
+    (
+        "matrix.real_quadratic.singular_spectrum.compute",
+        "matrices.quadratic_spectral.operations",
+        "verify_singular_spectrum",
+        "singular_spectrum",
+    ),
+    (
+        "matrix.real_quadratic.inertia.compute",
+        "matrices.quadratic_spectral.operations",
+        "verify_inertia",
+        "inertia",
+    ),
+    (
+        "matrix.subsystem.kronecker_product.compute",
+        "matrices.subsystems.operations",
+        "verify_subsystem_kronecker_product",
+        "kronecker_product",
+    ),
+    (
+        "matrix.subsystem.partial_trace.compute",
+        "matrices.subsystems.operations",
+        "verify_partial_trace",
+        "partial_trace",
+    ),
+    (
+        "matrix.subsystem.psd_order.decide",
+        "matrices.subsystems.operations",
+        "verify_psd_order",
+        "psd_order",
+    ),
+    (
+        "matrix.inertia.compute",
+        "matrices.analysis.operations",
+        "verify_inertia",
+        "compute_inertia",
+    ),
+    (
+        "polynomial.compute.gcd",
+        "polynomials.operations",
+        "verify_polynomial_gcd",
+        "polynomial_gcd",
+    ),
+    (
+        "polynomial.compute.resultant",
+        "polynomials.operations",
+        "verify_polynomial_resultant",
+        "polynomial_resultant",
+    ),
+    (
+        "polynomial.compute.discriminant",
+        "polynomials.operations",
+        "verify_polynomial_discriminant",
+        "polynomial_discriminant",
+    ),
+    (
+        "polynomial.compute.square_free_decomposition",
+        "polynomials.operations",
+        "verify_polynomial_square_free_decomposition",
+        "polynomial_square_free_decomposition",
+    ),
+    (
+        "polynomial.factor.compute",
+        "polynomials.operations",
+        "verify_polynomial_factorization",
+        "polynomial_factorization",
+    ),
+    (
+        "polynomial.unit_circle.arc_energy.compute",
+        "polynomials.unit_circle.operations",
+        "verify_unit_circle_arc_energy",
+        "_real_cyclotomic_record",
+    ),
+    (
+        "polynomial.unit_circle.real_symmetric_degree_one_fejer_riesz_factor.compute",
+        "polynomials.unit_circle.operations",
+        "verify_real_symmetric_degree_one_fejer_riesz_factor",
+        "_laurent_coefficients",
+    ),
+    (
+        "polynomial_field.scalar.gradient.compute",
+        "polynomials.vector_calculus.operations",
+        "verify_gradient",
+        "gradient",
+    ),
+    (
+        "polynomial_field.vector.divergence.compute",
+        "polynomials.vector_calculus.operations",
+        "verify_divergence",
+        "divergence",
+    ),
+    (
+        "polynomial_field.vector.curl.compute",
+        "polynomials.vector_calculus.operations",
+        "verify_curl",
+        "curl",
+    ),
+    (
+        "polynomial_field.scalar.laplacian.compute",
+        "polynomials.vector_calculus.operations",
+        "verify_laplacian",
+        "laplacian",
+    ),
+    (
+        "polynomial_field.scalar.directional_derivative.compute",
+        "polynomials.vector_calculus.operations",
+        "verify_directional_derivative",
+        "directional_derivative",
+    ),
+    (
+        "polynomial.interpolation.divided_differences.compute",
+        "polynomials.interpolation.operations",
+        "verify_divided_differences",
+        "divided_differences",
+    ),
+    (
+        "polynomial.interpolation.newton_evaluate.compute",
+        "polynomials.interpolation.operations",
+        "verify_newton_evaluation",
+        "evaluate_newton",
+    ),
+    (
+        "polynomial.interpolation.hermite.compute",
+        "polynomials.interpolation.operations",
+        "verify_hermite_interpolation",
+        "hermite_interpolation",
+    ),
+    (
+        "polynomial.map.jacobian",
+        "polynomials.maps.operations",
+        "verify_jacobian",
+        "jacobian_matrix",
+    ),
+    (
+        "polynomial.multivariate.divide.compute",
+        "polynomials.multivariate.operations",
+        "verify_multivariate_division",
+        "multivariate_division",
+    ),
+    (
+        "polynomial.multivariate.factor.compute",
+        "polynomials.multivariate.operations",
+        "verify_multivariate_factor",
+        "multivariate_factor",
+    ),
+    (
+        "polynomial.multivariate.subresultant_sequence.compute",
+        "polynomials.multivariate.operations",
+        "verify_multivariate_subresultant_sequence",
+        "multivariate_subresultant_sequence",
+    ),
+    (
+        "polynomial.real.common_interlacing_profile.compute",
+        "polynomials.real_algebra.operations",
+        "verify_common_interlacing_profile",
+        "common_interlacing_profile",
+    ),
+    (
+        "polynomial.sturm_chain.compute",
+        "polynomials.real_algebra.operations",
+        "verify_sturm_chain",
+        "compute_sturm_chain",
+    ),
+    (
+        "polynomial.root_count.compute",
+        "polynomials.real_algebra.operations",
+        "verify_root_count",
+        "compute_root_count",
+    ),
+    (
+        "polynomial.real.strict_sublevel_measure.compute",
+        "polynomials.real_algebra.operations",
+        "verify_strict_sublevel_measure",
+        "compute_strict_sublevel_measure",
+    ),
+)
+
+EXPANDED_CASES += (
+    (
+        "polynomial.ideal.groebner_basis.compute",
+        "polynomials.ideals.operations",
+        "verify_groebner_basis",
+        "_run_sympy_kernel",
+    ),
+    (
+        "rational_function.hermite_reduction.compute",
+        "polynomials.rational_functions.operations",
+        "verify_hermite_reduction",
+        "hermite_reduction",
+    ),
+    (
+        "formal_series.rational.inverse.compute",
+        "polynomials.series.operations",
+        "verify_inverse",
+        "_cauchy_convolve",
+    ),
+    (
+        "formal_series.rational.divide.compute",
+        "polynomials.series.operations",
+        "verify_divide",
+        "_cauchy_convolve",
+    ),
+    (
+        "formal_series.rational.reversion.compute",
+        "polynomials.series.operations",
+        "verify_reversion",
+        "_compose_coefficients",
+    ),
+    (
+        "boolean.fourier.walsh_transform.compute",
+        "analysis.boolean.operations",
+        "verify_walsh_transform",
+        "walsh_hadamard_transform",
+    ),
+)
+
+EXPANDED_CASES += (
+    (
+        "polynomial.multivariate.gcd.compute",
+        "polynomials.multivariate.operations",
+        "verify_multivariate_gcd",
+        "rational_polynomial_to_sympy",
+    ),
+    (
+        "polynomial.multivariate.resultant.compute",
+        "polynomials.multivariate.operations",
+        "verify_multivariate_resultant",
+        "_sylvester_resultant_value",
+    ),
+    (
+        "real_algebraic.plane_semialgebraic.component_profile.compute",
+        "polynomials.real_algebra.operations",
+        "verify_plane_component_profile",
+        "compute_plane_component_profile",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "operation_id,module_name,verifier_name,boundary", EXPANDED_CASES
+)
+@pytest.mark.parametrize(
+    "failure", (ValueError, TypeError, OperationResourceAdmissionError)
+)
+def test_additional_verifier_preserves_operational_noncompletion(
+    monkeypatch: pytest.MonkeyPatch,
+    operation_id: str,
+    module_name: str,
+    verifier_name: str,
+    boundary: str,
+    failure: type[Exception],
+) -> None:
+    test_verifier_preserves_operational_noncompletion(
+        monkeypatch, operation_id, module_name, verifier_name, boundary, failure
+    )
+
+
+@pytest.mark.parametrize("kind", ("smith", "membership"))
+@pytest.mark.parametrize(
+    "failure", (ValueError, TypeError, OperationResourceAdmissionError)
+)
+def test_authored_identity_verifier_preserves_operational_noncompletion(
+    monkeypatch: pytest.MonkeyPatch, kind: str, failure: type[Exception]
+) -> None:
+    if kind == "smith":
+        operation_id = "matrix.normal_form.smith.certified.compute"
+        module_name = "jacobian.math.matrices.certified_snf.operations"
+        verifier_name, boundary = (
+            "verify_smith_normal_form_certificate",
+            "matrix_determinant",
+        )
+    else:
+        operation_id = "polynomial.ideal.membership_certificate.compute"
+        module_name = "jacobian.math.polynomials.ideals.operations"
+        verifier_name, boundary = (
+            "verify_ideal_membership_certificate",
+            "rational_polynomial_to_sympy",
+        )
+    tool = next(t for t in BUILTIN_TOOLS if t.operation_id == operation_id)
+    result = tool.run(
+        tool.request_type.model_validate_json(json.dumps(tool.examples[0].input))
+    )
+    parsed = tool.result_type.model_validate_json(result.model_dump_json())
+    claim = parsed.certificate if kind == "smith" else parsed
+    module = importlib.import_module(module_name)
+    verifier = getattr(module, verifier_name)
+    assert verifier(claim)
+    error = (
+        OperationResourceAdmissionError(
+            location=(), code="test.resource", message="injected noncompletion"
+        )
+        if failure is OperationResourceAdmissionError
+        else failure("injected noncompletion")
+    )
+
+    def fail(*args: Any, **kwargs: Any) -> Any:
+        raise error
+
+    monkeypatch.setattr(module, boundary, fail)
+    with pytest.raises(failure, match="injected noncompletion"):
+        verifier(claim)
+
+
+@pytest.mark.parametrize("kind", ("inverse", "divide", "reversion"))
+def test_long_trivial_series_admits_and_verifies(kind: str) -> None:
+    from jacobian._exact import CanonicalRational
+    from jacobian.math.polynomials.series import operations
+    from jacobian.math.polynomials.series._models import TruncatedSeries
+
+    zero = CanonicalRational(num=0, den=1)
+    one = CanonicalRational(num=1, den=1)
+    coefficients = (zero, one) if kind == "reversion" else (one,)
+    source = TruncatedSeries(
+        variable="x",
+        truncation_order=513,
+        coefficients=coefficients + (zero,) * (513 - len(coefficients)),
+    )
+    if kind == "divide":
+        result = operations.divide(source, source)
+    else:
+        result = getattr(operations, kind)(source)
+    assert getattr(operations, "verify_" + kind)(
+        type(result).model_validate_json(result.model_dump_json())
+    )
+    tool = next(
+        t
+        for t in BUILTIN_TOOLS
+        if t.operation_id == f"formal_series.rational.{kind}.compute"
+    )
+    wire_source = source.model_dump(mode="json")
+    payload = (
+        {"left": wire_source, "right": wire_source} if kind == "divide" else wire_source
+    )
+    published = tool.run(tool.request_type.model_validate_json(json.dumps(payload)))
+    assert published == result
+
+
+@pytest.mark.parametrize("kind", ("inverse", "divide", "reversion"))
+def test_nontrivial_long_series_verification_preserves_resource_refusal(
+    kind: str,
+) -> None:
+    from math import comb
+
+    from jacobian._exact import CanonicalRational
+    from jacobian.math.polynomials.series import operations
+    from jacobian.math.polynomials.series._models import (
+        SeriesDivideResult,
+        SeriesInverseResult,
+        SeriesReversionResult,
+        TruncatedSeries,
+    )
+
+    n = 513
+    zero = CanonicalRational(num=0, den=1)
+
+    def series(values: tuple[int, ...]) -> TruncatedSeries:
+        return TruncatedSeries(
+            variable="x",
+            truncation_order=n,
+            coefficients=tuple(CanonicalRational(num=value, den=1) for value in values)
+            + (zero,) * (n - len(values)),
+        )
+
+    claim: SeriesInverseResult | SeriesDivideResult | SeriesReversionResult
+    if kind == "inverse":
+        source = series((1, 1))
+        claim = SeriesInverseResult(
+            source=source,
+            result=series(tuple((-1) ** i for i in range(n))),
+            residual_coefficients=(zero,) * n,
+        )
+    elif kind == "divide":
+        source = series((1, 1))
+        claim = SeriesDivideResult(
+            numerator=source,
+            denominator=source,
+            quotient=series((1,)),
+            residual_coefficients=(zero,) * n,
+        )
+    else:
+        coefficients = (
+            0,
+            *((-1) ** (i - 1) * (comb(2 * (i - 1), i - 1) // i) for i in range(1, n)),
+        )
+        claim = SeriesReversionResult(
+            source=series((0, 1, 1)),
+            result=series(coefficients),
+            left_residual=(zero,) * n,
+            right_residual=(zero,) * n,
+        )
+    with pytest.raises(OperationResourceAdmissionError):
+        getattr(operations, "verify_" + kind)(
+            type(claim).model_validate_json(claim.model_dump_json())
+        )

--- a/tests/integration/test_discrete_native_verification_failures.py
+++ b/tests/integration/test_discrete_native_verification_failures.py
@@ -1,0 +1,169 @@
+"""Native-only discrete certificate consumers preserve operational noncompletion."""
+
+from importlib import import_module
+from types import ModuleType
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.additive.zero_sum_atoms._models import (
+    ZeroSumAtomSource,
+)
+from jacobian.math.combinatorics.discrepancy._models import FiniteSetSystem
+from jacobian.math.combinatorics.finite_structures.sets._models import FiniteIntegerSet
+from jacobian.math.groups.finite_abelian import FiniteAbelianProductGroup
+
+_RATIONALS = (CanonicalRational(num=1, den=1), CanonicalRational(num=2, den=1))
+_SET = FiniteIntegerSet(elements=(1, 2))
+_ATOMS = ZeroSumAtomSource(
+    group=FiniteAbelianProductGroup(moduli=(3,)), elements=((1,), (2,))
+)
+_CASES = (
+    (
+        "arithmetic_progression_hypergraph",
+        "construct_arithmetic_progression_hypergraph",
+        "verify_arithmetic_progression_hypergraph",
+        (1, 5, 3),
+        "_models",
+        "MAX_EDGES",
+    ),
+    (
+        "finite_structures.axis_aligned_square_grid",
+        "construct_axis_aligned_square_grid",
+        "verify_axis_aligned_square_grid",
+        (3,),
+        "operations",
+        "MAX_EDGES",
+    ),
+    (
+        "finite_structures.divisibility_sum_triples",
+        "construct_divisibility_sum_triples_hypergraph",
+        "verify_divisibility_sum_triples",
+        (1, 5),
+        "operations",
+        "MAX_TRIPLE_ENUMERATION",
+    ),
+    (
+        "additive.cyclic_sumset_profile",
+        "compute_cyclic_sumset_profile",
+        "verify_cyclic_sumset_profile",
+        (3, (0, 1), (0, 1)),
+        "operations",
+        "MAX_CYCLIC_SUMSET_PAIRS",
+    ),
+    (
+        "additive.product_representation",
+        "compute_product_representation_profile",
+        "verify_product_representation_profile",
+        (_SET, _SET),
+        "operations",
+        "MAX_PRODUCT_REPRESENTATION_PAIRS",
+    ),
+    (
+        "additive.gowers_cube_profile",
+        "compute_gowers_cube_profile",
+        "verify_gowers_cube_profile",
+        (3, (0, 1), 2),
+        "operations",
+        "MAX_GOWERS_CUBE_VERTEX_CHECKS",
+    ),
+    (
+        "additive.rational_fixed_arity",
+        "compute_rational_fixed_arity_sum_profile",
+        "verify_rational_fixed_arity_sum_profile",
+        (_RATIONALS, 1),
+        "operations",
+        "MAX_ENUMERATION_WORK",
+    ),
+    (
+        "additive.rational_subset_sum",
+        "compute_rational_subset_sum_profile",
+        "verify_rational_subset_sum_profile",
+        (_RATIONALS,),
+        "operations",
+        "MAX_SEQUENCE_LENGTH",
+    ),
+    (
+        "additive.zero_sum_atoms",
+        "construct_zero_sum_atom_hypergraph",
+        "verify_zero_sum_atom_hypergraph",
+        (_ATOMS,),
+        "operations",
+        "MAX_ATOM_SUBSET_CHECKS",
+    ),
+)
+
+
+def _module(owner: str, component: str = "operations") -> ModuleType:
+    return import_module("jacobian.math.combinatorics." + owner + "." + component)
+
+
+@pytest.mark.parametrize("owner,producer,verifier,args,budget_module,budget", _CASES)
+@pytest.mark.parametrize(
+    "error_type", [RuntimeError, ValueError, TypeError, MemoryError, TimeoutError]
+)
+def test_native_verifier_preserves_backend_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    owner: str,
+    producer: str,
+    verifier: str,
+    args: tuple[object, ...],
+    budget_module: str,
+    budget: str,
+    error_type: type[Exception],
+) -> None:
+    module = _module(owner)
+    claim = getattr(module, producer)(*args)
+    verify = getattr(module, verifier)
+    assert verify(claim)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise error_type("backend failure")
+
+    monkeypatch.setattr(module, producer, fail)
+    with pytest.raises(error_type, match="backend failure"):
+        verify(claim)
+
+
+@pytest.mark.parametrize("owner,producer,verifier,args,budget_module,budget", _CASES)
+def test_native_verifier_preserves_actual_resource_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+    owner: str,
+    producer: str,
+    verifier: str,
+    args: tuple[object, ...],
+    budget_module: str,
+    budget: str,
+) -> None:
+    module = _module(owner)
+    claim = getattr(module, producer)(*args)
+    monkeypatch.setattr(_module(owner, budget_module), budget, 0)
+    with pytest.raises(OperationResourceAdmissionError):
+        getattr(module, verifier)(claim)
+
+
+def test_single_atom_verifier_preserves_resource_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _module("additive.zero_sum_atoms")
+    assert module.verify_zero_sum_atom(_ATOMS, (0, 1))
+    monkeypatch.setattr(module, "MAX_ATOM_SUBSET_CHECKS", 0)
+    with pytest.raises(OperationResourceAdmissionError):
+        module.verify_zero_sum_atom(_ATOMS, (0, 1))
+
+
+def test_discrepancy_verifier_preserves_backend_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _module("discrepancy", "_tools")
+    source = FiniteSetSystem(ground_set_size=2, sets=((0, 1),))
+    claim = module._compute_discrepancy_native(source, (1, -1))
+    assert module.verify_discrepancy(claim)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("backend failure")
+
+    monkeypatch.setattr(module, "_compute_discrepancy_native", fail)
+    with pytest.raises(RuntimeError, match="backend failure"):
+        module.verify_discrepancy(claim)

--- a/tests/integration/test_exact_geometry_verification_failures.py
+++ b/tests/integration/test_exact_geometry_verification_failures.py
@@ -1,0 +1,106 @@
+"""Exact geometry verifiers retain operational failures across supplied claims."""
+
+import json
+from importlib import import_module
+from typing import Any, get_type_hints
+
+import pytest
+
+from jacobian.catalog.models import OperationResourceAdmissionError
+
+_CASES = (
+    ("exact", "verify_distance_profile", "distance_profile", None),
+    ("exact", "verify_distance_graph", "distance_graph", None),
+    ("exact", "verify_euclidean_orbit_profile", "euclidean_orbit_profile", None),
+    (
+        "exact",
+        "verify_pinned_line_distance_profile",
+        "pinned_line_distance_profile",
+        None,
+    ),
+    (
+        "exact.triangle_area_profile",
+        "verify_triangle_area_profile",
+        "compute_triangle_area_profile",
+        "MAX_CANONICAL_RATIONAL_DIGITS",
+    ),
+    (
+        "exact.spanned_line_profile",
+        "verify_spanned_line_profile",
+        "compute_spanned_line_profile",
+        "MAX_CANONICAL_RATIONAL_DIGITS",
+    ),
+    (
+        "exact.pinned_distance",
+        "verify_pinned_distance_support_profile",
+        "compute_pinned_distance_support_profile",
+        "MAX_DISTANCE_INTERMEDIATE_DIGITS",
+    ),
+    (
+        "framework",
+        "verify_planar_rigidity_profile",
+        "rank_result",
+        "MAX_FRAMEWORK_COORDINATE_WORK",
+    ),
+    ("differential", "verify_lie_derivative", "lie_derivative", None),
+)
+
+
+def _claim(owner: str, verifier: str) -> tuple[Any, Any]:
+    module = import_module("jacobian.math.geometry." + owner + ".operations")
+    tools = import_module("jacobian.math.geometry." + owner + "._tools").TOOLS
+    result_type = get_type_hints(getattr(module, verifier))["claim"]
+    tool = next(tool for tool in tools if tool.result_type is result_type)
+    request = tool.request_type.model_validate_json(json.dumps(tool.examples[0].input))
+    return module, tool.run(request)
+
+
+@pytest.mark.parametrize("owner,verifier,backend,budget", _CASES)
+def test_geometry_verifier_preserves_backend_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+    owner: str,
+    verifier: str,
+    backend: str,
+    budget: str | None,
+) -> None:
+    module, claim = _claim(owner, verifier)
+    verify = getattr(module, verifier)
+    assert verify(claim)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise ValueError("backend failure")
+
+    monkeypatch.setattr(module, backend, fail)
+    with pytest.raises(ValueError, match="backend failure"):
+        verify(claim)
+
+
+@pytest.mark.parametrize(
+    "owner,verifier,backend,budget", [case for case in _CASES if case[3]]
+)
+def test_geometry_verifier_preserves_real_resource_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+    owner: str,
+    verifier: str,
+    backend: str,
+    budget: str,
+) -> None:
+    module, claim = _claim(owner, verifier)
+    if owner == "exact.spanned_line_profile":
+        # Two points and coordinate-axis lines use a proved reduction. Keep
+        # this refusal test on the general noncollinear line-key path.
+        configuration = type(claim.configuration).model_validate(
+            {
+                "points": [
+                    {
+                        "label": label,
+                        "coordinates": [{"num": x, "den": 1}, {"num": y, "den": 1}],
+                    }
+                    for label, x, y in (("a", 0, 0), ("b", 1, 0), ("c", 0, 1))
+                ]
+            }
+        )
+        claim = module.compute_spanned_line_profile(configuration)
+    monkeypatch.setattr(module, budget, 0)
+    with pytest.raises(OperationResourceAdmissionError):
+        getattr(module, verifier)(claim)

--- a/tests/math/analysis/boolean/test_walsh_transform.py
+++ b/tests/math/analysis/boolean/test_walsh_transform.py
@@ -153,3 +153,15 @@ def test_walsh_transform_kernel_rejects_non_binary_values() -> None:
 
     with pytest.raises(OperationDomainValidationError, match="0 or 1"):
         walsh_hadamard_transform([0, 1, 1, 2])
+
+
+def test_walsh_result_round_trip_composes_with_its_native_verifier() -> None:
+    from jacobian.math.analysis.boolean import verify_walsh_transform
+    from jacobian.math.analysis.boolean._models import BooleanWalshTransformResult
+
+    result = _walsh_hadamard_transform(_request([0, 1]))
+    claim = BooleanWalshTransformResult.model_validate_json(result.model_dump_json())
+    assert verify_walsh_transform(claim)
+    assert tuple(v.as_integer_ratio() for v in claim.source.values) == ((0, 1), (1, 1))
+    forged = claim.model_copy(update={"spectrum": (2, 0)})
+    assert not verify_walsh_transform(forged)

--- a/tests/math/canonical/test_json.py
+++ b/tests/math/canonical/test_json.py
@@ -233,3 +233,26 @@ def test_scaled_rationals_have_the_same_canonical_bytes(
     )
 
     assert scaled == reduced
+
+
+def test_strict_decoder_enforces_its_configured_depth() -> None:
+    from jacobian.canonical import loads_strict_json
+
+    limits = CanonicalLimits(max_depth=2)
+    assert loads_strict_json("[[0]]", limits=limits) == [[0]]
+    with pytest.raises(CanonicalizationError, match="depth"):
+        loads_strict_json("[[[0]]]", limits=limits)
+
+
+def test_strict_decoder_reports_oversized_numeric_literals_as_encoding_errors() -> None:
+    from jacobian.canonical import loads_strict_json
+
+    with pytest.raises(CanonicalizationError):
+        loads_strict_json("9" * 5000)
+
+
+def test_strict_decoder_reports_invalid_unicode_as_encoding_error() -> None:
+    from jacobian.canonical import loads_strict_json
+
+    with pytest.raises(CanonicalizationError, match="UTF-8"):
+        loads_strict_json('"\ud800"')

--- a/tests/math/combinatorics/additive/test_verification_execution.py
+++ b/tests/math/combinatorics/additive/test_verification_execution.py
@@ -1,0 +1,88 @@
+"""Additive profile verification distinguishes failure from disagreement."""
+
+import pytest
+
+from jacobian.math.combinatorics.additive import operations
+from jacobian.math.combinatorics.additive._models import FiniteIntegerSet
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "representation_profile",
+        "additive_energy",
+        "sumset_cardinality",
+        "direct_sum_predicate",
+    ],
+)
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("backend"),
+        ValueError("backend"),
+        TypeError("backend"),
+        MemoryError("backend"),
+        TimeoutError("backend"),
+    ],
+)
+def test_verifier_preserves_execution_failure(
+    monkeypatch: pytest.MonkeyPatch, operation: str, error: Exception
+) -> None:
+    source = FiniteIntegerSet(elements=(0, 1))
+    args = (
+        (3, source, source) if operation == "direct_sum_predicate" else (source, source)
+    )
+    claim = getattr(operations, operation)(*args)
+    verifier = getattr(operations, "verify_" + operation)
+    assert verifier(claim)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise error
+
+    monkeypatch.setattr(operations, operation, fail)
+    with pytest.raises(type(error), match="backend"):
+        verifier(claim)
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "representation_profile",
+        "additive_energy",
+        "sumset_cardinality",
+        "direct_sum_predicate",
+    ],
+)
+def test_verifier_preserves_cartesian_resource_refusal(
+    monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    from jacobian.catalog.models import OperationResourceAdmissionError
+    from jacobian.math.combinatorics.additive import _models
+
+    source = FiniteIntegerSet(elements=(0, 1))
+    args = (
+        (3, source, source) if operation == "direct_sum_predicate" else (source, source)
+    )
+    claim = getattr(operations, operation)(*args)
+    monkeypatch.setattr(_models, "_MAX_CARTESIAN_PAIR_COUNT", 0)
+    with pytest.raises(OperationResourceAdmissionError):
+        getattr(operations, "verify_" + operation)(claim)
+
+
+def test_ordered_difference_verifier_preserves_incomplete_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.catalog.models import OperationResourceAdmissionError
+    from jacobian.math.combinatorics.additive._models import (
+        IntegerVector,
+        IntegerVectorSet,
+    )
+
+    source = IntegerVectorSet(
+        vectors=(IntegerVector(coordinates=(0,)), IntegerVector(coordinates=(1,)))
+    )
+    claim = operations.ordered_difference_profile(source)
+    assert operations.verify_ordered_difference_profile(claim)
+    monkeypatch.setattr(operations, "MAX_ORDERED_DIFFERENCE_COORDINATE_WORK", 0)
+    with pytest.raises(OperationResourceAdmissionError):
+        operations.verify_ordered_difference_profile(claim)

--- a/tests/math/combinatorics/codes/general/test_exact_code_enumeration.py
+++ b/tests/math/combinatorics/codes/general/test_exact_code_enumeration.py
@@ -102,11 +102,11 @@ def test_zero_code_uses_length_convention_for_minimum_distance() -> None:
     assert minimum_distance(_encoder((), 2, width=4)) == 4
 
 
-def test_native_code_api_rejects_empty_generator_matrix_structurally() -> None:
-    with pytest.raises(OperationDomainValidationError) as error:
-        minimum_distance(_encoder((), 2, width=0))
-    assert (
-        error.value.errors()[0]["type"] == "code_theory.generator_width_out_of_bounds"
+def test_zero_length_code_keeps_the_prime_field_contract() -> None:
+    assert minimum_distance(_encoder((), 2, width=0)) == 0
+    _assert_operation_error(
+        lambda: minimum_distance(_encoder((), 4, width=0)),
+        "code_theory.field_order_not_prime",
     )
 
 

--- a/tests/math/combinatorics/codes/general/test_verification_execution.py
+++ b/tests/math/combinatorics/codes/general/test_verification_execution.py
@@ -1,0 +1,71 @@
+"""Code certificates retain empty axes and distinguish failed verification."""
+
+import pytest
+
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.codes.general import _models, _tools, operations
+from jacobian.math.combinatorics.codes.linear.values import PrimeFieldLinearEncoder
+
+
+def _encoder(*, empty: bool = False) -> PrimeFieldLinearEncoder:
+    return PrimeFieldLinearEncoder(
+        field_order=2,
+        message_axis=() if empty else ("m",),
+        coordinate_axis=() if empty else ("x", "y"),
+        generator_matrix=() if empty else ((1, 1),),
+    )
+
+
+def _claim(operation: str, *, empty: bool = False) -> object:
+    request_type = (
+        _models.CoveringRadiusRequest
+        if operation == "covering_radius"
+        else _models.LinearCodeRequest
+    )
+    return getattr(_tools, "_" + operation)(request_type(encoder=_encoder(empty=empty)))
+
+
+@pytest.mark.parametrize(
+    "operation", ["minimum_distance", "weight_distribution", "covering_radius"]
+)
+@pytest.mark.parametrize("error_type", [ArithmeticError, ValueError, TypeError])
+def test_code_verifier_preserves_failed_backend(
+    monkeypatch: pytest.MonkeyPatch, operation: str, error_type: type[Exception]
+) -> None:
+    claim = _claim(operation)
+    verify = getattr(operations, "verify_" + operation)
+    assert verify(claim)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise error_type("backend failure")
+
+    monkeypatch.setattr(operations, operation, fail)
+    with pytest.raises(error_type, match="backend failure"):
+        verify(claim)
+
+
+@pytest.mark.parametrize(
+    "operation", ["minimum_distance", "weight_distribution", "covering_radius"]
+)
+def test_code_verifier_preserves_actual_resource_refusal(
+    monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    claim = _claim(operation)
+    budget = (
+        "MAX_COVERING_RADIUS_STATES_PER_PASS"
+        if operation == "covering_radius"
+        else "MAX_EXACT_CODEWORD_EVALUATIONS"
+    )
+    monkeypatch.setattr(operations, budget, 0)
+    with pytest.raises(OperationResourceAdmissionError):
+        getattr(operations, "verify_" + operation)(claim)
+
+
+def test_zero_length_code_retains_its_canonical_empty_axes() -> None:
+    encoder = _encoder(empty=True)
+    assert operations.minimum_distance(encoder) == 0
+    assert operations.weight_distribution(encoder) == [(0, 1)]
+    assert operations.covering_radius(encoder) == 0
+    for operation in ("minimum_distance", "weight_distribution", "covering_radius"):
+        claim = _claim(operation, empty=True)
+        assert getattr(operations, "verify_" + operation)(claim)

--- a/tests/math/combinatorics/finite_structures/hypergraph_coloring/test_verification_execution.py
+++ b/tests/math/combinatorics/finite_structures/hypergraph_coloring/test_verification_execution.py
@@ -1,0 +1,51 @@
+"""Coloring witnesses need only their relation, while noncolorability needs search."""
+
+import pytest
+
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.finite_structures.hypergraph_coloring import (
+    _models,
+    operations,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+
+
+def _cycle(n: int) -> FiniteHypergraph:
+    return FiniteHypergraph(
+        vertices=tuple(str(i) for i in range(n)),
+        edges=tuple((str(i), (str(i), str((i + 1) % n))) for i in range(n)),
+    )
+
+
+def test_coloring_witness_does_not_require_exhaustive_search_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    claim = operations.decide_nonmonochromatic_coloring(_cycle(4), 2)
+    monkeypatch.setattr(_models, "MAX_COLORING_WORK", 0)
+    assert operations.verify_coloring_witness(claim)
+
+
+def test_noncolorability_resource_refusal_is_not_a_false_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    claim = operations.decide_nonmonochromatic_coloring(_cycle(3), 2)
+    assert operations.verify_non_colorable(claim)
+    monkeypatch.setattr(_models, "MAX_COLORING_WORK", 0)
+    with pytest.raises(OperationResourceAdmissionError):
+        operations.verify_non_colorable(claim)
+
+
+@pytest.mark.parametrize("error_type", [ValueError, TypeError])
+def test_noncolorability_verifier_preserves_failed_search(
+    monkeypatch: pytest.MonkeyPatch, error_type: type[Exception]
+) -> None:
+    claim = operations.decide_nonmonochromatic_coloring(_cycle(3), 2)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise error_type("backend failure")
+
+    monkeypatch.setattr(operations, "decide_nonmonochromatic_coloring", fail)
+    with pytest.raises(error_type, match="backend failure"):
+        operations.verify_non_colorable(claim)

--- a/tests/math/combinatorics/finite_structures/hypergraphs/test_verification_execution.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/test_verification_execution.py
@@ -1,0 +1,83 @@
+"""Verification failures are not mathematical counterexamples."""
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.finite_structures.hypergraphs import operations
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    EdgeWeight,
+    FiniteHypergraph,
+    HypergraphIndependenceBudget,
+    HypergraphIndependenceResult,
+)
+
+
+def _source() -> FiniteHypergraph:
+    return FiniteHypergraph(vertices=("a", "b"), edges=(("e", ("a", "b")),))
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "independence_number",
+        "minimum_transversal",
+        "maximum_edge_matching",
+        "maximum_weight_packing",
+    ],
+)
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("backend"),
+        ValueError("backend"),
+        TypeError("backend"),
+        MemoryError("backend"),
+        TimeoutError("backend"),
+    ],
+)
+def test_verifier_propagates_computation_failures(
+    monkeypatch: pytest.MonkeyPatch, operation: str, error: Exception
+) -> None:
+    producer = getattr(operations, operation)
+    arguments = (_source(),)
+    if operation == "maximum_weight_packing":
+        claim = producer(
+            *arguments,
+            (EdgeWeight(edge_id="e", weight=CanonicalRational(num=1, den=1)),),
+        )
+    else:
+        claim = producer(*arguments)
+    verifier = getattr(
+        operations,
+        "verify_weighted_packing"
+        if operation == "maximum_weight_packing"
+        else "verify_" + operation,
+    )
+    assert verifier(claim)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise error
+
+    monkeypatch.setattr(operations, operation, fail)
+    with pytest.raises(type(error), match="backend"):
+        verifier(claim)
+
+
+def test_exact_independence_verification_reports_actual_incomplete_search() -> None:
+    source = FiniteHypergraph(
+        vertices=tuple(str(i) for i in range(5)),
+        edges=tuple(
+            (str(i), tuple(sorted((str(i), str((i + 1) % 5))))) for i in range(5)
+        ),
+    )
+    exact = operations.independence_number(
+        source, HypergraphIndependenceBudget(max_solver_calls=2)
+    )
+    assert exact.independence_number == 2
+    payload = exact.model_dump(mode="json")
+    payload["resource_budget"]["max_solver_calls"] = 1
+    payload["solver_calls"] = 0
+    claim = HypergraphIndependenceResult.model_validate(payload)
+    with pytest.raises(OperationResourceAdmissionError, match="could not establish"):
+        operations.verify_independence_number(claim)

--- a/tests/math/combinatorics/test_rational_generating_functions.py
+++ b/tests/math/combinatorics/test_rational_generating_functions.py
@@ -189,3 +189,20 @@ def test_denominator_degree_controls_the_recurrence_work_envelope() -> None:
 
 def test_large_constant_prefix_is_admitted_by_recurrence_work() -> None:
     assert len(_expand((ONE,), 250_000).series.coefficients) == 250_000
+
+
+def test_verifier_resource_refusal_is_not_disagreement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.catalog.models import OperationResourceAdmissionError
+    from jacobian.math.combinatorics import operations
+
+    one = CanonicalRational(num=1, den=1)
+    minus_one = CanonicalRational(num=-1, den=1)
+    claim = operations.rational_generating_function_coefficients(
+        (one,), (one, minus_one), "ASCENDING_POWERS_OF_X", 0, 4
+    )
+    assert operations.verify_rational_generating_function_coefficients(claim)
+    monkeypatch.setattr(operations, "MAX_RATIONAL_SERIES_WORK_UNITS", 0)
+    with pytest.raises(OperationResourceAdmissionError):
+        operations.verify_rational_generating_function_coefficients(claim)

--- a/tests/math/crossed_products/test_crossed_products.py
+++ b/tests/math/crossed_products/test_crossed_products.py
@@ -530,3 +530,26 @@ def test_published_example_is_valid_and_runs() -> None:
             exponents=(-1,),
         ),
     )
+
+
+def test_product_claim_verifier_does_not_refute_unadmitted_convolution() -> None:
+    from jacobian.catalog.models import OperationResourceAdmissionError
+
+    presentation = _c2_presentation()
+    side = isqrt(MAX_CONVOLUTION_PAIRS) + 1
+    operand = _element(presentation, {"e": {(i,) for i in range(side)}})
+    # Independent triangular convolution for (1+t+...+t^(side-1))^2 over F_5.
+    product = FiniteCosetCrossedProductElement(
+        presentation=presentation,
+        terms=tuple(
+            FiniteCosetCrossedProductTerm(
+                coefficient=coefficient, coset="e", exponents=(i,)
+            )
+            for i in range(2 * side - 1)
+            if (coefficient := min(i + 1, 2 * side - 1 - i, side) % 5)
+        ),
+    )
+    claim = CrossedProductMultiplyResult(left=operand, right=operand, product=product)
+    decoded = CrossedProductMultiplyResult.model_validate_json(claim.model_dump_json())
+    with pytest.raises(OperationResourceAdmissionError, match="convolution budget"):
+        verify_multiply(decoded)

--- a/tests/math/dynamics/arithmetic/test_native_admission.py
+++ b/tests/math/dynamics/arithmetic/test_native_admission.py
@@ -1,0 +1,141 @@
+"""Native arithmetic-dynamics admission and claim failure boundaries."""
+
+import json
+from collections.abc import Callable
+from fractions import Fraction
+from typing import Any
+
+import pytest
+import sympy
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.dynamics.arithmetic import _tools as wire
+from jacobian.math.dynamics.arithmetic import operations as native
+from jacobian.math.dynamics.arithmetic._models import MapIterateRequest
+
+
+class OversizedCoefficients(list[int]):
+    def __iter__(self) -> Any:
+        pytest.fail("oversized input was converted before length admission")
+
+
+def test_coefficients_length_is_admitted_before_conversion() -> None:
+    with pytest.raises(ValueError, match="coefficients"):
+        native.polynomial_from_coefficients(OversizedCoefficients([1] * 32))
+
+
+def test_dynatomic_index_is_admitted_before_coefficient_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    polynomial = native.polynomial_from_coefficients((0, 0, 1))
+    monkeypatch.setattr(
+        native,
+        "polynomial_coefficients",
+        lambda *_: pytest.fail("expanded before index admission"),
+    )
+    with pytest.raises(ValueError, match="index"):
+        native.dynatomic_polynomial(polynomial, 10**100)
+
+
+def test_cycle_multiplier_admits_and_converts_its_source_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    polynomial = native.polynomial_from_coefficients((-1, 0, 1))
+    original = native._require_input_polynomial
+    calls = 0
+
+    def count(source: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(source)
+
+    monkeypatch.setattr(native, "_require_input_polynomial", count)
+    assert (
+        native.cycle_multiplier(
+            polynomial,
+            (
+                CanonicalRational.from_fraction(Fraction(0)),
+                CanonicalRational.from_fraction(Fraction(-1)),
+            ),
+        ).as_fraction()
+        == 0
+    )
+    assert calls == 1
+
+
+@pytest.mark.parametrize("operation", wire.TOOLS)
+def test_claim_verifiers_propagate_backend_value_errors(
+    operation: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = operation.request_type.model_validate_json(
+        json.dumps(operation.examples[0].input)
+    )
+    # Every declaration has its native verifier in this owner.
+    names: dict[str, tuple[Callable[..., Any], Callable[..., bool], str]] = {
+        "arithmetic_dynamics.map.iterate.compute": (
+            wire.compute_map_iterate,
+            wire.verify_map_iterate,
+            "compose",
+        ),
+        "arithmetic_dynamics.point.orbit.compute": (
+            wire.compute_orbit_prefix,
+            wire.verify_orbit_prefix,
+            "eval",
+        ),
+        "arithmetic_dynamics.dynatomic_polynomial.compute": (
+            wire.compute_dynatomic_polynomial,
+            wire.verify_dynatomic_polynomial,
+            "compose",
+        ),
+        "arithmetic_dynamics.cycle.multiplier.compute": (
+            wire.compute_cycle_multiplier,
+            wire.verify_cycle_multiplier,
+            "eval",
+        ),
+        "arithmetic_dynamics.finite_field.functional_graph.compute": (
+            wire.compute_finite_field_map,
+            wire.verify_finite_field_map,
+            "isprime",
+        ),
+    }
+    compute, verify, method = names[operation.operation_id]
+    claim = compute(request)
+
+    def fail(*args: Any, **kwargs: Any) -> Any:
+        raise ValueError("unexpected backend failure")
+
+    monkeypatch.setattr(sympy if method == "isprime" else sympy.Poly, method, fail)
+    with pytest.raises(ValueError, match="unexpected backend failure"):
+        verify(claim)
+
+
+def test_unadmitted_iterate_claim_is_not_refuted() -> None:
+    request = MapIterateRequest(
+        polynomial=native.polynomial_from_coefficients((0, 0, 1)), n=1
+    )
+    claim = wire.compute_map_iterate(request)
+    authored = claim.model_copy(update={"n": 11})
+    restored = type(claim).model_validate_json(authored.model_dump_json())
+    with pytest.raises(OperationResourceAdmissionError, match="degree"):
+        wire.verify_map_iterate(restored)
+
+
+def test_finite_field_coefficients_length_is_admitted_before_conversion() -> None:
+    with pytest.raises(ValueError, match="coefficients"):
+        native.finite_field_functional_graph(OversizedCoefficients([1] * 32), 5)
+
+
+def test_source_degree_is_admitted_before_backend_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = native.iterate_polynomial(
+        native.polynomial_from_coefficients((0, 0, 1)), 5
+    )
+    monkeypatch.setattr(
+        native,
+        "rational_polynomial_to_sympy",
+        lambda *_: pytest.fail("converted before input degree admission"),
+    )
+    with pytest.raises(ValueError, match="degree"):
+        native.orbit_prefix(source, CanonicalRational.from_fraction(Fraction(0)), 1)

--- a/tests/math/geometry/arrangements/test_verification_execution.py
+++ b/tests/math/geometry/arrangements/test_verification_execution.py
@@ -1,0 +1,68 @@
+"""Native arrangement verifiers preserve operational failures."""
+
+import pytest
+
+from jacobian.math.geometry.arrangements import operations
+
+
+@pytest.mark.parametrize("operation", ["characteristic_polynomial", "chamber_count"])
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("backend"),
+        ValueError("backend"),
+        TypeError("backend"),
+        MemoryError("backend"),
+        TimeoutError("backend"),
+    ],
+)
+def test_formula_verifier_propagates_computation_failure(
+    monkeypatch: pytest.MonkeyPatch, operation: str, error: Exception
+) -> None:
+    claim = getattr(operations, operation)(2, 3)
+    verifier = getattr(operations, "verify_" + operation)
+    assert verifier(claim)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise error
+
+    monkeypatch.setattr(operations, operation, fail)
+    with pytest.raises(type(error), match="backend"):
+        verifier(claim)
+
+
+@pytest.mark.parametrize("operation", ["characteristic_polynomial", "chamber_count"])
+def test_formula_verifier_preserves_resource_refusal(
+    monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    from jacobian.catalog.models import OperationResourceAdmissionError
+
+    claim = getattr(operations, operation)(2, 3)
+    monkeypatch.setattr(operations, "MAX_GENERIC_FORMULA_WORK", 0)
+    with pytest.raises(OperationResourceAdmissionError):
+        getattr(operations, "verify_" + operation)(claim)
+
+
+def test_arrangement_verifier_preserves_execution_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian._exact import CanonicalRational
+    from jacobian.math.geometry.arrangements._models import RationalHyperplane
+
+    claim = operations.arrangement(
+        1,
+        (
+            RationalHyperplane(
+                coefficients=(CanonicalRational(num=1, den=1),),
+                constant=CanonicalRational(num=0, den=1),
+            ),
+        ),
+    )
+    assert operations.verify_arrangement(claim)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("backend failure")
+
+    monkeypatch.setattr(operations, "arrangement", fail)
+    with pytest.raises(RuntimeError, match="backend failure"):
+        operations.verify_arrangement(claim)

--- a/tests/math/geometry/exact/spanned_line_profile/test_scale_reductions.py
+++ b/tests/math/geometry/exact/spanned_line_profile/test_scale_reductions.py
@@ -1,0 +1,91 @@
+"""Tractable pair and axis-line profiles precede private line-key growth."""
+
+from itertools import combinations, permutations
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.geometry.exact._models import (
+    LabelledRationalPoint,
+    PointConfiguration,
+)
+from jacobian.math.geometry.exact.spanned_line_profile.operations import (
+    compute_spanned_line_profile,
+    verify_spanned_line_profile,
+)
+
+
+def _configuration(rows: tuple[tuple[str, tuple[int, ...]], ...]) -> PointConfiguration:
+    return PointConfiguration(
+        points=tuple(
+            LabelledRationalPoint(
+                label=label,
+                coordinates=tuple(CanonicalRational(num=value, den=1) for value in row),
+            )
+            for label, row in rows
+        )
+    )
+
+
+@pytest.mark.parametrize("axis_parallel", [False, True])
+def test_large_two_point_profile_preserves_source_order_and_labels(
+    axis_parallel: bool,
+) -> None:
+    translation = 10**10000
+    points = (
+        ("zeta", (translation, 0)),
+        ("alpha", (translation if axis_parallel else -translation, 1)),
+    )
+    for rows in permutations(points):
+        source = _configuration(rows)
+        result = compute_spanned_line_profile(source)
+        assert result.line_count == 1
+        assert result.lines[0].source_pairs == ((0, 1),)
+        assert result.lines[0].point_count == 2
+        restored = type(result).model_validate_json(result.model_dump_json())
+        assert restored.configuration == source
+        assert verify_spanned_line_profile(restored)
+
+
+@pytest.mark.parametrize("variable_axis", [0, 1, 2])
+def test_translated_axis_line_profile_retains_all_pairs(variable_axis: int) -> None:
+    translation = 10**10000
+    points = tuple(
+        (
+            label,
+            tuple(value if axis == variable_axis else translation for axis in range(3)),
+        )
+        for label, value in (("q", 3), ("a", -2), ("z", 0))
+    )
+    for rows in permutations(points):
+        source = _configuration(rows)
+        result = compute_spanned_line_profile(source)
+        assert result.line_count == 1
+        assert result.lines[0].source_pairs == tuple(combinations(range(3), 2))
+        assert result.lines[0].point_count == 3
+        assert verify_spanned_line_profile(
+            type(result).model_validate_json(result.model_dump_json())
+        )
+
+
+@pytest.mark.parametrize("constant_axis", [0, 1, 2])
+@pytest.mark.parametrize("collinear", [False, True])
+def test_common_translated_axes_do_not_charge_line_key_growth(
+    constant_axis: int, collinear: bool
+) -> None:
+    translation = 10**10000
+    plane_points = ((0, 0), (1, 1), (2, 2) if collinear else (0, 2))
+    points = []
+    for label, coordinates in zip(("z", "q", "a"), plane_points, strict=True):
+        row = list(coordinates)
+        row.insert(constant_axis, translation)
+        points.append((label, tuple(row)))
+    for rows in permutations(points):
+        source = _configuration(rows)
+        result = compute_spanned_line_profile(source)
+        assert result.configuration == source
+        assert result.line_count == (1 if collinear else 3)
+        assert sorted(
+            pair for line in result.lines for pair in line.source_pairs
+        ) == list(combinations(range(3), 2))
+        assert all(line.point_count == (3 if collinear else 2) for line in result.lines)

--- a/tests/math/geometry/exact/spanned_line_profile/test_spanned_line_profile.py
+++ b/tests/math/geometry/exact/spanned_line_profile/test_spanned_line_profile.py
@@ -85,6 +85,9 @@ def test_derived_line_key_growth_is_rejected_before_pair_enumeration() -> None:
         LabelledRationalPoint(
             label="b", coordinates=(CanonicalRational(num=0, den=1),) * 20
         ),
+        LabelledRationalPoint(
+            label="c", coordinates=(wide,) + (CanonicalRational(num=0, den=1),) * 19
+        ),
     )
     with pytest.raises(ValueError, match="line keys exceed"):
         compute_spanned_line_profile(PointConfiguration(points=points))

--- a/tests/math/geometry/polytopes/test_vertex_enumeration_failures.py
+++ b/tests/math/geometry/polytopes/test_vertex_enumeration_failures.py
@@ -1,0 +1,21 @@
+"""A failed exact solve cannot establish that a polytope has no vertices."""
+
+import pytest
+from sympy import Rational
+from sympy.matrices.matrixbase import MatrixBase
+
+from jacobian.math.geometry.polytopes._rational_geometry import vertices_from_halfspaces
+
+
+def test_vertex_enumeration_preserves_failed_solve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows = [([Rational(1)], Rational(1)), ([Rational(-1)], Rational(0))]
+    assert set(vertices_from_halfspaces(rows, 1)) == {(Rational(0),), (Rational(1),)}
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise ValueError("backend solve failure")
+
+    monkeypatch.setattr(MatrixBase, "solve", fail)
+    with pytest.raises(RuntimeError, match=r"vertex.*computation failed"):
+        vertices_from_halfspaces(rows, 1)

--- a/tests/math/graphs/decomposition/tree_decompositions/test_verification_execution.py
+++ b/tests/math/graphs/decomposition/tree_decompositions/test_verification_execution.py
@@ -1,0 +1,36 @@
+"""Decomposition verification cannot turn failed recomputation into disagreement."""
+
+import pytest
+
+from jacobian.math.graphs.decomposition.tree_decompositions import operations
+from jacobian.math.graphs.decomposition.tree_decompositions.values import (
+    TreeDecomposition,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["width", "vertex_occurrences", "adhesions", "reroot", "bag_intersection_graph"],
+)
+@pytest.mark.parametrize("error_type", [RuntimeError, ValueError, TypeError])
+def test_decomposition_verifier_preserves_backend_failure(
+    monkeypatch: pytest.MonkeyPatch, operation: str, error_type: type[Exception]
+) -> None:
+    td = TreeDecomposition(
+        graph=SimpleUndirectedGraph(vertices=("a",), edges=()),
+        tree_nodes=("t",),
+        tree_edges=(),
+        bags=(("a",),),
+    )
+    args = (td, "t") if operation == "reroot" else (td,)
+    claim = getattr(operations, operation)(*args)
+    verify = getattr(operations, "verify_" + operation)
+    assert verify(claim)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise error_type("backend failure")
+
+    monkeypatch.setattr(operations, operation, fail)
+    with pytest.raises(error_type, match="backend failure"):
+        verify(claim)

--- a/tests/math/graphs/test_triangle_free_backend_failures.py
+++ b/tests/math/graphs/test_triangle_free_backend_failures.py
@@ -1,0 +1,20 @@
+"""Operational failures do not disprove triangle-freeness."""
+
+import networkx as nx
+import pytest
+
+from jacobian.math.graphs.triangle_free_diameter_augmentation.operations import (
+    triangle_free_diameter_augmentation,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def test_triangle_check_failure_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    graph = SimpleUndirectedGraph(vertices=("a", "b"), edges=(("a", "b"),))
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("triangle backend failure")
+
+    monkeypatch.setattr(nx, "triangles", fail)
+    with pytest.raises(RuntimeError, match="triangle backend failure"):
+        triangle_free_diameter_augmentation(graph, 1)

--- a/tests/math/groups/finite_abelian/test_character_sum_interval_profile.py
+++ b/tests/math/groups/finite_abelian/test_character_sum_interval_profile.py
@@ -19,7 +19,10 @@ from jacobian._execution import (
     request_execution,
 )
 from jacobian.canonical import encode_strict_json
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.groups import finite_abelian as domain
 from jacobian.math.groups._tools import TOOLS as GROUP_TOOLS
 from jacobian.math.groups.finite_abelian import (
@@ -535,10 +538,9 @@ def test_work_bounds_rejections() -> None:
     with pytest.raises(ValueError, match="cyclotomic degree"):
         src_deg = _source((71,), ((0,), (1,)), ((0,), (1,)), ((0, 2),))
         compute_finite_abelian_character_sum_interval_profile(src_deg)
-    # Dense ops bound: exponent 128 phi 64 but dense ops 10*8*129*129 >524k?
-    # 128 bit_length 8 => 10*8*129*129 = 1,331,280 >524k
+    # Squarefree exponent 105 has degree 48 but exceeds construction work.
     with pytest.raises(ValueError, match="dense-op"):
-        src_dense = _source((128,), ((0,),), ((0,),), ((0, 1),))
+        src_dense = _source((105,), ((0,),), ((0,),), ((0, 1),))
         compute_finite_abelian_character_sum_interval_profile(src_dense)
 
 
@@ -664,7 +666,6 @@ def test_z2_power_17_singleton_profile_is_admitted() -> None:
     source = _source((2,) * rank, (zero,), (zero,), ((0, 1),))
     work = domain._character_sum_interval_profile_work(source)
     assert work.cells == 1
-    assert work.prefix_work == rank + 1
     result = compute_finite_abelian_character_sum_interval_profile(source)
     assert result.group_exponent == 2
     assert result.cyclotomic_degree == 1
@@ -687,11 +688,11 @@ def test_rank_linear_prefix_work_rejects_expensive_profiles() -> None:
         compute_finite_abelian_character_sum_interval_profile(source)
 
 
-def test_catalog_projects_admission_as_domain_error() -> None:
+def test_catalog_projects_admission_as_resource_error() -> None:
     request = FiniteAbelianCharacterSumIntervalProfileRequest(
-        source=_source((128,), ((0,),), ((0,),), ((0, 1),))
+        source=_source((105,), ((0,),), ((0,),), ((0, 1),))
     )
-    with pytest.raises(OperationDomainValidationError, match="dense-op"):
+    with pytest.raises(OperationResourceAdmissionError, match="dense-op"):
         PROFILE_OPERATION.run(request)
 
 
@@ -716,3 +717,47 @@ def test_profile_observes_expired_owner_deadline() -> None:
         pytest.raises(OperationExecutionTimeoutError, match="character-sum"),
     ):
         compute_finite_abelian_character_sum_interval_profile(source)
+
+
+def test_order_100_interval_profile_uses_shared_prime_power_structure() -> None:
+    sequence = (
+        2,
+        14,
+        62,
+        74,
+        22,
+        34,
+        86,
+        18,
+        46,
+        78,
+        6,
+        38,
+        82,
+        94,
+        66,
+        98,
+        42,
+        54,
+        26,
+        58,
+    )
+    source = _source(
+        (100,),
+        tuple((x,) for x in sequence),
+        tuple((x,) for x in range(100)),
+        ((0, 6), (0, 20)),
+    )
+    request = PROFILE_OPERATION.request_type.model_validate_json(
+        encode_strict_json({"source": source.model_dump(mode="json")})
+    )
+    result = PROFILE_OPERATION.run(request)
+    assert result.group_exponent == 100
+    assert result.cyclotomic_degree == 40
+    assert len(result.sums) == 200
+    for cell in result.sums:
+        expected, _ = _oracle_remainder(
+            (100,), source.sequence, cell.frequency, cell.interval
+        )
+        assert cell.remainder_coefficients == expected
+    assert type(result).model_validate_json(result.model_dump_json()) == result

--- a/tests/math/lattices/test_lattice_operations.py
+++ b/tests/math/lattices/test_lattice_operations.py
@@ -460,3 +460,48 @@ def test_lattice_wire_parsing_does_not_prove_rank(
         lambda *_: pytest.fail("parsing must not compute rank"),
     )
     assert IntegerLattice.model_validate_json(lattice.model_dump_json()) == lattice
+
+
+def test_native_lll_uses_the_same_envelope_as_the_published_operation() -> None:
+    from jacobian.math.lattices import reduce_basis
+
+    with pytest.raises(OperationDomainValidationError, match="32"):
+        reduce_basis(_identity_entries(33))
+    with pytest.raises(OperationDomainValidationError, match="256"):
+        reduce_basis([[10**256]])
+
+
+@pytest.mark.parametrize("hermite", [False, True])
+def test_lattice_transform_results_retain_their_source_through_serialization(
+    hermite: bool,
+) -> None:
+    matrix = IntegerMatrix(entries=((2, 3, 1), (5, 7, 2)))
+    if hermite:
+        hnf_result = compute_hermite_normal_form(
+            HermiteNormalFormRequest(matrix=matrix)
+        )
+        restored_hnf = type(hnf_result).model_validate_json(
+            hnf_result.model_dump_json()
+        )
+        assert restored_hnf.matrix == matrix
+        left = restored_hnf.normal_form.entries
+        transformation = restored_hnf.transformation
+    else:
+        lll_result = reduce_lattice_basis(LatticeReductionRequest(basis=matrix))
+        restored_lll = type(lll_result).model_validate_json(
+            lll_result.model_dump_json()
+        )
+        assert restored_lll.basis == matrix
+        left = restored_lll.reduced_basis.entries
+        transformation = restored_lll.transformation
+    transformed = tuple(
+        tuple(
+            sum(
+                transformation.entries[i][k] * matrix.entries[k][j]
+                for k in range(matrix.row_count)
+            )
+            for j in range(matrix.column_count)
+        )
+        for i in range(matrix.row_count)
+    )
+    assert left == transformed

--- a/tests/math/logic/automata/petri_nets/test_native_admission.py
+++ b/tests/math/logic/automata/petri_nets/test_native_admission.py
@@ -1,0 +1,42 @@
+"""Resource refusal remains non-completion for authored Petri claims."""
+
+import pytest
+
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.logic.automata.petri_nets._models import (
+    SiphonTrapRequest,
+    SiphonTrapResult,
+)
+from jacobian.math.logic.automata.petri_nets._tools import compute_siphon_trap
+from jacobian.math.logic.automata.petri_nets.operations import verify_siphon_trap
+from jacobian.math.logic.automata.petri_nets.values import PetriNet, PetriPlaceSubset
+
+
+@pytest.mark.parametrize("places", [0, 1, 21, 64])
+def test_zero_transition_siphon_trap_uses_singleton_closed_form(places: int) -> None:
+    # With no transitions, every singleton is a minimal nonempty siphon and trap.
+    net = PetriNet(
+        place_count=places, transition_count=0, pre=((),) * places, post=((),) * places
+    )
+    subsets = tuple(PetriPlaceSubset(places=(i,)) for i in range(places))
+    claim = SiphonTrapResult(net=net, siphons=subsets, traps=subsets)
+    assert verify_siphon_trap(type(claim).model_validate_json(claim.model_dump_json()))
+    assert compute_siphon_trap(SiphonTrapRequest(net=net)) == claim
+
+
+def test_nontrivial_siphon_trap_enumeration_refusal_remains_typed() -> None:
+    net = PetriNet(
+        place_count=21,
+        transition_count=12,
+        pre=tuple(
+            tuple(int((i * 7 + j * 3) % 11 < 3) for j in range(12)) for i in range(21)
+        ),
+        post=tuple(
+            tuple(int((i * 5 + j * 2) % 13 < 4) for j in range(12)) for i in range(21)
+        ),
+    )
+    claim = SiphonTrapResult(net=net, siphons=(), traps=())
+    with pytest.raises(OperationResourceAdmissionError, match="places"):
+        verify_siphon_trap(claim)
+    with pytest.raises(OperationResourceAdmissionError, match="places"):
+        compute_siphon_trap(SiphonTrapRequest(net=net))

--- a/tests/math/logic/automata/tree/test_native_admission.py
+++ b/tests/math/logic/automata/tree/test_native_admission.py
@@ -1,0 +1,67 @@
+"""Tree-count admission and serialized resource boundaries."""
+
+from fractions import Fraction
+from typing import Any
+
+import pytest
+
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.logic.automata.tree._models import AcceptedTreeCountResult
+from jacobian.math.logic.automata.tree.operations import (
+    accepted_tree_count,
+    verify_accepted_tree_count,
+)
+from jacobian.math.logic.automata.tree.values import (
+    BottomUpTreeAutomaton,
+    TreeAutomatonTransition,
+)
+
+
+def test_native_tree_count_handles_nullary_sizes_without_allocation() -> None:
+    automaton = BottomUpTreeAutomaton(
+        state_count=1,
+        arity=(0,),
+        transitions=(
+            TreeAutomatonTransition(symbol=0, child_states=(), target_state=0),
+        ),
+        final_states=(0,),
+    )
+    assert accepted_tree_count(automaton, 0) == 0
+    assert accepted_tree_count(automaton, 1) == 1
+    assert accepted_tree_count(automaton, 101) == 0
+    assert accepted_tree_count(automaton, 10**100) == 0
+
+
+def test_tree_count_claim_cannot_refute_unadmitted_work() -> None:
+    automaton = BottomUpTreeAutomaton(
+        state_count=32,
+        arity=(0, 2),
+        transitions=(
+            TreeAutomatonTransition(symbol=0, child_states=(), target_state=0),
+            TreeAutomatonTransition(symbol=1, child_states=(0, 0), target_state=0),
+        ),
+        final_states=(0,),
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="size"):
+        accepted_tree_count(automaton, 101)
+    claim = AcceptedTreeCountResult(
+        automaton=automaton, tree_size=100, count=0, estimated_work_bound=0
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="work"):
+        verify_accepted_tree_count(claim)
+
+
+@pytest.mark.parametrize("size", [False, True, 1.5, Fraction(1, 1)])
+def test_nullary_tree_count_requires_integer_size(size: Any) -> None:
+    from jacobian.math.logic.automata.tree.values import accepted_tree_count_work_bound
+
+    automaton = BottomUpTreeAutomaton(
+        state_count=1, arity=(0,), transitions=(), final_states=()
+    )
+    with pytest.raises(OperationDomainValidationError, match="integer"):
+        accepted_tree_count(automaton, size)
+    with pytest.raises(OperationDomainValidationError, match="integer"):
+        accepted_tree_count_work_bound(automaton, size)

--- a/tests/math/logic/games/finite/test_finite_game_theory.py
+++ b/tests/math/logic/games/finite/test_finite_game_theory.py
@@ -64,7 +64,8 @@ class TestBestResponse:
         assert result.best_row == 0  # Row 0 has minimum 0, Row 1 has minimum 0
         decoded = type(result).model_validate_json(result.model_dump_json())
         assert verify_best_response(decoded)
-        assert not verify_best_response(decoded.model_copy(update={"best_row": 1}))
+        assert verify_best_response(decoded.model_copy(update={"best_row": 1}))
+        assert not verify_best_response(decoded.model_copy(update={"value": _r(1)}))
 
     def test_payoffs_beyond_the_equilibrium_bound_still_admit_best_response(
         self,
@@ -219,3 +220,50 @@ class TestNashEquilibrium:
         )
         result = best_response(req.payoff_matrix)
         assert result.value.as_fraction() == -100000000000000000000
+
+
+def test_equilibrium_verifier_accepts_alternative_exact_saddle_point() -> None:
+    from jacobian.math.logic.games.finite._models import NashEquilibriumResult
+
+    matrix = PayoffMatrix(n_rows=2, n_cols=2, entries=(_r(0),) * 4)
+    claim = NashEquilibriumResult(
+        payoff_matrix=matrix,
+        row_strategy=(_r(Fraction(1, 3)), _r(Fraction(2, 3))),
+        col_strategy=(_r(Fraction(2, 5)), _r(Fraction(3, 5))),
+        value=_r(0),
+    )
+    assert verify_nash_equilibrium(
+        type(claim).model_validate_json(claim.model_dump_json())
+    )
+
+
+def test_best_response_verifier_accepts_a_tied_maximizing_row() -> None:
+    matrix = PayoffMatrix(n_rows=2, n_cols=2, entries=(_r(0),) * 4)
+    claim = best_response(matrix).model_copy(update={"best_row": 1})
+    assert verify_best_response(
+        type(claim).model_validate_json(claim.model_dump_json())
+    )
+
+
+@pytest.mark.parametrize(
+    "rows,columns,value",
+    [
+        ((Fraction(-1), Fraction(2)), (Fraction(1), Fraction(0)), 0),
+        ((Fraction(1), Fraction(1)), (Fraction(1), Fraction(0)), 0),
+        ((Fraction(1), Fraction(0)), (Fraction(1), Fraction(0)), 1),
+    ],
+)
+def test_equilibrium_verifier_rejects_invalid_simplex_and_value(
+    rows: tuple[Fraction, ...], columns: tuple[Fraction, ...], value: int
+) -> None:
+    from jacobian.math.logic.games.finite._models import NashEquilibriumResult
+
+    matrix = PayoffMatrix(n_rows=2, n_cols=2, entries=(_r(0),) * 4)
+    assert not verify_nash_equilibrium(
+        NashEquilibriumResult(
+            payoff_matrix=matrix,
+            row_strategy=tuple(_r(x) for x in rows),
+            col_strategy=tuple(_r(x) for x in columns),
+            value=_r(value),
+        )
+    )

--- a/tests/math/logic/languages/context_free/test_native_contracts.py
+++ b/tests/math/logic/languages/context_free/test_native_contracts.py
@@ -1,0 +1,67 @@
+"""Degenerate grammar axes and native verifier failure boundaries."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.logic.languages.context_free import operations as native
+from jacobian.math.logic.languages.context_free._models import (
+    FiniteCFGO,
+    FirstSetsResult,
+)
+
+
+def test_ruleless_grammar_retains_nonterminal_axes() -> None:
+    grammar = FiniteCFGO(
+        nonterminals=("S", "T"), terminals=(), rules=(), start_symbol="S"
+    )
+    assert native.nullable_nonterminals(grammar) == (False, False)
+    assert native.first_sets(grammar) == ((), ())
+    assert native.dependency_edges(grammar) == ()
+    result = FirstSetsResult(grammar=grammar, first_sets=((), ()))
+    assert native.verify_first_sets(
+        type(result).model_validate_json(result.model_dump_json())
+    )
+
+
+@pytest.mark.parametrize("axis", ["nonterminals", "terminals"])
+def test_grammar_symbol_axes_are_unique(axis: str) -> None:
+    payload = {
+        "nonterminals": ("S",),
+        "terminals": ("a",),
+        "rules": ({"head": "S", "body": ("a",)},),
+        "start_symbol": "S",
+    }
+    payload[axis] = ("S", "S") if axis == "nonterminals" else ("a", "a")
+    with pytest.raises(ValidationError, match="unique"):
+        FiniteCFGO.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "kernel,verifier,result_type",
+    [
+        ("nullable_nonterminals", "verify_symbol_profiles", "SymbolProfilesResult"),
+        ("dependency_edges", "verify_dependency_graph", "DependencyGraphResult"),
+        ("first_sets", "verify_first_sets", "FirstSetsResult"),
+    ],
+)
+def test_verifiers_propagate_unexpected_kernel_failures(
+    kernel: str, verifier: str, result_type: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jacobian.math.logic.languages.context_free import _models
+
+    grammar = FiniteCFGO(nonterminals=("S",), terminals=(), rules=(), start_symbol="S")
+    field = {
+        "nullable_nonterminals": "nullable",
+        "dependency_edges": "edges",
+        "first_sets": "first_sets",
+    }[kernel]
+    claim = getattr(_models, result_type)(
+        grammar=grammar, **{field: getattr(native, kernel)(grammar)}
+    )
+
+    def fail(*args: object) -> object:
+        raise ValueError("unexpected execution failure")
+
+    monkeypatch.setattr(native, kernel, fail)
+    with pytest.raises(ValueError, match="unexpected execution failure"):
+        getattr(native, verifier)(claim)

--- a/tests/math/logic/languages/regular/test_native_failure_boundaries.py
+++ b/tests/math/logic/languages/regular/test_native_failure_boundaries.py
@@ -1,0 +1,65 @@
+"""Resource refusal cannot refute a DFA count claim."""
+
+import pytest
+
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.logic.languages.regular._models import CountResult
+from jacobian.math.logic.languages.regular.operations import verify_accepted_word_count
+from jacobian.math.logic.languages.regular.values import DFA, DFATransition
+
+
+def test_count_claim_resource_refusal_propagates() -> None:
+    dfa = DFA(
+        state_count=1,
+        alphabet_size=2,
+        initial_state=0,
+        accepting_states=(0,),
+        transitions=(
+            DFATransition(source=0, symbol=0, target=0),
+            DFATransition(source=0, symbol=1, target=0),
+        ),
+    )
+    claim = CountResult(dfa=dfa, word_length=200_000, count=0)
+    with pytest.raises(OperationResourceAdmissionError):
+        verify_accepted_word_count(claim)
+
+
+def test_transition_profile_resource_refusal_propagates_through_consumers() -> None:
+    from jacobian.math.logic.languages.regular._models import (
+        TransitionParikhProfileRequest,
+    )
+    from jacobian.math.logic.languages.regular._tools import (
+        compute_transition_parikh_profile,
+    )
+    from jacobian.math.logic.languages.regular.operations import (
+        verify_transition_parikh_profile,
+    )
+    from jacobian.math.logic.languages.regular.values import (
+        AutomatonTransition,
+        FiniteLabeledAutomaton,
+        TransitionParikhProfile,
+    )
+
+    automaton = FiniteLabeledAutomaton(
+        state_count=1,
+        alphabet_size=9,
+        transitions=tuple(
+            AutomatonTransition(transition_id=i, source=0, target=0, symbol=i)
+            for i in range(9)
+        ),
+    )
+    request = TransitionParikhProfileRequest(
+        automaton=automaton, source_state=0, target_state=0, path_length=10
+    )
+    claim = TransitionParikhProfile(
+        automaton=automaton,
+        source_state=0,
+        target_state=0,
+        path_length=10,
+        entries=(),
+        total_path_count=0,
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="profile-cell"):
+        compute_transition_parikh_profile(request)
+    with pytest.raises(OperationResourceAdmissionError, match="profile-cell"):
+        verify_transition_parikh_profile(claim)

--- a/tests/math/logic/languages/words/test_words.py
+++ b/tests/math/logic/languages/words/test_words.py
@@ -698,3 +698,74 @@ def test_serialized_prolongability_remains_a_claim() -> None:
     )
     with pytest.raises(ValueError, match="eventually erase"):
         fixed_point_prefix(source, 3)
+
+
+def test_primitivity_rejects_missing_dependency_support() -> None:
+    source = _substitution((("0", "1"), ("0",)))
+    graph = substitution_dependency_graph(source)
+    assert substitution_primitivity_profile(graph).primitive
+    payload = graph.model_dump(mode="json")
+    payload["edges"] = []
+    authored = SubstitutionDependencyGraph.model_validate(payload)
+    with pytest.raises(ValueError, match=r"dependency.*support"):
+        substitution_primitivity_profile(authored)
+
+
+def test_composition_admits_length_before_expansion() -> None:
+    import tracemalloc
+
+    morphism = WordMorphism(
+        source_alphabet=("x",),
+        target_alphabet=("x",),
+        images=(("x",) * 1000,),
+    )
+    tracemalloc.start()
+    try:
+        with pytest.raises(ValueError, match="composed morphism image"):
+            compose_morphisms(morphism, morphism)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert peak < 1_000_000
+
+
+def test_dependency_verification_preserves_resource_refusal() -> None:
+    from jacobian.catalog.models import OperationResourceAdmissionError
+    from jacobian.math.logic.languages.words.operations import (
+        verify_substitution_primitivity_profile,
+    )
+
+    graph = substitution_dependency_graph(_substitution((("0", "1"), ("0",))))
+    claim = compute_substitution_primitivity_profile(
+        SubstitutionPrimitivityProfileRequest(dependency_graph=graph)
+    )
+    oversized = SubstitutionDependencyGraph(
+        substitution=_substitution((("0",) * 5001, ("1",) * 5000)), edges=()
+    )
+    authored = claim.model_copy(update={"dependency_graph": oversized})
+    with pytest.raises(OperationResourceAdmissionError):
+        verify_substitution_primitivity_profile(authored)
+
+
+def test_primitivity_verifier_preserves_backend_value_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import networkx as nx
+
+    from jacobian.math.logic.languages.words.operations import (
+        verify_substitution_primitivity_profile,
+    )
+
+    graph = substitution_dependency_graph(_substitution((("0", "1"), ("0",))))
+    request = SubstitutionPrimitivityProfileRequest(dependency_graph=graph)
+    claim = compute_substitution_primitivity_profile(request)
+
+    def fail(*args: object, **kwargs: object) -> bool:
+        raise ValueError("backend failed")
+
+    monkeypatch.setattr(nx, "is_aperiodic", fail)
+    with pytest.raises(ValueError, match="backend failed"):
+        verify_substitution_primitivity_profile(claim)
+    with pytest.raises(ValueError, match="backend failed") as error:
+        compute_substitution_primitivity_profile(request)
+    assert not isinstance(error.value, OperationDomainValidationError)

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -637,3 +637,32 @@ def test_serialization_round_trip_preserves_source_and_axis() -> None:
         restored = type(result).model_validate_json(result.model_dump_json())
         assert restored == result
         assert restored.matrix == req
+
+
+def test_minimal_polynomial_reuses_krylov_reduction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sympy.matrices.matrixbase import MatrixBase
+
+    calls = 0
+    original = MatrixBase.nullspace
+
+    def counted(self: MatrixBase, *args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(MatrixBase, "nullspace", counted)
+    entries = (
+        (Fraction(2), Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(2), Fraction(0)),
+        (Fraction(0), Fraction(0), Fraction(3)),
+    )
+    # A size-two Jordan block at2 and an independent eigenvalue3.
+    assert minimal_polynomial(entries) == (
+        Fraction(-12),
+        Fraction(16),
+        Fraction(-7),
+        Fraction(1),
+    )
+    assert calls == 0

--- a/tests/math/matrices/test_certified_snf_models.py
+++ b/tests/math/matrices/test_certified_snf_models.py
@@ -409,3 +409,28 @@ def test_smith_producer_leaves_relation_replay_to_claim_verifier(
         update={"source": IntegerMatrix(entries=((3, 4), (6, 8)))}
     )
     assert not verify_smith_normal_form_certificate(forged)
+
+
+def test_unimodular_inverse_retains_backend_result_without_product_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sympy.polys.matrices import DomainMatrix
+
+    from jacobian.math.matrices.certified_snf.operations import inverse_unimodular
+
+    original = DomainMatrix.matmul
+    products = 0
+
+    def counted_product(left: DomainMatrix, right: DomainMatrix) -> DomainMatrix:
+        nonlocal products
+        products += 1
+        return original(left, right)
+
+    monkeypatch.setattr(DomainMatrix, "matmul", counted_product)
+    assert inverse_unimodular([[1, 2], [0, 1]]) == [[1, -2], [0, 1]]
+    assert products == 0
+    assert inverse_unimodular([]) == []
+    with pytest.raises(ValueError, match="not unimodular"):
+        inverse_unimodular([[2]])
+    with pytest.raises(ValueError, match="singular"):
+        inverse_unimodular([[0]])

--- a/tests/math/number_theory/p_adic/test_padic.py
+++ b/tests/math/number_theory/p_adic/test_padic.py
@@ -404,3 +404,78 @@ def test_hensel_root_does_not_replay_admitted_root_relations(
         type(result).model_validate_json(result.model_dump_json())
     )
     assert evaluations.count(((1, 0, 1), 2, 5)) == 1
+
+
+def test_factor_lift_producer_does_not_reprove_its_completed_product(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from collections.abc import Sequence
+
+    from jacobian.math.number_theory.p_adic import operations
+
+    products: list[tuple[tuple[int, ...], tuple[int, ...], int]] = []
+    original = operations._poly_mul_exact_mod
+
+    def counted(a: Sequence[int], b: Sequence[int], modulus: int) -> list[int]:
+        products.append((tuple(a), tuple(b), modulus))
+        return original(a, b, modulus)
+
+    monkeypatch.setattr(operations, "_poly_mul_exact_mod", counted)
+    result = hensel_lift_factors(
+        IntegerPolynomial(coefficients=(1, 0, 1)),
+        IntegerPolynomial(coefficients=(1, 3)),
+        IntegerPolynomial(coefficients=(1, 2)),
+        5,
+        4,
+    )
+    final_product = (
+        tuple(reversed(result.lifted_g.coefficients)),
+        tuple(reversed(result.lifted_h.coefficients)),
+        625,
+    )
+    assert final_product not in products
+    assert verify_hensel_factor_lift(
+        type(result).model_validate_json(result.model_dump_json())
+    )
+    assert final_product in products
+
+
+@pytest.mark.parametrize("prime", [2, 3, 5, 7])
+def test_factor_lifting_preserves_product_and_residue_for_nonmonic_factors(
+    prime: int,
+) -> None:
+    from itertools import permutations
+
+    for root_g, root_h in permutations(range(prime), 2):
+        g = (-root_g * (prime - 1), prime - 1)
+        h = (-root_h, 1)
+        product = [
+            sum(g[i] * h[k - i] for i in range(2) if 0 <= k - i < 2) for k in range(3)
+        ]
+        # A leading coefficient divisible by p exercises degree growth in h.
+        f = tuple(
+            (product[k] if k < 3 else 0) + prime * (k + root_g + 1) for k in range(4)
+        )
+        for precision in (1, 2, 4):
+            result = hensel_lift_factors(
+                IntegerPolynomial(coefficients=tuple(reversed(f))),
+                IntegerPolynomial(coefficients=tuple(reversed(g))),
+                IntegerPolynomial(coefficients=tuple(reversed(h))),
+                prime,
+                precision,
+            )
+            lifted_g = tuple(reversed(result.lifted_g.coefficients))
+            lifted_h = tuple(reversed(result.lifted_h.coefficients))
+            modulus = prime**precision
+            for k in range(max(len(f), len(lifted_g) + len(lifted_h) - 1)):
+                coefficient = sum(
+                    lifted_g[i] * lifted_h[k - i]
+                    for i in range(len(lifted_g))
+                    if 0 <= k - i < len(lifted_h)
+                )
+                assert (coefficient - (f[k] if k < len(f) else 0)) % modulus == 0
+            for source, lifted in ((g, lifted_g), (h, lifted_h)):
+                assert all(
+                    (value - (source[i] if i < len(source) else 0)) % prime == 0
+                    for i, value in enumerate(lifted)
+                )

--- a/tests/math/polynomials/rational_functions/test_hermite_reduction.py
+++ b/tests/math/polynomials/rational_functions/test_hermite_reduction.py
@@ -110,7 +110,7 @@ def test_adding_exact_derivative_preserves_remainder() -> None:
     [
         (x**7, "numerator exponent"),
         (1 / (x**4 + 1), "denominator exponent"),
-        (100 * x, "numerator coefficient"),
+        (100 / (x + 1), "numerator coefficient"),
     ],
 )
 def test_request_rejects_above_conservative_work_envelope(
@@ -207,3 +207,44 @@ def test_request_accepts_repeated_pole_work_envelope_boundary() -> None:
                 coefficient = term.coefficient
                 assert abs(coefficient.num) < 10**128
                 assert coefficient.den < 10**128
+
+
+def test_polynomial_hermite_reduction_admits_three_digit_constant() -> None:
+    result = compute_hermite_reduction(_request(100))
+    assert rational_function_to_sympy(result.rational_part) == 100 * x
+    assert verify_hermite_reduction(
+        HermiteReductionResult.model_validate_json(result.model_dump_json())
+    )
+
+
+def test_hermite_verifier_preserves_nonpolynomial_resource_refusal() -> None:
+    from jacobian.catalog.models import OperationResourceAdmissionError
+
+    function = rational_function_from_sympy(100 / (x**2 + 1), ("x",))
+    claim = HermiteReductionResult(
+        function=function,
+        rational_part=rational_function_from_sympy(0, ("x",)),
+        remainder=function,
+        rational_primitive_status="NO_RATIONAL_PRIMITIVE",
+        rational_primitive=None,
+    )
+    with pytest.raises(OperationResourceAdmissionError):
+        verify_hermite_reduction(
+            HermiteReductionResult.model_validate_json(claim.model_dump_json())
+        )
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [100 * x**6, sum((10**126 + degree) * x**degree for degree in range(7))],
+)
+def test_degree_six_polynomial_primitive_round_trips(expression: object) -> None:
+    result = compute_hermite_reduction(_request(expression))
+    parsed = HermiteReductionResult.model_validate_json(result.model_dump_json())
+    primitive = rational_function_to_sympy(parsed.rational_part)
+
+    assert max(term.exponents[0] for term in parsed.rational_part.numerator.terms) == 7
+    assert len(parsed.rational_part.numerator.terms) <= 7
+    assert primitive.subs(x, 0) == 0
+    assert cancel(diff(primitive, x) - expression) == 0
+    assert verify_hermite_reduction(parsed)

--- a/tests/math/polynomials/series/test_formal_power_series.py
+++ b/tests/math/polynomials/series/test_formal_power_series.py
@@ -5,7 +5,11 @@ from typing import Any, cast
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
-from jacobian.catalog.models import MathTool, OperationDomainValidationError
+from jacobian.catalog.models import (
+    MathTool,
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials.series import (
     compose,
     derivative,
@@ -170,9 +174,9 @@ def test_input_series_rejects_oversized_coefficients() -> None:
         truncation_order=1,
         coefficients=(_coeff(huge),),
     )
-    with pytest.raises(OperationDomainValidationError) as error:
+    with pytest.raises(OperationResourceAdmissionError) as error:
         derivative(oversized)
-    assert error.value.errors()[0]["type"] == "formal_power_series.admission"
+    assert error.value.errors()[0]["type"] == "formal_power_series.input_coefficient"
 
 
 def test_product_can_exceed_input_digit_bound() -> None:

--- a/tests/math/polynomials/test_common_interlacing.py
+++ b/tests/math/polynomials/test_common_interlacing.py
@@ -47,8 +47,8 @@ from jacobian.math.polynomials.real_algebra._common_interlacing_models import (
 )
 from jacobian.math.polynomials.real_algebra._common_interlacing_process import (
     _profile_from_worker,
+    _require_declared_factor_structure,
     _root_profile_from_worker,
-    _verify_declared_factors,
     run_common_interlacing_profile,
 )
 from jacobian.math.polynomials.real_algebra._common_interlacing_worker import (
@@ -410,14 +410,14 @@ def test_worker_factor_multiplicity_is_capped_before_expansion() -> None:
     source = _source("linear", (1, 1), (-1, 0))
 
     with pytest.raises(ValueError, match="multiplicity exceeds source degree"):
-        _verify_declared_factors(source, [(["1", "0"], 10**100)])
+        _require_declared_factor_structure(source, [(["1", "0"], 10**100)])
 
 
 def test_worker_factor_declarations_require_positive_primitive_form() -> None:
     source = _source("quadratic", (1, 2), (-1, 0))
 
     with pytest.raises(ValueError, match="non-positive leading coefficient"):
-        _verify_declared_factors(
+        _require_declared_factor_structure(
             source,
             [(["-1", "1"], 1), (["-1", "-1"], 1)],
         )
@@ -427,7 +427,7 @@ def test_worker_factor_declarations_require_canonical_coefficients() -> None:
     source = _source("quadratic", (1, 2), (-1, 0))
 
     with pytest.raises(ValueError, match="factor coefficient is not canonical"):
-        _verify_declared_factors(
+        _require_declared_factor_structure(
             source,
             [(["01", "0", "-1"], 1)],
         )
@@ -435,7 +435,7 @@ def test_worker_factor_declarations_require_canonical_coefficients() -> None:
 
 def test_worker_root_intervals_are_bounded_before_model_validation() -> None:
     factor = ["1", "0", "-1"]
-    oversized_endpoint = "9" * 26
+    oversized_endpoint = "9" * 31
 
     with pytest.raises(ValueError, match="isolating interval endpoint exceeds"):
         _root_profile_from_worker(
@@ -995,3 +995,16 @@ def test_small_split_quadratics_match_the_gap_criterion_exhaustively() -> None:
             right_lower,
             right_upper,
         )
+
+
+def test_worker_factor_structure_does_not_reprove_source_factorization() -> None:
+    source = _source("quadratic", (1, 2), (-1, 0))
+    # This is a trusted-worker decoding boundary. Source reconstruction is
+    # established in the worker and independently checked in producer tests.
+    _require_declared_factor_structure(source, [(["1", "0", "1"], 1)])
+
+
+def test_worker_factor_structure_retains_total_degree() -> None:
+    source = _source("quadratic", (1, 2), (-1, 0))
+    with pytest.raises(ValueError, match="degrees differ"):
+        _require_declared_factor_structure(source, [(["1", "0"], 1)])

--- a/tests/math/polynomials/test_jacobian_syzygy_invariants.py
+++ b/tests/math/polynomials/test_jacobian_syzygy_invariants.py
@@ -402,3 +402,33 @@ def test_result_rejects_labelled_provenance_off_three_variables() -> None:
         payload["source_kind"] = "LABELLED_LINEAR_FACTOR_PRODUCT"
         with polynomial_validation_error():
             GradedJacobianSyzygyResult.model_validate_json(json.dumps(payload))
+
+
+def test_syzygy_witness_reuses_coefficient_map_reduction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sympy.matrices.matrixbase import MatrixBase
+
+    calls = 0
+    original = MatrixBase.nullspace
+
+    def counted(self: MatrixBase, *args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(MatrixBase, "nullspace", counted)
+    result = compute_graded_jacobian_syzygy(
+        GradedJacobianSyzygyRequest(
+            polynomial=_sparse_polynomial(
+                ("x", "y", "z"), {(2, 0, 2): 1, (1, 1, 2): -2, (0, 2, 2): 1}
+            ),
+            max_degree=0,
+        )
+    )
+    assert result.status == "FOUND"
+    assert result.kernel_witness is not None
+    assert tuple(
+        value.as_fraction() for value in result.kernel_witness.coefficient_vector
+    ) == (Fraction(1), Fraction(1), Fraction(0))
+    assert calls == 0

--- a/tests/math/test_verifier_failure_channels.py
+++ b/tests/math/test_verifier_failure_channels.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+import json
+from types import ModuleType
+from typing import get_type_hints
 
 import pytest
 
+from jacobian.catalog.builtins import BUILTIN_TOOLS
 from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.geometry.differential import operations as differential
 from jacobian.math.geometry.exact import operations as exact_geometry
@@ -15,80 +18,44 @@ from jacobian.math.polynomials.real_algebra import operations as real_algebra
 
 
 @pytest.mark.parametrize(
-    ("module", "recompute", "claim"),
+    ("module", "recompute"),
     [
-        (
-            differential,
-            "lie_derivative",
-            SimpleNamespace(vector_field=None, source=None, lie_derivative=None),
-        ),
-        (
-            real_algebra,
-            "common_interlacing_profile",
-            SimpleNamespace(family=None),
-        ),
-        (
-            quadratic_spectral,
-            "inertia",
-            SimpleNamespace(matrix=None),
-        ),
-        (exact_geometry, "distance_profile", SimpleNamespace(configuration=None)),
-        (
-            recurrence,
-            "closed_form",
-            SimpleNamespace(characteristic_coefficients=None, initial_values=None),
-        ),
+        (differential, "lie_derivative"),
+        (real_algebra, "common_interlacing_profile"),
+        (quadratic_spectral, "inertia"),
+        (exact_geometry, "distance_profile"),
+        (recurrence, "closed_form"),
     ],
 )
-def test_verifiers_propagate_operational_runtime_failures(
+@pytest.mark.parametrize("resource_refusal", [False, True])
+def test_verifiers_propagate_operational_failures(
     monkeypatch: pytest.MonkeyPatch,
-    module: object,
+    module: ModuleType,
     recompute: str,
-    claim: object,
+    resource_refusal: bool,
 ) -> None:
-    def fail(*_args: object, **_kwargs: object) -> object:
-        raise RuntimeError("backend failed")
-
-    monkeypatch.setattr(module, recompute, fail)
     verifier = getattr(module, f"verify_{recompute}")
+    result_type = get_type_hints(verifier)["claim"]
+    tool = next(tool for tool in BUILTIN_TOOLS if tool.result_type is result_type)
+    request = tool.request_type.model_validate_json(json.dumps(tool.examples[0].input))
+    result = tool.run(request)
+    claim = tool.result_type.model_validate_json(result.model_dump_json())
+    assert verifier(claim)
 
-    with pytest.raises(RuntimeError, match="backend failed"):
-        verifier(claim)
-
-
-@pytest.mark.parametrize(
-    ("module", "recompute", "claim"),
-    [
-        (
-            differential,
-            "lie_derivative",
-            SimpleNamespace(vector_field=None, source=None, lie_derivative=None),
-        ),
-        (real_algebra, "common_interlacing_profile", SimpleNamespace(family=None)),
-        (quadratic_spectral, "inertia", SimpleNamespace(matrix=None)),
-        (exact_geometry, "distance_profile", SimpleNamespace(configuration=None)),
-        (
-            recurrence,
-            "closed_form",
-            SimpleNamespace(characteristic_coefficients=None, initial_values=None),
-        ),
-    ],
-)
-def test_verifiers_propagate_resource_admission_failures(
-    monkeypatch: pytest.MonkeyPatch,
-    module: object,
-    recompute: str,
-    claim: object,
-) -> None:
-    def reject(*_args: object, **_kwargs: object) -> object:
-        raise OperationResourceAdmissionError(
+    failure = (
+        OperationResourceAdmissionError(
             location=("source",),
             code="test.resource_bound",
             message="resource bound exceeded",
         )
+        if resource_refusal
+        else RuntimeError("backend failed")
+    )
 
-    monkeypatch.setattr(module, recompute, reject)
-    verifier = getattr(module, f"verify_{recompute}")
+    def fail(*_args: object, **_kwargs: object) -> object:
+        raise failure
 
-    with pytest.raises(OperationResourceAdmissionError, match="resource bound"):
+    monkeypatch.setattr(module, recompute, fail)
+    with pytest.raises(type(failure)) as caught:
         verifier(claim)
+    assert caught.value is failure

--- a/tests/math/topology/cubical_complexes/test_cubical.py
+++ b/tests/math/topology/cubical_complexes/test_cubical.py
@@ -80,3 +80,39 @@ class TestValidation:
         with pytest.raises(ValidationError) as error:
             CubicalCell(intervals=((1, 0),))
         assert error.value.errors()[0]["type"] == "cubical_complex.interval_order"
+
+
+@pytest.mark.parametrize("published", [False, True])
+def test_face_closure_refuses_output_growth_as_resource_admission(
+    published: bool,
+) -> None:
+    from jacobian.catalog.models import OperationResourceAdmissionError
+    from jacobian.math.topology.cubical_complexes._tools import _face_closure
+
+    source = (
+        CubicalCell(intervals=((0, 1),) * 10),
+        CubicalCell(intervals=((3, 4),) * 10),
+    )
+    with pytest.raises(OperationResourceAdmissionError):
+        if published:
+            _face_closure(FaceClosureRequest(cells=source))
+        else:
+            face_closure(source)
+
+
+def test_repeated_cubes_share_face_admission() -> None:
+    source = CubicalCell(intervals=((0, 1),) * 7)
+    result = face_closure((source,) * 10)
+    assert result.total_cells == 3**7
+    assert result.original_cells == 1
+
+
+def test_full_cube_beyond_source_cell_limit_is_admitted() -> None:
+    from math import comb
+
+    result = face_closure((CubicalCell(intervals=((0, 1),) * 8),))
+    assert result.total_cells == 3**8
+    assert result.cells_by_dimension.counts == tuple(
+        comb(8, degree) * 2 ** (8 - degree) for degree in range(9)
+    )
+    assert FaceClosureResult.model_validate_json(result.model_dump_json()) == result

--- a/tests/math/topology/edge_paths/test_algebraic_topology.py
+++ b/tests/math/topology/edge_paths/test_algebraic_topology.py
@@ -4,7 +4,9 @@ import pytest
 
 from jacobian.math.topology.edge_paths._models import (
     EdgePathConcatenateRequest,
+    EdgePathConcatenateResult,
     EdgePathWordRequest,
+    EdgePathWordResult,
     OrientedEdge,
 )
 from jacobian.math.topology.edge_paths._tools import TOOLS
@@ -16,13 +18,13 @@ from jacobian.math.topology.edge_paths.operations import (
 )
 
 
-def _word(request: EdgePathWordRequest):
+def _word(request: EdgePathWordRequest) -> EdgePathWordResult:
     return edge_path_word(
         request.vertex_count, request.edges, request.start_vertex, request.path
     )
 
 
-def _concatenate(request: EdgePathConcatenateRequest):
+def _concatenate(request: EdgePathConcatenateRequest) -> EdgePathConcatenateResult:
     return concatenate_edge_paths(request.vertex_count, request.path_a, request.path_b)
 
 
@@ -137,3 +139,33 @@ def test_edge_path_concatenate_rejects_discontinuous() -> None:
                 path_b=(2, 0),
             )
         )
+
+
+def test_stationary_path_on_singleton_graph_round_trips() -> None:
+    from jacobian.math.topology.edge_paths._models import (
+        EdgePathWordRequest,
+        EdgePathWordResult,
+    )
+    from jacobian.math.topology.edge_paths._tools import _word
+
+    request = EdgePathWordRequest(vertex_count=1, edges=(), start_vertex=0, path=())
+    result = _word(request)
+    assert result.word == ()
+    assert result.graph.vertex_count == 1
+    assert EdgePathWordResult.model_validate_json(result.model_dump_json()) == result
+
+
+def test_single_vertex_paths_are_concatenation_identities() -> None:
+    from jacobian.math.topology.edge_paths.operations import concatenate_edge_paths
+
+    result = concatenate_edge_paths(1, (0,), (0,))
+    assert result.path == (0,)
+    assert result.length == 1
+
+
+def test_native_concatenation_rejects_missing_endpoint_before_indexing() -> None:
+    from jacobian.catalog.models import OperationDomainValidationError
+    from jacobian.math.topology.edge_paths.operations import concatenate_edge_paths
+
+    with pytest.raises(OperationDomainValidationError):
+        concatenate_edge_paths(2, (), (0, 1))

--- a/tests/math/topology/finite/spaces/test_finite_topology_spaces.py
+++ b/tests/math/topology/finite/spaces/test_finite_topology_spaces.py
@@ -330,10 +330,12 @@ class TestSerializedSubsetClaims:
     def test_subset_indices_are_canonical(self) -> None:
         space = _sierpinski()
         with pytest.raises(ValidationError) as error:
-            InteriorResult(
-                space=space,
-                subset={"space": space, "indices": (1, 0)},
-                interior={"space": space, "indices": ()},
+            InteriorResult.model_validate(
+                {
+                    "space": space,
+                    "subset": {"space": space, "indices": (1, 0)},
+                    "interior": {"space": space, "indices": ()},
+                }
             )
         assert (
             error.value.errors()[0]["type"]
@@ -356,3 +358,31 @@ class TestSerializedSubsetClaims:
         payload = result.model_dump(mode="json")
         payload["quotient_map"]["target"]["preorder"] = [[0], [1]]
         assert not verify_kolmogorov_quotient(type(result).model_validate(payload))
+
+
+def test_native_interior_rejects_subset_outside_carrier() -> None:
+    import pytest
+
+    from jacobian.catalog.models import OperationDomainValidationError
+    from jacobian.math.topology.finite.spaces.operations import from_preorder, interior
+
+    space = from_preorder(("a",), ((0,),))
+    with pytest.raises(OperationDomainValidationError, match="subset"):
+        interior(space, frozenset({1}))
+
+
+@pytest.mark.parametrize("kind", ["interior", "closure", "boundary"])
+def test_subset_claim_checks_retained_space_before_indexing(kind: str) -> None:
+    from jacobian.math.topology.finite.spaces import _models, operations
+    from jacobian.math.topology.finite.spaces.values import FiniteTopologicalSubset
+
+    source = operations.from_preorder(("a",), ((0,),))
+    other = operations.from_preorder(("a", "b"), ((0,), (1,)))
+    claim_type = getattr(_models, kind.capitalize() + "Result")
+    claim = claim_type(
+        space=source,
+        subset=FiniteTopologicalSubset(space=other, indices=(1,)),
+        **{kind: FiniteTopologicalSubset(space=source, indices=())},
+    )
+    restored = claim_type.model_validate_json(claim.model_dump_json())
+    assert not getattr(operations, "verify_" + kind)(restored)

--- a/tests/math/topology/frames/test_frames.py
+++ b/tests/math/topology/frames/test_frames.py
@@ -8,10 +8,7 @@ from jacobian.canonical import encode_strict_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.matrices.values import IntegerMatrix
 from jacobian.math.topology.frames._models import (
-    CoherenceRequest,
-    FiniteFrameRequest,
     GramResult,
-    VectorFamilyRequest,
 )
 from jacobian.math.topology.frames._tools import _coherence, _frame_potential, _gram
 from jacobian.math.topology.frames.operations import gram, verify_gram
@@ -33,7 +30,9 @@ def _repeated_standard_basis(
 
 def test_gram_accepts_nonspanning_vector_family() -> None:
     assert _gram(
-        VectorFamilyRequest.model_validate({"vectors": [[1, 0], [2, 0]]})
+        VectorFamily.model_validate(
+            {"dimension": len(([[1, 0], [2, 0]])[0]), "vectors": [[1, 0], [2, 0]]}
+        )
     ).gram == (
         (1, 2),
         (2, 4),
@@ -41,7 +40,7 @@ def test_gram_accepts_nonspanning_vector_family() -> None:
 
 
 def test_decoded_gram_rejects_shape_forgery() -> None:
-    result = gram(VectorFamily(vectors=((1, 0), (0, 1))))
+    result = gram(VectorFamily(dimension=2, vectors=((1, 0), (0, 1))))
     payload = result.model_dump()
     payload["gram"]["row_count"] = 1
     with pytest.raises(ValueError, match="shape"):
@@ -66,7 +65,7 @@ def test_vector_family_schema_advertises_cell_budget() -> None:
 
 def test_gram_accepts_a_single_vector_beyond_the_old_side_cap() -> None:
     vector = (1,) * 513
-    result = gram(VectorFamily(vectors=(vector,)))
+    result = gram(VectorFamily(dimension=len(vector), vectors=(vector,)))
 
     assert result.dimension == 513
     assert result.gram == ((513,),)
@@ -75,26 +74,33 @@ def test_gram_accepts_a_single_vector_beyond_the_old_side_cap() -> None:
 def test_frame_operations_admit_shape_sensitive_vector_count() -> None:
     vectors = ((1,),) * 1_025
 
-    result = _frame_potential(FiniteFrameRequest(vectors=vectors))
+    result = _frame_potential(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
 
     assert result.potential == 1_025**2
 
 
 def test_frame_operations_admit_coefficient_beyond_the_old_value_cap() -> None:
-    result = _frame_potential(FiniteFrameRequest(vectors=((1_001,),)))
+    result = _frame_potential(VectorFamily(dimension=1, vectors=((1_001,),)))
 
     assert result.potential == 1004006004001
 
 
 def test_frame_requires_full_ambient_span() -> None:
-    request = FiniteFrameRequest.model_validate({"vectors": [[1, 0], [2, 0]]})
+    request = VectorFamily.model_validate(
+        {"dimension": len(([[1, 0], [2, 0]])[0]), "vectors": [[1, 0], [2, 0]]}
+    )
     with pytest.raises(OperationDomainValidationError) as error:
         _frame_potential(request)
     assert error.value.errors()[0]["type"] == "frames.frame_does_not_span"
 
 
 def test_coherence_rejects_zero_vector() -> None:
-    request = CoherenceRequest.model_validate({"vectors": [[0, 0], [1, 0], [0, 1]]})
+    request = VectorFamily.model_validate(
+        {
+            "dimension": len(([[0, 0], [1, 0], [0, 1]])[0]),
+            "vectors": [[0, 0], [1, 0], [0, 1]],
+        }
+    )
     with pytest.raises(OperationDomainValidationError) as error:
         _coherence(request)
     assert error.value.errors()[0]["type"] == "frames.zero_vector"
@@ -102,7 +108,12 @@ def test_coherence_rejects_zero_vector() -> None:
 
 def test_coherence_is_exact_and_carries_canonical_maximizer() -> None:
     result = _coherence(
-        CoherenceRequest.model_validate({"vectors": [[1, 1], [1, 0], [0, 1]]})
+        VectorFamily.model_validate(
+            {
+                "dimension": len(([[1, 1], [1, 0], [0, 1]])[0]),
+                "vectors": [[1, 1], [1, 0], [0, 1]],
+            }
+        )
     )
     assert result.coherence_squared.as_integer_ratio() == (1, 2)
     assert result.maximizing_pair == (0, 2)
@@ -114,7 +125,11 @@ def test_potential_remains_exact_above_json_safe_integer() -> None:
     vectors = (
         [repeated] * 5 + [final] + [[int(i == j) for j in range(16)] for i in range(16)]
     )
-    result = _frame_potential(FiniteFrameRequest.model_validate({"vectors": vectors}))
+    result = _frame_potential(
+        VectorFamily.model_validate(
+            {"dimension": len((vectors)[0]), "vectors": vectors}
+        )
+    )
     expected = sum(
         sum(a * b for a, b in zip(left, right, strict=True)) ** 2
         for left in result.vectors
@@ -128,7 +143,7 @@ def test_flint_gram_reconstructs_dot_products_and_quadratic_form() -> None:
         tuple(((row * 17 + column * 31) % 11) - 5 for column in range(128))
         for row in range(256)
     )
-    result = gram(VectorFamily(vectors=vectors))
+    result = gram(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
 
     assert result.gram[17][203] == sum(
         left * right for left, right in zip(vectors[17], vectors[203], strict=True)
@@ -149,11 +164,13 @@ def test_flint_gram_reconstructs_dot_products_and_quadratic_form() -> None:
 
 def test_repeated_basis_retains_exact_frame_results_and_wire_values() -> None:
     vectors = _repeated_standard_basis(dimension=2, repeats=2)
-    result = gram(VectorFamily(vectors=vectors))
+    result = gram(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
     assert result.gram == ((1, 0, 1, 0), (0, 1, 0, 1), (1, 0, 1, 0), (0, 1, 0, 1))
-    potential = _frame_potential(FiniteFrameRequest(vectors=vectors))
+    potential = _frame_potential(
+        VectorFamily(dimension=len(vectors[0]), vectors=vectors)
+    )
     assert potential.potential == 8
-    coherence = _coherence(CoherenceRequest(vectors=vectors))
+    coherence = _coherence(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
     assert coherence.coherence_squared.as_integer_ratio() == (1, 1)
     assert coherence.maximizing_pair == (1, 3)
     assert (
@@ -167,7 +184,7 @@ def test_repeated_basis_retains_exact_frame_results_and_wire_values() -> None:
 
 def test_sparse_high_height_gram_retains_zero_and_repeated_dot_products() -> None:
     vectors = ((1_000, 0), (0, 1_000)) * 2
-    result = gram(VectorFamily(vectors=vectors))
+    result = gram(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
     assert result.gram == (
         (1_000_000, 0, 1_000_000, 0),
         (0, 1_000_000, 0, 1_000_000),
@@ -179,7 +196,7 @@ def test_sparse_high_height_gram_retains_zero_and_repeated_dot_products() -> Non
 
 def test_high_coefficients_retain_exact_gram_entries() -> None:
     vectors = ((70_000_000, 70_000_000),) * 2
-    result = _gram(VectorFamilyRequest(vectors=vectors))
+    result = _gram(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
     expected = 2 * 70_000_000**2
     assert expected > 2**53
     assert result.gram == ((expected, expected), (expected, expected))
@@ -189,12 +206,14 @@ def test_high_coefficients_retain_exact_gram_entries() -> None:
 def test_result_sensitive_operations_diverge_at_full_carrier_boundary() -> None:
     dimension = 512
     vectors = _repeated_standard_basis(dimension=dimension, repeats=2)
-    family = VectorFamily(vectors=vectors)
+    family = VectorFamily(dimension=len(vectors[0]), vectors=vectors)
 
     assert len(vectors) == MAX_VECTOR_CELLS // dimension
     gram_result = gram(family)
-    potential = _frame_potential(FiniteFrameRequest(vectors=vectors))
-    coherence = _coherence(CoherenceRequest(vectors=vectors))
+    potential = _frame_potential(
+        VectorFamily(dimension=len(vectors[0]), vectors=vectors)
+    )
+    coherence = _coherence(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
     assert len(gram_result.gram) == MAX_VECTOR_CELLS // dimension
     assert gram_result.gram[0][dimension] == 1
     assert potential.potential == 2 * (MAX_VECTOR_CELLS // dimension)
@@ -214,7 +233,7 @@ def test_sparse_high_height_gram_is_admitted_by_occupancy() -> None:
         tuple(1_000 * entry for entry in vector)
         for vector in _repeated_standard_basis(dimension=dimension, repeats=2)
     )
-    family = VectorFamily(vectors=vectors)
+    family = VectorFamily(dimension=len(vectors[0]), vectors=vectors)
     naive_entry_bound = 512 * 1_000**2
     naive_chars = len(str(naive_entry_bound)) + int(naive_entry_bound > 0)
     assert naive_chars > 0
@@ -227,9 +246,9 @@ def test_sparse_high_height_gram_is_admitted_by_occupancy() -> None:
 
 
 def test_sparse_row_norm_controls_gram_entry_admission() -> None:
-    family = VectorFamily(vectors=((70_000_000, 0),))
+    family = VectorFamily(dimension=2, vectors=((70_000_000, 0),))
 
-    result = _gram(VectorFamilyRequest(vectors=family.vectors))
+    result = _gram(VectorFamily(dimension=family.dimension, vectors=family.vectors))
 
     assert result.gram == ((4_900_000_000_000_000,),)
 
@@ -242,9 +261,11 @@ def test_dense_high_height_gram_uses_the_structural_work_bound() -> None:
         for row in range(dimension)
     )
     vectors = basis * 2
-    result = _gram(VectorFamilyRequest(vectors=vectors))
+    result = _gram(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
 
-    potential = _frame_potential(FiniteFrameRequest(vectors=vectors))
+    potential = _frame_potential(
+        VectorFamily(dimension=len(vectors[0]), vectors=vectors)
+    )
     diagonal = 1_000**2 + (dimension - 1) * 999**2
     off_diagonal = 2 * 1_000 * 999 + (dimension - 2) * 999**2
     expected = 4 * dimension * (diagonal**2 + (dimension - 1) * off_diagonal**2)
@@ -257,14 +278,14 @@ def test_high_coefficients_remain_exact_within_the_cell_bound() -> None:
     dimension = 512
     vectors = ((4_000_000,) * dimension,) * (MAX_VECTOR_CELLS // dimension)
 
-    result = _gram(VectorFamilyRequest(vectors=vectors))
+    result = _gram(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
 
     assert result.gram[0][0] == dimension * 4_000_000**2
 
 
 def test_flint_rank_rejects_nonspanning_family_above_previous_boundary() -> None:
     vector = (1,) * 32
-    request = FiniteFrameRequest(vectors=(vector,) * 64)
+    request = VectorFamily(dimension=len(vector), vectors=(vector,) * 64)
 
     with pytest.raises(OperationDomainValidationError) as error:
         _frame_potential(request)
@@ -273,8 +294,8 @@ def test_flint_rank_rejects_nonspanning_family_above_previous_boundary() -> None
 
 def test_coherence_maximizer_matches_complete_exact_profile() -> None:
     vectors = _repeated_standard_basis(dimension=32, repeats=2)
-    result = _coherence(CoherenceRequest(vectors=vectors))
-    gram_result = _gram(VectorFamilyRequest(vectors=vectors)).gram
+    result = _coherence(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
+    gram_result = _gram(VectorFamily(dimension=len(vectors[0]), vectors=vectors)).gram
     candidates = (
         (
             Fraction(
@@ -293,3 +314,20 @@ def test_coherence_maximizer_matches_complete_exact_profile() -> None:
         maximum.denominator,
     )
     assert result.maximizing_pair == pair
+
+
+def test_gram_verifier_propagates_unexpected_kernel_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.topology.frames import operations
+
+    claim = gram(VectorFamily(dimension=1, vectors=((1,),)))
+
+    def unavailable(
+        vectors: tuple[tuple[int, ...], ...],
+    ) -> tuple[tuple[int, ...], ...]:
+        raise ValueError("backend arithmetic unavailable")
+
+    monkeypatch.setattr(operations, "integer_gram", unavailable)
+    with pytest.raises(ValueError, match="backend arithmetic unavailable"):
+        verify_gram(claim)

--- a/tests/math/topology/frames/test_native.py
+++ b/tests/math/topology/frames/test_native.py
@@ -6,30 +6,27 @@ import pytest
 
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.topology.frames import VectorFamily, coherence, frame_potential, gram
-from jacobian.math.topology.frames._models import (
-    CoherenceRequest,
-    FiniteFrameRequest,
-    VectorFamilyRequest,
-)
 from jacobian.math.topology.frames._tools import _coherence, _frame_potential, _gram
 from jacobian.math.topology.frames.values import MAX_VECTOR_CELLS
 
 
 def test_native_gram_and_potential_match_wire_adapters() -> None:
-    family = VectorFamily(vectors=((1, 1), (1, 0), (0, 1)))
+    family = VectorFamily(dimension=2, vectors=((1, 1), (1, 0), (0, 1)))
 
     assert gram(family).gram == ((2, 1, 1), (1, 1, 0), (1, 0, 1))
     assert (
         frame_potential(family).potential
-        == _frame_potential(FiniteFrameRequest(vectors=family.vectors)).potential
+        == _frame_potential(
+            VectorFamily(dimension=family.dimension, vectors=family.vectors)
+        ).potential
     )
 
 
 def test_native_coherence_matches_wire_adapter() -> None:
-    family = VectorFamily(vectors=((1, 1), (1, 0), (0, 1)))
+    family = VectorFamily(dimension=2, vectors=((1, 1), (1, 0), (0, 1)))
 
     native = coherence(family)
-    wire = _coherence(CoherenceRequest(vectors=family.vectors))
+    wire = _coherence(VectorFamily(dimension=family.dimension, vectors=family.vectors))
 
     assert native.model_dump() == wire.model_dump()
 
@@ -39,7 +36,7 @@ def test_native_frame_operations_keep_semantic_admission(
     operation: Callable[[VectorFamily], object],
 ) -> None:
     with pytest.raises(OperationDomainValidationError) as error:
-        operation(VectorFamily(vectors=((1, 0), (2, 0))))
+        operation(VectorFamily(dimension=2, vectors=((1, 0), (2, 0))))
     assert error.value.errors()[0]["type"] == "frames.frame_does_not_span"
 
 
@@ -48,10 +45,11 @@ def test_frame_operations_reject_undercomplete_families_before_rank(
     operation: Callable[[VectorFamily], object],
 ) -> None:
     family = VectorFamily(
+        dimension=64,
         vectors=tuple(
             tuple(1 if index == coordinate else 0 for coordinate in range(64))
             for index in range(32)
-        )
+        ),
     )
 
     with pytest.raises(OperationDomainValidationError) as error:
@@ -61,7 +59,10 @@ def test_frame_operations_reject_undercomplete_families_before_rank(
 
 
 def test_native_and_catalog_dense_gram_and_potential_are_exact() -> None:
-    family = VectorFamily(vectors=((1_000, 999), (999, 1_000)) * 2)
+    family = VectorFamily(
+        dimension=2,
+        vectors=((1_000, 999), (999, 1_000)) * 2,
+    )
     result = gram(family)
     diagonal, off_diagonal = 1_998_001, 1_998_000
     assert result.gram == (
@@ -70,7 +71,10 @@ def test_native_and_catalog_dense_gram_and_potential_are_exact() -> None:
         (diagonal, off_diagonal, diagonal, off_diagonal),
         (off_diagonal, diagonal, off_diagonal, diagonal),
     )
-    assert _gram(VectorFamilyRequest(vectors=family.vectors)) == result
+    assert (
+        _gram(VectorFamily(dimension=family.dimension, vectors=family.vectors))
+        == result
+    )
     assert frame_potential(family).potential == 8 * (diagonal**2 + off_diagonal**2)
 
 
@@ -82,15 +86,53 @@ def test_native_and_catalog_gram_return_the_same_large_exact_matrix() -> None:
         for row in range(dimension)
     )
     vectors = basis * 2
-    family = VectorFamily(vectors=vectors)
+    family = VectorFamily(dimension=len(vectors[0]), vectors=vectors)
     diagonal = 1_000**2 + (dimension - 1) * 999**2
     off_diagonal = 2 * 1_000 * 999 + (dimension - 2) * 999**2
 
     assert len(vectors) == MAX_VECTOR_CELLS // dimension
     result = gram(family)
-    catalog_result = _gram(VectorFamilyRequest(vectors=vectors))
+    catalog_result = _gram(VectorFamily(dimension=len(vectors[0]), vectors=vectors))
     assert catalog_result == result
     assert result.gram[0][0] == diagonal
     assert result.gram[0][1] == off_diagonal
     assert result.gram[0][dimension] == diagonal
     assert result.gram[1][dimension] == off_diagonal
+
+
+def test_empty_gram_retains_ambient_dimension() -> None:
+    from jacobian.math.topology.frames._models import GramResult
+
+    source = VectorFamily(dimension=7, vectors=())
+    result = gram(source)
+    assert result.dimension == 7
+    assert result.gram.row_count == result.gram.column_count == 0
+    assert GramResult.model_validate_json(result.model_dump_json()) == result
+    with pytest.raises(ValueError, match="at least as many"):
+        frame_potential(source)
+
+
+def test_zero_dimensional_frame_potential() -> None:
+    result = frame_potential(VectorFamily(dimension=0, vectors=()))
+    assert result.dimension == 0
+    assert result.potential == 0
+
+
+def test_zero_dimensional_vectors_have_zero_gram_but_no_coherence() -> None:
+    from jacobian.math.topology.frames.operations import coherence, verify_gram
+
+    source = VectorFamily(dimension=0, vectors=((), ()))
+    result = gram(source)
+    assert result.gram.entries == ((0, 0), (0, 0))
+    assert verify_gram(result)
+    assert frame_potential(source).potential == 0
+    with pytest.raises(ValueError, match="nonzero"):
+        coherence(source)
+
+
+def test_empty_zero_dimensional_coherence_has_no_maximizer() -> None:
+    from jacobian.math.topology.frames.operations import coherence
+
+    result = coherence(VectorFamily(dimension=0, vectors=()))
+    assert result.coherence_squared.num == 0
+    assert result.maximizing_pair is None

--- a/tests/math/universal_algebra/test_universal_algebra.py
+++ b/tests/math/universal_algebra/test_universal_algebra.py
@@ -671,3 +671,14 @@ class TestValidation:
         assert (
             error.value.errors()[0]["type"] == "universal_algebra.table_cells_exceeded"
         )
+
+
+def test_native_evaluation_binds_assignment_keys_to_the_term_variable_axis() -> None:
+    from jacobian.catalog.models import OperationDomainValidationError
+    from jacobian.math.universal_algebra import evaluate_term
+
+    algebra = _boolean_algebra()
+    term = _variable_term(2)
+    assert evaluate_term(algebra, term, {2: 1, 1: 0, 0: 0}) == 1
+    with pytest.raises(OperationDomainValidationError, match="variable axis"):
+        evaluate_term(algebra, term, {2: 1, 3: 0, 4: 0})

--- a/tests/mcp/test_direct_operations.py
+++ b/tests/mcp/test_direct_operations.py
@@ -402,9 +402,16 @@ def test_direct_calls_preserve_owner_cancellation_diagnosis() -> None:
         assert result.is_error is True
         assert result.structured_content is None
         assert result.content and isinstance(result.content[0], TextContent)
-        assert _content_text(result.content[0]) == (
-            "Error executing tool test.direct.cancel: operation cancelled"
+        diagnostic = json.loads(
+            _content_text(result.content[0]).removeprefix(
+                "Error executing tool test.direct.cancel: "
+            )
         )
+        assert diagnostic == {
+            "code": "OPERATION_CANCELLED",
+            "operation_id": operation.operation_id,
+            "stage": "operation_execution",
+        }
         assert "private cancellation detail" not in _content_text(result.content[0])
         assert "operation execution failed" not in _content_text(result.content[0])
 
@@ -421,8 +428,9 @@ def test_direct_calls_preserve_owner_cancellation_diagnosis() -> None:
         ),
     ),
 )
-def test_math_run_preserves_bounded_operation_failure_context(
-    exception: Exception, code: str
+@pytest.mark.parametrize("direct", [False, True])
+def test_calls_preserve_bounded_operation_failure_context(
+    exception: Exception, code: str, direct: bool
 ) -> None:
     class Request(StrictModel):
         value: int
@@ -449,15 +457,17 @@ def test_math_run_preserves_bounded_operation_failure_context(
             _direct_server(Catalog((operation,))), raise_exceptions=False
         ) as client:
             result = await client.call_tool(
-                "math.run",
-                {"operation_id": operation.operation_id, "payload": {"value": 1}},
+                operation.operation_id if direct else "math.run",
+                {"value": 1}
+                if direct
+                else {"operation_id": operation.operation_id, "payload": {"value": 1}},
             )
 
         assert result.is_error is True
         assert result.content and isinstance(result.content[0], TextContent)
         diagnostic = json.loads(
             _content_text(result.content[0]).removeprefix(
-                "Error executing tool math.run: "
+                f"Error executing tool {operation.operation_id if direct else 'math.run'}: "
             )
         )
         assert diagnostic == {

--- a/tests/mcp/test_direct_operations.py
+++ b/tests/mcp/test_direct_operations.py
@@ -328,8 +328,8 @@ def test_direct_calls_preserve_strict_and_domain_invalid_params() -> None:
             assert domain_data["errors"] == [
                 {
                     "location": ["assignment"],
-                    "code": "universal_algebra.assignment_coverage",
-                    "message": "assignment must cover exactly the referenced variables",
+                    "code": "universal_algebra.assignment_variable_axis",
+                    "message": "assignment keys must cover exactly the term variable axis 0..variable_count-1",
                 }
             ]
 

--- a/tests/mcp/test_mcp_invocation_journey.py
+++ b/tests/mcp/test_mcp_invocation_journey.py
@@ -252,8 +252,8 @@ def test_mcp_describes_and_invokes_operations() -> None:
             assert semantic_data["errors"] == [
                 {
                     "location": ["assignment"],
-                    "code": "universal_algebra.assignment_coverage",
-                    "message": "assignment must cover exactly the referenced variables",
+                    "code": "universal_algebra.assignment_variable_axis",
+                    "message": "assignment keys must cover exactly the term variable axis 0..variable_count-1",
                 }
             ]
 


### PR DESCRIPTION
## Problem

Native helpers and published operations disagreed about empty mathematical values, authored claims, and operational failure. Several cheap exact computations were rejected by estimates for a more expensive general algorithm. The motivating character-sum request over Z/100Z (20 sequence entries, all 100 frequencies, two intervals) failed cyclotomic construction admission.

## Outcome

- Reduce character-sum construction to the squarefree conductor and reduce powers by residue class. The motivating request now returns all 200 exact cells in the original degree-40 cyclotomic basis.
- Admit constant-series inversion, constant-denominator division, and linear reversion through order 25,280; polynomial Hermite sources with 127-digit coefficients; translated spanned-line configurations; nullary-only tree counts; and transition-free Petri nets. Retain explicit bounds for the general cases.
- Preserve ambient dimension for empty vector families, stationary paths on singleton graphs, empty codes, and full cubical face closures. Frame requests now use the canonical `VectorFamily` with required `dimension`; sign-Walsh results retain their `BooleanTruthTable` source. These intentionally supersede the incomplete request/result schemas.
- Check the relation supplied by Nash, word-dependency, and finite-topology claims. Propagate backend failure and resource refusal instead of reporting mathematical falsehood. Reuse completed reductions and trusted worker results where a producer was repeating its own computation.
- Enforce strict JSON depth and numeric boundaries, distinguish CLI resource/backend errors, and retain operation context in direct MCP timeout/cancellation errors.

## Validation

Final head: `29503eb9a60ff2218814f137651f0cace19ffbd6`.

- [Required CI passed](https://github.com/morluto/jacobian/actions/runs/34174814648) on this exact head: all four mathematical shards, catalog/examples, CLI, dispatch, integration, tooling, MCP/process boundaries, exact-algebra runtimes, static checks, and installed wheels on Python 3.12 and 3.13.
- Local validation started with `make affected AFFECTED_BASE=origin/main`; after repairing stale test fixtures/diagnostics, the affected test files and all remaining planner-selected commands were completed individually. No implementation changed after the mathematical run.
- Passing local lanes: catalog (156), catalog examples (914), CLI (6), integration (455), tooling (311), MCP (73), process (308), Singular (1,137), and QEPCAD (27). The repaired verifier and dispatch files pass all 10 and 17 cases respectively.
- `make test-scale TESTS=tests/math/topology/frames`: all 5 pass. Hosted scale is conditional and was skipped; these local scale results are separate evidence.
- `make architecture repository-hygiene todo-check import-contracts` and `make docs-linkcheck`: pass. Scoped Ruff/mypy pass for every changed Python file.

Independent mathematical probes include 1,052 character-sum cells against full cyclotomic division, 3,645 Nash claims, 120 Hensel cases, 100 lattice transformations, 756 coloring claims, and 84 translated-grid triples. Serialized producer/consumer regressions cover the changed canonical carriers and accepted scale cases. Documentation link checks pass.

## Contract impact

No new operation IDs are introduced. Intentional schema changes are the required frame dimension and retained sign-Walsh source. Canonical values retain original axes through private scale reductions. Mathematical admission remains separate from structural parsing; a resource refusal or backend exception cannot establish a negative mathematical conclusion.

The character-sum bound retains degree at most 60 and bounded squarefree cyclotomic work: this does not admit every conductor. General nonlinear series and nonpolynomial Hermite envelopes remain bounded. Native and MCP paths share the revised owner admission.

## Review closure

Independent exact-diff review covered the changed mathematical owners and runtime paths. Findings were repaired with regression evidence, including cross-space subset claims and the degree-7 primitive produced by a degree-6 polynomial Hermite source.

## Audit coverage

This follows merged #3525. The audit inventoried 8,404 function definitions and screened calls, exception handling, admission ownership, and producer/consumer boundaries, then investigated concrete candidates with source traces and behavioral probes. That is not an exhaustive proof of every function or branch. Specialized unprobed paths and remaining conservative envelopes are outside this repair's correctness claims; this PR does not close a repository-wide all-clear issue.

Review the scale reductions and canonical carrier changes first, then the domain failure boundaries, and finally JSON/CLI/MCP behavior. Commits group these outcomes with their tests.
