### PR TITLE
feat(probability): exact hypergraph edge-count moments

### DIFF
--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/__init__.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/__init__.py
@@ -1,0 +1,8 @@
+from ._models import (
+    EdgeOverlapMomentRow,
+    HypergraphEdgeCountMomentsRequest,
+    HypergraphEdgeCountMomentsResult,
+)
+from .operations import compute_hypergraph_edge_count_moments
+
+__all__ = ["EdgeOverlapMomentRow", "HypergraphEdgeCountMomentsRequest", "HypergraphEdgeCountMomentsResult", "compute_hypergraph_edge_count_moments"]

--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/__init__.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/__init__.py
@@ -5,4 +5,9 @@ from ._models import (
 )
 from .operations import compute_hypergraph_edge_count_moments
 
-__all__ = ["EdgeOverlapMomentRow", "HypergraphEdgeCountMomentsRequest", "HypergraphEdgeCountMomentsResult", "compute_hypergraph_edge_count_moments"]
+__all__ = [
+    "EdgeOverlapMomentRow",
+    "HypergraphEdgeCountMomentsRequest",
+    "HypergraphEdgeCountMomentsResult",
+    "compute_hypergraph_edge_count_moments",
+]

--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/_models.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/_models.py
@@ -36,12 +36,16 @@ class EdgeOverlapMomentRow(StrictModel):
 class HypergraphEdgeCountMomentsRequest(StrictModel):
     hypergraph: FiniteHypergraph
     retention_probability: CanonicalRational = Field(
-        description="Exact edge-retention probability in the closed interval [0, 1]."
+        description=(
+            "Exact independent vertex-retention probability in the closed "
+            "interval [0, 1]. An edge survives with probability p^|e|."
+        )
     )
 
     @model_validator(mode="after")
     def validate_probability(self) -> Self:
-        if not 0 <= self.retention_probability.as_fraction() <= 1:
+        probability = self.retention_probability
+        if not 0 <= probability.num <= probability.den:
             raise ValueError("retention_probability must be between 0 and 1")
         return self
 

--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/_models.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/_models.py
@@ -1,0 +1,37 @@
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational, ExactInteger
+from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+
+
+class EdgeOverlapMomentRow(StrictModel):
+    edge_size_min: int = Field(ge=0)
+    edge_size_max: int = Field(ge=0)
+    intersection_size: int = Field(ge=0)
+    pair_count: ExactInteger = Field(ge=0)
+    union_size: int = Field(ge=0)
+    covariance: CanonicalRational
+
+class HypergraphEdgeCountMomentsRequest(StrictModel):
+    hypergraph: FiniteHypergraph
+    retention_probability: CanonicalRational
+    @model_validator(mode="after")
+    def validate_probability(self) -> Self:
+        if not 0 <= self.retention_probability.as_fraction() <= 1:
+            raise ValueError("retention_probability must be between 0 and 1")
+        return self
+
+class HypergraphEdgeCountMomentsResult(StrictModel):
+    hypergraph: FiniteHypergraph
+    retention_probability: CanonicalRational
+    edge_count_expectation: CanonicalRational
+    edge_count_second_moment: CanonicalRational
+    edge_count_variance: CanonicalRational
+    overlap_profile: tuple[EdgeOverlapMomentRow, ...]
+
+__all__ = ["EdgeOverlapMomentRow", "HypergraphEdgeCountMomentsRequest", "HypergraphEdgeCountMomentsResult"]

--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/_models.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/_models.py
@@ -35,7 +35,9 @@ class EdgeOverlapMomentRow(StrictModel):
 
 class HypergraphEdgeCountMomentsRequest(StrictModel):
     hypergraph: FiniteHypergraph
-    retention_probability: CanonicalRational
+    retention_probability: CanonicalRational = Field(
+        description="Exact edge-retention probability in the closed interval [0, 1]."
+    )
 
     @model_validator(mode="after")
     def validate_probability(self) -> Self:

--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/_models.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/_models.py
@@ -10,21 +10,39 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 
 
 class EdgeOverlapMomentRow(StrictModel):
-    edge_size_min: int = Field(ge=0)
-    edge_size_max: int = Field(ge=0)
-    intersection_size: int = Field(ge=0)
-    pair_count: ExactInteger = Field(ge=0)
-    union_size: int = Field(ge=0)
+    edge_size_min: int = Field(ge=0, le=256)
+    edge_size_max: int = Field(ge=0, le=256)
+    intersection_size: int = Field(ge=0, le=256)
+    pair_count: ExactInteger = Field(ge=1, le=71_994_000)
+    union_size: int = Field(ge=0, le=256)
     covariance: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_overlap_shape(self) -> Self:
+        if not self.intersection_size <= self.edge_size_min <= self.edge_size_max:
+            raise ValueError(
+                "overlap sizes must satisfy intersection <= smaller <= larger"
+            )
+        if (
+            self.union_size
+            != self.edge_size_min + self.edge_size_max - self.intersection_size
+        ):
+            raise ValueError(
+                "union size must equal the sum of edge sizes minus intersection"
+            )
+        return self
+
 
 class HypergraphEdgeCountMomentsRequest(StrictModel):
     hypergraph: FiniteHypergraph
     retention_probability: CanonicalRational
+
     @model_validator(mode="after")
     def validate_probability(self) -> Self:
         if not 0 <= self.retention_probability.as_fraction() <= 1:
             raise ValueError("retention_probability must be between 0 and 1")
         return self
+
 
 class HypergraphEdgeCountMomentsResult(StrictModel):
     hypergraph: FiniteHypergraph
@@ -32,6 +50,11 @@ class HypergraphEdgeCountMomentsResult(StrictModel):
     edge_count_expectation: CanonicalRational
     edge_count_second_moment: CanonicalRational
     edge_count_variance: CanonicalRational
-    overlap_profile: tuple[EdgeOverlapMomentRow, ...]
+    overlap_profile: tuple[EdgeOverlapMomentRow, ...] = Field(max_length=65_536)
 
-__all__ = ["EdgeOverlapMomentRow", "HypergraphEdgeCountMomentsRequest", "HypergraphEdgeCountMomentsResult"]
+
+__all__ = [
+    "EdgeOverlapMomentRow",
+    "HypergraphEdgeCountMomentsRequest",
+    "HypergraphEdgeCountMomentsResult",
+]

--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/_tools.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/_tools.py
@@ -1,0 +1,10 @@
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+
+from ._models import HypergraphEdgeCountMomentsRequest, HypergraphEdgeCountMomentsResult
+from .operations import compute_hypergraph_edge_count_moments
+
+
+def _run(request: HypergraphEdgeCountMomentsRequest) -> HypergraphEdgeCountMomentsResult:
+    return compute_hypergraph_edge_count_moments(request.hypergraph, request.retention_probability)
+TOOLS: MathTools = (MathTool(operation_id="probability.hypergraph_edge_count_moments.compute", title="Compute exact hypergraph edge-count moments", description="Return exact first and second moments, variance, and compact edge-overlap covariance profile under independent vertex retention.", request_type=HypergraphEdgeCountMomentsRequest, result_type=HypergraphEdgeCountMomentsResult, run=_run, tags=("probability", "combinatorics", "exact"), examples=(OperationExample(name="two_intersecting_edges", description="Two edges sharing one vertex at retention probability one half.", input={"hypergraph": {"vertices": ["a", "b", "c"], "edges": [["e1", ["a", "b"]], ["e2", ["b", "c"]]]}, "retention_probability": {"num": "1", "den": "2"}}),)),)
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/_tools.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/_tools.py
@@ -4,7 +4,36 @@ from ._models import HypergraphEdgeCountMomentsRequest, HypergraphEdgeCountMomen
 from .operations import compute_hypergraph_edge_count_moments
 
 
-def _run(request: HypergraphEdgeCountMomentsRequest) -> HypergraphEdgeCountMomentsResult:
-    return compute_hypergraph_edge_count_moments(request.hypergraph, request.retention_probability)
-TOOLS: MathTools = (MathTool(operation_id="probability.hypergraph_edge_count_moments.compute", title="Compute exact hypergraph edge-count moments", description="Return exact first and second moments, variance, and compact edge-overlap covariance profile under independent vertex retention.", request_type=HypergraphEdgeCountMomentsRequest, result_type=HypergraphEdgeCountMomentsResult, run=_run, tags=("probability", "combinatorics", "exact"), examples=(OperationExample(name="two_intersecting_edges", description="Two edges sharing one vertex at retention probability one half.", input={"hypergraph": {"vertices": ["a", "b", "c"], "edges": [["e1", ["a", "b"]], ["e2", ["b", "c"]]]}, "retention_probability": {"num": "1", "den": "2"}}),)),)
+def _run(
+    request: HypergraphEdgeCountMomentsRequest,
+) -> HypergraphEdgeCountMomentsResult:
+    return compute_hypergraph_edge_count_moments(
+        request.hypergraph, request.retention_probability
+    )
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="probability.hypergraph_edge_count_moments.compute",
+        title="Compute exact hypergraph edge-count moments",
+        description="Return exact first and second moments, variance, and compact edge-overlap covariance profile under independent vertex retention.",
+        request_type=HypergraphEdgeCountMomentsRequest,
+        result_type=HypergraphEdgeCountMomentsResult,
+        run=_run,
+        tags=("probability", "combinatorics", "exact"),
+        examples=(
+            OperationExample(
+                name="two_intersecting_edges",
+                description="Two edges sharing one vertex at retention probability one half.",
+                input={
+                    "hypergraph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["e1", ["a", "b"]], ["e2", ["b", "c"]]],
+                    },
+                    "retention_probability": {"num": "1", "den": "2"},
+                },
+            ),
+        ),
+    ),
+)
 __all__ = ["TOOLS"]

--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/operations.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/operations.py
@@ -1,0 +1,70 @@
+"""Exact moments of the surviving-edge count under Bernoulli vertex retention."""
+from collections import Counter
+from fractions import Fraction
+from math import comb
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+
+from ._models import EdgeOverlapMomentRow, HypergraphEdgeCountMomentsResult
+
+MAX_PAIR_WORK = 20_000_000
+MAX_PROFILE_ROWS = 65_536
+MAX_RATIONAL_DIGITS = 32_768
+
+def _reject(code: str, message: str) -> None:
+    raise OperationResourceAdmissionError(location=("hypergraph",), code=f"hypergraph_edge_count_moments.{code}", message=message)
+
+def compute_hypergraph_edge_count_moments(hypergraph: FiniteHypergraph, retention_probability: CanonicalRational) -> HypergraphEdgeCountMomentsResult:
+    if not isinstance(hypergraph, FiniteHypergraph):
+        raise OperationDomainValidationError(location=("hypergraph",), code="hypergraph_edge_count_moments.invalid_hypergraph", message="hypergraph must be a FiniteHypergraph")
+    if not isinstance(retention_probability, CanonicalRational):
+        raise OperationDomainValidationError(location=("retention_probability",), code="hypergraph_edge_count_moments.invalid_probability", message="retention_probability must be a CanonicalRational")
+    p = retention_probability.as_fraction()
+    if not 0 <= p <= 1:
+        raise OperationDomainValidationError(location=("retention_probability",), code="hypergraph_edge_count_moments.probability_out_of_range", message="retention_probability must be between 0 and 1")
+    vertex_index = {vertex: index for index, vertex in enumerate(hypergraph.vertices)}
+    masks = tuple(sum(1 << vertex_index[vertex] for vertex in members) for _, members in hypergraph.edges)
+    multiplicities = Counter(masks)
+    sizes = tuple(sorted({mask.bit_count() for mask in multiplicities}))
+    possible_rows = sum(min(a, b) + 1 for a in sizes for b in sizes if a <= b)
+    if possible_rows > MAX_PROFILE_ROWS:
+        _reject("profile_size", "source size classes can produce too many overlap rows")
+    pair_work = len(multiplicities) ** 2 + len(masks) + sum(mask.bit_count() for mask in masks)
+    max_size = max(sizes, default=0)
+    estimated_digits = len(str(p.denominator)) * (2 * max_size) + len(str(max(1, len(masks)))) + 2
+    if pair_work > MAX_PAIR_WORK:
+        _reject("pair_work", "edge overlap work exceeds the admitted bound")
+    if estimated_digits > MAX_RATIONAL_DIGITS:
+        _reject("rational_height", "exact moments exceed the rational height bound")
+    powers: dict[int, Fraction] = {0: Fraction(1)}
+    powers.update({exponent: p**exponent for exponent in range(1, 2 * max_size + 1)})
+    expectation = sum((powers[mask.bit_count()] for mask in masks), Fraction(0))
+    rows: Counter[tuple[int, int, int]] = Counter()
+    for left, left_count in multiplicities.items():
+        for right, right_count in multiplicities.items():
+            if left > right:
+                continue
+            count = comb(left_count, 2) if left == right else left_count * right_count
+            if count:
+                a, b = sorted((left.bit_count(), right.bit_count()))
+                rows[(a, b, (left & right).bit_count())] += count
+    second = expectation + sum((2 * count * powers[a + b - q] for (a, b, q), count in rows.items()), Fraction(0))
+    variance = second - expectation * expectation
+    def canonical(value: Fraction) -> CanonicalRational:
+        result = CanonicalRational.from_fraction(value)
+        if max(len(str(abs(result.num))), len(str(result.den))) > MAX_RATIONAL_DIGITS:
+            _reject("rational_height", "exact moment exceeds the rational height bound")
+        return result
+    profile = tuple(EdgeOverlapMomentRow(edge_size_min=a, edge_size_max=b, intersection_size=q, pair_count=count, union_size=a+b-q, covariance=canonical(powers[a+b-q] - powers[a] * powers[b])) for (a, b, q), count in sorted(rows.items()))
+    output_bits = (len(profile) + 3) * estimated_digits * 4 + len(masks) * (len(hypergraph.vertices) + 1)
+    if output_bits > 268_435_456:
+        _reject("output_size", "exact moment profile exceeds its output bit bound")
+    return HypergraphEdgeCountMomentsResult(hypergraph=hypergraph, retention_probability=retention_probability, edge_count_expectation=canonical(expectation), edge_count_second_moment=canonical(second), edge_count_variance=canonical(variance), overlap_profile=profile)
+__all__ = ["compute_hypergraph_edge_count_moments"]

--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/operations.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/operations.py
@@ -1,9 +1,18 @@
 """Exact moments of the surviving-edge count under Bernoulli vertex retention."""
+
+import time
 from collections import Counter
 from fractions import Fraction
+from itertools import combinations_with_replacement
 from math import comb
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
@@ -16,55 +25,155 @@ from ._models import EdgeOverlapMomentRow, HypergraphEdgeCountMomentsResult
 
 MAX_PAIR_WORK = 20_000_000
 MAX_PROFILE_ROWS = 65_536
-MAX_RATIONAL_DIGITS = 32_768
+MAX_OUTPUT_BITS = 268_435_456
+MAX_ARITHMETIC_WORK = 1 << 40
+
 
 def _reject(code: str, message: str) -> None:
-    raise OperationResourceAdmissionError(location=("hypergraph",), code=f"hypergraph_edge_count_moments.{code}", message=message)
+    raise OperationResourceAdmissionError(
+        location=("hypergraph", "retention_probability"),
+        code=f"hypergraph_edge_count_moments.{code}",
+        message=message,
+    )
 
-def compute_hypergraph_edge_count_moments(hypergraph: FiniteHypergraph, retention_probability: CanonicalRational) -> HypergraphEdgeCountMomentsResult:
-    if not isinstance(hypergraph, FiniteHypergraph):
-        raise OperationDomainValidationError(location=("hypergraph",), code="hypergraph_edge_count_moments.invalid_hypergraph", message="hypergraph must be a FiniteHypergraph")
-    if not isinstance(retention_probability, CanonicalRational):
-        raise OperationDomainValidationError(location=("retention_probability",), code="hypergraph_edge_count_moments.invalid_probability", message="retention_probability must be a CanonicalRational")
-    p = retention_probability.as_fraction()
-    if not 0 <= p <= 1:
-        raise OperationDomainValidationError(location=("retention_probability",), code="hypergraph_edge_count_moments.probability_out_of_range", message="retention_probability must be between 0 and 1")
-    vertex_index = {vertex: index for index, vertex in enumerate(hypergraph.vertices)}
-    masks = tuple(sum(1 << vertex_index[vertex] for vertex in members) for _, members in hypergraph.edges)
-    multiplicities = Counter(masks)
-    sizes = tuple(sorted({mask.bit_count() for mask in multiplicities}))
-    possible_rows = sum(min(a, b) + 1 for a in sizes for b in sizes if a <= b)
-    if possible_rows > MAX_PROFILE_ROWS:
-        _reject("profile_size", "source size classes can produce too many overlap rows")
-    pair_work = len(multiplicities) ** 2 + len(masks) + sum(mask.bit_count() for mask in masks)
+
+def compute_hypergraph_edge_count_moments(
+    hypergraph: FiniteHypergraph, retention_probability: CanonicalRational
+) -> HypergraphEdgeCountMomentsResult:
+    if not isinstance(hypergraph, FiniteHypergraph) or not isinstance(
+        retention_probability, CanonicalRational
+    ):
+        raise OperationDomainValidationError(
+            location=("hypergraph", "retention_probability"),
+            code="hypergraph_edge_count_moments.source_type",
+            message="expected a FiniteHypergraph and CanonicalRational",
+        )
+    if not 0 <= retention_probability.num <= retention_probability.den:
+        raise OperationDomainValidationError(
+            location=("retention_probability",),
+            code="hypergraph_edge_count_moments.probability_out_of_range",
+            message="retention_probability must be between 0 and 1",
+        )
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return compute_hypergraph_edge_count_moments(
+                hypergraph, retention_probability
+            )
+    deadline = execution.started_at + 60
+    bind_request_deadline(
+        min(deadline, execution.deadline)
+        if execution.deadline is not None
+        else deadline
+    )
+    request_checkpoint("before hypergraph moment admission")
+    # Source canonicalization already bounds 256 vertices, 12000 indexed edges,
+    # and 36000 incidences. Counting identical authored member tuples is linear
+    # in that envelope; no edge-pair or probability expansion occurs here.
+    memberships = Counter(members for _, members in hypergraph.edges)
+    sizes = sorted({len(members) for members in memberships})
+    edge_count = len(hypergraph.edges)
     max_size = max(sizes, default=0)
-    estimated_digits = len(str(p.denominator)) * (2 * max_size) + len(str(max(1, len(masks)))) + 2
+    possible_rows = min(
+        comb(edge_count, 2),
+        sum(a + 1 for a, b in combinations_with_replacement(sizes, 2)),
+    )
+    if possible_rows > MAX_PROFILE_ROWS:
+        _reject(
+            "profile_size", "source size classes exceed the compact overlap row bound"
+        )
+    words = max(1, (len(hypergraph.vertices) + 63) // 64)
+    pair_work = words * (
+        len(memberships) ** 2 + sum(len(members) for members in memberships)
+    )
     if pair_work > MAX_PAIR_WORK:
         _reject("pair_work", "edge overlap work exceeds the admitted bound")
-    if estimated_digits > MAX_RATIONAL_DIGITS:
-        _reject("rational_height", "exact moments exceed the rational height bound")
-    powers: dict[int, Fraction] = {0: Fraction(1)}
-    powers.update({exponent: p**exponent for exponent in range(1, 2 * max_size + 1)})
-    expectation = sum((powers[mask.bit_count()] for mask in masks), Fraction(0))
+    # A common q^(2s) denominator contains every moment and covariance.
+    # Z <= m bounds both second moment and variance numerator by m²q^(2s).
+    # Bit bounds avoid decimal conversion of large authored integers.
+    q_bits = retention_probability.den.bit_length()
+    height = 2 * max_size * q_bits + 2 * max(1, edge_count.bit_length()) + 2
+    if (height * 30103 + 99999) // 100000 > MAX_CANONICAL_RATIONAL_DIGITS:
+        _reject(
+            "rational_height",
+            "exact moments exceed canonical rational coefficient bounds",
+        )
+    output_bits = (
+        2 * (possible_rows + 3) * height
+        + 2 * q_bits
+        + 128
+        * (
+            edge_count
+            + len(hypergraph.vertices)
+            + sum(len(members) for _, members in hypergraph.edges)
+        )
+    )
+    if output_bits > MAX_OUTPUT_BITS:
+        _reject(
+            "output_size", "exact moment profile exceeds its output allocation bound"
+        )
+    # Schoolbook integer arithmetic and Euclidean rational reduction are bounded
+    # by a quadratic bit envelope per cached power, weighted sum and output.
+    arithmetic_work = (
+        (edge_count + 16 * possible_rows + 8 * max_size + 16) * height * height
+    )
+    if arithmetic_work > MAX_ARITHMETIC_WORK:
+        _reject(
+            "arithmetic_work",
+            "exact rational arithmetic exceeds the admitted work bound",
+        )
+    request_checkpoint("after complete hypergraph moment admission")
+    vertex_index = {vertex: index for index, vertex in enumerate(hypergraph.vertices)}
+    multiplicities = Counter(
+        {
+            sum(1 << vertex_index[v] for v in members): count
+            for members, count in memberships.items()
+        }
+    )
     rows: Counter[tuple[int, int, int]] = Counter()
-    for left, left_count in multiplicities.items():
-        for right, right_count in multiplicities.items():
-            if left > right:
-                continue
-            count = comb(left_count, 2) if left == right else left_count * right_count
-            if count:
-                a, b = sorted((left.bit_count(), right.bit_count()))
-                rows[(a, b, (left & right).bit_count())] += count
-    second = expectation + sum((2 * count * powers[a + b - q] for (a, b, q), count in rows.items()), Fraction(0))
+    for (left, left_count), (right, right_count) in combinations_with_replacement(
+        multiplicities.items(), 2
+    ):
+        count = comb(left_count, 2) if left == right else left_count * right_count
+        if count:
+            a, b = sorted((left.bit_count(), right.bit_count()))
+            rows[(a, b, (left & right).bit_count())] += count
+        request_checkpoint("during hypergraph overlap enumeration")
+    p = retention_probability.as_fraction()
+    powers = [Fraction(1)]
+    for _exponent in range(1, 2 * max_size + 1):
+        powers.append(powers[-1] * p)
+    expectation = sum(
+        (count * powers[mask.bit_count()] for mask, count in multiplicities.items()),
+        Fraction(0),
+    )
+    second = expectation + sum(
+        (2 * count * powers[a + b - q] for (a, b, q), count in rows.items()),
+        Fraction(0),
+    )
     variance = second - expectation * expectation
-    def canonical(value: Fraction) -> CanonicalRational:
-        result = CanonicalRational.from_fraction(value)
-        if max(len(str(abs(result.num))), len(str(result.den))) > MAX_RATIONAL_DIGITS:
-            _reject("rational_height", "exact moment exceeds the rational height bound")
-        return result
-    profile = tuple(EdgeOverlapMomentRow(edge_size_min=a, edge_size_max=b, intersection_size=q, pair_count=count, union_size=a+b-q, covariance=canonical(powers[a+b-q] - powers[a] * powers[b])) for (a, b, q), count in sorted(rows.items()))
-    output_bits = (len(profile) + 3) * estimated_digits * 4 + len(masks) * (len(hypergraph.vertices) + 1)
-    if output_bits > 268_435_456:
-        _reject("output_size", "exact moment profile exceeds its output bit bound")
-    return HypergraphEdgeCountMomentsResult(hypergraph=hypergraph, retention_probability=retention_probability, edge_count_expectation=canonical(expectation), edge_count_second_moment=canonical(second), edge_count_variance=canonical(variance), overlap_profile=profile)
+    profile = tuple(
+        EdgeOverlapMomentRow(
+            edge_size_min=a,
+            edge_size_max=b,
+            intersection_size=q,
+            pair_count=count,
+            union_size=a + b - q,
+            covariance=CanonicalRational.from_fraction(
+                powers[a + b - q] - powers[a] * powers[b]
+            ),
+        )
+        for (a, b, q), count in sorted(rows.items())
+    )
+    request_checkpoint("after exact hypergraph moments")
+    return HypergraphEdgeCountMomentsResult(
+        hypergraph=hypergraph,
+        retention_probability=retention_probability,
+        edge_count_expectation=CanonicalRational.from_fraction(expectation),
+        edge_count_second_moment=CanonicalRational.from_fraction(second),
+        edge_count_variance=CanonicalRational.from_fraction(variance),
+        overlap_profile=profile,
+    )
+
+
 __all__ = ["compute_hypergraph_edge_count_moments"]

--- a/tests/math/probability/hypergraph_edge_count_moments/test_operations.py
+++ b/tests/math/probability/hypergraph_edge_count_moments/test_operations.py
@@ -1,0 +1,48 @@
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.combinatorics.finite_structures.hypergraphs import FiniteHypergraph
+from jacobian.math.probability.hypergraph_edge_count_moments import (
+    HypergraphEdgeCountMomentsResult,
+    compute_hypergraph_edge_count_moments,
+)
+
+
+def run(vertices: tuple[str, ...], edges: tuple[tuple[str, tuple[str, ...]], ...], p: Fraction) -> HypergraphEdgeCountMomentsResult:
+    return compute_hypergraph_edge_count_moments(FiniteHypergraph(vertices=vertices, edges=edges), CanonicalRational.from_fraction(p))
+
+def oracle(vertices: tuple[str, ...], edges: tuple[tuple[str, tuple[str, ...]], ...], p: Fraction) -> tuple[Fraction, Fraction, Fraction]:
+    first = second = Fraction(0)
+    for mask in range(1 << len(vertices)):
+        retained = {v for i, v in enumerate(vertices) if mask >> i & 1}
+        z = sum(members_set <= retained for _, members in edges for members_set in (set(members),))
+        probability = p ** len(retained) * (1 - p) ** (len(vertices) - len(retained))
+        first += probability * z
+        second += probability * z * z
+    return first, second, second - first * first
+
+def test_exhaustive_subset_oracle_and_overlap_counts() -> None:
+    vertices = ("a", "b", "c", "d")
+    edges = (("e1", ("a", "b")), ("e2", ("b", "c")), ("e3", ("a", "b")), ("e4", ("d",)))
+    for p in (Fraction(0), Fraction(1), Fraction(1, 2), Fraction(2, 3)):
+        result = run(vertices, edges, p)
+        expected = oracle(vertices, edges, p)
+        assert tuple(value.as_fraction() for value in (result.edge_count_expectation, result.edge_count_second_moment, result.edge_count_variance)) == expected
+    rows = {(row.edge_size_min, row.edge_size_max, row.intersection_size): row.pair_count for row in run(vertices, edges, Fraction(1, 2)).overlap_profile}
+    assert rows[(2, 2, 2)] == 1  # duplicate host pair
+    assert rows[(1, 2, 0)] == 3
+
+def test_empty_edges_and_disjoint_nonuniform_profile() -> None:
+    result = run(("a", "b", "c"), (("empty", ()), ("e1", ("a",)), ("e2", ("b", "c"))), Fraction(1, 2))
+    assert result.edge_count_expectation.as_fraction() == Fraction(7, 4)
+    assert result.edge_count_variance.as_fraction() == Fraction(7, 16)
+    assert result.overlap_profile[0].intersection_size == 0
+    assert result.overlap_profile[0].covariance.as_fraction() == 0
+
+def test_accepted_large_compact_profile() -> None:
+    vertices = tuple(f"v{i}" for i in range(101))
+    edges = tuple((f"e{i}", (f"v{i}",)) for i in range(101))
+    result = run(vertices, edges, Fraction(1, 2))
+    assert len(result.overlap_profile) == 1
+    assert result.overlap_profile[0].pair_count == 5050
+    assert len(result.model_dump_json()) > 0

--- a/tests/math/probability/hypergraph_edge_count_moments/test_operations.py
+++ b/tests/math/probability/hypergraph_edge_count_moments/test_operations.py
@@ -127,9 +127,9 @@ def test_pair_work_is_refused_before_overlap_expansion() -> None:
 
 
 def test_schema_documents_the_closed_probability_interval() -> None:
-    description = HypergraphEdgeCountMomentsRequest.model_json_schema()[
-        "properties"
-    ]["retention_probability"]["description"]
+    description = HypergraphEdgeCountMomentsRequest.model_json_schema()["properties"][
+        "retention_probability"
+    ]["description"]
     assert "[0, 1]" in description
 
 

--- a/tests/math/probability/hypergraph_edge_count_moments/test_operations.py
+++ b/tests/math/probability/hypergraph_edge_count_moments/test_operations.py
@@ -1,25 +1,49 @@
+import time
 from fractions import Fraction
 
+import pytest
+
 from jacobian._exact import CanonicalRational
+from jacobian._execution import bind_request_deadline, request_execution
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.combinatorics.finite_structures.hypergraphs import FiniteHypergraph
+from jacobian.math.probability._distribution import FiniteDistributionAtom
 from jacobian.math.probability.hypergraph_edge_count_moments import (
     HypergraphEdgeCountMomentsResult,
     compute_hypergraph_edge_count_moments,
 )
+from jacobian.math.probability.operations import raw_moment
 
 
-def run(vertices: tuple[str, ...], edges: tuple[tuple[str, tuple[str, ...]], ...], p: Fraction) -> HypergraphEdgeCountMomentsResult:
-    return compute_hypergraph_edge_count_moments(FiniteHypergraph(vertices=vertices, edges=edges), CanonicalRational.from_fraction(p))
+def run(
+    vertices: tuple[str, ...],
+    edges: tuple[tuple[str, tuple[str, ...]], ...],
+    p: Fraction,
+) -> HypergraphEdgeCountMomentsResult:
+    return compute_hypergraph_edge_count_moments(
+        FiniteHypergraph(vertices=vertices, edges=edges),
+        CanonicalRational.from_fraction(p),
+    )
 
-def oracle(vertices: tuple[str, ...], edges: tuple[tuple[str, tuple[str, ...]], ...], p: Fraction) -> tuple[Fraction, Fraction, Fraction]:
+
+def oracle(
+    vertices: tuple[str, ...],
+    edges: tuple[tuple[str, tuple[str, ...]], ...],
+    p: Fraction,
+) -> tuple[Fraction, Fraction, Fraction]:
     first = second = Fraction(0)
     for mask in range(1 << len(vertices)):
         retained = {v for i, v in enumerate(vertices) if mask >> i & 1}
-        z = sum(members_set <= retained for _, members in edges for members_set in (set(members),))
+        z = sum(
+            members_set <= retained
+            for _, members in edges
+            for members_set in (set(members),)
+        )
         probability = p ** len(retained) * (1 - p) ** (len(vertices) - len(retained))
         first += probability * z
         second += probability * z * z
     return first, second, second - first * first
+
 
 def test_exhaustive_subset_oracle_and_overlap_counts() -> None:
     vertices = ("a", "b", "c", "d")
@@ -27,17 +51,36 @@ def test_exhaustive_subset_oracle_and_overlap_counts() -> None:
     for p in (Fraction(0), Fraction(1), Fraction(1, 2), Fraction(2, 3)):
         result = run(vertices, edges, p)
         expected = oracle(vertices, edges, p)
-        assert tuple(value.as_fraction() for value in (result.edge_count_expectation, result.edge_count_second_moment, result.edge_count_variance)) == expected
-    rows = {(row.edge_size_min, row.edge_size_max, row.intersection_size): row.pair_count for row in run(vertices, edges, Fraction(1, 2)).overlap_profile}
+        assert (
+            tuple(
+                value.as_fraction()
+                for value in (
+                    result.edge_count_expectation,
+                    result.edge_count_second_moment,
+                    result.edge_count_variance,
+                )
+            )
+            == expected
+        )
+    rows = {
+        (row.edge_size_min, row.edge_size_max, row.intersection_size): row.pair_count
+        for row in run(vertices, edges, Fraction(1, 2)).overlap_profile
+    }
     assert rows[(2, 2, 2)] == 1  # duplicate host pair
     assert rows[(1, 2, 0)] == 3
 
+
 def test_empty_edges_and_disjoint_nonuniform_profile() -> None:
-    result = run(("a", "b", "c"), (("empty", ()), ("e1", ("a",)), ("e2", ("b", "c"))), Fraction(1, 2))
+    result = run(
+        ("a", "b", "c"),
+        (("empty", ()), ("e1", ("a",)), ("e2", ("b", "c"))),
+        Fraction(1, 2),
+    )
     assert result.edge_count_expectation.as_fraction() == Fraction(7, 4)
     assert result.edge_count_variance.as_fraction() == Fraction(7, 16)
     assert result.overlap_profile[0].intersection_size == 0
     assert result.overlap_profile[0].covariance.as_fraction() == 0
+
 
 def test_accepted_large_compact_profile() -> None:
     vertices = tuple(f"v{i}" for i in range(101))
@@ -45,4 +88,50 @@ def test_accepted_large_compact_profile() -> None:
     result = run(vertices, edges, Fraction(1, 2))
     assert len(result.overlap_profile) == 1
     assert result.overlap_profile[0].pair_count == 5050
-    assert len(result.model_dump_json()) > 0
+    restored = HypergraphEdgeCountMomentsResult.model_validate_json(
+        result.model_dump_json()
+    )
+    assert restored == result
+    assert (
+        restored.edge_count_second_moment.as_fraction()
+        >= restored.edge_count_expectation.as_fraction()
+    )
+    assert restored.edge_count_variance.as_fraction() >= 0
+    consumed = raw_moment(
+        (
+            FiniteDistributionAtom(
+                value=restored.edge_count_expectation,
+                probability=CanonicalRational(num=1, den=1),
+            ),
+        ),
+        1,
+    )
+    assert consumed.moment == restored.edge_count_expectation
+
+
+def test_pair_work_is_refused_before_overlap_expansion() -> None:
+    vertices = tuple(f"v{i}" for i in range(16))
+    masks = range(4501)
+    edges = tuple(
+        (
+            f"e{mask}",
+            tuple(vertices[index] for index in range(16) if mask & (1 << index)),
+        )
+        for mask in masks
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="overlap work"):
+        run(vertices, edges, Fraction(1, 2))
+
+
+def test_rational_height_and_shared_deadline_are_admitted_before_execution() -> None:
+    vertices = tuple(f"v{i}" for i in range(256))
+    edges = (("e", vertices),)
+    huge = CanonicalRational(num=1, den=10**200)
+    with pytest.raises(OperationResourceAdmissionError, match="canonical rational"):
+        compute_hypergraph_edge_count_moments(
+            FiniteHypergraph(vertices=vertices, edges=edges), huge
+        )
+    with request_execution(time.monotonic()):
+        bind_request_deadline(time.monotonic() - 1)
+        with pytest.raises(TimeoutError):
+            run(vertices, edges, Fraction(1, 2))

--- a/tests/math/probability/hypergraph_edge_count_moments/test_operations.py
+++ b/tests/math/probability/hypergraph_edge_count_moments/test_operations.py
@@ -12,6 +12,9 @@ from jacobian.math.probability.hypergraph_edge_count_moments import (
     HypergraphEdgeCountMomentsResult,
     compute_hypergraph_edge_count_moments,
 )
+from jacobian.math.probability.hypergraph_edge_count_moments._models import (
+    HypergraphEdgeCountMomentsRequest,
+)
 from jacobian.math.probability.operations import raw_moment
 
 
@@ -121,6 +124,13 @@ def test_pair_work_is_refused_before_overlap_expansion() -> None:
     )
     with pytest.raises(OperationResourceAdmissionError, match="overlap work"):
         run(vertices, edges, Fraction(1, 2))
+
+
+def test_schema_documents_the_closed_probability_interval() -> None:
+    description = HypergraphEdgeCountMomentsRequest.model_json_schema()[
+        "properties"
+    ]["retention_probability"]["description"]
+    assert "[0, 1]" in description
 
 
 def test_rational_height_and_shared_deadline_are_admitted_before_execution() -> None:

--- a/tests/mcp/test_hypergraph_edge_count_moments.py
+++ b/tests/mcp/test_hypergraph_edge_count_moments.py
@@ -7,10 +7,25 @@ from mcp import Client
 
 def test_hypergraph_edge_count_moments_mcp_roundtrip() -> None:
     async def scenario() -> None:
-        async with Client(_server("probability.hypergraph_edge_count_moments.compute"), raise_exceptions=True) as client:
-            payload = {"hypergraph": {"vertices": ["a", "b"], "edges": [["e1", ["a"]], ["e2", ["b"]]]}, "retention_probability": {"num": "1", "den": "2"}}
-            result = await client.call_tool("probability.hypergraph_edge_count_moments.compute", payload)
+        async with Client(
+            _server("probability.hypergraph_edge_count_moments.compute"),
+            raise_exceptions=True,
+        ) as client:
+            payload = {
+                "hypergraph": {
+                    "vertices": ["a", "b"],
+                    "edges": [["e1", ["a"]], ["e2", ["b"]]],
+                },
+                "retention_probability": {"num": "1", "den": "2"},
+            }
+            result = await client.call_tool(
+                "probability.hypergraph_edge_count_moments.compute", payload
+            )
             assert result.structured_content is not None
-            assert result.structured_content["edge_count_expectation"] == {"num": "1", "den": "1"}
+            assert result.structured_content["edge_count_expectation"] == {
+                "num": "1",
+                "den": "1",
+            }
             assert result.structured_content["overlap_profile"][0]["pair_count"] == "1"
+
     asyncio.run(scenario())

--- a/tests/mcp/test_hypergraph_edge_count_moments.py
+++ b/tests/mcp/test_hypergraph_edge_count_moments.py
@@ -1,0 +1,16 @@
+import asyncio
+
+from tests.mcp.test_direct_operations import _server
+
+from mcp import Client
+
+
+def test_hypergraph_edge_count_moments_mcp_roundtrip() -> None:
+    async def scenario() -> None:
+        async with Client(_server("probability.hypergraph_edge_count_moments.compute"), raise_exceptions=True) as client:
+            payload = {"hypergraph": {"vertices": ["a", "b"], "edges": [["e1", ["a"]], ["e2", ["b"]]]}, "retention_probability": {"num": "1", "den": "2"}}
+            result = await client.call_tool("probability.hypergraph_edge_count_moments.compute", payload)
+            assert result.structured_content is not None
+            assert result.structured_content["edge_count_expectation"] == {"num": "1", "den": "1"}
+            assert result.structured_content["overlap_profile"][0]["pair_count"] == "1"
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

Adds `probability.hypergraph_edge_count_moments.compute` for exact Bernoulli vertex-retention moments of a finite hypergraph. The result binds the source hypergraph and probability to E[Z], E[Z²], Var(Z), and a compact overlap covariance profile grouped by edge sizes and intersection size.

The implementation groups identical edge masks with multiplicity, computes diagonal and off-diagonal terms from the identities
`E[Z] = sum_e p^|e|` and `E[Z²] = E[Z] + 2 sum_{e<f} p^|e union f|`, and reports each grouped covariance as `p^|e union f| - p^|e|p^|f|`. Empty edges and endpoint probabilities retain exact semantics.

Admission accounts for source incidence and bitmask width, pair work, source-derived profile row bounds, shared rational denominator height through the second moment, arithmetic work, output allocation, and the shared request deadline before overlap expansion.

## Validation

- Exhaustive subset enumeration oracle for n <= 4 across p = 0, 1, 1/2, 2/3, including duplicate, empty, disjoint, and nonuniform edges.
- Accepted 101-edge compact profile, JSON round-trip, and consumption through the existing exact raw-moment operation.
- Pair-work refusal and rational-height/deadline refusal tests.
- Native/MCP serialized parity test.
- 6 focused tests pass; mypy, Ruff, architecture/import contracts, and 885 catalog example/MCP example tests pass.
