### PR TITLE
feat(polynomials): compose rational coordinate maps

### DIFF
--- a/src/jacobian/math/polynomials/rational_functions/composition/__init__.py
+++ b/src/jacobian/math/polynomials/rational_functions/composition/__init__.py
@@ -1,0 +1,15 @@
+"""Exact rational coordinate-map composition."""
+
+from jacobian.math.polynomials.rational_functions.composition._models import (
+    RationalFunctionMapComposition,
+    RationalMapCompositionRequest,
+)
+from jacobian.math.polynomials.rational_functions.composition.operations import (
+    compose_maps,
+)
+
+__all__ = [
+    "RationalFunctionMapComposition",
+    "RationalMapCompositionRequest",
+    "compose_maps",
+]

--- a/src/jacobian/math/polynomials/rational_functions/composition/_models.py
+++ b/src/jacobian/math/polynomials/rational_functions/composition/_models.py
@@ -1,0 +1,87 @@
+"""Coordinate composition and its retained pre-cancellation open locus."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.canonical import encode_strict_json
+from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    require_sparse_polynomial_budget,
+)
+
+
+def guard_key(guard: RationalPolynomial) -> bytes:
+    """The existing canonical polynomial encoding determines guard order."""
+    return encode_strict_json(guard.model_dump(mode="json"))
+
+
+class RationalMapCompositionRequest(StrictModel):
+    outer: RationalFunctionMap
+    inner: RationalFunctionMap
+
+    @model_validator(mode="after")
+    def require_intermediate_axis(self) -> Self:
+        if self.inner.target_coordinates != self.outer.source_variables:
+            raise ValueError(
+                "inner target coordinates must equal outer source variables"
+            )
+        return self
+
+
+class RationalFunctionMapComposition(StrictModel):
+    """The composite field map with the domain of the supplied construction.
+
+    Guards mean a conjunction of polynomial nonvanishing conditions. They
+    retain every inner denominator and each substituted outer denominator,
+    even when the canonical composite extends across a removed point.
+    """
+
+    outer: RationalFunctionMap
+    inner: RationalFunctionMap
+    composite: RationalFunctionMap
+    construction_locus_guard: tuple[RationalPolynomial, ...] = Field(max_length=4104)
+
+    @model_validator(mode="after")
+    def require_axes_and_canonical_guards(self) -> Self:
+        if self.inner.target_coordinates != self.outer.source_variables:
+            raise ValueError(
+                "inner target coordinates must equal outer source variables"
+            )
+        if (
+            self.composite.source_variables != self.inner.source_variables
+            or self.composite.target_coordinates != self.outer.target_coordinates
+        ):
+            raise ValueError(
+                "composite must retain the inner source and outer target axes"
+            )
+        keys = []
+        for guard in self.construction_locus_guard:
+            if guard.variables != self.composite.source_variables:
+                raise ValueError(
+                    "construction guards must retain the composite source axis"
+                )
+            terms = guard.polynomial.terms
+            if (
+                not terms
+                or terms[0].coefficient.as_fraction() != 1
+                or not any(any(term.exponents) for term in terms)
+            ):
+                raise ValueError(
+                    "construction guards must be nonconstant monic polynomials"
+                )
+            require_sparse_polynomial_budget(
+                guard.polynomial,
+                maximum_terms=256,
+                maximum_exponent=64,
+                maximum_coefficient_digits=128,
+                label="construction guard",
+            )
+            keys.append(guard_key(guard))
+        if keys != sorted(set(keys)):
+            raise ValueError(
+                "construction guards must use unique canonical encoding order"
+            )
+        return self

--- a/src/jacobian/math/polynomials/rational_functions/composition/_tools.py
+++ b/src/jacobian/math/polynomials/rational_functions/composition/_tools.py
@@ -1,0 +1,156 @@
+"""Rational-map composition operation declaration."""
+
+from typing import Any
+
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.polynomials.rational_functions.composition._models import (
+    RationalFunctionMapComposition,
+    RationalMapCompositionRequest,
+)
+from jacobian.math.polynomials.rational_functions.composition.operations import (
+    compose_maps,
+)
+
+
+def _compute(
+    request: RationalMapCompositionRequest,
+) -> RationalFunctionMapComposition:
+    return compose_maps(request.outer, request.inner)
+
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="rational_function_map.compose.compute",
+        title="Compose two rational coordinate maps",
+        description=(
+            "Compose compatible canonical rational coordinate maps exactly. The "
+            "result retains both maps, the inner source and outer target axes, and "
+            "the complete pre-cancellation construction locus."
+        ),
+        request_type=RationalMapCompositionRequest,
+        result_type=RationalFunctionMapComposition,
+        run=_compute,
+        tags=("rational-function", "map", "composition", "exact"),
+        examples=(
+            OperationExample(
+                name="two_variable_chart_transition",
+                description=(
+                    "Compose a rational inner chart with an outer coordinate map; "
+                    "all denominator conditions remain explicit."
+                ),
+                input={
+                    "outer": {
+                        "source_variables": ["y1", "y2"],
+                        "target_coordinates": ["z1", "z2"],
+                        "components": [
+                            {
+                                "variables": ["y1", "y2"],
+                                "numerator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1, 0],
+                                        },
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [0, 1],
+                                        },
+                                    ]
+                                },
+                                "denominator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [0, 0],
+                                        }
+                                    ]
+                                },
+                            },
+                            {
+                                "variables": ["y1", "y2"],
+                                "numerator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1, 0],
+                                        }
+                                    ]
+                                },
+                                "denominator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [0, 1],
+                                        },
+                                        {
+                                            "coefficient": {"num": "-1", "den": "1"},
+                                            "exponents": [0, 0],
+                                        },
+                                    ]
+                                },
+                            },
+                        ],
+                    },
+                    "inner": {
+                        "source_variables": ["x"],
+                        "target_coordinates": ["y1", "y2"],
+                        "components": [
+                            {
+                                "variables": ["x"],
+                                "numerator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1],
+                                        }
+                                    ]
+                                },
+                                "denominator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1],
+                                        },
+                                        {
+                                            "coefficient": {"num": "-1", "den": "1"},
+                                            "exponents": [0],
+                                        },
+                                    ]
+                                },
+                            },
+                            {
+                                "variables": ["x"],
+                                "numerator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1],
+                                        },
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [0],
+                                        },
+                                    ]
+                                },
+                                "denominator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1],
+                                        },
+                                        {
+                                            "coefficient": {"num": "-2", "den": "1"},
+                                            "exponents": [0],
+                                        },
+                                    ]
+                                },
+                            },
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/polynomials/rational_functions/composition/_tools.py
+++ b/src/jacobian/math/polynomials/rational_functions/composition/_tools.py
@@ -35,7 +35,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
             OperationExample(
                 name="two_variable_chart_transition",
                 description=(
-                    "Compose a rational inner chart with an outer coordinate map; "
+                    "Compose a rational inner chart with an outer coordinate map "
+                    "whose source_variables equal the inner target_coordinates; "
                     "all denominator conditions remain explicit."
                 ),
                 input={

--- a/src/jacobian/math/polynomials/rational_functions/composition/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/composition/operations.py
@@ -1,0 +1,732 @@
+"""Exact composition of bounded rational coordinate maps."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, replace
+from fractions import Fraction
+from typing import Any, NoReturn
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.polynomials._conversions import (
+    rational_polynomial_from_sympy,
+    sparse_rational_polynomial_to_sympy,
+    symbols_for_variables,
+)
+from jacobian.math.polynomials.rational_functions._bounds import (
+    BoundWorkCategory,
+    FractionBound,
+    PolynomialBound,
+    RationalFunctionBoundLimits,
+    _add_polynomials,
+    _fraction_bound,
+    _multiply_polynomials,
+    _one_polynomial,
+    _polynomial_backend_conversion_work_units,
+    _recognition_work_units,
+    _remove_guaranteed_common_monomial,
+    _total_degree_term_bound,
+    _validate_canonical_result_bound,
+    _zero_polynomial,
+)
+from jacobian.math.polynomials.rational_functions.composition._models import (
+    RationalFunctionMapComposition,
+    guard_key,
+)
+from jacobian.math.polynomials.rational_functions.gradient._kernel import (
+    _normalize_fraction,
+)
+from jacobian.math.polynomials.rational_functions.gradient.operations import (
+    _recognize_source,
+)
+from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+from jacobian.math.polynomials.values import (
+    RationalFunction,
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+MAX_COMPOSITION_WORK = 25_000_000
+MAX_COMPOSITION_TERMS = 65_536
+MAX_COMPOSITION_BITS = 8_388_608
+MAX_COMPOSITION_RAW_EXPONENT = 32_768
+
+
+def _reject(reason: str, message: str) -> NoReturn:
+    raise OperationResourceAdmissionError(
+        location=("outer", "inner"),
+        code=f"rational_function_map.compose.{reason}",
+        message=message,
+    )
+
+
+def _reject_undefined_outer_denominator() -> NoReturn:
+    raise OperationDomainValidationError(
+        location=("outer", "components"),
+        code="rational_function_map.compose.undefined_outer_denominator",
+        message="an outer denominator vanishes identically after substitution",
+    )
+
+
+class _Ledger:
+    def __init__(self) -> None:
+        self.work = 0
+        self.limits = RationalFunctionBoundLimits(
+            raw_terms=4_096,
+            raw_digits=4_096,
+            result_exponent=64,
+            result_terms=256,
+            result_digits=128,
+            label="Rational map composition",
+            reject=_reject,
+        )
+
+    def charge(self, category: BoundWorkCategory, amount: int) -> None:
+        request_checkpoint(f"during rational map composition {category}")
+        self.work += amount
+        if self.work > MAX_COMPOSITION_WORK:
+            _reject(
+                "work_budget",
+                "rational map composition exceeds its aggregate coefficient-work bound",
+            )
+
+
+class _Allocation:
+    """Bound exact sparse terms and coefficient bits retained by the result."""
+
+    def __init__(self) -> None:
+        self.terms = 0
+        self.bits = 0
+
+    def charge(self, terms: int, bits: int) -> None:
+        request_checkpoint("during rational map composition allocation")
+        self.terms += terms
+        self.bits += bits
+        if self.terms > MAX_COMPOSITION_TERMS:
+            _reject(
+                "allocation",
+                "composition source, guards, or complete output exceeds "
+                f"{MAX_COMPOSITION_TERMS} polynomial terms",
+            )
+        if self.bits > MAX_COMPOSITION_BITS:
+            _reject(
+                "allocation",
+                "composition source, guards, or complete output exceeds "
+                f"{MAX_COMPOSITION_BITS} coefficient bits",
+            )
+
+
+def _support_bound(polynomial: PolynomialBound) -> int:
+    """Use the shared coordinate and total-degree support bound."""
+    return _total_degree_term_bound(polynomial)
+
+
+def _check_raw_exponents(polynomial: PolynomialBound) -> None:
+    if any(degree > MAX_COMPOSITION_RAW_EXPONENT for degree in polynomial.degrees):
+        _reject(
+            "intermediate_exponent",
+            "substitution exceeds the sparse polynomial exponent envelope",
+        )
+
+
+@dataclass(frozen=True)
+class _SubstitutionBound:
+    numerator: PolynomialBound
+    denominator: PolynomialBound
+
+
+@dataclass(frozen=True)
+class _PreparedPolynomial:
+    """A backend-free sparse polynomial retained for execution."""
+
+    terms: tuple[tuple[Fraction, tuple[int, ...]], ...]
+
+
+@dataclass(frozen=True)
+class _PreparedComposition:
+    numerator: _PreparedPolynomial | None
+    numerator_denominator: _PreparedPolynomial | None
+    denominator: _PreparedPolynomial | None
+    denominator_denominator: _PreparedPolynomial | None
+
+
+def _bits_for_fraction(value: Fraction) -> int:
+    return value.numerator.bit_length() + value.denominator.bit_length()
+
+
+def _charge_source(
+    value: RationalFunction, ledger: _Ledger, allocation: _Allocation
+) -> None:
+    for polynomial in (value.numerator, value.denominator):
+        allocation.charge(
+            len(polynomial.terms),
+            sum(
+                _bits_for_fraction(term.coefficient.as_fraction())
+                for term in polynomial.terms
+            ),
+        )
+    ledger.charge(
+        "source_conversion",
+        (len(value.numerator.terms) + len(value.denominator.terms))
+        * (len(value.variables) + 1),
+    )
+
+
+def _power(
+    source: PolynomialBound,
+    exponent: int,
+    variable_count: int,
+    ledger: _Ledger,
+) -> PolynomialBound:
+    if exponent == 0:
+        return _one_polynomial(variable_count)
+    if source.is_zero:
+        return _zero_polynomial(variable_count)
+    result = _one_polynomial(variable_count)
+    for _ in range(exponent):
+        result = _multiply_polynomials(result, source, ledger)
+    return result
+
+
+def _substitute_bound(
+    polynomial: SparseRationalPolynomial,
+    inner_bounds: tuple[FractionBound, ...],
+    ledger: _Ledger,
+) -> _SubstitutionBound:
+    """Bound a cleared-denominator substitution before any CAS expansion."""
+    variable_count = len(inner_bounds[0].numerator.degrees) if inner_bounds else 0
+    if not polynomial.terms:
+        return _SubstitutionBound(
+            numerator=_zero_polynomial(variable_count),
+            denominator=_one_polynomial(variable_count),
+        )
+    powers = tuple(
+        max(term.exponents[axis] for term in polynomial.terms)
+        for axis in range(len(inner_bounds))
+    )
+    denominator = _one_polynomial(variable_count)
+    for bound, exponent in zip(inner_bounds, powers, strict=True):
+        denominator = _multiply_polynomials(
+            denominator,
+            _power(bound.denominator, exponent, variable_count, ledger),
+            ledger,
+        )
+        _check_raw_exponents(denominator)
+    numerator: PolynomialBound | None = None
+    for term in polynomial.terms:
+        product = _one_polynomial(variable_count)
+        coefficient = term.coefficient.as_fraction()
+        # A zero inner coordinate annihilates this monomial when its exponent
+        # is positive. The denominator is still formed from its canonical one.
+        for bound, exponent, common_power in zip(
+            inner_bounds, term.exponents, powers, strict=True
+        ):
+            if bound.is_zero and exponent:
+                product = _zero_polynomial(variable_count)
+                break
+            product = _multiply_polynomials(
+                product,
+                _power(bound.numerator, exponent, variable_count, ledger),
+                ledger,
+            )
+            _check_raw_exponents(product)
+            product = _multiply_polynomials(
+                product,
+                _power(
+                    bound.denominator,
+                    common_power - exponent,
+                    variable_count,
+                    ledger,
+                ),
+                ledger,
+            )
+            _check_raw_exponents(product)
+        if product.is_zero:
+            continue
+        product = replace(
+            product,
+            coefficient_digits=product.coefficient_digits
+            + max(1, len(str(abs(coefficient)))),
+            rational_content=product.rational_content * coefficient,
+        )
+        numerator = (
+            product
+            if numerator is None
+            else _add_polynomials(numerator, product, ledger)
+        )
+    if numerator is None:
+        numerator = _zero_polynomial(variable_count)
+    return _SubstitutionBound(numerator=numerator, denominator=denominator)
+
+
+def _monomial_inner(value: RationalFunction) -> tuple[Fraction, tuple[int, ...]] | None:
+    if len(value.denominator.terms) != 1 or value.denominator.terms[0].exponents != (
+        0,
+    ) * len(value.variables):
+        return None
+    if len(value.numerator.terms) != 1:
+        return None
+    term = value.numerator.terms[0]
+    return term.coefficient.as_fraction(), term.exponents
+
+
+def _substitute_monomial(
+    polynomial: SparseRationalPolynomial,
+    monomials: tuple[tuple[Fraction, tuple[int, ...]], ...],
+    ledger: _Ledger,
+    *,
+    charge: bool = True,
+) -> _PreparedPolynomial:
+    if not polynomial.terms:
+        return _PreparedPolynomial(())
+    combined: dict[tuple[int, ...], Fraction] = {}
+    for source_term in polynomial.terms:
+        coefficient = source_term.coefficient.as_fraction()
+        exponents = [0] * len(monomials[0][1]) if monomials else []
+        for scalar, monomial_exponents, exponent in zip(
+            (item[0] for item in monomials),
+            (item[1] for item in monomials),
+            source_term.exponents,
+            strict=True,
+        ):
+            coefficient *= scalar**exponent
+            for axis, power in enumerate(monomial_exponents):
+                exponents[axis] += power * exponent
+        exponent_tuple = tuple(exponents)
+        if any(exponent > MAX_COMPOSITION_RAW_EXPONENT for exponent in exponent_tuple):
+            _reject(
+                "intermediate_exponent",
+                "substitution exceeds the sparse polynomial exponent envelope",
+            )
+        combined[exponent_tuple] = (
+            combined.get(exponent_tuple, Fraction(0)) + coefficient
+        )
+        if charge:
+            ledger.charge("multiplication", len(monomials) + len(exponent_tuple) + 1)
+    return _PreparedPolynomial(
+        tuple(
+            (coefficient, exponents)
+            for exponents, coefficient in sorted(combined.items(), reverse=True)
+            if coefficient
+        )
+    )
+
+
+def _prepared_to_sparse(value: _PreparedPolynomial) -> SparseRationalPolynomial:
+    return SparseRationalPolynomial(
+        terms=tuple(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational.from_fraction(coefficient),
+                exponents=exponents,
+            )
+            for coefficient, exponents in value.terms
+        )
+    )
+
+
+def _monic_guard(value: RationalFunction) -> RationalPolynomial | None:
+    if not value.numerator.terms:
+        _reject_undefined_outer_denominator()
+    if len(value.numerator.terms) == 1 and not any(value.numerator.terms[0].exponents):
+        return None
+    polynomial = sparse_rational_polynomial_to_sympy(value.numerator, value.variables)
+    return rational_polynomial_from_sympy(polynomial.monic(), value.variables)
+
+
+def _constant_fraction(value: RationalFunction) -> Fraction:
+    if value.variables:
+        raise AssertionError("constant evaluator requires an empty source axis")
+    if not value.numerator.terms:
+        return Fraction(0)
+    return value.numerator.terms[0].coefficient.as_fraction()
+
+
+def _constant_substitute_polynomial(
+    polynomial: SparseRationalPolynomial,
+    values: tuple[Fraction, ...],
+    ledger: _Ledger,
+) -> Fraction:
+    result = Fraction(0)
+    for term in polynomial.terms:
+        coefficient = term.coefficient.as_fraction()
+        for value, exponent in zip(values, term.exponents, strict=True):
+            ledger.charge("multiplication", exponent + 1)
+            coefficient *= value**exponent
+        ledger.charge("addition", 1)
+        result += coefficient
+    return result
+
+
+def _constant_map_composition(
+    outer: RationalFunctionMap,
+    inner: RationalFunctionMap,
+    ledger: _Ledger,
+    allocation: _Allocation,
+) -> RationalFunctionMapComposition:
+    for component in (*outer.components, *inner.components):
+        _recognize_source(component)
+    values = tuple(_constant_fraction(component) for component in inner.components)
+    guards: tuple[RationalPolynomial, ...] = ()
+    composites: list[RationalFunction] = []
+    for outer_component in outer.components:
+        numerator = _constant_substitute_polynomial(
+            outer_component.numerator, values, ledger
+        )
+        denominator = _constant_substitute_polynomial(
+            outer_component.denominator, values, ledger
+        )
+        if denominator == 0:
+            raise OperationDomainValidationError(
+                location=("outer", "components"),
+                code="rational_function_map.compose.undefined_outer_denominator",
+                message="an outer denominator vanishes identically after substitution",
+            )
+        result_value = numerator / denominator
+        result_digits = max(
+            len(str(abs(result_value.numerator))), len(str(result_value.denominator))
+        )
+        if result_digits > 128:
+            _reject(
+                "result_height",
+                "constant composite exceeds the 128-digit canonical coefficient bound",
+            )
+        ledger.charge("normalization", result_digits)
+        allocation.charge(1, _bits_for_fraction(result_value))
+        composites.append(
+            RationalFunction._from_kernel(
+                variables=(),
+                numerator=SparseRationalPolynomial(
+                    terms=()
+                    if numerator == 0
+                    else (
+                        RationalPolynomialTerm(
+                            coefficient=CanonicalRational.from_fraction(result_value),
+                            exponents=(),
+                        ),
+                    )
+                ),
+                denominator=SparseRationalPolynomial(
+                    terms=(
+                        RationalPolynomialTerm(
+                            coefficient=CanonicalRational(num=1, den=1), exponents=()
+                        ),
+                    )
+                ),
+            )
+        )
+    return RationalFunctionMapComposition(
+        outer=outer,
+        inner=inner,
+        composite=RationalFunctionMap(
+            source_variables=inner.source_variables,
+            target_coordinates=outer.target_coordinates,
+            components=tuple(composites),
+        ),
+        construction_locus_guard=guards,
+    )
+
+
+def _prepared_poly_to_sympy(
+    value: _PreparedPolynomial, variables: tuple[str, ...]
+) -> Any:
+    from jacobian.math.polynomials._conversions import (
+        sparse_rational_polynomial_to_sympy,
+    )
+
+    return sparse_rational_polynomial_to_sympy(_prepared_to_sparse(value), variables)
+
+
+def compose_maps(  # noqa: C901
+    outer: RationalFunctionMap,
+    inner: RationalFunctionMap,
+) -> RationalFunctionMapComposition:
+    """Compose two canonical rational maps on their retained construction locus."""
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return compose_maps(outer, inner)
+    deadline = execution.started_at + 60
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before rational map composition admission")
+    if inner.target_coordinates != outer.source_variables:
+        raise OperationDomainValidationError(
+            location=("inner", "target_coordinates"),
+            code="rational_function_map.compose.axis_mismatch",
+            message="inner target coordinates must equal outer source variables",
+        )
+    ledger = _Ledger()
+    allocation = _Allocation()
+    for value in (*outer.components, *inner.components):
+        _charge_source(value, ledger, allocation)
+
+    outer_bounds = tuple(
+        _fraction_bound(component, ledger) for component in outer.components
+    )
+    inner_bounds = tuple(
+        _fraction_bound(component, ledger) for component in inner.components
+    )
+    for component_bound in (*outer_bounds, *inner_bounds):
+        # This is caller-authored semantic recognition; charge it after the
+        # complete source representation has been admitted.
+        ledger.charge("recognition", _recognition_work_units(component_bound))
+
+    # Empty source axes contain only exact constants and cannot be represented
+    # by SymPy Poly. Handle that degenerate field after source admission.
+    if not inner.source_variables:
+        return _constant_map_composition(outer, inner, ledger, allocation)
+
+    monomials = tuple(_monomial_inner(component) for component in inner.components)
+    use_monomial_path = bool(monomials) and all(item is not None for item in monomials)
+    guards: list[RationalPolynomial] = []
+    prepared: list[_PreparedComposition] = []
+
+    # Inner denominators are construction guards, including denominators that
+    # happen not to occur in a particular outer coordinate.
+    for component in inner.components:
+        denominator = component.denominator
+        if denominator.terms and any(denominator.terms[0].exponents):
+            guard = RationalPolynomial(
+                variables=inner.source_variables,
+                polynomial=denominator,
+            )
+            guards.append(guard)
+            allocation.charge(
+                len(guard.polynomial.terms),
+                sum(
+                    _bits_for_fraction(t.coefficient.as_fraction())
+                    for t in guard.polynomial.terms
+                ),
+            )
+
+    for outer_component in outer.components:
+        outer_numerator_bound = _substitute_bound(
+            outer_component.numerator, inner_bounds, ledger
+        )
+        outer_denominator_bound = _substitute_bound(
+            outer_component.denominator, inner_bounds, ledger
+        )
+        raw_numerator_bound = _multiply_polynomials(
+            outer_numerator_bound.numerator,
+            outer_denominator_bound.denominator,
+            ledger,
+        )
+        _check_raw_exponents(raw_numerator_bound)
+        raw_denominator_bound = _multiply_polynomials(
+            outer_numerator_bound.denominator,
+            outer_denominator_bound.numerator,
+            ledger,
+        )
+        _check_raw_exponents(raw_denominator_bound)
+        result_bound = _remove_guaranteed_common_monomial(
+            FractionBound(raw_numerator_bound, raw_denominator_bound)
+        )
+        ledger.charge(
+            "source_conversion",
+            _polynomial_backend_conversion_work_units(outer_numerator_bound.numerator)
+            + _polynomial_backend_conversion_work_units(
+                outer_numerator_bound.denominator
+            )
+            + _polynomial_backend_conversion_work_units(
+                outer_denominator_bound.numerator
+            )
+            + _polynomial_backend_conversion_work_units(
+                outer_denominator_bound.denominator
+            ),
+        )
+        digits = _validate_canonical_result_bound(result_bound, ledger)
+        denominator_is_unit = all(
+            degree == 0 for degree in result_bound.denominator.degrees
+        )
+        result_terms = sum(
+            polynomial.terms if denominator_is_unit else _support_bound(polynomial)
+            for polynomial in (result_bound.numerator, result_bound.denominator)
+        )
+        allocation.charge(result_terms, result_terms * 8 * digits)
+        if not (
+            len(outer_component.denominator.terms) == 1
+            and not any(outer_component.denominator.terms[0].exponents)
+        ):
+            guard_digits = _validate_canonical_result_bound(
+                _remove_guaranteed_common_monomial(
+                    FractionBound(
+                        outer_denominator_bound.numerator,
+                        outer_denominator_bound.denominator,
+                    )
+                ),
+                ledger,
+            )
+            guard_terms = _support_bound(outer_denominator_bound.numerator)
+            allocation.charge(guard_terms, guard_terms * 8 * guard_digits)
+        if use_monomial_path:
+            monomial_values = tuple(item for item in monomials if item is not None)
+            for polynomial in (
+                outer_component.numerator,
+                outer_component.denominator,
+            ):
+                ledger.charge(
+                    "multiplication",
+                    len(polynomial.terms)
+                    * (len(monomial_values) + len(inner.source_variables) + 1),
+                )
+            prepared.append(
+                _PreparedComposition(
+                    numerator=None,
+                    numerator_denominator=None,
+                    denominator=None,
+                    denominator_denominator=None,
+                )
+            )
+        else:
+            prepared.append(
+                _PreparedComposition(
+                    numerator=None,
+                    numerator_denominator=None,
+                    denominator=None,
+                    denominator_denominator=None,
+                )
+            )
+
+    # #2880's source bounds are cached above; no caller-side canonical check is
+    # performed until every substitution bound and retained allocation is known.
+    # Every source, substitution bound, output bound and guard allocation has
+    # been admitted. Only now construct backend polynomials and normalize.
+    require_canonical = tuple(
+        component for component in (*outer.components, *inner.components)
+    )
+    for component in require_canonical:
+        _recognize_source(component)
+    outer_components = require_canonical[: len(outer.components)]
+    inner_components = require_canonical[len(outer.components) :]
+    if use_monomial_path:
+        monomial_values = tuple(item for item in monomials if item is not None)
+        prepared = [
+            _PreparedComposition(
+                numerator=_substitute_monomial(
+                    component.numerator, monomial_values, ledger, charge=False
+                ),
+                numerator_denominator=_substitute_monomial(
+                    SparseRationalPolynomial(
+                        terms=(
+                            RationalPolynomialTerm(
+                                coefficient=CanonicalRational(num=1, den=1),
+                                exponents=(0,) * len(outer.source_variables),
+                            ),
+                        )
+                    ),
+                    monomial_values,
+                    ledger,
+                    charge=False,
+                ),
+                denominator=_substitute_monomial(
+                    component.denominator, monomial_values, ledger, charge=False
+                ),
+                denominator_denominator=_substitute_monomial(
+                    SparseRationalPolynomial(
+                        terms=(
+                            RationalPolynomialTerm(
+                                coefficient=CanonicalRational(num=1, den=1),
+                                exponents=(0,) * len(outer.source_variables),
+                            ),
+                        )
+                    ),
+                    monomial_values,
+                    ledger,
+                    charge=False,
+                ),
+            )
+            for component in outer_components
+        ]
+    xvars = inner.source_variables
+    inner_num = tuple(
+        sparse_rational_polynomial_to_sympy(c.numerator, xvars)
+        for c in inner_components
+    )
+    inner_den = tuple(
+        sparse_rational_polynomial_to_sympy(c.denominator, xvars)
+        for c in inner_components
+    )
+
+    def substitute(polynomial: SparseRationalPolynomial) -> tuple[Any, Any]:
+        from sympy import Poly
+
+        xgens = symbols_for_variables(xvars)
+        if not polynomial.terms:
+            one = Poly(1, *xgens, domain="QQ")
+            return Poly(0, *xgens, domain="QQ"), one
+        powers = tuple(
+            max(term.exponents[axis] for term in polynomial.terms)
+            for axis in range(len(inner_components))
+        )
+        common_denominator = Poly(1, *xgens, domain="QQ")
+        for denominator, exponent in zip(inner_den, powers, strict=True):
+            common_denominator *= denominator**exponent
+        numerator = Poly(0, *xgens, domain="QQ")
+        for term in polynomial.terms:
+            value = Poly(term.coefficient.as_fraction(), *xgens, domain="QQ")
+            for num, den, exponent, max_exponent in zip(
+                inner_num, inner_den, term.exponents, powers, strict=True
+            ):
+                value *= num**exponent * den ** (max_exponent - exponent)
+            numerator += value
+        return numerator, common_denominator
+
+    composites: list[RationalFunction] = []
+    for outer_component, prepared_component in zip(
+        outer_components, prepared, strict=True
+    ):
+        if use_monomial_path:
+            assert (
+                prepared_component.numerator is not None
+                and prepared_component.numerator_denominator is not None
+                and prepared_component.denominator is not None
+                and prepared_component.denominator_denominator is not None
+            )
+            p_num = _prepared_poly_to_sympy(prepared_component.numerator, xvars)
+            p_den = _prepared_poly_to_sympy(
+                prepared_component.numerator_denominator, xvars
+            )
+            q_num = _prepared_poly_to_sympy(prepared_component.denominator, xvars)
+            q_den = _prepared_poly_to_sympy(
+                prepared_component.denominator_denominator, xvars
+            )
+        else:
+            p_num, p_den = substitute(outer_component.numerator)
+            q_num, q_den = substitute(outer_component.denominator)
+        if q_num.is_zero:
+            _reject_undefined_outer_denominator()
+        denominator_value = _normalize_fraction(q_num, q_den, xvars)
+        outer_guard = _monic_guard(denominator_value)
+        if outer_guard is not None:
+            guards.append(outer_guard)
+        composites.append(_normalize_fraction(p_num * q_den, p_den * q_num, xvars))
+    guards = sorted(
+        {guard_key(guard): guard for guard in guards}.values(), key=guard_key
+    )
+    result = RationalFunctionMapComposition(
+        outer=outer,
+        inner=inner,
+        composite=RationalFunctionMap(
+            source_variables=inner.source_variables,
+            target_coordinates=outer.target_coordinates,
+            components=tuple(composites),
+        ),
+        construction_locus_guard=tuple(guards),
+    )
+    request_checkpoint("after rational map composition construction")
+    return result
+
+
+__all__ = ["compose_maps"]

--- a/tests/math/polynomials/test_rational_map_composition.py
+++ b/tests/math/polynomials/test_rational_map_composition.py
@@ -15,6 +15,7 @@ from jacobian.math.polynomials.rational_functions.composition import (
     RationalMapCompositionRequest,
     compose_maps,
 )
+from jacobian.math.polynomials.rational_functions.composition._tools import TOOLS
 from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
 from jacobian.math.polynomials.values import RationalFunction, SparseRationalPolynomial
 
@@ -53,6 +54,11 @@ def _evaluate(value: RationalFunction, point: tuple[Fraction, ...]) -> Fraction:
     if not denominator:
         raise ZeroDivisionError
     return numerator / denominator
+
+
+def test_example_states_the_intermediate_axis_precondition() -> None:
+    description = TOOLS[0].examples[0].description
+    assert "source_variables equal the inner target_coordinates" in description
 
 
 def test_example_composition_retains_all_construction_guards() -> None:

--- a/tests/math/polynomials/test_rational_map_composition.py
+++ b/tests/math/polynomials/test_rational_map_composition.py
@@ -1,0 +1,256 @@
+"""Exact rational-map composition checked by sparse evaluation oracles."""
+
+from fractions import Fraction
+from itertools import product
+from time import monotonic
+
+import pytest
+from sympy import symbols
+
+from jacobian._execution import OperationExecutionTimeoutError, request_execution
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.polynomials._conversions import rational_function_from_sympy
+from jacobian.math.polynomials.rational_functions.composition import (
+    RationalFunctionMapComposition,
+    RationalMapCompositionRequest,
+    compose_maps,
+)
+from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+from jacobian.math.polynomials.values import RationalFunction, SparseRationalPolynomial
+
+
+def _rf(expression: object, variables: tuple[object, ...]) -> RationalFunction:
+    return rational_function_from_sympy(expression, tuple(str(v) for v in variables))
+
+
+def _map(
+    source: tuple[str, ...],
+    target: tuple[str, ...],
+    components: tuple[RationalFunction, ...],
+) -> RationalFunctionMap:
+    return RationalFunctionMap(
+        source_variables=source,
+        target_coordinates=target,
+        components=components,
+    )
+
+
+def _evaluate_polynomial(
+    polynomial: SparseRationalPolynomial, point: tuple[Fraction, ...]
+) -> Fraction:
+    result = Fraction(0)
+    for term in polynomial.terms:
+        coefficient = term.coefficient.as_fraction()
+        for coordinate, exponent in zip(point, term.exponents, strict=True):
+            coefficient *= coordinate**exponent
+        result += coefficient
+    return result
+
+
+def _evaluate(value: RationalFunction, point: tuple[Fraction, ...]) -> Fraction:
+    numerator = _evaluate_polynomial(value.numerator, point)
+    denominator = _evaluate_polynomial(value.denominator, point)
+    if not denominator:
+        raise ZeroDivisionError
+    return numerator / denominator
+
+
+def test_example_composition_retains_all_construction_guards() -> None:
+    x = symbols("x")
+    y1, y2 = symbols("y1 y2")
+    inner = _map(
+        ("x",),
+        ("y1", "y2"),
+        (_rf(x / (x - 1), (x,)), _rf((x + 1) / (x - 2), (x,))),
+    )
+    outer = _map(
+        ("y1", "y2"),
+        ("z1", "z2"),
+        (_rf(y1 + y2, (y1, y2)), _rf(y1 / y2, (y1, y2))),
+    )
+
+    result = compose_maps(outer, inner)
+
+    assert result.composite.source_variables == ("x",)
+    assert result.composite.target_coordinates == ("z1", "z2")
+    assert result.composite.components[0] == _rf(
+        (2 * x**2 - 2 * x - 1) / (x**2 - 3 * x + 2), (x,)
+    )
+    assert result.composite.components[1] == _rf((x**2 - 2 * x) / (x**2 - 1), (x,))
+    guard_polynomials = tuple(
+        tuple(
+            (term.exponents, term.coefficient.as_fraction())
+            for term in guard.polynomial.terms
+        )
+        for guard in result.construction_locus_guard
+    )
+    assert guard_polynomials == (
+        (((1,), Fraction(1)), ((0,), Fraction(-1))),
+        (((1,), Fraction(1)), ((0,), Fraction(-2))),
+        (((1,), Fraction(1)), ((0,), Fraction(1))),
+    )
+    assert (
+        RationalFunctionMapComposition.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+def test_cancellation_does_not_erase_stricter_locus() -> None:
+    x, y = symbols("x y")
+    inner = _map(("x",), ("y",), (_rf(x / (x - 1), (x,)),))
+    outer = _map(("y",), ("z",), (_rf(1 / y, (y,)),))
+    result = compose_maps(outer, inner)
+
+    assert result.composite.components[0] == _rf((x - 1) / x, (x,))
+    assert {
+        tuple(
+            (term.exponents, term.coefficient.as_fraction())
+            for term in guard.polynomial.terms
+        )
+        for guard in result.construction_locus_guard
+    } == {
+        (((1,), Fraction(1)),),
+        (((1,), Fraction(1)), ((0,), Fraction(-1))),
+    }
+
+
+def test_outer_denominator_zero_after_substitution_is_domain_error() -> None:
+    x, y = symbols("x y")
+    inner = _map(("x",), ("y",), (_rf(1, (x,)),))
+    outer = _map(("y",), ("z",), (_rf(1 / (y - 1), (y,)),))
+
+    with pytest.raises(OperationDomainValidationError, match="vanishes identically"):
+        compose_maps(outer, inner)
+
+
+def test_permuted_scaled_monomial_map_preserves_sparse_structure() -> None:
+    x, y, u, v = symbols("x y u v")
+    inner = _map(
+        ("x", "y"),
+        ("u", "v"),
+        (_rf(y, (x, y)), _rf(2 * x, (x, y))),
+    )
+    outer = _map(("u", "v"), ("z",), (_rf(u**64 + v, (u, v)),))
+
+    result = compose_maps(outer, inner)
+    expected = _rf(y**64 + 2 * x, (x, y))
+    assert result.composite.components == (expected,)
+
+
+def test_monomial_fast_path_handles_every_outer_component() -> None:
+    x, y, u, v = symbols("x y u v")
+    inner = _map(
+        ("x", "y"),
+        ("u", "v"),
+        (_rf(y, (x, y)), _rf(2 * x, (x, y))),
+    )
+    outer = _map(
+        ("u", "v"),
+        ("z1", "z2"),
+        (_rf(u**3 + v, (u, v)), _rf(u - v**2, (u, v))),
+    )
+
+    result = compose_maps(outer, inner)
+
+    assert result.composite.components == (
+        _rf(y**3 + 2 * x, (x, y)),
+        _rf(y - 4 * x**2, (x, y)),
+    )
+
+
+def test_sparse_eight_axis_degree_sixty_four_composition_is_admitted() -> None:
+    source = symbols("x0:8")
+    intermediate = symbols("y0:8")
+    target = symbols("z0:8")
+    inner = _map(
+        tuple(map(str, source)),
+        tuple(map(str, intermediate)),
+        tuple(_rf(value, source) for value in source),
+    )
+    outer = _map(
+        tuple(map(str, intermediate)),
+        tuple(map(str, target)),
+        tuple(_rf(value**64, intermediate) for value in intermediate),
+    )
+
+    result = compose_maps(outer, inner)
+
+    assert all(
+        component.numerator.terms[0].exponents
+        == tuple(64 * (axis == index) for axis in range(8))
+        for index, component in enumerate(result.composite.components)
+    )
+
+
+def test_empty_inner_axis_composes_exact_constants() -> None:
+    y = symbols("y")
+    inner = _map((), ("y",), (_rf(2, ()),))
+    outer = _map(("y",), ("z",), (_rf(y**3 - y, (y,)),))
+
+    result = compose_maps(outer, inner)
+    assert result.composite.source_variables == ()
+    assert result.composite.components[0] == _rf(6, ())
+    assert result.construction_locus_guard == ()
+
+
+def test_composition_matches_independent_fraction_oracle() -> None:
+    x = symbols("x")
+    y1, y2 = symbols("y1 y2")
+    inner = _map(
+        ("x",),
+        ("y1", "y2"),
+        (_rf((x + 1) / (x - 3), (x,)), _rf((x - 2) / (x + 2), (x,))),
+    )
+    outer = _map(
+        ("y1", "y2"),
+        ("z1", "z2"),
+        (_rf(y1**2 + y2, (y1, y2)), _rf((y1 - y2) / (y1 + y2), (y1, y2))),
+    )
+    result = compose_maps(outer, inner)
+
+    for numerator, denominator in product(range(-4, 5), repeat=2):
+        point = (Fraction(numerator, denominator or 1),)
+        try:
+            inner_values = tuple(
+                _evaluate(component, point) for component in inner.components
+            )
+            expected = (
+                inner_values[0] ** 2 + inner_values[1],
+                (inner_values[0] - inner_values[1])
+                / (inner_values[0] + inner_values[1]),
+            )
+            actual = tuple(
+                _evaluate(component, point) for component in result.composite.components
+            )
+        except ZeroDivisionError:
+            continue
+        assert actual == expected
+
+
+def test_axis_mismatch_and_authored_noncanonical_source_are_rejected() -> None:
+    x, y = symbols("x y")
+    inner = _map(("x",), ("u",), (_rf(x, (x,)),))
+    outer = _map(("y",), ("z",), (_rf(y, (y,)),))
+    with pytest.raises(ValueError, match="must equal"):
+        RationalMapCompositionRequest(outer=outer, inner=inner)
+
+    authored = RationalFunction(
+        variables=("x",),
+        numerator=_rf((x - 1) * (x + 1), (x,)).numerator,
+        denominator=_rf(x - 1, (x,)).numerator,
+    )
+    bad_inner = _map(("x",), ("y",), (authored,))
+    outer = _map(("y",), ("z",), (_rf(y, (y,)),))
+    with pytest.raises(OperationDomainValidationError, match="coprime"):
+        compose_maps(outer, bad_inner)
+
+
+def test_shared_deadline_is_honored() -> None:
+    x, y = symbols("x y")
+    inner = _map(("x",), ("y",), (_rf(x, (x,)),))
+    outer = _map(("y",), ("z",), (_rf(y, (y,)),))
+    with (
+        request_execution(monotonic() - 100),
+        pytest.raises(OperationExecutionTimeoutError),
+    ):
+        compose_maps(outer, inner)

--- a/tests/mcp/test_rational_map_composition.py
+++ b/tests/mcp/test_rational_map_composition.py
@@ -1,0 +1,11 @@
+"""MCP declaration coverage for rational-map composition."""
+
+from jacobian.math.polynomials.rational_functions.composition._tools import TOOLS
+
+
+def test_rational_map_composition_tool_is_declared() -> None:
+    assert len(TOOLS) == 1
+    tool = TOOLS[0]
+    assert tool.operation_id == "rational_function_map.compose.compute"
+    assert tool.request_type.__name__ == "RationalMapCompositionRequest"
+    assert tool.result_type.__name__ == "RationalFunctionMapComposition"


### PR DESCRIPTION
## Problem

Jacobian has typed rational coordinate maps and direct map Jacobians, but no operation for composing two compatible maps while preserving the intermediate axis binding and the stricter locus where the supplied maps and every outer denominator are defined.

## Outcome

Adds `rational_function_map.compose.compute`. It composes canonical rational maps exactly, retains the inner source and outer target axes, and returns a source-bound `construction_locus_guard` containing every inner component denominator and every substituted outer denominator condition. Identically zero substituted denominators are rejected, while removable cancellation never erases the construction guard.

Admission accounts for source, substitution, denominator clearing, normalization, guard, and complete output work before backend expansion. A bounded monomial path preserves sparse high-degree cases; general substitution uses exact polynomial arithmetic and the existing rational-function normalizer.

Closes #2880.

## Validation

- Commands run: `make affected AFFECTED_BASE=eb211888e032069eabf0b9b250d001d614617e7e`
- Final head SHA tested: `6562accfdcbfdc3926e9ae2ec3d98118581d4647`
- Result: 6 affected commands passed, including 32 mathematical tests, 156 catalog tests, 917 catalog integration tests, and 76 MCP tests.
- Additional checks: `make import-contracts`, `make architecture`, and focused catalog conformance passed.
- Hosted CI: [run 34182028738](https://github.com/morluto/jacobian/actions/runs/34182028738) passed, including the required selected evidence and final-tree specialist lanes.

## Contract impact

- Public contract impact: adds one immutable catalog operation and its typed request/result models; no existing operation IDs changed.
- Exact results retain source/target axes, complete component output, and pre-cancellation construction guards.
- Native and MCP behavior share the same operation implementation; serialization and live MCP parity are covered.
