### PR TITLE
feat(geometry): compute exact rational metric curvature

### DIFF
--- a/src/jacobian/math/geometry/differential/metrics/__init__.py
+++ b/src/jacobian/math/geometry/differential/metrics/__init__.py
@@ -1,0 +1,15 @@
+"""Exact rational metric, Levi-Civita connection and curvature ownership."""
+
+from jacobian.math.geometry.differential.metrics._models import (
+    RationalCoordinateConnection,
+    RationalCoordinateMetric,
+    RationalMetricCurvatureProfile,
+)
+from jacobian.math.geometry.differential.metrics.operations import curvature_profile
+
+__all__ = [
+    "RationalCoordinateConnection",
+    "RationalCoordinateMetric",
+    "RationalMetricCurvatureProfile",
+    "curvature_profile",
+]

--- a/src/jacobian/math/geometry/differential/metrics/_dag.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag.py
@@ -154,8 +154,26 @@ class Dag:
             self.source(value.numerator),
             self.source(value.denominator),
         )
+
+        # Recognition sees the authored numerator and denominator separately.
+        # Preserve those raw bounds before structural factor cancellation can
+        # make a presentation such as x**2/x look constant. Source conversion
+        # is charged again here for the recognition backend; ``source`` owns
+        # the separate conversion reservation used by the executor.
+        raw_numerator = self.nodes[
+            self.polynomial(numerator.numerator, numerator.scalar)
+        ].bound
+        raw_denominator = self.nodes[
+            self.polynomial(denominator.numerator, denominator.scalar)
+        ].bound
+        raw_bound = FractionBound(raw_numerator, raw_denominator)
+        self.ledger.charge("recognition", _recognition_work_units(raw_bound))
+        self.ledger.charge(
+            "source_conversion",
+            _polynomial_backend_conversion_work_units(raw_numerator)
+            + _polynomial_backend_conversion_work_units(raw_denominator),
+        )
         result = self.multiply(numerator, self.inverse(denominator))
-        self.ledger.charge("recognition", _recognition_work_units(self.bound(result)))
         return result
 
     @staticmethod

--- a/src/jacobian/math/geometry/differential/metrics/_dag.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag.py
@@ -1,0 +1,346 @@
+"""Preflight polynomial DAG with explicitly shared rational denominator factors."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, replace
+from fractions import Fraction
+from typing import NoReturn
+
+from jacobian._execution import request_checkpoint
+from jacobian.canonical import format_canonical_integer
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.polynomials.rational_functions._bounds import (
+    BoundWorkCategory,
+    FractionBound,
+    PolynomialBound,
+    RationalFunctionBoundLimits,
+    _add_polynomials,
+    _check_raw_polynomial,
+    _differentiate_polynomial,
+    _multiply_polynomials,
+    _one_polynomial,
+    _polynomial_admission_work_units,
+    _polynomial_backend_conversion_work_units,
+    _polynomial_bound,
+    _recognition_work_units,
+    _remove_guaranteed_common_monomial,
+    _validate_canonical_result_bound,
+    _zero_polynomial,
+)
+from jacobian.math.polynomials.values import RationalFunction, SparseRationalPolynomial
+
+
+def reject(reason: str, message: str) -> NoReturn:
+    raise OperationResourceAdmissionError(
+        location=("metric",),
+        code=f"differential_geometry.curvature.{reason}",
+        message=message,
+    )
+
+
+class Ledger:
+    limits = RationalFunctionBoundLimits(
+        raw_terms=4096,
+        raw_digits=4096,
+        result_exponent=64,
+        result_terms=256,
+        result_digits=128,
+        label="metric curvature",
+        reject=reject,
+    )
+
+    def __init__(self) -> None:
+        self.work = 0
+        self.allocation_bits = 0
+
+    def charge(self, category: BoundWorkCategory, amount: int) -> None:
+        request_checkpoint(f"admitting metric curvature {category}")
+        self.work += amount
+        if self.work > 50_000_000:
+            reject("work", "complete curvature DAG exceeds 50,000,000 work units")
+
+
+@dataclass(frozen=True)
+class Expression:
+    """Scalar times polynomial-node factors divided by polynomial-node factors."""
+
+    scalar: Fraction = Fraction(1)
+    numerator: tuple[int, ...] = ()
+    denominator: tuple[int, ...] = ()
+
+
+ZERO = Expression(Fraction(0))
+ONE = Expression()
+
+
+@dataclass(frozen=True)
+class Node:
+    operation: str
+    arguments: tuple[int, ...]
+    bound: PolynomialBound
+    source: SparseRationalPolynomial | None = None
+    scalar: Fraction = Fraction(1)
+    axis: int = 0
+
+
+class Dag:
+    """Plan once without polynomial expansion; executor evaluates these nodes.
+
+    Polynomial identity is used only when identical nodes occur. Fraction
+    addition uses a common multiset of denominator factors. Multiplication
+    cancels identical numerator/denominator factors before expansion. These
+    exact structural reductions retain shared metric denominators across the
+    complete inverse/connection/curvature formula.
+    """
+
+    def __init__(self, dimension: int) -> None:
+        self.dimension = dimension
+        self.ledger = Ledger()
+        self.nodes = [
+            Node("ZERO", (), _zero_polynomial(dimension)),
+            Node("ONE", (), _one_polynomial(dimension)),
+        ]
+        self.keys: dict[tuple[object, ...], int] = {}
+
+    def intern(self, key: tuple[object, ...], node: Node) -> int:
+        if key in self.keys:
+            return self.keys[key]
+        _check_raw_polynomial(node.bound, self.ledger.limits)
+        content_digits = len(
+            format_canonical_integer(abs(node.bound.rational_content.numerator))
+        ) + len(format_canonical_integer(node.bound.rational_content.denominator))
+        self.ledger.allocation_bits += max(
+            node.bound.terms, self.dense(node.bound.degrees)
+        ) * (
+            16
+            + 4 * (node.bound.coefficient_digits + content_digits)
+            + 64 * self.dimension
+        )
+        if len(self.nodes) >= 16384 or self.ledger.allocation_bits > 268_435_456:
+            reject("allocation", "curvature DAG exceeds node or coefficient allocation")
+        result = len(self.nodes)
+        self.nodes.append(node)
+        self.keys[key] = result
+        return result
+
+    def source(self, polynomial: SparseRationalPolynomial) -> Expression:
+        self.ledger.charge(
+            "source_conversion",
+            _polynomial_admission_work_units(polynomial, self.dimension),
+        )
+        if not polynomial.terms:
+            return ZERO
+        if len(polynomial.terms) == 1 and not any(polynomial.terms[0].exponents):
+            return Expression(polynomial.terms[0].coefficient.as_fraction())
+        key = (
+            "SOURCE",
+            tuple(
+                (term.exponents, term.coefficient.as_fraction())
+                for term in polynomial.terms
+            ),
+        )
+        if key in self.keys:
+            return Expression(numerator=(self.keys[key],))
+        bound = _polynomial_bound(polynomial)
+        self.ledger.charge(
+            "source_conversion", _polynomial_backend_conversion_work_units(bound)
+        )
+        index = self.intern(key, Node("SOURCE", (), bound, source=polynomial))
+        return Expression(numerator=(index,))
+
+    def fraction(self, value: RationalFunction) -> Expression:
+        numerator, denominator = (
+            self.source(value.numerator),
+            self.source(value.denominator),
+        )
+        result = self.multiply(numerator, self.inverse(denominator))
+        self.ledger.charge("recognition", _recognition_work_units(self.bound(result)))
+        return result
+
+    @staticmethod
+    def inverse(value: Expression) -> Expression:
+        if not value.scalar:
+            raise ZeroDivisionError("zero expression cannot be inverted")
+        return Expression(1 / value.scalar, value.denominator, value.numerator)
+
+    @staticmethod
+    def multiply(*values: Expression) -> Expression:
+        numerator: Counter[int] = Counter()
+        denominator: Counter[int] = Counter()
+        scalar = Fraction(1)
+        for value in values:
+            scalar *= value.scalar
+            if not scalar:
+                return ZERO
+            numerator.update(value.numerator)
+            denominator.update(value.denominator)
+        common = numerator & denominator
+        return Expression(
+            scalar,
+            tuple(sorted((numerator - common).elements())),
+            tuple(sorted((denominator - common).elements())),
+        )
+
+    def polynomial(
+        self, factors: tuple[int, ...], scalar: Fraction = Fraction(1)
+    ) -> int:
+        if not scalar:
+            return 0
+        result = 1
+        for factor in factors:
+            if result == 1:
+                result = factor
+            else:
+                key: tuple[object, ...] = ("MULTIPLY", result, factor)
+                if key in self.keys:
+                    result = self.keys[key]
+                else:
+                    bound = _multiply_polynomials(
+                        self.nodes[result].bound, self.nodes[factor].bound, self.ledger
+                    )
+                    result = self.intern(key, Node("MULTIPLY", (result, factor), bound))
+        if scalar != 1:
+            key = ("SCALE", result, scalar)
+            bound = replace(
+                self.nodes[result].bound,
+                rational_content=self.nodes[result].bound.rational_content * scalar,
+            )
+            result = self.intern(key, Node("SCALE", (result,), bound, scalar=scalar))
+        return result
+
+    def add(self, *values: Expression) -> Expression:
+        grouped: dict[tuple[tuple[int, ...], tuple[int, ...]], Fraction] = {}
+        for value in values:
+            fraction_key = (value.numerator, value.denominator)
+            grouped[fraction_key] = (
+                grouped.get(fraction_key, Fraction(0)) + value.scalar
+            )
+        nonzero = [
+            Expression(scalar, *key)
+            for key, scalar in sorted(grouped.items())
+            if scalar
+        ]
+        if not nonzero:
+            return ZERO
+        if len(nonzero) == 1:
+            return nonzero[0]
+        denominator: Counter[int] = Counter()
+        for value in nonzero:
+            denominator |= Counter(value.denominator)
+        terms = tuple(
+            self.polynomial(
+                tuple(
+                    sorted(
+                        (
+                            *value.numerator,
+                            *(denominator - Counter(value.denominator)).elements(),
+                        )
+                    )
+                ),
+                value.scalar,
+            )
+            for value in nonzero
+        )
+        key = ("ADD", *terms)
+        if key in self.keys:
+            result = self.keys[key]
+        else:
+            bound = self.nodes[terms[0]].bound
+            for term in terms[1:]:
+                bound = _add_polynomials(bound, self.nodes[term].bound, self.ledger)
+            result = self.intern(key, Node("ADD", terms, bound))
+        return Expression(
+            numerator=(result,), denominator=tuple(sorted(denominator.elements()))
+        )
+
+    def derivative(self, value: Expression, axis: int) -> Expression:
+        if not value.scalar:
+            return ZERO
+        numerator = self.polynomial(value.numerator)
+        denominator = self.polynomial(value.denominator)
+        a, b = self.nodes[numerator].bound, self.nodes[denominator].bound
+        if a.degrees[axis] == b.degrees[axis] == 0:
+            return ZERO
+        key = ("DERIVATIVE", numerator, denominator, axis)
+        if key in self.keys:
+            result = self.keys[key]
+        else:
+
+            def differential(bound: PolynomialBound) -> PolynomialBound:
+                return _differentiate_polynomial(
+                    bound,
+                    axis,
+                    self.ledger,
+                    active_terms=bound.terms if bound.degrees[axis] else 0,
+                    maximum_axis_exponent=max(1, bound.degrees[axis]),
+                    minimum_exponents=tuple(
+                        max(0, e - int(i == axis))
+                        for i, e in enumerate(bound.minimum_exponents)
+                    ),
+                )
+
+            da, db = differential(a), differential(b)
+            self.ledger.charge("differentiation", a.terms + b.terms)
+            # The quotient-rule kernel materializes D squared even when
+            # later factor cancellation removes it from the result.
+            temporary = _multiply_polynomials(b, b, self.ledger)
+            temporary_digits = (
+                temporary.coefficient_digits
+                + len(
+                    format_canonical_integer(abs(temporary.rational_content.numerator))
+                )
+                + len(format_canonical_integer(temporary.rational_content.denominator))
+            )
+            self.ledger.allocation_bits += self.dense(temporary.degrees) * (
+                64 * self.dimension + 4 * temporary_digits + 16
+            )
+            bound = _add_polynomials(
+                _multiply_polynomials(da, b, self.ledger),
+                _multiply_polynomials(a, db, self.ledger),
+                self.ledger,
+            )
+            result = self.intern(
+                key, Node("DERIVATIVE", (numerator, denominator), bound, axis=axis)
+            )
+        return Expression(value.scalar, (result,), tuple(sorted(value.denominator * 2)))
+
+    def bound(self, value: Expression) -> FractionBound:
+        return FractionBound(
+            self.nodes[self.polynomial(value.numerator, value.scalar)].bound,
+            self.nodes[self.polynomial(value.denominator)].bound,
+        )
+
+    def admit_output(self, value: Expression) -> tuple[int, int, int]:
+        """Bound canonical polynomial terms, coefficient bits and coordinate slots."""
+        if not value.numerator and not value.denominator:
+            # Exact scalar metadata avoids charging a factor-height bound to
+            # unchanged constant metric entries or their reciprocals.
+            digits = max(
+                len(format_canonical_integer(abs(value.scalar.numerator))),
+                len(format_canonical_integer(value.scalar.denominator)),
+            )
+            if digits > 128:
+                reject(
+                    "result_height", "constant result exceeds 128 coefficient digits"
+                )
+            self.ledger.charge("normalization", 1)
+            terms = 1 + int(bool(value.scalar))
+            return terms, 8 * digits * terms, self.dimension * (terms + 2)
+        bound = _remove_guaranteed_common_monomial(self.bound(value))
+        digits = _validate_canonical_result_bound(bound, self.ledger)
+        terms = sum(
+            min(256, self.dense(part.degrees))
+            for part in (bound.numerator, bound.denominator)
+        )
+        # Both integers in each rational coefficient have fewer than 4h
+        # bits for h decimal digits. Each term retains its exponent vector,
+        # and each numerator/denominator polynomial retains its variable axis.
+        return terms, 8 * digits * terms, self.dimension * (terms + 2)
+
+    @staticmethod
+    def dense(degrees: tuple[int, ...]) -> int:
+        result = 1
+        for degree in degrees:
+            result *= degree + 1
+        return result

--- a/src/jacobian/math/geometry/differential/metrics/_dag.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag.py
@@ -157,7 +157,7 @@ class Dag:
 
         # Recognition sees the authored numerator and denominator separately.
         # Preserve those raw bounds before structural factor cancellation can
-        # make a presentation such as x**2/x look constant. Source conversion
+        # make a presentation such as x/x look constant. Source conversion
         # is charged again here for the recognition backend; ``source`` owns
         # the separate conversion reservation used by the executor.
         raw_numerator = self.nodes[

--- a/src/jacobian/math/geometry/differential/metrics/_dag_process.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag_process.py
@@ -32,7 +32,7 @@ _WORKER_PATH = Path(__file__).resolve().with_name("_dag_worker.py")
 _STDOUT_BYTES = 64 * 1024 * 1024
 _STDERR_BYTES = 64 * 1024
 _ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
-_PARENT_FINALIZATION_SECONDS = 1.0
+_PARENT_FINALIZATION_SECONDS = 0.05
 
 
 def _source_payload(polynomial: SparseRationalPolynomial) -> list[list[object]]:
@@ -81,8 +81,12 @@ def _poly_from_payload(records: object, symbols: tuple[Any, ...]) -> Any:
 
 def evaluate_polynomial_dag(
     nodes: list[Node], axis: tuple[str, ...], *, deadline: float
-) -> dict[int, Any]:
-    """Expand one admitted DAG in a killable worker under the shared deadline."""
+) -> tuple[list[Any], tuple[Any, ...]]:
+    """Expand one admitted DAG in a killable worker under the shared deadline.
+
+    Expanded polynomials remain as worker term dumps. The parent materializes
+    only the nodes later consumed, under the remaining request deadline.
+    """
 
     remaining = deadline - monotonic() - _PARENT_FINALIZATION_SECONDS
     if remaining <= 0:
@@ -153,7 +157,16 @@ def evaluate_polynomial_dag(
             "bounded metric-curvature DAG worker returned malformed output"
         )
     generators = symbols_for_variables(axis)
-    return {
-        index: _poly_from_payload(record, generators)
-        for index, record in enumerate(response["values"])
-    }
+    return response["values"], generators
+
+
+def materialize_expanded_polynomial(
+    records: object, symbols: tuple[Any, ...], *, deadline: float
+) -> Any:
+    """Decode one worker polynomial under the remaining request deadline."""
+
+    if monotonic() >= deadline:
+        raise OperationExecutionTimeoutError(
+            "metric curvature deadline expired during polynomial DAG decoding"
+        )
+    return _poly_from_payload(records, symbols)

--- a/src/jacobian/math/geometry/differential/metrics/_dag_process.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag_process.py
@@ -1,0 +1,159 @@
+"""Killable SymPy expansion for an admitted metric-curvature polynomial DAG."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from time import monotonic
+from typing import Any
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+    loads_strict_json,
+)
+from jacobian.math.geometry.differential.metrics._dag import Node
+from jacobian.math.polynomials._conversions import symbols_for_variables
+from jacobian.math.polynomials.values import SparseRationalPolynomial
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_WORKER_PATH = Path(__file__).resolve().with_name("_dag_worker.py")
+_STDOUT_BYTES = 64 * 1024 * 1024
+_STDERR_BYTES = 64 * 1024
+_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_PARENT_FINALIZATION_SECONDS = 1.0
+
+
+def _source_payload(polynomial: SparseRationalPolynomial) -> list[list[object]]:
+    return [
+        [*term.exponents, str(term.coefficient.num), str(term.coefficient.den)]
+        for term in polynomial.terms
+    ]
+
+
+def _node_payload(node: Node) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "operation": node.operation,
+        "arguments": list(node.arguments),
+    }
+    if node.source is not None:
+        payload["source"] = _source_payload(node.source)
+    if node.operation == "SCALE":
+        payload["scalar"] = [
+            str(node.scalar.numerator),
+            str(node.scalar.denominator),
+        ]
+    if node.operation == "DERIVATIVE":
+        payload["axis"] = node.axis
+    return payload
+
+
+def _poly_from_payload(records: object, symbols: tuple[Any, ...]) -> Any:
+    from sympy import QQ, Poly, Rational
+
+    if not isinstance(records, list):
+        raise ValueError("malformed expanded polynomial")
+    coefficients: dict[tuple[int, ...], Any] = {}
+    variable_count = len(symbols)
+    for record in records:
+        if not isinstance(record, list) or len(record) != variable_count + 2:
+            raise ValueError("malformed expanded polynomial")
+        exponents = tuple(record[:variable_count])
+        if any(type(exponent) is not int or exponent < 0 for exponent in exponents):
+            raise ValueError("malformed expanded polynomial")
+        numerator, denominator = record[-2], record[-1]
+        if not isinstance(numerator, str) or not isinstance(denominator, str):
+            raise ValueError("malformed expanded polynomial")
+        coefficients[exponents] = Rational(int(numerator), int(denominator))
+    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+
+
+def evaluate_polynomial_dag(
+    nodes: list[Node], axis: tuple[str, ...], *, deadline: float
+) -> dict[int, Any]:
+    """Expand one admitted DAG in a killable worker under the shared deadline."""
+
+    remaining = deadline - monotonic() - _PARENT_FINALIZATION_SECONDS
+    if remaining <= 0:
+        raise OperationExecutionTimeoutError(
+            "metric curvature deadline expired before DAG expansion"
+        )
+    payload = encode_strict_json(
+        {
+            "variables": list(axis),
+            "nodes": [_node_payload(node) for node in nodes],
+        }
+    )
+    try:
+        with TemporaryDirectory(prefix="jacobian-metric-dag-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_WORKER_PATH)],
+                input_bytes=payload,
+                timeout_seconds=remaining,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_STDOUT_BYTES,
+                stderr_limit=_STDERR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(remaining)),
+                    address_space_bytes=_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_STDOUT_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded metric-curvature DAG worker could not be started"
+        ) from exc
+    if completed.cancelled:
+        raise OperationExecutionCancelledError(
+            "metric curvature cancelled during polynomial DAG expansion"
+        )
+    if completed.timed_out:
+        raise OperationExecutionTimeoutError(
+            "metric curvature deadline expired during polynomial DAG expansion"
+        )
+    if (
+        completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        raise RuntimeError(
+            "bounded metric-curvature DAG worker did not return expanded polynomials"
+        )
+    try:
+        response = loads_strict_json(
+            completed.stdout,
+            limits=CanonicalLimits(
+                max_input_bytes=_STDOUT_BYTES,
+                max_output_bytes=_STDOUT_BYTES,
+            ),
+        )
+    except CanonicalizationError as exc:
+        raise RuntimeError(
+            "bounded metric-curvature DAG worker returned malformed output"
+        ) from exc
+    if (
+        not isinstance(response, dict)
+        or response.get("status") != "ok"
+        or not isinstance(response.get("values"), list)
+        or len(response["values"]) != len(nodes)
+    ):
+        raise RuntimeError(
+            "bounded metric-curvature DAG worker returned malformed output"
+        )
+    generators = symbols_for_variables(axis)
+    return {
+        index: _poly_from_payload(record, generators)
+        for index, record in enumerate(response["values"])
+    }

--- a/src/jacobian/math/geometry/differential/metrics/_dag_worker.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag_worker.py
@@ -1,0 +1,126 @@
+"""Standalone SymPy worker for admitted metric-curvature DAG expansion."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def _polynomial(records: list[Any], symbols: tuple[Any, ...]) -> Any:
+    from sympy import QQ, Poly, Rational
+
+    coefficients: dict[tuple[int, ...], Any] = {}
+    variable_count = len(symbols)
+    for record in records:
+        if not isinstance(record, list) or len(record) != variable_count + 2:
+            raise ValueError("malformed polynomial record")
+        exponents = tuple(record[:variable_count])
+        numerator = record[-2]
+        denominator = record[-1]
+        if (
+            any(type(exponent) is not int or exponent < 0 for exponent in exponents)
+            or not isinstance(numerator, str)
+            or not isinstance(denominator, str)
+        ):
+            raise ValueError("malformed polynomial record")
+        coefficients[exponents] = Rational(int(numerator), int(denominator))
+    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+
+
+def _dump(polynomial: Any) -> list[list[Any]]:
+    return [
+        [*exponents, str(coefficient.p), str(coefficient.q)]
+        for exponents, coefficient in polynomial.terms()
+    ]
+
+
+def _run(payload: dict[str, Any]) -> dict[str, Any]:
+    from sympy import QQ, Poly, Symbol
+
+    if set(payload) != {"variables", "nodes"}:
+        raise ValueError("malformed DAG request")
+    variables = payload["variables"]
+    nodes = payload["nodes"]
+    if (
+        not isinstance(variables, list)
+        or not variables
+        or any(not isinstance(name, str) or not name for name in variables)
+        or not isinstance(nodes, list)
+        or len(nodes) < 2
+    ):
+        raise ValueError("malformed DAG request")
+    variable_count = len(variables)
+    generators = tuple(Symbol(name) for name in variables)
+    cache: list[Any] = [Poly(0, *generators, domain=QQ), Poly(1, *generators, domain=QQ)]
+    for index, node in enumerate(nodes):
+        if not isinstance(node, dict):
+            raise ValueError("malformed DAG node")
+        operation = node.get("operation")
+        arguments = node.get("arguments")
+        if not isinstance(arguments, list) or any(
+            type(argument) is not int or argument < 0 or argument >= index
+            for argument in arguments
+        ):
+            raise ValueError("malformed DAG node")
+        if operation == "ZERO":
+            result = cache[0]
+        elif operation == "ONE":
+            result = cache[1]
+        elif operation == "SOURCE":
+            source = node.get("source")
+            if not isinstance(source, list):
+                raise ValueError("malformed SOURCE node")
+            result = _polynomial(source, generators)
+        elif operation == "SCALE":
+            scalar = node.get("scalar")
+            if (
+                not isinstance(scalar, list)
+                or len(scalar) != 2
+                or not isinstance(scalar[0], str)
+                or not isinstance(scalar[1], str)
+                or len(arguments) != 1
+            ):
+                raise ValueError("malformed SCALE node")
+            result = cache[arguments[0]].mul_ground(QQ(int(scalar[0]), int(scalar[1])))
+        elif operation == "MULTIPLY":
+            if len(arguments) != 2:
+                raise ValueError("malformed MULTIPLY node")
+            result = cache[arguments[0]] * cache[arguments[1]]
+        elif operation == "ADD":
+            result = sum((cache[argument] for argument in arguments), cache[0])
+        elif operation == "DERIVATIVE":
+            if len(arguments) != 2:
+                raise ValueError("malformed DERIVATIVE node")
+            axis = node.get("axis")
+            if type(axis) is not int or not 0 <= axis < variable_count:
+                raise ValueError("malformed DERIVATIVE node")
+            numerator = cache[arguments[0]]
+            denominator = cache[arguments[1]]
+            result = numerator.diff(axis) * denominator - numerator * denominator.diff(
+                axis
+            )
+        else:
+            raise ValueError("unknown DAG operation")
+        if index < 2:
+            continue
+        cache.append(result)
+    return {"status": "ok", "values": [_dump(value) for value in cache]}
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("malformed DAG request")
+        response = _run(payload)
+    except Exception:
+        return 1
+    sys.stdout.buffer.write(
+        json.dumps(response, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/geometry/differential/metrics/_models.py
+++ b/src/jacobian/math/geometry/differential/metrics/_models.py
@@ -1,0 +1,146 @@
+"""Rational coordinate metrics and their complete curvature profiles."""
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.geometry.differential.values import (
+    RationalCoordinateTensor,
+    _is_unit_polynomial,
+    _polynomial_key,
+)
+from jacobian.math.polynomials.values import (
+    PolynomialVariable,
+    RationalFunction,
+    SparseRationalPolynomial,
+    require_sparse_polynomial_budget,
+)
+
+
+class RationalCoordinateMetric(StrictModel):
+    """A symmetric covariant tensor on its generic nondegenerate locus.
+
+    Nondegeneracy is established by the consuming operation. No signature,
+    positivity, global chart, or completeness is asserted by this value.
+    """
+
+    tensor: RationalCoordinateTensor
+    chart_semantics: Literal["GENERIC_NONDEGENERATE_LOCUS"] = (
+        "GENERIC_NONDEGENERATE_LOCUS"
+    )
+
+    @model_validator(mode="after")
+    def require_metric_shape(self) -> Self:
+        n = len(self.tensor.coordinate_axis)
+        if n > 4 or self.tensor.variance != ("COVARIANT", "COVARIANT"):
+            raise ValueError("metric must be a covariant rank-two tensor on 1..4 axes")
+        if any(
+            self.tensor.components[i * n + j] != self.tensor.components[j * n + i]
+            for i in range(n)
+            for j in range(i)
+        ):
+            raise ValueError("metric components must be symmetric")
+        return self
+
+
+class RationalCoordinateConnection(StrictModel):
+    """Connection coefficients Gamma^k_ij in the ordered coordinate frame.
+
+    Components follow (k,i,j), last index fastest. A connection is not a
+    tensor; its coordinates and retained chart locus travel with its values.
+    """
+
+    coordinate_axis: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    components: tuple[RationalFunction, ...] = Field(min_length=1, max_length=64)
+    retained_nonzero_denominators: tuple[SparseRationalPolynomial, ...] = Field(
+        max_length=768
+    )
+
+    @model_validator(mode="after")
+    def require_connection_shape(self) -> Self:
+        if len(set(self.coordinate_axis)) != len(self.coordinate_axis):
+            raise ValueError("connection coordinate axis must be unique")
+        if len(self.components) != len(self.coordinate_axis) ** 3:
+            raise ValueError("connection requires exactly n cubed components")
+        if any(value.variables != self.coordinate_axis for value in self.components):
+            raise ValueError(
+                "connection components must use its complete ordered field"
+            )
+        keys = []
+        for guard in self.retained_nonzero_denominators:
+            if not guard.terms or any(
+                len(term.exponents) != len(self.coordinate_axis) for term in guard.terms
+            ):
+                raise ValueError(
+                    "connection guards must be nonzero on the coordinate field"
+                )
+            if guard.terms[0].coefficient.as_fraction() != 1 or _is_unit_polynomial(
+                guard, len(self.coordinate_axis)
+            ):
+                raise ValueError("connection guards must be monic and nonconstant")
+            require_sparse_polynomial_budget(
+                guard,
+                maximum_terms=256,
+                maximum_exponent=64,
+                maximum_coefficient_digits=128,
+                label="connection locus guard",
+            )
+            keys.append(_polynomial_key(guard))
+        if keys != sorted(set(keys)):
+            raise ValueError("connection guards must be unique and canonically ordered")
+        key_set = set(keys)
+        if any(
+            not _is_unit_polynomial(value.denominator, len(self.coordinate_axis))
+            and _polynomial_key(value.denominator) not in key_set
+            for value in self.components
+        ):
+            raise ValueError("connection locus must retain every component denominator")
+        return self
+
+
+class RationalMetricCurvatureRequest(StrictModel):
+    metric: RationalCoordinateMetric
+
+
+class RationalMetricCurvatureProfile(StrictModel):
+    """Exact source-bound curvature on the retained nondegenerate locus.
+
+    Riemann components use (l,k,i,j): [nabla_i,nabla_j]v^l=R^l_kij v^k.
+    Ricci uses (k,j): Ric_kj=sum_i R^i_kij. Scalar curvature contracts
+    inverse_metric with ricci. Component decoding does not replay these
+    operation-owned identities.
+    """
+
+    metric: RationalCoordinateMetric
+    inverse_metric: RationalCoordinateTensor
+    connection: RationalCoordinateConnection
+    riemann: RationalCoordinateTensor
+    ricci: RationalCoordinateTensor
+    scalar_curvature: RationalCoordinateTensor
+
+    @model_validator(mode="after")
+    def require_profile_axes(self) -> Self:
+        axis = self.metric.tensor.coordinate_axis
+        guards = self.connection.retained_nonzero_denominators
+        if self.connection.coordinate_axis != axis:
+            raise ValueError("connection must retain the metric coordinate axis")
+        for value, variance in (
+            (self.inverse_metric, ("CONTRAVARIANT", "CONTRAVARIANT")),
+            (self.riemann, ("CONTRAVARIANT", "COVARIANT", "COVARIANT", "COVARIANT")),
+            (self.ricci, ("COVARIANT", "COVARIANT")),
+            (self.scalar_curvature, ()),
+        ):
+            if (
+                value.coordinate_axis != axis
+                or value.variance != variance
+                or value.retained_nonzero_denominators != guards
+            ):
+                raise ValueError(
+                    "profile tensors must retain their declared axes, variance and locus"
+                )
+        if not set(
+            map(_polynomial_key, self.metric.tensor.retained_nonzero_denominators)
+        ) <= set(map(_polynomial_key, guards)):
+            raise ValueError("profile must retain every source locus guard")
+        return self

--- a/src/jacobian/math/geometry/differential/metrics/_normalize_process.py
+++ b/src/jacobian/math/geometry/differential/metrics/_normalize_process.py
@@ -1,0 +1,140 @@
+"""Killable SymPy cancellation for admitted curvature components."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from time import monotonic
+from typing import Any
+
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+)
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+    loads_strict_json,
+)
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_WORKER_PATH = Path(__file__).resolve().with_name("_normalize_worker.py")
+_STDOUT_BYTES = 8 * 1024 * 1024
+_STDERR_BYTES = 64 * 1024
+_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_PARENT_FINALIZATION_SECONDS = 1.0
+
+
+def _poly_payload(polynomial: Any) -> list[list[Any]]:
+    return [
+        [*exponents, str(coefficient.p), str(coefficient.q)]
+        for exponents, coefficient in polynomial.terms()
+    ]
+
+
+def _poly_from_payload(records: object, symbols: tuple[Any, ...]) -> Any:
+    from sympy import QQ, Poly, Rational
+
+    if not isinstance(records, list):
+        raise ValueError("malformed cancelled polynomial")
+    coefficients: dict[tuple[int, ...], Any] = {}
+    variable_count = len(symbols)
+    for record in records:
+        if not isinstance(record, list) or len(record) != variable_count + 2:
+            raise ValueError("malformed cancelled polynomial")
+        exponents = tuple(record[:variable_count])
+        if any(type(exponent) is not int or exponent < 0 for exponent in exponents):
+            raise ValueError("malformed cancelled polynomial")
+        numerator, denominator = record[-2], record[-1]
+        if not isinstance(numerator, str) or not isinstance(denominator, str):
+            raise ValueError("malformed cancelled polynomial")
+        coefficients[exponents] = Rational(int(numerator), int(denominator))
+    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+
+
+def cancel_fraction(
+    numerator: Any, denominator: Any, *, deadline: float
+) -> tuple[Any, Any]:
+    """Cancel one admitted pair in a killable worker under the shared deadline."""
+
+    remaining = deadline - monotonic() - _PARENT_FINALIZATION_SECONDS
+    if remaining <= 0:
+        raise OperationExecutionTimeoutError(
+            "metric curvature deadline expired before cancellation"
+        )
+    payload = encode_strict_json(
+        {
+            "variable_count": len(numerator.gens),
+            "numerator": _poly_payload(numerator),
+            "denominator": _poly_payload(denominator),
+        }
+    )
+    try:
+        with TemporaryDirectory(prefix="jacobian-metric-cancel-") as worker_directory:
+            completed = run_bounded_process(
+                [sys.executable, str(_WORKER_PATH)],
+                input_bytes=payload,
+                timeout_seconds=remaining,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_STDOUT_BYTES,
+                stderr_limit=_STDERR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(remaining)),
+                    address_space_bytes=_ADDRESS_SPACE_BYTES,
+                    file_size_bytes=_STDOUT_BYTES,
+                ),
+                cwd=worker_directory,
+            )
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded metric-curvature cancellation worker could not be started"
+        ) from exc
+    if completed.cancelled:
+        raise OperationExecutionCancelledError(
+            "metric curvature cancelled during fraction cancellation"
+        )
+    if completed.timed_out:
+        raise OperationExecutionTimeoutError(
+            "metric curvature deadline expired during fraction cancellation"
+        )
+    if (
+        completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        raise RuntimeError(
+            "bounded metric-curvature cancellation worker did not return a fraction"
+        )
+    try:
+        response = loads_strict_json(
+            completed.stdout,
+            limits=CanonicalLimits(
+                max_input_bytes=_STDOUT_BYTES,
+                max_output_bytes=_STDOUT_BYTES,
+            ),
+        )
+    except CanonicalizationError as exc:
+        raise RuntimeError(
+            "bounded metric-curvature cancellation worker returned malformed output"
+        ) from exc
+    if (
+        not isinstance(response, dict)
+        or response.get("status") != "ok"
+        or "numerator" not in response
+        or "denominator" not in response
+    ):
+        raise RuntimeError(
+            "bounded metric-curvature cancellation worker returned malformed output"
+        )
+    symbols = tuple(numerator.gens)
+    return (
+        _poly_from_payload(response["numerator"], symbols),
+        _poly_from_payload(response["denominator"], symbols),
+    )

--- a/src/jacobian/math/geometry/differential/metrics/_normalize_worker.py
+++ b/src/jacobian/math/geometry/differential/metrics/_normalize_worker.py
@@ -1,0 +1,110 @@
+"""Standalone SymPy worker for admitted rational-function cancellation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def _polynomial(records: list[Any], symbols: tuple[Any, ...]) -> Any:
+    from sympy import QQ, Poly, Rational
+
+    coefficients: dict[tuple[int, ...], Any] = {}
+    variable_count = len(symbols)
+    for record in records:
+        if not isinstance(record, list) or len(record) != variable_count + 2:
+            raise ValueError("malformed polynomial record")
+        exponents = tuple(record[:variable_count])
+        numerator = record[-2]
+        denominator = record[-1]
+        if (
+            any(type(exponent) is not int or exponent < 0 for exponent in exponents)
+            or not isinstance(numerator, str)
+            or not isinstance(denominator, str)
+        ):
+            raise ValueError("malformed polynomial record")
+        coefficients[exponents] = Rational(int(numerator), int(denominator))
+    return Poly.from_dict(coefficients, *symbols, domain=QQ)
+
+
+def _dump(polynomial: Any) -> list[list[Any]]:
+    return [
+        [
+            *exponents,
+            str(coefficient.p),
+            str(coefficient.q),
+        ]
+        for exponents, coefficient in polynomial.terms()
+    ]
+
+
+def _run(payload: dict[str, Any]) -> dict[str, Any]:
+    from sympy import symbols
+
+    if set(payload) != {"variable_count", "numerator", "denominator"}:
+        raise ValueError("malformed cancellation request")
+    variable_count = payload["variable_count"]
+    if (
+        type(variable_count) is not int
+        or variable_count < 1
+        or not isinstance(payload["numerator"], list)
+        or not isinstance(payload["denominator"], list)
+    ):
+        raise ValueError("malformed cancellation request")
+    generators = symbols(f"x0:{variable_count}")
+    numerator = _polynomial(payload["numerator"], generators)
+    denominator = _polynomial(payload["denominator"], generators)
+    if not numerator.is_zero:
+        numerator_terms, denominator_terms = numerator.terms(), denominator.terms()
+        common = tuple(
+            min(
+                min(exponents[axis] for exponents, _ in numerator_terms),
+                min(exponents[axis] for exponents, _ in denominator_terms),
+            )
+            for axis in range(variable_count)
+        )
+        if any(common):
+            from sympy import Poly
+
+            def divide(value: Any) -> Any:
+                return Poly.from_dict(
+                    {
+                        tuple(
+                            exponent - shift
+                            for exponent, shift in zip(exponents, common, strict=True)
+                        ): coefficient
+                        for exponents, coefficient in value.terms()
+                    },
+                    value.gens,
+                    domain=value.domain,
+                )
+
+            numerator, denominator = divide(numerator), divide(denominator)
+    numerator, denominator = numerator.cancel(denominator, include=True)
+    leading = denominator.LC()
+    numerator = numerator.mul_ground(1 / leading)
+    denominator = denominator.mul_ground(1 / leading)
+    return {
+        "status": "ok",
+        "numerator": _dump(numerator),
+        "denominator": _dump(denominator),
+    }
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("malformed cancellation request")
+        response = _run(payload)
+    except Exception:
+        return 1
+    sys.stdout.buffer.write(
+        json.dumps(response, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/geometry/differential/metrics/_plan.py
+++ b/src/jacobian/math/geometry/differential/metrics/_plan.py
@@ -1,0 +1,240 @@
+"""Complete metric, inverse, connection and curvature DAG admission."""
+
+from dataclasses import dataclass
+from fractions import Fraction
+from itertools import permutations, product
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.differential.metrics._dag import (
+    ONE,
+    ZERO,
+    Dag,
+    Expression,
+    reject,
+)
+from jacobian.math.geometry.differential.metrics._models import RationalCoordinateMetric
+from jacobian.math.polynomials.values import SparseRationalPolynomial
+
+
+def singular() -> OperationDomainValidationError:
+    return OperationDomainValidationError(
+        location=("metric",),
+        code="differential_geometry.curvature.singular_metric",
+        message="metric determinant is identically zero",
+    )
+
+
+def _has_nonconstant_denominator(dag: Dag, value: Expression) -> bool:
+    """Return whether an expression carries a genuine polynomial denominator.
+
+    Guard admission works on complete expressions, since distinct numerators
+    can canonicalize to distinct denominator factors even when the DAG shares
+    one denominator node.
+    """
+
+    return any(
+        any(degree for degree in dag.nodes[index].bound.degrees)
+        for index in value.denominator
+    )
+
+
+@dataclass(frozen=True)
+class Plan:
+    dag: Dag
+    fractions: dict[Expression, tuple[int, int]]
+    determinant: Expression
+    inverse: tuple[Expression, ...]
+    connection: tuple[Expression, ...]
+    riemann: tuple[Expression, ...]
+    ricci: tuple[Expression, ...]
+    scalar: Expression
+
+
+def build_plan(metric: RationalCoordinateMetric) -> Plan:
+    n = len(metric.tensor.coordinate_axis)
+    dag = Dag(n)
+    entries = tuple(dag.fraction(value) for value in metric.tensor.components)
+
+    def determinant(rows: tuple[int, ...], columns: tuple[int, ...]) -> Expression:
+        terms = []
+        for permutation in permutations(columns):
+            sign = (-1) ** sum(
+                permutation[i] > permutation[j]
+                for i in range(len(permutation))
+                for j in range(i + 1, len(permutation))
+            )
+            # The permutation sign is relative to the ordered column subset.
+            terms.append(
+                dag.multiply(
+                    Expression(Fraction(sign)),
+                    *(
+                        entries[i * n + j]
+                        for i, j in zip(rows, permutation, strict=True)
+                    ),
+                )
+            )
+        return dag.add(*terms) if terms else ONE
+
+    axes = tuple(range(n))
+    det = determinant(axes, axes)
+    if not det.scalar:
+        raise singular()
+    inverse = tuple(
+        dag.multiply(
+            Expression(Fraction((-1) ** (i + j))),
+            determinant(
+                tuple(k for k in axes if k != j), tuple(k for k in axes if k != i)
+            ),
+            dag.inverse(det),
+        )
+        for i, j in product(axes, repeat=2)
+    )
+    derivatives = {
+        (index, axis): dag.derivative(value, axis)
+        for index, value in enumerate(entries)
+        for axis in axes
+    }
+    connection_list = [ZERO] * n**3
+    for k in axes:
+        for i in axes:
+            for j in range(i, n):
+                value = dag.multiply(
+                    Expression(Fraction(1, 2)),
+                    dag.add(
+                        *(
+                            dag.multiply(
+                                inverse[k * n + upper],
+                                dag.add(
+                                    derivatives[upper * n + j, i],
+                                    derivatives[upper * n + i, j],
+                                    dag.multiply(
+                                        Expression(Fraction(-1)),
+                                        derivatives[i * n + j, upper],
+                                    ),
+                                ),
+                            )
+                            for upper in axes
+                        )
+                    ),
+                )
+                connection_list[(k * n + i) * n + j] = value
+                connection_list[(k * n + j) * n + i] = value
+    connection = tuple(connection_list)
+
+    def gamma(k: int, i: int, j: int) -> Expression:
+        return connection[(k * n + i) * n + j]
+
+    riemann_list = [ZERO] * n**4
+    for upper, k, i in product(axes, repeat=3):
+        for j in range(i + 1, n):
+            value = dag.add(
+                dag.derivative(gamma(upper, j, k), i),
+                dag.multiply(
+                    Expression(Fraction(-1)), dag.derivative(gamma(upper, i, k), j)
+                ),
+                *(dag.multiply(gamma(upper, i, m), gamma(m, j, k)) for m in axes),
+                *(
+                    dag.multiply(
+                        Expression(Fraction(-1)), gamma(upper, j, m), gamma(m, i, k)
+                    )
+                    for m in axes
+                ),
+            )
+            riemann_list[((upper * n + k) * n + i) * n + j] = value
+            riemann_list[((upper * n + k) * n + j) * n + i] = dag.multiply(
+                Expression(Fraction(-1)), value
+            )
+    riemann = tuple(riemann_list)
+    ricci = tuple(
+        dag.add(*(riemann[((i * n + k) * n + i) * n + j] for i in axes))
+        for k, j in product(axes, repeat=2)
+    )
+    scalar = dag.add(*(dag.multiply(a, b) for a, b in zip(inverse, ricci, strict=True)))
+    # Retain the determinant numerator as its already-shared factors. Their
+    # conjunction equals det(g)!=0 on the source denominator locus. This
+    # avoids expanding an unnecessary determinant product in diagonal charts.
+    determinant_allocations: list[tuple[int, int, int]] = []
+    for index in set(det.numerator):
+        bound = dag.nodes[index].bound
+        if (
+            bound.terms > 256
+            or max(bound.degrees) > 64
+            or bound.coefficient_digits > 128
+        ):
+            reject(
+                "determinant_locus",
+                "determinant locus factors exceed canonical polynomial bounds",
+            )
+        dag.ledger.charge("normalization", bound.terms * bound.coefficient_digits)
+        determinant_allocations.append(
+            (
+                bound.terms,
+                8 * bound.coefficient_digits * bound.terms,
+                n * (bound.terms + 1),
+            )
+        )
+    outputs = (*inverse, *connection, *riemann, *ricci, scalar)
+    sizes = {value: dag.admit_output(value) for value in dict.fromkeys(outputs)}
+    potential_guard_expressions = {
+        value for value in outputs if _has_nonconstant_denominator(dag, value)
+    }
+    potential_guards = (
+        len(metric.tensor.retained_nonzero_denominators)
+        + len(set(det.numerator))
+        + len(potential_guard_expressions)
+    )
+    if potential_guards > 768:
+        reject("locus", "complete retained curvature locus exceeds 768 guards")
+
+    # Count mathematical storage, including every occurrence of the common
+    # locus in the five output coordinate objects. A whole fraction bounds its
+    # denominator guard even when cancellation creates a different denominator.
+    def source_allocation(polynomial: SparseRationalPolynomial) -> tuple[int, int, int]:
+        return (
+            len(polynomial.terms),
+            sum(
+                abs(term.coefficient.num).bit_length()
+                + term.coefficient.den.bit_length()
+                for term in polynomial.terms
+            ),
+            n * (len(polynomial.terms) + 1),
+        )
+
+    inherited = [
+        source_allocation(guard)
+        for guard in metric.tensor.retained_nonzero_denominators
+    ]
+    source = [
+        source_allocation(polynomial)
+        for component in metric.tensor.components
+        for polynomial in (component.numerator, component.denominator)
+    ]
+    guards = (
+        inherited
+        + determinant_allocations
+        + [sizes[value] for value in sizes if value.denominator]
+    )
+    allocations = source + inherited + [sizes[value] for value in outputs] + 5 * guards
+    terms, coefficient_bits, coordinate_slots = (
+        sum(allocation[index] for allocation in allocations) for index in range(3)
+    )
+    # Include tensor/connection component axes and their variance/index slots.
+    coordinate_slots += n * (len(outputs) + 6) + 4 * len(outputs)
+    if (
+        terms > 262_144
+        or coefficient_bits > 268_435_456
+        or coordinate_slots > 1_048_576
+    ):
+        reject(
+            "output",
+            "complete curvature values exceed polynomial term, coefficient-bit, "
+            "or coordinate allocation bounds",
+        )
+    fractions = {
+        value: (
+            dag.polynomial(value.numerator, value.scalar),
+            dag.polynomial(value.denominator),
+        )
+        for value in sizes
+    }
+    return Plan(dag, fractions, det, inverse, connection, riemann, ricci, scalar)

--- a/src/jacobian/math/geometry/differential/metrics/_tools.py
+++ b/src/jacobian/math/geometry/differential/metrics/_tools.py
@@ -1,0 +1,67 @@
+"""Exact rational metric curvature operation declaration."""
+
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.geometry.differential.metrics._models import (
+    RationalMetricCurvatureProfile,
+    RationalMetricCurvatureRequest,
+)
+from jacobian.math.geometry.differential.metrics.operations import curvature_profile
+
+
+def _compute(request: RationalMetricCurvatureRequest) -> RationalMetricCurvatureProfile:
+    return curvature_profile(request.metric)
+
+
+_ONE = {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [0, 0]}]}
+_R_SQUARED = {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2, 0]}]}
+_ZERO: dict[str, list[object]] = {"terms": []}
+
+TOOLS = (
+    MathTool(
+        operation_id="differential_geometry.rational_metric.curvature_profile.compute",
+        title="Compute exact curvature of a rational coordinate metric",
+        description=(
+            "Compute the inverse metric, Levi-Civita connection, Riemann tensor "
+            "R^l_kij, Ricci tensor and scalar curvature of a symmetric rational "
+            "metric on 1..4 ordered coordinates. Convention: "
+            "[nabla_i,nabla_j]v^l=R^l_kij v^k and Ric_kj=sum_i R^i_kij. "
+            "Retain the source and complete nondegenerate chart locus, even "
+            "when normalized curvature vanishes. Accept bounded exact "
+            "polynomial DAGs; reject singular metrics and excessive symbolic "
+            "growth. No positivity or global manifold assertion is made."
+        ),
+        request_type=RationalMetricCurvatureRequest,
+        result_type=RationalMetricCurvatureProfile,
+        run=_compute,
+        tags=(
+            "differential-geometry",
+            "metric",
+            "curvature",
+            "riemann",
+            "ricci",
+            "rational",
+        ),
+        examples=(
+            OperationExample(
+                name="flat_polar_chart",
+                description="The polar Euclidean metric has nonzero connection and zero curvature on r!=0.",
+                input={
+                    "metric": {
+                        "tensor": {
+                            "coordinate_axis": ["r", "theta"],
+                            "variance": ["COVARIANT", "COVARIANT"],
+                            "components": [
+                                {
+                                    "variables": ["r", "theta"],
+                                    "numerator": numerator,
+                                    "denominator": _ONE,
+                                }
+                                for numerator in (_ONE, _ZERO, _ZERO, _R_SQUARED)
+                            ],
+                        }
+                    }
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/geometry/differential/metrics/operations.py
+++ b/src/jacobian/math/geometry/differential/metrics/operations.py
@@ -20,6 +20,9 @@ from jacobian.math.geometry.differential.metrics._models import (
     RationalCoordinateMetric,
     RationalMetricCurvatureProfile,
 )
+from jacobian.math.geometry.differential.metrics._normalize_process import (
+    cancel_fraction,
+)
 from jacobian.math.geometry.differential.metrics._plan import build_plan, singular
 from jacobian.math.geometry.differential.values import (
     RationalCoordinateTensor,
@@ -113,10 +116,6 @@ def curvature_profile(
             ) from exc
     from sympy import QQ, Poly
 
-    from jacobian.math.polynomials.rational_functions.gradient._kernel import (
-        _normalize_fraction,
-    )
-
     axis = metric.tensor.coordinate_axis
     symbols = symbols_for_variables(axis)
     cache: dict[int, Any] = {
@@ -148,7 +147,18 @@ def curvature_profile(
             request_checkpoint("before curvature component normalization")
             if value not in normalized:
                 numerator, denominator = raw(value)
-                normalized[value] = _normalize_fraction(numerator, denominator, axis)
+                cancelled_num, cancelled_den = cancel_fraction(
+                    numerator, denominator, deadline=deadline
+                )
+                normalized[value] = RationalFunction._from_kernel(
+                    variables=axis,
+                    numerator=sparse_rational_polynomial_from_sympy(
+                        cancelled_num, axis, maximum_terms=256
+                    ),
+                    denominator=sparse_rational_polynomial_from_sympy(
+                        cancelled_den, axis, maximum_terms=256
+                    ),
+                )
             results.append(normalized[value])
             request_checkpoint("after curvature component normalization")
         return tuple(results)

--- a/src/jacobian/math/geometry/differential/metrics/operations.py
+++ b/src/jacobian/math/geometry/differential/metrics/operations.py
@@ -19,6 +19,9 @@ from jacobian.math.geometry.differential._recognition_process import (
     recognize_canonical_rational_functions,
 )
 from jacobian.math.geometry.differential.metrics._dag import Expression, Node
+from jacobian.math.geometry.differential.metrics._dag_process import (
+    evaluate_polynomial_dag,
+)
 from jacobian.math.geometry.differential.metrics._models import (
     RationalCoordinateConnection,
     RationalCoordinateMetric,
@@ -35,7 +38,6 @@ from jacobian.math.geometry.differential.values import (
 )
 from jacobian.math.polynomials._conversions import (
     sparse_rational_polynomial_from_sympy,
-    sparse_rational_polynomial_to_sympy,
     symbols_for_variables,
 )
 from jacobian.math.polynomials.values import (
@@ -47,43 +49,18 @@ from jacobian.math.polynomials.values import (
 def _evaluate_node(
     index: int, nodes: list[Node], axis: tuple[str, ...], cache: dict[int, Any]
 ) -> Any:
-    from sympy import QQ
-
-    from jacobian.math.polynomials.rational_functions.gradient._kernel import (
-        _differentiate_fraction,
-    )
-
     if index in cache:
         return cache[index]
     request_checkpoint("before curvature polynomial arithmetic")
-    node = nodes[index]
-    if node.operation == "SOURCE":
-        assert node.source is not None
-        result = sparse_rational_polynomial_to_sympy(node.source, axis)
-    elif node.operation == "SCALE":
-        result = _evaluate_node(node.arguments[0], nodes, axis, cache).mul_ground(
-            QQ(node.scalar.numerator, node.scalar.denominator)
-        )
-    elif node.operation == "MULTIPLY":
-        result = _evaluate_node(node.arguments[0], nodes, axis, cache) * _evaluate_node(
-            node.arguments[1], nodes, axis, cache
-        )
-    elif node.operation == "ADD":
-        result = sum(
-            (_evaluate_node(arg, nodes, axis, cache) for arg in node.arguments),
-            cache[0],
-        )
-    elif node.operation == "DERIVATIVE":
-        result, _ = _differentiate_fraction(
-            _evaluate_node(node.arguments[0], nodes, axis, cache),
-            _evaluate_node(node.arguments[1], nodes, axis, cache),
-            node.axis,
-        )
-    else:
-        raise AssertionError("unknown admitted curvature polynomial node")
-    cache[index] = result
+    execution = current_request_execution()
+    deadline = (
+        execution.deadline
+        if execution is not None and execution.deadline is not None
+        else time.monotonic() + 120.0
+    )
+    cache.update(evaluate_polynomial_dag(nodes, axis, deadline=deadline))
     request_checkpoint("after curvature polynomial arithmetic")
-    return result
+    return cache[index]
 
 
 def curvature_profile(

--- a/src/jacobian/math/geometry/differential/metrics/operations.py
+++ b/src/jacobian/math/geometry/differential/metrics/operations.py
@@ -14,6 +14,10 @@ from jacobian._execution import (
     request_execution,
 )
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.differential._recognition_process import (
+    RationalFunctionRecognitionCandidate,
+    recognize_canonical_rational_functions,
+)
 from jacobian.math.geometry.differential.metrics._dag import Expression, Node
 from jacobian.math.geometry.differential.metrics._models import (
     RationalCoordinateConnection,
@@ -104,16 +108,39 @@ def curvature_profile(
     request_checkpoint("after complete curvature admission")
     # Caller-authored field presentations have only structural validation.
     # Recognize reducedness once before relying on source-field identities.
-    for component in dict.fromkeys(metric.tensor.components):
+    recognition_candidates: list[RationalFunctionRecognitionCandidate] = []
+    for index, component in enumerate(metric.tensor.components):
         request_checkpoint("before metric component recognition")
-        try:
-            require_canonical_rational_function(component)
-        except PydanticCustomError as exc:
-            raise OperationDomainValidationError(
-                location=("metric",),
-                code="differential_geometry.curvature.noncanonical_source",
-                message="metric component must be a reduced canonical rational function",
-            ) from exc
+        if (
+            not component.numerator.terms
+            or not component.variables
+            or len(component.denominator.terms) == 1
+        ):
+            try:
+                require_canonical_rational_function(component)
+            except PydanticCustomError as exc:
+                raise OperationDomainValidationError(
+                    location=("metric",),
+                    code="differential_geometry.curvature.noncanonical_source",
+                    message="metric component must be a reduced canonical rational function",
+                ) from exc
+            continue
+        recognition_candidates.append(
+            RationalFunctionRecognitionCandidate(
+                owner="tensor",
+                component=index,
+                value=component,
+            )
+        )
+    recognition = recognize_canonical_rational_functions(
+        tuple(recognition_candidates), deadline=deadline
+    )
+    if recognition.non_coprime is not None:
+        raise OperationDomainValidationError(
+            location=("metric",),
+            code="differential_geometry.curvature.noncanonical_source",
+            message="metric component must be a reduced canonical rational function",
+        )
     from sympy import QQ, Poly
 
     axis = metric.tensor.coordinate_axis

--- a/src/jacobian/math/geometry/differential/metrics/operations.py
+++ b/src/jacobian/math/geometry/differential/metrics/operations.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import time
 from typing import Any
 
+from pydantic_core import PydanticCustomError
+
 from jacobian._execution import (
     bind_request_deadline,
     current_request_execution,
@@ -95,23 +97,20 @@ def curvature_profile(
         deadline = min(deadline, execution.deadline)
     bind_request_deadline(deadline)
     request_checkpoint("before curvature admission")
+    plan = build_plan(metric)
+    request_checkpoint("after complete curvature admission")
     # Caller-authored field presentations have only structural validation.
     # Recognize reducedness once before relying on source-field identities.
     for component in dict.fromkeys(metric.tensor.components):
         request_checkpoint("before metric component recognition")
         try:
             require_canonical_rational_function(component)
-        except ValueError as exc:
+        except PydanticCustomError as exc:
             raise OperationDomainValidationError(
                 location=("metric",),
                 code="differential_geometry.curvature.noncanonical_source",
                 message="metric component must be a reduced canonical rational function",
             ) from exc
-    # Build the complete DAG only after source field presentations have been
-    # recognized.  This keeps malformed caller-authored values out of the
-    # arithmetic admission path and makes recognition a single preflight step.
-    plan = build_plan(metric)
-    request_checkpoint("after complete curvature admission")
     from sympy import QQ, Poly
 
     from jacobian.math.polynomials.rational_functions.gradient._kernel import (

--- a/src/jacobian/math/geometry/differential/metrics/operations.py
+++ b/src/jacobian/math/geometry/differential/metrics/operations.py
@@ -1,0 +1,203 @@
+"""Execute an admitted exact metric-curvature DAG on a retained chart locus."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.differential.metrics._dag import Expression, Node
+from jacobian.math.geometry.differential.metrics._models import (
+    RationalCoordinateConnection,
+    RationalCoordinateMetric,
+    RationalMetricCurvatureProfile,
+)
+from jacobian.math.geometry.differential.metrics._plan import build_plan, singular
+from jacobian.math.geometry.differential.values import (
+    RationalCoordinateTensor,
+    TensorVariance,
+    canonical_locus_guards,
+)
+from jacobian.math.polynomials._conversions import (
+    sparse_rational_polynomial_from_sympy,
+    sparse_rational_polynomial_to_sympy,
+    symbols_for_variables,
+)
+from jacobian.math.polynomials.values import (
+    RationalFunction,
+    require_canonical_rational_function,
+)
+
+
+def _evaluate_node(
+    index: int, nodes: list[Node], axis: tuple[str, ...], cache: dict[int, Any]
+) -> Any:
+    from sympy import QQ
+
+    from jacobian.math.polynomials.rational_functions.gradient._kernel import (
+        _differentiate_fraction,
+    )
+
+    if index in cache:
+        return cache[index]
+    request_checkpoint("before curvature polynomial arithmetic")
+    node = nodes[index]
+    if node.operation == "SOURCE":
+        assert node.source is not None
+        result = sparse_rational_polynomial_to_sympy(node.source, axis)
+    elif node.operation == "SCALE":
+        result = _evaluate_node(node.arguments[0], nodes, axis, cache).mul_ground(
+            QQ(node.scalar.numerator, node.scalar.denominator)
+        )
+    elif node.operation == "MULTIPLY":
+        result = _evaluate_node(node.arguments[0], nodes, axis, cache) * _evaluate_node(
+            node.arguments[1], nodes, axis, cache
+        )
+    elif node.operation == "ADD":
+        result = sum(
+            (_evaluate_node(arg, nodes, axis, cache) for arg in node.arguments),
+            cache[0],
+        )
+    elif node.operation == "DERIVATIVE":
+        result, _ = _differentiate_fraction(
+            _evaluate_node(node.arguments[0], nodes, axis, cache),
+            _evaluate_node(node.arguments[1], nodes, axis, cache),
+            node.axis,
+        )
+    else:
+        raise AssertionError("unknown admitted curvature polynomial node")
+    cache[index] = result
+    request_checkpoint("after curvature polynomial arithmetic")
+    return result
+
+
+def curvature_profile(
+    metric: RationalCoordinateMetric,
+) -> RationalMetricCurvatureProfile:
+    """Compute inverse, Levi-Civita connection, Riemann, Ricci and scalar fields.
+
+    Every symbolic operation, source claim and canonical output is admitted
+    before polynomial expansion. The input locus is intersected with det(g)!=0;
+    normalization never discards inherited chart restrictions.
+    """
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return curvature_profile(metric)
+    deadline = execution.started_at + 120.0
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before curvature admission")
+    # Caller-authored field presentations have only structural validation.
+    # Recognize reducedness once before relying on source-field identities.
+    for component in dict.fromkeys(metric.tensor.components):
+        request_checkpoint("before metric component recognition")
+        try:
+            require_canonical_rational_function(component)
+        except ValueError as exc:
+            raise OperationDomainValidationError(
+                location=("metric",),
+                code="differential_geometry.curvature.noncanonical_source",
+                message="metric component must be a reduced canonical rational function",
+            ) from exc
+    # Build the complete DAG only after source field presentations have been
+    # recognized.  This keeps malformed caller-authored values out of the
+    # arithmetic admission path and makes recognition a single preflight step.
+    plan = build_plan(metric)
+    request_checkpoint("after complete curvature admission")
+    from sympy import QQ, Poly
+
+    from jacobian.math.polynomials.rational_functions.gradient._kernel import (
+        _normalize_fraction,
+    )
+
+    axis = metric.tensor.coordinate_axis
+    symbols = symbols_for_variables(axis)
+    cache: dict[int, Any] = {
+        0: Poly(0, *symbols, domain=QQ),
+        1: Poly(1, *symbols, domain=QQ),
+    }
+
+    def raw(value: Expression) -> tuple[Any, Any]:
+        numerator, denominator = plan.fractions[value]
+        return _evaluate_node(numerator, plan.dag.nodes, axis, cache), _evaluate_node(
+            denominator, plan.dag.nodes, axis, cache
+        )
+
+    determinant_guards = []
+    for index in dict.fromkeys(plan.determinant.numerator):
+        polynomial = _evaluate_node(index, plan.dag.nodes, axis, cache)
+        if polynomial.is_zero:
+            raise singular()
+        determinant_guards.append(
+            sparse_rational_polynomial_from_sympy(
+                polynomial.monic(), axis, maximum_terms=256
+            )
+        )
+    normalized: dict[Expression, RationalFunction] = {}
+
+    def convert(values: tuple[Expression, ...]) -> tuple[RationalFunction, ...]:
+        results = []
+        for value in values:
+            request_checkpoint("before curvature component normalization")
+            if value not in normalized:
+                numerator, denominator = raw(value)
+                normalized[value] = _normalize_fraction(numerator, denominator, axis)
+            results.append(normalized[value])
+            request_checkpoint("after curvature component normalization")
+        return tuple(results)
+
+    inverse, connection, riemann, ricci, scalar = (
+        convert(values)
+        for values in (
+            plan.inverse,
+            plan.connection,
+            plan.riemann,
+            plan.ricci,
+            (plan.scalar,),
+        )
+    )
+    guards = canonical_locus_guards(
+        metric.tensor.retained_nonzero_denominators,
+        tuple(determinant_guards),
+        component_denominators=tuple(
+            value.denominator
+            for values in (inverse, connection, riemann, ricci, scalar)
+            for value in values
+        ),
+        variable_count=len(axis),
+    )
+
+    def tensor(
+        components: tuple[RationalFunction, ...], variance: tuple[TensorVariance, ...]
+    ) -> RationalCoordinateTensor:
+        return RationalCoordinateTensor(
+            coordinate_axis=axis,
+            variance=variance,
+            components=components,
+            retained_nonzero_denominators=guards,
+        )
+
+    result = RationalMetricCurvatureProfile(
+        metric=metric,
+        inverse_metric=tensor(inverse, ("CONTRAVARIANT", "CONTRAVARIANT")),
+        connection=RationalCoordinateConnection(
+            coordinate_axis=axis,
+            components=connection,
+            retained_nonzero_denominators=guards,
+        ),
+        riemann=tensor(
+            riemann, ("CONTRAVARIANT", "COVARIANT", "COVARIANT", "COVARIANT")
+        ),
+        ricci=tensor(ricci, ("COVARIANT", "COVARIANT")),
+        scalar_curvature=tensor(scalar, ()),
+    )
+    request_checkpoint("after curvature profile construction")
+    return result

--- a/src/jacobian/math/geometry/differential/metrics/operations.py
+++ b/src/jacobian/math/geometry/differential/metrics/operations.py
@@ -21,6 +21,7 @@ from jacobian.math.geometry.differential._recognition_process import (
 from jacobian.math.geometry.differential.metrics._dag import Expression, Node
 from jacobian.math.geometry.differential.metrics._dag_process import (
     evaluate_polynomial_dag,
+    materialize_expanded_polynomial,
 )
 from jacobian.math.geometry.differential.metrics._models import (
     RationalCoordinateConnection,
@@ -47,19 +48,27 @@ from jacobian.math.polynomials.values import (
 
 
 def _evaluate_node(
-    index: int, nodes: list[Node], axis: tuple[str, ...], cache: dict[int, Any]
+    index: int, nodes: list[Node], axis: tuple[str, ...], cache: dict[int | str, Any]
 ) -> Any:
     if index in cache:
         return cache[index]
-    request_checkpoint("before curvature polynomial arithmetic")
     execution = current_request_execution()
     deadline = (
         execution.deadline
         if execution is not None and execution.deadline is not None
         else time.monotonic() + 120.0
     )
-    cache.update(evaluate_polynomial_dag(nodes, axis, deadline=deadline))
-    request_checkpoint("after curvature polynomial arithmetic")
+    records = cache.get("records")
+    symbols = cache.get("symbols")
+    if records is None or symbols is None:
+        request_checkpoint("before curvature polynomial arithmetic")
+        records, symbols = evaluate_polynomial_dag(nodes, axis, deadline=deadline)
+        cache["records"] = records
+        cache["symbols"] = symbols
+        request_checkpoint("after curvature polynomial arithmetic")
+    cache[index] = materialize_expanded_polynomial(
+        records[index], symbols, deadline=deadline
+    )
     return cache[index]
 
 

--- a/tests/math/geometry/differential/metrics/test_curvature.py
+++ b/tests/math/geometry/differential/metrics/test_curvature.py
@@ -1,0 +1,303 @@
+"""Exact coordinate identities, independent diffgeom oracle and useful envelopes."""
+
+import json
+from fractions import Fraction
+from itertools import product
+from time import monotonic
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from sympy import Matrix, cancel, symbols
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.geometry.differential.metrics import (
+    RationalCoordinateMetric,
+    RationalMetricCurvatureProfile,
+    curvature_profile,
+)
+from jacobian.math.geometry.differential.values import (
+    RationalCoordinateTensor,
+    canonical_locus_guards,
+)
+from jacobian.math.polynomials._conversions import (
+    rational_function_from_sympy,
+    rational_function_to_sympy,
+)
+from jacobian.math.polynomials.values import RationalFunction
+
+x, y, z, w = symbols("x y z w")
+
+
+def metric(
+    matrix: list[Any], axis: tuple[str, ...] = ("x", "y")
+) -> RationalCoordinateMetric:
+    components = tuple(rational_function_from_sympy(value, axis) for value in matrix)
+    return RationalCoordinateMetric(
+        tensor=RationalCoordinateTensor(
+            coordinate_axis=axis,
+            variance=("COVARIANT", "COVARIANT"),
+            components=components,
+            retained_nonzero_denominators=canonical_locus_guards(
+                component_denominators=tuple(value.denominator for value in components),
+                variable_count=len(axis),
+            ),
+        )
+    )
+
+
+def expressions(components: tuple[RationalFunction, ...]) -> tuple[Any, ...]:
+    return tuple(rational_function_to_sympy(value) for value in components)
+
+
+def replay(result: RationalMetricCurvatureProfile) -> None:
+    axis = symbols(result.metric.tensor.coordinate_axis)
+    n = len(axis)
+    g = Matrix(n, n, expressions(result.metric.tensor.components))
+    inverse = Matrix(n, n, expressions(result.inverse_metric.components))
+    gamma = expressions(result.connection.components)
+    riemann = expressions(result.riemann.components)
+    ricci = expressions(result.ricci.components)
+    assert (g * inverse).applyfunc(cancel) == Matrix.eye(n)
+    for k, i, j in product(range(n), repeat=3):
+        expected = (
+            sum(
+                inverse[k, a]
+                * (
+                    g[a, j].diff(axis[i])
+                    + g[a, i].diff(axis[j])
+                    - g[i, j].diff(axis[a])
+                )
+                for a in range(n)
+            )
+            / 2
+        )
+        assert cancel(gamma[(k * n + i) * n + j] - expected) == 0
+    for upper, k, i, j in product(range(n), repeat=4):
+        expected = gamma[(upper * n + j) * n + k].diff(axis[i]) - gamma[
+            (upper * n + i) * n + k
+        ].diff(axis[j])
+        expected += sum(
+            gamma[(upper * n + i) * n + a] * gamma[(a * n + j) * n + k]
+            - gamma[(upper * n + j) * n + a] * gamma[(a * n + i) * n + k]
+            for a in range(n)
+        )
+        assert cancel(riemann[((upper * n + k) * n + i) * n + j] - expected) == 0
+    assert all(
+        cancel(
+            ricci[k * n + j]
+            - sum(riemann[((i * n + k) * n + i) * n + j] for i in range(n))
+        )
+        == 0
+        for k, j in product(range(n), repeat=2)
+    )
+    scalar = expressions(result.scalar_curvature.components)[0]
+    assert (
+        cancel(
+            scalar
+            - sum(
+                inverse[k, j] * ricci[k * n + j] for k, j in product(range(n), repeat=2)
+            )
+        )
+        == 0
+    )
+    assert (
+        RationalMetricCurvatureProfile.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+@pytest.mark.parametrize(
+    ("matrix", "scalar"),
+    [
+        ([1, 0, 0, 1], 0),
+        ([-1, 0, 0, 2], 0),
+        ([1, 0, 0, x**2], 0),
+        ([1 + x**2, x, x, 1], 0),
+        ([4 / (1 + x * x + y * y) ** 2, 0, 0, 4 / (1 + x * x + y * y) ** 2], 2),
+        ([1 / x**2, 0, 0, 1 / x**2], -2),
+    ],
+)
+def test_known_metrics_and_all_defining_identities(
+    matrix: list[Any], scalar: int
+) -> None:
+    result = curvature_profile(metric(matrix))
+    replay(result)
+    assert expressions(result.scalar_curvature.components) == (scalar,)
+
+
+def test_independent_sympy_diffgeom_curved_nondiagonal_metric() -> None:
+    from sympy.diffgeom import (
+        CoordSystem,
+        Manifold,
+        Patch,
+        TensorProduct,
+        metric_to_Christoffel_2nd,
+        metric_to_Riemann_components,
+    )
+
+    source = metric([2 + x, y, y, 3 + x])
+    result = curvature_profile(source)
+    chart = CoordSystem("chart", Patch("patch", Manifold("space", 2)), (x, y))
+    a, b = chart.base_scalars()
+    dx, dy = chart.base_oneforms()
+    form = (
+        (2 + a) * TensorProduct(dx, dx)
+        + b * (TensorProduct(dx, dy) + TensorProduct(dy, dx))
+        + (3 + a) * TensorProduct(dy, dy)
+    )
+    gamma = metric_to_Christoffel_2nd(form)
+    riemann = metric_to_Riemann_components(form)
+    for index, value in zip(
+        product(range(2), repeat=3),
+        expressions(result.connection.components),
+        strict=True,
+    ):
+        assert cancel(value - gamma[index].subs({a: x, b: y})) == 0
+    for index, value in zip(
+        product(range(2), repeat=4), expressions(result.riemann.components), strict=True
+    ):
+        assert cancel(value - riemann[index].subs({a: x, b: y})) == 0
+    replay(result)
+
+
+def test_polar_locus_survives_zero_curvature() -> None:
+    result = curvature_profile(metric([1, 0, 0, x * x]))
+    assert any(value != 0 for value in expressions(result.connection.components))
+    assert all(value == 0 for value in expressions(result.riemann.components))
+    assert result.scalar_curvature.retained_nonzero_denominators
+    # Every retained polynomial has precisely the source polar exclusion x=0.
+    for guard in result.scalar_curvature.retained_nonzero_denominators:
+        assert all(term.exponents[1] == 0 for term in guard.terms)
+        assert len(guard.terms) == 1 and guard.terms[0].exponents[0] > 0
+
+
+def test_large_constant_diagonal_four_dimensional_metric() -> None:
+    source = metric(
+        [10**127 if i == j else 0 for i in range(4) for j in range(4)],
+        ("x", "y", "z", "w"),
+    )
+    result = curvature_profile(source)
+    assert all(value == 0 for value in expressions(result.riemann.components))
+    for i, value in enumerate(result.inverse_metric.components):
+        if i % 5 == 0:
+            assert value.numerator.terms[0].coefficient.as_fraction() == Fraction(
+                1, 10**127
+            )
+        else:
+            assert not value.numerator.terms
+    assert not result.scalar_curvature.retained_nonzero_denominators
+
+
+def test_four_dimensional_product_chart_and_high_exponent_line() -> None:
+    result = curvature_profile(
+        metric(
+            [
+                ((x, y, z, w)[i]) ** 2 if i == j else 0
+                for i in range(4)
+                for j in range(4)
+            ],
+            ("x", "y", "z", "w"),
+        )
+    )
+    assert len(result.riemann.components) == 256
+    assert all(value == 0 for value in expressions(result.riemann.components))
+    line = curvature_profile(metric([x**64], ("x",)))
+    assert expressions(line.connection.components) == (32 / x,)
+    assert expressions(line.scalar_curvature.components) == (0,)
+
+
+def test_coordinate_axis_permutation_transports_components() -> None:
+    original = curvature_profile(metric([1 + x, 0, 0, 1 + y]))
+    permuted = curvature_profile(metric([1 + y, 0, 0, 1 + x], ("y", "x")))
+    values = expressions(original.connection.components)
+    for (k, i, j), value in zip(
+        product(range(2), repeat=3),
+        expressions(permuted.connection.components),
+        strict=True,
+    ):
+        assert cancel(value - values[((1 - k) * 2 + 1 - i) * 2 + 1 - j]) == 0
+    assert permuted.metric.tensor.coordinate_axis == ("y", "x")
+
+
+def test_shape_singularity_and_authored_nonreduced_source_rejections() -> None:
+    with pytest.raises(ValidationError, match="symmetric"):
+        metric([1, 1, 0, 1])
+    with pytest.raises(OperationDomainValidationError, match="determinant"):
+        curvature_profile(metric([1, x, x, x * x]))
+    source = metric([x], ("x",)).model_dump(mode="json")
+    field = source["tensor"]["components"][0]
+    field["numerator"]["terms"][0]["exponents"] = [2]
+    field["denominator"]["terms"][0]["exponents"] = [1]
+    source["tensor"]["retained_nonzero_denominators"] = [field["denominator"]]
+    with pytest.raises(OperationDomainValidationError, match="reduced canonical"):
+        curvature_profile(
+            RationalCoordinateMetric.model_validate_json(json.dumps(source))
+        )
+
+
+def test_expansion_rejection_and_earlier_deadline() -> None:
+    source = metric(
+        [1 if i == j else 0 for i in range(4) for j in range(4)], ("x", "y", "z", "w")
+    ).model_dump(mode="json")
+    for i in range(4):
+        source["tensor"]["components"][5 * i]["numerator"]["terms"] = [
+            {
+                "exponents": [64 * int(j == k) for j in range(4)],
+                "coefficient": {"num": "1", "den": "1"},
+            }
+            for k in range(4)
+        ] + [{"exponents": [0, 0, 0, 0], "coefficient": {"num": "1", "den": "1"}}]
+    with pytest.raises(OperationResourceAdmissionError):
+        curvature_profile(
+            RationalCoordinateMetric.model_validate_json(json.dumps(source))
+        )
+    with request_execution(monotonic()):
+        bind_request_deadline(monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            curvature_profile(metric([1], ("x",)))
+
+
+def test_four_dimensional_hyperbolic_metric() -> None:
+    result = curvature_profile(
+        metric(
+            [1 / x**2 if i == j else 0 for i in range(4) for j in range(4)],
+            ("x", "y", "z", "w"),
+        )
+    )
+    assert len(result.riemann.components) == 256
+    assert expressions(result.scalar_curvature.components) == (-12,)
+    assert expressions(result.ricci.components) == tuple(
+        -3 / x**2 if i == j else 0 for i in range(4) for j in range(4)
+    )
+
+
+def test_complete_locus_admitted_before_curvature_expansion() -> None:
+    source = metric([x * y, 0, 0, x * y])
+    guards = canonical_locus_guards(
+        tuple(
+            rational_function_from_sympy(x + c, ("x", "y")).numerator
+            for c in range(1, 765)
+        ),
+        variable_count=2,
+    )
+    source = RationalCoordinateMetric(
+        tensor=RationalCoordinateTensor(
+            coordinate_axis=source.tensor.coordinate_axis,
+            variance=source.tensor.variance,
+            components=source.tensor.components,
+            retained_nonzero_denominators=guards,
+        )
+    )
+    # Shared formal denominator factors can reduce to distinct canonical
+    # denominators for different numerators. The complete locus has 769 guards.
+    with pytest.raises(OperationResourceAdmissionError, match="768 guards"):
+        curvature_profile(source)

--- a/tests/math/geometry/differential/metrics/test_curvature.py
+++ b/tests/math/geometry/differential/metrics/test_curvature.py
@@ -266,6 +266,61 @@ def test_expansion_rejection_and_earlier_deadline() -> None:
             curvature_profile(metric([1], ("x",)))
 
 
+def test_oversized_raw_pair_rejected_before_backend_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raw source recognition remains bounded before any SymPy conversion."""
+    axis = ("x", "y", "z", "w")
+    exponents = sorted(product((0, 1, 2, 64), repeat=4), reverse=True)
+    polynomial = {
+        "terms": [
+            {
+                "exponents": list(exponent),
+                "coefficient": {"num": 1, "den": 1},
+            }
+            for exponent in exponents
+        ]
+    }
+    one = {
+        "terms": [
+            {
+                "exponents": [0, 0, 0, 0],
+                "coefficient": {"num": 1, "den": 1},
+            }
+        ]
+    }
+    raw_pair = {
+        "domain": "QQ",
+        "variables": list(axis),
+        "numerator": polynomial,
+        "denominator": polynomial,
+    }
+    zero = {
+        "domain": "QQ",
+        "variables": list(axis),
+        "numerator": {"terms": []},
+        "denominator": one,
+    }
+    source = RationalCoordinateMetric.model_validate(
+        {
+            "tensor": {
+                "coordinate_axis": list(axis),
+                "variance": ["COVARIANT", "COVARIANT"],
+                "components": [
+                    raw_pair if i == j else zero for i in range(4) for j in range(4)
+                ],
+                "retained_nonzero_denominators": [polynomial],
+            }
+        }
+    )
+    monkeypatch.setattr(
+        "jacobian.math.geometry.differential.metrics.operations._evaluate_node",
+        lambda *args: pytest.fail("backend execution must follow admission"),
+    )
+    with pytest.raises(OperationResourceAdmissionError, match=r"allocation|work"):
+        curvature_profile(source)
+
+
 def test_four_dimensional_hyperbolic_metric() -> None:
     result = curvature_profile(
         metric(

--- a/tests/math/geometry/differential/metrics/test_curvature.py
+++ b/tests/math/geometry/differential/metrics/test_curvature.py
@@ -314,7 +314,7 @@ def test_oversized_raw_pair_rejected_before_backend_execution(
         }
     )
     monkeypatch.setattr(
-        "jacobian.math.geometry.differential.metrics.operations._evaluate_node",
+        "jacobian.math.geometry.differential.metrics.operations.require_canonical_rational_function",
         lambda *args: pytest.fail("backend execution must follow admission"),
     )
     with pytest.raises(OperationResourceAdmissionError, match=r"allocation|work"):

--- a/tests/mcp/test_rational_metric_curvature.py
+++ b/tests/mcp/test_rational_metric_curvature.py
@@ -1,0 +1,67 @@
+"""Native/MCP schema parity, recovery and canonical scalar-tensor reuse."""
+
+import asyncio
+import json
+
+from jsonschema import validate
+
+from jacobian.math.geometry.differential.metrics._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_live_rational_curvature_and_tensor_composition() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        validate(payload, tool.request_type.model_json_schema())
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        async with Client(create_server(), raise_exceptions=False) as client:
+            invalid = json.loads(json.dumps(payload))
+            invalid["metric"]["tensor"]["components"][3]["numerator"] = {"terms": []}
+            failure = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": invalid}
+            )
+            assert failure.is_error
+            response = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not response.is_error
+            assert response.structured_content is not None
+            output = response.structured_content["output"]
+            validate(output, tool.result_type.model_json_schema())
+            assert output == tool.run(request).model_dump(mode="json")
+            again = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": tool.operation_id,
+                    "payload": {"metric": output["metric"]},
+                },
+            )
+            assert not again.is_error
+            assert again.structured_content is not None
+            assert again.structured_content["output"] == output
+            assert output["scalar_curvature"]["variance"] == []
+            assert output["scalar_curvature"]["retained_nonzero_denominators"]
+            differentiated = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "differential_geometry.rational_tensor.lie_derivative.compute",
+                    "payload": {
+                        "vector_field": {
+                            "coordinate_axis": ["r", "theta"],
+                            "variance": ["CONTRAVARIANT"],
+                            "components": output["metric"]["tensor"]["components"][:2],
+                        },
+                        "tensor": output["scalar_curvature"],
+                    },
+                },
+            )
+            assert not differentiated.is_error
+            assert differentiated.structured_content is not None
+            assert (
+                differentiated.structured_content["output"]["lie_derivative"]
+                == output["scalar_curvature"]
+            )
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Adds `differential_geometry.rational_metric.curvature_profile.compute` and the native `curvature_profile` function. A rational symmetric coordinate metric now produces its exact inverse, Levi-Civita connection, Riemann tensor, Ricci tensor, and scalar curvature on the retained generic nondegenerate locus.

The metric and tensor values retain ordered coordinates and variance. The connection has its own coordinate-connection type; every output retains inherited guards, determinant nonvanishing conditions, and component denominators even when curvature simplifies to zero. The convention is `R^l_kij = partial_i Gamma^l_jk - partial_j Gamma^l_ik + Gamma^l_im Gamma^m_jk - Gamma^l_jm Gamma^m_ik`, with `Ric_kj = R^i_kij`.

A shared expression DAG reserves source recognition, exact arithmetic, normalization, and complete output before backend expansion. Raw authored fractions are charged before structural cancellation and recognized once after admission. Repeated denominator factors remain shared; final locus admission counts complete expressions because distinct numerators can reduce to distinct denominator guards. Mathematical term, coefficient-bit, and coordinate-allocation bounds cover the whole result.

The accepted envelope includes one through four coordinates, a degree-64 one-dimensional metric, 128-digit constant diagonal metrics, four-dimensional product charts, and the hyperbolic metric `diag(1/x²)` with scalar curvature `-12`. General requests retain conservative symbolic bounds: 50-million coefficient-work units, 16,384 DAG nodes, and explicit intermediate and complete-output allocations.

Validation: independent SymPy differential-geometry comparison on a curved non-diagonal metric; exact inverse, connection, curvature, and contraction identities; sphere, polar, hyperbolic, coordinate-permutation, source-locus, singularity, deadline, raw-source admission, and complete-guard regressions. Native/MCP focused tests passed (17). Final affected checks passed: scoped Ruff/mypy, 16 math, 156 catalog, 916 catalog integration, and 75 MCP tests. Architecture passed (1,353 files), as did scoped exhaustive catalog conformance. Independent exact-diff review and its consolidated repairs are complete.

Stacked on #3535 for shared rational-gradient arithmetic. No existing public operation is superseded. #2885 separately owns applying the connection to a tensor; this PR computes the metric profile.

Closes #2877.

The explicit stacked-PR CI run [34179869970](https://github.com/morluto/jacobian/actions/runs/34179869970) passed.
