### PR TITLE
feat(approximation): compute exact Lebesgue interval profiles

### DIFF
--- a/src/jacobian/math/analysis/approximation/lebesgue/__init__.py
+++ b/src/jacobian/math/analysis/approximation/lebesgue/__init__.py
@@ -1,0 +1,19 @@
+"""Exact fixed-node Lebesgue functions on rational intervals."""
+
+from jacobian.math.analysis.approximation.lebesgue._models import (
+    LebesgueCriticalPoint,
+    LebesgueIntervalProfile,
+    LebesgueIntervalSource,
+    LebesgueSignCell,
+)
+from jacobian.math.analysis.approximation.lebesgue.operations import (
+    lebesgue_interval_profile,
+)
+
+__all__ = [
+    "LebesgueCriticalPoint",
+    "LebesgueIntervalProfile",
+    "LebesgueIntervalSource",
+    "LebesgueSignCell",
+    "lebesgue_interval_profile",
+]

--- a/src/jacobian/math/analysis/approximation/lebesgue/_admission.py
+++ b/src/jacobian/math/analysis/approximation/lebesgue/_admission.py
@@ -169,9 +169,15 @@ def admit(source: LebesgueIntervalSource) -> LebesguePlan:
                 "complete extrema can exceed canonical real-algebraic coefficient digits",
             )
         radius = max(
-            1,
-            abs(lower.numerator) // lower.denominator + 1,
-            abs(upper.numerator) // upper.denominator + 1,
+            (
+                max(
+                    abs(cell.lower.numerator) // cell.lower.denominator + 1,
+                    abs(cell.upper.numerator) // cell.upper.denominator + 1,
+                )
+                for cell in cells
+                if cell.kind == "INTERIOR"
+            ),
+            default=1,
         )
         # Interval Horner has width(A*X) <= R*width(A) + max|A|*width(X).
         # With R >= 1 and |X| <= R, induction bounds the final width by

--- a/src/jacobian/math/analysis/approximation/lebesgue/_admission.py
+++ b/src/jacobian/math/analysis/approximation/lebesgue/_admission.py
@@ -6,6 +6,7 @@ from itertools import pairwise
 from math import lcm, prod
 from typing import Literal, NoReturn
 
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
 from jacobian._execution import request_checkpoint
 from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.analysis.approximation.lebesgue._models import LebesgueIntervalSource
@@ -160,7 +161,13 @@ def admit(source: LebesgueIntervalSource) -> LebesguePlan:
         )
         value_bits = _factor_bits(critical_degree, resultant_bits)
         point_bits = _factor_bits(critical_degree, derivative_bits)
-        coefficient_bits = max(coefficient_bits, value_bits, point_bits)
+        algebraic_bits = max(value_bits, point_bits)
+        coefficient_bits = max(coefficient_bits, algebraic_bits)
+        if _digits(algebraic_bits) > MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS:
+            reject(
+                "algebraic_height",
+                "complete extrema can exceed canonical real-algebraic coefficient digits",
+            )
         radius = max(
             1,
             abs(lower.numerator) // lower.denominator + 1,
@@ -178,10 +185,10 @@ def admit(source: LebesgueIntervalSource) -> LebesguePlan:
         refinement_bits = (
             _separation_bits(critical_degree, value_bits) + lipschitz_bits + 8
         )
-    if _digits(coefficient_bits) > MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS:
+    if _digits(endpoint_bits) > MAX_CANONICAL_RATIONAL_DIGITS:
         reject(
-            "algebraic_height",
-            "complete extrema can exceed canonical real-algebraic coefficient digits",
+            "endpoint_height",
+            "endpoint values exceed the canonical rational digit envelope",
         )
     if refinement_bits > 65_536:
         reject(

--- a/src/jacobian/math/analysis/approximation/lebesgue/_admission.py
+++ b/src/jacobian/math/analysis/approximation/lebesgue/_admission.py
@@ -1,0 +1,246 @@
+"""Source-derived bounds for complete fixed-node algebraic extrema."""
+
+from dataclasses import dataclass
+from fractions import Fraction
+from itertools import pairwise
+from math import lcm, prod
+from typing import Literal, NoReturn
+
+from jacobian._execution import request_checkpoint
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.analysis.approximation.lebesgue._models import LebesgueIntervalSource
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS,
+    MAX_REAL_ALGEBRAIC_DEGREE,
+)
+
+type CellKind = Literal["CONSTANT", "LEFT", "INTERIOR", "RIGHT"]
+
+
+@dataclass(frozen=True)
+class CellPlan:
+    lower: Fraction
+    upper: Fraction
+    kind: CellKind
+
+
+@dataclass(frozen=True)
+class LebesguePlan:
+    nodes: tuple[Fraction, ...]
+    weights: tuple[Fraction, ...]
+    cells: tuple[CellPlan, ...]
+    constant_query: bool
+    maximum_refinement_bits: int
+    coefficient_bits: int
+
+
+def reject(reason: str, message: str) -> NoReturn:
+    raise OperationResourceAdmissionError(
+        location=("source",),
+        code=f"approximation.lebesgue.{reason}",
+        message=message,
+    )
+
+
+def _digits(bits: int) -> int:
+    # log10(2) < 30103/100000, with integer rounding upwards.
+    return max(1, (bits * 30103 + 99999) // 100000)
+
+
+def _factor_bits(degree: int, height_bits: int) -> int:
+    # H(F) <= 2^degree sqrt(degree+1) H(P) for an integral factor F of P.
+    return height_bits + degree + (degree + 1).bit_length()
+
+
+def _separation_bits(degree: int, height_bits: int) -> int:
+    # A deliberately larger exponent than the Mignotte bound
+    # sep(P) > sqrt(3) n^(-(n+2)/2) ||P||_2^(1-n), for square-free P.
+    return max(8, degree * (height_bits + 2 * (degree + 1).bit_length() + 2) + 8)
+
+
+def admit(source: LebesgueIntervalSource) -> LebesguePlan:
+    """Reserve basis expansion, resultants, root refinement and complete values.
+
+    The shared node carrier already bounds the preliminary scalar products:
+    at most 32 nodes and 512 total rational-component digits. No polynomial
+    is expanded in this phase. Exact barycentric weights are retained for the
+    executor so the node-difference products are not computed a second time.
+    """
+    request_checkpoint("before Lebesgue source admission")
+    nodes = tuple(node.as_fraction() for node in source.nodes.nodes)
+    lower, upper = (
+        source.interval.lower.as_fraction(),
+        source.interval.upper.as_fraction(),
+    )
+    count = len(nodes)
+    degree = count - 1
+    constant_query = count == 1 or (
+        count == 2 and nodes[0] <= lower <= upper <= nodes[-1]
+    )
+    boundaries = [lower]
+    if count > 1:
+        boundaries.extend(node for node in nodes if lower < node < upper)
+    if upper != lower:
+        boundaries.append(upper)
+    cells = tuple(
+        CellPlan(
+            a,
+            b,
+            "CONSTANT"
+            if count == 1 or (count == 2 and nodes[0] <= a < b <= nodes[-1])
+            else "LEFT"
+            if b <= nodes[0]
+            else "RIGHT"
+            if a >= nodes[-1]
+            else "INTERIOR",
+        )
+        for a, b in pairwise(boundaries)
+    )
+    interior_count = sum(cell.kind == "INTERIOR" for cell in cells)
+    if interior_count and degree - 1 > MAX_REAL_ALGEBRAIC_DEGREE:
+        reject(
+            "algebraic_degree",
+            "interior critical values can exceed the canonical real-algebraic degree bound",
+        )
+
+    denominators = [Fraction(1) for _ in nodes]
+    for i, node in enumerate(nodes):
+        request_checkpoint("during Lebesgue node-difference admission")
+        for j in range(i):
+            difference = nodes[j] - node
+            denominators[j] *= difference
+            denominators[i] *= -difference
+    weights = tuple(1 / denominator for denominator in denominators)
+    # l_i = c_i * product_{j!=i}(q_j*x-p_j). These integer polynomials
+    # have coefficient l1 norm at most product(|p_j|+q_j).
+    scales = tuple(
+        weight / prod(node.denominator for j, node in enumerate(nodes) if j != i)
+        for i, weight in enumerate(weights)
+    )
+    common_denominator = lcm(*(scale.denominator for scale in scales))
+    height = sum(
+        abs(scale.numerator)
+        * (common_denominator // scale.denominator)
+        * prod(
+            abs(node.numerator) + node.denominator
+            for j, node in enumerate(nodes)
+            if j != i
+        )
+        for i, scale in enumerate(scales)
+    )
+    height_bits = max(1, height.bit_length())
+    denominator_bits = common_denominator.bit_length()
+    # Every sign-cell polynomial is S(x)/D with integer coefficients of
+    # magnitude at most height, regardless of its sign vector.
+    endpoint_bits = 2
+    if not constant_query:
+        endpoint_bits = max(
+            max(
+                height_bits
+                + count.bit_length()
+                + degree
+                * max(
+                    abs(point.numerator).bit_length(), point.denominator.bit_length()
+                ),
+                denominator_bits + degree * point.denominator.bit_length(),
+            )
+            for point in boundaries
+        )
+    coefficient_bits = endpoint_bits
+    refinement_bits = 8
+    if interior_count:
+        critical_degree = degree - 1
+        derivative_bits = height_bits + max(1, degree).bit_length()
+        # Hadamard on the Sylvester matrix of S' and D*y-S. On |y|=1,
+        # their row l1 norms are bounded by d(d+1)H/2 and (d+1)H+D.
+        # Cauchy's coefficient inequality gives the same bound coefficientwise.
+        resultant_bits = (
+            degree * (degree * (degree + 1) // 2 * height).bit_length()
+            + critical_degree * (count * height + common_denominator).bit_length()
+        )
+        value_bits = _factor_bits(critical_degree, resultant_bits)
+        point_bits = _factor_bits(critical_degree, derivative_bits)
+        coefficient_bits = max(coefficient_bits, value_bits, point_bits)
+        radius = max(
+            1,
+            abs(lower.numerator) // lower.denominator + 1,
+            abs(upper.numerator) // upper.denominator + 1,
+        )
+        # Interval Horner has width(A*X) <= R*width(A) + max|A|*width(X).
+        # With R >= 1 and |X| <= R, induction bounds the final width by
+        # H*d(d+1)/2 * R^(d-1) * width(X); dependency does not require
+        # replacing R by R+1. The two bit lengths below round upwards.
+        lipschitz_bits = (
+            height_bits
+            + 2 * count.bit_length()
+            + max(0, degree - 1) * radius.bit_length()
+        )
+        refinement_bits = (
+            _separation_bits(critical_degree, value_bits) + lipschitz_bits + 8
+        )
+    if _digits(coefficient_bits) > MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS:
+        reject(
+            "algebraic_height",
+            "complete extrema can exceed canonical real-algebraic coefficient digits",
+        )
+    if refinement_bits > 65_536:
+        reject(
+            "refinement",
+            "critical-value isolation exceeds the admitted rational refinement depth",
+        )
+    critical_rows = interior_count * max(0, degree - 1)
+    # Each critical row has two algebraic polynomials and four interval
+    # endpoints. The latter retain rational numerators and denominators.
+    query_component_bits = max(
+        max(abs(point.numerator).bit_length(), point.denominator.bit_length())
+        for point in (lower, upper)
+    )
+    interval_component_bits = max(
+        query_component_bits, 2 * refinement_bits + coefficient_bits + 32
+    )
+    output_bits = (
+        (count * count + count) * (height_bits + denominator_bits)
+        + (critical_rows + 2 * len(cells) + 4)
+        * (4 * count * coefficient_bits + 8 * interval_component_bits)
+        + 2
+        * sum(
+            abs(node.numerator).bit_length() + node.denominator.bit_length()
+            for node in (*nodes, lower, upper)
+        )
+    )
+    if output_bits > 268_435_456:
+        reject(
+            "output_allocation",
+            "complete Lebesgue values exceed the exact coefficient allocation",
+        )
+    # Comparing values from different cells can isolate a product of two
+    # distinct irreducible polynomials. These refined intervals are private;
+    # reserve their degree, height, and rational arithmetic separately from
+    # the serialized intervals retained above.
+    comparison_degree = 2 * max(1, degree - 1)
+    comparison_height = (
+        2 * max(coefficient_bits, query_component_bits) + count.bit_length()
+    )
+    comparison_bits = _separation_bits(comparison_degree, comparison_height)
+    intermediate_bits = max(1, count * count) * (
+        comparison_bits + comparison_height
+    ) + count * count * (interval_component_bits + height_bits + denominator_bits)
+    if intermediate_bits > 268_435_456:
+        reject(
+            "intermediate_allocation",
+            "exact isolation and comparison arithmetic exceed the admitted allocation",
+        )
+    work = (
+        max(1, interior_count)
+        * count**4
+        * (coefficient_bits + refinement_bits + comparison_bits)
+    )
+    if work > 1_000_000_000_000:
+        reject(
+            "work",
+            "complete Lebesgue root and comparison work exceeds its admitted envelope",
+        )
+    request_checkpoint("after complete Lebesgue admission")
+    return LebesguePlan(
+        nodes, weights, cells, constant_query, refinement_bits, coefficient_bits
+    )

--- a/src/jacobian/math/analysis/approximation/lebesgue/_models.py
+++ b/src/jacobian/math/analysis/approximation/lebesgue/_models.py
@@ -1,0 +1,122 @@
+"""Exact fixed-node Lebesgue functions on closed rational intervals."""
+
+from itertools import pairwise
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.math.analysis.approximation._models import (
+    LagrangeBasisResult,
+    RationalNodeSet,
+)
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+    RealAlgebraicValue,
+)
+from jacobian.math.polynomials.values import RationalPolynomial
+
+
+class LebesgueIntervalSource(StrictModel):
+    """A fixed node set and the interval on which its Lebesgue function is studied.
+
+    The query interval may contain only some of the interpolation nodes, or
+    lie outside their convex hull. Nodes retain their canonical increasing order.
+    """
+
+    nodes: RationalNodeSet
+    interval: ClosedRationalInterval
+
+
+class LebesgueIntervalRequest(StrictModel):
+    source: LebesgueIntervalSource
+
+
+class LebesgueCriticalPoint(StrictModel):
+    """An isolated derivative root and the exact value of its cell polynomial."""
+
+    point: RealAlgebraicValue
+    point_isolating_interval: RationalIsolatingInterval
+    derivative_multiplicity: int = Field(ge=1, le=31)
+    value: RealAlgebraicValue
+    value_isolating_interval: RationalIsolatingInterval
+
+
+class LebesgueSignCell(StrictModel):
+    """One positive-length cell, closed for evaluating its extrema.
+
+    The sign vector refers to the open interior, where no basis polynomial
+    vanishes. Endpoint values use the continuous extension. For a constant
+    cell every point is stationary and maximizing; otherwise critical_points
+    lists all derivative roots in the closed cell and maximizing_points lists
+    every point attaining its maximum.
+    """
+
+    interval: ClosedRationalInterval
+    basis_signs: tuple[Literal[-1, 1], ...] = Field(min_length=1, max_length=32)
+    polynomial: RationalPolynomial
+    endpoint_values: tuple[CanonicalRational, CanonicalRational]
+    constant_on_cell: bool
+    critical_points: tuple[LebesgueCriticalPoint, ...] = Field(max_length=31)
+    maximum: RealAlgebraicValue
+    maximum_isolating_interval: RationalIsolatingInterval
+    maximizing_points: tuple[RealAlgebraicValue, ...] = Field(max_length=33)
+
+    @model_validator(mode="after")
+    def require_cell_structure(self) -> Self:
+        if self.interval.lower.as_fraction() >= self.interval.upper.as_fraction():
+            raise ValueError("Lebesgue sign cells must have positive length")
+        if self.polynomial.variables != ("x",):
+            raise ValueError("Lebesgue cell polynomials must use the basis variable x")
+        if self.constant_on_cell and (self.critical_points or self.maximizing_points):
+            raise ValueError(
+                "constant cells represent the entire interval of maximizers"
+            )
+        if not self.constant_on_cell and not self.maximizing_points:
+            raise ValueError("a nonconstant closed cell needs at least one maximizer")
+        return self
+
+
+class LebesgueIntervalProfile(StrictModel):
+    """Complete sign cells, critical values, and the exact global maximum locus.
+
+    The global maximizer set is the union of maximizing_intervals and the
+    isolated maximizing_points. A singleton query has no positive-length
+    sign cell and retains its one-point interval as the maximizing interval.
+    """
+
+    source: LebesgueIntervalSource
+    basis: LagrangeBasisResult
+    cells: tuple[LebesgueSignCell, ...] = Field(max_length=33)
+    maximum: RealAlgebraicValue
+    maximum_isolating_interval: RationalIsolatingInterval
+    maximizing_points: tuple[RealAlgebraicValue, ...] = Field(max_length=1100)
+    maximizing_intervals: tuple[ClosedRationalInterval, ...] = Field(max_length=33)
+
+    @model_validator(mode="after")
+    def require_complete_source_axes(self) -> Self:
+        if self.basis.nodes != self.source.nodes:
+            raise ValueError("the complete basis must retain the source node set")
+        if any(
+            len(cell.basis_signs) != len(self.source.nodes.nodes) for cell in self.cells
+        ):
+            raise ValueError("every sign vector must retain the complete basis axis")
+        if self.source.interval.lower == self.source.interval.upper:
+            if self.cells:
+                raise ValueError("a singleton query has no positive-length sign cells")
+        elif (
+            not self.cells
+            or self.cells[0].interval.lower != self.source.interval.lower
+            or self.cells[-1].interval.upper != self.source.interval.upper
+            or any(
+                a.interval.upper != b.interval.lower for a, b in pairwise(self.cells)
+            )
+        ):
+            raise ValueError(
+                "sign cells must cover the closed source interval without gaps"
+            )
+        if not self.maximizing_points and not self.maximizing_intervals:
+            raise ValueError("a closed interval must have a nonempty maximum locus")
+        return self

--- a/src/jacobian/math/analysis/approximation/lebesgue/_roots.py
+++ b/src/jacobian/math/analysis/approximation/lebesgue/_roots.py
@@ -1,0 +1,164 @@
+"""Exact critical points and their images, with admitted interval refinement."""
+
+from dataclasses import dataclass
+from fractions import Fraction
+
+from sympy import Poly, Rational, Symbol
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import request_checkpoint
+from jacobian.math.number_theory.algebraic_numbers.real import (
+    RationalIsolatingInterval,
+    RealAlgebraicValue,
+    _compare_admitted_real_algebraic,
+)
+
+
+@dataclass(frozen=True)
+class Root:
+    value: RealAlgebraicValue
+    interval: RationalIsolatingInterval
+
+
+def interval(lower: Fraction, upper: Fraction) -> RationalIsolatingInterval:
+    return RationalIsolatingInterval(
+        lower=CanonicalRational.from_fraction(lower),
+        upper=CanonicalRational.from_fraction(upper),
+        interval_type="SINGLETON" if lower == upper else "OPEN",
+    )
+
+
+def rational(value: Fraction) -> Root:
+    return Root(
+        RealAlgebraicValue._from_admitted_polynomial(
+            polynomial=(value.denominator, -value.numerator), real_root_index=0
+        ),
+        interval(value, value),
+    )
+
+
+def compare(left: Root, right: Root) -> int:
+    request_checkpoint("during exact Lebesgue extrema comparison")
+    order = _compare_admitted_real_algebraic(
+        left.value, right.value, left.interval, right.interval
+    )
+    return {"LT": -1, "EQ": 0, "GT": 1}[order]
+
+
+def evaluate(coefficients: tuple[Fraction, ...], point: Fraction) -> Fraction:
+    result = Fraction(0)
+    for coefficient in reversed(coefficients):
+        result = result * point + coefficient
+    return result
+
+
+def image_interval(
+    coefficients: tuple[Fraction, ...], lower: Fraction, upper: Fraction
+) -> tuple[Fraction, Fraction]:
+    a = b = Fraction(0)
+    for coefficient in reversed(coefficients):
+        products = (a * lower, a * upper, b * lower, b * upper)
+        a, b = min(products) + coefficient, max(products) + coefficient
+    return a, b
+
+
+def factor_roots(polynomial: Poly, bits: int) -> tuple[tuple[Root, Poly, int], ...]:
+    result = []
+    for factor, multiplicity in polynomial.factor_list()[1]:
+        request_checkpoint("during exact Lebesgue root isolation")
+        factor = factor.primitive()[1]
+        if factor.LC() < 0:
+            factor = -factor
+        encoded = tuple(int(c) for c in factor.all_coeffs())
+        for index, ((a, b), _) in enumerate(factor.intervals(eps=Rational(1, 2**bits))):
+            result.append(
+                (
+                    Root(
+                        RealAlgebraicValue._from_admitted_polynomial(
+                            polynomial=encoded, real_root_index=index
+                        ),
+                        interval(Fraction(a), Fraction(b)),
+                    ),
+                    factor,
+                    int(multiplicity),
+                )
+            )
+    return tuple(result)
+
+
+def refine(root: Root, polynomial: Poly, bits: int) -> Root:
+    a, b = polynomial.intervals(eps=Rational(1, 2**bits))[root.value.real_root_index][0]
+    return Root(root.value, interval(Fraction(a), Fraction(b)))
+
+
+def critical_points(
+    coefficients: tuple[Fraction, ...],
+    lower: Fraction,
+    upper: Fraction,
+    refinement_bits: int,
+) -> tuple[tuple[Root, int, Root], ...]:
+    x, y = Symbol("x"), Symbol("y")
+    polynomial = Poly.from_dict(
+        {
+            (i,): Rational(c.numerator, c.denominator)
+            for i, c in enumerate(coefficients)
+        },
+        x,
+        domain="QQ",
+    )
+    denominator, integral = polynomial.clear_denoms(convert=True)
+    derivative = integral.diff()
+    roots = factor_roots(derivative, 8)
+    selected = [
+        (root, factor, multiplicity)
+        for root, factor, multiplicity in roots
+        if compare(root, rational(lower)) >= 0 and compare(root, rational(upper)) <= 0
+    ]
+    if not selected:
+        return ()
+    # The resultant contains every critical image, including possible images
+    # of nonreal critical points. Interval association selects the actual image.
+    images: tuple[tuple[Root, Poly, int], ...] = ()
+    if any(len(root.value.polynomial) > 2 for root, _, _ in selected):
+        request_checkpoint("before exact Lebesgue critical-value resultant")
+        resultant = Poly(
+            derivative.resultant(Poly(denominator * y - integral.as_expr(), x)),
+            y,
+            domain="ZZ",
+        )
+        images = factor_roots(resultant, 8)
+    result = []
+    for root, factor, multiplicity in selected:
+        if len(root.value.polynomial) == 2:
+            point = -Fraction(root.value.polynomial[1], root.value.polynomial[0])
+            result.append((root, multiplicity, rational(evaluate(coefficients, point))))
+            continue
+        bits = 8
+        candidates = images
+        while True:
+            request_checkpoint("during exact Lebesgue critical-value association")
+            a, b = image_interval(
+                coefficients,
+                max(lower, root.interval.lower.as_fraction()),
+                min(upper, root.interval.upper.as_fraction()),
+            )
+            candidates = tuple(
+                entry
+                for entry in candidates
+                if entry[0].interval.lower.as_fraction() <= b
+                and entry[0].interval.upper.as_fraction() >= a
+            )
+            if len(candidates) == 1:
+                result.append((root, multiplicity, candidates[0][0]))
+                break
+            if not candidates or bits == refinement_bits:
+                raise ArithmeticError(
+                    "admitted critical-value separation did not resolve an image"
+                )
+            bits = min(2 * bits, refinement_bits)
+            root = refine(root, factor, bits)
+            candidates = tuple(
+                (refine(image, image_factor, bits), image_factor, exponent)
+                for image, image_factor, exponent in candidates
+            )
+    return tuple(result)

--- a/src/jacobian/math/analysis/approximation/lebesgue/_tools.py
+++ b/src/jacobian/math/analysis/approximation/lebesgue/_tools.py
@@ -1,0 +1,52 @@
+"""Publication of complete fixed-node Lebesgue interval profiles."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.analysis.approximation.lebesgue._models import (
+    LebesgueIntervalProfile,
+    LebesgueIntervalRequest,
+)
+from jacobian.math.analysis.approximation.lebesgue.operations import (
+    lebesgue_interval_profile,
+)
+
+
+def _run(request: LebesgueIntervalRequest) -> LebesgueIntervalProfile:
+    return lebesgue_interval_profile(request.source)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="approximation.lebesgue.interval_profiles.compute",
+        title="Compute exact fixed-node Lebesgue interval profiles",
+        description=(
+            "For distinct rational interpolation nodes and a closed rational query interval, "
+            "return the complete Lagrange basis, sign-cell polynomials for the sum of its "
+            "absolute values, all isolated derivative critical points, cell maxima, and the "
+            "global maximum with every tied maximizing point or constant interval. "
+            "The query may lie inside or outside the node hull. Exact real-algebraic values "
+            "retain irreducible polynomials and real-root indices. Source-derived admission "
+            "bounds algebraic degree, coefficient growth, root isolation and complete output."
+        ),
+        request_type=LebesgueIntervalRequest,
+        result_type=LebesgueIntervalProfile,
+        run=_run,
+        tags=("approximation", "interpolation", "lebesgue", "exact", "maximum"),
+        examples=(
+            OperationExample(
+                name="three_nodes",
+                description="Nodes -1, 0, 1 on [-1,1] give maximum 5/4 at both -1/2 and 1/2.",
+                input={
+                    "source": {
+                        "nodes": {
+                            "nodes": [{"num": str(n), "den": "1"} for n in (-1, 0, 1)]
+                        },
+                        "interval": {
+                            "lower": {"num": "-1", "den": "1"},
+                            "upper": {"num": "1", "den": "1"},
+                        },
+                    }
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/analysis/approximation/lebesgue/_tools.py
+++ b/src/jacobian/math/analysis/approximation/lebesgue/_tools.py
@@ -34,7 +34,7 @@ TOOLS: MathTools = (
         examples=(
             OperationExample(
                 name="three_nodes",
-                description="Nodes -1, 0, 1 on [-1,1] give maximum 5/4 at both -1/2 and 1/2.",
+                description="Nodes -1, 0, 1 on [-1,1] give maximum 5/4 at both -1/2 and 1/2. Nodes must be distinct and strictly increasing, and the query interval endpoints must be ordered.",
                 input={
                     "source": {
                         "nodes": {

--- a/src/jacobian/math/analysis/approximation/lebesgue/operations.py
+++ b/src/jacobian/math/analysis/approximation/lebesgue/operations.py
@@ -1,0 +1,212 @@
+"""Complete exact fixed-node Lebesgue profiles."""
+
+import time
+from fractions import Fraction
+from functools import cmp_to_key
+from typing import Literal
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.math.analysis.approximation._models import (
+    LagrangeBasisPolynomial,
+    LagrangeBasisResult,
+)
+from jacobian.math.analysis.approximation.lebesgue._admission import admit
+from jacobian.math.analysis.approximation.lebesgue._models import (
+    LebesgueCriticalPoint,
+    LebesgueIntervalProfile,
+    LebesgueIntervalSource,
+    LebesgueSignCell,
+)
+from jacobian.math.analysis.approximation.lebesgue._roots import (
+    Root,
+    compare,
+    critical_points,
+    evaluate,
+    rational,
+)
+from jacobian.math.analysis.approximation.operations import (
+    _divide_by_nodal_factor,
+    _poly_multiply,
+    _polynomial_from_coeffs,
+)
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+
+
+def _closed(lower: Fraction, upper: Fraction) -> ClosedRationalInterval:
+    return ClosedRationalInterval(
+        lower=CanonicalRational.from_fraction(lower),
+        upper=CanonicalRational.from_fraction(upper),
+    )
+
+
+def _maximum(entries: tuple[tuple[Root, Root], ...]) -> tuple[Root, tuple[Root, ...]]:
+    maximum = entries[0][1]
+    points = []
+    for point, value in entries:
+        order = compare(value, maximum)
+        if order > 0:
+            maximum, points = value, [point]
+        elif order == 0:
+            points.append(point)
+    unique = {
+        (point.value.polynomial, point.value.real_root_index): point for point in points
+    }
+    return maximum, tuple(sorted(unique.values(), key=cmp_to_key(compare)))
+
+
+def _critical_order(left: tuple[Root, int, Root], right: tuple[Root, int, Root]) -> int:
+    return compare(left[0], right[0])
+
+
+def lebesgue_interval_profile(
+    source: LebesgueIntervalSource,
+) -> LebesgueIntervalProfile:
+    """Return all sign cells, critical points, and tied interval maximizers."""
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return lebesgue_interval_profile(source)
+    deadline = execution.started_at + 180
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    plan = admit(source)
+    nodal = [Fraction(1)]
+    for node in plan.nodes:
+        nodal = _poly_multiply(nodal, [-node, Fraction(1)])
+    coefficients = tuple(
+        tuple(weight * c for c in _divide_by_nodal_factor(nodal, node))
+        for node, weight in zip(plan.nodes, plan.weights, strict=True)
+    )
+    basis = LagrangeBasisResult(
+        nodes=source.nodes,
+        node_count=len(plan.nodes),
+        basis=tuple(
+            LagrangeBasisPolynomial(
+                index=i,
+                polynomial=_polynomial_from_coeffs(row),
+                barycentric_weight=CanonicalRational.from_fraction(plan.weights[i]),
+            )
+            for i, row in enumerate(coefficients)
+        ),
+    )
+    if not plan.cells:
+        point = source.interval.lower.as_fraction()
+        value = rational(
+            sum((abs(evaluate(row, point)) for row in coefficients), Fraction(0))
+        )
+        return LebesgueIntervalProfile(
+            source=source,
+            basis=basis,
+            cells=(),
+            maximum=value.value,
+            maximum_isolating_interval=value.interval,
+            maximizing_points=(),
+            maximizing_intervals=(source.interval,),
+        )
+    cells = []
+    cell_extrema = []
+    for cell in plan.cells:
+        request_checkpoint("before Lebesgue sign-cell expansion")
+        midpoint = (cell.lower + cell.upper) / 2
+        signs: tuple[Literal[-1, 1], ...] = tuple(
+            1 if evaluate(row, midpoint) > 0 else -1 for row in coefficients
+        )
+        polynomial = tuple(
+            sum(
+                (sign * row[i] for sign, row in zip(signs, coefficients, strict=True)),
+                Fraction(0),
+            )
+            for i in range(len(plan.nodes))
+        )
+        constant = not any(polynomial[1:])
+        endpoint_values = (
+            evaluate(polynomial, cell.lower),
+            evaluate(polynomial, cell.upper),
+        )
+        critical = (
+            critical_points(
+                polynomial, cell.lower, cell.upper, plan.maximum_refinement_bits
+            )
+            if cell.kind == "INTERIOR" and not constant
+            else ()
+        )
+        entries = (
+            (rational(cell.lower), rational(endpoint_values[0])),
+            (rational(cell.upper), rational(endpoint_values[1])),
+            *((point, value) for point, _, value in critical),
+        )
+        maximum, points = _maximum(entries)
+        closed = _closed(cell.lower, cell.upper)
+        cells.append(
+            LebesgueSignCell(
+                interval=closed,
+                basis_signs=signs,
+                polynomial=_polynomial_from_coeffs(polynomial),
+                endpoint_values=(
+                    CanonicalRational.from_fraction(endpoint_values[0]),
+                    CanonicalRational.from_fraction(endpoint_values[1]),
+                ),
+                constant_on_cell=constant,
+                critical_points=tuple(
+                    LebesgueCriticalPoint(
+                        point=point.value,
+                        point_isolating_interval=point.interval,
+                        derivative_multiplicity=multiplicity,
+                        value=value.value,
+                        value_isolating_interval=value.interval,
+                    )
+                    for point, multiplicity, value in sorted(
+                        critical, key=cmp_to_key(_critical_order)
+                    )
+                ),
+                maximum=maximum.value,
+                maximum_isolating_interval=maximum.interval,
+                maximizing_points=()
+                if constant
+                else tuple(point.value for point in points),
+            )
+        )
+        cell_extrema.append((maximum, points, closed if constant else None))
+    global_maximum, _ = _maximum(
+        tuple((points[0], maximum) for maximum, points, _ in cell_extrema)
+    )
+    plateaus: list[ClosedRationalInterval] = []
+    candidates: list[Root] = []
+    for maximum, points, plateau in cell_extrema:
+        if compare(maximum, global_maximum):
+            continue
+        if plateau is not None:
+            if plateaus and plateaus[-1].upper == plateau.lower:
+                plateaus[-1] = ClosedRationalInterval(
+                    lower=plateaus[-1].lower, upper=plateau.upper
+                )
+            else:
+                plateaus.append(plateau)
+        else:
+            candidates.extend(points)
+    isolated = tuple(
+        (point, global_maximum)
+        for point in candidates
+        if not any(
+            compare(point, rational(p.lower.as_fraction())) >= 0
+            and compare(point, rational(p.upper.as_fraction())) <= 0
+            for p in plateaus
+        )
+    )
+    points = _maximum(isolated)[1] if isolated else ()
+    return LebesgueIntervalProfile(
+        source=source,
+        basis=basis,
+        cells=tuple(cells),
+        maximum=global_maximum.value,
+        maximum_isolating_interval=global_maximum.interval,
+        maximizing_points=tuple(point.value for point in points),
+        maximizing_intervals=tuple(plateaus),
+    )

--- a/tests/math/analysis/approximation/test_lebesgue_interval_profile.py
+++ b/tests/math/analysis/approximation/test_lebesgue_interval_profile.py
@@ -170,6 +170,16 @@ def test_constant_query_retains_large_rational_endpoints() -> None:
     )
 
 
+def test_rational_endpoints_are_not_capped_by_algebraic_height() -> None:
+    result = lebesgue_interval_profile(
+        source((-1, 0, 1), Fraction(1, 2), Fraction(1, 2) + Fraction(1, 10**2000))
+    )
+    assert result.cells
+    assert (
+        LebesgueIntervalProfile.model_validate_json(result.model_dump_json()) == result
+    )
+
+
 def test_unrepresentable_interior_degree_rejects_before_basis_expansion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/math/analysis/approximation/test_lebesgue_interval_profile.py
+++ b/tests/math/analysis/approximation/test_lebesgue_interval_profile.py
@@ -1,0 +1,183 @@
+"""Independent identities for complete fixed-node Lebesgue extrema."""
+
+import time
+from fractions import Fraction
+
+import pytest
+from sympy import Expr, Poly, Rational, Symbol, expand
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.analysis.approximation import lagrange_basis
+from jacobian.math.analysis.approximation._models import RationalNodeSet
+from jacobian.math.analysis.approximation.lebesgue import (
+    LebesgueIntervalProfile,
+    LebesgueIntervalSource,
+    lebesgue_interval_profile,
+)
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.polynomials.values import RationalPolynomial
+
+
+def source(
+    nodes: tuple[int, ...], lower: int | Fraction, upper: int | Fraction
+) -> LebesgueIntervalSource:
+    def q(v: int | Fraction) -> CanonicalRational:
+        return CanonicalRational.from_fraction(Fraction(v))
+
+    return LebesgueIntervalSource(
+        nodes=RationalNodeSet(nodes=tuple(q(v) for v in nodes)),
+        interval=ClosedRationalInterval(lower=q(lower), upper=q(upper)),
+    )
+
+
+def expression(polynomial: RationalPolynomial) -> Expr:
+    x = Symbol("x")
+    return sum(
+        Rational(t.coefficient.num, t.coefficient.den) * x ** t.exponents[0]
+        for t in polynomial.polynomial.terms
+    )
+
+
+def test_complete_three_node_fixture() -> None:
+    request = source((-1, 0, 1), -1, 1)
+    result = lebesgue_interval_profile(request)
+    x = Symbol("x")
+    assert result.basis == lagrange_basis(request.nodes)
+    assert [expression(c.polynomial) for c in result.cells] == [
+        1 - x - x * x,
+        1 + x - x * x,
+    ]
+    assert [c.basis_signs for c in result.cells] == [(1, 1, -1), (-1, 1, 1)]
+    assert result.maximum.polynomial == (4, -5)
+    assert [p.polynomial for p in result.maximizing_points] == [(2, 1), (2, -1)]
+    assert all(
+        c.endpoint_values == (CanonicalRational(num=1, den=1),) * 2
+        for c in result.cells
+    )
+    assert [len(c.critical_points) for c in result.cells] == [1, 1]
+    assert (
+        LebesgueIntervalProfile.model_validate_json(result.model_dump_json()) == result
+    )
+
+
+@pytest.mark.parametrize(
+    "nodes,lower,upper",
+    [((3,), -5, 7), ((-1, 1), -1, 1), ((-1, 1), Fraction(-1, 3), Fraction(1, 2))],
+)
+def test_constant_intervals_retain_entire_maximum_locus(
+    nodes: tuple[int, ...], lower: int | Fraction, upper: int | Fraction
+) -> None:
+    request = source(nodes, lower, upper)
+    result = lebesgue_interval_profile(request)
+    assert result.maximum.polynomial == (1, -1)
+    assert result.maximizing_points == ()
+    assert result.maximizing_intervals == (request.interval,)
+    assert all(c.constant_on_cell and not c.critical_points for c in result.cells)
+
+
+def test_subinterval_and_singleton_do_not_require_all_nodes() -> None:
+    result = lebesgue_interval_profile(
+        source((-1, 0, 1), Fraction(1, 4), Fraction(3, 4))
+    )
+    assert len(result.cells) == 1
+    assert result.maximum.polynomial == (4, -5)
+    point = source((-1, 0, 1), Fraction(1, 4), Fraction(1, 4))
+    singleton = lebesgue_interval_profile(point)
+    assert singleton.cells == ()
+    assert singleton.maximum.polynomial == (16, -19)
+    assert singleton.maximizing_intervals == (point.interval,)
+
+
+def test_irrational_critical_values_and_affine_invariance() -> None:
+    original = lebesgue_interval_profile(source((0, 1, 2, 3), 0, 3))
+    translated = lebesgue_interval_profile(source((5, 7, 9, 11), 5, 11))
+    assert original.maximum == translated.maximum
+    assert original.maximum.polynomial == (27, -14, -49)
+    assert original.maximum.real_root_index == 1
+    assert len(original.maximizing_points) == 2
+    x = Symbol("x")
+    for cell in original.cells:
+        derivative = Poly(expression(cell.polynomial), x).diff()
+        a, b = cell.interval.lower.as_fraction(), cell.interval.upper.as_fraction()
+        assert derivative.count_roots(
+            Rational(a.numerator, a.denominator), Rational(b.numerator, b.denominator)
+        ) == len(cell.critical_points)
+        for critical in cell.critical_points:
+            minimal = Poly.from_list(critical.point.polynomial, x)
+            assert derivative.rem(minimal).is_zero
+            value_polynomial = Poly.from_list(critical.value.polynomial, x)
+            assert (
+                Poly(
+                    expand(
+                        value_polynomial.as_expr().subs(x, expression(cell.polynomial))
+                    ),
+                    x,
+                )
+                .rem(minimal)
+                .is_zero
+            )
+
+
+def test_32_node_exterior_query_remains_accepted() -> None:
+    result = lebesgue_interval_profile(source(tuple(range(32)), 32, 33))
+    assert len(result.cells) == 1
+    assert not result.cells[0].critical_points
+    assert result.maximizing_points[0].polynomial == (1, -33)
+    # Independently evaluate product-defined cardinal polynomials at the maximum.
+    expected = Fraction(0)
+    for i in range(32):
+        value = Fraction(1)
+        for j in range(32):
+            if i != j:
+                value *= Fraction(33 - j, i - j)
+        expected += abs(value)
+    assert result.maximum.polynomial == (expected.denominator, -expected.numerator)
+
+
+def test_inherited_deadline_is_not_replaced() -> None:
+    request = source((-1, 0, 1), -1, 1)
+    with request_execution(time.monotonic()):
+        bind_request_deadline(time.monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            lebesgue_interval_profile(request)
+
+
+def test_sixteen_node_complete_profile_remains_accepted() -> None:
+    result = lebesgue_interval_profile(source(tuple(range(16)), 0, 15))
+    assert len(result.cells) == 15
+    assert all(len(cell.critical_points) == 1 for cell in result.cells)
+    assert len(result.maximizing_points) == 2
+    assert result.maximum.real_root_index >= 0
+    assert (
+        LebesgueIntervalProfile.model_validate_json(result.model_dump_json()) == result
+    )
+
+
+def test_constant_query_retains_large_rational_endpoints() -> None:
+    endpoint = 10**2000
+    request = source((0,), -endpoint, endpoint)
+    result = lebesgue_interval_profile(request)
+    assert result.maximizing_intervals == (request.interval,)
+    assert result.maximum.polynomial == (1, -1)
+    assert (
+        LebesgueIntervalProfile.model_validate_json(result.model_dump_json()) == result
+    )
+
+
+def test_unrepresentable_interior_degree_rejects_before_basis_expansion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.analysis.approximation.lebesgue import operations
+
+    def unexpected_expansion(*args: object) -> None:
+        pytest.fail("basis expansion preceded complete source admission")
+
+    monkeypatch.setattr(operations, "_poly_multiply", unexpected_expansion)
+    with pytest.raises(OperationResourceAdmissionError, match="degree"):
+        lebesgue_interval_profile(source(tuple(range(32)), 0, 31))

--- a/tests/mcp/test_lebesgue_interval_boundary.py
+++ b/tests/mcp/test_lebesgue_interval_boundary.py
@@ -1,0 +1,35 @@
+"""Live exact Lebesgue profile parity and retained basis composition."""
+
+import asyncio
+import json
+
+from jacobian.math.analysis.approximation.lebesgue._tools import TOOLS
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_lebesgue_profile_native_mcp_and_basis_composition() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        async with Client(create_server(), raise_exceptions=False) as client:
+            result = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not result.is_error
+            assert result.structured_content is not None
+            output = result.structured_content["output"]
+            assert output == tool.run(request).model_dump(mode="json")
+            basis = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "approximation.lagrange.basis.compute",
+                    "payload": {"nodes": output["source"]["nodes"]},
+                },
+            )
+            assert not basis.is_error
+            assert basis.structured_content is not None
+            assert basis.structured_content["output"] == output["basis"]
+
+    asyncio.run(scenario())


### PR DESCRIPTION
The approximation catalog exposes a rational Lagrange basis but cannot return the complete extrema of its Lebesgue function on a supplied subinterval. This adds `approximation.lebesgue.interval_profiles.compute`, retaining every sign cell, exact derivative critical point and value, cell maximum, and tied global maximizing point or constant interval.

For nodes `(-1,0,1)` on `[-1,1]`, the profile returns the two cell polynomials `1-x-x²` and `1+x-x²`, with global maximum `5/4` at both `-1/2` and `1/2`. Query intervals may be proper subintervals, singletons, or outside the node hull. The result reuses the canonical Lagrange basis, rational intervals, and real-algebraic values.

Source-derived admission bounds basis and resultant coefficient growth, root separation/refinement, comparison products, and complete mathematical allocation before expansion. Structural exterior cells avoid unnecessary root isolation; accepted regressions include a complete 16-node interior profile and a 32-node exterior profile. A separate 18-node interior probe also completed. Generic interior critical degrees above the canonical degree-16 carrier remain rejected. The retained cell polynomials support the later threshold query discussed in the issue; this PR implements maximization first, as that comment permits.

Closes #2859. This completes the fixed-node interval-profile portion omitted from #1842; it does not supersede an existing public operation.

Validation:

- Independent exact-diff review completed; the interval-Horner refinement bound was checked explicitly.
- `make affected AFFECTED_BASE=origin/main`: all six commands passed (scoped Ruff/mypy, 38 approximation tests, 156 catalog tests, 916 catalog integration tests, 75 MCP tests).
- Scoped public-operation conformance passed; architecture passed (1352 files); all four import contracts passed.
- Independent polynomial identities check irrational critical values, endpoint ties, constant loci, serialization and live MCP parity.

Mathematical source: [Tao, Lower bounds for Lagrange functions](https://terrytao.wordpress.com/wp-content/uploads/2026/02/erdos-1153-1.pdf), for the fixed-node Lebesgue function and arbitrary-subinterval use case. The operation evaluates supplied finite data.

[Hosted CI](https://github.com/morluto/jacobian/actions/runs/34182703503) passed on the published head.
