### PR TITLE
feat(geometry): extend distance profiles to real quadratic coordinates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "scipy==1.16.1",
     "sympy==1.14.0",
     "typer>=0.20,<1",
+    "typing-extensions>=4.14.1",
     "z3-solver==5.1.0.0",
 ]
 

--- a/src/jacobian/math/geometry/exact/__init__.py
+++ b/src/jacobian/math/geometry/exact/__init__.py
@@ -1,5 +1,9 @@
 """Exact-geometry operation ownership."""
 
+from jacobian.math.geometry.exact._models import (
+    LabelledQuadraticPoint,
+    QuadraticPointConfiguration,
+)
 from jacobian.math.geometry.exact.operations import (
     distance_graph,
     distance_profile,
@@ -12,6 +16,8 @@ from jacobian.math.geometry.exact.operations import (
 )
 
 __all__ = [
+    "LabelledQuadraticPoint",
+    "QuadraticPointConfiguration",
     "distance_graph",
     "distance_profile",
     "euclidean_orbit_profile",

--- a/src/jacobian/math/geometry/exact/_models.py
+++ b/src/jacobian/math/geometry/exact/_models.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Self
+from typing import Annotated, Generic, Literal, Self
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
+from typing_extensions import TypeVar
 
 from jacobian._exact import CanonicalRational, DecimalIntegerEncoding
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 from jacobian.math.matrices.values import RationalMatrix
+from jacobian.math.number_theory.algebraic_numbers.quadratic import RealQuadraticValue
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -95,24 +97,117 @@ class PointConfiguration(StrictModel):
         return self
 
 
-class DistanceProfileRequest(StrictModel):
+class LabelledQuadraticPoint(StrictModel):
+    """A labelled planar point with coordinates in one real quadratic field."""
+
+    label: str = Field(min_length=1, max_length=64)
+    coordinates: tuple[RealQuadraticValue, RealQuadraticValue]
+
+
+class QuadraticPointConfiguration(StrictModel):
+    """One positive-root embedding and a retained labelled point axis.
+
+    Distinct labels may share coordinates; their pair then has exact distance
+    zero. Parsing binds the coordinate parents; the consuming operation admits
+    square-freeness once for the common field.
+    """
+
+    radicand: StrictInt = Field(ge=2, le=1_000_000)
+    embedding: Literal["POSITIVE_ROOT"] = "POSITIVE_ROOT"
+    points: tuple[LabelledQuadraticPoint, ...] = Field(max_length=MAX_POINTS)
+
+    @model_validator(mode="after")
+    def require_shared_parent_and_labels(self) -> Self:
+        if len({point.label for point in self.points}) != len(self.points):
+            raise _validation_error(
+                "point_labels_unique", "point labels must be unique"
+            )
+        if any(
+            coordinate.radicand != self.radicand
+            for point in self.points
+            for coordinate in point.coordinates
+        ):
+            raise _validation_error(
+                "quadratic_parent_mismatch",
+                "every coordinate must retain the configuration radicand",
+            )
+        return self
+
+
+type DistanceConfiguration = PointConfiguration | QuadraticPointConfiguration
+type ExactSquaredDistance = CanonicalRational | RealQuadraticValue
+
+ConfigurationT = TypeVar(
+    "ConfigurationT",
+    bound=DistanceConfiguration,
+    default=PointConfiguration,
+    covariant=True,
+)
+DistanceT = TypeVar(
+    "DistanceT", bound=ExactSquaredDistance, default=CanonicalRational, covariant=True
+)
+
+
+class DistanceProfileRequest(StrictModel, Generic[ConfigurationT]):
     """Compute exact pairwise squared distances."""
 
-    configuration: PointConfiguration
+    configuration: ConfigurationT
 
 
-class DistanceMultiplicityEntry(StrictModel):
+class DistanceMultiplicityEntry(StrictModel, Generic[DistanceT]):
     """One squared distance and how many pairs have it."""
 
-    squared_distance: CanonicalRational
+    squared_distance: DistanceT
     pair_count: int = Field(gt=0)
+    pairs: tuple[tuple[int, int], ...] = Field(min_length=1, max_length=MAX_PAIRS)
+
+    @model_validator(mode="after")
+    def require_pair_axis(self) -> Self:
+        if self.pair_count != len(self.pairs) or self.pairs != tuple(
+            sorted(set(self.pairs))
+        ):
+            raise _validation_error(
+                "distance_pair_axis",
+                "pair count must match the sorted unique pair rows",
+            )
+        return self
 
 
-class DistanceProfileResult(StrictModel):
+class DistanceProfileResult(StrictModel, Generic[ConfigurationT, DistanceT]):
     """Complete distance multiplicity profile of a point configuration."""
 
-    configuration: PointConfiguration
-    entries: tuple[DistanceMultiplicityEntry, ...]
+    configuration: ConfigurationT
+    entries: tuple[DistanceMultiplicityEntry[DistanceT], ...]
+
+    @model_validator(mode="after")
+    def require_complete_pair_axis(self) -> Self:
+        size = len(self.configuration.points)
+        pairs = [pair for entry in self.entries for pair in entry.pairs]
+        if (
+            len(pairs) != size * (size - 1) // 2
+            or len(set(pairs)) != len(pairs)
+            or any(not 0 <= i < j < size for i, j in pairs)
+        ):
+            raise _validation_error(
+                "distance_pair_coverage",
+                "distance classes must partition the complete source pair axis",
+            )
+        for entry in self.entries:
+            if isinstance(self.configuration, QuadraticPointConfiguration):
+                if (
+                    not isinstance(entry.squared_distance, RealQuadraticValue)
+                    or entry.squared_distance.radicand != self.configuration.radicand
+                ):
+                    raise _validation_error(
+                        "distance_value_parent",
+                        "distance values must retain the source quadratic field",
+                    )
+            elif not isinstance(entry.squared_distance, CanonicalRational):
+                raise _validation_error(
+                    "distance_value_parent",
+                    "rational points require rational distance values",
+                )
+        return self
 
 
 class EuclideanOrbitProfileRequest(StrictModel):
@@ -164,20 +259,20 @@ class EuclideanOrbitProfileResult(StrictModel):
         return self
 
 
-class DistanceGraphRequest(StrictModel):
+class DistanceGraphRequest(StrictModel, Generic[ConfigurationT, DistanceT]):
     """Build the graph induced by a selected squared distance."""
 
-    configuration: PointConfiguration
-    target_squared_distance: CanonicalRational = Field(
+    configuration: ConfigurationT
+    target_squared_distance: DistanceT = Field(
         description="Nonnegative squared Euclidean distance to select.",
     )
 
 
-class DistanceGraphResult(StrictModel):
+class DistanceGraphResult(StrictModel, Generic[ConfigurationT, DistanceT]):
     """Distance-selected graph retained with its source and target."""
 
-    configuration: PointConfiguration
-    target_squared_distance: CanonicalRational
+    configuration: ConfigurationT
+    target_squared_distance: DistanceT
     graph: IndexedSimpleUndirectedGraph
 
 
@@ -189,11 +284,13 @@ __all__ = [
     "DistanceProfileResult",
     "EuclideanOrbitProfileRequest",
     "EuclideanOrbitProfileResult",
+    "LabelledQuadraticPoint",
     "LabelledRationalPoint",
     "PinnedLineDistanceRequest",
     "PinnedLineDistanceResult",
     "PinnedLineEntry",
     "PointConfiguration",
+    "QuadraticPointConfiguration",
 ]
 
 

--- a/src/jacobian/math/geometry/exact/_quadratic_distances.py
+++ b/src/jacobian/math/geometry/exact/_quadratic_distances.py
@@ -112,9 +112,10 @@ def _admit(
             for bound in (rational_bits, radical_bits, denominator_bits)
         ):
             _reject()
-        output_bits += rational_bits + radical_bits + 2 * denominator_bits
+        if retain_values:
+            output_bits += rational_bits + radical_bits + 2 * denominator_bits
         rows.append(_Pair((i, j), (a, b, c, e)))
-    if output_bits > 16_777_216:
+    if retain_values and output_bits > 16_777_216:
         raise OperationResourceAdmissionError(
             location=("configuration",),
             code="geometry.quadratic_distance.output_allocation",

--- a/src/jacobian/math/geometry/exact/_quadratic_distances.py
+++ b/src/jacobian/math/geometry/exact/_quadratic_distances.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from fractions import Fraction
 from functools import cmp_to_key
 from itertools import combinations
-from math import lcm
 
 from jacobian._exact import CanonicalRational
 from jacobian._execution import (
@@ -87,35 +86,30 @@ def _admit(
             )
         )
         a, b, c, e = differences
-        denominator = lcm(*(v.denominator for v in differences))
-        # Bring all four differences to one positive denominator D. These
-        # integer component bit bounds price the sum of squares and the two
-        # cross terms before either is expanded.
-        bits = tuple(
-            0
-            if not v
-            else abs(v.numerator).bit_length()
-            + (denominator // v.denominator).bit_length()
-            for v in differences
+        # Reduced squared-distance coefficients are admitted after cancellation,
+        # not the unreduced common-denominator expansion.
+        rational = (
+            a * a
+            + configuration.radicand * b * b
+            + c * c
+            + configuration.radicand * e * e
         )
-        terms = [
-            2 * k + (configuration.radicand.bit_length() if index in (1, 3) else 0)
-            for index, k in enumerate(bits)
-            if k
-        ]
-        rational_bits = max(terms, default=0) + max(1, len(terms)).bit_length()
-        products = [
-            bits[i] + bits[j] + 1 for i, j in ((0, 1), (2, 3)) if bits[i] and bits[j]
-        ]
-        radical_bits = max(products, default=0) + max(1, len(products)).bit_length()
-        denominator_bits = 2 * denominator.bit_length()
-        if retain_values and any(
-            (bound * 30103 + 99999) // 100000 > 256
-            for bound in (rational_bits, radical_bits, denominator_bits)
-        ):
-            _reject()
+        radical = 2 * (a * b + c * e)
         if retain_values:
-            output_bits += rational_bits + radical_bits + 2 * denominator_bits
+            rational_bits = max(
+                abs(rational.numerator).bit_length(),
+                rational.denominator.bit_length(),
+            )
+            radical_bits = max(
+                abs(radical.numerator).bit_length(),
+                radical.denominator.bit_length(),
+            )
+            if any(
+                (bound * 30103 + 99999) // 100000 > 256
+                for bound in (rational_bits, radical_bits)
+            ):
+                _reject()
+            output_bits += rational_bits + radical_bits
         rows.append(_Pair((i, j), (a, b, c, e)))
     if retain_values and output_bits > 16_777_216:
         raise OperationResourceAdmissionError(

--- a/src/jacobian/math/geometry/exact/_quadratic_distances.py
+++ b/src/jacobian/math/geometry/exact/_quadratic_distances.py
@@ -70,7 +70,9 @@ def _admit(
     # bounded before polynomial field multiplication, and is retained rather
     # than repeated. This accepts a large common translation of small points.
     request_checkpoint("before quadratic distance admission")
-    require_square_free_radicand(configuration.radicand)
+    require_square_free_radicand(
+        configuration.radicand, location=("configuration", "radicand")
+    )
     rows = []
     output_bits = 0
     for i, j in combinations(range(len(configuration.points)), 2):
@@ -176,7 +178,9 @@ def quadratic_distance_graph(
             message="target and coordinates must use the same quadratic field",
         )
     with _deadline():
-        plan = _admit(configuration, retain_values=False)
+        require_square_free_radicand(
+            configuration.radicand, location=("configuration", "radicand")
+        )
         wanted = (
             target.rational_part.as_fraction(),
             target.radical_coefficient.as_fraction(),
@@ -188,6 +192,7 @@ def quadratic_distance_graph(
                 code="geometry.squared_distance_target_nonnegative",
                 message="squared distance target must be nonnegative",
             )
+        plan = _admit(configuration, retain_values=False)
         edges = []
         for row in plan:
             request_checkpoint("during exact quadratic distance selection")

--- a/src/jacobian/math/geometry/exact/_quadratic_distances.py
+++ b/src/jacobian/math/geometry/exact/_quadratic_distances.py
@@ -1,0 +1,202 @@
+"""Admitted exact pair ledgers in one selected real quadratic field."""
+
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from fractions import Fraction
+from functools import cmp_to_key
+from itertools import combinations
+from math import lcm
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.geometry.exact._models import (
+    DistanceGraphResult,
+    DistanceMultiplicityEntry,
+    DistanceProfileResult,
+    QuadraticPointConfiguration,
+)
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+from jacobian.math.number_theory.algebraic_numbers.quadratic import (
+    RealQuadraticValue,
+    _sign,
+    require_square_free_radicand,
+)
+
+
+@dataclass(frozen=True)
+class _Pair:
+    indices: tuple[int, int]
+    differences: tuple[Fraction, Fraction, Fraction, Fraction]
+
+
+def _reject() -> None:
+    raise OperationResourceAdmissionError(
+        location=("configuration",),
+        code="geometry.quadratic_distance.coefficient_growth",
+        message="complete squared distances can exceed the canonical 256-digit quadratic coefficients",
+    )
+
+
+@contextmanager
+def _deadline() -> Iterator[None]:
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()), _deadline():
+            yield
+        return
+    deadline = execution.started_at + 60
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    yield
+
+
+def _admit(
+    configuration: QuadraticPointConfiguration, *, retain_values: bool = True
+) -> tuple[_Pair, ...]:
+    # The shared value bounds each input coefficient to 256 digits and the
+    # geometry owner bounds 64 points. Linear scalar cancellation is therefore
+    # bounded before polynomial field multiplication, and is retained rather
+    # than repeated. This accepts a large common translation of small points.
+    request_checkpoint("before quadratic distance admission")
+    require_square_free_radicand(configuration.radicand)
+    rows = []
+    output_bits = 0
+    for i, j in combinations(range(len(configuration.points)), 2):
+        request_checkpoint("during quadratic distance admission")
+        left, right = configuration.points[i], configuration.points[j]
+        differences = tuple(
+            part.as_fraction() - other.as_fraction()
+            for x, y in zip(left.coordinates, right.coordinates, strict=True)
+            for part, other in (
+                (x.rational_part, y.rational_part),
+                (x.radical_coefficient, y.radical_coefficient),
+            )
+        )
+        a, b, c, e = differences
+        denominator = lcm(*(v.denominator for v in differences))
+        # Bring all four differences to one positive denominator D. These
+        # integer component bit bounds price the sum of squares and the two
+        # cross terms before either is expanded.
+        bits = tuple(
+            0
+            if not v
+            else abs(v.numerator).bit_length()
+            + (denominator // v.denominator).bit_length()
+            for v in differences
+        )
+        terms = [
+            2 * k + (configuration.radicand.bit_length() if index in (1, 3) else 0)
+            for index, k in enumerate(bits)
+            if k
+        ]
+        rational_bits = max(terms, default=0) + max(1, len(terms)).bit_length()
+        products = [
+            bits[i] + bits[j] + 1 for i, j in ((0, 1), (2, 3)) if bits[i] and bits[j]
+        ]
+        radical_bits = max(products, default=0) + max(1, len(products)).bit_length()
+        denominator_bits = 2 * denominator.bit_length()
+        if retain_values and any(
+            (bound * 30103 + 99999) // 100000 > 256
+            for bound in (rational_bits, radical_bits, denominator_bits)
+        ):
+            _reject()
+        output_bits += rational_bits + radical_bits + 2 * denominator_bits
+        rows.append(_Pair((i, j), (a, b, c, e)))
+    if output_bits > 16_777_216:
+        raise OperationResourceAdmissionError(
+            location=("configuration",),
+            code="geometry.quadratic_distance.output_allocation",
+            message="complete quadratic distance coefficients exceed the admitted allocation",
+        )
+    return tuple(rows)
+
+
+def _value(a: Fraction, b: Fraction, d: int) -> RealQuadraticValue:
+    return RealQuadraticValue(
+        rational_part=CanonicalRational.from_fraction(a),
+        radical_coefficient=CanonicalRational.from_fraction(b),
+        radicand=d,
+    )
+
+
+def quadratic_distance_profile(
+    configuration: QuadraticPointConfiguration,
+) -> DistanceProfileResult[QuadraticPointConfiguration, RealQuadraticValue]:
+    with _deadline():
+        return _profile(configuration, _admit(configuration))
+
+
+def _profile(
+    configuration: QuadraticPointConfiguration, plan: tuple[_Pair, ...]
+) -> DistanceProfileResult[QuadraticPointConfiguration, RealQuadraticValue]:
+    d = configuration.radicand
+    classes: dict[tuple[Fraction, Fraction], list[tuple[int, int]]] = {}
+    for row in plan:
+        request_checkpoint("during exact quadratic distance expansion")
+        a, b, c, e = row.differences
+        key = (a * a + d * b * b + c * c + d * e * e, 2 * (a * b + c * e))
+        classes.setdefault(key, []).append(row.indices)
+
+    def order(left: tuple[Fraction, Fraction], right: tuple[Fraction, Fraction]) -> int:
+        return _sign(left[0] - right[0], left[1] - right[1], d)
+
+    return DistanceProfileResult[QuadraticPointConfiguration, RealQuadraticValue](
+        configuration=configuration,
+        entries=tuple(
+            DistanceMultiplicityEntry[RealQuadraticValue](
+                squared_distance=_value(*key, d),
+                pair_count=len(classes[key]),
+                pairs=tuple(classes[key]),
+            )
+            for key in sorted(classes, key=cmp_to_key(order))
+        ),
+    )
+
+
+def quadratic_distance_graph(
+    configuration: QuadraticPointConfiguration, target: RealQuadraticValue
+) -> DistanceGraphResult[QuadraticPointConfiguration, RealQuadraticValue]:
+    if target.radicand != configuration.radicand:
+        raise OperationDomainValidationError(
+            location=("target_squared_distance", "radicand"),
+            code="geometry.quadratic_distance.target_parent_mismatch",
+            message="target and coordinates must use the same quadratic field",
+        )
+    with _deadline():
+        plan = _admit(configuration, retain_values=False)
+        wanted = (
+            target.rational_part.as_fraction(),
+            target.radical_coefficient.as_fraction(),
+        )
+        d = configuration.radicand
+        if _sign(*wanted, d) < 0:
+            raise OperationDomainValidationError(
+                location=("target_squared_distance",),
+                code="geometry.squared_distance_target_nonnegative",
+                message="squared distance target must be nonnegative",
+            )
+        edges = []
+        for row in plan:
+            request_checkpoint("during exact quadratic distance selection")
+            a, b, c, e = row.differences
+            if (a * a + d * b * b + c * c + d * e * e, 2 * (a * b + c * e)) == wanted:
+                edges.append(row.indices)
+        return DistanceGraphResult[QuadraticPointConfiguration, RealQuadraticValue](
+            configuration=configuration,
+            target_squared_distance=target,
+            graph=IndexedSimpleUndirectedGraph(
+                vertex_count=len(configuration.points), edges=tuple(edges)
+            ),
+        )

--- a/src/jacobian/math/geometry/exact/_quadratic_distances.py
+++ b/src/jacobian/math/geometry/exact/_quadratic_distances.py
@@ -37,6 +37,7 @@ from jacobian.math.number_theory.algebraic_numbers.quadratic import (
 class _Pair:
     indices: tuple[int, int]
     differences: tuple[Fraction, Fraction, Fraction, Fraction]
+    squared: tuple[Fraction, Fraction]
 
 
 def _reject() -> None:
@@ -96,21 +97,20 @@ def _admit(
         )
         radical = 2 * (a * b + c * e)
         if retain_values:
-            rational_bits = max(
+            limit = 10**256
+            if any(
+                abs(component.numerator) >= limit or component.denominator >= limit
+                for component in (rational, radical)
+            ):
+                _reject()
+            output_bits += max(
                 abs(rational.numerator).bit_length(),
                 rational.denominator.bit_length(),
-            )
-            radical_bits = max(
+            ) + max(
                 abs(radical.numerator).bit_length(),
                 radical.denominator.bit_length(),
             )
-            if any(
-                (bound * 30103 + 99999) // 100000 > 256
-                for bound in (rational_bits, radical_bits)
-            ):
-                _reject()
-            output_bits += rational_bits + radical_bits
-        rows.append(_Pair((i, j), (a, b, c, e)))
+        rows.append(_Pair((i, j), (a, b, c, e), (rational, radical)))
     if retain_values and output_bits > 16_777_216:
         raise OperationResourceAdmissionError(
             location=("configuration",),
@@ -142,9 +142,7 @@ def _profile(
     classes: dict[tuple[Fraction, Fraction], list[tuple[int, int]]] = {}
     for row in plan:
         request_checkpoint("during exact quadratic distance expansion")
-        a, b, c, e = row.differences
-        key = (a * a + d * b * b + c * c + d * e * e, 2 * (a * b + c * e))
-        classes.setdefault(key, []).append(row.indices)
+        classes.setdefault(row.squared, []).append(row.indices)
 
     def order(left: tuple[Fraction, Fraction], right: tuple[Fraction, Fraction]) -> int:
         return _sign(left[0] - right[0], left[1] - right[1], d)
@@ -190,8 +188,7 @@ def quadratic_distance_graph(
         edges = []
         for row in plan:
             request_checkpoint("during exact quadratic distance selection")
-            a, b, c, e = row.differences
-            if (a * a + d * b * b + c * c + d * e * e, 2 * (a * b + c * e)) == wanted:
+            if row.squared == wanted:
                 edges.append(row.indices)
         return DistanceGraphResult[QuadraticPointConfiguration, RealQuadraticValue](
             configuration=configuration,

--- a/src/jacobian/math/geometry/exact/_tools.py
+++ b/src/jacobian/math/geometry/exact/_tools.py
@@ -4,12 +4,14 @@ from typing import Any
 
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.geometry.exact._models import (
+    DistanceConfiguration,
     DistanceGraphRequest,
     DistanceGraphResult,
     DistanceProfileRequest,
     DistanceProfileResult,
     EuclideanOrbitProfileRequest,
     EuclideanOrbitProfileResult,
+    ExactSquaredDistance,
     PinnedLineDistanceRequest,
     PinnedLineDistanceResult,
 )
@@ -21,8 +23,13 @@ from jacobian.math.geometry.exact.operations import (
 )
 
 
-def _run_distance_profile(request: DistanceProfileRequest) -> DistanceProfileResult:
-    return distance_profile(request.configuration)
+def _run_distance_profile(
+    request: DistanceProfileRequest[DistanceConfiguration],
+) -> DistanceProfileResult[DistanceConfiguration, ExactSquaredDistance]:
+    result = distance_profile(request.configuration)
+    return DistanceProfileResult[DistanceConfiguration, ExactSquaredDistance](
+        configuration=result.configuration, entries=result.entries
+    )
 
 
 def _run_euclidean_orbit_profile(
@@ -31,8 +38,15 @@ def _run_euclidean_orbit_profile(
     return euclidean_orbit_profile(request.configuration)
 
 
-def _run_distance_graph(request: DistanceGraphRequest) -> DistanceGraphResult:
-    return distance_graph(request.configuration, request.target_squared_distance)
+def _run_distance_graph(
+    request: DistanceGraphRequest[DistanceConfiguration, ExactSquaredDistance],
+) -> DistanceGraphResult[DistanceConfiguration, ExactSquaredDistance]:
+    result = distance_graph(request.configuration, request.target_squared_distance)
+    return DistanceGraphResult[DistanceConfiguration, ExactSquaredDistance](
+        configuration=result.configuration,
+        target_squared_distance=result.target_squared_distance,
+        graph=result.graph,
+    )
 
 
 def _run_pinned_line_distance_profile(
@@ -108,15 +122,57 @@ UNIT_SQUARE_ORIGIN = {
     "anchor": [{"num": "0", "den": "1"}, {"num": "0", "den": "1"}],
 }
 
+
+def _quadratic_example_value(
+    a: int, b: int = 0, denominator: int = 1
+) -> dict[str, Any]:
+    return {
+        "rational_part": {"num": str(a), "den": str(denominator) if a else "1"},
+        "radical_coefficient": {"num": str(b), "den": str(denominator) if b else "1"},
+        "radicand": 3,
+    }
+
+
+EQUILATERAL_QUADRATIC = {
+    "configuration": {
+        "radicand": 3,
+        "embedding": "POSITIVE_ROOT",
+        "points": [
+            {
+                "label": "A",
+                "coordinates": [
+                    _quadratic_example_value(0),
+                    _quadratic_example_value(0),
+                ],
+            },
+            {
+                "label": "B",
+                "coordinates": [
+                    _quadratic_example_value(1),
+                    _quadratic_example_value(0),
+                ],
+            },
+            {
+                "label": "C",
+                "coordinates": [
+                    _quadratic_example_value(1, denominator=2),
+                    _quadratic_example_value(0, 1, 2),
+                ],
+            },
+        ],
+    },
+}
+
+
 TOOLS: tuple[MathTool[Any, Any], ...] = (
     MathTool(
         operation_id="geometry.points.distance_profile.compute",
         title="Compute pairwise distance profile",
-        description="Given a finite set of labelled rational points, compute the exact "
+        description="Given labelled rational points or planar points in one explicitly selected positive-root real quadratic field, compute the exact "
         "squared distance for every unordered pair and return the distance "
-        "multiplicity profile.",
-        request_type=DistanceProfileRequest,
-        result_type=DistanceProfileResult,
+        "multiplicity profile with every source-indexed pair in each equality class. Distinct labels may coincide, producing squared distance zero.",
+        request_type=DistanceProfileRequest[DistanceConfiguration],
+        result_type=DistanceProfileResult[DistanceConfiguration, ExactSquaredDistance],
         run=_run_distance_profile,
         tags=("geometry", "distance", "exact"),
         examples=(
@@ -124,6 +180,11 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 name="unit_square_profile",
                 description="Distance profile of the unit square.",
                 input=UNIT_SQUARE,
+            ),
+            OperationExample(
+                name="quadratic_equilateral",
+                description="The triangle over QQ(sqrt(3)) has three source pairs of squared distance one.",
+                input=EQUILATERAL_QUADRATIC,
             ),
         ),
     ),
@@ -161,9 +222,9 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         title="Build distance-selected graph",
         description="Given a point configuration and a target squared distance, return "
         "the canonical integer-indexed simple graph whose edges connect pairs "
-        "at exactly that distance.",
-        request_type=DistanceGraphRequest,
-        result_type=DistanceGraphResult,
+        "at exactly that distance. Quadratic planar coordinates require a target RealQuadraticValue in the same positive-root field; rational coordinates require a rational target.",
+        request_type=DistanceGraphRequest[DistanceConfiguration, ExactSquaredDistance],
+        result_type=DistanceGraphResult[DistanceConfiguration, ExactSquaredDistance],
         run=_run_distance_graph,
         tags=("geometry", "distance-graph", "exact"),
         examples=(
@@ -173,6 +234,14 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 input={
                     **UNIT_SQUARE,
                     "target_squared_distance": {"num": "1", "den": "1"},
+                },
+            ),
+            OperationExample(
+                name="quadratic_unit_triangle",
+                description="Select all three unit pairs of the exact quadratic equilateral triangle.",
+                input={
+                    **EQUILATERAL_QUADRATIC,
+                    "target_squared_distance": _quadratic_example_value(1),
                 },
             ),
         ),

--- a/src/jacobian/math/geometry/exact/operations.py
+++ b/src/jacobian/math/geometry/exact/operations.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from fractions import Fraction
 from itertools import combinations, permutations
+from typing import overload
 
 from pydantic_core import PydanticCustomError
 
@@ -18,20 +18,28 @@ from jacobian.math.geometry.exact._line_arithmetic import (
     squared_point_line_distance,
 )
 from jacobian.math.geometry.exact._models import (
+    DistanceConfiguration,
     DistanceGraphResult,
     DistanceMultiplicityEntry,
     DistanceProfileResult,
     EuclideanOrbitProfileResult,
+    ExactSquaredDistance,
     LabelledRationalPoint,
     PinnedLineConfiguration,
     PinnedLineDistanceResult,
     PointConfiguration,
+    QuadraticPointConfiguration,
     _require_bounded_point_configuration,
     _validation_error,
 )
 from jacobian.math.geometry.exact._orbit_bounds import admit_orbit_profile
+from jacobian.math.geometry.exact._quadratic_distances import (
+    quadratic_distance_graph,
+    quadratic_distance_profile,
+)
 from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 from jacobian.math.matrices.values import RationalMatrix
+from jacobian.math.number_theory.algebraic_numbers.quadratic import RealQuadraticValue
 
 
 def _to_fraction_point(point: LabelledRationalPoint) -> tuple[Fraction, ...]:
@@ -47,20 +55,38 @@ def _squared_distance(
     return result
 
 
-def distance_profile(configuration: PointConfiguration) -> DistanceProfileResult:
+@overload
+def distance_profile(configuration: PointConfiguration) -> DistanceProfileResult: ...
+
+
+@overload
+def distance_profile(
+    configuration: QuadraticPointConfiguration,
+) -> DistanceProfileResult[QuadraticPointConfiguration, RealQuadraticValue]: ...
+
+
+def distance_profile(
+    configuration: DistanceConfiguration,
+) -> (
+    DistanceProfileResult
+    | DistanceProfileResult[QuadraticPointConfiguration, RealQuadraticValue]
+):
     """Compute exact pairwise squared distances for every unordered pair."""
+    if isinstance(configuration, QuadraticPointConfiguration):
+        return quadratic_distance_profile(configuration)
     points = [_to_fraction_point(point) for point in configuration.points]
-    distances: Counter[Fraction] = Counter(
-        _squared_distance(points[left], points[right])
-        for left in range(len(points))
-        for right in range(left + 1, len(points))
-    )
+    distances: dict[Fraction, list[tuple[int, int]]] = {}
+    for left, right in combinations(range(len(points)), 2):
+        distances.setdefault(_squared_distance(points[left], points[right]), []).append(
+            (left, right)
+        )
     entries = tuple(
         DistanceMultiplicityEntry(
             squared_distance=CanonicalRational.from_fraction(distance),
-            pair_count=count,
+            pair_count=len(pairs),
+            pairs=tuple(pairs),
         )
-        for distance, count in sorted(distances.items())
+        for distance, pairs in sorted(distances.items())
     )
     return DistanceProfileResult(
         configuration=configuration,
@@ -68,11 +94,44 @@ def distance_profile(configuration: PointConfiguration) -> DistanceProfileResult
     )
 
 
+@overload
 def distance_graph(
-    configuration: PointConfiguration,
-    target_squared_distance: CanonicalRational,
-) -> DistanceGraphResult:
+    configuration: PointConfiguration, target_squared_distance: CanonicalRational
+) -> DistanceGraphResult: ...
+
+
+@overload
+def distance_graph(
+    configuration: QuadraticPointConfiguration,
+    target_squared_distance: RealQuadraticValue,
+) -> DistanceGraphResult[QuadraticPointConfiguration, RealQuadraticValue]: ...
+
+
+@overload
+def distance_graph(
+    configuration: DistanceConfiguration, target_squared_distance: ExactSquaredDistance
+) -> DistanceGraphResult[DistanceConfiguration, ExactSquaredDistance]: ...
+
+
+def distance_graph(
+    configuration: DistanceConfiguration,
+    target_squared_distance: ExactSquaredDistance,
+) -> DistanceGraphResult[DistanceConfiguration, ExactSquaredDistance]:
     """Build the graph whose edges connect pairs at the target distance."""
+    if isinstance(configuration, QuadraticPointConfiguration):
+        if isinstance(target_squared_distance, RealQuadraticValue):
+            return quadratic_distance_graph(configuration, target_squared_distance)
+        raise OperationDomainValidationError(
+            location=("target_squared_distance",),
+            code="geometry.quadratic_distance.target_domain",
+            message="quadratic coordinates require a target in their explicit quadratic field",
+        )
+    if not isinstance(target_squared_distance, CanonicalRational):
+        raise OperationDomainValidationError(
+            location=("target_squared_distance",),
+            code="geometry.distance.target_domain",
+            message="rational coordinates require a rational squared-distance target",
+        )
     if target_squared_distance.as_fraction() < 0:
         raise OperationDomainValidationError(
             location=("target_squared_distance",),

--- a/tests/dispatch/test_matrix_dispatch.py
+++ b/tests/dispatch/test_matrix_dispatch.py
@@ -74,7 +74,7 @@ def _oversized_partial_trace_payload() -> dict[str, Any]:
         ),
         (
             "matrix.permanent.compute",
-            _identity_payload(MAX_MATRIX_DIMENSION + 1),
+            _identity_payload(MAX_PERMANENT_MATRIX_ORDER + 1),
             MAX_PERMANENT_MATRIX_ORDER,
             OperationRequestValidationError,
         ),

--- a/tests/integration/test_exact_geometry_verification_failures.py
+++ b/tests/integration/test_exact_geometry_verification_failures.py
@@ -50,7 +50,18 @@ def _claim(owner: str, verifier: str) -> tuple[Any, Any]:
     module = import_module("jacobian.math.geometry." + owner + ".operations")
     tools = import_module("jacobian.math.geometry." + owner + "._tools").TOOLS
     result_type = get_type_hints(getattr(module, verifier))["claim"]
-    tool = next(tool for tool in tools if tool.result_type is result_type)
+    if owner == "exact" and verifier in (
+        "verify_distance_profile",
+        "verify_distance_graph",
+    ):
+        # Catalog union and native rational specializations have distinct
+        # generic identities; select the public operation being exercised.
+        operation_id = (
+            "geometry.points." + verifier.removeprefix("verify_") + ".compute"
+        )
+        tool = next(tool for tool in tools if tool.operation_id == operation_id)
+    else:
+        tool = next(tool for tool in tools if tool.result_type is result_type)
     request = tool.request_type.model_validate_json(json.dumps(tool.examples[0].input))
     return module, tool.run(request)
 

--- a/tests/math/geometry/test_quadratic_distance_profiles.py
+++ b/tests/math/geometry/test_quadratic_distance_profiles.py
@@ -206,6 +206,18 @@ def test_existing_operation_ids_accept_quadratic_sources_and_retain_types() -> N
     assert tool.result_type.model_validate_json(result.model_dump_json()) == result
 
 
+def test_256_digit_squared_distance_is_admitted() -> None:
+    source = configuration(
+        (
+            (value(0, d=2), value(0, d=2)),
+            (value(9 * 10**127, d=2), value(0, d=2)),
+        ),
+        d=2,
+    )
+    result = distance_profile(source)
+    assert result.entries[0].squared_distance.rational_part.num == 81 * 10**254
+
+
 def test_expired_deadline_is_preserved() -> None:
     source = configuration(((value(0), value(0)), (value(1), value(0))))
     with request_execution(time.monotonic()):

--- a/tests/math/geometry/test_quadratic_distance_profiles.py
+++ b/tests/math/geometry/test_quadratic_distance_profiles.py
@@ -184,6 +184,17 @@ def test_mixed_and_non_square_free_fields_reject() -> None:
         distance_graph(source, value(1, d=2))
     with pytest.raises(OperationDomainValidationError, match="nonnegative"):
         distance_graph(source, value(-1))
+    heavy = configuration(
+        tuple(
+            (
+                value(Fraction(1, 10**250 + i + 3)),
+                value(Fraction(1, 10**249 + i + 5)),
+            )
+            for i in range(64)
+        )
+    )
+    with pytest.raises(OperationDomainValidationError, match="nonnegative"):
+        distance_graph(heavy, value(-1))
 
 
 def test_existing_operation_ids_accept_quadratic_sources_and_retain_types() -> None:

--- a/tests/math/geometry/test_quadratic_distance_profiles.py
+++ b/tests/math/geometry/test_quadratic_distance_profiles.py
@@ -201,3 +201,16 @@ def test_expired_deadline_is_preserved() -> None:
         bind_request_deadline(time.monotonic() - 1)
         with pytest.raises(OperationExecutionTimeoutError):
             distance_profile(source)
+
+
+def test_graph_selection_does_not_inherit_profile_output_bits() -> None:
+    huge = Fraction(1, 10**250 + 7)
+    points = tuple(
+        (
+            value(huge, Fraction(1, 10**249 + i + 3)),
+            value(Fraction(1, 10**248 + i + 5), Fraction(1, 10**247 + i + 11)),
+        )
+        for i in range(64)
+    )
+    selected = distance_graph(configuration(points), value(0))
+    assert selected.graph.edges == ()

--- a/tests/math/geometry/test_quadratic_distance_profiles.py
+++ b/tests/math/geometry/test_quadratic_distance_profiles.py
@@ -1,0 +1,203 @@
+"""Exact quadratic pair classes and composition with distance graphs."""
+
+import json
+import time
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+from sympy import Rational, expand, sqrt
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.geometry.exact import (
+    LabelledQuadraticPoint,
+    QuadraticPointConfiguration,
+    distance_graph,
+    distance_profile,
+)
+from jacobian.math.geometry.exact._models import DistanceProfileResult
+from jacobian.math.geometry.exact._tools import EQUILATERAL_QUADRATIC, TOOLS
+from jacobian.math.number_theory.algebraic_numbers.quadratic import RealQuadraticValue
+
+
+def value(a: int | Fraction, b: int | Fraction = 0, d: int = 3) -> RealQuadraticValue:
+    return RealQuadraticValue(
+        rational_part=CanonicalRational.from_fraction(Fraction(a)),
+        radical_coefficient=CanonicalRational.from_fraction(Fraction(b)),
+        radicand=d,
+    )
+
+
+def configuration(
+    points: tuple[tuple[RealQuadraticValue, RealQuadraticValue], ...], d: int = 3
+) -> QuadraticPointConfiguration:
+    return QuadraticPointConfiguration(
+        radicand=d,
+        points=tuple(
+            LabelledQuadraticPoint(label=str(i), coordinates=p)
+            for i, p in enumerate(points)
+        ),
+    )
+
+
+def test_equilateral_profile_and_selected_graph() -> None:
+    source = QuadraticPointConfiguration.model_validate_json(
+        json.dumps(EQUILATERAL_QUADRATIC["configuration"])
+    )
+    result = distance_profile(source)
+    assert len(result.entries) == 1
+    assert result.entries[0].squared_distance == value(1)
+    assert result.entries[0].pairs == ((0, 1), (0, 2), (1, 2))
+    assert result.entries[0].pair_count == 3
+    decoded = DistanceProfileResult[
+        QuadraticPointConfiguration, RealQuadraticValue
+    ].model_validate_json(result.model_dump_json())
+    selected = distance_graph(
+        decoded.configuration, decoded.entries[0].squared_distance
+    )
+    assert selected.graph.edges == ((0, 1), (0, 2), (1, 2))
+
+
+def test_every_class_replays_independent_symbolic_pair_identity() -> None:
+    source = configuration(
+        tuple(
+            (
+                value(Fraction(i, 3), Fraction(i % 3, 2)),
+                value(Fraction(i * i, 5), Fraction((-1) ** i, 3)),
+            )
+            for i in range(7)
+        )
+    )
+    result = distance_profile(source)
+    seen = set()
+    for entry in result.entries:
+        actual = entry.squared_distance
+        exact = Rational(actual.rational_part.num, actual.rational_part.den) + Rational(
+            actual.radical_coefficient.num, actual.radical_coefficient.den
+        ) * sqrt(3)
+        for i, j in entry.pairs:
+            expected = 0
+            for left, right in zip(
+                source.points[i].coordinates, source.points[j].coordinates, strict=True
+            ):
+                a = left.rational_part.as_fraction() - right.rational_part.as_fraction()
+                b = (
+                    left.radical_coefficient.as_fraction()
+                    - right.radical_coefficient.as_fraction()
+                )
+                expected += (
+                    Rational(a.numerator, a.denominator)
+                    + Rational(b.numerator, b.denominator) * sqrt(3)
+                ) ** 2
+            assert expand(expected - exact) == 0
+            seen.add((i, j))
+    assert len(seen) == 21
+    assert sum(entry.pair_count for entry in result.entries) == 21
+
+
+def test_anisotropic_lattice_retains_each_pinned_pair_partition() -> None:
+    positions = ((0, 0), (1, 0), (0, 1), (1, 1))
+    source = configuration(
+        tuple((value(x, d=2), value(0, y, d=2)) for x, y in positions), 2
+    )
+    result = distance_profile(source)
+    assert [
+        (e.squared_distance.rational_part.num, e.pair_count) for e in result.entries
+    ] == [(1, 2), (2, 2), (3, 2)]
+    for center in range(4):
+        assert (
+            sum(center in pair for entry in result.entries for pair in entry.pairs) == 3
+        )
+
+
+def test_source_permutation_preserves_labelled_classes() -> None:
+    source = configuration(
+        ((value(0), value(0)), (value(1, 1), value(0)), (value(1, -1), value(0)))
+    )
+    permuted = QuadraticPointConfiguration(
+        radicand=3, points=tuple(reversed(source.points))
+    )
+
+    def labelled(s: QuadraticPointConfiguration) -> dict[str, set[tuple[str, ...]]]:
+        return {
+            e.squared_distance.model_dump_json(): {
+                tuple(sorted((s.points[i].label, s.points[j].label)))
+                for i, j in e.pairs
+            }
+            for e in distance_profile(s).entries
+        }
+
+    assert labelled(source) == labelled(permuted)
+
+
+@pytest.mark.parametrize("size", [0, 1, 2])
+def test_empty_singleton_and_coincident_configurations(size: int) -> None:
+    source = configuration(tuple((value(0), value(0)) for _ in range(size)))
+    result = distance_profile(source)
+    assert sum(e.pair_count for e in result.entries) == size * (size - 1) // 2
+    assert all(e.squared_distance == value(0) for e in result.entries)
+    assert distance_graph(source, value(0)).graph.vertex_count == size
+
+
+def test_shared_large_translation_is_accepted_for_64_points() -> None:
+    translation = 10**250
+    source = configuration(tuple((value(translation + i), value(0)) for i in range(64)))
+    result = distance_profile(source)
+    assert sum(e.pair_count for e in result.entries) == 2016
+    assert len(result.entries) == 63
+    decoded = DistanceProfileResult[
+        QuadraticPointConfiguration, RealQuadraticValue
+    ].model_validate_json(result.model_dump_json())
+    assert distance_graph(
+        decoded.configuration, decoded.entries[0].squared_distance
+    ).graph.edges == tuple((i, i + 1) for i in range(63))
+
+
+def test_graph_selection_does_not_require_serializing_unselected_large_distances() -> (
+    None
+):
+    source = configuration(
+        ((value(0), value(0)), (value(1), value(0)), (value(10**250), value(0)))
+    )
+    with pytest.raises(OperationResourceAdmissionError):
+        distance_profile(source)
+    assert distance_graph(source, value(1)).graph.edges == ((0, 1),)
+
+
+def test_mixed_and_non_square_free_fields_reject() -> None:
+    with pytest.raises(ValidationError, match="radicand"):
+        configuration(((value(0), value(0, d=2)),))
+    invalid = configuration(((value(0, d=4), value(0, d=4)),), 4)
+    with pytest.raises(OperationDomainValidationError, match="square-free"):
+        distance_profile(invalid)
+    source = configuration(((value(0), value(0)),))
+    with pytest.raises(OperationDomainValidationError, match="same quadratic field"):
+        distance_graph(source, value(1, d=2))
+    with pytest.raises(OperationDomainValidationError, match="nonnegative"):
+        distance_graph(source, value(-1))
+
+
+def test_existing_operation_ids_accept_quadratic_sources_and_retain_types() -> None:
+    tool = next(
+        t for t in TOOLS if t.operation_id == "geometry.points.distance_profile.compute"
+    )
+    request = tool.request_type.model_validate_json(json.dumps(EQUILATERAL_QUADRATIC))
+    result = tool.run(request)
+    assert tool.result_type.model_validate_json(result.model_dump_json()) == result
+
+
+def test_expired_deadline_is_preserved() -> None:
+    source = configuration(((value(0), value(0)), (value(1), value(0))))
+    with request_execution(time.monotonic()):
+        bind_request_deadline(time.monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            distance_profile(source)

--- a/tests/math/geometry/test_source_bound_claim_verifiers.py
+++ b/tests/math/geometry/test_source_bound_claim_verifiers.py
@@ -66,7 +66,9 @@ def test_distance_profiles_retain_sources_and_reject_serialized_forgery() -> Non
     assert verify_distance_profile(decoded)
 
     forged = DistanceProfileResult.model_validate_json(
-        json.dumps(_forged_json(profile, ("entries", 0, "pair_count"), 99))
+        json.dumps(
+            _forged_json(profile, ("entries", 0, "squared_distance", "num"), "99")
+        )
     )
     assert not verify_distance_profile(forged)
 

--- a/tests/math/test_verifier_failure_channels.py
+++ b/tests/math/test_verifier_failure_channels.py
@@ -36,7 +36,16 @@ def test_verifiers_propagate_operational_failures(
 ) -> None:
     verifier = getattr(module, f"verify_{recompute}")
     result_type = get_type_hints(verifier)["claim"]
-    tool = next(tool for tool in BUILTIN_TOOLS if tool.result_type is result_type)
+    if module is exact_geometry and recompute == "distance_profile":
+        # Native rational-only and catalog union specializations intentionally
+        # have distinct Pydantic generic identities.
+        tool = next(
+            tool
+            for tool in BUILTIN_TOOLS
+            if tool.operation_id == "geometry.points.distance_profile.compute"
+        )
+    else:
+        tool = next(tool for tool in BUILTIN_TOOLS if tool.result_type is result_type)
     request = tool.request_type.model_validate_json(json.dumps(tool.examples[0].input))
     result = tool.run(request)
     claim = tool.result_type.model_validate_json(result.model_dump_json())

--- a/tests/mcp/test_quadratic_distance_boundary.py
+++ b/tests/mcp/test_quadratic_distance_boundary.py
@@ -1,0 +1,44 @@
+"""Quadratic profile values compose unchanged through the existing MCP IDs."""
+
+import asyncio
+
+from jacobian.math.geometry.exact._tools import EQUILATERAL_QUADRATIC
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_quadratic_pair_profile_composes_with_distance_graph() -> None:
+    async def scenario() -> None:
+        async with Client(create_server(), raise_exceptions=False) as client:
+            profile = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "geometry.points.distance_profile.compute",
+                    "payload": EQUILATERAL_QUADRATIC,
+                },
+            )
+            assert not profile.is_error
+            assert profile.structured_content is not None
+            result = profile.structured_content["output"]
+            assert result["entries"][0]["pairs"] == [[0, 1], [0, 2], [1, 2]]
+            selected = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "geometry.points.distance_graph.compute",
+                    "payload": {
+                        "configuration": result["configuration"],
+                        "target_squared_distance": result["entries"][0][
+                            "squared_distance"
+                        ],
+                    },
+                },
+            )
+            assert not selected.is_error
+            assert selected.structured_content is not None
+            assert selected.structured_content["output"]["graph"]["edges"] == [
+                [0, 1],
+                [0, 2],
+                [1, 2],
+            ]
+
+    asyncio.run(scenario())

--- a/uv.lock
+++ b/uv.lock
@@ -540,6 +540,7 @@ dependencies = [
     { name = "scipy" },
     { name = "sympy" },
     { name = "typer" },
+    { name = "typing-extensions" },
     { name = "z3-solver" },
 ]
 
@@ -600,6 +601,7 @@ requires-dist = [
     { name = "scipy", specifier = "==1.16.1" },
     { name = "sympy", specifier = "==1.14.0" },
     { name = "typer", specifier = ">=0.20,<1" },
+    { name = "typing-extensions", specifier = ">=4.14.1" },
     { name = "z3-solver", specifier = "==5.1.0.0" },
 ]
 


### PR DESCRIPTION
The existing distance profile and distance-graph operations cannot represent exact equilateral configurations over a real quadratic field. Both existing IDs now accept labelled planar coordinates in one explicit positive-root `QQ(sqrt(d))`, using canonical `RealQuadraticValue` coefficients and unchanged field-bound targets for graph selection.

Distance classes retain every source-indexed pair, including coincident labelled points at distance zero. Rational and quadratic profiles share the same typed profile and class models; generic type parameters preserve the rational native signatures. The rational profile also gains complete pair rows, so serialized multiplicity classes now include their provenance. This strengthens the earlier rational-only profile contract without adding another public operation ID.

The quadratic kernel admits coefficient growth before squaring and retains bounded coordinate differences, allowing large shared translations to cancel first. Graph selection does not require serializing unselected distances as quadratic result values. Mixed fields and negative targets are rejected explicitly; empty and singleton quadratic configurations preserve their parent and axes.

Closes #2825. Higher-degree fields and automatic composita remain outside this quadratic slice.

Validation:

- Independent exact-diff review completed. Exact ordering remains producer-owned; constructors check structural pair coverage and parent binding without replaying quadratic comparisons.
- `make affected AFFECTED_BASE=origin/main`: all six commands passed, including scoped Ruff/mypy, 56 affected geometry tests, 156 catalog tests, 916 catalog integration tests, and 76 MCP tests.
- Both public operation conformance checks passed; architecture passed (1352 files); all four import contracts passed.
- 44 existing geometry/claim tests passed. New tests independently replay every distance over the quadratic field, cover the equilateral and anisotropic lattice fixtures, and round-trip the actual 64-point result with a 250-digit shared translation through distance-graph selection.

Packaging and broader validation follow-up:

- Declare `typing-extensions` as a direct runtime dependency for Python 3.12 generic defaults; locked dependency analysis passes.
- Select the stable distance operation IDs in verifier-failure tests because native rational and catalog union specializations have different Pydantic identities. All 10 native failure-channel and 13 integration verifier cases pass.
- The shared dependency change selected all 13 affected commands. Full mathematics passed (9,428 tests), catalog passed (156), catalog examples passed (916), CLI and dispatch passed locally, and integration passed 453 cases with the two generic-identity failures subsequently repaired and rerun. Remaining selected tooling (311), MCP (76), process (308), Singular and QEPCAD (27) lanes passed. Import contracts, dependency analysis and architecture passed after the packaging change.
- Hosted CI on `3cabf5697` passed mathematics, static, catalog, integration, MCP/process, exact algebra and wheels. Its merge with current main exposed a stale permanent dispatch fixture that used another operation's dimension limit. The fixture now derives its refusal from `MAX_PERMANENT_MATRIX_ORDER`; all 10 focused dispatch cases passed. Final head: `bdc1be47e`.

[Final hosted CI](https://github.com/morluto/jacobian/actions/runs/34186071145) passed all selected required lanes on `bdc1be47ee07b82cc82a2d01352608caae2aac21`.
