### PR TITLE
feat(polynomials): compute exact rational function gradients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,9 @@ ignore_imports = [
     "jacobian.math.polynomials.multivariate._factor_backend -> jacobian.process",
     # Rational-function coprimality runs in one deadline-bound SymPy worker.
     "jacobian.math.geometry.differential._recognition_process -> jacobian.process",
+    # Metric DAG expansion and fraction normalization run in killable workers.
+    "jacobian.math.geometry.differential.metrics._dag_process -> jacobian.process",
+    "jacobian.math.geometry.differential.metrics._normalize_process -> jacobian.process",
     # Exact common-interlacing factorization and isolation run in one bounded worker.
     "jacobian.math.graphs.triangle_free_diameter_augmentation._augmentation_z3 -> jacobian.process",
     "jacobian.math.polynomials.real_algebra._common_interlacing_process -> jacobian.process",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,6 +260,7 @@ ignore_imports = [
     # Metric DAG expansion and fraction normalization run in killable workers.
     "jacobian.math.geometry.differential.metrics._dag_process -> jacobian.process",
     "jacobian.math.geometry.differential.metrics._normalize_process -> jacobian.process",
+    "jacobian.math.polynomials.rational_functions.gradient._normalize_process -> jacobian.process",
     # Exact common-interlacing factorization and isolation run in one bounded worker.
     "jacobian.math.graphs.triangle_free_diameter_augmentation._augmentation_z3 -> jacobian.process",
     "jacobian.math.polynomials.real_algebra._common_interlacing_process -> jacobian.process",

--- a/src/jacobian/math/geometry/differential/_bounds.py
+++ b/src/jacobian/math/geometry/differential/_bounds.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from fractions import Fraction
 from itertools import product
-from math import gcd, lcm
 from typing import Literal, NoReturn
 
-from jacobian.canonical import format_canonical_integer
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry.differential._execution import (
     begin_lie_derivative_deadline,
@@ -27,8 +24,20 @@ from jacobian.math.geometry.differential.values import (
     RationalCoordinateTensor,
     canonical_locus_guards,
 )
+from jacobian.math.polynomials.rational_functions._bounds import (
+    BoundWorkCategory,
+    FractionBound,
+    RationalFunctionBoundLimits,
+    _add_fractions,
+    _differentiate_fraction,
+    _fraction_bound,
+    _multiply_fractions,
+    _recognition_work_units,
+    _remove_guaranteed_common_monomial,
+    _validate_canonical_result_bound,
+    _zero_fraction,
+)
 from jacobian.math.polynomials.values import (
-    RationalFunction,
     SparseRationalPolynomial,
 )
 
@@ -36,14 +45,8 @@ MAX_LIE_DERIVATIVE_WORK_UNITS = 25_000_000
 MAX_LIE_DERIVATIVE_RAW_POLYNOMIAL_TERMS = 4_096
 MAX_LIE_DERIVATIVE_RAW_COEFFICIENT_DIGITS = 4_096
 
-type LieWorkCategory = Literal[
-    "recognition",
-    "source_conversion",
-    "differentiation",
-    "multiplication",
-    "addition",
-    "normalization",
-]
+type LieWorkCategory = BoundWorkCategory
+
 _LIE_WORK_CATEGORIES: tuple[LieWorkCategory, ...] = (
     "recognition",
     "source_conversion",
@@ -52,38 +55,6 @@ _LIE_WORK_CATEGORIES: tuple[LieWorkCategory, ...] = (
     "addition",
     "normalization",
 )
-
-
-@dataclass(frozen=True)
-class PolynomialBound:
-    """Bound ``rational_content * integral_polynomial`` exactly.
-
-    Input bounds start with a primitive integral polynomial. Arithmetic may
-    leave its integral factor nonprimitive, while ``coefficient_digits`` still
-    bounds every coefficient and ``rational_content`` remains an exact common
-    scale. Keeping that scale separate prevents unrelated coefficient
-    denominators from multiplying during height admission.
-    """
-
-    terms: int
-    degrees: tuple[int, ...]
-    minimum_exponents: tuple[int, ...]
-    coefficient_digits: int
-    rational_content: Fraction
-
-    @property
-    def is_zero(self) -> bool:
-        return self.terms == 0
-
-
-@dataclass(frozen=True)
-class FractionBound:
-    numerator: PolynomialBound
-    denominator: PolynomialBound
-
-    @property
-    def is_zero(self) -> bool:
-        return self.numerator.is_zero
 
 
 @dataclass(frozen=True)
@@ -122,6 +93,15 @@ class LieDerivativePlan:
 class _Ledger:
     def __init__(self, *, deadline: float) -> None:
         self.deadline = deadline
+        self.limits = RationalFunctionBoundLimits(
+            raw_terms=MAX_LIE_DERIVATIVE_RAW_POLYNOMIAL_TERMS,
+            raw_digits=MAX_LIE_DERIVATIVE_RAW_COEFFICIENT_DIGITS,
+            result_exponent=MAX_RATIONAL_TENSOR_EXPONENT,
+            result_terms=MAX_RATIONAL_TENSOR_POLYNOMIAL_TERMS,
+            result_digits=MAX_RATIONAL_TENSOR_COEFFICIENT_DIGITS,
+            label="Lie-derivative",
+            reject=_reject,
+        )
         self.work_units = 0
         self._by_category: dict[LieWorkCategory, int] = dict.fromkeys(
             _LIE_WORK_CATEGORIES, 0
@@ -162,526 +142,6 @@ def _reject(
     )
 
 
-def _dense_term_bound(degrees: tuple[int, ...], *, cap: int | None = None) -> int:
-    result = 1
-    for degree in degrees:
-        result *= degree + 1
-        if cap is not None and result > cap:
-            return cap + 1
-    return result
-
-
-def _polynomial_admission_work_units(
-    polynomial: SparseRationalPolynomial, variable_count: int
-) -> int:
-    """Price the scalar passes used to derive one exact polynomial bound.
-
-    Each nonzero coefficient is converted, participates in denominator/content
-    reduction, is scaled and made primitive, and is inspected for height. Each
-    exponent is inspected once for the maximum and once for the minimum. The
-    final unit prices construction of the separated rational content. Zero is
-    represented by one exact ``Fraction`` construction.
-    """
-
-    terms = len(polynomial.terms)
-    if terms == 0:
-        return 1
-    return terms * (6 + 2 * variable_count) + 1
-
-
-def _polynomial_backend_conversion_work_units(bound: PolynomialBound) -> int:
-    """Price sparse coefficient conversion and dense SymPy ``Poly`` creation."""
-
-    dense_coefficients = 1 if bound.is_zero else _dense_term_bound(bound.degrees)
-    coefficient_digits = (
-        bound.coefficient_digits
-        + len(format_canonical_integer(abs(bound.rational_content.numerator)))
-        + len(format_canonical_integer(bound.rational_content.denominator))
-    )
-    coefficient_chunks = max(1, (coefficient_digits + 31) // 32)
-    return bound.terms * coefficient_chunks + dense_coefficients
-
-
-def _polynomial_bound(polynomial: SparseRationalPolynomial) -> PolynomialBound:
-    if not polynomial.terms:
-        return PolynomialBound(
-            terms=0,
-            degrees=(),
-            minimum_exponents=(),
-            coefficient_digits=1,
-            rational_content=Fraction(0),
-        )
-    variable_count = len(polynomial.terms[0].exponents)
-    coefficients = tuple(
-        Fraction(*term.coefficient.as_integer_ratio()) for term in polynomial.terms
-    )
-    common_denominator = lcm(*(coefficient.denominator for coefficient in coefficients))
-    integral_coefficients = tuple(
-        coefficient.numerator * (common_denominator // coefficient.denominator)
-        for coefficient in coefficients
-    )
-    content_numerator = gcd(
-        *(abs(coefficient) for coefficient in integral_coefficients)
-    )
-    primitive_coefficients = tuple(
-        coefficient // content_numerator for coefficient in integral_coefficients
-    )
-    return PolynomialBound(
-        terms=len(polynomial.terms),
-        degrees=tuple(
-            max(term.exponents[axis] for term in polynomial.terms)
-            for axis in range(variable_count)
-        ),
-        minimum_exponents=tuple(
-            min(term.exponents[axis] for term in polynomial.terms)
-            for axis in range(variable_count)
-        ),
-        coefficient_digits=max(
-            len(format_canonical_integer(abs(coefficient)))
-            for coefficient in primitive_coefficients
-        ),
-        rational_content=Fraction(content_numerator, common_denominator),
-    )
-
-
-def _zero_polynomial(variable_count: int) -> PolynomialBound:
-    return PolynomialBound(
-        terms=0,
-        degrees=(0,) * variable_count,
-        minimum_exponents=(0,) * variable_count,
-        coefficient_digits=1,
-        rational_content=Fraction(0),
-    )
-
-
-def _one_polynomial(variable_count: int) -> PolynomialBound:
-    return PolynomialBound(
-        terms=1,
-        degrees=(0,) * variable_count,
-        minimum_exponents=(0,) * variable_count,
-        coefficient_digits=1,
-        rational_content=Fraction(1),
-    )
-
-
-def _zero_fraction(variable_count: int) -> FractionBound:
-    return FractionBound(
-        numerator=_zero_polynomial(variable_count),
-        denominator=_one_polynomial(variable_count),
-    )
-
-
-def _fraction_bound(value: RationalFunction, ledger: _Ledger) -> FractionBound:
-    variable_count = len(value.variables)
-    ledger.charge(
-        "source_conversion",
-        _polynomial_admission_work_units(value.numerator, variable_count)
-        + _polynomial_admission_work_units(value.denominator, variable_count),
-    )
-    numerator = (
-        _zero_polynomial(variable_count)
-        if not value.numerator.terms
-        else _polynomial_bound(value.numerator)
-    )
-    result = FractionBound(
-        numerator=numerator,
-        denominator=_polynomial_bound(value.denominator),
-    )
-    ledger.charge(
-        "source_conversion",
-        _polynomial_backend_conversion_work_units(result.numerator)
-        + _polynomial_backend_conversion_work_units(result.denominator),
-    )
-    return result
-
-
-def _check_raw_polynomial(bound: PolynomialBound) -> None:
-    if bound.terms > MAX_LIE_DERIVATIVE_RAW_POLYNOMIAL_TERMS:
-        _reject(
-            "intermediate_support",
-            "Lie-derivative polynomial expansion exceeds the "
-            f"{MAX_LIE_DERIVATIVE_RAW_POLYNOMIAL_TERMS}-term intermediate budget",
-        )
-    scaled_coefficient_digits = max(
-        len(format_canonical_integer(abs(bound.rational_content.numerator)))
-        + bound.coefficient_digits,
-        len(format_canonical_integer(bound.rational_content.denominator)),
-    )
-    if scaled_coefficient_digits > MAX_LIE_DERIVATIVE_RAW_COEFFICIENT_DIGITS:
-        _reject(
-            "intermediate_height",
-            "Lie-derivative coefficient growth exceeds the "
-            f"{MAX_LIE_DERIVATIVE_RAW_COEFFICIENT_DIGITS}-digit intermediate budget",
-        )
-
-
-def _differentiate_polynomial(
-    source: PolynomialBound,
-    axis: int,
-    *,
-    active_terms: int,
-    maximum_axis_exponent: int,
-    minimum_exponents: tuple[int, ...],
-) -> PolynomialBound:
-    if source.is_zero or active_terms == 0:
-        return _zero_polynomial(len(source.degrees))
-    degrees = list(source.degrees)
-    degrees[axis] -= 1
-    result = PolynomialBound(
-        terms=active_terms,
-        degrees=tuple(degrees),
-        minimum_exponents=minimum_exponents,
-        coefficient_digits=(
-            source.coefficient_digits
-            + len(format_canonical_integer(maximum_axis_exponent))
-        ),
-        rational_content=source.rational_content,
-    )
-    _check_raw_polynomial(result)
-    return result
-
-
-def _multiply_polynomials(
-    left: PolynomialBound,
-    right: PolynomialBound,
-    ledger: _Ledger,
-) -> PolynomialBound:
-    if left.is_zero or right.is_zero:
-        return _zero_polynomial(len(left.degrees))
-    pair_count = left.terms * right.terms
-    ledger.charge("multiplication", pair_count)
-    degrees = tuple(
-        left_degree + right_degree
-        for left_degree, right_degree in zip(left.degrees, right.degrees, strict=True)
-    )
-    collision_count = min(left.terms, right.terms)
-    product_digits = left.coefficient_digits + right.coefficient_digits
-    if collision_count == 1:
-        coefficient_digits = product_digits
-    else:
-        coefficient_digits = product_digits + len(
-            format_canonical_integer(collision_count)
-        )
-    result = PolynomialBound(
-        terms=min(pair_count, _dense_term_bound(degrees)),
-        degrees=degrees,
-        minimum_exponents=tuple(
-            left_exponent + right_exponent
-            for left_exponent, right_exponent in zip(
-                left.minimum_exponents,
-                right.minimum_exponents,
-                strict=True,
-            )
-        ),
-        coefficient_digits=coefficient_digits,
-        rational_content=left.rational_content * right.rational_content,
-    )
-    _check_raw_polynomial(result)
-    return result
-
-
-def _add_polynomials(
-    left: PolynomialBound,
-    right: PolynomialBound,
-    ledger: _Ledger,
-) -> PolynomialBound:
-    if left.is_zero:
-        return right
-    if right.is_zero:
-        return left
-    ledger.charge("addition", left.terms + right.terms)
-    degrees = tuple(
-        max(left_degree, right_degree)
-        for left_degree, right_degree in zip(left.degrees, right.degrees, strict=True)
-    )
-    common_content = Fraction(
-        gcd(
-            abs(left.rational_content.numerator),
-            abs(right.rational_content.numerator),
-        ),
-        lcm(
-            left.rational_content.denominator,
-            right.rational_content.denominator,
-        ),
-    )
-    left_multiplier = left.rational_content / common_content
-    right_multiplier = right.rational_content / common_content
-    if left_multiplier.denominator != 1 or right_multiplier.denominator != 1:
-        raise AssertionError(
-            "rational polynomial content gcd did not divide both inputs"
-        )
-
-    def scaled_digits(coefficient_digits: int, multiplier: int) -> int:
-        if abs(multiplier) <= 1:
-            return coefficient_digits
-        return coefficient_digits + len(format_canonical_integer(abs(multiplier)))
-
-    result = PolynomialBound(
-        terms=min(left.terms + right.terms, _dense_term_bound(degrees)),
-        degrees=degrees,
-        minimum_exponents=tuple(
-            min(left_exponent, right_exponent)
-            for left_exponent, right_exponent in zip(
-                left.minimum_exponents,
-                right.minimum_exponents,
-                strict=True,
-            )
-        ),
-        coefficient_digits=max(
-            scaled_digits(left.coefficient_digits, left_multiplier.numerator),
-            scaled_digits(right.coefficient_digits, right_multiplier.numerator),
-        )
-        + 1,
-        rational_content=common_content,
-    )
-    _check_raw_polynomial(result)
-    return result
-
-
-def _differentiate_fraction(
-    source_value: RationalFunction,
-    source_bound: FractionBound,
-    axis: int,
-    ledger: _Ledger,
-) -> FractionBound:
-    ledger.charge(
-        "differentiation",
-        source_bound.numerator.terms + source_bound.denominator.terms,
-    )
-    numerator_active = tuple(
-        term for term in source_value.numerator.terms if term.exponents[axis] > 0
-    )
-    denominator_active = tuple(
-        term for term in source_value.denominator.terms if term.exponents[axis] > 0
-    )
-    if not numerator_active and not denominator_active:
-        return _zero_fraction(len(source_bound.numerator.degrees))
-    numerator_derivative = _differentiate_polynomial(
-        source_bound.numerator,
-        axis,
-        active_terms=len(numerator_active),
-        maximum_axis_exponent=max(
-            (term.exponents[axis] for term in numerator_active), default=1
-        ),
-        minimum_exponents=tuple(
-            min(
-                term.exponents[coordinate] - int(coordinate == axis)
-                for term in numerator_active
-            )
-            for coordinate in range(len(source_value.variables))
-        )
-        if numerator_active
-        else (0,) * len(source_value.variables),
-    )
-    denominator_derivative = _differentiate_polynomial(
-        source_bound.denominator,
-        axis,
-        active_terms=len(denominator_active),
-        maximum_axis_exponent=max(
-            (term.exponents[axis] for term in denominator_active), default=1
-        ),
-        minimum_exponents=tuple(
-            min(
-                term.exponents[coordinate] - int(coordinate == axis)
-                for term in denominator_active
-            )
-            for coordinate in range(len(source_value.variables))
-        )
-        if denominator_active
-        else (0,) * len(source_value.variables),
-    )
-    first = _multiply_polynomials(
-        numerator_derivative, source_bound.denominator, ledger
-    )
-    second = _multiply_polynomials(
-        source_bound.numerator, denominator_derivative, ledger
-    )
-    numerator = _add_polynomials(first, second, ledger)
-    if numerator.is_zero:
-        return _zero_fraction(len(source_bound.numerator.degrees))
-    denominator = _multiply_polynomials(
-        source_bound.denominator, source_bound.denominator, ledger
-    )
-    return FractionBound(numerator=numerator, denominator=denominator)
-
-
-def _multiply_fractions(
-    left: FractionBound,
-    right: FractionBound,
-    ledger: _Ledger,
-) -> FractionBound:
-    if left.is_zero or right.is_zero:
-        return _zero_fraction(len(left.numerator.degrees))
-    return FractionBound(
-        numerator=_multiply_polynomials(left.numerator, right.numerator, ledger),
-        denominator=_multiply_polynomials(left.denominator, right.denominator, ledger),
-    )
-
-
-def _add_fractions(
-    left: FractionBound,
-    right: FractionBound,
-    ledger: _Ledger,
-) -> FractionBound:
-    if left.is_zero:
-        return right
-    if right.is_zero:
-        return left
-    left_scaled = _multiply_polynomials(left.numerator, right.denominator, ledger)
-    right_scaled = _multiply_polynomials(right.numerator, left.denominator, ledger)
-    numerator = _add_polynomials(left_scaled, right_scaled, ledger)
-    if numerator.is_zero:
-        return _zero_fraction(len(left.numerator.degrees))
-    return FractionBound(
-        numerator=numerator,
-        denominator=_multiply_polynomials(left.denominator, right.denominator, ledger),
-    )
-
-
-def _factor_coefficient_digits(bound: PolynomialBound) -> int:
-    """Bound every coefficient of a rational factor of ``bound``.
-
-    Clear source denominators, inject the multivariate polynomial into a
-    univariate polynomial by mixed-radix Kronecker substitution, and apply
-    Mignotte's ``2**degree * l2_norm`` integer-factor height bound.  A factor's
-    degree in each variable cannot exceed the source degree, so the mixed
-    radices introduce no carries in a factorization.
-    """
-
-    if bound.is_zero:
-        return 1
-    kronecker_degree = _dense_term_bound(bound.degrees) - 1
-    binary_factor_digits = (302 * kronecker_degree + 999) // 1000
-    norm_digits = len(format_canonical_integer(bound.terms)) + 1
-    return bound.coefficient_digits + binary_factor_digits + norm_digits + 2
-
-
-def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
-    """Apply exact valuation presolve before the canonical-result proof.
-
-    The coordinatewise minimum exponent is a factor of every monomial. Its
-    common part can therefore be canceled without expanding or factoring a
-    polynomial, which materially widens monomial-denominator requests.
-    """
-
-    if bound.is_zero:
-        return bound
-    common = tuple(
-        min(numerator, denominator)
-        for numerator, denominator in zip(
-            bound.numerator.minimum_exponents,
-            bound.denominator.minimum_exponents,
-            strict=True,
-        )
-    )
-    if not any(common):
-        return bound
-
-    def divide(polynomial: PolynomialBound) -> PolynomialBound:
-        return PolynomialBound(
-            terms=polynomial.terms,
-            degrees=tuple(
-                degree - exponent
-                for degree, exponent in zip(polynomial.degrees, common, strict=True)
-            ),
-            minimum_exponents=tuple(
-                minimum - exponent
-                for minimum, exponent in zip(
-                    polynomial.minimum_exponents, common, strict=True
-                )
-            ),
-            coefficient_digits=polynomial.coefficient_digits,
-            rational_content=polynomial.rational_content,
-        )
-
-    return FractionBound(
-        numerator=divide(bound.numerator), denominator=divide(bound.denominator)
-    )
-
-
-def _canonical_coefficient_digits(bound: FractionBound) -> int:
-    if bound.is_zero:
-        return 1
-    content_ratio = (
-        bound.numerator.rational_content / bound.denominator.rational_content
-    )
-    denominator_is_unit = all(degree == 0 for degree in bound.denominator.degrees)
-    numerator_factor_digits = (
-        bound.numerator.coefficient_digits
-        if denominator_is_unit
-        else _factor_coefficient_digits(bound.numerator)
-    )
-    denominator_factor_digits = (
-        bound.denominator.coefficient_digits
-        if denominator_is_unit
-        else _factor_coefficient_digits(bound.denominator)
-    )
-    return max(
-        len(format_canonical_integer(abs(content_ratio.numerator)))
-        + bound.numerator.coefficient_digits
-        + (0 if denominator_is_unit else numerator_factor_digits),
-        len(format_canonical_integer(content_ratio.denominator))
-        + bound.denominator.coefficient_digits
-        + (0 if denominator_is_unit else denominator_factor_digits),
-        denominator_factor_digits,
-    )
-
-
-def _validate_canonical_result_bound(bound: FractionBound, ledger: _Ledger) -> int:
-    if bound.is_zero:
-        ledger.charge("normalization", 1)
-        return 1
-    for label, polynomial in (
-        ("numerator", bound.numerator),
-        ("denominator", bound.denominator),
-    ):
-        if any(degree > MAX_RATIONAL_TENSOR_EXPONENT for degree in polynomial.degrees):
-            _reject(
-                "result_exponent",
-                f"Lie-derivative {label} can exceed the canonical "
-                f"exponent bound {MAX_RATIONAL_TENSOR_EXPONENT}",
-            )
-        dense_terms = _dense_term_bound(
-            polynomial.degrees,
-            cap=MAX_RATIONAL_TENSOR_POLYNOMIAL_TERMS,
-        )
-        # When the denominator is the unit polynomial, there can be no
-        # cancellation-induced support expansion, so the tracked sparse
-        # term count is the accurate support bound.
-        denominator_is_unit = all(degree == 0 for degree in bound.denominator.degrees)
-        support_terms = polynomial.terms if denominator_is_unit else dense_terms
-        if support_terms > MAX_RATIONAL_TENSOR_POLYNOMIAL_TERMS:
-            _reject(
-                "result_support",
-                f"Lie-derivative {label} can exceed the canonical "
-                f"{MAX_RATIONAL_TENSOR_POLYNOMIAL_TERMS}-term bound",
-            )
-    coefficient_digits = _canonical_coefficient_digits(bound)
-    if coefficient_digits > MAX_RATIONAL_TENSOR_COEFFICIENT_DIGITS:
-        _reject(
-            "result_height",
-            "Lie-derivative normalization can exceed the canonical "
-            f"{MAX_RATIONAL_TENSOR_COEFFICIENT_DIGITS}-digit coefficient bound",
-        )
-    denominator_is_unit = all(degree == 0 for degree in bound.denominator.degrees)
-    numerator_dense = (
-        bound.numerator.terms
-        if denominator_is_unit
-        else _dense_term_bound(bound.numerator.degrees)
-    )
-    denominator_dense = (
-        1 if denominator_is_unit else _dense_term_bound(bound.denominator.degrees)
-    )
-    normalization_degree = max(numerator_dense + denominator_dense - 2, 0)
-    ledger.charge(
-        "normalization",
-        (numerator_dense + denominator_dense)
-        * (normalization_degree + 1)
-        * coefficient_digits,
-    )
-    return coefficient_digits
-
-
 def _component_offset(index: tuple[int, ...], dimension: int) -> int:
     offset = 0
     for coordinate in index:
@@ -693,44 +153,6 @@ def _replace_index(
     index: tuple[int, ...], position: int, replacement: int
 ) -> tuple[int, ...]:
     return (*index[:position], replacement, *index[position + 1 :])
-
-
-def _recognition_work_units(bound: FractionBound) -> int:
-    """Charge the dense exact coefficient work exposed to SymPy's GCD.
-
-    SymPy 1.14 represents a multivariate ``Poly`` as a recursively dense DMP.
-    The product of per-axis degree ranges therefore bounds the coefficients
-    materialized by conversion.  Total degree steps and 32-digit coefficient
-    chunks conservatively price the subsequent exact GCD reductions.  A
-    killable worker still owns wall time and memory because SymPy exposes no
-    cooperative cancellation hook inside ``Poly.gcd``.
-    """
-
-    numerator_dense = _dense_term_bound(bound.numerator.degrees)
-    denominator_dense = _dense_term_bound(bound.denominator.degrees)
-    degree_steps = (
-        sum(
-            max(numerator, denominator)
-            for numerator, denominator in zip(
-                bound.numerator.degrees,
-                bound.denominator.degrees,
-                strict=True,
-            )
-        )
-        + 1
-    )
-    coefficient_digits = max(
-        bound.numerator.coefficient_digits
-        + len(format_canonical_integer(abs(bound.numerator.rational_content.numerator)))
-        + len(format_canonical_integer(bound.numerator.rational_content.denominator)),
-        bound.denominator.coefficient_digits
-        + len(
-            format_canonical_integer(abs(bound.denominator.rational_content.numerator))
-        )
-        + len(format_canonical_integer(bound.denominator.rational_content.denominator)),
-    )
-    coefficient_chunks = max(1, (coefficient_digits + 31) // 32)
-    return (numerator_dense + denominator_dense) * degree_steps * coefficient_chunks
 
 
 def build_lie_derivative_plan(

--- a/src/jacobian/math/geometry/differential/metrics/__init__.py
+++ b/src/jacobian/math/geometry/differential/metrics/__init__.py
@@ -1,0 +1,15 @@
+"""Exact rational metric, Levi-Civita connection and curvature ownership."""
+
+from jacobian.math.geometry.differential.metrics._models import (
+    RationalCoordinateConnection,
+    RationalCoordinateMetric,
+    RationalMetricCurvatureProfile,
+)
+from jacobian.math.geometry.differential.metrics.operations import curvature_profile
+
+__all__ = [
+    "RationalCoordinateConnection",
+    "RationalCoordinateMetric",
+    "RationalMetricCurvatureProfile",
+    "curvature_profile",
+]

--- a/src/jacobian/math/geometry/differential/metrics/_dag.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag.py
@@ -1,0 +1,364 @@
+"""Preflight polynomial DAG with explicitly shared rational denominator factors."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, replace
+from fractions import Fraction
+from typing import NoReturn
+
+from jacobian._execution import request_checkpoint
+from jacobian.canonical import format_canonical_integer
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.polynomials.rational_functions._bounds import (
+    BoundWorkCategory,
+    FractionBound,
+    PolynomialBound,
+    RationalFunctionBoundLimits,
+    _add_polynomials,
+    _check_raw_polynomial,
+    _differentiate_polynomial,
+    _multiply_polynomials,
+    _one_polynomial,
+    _polynomial_admission_work_units,
+    _polynomial_backend_conversion_work_units,
+    _polynomial_bound,
+    _recognition_work_units,
+    _remove_guaranteed_common_monomial,
+    _validate_canonical_result_bound,
+    _zero_polynomial,
+)
+from jacobian.math.polynomials.values import RationalFunction, SparseRationalPolynomial
+
+
+def reject(reason: str, message: str) -> NoReturn:
+    raise OperationResourceAdmissionError(
+        location=("metric",),
+        code=f"differential_geometry.curvature.{reason}",
+        message=message,
+    )
+
+
+class Ledger:
+    limits = RationalFunctionBoundLimits(
+        raw_terms=4096,
+        raw_digits=4096,
+        result_exponent=64,
+        result_terms=256,
+        result_digits=128,
+        label="metric curvature",
+        reject=reject,
+    )
+
+    def __init__(self) -> None:
+        self.work = 0
+        self.allocation_bits = 0
+
+    def charge(self, category: BoundWorkCategory, amount: int) -> None:
+        request_checkpoint(f"admitting metric curvature {category}")
+        self.work += amount
+        if self.work > 50_000_000:
+            reject("work", "complete curvature DAG exceeds 50,000,000 work units")
+
+
+@dataclass(frozen=True)
+class Expression:
+    """Scalar times polynomial-node factors divided by polynomial-node factors."""
+
+    scalar: Fraction = Fraction(1)
+    numerator: tuple[int, ...] = ()
+    denominator: tuple[int, ...] = ()
+
+
+ZERO = Expression(Fraction(0))
+ONE = Expression()
+
+
+@dataclass(frozen=True)
+class Node:
+    operation: str
+    arguments: tuple[int, ...]
+    bound: PolynomialBound
+    source: SparseRationalPolynomial | None = None
+    scalar: Fraction = Fraction(1)
+    axis: int = 0
+
+
+class Dag:
+    """Plan once without polynomial expansion; executor evaluates these nodes.
+
+    Polynomial identity is used only when identical nodes occur. Fraction
+    addition uses a common multiset of denominator factors. Multiplication
+    cancels identical numerator/denominator factors before expansion. These
+    exact structural reductions retain shared metric denominators across the
+    complete inverse/connection/curvature formula.
+    """
+
+    def __init__(self, dimension: int) -> None:
+        self.dimension = dimension
+        self.ledger = Ledger()
+        self.nodes = [
+            Node("ZERO", (), _zero_polynomial(dimension)),
+            Node("ONE", (), _one_polynomial(dimension)),
+        ]
+        self.keys: dict[tuple[object, ...], int] = {}
+
+    def intern(self, key: tuple[object, ...], node: Node) -> int:
+        if key in self.keys:
+            return self.keys[key]
+        _check_raw_polynomial(node.bound, self.ledger.limits)
+        content_digits = len(
+            format_canonical_integer(abs(node.bound.rational_content.numerator))
+        ) + len(format_canonical_integer(node.bound.rational_content.denominator))
+        self.ledger.allocation_bits += max(
+            node.bound.terms, self.dense(node.bound.degrees)
+        ) * (
+            16
+            + 4 * (node.bound.coefficient_digits + content_digits)
+            + 64 * self.dimension
+        )
+        if len(self.nodes) >= 16384 or self.ledger.allocation_bits > 268_435_456:
+            reject("allocation", "curvature DAG exceeds node or coefficient allocation")
+        result = len(self.nodes)
+        self.nodes.append(node)
+        self.keys[key] = result
+        return result
+
+    def source(self, polynomial: SparseRationalPolynomial) -> Expression:
+        self.ledger.charge(
+            "source_conversion",
+            _polynomial_admission_work_units(polynomial, self.dimension),
+        )
+        if not polynomial.terms:
+            return ZERO
+        if len(polynomial.terms) == 1 and not any(polynomial.terms[0].exponents):
+            return Expression(polynomial.terms[0].coefficient.as_fraction())
+        key = (
+            "SOURCE",
+            tuple(
+                (term.exponents, term.coefficient.as_fraction())
+                for term in polynomial.terms
+            ),
+        )
+        if key in self.keys:
+            return Expression(numerator=(self.keys[key],))
+        bound = _polynomial_bound(polynomial)
+        self.ledger.charge(
+            "source_conversion", _polynomial_backend_conversion_work_units(bound)
+        )
+        index = self.intern(key, Node("SOURCE", (), bound, source=polynomial))
+        return Expression(numerator=(index,))
+
+    def fraction(self, value: RationalFunction) -> Expression:
+        numerator, denominator = (
+            self.source(value.numerator),
+            self.source(value.denominator),
+        )
+
+        # Recognition sees the authored numerator and denominator separately.
+        # Preserve those raw bounds before structural factor cancellation can
+        # make a presentation such as x/x look constant. Source conversion
+        # is charged again here for the recognition backend; ``source`` owns
+        # the separate conversion reservation used by the executor.
+        raw_numerator = self.nodes[
+            self.polynomial(numerator.numerator, numerator.scalar)
+        ].bound
+        raw_denominator = self.nodes[
+            self.polynomial(denominator.numerator, denominator.scalar)
+        ].bound
+        raw_bound = FractionBound(raw_numerator, raw_denominator)
+        self.ledger.charge("recognition", _recognition_work_units(raw_bound))
+        self.ledger.charge(
+            "source_conversion",
+            _polynomial_backend_conversion_work_units(raw_numerator)
+            + _polynomial_backend_conversion_work_units(raw_denominator),
+        )
+        result = self.multiply(numerator, self.inverse(denominator))
+        return result
+
+    @staticmethod
+    def inverse(value: Expression) -> Expression:
+        if not value.scalar:
+            raise ZeroDivisionError("zero expression cannot be inverted")
+        return Expression(1 / value.scalar, value.denominator, value.numerator)
+
+    @staticmethod
+    def multiply(*values: Expression) -> Expression:
+        numerator: Counter[int] = Counter()
+        denominator: Counter[int] = Counter()
+        scalar = Fraction(1)
+        for value in values:
+            scalar *= value.scalar
+            if not scalar:
+                return ZERO
+            numerator.update(value.numerator)
+            denominator.update(value.denominator)
+        common = numerator & denominator
+        return Expression(
+            scalar,
+            tuple(sorted((numerator - common).elements())),
+            tuple(sorted((denominator - common).elements())),
+        )
+
+    def polynomial(
+        self, factors: tuple[int, ...], scalar: Fraction = Fraction(1)
+    ) -> int:
+        if not scalar:
+            return 0
+        result = 1
+        for factor in factors:
+            if result == 1:
+                result = factor
+            else:
+                key: tuple[object, ...] = ("MULTIPLY", result, factor)
+                if key in self.keys:
+                    result = self.keys[key]
+                else:
+                    bound = _multiply_polynomials(
+                        self.nodes[result].bound, self.nodes[factor].bound, self.ledger
+                    )
+                    result = self.intern(key, Node("MULTIPLY", (result, factor), bound))
+        if scalar != 1:
+            key = ("SCALE", result, scalar)
+            bound = replace(
+                self.nodes[result].bound,
+                rational_content=self.nodes[result].bound.rational_content * scalar,
+            )
+            result = self.intern(key, Node("SCALE", (result,), bound, scalar=scalar))
+        return result
+
+    def add(self, *values: Expression) -> Expression:
+        grouped: dict[tuple[tuple[int, ...], tuple[int, ...]], Fraction] = {}
+        for value in values:
+            fraction_key = (value.numerator, value.denominator)
+            grouped[fraction_key] = (
+                grouped.get(fraction_key, Fraction(0)) + value.scalar
+            )
+        nonzero = [
+            Expression(scalar, *key)
+            for key, scalar in sorted(grouped.items())
+            if scalar
+        ]
+        if not nonzero:
+            return ZERO
+        if len(nonzero) == 1:
+            return nonzero[0]
+        denominator: Counter[int] = Counter()
+        for value in nonzero:
+            denominator |= Counter(value.denominator)
+        terms = tuple(
+            self.polynomial(
+                tuple(
+                    sorted(
+                        (
+                            *value.numerator,
+                            *(denominator - Counter(value.denominator)).elements(),
+                        )
+                    )
+                ),
+                value.scalar,
+            )
+            for value in nonzero
+        )
+        key = ("ADD", *terms)
+        if key in self.keys:
+            result = self.keys[key]
+        else:
+            bound = self.nodes[terms[0]].bound
+            for term in terms[1:]:
+                bound = _add_polynomials(bound, self.nodes[term].bound, self.ledger)
+            result = self.intern(key, Node("ADD", terms, bound))
+        return Expression(
+            numerator=(result,), denominator=tuple(sorted(denominator.elements()))
+        )
+
+    def derivative(self, value: Expression, axis: int) -> Expression:
+        if not value.scalar:
+            return ZERO
+        numerator = self.polynomial(value.numerator)
+        denominator = self.polynomial(value.denominator)
+        a, b = self.nodes[numerator].bound, self.nodes[denominator].bound
+        if a.degrees[axis] == b.degrees[axis] == 0:
+            return ZERO
+        key = ("DERIVATIVE", numerator, denominator, axis)
+        if key in self.keys:
+            result = self.keys[key]
+        else:
+
+            def differential(bound: PolynomialBound) -> PolynomialBound:
+                return _differentiate_polynomial(
+                    bound,
+                    axis,
+                    self.ledger,
+                    active_terms=bound.terms if bound.degrees[axis] else 0,
+                    maximum_axis_exponent=max(1, bound.degrees[axis]),
+                    minimum_exponents=tuple(
+                        max(0, e - int(i == axis))
+                        for i, e in enumerate(bound.minimum_exponents)
+                    ),
+                )
+
+            da, db = differential(a), differential(b)
+            self.ledger.charge("differentiation", a.terms + b.terms)
+            # The quotient-rule kernel materializes D squared even when
+            # later factor cancellation removes it from the result.
+            temporary = _multiply_polynomials(b, b, self.ledger)
+            temporary_digits = (
+                temporary.coefficient_digits
+                + len(
+                    format_canonical_integer(abs(temporary.rational_content.numerator))
+                )
+                + len(format_canonical_integer(temporary.rational_content.denominator))
+            )
+            self.ledger.allocation_bits += self.dense(temporary.degrees) * (
+                64 * self.dimension + 4 * temporary_digits + 16
+            )
+            bound = _add_polynomials(
+                _multiply_polynomials(da, b, self.ledger),
+                _multiply_polynomials(a, db, self.ledger),
+                self.ledger,
+            )
+            result = self.intern(
+                key, Node("DERIVATIVE", (numerator, denominator), bound, axis=axis)
+            )
+        return Expression(value.scalar, (result,), tuple(sorted(value.denominator * 2)))
+
+    def bound(self, value: Expression) -> FractionBound:
+        return FractionBound(
+            self.nodes[self.polynomial(value.numerator, value.scalar)].bound,
+            self.nodes[self.polynomial(value.denominator)].bound,
+        )
+
+    def admit_output(self, value: Expression) -> tuple[int, int, int]:
+        """Bound canonical polynomial terms, coefficient bits and coordinate slots."""
+        if not value.numerator and not value.denominator:
+            # Exact scalar metadata avoids charging a factor-height bound to
+            # unchanged constant metric entries or their reciprocals.
+            digits = max(
+                len(format_canonical_integer(abs(value.scalar.numerator))),
+                len(format_canonical_integer(value.scalar.denominator)),
+            )
+            if digits > 128:
+                reject(
+                    "result_height", "constant result exceeds 128 coefficient digits"
+                )
+            self.ledger.charge("normalization", 1)
+            terms = 1 + int(bool(value.scalar))
+            return terms, 8 * digits * terms, self.dimension * (terms + 2)
+        bound = _remove_guaranteed_common_monomial(self.bound(value))
+        digits = _validate_canonical_result_bound(bound, self.ledger)
+        terms = sum(
+            min(256, self.dense(part.degrees))
+            for part in (bound.numerator, bound.denominator)
+        )
+        # Both integers in each rational coefficient have fewer than 4h
+        # bits for h decimal digits. Each term retains its exponent vector,
+        # and each numerator/denominator polynomial retains its variable axis.
+        return terms, 8 * digits * terms, self.dimension * (terms + 2)
+
+    @staticmethod
+    def dense(degrees: tuple[int, ...]) -> int:
+        result = 1
+        for degree in degrees:
+            result *= degree + 1
+        return result

--- a/src/jacobian/math/geometry/differential/metrics/_dag_process.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag_process.py
@@ -1,0 +1,172 @@
+"""Killable SymPy expansion for an admitted metric-curvature polynomial DAG."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from time import monotonic
+from typing import Any
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+    loads_strict_json,
+)
+from jacobian.math.geometry.differential.metrics._dag import Node
+from jacobian.math.polynomials._conversions import symbols_for_variables
+from jacobian.math.polynomials.values import SparseRationalPolynomial
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_WORKER_PATH = Path(__file__).resolve().with_name("_dag_worker.py")
+_STDOUT_BYTES = 64 * 1024 * 1024
+_STDERR_BYTES = 64 * 1024
+_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_PARENT_FINALIZATION_SECONDS = 0.05
+
+
+def _source_payload(polynomial: SparseRationalPolynomial) -> list[list[object]]:
+    return [
+        [*term.exponents, str(term.coefficient.num), str(term.coefficient.den)]
+        for term in polynomial.terms
+    ]
+
+
+def _node_payload(node: Node) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "operation": node.operation,
+        "arguments": list(node.arguments),
+    }
+    if node.source is not None:
+        payload["source"] = _source_payload(node.source)
+    if node.operation == "SCALE":
+        payload["scalar"] = [
+            str(node.scalar.numerator),
+            str(node.scalar.denominator),
+        ]
+    if node.operation == "DERIVATIVE":
+        payload["axis"] = node.axis
+    return payload
+
+
+def _poly_from_payload(records: object, symbols: tuple[Any, ...]) -> Any:
+    from sympy import QQ, Poly, Rational
+
+    if not isinstance(records, list):
+        raise ValueError("malformed expanded polynomial")
+    coefficients: dict[tuple[int, ...], Any] = {}
+    variable_count = len(symbols)
+    for record in records:
+        if not isinstance(record, list) or len(record) != variable_count + 2:
+            raise ValueError("malformed expanded polynomial")
+        exponents = tuple(record[:variable_count])
+        if any(type(exponent) is not int or exponent < 0 for exponent in exponents):
+            raise ValueError("malformed expanded polynomial")
+        numerator, denominator = record[-2], record[-1]
+        if not isinstance(numerator, str) or not isinstance(denominator, str):
+            raise ValueError("malformed expanded polynomial")
+        coefficients[exponents] = Rational(int(numerator), int(denominator))
+    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+
+
+def evaluate_polynomial_dag(
+    nodes: list[Node], axis: tuple[str, ...], *, deadline: float
+) -> tuple[list[Any], tuple[Any, ...]]:
+    """Expand one admitted DAG in a killable worker under the shared deadline.
+
+    Expanded polynomials remain as worker term dumps. The parent materializes
+    only the nodes later consumed, under the remaining request deadline.
+    """
+
+    remaining = deadline - monotonic() - _PARENT_FINALIZATION_SECONDS
+    if remaining <= 0:
+        raise OperationExecutionTimeoutError(
+            "metric curvature deadline expired before DAG expansion"
+        )
+    payload = encode_strict_json(
+        {
+            "variables": list(axis),
+            "nodes": [_node_payload(node) for node in nodes],
+        }
+    )
+    try:
+        with TemporaryDirectory(prefix="jacobian-metric-dag-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_WORKER_PATH)],
+                input_bytes=payload,
+                timeout_seconds=remaining,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_STDOUT_BYTES,
+                stderr_limit=_STDERR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(remaining)),
+                    address_space_bytes=_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_STDOUT_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded metric-curvature DAG worker could not be started"
+        ) from exc
+    if completed.cancelled:
+        raise OperationExecutionCancelledError(
+            "metric curvature cancelled during polynomial DAG expansion"
+        )
+    if completed.timed_out:
+        raise OperationExecutionTimeoutError(
+            "metric curvature deadline expired during polynomial DAG expansion"
+        )
+    if (
+        completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        raise RuntimeError(
+            "bounded metric-curvature DAG worker did not return expanded polynomials"
+        )
+    try:
+        response = loads_strict_json(
+            completed.stdout,
+            limits=CanonicalLimits(
+                max_input_bytes=_STDOUT_BYTES,
+                max_output_bytes=_STDOUT_BYTES,
+            ),
+        )
+    except CanonicalizationError as exc:
+        raise RuntimeError(
+            "bounded metric-curvature DAG worker returned malformed output"
+        ) from exc
+    if (
+        not isinstance(response, dict)
+        or response.get("status") != "ok"
+        or not isinstance(response.get("values"), list)
+        or len(response["values"]) != len(nodes)
+    ):
+        raise RuntimeError(
+            "bounded metric-curvature DAG worker returned malformed output"
+        )
+    generators = symbols_for_variables(axis)
+    return response["values"], generators
+
+
+def materialize_expanded_polynomial(
+    records: object, symbols: tuple[Any, ...], *, deadline: float
+) -> Any:
+    """Decode one worker polynomial under the remaining request deadline."""
+
+    if monotonic() >= deadline:
+        raise OperationExecutionTimeoutError(
+            "metric curvature deadline expired during polynomial DAG decoding"
+        )
+    return _poly_from_payload(records, symbols)

--- a/src/jacobian/math/geometry/differential/metrics/_dag_process.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag_process.py
@@ -17,6 +17,7 @@ from jacobian.canonical import (
     CanonicalizationError,
     CanonicalLimits,
     encode_strict_json,
+    format_canonical_integer,
     loads_strict_json,
 )
 from jacobian.math.geometry.differential.metrics._dag import Node
@@ -37,7 +38,11 @@ _PARENT_FINALIZATION_SECONDS = 0.05
 
 def _source_payload(polynomial: SparseRationalPolynomial) -> list[list[object]]:
     return [
-        [*term.exponents, str(term.coefficient.num), str(term.coefficient.den)]
+        [
+            *term.exponents,
+            format_canonical_integer(term.coefficient.num),
+            format_canonical_integer(term.coefficient.den),
+        ]
         for term in polynomial.terms
     ]
 

--- a/src/jacobian/math/geometry/differential/metrics/_dag_worker.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag_worker.py
@@ -35,6 +35,54 @@ def _dump(polynomial: Any) -> list[list[Any]]:
     ]
 
 
+def _apply_operation(
+    operation: object,
+    arguments: list[int],
+    node: dict[str, Any],
+    cache: list[Any],
+    generators: tuple[Any, ...],
+    variable_count: int,
+) -> Any:
+    from sympy import QQ
+
+    if operation == "ZERO":
+        return cache[0]
+    if operation == "ONE":
+        return cache[1]
+    if operation == "SOURCE":
+        source = node.get("source")
+        if not isinstance(source, list):
+            raise ValueError("malformed SOURCE node")
+        return _polynomial(source, generators)
+    if operation == "SCALE":
+        scalar = node.get("scalar")
+        if (
+            not isinstance(scalar, list)
+            or len(scalar) != 2
+            or not isinstance(scalar[0], str)
+            or not isinstance(scalar[1], str)
+            or len(arguments) != 1
+        ):
+            raise ValueError("malformed SCALE node")
+        return cache[arguments[0]].mul_ground(QQ(int(scalar[0]), int(scalar[1])))
+    if operation == "MULTIPLY":
+        if len(arguments) != 2:
+            raise ValueError("malformed MULTIPLY node")
+        return cache[arguments[0]] * cache[arguments[1]]
+    if operation == "ADD":
+        return sum((cache[argument] for argument in arguments), cache[0])
+    if operation == "DERIVATIVE":
+        if len(arguments) != 2:
+            raise ValueError("malformed DERIVATIVE node")
+        axis = node.get("axis")
+        if type(axis) is not int or not 0 <= axis < variable_count:
+            raise ValueError("malformed DERIVATIVE node")
+        numerator = cache[arguments[0]]
+        denominator = cache[arguments[1]]
+        return numerator.diff(axis) * denominator - numerator * denominator.diff(axis)
+    raise ValueError("unknown DAG operation")
+
+
 def _run(payload: dict[str, Any]) -> dict[str, Any]:
     from sympy import QQ, Poly, Symbol
 
@@ -56,52 +104,20 @@ def _run(payload: dict[str, Any]) -> dict[str, Any]:
     for index, node in enumerate(nodes):
         if not isinstance(node, dict):
             raise ValueError("malformed DAG node")
-        operation = node.get("operation")
         arguments = node.get("arguments")
         if not isinstance(arguments, list) or any(
             type(argument) is not int or argument < 0 or argument >= index
             for argument in arguments
         ):
             raise ValueError("malformed DAG node")
-        if operation == "ZERO":
-            result = cache[0]
-        elif operation == "ONE":
-            result = cache[1]
-        elif operation == "SOURCE":
-            source = node.get("source")
-            if not isinstance(source, list):
-                raise ValueError("malformed SOURCE node")
-            result = _polynomial(source, generators)
-        elif operation == "SCALE":
-            scalar = node.get("scalar")
-            if (
-                not isinstance(scalar, list)
-                or len(scalar) != 2
-                or not isinstance(scalar[0], str)
-                or not isinstance(scalar[1], str)
-                or len(arguments) != 1
-            ):
-                raise ValueError("malformed SCALE node")
-            result = cache[arguments[0]].mul_ground(QQ(int(scalar[0]), int(scalar[1])))
-        elif operation == "MULTIPLY":
-            if len(arguments) != 2:
-                raise ValueError("malformed MULTIPLY node")
-            result = cache[arguments[0]] * cache[arguments[1]]
-        elif operation == "ADD":
-            result = sum((cache[argument] for argument in arguments), cache[0])
-        elif operation == "DERIVATIVE":
-            if len(arguments) != 2:
-                raise ValueError("malformed DERIVATIVE node")
-            axis = node.get("axis")
-            if type(axis) is not int or not 0 <= axis < variable_count:
-                raise ValueError("malformed DERIVATIVE node")
-            numerator = cache[arguments[0]]
-            denominator = cache[arguments[1]]
-            result = numerator.diff(axis) * denominator - numerator * denominator.diff(
-                axis
-            )
-        else:
-            raise ValueError("unknown DAG operation")
+        result = _apply_operation(
+            node.get("operation"),
+            arguments,
+            node,
+            cache,
+            generators,
+            variable_count,
+        )
         if index < 2:
             continue
         cache.append(result)

--- a/src/jacobian/math/geometry/differential/metrics/_dag_worker.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag_worker.py
@@ -100,7 +100,10 @@ def _run(payload: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("malformed DAG request")
     variable_count = len(variables)
     generators = tuple(Symbol(name) for name in variables)
-    cache: list[Any] = [Poly(0, *generators, domain=QQ), Poly(1, *generators, domain=QQ)]
+    cache: list[Any] = [
+        Poly(0, *generators, domain=QQ),
+        Poly(1, *generators, domain=QQ),
+    ]
     for index, node in enumerate(nodes):
         if not isinstance(node, dict):
             raise ValueError("malformed DAG node")

--- a/src/jacobian/math/geometry/differential/metrics/_dag_worker.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag_worker.py
@@ -1,0 +1,126 @@
+"""Standalone SymPy worker for admitted metric-curvature DAG expansion."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def _polynomial(records: list[Any], symbols: tuple[Any, ...]) -> Any:
+    from sympy import QQ, Poly, Rational
+
+    coefficients: dict[tuple[int, ...], Any] = {}
+    variable_count = len(symbols)
+    for record in records:
+        if not isinstance(record, list) or len(record) != variable_count + 2:
+            raise ValueError("malformed polynomial record")
+        exponents = tuple(record[:variable_count])
+        numerator = record[-2]
+        denominator = record[-1]
+        if (
+            any(type(exponent) is not int or exponent < 0 for exponent in exponents)
+            or not isinstance(numerator, str)
+            or not isinstance(denominator, str)
+        ):
+            raise ValueError("malformed polynomial record")
+        coefficients[exponents] = Rational(int(numerator), int(denominator))
+    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+
+
+def _dump(polynomial: Any) -> list[list[Any]]:
+    return [
+        [*exponents, str(coefficient.p), str(coefficient.q)]
+        for exponents, coefficient in polynomial.terms()
+    ]
+
+
+def _run(payload: dict[str, Any]) -> dict[str, Any]:
+    from sympy import QQ, Poly, Symbol
+
+    if set(payload) != {"variables", "nodes"}:
+        raise ValueError("malformed DAG request")
+    variables = payload["variables"]
+    nodes = payload["nodes"]
+    if (
+        not isinstance(variables, list)
+        or not variables
+        or any(not isinstance(name, str) or not name for name in variables)
+        or not isinstance(nodes, list)
+        or len(nodes) < 2
+    ):
+        raise ValueError("malformed DAG request")
+    variable_count = len(variables)
+    generators = tuple(Symbol(name) for name in variables)
+    cache: list[Any] = [Poly(0, *generators, domain=QQ), Poly(1, *generators, domain=QQ)]
+    for index, node in enumerate(nodes):
+        if not isinstance(node, dict):
+            raise ValueError("malformed DAG node")
+        operation = node.get("operation")
+        arguments = node.get("arguments")
+        if not isinstance(arguments, list) or any(
+            type(argument) is not int or argument < 0 or argument >= index
+            for argument in arguments
+        ):
+            raise ValueError("malformed DAG node")
+        if operation == "ZERO":
+            result = cache[0]
+        elif operation == "ONE":
+            result = cache[1]
+        elif operation == "SOURCE":
+            source = node.get("source")
+            if not isinstance(source, list):
+                raise ValueError("malformed SOURCE node")
+            result = _polynomial(source, generators)
+        elif operation == "SCALE":
+            scalar = node.get("scalar")
+            if (
+                not isinstance(scalar, list)
+                or len(scalar) != 2
+                or not isinstance(scalar[0], str)
+                or not isinstance(scalar[1], str)
+                or len(arguments) != 1
+            ):
+                raise ValueError("malformed SCALE node")
+            result = cache[arguments[0]].mul_ground(QQ(int(scalar[0]), int(scalar[1])))
+        elif operation == "MULTIPLY":
+            if len(arguments) != 2:
+                raise ValueError("malformed MULTIPLY node")
+            result = cache[arguments[0]] * cache[arguments[1]]
+        elif operation == "ADD":
+            result = sum((cache[argument] for argument in arguments), cache[0])
+        elif operation == "DERIVATIVE":
+            if len(arguments) != 2:
+                raise ValueError("malformed DERIVATIVE node")
+            axis = node.get("axis")
+            if type(axis) is not int or not 0 <= axis < variable_count:
+                raise ValueError("malformed DERIVATIVE node")
+            numerator = cache[arguments[0]]
+            denominator = cache[arguments[1]]
+            result = numerator.diff(axis) * denominator - numerator * denominator.diff(
+                axis
+            )
+        else:
+            raise ValueError("unknown DAG operation")
+        if index < 2:
+            continue
+        cache.append(result)
+    return {"status": "ok", "values": [_dump(value) for value in cache]}
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("malformed DAG request")
+        response = _run(payload)
+    except Exception:
+        return 1
+    sys.stdout.buffer.write(
+        json.dumps(response, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/geometry/differential/metrics/_models.py
+++ b/src/jacobian/math/geometry/differential/metrics/_models.py
@@ -1,0 +1,146 @@
+"""Rational coordinate metrics and their complete curvature profiles."""
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.geometry.differential.values import (
+    RationalCoordinateTensor,
+    _is_unit_polynomial,
+    _polynomial_key,
+)
+from jacobian.math.polynomials.values import (
+    PolynomialVariable,
+    RationalFunction,
+    SparseRationalPolynomial,
+    require_sparse_polynomial_budget,
+)
+
+
+class RationalCoordinateMetric(StrictModel):
+    """A symmetric covariant tensor on its generic nondegenerate locus.
+
+    Nondegeneracy is established by the consuming operation. No signature,
+    positivity, global chart, or completeness is asserted by this value.
+    """
+
+    tensor: RationalCoordinateTensor
+    chart_semantics: Literal["GENERIC_NONDEGENERATE_LOCUS"] = (
+        "GENERIC_NONDEGENERATE_LOCUS"
+    )
+
+    @model_validator(mode="after")
+    def require_metric_shape(self) -> Self:
+        n = len(self.tensor.coordinate_axis)
+        if n > 4 or self.tensor.variance != ("COVARIANT", "COVARIANT"):
+            raise ValueError("metric must be a covariant rank-two tensor on 1..4 axes")
+        if any(
+            self.tensor.components[i * n + j] != self.tensor.components[j * n + i]
+            for i in range(n)
+            for j in range(i)
+        ):
+            raise ValueError("metric components must be symmetric")
+        return self
+
+
+class RationalCoordinateConnection(StrictModel):
+    """Connection coefficients Gamma^k_ij in the ordered coordinate frame.
+
+    Components follow (k,i,j), last index fastest. A connection is not a
+    tensor; its coordinates and retained chart locus travel with its values.
+    """
+
+    coordinate_axis: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    components: tuple[RationalFunction, ...] = Field(min_length=1, max_length=64)
+    retained_nonzero_denominators: tuple[SparseRationalPolynomial, ...] = Field(
+        max_length=768
+    )
+
+    @model_validator(mode="after")
+    def require_connection_shape(self) -> Self:
+        if len(set(self.coordinate_axis)) != len(self.coordinate_axis):
+            raise ValueError("connection coordinate axis must be unique")
+        if len(self.components) != len(self.coordinate_axis) ** 3:
+            raise ValueError("connection requires exactly n cubed components")
+        if any(value.variables != self.coordinate_axis for value in self.components):
+            raise ValueError(
+                "connection components must use its complete ordered field"
+            )
+        keys = []
+        for guard in self.retained_nonzero_denominators:
+            if not guard.terms or any(
+                len(term.exponents) != len(self.coordinate_axis) for term in guard.terms
+            ):
+                raise ValueError(
+                    "connection guards must be nonzero on the coordinate field"
+                )
+            if guard.terms[0].coefficient.as_fraction() != 1 or _is_unit_polynomial(
+                guard, len(self.coordinate_axis)
+            ):
+                raise ValueError("connection guards must be monic and nonconstant")
+            require_sparse_polynomial_budget(
+                guard,
+                maximum_terms=256,
+                maximum_exponent=64,
+                maximum_coefficient_digits=128,
+                label="connection locus guard",
+            )
+            keys.append(_polynomial_key(guard))
+        if keys != sorted(set(keys)):
+            raise ValueError("connection guards must be unique and canonically ordered")
+        key_set = set(keys)
+        if any(
+            not _is_unit_polynomial(value.denominator, len(self.coordinate_axis))
+            and _polynomial_key(value.denominator) not in key_set
+            for value in self.components
+        ):
+            raise ValueError("connection locus must retain every component denominator")
+        return self
+
+
+class RationalMetricCurvatureRequest(StrictModel):
+    metric: RationalCoordinateMetric
+
+
+class RationalMetricCurvatureProfile(StrictModel):
+    """Exact source-bound curvature on the retained nondegenerate locus.
+
+    Riemann components use (l,k,i,j): [nabla_i,nabla_j]v^l=R^l_kij v^k.
+    Ricci uses (k,j): Ric_kj=sum_i R^i_kij. Scalar curvature contracts
+    inverse_metric with ricci. Component decoding does not replay these
+    operation-owned identities.
+    """
+
+    metric: RationalCoordinateMetric
+    inverse_metric: RationalCoordinateTensor
+    connection: RationalCoordinateConnection
+    riemann: RationalCoordinateTensor
+    ricci: RationalCoordinateTensor
+    scalar_curvature: RationalCoordinateTensor
+
+    @model_validator(mode="after")
+    def require_profile_axes(self) -> Self:
+        axis = self.metric.tensor.coordinate_axis
+        guards = self.connection.retained_nonzero_denominators
+        if self.connection.coordinate_axis != axis:
+            raise ValueError("connection must retain the metric coordinate axis")
+        for value, variance in (
+            (self.inverse_metric, ("CONTRAVARIANT", "CONTRAVARIANT")),
+            (self.riemann, ("CONTRAVARIANT", "COVARIANT", "COVARIANT", "COVARIANT")),
+            (self.ricci, ("COVARIANT", "COVARIANT")),
+            (self.scalar_curvature, ()),
+        ):
+            if (
+                value.coordinate_axis != axis
+                or value.variance != variance
+                or value.retained_nonzero_denominators != guards
+            ):
+                raise ValueError(
+                    "profile tensors must retain their declared axes, variance and locus"
+                )
+        if not set(
+            map(_polynomial_key, self.metric.tensor.retained_nonzero_denominators)
+        ) <= set(map(_polynomial_key, guards)):
+            raise ValueError("profile must retain every source locus guard")
+        return self

--- a/src/jacobian/math/geometry/differential/metrics/_normalize_process.py
+++ b/src/jacobian/math/geometry/differential/metrics/_normalize_process.py
@@ -1,0 +1,140 @@
+"""Killable SymPy cancellation for admitted curvature components."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from time import monotonic
+from typing import Any
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+    loads_strict_json,
+)
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_WORKER_PATH = Path(__file__).resolve().with_name("_normalize_worker.py")
+_STDOUT_BYTES = 8 * 1024 * 1024
+_STDERR_BYTES = 64 * 1024
+_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_PARENT_FINALIZATION_SECONDS = 1.0
+
+
+def _poly_payload(polynomial: Any) -> list[list[Any]]:
+    return [
+        [*exponents, str(coefficient.p), str(coefficient.q)]
+        for exponents, coefficient in polynomial.terms()
+    ]
+
+
+def _poly_from_payload(records: object, symbols: tuple[Any, ...]) -> Any:
+    from sympy import QQ, Poly, Rational
+
+    if not isinstance(records, list):
+        raise ValueError("malformed cancelled polynomial")
+    coefficients: dict[tuple[int, ...], Any] = {}
+    variable_count = len(symbols)
+    for record in records:
+        if not isinstance(record, list) or len(record) != variable_count + 2:
+            raise ValueError("malformed cancelled polynomial")
+        exponents = tuple(record[:variable_count])
+        if any(type(exponent) is not int or exponent < 0 for exponent in exponents):
+            raise ValueError("malformed cancelled polynomial")
+        numerator, denominator = record[-2], record[-1]
+        if not isinstance(numerator, str) or not isinstance(denominator, str):
+            raise ValueError("malformed cancelled polynomial")
+        coefficients[exponents] = Rational(int(numerator), int(denominator))
+    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+
+
+def cancel_fraction(
+    numerator: Any, denominator: Any, *, deadline: float
+) -> tuple[Any, Any]:
+    """Cancel one admitted pair in a killable worker under the shared deadline."""
+
+    remaining = deadline - monotonic() - _PARENT_FINALIZATION_SECONDS
+    if remaining <= 0:
+        raise OperationExecutionTimeoutError(
+            "metric curvature deadline expired before cancellation"
+        )
+    payload = encode_strict_json(
+        {
+            "variable_count": len(numerator.gens),
+            "numerator": _poly_payload(numerator),
+            "denominator": _poly_payload(denominator),
+        }
+    )
+    try:
+        with TemporaryDirectory(prefix="jacobian-metric-cancel-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_WORKER_PATH)],
+                input_bytes=payload,
+                timeout_seconds=remaining,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_STDOUT_BYTES,
+                stderr_limit=_STDERR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(remaining)),
+                    address_space_bytes=_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_STDOUT_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded metric-curvature cancellation worker could not be started"
+        ) from exc
+    if completed.cancelled:
+        raise OperationExecutionCancelledError(
+            "metric curvature cancelled during fraction cancellation"
+        )
+    if completed.timed_out:
+        raise OperationExecutionTimeoutError(
+            "metric curvature deadline expired during fraction cancellation"
+        )
+    if (
+        completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        raise RuntimeError(
+            "bounded metric-curvature cancellation worker did not return a fraction"
+        )
+    try:
+        response = loads_strict_json(
+            completed.stdout,
+            limits=CanonicalLimits(
+                max_input_bytes=_STDOUT_BYTES,
+                max_output_bytes=_STDOUT_BYTES,
+            ),
+        )
+    except CanonicalizationError as exc:
+        raise RuntimeError(
+            "bounded metric-curvature cancellation worker returned malformed output"
+        ) from exc
+    if (
+        not isinstance(response, dict)
+        or response.get("status") != "ok"
+        or "numerator" not in response
+        or "denominator" not in response
+    ):
+        raise RuntimeError(
+            "bounded metric-curvature cancellation worker returned malformed output"
+        )
+    symbols = tuple(numerator.gens)
+    return (
+        _poly_from_payload(response["numerator"], symbols),
+        _poly_from_payload(response["denominator"], symbols),
+    )

--- a/src/jacobian/math/geometry/differential/metrics/_normalize_worker.py
+++ b/src/jacobian/math/geometry/differential/metrics/_normalize_worker.py
@@ -1,0 +1,110 @@
+"""Standalone SymPy worker for admitted rational-function cancellation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def _polynomial(records: list[Any], symbols: tuple[Any, ...]) -> Any:
+    from sympy import QQ, Poly, Rational
+
+    coefficients: dict[tuple[int, ...], Any] = {}
+    variable_count = len(symbols)
+    for record in records:
+        if not isinstance(record, list) or len(record) != variable_count + 2:
+            raise ValueError("malformed polynomial record")
+        exponents = tuple(record[:variable_count])
+        numerator = record[-2]
+        denominator = record[-1]
+        if (
+            any(type(exponent) is not int or exponent < 0 for exponent in exponents)
+            or not isinstance(numerator, str)
+            or not isinstance(denominator, str)
+        ):
+            raise ValueError("malformed polynomial record")
+        coefficients[exponents] = Rational(int(numerator), int(denominator))
+    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+
+
+def _dump(polynomial: Any) -> list[list[Any]]:
+    return [
+        [
+            *exponents,
+            str(coefficient.p),
+            str(coefficient.q),
+        ]
+        for exponents, coefficient in polynomial.terms()
+    ]
+
+
+def _run(payload: dict[str, Any]) -> dict[str, Any]:
+    from sympy import symbols
+
+    if set(payload) != {"variable_count", "numerator", "denominator"}:
+        raise ValueError("malformed cancellation request")
+    variable_count = payload["variable_count"]
+    if (
+        type(variable_count) is not int
+        or variable_count < 1
+        or not isinstance(payload["numerator"], list)
+        or not isinstance(payload["denominator"], list)
+    ):
+        raise ValueError("malformed cancellation request")
+    generators = symbols(f"x0:{variable_count}")
+    numerator = _polynomial(payload["numerator"], generators)
+    denominator = _polynomial(payload["denominator"], generators)
+    if not numerator.is_zero:
+        numerator_terms, denominator_terms = numerator.terms(), denominator.terms()
+        common = tuple(
+            min(
+                min(exponents[axis] for exponents, _ in numerator_terms),
+                min(exponents[axis] for exponents, _ in denominator_terms),
+            )
+            for axis in range(variable_count)
+        )
+        if any(common):
+            from sympy import Poly
+
+            def divide(value: Any) -> Any:
+                return Poly.from_dict(
+                    {
+                        tuple(
+                            exponent - shift
+                            for exponent, shift in zip(exponents, common, strict=True)
+                        ): coefficient
+                        for exponents, coefficient in value.terms()
+                    },
+                    value.gens,
+                    domain=value.domain,
+                )
+
+            numerator, denominator = divide(numerator), divide(denominator)
+    numerator, denominator = numerator.cancel(denominator, include=True)
+    leading = denominator.LC()
+    numerator = numerator.mul_ground(1 / leading)
+    denominator = denominator.mul_ground(1 / leading)
+    return {
+        "status": "ok",
+        "numerator": _dump(numerator),
+        "denominator": _dump(denominator),
+    }
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("malformed cancellation request")
+        response = _run(payload)
+    except Exception:
+        return 1
+    sys.stdout.buffer.write(
+        json.dumps(response, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/geometry/differential/metrics/_plan.py
+++ b/src/jacobian/math/geometry/differential/metrics/_plan.py
@@ -1,0 +1,240 @@
+"""Complete metric, inverse, connection and curvature DAG admission."""
+
+from dataclasses import dataclass
+from fractions import Fraction
+from itertools import permutations, product
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.differential.metrics._dag import (
+    ONE,
+    ZERO,
+    Dag,
+    Expression,
+    reject,
+)
+from jacobian.math.geometry.differential.metrics._models import RationalCoordinateMetric
+from jacobian.math.polynomials.values import SparseRationalPolynomial
+
+
+def singular() -> OperationDomainValidationError:
+    return OperationDomainValidationError(
+        location=("metric",),
+        code="differential_geometry.curvature.singular_metric",
+        message="metric determinant is identically zero",
+    )
+
+
+def _has_nonconstant_denominator(dag: Dag, value: Expression) -> bool:
+    """Return whether an expression carries a genuine polynomial denominator.
+
+    Guard admission works on complete expressions, since distinct numerators
+    can canonicalize to distinct denominator factors even when the DAG shares
+    one denominator node.
+    """
+
+    return any(
+        any(degree for degree in dag.nodes[index].bound.degrees)
+        for index in value.denominator
+    )
+
+
+@dataclass(frozen=True)
+class Plan:
+    dag: Dag
+    fractions: dict[Expression, tuple[int, int]]
+    determinant: Expression
+    inverse: tuple[Expression, ...]
+    connection: tuple[Expression, ...]
+    riemann: tuple[Expression, ...]
+    ricci: tuple[Expression, ...]
+    scalar: Expression
+
+
+def build_plan(metric: RationalCoordinateMetric) -> Plan:
+    n = len(metric.tensor.coordinate_axis)
+    dag = Dag(n)
+    entries = tuple(dag.fraction(value) for value in metric.tensor.components)
+
+    def determinant(rows: tuple[int, ...], columns: tuple[int, ...]) -> Expression:
+        terms = []
+        for permutation in permutations(columns):
+            sign = (-1) ** sum(
+                permutation[i] > permutation[j]
+                for i in range(len(permutation))
+                for j in range(i + 1, len(permutation))
+            )
+            # The permutation sign is relative to the ordered column subset.
+            terms.append(
+                dag.multiply(
+                    Expression(Fraction(sign)),
+                    *(
+                        entries[i * n + j]
+                        for i, j in zip(rows, permutation, strict=True)
+                    ),
+                )
+            )
+        return dag.add(*terms) if terms else ONE
+
+    axes = tuple(range(n))
+    det = determinant(axes, axes)
+    if not det.scalar:
+        raise singular()
+    inverse = tuple(
+        dag.multiply(
+            Expression(Fraction((-1) ** (i + j))),
+            determinant(
+                tuple(k for k in axes if k != j), tuple(k for k in axes if k != i)
+            ),
+            dag.inverse(det),
+        )
+        for i, j in product(axes, repeat=2)
+    )
+    derivatives = {
+        (index, axis): dag.derivative(value, axis)
+        for index, value in enumerate(entries)
+        for axis in axes
+    }
+    connection_list = [ZERO] * n**3
+    for k in axes:
+        for i in axes:
+            for j in range(i, n):
+                value = dag.multiply(
+                    Expression(Fraction(1, 2)),
+                    dag.add(
+                        *(
+                            dag.multiply(
+                                inverse[k * n + upper],
+                                dag.add(
+                                    derivatives[upper * n + j, i],
+                                    derivatives[upper * n + i, j],
+                                    dag.multiply(
+                                        Expression(Fraction(-1)),
+                                        derivatives[i * n + j, upper],
+                                    ),
+                                ),
+                            )
+                            for upper in axes
+                        )
+                    ),
+                )
+                connection_list[(k * n + i) * n + j] = value
+                connection_list[(k * n + j) * n + i] = value
+    connection = tuple(connection_list)
+
+    def gamma(k: int, i: int, j: int) -> Expression:
+        return connection[(k * n + i) * n + j]
+
+    riemann_list = [ZERO] * n**4
+    for upper, k, i in product(axes, repeat=3):
+        for j in range(i + 1, n):
+            value = dag.add(
+                dag.derivative(gamma(upper, j, k), i),
+                dag.multiply(
+                    Expression(Fraction(-1)), dag.derivative(gamma(upper, i, k), j)
+                ),
+                *(dag.multiply(gamma(upper, i, m), gamma(m, j, k)) for m in axes),
+                *(
+                    dag.multiply(
+                        Expression(Fraction(-1)), gamma(upper, j, m), gamma(m, i, k)
+                    )
+                    for m in axes
+                ),
+            )
+            riemann_list[((upper * n + k) * n + i) * n + j] = value
+            riemann_list[((upper * n + k) * n + j) * n + i] = dag.multiply(
+                Expression(Fraction(-1)), value
+            )
+    riemann = tuple(riemann_list)
+    ricci = tuple(
+        dag.add(*(riemann[((i * n + k) * n + i) * n + j] for i in axes))
+        for k, j in product(axes, repeat=2)
+    )
+    scalar = dag.add(*(dag.multiply(a, b) for a, b in zip(inverse, ricci, strict=True)))
+    # Retain the determinant numerator as its already-shared factors. Their
+    # conjunction equals det(g)!=0 on the source denominator locus. This
+    # avoids expanding an unnecessary determinant product in diagonal charts.
+    determinant_allocations: list[tuple[int, int, int]] = []
+    for index in set(det.numerator):
+        bound = dag.nodes[index].bound
+        if (
+            bound.terms > 256
+            or max(bound.degrees) > 64
+            or bound.coefficient_digits > 128
+        ):
+            reject(
+                "determinant_locus",
+                "determinant locus factors exceed canonical polynomial bounds",
+            )
+        dag.ledger.charge("normalization", bound.terms * bound.coefficient_digits)
+        determinant_allocations.append(
+            (
+                bound.terms,
+                8 * bound.coefficient_digits * bound.terms,
+                n * (bound.terms + 1),
+            )
+        )
+    outputs = (*inverse, *connection, *riemann, *ricci, scalar)
+    sizes = {value: dag.admit_output(value) for value in dict.fromkeys(outputs)}
+    potential_guard_expressions = {
+        value for value in outputs if _has_nonconstant_denominator(dag, value)
+    }
+    potential_guards = (
+        len(metric.tensor.retained_nonzero_denominators)
+        + len(set(det.numerator))
+        + len(potential_guard_expressions)
+    )
+    if potential_guards > 768:
+        reject("locus", "complete retained curvature locus exceeds 768 guards")
+
+    # Count mathematical storage, including every occurrence of the common
+    # locus in the five output coordinate objects. A whole fraction bounds its
+    # denominator guard even when cancellation creates a different denominator.
+    def source_allocation(polynomial: SparseRationalPolynomial) -> tuple[int, int, int]:
+        return (
+            len(polynomial.terms),
+            sum(
+                abs(term.coefficient.num).bit_length()
+                + term.coefficient.den.bit_length()
+                for term in polynomial.terms
+            ),
+            n * (len(polynomial.terms) + 1),
+        )
+
+    inherited = [
+        source_allocation(guard)
+        for guard in metric.tensor.retained_nonzero_denominators
+    ]
+    source = [
+        source_allocation(polynomial)
+        for component in metric.tensor.components
+        for polynomial in (component.numerator, component.denominator)
+    ]
+    guards = (
+        inherited
+        + determinant_allocations
+        + [sizes[value] for value in sizes if value.denominator]
+    )
+    allocations = source + inherited + [sizes[value] for value in outputs] + 5 * guards
+    terms, coefficient_bits, coordinate_slots = (
+        sum(allocation[index] for allocation in allocations) for index in range(3)
+    )
+    # Include tensor/connection component axes and their variance/index slots.
+    coordinate_slots += n * (len(outputs) + 6) + 4 * len(outputs)
+    if (
+        terms > 262_144
+        or coefficient_bits > 268_435_456
+        or coordinate_slots > 1_048_576
+    ):
+        reject(
+            "output",
+            "complete curvature values exceed polynomial term, coefficient-bit, "
+            "or coordinate allocation bounds",
+        )
+    fractions = {
+        value: (
+            dag.polynomial(value.numerator, value.scalar),
+            dag.polynomial(value.denominator),
+        )
+        for value in sizes
+    }
+    return Plan(dag, fractions, det, inverse, connection, riemann, ricci, scalar)

--- a/src/jacobian/math/geometry/differential/metrics/_tools.py
+++ b/src/jacobian/math/geometry/differential/metrics/_tools.py
@@ -1,0 +1,67 @@
+"""Exact rational metric curvature operation declaration."""
+
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.geometry.differential.metrics._models import (
+    RationalMetricCurvatureProfile,
+    RationalMetricCurvatureRequest,
+)
+from jacobian.math.geometry.differential.metrics.operations import curvature_profile
+
+
+def _compute(request: RationalMetricCurvatureRequest) -> RationalMetricCurvatureProfile:
+    return curvature_profile(request.metric)
+
+
+_ONE = {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [0, 0]}]}
+_R_SQUARED = {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2, 0]}]}
+_ZERO: dict[str, list[object]] = {"terms": []}
+
+TOOLS = (
+    MathTool(
+        operation_id="differential_geometry.rational_metric.curvature_profile.compute",
+        title="Compute exact curvature of a rational coordinate metric",
+        description=(
+            "Compute the inverse metric, Levi-Civita connection, Riemann tensor "
+            "R^l_kij, Ricci tensor and scalar curvature of a symmetric rational "
+            "metric on 1..4 ordered coordinates. Convention: "
+            "[nabla_i,nabla_j]v^l=R^l_kij v^k and Ric_kj=sum_i R^i_kij. "
+            "Retain the source and complete nondegenerate chart locus, even "
+            "when normalized curvature vanishes. Accept bounded exact "
+            "polynomial DAGs; reject singular metrics and excessive symbolic "
+            "growth. No positivity or global manifold assertion is made."
+        ),
+        request_type=RationalMetricCurvatureRequest,
+        result_type=RationalMetricCurvatureProfile,
+        run=_compute,
+        tags=(
+            "differential-geometry",
+            "metric",
+            "curvature",
+            "riemann",
+            "ricci",
+            "rational",
+        ),
+        examples=(
+            OperationExample(
+                name="flat_polar_chart",
+                description="The polar Euclidean metric has nonzero connection and zero curvature on r!=0.",
+                input={
+                    "metric": {
+                        "tensor": {
+                            "coordinate_axis": ["r", "theta"],
+                            "variance": ["COVARIANT", "COVARIANT"],
+                            "components": [
+                                {
+                                    "variables": ["r", "theta"],
+                                    "numerator": numerator,
+                                    "denominator": _ONE,
+                                }
+                                for numerator in (_ONE, _ZERO, _ZERO, _R_SQUARED)
+                            ],
+                        }
+                    }
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/geometry/differential/metrics/operations.py
+++ b/src/jacobian/math/geometry/differential/metrics/operations.py
@@ -131,7 +131,7 @@ def curvature_profile(
 
     axis = metric.tensor.coordinate_axis
     symbols = symbols_for_variables(axis)
-    cache: dict[int, Any] = {
+    cache: dict[int | str, Any] = {
         0: Poly(0, *symbols, domain=QQ),
         1: Poly(1, *symbols, domain=QQ),
     }

--- a/src/jacobian/math/geometry/differential/metrics/operations.py
+++ b/src/jacobian/math/geometry/differential/metrics/operations.py
@@ -1,0 +1,225 @@
+"""Execute an admitted exact metric-curvature DAG on a retained chart locus."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from pydantic_core import PydanticCustomError
+
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.differential._recognition_process import (
+    RationalFunctionRecognitionCandidate,
+    recognize_canonical_rational_functions,
+)
+from jacobian.math.geometry.differential.metrics._dag import Expression, Node
+from jacobian.math.geometry.differential.metrics._dag_process import (
+    evaluate_polynomial_dag,
+    materialize_expanded_polynomial,
+)
+from jacobian.math.geometry.differential.metrics._models import (
+    RationalCoordinateConnection,
+    RationalCoordinateMetric,
+    RationalMetricCurvatureProfile,
+)
+from jacobian.math.geometry.differential.metrics._normalize_process import (
+    cancel_fraction,
+)
+from jacobian.math.geometry.differential.metrics._plan import build_plan, singular
+from jacobian.math.geometry.differential.values import (
+    RationalCoordinateTensor,
+    TensorVariance,
+    canonical_locus_guards,
+)
+from jacobian.math.polynomials._conversions import (
+    sparse_rational_polynomial_from_sympy,
+    symbols_for_variables,
+)
+from jacobian.math.polynomials.values import (
+    RationalFunction,
+    require_canonical_rational_function,
+)
+
+
+def _evaluate_node(
+    index: int, nodes: list[Node], axis: tuple[str, ...], cache: dict[int | str, Any]
+) -> Any:
+    if index in cache:
+        return cache[index]
+    execution = current_request_execution()
+    deadline = (
+        execution.deadline
+        if execution is not None and execution.deadline is not None
+        else time.monotonic() + 120.0
+    )
+    records = cache.get("records")
+    symbols = cache.get("symbols")
+    if records is None or symbols is None:
+        request_checkpoint("before curvature polynomial arithmetic")
+        records, symbols = evaluate_polynomial_dag(nodes, axis, deadline=deadline)
+        cache["records"] = records
+        cache["symbols"] = symbols
+        request_checkpoint("after curvature polynomial arithmetic")
+    cache[index] = materialize_expanded_polynomial(
+        records[index], symbols, deadline=deadline
+    )
+    return cache[index]
+
+
+def curvature_profile(
+    metric: RationalCoordinateMetric,
+) -> RationalMetricCurvatureProfile:
+    """Compute inverse, Levi-Civita connection, Riemann, Ricci and scalar fields.
+
+    Every symbolic operation, source claim and canonical output is admitted
+    before polynomial expansion. The input locus is intersected with det(g)!=0;
+    normalization never discards inherited chart restrictions.
+    """
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return curvature_profile(metric)
+    deadline = execution.started_at + 120.0
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before curvature admission")
+    plan = build_plan(metric)
+    request_checkpoint("after complete curvature admission")
+    # Caller-authored field presentations have only structural validation.
+    # Recognize reducedness once before relying on source-field identities.
+    recognition_candidates: list[RationalFunctionRecognitionCandidate] = []
+    for index, component in enumerate(metric.tensor.components):
+        request_checkpoint("before metric component recognition")
+        if (
+            not component.numerator.terms
+            or not component.variables
+            or len(component.denominator.terms) == 1
+        ):
+            try:
+                require_canonical_rational_function(component)
+            except PydanticCustomError as exc:
+                raise OperationDomainValidationError(
+                    location=("metric",),
+                    code="differential_geometry.curvature.noncanonical_source",
+                    message="metric component must be a reduced canonical rational function",
+                ) from exc
+            continue
+        recognition_candidates.append(
+            RationalFunctionRecognitionCandidate(
+                owner="tensor",
+                component=index,
+                value=component,
+            )
+        )
+    recognition = recognize_canonical_rational_functions(
+        tuple(recognition_candidates), deadline=deadline
+    )
+    if recognition.non_coprime is not None:
+        raise OperationDomainValidationError(
+            location=("metric",),
+            code="differential_geometry.curvature.noncanonical_source",
+            message="metric component must be a reduced canonical rational function",
+        )
+    from sympy import QQ, Poly
+
+    axis = metric.tensor.coordinate_axis
+    symbols = symbols_for_variables(axis)
+    cache: dict[int, Any] = {
+        0: Poly(0, *symbols, domain=QQ),
+        1: Poly(1, *symbols, domain=QQ),
+    }
+
+    def raw(value: Expression) -> tuple[Any, Any]:
+        numerator, denominator = plan.fractions[value]
+        return _evaluate_node(numerator, plan.dag.nodes, axis, cache), _evaluate_node(
+            denominator, plan.dag.nodes, axis, cache
+        )
+
+    determinant_guards = []
+    for index in dict.fromkeys(plan.determinant.numerator):
+        polynomial = _evaluate_node(index, plan.dag.nodes, axis, cache)
+        if polynomial.is_zero:
+            raise singular()
+        determinant_guards.append(
+            sparse_rational_polynomial_from_sympy(
+                polynomial.monic(), axis, maximum_terms=256
+            )
+        )
+    normalized: dict[Expression, RationalFunction] = {}
+
+    def convert(values: tuple[Expression, ...]) -> tuple[RationalFunction, ...]:
+        results = []
+        for value in values:
+            request_checkpoint("before curvature component normalization")
+            if value not in normalized:
+                numerator, denominator = raw(value)
+                cancelled_num, cancelled_den = cancel_fraction(
+                    numerator, denominator, deadline=deadline
+                )
+                normalized[value] = RationalFunction._from_kernel(
+                    variables=axis,
+                    numerator=sparse_rational_polynomial_from_sympy(
+                        cancelled_num, axis, maximum_terms=256
+                    ),
+                    denominator=sparse_rational_polynomial_from_sympy(
+                        cancelled_den, axis, maximum_terms=256
+                    ),
+                )
+            results.append(normalized[value])
+            request_checkpoint("after curvature component normalization")
+        return tuple(results)
+
+    inverse, connection, riemann, ricci, scalar = (
+        convert(values)
+        for values in (
+            plan.inverse,
+            plan.connection,
+            plan.riemann,
+            plan.ricci,
+            (plan.scalar,),
+        )
+    )
+    guards = canonical_locus_guards(
+        metric.tensor.retained_nonzero_denominators,
+        tuple(determinant_guards),
+        component_denominators=tuple(
+            value.denominator
+            for values in (inverse, connection, riemann, ricci, scalar)
+            for value in values
+        ),
+        variable_count=len(axis),
+    )
+
+    def tensor(
+        components: tuple[RationalFunction, ...], variance: tuple[TensorVariance, ...]
+    ) -> RationalCoordinateTensor:
+        return RationalCoordinateTensor(
+            coordinate_axis=axis,
+            variance=variance,
+            components=components,
+            retained_nonzero_denominators=guards,
+        )
+
+    result = RationalMetricCurvatureProfile(
+        metric=metric,
+        inverse_metric=tensor(inverse, ("CONTRAVARIANT", "CONTRAVARIANT")),
+        connection=RationalCoordinateConnection(
+            coordinate_axis=axis,
+            components=connection,
+            retained_nonzero_denominators=guards,
+        ),
+        riemann=tensor(
+            riemann, ("CONTRAVARIANT", "COVARIANT", "COVARIANT", "COVARIANT")
+        ),
+        ricci=tensor(ricci, ("COVARIANT", "COVARIANT")),
+        scalar_curvature=tensor(scalar, ()),
+    )
+    request_checkpoint("after curvature profile construction")
+    return result

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -645,6 +645,110 @@ def _guaranteed_univariate_perfect_power_gcd(
     return best
 
 
+def _dense_univariate_gcd_degree(by_degree: dict[int, Fraction]) -> int:
+    """Return ``deg(gcd(q, q'))`` by the Euclidean algorithm on dense coefficients."""
+
+    if not by_degree:
+        return 0
+    total = max(by_degree)
+    dividend = [by_degree.get(degree, Fraction(0)) for degree in range(total + 1)]
+    divisor = [Fraction(index) * dividend[index] for index in range(1, len(dividend))]
+
+    def degree_of(polynomial: list[Fraction]) -> int:
+        index = len(polynomial) - 1
+        while index >= 0 and polynomial[index] == 0:
+            index -= 1
+        return index
+
+    def remainder(
+        left: list[Fraction], right: list[Fraction]
+    ) -> list[Fraction]:
+        left = list(left)
+        while degree_of(left) >= degree_of(right) >= 0:
+            shift = degree_of(left) - degree_of(right)
+            scale = left[degree_of(left)] / right[degree_of(right)]
+            for index, coefficient in enumerate(right):
+                left[index + shift] -= scale * coefficient
+        while left and left[-1] == 0:
+            left.pop()
+        return left
+
+    while degree_of(divisor) >= 0:
+        dividend, divisor = divisor, remainder(dividend, divisor)
+    return max(0, degree_of(dividend))
+
+
+def _binomial_linear_form_power_gcd(denominator: SparseRationalPolynomial) -> int:
+    """Return ``n-1`` when the denominator is a square-free-linear form to the n."""
+
+    if not denominator.terms:
+        return 0
+    axes = len(denominator.terms[0].exponents)
+    used = [
+        axis
+        for axis in range(axes)
+        if any(term.exponents[axis] for term in denominator.terms)
+    ]
+    if len(used) != 2:
+        return 0
+    left, right = used
+    total = max(sum(term.exponents) for term in denominator.terms)
+    if total < 2 or len(denominator.terms) != total + 1:
+        return 0
+    by_power: dict[int, Fraction] = {}
+    for term in denominator.terms:
+        if any(term.exponents[axis] for axis in range(axes) if axis not in used):
+            return 0
+        if term.exponents[left] + term.exponents[right] != total:
+            return 0
+        power = term.exponents[right]
+        if power in by_power:
+            return 0
+        by_power[power] = term.coefficient.as_fraction()
+    if set(by_power) != set(range(total + 1)) or by_power[0] == 0:
+        return 0
+    ratio = by_power[1] / (by_power[0] * total)
+    for power in range(total + 1):
+        expected = by_power[0] * Fraction(comb(total, power)) * (ratio**power)
+        if by_power[power] != expected:
+            return 0
+    return total - 1
+
+
+def _univariate_denominator_gcd_degree(by_degree: dict[int, Fraction]) -> int:
+    """Return ``deg(gcd(q, q'))`` for a dense univariate coefficient map."""
+
+    extra = _guaranteed_univariate_perfect_power_gcd(by_degree)
+    if extra > 0:
+        return extra
+    extra = _dense_univariate_gcd_degree(by_degree)
+    if extra > 0:
+        return extra
+    exponents = sorted(by_degree)
+    if 0 not in by_degree:
+        return 0
+    step = 0
+    for exponent in by_degree:
+        if exponent:
+            step = exponent if step == 0 else gcd(step, exponent)
+    if step < 1:
+        return 0
+    power = max(by_degree) // step
+    if power < 2 or exponents != list(range(0, power * step + 1, step)):
+        return 0
+    constant = by_degree[0]
+    if constant == 0:
+        return 0
+    scale = by_degree[step] / (constant * power)
+    for index in range(1, power + 1):
+        expected = (
+            by_degree[(index - 1) * step] * Fraction(power - index + 1, index) * scale
+        )
+        if by_degree[index * step] != expected:
+            return 0
+    return (power - 1) * step
+
+
 def _guaranteed_linear_power_gcd(
     denominator: SparseRationalPolynomial,
 ) -> tuple[int, int]:
@@ -658,6 +762,9 @@ def _guaranteed_linear_power_gcd(
 
     if not denominator.terms:
         return -1, 0
+    binomial_extra = _binomial_linear_form_power_gcd(denominator)
+    if binomial_extra > 0:
+        return -1, binomial_extra
     axes = len(denominator.terms[0].exponents)
     used = [
         axis
@@ -675,32 +782,10 @@ def _guaranteed_linear_power_gcd(
         if degree in by_degree:
             return -1, 0
         by_degree[degree] = term.coefficient.as_fraction()
-    extra = _guaranteed_univariate_perfect_power_gcd(by_degree)
-    if extra > 0:
-        return axis, extra
-    exponents = sorted(by_degree)
-    if 0 not in by_degree:
+    extra = _univariate_denominator_gcd_degree(by_degree)
+    if extra <= 0:
         return -1, 0
-    step = 0
-    for exponent in by_degree:
-        if exponent:
-            step = exponent if step == 0 else gcd(step, exponent)
-    if step < 1:
-        return -1, 0
-    power = max(by_degree) // step
-    if power < 2 or exponents != list(range(0, power * step + 1, step)):
-        return -1, 0
-    constant = by_degree[0]
-    if constant == 0:
-        return -1, 0
-    scale = by_degree[step] / (constant * power)
-    for index in range(1, power + 1):
-        expected = (
-            by_degree[(index - 1) * step] * Fraction(power - index + 1, index) * scale
-        )
-        if by_degree[index * step] != expected:
-            return -1, 0
-    return axis, (power - 1) * step
+    return axis, extra
 
 
 def _remove_guaranteed_linear_power_factor(
@@ -713,6 +798,22 @@ def _remove_guaranteed_linear_power_factor(
         return bound
 
     def reduce(polynomial: PolynomialBound) -> PolynomialBound:
+        if not polynomial.degrees:
+            return polynomial
+        if axis < 0:
+            drop = min(extra, polynomial.total_degree, *polynomial.degrees)
+            if drop <= 0:
+                return polynomial
+            degrees = tuple(max(0, degree - drop) for degree in polynomial.degrees)
+            total_degree = max(0, polynomial.total_degree - drop)
+            return PolynomialBound(
+                terms=min(polynomial.terms, total_degree + 1),
+                degrees=degrees,
+                total_degree=total_degree,
+                minimum_exponents=polynomial.minimum_exponents,
+                coefficient_digits=polynomial.coefficient_digits,
+                rational_content=polynomial.rational_content,
+            )
         if axis >= len(polynomial.degrees):
             return polynomial
         drop = min(extra, polynomial.degrees[axis], polynomial.total_degree)
@@ -722,10 +823,19 @@ def _remove_guaranteed_linear_power_factor(
             max(0, degree - drop) if index == axis else degree
             for index, degree in enumerate(polynomial.degrees)
         )
+        total_degree = max(0, polynomial.total_degree - drop)
+        univariate = all(
+            degree == 0 or index == axis for index, degree in enumerate(degrees)
+        )
+        terms = (
+            min(polynomial.terms, total_degree + 1)
+            if univariate
+            else polynomial.terms
+        )
         return PolynomialBound(
-            terms=polynomial.terms,
+            terms=terms,
             degrees=degrees,
-            total_degree=max(0, polynomial.total_degree - drop),
+            total_degree=total_degree,
             minimum_exponents=polynomial.minimum_exponents,
             coefficient_digits=polynomial.coefficient_digits,
             rational_content=polynomial.rational_content,
@@ -794,9 +904,14 @@ def _validate_canonical_result_bound(
         dense_terms = _total_degree_term_bound(polynomial)
         # When the denominator is the unit polynomial, there can be no
         # cancellation-induced support expansion, so the tracked sparse
-        # term count is the accurate support bound.
+        # term count is the accurate support bound. After a source-intrinsic
+        # linear-power cancel, ``terms`` may be tighter than the dense box.
         denominator_is_unit = all(degree == 0 for degree in bound.denominator.degrees)
-        support_terms = polynomial.terms if denominator_is_unit else dense_terms
+        support_terms = (
+            polynomial.terms
+            if denominator_is_unit
+            else min(dense_terms, polynomial.terms)
+        )
         if support_terms > limits.result_terms:
             limits.reject(
                 "result_support",
@@ -818,12 +933,17 @@ def _validate_canonical_result_bound(
     numerator_dense = (
         charged.numerator.terms
         if charged_denominator_is_unit
-        else _dense_term_bound(charged.numerator.degrees)
+        else min(
+            _dense_term_bound(charged.numerator.degrees), charged.numerator.terms
+        )
     )
     denominator_dense = (
         1
         if charged_denominator_is_unit
-        else _dense_term_bound(charged.denominator.degrees)
+        else min(
+            _dense_term_bound(charged.denominator.degrees),
+            charged.denominator.terms,
+        )
     )
     work_digits = _canonical_coefficient_digits(charged)
     normalization_degree = max(numerator_dense + denominator_dense - 2, 0)

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -552,10 +552,10 @@ def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
 def _guaranteed_linear_power_gcd(
     denominator: SparseRationalPolynomial,
 ) -> tuple[int, int]:
-    """Return ``(axis, deg(gcd(q, q')))`` for a power of a linear polynomial.
+    """Return ``(axis, deg(gcd(q, q')))`` for a univariate binomial power.
 
-    In characteristic zero, ``q = (alpha x_i + beta)^n`` with ``n >= 2`` and
-    ``beta != 0`` has ``gcd(q, q') = (alpha x_i + beta)^{n-1}``. The binomial
+    In characteristic zero, ``q = (alpha x_i^g + beta)^n`` with ``n >= 2`` and
+    ``beta != 0`` has ``gcd(q, q')`` of degree ``(n-1) g``. The binomial
     coefficient recurrence is a source-intrinsic identity, so this lower bound
     does not replay differentiation or polynomial GCD.
     """
@@ -579,20 +579,29 @@ def _guaranteed_linear_power_gcd(
         if degree in by_degree:
             return -1, 0
         by_degree[degree] = term.coefficient.as_fraction()
-    degree = max(by_degree, default=0)
-    if degree < 2 or len(by_degree) != degree + 1:
+    exponents = sorted(by_degree)
+    if 0 not in by_degree:
         return -1, 0
-    if any(index not in by_degree for index in range(degree + 1)):
+    step = 0
+    for exponent in by_degree:
+        if exponent:
+            step = exponent if step == 0 else gcd(step, exponent)
+    if step < 1:
+        return -1, 0
+    power = max(by_degree) // step
+    if power < 2 or exponents != list(range(0, power * step + 1, step)):
         return -1, 0
     constant = by_degree[0]
     if constant == 0:
         return -1, 0
-    scale = by_degree[1] / (constant * degree)
-    for index in range(1, degree + 1):
-        expected = by_degree[index - 1] * Fraction(degree - index + 1, index) * scale
-        if by_degree[index] != expected:
+    scale = by_degree[step] / (constant * power)
+    for index in range(1, power + 1):
+        expected = (
+            by_degree[(index - 1) * step] * Fraction(power - index + 1, index) * scale
+        )
+        if by_degree[index * step] != expected:
             return -1, 0
-    return axis, degree - 1
+    return axis, (power - 1) * step
 
 
 def _remove_guaranteed_linear_power_factor(
@@ -662,8 +671,14 @@ def _canonical_coefficient_digits(bound: FractionBound) -> int:
     )
 
 
-def _validate_canonical_result_bound(bound: FractionBound, ledger: BoundsLedger) -> int:
+def _validate_canonical_result_bound(
+    bound: FractionBound,
+    ledger: BoundsLedger,
+    *,
+    work_bound: FractionBound | None = None,
+) -> int:
     limits = ledger.limits
+    charged = bound if work_bound is None else work_bound
     if bound.is_zero:
         ledger.charge("normalization", 1)
         return 1
@@ -696,23 +711,28 @@ def _validate_canonical_result_bound(bound: FractionBound, ledger: BoundsLedger)
             f"{limits.label} normalization can exceed the canonical "
             f"{limits.result_digits}-digit coefficient bound",
         )
-    denominator_is_unit = all(degree == 0 for degree in bound.denominator.degrees)
+    charged_denominator_is_unit = all(
+        degree == 0 for degree in charged.denominator.degrees
+    )
     # Normalization still uses the recursively dense backend. A sparse
     # canonical support bound does not justify reducing this work charge.
     numerator_dense = (
-        bound.numerator.terms
-        if denominator_is_unit
-        else _dense_term_bound(bound.numerator.degrees)
+        charged.numerator.terms
+        if charged_denominator_is_unit
+        else _dense_term_bound(charged.numerator.degrees)
     )
     denominator_dense = (
-        1 if denominator_is_unit else _dense_term_bound(bound.denominator.degrees)
+        1
+        if charged_denominator_is_unit
+        else _dense_term_bound(charged.denominator.degrees)
     )
+    work_digits = _canonical_coefficient_digits(charged)
     normalization_degree = max(numerator_dense + denominator_dense - 2, 0)
     ledger.charge(
         "normalization",
         (numerator_dense + denominator_dense)
         * (normalization_degree + 1)
-        * coefficient_digits,
+        * work_digits,
     )
     return coefficient_digits
 

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -795,7 +795,9 @@ def _remove_guaranteed_linear_power_factor(
     if extra <= 0 or bound.is_zero:
         return bound
 
-    def reduce(polynomial: PolynomialBound) -> PolynomialBound:
+    def reduce(
+        polynomial: PolynomialBound, *, linear_form_power: bool
+    ) -> PolynomialBound:
         if not polynomial.degrees:
             return polynomial
         if axis < 0:
@@ -812,10 +814,16 @@ def _remove_guaranteed_linear_power_factor(
                 coefficient_digits=polynomial.coefficient_digits,
                 rational_content=polynomial.rational_content,
             )
-            return replace(
-                reduced,
-                terms=min(polynomial.terms, _total_degree_term_bound(reduced)),
+            # After canceling (ax+by)^{n-1} from q=(ax+by)^n, the denominator
+            # remains a linear-form power, whose support has size total_degree+1.
+            # The cofactor numerator need not be homogeneous on that diagonal, so
+            # total_degree+1 is not a support bound there.
+            support = (
+                total_degree + 1
+                if linear_form_power
+                else _total_degree_term_bound(reduced)
             )
+            return replace(reduced, terms=min(polynomial.terms, support))
         if axis >= len(polynomial.degrees):
             return polynomial
         drop = min(extra, polynomial.degrees[axis], polynomial.total_degree)
@@ -842,7 +850,8 @@ def _remove_guaranteed_linear_power_factor(
         )
 
     return FractionBound(
-        numerator=reduce(bound.numerator), denominator=reduce(bound.denominator)
+        numerator=reduce(bound.numerator, linear_form_power=False),
+        denominator=reduce(bound.denominator, linear_form_power=True),
     )
 
 

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -1,0 +1,642 @@
+"""Composable rational-function arithmetic and normalization bounds.
+
+Consumers supply their work ledger, finite representation limits, and rejection
+callback. These estimates own no operation-specific deadline or error policy.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from fractions import Fraction
+from math import gcd, lcm
+from typing import Literal, NoReturn, Protocol
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.polynomials.values import RationalFunction, SparseRationalPolynomial
+
+type BoundWorkCategory = Literal[
+    "recognition",
+    "source_conversion",
+    "differentiation",
+    "multiplication",
+    "addition",
+    "normalization",
+]
+
+
+@dataclass(frozen=True)
+class RationalFunctionBoundLimits:
+    """Owner-selected finite arithmetic and canonical representation limits."""
+
+    raw_terms: int
+    raw_digits: int
+    result_exponent: int
+    result_terms: int
+    result_digits: int
+    label: str
+    reject: Callable[[str, str], NoReturn]
+
+
+class BoundsLedger(Protocol):
+    """An operation-owned work ledger used by the shared estimates."""
+
+    limits: RationalFunctionBoundLimits
+
+    def charge(self, category: BoundWorkCategory, amount: int) -> None: ...
+
+
+@dataclass(frozen=True)
+class PolynomialBound:
+    """Bound ``rational_content * integral_polynomial`` exactly.
+
+    Input bounds start with a primitive integral polynomial. Arithmetic may
+    leave its integral factor nonprimitive, while ``coefficient_digits`` still
+    bounds every coefficient and ``rational_content`` remains an exact common
+    scale. Keeping that scale separate prevents unrelated coefficient
+    denominators from multiplying during height admission.
+    """
+
+    terms: int
+    degrees: tuple[int, ...]
+    minimum_exponents: tuple[int, ...]
+    coefficient_digits: int
+    rational_content: Fraction
+
+    @property
+    def is_zero(self) -> bool:
+        return self.terms == 0
+
+
+@dataclass(frozen=True)
+class FractionBound:
+    numerator: PolynomialBound
+    denominator: PolynomialBound
+
+    @property
+    def is_zero(self) -> bool:
+        return self.numerator.is_zero
+
+
+def _dense_term_bound(degrees: tuple[int, ...], *, cap: int | None = None) -> int:
+    result = 1
+    for degree in degrees:
+        result *= degree + 1
+        if cap is not None and result > cap:
+            return cap + 1
+    return result
+
+
+def _polynomial_admission_work_units(
+    polynomial: SparseRationalPolynomial, variable_count: int
+) -> int:
+    """Price the scalar passes used to derive one exact polynomial bound.
+
+    Each nonzero coefficient is converted, participates in denominator/content
+    reduction, is scaled and made primitive, and is inspected for height. Each
+    exponent is inspected once for the maximum and once for the minimum. The
+    final unit prices construction of the separated rational content. Zero is
+    represented by one exact ``Fraction`` construction.
+    """
+
+    terms = len(polynomial.terms)
+    if terms == 0:
+        return 1
+    return terms * (6 + 2 * variable_count) + 1
+
+
+def _polynomial_backend_conversion_work_units(bound: PolynomialBound) -> int:
+    """Price sparse coefficient conversion and dense SymPy ``Poly`` creation."""
+
+    dense_coefficients = 1 if bound.is_zero else _dense_term_bound(bound.degrees)
+    coefficient_digits = (
+        bound.coefficient_digits
+        + len(format_canonical_integer(abs(bound.rational_content.numerator)))
+        + len(format_canonical_integer(bound.rational_content.denominator))
+    )
+    coefficient_chunks = max(1, (coefficient_digits + 31) // 32)
+    return bound.terms * coefficient_chunks + dense_coefficients
+
+
+def _polynomial_bound(polynomial: SparseRationalPolynomial) -> PolynomialBound:
+    if not polynomial.terms:
+        return PolynomialBound(
+            terms=0,
+            degrees=(),
+            minimum_exponents=(),
+            coefficient_digits=1,
+            rational_content=Fraction(0),
+        )
+    variable_count = len(polynomial.terms[0].exponents)
+    coefficients = tuple(
+        Fraction(*term.coefficient.as_integer_ratio()) for term in polynomial.terms
+    )
+    common_denominator = lcm(*(coefficient.denominator for coefficient in coefficients))
+    integral_coefficients = tuple(
+        coefficient.numerator * (common_denominator // coefficient.denominator)
+        for coefficient in coefficients
+    )
+    content_numerator = gcd(
+        *(abs(coefficient) for coefficient in integral_coefficients)
+    )
+    primitive_coefficients = tuple(
+        coefficient // content_numerator for coefficient in integral_coefficients
+    )
+    return PolynomialBound(
+        terms=len(polynomial.terms),
+        degrees=tuple(
+            max(term.exponents[axis] for term in polynomial.terms)
+            for axis in range(variable_count)
+        ),
+        minimum_exponents=tuple(
+            min(term.exponents[axis] for term in polynomial.terms)
+            for axis in range(variable_count)
+        ),
+        coefficient_digits=max(
+            len(format_canonical_integer(abs(coefficient)))
+            for coefficient in primitive_coefficients
+        ),
+        rational_content=Fraction(content_numerator, common_denominator),
+    )
+
+
+def _zero_polynomial(variable_count: int) -> PolynomialBound:
+    return PolynomialBound(
+        terms=0,
+        degrees=(0,) * variable_count,
+        minimum_exponents=(0,) * variable_count,
+        coefficient_digits=1,
+        rational_content=Fraction(0),
+    )
+
+
+def _one_polynomial(variable_count: int) -> PolynomialBound:
+    return PolynomialBound(
+        terms=1,
+        degrees=(0,) * variable_count,
+        minimum_exponents=(0,) * variable_count,
+        coefficient_digits=1,
+        rational_content=Fraction(1),
+    )
+
+
+def _zero_fraction(variable_count: int) -> FractionBound:
+    return FractionBound(
+        numerator=_zero_polynomial(variable_count),
+        denominator=_one_polynomial(variable_count),
+    )
+
+
+def _fraction_bound(value: RationalFunction, ledger: BoundsLedger) -> FractionBound:
+    variable_count = len(value.variables)
+    ledger.charge(
+        "source_conversion",
+        _polynomial_admission_work_units(value.numerator, variable_count)
+        + _polynomial_admission_work_units(value.denominator, variable_count),
+    )
+    numerator = (
+        _zero_polynomial(variable_count)
+        if not value.numerator.terms
+        else _polynomial_bound(value.numerator)
+    )
+    result = FractionBound(
+        numerator=numerator,
+        denominator=_polynomial_bound(value.denominator),
+    )
+    ledger.charge(
+        "source_conversion",
+        _polynomial_backend_conversion_work_units(result.numerator)
+        + _polynomial_backend_conversion_work_units(result.denominator),
+    )
+    return result
+
+
+def _check_raw_polynomial(
+    bound: PolynomialBound, limits: RationalFunctionBoundLimits
+) -> None:
+    if bound.terms > limits.raw_terms:
+        limits.reject(
+            "intermediate_support",
+            f"{limits.label} polynomial expansion exceeds the "
+            f"{limits.raw_terms}-term intermediate budget",
+        )
+    scaled_coefficient_digits = max(
+        len(format_canonical_integer(abs(bound.rational_content.numerator)))
+        + bound.coefficient_digits,
+        len(format_canonical_integer(bound.rational_content.denominator)),
+    )
+    if scaled_coefficient_digits > limits.raw_digits:
+        limits.reject(
+            "intermediate_height",
+            f"{limits.label} coefficient growth exceeds the "
+            f"{limits.raw_digits}-digit intermediate budget",
+        )
+
+
+def _differentiate_polynomial(
+    source: PolynomialBound,
+    axis: int,
+    ledger: BoundsLedger,
+    *,
+    active_terms: int,
+    maximum_axis_exponent: int,
+    minimum_exponents: tuple[int, ...],
+) -> PolynomialBound:
+    if source.is_zero or active_terms == 0:
+        return _zero_polynomial(len(source.degrees))
+    degrees = list(source.degrees)
+    degrees[axis] -= 1
+    result = PolynomialBound(
+        terms=active_terms,
+        degrees=tuple(degrees),
+        minimum_exponents=minimum_exponents,
+        coefficient_digits=(
+            source.coefficient_digits
+            + len(format_canonical_integer(maximum_axis_exponent))
+        ),
+        rational_content=source.rational_content,
+    )
+    _check_raw_polynomial(result, ledger.limits)
+    return result
+
+
+def _multiply_polynomials(
+    left: PolynomialBound,
+    right: PolynomialBound,
+    ledger: BoundsLedger,
+) -> PolynomialBound:
+    if left.is_zero or right.is_zero:
+        return _zero_polynomial(len(left.degrees))
+    pair_count = left.terms * right.terms
+    ledger.charge("multiplication", pair_count)
+    degrees = tuple(
+        left_degree + right_degree
+        for left_degree, right_degree in zip(left.degrees, right.degrees, strict=True)
+    )
+    collision_count = min(left.terms, right.terms)
+    product_digits = left.coefficient_digits + right.coefficient_digits
+    if collision_count == 1:
+        coefficient_digits = product_digits
+    else:
+        coefficient_digits = product_digits + len(
+            format_canonical_integer(collision_count)
+        )
+    result = PolynomialBound(
+        terms=min(pair_count, _dense_term_bound(degrees)),
+        degrees=degrees,
+        minimum_exponents=tuple(
+            left_exponent + right_exponent
+            for left_exponent, right_exponent in zip(
+                left.minimum_exponents,
+                right.minimum_exponents,
+                strict=True,
+            )
+        ),
+        coefficient_digits=coefficient_digits,
+        rational_content=left.rational_content * right.rational_content,
+    )
+    _check_raw_polynomial(result, ledger.limits)
+    return result
+
+
+def _add_polynomials(
+    left: PolynomialBound,
+    right: PolynomialBound,
+    ledger: BoundsLedger,
+) -> PolynomialBound:
+    if left.is_zero:
+        return right
+    if right.is_zero:
+        return left
+    ledger.charge("addition", left.terms + right.terms)
+    degrees = tuple(
+        max(left_degree, right_degree)
+        for left_degree, right_degree in zip(left.degrees, right.degrees, strict=True)
+    )
+    common_content = Fraction(
+        gcd(
+            abs(left.rational_content.numerator),
+            abs(right.rational_content.numerator),
+        ),
+        lcm(
+            left.rational_content.denominator,
+            right.rational_content.denominator,
+        ),
+    )
+    left_multiplier = left.rational_content / common_content
+    right_multiplier = right.rational_content / common_content
+    if left_multiplier.denominator != 1 or right_multiplier.denominator != 1:
+        raise AssertionError(
+            "rational polynomial content gcd did not divide both inputs"
+        )
+
+    def scaled_digits(coefficient_digits: int, multiplier: int) -> int:
+        if abs(multiplier) <= 1:
+            return coefficient_digits
+        return coefficient_digits + len(format_canonical_integer(abs(multiplier)))
+
+    result = PolynomialBound(
+        terms=min(left.terms + right.terms, _dense_term_bound(degrees)),
+        degrees=degrees,
+        minimum_exponents=tuple(
+            min(left_exponent, right_exponent)
+            for left_exponent, right_exponent in zip(
+                left.minimum_exponents,
+                right.minimum_exponents,
+                strict=True,
+            )
+        ),
+        coefficient_digits=max(
+            scaled_digits(left.coefficient_digits, left_multiplier.numerator),
+            scaled_digits(right.coefficient_digits, right_multiplier.numerator),
+        )
+        + 1,
+        rational_content=common_content,
+    )
+    _check_raw_polynomial(result, ledger.limits)
+    return result
+
+
+def _differentiate_fraction(
+    source_value: RationalFunction,
+    source_bound: FractionBound,
+    axis: int,
+    ledger: BoundsLedger,
+) -> FractionBound:
+    ledger.charge(
+        "differentiation",
+        source_bound.numerator.terms + source_bound.denominator.terms,
+    )
+    numerator_active = tuple(
+        term for term in source_value.numerator.terms if term.exponents[axis] > 0
+    )
+    denominator_active = tuple(
+        term for term in source_value.denominator.terms if term.exponents[axis] > 0
+    )
+    if not numerator_active and not denominator_active:
+        return _zero_fraction(len(source_bound.numerator.degrees))
+    numerator_derivative = _differentiate_polynomial(
+        source_bound.numerator,
+        axis,
+        ledger,
+        active_terms=len(numerator_active),
+        maximum_axis_exponent=max(
+            (term.exponents[axis] for term in numerator_active), default=1
+        ),
+        minimum_exponents=tuple(
+            min(
+                term.exponents[coordinate] - int(coordinate == axis)
+                for term in numerator_active
+            )
+            for coordinate in range(len(source_value.variables))
+        )
+        if numerator_active
+        else (0,) * len(source_value.variables),
+    )
+    denominator_derivative = _differentiate_polynomial(
+        source_bound.denominator,
+        axis,
+        ledger,
+        active_terms=len(denominator_active),
+        maximum_axis_exponent=max(
+            (term.exponents[axis] for term in denominator_active), default=1
+        ),
+        minimum_exponents=tuple(
+            min(
+                term.exponents[coordinate] - int(coordinate == axis)
+                for term in denominator_active
+            )
+            for coordinate in range(len(source_value.variables))
+        )
+        if denominator_active
+        else (0,) * len(source_value.variables),
+    )
+    first = _multiply_polynomials(
+        numerator_derivative, source_bound.denominator, ledger
+    )
+    second = _multiply_polynomials(
+        source_bound.numerator, denominator_derivative, ledger
+    )
+    numerator = _add_polynomials(first, second, ledger)
+    if numerator.is_zero:
+        return _zero_fraction(len(source_bound.numerator.degrees))
+    denominator = _multiply_polynomials(
+        source_bound.denominator, source_bound.denominator, ledger
+    )
+    return FractionBound(numerator=numerator, denominator=denominator)
+
+
+def _multiply_fractions(
+    left: FractionBound,
+    right: FractionBound,
+    ledger: BoundsLedger,
+) -> FractionBound:
+    if left.is_zero or right.is_zero:
+        return _zero_fraction(len(left.numerator.degrees))
+    return FractionBound(
+        numerator=_multiply_polynomials(left.numerator, right.numerator, ledger),
+        denominator=_multiply_polynomials(left.denominator, right.denominator, ledger),
+    )
+
+
+def _add_fractions(
+    left: FractionBound,
+    right: FractionBound,
+    ledger: BoundsLedger,
+) -> FractionBound:
+    if left.is_zero:
+        return right
+    if right.is_zero:
+        return left
+    left_scaled = _multiply_polynomials(left.numerator, right.denominator, ledger)
+    right_scaled = _multiply_polynomials(right.numerator, left.denominator, ledger)
+    numerator = _add_polynomials(left_scaled, right_scaled, ledger)
+    if numerator.is_zero:
+        return _zero_fraction(len(left.numerator.degrees))
+    return FractionBound(
+        numerator=numerator,
+        denominator=_multiply_polynomials(left.denominator, right.denominator, ledger),
+    )
+
+
+def _factor_coefficient_digits(bound: PolynomialBound) -> int:
+    """Bound every coefficient of a rational factor of ``bound``.
+
+    Clear source denominators, inject the multivariate polynomial into a
+    univariate polynomial by mixed-radix Kronecker substitution, and apply
+    Mignotte's ``2**degree * l2_norm`` integer-factor height bound.  A factor's
+    degree in each variable cannot exceed the source degree, so the mixed
+    radices introduce no carries in a factorization.
+    """
+
+    if bound.is_zero:
+        return 1
+    kronecker_degree = _dense_term_bound(bound.degrees) - 1
+    binary_factor_digits = (302 * kronecker_degree + 999) // 1000
+    norm_digits = len(format_canonical_integer(bound.terms)) + 1
+    return bound.coefficient_digits + binary_factor_digits + norm_digits + 2
+
+
+def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
+    """Apply exact valuation presolve before the canonical-result proof.
+
+    The coordinatewise minimum exponent is a factor of every monomial. Its
+    common part can therefore be canceled without expanding or factoring a
+    polynomial, which materially widens monomial-denominator requests.
+    """
+
+    if bound.is_zero:
+        return bound
+    common = tuple(
+        min(numerator, denominator)
+        for numerator, denominator in zip(
+            bound.numerator.minimum_exponents,
+            bound.denominator.minimum_exponents,
+            strict=True,
+        )
+    )
+    if not any(common):
+        return bound
+
+    def divide(polynomial: PolynomialBound) -> PolynomialBound:
+        return PolynomialBound(
+            terms=polynomial.terms,
+            degrees=tuple(
+                degree - exponent
+                for degree, exponent in zip(polynomial.degrees, common, strict=True)
+            ),
+            minimum_exponents=tuple(
+                minimum - exponent
+                for minimum, exponent in zip(
+                    polynomial.minimum_exponents, common, strict=True
+                )
+            ),
+            coefficient_digits=polynomial.coefficient_digits,
+            rational_content=polynomial.rational_content,
+        )
+
+    return FractionBound(
+        numerator=divide(bound.numerator), denominator=divide(bound.denominator)
+    )
+
+
+def _canonical_coefficient_digits(bound: FractionBound) -> int:
+    if bound.is_zero:
+        return 1
+    content_ratio = (
+        bound.numerator.rational_content / bound.denominator.rational_content
+    )
+    denominator_is_unit = all(degree == 0 for degree in bound.denominator.degrees)
+    numerator_factor_digits = (
+        bound.numerator.coefficient_digits
+        if denominator_is_unit
+        else _factor_coefficient_digits(bound.numerator)
+    )
+    denominator_factor_digits = (
+        bound.denominator.coefficient_digits
+        if denominator_is_unit
+        else _factor_coefficient_digits(bound.denominator)
+    )
+    return max(
+        len(format_canonical_integer(abs(content_ratio.numerator)))
+        + bound.numerator.coefficient_digits
+        + (0 if denominator_is_unit else numerator_factor_digits),
+        len(format_canonical_integer(content_ratio.denominator))
+        + bound.denominator.coefficient_digits
+        + (0 if denominator_is_unit else denominator_factor_digits),
+        denominator_factor_digits,
+    )
+
+
+def _validate_canonical_result_bound(bound: FractionBound, ledger: BoundsLedger) -> int:
+    limits = ledger.limits
+    if bound.is_zero:
+        ledger.charge("normalization", 1)
+        return 1
+    for label, polynomial in (
+        ("numerator", bound.numerator),
+        ("denominator", bound.denominator),
+    ):
+        if any(degree > limits.result_exponent for degree in polynomial.degrees):
+            limits.reject(
+                "result_exponent",
+                f"{limits.label} {label} can exceed the canonical "
+                f"exponent bound {limits.result_exponent}",
+            )
+        dense_terms = _dense_term_bound(
+            polynomial.degrees,
+            cap=limits.result_terms,
+        )
+        # When the denominator is the unit polynomial, there can be no
+        # cancellation-induced support expansion, so the tracked sparse
+        # term count is the accurate support bound.
+        denominator_is_unit = all(degree == 0 for degree in bound.denominator.degrees)
+        support_terms = polynomial.terms if denominator_is_unit else dense_terms
+        if support_terms > limits.result_terms:
+            limits.reject(
+                "result_support",
+                f"{limits.label} {label} can exceed the canonical "
+                f"{limits.result_terms}-term bound",
+            )
+    coefficient_digits = _canonical_coefficient_digits(bound)
+    if coefficient_digits > limits.result_digits:
+        limits.reject(
+            "result_height",
+            f"{limits.label} normalization can exceed the canonical "
+            f"{limits.result_digits}-digit coefficient bound",
+        )
+    denominator_is_unit = all(degree == 0 for degree in bound.denominator.degrees)
+    numerator_dense = (
+        bound.numerator.terms
+        if denominator_is_unit
+        else _dense_term_bound(bound.numerator.degrees)
+    )
+    denominator_dense = (
+        1 if denominator_is_unit else _dense_term_bound(bound.denominator.degrees)
+    )
+    normalization_degree = max(numerator_dense + denominator_dense - 2, 0)
+    ledger.charge(
+        "normalization",
+        (numerator_dense + denominator_dense)
+        * (normalization_degree + 1)
+        * coefficient_digits,
+    )
+    return coefficient_digits
+
+
+def _recognition_work_units(bound: FractionBound) -> int:
+    """Charge the dense exact coefficient work exposed to SymPy's GCD.
+
+    SymPy 1.14 represents a multivariate ``Poly`` as a recursively dense DMP.
+    The product of per-axis degree ranges therefore bounds the coefficients
+    materialized by conversion.  Total degree steps and 32-digit coefficient
+    chunks conservatively price the subsequent exact GCD reductions.  A
+    killable worker still owns wall time and memory because SymPy exposes no
+    cooperative cancellation hook inside ``Poly.gcd``.
+    """
+
+    numerator_dense = _dense_term_bound(bound.numerator.degrees)
+    denominator_dense = _dense_term_bound(bound.denominator.degrees)
+    degree_steps = (
+        sum(
+            max(numerator, denominator)
+            for numerator, denominator in zip(
+                bound.numerator.degrees,
+                bound.denominator.degrees,
+                strict=True,
+            )
+        )
+        + 1
+    )
+    coefficient_digits = max(
+        bound.numerator.coefficient_digits
+        + len(format_canonical_integer(abs(bound.numerator.rational_content.numerator)))
+        + len(format_canonical_integer(bound.numerator.rational_content.denominator)),
+        bound.denominator.coefficient_digits
+        + len(
+            format_canonical_integer(abs(bound.denominator.rational_content.numerator))
+        )
+        + len(format_canonical_integer(bound.denominator.rational_content.denominator)),
+    )
+    coefficient_chunks = max(1, (coefficient_digits + 31) // 32)
+    return (numerator_dense + denominator_dense) * degree_steps * coefficient_chunks

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -7,7 +7,7 @@ callback. These estimates own no operation-specific deadline or error policy.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from fractions import Fraction
 from math import comb, gcd, isqrt, lcm
 from typing import Literal, NoReturn, Protocol
@@ -804,13 +804,17 @@ def _remove_guaranteed_linear_power_factor(
                 return polynomial
             degrees = tuple(max(0, degree - drop) for degree in polynomial.degrees)
             total_degree = max(0, polynomial.total_degree - drop)
-            return PolynomialBound(
-                terms=min(polynomial.terms, total_degree + 1),
+            reduced = PolynomialBound(
+                terms=polynomial.terms,
                 degrees=degrees,
                 total_degree=total_degree,
                 minimum_exponents=polynomial.minimum_exponents,
                 coefficient_digits=polynomial.coefficient_digits,
                 rational_content=polynomial.rational_content,
+            )
+            return replace(
+                reduced,
+                terms=min(polynomial.terms, _total_degree_term_bound(reduced)),
             )
         if axis >= len(polynomial.degrees):
             return polynomial

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -63,6 +63,7 @@ class PolynomialBound:
     minimum_exponents: tuple[int, ...]
     coefficient_digits: int
     rational_content: Fraction
+    proven_cancellation_support: bool = False
 
     @property
     def is_zero(self) -> bool:
@@ -527,8 +528,8 @@ def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
         return bound
 
     def divide(polynomial: PolynomialBound) -> PolynomialBound:
-        return PolynomialBound(
-            terms=polynomial.terms,
+        return replace(
+            polynomial,
             degrees=tuple(
                 degree - exponent
                 for degree, exponent in zip(polynomial.degrees, common, strict=True)
@@ -540,8 +541,6 @@ def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
                     polynomial.minimum_exponents, common, strict=True
                 )
             ),
-            coefficient_digits=polynomial.coefficient_digits,
-            rational_content=polynomial.rational_content,
         )
 
     return FractionBound(
@@ -816,14 +815,19 @@ def _remove_guaranteed_linear_power_factor(
             )
             # After canceling (ax+by)^{n-1} from q=(ax+by)^n, the denominator
             # remains a linear-form power, whose support has size total_degree+1.
-            # The cofactor numerator need not be homogeneous on that diagonal, so
-            # total_degree+1 is not a support bound there.
+            # The cofactor numerator is bounded by the factor/quotient box.
+            # Do not min with the pre-cancel sparse count: division can grow
+            # support.
             support = (
                 total_degree + 1
                 if linear_form_power
                 else _total_degree_term_bound(reduced)
             )
-            return replace(reduced, terms=min(polynomial.terms, support))
+            return replace(
+                reduced,
+                terms=support,
+                proven_cancellation_support=True,
+            )
         if axis >= len(polynomial.degrees):
             return polynomial
         drop = min(extra, polynomial.degrees[axis], polynomial.total_degree)
@@ -834,19 +838,22 @@ def _remove_guaranteed_linear_power_factor(
             for index, degree in enumerate(polynomial.degrees)
         )
         total_degree = max(0, polynomial.total_degree - drop)
-        univariate = all(
-            degree == 0 or index == axis for index, degree in enumerate(degrees)
-        )
-        terms = (
-            min(polynomial.terms, total_degree + 1) if univariate else polynomial.terms
-        )
-        return PolynomialBound(
-            terms=terms,
+        reduced = PolynomialBound(
+            terms=polynomial.terms,
             degrees=degrees,
             total_degree=total_degree,
             minimum_exponents=polynomial.minimum_exponents,
             coefficient_digits=polynomial.coefficient_digits,
             rational_content=polynomial.rational_content,
+        )
+        univariate = all(
+            degree == 0 or index == axis for index, degree in enumerate(degrees)
+        )
+        terms = total_degree + 1 if univariate else _total_degree_term_bound(reduced)
+        return replace(
+            reduced,
+            terms=terms,
+            proven_cancellation_support=True,
         )
 
     return FractionBound(
@@ -913,14 +920,17 @@ def _validate_canonical_result_bound(
         dense_terms = _total_degree_term_bound(polynomial)
         # When the denominator is the unit polynomial, there can be no
         # cancellation-induced support expansion, so the tracked sparse
-        # term count is the accurate support bound. After a source-intrinsic
-        # linear-power cancel, ``terms`` may be tighter than the dense box.
+        # term count is the accurate support bound. After a proven
+        # cancellation-specific bound, ``terms`` may be tighter than the
+        # factor/quotient box. Raw arithmetic term counts are not a bound
+        # on post-cancellation support: division can increase it.
         denominator_is_unit = all(degree == 0 for degree in bound.denominator.degrees)
-        support_terms = (
-            polynomial.terms
-            if denominator_is_unit
-            else min(dense_terms, polynomial.terms)
-        )
+        if denominator_is_unit:
+            support_terms = polynomial.terms
+        elif polynomial.proven_cancellation_support:
+            support_terms = min(dense_terms, polynomial.terms)
+        else:
+            support_terms = dense_terms
         if support_terms > limits.result_terms:
             limits.reject(
                 "result_support",

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -549,15 +549,111 @@ def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
     )
 
 
+def _integer_nth_root(value: int, n: int) -> int | None:
+    if value < 0:
+        return None
+    if value in (0, 1) or n == 1:
+        return value
+    low, high = 1, value
+    while low < high:
+        mid = (low + high + 1) // 2
+        power = mid**n
+        if power == value:
+            return mid
+        if power < value:
+            low = mid
+        else:
+            high = mid - 1
+    return low if low**n == value else None
+
+
+def _rational_nth_root(value: Fraction, n: int) -> Fraction | None:
+    if n < 2:
+        return None
+    sign = -1 if value.numerator < 0 else 1
+    if sign < 0 and n % 2 == 0:
+        return None
+    root_num = _integer_nth_root(abs(value.numerator), n)
+    root_den = _integer_nth_root(value.denominator, n)
+    if root_num is None or root_den is None:
+        return None
+    return Fraction(sign * root_num, root_den)
+
+
+def _poly_mul(left: list[Fraction], right: list[Fraction]) -> list[Fraction]:
+    product = [Fraction(0)] * (len(left) + len(right) - 1)
+    for i, left_coeff in enumerate(left):
+        if left_coeff == 0:
+            continue
+        for j, right_coeff in enumerate(right):
+            if right_coeff != 0:
+                product[i + j] += left_coeff * right_coeff
+    return product
+
+
+def _poly_pow(coefficients: list[Fraction], exponent: int) -> list[Fraction]:
+    result = [Fraction(1)]
+    base = coefficients
+    remaining = exponent
+    while remaining:
+        if remaining & 1:
+            result = _poly_mul(result, base)
+        remaining >>= 1
+        if remaining:
+            base = _poly_mul(base, base)
+    return result
+
+
+def _guaranteed_univariate_perfect_power_gcd(
+    by_degree: dict[int, Fraction],
+) -> int:
+    """Return ``deg(gcd(p^n, (p^n)'))`` when the source is a univariate ``p^n``."""
+
+    if 0 not in by_degree:
+        return 0
+    total_degree = max(by_degree)
+    if total_degree < 2:
+        return 0
+    source = [by_degree.get(degree, Fraction(0)) for degree in range(total_degree + 1)]
+    best = 0
+    for power in range(2, total_degree + 1):
+        if total_degree % power:
+            continue
+        inner_degree = total_degree // power
+        constant = _rational_nth_root(source[0], power)
+        if constant is None:
+            continue
+        inner = [Fraction(0)] * (inner_degree + 1)
+        inner[0] = constant
+        failed = False
+        for degree in range(1, inner_degree + 1):
+            known = _poly_pow(inner[:degree], power)
+            known_coeff = known[degree] if degree < len(known) else Fraction(0)
+            scale = power * (constant ** (power - 1))
+            if scale == 0:
+                failed = True
+                break
+            inner[degree] = (source[degree] - known_coeff) / scale
+        if failed:
+            continue
+        expanded = _poly_pow(inner, power)
+        if len(expanded) < total_degree + 1:
+            expanded.extend([Fraction(0)] * (total_degree + 1 - len(expanded)))
+        if expanded[: total_degree + 1] != source:
+            continue
+        best = max(best, (power - 1) * inner_degree)
+    return best
+
+
 def _guaranteed_linear_power_gcd(
     denominator: SparseRationalPolynomial,
 ) -> tuple[int, int]:
-    """Return ``(axis, deg(gcd(q, q')))`` for a univariate binomial power.
+    """Return ``(axis, deg(gcd(q, q')))`` for a univariate perfect power.
 
-    In characteristic zero, ``q = (alpha x_i^g + beta)^n`` with ``n >= 2`` and
-    ``beta != 0`` has ``gcd(q, q')`` of degree ``(n-1) g``. The binomial
-    coefficient recurrence is a source-intrinsic identity, so this lower bound
-    does not replay differentiation or polynomial GCD.
+    In characteristic zero, ``q = p^n`` has ``gcd(q, q')`` of degree
+    ``(n-1) deg(p)``. The coefficient recurrence is a source-intrinsic identity,
+    so this lower bound does not replay differentiation or polynomial GCD. Products
+    of equal linear powers are perfect powers of their product polynomial.
     """
 
     if not denominator.terms:
@@ -579,6 +675,9 @@ def _guaranteed_linear_power_gcd(
         if degree in by_degree:
             return -1, 0
         by_degree[degree] = term.coefficient.as_fraction()
+    extra = _guaranteed_univariate_perfect_power_gcd(by_degree)
+    if extra > 0:
+        return axis, extra
     exponents = sorted(by_degree)
     if 0 not in by_degree:
         return -1, 0

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -660,9 +660,7 @@ def _dense_univariate_gcd_degree(by_degree: dict[int, Fraction]) -> int:
             index -= 1
         return index
 
-    def remainder(
-        left: list[Fraction], right: list[Fraction]
-    ) -> list[Fraction]:
+    def remainder(left: list[Fraction], right: list[Fraction]) -> list[Fraction]:
         left = list(left)
         while degree_of(left) >= degree_of(right) >= 0:
             shift = degree_of(left) - degree_of(right)
@@ -828,9 +826,7 @@ def _remove_guaranteed_linear_power_factor(
             degree == 0 or index == axis for index, degree in enumerate(degrees)
         )
         terms = (
-            min(polynomial.terms, total_degree + 1)
-            if univariate
-            else polynomial.terms
+            min(polynomial.terms, total_degree + 1) if univariate else polynomial.terms
         )
         return PolynomialBound(
             terms=terms,
@@ -933,9 +929,7 @@ def _validate_canonical_result_bound(
     numerator_dense = (
         charged.numerator.terms
         if charged_denominator_is_unit
-        else min(
-            _dense_term_bound(charged.numerator.degrees), charged.numerator.terms
-        )
+        else min(_dense_term_bound(charged.numerator.degrees), charged.numerator.terms)
     )
     denominator_dense = (
         1

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -549,6 +549,69 @@ def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
     )
 
 
+def _guaranteed_linear_power_gcd_degree(denominator: SparseRationalPolynomial) -> int:
+    """Return ``deg(gcd(q, q'))`` when ``q`` is a power of a linear polynomial.
+
+    In characteristic zero, ``q = (alpha x + beta)^n`` with ``n >= 2`` and
+    ``beta != 0`` has ``gcd(q, q') = (alpha x + beta)^{n-1}``. The binomial
+    coefficient recurrence is a source-intrinsic identity, so this lower bound
+    does not replay differentiation or polynomial GCD.
+    """
+
+    if not denominator.terms:
+        return 0
+    axes = len(denominator.terms[0].exponents)
+    by_degree: dict[int, Fraction] = {}
+    for term in denominator.terms:
+        if any(term.exponents[axis] for axis in range(1, axes)):
+            return 0
+        degree = term.exponents[0]
+        if degree in by_degree:
+            return 0
+        by_degree[degree] = term.coefficient.as_fraction()
+    degree = max(by_degree, default=0)
+    if degree < 2 or len(by_degree) != degree + 1:
+        return 0
+    if any(index not in by_degree for index in range(degree + 1)):
+        return 0
+    constant = by_degree[0]
+    if constant == 0:
+        return 0
+    scale = by_degree[1] / (constant * degree)
+    for index in range(1, degree + 1):
+        expected = by_degree[index - 1] * ((degree - index + 1) / index) * scale
+        if by_degree[index] != expected:
+            return 0
+    return degree - 1
+
+
+def _remove_guaranteed_linear_power_factor(
+    bound: FractionBound, source: RationalFunction
+) -> FractionBound:
+    """Cancel the forced ``gcd(q, q')`` factor before canonical-result caps."""
+
+    extra = _guaranteed_linear_power_gcd_degree(source.denominator)
+    if extra <= 0 or bound.is_zero:
+        return bound
+
+    def reduce(polynomial: PolynomialBound) -> PolynomialBound:
+        drop = min(extra, polynomial.total_degree)
+        if drop <= 0:
+            return polynomial
+        return PolynomialBound(
+            terms=polynomial.terms,
+            degrees=tuple(max(0, degree - drop) for degree in polynomial.degrees),
+            total_degree=polynomial.total_degree - drop,
+            minimum_exponents=polynomial.minimum_exponents,
+            coefficient_digits=polynomial.coefficient_digits,
+            rational_content=polynomial.rational_content,
+        )
+
+    return FractionBound(
+        numerator=reduce(bound.numerator), denominator=reduce(bound.denominator)
+    )
+
+
 def _canonical_coefficient_digits(bound: FractionBound) -> int:
     """Bound monic reduction without counting integral content twice.
 

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from fractions import Fraction
-from math import gcd, lcm
+from math import comb, gcd, isqrt, lcm
 from typing import Literal, NoReturn, Protocol
 
 from jacobian.canonical import format_canonical_integer
@@ -59,6 +59,7 @@ class PolynomialBound:
 
     terms: int
     degrees: tuple[int, ...]
+    total_degree: int
     minimum_exponents: tuple[int, ...]
     coefficient_digits: int
     rational_content: Fraction
@@ -87,6 +88,19 @@ def _dense_term_bound(degrees: tuple[int, ...], *, cap: int | None = None) -> in
     return result
 
 
+def _total_degree_term_bound(bound: PolynomialBound) -> int:
+    """Bound support using both coordinate degrees and total degree.
+
+    Every factor has at most the source's total and coordinate degrees.
+    Stars and bars counts all exponent vectors of total degree at most T
+    in the active variables, including the constant monomial.
+    """
+    active = sum(degree > 0 for degree in bound.degrees)
+    return min(
+        _dense_term_bound(bound.degrees), comb(bound.total_degree + active, active)
+    )
+
+
 def _polynomial_admission_work_units(
     polynomial: SparseRationalPolynomial, variable_count: int
 ) -> int:
@@ -94,7 +108,7 @@ def _polynomial_admission_work_units(
 
     Each nonzero coefficient is converted, participates in denominator/content
     reduction, is scaled and made primitive, and is inspected for height. Each
-    exponent is inspected once for the maximum and once for the minimum. The
+    exponent is inspected for the maximum, minimum, and total degree. The
     final unit prices construction of the separated rational content. Zero is
     represented by one exact ``Fraction`` construction.
     """
@@ -102,7 +116,7 @@ def _polynomial_admission_work_units(
     terms = len(polynomial.terms)
     if terms == 0:
         return 1
-    return terms * (6 + 2 * variable_count) + 1
+    return terms * (6 + 3 * variable_count) + 1
 
 
 def _polynomial_backend_conversion_work_units(bound: PolynomialBound) -> int:
@@ -123,6 +137,7 @@ def _polynomial_bound(polynomial: SparseRationalPolynomial) -> PolynomialBound:
         return PolynomialBound(
             terms=0,
             degrees=(),
+            total_degree=0,
             minimum_exponents=(),
             coefficient_digits=1,
             rational_content=Fraction(0),
@@ -148,6 +163,7 @@ def _polynomial_bound(polynomial: SparseRationalPolynomial) -> PolynomialBound:
             max(term.exponents[axis] for term in polynomial.terms)
             for axis in range(variable_count)
         ),
+        total_degree=max(sum(term.exponents) for term in polynomial.terms),
         minimum_exponents=tuple(
             min(term.exponents[axis] for term in polynomial.terms)
             for axis in range(variable_count)
@@ -164,6 +180,7 @@ def _zero_polynomial(variable_count: int) -> PolynomialBound:
     return PolynomialBound(
         terms=0,
         degrees=(0,) * variable_count,
+        total_degree=0,
         minimum_exponents=(0,) * variable_count,
         coefficient_digits=1,
         rational_content=Fraction(0),
@@ -174,6 +191,7 @@ def _one_polynomial(variable_count: int) -> PolynomialBound:
     return PolynomialBound(
         terms=1,
         degrees=(0,) * variable_count,
+        total_degree=0,
         minimum_exponents=(0,) * variable_count,
         coefficient_digits=1,
         rational_content=Fraction(1),
@@ -244,11 +262,15 @@ def _differentiate_polynomial(
 ) -> PolynomialBound:
     if source.is_zero or active_terms == 0:
         return _zero_polynomial(len(source.degrees))
-    degrees = list(source.degrees)
-    degrees[axis] -= 1
+    total_degree = source.total_degree - 1
+    degrees = tuple(
+        min(degree - int(i == axis), total_degree)
+        for i, degree in enumerate(source.degrees)
+    )
     result = PolynomialBound(
         terms=active_terms,
-        degrees=tuple(degrees),
+        degrees=degrees,
+        total_degree=total_degree,
         minimum_exponents=minimum_exponents,
         coefficient_digits=(
             source.coefficient_digits
@@ -284,6 +306,7 @@ def _multiply_polynomials(
     result = PolynomialBound(
         terms=min(pair_count, _dense_term_bound(degrees)),
         degrees=degrees,
+        total_degree=left.total_degree + right.total_degree,
         minimum_exponents=tuple(
             left_exponent + right_exponent
             for left_exponent, right_exponent in zip(
@@ -338,6 +361,7 @@ def _add_polynomials(
     result = PolynomialBound(
         terms=min(left.terms + right.terms, _dense_term_bound(degrees)),
         degrees=degrees,
+        total_degree=max(left.total_degree, right.total_degree),
         minimum_exponents=tuple(
             min(left_exponent, right_exponent)
             for left_exponent, right_exponent in zip(
@@ -460,21 +484,25 @@ def _add_fractions(
 
 
 def _factor_coefficient_digits(bound: PolynomialBound) -> int:
-    """Bound every coefficient of a rational factor of ``bound``.
+    """Bound coefficients of a primitive integral factor of ``bound``.
 
-    Clear source denominators, inject the multivariate polynomial into a
-    univariate polynomial by mixed-radix Kronecker substitution, and apply
-    Mignotte's ``2**degree * l2_norm`` integer-factor height bound.  A factor's
-    degree in each variable cannot exceed the source degree, so the mixed
-    radices introduce no carries in a factorization.
+    For an integral factor F of P, multiplicativity of Mahler measure and
+    M(P/F)>=1 give H(F)<=L(F)<=2**sum(deg_i(F))*M(F)
+    <=2**sum(deg_i(P))*||P||_2. The alternative bound
+    L(F)<=(a+1)**deg(F)*M(F), for a active variables, can be sharper.
+    See Amoroso--Mignotte, Acta Arith.
+    99 (2001), p. 1, https://doi.org/10.4064/aa99-1-1.
+    The separated rational content is handled by the caller.
     """
 
     if bound.is_zero:
         return 1
-    kronecker_degree = _dense_term_bound(bound.degrees) - 1
-    binary_factor_digits = (302 * kronecker_degree + 999) // 1000
-    norm_digits = len(format_canonical_integer(bound.terms)) + 1
-    return bound.coefficient_digits + binary_factor_digits + norm_digits + 2
+    active = sum(degree > 0 for degree in bound.degrees)
+    multiplier = min(1 << sum(bound.degrees), (active + 1) ** bound.total_degree)
+    norm_multiplier = isqrt(bound.terms - 1) + 1
+    return bound.coefficient_digits + len(
+        format_canonical_integer(multiplier * norm_multiplier)
+    )
 
 
 def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
@@ -505,6 +533,7 @@ def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
                 degree - exponent
                 for degree, exponent in zip(polynomial.degrees, common, strict=True)
             ),
+            total_degree=polynomial.total_degree - sum(common),
             minimum_exponents=tuple(
                 minimum - exponent
                 for minimum, exponent in zip(
@@ -521,6 +550,14 @@ def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
 
 
 def _canonical_coefficient_digits(bound: FractionBound) -> int:
+    """Bound monic reduction without counting integral content twice.
+
+    Write the raw pair as cN*N, cD*D with integral N,D. A primitive integral
+    common gcd G leaves integral factors A=N/G and B=D/G; their contents are
+    already included in the factor-height bounds. Canonical coefficients are
+    (cN/cD)*A_i/LC(B) and B_i/LC(B), so their rational components need only
+    the corresponding factor height and the separated content ratio.
+    """
     if bound.is_zero:
         return 1
     content_ratio = (
@@ -539,11 +576,9 @@ def _canonical_coefficient_digits(bound: FractionBound) -> int:
     )
     return max(
         len(format_canonical_integer(abs(content_ratio.numerator)))
-        + bound.numerator.coefficient_digits
-        + (0 if denominator_is_unit else numerator_factor_digits),
+        + numerator_factor_digits,
         len(format_canonical_integer(content_ratio.denominator))
-        + bound.denominator.coefficient_digits
-        + (0 if denominator_is_unit else denominator_factor_digits),
+        + denominator_factor_digits,
         denominator_factor_digits,
     )
 
@@ -563,10 +598,7 @@ def _validate_canonical_result_bound(bound: FractionBound, ledger: BoundsLedger)
                 f"{limits.label} {label} can exceed the canonical "
                 f"exponent bound {limits.result_exponent}",
             )
-        dense_terms = _dense_term_bound(
-            polynomial.degrees,
-            cap=limits.result_terms,
-        )
+        dense_terms = _total_degree_term_bound(polynomial)
         # When the denominator is the unit polynomial, there can be no
         # cancellation-induced support expansion, so the tracked sparse
         # term count is the accurate support bound.
@@ -586,6 +618,8 @@ def _validate_canonical_result_bound(bound: FractionBound, ledger: BoundsLedger)
             f"{limits.result_digits}-digit coefficient bound",
         )
     denominator_is_unit = all(degree == 0 for degree in bound.denominator.degrees)
+    # Normalization still uses the recursively dense backend. A sparse
+    # canonical support bound does not justify reducing this work charge.
     numerator_dense = (
         bound.numerator.terms
         if denominator_is_unit

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -549,7 +549,9 @@ def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
     )
 
 
-def _guaranteed_linear_power_gcd(denominator: SparseRationalPolynomial) -> tuple[int, int]:
+def _guaranteed_linear_power_gcd(
+    denominator: SparseRationalPolynomial,
+) -> tuple[int, int]:
     """Return ``(axis, deg(gcd(q, q')))`` for a power of a linear polynomial.
 
     In characteristic zero, ``q = (alpha x_i + beta)^n`` with ``n >= 2`` and

--- a/src/jacobian/math/polynomials/rational_functions/_bounds.py
+++ b/src/jacobian/math/polynomials/rational_functions/_bounds.py
@@ -549,40 +549,48 @@ def _remove_guaranteed_common_monomial(bound: FractionBound) -> FractionBound:
     )
 
 
-def _guaranteed_linear_power_gcd_degree(denominator: SparseRationalPolynomial) -> int:
-    """Return ``deg(gcd(q, q'))`` when ``q`` is a power of a linear polynomial.
+def _guaranteed_linear_power_gcd(denominator: SparseRationalPolynomial) -> tuple[int, int]:
+    """Return ``(axis, deg(gcd(q, q')))`` for a power of a linear polynomial.
 
-    In characteristic zero, ``q = (alpha x + beta)^n`` with ``n >= 2`` and
-    ``beta != 0`` has ``gcd(q, q') = (alpha x + beta)^{n-1}``. The binomial
+    In characteristic zero, ``q = (alpha x_i + beta)^n`` with ``n >= 2`` and
+    ``beta != 0`` has ``gcd(q, q') = (alpha x_i + beta)^{n-1}``. The binomial
     coefficient recurrence is a source-intrinsic identity, so this lower bound
     does not replay differentiation or polynomial GCD.
     """
 
     if not denominator.terms:
-        return 0
+        return -1, 0
     axes = len(denominator.terms[0].exponents)
+    used = [
+        axis
+        for axis in range(axes)
+        if any(term.exponents[axis] for term in denominator.terms)
+    ]
+    if len(used) != 1:
+        return -1, 0
+    axis = used[0]
     by_degree: dict[int, Fraction] = {}
     for term in denominator.terms:
-        if any(term.exponents[axis] for axis in range(1, axes)):
-            return 0
-        degree = term.exponents[0]
+        if any(term.exponents[other] for other in range(axes) if other != axis):
+            return -1, 0
+        degree = term.exponents[axis]
         if degree in by_degree:
-            return 0
+            return -1, 0
         by_degree[degree] = term.coefficient.as_fraction()
     degree = max(by_degree, default=0)
     if degree < 2 or len(by_degree) != degree + 1:
-        return 0
+        return -1, 0
     if any(index not in by_degree for index in range(degree + 1)):
-        return 0
+        return -1, 0
     constant = by_degree[0]
     if constant == 0:
-        return 0
+        return -1, 0
     scale = by_degree[1] / (constant * degree)
     for index in range(1, degree + 1):
-        expected = by_degree[index - 1] * ((degree - index + 1) / index) * scale
+        expected = by_degree[index - 1] * Fraction(degree - index + 1, index) * scale
         if by_degree[index] != expected:
-            return 0
-    return degree - 1
+            return -1, 0
+    return axis, degree - 1
 
 
 def _remove_guaranteed_linear_power_factor(
@@ -590,18 +598,24 @@ def _remove_guaranteed_linear_power_factor(
 ) -> FractionBound:
     """Cancel the forced ``gcd(q, q')`` factor before canonical-result caps."""
 
-    extra = _guaranteed_linear_power_gcd_degree(source.denominator)
+    axis, extra = _guaranteed_linear_power_gcd(source.denominator)
     if extra <= 0 or bound.is_zero:
         return bound
 
     def reduce(polynomial: PolynomialBound) -> PolynomialBound:
-        drop = min(extra, polynomial.total_degree)
+        if axis >= len(polynomial.degrees):
+            return polynomial
+        drop = min(extra, polynomial.degrees[axis], polynomial.total_degree)
         if drop <= 0:
             return polynomial
+        degrees = tuple(
+            max(0, degree - drop) if index == axis else degree
+            for index, degree in enumerate(polynomial.degrees)
+        )
         return PolynomialBound(
             terms=polynomial.terms,
-            degrees=tuple(max(0, degree - drop) for degree in polynomial.degrees),
-            total_degree=polynomial.total_degree - drop,
+            degrees=degrees,
+            total_degree=max(0, polynomial.total_degree - drop),
             minimum_exponents=polynomial.minimum_exponents,
             coefficient_digits=polynomial.coefficient_digits,
             rational_content=polynomial.rational_content,

--- a/src/jacobian/math/polynomials/rational_functions/gradient/__init__.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/__init__.py
@@ -1,0 +1,8 @@
+"""Exact gradients of canonical multivariate rational functions."""
+
+from jacobian.math.polynomials.rational_functions.gradient._models import (
+    RationalFunctionGradient,
+)
+from jacobian.math.polynomials.rational_functions.gradient.operations import gradient
+
+__all__ = ["RationalFunctionGradient", "gradient"]

--- a/src/jacobian/math/polynomials/rational_functions/gradient/_kernel.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/_kernel.py
@@ -4,6 +4,9 @@ from typing import Any
 
 from jacobian._execution import request_checkpoint
 from jacobian.math.polynomials._conversions import sparse_rational_polynomial_from_sympy
+from jacobian.math.polynomials.rational_functions.gradient._normalize_process import (
+    cancel_fraction,
+)
 from jacobian.math.polynomials.values import RationalFunction
 
 
@@ -23,42 +26,15 @@ def _differentiate_fraction(
 
 
 def _normalize_fraction(
-    numerator: Any, denominator: Any, variables: tuple[str, ...]
+    numerator: Any,
+    denominator: Any,
+    variables: tuple[str, ...],
+    *,
+    deadline: float,
 ) -> RationalFunction:
     """Normalize an admitted pair once; preserve canonical field representation."""
     request_checkpoint("before rational gradient normalization")
-    # Match the bound's guaranteed common-monomial presolve before GCD.
-    # A uniform exponent shift preserves every coefficient and sparse term.
-    if not numerator.is_zero:
-        from sympy import Poly
-
-        numerator_terms, denominator_terms = numerator.terms(), denominator.terms()
-        common = tuple(
-            min(
-                min(exponents[axis] for exponents, _ in numerator_terms),
-                min(exponents[axis] for exponents, _ in denominator_terms),
-            )
-            for axis in range(len(variables))
-        )
-        if any(common):
-
-            def divide(value: Any) -> Any:
-                return Poly.from_dict(
-                    {
-                        tuple(
-                            e - c for e, c in zip(exponents, common, strict=True)
-                        ): coefficient
-                        for exponents, coefficient in value.terms()
-                    },
-                    value.gens,
-                    domain=value.domain,
-                )
-
-            numerator, denominator = divide(numerator), divide(denominator)
-    numerator, denominator = numerator.cancel(denominator, include=True)
-    leading = denominator.LC()
-    numerator = numerator.mul_ground(1 / leading)
-    denominator = denominator.mul_ground(1 / leading)
+    numerator, denominator = cancel_fraction(numerator, denominator, deadline=deadline)
     request_checkpoint("after rational gradient normalization")
     return RationalFunction._from_kernel(
         variables=variables,

--- a/src/jacobian/math/polynomials/rational_functions/gradient/_kernel.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/_kernel.py
@@ -1,47 +1,20 @@
 """Admitted exact quotient differentiation and owner-canonical normalization."""
 
-from typing import Any
-
 from jacobian._execution import request_checkpoint
-from jacobian.math.polynomials._conversions import sparse_rational_polynomial_from_sympy
 from jacobian.math.polynomials.rational_functions.gradient._normalize_process import (
-    cancel_fraction,
+    normalize_partial,
 )
 from jacobian.math.polynomials.values import RationalFunction
 
 
-def _differentiate_fraction(
-    numerator: Any, denominator: Any, axis: int
-) -> tuple[Any, Any]:
-    """Return the raw quotient-rule pair after the caller admits its entire DAG.
-
-    Inputs are exact SymPy QQ Poly values on identical ordered generators.
-    Keeping normalization separate lets a tensor owner share its own complete
-    arithmetic ledger, rather than invoking independent scalar admissions.
-    """
-    return (
-        numerator.diff(axis) * denominator - numerator * denominator.diff(axis),
-        denominator * denominator,
-    )
-
-
 def _normalize_fraction(
-    numerator: Any,
-    denominator: Any,
-    variables: tuple[str, ...],
+    source: RationalFunction,
+    axis: int,
     *,
     deadline: float,
 ) -> RationalFunction:
-    """Normalize an admitted pair once; preserve canonical field representation."""
+    """Normalize one admitted partial; preserve canonical field representation."""
     request_checkpoint("before rational gradient normalization")
-    numerator, denominator = cancel_fraction(numerator, denominator, deadline=deadline)
+    result = normalize_partial(source, axis, deadline=deadline)
     request_checkpoint("after rational gradient normalization")
-    return RationalFunction._from_kernel(
-        variables=variables,
-        numerator=sparse_rational_polynomial_from_sympy(
-            numerator, variables, maximum_terms=256
-        ),
-        denominator=sparse_rational_polynomial_from_sympy(
-            denominator, variables, maximum_terms=256
-        ),
-    )
+    return result

--- a/src/jacobian/math/polynomials/rational_functions/gradient/_kernel.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/_kernel.py
@@ -1,0 +1,71 @@
+"""Admitted exact quotient differentiation and owner-canonical normalization."""
+
+from typing import Any
+
+from jacobian._execution import request_checkpoint
+from jacobian.math.polynomials._conversions import sparse_rational_polynomial_from_sympy
+from jacobian.math.polynomials.values import RationalFunction
+
+
+def _differentiate_fraction(
+    numerator: Any, denominator: Any, axis: int
+) -> tuple[Any, Any]:
+    """Return the raw quotient-rule pair after the caller admits its entire DAG.
+
+    Inputs are exact SymPy QQ Poly values on identical ordered generators.
+    Keeping normalization separate lets a tensor owner share its own complete
+    arithmetic ledger, rather than invoking independent scalar admissions.
+    """
+    return (
+        numerator.diff(axis) * denominator - numerator * denominator.diff(axis),
+        denominator * denominator,
+    )
+
+
+def _normalize_fraction(
+    numerator: Any, denominator: Any, variables: tuple[str, ...]
+) -> RationalFunction:
+    """Normalize an admitted pair once; preserve canonical field representation."""
+    request_checkpoint("before rational gradient normalization")
+    # Match the bound's guaranteed common-monomial presolve before GCD.
+    # A uniform exponent shift preserves every coefficient and sparse term.
+    if not numerator.is_zero:
+        from sympy import Poly
+
+        numerator_terms, denominator_terms = numerator.terms(), denominator.terms()
+        common = tuple(
+            min(
+                min(exponents[axis] for exponents, _ in numerator_terms),
+                min(exponents[axis] for exponents, _ in denominator_terms),
+            )
+            for axis in range(len(variables))
+        )
+        if any(common):
+
+            def divide(value: Any) -> Any:
+                return Poly.from_dict(
+                    {
+                        tuple(
+                            e - c for e, c in zip(exponents, common, strict=True)
+                        ): coefficient
+                        for exponents, coefficient in value.terms()
+                    },
+                    value.gens,
+                    domain=value.domain,
+                )
+
+            numerator, denominator = divide(numerator), divide(denominator)
+    numerator, denominator = numerator.cancel(denominator, include=True)
+    leading = denominator.LC()
+    numerator = numerator.mul_ground(1 / leading)
+    denominator = denominator.mul_ground(1 / leading)
+    request_checkpoint("after rational gradient normalization")
+    return RationalFunction._from_kernel(
+        variables=variables,
+        numerator=sparse_rational_polynomial_from_sympy(
+            numerator, variables, maximum_terms=256
+        ),
+        denominator=sparse_rational_polynomial_from_sympy(
+            denominator, variables, maximum_terms=256
+        ),
+    )

--- a/src/jacobian/math/polynomials/rational_functions/gradient/_models.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/_models.py
@@ -1,0 +1,30 @@
+"""Complete scalar field gradients on an unchanged coordinate axis."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.polynomials.values import PolynomialVariable, RationalFunction
+
+
+class RationalGradientRequest(StrictModel):
+    function: RationalFunction
+
+
+class RationalFunctionGradient(StrictModel):
+    """The complete coordinate partial derivatives of a retained field element."""
+
+    source: RationalFunction
+    variables: tuple[PolynomialVariable, ...] = Field(max_length=8)
+    partial_derivatives: tuple[RationalFunction, ...] = Field(max_length=8)
+
+    @model_validator(mode="after")
+    def require_axes(self) -> Self:
+        if self.variables != self.source.variables:
+            raise ValueError("gradient axis must equal the source coordinate axis")
+        if len(self.partial_derivatives) != len(self.variables):
+            raise ValueError("gradient must have one component per coordinate")
+        if any(value.variables != self.variables for value in self.partial_derivatives):
+            raise ValueError("every partial derivative must retain the source axis")
+        return self

--- a/src/jacobian/math/polynomials/rational_functions/gradient/_normalize_process.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/_normalize_process.py
@@ -1,0 +1,140 @@
+"""Killable SymPy cancellation for admitted rational-gradient components."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from time import monotonic
+from typing import Any
+
+from sympy import QQ, Poly, Rational
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+    loads_strict_json,
+)
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_WORKER_PATH = Path(__file__).resolve().with_name("_normalize_worker.py")
+_STDOUT_BYTES = 8 * 1024 * 1024
+_STDERR_BYTES = 64 * 1024
+_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_PARENT_FINALIZATION_SECONDS = 1.0
+
+
+def _poly_payload(polynomial: Any) -> list[list[Any]]:
+    return [
+        [*exponents, str(coefficient.p), str(coefficient.q)]
+        for exponents, coefficient in polynomial.terms()
+    ]
+
+
+def _poly_from_payload(records: object, symbols: tuple[Any, ...]) -> Any:
+    if not isinstance(records, list):
+        raise ValueError("malformed cancelled polynomial")
+    coefficients: dict[tuple[int, ...], Any] = {}
+    variable_count = len(symbols)
+    for record in records:
+        if not isinstance(record, list) or len(record) != variable_count + 2:
+            raise ValueError("malformed cancelled polynomial")
+        exponents = tuple(record[:variable_count])
+        if any(type(exponent) is not int or exponent < 0 for exponent in exponents):
+            raise ValueError("malformed cancelled polynomial")
+        numerator, denominator = record[-2], record[-1]
+        if not isinstance(numerator, str) or not isinstance(denominator, str):
+            raise ValueError("malformed cancelled polynomial")
+        coefficients[exponents] = Rational(int(numerator), int(denominator))
+    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+
+
+def cancel_fraction(
+    numerator: Any, denominator: Any, *, deadline: float
+) -> tuple[Any, Any]:
+    """Cancel one admitted pair in a killable worker under the shared deadline."""
+
+    remaining = deadline - monotonic() - _PARENT_FINALIZATION_SECONDS
+    if remaining <= 0:
+        raise OperationExecutionTimeoutError(
+            "rational gradient deadline expired before fraction cancellation"
+        )
+    payload = encode_strict_json(
+        {
+            "variable_count": len(numerator.gens),
+            "numerator": _poly_payload(numerator),
+            "denominator": _poly_payload(denominator),
+        }
+    )
+    try:
+        with TemporaryDirectory(prefix="jacobian-gradient-cancel-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_WORKER_PATH)],
+                input_bytes=payload,
+                timeout_seconds=remaining,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_STDOUT_BYTES,
+                stderr_limit=_STDERR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(remaining)),
+                    address_space_bytes=_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_STDOUT_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded rational-gradient cancellation worker could not be started"
+        ) from exc
+    if completed.cancelled:
+        raise OperationExecutionCancelledError(
+            "rational gradient cancelled during fraction cancellation"
+        )
+    if completed.timed_out:
+        raise OperationExecutionTimeoutError(
+            "rational gradient deadline expired during fraction cancellation"
+        )
+    if (
+        completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        raise RuntimeError(
+            "bounded rational-gradient cancellation worker did not return a fraction"
+        )
+    try:
+        response = loads_strict_json(
+            completed.stdout,
+            limits=CanonicalLimits(
+                max_input_bytes=_STDOUT_BYTES,
+                max_output_bytes=_STDOUT_BYTES,
+            ),
+        )
+    except CanonicalizationError as exc:
+        raise RuntimeError(
+            "bounded rational-gradient cancellation worker returned malformed output"
+        ) from exc
+    if (
+        not isinstance(response, dict)
+        or response.get("status") != "ok"
+        or "numerator" not in response
+        or "denominator" not in response
+    ):
+        raise RuntimeError(
+            "bounded rational-gradient cancellation worker returned malformed output"
+        )
+    symbols = tuple(numerator.gens)
+    return (
+        _poly_from_payload(response["numerator"], symbols),
+        _poly_from_payload(response["denominator"], symbols),
+    )

--- a/src/jacobian/math/polynomials/rational_functions/gradient/_normalize_process.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/_normalize_process.py
@@ -1,4 +1,4 @@
-"""Killable SymPy cancellation for admitted rational-gradient components."""
+"""Killable SymPy quotient-rule expansion and cancellation for gradients."""
 
 from __future__ import annotations
 
@@ -9,8 +9,7 @@ from tempfile import TemporaryDirectory
 from time import monotonic
 from typing import Any
 
-from sympy import QQ, Poly, Rational
-
+from jacobian._exact import CanonicalRational
 from jacobian._execution import (
     OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
@@ -19,7 +18,13 @@ from jacobian.canonical import (
     CanonicalizationError,
     CanonicalLimits,
     encode_strict_json,
+    format_canonical_integer,
     loads_strict_json,
+)
+from jacobian.math.polynomials.values import (
+    RationalFunction,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
 )
 from jacobian.process import (
     ProcessResourceLimits,
@@ -32,20 +37,26 @@ _STDOUT_BYTES = 8 * 1024 * 1024
 _STDERR_BYTES = 64 * 1024
 _ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
 _PARENT_FINALIZATION_SECONDS = 1.0
+_MAX_RESULT_TERMS = 256
 
 
-def _poly_payload(polynomial: Any) -> list[list[Any]]:
+def _poly_payload(polynomial: SparseRationalPolynomial) -> list[list[Any]]:
     return [
-        [*exponents, str(coefficient.p), str(coefficient.q)]
-        for exponents, coefficient in polynomial.terms()
+        [
+            *term.exponents,
+            format_canonical_integer(term.coefficient.num),
+            format_canonical_integer(term.coefficient.den),
+        ]
+        for term in polynomial.terms
     ]
 
 
-def _poly_from_payload(records: object, symbols: tuple[Any, ...]) -> Any:
+def _poly_from_payload(
+    records: object, variable_count: int
+) -> SparseRationalPolynomial:
     if not isinstance(records, list):
         raise ValueError("malformed cancelled polynomial")
-    coefficients: dict[tuple[int, ...], Any] = {}
-    variable_count = len(symbols)
+    terms: list[RationalPolynomialTerm] = []
     for record in records:
         if not isinstance(record, list) or len(record) != variable_count + 2:
             raise ValueError("malformed cancelled polynomial")
@@ -55,25 +66,34 @@ def _poly_from_payload(records: object, symbols: tuple[Any, ...]) -> Any:
         numerator, denominator = record[-2], record[-1]
         if not isinstance(numerator, str) or not isinstance(denominator, str):
             raise ValueError("malformed cancelled polynomial")
-        coefficients[exponents] = Rational(int(numerator), int(denominator))
-    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+        terms.append(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational(num=int(numerator), den=int(denominator)),
+                exponents=exponents,
+            )
+        )
+    if len(terms) > _MAX_RESULT_TERMS:
+        raise ValueError("cancelled polynomial exceeds the canonical term bound")
+    return SparseRationalPolynomial(terms=tuple(terms))
 
 
-def cancel_fraction(
-    numerator: Any, denominator: Any, *, deadline: float
-) -> tuple[Any, Any]:
-    """Cancel one admitted pair in a killable worker under the shared deadline."""
+def normalize_partial(
+    source: RationalFunction, axis: int, *, deadline: float
+) -> RationalFunction:
+    """Expand and cancel one admitted partial in a killable worker."""
 
     remaining = deadline - monotonic() - _PARENT_FINALIZATION_SECONDS
     if remaining <= 0:
         raise OperationExecutionTimeoutError(
-            "rational gradient deadline expired before fraction cancellation"
+            "rational gradient deadline expired before the gradient kernel"
         )
+    variable_count = len(source.variables)
     payload = encode_strict_json(
         {
-            "variable_count": len(numerator.gens),
-            "numerator": _poly_payload(numerator),
-            "denominator": _poly_payload(denominator),
+            "variable_count": variable_count,
+            "axis": axis,
+            "numerator": _poly_payload(source.numerator),
+            "denominator": _poly_payload(source.denominator),
         }
     )
     try:
@@ -94,15 +114,15 @@ def cancel_fraction(
             )
     except OSError as exc:
         raise RuntimeError(
-            "bounded rational-gradient cancellation worker could not be started"
+            "bounded rational-gradient kernel worker could not be started"
         ) from exc
     if completed.cancelled:
         raise OperationExecutionCancelledError(
-            "rational gradient cancelled during fraction cancellation"
+            "rational gradient cancelled during the gradient kernel"
         )
     if completed.timed_out:
         raise OperationExecutionTimeoutError(
-            "rational gradient deadline expired during fraction cancellation"
+            "rational gradient deadline expired during the gradient kernel"
         )
     if (
         completed.stdout_exceeded
@@ -110,7 +130,7 @@ def cancel_fraction(
         or completed.returncode != 0
     ):
         raise RuntimeError(
-            "bounded rational-gradient cancellation worker did not return a fraction"
+            "bounded rational-gradient kernel worker did not return a fraction"
         )
     try:
         response = loads_strict_json(
@@ -122,7 +142,7 @@ def cancel_fraction(
         )
     except CanonicalizationError as exc:
         raise RuntimeError(
-            "bounded rational-gradient cancellation worker returned malformed output"
+            "bounded rational-gradient kernel worker returned malformed output"
         ) from exc
     if (
         not isinstance(response, dict)
@@ -131,10 +151,17 @@ def cancel_fraction(
         or "denominator" not in response
     ):
         raise RuntimeError(
-            "bounded rational-gradient cancellation worker returned malformed output"
+            "bounded rational-gradient kernel worker returned malformed output"
         )
-    symbols = tuple(numerator.gens)
-    return (
-        _poly_from_payload(response["numerator"], symbols),
-        _poly_from_payload(response["denominator"], symbols),
+    try:
+        numerator = _poly_from_payload(response["numerator"], variable_count)
+        denominator = _poly_from_payload(response["denominator"], variable_count)
+    except ValueError as exc:
+        raise RuntimeError(
+            "bounded rational-gradient kernel worker returned malformed output"
+        ) from exc
+    return RationalFunction._from_kernel(
+        variables=source.variables,
+        numerator=numerator,
+        denominator=denominator,
     )

--- a/src/jacobian/math/polynomials/rational_functions/gradient/_normalize_worker.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/_normalize_worker.py
@@ -1,4 +1,4 @@
-"""Standalone SymPy worker for admitted rational-gradient cancellation."""
+"""Standalone SymPy worker for admitted rational-gradient quotient rule."""
 
 from __future__ import annotations
 
@@ -42,27 +42,35 @@ def _dump(polynomial: Any) -> list[list[Any]]:
 def _run(payload: dict[str, Any]) -> dict[str, Any]:
     from sympy import symbols
 
-    if set(payload) != {"variable_count", "numerator", "denominator"}:
-        raise ValueError("malformed cancellation request")
+    if set(payload) != {"variable_count", "axis", "numerator", "denominator"}:
+        raise ValueError("malformed gradient kernel request")
     variable_count = payload["variable_count"]
+    axis = payload["axis"]
     if (
         type(variable_count) is not int
         or variable_count < 1
+        or type(axis) is not int
+        or not 0 <= axis < variable_count
         or not isinstance(payload["numerator"], list)
         or not isinstance(payload["denominator"], list)
     ):
-        raise ValueError("malformed cancellation request")
+        raise ValueError("malformed gradient kernel request")
     generators = symbols(f"x0:{variable_count}")
     numerator = _polynomial(payload["numerator"], generators)
     denominator = _polynomial(payload["denominator"], generators)
+    generator = generators[axis]
+    numerator = numerator.diff(generator) * denominator - numerator * denominator.diff(
+        generator
+    )
+    denominator = denominator * denominator
     if not numerator.is_zero:
         numerator_terms, denominator_terms = numerator.terms(), denominator.terms()
         common = tuple(
             min(
-                min(exponents[axis] for exponents, _ in numerator_terms),
-                min(exponents[axis] for exponents, _ in denominator_terms),
+                min(exponents[index] for exponents, _ in numerator_terms),
+                min(exponents[index] for exponents, _ in denominator_terms),
             )
-            for axis in range(variable_count)
+            for index in range(variable_count)
         )
         if any(common):
             from sympy import Poly
@@ -96,7 +104,7 @@ def main() -> int:
     try:
         payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
         if not isinstance(payload, dict):
-            raise ValueError("malformed cancellation request")
+            raise ValueError("malformed gradient kernel request")
         response = _run(payload)
     except Exception:
         return 1

--- a/src/jacobian/math/polynomials/rational_functions/gradient/_normalize_worker.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/_normalize_worker.py
@@ -1,0 +1,110 @@
+"""Standalone SymPy worker for admitted rational-gradient cancellation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def _polynomial(records: list[Any], symbols: tuple[Any, ...]) -> Any:
+    from sympy import QQ, Poly, Rational
+
+    coefficients: dict[tuple[int, ...], Any] = {}
+    variable_count = len(symbols)
+    for record in records:
+        if not isinstance(record, list) or len(record) != variable_count + 2:
+            raise ValueError("malformed polynomial record")
+        exponents = tuple(record[:variable_count])
+        numerator = record[-2]
+        denominator = record[-1]
+        if (
+            any(type(exponent) is not int or exponent < 0 for exponent in exponents)
+            or not isinstance(numerator, str)
+            or not isinstance(denominator, str)
+        ):
+            raise ValueError("malformed polynomial record")
+        coefficients[exponents] = Rational(int(numerator), int(denominator))
+    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+
+
+def _dump(polynomial: Any) -> list[list[Any]]:
+    return [
+        [
+            *exponents,
+            str(coefficient.p),
+            str(coefficient.q),
+        ]
+        for exponents, coefficient in polynomial.terms()
+    ]
+
+
+def _run(payload: dict[str, Any]) -> dict[str, Any]:
+    from sympy import symbols
+
+    if set(payload) != {"variable_count", "numerator", "denominator"}:
+        raise ValueError("malformed cancellation request")
+    variable_count = payload["variable_count"]
+    if (
+        type(variable_count) is not int
+        or variable_count < 1
+        or not isinstance(payload["numerator"], list)
+        or not isinstance(payload["denominator"], list)
+    ):
+        raise ValueError("malformed cancellation request")
+    generators = symbols(f"x0:{variable_count}")
+    numerator = _polynomial(payload["numerator"], generators)
+    denominator = _polynomial(payload["denominator"], generators)
+    if not numerator.is_zero:
+        numerator_terms, denominator_terms = numerator.terms(), denominator.terms()
+        common = tuple(
+            min(
+                min(exponents[axis] for exponents, _ in numerator_terms),
+                min(exponents[axis] for exponents, _ in denominator_terms),
+            )
+            for axis in range(variable_count)
+        )
+        if any(common):
+            from sympy import Poly
+
+            def divide(value: Any) -> Any:
+                return Poly.from_dict(
+                    {
+                        tuple(
+                            exponent - shift
+                            for exponent, shift in zip(exponents, common, strict=True)
+                        ): coefficient
+                        for exponents, coefficient in value.terms()
+                    },
+                    value.gens,
+                    domain=value.domain,
+                )
+
+            numerator, denominator = divide(numerator), divide(denominator)
+    numerator, denominator = numerator.cancel(denominator, include=True)
+    leading = denominator.LC()
+    numerator = numerator.mul_ground(1 / leading)
+    denominator = denominator.mul_ground(1 / leading)
+    return {
+        "status": "ok",
+        "numerator": _dump(numerator),
+        "denominator": _dump(denominator),
+    }
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("malformed cancellation request")
+        response = _run(payload)
+    except Exception:
+        return 1
+    sys.stdout.buffer.write(
+        json.dumps(response, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/polynomials/rational_functions/gradient/_tools.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/_tools.py
@@ -1,0 +1,68 @@
+"""The scalar rational-function field gradient declaration."""
+
+from typing import Any
+
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.polynomials.rational_functions.gradient._models import (
+    RationalFunctionGradient,
+    RationalGradientRequest,
+)
+from jacobian.math.polynomials.rational_functions.gradient.operations import gradient
+
+
+def _compute(request: RationalGradientRequest) -> RationalFunctionGradient:
+    return gradient(request.function)
+
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="rational_function.gradient.compute",
+        title="Differentiate a rational function in every coordinate",
+        description=(
+            "Return the complete exact partial-derivative profile of a canonical "
+            "multivariate QQ rational function, retaining its source and ordered "
+            "coordinate axis. Normalize quotient-rule derivatives in the same "
+            "rational-function field. Constants on empty axes have empty gradients; "
+            "zero components retain all declared coordinates."
+        ),
+        request_type=RationalGradientRequest,
+        result_type=RationalFunctionGradient,
+        run=_compute,
+        tags=("polynomial", "rational-function", "gradient", "derivative", "exact"),
+        examples=(
+            OperationExample(
+                name="two_variable_quotient",
+                description="Differentiate (x²+y)/(x-y) on the declared (x,y) axis.",
+                input={
+                    "function": {
+                        "variables": ["x", "y"],
+                        "numerator": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [2, 0],
+                                },
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [0, 1],
+                                },
+                            ]
+                        },
+                        "denominator": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [1, 0],
+                                },
+                                {
+                                    "coefficient": {"num": "-1", "den": "1"},
+                                    "exponents": [0, 1],
+                                },
+                            ]
+                        },
+                    }
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
@@ -203,7 +203,7 @@ def _admit_general_gradient(
             _derivative_bound(function, source_bound, axis, ledger)
         )
         bound = _remove_guaranteed_linear_power_factor(raw, function)
-        digits = _validate_canonical_result_bound(bound, ledger, work_bound=raw)
+        digits = _validate_canonical_result_bound(bound, ledger, work_bound=bound)
         components.append((bound, digits))
     return tuple(components)
 

--- a/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
@@ -18,6 +18,10 @@ from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
 )
+from jacobian.math.geometry.differential._recognition_process import (
+    RationalFunctionRecognitionCandidate,
+    recognize_canonical_rational_functions,
+)
 from jacobian.math.polynomials._conversions import sparse_rational_polynomial_to_sympy
 from jacobian.math.polynomials.rational_functions._bounds import (
     BoundsLedger,
@@ -85,17 +89,41 @@ type _MonomialGradientPlan = tuple[
 ]
 
 
-def _recognize_source(source: RationalFunction) -> None:
+def _recognize_source(source: RationalFunction, deadline: float) -> None:
     """Recognize the authored field presentation at the admitted owner boundary."""
-    try:
-        require_canonical_rational_function(source)
-    except PydanticCustomError as exc:
+    if (
+        not source.numerator.terms
+        or not source.variables
+        or len(source.denominator.terms) == 1
+    ):
+        try:
+            require_canonical_rational_function(source)
+        except PydanticCustomError as exc:
+            raise OperationDomainValidationError(
+                location=(), code=exc.type, message=exc.message()
+            ) from exc
+        return
+    recognition = recognize_canonical_rational_functions(
+        (
+            RationalFunctionRecognitionCandidate(
+                owner="tensor",
+                component=0,
+                value=source,
+            ),
+        ),
+        deadline=deadline,
+    )
+    if recognition.non_coprime is not None:
         raise OperationDomainValidationError(
-            location=(), code=exc.type, message=exc.message()
-        ) from exc
+            location=(),
+            code="not_coprime",
+            message="rational-function numerator and denominator must be coprime",
+        )
 
 
-def _prepare_monomial_gradient(source: RationalFunction) -> _MonomialGradientPlan:
+def _prepare_monomial_gradient(
+    source: RationalFunction, deadline: float
+) -> _MonomialGradientPlan:
     """Differentiate finite Laurent support without a dense polynomial expansion.
 
     The canonical carrier bounds this phase by 8*256 coefficient scalings of
@@ -103,7 +131,7 @@ def _prepare_monomial_gradient(source: RationalFunction) -> _MonomialGradientPla
     normalization only shifts the unchanged surviving support. All component
     supports, exponents and scalar sizes are checked before result construction.
     """
-    _recognize_source(source)
+    _recognize_source(source, deadline)
     variables = source.variables
     denominator_powers = source.denominator.terms[0].exponents
     plans: list[
@@ -209,10 +237,10 @@ def _admit_general_gradient(
 
 
 def _general_gradient_admitted(
-    function: RationalFunction,
+    function: RationalFunction, deadline: float
 ) -> tuple[RationalFunction, ...]:
     """Recognize and differentiate after the caller's whole-profile admission."""
-    _recognize_source(function)
+    _recognize_source(function, deadline)
     request_checkpoint("after rational gradient source recognition")
     numerator = sparse_rational_polynomial_to_sympy(
         function.numerator, function.variables
@@ -222,7 +250,9 @@ def _general_gradient_admitted(
     )
     return tuple(
         _normalize_fraction(
-            *_differentiate_fraction(numerator, denominator, axis), function.variables
+            *_differentiate_fraction(numerator, denominator, axis),
+            function.variables,
+            deadline=deadline,
         )
         for axis in range(len(function.variables))
     )
@@ -241,12 +271,12 @@ def gradient(function: RationalFunction) -> RationalFunctionGradient:
     request_checkpoint("before rational gradient admission")
     if len(function.denominator.terms) == 1:
         derivatives = _build_monomial_gradient(
-            function.variables, _prepare_monomial_gradient(function)
+            function.variables, _prepare_monomial_gradient(function, deadline)
         )
     else:
         ledger = _Ledger()
         _admit_general_gradient(function, ledger)
-        derivatives = _general_gradient_admitted(function)
+        derivatives = _general_gradient_admitted(function, deadline)
     result = RationalFunctionGradient(
         source=function, variables=function.variables, partial_derivatives=derivatives
     )

--- a/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
@@ -28,6 +28,7 @@ from jacobian.math.polynomials.rational_functions._bounds import (
     _polynomial_backend_conversion_work_units,
     _recognition_work_units,
     _remove_guaranteed_common_monomial,
+    _remove_guaranteed_linear_power_factor,
     _validate_canonical_result_bound,
 )
 from jacobian.math.polynomials.rational_functions._bounds import (
@@ -198,8 +199,11 @@ def _admit_general_gradient(
     )
     components = []
     for axis in range(len(function.variables)):
-        bound = _remove_guaranteed_common_monomial(
-            _derivative_bound(function, source_bound, axis, ledger)
+        bound = _remove_guaranteed_linear_power_factor(
+            _remove_guaranteed_common_monomial(
+                _derivative_bound(function, source_bound, axis, ledger)
+            ),
+            function,
         )
         digits = _validate_canonical_result_bound(bound, ledger)
         components.append((bound, digits))

--- a/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
@@ -1,0 +1,237 @@
+"""Admitted complete field gradients, preserving sparse Laurent structure."""
+
+import time
+from fractions import Fraction
+from typing import NoReturn
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.canonical import format_canonical_integer
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.polynomials._conversions import sparse_rational_polynomial_to_sympy
+from jacobian.math.polynomials.rational_functions._bounds import (
+    BoundsLedger,
+    BoundWorkCategory,
+    FractionBound,
+    RationalFunctionBoundLimits,
+    _fraction_bound,
+    _polynomial_backend_conversion_work_units,
+    _recognition_work_units,
+    _remove_guaranteed_common_monomial,
+    _validate_canonical_result_bound,
+)
+from jacobian.math.polynomials.rational_functions._bounds import (
+    _differentiate_fraction as _derivative_bound,
+)
+from jacobian.math.polynomials.rational_functions.gradient._kernel import (
+    _differentiate_fraction,
+    _normalize_fraction,
+)
+from jacobian.math.polynomials.rational_functions.gradient._models import (
+    RationalFunctionGradient,
+)
+from jacobian.math.polynomials.values import (
+    RationalFunction,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+    require_canonical_rational_function,
+)
+
+
+def _reject(reason: str, message: str) -> NoReturn:
+    raise OperationResourceAdmissionError(
+        location=("function",),
+        code=f"rational_function.gradient.{reason}",
+        message=message,
+    )
+
+
+class _Ledger:
+    def __init__(self) -> None:
+        self.work = 0
+        self.limits = RationalFunctionBoundLimits(
+            raw_terms=4096,
+            raw_digits=4096,
+            result_exponent=64,
+            result_terms=256,
+            result_digits=128,
+            label="Rational gradient",
+            reject=_reject,
+        )
+
+    def charge(self, category: BoundWorkCategory, amount: int) -> None:
+        request_checkpoint(f"during rational gradient {category}")
+        self.work += amount
+        if self.work > 25_000_000:
+            _reject(
+                "work_budget",
+                "rational gradient exceeds its exact coefficient-work envelope",
+            )
+
+
+type _MonomialGradientPlan = tuple[
+    tuple[tuple[int, ...], tuple[tuple[Fraction, tuple[int, ...]], ...]], ...
+]
+
+
+def _prepare_monomial_gradient(source: RationalFunction) -> _MonomialGradientPlan:
+    """Differentiate finite Laurent support without a dense polynomial expansion.
+
+    The canonical carrier bounds this phase by 8*256 coefficient scalings of
+    at most 128-digit rationals by integers of magnitude <=64. Exact valuation
+    normalization only shifts the unchanged surviving support. All component
+    supports, exponents and scalar sizes are checked before result construction.
+    """
+    require_canonical_rational_function(source)
+    variables = source.variables
+    denominator_powers = source.denominator.terms[0].exponents
+    plans: list[
+        tuple[tuple[int, ...], tuple[tuple[Fraction, tuple[int, ...]], ...]]
+    ] = []
+    for axis in range(len(variables)):
+        raw = tuple(
+            (
+                term.coefficient.as_fraction()
+                * (term.exponents[axis] - denominator_powers[axis]),
+                tuple(
+                    exponent - power - int(j == axis)
+                    for j, (exponent, power) in enumerate(
+                        zip(term.exponents, denominator_powers, strict=True)
+                    )
+                ),
+            )
+            for term in source.numerator.terms
+            if term.exponents[axis] != denominator_powers[axis]
+        )
+        powers = tuple(
+            max(0, -min((e[j] for _, e in raw), default=0))
+            for j in range(len(variables))
+        )
+        normalized = tuple(
+            (coefficient, tuple(e + p for e, p in zip(exponents, powers, strict=True)))
+            for coefficient, exponents in raw
+        )
+        if any(p > 64 for p in powers) or any(
+            any(e > 64 for e in exponents) for _, exponents in normalized
+        ):
+            _reject(
+                "result_exponent",
+                "Laurent derivative exceeds the canonical exponent bound",
+            )
+        if any(
+            len(format_canonical_integer(abs(value.numerator))) > 128
+            or len(format_canonical_integer(value.denominator)) > 128
+            for value, _ in normalized
+        ):
+            _reject(
+                "result_height",
+                "Laurent derivative exceeds the canonical coefficient bound",
+            )
+        plans.append((powers, normalized))
+    request_checkpoint("after sparse Laurent gradient admission")
+    return tuple(plans)
+
+
+def _build_monomial_gradient(
+    variables: tuple[str, ...], plans: _MonomialGradientPlan
+) -> tuple[RationalFunction, ...]:
+    """Construct the already computed Laurent derivatives after aggregate admission."""
+    return tuple(
+        RationalFunction._from_kernel(
+            variables=variables,
+            numerator=SparseRationalPolynomial(
+                terms=tuple(
+                    RationalPolynomialTerm(
+                        coefficient=CanonicalRational.from_fraction(value),
+                        exponents=exponents,
+                    )
+                    for value, exponents in terms
+                )
+            ),
+            denominator=SparseRationalPolynomial(
+                terms=(
+                    RationalPolynomialTerm(
+                        coefficient=CanonicalRational(num=1, den=1),
+                        exponents=powers,
+                    ),
+                )
+            ),
+        )
+        for powers, terms in plans
+    )
+
+
+def _admit_general_gradient(
+    function: RationalFunction, ledger: BoundsLedger
+) -> tuple[tuple[FractionBound, int], ...]:
+    """Admit one row into a caller-owned complete scalar or matrix ledger."""
+    source_bound = _fraction_bound(function, ledger)
+    ledger.charge("recognition", _recognition_work_units(source_bound))
+    # Source recognition constructs its own exact pair; account for the
+    # additional conversion used to retain the pair through differentiation.
+    ledger.charge(
+        "source_conversion",
+        sum(
+            _polynomial_backend_conversion_work_units(bound)
+            for bound in (source_bound.numerator, source_bound.denominator)
+        ),
+    )
+    components = []
+    for axis in range(len(function.variables)):
+        bound = _remove_guaranteed_common_monomial(
+            _derivative_bound(function, source_bound, axis, ledger)
+        )
+        digits = _validate_canonical_result_bound(bound, ledger)
+        components.append((bound, digits))
+    return tuple(components)
+
+
+def _general_gradient_admitted(
+    function: RationalFunction,
+) -> tuple[RationalFunction, ...]:
+    """Recognize and differentiate after the caller's whole-profile admission."""
+    require_canonical_rational_function(function)
+    request_checkpoint("after rational gradient source recognition")
+    numerator = sparse_rational_polynomial_to_sympy(
+        function.numerator, function.variables
+    )
+    denominator = sparse_rational_polynomial_to_sympy(
+        function.denominator, function.variables
+    )
+    return tuple(
+        _normalize_fraction(
+            *_differentiate_fraction(numerator, denominator, axis), function.variables
+        )
+        for axis in range(len(function.variables))
+    )
+
+
+def gradient(function: RationalFunction) -> RationalFunctionGradient:
+    """Return every exact coordinate partial derivative with its retained source."""
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return gradient(function)
+    deadline = execution.started_at + 60
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before rational gradient admission")
+    if len(function.denominator.terms) == 1:
+        derivatives = _build_monomial_gradient(
+            function.variables, _prepare_monomial_gradient(function)
+        )
+    else:
+        ledger = _Ledger()
+        _admit_general_gradient(function, ledger)
+        derivatives = _general_gradient_admitted(function)
+    result = RationalFunctionGradient(
+        source=function, variables=function.variables, partial_derivatives=derivatives
+    )
+    request_checkpoint("after rational gradient construction")
+    return result

--- a/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
@@ -4,6 +4,8 @@ import time
 from fractions import Fraction
 from typing import NoReturn
 
+from pydantic_core import PydanticCustomError
+
 from jacobian._exact import CanonicalRational
 from jacobian._execution import (
     bind_request_deadline,
@@ -12,7 +14,10 @@ from jacobian._execution import (
     request_execution,
 )
 from jacobian.canonical import format_canonical_integer
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials._conversions import sparse_rational_polynomial_to_sympy
 from jacobian.math.polynomials.rational_functions._bounds import (
     BoundsLedger,
@@ -79,6 +84,16 @@ type _MonomialGradientPlan = tuple[
 ]
 
 
+def _recognize_source(source: RationalFunction) -> None:
+    """Recognize the authored field presentation at the admitted owner boundary."""
+    try:
+        require_canonical_rational_function(source)
+    except PydanticCustomError as exc:
+        raise OperationDomainValidationError(
+            location=(), code=exc.type, message=exc.message()
+        ) from exc
+
+
 def _prepare_monomial_gradient(source: RationalFunction) -> _MonomialGradientPlan:
     """Differentiate finite Laurent support without a dense polynomial expansion.
 
@@ -87,7 +102,7 @@ def _prepare_monomial_gradient(source: RationalFunction) -> _MonomialGradientPla
     normalization only shifts the unchanged surviving support. All component
     supports, exponents and scalar sizes are checked before result construction.
     """
-    require_canonical_rational_function(source)
+    _recognize_source(source)
     variables = source.variables
     denominator_powers = source.denominator.terms[0].exponents
     plans: list[
@@ -195,7 +210,7 @@ def _general_gradient_admitted(
     function: RationalFunction,
 ) -> tuple[RationalFunction, ...]:
     """Recognize and differentiate after the caller's whole-profile admission."""
-    require_canonical_rational_function(function)
+    _recognize_source(function)
     request_checkpoint("after rational gradient source recognition")
     numerator = sparse_rational_polynomial_to_sympy(
         function.numerator, function.variables

--- a/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
@@ -22,7 +22,6 @@ from jacobian.math.geometry.differential._recognition_process import (
     RationalFunctionRecognitionCandidate,
     recognize_canonical_rational_functions,
 )
-from jacobian.math.polynomials._conversions import sparse_rational_polynomial_to_sympy
 from jacobian.math.polynomials.rational_functions._bounds import (
     BoundsLedger,
     BoundWorkCategory,
@@ -39,7 +38,6 @@ from jacobian.math.polynomials.rational_functions._bounds import (
     _differentiate_fraction as _derivative_bound,
 )
 from jacobian.math.polynomials.rational_functions.gradient._kernel import (
-    _differentiate_fraction,
     _normalize_fraction,
 )
 from jacobian.math.polynomials.rational_functions.gradient._models import (
@@ -242,18 +240,8 @@ def _general_gradient_admitted(
     """Recognize and differentiate after the caller's whole-profile admission."""
     _recognize_source(function, deadline)
     request_checkpoint("after rational gradient source recognition")
-    numerator = sparse_rational_polynomial_to_sympy(
-        function.numerator, function.variables
-    )
-    denominator = sparse_rational_polynomial_to_sympy(
-        function.denominator, function.variables
-    )
     return tuple(
-        _normalize_fraction(
-            *_differentiate_fraction(numerator, denominator, axis),
-            function.variables,
-            deadline=deadline,
-        )
+        _normalize_fraction(function, axis, deadline=deadline)
         for axis in range(len(function.variables))
     )
 

--- a/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/gradient/operations.py
@@ -199,13 +199,11 @@ def _admit_general_gradient(
     )
     components = []
     for axis in range(len(function.variables)):
-        bound = _remove_guaranteed_linear_power_factor(
-            _remove_guaranteed_common_monomial(
-                _derivative_bound(function, source_bound, axis, ledger)
-            ),
-            function,
+        raw = _remove_guaranteed_common_monomial(
+            _derivative_bound(function, source_bound, axis, ledger)
         )
-        digits = _validate_canonical_result_bound(bound, ledger)
+        bound = _remove_guaranteed_linear_power_factor(raw, function)
+        digits = _validate_canonical_result_bound(bound, ledger, work_bound=raw)
         components.append((bound, digits))
     return tuple(components)
 

--- a/src/jacobian/math/polynomials/values.py
+++ b/src/jacobian/math/polynomials/values.py
@@ -320,6 +320,21 @@ def require_canonical_rational_function(
     if not value.numerator.terms or not value.variables:
         return value
 
+    # A monic monomial denominator has only coordinate-variable factors.
+    # Recognize their common valuations directly, without materializing a
+    # dense multivariate backend polynomial for an otherwise sparse value.
+    if len(value.denominator.terms) == 1:
+        powers = value.denominator.terms[0].exponents
+        if any(
+            exponent and all(term.exponents[axis] for term in value.numerator.terms)
+            for axis, exponent in enumerate(powers)
+        ):
+            raise _validation_error(
+                "not_coprime",
+                "rational-function numerator and denominator must be coprime",
+            )
+        return value
+
     # Construct exact polynomials from already structurally validated term
     # data. No caller text is parsed or evaluated at this semantic boundary.
     from jacobian.math.polynomials._conversions import (

--- a/tests/math/geometry/differential/metrics/test_curvature.py
+++ b/tests/math/geometry/differential/metrics/test_curvature.py
@@ -1,0 +1,358 @@
+"""Exact coordinate identities, independent diffgeom oracle and useful envelopes."""
+
+import json
+from fractions import Fraction
+from itertools import product
+from time import monotonic
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from sympy import Matrix, cancel, symbols
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.geometry.differential.metrics import (
+    RationalCoordinateMetric,
+    RationalMetricCurvatureProfile,
+    curvature_profile,
+)
+from jacobian.math.geometry.differential.values import (
+    RationalCoordinateTensor,
+    canonical_locus_guards,
+)
+from jacobian.math.polynomials._conversions import (
+    rational_function_from_sympy,
+    rational_function_to_sympy,
+)
+from jacobian.math.polynomials.values import RationalFunction
+
+x, y, z, w = symbols("x y z w")
+
+
+def metric(
+    matrix: list[Any], axis: tuple[str, ...] = ("x", "y")
+) -> RationalCoordinateMetric:
+    components = tuple(rational_function_from_sympy(value, axis) for value in matrix)
+    return RationalCoordinateMetric(
+        tensor=RationalCoordinateTensor(
+            coordinate_axis=axis,
+            variance=("COVARIANT", "COVARIANT"),
+            components=components,
+            retained_nonzero_denominators=canonical_locus_guards(
+                component_denominators=tuple(value.denominator for value in components),
+                variable_count=len(axis),
+            ),
+        )
+    )
+
+
+def expressions(components: tuple[RationalFunction, ...]) -> tuple[Any, ...]:
+    return tuple(rational_function_to_sympy(value) for value in components)
+
+
+def replay(result: RationalMetricCurvatureProfile) -> None:
+    axis = symbols(result.metric.tensor.coordinate_axis)
+    n = len(axis)
+    g = Matrix(n, n, expressions(result.metric.tensor.components))
+    inverse = Matrix(n, n, expressions(result.inverse_metric.components))
+    gamma = expressions(result.connection.components)
+    riemann = expressions(result.riemann.components)
+    ricci = expressions(result.ricci.components)
+    assert (g * inverse).applyfunc(cancel) == Matrix.eye(n)
+    for k, i, j in product(range(n), repeat=3):
+        expected = (
+            sum(
+                inverse[k, a]
+                * (
+                    g[a, j].diff(axis[i])
+                    + g[a, i].diff(axis[j])
+                    - g[i, j].diff(axis[a])
+                )
+                for a in range(n)
+            )
+            / 2
+        )
+        assert cancel(gamma[(k * n + i) * n + j] - expected) == 0
+    for upper, k, i, j in product(range(n), repeat=4):
+        expected = gamma[(upper * n + j) * n + k].diff(axis[i]) - gamma[
+            (upper * n + i) * n + k
+        ].diff(axis[j])
+        expected += sum(
+            gamma[(upper * n + i) * n + a] * gamma[(a * n + j) * n + k]
+            - gamma[(upper * n + j) * n + a] * gamma[(a * n + i) * n + k]
+            for a in range(n)
+        )
+        assert cancel(riemann[((upper * n + k) * n + i) * n + j] - expected) == 0
+    assert all(
+        cancel(
+            ricci[k * n + j]
+            - sum(riemann[((i * n + k) * n + i) * n + j] for i in range(n))
+        )
+        == 0
+        for k, j in product(range(n), repeat=2)
+    )
+    scalar = expressions(result.scalar_curvature.components)[0]
+    assert (
+        cancel(
+            scalar
+            - sum(
+                inverse[k, j] * ricci[k * n + j] for k, j in product(range(n), repeat=2)
+            )
+        )
+        == 0
+    )
+    assert (
+        RationalMetricCurvatureProfile.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+@pytest.mark.parametrize(
+    ("matrix", "scalar"),
+    [
+        ([1, 0, 0, 1], 0),
+        ([-1, 0, 0, 2], 0),
+        ([1, 0, 0, x**2], 0),
+        ([1 + x**2, x, x, 1], 0),
+        ([4 / (1 + x * x + y * y) ** 2, 0, 0, 4 / (1 + x * x + y * y) ** 2], 2),
+        ([1 / x**2, 0, 0, 1 / x**2], -2),
+    ],
+)
+def test_known_metrics_and_all_defining_identities(
+    matrix: list[Any], scalar: int
+) -> None:
+    result = curvature_profile(metric(matrix))
+    replay(result)
+    assert expressions(result.scalar_curvature.components) == (scalar,)
+
+
+def test_independent_sympy_diffgeom_curved_nondiagonal_metric() -> None:
+    from sympy.diffgeom import (
+        CoordSystem,
+        Manifold,
+        Patch,
+        TensorProduct,
+        metric_to_Christoffel_2nd,
+        metric_to_Riemann_components,
+    )
+
+    source = metric([2 + x, y, y, 3 + x])
+    result = curvature_profile(source)
+    chart = CoordSystem("chart", Patch("patch", Manifold("space", 2)), (x, y))
+    a, b = chart.base_scalars()
+    dx, dy = chart.base_oneforms()
+    form = (
+        (2 + a) * TensorProduct(dx, dx)
+        + b * (TensorProduct(dx, dy) + TensorProduct(dy, dx))
+        + (3 + a) * TensorProduct(dy, dy)
+    )
+    gamma = metric_to_Christoffel_2nd(form)
+    riemann = metric_to_Riemann_components(form)
+    for index, value in zip(
+        product(range(2), repeat=3),
+        expressions(result.connection.components),
+        strict=True,
+    ):
+        assert cancel(value - gamma[index].subs({a: x, b: y})) == 0
+    for index, value in zip(
+        product(range(2), repeat=4), expressions(result.riemann.components), strict=True
+    ):
+        assert cancel(value - riemann[index].subs({a: x, b: y})) == 0
+    replay(result)
+
+
+def test_polar_locus_survives_zero_curvature() -> None:
+    result = curvature_profile(metric([1, 0, 0, x * x]))
+    assert any(value != 0 for value in expressions(result.connection.components))
+    assert all(value == 0 for value in expressions(result.riemann.components))
+    assert result.scalar_curvature.retained_nonzero_denominators
+    # Every retained polynomial has precisely the source polar exclusion x=0.
+    for guard in result.scalar_curvature.retained_nonzero_denominators:
+        assert all(term.exponents[1] == 0 for term in guard.terms)
+        assert len(guard.terms) == 1 and guard.terms[0].exponents[0] > 0
+
+
+def test_large_constant_diagonal_four_dimensional_metric() -> None:
+    source = metric(
+        [10**127 if i == j else 0 for i in range(4) for j in range(4)],
+        ("x", "y", "z", "w"),
+    )
+    result = curvature_profile(source)
+    assert all(value == 0 for value in expressions(result.riemann.components))
+    for i, value in enumerate(result.inverse_metric.components):
+        if i % 5 == 0:
+            assert value.numerator.terms[0].coefficient.as_fraction() == Fraction(
+                1, 10**127
+            )
+        else:
+            assert not value.numerator.terms
+    assert not result.scalar_curvature.retained_nonzero_denominators
+
+
+def test_four_dimensional_product_chart_and_high_exponent_line() -> None:
+    result = curvature_profile(
+        metric(
+            [
+                ((x, y, z, w)[i]) ** 2 if i == j else 0
+                for i in range(4)
+                for j in range(4)
+            ],
+            ("x", "y", "z", "w"),
+        )
+    )
+    assert len(result.riemann.components) == 256
+    assert all(value == 0 for value in expressions(result.riemann.components))
+    line = curvature_profile(metric([x**64], ("x",)))
+    assert expressions(line.connection.components) == (32 / x,)
+    assert expressions(line.scalar_curvature.components) == (0,)
+
+
+def test_coordinate_axis_permutation_transports_components() -> None:
+    original = curvature_profile(metric([1 + x, 0, 0, 1 + y]))
+    permuted = curvature_profile(metric([1 + y, 0, 0, 1 + x], ("y", "x")))
+    values = expressions(original.connection.components)
+    for (k, i, j), value in zip(
+        product(range(2), repeat=3),
+        expressions(permuted.connection.components),
+        strict=True,
+    ):
+        assert cancel(value - values[((1 - k) * 2 + 1 - i) * 2 + 1 - j]) == 0
+    assert permuted.metric.tensor.coordinate_axis == ("y", "x")
+
+
+def test_shape_singularity_and_authored_nonreduced_source_rejections() -> None:
+    with pytest.raises(ValidationError, match="symmetric"):
+        metric([1, 1, 0, 1])
+    with pytest.raises(OperationDomainValidationError, match="determinant"):
+        curvature_profile(metric([1, x, x, x * x]))
+    source = metric([x], ("x",)).model_dump(mode="json")
+    field = source["tensor"]["components"][0]
+    field["numerator"]["terms"][0]["exponents"] = [2]
+    field["denominator"]["terms"][0]["exponents"] = [1]
+    source["tensor"]["retained_nonzero_denominators"] = [field["denominator"]]
+    with pytest.raises(OperationDomainValidationError, match="reduced canonical"):
+        curvature_profile(
+            RationalCoordinateMetric.model_validate_json(json.dumps(source))
+        )
+
+
+def test_expansion_rejection_and_earlier_deadline() -> None:
+    source = metric(
+        [1 if i == j else 0 for i in range(4) for j in range(4)], ("x", "y", "z", "w")
+    ).model_dump(mode="json")
+    for i in range(4):
+        source["tensor"]["components"][5 * i]["numerator"]["terms"] = [
+            {
+                "exponents": [64 * int(j == k) for j in range(4)],
+                "coefficient": {"num": "1", "den": "1"},
+            }
+            for k in range(4)
+        ] + [{"exponents": [0, 0, 0, 0], "coefficient": {"num": "1", "den": "1"}}]
+    with pytest.raises(OperationResourceAdmissionError):
+        curvature_profile(
+            RationalCoordinateMetric.model_validate_json(json.dumps(source))
+        )
+    with request_execution(monotonic()):
+        bind_request_deadline(monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            curvature_profile(metric([1], ("x",)))
+
+
+def test_oversized_raw_pair_rejected_before_backend_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raw source recognition remains bounded before any SymPy conversion."""
+    axis = ("x", "y", "z", "w")
+    exponents = sorted(product((0, 1, 2, 64), repeat=4), reverse=True)
+    polynomial = {
+        "terms": [
+            {
+                "exponents": list(exponent),
+                "coefficient": {"num": 1, "den": 1},
+            }
+            for exponent in exponents
+        ]
+    }
+    one = {
+        "terms": [
+            {
+                "exponents": [0, 0, 0, 0],
+                "coefficient": {"num": 1, "den": 1},
+            }
+        ]
+    }
+    raw_pair = {
+        "domain": "QQ",
+        "variables": list(axis),
+        "numerator": polynomial,
+        "denominator": polynomial,
+    }
+    zero = {
+        "domain": "QQ",
+        "variables": list(axis),
+        "numerator": {"terms": []},
+        "denominator": one,
+    }
+    source = RationalCoordinateMetric.model_validate(
+        {
+            "tensor": {
+                "coordinate_axis": list(axis),
+                "variance": ["COVARIANT", "COVARIANT"],
+                "components": [
+                    raw_pair if i == j else zero for i in range(4) for j in range(4)
+                ],
+                "retained_nonzero_denominators": [polynomial],
+            }
+        }
+    )
+    monkeypatch.setattr(
+        "jacobian.math.geometry.differential.metrics.operations.require_canonical_rational_function",
+        lambda *args: pytest.fail("backend execution must follow admission"),
+    )
+    with pytest.raises(OperationResourceAdmissionError, match=r"allocation|work"):
+        curvature_profile(source)
+
+
+def test_four_dimensional_hyperbolic_metric() -> None:
+    result = curvature_profile(
+        metric(
+            [1 / x**2 if i == j else 0 for i in range(4) for j in range(4)],
+            ("x", "y", "z", "w"),
+        )
+    )
+    assert len(result.riemann.components) == 256
+    assert expressions(result.scalar_curvature.components) == (-12,)
+    assert expressions(result.ricci.components) == tuple(
+        -3 / x**2 if i == j else 0 for i in range(4) for j in range(4)
+    )
+
+
+def test_complete_locus_admitted_before_curvature_expansion() -> None:
+    source = metric([x * y, 0, 0, x * y])
+    guards = canonical_locus_guards(
+        tuple(
+            rational_function_from_sympy(x + c, ("x", "y")).numerator
+            for c in range(1, 765)
+        ),
+        variable_count=2,
+    )
+    source = RationalCoordinateMetric(
+        tensor=RationalCoordinateTensor(
+            coordinate_axis=source.tensor.coordinate_axis,
+            variance=source.tensor.variance,
+            components=source.tensor.components,
+            retained_nonzero_denominators=guards,
+        )
+    )
+    # Shared formal denominator factors can reduce to distinct canonical
+    # denominators for different numerators. The complete locus has 769 guards.
+    with pytest.raises(OperationResourceAdmissionError, match="768 guards"):
+        curvature_profile(source)

--- a/tests/math/geometry/differential/test_lie_derivative.py
+++ b/tests/math/geometry/differential/test_lie_derivative.py
@@ -53,6 +53,7 @@ from jacobian.math.polynomials._conversions import (
     rational_function_to_sympy,
     sparse_rational_polynomial_to_sympy,
 )
+from jacobian.math.polynomials.rational_functions import _bounds as rational_bounds
 from jacobian.math.polynomials.values import RationalFunction, SparseRationalPolynomial
 
 type Coefficient = int | tuple[int, int]
@@ -715,8 +716,8 @@ class _SourceConversionObserver:
         self.executed = executed
         self.calls = calls
         self.observing_bound = False
-        self.original_fraction_bound = lie_bounds._fraction_bound
-        self.original_polynomial_bound = lie_bounds._polynomial_bound
+        self.original_fraction_bound = rational_bounds._fraction_bound
+        self.original_polynomial_bound = rational_bounds._polynomial_bound
         self.original_fraction = Fraction
         self.original_gcd = gcd
         self.original_lcm = lcm
@@ -889,11 +890,11 @@ def test_work_categories_cover_observed_backend_primitives_and_detect_mutations(
     )
     monkeypatch.setattr(lie_bounds, "_fraction_bound", source_observer.bound)
     monkeypatch.setattr(
-        lie_bounds, "_polynomial_bound", source_observer.polynomial_bound
+        rational_bounds, "_polynomial_bound", source_observer.polynomial_bound
     )
-    monkeypatch.setattr(lie_bounds, "Fraction", source_observer.fraction)
-    monkeypatch.setattr(lie_bounds, "gcd", source_observer.gcd)
-    monkeypatch.setattr(lie_bounds, "lcm", source_observer.lcm)
+    monkeypatch.setattr(rational_bounds, "Fraction", source_observer.fraction)
+    monkeypatch.setattr(rational_bounds, "gcd", source_observer.gcd)
+    monkeypatch.setattr(rational_bounds, "lcm", source_observer.lcm)
     monkeypatch.setattr(
         lie_backend,
         "sparse_rational_polynomial_to_sympy",
@@ -954,7 +955,9 @@ def test_source_conversion_is_precharged_before_content_arithmetic(
         raise AssertionError("unadmitted source reached coefficient arithmetic")
 
     monkeypatch.setattr(lie_bounds, "MAX_LIE_DERIVATIVE_WORK_UNITS", 1)
-    monkeypatch.setattr(lie_bounds, "_polynomial_bound", forbidden_content_arithmetic)
+    monkeypatch.setattr(
+        rational_bounds, "_polynomial_bound", forbidden_content_arithmetic
+    )
 
     with pytest.raises(OperationDomainValidationError) as error:
         build_lie_derivative_plan(vector, scalar)

--- a/tests/math/geometry/differential/test_lie_derivative.py
+++ b/tests/math/geometry/differential/test_lie_derivative.py
@@ -1274,3 +1274,52 @@ def test_profile_rejects_a_forged_result_that_drops_an_inherited_guard() -> None
             source=scalar,
             lie_derivative=forged_result,
         )
+
+
+def test_polynomial_cancellation_support_growth_is_rejected_before_conversion() -> None:
+    """Division can increase support; admission must not min against raw terms."""
+
+    from jacobian.catalog.models import OperationDomainValidationError
+
+    variables = ("x", "y", "z")
+    denominator = (
+        (1, (1, 1, 1)),
+        (-1, (1, 1, 0)),
+        (-1, (1, 0, 1)),
+        (1, (1, 0, 0)),
+        (-1, (0, 1, 1)),
+        (1, (0, 1, 0)),
+        (1, (0, 0, 1)),
+        (-1, (0, 0, 0)),
+    )
+    vector = _tensor(
+        variables,
+        ("CONTRAVARIANT",),
+        (
+            _function(
+                variables,
+                (1, (7, 7, 7)),
+                (-1, (7, 7, 0)),
+                (-1, (7, 0, 7)),
+                (-1, (0, 7, 7)),
+                denominator=denominator,
+            ),
+            _function(
+                variables,
+                (1, (7, 0, 0)),
+                (1, (0, 7, 0)),
+                (1, (0, 0, 7)),
+                (-1, (0, 0, 0)),
+                denominator=denominator,
+            ),
+            _zero(variables),
+        ),
+        guards=(_guard(*denominator),),
+    )
+    scalar = _tensor(
+        variables,
+        (),
+        (_function(variables, (1, (1, 0, 0)), (1, (0, 1, 0))),),
+    )
+    with pytest.raises(OperationDomainValidationError, match="256-term"):
+        lie_derivative(vector, scalar)

--- a/tests/math/geometry/differential/test_lie_derivative.py
+++ b/tests/math/geometry/differential/test_lie_derivative.py
@@ -1130,6 +1130,48 @@ def test_expired_dispatch_deadline_stops_before_semantic_preflight() -> None:
         lie_derivative(vector, scalar)
 
 
+def test_cancellation_support_growth_is_rejected_before_conversion() -> None:
+    """Quotient support can exceed the raw sum; reject at admission, not convert."""
+
+    axis = ("x", "y", "z")
+    x, y, z = sympy.symbols("x y z")
+    power_x, power_y, power_z = x**7, y**7, z**7
+    denominator = (x - 1) * (y - 1) * (z - 1)
+    first_numerator = (
+        power_x * power_y * power_z
+        - power_x * power_y
+        - power_x * power_z
+        - power_y * power_z
+    )
+    second_numerator = power_x + power_y + power_z - 1
+    first = rational_function_from_sympy(first_numerator / denominator, axis)
+    second = rational_function_from_sympy(second_numerator / denominator, axis)
+    zero = rational_function_from_sympy(0, axis)
+    vector = _tensor(
+        axis,
+        ("CONTRAVARIANT",),
+        (first, second, zero),
+        guards=tuple(
+            polynomial.model_dump()
+            for polynomial in canonical_locus_guards(
+                component_denominators=(
+                    first.denominator,
+                    second.denominator,
+                    zero.denominator,
+                ),
+                variable_count=3,
+            )
+        ),
+    )
+    scalar = _tensor(axis, (), (rational_function_from_sympy(x + y, axis),))
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="256-term",
+    ) as error:
+        lie_derivative(vector, scalar)
+    assert error.value.errors()[0]["type"].endswith("result_support")
+
+
 def test_result_exponent_admission_has_an_accepted_and_rejected_edge() -> None:
     variables = ("x",)
 

--- a/tests/math/polynomials/test_rational_gradient.py
+++ b/tests/math/polynomials/test_rational_gradient.py
@@ -1,0 +1,199 @@
+"""Quotient identities checked by independent sparse coefficient arithmetic."""
+
+from fractions import Fraction
+from random import Random
+from time import monotonic
+
+import pytest
+from pydantic_core import PydanticCustomError
+from sympy import symbols
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import OperationExecutionTimeoutError, request_execution
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.polynomials._conversions import rational_function_from_sympy
+from jacobian.math.polynomials.rational_functions.gradient import (
+    RationalFunctionGradient,
+    gradient,
+)
+from jacobian.math.polynomials.values import (
+    RationalFunction,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+    require_canonical_rational_function,
+)
+
+type Coefficients = dict[tuple[int, ...], Fraction]
+
+
+def _coefficients(value: SparseRationalPolynomial) -> Coefficients:
+    return {t.exponents: t.coefficient.as_fraction() for t in value.terms}
+
+
+def _product(a: Coefficients, b: Coefficients) -> Coefficients:
+    out: Coefficients = {}
+    for e, c in a.items():
+        for f, d in b.items():
+            key = tuple(x + y for x, y in zip(e, f, strict=True))
+            out[key] = out.get(key, Fraction(0)) + c * d
+    return {e: c for e, c in out.items() if c}
+
+
+def _difference(a: Coefficients, b: Coefficients) -> Coefficients:
+    return {
+        e: c
+        for e in a.keys() | b.keys()
+        if (c := a.get(e, Fraction(0)) - b.get(e, Fraction(0)))
+    }
+
+
+def _derivative(a: Coefficients, axis: int) -> Coefficients:
+    return {
+        tuple(x - int(i == axis) for i, x in enumerate(e)): c * e[axis]
+        for e, c in a.items()
+        if e[axis]
+    }
+
+
+def _identity(source: RationalFunction) -> RationalFunctionGradient:
+    result = gradient(source)
+    assert result.source == source
+    assert result.variables == source.variables
+    p, q = _coefficients(source.numerator), _coefficients(source.denominator)
+    for axis, component in enumerate(result.partial_derivatives):
+        quotient = _difference(
+            _product(_derivative(p, axis), q), _product(p, _derivative(q, axis))
+        )
+        assert _product(_coefficients(component.numerator), _product(q, q)) == _product(
+            quotient, _coefficients(component.denominator)
+        )
+        assert component.variables == source.variables
+        assert require_canonical_rational_function(component) == component
+    assert (
+        RationalFunctionGradient.model_validate_json(result.model_dump_json()) == result
+    )
+    return result
+
+
+def _monomial_source(
+    variables: tuple[str, ...],
+    numerator: tuple[int, ...],
+    denominator: tuple[int, ...],
+    coefficient: int = 1,
+) -> RationalFunction:
+    return RationalFunction(
+        variables=variables,
+        numerator=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(num=coefficient, den=1),
+                    exponents=numerator,
+                ),
+            )
+        ),
+        denominator=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(num=1, den=1),
+                    exponents=denominator,
+                ),
+            )
+        ),
+    )
+
+
+def test_multivariate_quotient_and_mixed_partial_composition() -> None:
+    x, y = symbols("x y")
+    source = rational_function_from_sympy((x * x + y) / (x - y), ("x", "y"))
+    result = _identity(source)
+    a, b = (
+        RationalFunction.model_validate_json(v.model_dump_json())
+        for v in result.partial_derivatives
+    )
+    assert gradient(a).partial_derivatives[1] == gradient(b).partial_derivatives[0]
+
+
+@pytest.mark.parametrize("axis", [(), ("x",), ("x", "y")])
+@pytest.mark.parametrize("constant", [0, 3, 10**127])
+def test_constants_and_empty_axes(axis: tuple[str, ...], constant: int) -> None:
+    source = rational_function_from_sympy(constant, axis)
+    result = _identity(source)
+    assert len(result.partial_derivatives) == len(axis)
+    assert all(not c.numerator.terms for c in result.partial_derivatives)
+
+
+def test_seeded_small_rational_corpus_by_exact_quotient_identity() -> None:
+    x, y = symbols("x y")
+    rng = Random(2878)
+    for _ in range(20):
+        a, b, c, d = [rng.randrange(-3, 4) for _ in range(4)]
+        source = rational_function_from_sympy(
+            (a * x * x + b * y + c) / (x + y + d), ("x", "y")
+        )
+        _identity(source)
+
+
+def test_cancellation_and_axis_permutation() -> None:
+    x, y = symbols("x y")
+    source = rational_function_from_sympy(1 / (x + y) ** 2, ("x", "y"))
+    result = _identity(source)
+    expected = rational_function_from_sympy(-2 / (x + y) ** 3, ("x", "y"))
+    assert result.partial_derivatives == (expected, expected)
+    swapped = _identity(rational_function_from_sympy(1 / (x + y) ** 2, ("y", "x")))
+    assert swapped.variables == ("y", "x")
+
+
+def test_polynomial_sparse_eight_axis_boundary_avoids_dense_expansion() -> None:
+    axes = tuple(f"x{i}" for i in range(8))
+    source = _monomial_source(axes, (64,) * 8, (0,) * 8)
+    result = _identity(source)
+    for axis, component in enumerate(result.partial_derivatives):
+        assert component.numerator.terms[0].coefficient.num == 64
+        assert component.numerator.terms[0].exponents == tuple(
+            63 if j == axis else 64 for j in range(8)
+        )
+
+
+def test_monomial_denominator_near_exponent_boundary() -> None:
+    result = _identity(_monomial_source(("x", "y"), (0, 64), (63, 0)))
+    assert result.partial_derivatives[0].denominator.terms[0].exponents == (64, 0)
+    with pytest.raises(OperationResourceAdmissionError, match="exponent"):
+        gradient(_monomial_source(("x", "y"), (0, 64), (64, 0)))
+
+
+def test_true_output_coefficient_boundary() -> None:
+    _identity(_monomial_source(("x",), (64,), (0,), 10**125))
+    with pytest.raises(OperationResourceAdmissionError, match="coefficient"):
+        gradient(_monomial_source(("x",), (64,), (0,), 10**127))
+
+
+def test_authored_common_factor_is_rejected() -> None:
+    source = _monomial_source(("x", "y"), (1, 1), (1, 0))
+    with pytest.raises(PydanticCustomError, match="coprime"):
+        gradient(source)
+    x, y = symbols("x y")
+    p = rational_function_from_sympy((x - y) * (x + 1), ("x", "y"))
+    q = rational_function_from_sympy(x - y, ("x", "y"))
+    authored = RationalFunction(
+        variables=("x", "y"), numerator=p.numerator, denominator=q.numerator
+    )
+    with pytest.raises(PydanticCustomError, match="coprime"):
+        gradient(authored)
+
+
+def test_shared_request_deadline() -> None:
+    source = _monomial_source(("x",), (1,), (0,))
+    with (
+        request_execution(monotonic() - 100),
+        pytest.raises(OperationExecutionTimeoutError),
+    ):
+        gradient(source)
+
+
+def test_polar_metric_component_gradient() -> None:
+    r, _theta = symbols("r theta")
+    result = _identity(rational_function_from_sympy(r * r, ("r", "theta")))
+    assert result.partial_derivatives[0] == rational_function_from_sympy(
+        2 * r, ("r", "theta")
+    )
+    assert not result.partial_derivatives[1].numerator.terms

--- a/tests/math/polynomials/test_rational_gradient.py
+++ b/tests/math/polynomials/test_rational_gradient.py
@@ -5,12 +5,14 @@ from random import Random
 from time import monotonic
 
 import pytest
-from pydantic_core import PydanticCustomError
 from sympy import symbols
 
 from jacobian._exact import CanonicalRational
 from jacobian._execution import OperationExecutionTimeoutError, request_execution
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials._conversions import rational_function_from_sympy
 from jacobian.math.polynomials.rational_functions.gradient import (
     RationalFunctionGradient,
@@ -186,7 +188,7 @@ def test_true_output_coefficient_boundary() -> None:
 
 def test_authored_common_factor_is_rejected() -> None:
     source = _monomial_source(("x", "y"), (1, 1), (1, 0))
-    with pytest.raises(PydanticCustomError, match="coprime"):
+    with pytest.raises(OperationDomainValidationError, match="coprime"):
         gradient(source)
     x, y = symbols("x y")
     p = rational_function_from_sympy((x - y) * (x + 1), ("x", "y"))
@@ -194,7 +196,7 @@ def test_authored_common_factor_is_rejected() -> None:
     authored = RationalFunction(
         variables=("x", "y"), numerator=p.numerator, denominator=q.numerator
     )
-    with pytest.raises(PydanticCustomError, match="coprime"):
+    with pytest.raises(OperationDomainValidationError, match="coprime"):
         gradient(authored)
 
 

--- a/tests/math/polynomials/test_rational_gradient.py
+++ b/tests/math/polynomials/test_rational_gradient.py
@@ -211,7 +211,12 @@ def test_repeated_linear_denominator_cancels_before_result_exponent() -> None:
         gradient(authored)
 
 
-def test_linear_power_cancellation_preserves_unrelated_degrees() -> None:
+def test_univariate_binomial_power_cancellation() -> None:
+    x = symbols("x")
+    source = rational_function_from_sympy(1 / (x**2 + 1) ** 17, ("x",))
+    result = gradient(source)
+    expected = rational_function_from_sympy(-34 * x / (x**2 + 1) ** 18, ("x",))
+    assert result.partial_derivatives == (expected,)
     x, y = symbols("x y")
     numerator = sum(x ** (2 * i) for i in range(32)) * sum(y**j for j in range(5))
     source = rational_function_from_sympy(numerator / (x + 1) ** 33, ("x", "y"))

--- a/tests/math/polynomials/test_rational_gradient.py
+++ b/tests/math/polynomials/test_rational_gradient.py
@@ -238,6 +238,10 @@ def test_univariate_binomial_power_cancellation() -> None:
     source = rational_function_from_sympy(numerator / (x + 1) ** 33, ("x", "y"))
     with pytest.raises(OperationResourceAdmissionError, match="term"):
         gradient(source)
+    even_grid = sum(x ** (2 * a) * y ** (2 * b) for a in range(16) for b in range(16))
+    source = rational_function_from_sympy(even_grid / (x + y) ** 33, ("x", "y"))
+    with pytest.raises(OperationResourceAdmissionError, match="term"):
+        gradient(source)
 
 
 def test_shared_request_deadline() -> None:

--- a/tests/math/polynomials/test_rational_gradient.py
+++ b/tests/math/polynomials/test_rational_gradient.py
@@ -193,6 +193,11 @@ def test_repeated_linear_denominator_cancels_before_result_exponent() -> None:
     assert result.partial_derivatives[0] == rational_function_from_sympy(
         -33 / (x + 1) ** 34, ("x",)
     )
+    source = rational_function_from_sympy(1 / (x + 1) ** 35, ("x",))
+    result = _identity(source)
+    assert result.partial_derivatives[0] == rational_function_from_sympy(
+        -35 / (x + 1) ** 36, ("x",)
+    )
     source = _monomial_source(("x", "y"), (1, 1), (1, 0))
     with pytest.raises(OperationDomainValidationError, match="coprime"):
         gradient(source)
@@ -204,6 +209,14 @@ def test_repeated_linear_denominator_cancels_before_result_exponent() -> None:
     )
     with pytest.raises(OperationDomainValidationError, match="coprime"):
         gradient(authored)
+
+
+def test_linear_power_cancellation_preserves_unrelated_degrees() -> None:
+    x, y = symbols("x y")
+    numerator = sum(x ** (2 * i) for i in range(32)) * sum(y**j for j in range(5))
+    source = rational_function_from_sympy(numerator / (x + 1) ** 33, ("x", "y"))
+    with pytest.raises(OperationResourceAdmissionError, match="term"):
+        gradient(source)
 
 
 def test_shared_request_deadline() -> None:

--- a/tests/math/polynomials/test_rational_gradient.py
+++ b/tests/math/polynomials/test_rational_gradient.py
@@ -186,7 +186,13 @@ def test_true_output_coefficient_boundary() -> None:
         gradient(_monomial_source(("x",), (64,), (0,), 10**127))
 
 
-def test_authored_common_factor_is_rejected() -> None:
+def test_repeated_linear_denominator_cancels_before_result_exponent() -> None:
+    x = symbols("x")
+    source = rational_function_from_sympy(1 / (x + 1) ** 33, ("x",))
+    result = _identity(source)
+    assert result.partial_derivatives[0] == rational_function_from_sympy(
+        -33 / (x + 1) ** 34, ("x",)
+    )
     source = _monomial_source(("x", "y"), (1, 1), (1, 0))
     with pytest.raises(OperationDomainValidationError, match="coprime"):
         gradient(source)

--- a/tests/math/polynomials/test_rational_gradient.py
+++ b/tests/math/polynomials/test_rational_gradient.py
@@ -203,6 +203,17 @@ def test_repeated_linear_denominator_cancels_before_result_exponent() -> None:
     assert result.partial_derivatives[0] == rational_function_from_sympy(
         -20 * (2 * x + 3) / ((x + 1) ** 21 * (x + 2) ** 21), ("x",)
     )
+    source = rational_function_from_sympy(1 / ((x + 1) ** 33 * (x + 2)), ("x",))
+    result = _identity(source)
+    assert result.partial_derivatives[0] == rational_function_from_sympy(
+        -(34 * x + 67) / ((x + 1) ** 34 * (x + 2) ** 2), ("x",)
+    )
+    x, y = symbols("x y")
+    source = rational_function_from_sympy(1 / (x + y) ** 33, ("x", "y"))
+    result = _identity(source)
+    assert result.partial_derivatives[0] == rational_function_from_sympy(
+        -33 / (x + y) ** 34, ("x", "y")
+    )
     source = _monomial_source(("x", "y"), (1, 1), (1, 0))
     with pytest.raises(OperationDomainValidationError, match="coprime"):
         gradient(source)

--- a/tests/math/polynomials/test_rational_gradient.py
+++ b/tests/math/polynomials/test_rational_gradient.py
@@ -113,6 +113,23 @@ def test_multivariate_quotient_and_mixed_partial_composition() -> None:
     assert gradient(a).partial_derivatives[1] == gradient(b).partial_derivatives[0]
 
 
+@pytest.mark.parametrize("weights", [(1, 1, 1), (2, 3, 5), (1, -2, 3)])
+def test_low_total_degree_reciprocal_quadratic_power(
+    weights: tuple[int, int, int],
+) -> None:
+    x, y, z = symbols("x y z")
+    axes = (x, y, z)
+    quadratic = 1 + sum(c * v * v for c, v in zip(weights, axes, strict=True))
+    source = rational_function_from_sympy(1 / quadratic**2, ("x", "y", "z"))
+    result = _identity(source)
+    for c, v, partial in zip(weights, axes, result.partial_derivatives, strict=True):
+        expected = rational_function_from_sympy(
+            -4 * c * v / quadratic**3, source.variables
+        )
+        assert partial == expected
+        assert len(partial.denominator.terms) == 20
+
+
 @pytest.mark.parametrize("axis", [(), ("x",), ("x", "y")])
 @pytest.mark.parametrize("constant", [0, 3, 10**127])
 def test_constants_and_empty_axes(axis: tuple[str, ...], constant: int) -> None:

--- a/tests/math/polynomials/test_rational_gradient.py
+++ b/tests/math/polynomials/test_rational_gradient.py
@@ -198,6 +198,11 @@ def test_repeated_linear_denominator_cancels_before_result_exponent() -> None:
     assert result.partial_derivatives[0] == rational_function_from_sympy(
         -35 / (x + 1) ** 36, ("x",)
     )
+    source = rational_function_from_sympy(1 / ((x + 1) ** 20 * (x + 2) ** 20), ("x",))
+    result = _identity(source)
+    assert result.partial_derivatives[0] == rational_function_from_sympy(
+        -20 * (2 * x + 3) / ((x + 1) ** 21 * (x + 2) ** 21), ("x",)
+    )
     source = _monomial_source(("x", "y"), (1, 1), (1, 0))
     with pytest.raises(OperationDomainValidationError, match="coprime"):
         gradient(source)

--- a/tests/mcp/test_rational_gradient_boundary.py
+++ b/tests/mcp/test_rational_gradient_boundary.py
@@ -1,0 +1,33 @@
+"""Live scalar-gradient composition and recovery."""
+
+import asyncio
+import json
+
+from jacobian.math.polynomials.rational_functions.gradient._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_gradient_native_mcp_and_serialized_component_composition() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        async with Client(create_server(), raise_exceptions=False) as client:
+            result = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            output = result.structured_content["output"]
+            assert output == tool.run(request).model_dump(mode="json")
+            repeated = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": {"function": output["partial_derivatives"][0]},
+                },
+            )
+            assert not repeated.is_error
+
+    asyncio.run(scenario())

--- a/tests/mcp/test_rational_metric_curvature.py
+++ b/tests/mcp/test_rational_metric_curvature.py
@@ -1,0 +1,67 @@
+"""Native/MCP schema parity, recovery and canonical scalar-tensor reuse."""
+
+import asyncio
+import json
+
+from jsonschema import validate
+
+from jacobian.math.geometry.differential.metrics._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_live_rational_curvature_and_tensor_composition() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        validate(payload, tool.request_type.model_json_schema())
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        async with Client(create_server(), raise_exceptions=False) as client:
+            invalid = json.loads(json.dumps(payload))
+            invalid["metric"]["tensor"]["components"][3]["numerator"] = {"terms": []}
+            failure = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": invalid}
+            )
+            assert failure.is_error
+            response = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not response.is_error
+            assert response.structured_content is not None
+            output = response.structured_content["output"]
+            validate(output, tool.result_type.model_json_schema())
+            assert output == tool.run(request).model_dump(mode="json")
+            again = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": {"metric": output["metric"]},
+                },
+            )
+            assert not again.is_error
+            assert again.structured_content is not None
+            assert again.structured_content["output"] == output
+            assert output["scalar_curvature"]["variance"] == []
+            assert output["scalar_curvature"]["retained_nonzero_denominators"]
+            differentiated = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "differential_geometry.rational_tensor.lie_derivative.compute",
+                    "payload": {
+                        "vector_field": {
+                            "coordinate_axis": ["r", "theta"],
+                            "variance": ["CONTRAVARIANT"],
+                            "components": output["metric"]["tensor"]["components"][:2],
+                        },
+                        "tensor": output["scalar_curvature"],
+                    },
+                },
+            )
+            assert not differentiated.is_error
+            assert differentiated.structured_content is not None
+            assert (
+                differentiated.structured_content["output"]["lie_derivative"]
+                == output["scalar_curvature"]
+            )
+
+    asyncio.run(scenario())

--- a/tests/process/polynomials/test_rational_gradient_process.py
+++ b/tests/process/polynomials/test_rational_gradient_process.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from time import monotonic
 from typing import Any
 
@@ -86,11 +87,17 @@ def test_cancellation_worker_timeout_uses_remaining_request_deadline(
         request_execution(started),
         pytest.raises(
             OperationExecutionTimeoutError,
-            match="during fraction cancellation",
+            match="during the gradient kernel",
         ),
     ):
         bind_request_deadline(started + 8.0)
         gradient(_general_source())
+
+    payload = json.loads(observed["input_bytes"])
+    assert payload["axis"] in (0, 1)
+    assert payload["variable_count"] == 2
+    assert len(payload["numerator"]) == 2
+    assert len(payload["denominator"]) == 2
 
     assert 0 < observed["timeout_seconds"] <= 8.0
     resource_limits = observed["resource_limits"]

--- a/tests/process/polynomials/test_rational_gradient_process.py
+++ b/tests/process/polynomials/test_rational_gradient_process.py
@@ -1,0 +1,100 @@
+"""Process-boundary tests for rational-gradient recognition and cancellation."""
+
+from __future__ import annotations
+
+from time import monotonic
+from typing import Any
+
+import pytest
+from sympy import symbols
+
+from jacobian import process
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
+from jacobian.math.polynomials._conversions import rational_function_from_sympy
+from jacobian.math.polynomials.rational_functions.gradient import (
+    _normalize_process,
+    gradient,
+)
+from jacobian.math.polynomials.values import RationalFunction
+from jacobian.process import BoundedProcessResult, ProcessResourceLimits
+
+
+def _general_source() -> RationalFunction:
+    x, y = symbols("x y")
+    return rational_function_from_sympy((x * x + y) / (x - y), ("x", "y"))
+
+
+def test_recognition_worker_timeout_uses_remaining_request_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, Any] = {}
+
+    def timed_out(*_args: Any, **kwargs: Any) -> BoundedProcessResult:
+        observed.update(kwargs)
+        return BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        )
+
+    monkeypatch.setattr(process, "run_bounded_process", timed_out)
+    started = monotonic()
+    with (
+        request_execution(started),
+        pytest.raises(
+            OperationExecutionTimeoutError,
+            match="during coprimality recognition",
+        ),
+    ):
+        bind_request_deadline(started + 5.0)
+        gradient(_general_source())
+
+    assert 0 < observed["timeout_seconds"] <= 5.0
+    resource_limits = observed["resource_limits"]
+    assert isinstance(resource_limits, ProcessResourceLimits)
+    assert resource_limits.cpu_seconds is not None
+    assert resource_limits.address_space_bytes is not None
+    assert str(observed["cwd"]).split("/")[-1].startswith("jacobian-lie-recognition-")
+
+
+def test_cancellation_worker_timeout_uses_remaining_request_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, Any] = {}
+
+    def timed_out(*_args: Any, **kwargs: Any) -> BoundedProcessResult:
+        observed.update(kwargs)
+        return BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        )
+
+    monkeypatch.setattr(_normalize_process, "run_bounded_process", timed_out)
+    started = monotonic()
+    with (
+        request_execution(started),
+        pytest.raises(
+            OperationExecutionTimeoutError,
+            match="during fraction cancellation",
+        ),
+    ):
+        bind_request_deadline(started + 8.0)
+        gradient(_general_source())
+
+    assert 0 < observed["timeout_seconds"] <= 8.0
+    resource_limits = observed["resource_limits"]
+    assert isinstance(resource_limits, ProcessResourceLimits)
+    assert resource_limits.cpu_seconds is not None
+    assert resource_limits.address_space_bytes is not None
+    assert str(observed["cwd"]).split("/")[-1].startswith("jacobian-gradient-cancel-")


### PR DESCRIPTION
Adds `rational_function.gradient.compute` and the native `gradient` function. A canonical rational function now produces every coordinate partial on its original ordered axis, including canonical zeros and the empty gradient for an empty axis. The retained source records the original denominator even when differentiation cancels it.

The implementation shares rational arithmetic bounds with the existing Lie derivative and exposes a private admitted derivative/normalization kernel for the Jacobian and metric requests. Sparse Laurent functions use exact exponent shifts; other functions reserve quotient arithmetic, normalization, and the complete result before backend expansion. Total-degree support bounds and the multivariate factor-height inequality from [Amoroso–Mignotte (2001), p. 1](https://doi.org/10.4064/aa99-1-1) admit low-degree multivariate inputs without increasing the representation or work limits.

A motivating rejected input, `1/(1+x²+y²+z²)²`, now returns all three derivatives with 20-term denominators. Eight-axis sparse degree-64 inputs and 128-digit constants are also accepted. General symbolic requests remain subject to conservative intermediate, canonical-result, and 25-million coefficient-work bounds.

Validation: independent sparse quotient identities, seeded rational examples, serialized mixed-partial composition, axis/empty/constant cases, canonical-source rejection, useful admission boundaries, and live MCP parity/recovery. Independent review covers the operation, shared-bound extraction, and subsequent precision repair. Final affected validation passed: scoped Ruff/mypy, 850 math tests, 156 catalog tests, 915 catalog integration tests, and 74 MCP tests. Architecture (1,347 files) and the scoped exhaustive catalog conformance case passed. Authored non-coprime inputs receive typed domain rejections.

Closes #2878. This publishes a new operation; it supersedes no existing public contract. #2879 owns the separate map-level Jacobian profile.

Hosted required CI passed.
