### PR TITLE
feat(geometry): compute rational metric pullbacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,7 @@ ignore_imports = [
     "jacobian.math.graphs.optimization._maximum_cut_process -> jacobian.process",
     "jacobian.math.graphs.chip_firing._snf_process -> jacobian.process",
     "jacobian.math.geometry.affine_tori._flint_process -> jacobian.process",
+    "jacobian.math.geometry.differential.metrics._normalize_process -> jacobian.process",
     "jacobian.math.topology.chain_complexes._smith_process -> jacobian.process",
     "jacobian.math.combinatorics.finite_structures.hypergraphs._independence_z3 -> jacobian.process",
     "jacobian.math.combinatorics.discrepancy._optimum_process -> jacobian.process",

--- a/src/jacobian/math/geometry/differential/pullback/__init__.py
+++ b/src/jacobian/math/geometry/differential/pullback/__init__.py
@@ -2,12 +2,10 @@
 
 from jacobian.math.geometry.differential.pullback._models import (
     RationalMetricPullbackProfile,
-    RationalMetricPullbackRequest,
 )
 from jacobian.math.geometry.differential.pullback.operations import pullback_metric
 
 __all__ = [
     "RationalMetricPullbackProfile",
-    "RationalMetricPullbackRequest",
     "pullback_metric",
 ]

--- a/src/jacobian/math/geometry/differential/pullback/__init__.py
+++ b/src/jacobian/math/geometry/differential/pullback/__init__.py
@@ -1,0 +1,13 @@
+"""Exact pullback of rational coordinate metrics."""
+
+from jacobian.math.geometry.differential.pullback._models import (
+    RationalMetricPullbackProfile,
+    RationalMetricPullbackRequest,
+)
+from jacobian.math.geometry.differential.pullback.operations import pullback_metric
+
+__all__ = [
+    "RationalMetricPullbackProfile",
+    "RationalMetricPullbackRequest",
+    "pullback_metric",
+]

--- a/src/jacobian/math/geometry/differential/pullback/_models.py
+++ b/src/jacobian/math/geometry/differential/pullback/_models.py
@@ -1,0 +1,63 @@
+"""Typed values for exact rational metric pullbacks."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.geometry.differential.metrics._models import RationalCoordinateMetric
+from jacobian.math.geometry.differential.values import (
+    RationalCoordinateTensor,
+    _polynomial_key,
+)
+from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+from jacobian.math.polynomials.values import SparseRationalPolynomial
+
+
+class RationalMetricPullbackRequest(StrictModel):
+    metric: RationalCoordinateMetric
+    map: RationalFunctionMap
+
+    @model_validator(mode="after")
+    def require_target_axis(self) -> Self:
+        if self.map.target_coordinates != self.metric.tensor.coordinate_axis:
+            raise ValueError("map target coordinates must equal metric coordinate axis")
+        return self
+
+
+class RationalMetricPullbackProfile(StrictModel):
+    metric: RationalCoordinateMetric
+    map: RationalFunctionMap
+    pullback: RationalCoordinateTensor
+    pullback_locus_guard: tuple[SparseRationalPolynomial, ...] = Field(max_length=768)
+
+    @model_validator(mode="after")
+    def require_profile_contract(self) -> Self:
+        source_axis = self.map.source_variables
+        if self.pullback.coordinate_axis != source_axis:
+            raise ValueError("pullback must use the map source coordinate axis")
+        if self.pullback.variance != ("COVARIANT", "COVARIANT"):
+            raise ValueError("pullback must be a covariant rank-two tensor")
+        if self.map.target_coordinates != self.metric.tensor.coordinate_axis:
+            raise ValueError("map target coordinates must equal metric coordinate axis")
+        keys = [_polynomial_key(value) for value in self.pullback_locus_guard]
+        if keys != sorted(set(keys)):
+            raise ValueError("pullback guards must be unique and canonically ordered")
+        if any(
+            any(len(term.exponents) != len(source_axis) for term in value.terms)
+            for value in self.pullback_locus_guard
+        ):
+            raise ValueError("pullback guards must use the map source axis")
+        guard_keys = set(keys)
+        tensor_keys = {
+            _polynomial_key(value)
+            for value in self.pullback.retained_nonzero_denominators
+        }
+        if not tensor_keys <= guard_keys:
+            raise ValueError(
+                "pullback tensor denominators must be retained by its locus"
+            )
+        return self
+
+
+__all__ = ["RationalMetricPullbackProfile", "RationalMetricPullbackRequest"]

--- a/src/jacobian/math/geometry/differential/pullback/_plan.py
+++ b/src/jacobian/math/geometry/differential/pullback/_plan.py
@@ -1,9 +1,13 @@
 """Whole request admission for rational metric pullbacks."""
+
 from dataclasses import dataclass, replace
 from fractions import Fraction
 from itertools import permutations
 
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.geometry.differential.metrics._dag import ONE, ZERO, Dag, Expression
 from jacobian.math.geometry.differential.metrics._models import RationalCoordinateMetric
 from jacobian.math.polynomials.rational_functions._bounds import (
@@ -18,7 +22,13 @@ from jacobian.math.polynomials.values import SparseRationalPolynomial
 
 
 def reject(reason: str, message: str) -> None:
-    raise OperationResourceAdmissionError(location=("metric", "map"), code=f"differential_geometry.rational_metric.pullback.{reason}", message=message)
+    raise OperationResourceAdmissionError(
+        location=("metric", "map"),
+        code=f"differential_geometry.rational_metric.pullback.{reason}",
+        message=message,
+    )
+
+
 @dataclass(frozen=True)
 class Plan:
     dag: Dag
@@ -29,8 +39,12 @@ class Plan:
     output: tuple[Expression, ...]
     determinant: Expression
     guards: tuple[Expression, ...]
+    fractions: dict[Expression, tuple[int, int]]
 
-def _substitute(dag: Dag, value: SparseRationalPolynomial, inner: tuple[Expression, ...]) -> Expression:
+
+def _substitute(
+    dag: Dag, value: SparseRationalPolynomial, inner: tuple[Expression, ...]
+) -> Expression:
     result = ZERO
     powers: dict[tuple[int, int], Expression] = {}
     for term in value.terms:
@@ -46,14 +60,25 @@ def _substitute(dag: Dag, value: SparseRationalPolynomial, inner: tuple[Expressi
         result = dag.add(result, part)
     return result
 
+
 def _determinant(dag: Dag, entries: tuple[Expression, ...], n: int) -> Expression:
     terms = []
     for permutation in permutations(range(n)):
-        inversions = sum(permutation[i] > permutation[j] for i in range(n) for j in range(i + 1, n))
-        terms.append(dag.multiply(Expression(Fraction((-1) ** inversions)), *(entries[i * n + j] for i, j in enumerate(permutation))))
+        inversions = sum(
+            permutation[i] > permutation[j] for i in range(n) for j in range(i + 1, n)
+        )
+        terms.append(
+            dag.multiply(
+                Expression(Fraction((-1) ** inversions)),
+                *(entries[i * n + j] for i, j in enumerate(permutation)),
+            )
+        )
     return dag.add(*terms)
 
-def build_plan(metric: RationalCoordinateMetric, map_value: RationalFunctionMap) -> Plan:
+
+def build_plan(
+    metric: RationalCoordinateMetric, map_value: RationalFunctionMap
+) -> Plan:
     n, m = len(map_value.source_variables), len(metric.tensor.coordinate_axis)
     if not 1 <= n <= 4 or not 1 <= m <= 4:
         reject("shape", "source and target dimensions must be between 1 and 4")
@@ -61,36 +86,152 @@ def build_plan(metric: RationalCoordinateMetric, map_value: RationalFunctionMap)
     # Metric components are authored on the target axis. Reserve their raw
     # parsing, backend conversion, and canonical recognition before any
     # substituted DAG node can be evaluated.
-    for value in metric.tensor.components:
+    for value in dict.fromkeys(metric.tensor.components):
         for polynomial in (value.numerator, value.denominator):
-            dag.ledger.charge("source_conversion", _polynomial_admission_work_units(polynomial, m))
-            dag.ledger.charge("source_conversion", _polynomial_backend_conversion_work_units(_polynomial_bound(polynomial)))
-        nb, db = _polynomial_bound(value.numerator), _polynomial_bound(value.denominator)
+            dag.ledger.charge(
+                "source_conversion", _polynomial_admission_work_units(polynomial, m)
+            )
+            dag.ledger.charge(
+                "source_conversion",
+                _polynomial_backend_conversion_work_units(
+                    _polynomial_bound(polynomial)
+                ),
+            )
+        nb, db = (
+            _polynomial_bound(value.numerator),
+            _polynomial_bound(value.denominator),
+        )
         width = max(len(nb.degrees), len(db.degrees))
         if len(nb.degrees) != width:
-            nb = replace(nb, degrees=nb.degrees + (0,) * (width - len(nb.degrees)), minimum_exponents=nb.minimum_exponents + (0,) * (width - len(nb.minimum_exponents)))
+            nb = replace(
+                nb,
+                degrees=nb.degrees + (0,) * (width - len(nb.degrees)),
+                minimum_exponents=nb.minimum_exponents
+                + (0,) * (width - len(nb.minimum_exponents)),
+            )
         if len(db.degrees) != width:
-            db = replace(db, degrees=db.degrees + (0,) * (width - len(db.degrees)), minimum_exponents=db.minimum_exponents + (0,) * (width - len(db.minimum_exponents)))
+            db = replace(
+                db,
+                degrees=db.degrees + (0,) * (width - len(db.degrees)),
+                minimum_exponents=db.minimum_exponents
+                + (0,) * (width - len(db.minimum_exponents)),
+            )
         dag.ledger.charge("recognition", _recognition_work_units(FractionBound(nb, db)))
     for guard in metric.tensor.retained_nonzero_denominators:
-        dag.ledger.charge("source_conversion", _polynomial_admission_work_units(guard, m))
+        dag.ledger.charge(
+            "source_conversion", _polynomial_admission_work_units(guard, m)
+        )
     maps = tuple(dag.fraction(value) for value in map_value.components)
-    map_denominators = tuple(dag.source(value.denominator) for value in map_value.components)
-    substitutions = tuple(_substitute(dag, value.numerator, maps) for value in metric.tensor.components)
-    substitutions = tuple(dag.multiply(value, dag.inverse(_substitute(dag, metric.tensor.components[i].denominator, maps))) for i, value in enumerate(substitutions))
+    map_denominators = tuple(
+        dag.source(value.denominator) for value in map_value.components
+    )
+    component_guards = tuple(
+        _substitute(dag, value.denominator, maps) for value in metric.tensor.components
+    )
+    if any(not value.scalar for value in component_guards):
+        raise OperationDomainValidationError(
+            location=("metric", "map"),
+            code="differential_geometry.rational_metric.pullback.undefined_metric_locus",
+            message="a required metric denominator vanishes identically after substitution",
+        )
+    substitutions = tuple(
+        _substitute(dag, value.numerator, maps) for value in metric.tensor.components
+    )
+    substitutions = tuple(
+        dag.multiply(
+            value,
+            dag.inverse(component_guards[i]),
+        )
+        for i, value in enumerate(substitutions)
+    )
     jacobian = tuple(dag.derivative(value, axis) for value in maps for axis in range(n))
     determinant = _determinant(dag, substitutions, m)
-    output = tuple(dag.add(*(dag.multiply(jacobian[i * n + a], substitutions[i * m + j], jacobian[j * n + b]) for i in range(m) for j in range(m))) for a in range(n) for b in range(n))
-    inherited = tuple(_substitute(dag, guard, maps) for guard in metric.tensor.retained_nonzero_denominators)
-    component_guards = tuple(_substitute(dag, value.denominator, maps) for value in metric.tensor.components)
+    output = tuple(
+        dag.add(
+            *(
+                dag.multiply(
+                    jacobian[i * n + a], substitutions[i * m + j], jacobian[j * n + b]
+                )
+                for i in range(m)
+                for j in range(m)
+            )
+        )
+        for a in range(n)
+        for b in range(n)
+    )
+    inherited = tuple(
+        _substitute(dag, guard, maps)
+        for guard in metric.tensor.retained_nonzero_denominators
+    )
     guards = tuple(map_denominators) + component_guards + inherited + (determinant,)
     values = tuple(dict.fromkeys((*output, *guards)))
     sizes = {value: dag.admit_output(value) for value in values}
-    if len(guards) > 768:
+    fractions = {
+        value: (
+            dag.polynomial(value.numerator, value.scalar),
+            dag.polynomial(value.denominator),
+        )
+        for value in values
+    }
+    # Cancellation may change each denominator polynomial. Count distinct full
+    # expressions, not merely shared raw denominator factors, as in curvature.
+    guard_values = {value for value in guards if value.numerator}
+    output_denominators = {value for value in output if value.denominator}
+    if len(guard_values) + len(output_denominators) > 768:
         reject("locus", "complete pullback locus exceeds 768 guards")
-    terms = sum(sizes[value][0] for value in sizes) + len(output) * n * (len(values) + 2)
-    bits = sum(sizes[value][1] for value in sizes)
-    if terms > 65536 or bits > 8388608:
-        reject("allocation", "complete pullback output exceeds its exact allocation budget")
-    return Plan(dag, metric, map_value, substitutions, jacobian, output, determinant, guards)
+
+    def source_allocation(
+        polynomial: SparseRationalPolynomial, dimension: int
+    ) -> tuple[int, int, int]:
+        return (
+            len(polynomial.terms),
+            sum(
+                abs(term.coefficient.num).bit_length()
+                + term.coefficient.den.bit_length()
+                for term in polynomial.terms
+            ),
+            dimension * (len(polynomial.terms) + 1),
+        )
+
+    source = [
+        source_allocation(polynomial, m)
+        for value in metric.tensor.components
+        for polynomial in (value.numerator, value.denominator)
+    ]
+    source += [
+        source_allocation(guard, m)
+        for guard in metric.tensor.retained_nonzero_denominators
+    ]
+    source += [
+        source_allocation(polynomial, n)
+        for value in map_value.components
+        for polynomial in (value.numerator, value.denominator)
+    ]
+    # The result repeats its complete locus in the tensor and profile fields.
+    # A whole admitted fraction bounds its monic numerator/denominator guard.
+    locus = [sizes[value] for value in guard_values] + [
+        sizes[value] for value in output_denominators
+    ]
+    allocations = source + [sizes[value] for value in output] + 2 * locus
+    terms, bits, coordinates = (sum(row[i] for row in allocations) for i in range(3))
+    coordinates += (n + m) * (
+        len(output) + len(metric.tensor.components) + len(map_value.components) + 6
+    )
+    if terms > 65536 or bits > 8388608 or coordinates > 1_048_576:
+        reject(
+            "allocation", "complete pullback output exceeds its exact allocation budget"
+        )
+    return Plan(
+        dag,
+        metric,
+        map_value,
+        substitutions,
+        jacobian,
+        output,
+        determinant,
+        guards,
+        fractions,
+    )
+
+
 __all__ = ["Plan", "build_plan"]

--- a/src/jacobian/math/geometry/differential/pullback/_plan.py
+++ b/src/jacobian/math/geometry/differential/pullback/_plan.py
@@ -1,0 +1,252 @@
+"""Backend-free whole-request admission for metric pullbacks."""
+
+from dataclasses import dataclass
+from typing import Any, NoReturn
+
+from jacobian._execution import request_checkpoint
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.geometry.differential.metrics._models import RationalCoordinateMetric
+from jacobian.math.polynomials.rational_functions._bounds import (
+    BoundWorkCategory,
+    FractionBound,
+    RationalFunctionBoundLimits,
+    _add_polynomials,
+    _differentiate_polynomial,
+    _fraction_bound,
+    _multiply_polynomials,
+    _one_polynomial,
+    _remove_guaranteed_common_monomial,
+    _validate_canonical_result_bound,
+)
+from jacobian.math.polynomials.rational_functions.composition.operations import (
+    _substitute_bound,
+)
+from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+
+
+def reject(reason: str, message: str) -> NoReturn:
+    raise OperationResourceAdmissionError(
+        location=("metric", "map"),
+        code=f"differential_geometry.rational_metric.pullback.{reason}",
+        message=message,
+    )
+
+
+class Ledger:
+    limits = RationalFunctionBoundLimits(
+        raw_terms=4096,
+        raw_digits=4096,
+        result_exponent=64,
+        result_terms=256,
+        result_digits=128,
+        label="rational metric pullback",
+        reject=reject,
+    )
+
+    def __init__(self) -> None:
+        self.work = 0
+
+    def charge(self, category: BoundWorkCategory, amount: int) -> None:
+        request_checkpoint(f"during rational metric pullback admission {category}")
+        self.work += amount
+        if self.work > 100_000_000:
+            reject("work", "complete metric pullback exceeds its exact work envelope")
+
+
+@dataclass(frozen=True)
+class Plan:
+    metric: RationalCoordinateMetric
+    map: RationalFunctionMap
+    metric_substitutions: tuple[FractionBound, ...]
+    jacobian_entries: tuple[FractionBound, ...]
+
+
+def _add_fraction(
+    left: FractionBound, right: FractionBound, ledger: Ledger
+) -> FractionBound:
+    return FractionBound(
+        _add_polynomials(
+            _multiply_polynomials(left.numerator, right.denominator, ledger),
+            _multiply_polynomials(right.numerator, left.denominator, ledger),
+            ledger,
+        ),
+        _multiply_polynomials(left.denominator, right.denominator, ledger),
+    )
+
+
+def _determinant_bound(
+    entries: tuple[FractionBound, ...], dimension: int, ledger: Ledger
+) -> FractionBound:
+    from itertools import permutations
+
+    result: FractionBound | None = None
+    for permutation in permutations(range(dimension)):
+        term = FractionBound(_one_polynomial(dimension), _one_polynomial(dimension))
+        for row, column in enumerate(permutation):
+            entry = entries[row * dimension + column]
+            term = FractionBound(
+                _multiply_polynomials(term.numerator, entry.numerator, ledger),
+                _multiply_polynomials(term.denominator, entry.denominator, ledger),
+            )
+        result = term if result is None else _add_fraction(result, term, ledger)
+    assert result is not None
+    return result
+
+
+def _substitute_bound_only(
+    polynomial: Any, inner_bounds: tuple[FractionBound, ...], ledger: Ledger
+) -> FractionBound:
+    variable_count = len(inner_bounds[0].numerator.degrees) if inner_bounds else 0
+    numerator = _one_polynomial(variable_count)
+    denominator = _one_polynomial(variable_count)
+    for degree, bound in zip(polynomial.degrees, inner_bounds, strict=True):
+        for _ in range(degree):
+            numerator = _multiply_polynomials(numerator, bound.numerator, ledger)
+            denominator = _multiply_polynomials(denominator, bound.denominator, ledger)
+    return FractionBound(numerator, denominator)
+
+
+def _derivative_bound(value: FractionBound, axis: int, ledger: Ledger) -> FractionBound:
+    n, d = value.numerator, value.denominator
+    dn = _differentiate_polynomial(
+        n,
+        axis,
+        ledger,
+        active_terms=n.terms if n.degrees[axis] else 0,
+        maximum_axis_exponent=max(1, n.degrees[axis]),
+        minimum_exponents=tuple(
+            max(0, e - int(i == axis)) for i, e in enumerate(n.minimum_exponents)
+        ),
+    )
+    dd = _differentiate_polynomial(
+        d,
+        axis,
+        ledger,
+        active_terms=d.terms if d.degrees[axis] else 0,
+        maximum_axis_exponent=max(1, d.degrees[axis]),
+        minimum_exponents=tuple(
+            max(0, e - int(i == axis)) for i, e in enumerate(d.minimum_exponents)
+        ),
+    )
+    numerator = _add_polynomials(
+        _multiply_polynomials(dn, d, ledger),
+        _multiply_polynomials(n, dd, ledger),
+        ledger,
+    )
+    return FractionBound(numerator, _multiply_polynomials(d, d, ledger))
+
+
+def build_plan(
+    metric: RationalCoordinateMetric, map_value: RationalFunctionMap
+) -> Plan:
+    n, m = len(map_value.source_variables), len(metric.tensor.coordinate_axis)
+    if n**2 > 256 or m**2 > 256 or m * n > 4096:
+        reject(
+            "shape",
+            "complete metric pullback exceeds the tensor or Jacobian shape budget",
+        )
+    ledger = Ledger()
+    metric_bounds = tuple(
+        _fraction_bound(value, ledger) for value in metric.tensor.components
+    )
+    map_bounds = tuple(_fraction_bound(value, ledger) for value in map_value.components)
+    substitutions = []
+    for value in metric.tensor.components:
+        substituted = _substitute_bound(value.numerator, map_bounds, ledger)
+        denominator = _substitute_bound(value.denominator, map_bounds, ledger)
+        substitutions.append(
+            FractionBound(
+                _multiply_polynomials(
+                    substituted.numerator, denominator.denominator, ledger
+                ),
+                _multiply_polynomials(
+                    substituted.denominator, denominator.numerator, ledger
+                ),
+            )
+        )
+    determinant_bound = _determinant_bound(metric_bounds, m, ledger)
+    determinant_num = _substitute_bound_only(
+        determinant_bound.numerator, map_bounds, ledger
+    )
+    determinant_den = _substitute_bound_only(
+        determinant_bound.denominator, map_bounds, ledger
+    )
+    _multiply_polynomials(
+        determinant_num.numerator, determinant_den.denominator, ledger
+    )
+    _multiply_polynomials(
+        determinant_num.denominator, determinant_den.numerator, ledger
+    )
+    jacobian = []
+    for bound in map_bounds:
+        for axis in range(n):
+            jacobian.append(_derivative_bound(bound, axis, ledger))
+    # Reserve the complete contraction using raw cleared fractions. This is
+    # deliberately conservative and happens before any nested executor runs.
+    output_terms = 0
+    output_digits = 0
+    for a in range(n):
+        for b in range(n):
+            contraction: FractionBound | None = None
+            for i in range(m):
+                for j in range(m):
+                    left = jacobian[i * n + a]
+                    right = jacobian[j * n + b]
+                    middle = substitutions[i * m + j]
+                    term = FractionBound(
+                        _multiply_polynomials(
+                            _multiply_polynomials(
+                                left.numerator, middle.numerator, ledger
+                            ),
+                            right.numerator,
+                            ledger,
+                        ),
+                        _multiply_polynomials(
+                            _multiply_polynomials(
+                                left.denominator, middle.denominator, ledger
+                            ),
+                            right.denominator,
+                            ledger,
+                        ),
+                    )
+                    contraction = (
+                        term
+                        if contraction is None
+                        else FractionBound(
+                            _add_polynomials(
+                                _multiply_polynomials(
+                                    contraction.numerator, term.denominator, ledger
+                                ),
+                                _multiply_polynomials(
+                                    term.numerator, contraction.denominator, ledger
+                                ),
+                                ledger,
+                            ),
+                            _multiply_polynomials(
+                                contraction.denominator, term.denominator, ledger
+                            ),
+                        )
+                    )
+            assert contraction is not None
+            canonical = _remove_guaranteed_common_monomial(contraction)
+            digits = _validate_canonical_result_bound(canonical, ledger)
+            output_terms += canonical.numerator.terms + canonical.denominator.terms
+            output_digits += (
+                8 * digits * (canonical.numerator.terms + canonical.denominator.terms)
+            )
+    guard_count = (
+        len(map_value.components)
+        + len(metric.tensor.components)
+        + len(metric.tensor.retained_nonzero_denominators)
+        + 1
+    )
+    if guard_count > 768:
+        reject("locus", "complete pullback locus exceeds 768 guards")
+    if output_terms > 65_536 or output_digits > 8_388_608:
+        reject(
+            "allocation", "complete pullback output exceeds its exact allocation budget"
+        )
+    return Plan(metric, map_value, tuple(substitutions), tuple(jacobian))
+
+
+__all__ = ["Plan", "build_plan"]

--- a/src/jacobian/math/geometry/differential/pullback/_plan.py
+++ b/src/jacobian/math/geometry/differential/pullback/_plan.py
@@ -1,6 +1,6 @@
 """Backend-free whole-request admission for metric pullbacks."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, NoReturn
 
 from jacobian._execution import request_checkpoint
@@ -103,6 +103,14 @@ def _substitute_bound_only(
         for _ in range(degree):
             numerator = _multiply_polynomials(numerator, bound.numerator, ledger)
             denominator = _multiply_polynomials(denominator, bound.denominator, ledger)
+    if polynomial.terms > 1:
+        numerator = replace(
+            numerator,
+            terms=min(4096, numerator.terms * polynomial.terms),
+            coefficient_digits=numerator.coefficient_digits
+            + polynomial.coefficient_digits
+            + polynomial.terms.bit_length(),
+        )
     return FractionBound(numerator, denominator)
 
 

--- a/src/jacobian/math/geometry/differential/pullback/_plan.py
+++ b/src/jacobian/math/geometry/differential/pullback/_plan.py
@@ -15,6 +15,7 @@ from jacobian.math.polynomials.rational_functions._bounds import (
     _fraction_bound,
     _multiply_polynomials,
     _one_polynomial,
+    _polynomial_bound,
     _remove_guaranteed_common_monomial,
     _validate_canonical_result_bound,
 )
@@ -100,17 +101,22 @@ def _substitute_bound_only(
     numerator = _one_polynomial(variable_count)
     denominator = _one_polynomial(variable_count)
     for degree, bound in zip(polynomial.degrees, inner_bounds, strict=True):
+        # Clearing denominators for every monomial of P is bounded by
+        # (N_i + D_i)^degree; this retains both numerator and denominator
+        # support, including terms whose exponent is not the maximum degree.
+        base = _add_polynomials(bound.numerator, bound.denominator, ledger)
         for _ in range(degree):
-            numerator = _multiply_polynomials(numerator, bound.numerator, ledger)
+            numerator = _multiply_polynomials(numerator, base, ledger)
             denominator = _multiply_polynomials(denominator, bound.denominator, ledger)
-    if polynomial.terms > 1:
-        numerator = replace(
-            numerator,
-            terms=min(4096, numerator.terms * polynomial.terms),
-            coefficient_digits=numerator.coefficient_digits
+    numerator = replace(
+        numerator,
+        coefficient_digits=(
+            numerator.coefficient_digits
             + polynomial.coefficient_digits
-            + polynomial.terms.bit_length(),
-        )
+            + polynomial.terms.bit_length()
+        ),
+        rational_content=numerator.rational_content,
+    )
     return FractionBound(numerator, denominator)
 
 
@@ -148,7 +154,7 @@ def build_plan(
     metric: RationalCoordinateMetric, map_value: RationalFunctionMap
 ) -> Plan:
     n, m = len(map_value.source_variables), len(metric.tensor.coordinate_axis)
-    if n**2 > 256 or m**2 > 256 or m * n > 4096:
+    if n < 1 or n > 4 or n**2 > 256 or m**2 > 256 or m * n > 4096:
         reject(
             "shape",
             "complete metric pullback exceeds the tensor or Jacobian shape budget",
@@ -185,6 +191,15 @@ def build_plan(
     _multiply_polynomials(
         determinant_num.denominator, determinant_den.numerator, ledger
     )
+    guard_terms = sum(bound.denominator.terms for bound in map_bounds)
+    guard_terms += sum(value.denominator.terms for value in substitutions)
+    guard_terms += determinant_num.numerator.terms
+    for guard in metric.tensor.retained_nonzero_denominators:
+        guard_bound = _substitute_bound_only(
+            _polynomial_bound(guard), map_bounds, ledger
+        )
+        _validate_canonical_result_bound(guard_bound, ledger)
+        guard_terms += guard_bound.numerator.terms
     jacobian = []
     for bound in map_bounds:
         for axis in range(n):
@@ -247,9 +262,12 @@ def build_plan(
         + len(metric.tensor.components)
         + len(metric.tensor.retained_nonzero_denominators)
         + 1
+        + n * n
     )
     if guard_count > 768:
         reject("locus", "complete pullback locus exceeds 768 guards")
+    output_terms += guard_terms
+    output_digits += guard_terms * 8 * 128
     if output_terms > 65_536 or output_digits > 8_388_608:
         reject(
             "allocation", "complete pullback output exceeds its exact allocation budget"

--- a/src/jacobian/math/geometry/differential/pullback/_plan.py
+++ b/src/jacobian/math/geometry/differential/pullback/_plan.py
@@ -1,278 +1,96 @@
-"""Backend-free whole-request admission for metric pullbacks."""
-
+"""Whole request admission for rational metric pullbacks."""
 from dataclasses import dataclass, replace
-from typing import Any, NoReturn
+from fractions import Fraction
+from itertools import permutations
 
-from jacobian._execution import request_checkpoint
 from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.geometry.differential.metrics._dag import ONE, ZERO, Dag, Expression
 from jacobian.math.geometry.differential.metrics._models import RationalCoordinateMetric
 from jacobian.math.polynomials.rational_functions._bounds import (
-    BoundWorkCategory,
     FractionBound,
-    RationalFunctionBoundLimits,
-    _add_polynomials,
-    _differentiate_polynomial,
-    _fraction_bound,
-    _multiply_polynomials,
-    _one_polynomial,
+    _polynomial_admission_work_units,
+    _polynomial_backend_conversion_work_units,
     _polynomial_bound,
-    _remove_guaranteed_common_monomial,
-    _validate_canonical_result_bound,
-)
-from jacobian.math.polynomials.rational_functions.composition.operations import (
-    _substitute_bound,
+    _recognition_work_units,
 )
 from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+from jacobian.math.polynomials.values import SparseRationalPolynomial
 
 
-def reject(reason: str, message: str) -> NoReturn:
-    raise OperationResourceAdmissionError(
-        location=("metric", "map"),
-        code=f"differential_geometry.rational_metric.pullback.{reason}",
-        message=message,
-    )
-
-
-class Ledger:
-    limits = RationalFunctionBoundLimits(
-        raw_terms=4096,
-        raw_digits=4096,
-        result_exponent=64,
-        result_terms=256,
-        result_digits=128,
-        label="rational metric pullback",
-        reject=reject,
-    )
-
-    def __init__(self) -> None:
-        self.work = 0
-
-    def charge(self, category: BoundWorkCategory, amount: int) -> None:
-        request_checkpoint(f"during rational metric pullback admission {category}")
-        self.work += amount
-        if self.work > 100_000_000:
-            reject("work", "complete metric pullback exceeds its exact work envelope")
-
-
+def reject(reason: str, message: str) -> None:
+    raise OperationResourceAdmissionError(location=("metric", "map"), code=f"differential_geometry.rational_metric.pullback.{reason}", message=message)
 @dataclass(frozen=True)
 class Plan:
+    dag: Dag
     metric: RationalCoordinateMetric
     map: RationalFunctionMap
-    metric_substitutions: tuple[FractionBound, ...]
-    jacobian_entries: tuple[FractionBound, ...]
+    substitutions: tuple[Expression, ...]
+    jacobian: tuple[Expression, ...]
+    output: tuple[Expression, ...]
+    determinant: Expression
+    guards: tuple[Expression, ...]
 
-
-def _add_fraction(
-    left: FractionBound, right: FractionBound, ledger: Ledger
-) -> FractionBound:
-    return FractionBound(
-        _add_polynomials(
-            _multiply_polynomials(left.numerator, right.denominator, ledger),
-            _multiply_polynomials(right.numerator, left.denominator, ledger),
-            ledger,
-        ),
-        _multiply_polynomials(left.denominator, right.denominator, ledger),
-    )
-
-
-def _determinant_bound(
-    entries: tuple[FractionBound, ...], dimension: int, ledger: Ledger
-) -> FractionBound:
-    from itertools import permutations
-
-    result: FractionBound | None = None
-    for permutation in permutations(range(dimension)):
-        term = FractionBound(_one_polynomial(dimension), _one_polynomial(dimension))
-        for row, column in enumerate(permutation):
-            entry = entries[row * dimension + column]
-            term = FractionBound(
-                _multiply_polynomials(term.numerator, entry.numerator, ledger),
-                _multiply_polynomials(term.denominator, entry.denominator, ledger),
-            )
-        result = term if result is None else _add_fraction(result, term, ledger)
-    assert result is not None
+def _substitute(dag: Dag, value: SparseRationalPolynomial, inner: tuple[Expression, ...]) -> Expression:
+    result = ZERO
+    powers: dict[tuple[int, int], Expression] = {}
+    for term in value.terms:
+        part = Expression(term.coefficient.as_fraction())
+        for axis, exponent in enumerate(term.exponents):
+            power = ONE
+            for degree in range(1, exponent + 1):
+                key = (axis, degree)
+                if key not in powers:
+                    powers[key] = dag.multiply(power, inner[axis])
+                power = powers[key]
+            part = dag.multiply(part, power)
+        result = dag.add(result, part)
     return result
 
+def _determinant(dag: Dag, entries: tuple[Expression, ...], n: int) -> Expression:
+    terms = []
+    for permutation in permutations(range(n)):
+        inversions = sum(permutation[i] > permutation[j] for i in range(n) for j in range(i + 1, n))
+        terms.append(dag.multiply(Expression(Fraction((-1) ** inversions)), *(entries[i * n + j] for i, j in enumerate(permutation))))
+    return dag.add(*terms)
 
-def _substitute_bound_only(
-    polynomial: Any, inner_bounds: tuple[FractionBound, ...], ledger: Ledger
-) -> FractionBound:
-    variable_count = len(inner_bounds[0].numerator.degrees) if inner_bounds else 0
-    numerator = _one_polynomial(variable_count)
-    denominator = _one_polynomial(variable_count)
-    for degree, bound in zip(polynomial.degrees, inner_bounds, strict=True):
-        # Clearing denominators for every monomial of P is bounded by
-        # (N_i + D_i)^degree; this retains both numerator and denominator
-        # support, including terms whose exponent is not the maximum degree.
-        base = _add_polynomials(bound.numerator, bound.denominator, ledger)
-        for _ in range(degree):
-            numerator = _multiply_polynomials(numerator, base, ledger)
-            denominator = _multiply_polynomials(denominator, bound.denominator, ledger)
-    numerator = replace(
-        numerator,
-        coefficient_digits=(
-            numerator.coefficient_digits
-            + polynomial.coefficient_digits
-            + polynomial.terms.bit_length()
-        ),
-        rational_content=numerator.rational_content,
-    )
-    return FractionBound(numerator, denominator)
-
-
-def _derivative_bound(value: FractionBound, axis: int, ledger: Ledger) -> FractionBound:
-    n, d = value.numerator, value.denominator
-    dn = _differentiate_polynomial(
-        n,
-        axis,
-        ledger,
-        active_terms=n.terms if n.degrees[axis] else 0,
-        maximum_axis_exponent=max(1, n.degrees[axis]),
-        minimum_exponents=tuple(
-            max(0, e - int(i == axis)) for i, e in enumerate(n.minimum_exponents)
-        ),
-    )
-    dd = _differentiate_polynomial(
-        d,
-        axis,
-        ledger,
-        active_terms=d.terms if d.degrees[axis] else 0,
-        maximum_axis_exponent=max(1, d.degrees[axis]),
-        minimum_exponents=tuple(
-            max(0, e - int(i == axis)) for i, e in enumerate(d.minimum_exponents)
-        ),
-    )
-    numerator = _add_polynomials(
-        _multiply_polynomials(dn, d, ledger),
-        _multiply_polynomials(n, dd, ledger),
-        ledger,
-    )
-    return FractionBound(numerator, _multiply_polynomials(d, d, ledger))
-
-
-def build_plan(
-    metric: RationalCoordinateMetric, map_value: RationalFunctionMap
-) -> Plan:
+def build_plan(metric: RationalCoordinateMetric, map_value: RationalFunctionMap) -> Plan:
     n, m = len(map_value.source_variables), len(metric.tensor.coordinate_axis)
-    if n < 1 or n > 4 or n**2 > 256 or m**2 > 256 or m * n > 4096:
-        reject(
-            "shape",
-            "complete metric pullback exceeds the tensor or Jacobian shape budget",
-        )
-    ledger = Ledger()
-    metric_bounds = tuple(
-        _fraction_bound(value, ledger) for value in metric.tensor.components
-    )
-    map_bounds = tuple(_fraction_bound(value, ledger) for value in map_value.components)
-    substitutions = []
+    if not 1 <= n <= 4 or not 1 <= m <= 4:
+        reject("shape", "source and target dimensions must be between 1 and 4")
+    dag = Dag(n)
+    # Metric components are authored on the target axis. Reserve their raw
+    # parsing, backend conversion, and canonical recognition before any
+    # substituted DAG node can be evaluated.
     for value in metric.tensor.components:
-        substituted = _substitute_bound(value.numerator, map_bounds, ledger)
-        denominator = _substitute_bound(value.denominator, map_bounds, ledger)
-        substitutions.append(
-            FractionBound(
-                _multiply_polynomials(
-                    substituted.numerator, denominator.denominator, ledger
-                ),
-                _multiply_polynomials(
-                    substituted.denominator, denominator.numerator, ledger
-                ),
-            )
-        )
-    determinant_bound = _determinant_bound(metric_bounds, m, ledger)
-    determinant_num = _substitute_bound_only(
-        determinant_bound.numerator, map_bounds, ledger
-    )
-    determinant_den = _substitute_bound_only(
-        determinant_bound.denominator, map_bounds, ledger
-    )
-    _multiply_polynomials(
-        determinant_num.numerator, determinant_den.denominator, ledger
-    )
-    _multiply_polynomials(
-        determinant_num.denominator, determinant_den.numerator, ledger
-    )
-    guard_terms = sum(bound.denominator.terms for bound in map_bounds)
-    guard_terms += sum(value.denominator.terms for value in substitutions)
-    guard_terms += determinant_num.numerator.terms
+        for polynomial in (value.numerator, value.denominator):
+            dag.ledger.charge("source_conversion", _polynomial_admission_work_units(polynomial, m))
+            dag.ledger.charge("source_conversion", _polynomial_backend_conversion_work_units(_polynomial_bound(polynomial)))
+        nb, db = _polynomial_bound(value.numerator), _polynomial_bound(value.denominator)
+        width = max(len(nb.degrees), len(db.degrees))
+        if len(nb.degrees) != width:
+            nb = replace(nb, degrees=nb.degrees + (0,) * (width - len(nb.degrees)), minimum_exponents=nb.minimum_exponents + (0,) * (width - len(nb.minimum_exponents)))
+        if len(db.degrees) != width:
+            db = replace(db, degrees=db.degrees + (0,) * (width - len(db.degrees)), minimum_exponents=db.minimum_exponents + (0,) * (width - len(db.minimum_exponents)))
+        dag.ledger.charge("recognition", _recognition_work_units(FractionBound(nb, db)))
     for guard in metric.tensor.retained_nonzero_denominators:
-        guard_bound = _substitute_bound_only(
-            _polynomial_bound(guard), map_bounds, ledger
-        )
-        _validate_canonical_result_bound(guard_bound, ledger)
-        guard_terms += guard_bound.numerator.terms
-    jacobian = []
-    for bound in map_bounds:
-        for axis in range(n):
-            jacobian.append(_derivative_bound(bound, axis, ledger))
-    # Reserve the complete contraction using raw cleared fractions. This is
-    # deliberately conservative and happens before any nested executor runs.
-    output_terms = 0
-    output_digits = 0
-    for a in range(n):
-        for b in range(n):
-            contraction: FractionBound | None = None
-            for i in range(m):
-                for j in range(m):
-                    left = jacobian[i * n + a]
-                    right = jacobian[j * n + b]
-                    middle = substitutions[i * m + j]
-                    term = FractionBound(
-                        _multiply_polynomials(
-                            _multiply_polynomials(
-                                left.numerator, middle.numerator, ledger
-                            ),
-                            right.numerator,
-                            ledger,
-                        ),
-                        _multiply_polynomials(
-                            _multiply_polynomials(
-                                left.denominator, middle.denominator, ledger
-                            ),
-                            right.denominator,
-                            ledger,
-                        ),
-                    )
-                    contraction = (
-                        term
-                        if contraction is None
-                        else FractionBound(
-                            _add_polynomials(
-                                _multiply_polynomials(
-                                    contraction.numerator, term.denominator, ledger
-                                ),
-                                _multiply_polynomials(
-                                    term.numerator, contraction.denominator, ledger
-                                ),
-                                ledger,
-                            ),
-                            _multiply_polynomials(
-                                contraction.denominator, term.denominator, ledger
-                            ),
-                        )
-                    )
-            assert contraction is not None
-            canonical = _remove_guaranteed_common_monomial(contraction)
-            digits = _validate_canonical_result_bound(canonical, ledger)
-            output_terms += canonical.numerator.terms + canonical.denominator.terms
-            output_digits += (
-                8 * digits * (canonical.numerator.terms + canonical.denominator.terms)
-            )
-    guard_count = (
-        len(map_value.components)
-        + len(metric.tensor.components)
-        + len(metric.tensor.retained_nonzero_denominators)
-        + 1
-        + n * n
-    )
-    if guard_count > 768:
+        dag.ledger.charge("source_conversion", _polynomial_admission_work_units(guard, m))
+    maps = tuple(dag.fraction(value) for value in map_value.components)
+    map_denominators = tuple(dag.source(value.denominator) for value in map_value.components)
+    substitutions = tuple(_substitute(dag, value.numerator, maps) for value in metric.tensor.components)
+    substitutions = tuple(dag.multiply(value, dag.inverse(_substitute(dag, metric.tensor.components[i].denominator, maps))) for i, value in enumerate(substitutions))
+    jacobian = tuple(dag.derivative(value, axis) for value in maps for axis in range(n))
+    determinant = _determinant(dag, substitutions, m)
+    output = tuple(dag.add(*(dag.multiply(jacobian[i * n + a], substitutions[i * m + j], jacobian[j * n + b]) for i in range(m) for j in range(m))) for a in range(n) for b in range(n))
+    inherited = tuple(_substitute(dag, guard, maps) for guard in metric.tensor.retained_nonzero_denominators)
+    component_guards = tuple(_substitute(dag, value.denominator, maps) for value in metric.tensor.components)
+    guards = tuple(map_denominators) + component_guards + inherited + (determinant,)
+    values = tuple(dict.fromkeys((*output, *guards)))
+    sizes = {value: dag.admit_output(value) for value in values}
+    if len(guards) > 768:
         reject("locus", "complete pullback locus exceeds 768 guards")
-    output_terms += guard_terms
-    output_digits += guard_terms * 8 * 128
-    if output_terms > 65_536 or output_digits > 8_388_608:
-        reject(
-            "allocation", "complete pullback output exceeds its exact allocation budget"
-        )
-    return Plan(metric, map_value, tuple(substitutions), tuple(jacobian))
-
-
+    terms = sum(sizes[value][0] for value in sizes) + len(output) * n * (len(values) + 2)
+    bits = sum(sizes[value][1] for value in sizes)
+    if terms > 65536 or bits > 8388608:
+        reject("allocation", "complete pullback output exceeds its exact allocation budget")
+    return Plan(dag, metric, map_value, substitutions, jacobian, output, determinant, guards)
 __all__ = ["Plan", "build_plan"]

--- a/src/jacobian/math/geometry/differential/pullback/_tools.py
+++ b/src/jacobian/math/geometry/differential/pullback/_tools.py
@@ -1,0 +1,29 @@
+"""Operation declaration for exact rational metric pullbacks."""
+
+from typing import Any
+
+from jacobian.catalog.models import MathTool
+from jacobian.math.geometry.differential.pullback._models import (
+    RationalMetricPullbackProfile,
+    RationalMetricPullbackRequest,
+)
+from jacobian.math.geometry.differential.pullback.operations import pullback_metric
+
+
+def _compute(request: RationalMetricPullbackRequest) -> RationalMetricPullbackProfile:
+    return pullback_metric(request.metric, request.map)
+
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="differential_geometry.rational_metric.pullback.compute",
+        title="Pull back a rational coordinate metric",
+        description="Compute the exact covariant pullback tensor and retain its source-bound construction locus.",
+        request_type=RationalMetricPullbackRequest,
+        result_type=RationalMetricPullbackProfile,
+        run=_compute,
+        tags=("differential-geometry", "metric", "pullback", "rational"),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/geometry/differential/pullback/_tools.py
+++ b/src/jacobian/math/geometry/differential/pullback/_tools.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jacobian.catalog.models import MathTool
+from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.geometry.differential.pullback._models import (
     RationalMetricPullbackProfile,
     RationalMetricPullbackRequest,
@@ -23,6 +23,66 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         result_type=RationalMetricPullbackProfile,
         run=_compute,
         tags=("differential-geometry", "metric", "pullback", "rational"),
+        examples=(
+            OperationExample(
+                name="square_map_on_a_line",
+                description="Pull back du² along u=x² to obtain 4x² dx², retaining the valid degenerate point x=0.",
+                input={
+                    "metric": {
+                        "tensor": {
+                            "coordinate_axis": ["u"],
+                            "variance": ["COVARIANT", "COVARIANT"],
+                            "components": [
+                                {
+                                    "variables": ["u"],
+                                    "numerator": {
+                                        "terms": [
+                                            {
+                                                "coefficient": {"num": "1", "den": "1"},
+                                                "exponents": [0],
+                                            }
+                                        ]
+                                    },
+                                    "denominator": {
+                                        "terms": [
+                                            {
+                                                "coefficient": {"num": "1", "den": "1"},
+                                                "exponents": [0],
+                                            }
+                                        ]
+                                    },
+                                }
+                            ],
+                        }
+                    },
+                    "map": {
+                        "source_variables": ["x"],
+                        "target_coordinates": ["u"],
+                        "components": [
+                            {
+                                "variables": ["x"],
+                                "numerator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [2],
+                                        }
+                                    ]
+                                },
+                                "denominator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [0],
+                                        }
+                                    ]
+                                },
+                            }
+                        ],
+                    },
+                },
+            ),
+        ),
     ),
 )
 

--- a/src/jacobian/math/geometry/differential/pullback/operations.py
+++ b/src/jacobian/math/geometry/differential/pullback/operations.py
@@ -188,12 +188,14 @@ def pullback_metric(
             variable_count=n,
         ),
     )
-    return RationalMetricPullbackProfile(
+    profile = RationalMetricPullbackProfile(
         metric=metric,
         map=map_value,
         pullback=tensor,
         pullback_locus_guard=tensor.retained_nonzero_denominators,
     )
+    request_checkpoint("after rational metric pullback construction")
+    return profile
 
 
 __all__ = ["pullback_metric"]

--- a/src/jacobian/math/geometry/differential/pullback/operations.py
+++ b/src/jacobian/math/geometry/differential/pullback/operations.py
@@ -1,7 +1,9 @@
 """Exact rational metric pullback operation."""
+
 from __future__ import annotations
 
 import time
+from typing import Any
 
 from pydantic_core import PydanticCustomError
 
@@ -12,7 +14,12 @@ from jacobian._execution import (
     request_execution,
 )
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.differential._recognition_process import (
+    RationalFunctionRecognitionCandidate,
+    recognize_canonical_rational_functions,
+)
 from jacobian.math.geometry.differential.metrics._dag import Expression
+from jacobian.math.geometry.differential.metrics._models import RationalCoordinateMetric
 from jacobian.math.geometry.differential.metrics._normalize_process import (
     cancel_fraction,
 )
@@ -25,14 +32,58 @@ from jacobian.math.geometry.differential.values import (
     RationalCoordinateTensor,
     canonical_locus_guards,
 )
-from jacobian.math.polynomials._conversions import sparse_rational_polynomial_from_sympy
+from jacobian.math.polynomials._conversions import (
+    sparse_rational_polynomial_from_sympy,
+    symbols_for_variables,
+)
+from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
 from jacobian.math.polynomials.values import (
     RationalFunction,
     require_canonical_rational_function,
 )
 
 
-def pullback_metric(metric, map_value) -> RationalMetricPullbackProfile:
+def _recognize_sources(
+    components: tuple[RationalFunction, ...], deadline: float
+) -> None:
+    candidates = []
+    for index, component in enumerate(dict.fromkeys(components)):
+        request_checkpoint("before pullback source recognition")
+        # Monomial denominators have an exact exponent-wise recognition path;
+        # general polynomial GCDs run in the existing killable worker.
+        if (
+            not component.numerator.terms
+            or not component.variables
+            or len(component.denominator.terms) == 1
+        ):
+            try:
+                require_canonical_rational_function(component)
+            except PydanticCustomError as exc:
+                raise OperationDomainValidationError(
+                    location=("metric", "map"),
+                    code="differential_geometry.rational_metric.pullback.noncanonical_source",
+                    message="metric and map components must be reduced canonical rational functions",
+                ) from exc
+        else:
+            candidates.append(
+                RationalFunctionRecognitionCandidate(
+                    owner="tensor", component=index, value=component
+                )
+            )
+    recognition = recognize_canonical_rational_functions(
+        tuple(candidates), deadline=deadline
+    )
+    if recognition.non_coprime is not None:
+        raise OperationDomainValidationError(
+            location=("metric", "map"),
+            code="differential_geometry.rational_metric.pullback.noncanonical_source",
+            message="metric and map components must be reduced canonical rational functions",
+        )
+
+
+def pullback_metric(
+    metric: RationalCoordinateMetric, map_value: RationalFunctionMap
+) -> RationalMetricPullbackProfile:
     execution = current_request_execution()
     if execution is None:
         with request_execution(time.monotonic()):
@@ -43,43 +94,106 @@ def pullback_metric(metric, map_value) -> RationalMetricPullbackProfile:
     bind_request_deadline(deadline)
     request_checkpoint("before rational metric pullback admission")
     if map_value.target_coordinates != metric.tensor.coordinate_axis:
-        raise OperationDomainValidationError(location=("map", "target_coordinates"), code="differential_geometry.rational_metric.pullback.axis_mismatch", message="map target coordinates must equal metric coordinate axis")
+        raise OperationDomainValidationError(
+            location=("map", "target_coordinates"),
+            code="differential_geometry.rational_metric.pullback.axis_mismatch",
+            message="map target coordinates must equal metric coordinate axis",
+        )
     n = len(map_value.source_variables)
     if not 1 <= n <= 4:
-        raise OperationDomainValidationError(location=("map", "source_variables"), code="differential_geometry.rational_metric.pullback.axis", message="source coordinate axis must have between 1 and 4 coordinates")
+        raise OperationDomainValidationError(
+            location=("map", "source_variables"),
+            code="differential_geometry.rational_metric.pullback.axis",
+            message="source coordinate axis must have between 1 and 4 coordinates",
+        )
     plan = build_plan(metric, map_value)
     request_checkpoint("after complete rational metric pullback admission")
-    for component in dict.fromkeys(metric.tensor.components):
-        try:
-            require_canonical_rational_function(component)
-        except PydanticCustomError as exc:
-            raise OperationDomainValidationError(location=("metric",), code="differential_geometry.rational_metric.pullback.noncanonical_source", message="metric component must be a reduced canonical rational function") from exc
+    _recognize_sources((*metric.tensor.components, *map_value.components), deadline)
     from sympy import QQ, Poly
+
     axis = map_value.source_variables
-    from jacobian.math.polynomials._conversions import symbols_for_variables
     symbols = symbols_for_variables(axis)
     cache = {0: Poly(0, *symbols, domain=QQ), 1: Poly(1, *symbols, domain=QQ)}
-    def raw(value: Expression):
-        return (_evaluate_node(plan.dag.polynomial(value.numerator, value.scalar), plan.dag.nodes, axis, cache), _evaluate_node(plan.dag.polynomial(value.denominator), plan.dag.nodes, axis, cache))
+
+    def raw(value: Expression) -> tuple[Any, Any]:
+        numerator, denominator = plan.fractions[value]
+        return (
+            _evaluate_node(
+                numerator,
+                plan.dag.nodes,
+                axis,
+                cache,
+            ),
+            _evaluate_node(denominator, plan.dag.nodes, axis, cache),
+        )
+
+    normalized: dict[Expression, tuple[Any, Any]] = {}
+
+    def normalize(value: Expression) -> tuple[Any, Any]:
+        if value not in normalized:
+            request_checkpoint("before rational metric pullback normalization")
+            numerator, denominator = raw(value)
+            normalized[value] = cancel_fraction(
+                numerator, denominator, deadline=deadline
+            )
+            request_checkpoint("after rational metric pullback normalization")
+        return normalized[value]
+
     guards = []
     for guard in plan.guards:
         numerator, _ = raw(guard)
         if numerator.is_zero:
-            if guard is plan.determinant:
-                raise OperationDomainValidationError(location=("metric",), code="differential_geometry.rational_metric.pullback.singular_metric", message="metric determinant vanishes identically after substitution")
-            raise OperationDomainValidationError(location=("metric",), code="differential_geometry.rational_metric.pullback.undefined_metric_locus", message="a required metric or map denominator guard vanishes identically after substitution")
-        guards.append(sparse_rational_polynomial_from_sympy(numerator.monic(), axis, maximum_terms=256))
-    normalized: dict[Expression, RationalFunction] = {}
+            if guard == plan.determinant:
+                raise OperationDomainValidationError(
+                    location=("metric",),
+                    code="differential_geometry.rational_metric.pullback.singular_metric",
+                    message="metric determinant vanishes identically after substitution",
+                )
+            raise OperationDomainValidationError(
+                location=("metric",),
+                code="differential_geometry.rational_metric.pullback.undefined_metric_locus",
+                message="a required metric or map denominator guard vanishes identically after substitution",
+            )
+        normalized_numerator, _ = normalize(guard)
+        guards.append(
+            sparse_rational_polynomial_from_sympy(
+                normalized_numerator.monic(), axis, maximum_terms=256
+            )
+        )
+    functions: dict[Expression, RationalFunction] = {}
+
     def convert(value: Expression) -> RationalFunction:
-        if value not in normalized:
-            request_checkpoint("before rational metric pullback normalization")
-            numerator, denominator = raw(value)
-            num, den = cancel_fraction(numerator, denominator, deadline=deadline)
-            normalized[value] = RationalFunction._from_kernel(variables=axis, numerator=sparse_rational_polynomial_from_sympy(num, axis, maximum_terms=256), denominator=sparse_rational_polynomial_from_sympy(den, axis, maximum_terms=256))
-            request_checkpoint("after rational metric pullback normalization")
-        return normalized[value]
+        if value not in functions:
+            num, den = normalize(value)
+            functions[value] = RationalFunction._from_kernel(
+                variables=axis,
+                numerator=sparse_rational_polynomial_from_sympy(
+                    num, axis, maximum_terms=256
+                ),
+                denominator=sparse_rational_polynomial_from_sympy(
+                    den, axis, maximum_terms=256
+                ),
+            )
+        return functions[value]
+
     output = tuple(convert(value) for value in plan.output)
     guard_polynomials = tuple(guards)
-    tensor = RationalCoordinateTensor(coordinate_axis=axis, variance=("COVARIANT", "COVARIANT"), components=output, retained_nonzero_denominators=canonical_locus_guards(guard_polynomials, component_denominators=tuple(value.denominator for value in output), variable_count=n))
-    return RationalMetricPullbackProfile(metric=metric, map=map_value, pullback=tensor, pullback_locus_guard=tensor.retained_nonzero_denominators)
+    tensor = RationalCoordinateTensor(
+        coordinate_axis=axis,
+        variance=("COVARIANT", "COVARIANT"),
+        components=output,
+        retained_nonzero_denominators=canonical_locus_guards(
+            guard_polynomials,
+            component_denominators=tuple(value.denominator for value in output),
+            variable_count=n,
+        ),
+    )
+    return RationalMetricPullbackProfile(
+        metric=metric,
+        map=map_value,
+        pullback=tensor,
+        pullback_locus_guard=tensor.retained_nonzero_denominators,
+    )
+
+
 __all__ = ["pullback_metric"]

--- a/src/jacobian/math/geometry/differential/pullback/operations.py
+++ b/src/jacobian/math/geometry/differential/pullback/operations.py
@@ -1,0 +1,213 @@
+"""Exact pullback of rational coordinate metrics along rational maps."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from jacobian._exact import CanonicalRational
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.differential.metrics._models import RationalCoordinateMetric
+from jacobian.math.geometry.differential.pullback._models import (
+    RationalMetricPullbackProfile,
+)
+from jacobian.math.geometry.differential.pullback._plan import build_plan
+from jacobian.math.geometry.differential.values import (
+    RationalCoordinateTensor,
+    canonical_locus_guards,
+)
+from jacobian.math.polynomials._conversions import (
+    rational_function_from_sympy,
+    rational_function_to_sympy,
+    sparse_rational_polynomial_from_sympy,
+    sparse_rational_polynomial_to_sympy,
+    symbols_for_variables,
+)
+from jacobian.math.polynomials.rational_functions.composition.operations import (
+    compose_maps,
+)
+from jacobian.math.polynomials.rational_functions.gradient._kernel import (
+    _normalize_fraction,
+)
+from jacobian.math.polynomials.rational_functions.maps.operations import jacobian_matrix
+from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+from jacobian.math.polynomials.values import (
+    RationalFunction,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _unit(variables: tuple[str, ...]) -> SparseRationalPolynomial:
+    return SparseRationalPolynomial(
+        terms=(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational(num=1, den=1),
+                exponents=(0,) * len(variables),
+            ),
+        )
+    )
+
+
+def _as_function(
+    polynomial: SparseRationalPolynomial, variables: tuple[str, ...]
+) -> RationalFunction:
+    return RationalFunction(
+        variables=variables, numerator=polynomial, denominator=_unit(variables)
+    )
+
+
+def _synthetic_map(
+    variables: tuple[str, ...], components: tuple[RationalFunction, ...], prefix: str
+) -> RationalFunctionMap:
+    return RationalFunctionMap(
+        source_variables=variables,
+        target_coordinates=tuple(f"{prefix}{i}" for i in range(len(components))),
+        components=components,
+    )
+
+
+def _metric_substitution(
+    metric: RationalCoordinateMetric, map_value: RationalFunctionMap
+) -> Any:
+    axis = metric.tensor.coordinate_axis
+    components = metric.tensor.components
+    outer = _synthetic_map(axis, components, "g")
+    return compose_maps(outer, map_value)
+
+
+def _determinant_substitution(
+    metric: RationalCoordinateMetric, map_value: RationalFunctionMap
+) -> Any:
+    from sympy import Matrix
+
+    axis = metric.tensor.coordinate_axis
+    matrix = Matrix(
+        [
+            [
+                rational_function_to_sympy(metric.tensor.components[i * len(axis) + j])
+                for j in range(len(axis))
+            ]
+            for i in range(len(axis))
+        ]
+    )
+    determinant = rational_function_from_sympy(matrix.det(), axis)
+    return compose_maps(_synthetic_map(axis, (determinant,), "det"), map_value)
+
+
+def pullback_metric(
+    metric: RationalCoordinateMetric, map_value: RationalFunctionMap
+) -> RationalMetricPullbackProfile:
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return pullback_metric(metric, map_value)
+    deadline = execution.started_at + 120
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before rational metric pullback admission")
+    if map_value.target_coordinates != metric.tensor.coordinate_axis:
+        raise OperationDomainValidationError(
+            location=("map", "target_coordinates"),
+            code="differential_geometry.rational_metric.pullback.axis_mismatch",
+            message="map target coordinates must equal metric coordinate axis",
+        )
+    build_plan(metric, map_value)
+    substituted = _metric_substitution(metric, map_value)
+    determinant = _determinant_substitution(metric, map_value)
+    if not determinant.composite.components[0].numerator.terms:
+        raise OperationDomainValidationError(
+            location=("metric", "tensor"),
+            code="differential_geometry.rational_metric.pullback.singular_metric",
+            message="metric determinant vanishes identically after substitution",
+        )
+    jacobian = jacobian_matrix(map_value)
+    axis = metric.tensor.coordinate_axis
+    xaxis = map_value.source_variables
+    xsymbols = symbols_for_variables(xaxis)
+    substituted_values = tuple(
+        rational_function_to_sympy(value) for value in substituted.composite.components
+    )
+    entries = jacobian.entries
+    metric_size = len(metric.tensor.coordinate_axis)
+    output = []
+    for a in range(len(xaxis)):
+        for b in range(len(xaxis)):
+            request_checkpoint("during rational metric pullback contraction")
+            expression = None
+            for i in range(metric_size):
+                for j in range(metric_size):
+                    left = rational_function_to_sympy(entries[i][a])
+                    middle = substituted_values[i * metric_size + j]
+                    right = rational_function_to_sympy(entries[j][b])
+                    term = left * middle * right
+                    expression = term if expression is None else expression + term
+            if expression is None:
+                expression = 0
+            from sympy import Poly, together
+
+            numerator, denominator = together(expression).as_numer_denom()
+            output.append(
+                _normalize_fraction(
+                    Poly(numerator, *xsymbols, domain="QQ"),
+                    Poly(denominator, *xsymbols, domain="QQ"),
+                    xaxis,
+                )
+            )
+    guards = [guard.polynomial for guard in substituted.construction_locus_guard]
+    guards.extend(guard.polynomial for guard in determinant.construction_locus_guard)
+    determinant_value = determinant.composite.components[0]
+    if any(term.exponents for term in determinant_value.numerator.terms):
+        guards.append(
+            sparse_rational_polynomial_from_sympy(
+                sparse_rational_polynomial_to_sympy(
+                    determinant_value.numerator, xaxis
+                ).monic(),
+                xaxis,
+            )
+        )
+    for guard in metric.tensor.retained_nonzero_denominators:
+        guard_map = _synthetic_map(axis, (_as_function(guard, axis),), "h")
+        guard_result = compose_maps(guard_map, map_value)
+        guard_value = guard_result.composite.components[0]
+        if not guard_value.numerator.terms:
+            raise OperationDomainValidationError(
+                location=("metric", "retained_nonzero_denominators"),
+                code="differential_geometry.rational_metric.pullback.undefined_metric_locus",
+                message="a retained metric locus guard vanishes identically after substitution",
+            )
+        guards.append(
+            sparse_rational_polynomial_from_sympy(
+                sparse_rational_polynomial_to_sympy(
+                    guard_value.numerator, xaxis
+                ).monic(),
+                xaxis,
+            )
+        )
+    guard_polynomials = tuple(guards)
+    result_tensor = RationalCoordinateTensor(
+        coordinate_axis=xaxis,
+        variance=("COVARIANT", "COVARIANT"),
+        components=tuple(output),
+        retained_nonzero_denominators=canonical_locus_guards(
+            guard_polynomials,
+            component_denominators=tuple(value.denominator for value in output),
+            variable_count=len(xaxis),
+        ),
+    )
+    return RationalMetricPullbackProfile(
+        metric=metric,
+        map=map_value,
+        pullback=result_tensor,
+        pullback_locus_guard=result_tensor.retained_nonzero_denominators,
+    )
+
+
+__all__ = ["pullback_metric"]

--- a/src/jacobian/math/geometry/differential/pullback/operations.py
+++ b/src/jacobian/math/geometry/differential/pullback/operations.py
@@ -1,11 +1,10 @@
-"""Exact pullback of rational coordinate metrics along rational maps."""
-
+"""Exact rational metric pullback operation."""
 from __future__ import annotations
 
 import time
-from typing import Any
 
-from jacobian._exact import CanonicalRational
+from pydantic_core import PydanticCustomError
+
 from jacobian._execution import (
     bind_request_deadline,
     current_request_execution,
@@ -13,7 +12,11 @@ from jacobian._execution import (
     request_execution,
 )
 from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.geometry.differential.metrics._models import RationalCoordinateMetric
+from jacobian.math.geometry.differential.metrics._dag import Expression
+from jacobian.math.geometry.differential.metrics._normalize_process import (
+    cancel_fraction,
+)
+from jacobian.math.geometry.differential.metrics.operations import _evaluate_node
 from jacobian.math.geometry.differential.pullback._models import (
     RationalMetricPullbackProfile,
 )
@@ -22,88 +25,14 @@ from jacobian.math.geometry.differential.values import (
     RationalCoordinateTensor,
     canonical_locus_guards,
 )
-from jacobian.math.polynomials._conversions import (
-    rational_function_from_sympy,
-    rational_function_to_sympy,
-    sparse_rational_polynomial_from_sympy,
-    sparse_rational_polynomial_to_sympy,
-    symbols_for_variables,
-)
-from jacobian.math.polynomials.rational_functions.composition.operations import (
-    compose_maps,
-)
-from jacobian.math.polynomials.rational_functions.gradient._kernel import (
-    _normalize_fraction,
-)
-from jacobian.math.polynomials.rational_functions.maps.operations import jacobian_matrix
-from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+from jacobian.math.polynomials._conversions import sparse_rational_polynomial_from_sympy
 from jacobian.math.polynomials.values import (
     RationalFunction,
-    RationalPolynomialTerm,
-    SparseRationalPolynomial,
+    require_canonical_rational_function,
 )
 
 
-def _unit(variables: tuple[str, ...]) -> SparseRationalPolynomial:
-    return SparseRationalPolynomial(
-        terms=(
-            RationalPolynomialTerm(
-                coefficient=CanonicalRational(num=1, den=1),
-                exponents=(0,) * len(variables),
-            ),
-        )
-    )
-
-
-def _as_function(
-    polynomial: SparseRationalPolynomial, variables: tuple[str, ...]
-) -> RationalFunction:
-    return RationalFunction(
-        variables=variables, numerator=polynomial, denominator=_unit(variables)
-    )
-
-
-def _synthetic_map(
-    variables: tuple[str, ...], components: tuple[RationalFunction, ...], prefix: str
-) -> RationalFunctionMap:
-    return RationalFunctionMap(
-        source_variables=variables,
-        target_coordinates=tuple(f"{prefix}{i}" for i in range(len(components))),
-        components=components,
-    )
-
-
-def _metric_substitution(
-    metric: RationalCoordinateMetric, map_value: RationalFunctionMap
-) -> Any:
-    axis = metric.tensor.coordinate_axis
-    components = metric.tensor.components
-    outer = _synthetic_map(axis, components, "g")
-    return compose_maps(outer, map_value)
-
-
-def _determinant_substitution(
-    metric: RationalCoordinateMetric, map_value: RationalFunctionMap
-) -> Any:
-    from sympy import Matrix
-
-    axis = metric.tensor.coordinate_axis
-    matrix = Matrix(
-        [
-            [
-                rational_function_to_sympy(metric.tensor.components[i * len(axis) + j])
-                for j in range(len(axis))
-            ]
-            for i in range(len(axis))
-        ]
-    )
-    determinant = rational_function_from_sympy(matrix.det(), axis)
-    return compose_maps(_synthetic_map(axis, (determinant,), "det"), map_value)
-
-
-def pullback_metric(
-    metric: RationalCoordinateMetric, map_value: RationalFunctionMap
-) -> RationalMetricPullbackProfile:
+def pullback_metric(metric, map_value) -> RationalMetricPullbackProfile:
     execution = current_request_execution()
     if execution is None:
         with request_execution(time.monotonic()):
@@ -114,100 +43,43 @@ def pullback_metric(
     bind_request_deadline(deadline)
     request_checkpoint("before rational metric pullback admission")
     if map_value.target_coordinates != metric.tensor.coordinate_axis:
-        raise OperationDomainValidationError(
-            location=("map", "target_coordinates"),
-            code="differential_geometry.rational_metric.pullback.axis_mismatch",
-            message="map target coordinates must equal metric coordinate axis",
-        )
-    build_plan(metric, map_value)
-    substituted = _metric_substitution(metric, map_value)
-    determinant = _determinant_substitution(metric, map_value)
-    if not determinant.composite.components[0].numerator.terms:
-        raise OperationDomainValidationError(
-            location=("metric", "tensor"),
-            code="differential_geometry.rational_metric.pullback.singular_metric",
-            message="metric determinant vanishes identically after substitution",
-        )
-    jacobian = jacobian_matrix(map_value)
-    axis = metric.tensor.coordinate_axis
-    xaxis = map_value.source_variables
-    xsymbols = symbols_for_variables(xaxis)
-    substituted_values = tuple(
-        rational_function_to_sympy(value) for value in substituted.composite.components
-    )
-    entries = jacobian.entries
-    metric_size = len(metric.tensor.coordinate_axis)
-    output = []
-    for a in range(len(xaxis)):
-        for b in range(len(xaxis)):
-            request_checkpoint("during rational metric pullback contraction")
-            expression = None
-            for i in range(metric_size):
-                for j in range(metric_size):
-                    left = rational_function_to_sympy(entries[i][a])
-                    middle = substituted_values[i * metric_size + j]
-                    right = rational_function_to_sympy(entries[j][b])
-                    term = left * middle * right
-                    expression = term if expression is None else expression + term
-            if expression is None:
-                expression = 0
-            from sympy import Poly, together
-
-            numerator, denominator = together(expression).as_numer_denom()
-            output.append(
-                _normalize_fraction(
-                    Poly(numerator, *xsymbols, domain="QQ"),
-                    Poly(denominator, *xsymbols, domain="QQ"),
-                    xaxis,
-                )
-            )
-    guards = [guard.polynomial for guard in substituted.construction_locus_guard]
-    guards.extend(guard.polynomial for guard in determinant.construction_locus_guard)
-    determinant_value = determinant.composite.components[0]
-    if any(term.exponents for term in determinant_value.numerator.terms):
-        guards.append(
-            sparse_rational_polynomial_from_sympy(
-                sparse_rational_polynomial_to_sympy(
-                    determinant_value.numerator, xaxis
-                ).monic(),
-                xaxis,
-            )
-        )
-    for guard in metric.tensor.retained_nonzero_denominators:
-        guard_map = _synthetic_map(axis, (_as_function(guard, axis),), "h")
-        guard_result = compose_maps(guard_map, map_value)
-        guard_value = guard_result.composite.components[0]
-        if not guard_value.numerator.terms:
-            raise OperationDomainValidationError(
-                location=("metric", "retained_nonzero_denominators"),
-                code="differential_geometry.rational_metric.pullback.undefined_metric_locus",
-                message="a retained metric locus guard vanishes identically after substitution",
-            )
-        guards.append(
-            sparse_rational_polynomial_from_sympy(
-                sparse_rational_polynomial_to_sympy(
-                    guard_value.numerator, xaxis
-                ).monic(),
-                xaxis,
-            )
-        )
+        raise OperationDomainValidationError(location=("map", "target_coordinates"), code="differential_geometry.rational_metric.pullback.axis_mismatch", message="map target coordinates must equal metric coordinate axis")
+    n = len(map_value.source_variables)
+    if not 1 <= n <= 4:
+        raise OperationDomainValidationError(location=("map", "source_variables"), code="differential_geometry.rational_metric.pullback.axis", message="source coordinate axis must have between 1 and 4 coordinates")
+    plan = build_plan(metric, map_value)
+    request_checkpoint("after complete rational metric pullback admission")
+    for component in dict.fromkeys(metric.tensor.components):
+        try:
+            require_canonical_rational_function(component)
+        except PydanticCustomError as exc:
+            raise OperationDomainValidationError(location=("metric",), code="differential_geometry.rational_metric.pullback.noncanonical_source", message="metric component must be a reduced canonical rational function") from exc
+    from sympy import QQ, Poly
+    axis = map_value.source_variables
+    from jacobian.math.polynomials._conversions import symbols_for_variables
+    symbols = symbols_for_variables(axis)
+    cache = {0: Poly(0, *symbols, domain=QQ), 1: Poly(1, *symbols, domain=QQ)}
+    def raw(value: Expression):
+        return (_evaluate_node(plan.dag.polynomial(value.numerator, value.scalar), plan.dag.nodes, axis, cache), _evaluate_node(plan.dag.polynomial(value.denominator), plan.dag.nodes, axis, cache))
+    guards = []
+    for guard in plan.guards:
+        numerator, _ = raw(guard)
+        if numerator.is_zero:
+            if guard is plan.determinant:
+                raise OperationDomainValidationError(location=("metric",), code="differential_geometry.rational_metric.pullback.singular_metric", message="metric determinant vanishes identically after substitution")
+            raise OperationDomainValidationError(location=("metric",), code="differential_geometry.rational_metric.pullback.undefined_metric_locus", message="a required metric or map denominator guard vanishes identically after substitution")
+        guards.append(sparse_rational_polynomial_from_sympy(numerator.monic(), axis, maximum_terms=256))
+    normalized: dict[Expression, RationalFunction] = {}
+    def convert(value: Expression) -> RationalFunction:
+        if value not in normalized:
+            request_checkpoint("before rational metric pullback normalization")
+            numerator, denominator = raw(value)
+            num, den = cancel_fraction(numerator, denominator, deadline=deadline)
+            normalized[value] = RationalFunction._from_kernel(variables=axis, numerator=sparse_rational_polynomial_from_sympy(num, axis, maximum_terms=256), denominator=sparse_rational_polynomial_from_sympy(den, axis, maximum_terms=256))
+            request_checkpoint("after rational metric pullback normalization")
+        return normalized[value]
+    output = tuple(convert(value) for value in plan.output)
     guard_polynomials = tuple(guards)
-    result_tensor = RationalCoordinateTensor(
-        coordinate_axis=xaxis,
-        variance=("COVARIANT", "COVARIANT"),
-        components=tuple(output),
-        retained_nonzero_denominators=canonical_locus_guards(
-            guard_polynomials,
-            component_denominators=tuple(value.denominator for value in output),
-            variable_count=len(xaxis),
-        ),
-    )
-    return RationalMetricPullbackProfile(
-        metric=metric,
-        map=map_value,
-        pullback=result_tensor,
-        pullback_locus_guard=result_tensor.retained_nonzero_denominators,
-    )
-
-
+    tensor = RationalCoordinateTensor(coordinate_axis=axis, variance=("COVARIANT", "COVARIANT"), components=output, retained_nonzero_denominators=canonical_locus_guards(guard_polynomials, component_denominators=tuple(value.denominator for value in output), variable_count=n))
+    return RationalMetricPullbackProfile(metric=metric, map=map_value, pullback=tensor, pullback_locus_guard=tensor.retained_nonzero_denominators)
 __all__ = ["pullback_metric"]

--- a/src/jacobian/math/polynomials/rational_functions/composition/__init__.py
+++ b/src/jacobian/math/polynomials/rational_functions/composition/__init__.py
@@ -2,7 +2,6 @@
 
 from jacobian.math.polynomials.rational_functions.composition._models import (
     RationalFunctionMapComposition,
-    RationalMapCompositionRequest,
 )
 from jacobian.math.polynomials.rational_functions.composition.operations import (
     compose_maps,
@@ -10,6 +9,5 @@ from jacobian.math.polynomials.rational_functions.composition.operations import 
 
 __all__ = [
     "RationalFunctionMapComposition",
-    "RationalMapCompositionRequest",
     "compose_maps",
 ]

--- a/src/jacobian/math/polynomials/rational_functions/composition/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/composition/operations.py
@@ -24,7 +24,6 @@ from jacobian.math.polynomials._conversions import (
     symbols_for_variables,
 )
 from jacobian.math.polynomials.rational_functions._bounds import (
-    BoundsLedger,
     BoundWorkCategory,
     FractionBound,
     PolynomialBound,
@@ -203,7 +202,7 @@ def _power(
 def _substitute_bound(
     polynomial: SparseRationalPolynomial,
     inner_bounds: tuple[FractionBound, ...],
-    ledger: BoundsLedger,
+    ledger: _Ledger,
 ) -> _SubstitutionBound:
     """Bound a cleared-denominator substitution before any CAS expansion."""
     variable_count = len(inner_bounds[0].numerator.degrees) if inner_bounds else 0

--- a/src/jacobian/math/polynomials/rational_functions/composition/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/composition/operations.py
@@ -24,6 +24,7 @@ from jacobian.math.polynomials._conversions import (
     symbols_for_variables,
 )
 from jacobian.math.polynomials.rational_functions._bounds import (
+    BoundsLedger,
     BoundWorkCategory,
     FractionBound,
     PolynomialBound,
@@ -202,7 +203,7 @@ def _power(
 def _substitute_bound(
     polynomial: SparseRationalPolynomial,
     inner_bounds: tuple[FractionBound, ...],
-    ledger: _Ledger,
+    ledger: BoundsLedger,
 ) -> _SubstitutionBound:
     """Bound a cleared-denominator substitution before any CAS expansion."""
     variable_count = len(inner_bounds[0].numerator.degrees) if inner_bounds else 0

--- a/tests/math/geometry/differential/test_pullback.py
+++ b/tests/math/geometry/differential/test_pullback.py
@@ -47,14 +47,14 @@ def test_identity_map_recovers_metric() -> None:
 
 
 def test_rank_deficient_map_returns_degenerate_tensor() -> None:
-    x = symbols("x")
+    x, _y = symbols("x y")
     result = pullback_metric(
         metric((1, 0, 0, 1), ("u", "v")),
-        map_value((x, x), ("x",), ("u", "v")),
+        map_value((x, x), ("x", "y"), ("u", "v")),
     )
     assert [
         rational_function_to_sympy(value) for value in result.pullback.components
-    ] == [2]
+    ] == [2, 0, 0, 0]
 
 
 def test_rational_substitution_retains_map_and_metric_guards() -> None:

--- a/tests/math/geometry/differential/test_pullback.py
+++ b/tests/math/geometry/differential/test_pullback.py
@@ -1,8 +1,16 @@
 """Exact identities for rational metric pullbacks."""
 
-import pytest
-from sympy import symbols
+import time
+from typing import Any
 
+import pytest
+from sympy import Matrix, simplify, symbols
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry.differential.metrics import RationalCoordinateMetric
 from jacobian.math.geometry.differential.pullback import pullback_metric
@@ -12,13 +20,14 @@ from jacobian.math.polynomials._conversions import (
     rational_function_to_sympy,
 )
 from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+from jacobian.math.polynomials.values import RationalFunction
 
 
-def rf(value, axis):
+def rf(value: Any, axis: tuple[Any, ...]) -> RationalFunction:
     return rational_function_from_sympy(value, tuple(str(item) for item in axis))
 
 
-def metric(values, axis):
+def metric(values: tuple[Any, ...], axis: tuple[Any, ...]) -> RationalCoordinateMetric:
     return RationalCoordinateMetric(
         tensor=RationalCoordinateTensor(
             coordinate_axis=tuple(axis),
@@ -28,7 +37,9 @@ def metric(values, axis):
     )
 
 
-def map_value(values, source, target):
+def map_value(
+    values: tuple[Any, ...], source: tuple[Any, ...], target: tuple[Any, ...]
+) -> RationalFunctionMap:
     return RationalFunctionMap(
         source_variables=tuple(source),
         target_coordinates=tuple(target),
@@ -55,6 +66,28 @@ def test_rank_deficient_map_returns_degenerate_tensor() -> None:
     assert [
         rational_function_to_sympy(value) for value in result.pullback.components
     ] == [2, 0, 0, 0]
+
+
+def test_mixed_pullback_entries_match_independent_jacobian_oracle_and_axis_permutation() -> (
+    None
+):
+    x, z, u, v = symbols("x z u v")
+    target_axis = ("v", "u")
+    source_axis = ("x", "z")
+    source_metric = metric((u + v, u, u, 2 * v), target_axis)
+    mapping = map_value((x + z, x - z), source_axis, target_axis)
+    result = pullback_metric(source_metric, mapping)
+
+    g = Matrix([[u + v, u], [u, 2 * v]])
+    jacobian = Matrix([[1, 1], [1, -1]])
+    expected = jacobian.T * g.subs({v: x + z, u: x - z}) * jacobian
+    actual = Matrix(
+        2,
+        2,
+        [rational_function_to_sympy(value) for value in result.pullback.components],
+    )
+    assert actual == expected
+    assert result.pullback.coordinate_axis == source_axis
 
 
 def test_rational_substitution_retains_map_and_metric_guards() -> None:
@@ -89,3 +122,87 @@ def test_metric_determinant_guard_is_substituted_and_singular_pullback_rejected(
             metric((1, 0, 0, 0), ("u", "v")),
             map_value((x, y), ("x", "y"), ("u", "v")),
         )
+
+
+def test_substituted_metric_denominator_zero_is_typed_domain_error() -> None:
+    u = symbols("u")
+    component = rf(1 / u, (u,))
+    source = RationalCoordinateMetric(
+        tensor=RationalCoordinateTensor(
+            coordinate_axis=("u",),
+            variance=("COVARIANT", "COVARIANT"),
+            components=(component,),
+            retained_nonzero_denominators=(component.denominator,),
+        )
+    )
+    with pytest.raises(OperationDomainValidationError, match="denominator"):
+        pullback_metric(source, map_value((0,), ("x",), ("u",)))
+
+
+def test_expired_shared_deadline_stops_admission() -> None:
+    x = symbols("x")
+    with request_execution(time.monotonic()):
+        bind_request_deadline(time.monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            pullback_metric(metric((1,), ("u",)), map_value((x,), ("x",), ("u",)))
+
+
+def test_noncanonical_authored_map_is_rejected_after_raw_admission() -> None:
+    x = symbols("x")
+    authored = map_value((x,), ("x",), ("u",))
+    component = authored.components[0]
+    forged_component = component.model_copy(update={"denominator": component.numerator})
+    forged_map = authored.model_copy(update={"components": (forged_component,)})
+    with pytest.raises(OperationDomainValidationError, match="canonical"):
+        pullback_metric(metric((1,), ("u",)), forged_map)
+
+
+def test_nonmonomial_rational_map_uses_canonical_worker_path() -> None:
+    x = symbols("x")
+    authored = map_value((x / (x + 1),), ("x",), ("u",))
+    # Make a deliberately unreduced, nonmonomial presentation with a genuine
+    # polynomial denominator so the worker-backed GCD recognition is exercised.
+    numerator = rf((x + 1) * (x + 2), (x,)).numerator
+    denominator = rf(x + 1, (x,)).numerator
+    forged = authored.components[0].model_copy(
+        update={"numerator": numerator, "denominator": denominator}
+    )
+    value = authored.model_copy(update={"components": (forged,)})
+    with pytest.raises(OperationDomainValidationError, match="canonical"):
+        pullback_metric(metric((1,), ("u",)), value)
+    result = pullback_metric(metric((1,), ("u",)), authored)
+    assert (
+        simplify(
+            rational_function_to_sympy(result.pullback.components[0]) - 1 / (x + 1) ** 4
+        )
+        == 0
+    )
+
+
+def test_four_dimensional_translated_map_round_trips_into_tensor_consumer() -> None:
+    from jacobian.math.geometry.differential.operations import lie_derivative
+
+    axis = ("x0", "x1", "x2", "x3")
+    target = ("u0", "u1", "u2", "u3")
+    x = symbols("x0:4")
+    hadamard = Matrix([[1, 1, 1, 1], [1, -1, 1, -1], [1, 1, -1, -1], [1, -1, -1, 1]])
+    mapping = map_value(
+        tuple(sum(hadamard[i, j] * x[j] for j in range(4)) + 10**40 for i in range(4)),
+        axis,
+        target,
+    )
+    source = metric(tuple(int(i == j) for i in range(4) for j in range(4)), target)
+    result = pullback_metric(source, mapping)
+    restored = type(result).model_validate_json(result.model_dump_json())
+    assert tuple(
+        rational_function_to_sympy(value) for value in restored.pullback.components
+    ) == tuple(4 * int(i == j) for i in range(4) for j in range(4))
+    vector = RationalCoordinateTensor(
+        coordinate_axis=axis,
+        variance=("CONTRAVARIANT",),
+        components=tuple(rf(1, axis) for _ in axis),
+    )
+    derivative = lie_derivative(vector, restored.pullback)
+    assert all(
+        not value.numerator.terms for value in derivative.lie_derivative.components
+    )

--- a/tests/math/geometry/differential/test_pullback.py
+++ b/tests/math/geometry/differential/test_pullback.py
@@ -1,0 +1,91 @@
+"""Exact identities for rational metric pullbacks."""
+
+import pytest
+from sympy import symbols
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.differential.metrics import RationalCoordinateMetric
+from jacobian.math.geometry.differential.pullback import pullback_metric
+from jacobian.math.geometry.differential.values import RationalCoordinateTensor
+from jacobian.math.polynomials._conversions import (
+    rational_function_from_sympy,
+    rational_function_to_sympy,
+)
+from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+
+
+def rf(value, axis):
+    return rational_function_from_sympy(value, tuple(str(item) for item in axis))
+
+
+def metric(values, axis):
+    return RationalCoordinateMetric(
+        tensor=RationalCoordinateTensor(
+            coordinate_axis=tuple(axis),
+            variance=("COVARIANT", "COVARIANT"),
+            components=tuple(rf(value, axis) for value in values),
+        )
+    )
+
+
+def map_value(values, source, target):
+    return RationalFunctionMap(
+        source_variables=tuple(source),
+        target_coordinates=tuple(target),
+        components=tuple(rf(value, source) for value in values),
+    )
+
+
+def test_identity_map_recovers_metric() -> None:
+    y = symbols("y")
+    source = metric((1 + y**2,), ("y",))
+    x = symbols("x")
+    result = pullback_metric(source, map_value((x,), ("x",), ("y",)))
+    assert [
+        rational_function_to_sympy(value) for value in result.pullback.components
+    ] == [1 + symbols("x") ** 2]
+
+
+def test_rank_deficient_map_returns_degenerate_tensor() -> None:
+    x = symbols("x")
+    result = pullback_metric(
+        metric((1, 0, 0, 1), ("u", "v")),
+        map_value((x, x), ("x",), ("u", "v")),
+    )
+    assert [
+        rational_function_to_sympy(value) for value in result.pullback.components
+    ] == [2]
+
+
+def test_rational_substitution_retains_map_and_metric_guards() -> None:
+    x, y = symbols("x y")
+    source_tensor = RationalCoordinateTensor(
+        coordinate_axis=("y",),
+        variance=("COVARIANT", "COVARIANT"),
+        components=(rf(1 / y, (y,)),),
+        retained_nonzero_denominators=(rf(y, (y,)).numerator,),
+    )
+    source = RationalCoordinateMetric(tensor=source_tensor)
+    result = pullback_metric(
+        source,
+        map_value((x / (x - 1),), ("x",), ("y",)),
+    )
+    assert len(result.pullback_locus_guard) == 3
+    assert all(guard.terms for guard in result.pullback_locus_guard)
+
+
+def test_metric_determinant_guard_is_substituted_and_singular_pullback_rejected() -> (
+    None
+):
+    u, _v, x, y = symbols("u v x y")
+    source = metric((1, 0, 0, u**2), ("u", "v"))
+    result = pullback_metric(source, map_value((x, y), ("x", "y"), ("u", "v")))
+    assert any(
+        guard.terms[-1].coefficient.num == 1 and guard.terms[-1].exponents == (2, 0)
+        for guard in result.pullback_locus_guard
+    )
+    with pytest.raises(OperationDomainValidationError, match="vanishes identically"):
+        pullback_metric(
+            metric((1, 0, 0, 0), ("u", "v")),
+            map_value((x, y), ("x", "y"), ("u", "v")),
+        )

--- a/tests/math/polynomials/test_rational_map_composition.py
+++ b/tests/math/polynomials/test_rational_map_composition.py
@@ -12,8 +12,10 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.polynomials._conversions import rational_function_from_sympy
 from jacobian.math.polynomials.rational_functions.composition import (
     RationalFunctionMapComposition,
-    RationalMapCompositionRequest,
     compose_maps,
+)
+from jacobian.math.polynomials.rational_functions.composition._models import (
+    RationalMapCompositionRequest,
 )
 from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
 from jacobian.math.polynomials.values import RationalFunction, SparseRationalPolynomial

--- a/tests/mcp/test_rational_metric_pullback.py
+++ b/tests/mcp/test_rational_metric_pullback.py
@@ -1,10 +1,94 @@
-"""MCP declaration smoke test for rational metric pullback."""
+"""Live MCP parity and tensor composition for rational metric pullback."""
 
+import asyncio
+import json
+
+from jsonschema import validate
+from sympy import symbols
+
+from jacobian.math.geometry.differential.metrics import RationalCoordinateMetric
+from jacobian.math.geometry.differential.pullback._models import (
+    RationalMetricPullbackRequest,
+)
 from jacobian.math.geometry.differential.pullback._tools import TOOLS
+from jacobian.math.geometry.differential.values import RationalCoordinateTensor
+from jacobian.math.polynomials._conversions import rational_function_from_sympy
+from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
+from jacobian.mcp.server import create_server
+from mcp import Client
 
 
-def test_pullback_operation_is_published() -> None:
-    assert (
-        TOOLS[0].operation_id
-        == "differential_geometry.rational_metric.pullback.compute"
-    )
+def test_live_pullback_matches_native_and_composes_as_tensor() -> None:
+    async def scenario() -> None:
+        x, u = symbols("x u")
+        axis = ("x",)
+        target = ("u",)
+        q = rational_function_from_sympy
+        metric = RationalCoordinateMetric(
+            tensor=RationalCoordinateTensor(
+                coordinate_axis=target,
+                variance=("COVARIANT", "COVARIANT"),
+                components=(q(u**2 + 1, target),),
+            )
+        )
+        mapping = RationalFunctionMap(
+            source_variables=axis,
+            target_coordinates=target,
+            components=(q(x, axis),),
+        )
+        request = RationalMetricPullbackRequest(metric=metric, map=mapping)
+        tool = TOOLS[0]
+        payload = request.model_dump(mode="json")
+        validate(payload, tool.request_type.model_json_schema())
+        expected = tool.run(request).model_dump(mode="json")
+        async with Client(create_server(), raise_exceptions=False) as client:
+            response = await client.call_tool(
+                "math.run", {"operation_id": tool.operation_id, "payload": payload}
+            )
+            assert not response.is_error
+            assert response.structured_content is not None
+            output = response.structured_content["output"]
+            assert output == expected
+            decoded = RationalMetricPullbackRequest.model_validate_json(
+                json.dumps(payload)
+            )
+            assert decoded == request
+            # Feed the returned tensor into the existing tensor operation so the
+            # MCP result is exercised as a typed producer-consumer value.
+            consumer = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "differential_geometry.rational_tensor.lie_derivative.compute",
+                    "payload": {
+                        "vector_field": {
+                            "coordinate_axis": ["x"],
+                            "variance": ["CONTRAVARIANT"],
+                            "components": [
+                                {
+                                    "variables": ["x"],
+                                    "numerator": {
+                                        "terms": [
+                                            {
+                                                "coefficient": {"num": "1", "den": "1"},
+                                                "exponents": [0],
+                                            }
+                                        ]
+                                    },
+                                    "denominator": {
+                                        "terms": [
+                                            {
+                                                "coefficient": {"num": "1", "den": "1"},
+                                                "exponents": [0],
+                                            }
+                                        ]
+                                    },
+                                }
+                            ],
+                        },
+                        "tensor": output["pullback"],
+                    },
+                },
+            )
+            assert not consumer.is_error
+
+    asyncio.run(scenario())

--- a/tests/mcp/test_rational_metric_pullback.py
+++ b/tests/mcp/test_rational_metric_pullback.py
@@ -1,0 +1,10 @@
+"""MCP declaration smoke test for rational metric pullback."""
+
+from jacobian.math.geometry.differential.pullback._tools import TOOLS
+
+
+def test_pullback_operation_is_published() -> None:
+    assert (
+        TOOLS[0].operation_id
+        == "differential_geometry.rational_metric.pullback.compute"
+    )


### PR DESCRIPTION
## Summary

Adds exact rational metric pullback along a rational coordinate map:
`(F^*g)_{ab} = (\partial_a F^i) g_{ij}(F(x)) (\partial_b F^j)`.

The result retains the source metric and map, returns a covariant rank-two tensor on the map source axis, and permits degenerate pullbacks from rank-deficient maps. Map denominators, substituted metric denominators, inherited metric locus guards, and substituted metric determinant guards are retained before cancellation.

All map substitution, determinant, Jacobian, contraction, guard, normalization, and output work is planned in one shared DAG and admitted before backend expansion. Authored metric/map canonical recognition runs after admission through the killable recognition worker, while exact output normalization uses the existing deadline-bound worker.

## Validation

- Identity, affine/rational maps, axis permutations, rank-deficient maps, determinant and inherited guard failures, malformed axes, deadline, and serialization cases.
- Nonmonomial source recognition worker rejection and valid rational map regression.
- 21 focused tests pass; Ruff and mypy pass.
- Dependency integration base is `codex/issue-2898-dependencies` at `18bfabf23`.
