### PR TITLE
feat(combinatorics): accept hypergraphs in containment profiles

### DIFF
--- a/src/jacobian/math/combinatorics/designs/incidence_structures/_kernel.py
+++ b/src/jacobian/math/combinatorics/designs/incidence_structures/_kernel.py
@@ -3,14 +3,16 @@
 from collections import Counter
 from itertools import combinations
 
+from jacobian._execution import request_checkpoint
 from jacobian.math.combinatorics.designs.incidence_structures._models import (
     IncidenceMomentComparison,
     IncidenceMultiplicityDifference,
     IncidenceStructure,
     _containment_axes,
 )
-
-from jacobian.math.combinatorics.finite_structures.hypergraphs._models import FiniteHypergraph
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
 
 type _SubsetProfile = tuple[tuple[tuple[str, ...], int], ...]
 type _Histogram = tuple[tuple[int, int], ...]
@@ -27,6 +29,7 @@ def containment_profile_data(
     points, blocks = _containment_axes(incidence)
     counts: Counter[tuple[str, ...]] = Counter()
     for block in blocks:
+        request_checkpoint("during containment profile enumeration")
         block_members = set(block)
         counts.update(
             combinations(

--- a/src/jacobian/math/combinatorics/designs/incidence_structures/_kernel.py
+++ b/src/jacobian/math/combinatorics/designs/incidence_structures/_kernel.py
@@ -7,7 +7,10 @@ from jacobian.math.combinatorics.designs.incidence_structures._models import (
     IncidenceMomentComparison,
     IncidenceMultiplicityDifference,
     IncidenceStructure,
+    _containment_axes,
 )
+
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import FiniteHypergraph
 
 type _SubsetProfile = tuple[tuple[tuple[str, ...], int], ...]
 type _Histogram = tuple[tuple[int, int], ...]
@@ -17,13 +20,13 @@ type ContainmentProfileData = tuple[
 
 
 def containment_profile_data(
-    incidence: IncidenceStructure, order: int
+    incidence: IncidenceStructure | FiniteHypergraph, order: int
 ) -> ContainmentProfileData:
     """Return one complete fixed-order multiplicity profile."""
 
-    points = incidence.points
+    points, blocks = _containment_axes(incidence)
     counts: Counter[tuple[str, ...]] = Counter()
-    for block in incidence.blocks:
+    for block in blocks:
         block_members = set(block)
         counts.update(
             combinations(

--- a/src/jacobian/math/combinatorics/designs/incidence_structures/_models.py
+++ b/src/jacobian/math/combinatorics/designs/incidence_structures/_models.py
@@ -16,6 +16,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.matrices.values import IntegerMatrix
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import FiniteHypergraph, MAX_EDGES as MAX_HYPERGRAPH_EDGES
 
 MAX_POINTS = 100
 MAX_BLOCKS = 100
@@ -115,25 +116,31 @@ def _subset_count(point_count: int, order: int) -> int:
     return comb(point_count, order) if order <= point_count else 0
 
 
-def _profile_work_units(incidence: IncidenceStructure, order: int) -> int:
-    subset_count = _subset_count(len(incidence.points), order)
-    generated_block_subsets = sum(
-        _subset_count(len(block), order) for block in incidence.blocks
-    )
-    canonicalization_units = len(incidence.points) * len(incidence.blocks)
-    return canonicalization_units + order * (subset_count + generated_block_subsets)
+def _containment_axes(incidence: IncidenceStructure | FiniteHypergraph) -> tuple[tuple[str, ...], tuple[tuple[str, ...], ...]]:
+    if isinstance(incidence, FiniteHypergraph):
+        return incidence.vertices, tuple(members for _, members in incidence.edges)
+    return incidence.points, incidence.blocks
+
+
+def _profile_work_units(incidence: IncidenceStructure | FiniteHypergraph, order: int) -> int:
+    points, blocks = _containment_axes(incidence)
+    subset_count = _subset_count(len(points), order)
+    generated_block_subsets = sum(_subset_count(len(block), order) for block in blocks)
+    canonicalization_units = len(points) * len(blocks) + sum(map(len, blocks))
+    return canonicalization_units + max(1, order) * (subset_count + generated_block_subsets)
 
 
 def _require_containment_profile_admitted(
-    incidence: IncidenceStructure,
+    incidence: IncidenceStructure | FiniteHypergraph,
     order: int,
 ) -> None:
-    if not 1 <= order <= MAX_T:
+    if not 0 <= order <= MAX_T:
         raise IncidenceStructureAdmissionError(
             "containment_order_out_of_range",
-            f"containment-profile order must be between 1 and {MAX_T}",
+            f"containment-profile order must be between 0 and {MAX_T}",
         )
-    subset_count = _subset_count(len(incidence.points), order)
+    points, _ = _containment_axes(incidence)
+    subset_count = _subset_count(len(points), order)
     if subset_count > MAX_SUBSETS:
         raise IncidenceStructureAdmissionError(
             "containment_subset_budget_exceeded",
@@ -231,14 +238,14 @@ class ContainmentProfileRequest(StrictModel):
         }
     )
 
-    incidence: IncidenceStructure = Field(
+    incidence: IncidenceStructure | FiniteHypergraph = Field(
         description=(
             "Indexed finite block family. Equal blocks with different IDs are "
             "counted separately."
         )
     )
     t: StrictInt = Field(
-        ge=1,
+        ge=0,
         le=MAX_T,
         description="Subset order for the complete containment profile.",
     )
@@ -247,19 +254,19 @@ class ContainmentProfileRequest(StrictModel):
 class ContainmentProfileResult(StrictModel):
     """One complete fixed-order profile bound to its indexed block family."""
 
-    incidence: IncidenceStructure
-    t: StrictInt = Field(ge=1, le=MAX_T)
+    incidence: IncidenceStructure | FiniteHypergraph
+    t: StrictInt = Field(ge=0, le=MAX_T)
     subset_profile: tuple[tuple[tuple[str, ...], StrictInt], ...] = Field(
         max_length=MAX_SUBSETS
     )
     histogram: tuple[tuple[StrictInt, StrictInt], ...] = Field(
-        max_length=MAX_BLOCKS + 1
+        max_length=MAX_HYPERGRAPH_EDGES + 1
     )
     total_multiplicity: StrictInt = Field(ge=0)
-    min_multiplicity: StrictInt = Field(ge=0, le=MAX_BLOCKS)
-    max_multiplicity: StrictInt = Field(ge=0, le=MAX_BLOCKS)
+    min_multiplicity: StrictInt = Field(ge=0, le=MAX_HYPERGRAPH_EDGES)
+    max_multiplicity: StrictInt = Field(ge=0, le=MAX_HYPERGRAPH_EDGES)
     is_constant: StrictBool
-    constant_lambda: StrictInt | None = Field(default=None, ge=0, le=MAX_BLOCKS)
+    constant_lambda: StrictInt | None = Field(default=None, ge=0, le=MAX_HYPERGRAPH_EDGES)
 
     @model_validator(mode="after")
     def require_structural_summary_consistency(self) -> Self:
@@ -280,7 +287,7 @@ class ContainmentProfileResult(StrictModel):
     @classmethod
     def _from_kernel(
         cls,
-        incidence: IncidenceStructure,
+        incidence: IncidenceStructure | FiniteHypergraph,
         order: int,
         data: tuple[
             tuple[tuple[tuple[str, ...], int], ...],

--- a/src/jacobian/math/combinatorics/designs/incidence_structures/_models.py
+++ b/src/jacobian/math/combinatorics/designs/incidence_structures/_models.py
@@ -121,18 +121,24 @@ def _subset_count(point_count: int, order: int) -> int:
     return comb(point_count, order) if order <= point_count else 0
 
 
-def _containment_axes(incidence: IncidenceStructure | FiniteHypergraph) -> tuple[tuple[str, ...], tuple[tuple[str, ...], ...]]:
+def _containment_axes(
+    incidence: IncidenceStructure | FiniteHypergraph,
+) -> tuple[tuple[str, ...], tuple[tuple[str, ...], ...]]:
     if isinstance(incidence, FiniteHypergraph):
         return incidence.vertices, tuple(members for _, members in incidence.edges)
     return incidence.points, incidence.blocks
 
 
-def _profile_work_units(incidence: IncidenceStructure | FiniteHypergraph, order: int) -> int:
+def _profile_work_units(
+    incidence: IncidenceStructure | FiniteHypergraph, order: int
+) -> int:
     points, blocks = _containment_axes(incidence)
     subset_count = _subset_count(len(points), order)
     generated_block_subsets = sum(_subset_count(len(block), order) for block in blocks)
     canonicalization_units = len(points) * len(blocks) + sum(map(len, blocks))
-    return canonicalization_units + max(1, order) * (subset_count + generated_block_subsets)
+    return canonicalization_units + max(1, order) * (
+        subset_count + generated_block_subsets
+    )
 
 
 def _require_containment_profile_admitted(
@@ -158,15 +164,43 @@ def _require_containment_profile_admitted(
             "containment_work_budget_exceeded",
             "containment profile exceeds the execution work budget",
         )
-    # Reserve the echoed source, subset labels, histogram, and multiplicity
-    # integers before constructing the complete profile.
-    blocks = _containment_axes(incidence)[1]
-    source_bytes = sum(len(label.encode("utf-8")) for label in _containment_axes(incidence)[0])
-    source_bytes += sum(len(label.encode("utf-8")) for block in blocks for label in block)
-    source_bytes += len(blocks) * 8
-    output_units = subset_count * (order * 8 + 16) + (len(blocks) + 1) * 32 + source_bytes
-    if output_units > 2**26:
-        raise IncidenceStructureAdmissionError("containment_output_budget_exceeded", "containment profile output exceeds its allocation budget")
+    # Count mathematical label positions, not encoded transport bytes or
+    # pointers. Each output subset repeats its actual source labels.
+    _, blocks = _containment_axes(incidence)
+    ids = (
+        incidence.block_ids
+        if isinstance(incidence, IncidenceStructure)
+        else tuple(edge_id for edge_id, _ in incidence.edges)
+    )
+    source_labels = (
+        sum(map(len, points))
+        + sum(map(len, ids))
+        + sum(len(label) for block in blocks for label in block)
+    )
+    subset_labels = subset_count * order * max(map(len, points), default=0)
+    histogram_rows = min(subset_count, len(blocks) + 1)
+    integer_slots = subset_count + 2 * histogram_rows + 5
+    coordinate_slots = (
+        sum(map(len, blocks)) + len(points) + len(blocks) + subset_count * order
+    )
+    if (
+        source_labels + subset_labels > 2**26
+        or coordinate_slots + integer_slots > 1_048_576
+    ):
+        raise IncidenceStructureAdmissionError(
+            "containment_output_budget_exceeded",
+            "containment profile exceeds its label and coordinate allocation bounds",
+        )
+    # Multiplicities <= indexed block count, total <= rows * block count.
+    # The histogram has at most one row per attained multiplicity and subset.
+    coefficient_bits = integer_slots * max(
+        1, max(subset_count, len(blocks), subset_count * len(blocks)).bit_length()
+    )
+    if coefficient_bits > 16_777_216:
+        raise IncidenceStructureAdmissionError(
+            "containment_output_budget_exceeded",
+            "containment profile exceeds its exact integer allocation bound",
+        )
 
 
 def _require_incidence_trade_admitted(
@@ -280,7 +314,9 @@ class ContainmentProfileResult(StrictModel):
     min_multiplicity: StrictInt = Field(ge=0, le=MAX_HYPERGRAPH_EDGES)
     max_multiplicity: StrictInt = Field(ge=0, le=MAX_HYPERGRAPH_EDGES)
     is_constant: StrictBool
-    constant_lambda: StrictInt | None = Field(default=None, ge=0, le=MAX_HYPERGRAPH_EDGES)
+    constant_lambda: StrictInt | None = Field(
+        default=None, ge=0, le=MAX_HYPERGRAPH_EDGES
+    )
 
     @model_validator(mode="after")
     def require_structural_summary_consistency(self) -> Self:

--- a/src/jacobian/math/combinatorics/designs/incidence_structures/_models.py
+++ b/src/jacobian/math/combinatorics/designs/incidence_structures/_models.py
@@ -15,8 +15,13 @@ from pydantic import (
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES as MAX_HYPERGRAPH_EDGES,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
 from jacobian.math.matrices.values import IntegerMatrix
-from jacobian.math.combinatorics.finite_structures.hypergraphs._models import FiniteHypergraph, MAX_EDGES as MAX_HYPERGRAPH_EDGES
 
 MAX_POINTS = 100
 MAX_BLOCKS = 100
@@ -153,6 +158,15 @@ def _require_containment_profile_admitted(
             "containment_work_budget_exceeded",
             "containment profile exceeds the execution work budget",
         )
+    # Reserve the echoed source, subset labels, histogram, and multiplicity
+    # integers before constructing the complete profile.
+    blocks = _containment_axes(incidence)[1]
+    source_bytes = sum(len(label.encode("utf-8")) for label in _containment_axes(incidence)[0])
+    source_bytes += sum(len(label.encode("utf-8")) for block in blocks for label in block)
+    source_bytes += len(blocks) * 8
+    output_units = subset_count * (order * 8 + 16) + (len(blocks) + 1) * 32 + source_bytes
+    if output_units > 2**26:
+        raise IncidenceStructureAdmissionError("containment_output_budget_exceeded", "containment profile output exceeds its allocation budget")
 
 
 def _require_incidence_trade_admitted(

--- a/src/jacobian/math/combinatorics/designs/incidence_structures/_tools.py
+++ b/src/jacobian/math/combinatorics/designs/incidence_structures/_tools.py
@@ -140,8 +140,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         request_type=ContainmentProfileRequest,
         result_type=ContainmentProfileResult,
         run=_containment_profile,
-        tags=("combinatorics", "incidence", "exact"),
-        discovery_terms=("t-codegree", "codegree profile"),
+        tags=("combinatorics", "incidence", "hypergraph", "exact"),
+        discovery_terms=("t-codegree", "codegree profile", "hypergraph containment"),
         examples=(
             OperationExample(
                 name="triangle_pair_codegrees",
@@ -149,6 +149,11 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 "2-block incidence structure, including the zero codegree of "
                 "the pair {p1, p3}.",
                 input={"incidence": _STRUCTURE, "t": 2},
+            ),
+            OperationExample(
+                name="empty_hypergraph_zero_order",
+                description="The t=0 profile has one empty subset and zero multiplicity for a hypergraph with no edges.",
+                input={"incidence": {"vertices": ["a", "b"], "edges": []}, "t": 0},
             ),
         ),
     ),

--- a/src/jacobian/math/combinatorics/designs/incidence_structures/_tools.py
+++ b/src/jacobian/math/combinatorics/designs/incidence_structures/_tools.py
@@ -134,8 +134,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
     MathTool(
         operation_id="incidence.containment_profiles.compute",
         title="Compute t-subset containment multiplicity profiles",
-        description="For a bounded order t, return the finite map from every t-subset "
-        "of points to the number of blocks containing it, plus the "
+        description="For a bounded order t (including t=0), return the finite map from every t-subset "
+        "of points in an incidence structure or finite hypergraph to the number of blocks containing it, plus the "
         "multiplicity histogram and whether the profile is constant.",
         request_type=ContainmentProfileRequest,
         result_type=ContainmentProfileResult,

--- a/src/jacobian/math/combinatorics/designs/incidence_structures/operations.py
+++ b/src/jacobian/math/combinatorics/designs/incidence_structures/operations.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from typing import Literal
 
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.designs.incidence_structures._kernel import (
     containment_profile_data,
@@ -28,8 +35,10 @@ from jacobian.math.combinatorics.designs.incidence_structures._models import (
     _require_containment_profile_admitted,
     _require_incidence_trade_admitted,
 )
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
 from jacobian.math.matrices.values import IntegerMatrix
-from jacobian.math.combinatorics.finite_structures.hypergraphs._models import FiniteHypergraph
 
 
 def containment_profile(
@@ -37,6 +46,15 @@ def containment_profile(
 ) -> ContainmentProfileResult:
     """Return every fixed-order subset containment multiplicity exactly."""
 
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return containment_profile(incidence, order)
+    deadline = execution.started_at + 60
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before containment profile admission")
     if not isinstance(incidence, (IncidenceStructure, FiniteHypergraph)):
         raise TypeError("incidence must be an IncidenceStructure or FiniteHypergraph")
     if type(order) is not int:
@@ -49,6 +67,7 @@ def containment_profile(
             code=f"incidence_structure.{exc.reason}",
             message=str(exc),
         ) from exc
+    request_checkpoint("after containment profile admission")
     return ContainmentProfileResult._from_kernel(
         incidence, order, containment_profile_data(incidence, order)
     )

--- a/src/jacobian/math/combinatorics/designs/incidence_structures/operations.py
+++ b/src/jacobian/math/combinatorics/designs/incidence_structures/operations.py
@@ -29,15 +29,16 @@ from jacobian.math.combinatorics.designs.incidence_structures._models import (
     _require_incidence_trade_admitted,
 )
 from jacobian.math.matrices.values import IntegerMatrix
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import FiniteHypergraph
 
 
 def containment_profile(
-    incidence: IncidenceStructure, order: int
+    incidence: IncidenceStructure | FiniteHypergraph, order: int
 ) -> ContainmentProfileResult:
     """Return every fixed-order subset containment multiplicity exactly."""
 
-    if not isinstance(incidence, IncidenceStructure):
-        raise TypeError("incidence must be an IncidenceStructure")
+    if not isinstance(incidence, (IncidenceStructure, FiniteHypergraph)):
+        raise TypeError("incidence must be an IncidenceStructure or FiniteHypergraph")
     if type(order) is not int:
         raise TypeError("containment-profile order must be an integer")
     try:

--- a/tests/math/combinatorics/designs/incidence_structures/test_finite_hypergraph_containment.py
+++ b/tests/math/combinatorics/designs/incidence_structures/test_finite_hypergraph_containment.py
@@ -1,0 +1,31 @@
+from itertools import combinations
+
+import pytest
+
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics.designs.incidence_structures.operations import (
+    containment_profile,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs import FiniteHypergraph
+
+
+def test_hypergraph_contains_duplicates_and_empty_order_zero():
+    h=FiniteHypergraph(vertices=("a","b","c"), edges=(("e1",("a","b")),("e2",("a","b")),("empty",())))
+    r=containment_profile(h,2)
+    assert dict(r.subset_profile)[("a","b")] == 2
+    z=containment_profile(h,0)
+    assert z.subset_profile == (((),3),)
+
+def test_hypergraph_bruteforce_orders():
+    h=FiniteHypergraph(vertices=("a","b","c"), edges=(("e1",("a","b")),("e2",("b","c"))))
+    for t in range(4):
+        r=containment_profile(h,t)
+        expected=[]
+        for subset in combinations(h.vertices,t):
+            expected.append((subset,sum(set(subset)<=set(m) for _,m in h.edges)))
+        assert r.subset_profile == tuple(expected)
+
+def test_hypergraph_source_bound_refusal():
+    h=FiniteHypergraph(vertices=tuple(f"v{i}" for i in range(100)), edges=tuple((f"e{i}",(f"v{i % 100}",)) for i in range(12000)))
+    with pytest.raises(OperationDomainValidationError):
+        containment_profile(h,10)

--- a/tests/math/combinatorics/designs/incidence_structures/test_finite_hypergraph_containment.py
+++ b/tests/math/combinatorics/designs/incidence_structures/test_finite_hypergraph_containment.py
@@ -29,3 +29,12 @@ def test_hypergraph_source_bound_refusal():
     h=FiniteHypergraph(vertices=tuple(f"v{i}" for i in range(100)), edges=tuple((f"e{i}",(f"v{i % 100}",)) for i in range(12000)))
     with pytest.raises(OperationDomainValidationError):
         containment_profile(h,10)
+
+def test_large_indexed_hypergraph_with_cheap_order_is_accepted():
+    vertices = tuple(f"v{i}" for i in range(256))
+    hypergraph = FiniteHypergraph(
+        vertices=vertices,
+        edges=tuple((f"e{i}", (vertices[i % 256],)) for i in range(12000)),
+    )
+    result = containment_profile(hypergraph, 1)
+    assert result.total_multiplicity == 12000

--- a/tests/math/combinatorics/designs/incidence_structures/test_finite_hypergraph_containment.py
+++ b/tests/math/combinatorics/designs/incidence_structures/test_finite_hypergraph_containment.py
@@ -1,7 +1,14 @@
+import time
+from collections import Counter
 from itertools import combinations
 
 import pytest
 
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.designs.incidence_structures.operations import (
     containment_profile,
@@ -9,32 +16,77 @@ from jacobian.math.combinatorics.designs.incidence_structures.operations import 
 from jacobian.math.combinatorics.finite_structures.hypergraphs import FiniteHypergraph
 
 
-def test_hypergraph_contains_duplicates_and_empty_order_zero():
-    h=FiniteHypergraph(vertices=("a","b","c"), edges=(("e1",("a","b")),("e2",("a","b")),("empty",())))
-    r=containment_profile(h,2)
-    assert dict(r.subset_profile)[("a","b")] == 2
-    z=containment_profile(h,0)
-    assert z.subset_profile == (((),3),)
+def test_hypergraph_contains_duplicates_and_empty_order_zero() -> None:
+    h = FiniteHypergraph(
+        vertices=("a", "b", "c"),
+        edges=(("e1", ("a", "b")), ("e2", ("a", "b")), ("empty", ())),
+    )
+    assert dict(containment_profile(h, 2).subset_profile)[("a", "b")] == 2
+    assert containment_profile(h, 0).subset_profile == (((), 3),)
 
-def test_hypergraph_bruteforce_orders():
-    h=FiniteHypergraph(vertices=("a","b","c"), edges=(("e1",("a","b")),("e2",("b","c"))))
+
+def test_hypergraph_bruteforce_orders() -> None:
+    h = FiniteHypergraph(
+        vertices=("a", "b", "c"), edges=(("e1", ("a", "b")), ("e2", ("b", "c")))
+    )
     for t in range(4):
-        r=containment_profile(h,t)
-        expected=[]
-        for subset in combinations(h.vertices,t):
-            expected.append((subset,sum(set(subset)<=set(m) for _,m in h.edges)))
-        assert r.subset_profile == tuple(expected)
+        expected = tuple(
+            (subset, sum(set(subset) <= set(m) for _, m in h.edges))
+            for subset in combinations(h.vertices, t)
+        )
+        result = containment_profile(h, t)
+        assert result.subset_profile == expected
+        counts = [count for _, count in expected]
+        assert result.histogram == tuple(sorted(Counter(counts).items()))
+        assert result.min_multiplicity == min(counts, default=0)
+        assert result.max_multiplicity == max(counts, default=0)
+        assert result.total_multiplicity == sum(counts)
 
-def test_hypergraph_source_bound_refusal():
-    h=FiniteHypergraph(vertices=tuple(f"v{i}" for i in range(100)), edges=tuple((f"e{i}",(f"v{i % 100}",)) for i in range(12000)))
+
+def test_hypergraph_source_bound_refusal() -> None:
+    h = FiniteHypergraph(
+        vertices=tuple(f"v{i}" for i in range(100)),
+        edges=tuple((f"e{i}", (f"v{i % 100}",)) for i in range(12000)),
+    )
     with pytest.raises(OperationDomainValidationError):
-        containment_profile(h,10)
+        containment_profile(h, 10)
 
-def test_large_indexed_hypergraph_with_cheap_order_is_accepted():
+
+def test_large_indexed_hypergraph_with_cheap_order_is_accepted() -> None:
     vertices = tuple(f"v{i}" for i in range(256))
-    hypergraph = FiniteHypergraph(
+    h = FiniteHypergraph(
         vertices=vertices,
         edges=tuple((f"e{i}", (vertices[i % 256],)) for i in range(12000)),
     )
-    result = containment_profile(hypergraph, 1)
-    assert result.total_multiplicity == 12000
+    assert containment_profile(h, 1).total_multiplicity == 12000
+
+
+@pytest.mark.parametrize(
+    "vertices,edges,t,expected",
+    [
+        ((), (), 0, (((), 0),)),
+        ((), (), 1, ()),
+        ((), (("empty", ()),), 0, (((), 1),)),
+        (("a",), (), 1, ((("a",), 0),)),
+        (("a",), (("empty", ()),), 2, ()),
+    ],
+)
+def test_empty_and_out_of_axis_orders(
+    vertices: tuple[str, ...],
+    edges: tuple[tuple[str, tuple[str, ...]], ...],
+    t: int,
+    expected: tuple[tuple[tuple[str, ...], int], ...],
+) -> None:
+    result = containment_profile(FiniteHypergraph(vertices=vertices, edges=edges), t)
+    assert result.subset_profile == expected
+    assert result.is_constant
+    assert result.constant_lambda == (expected[0][1] if expected else 0)
+    assert type(result).model_validate_json(result.model_dump_json()) == result
+
+
+def test_shared_deadline_is_honored() -> None:
+    source = FiniteHypergraph(vertices=(), edges=())
+    with request_execution(time.monotonic()):
+        bind_request_deadline(time.monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            containment_profile(source, 0)

--- a/tests/mcp/test_hypergraph_containment_profile.py
+++ b/tests/mcp/test_hypergraph_containment_profile.py
@@ -1,0 +1,16 @@
+import asyncio
+
+from tests.mcp.test_direct_operations import _server
+
+from mcp import Client
+
+
+def test_hypergraph_containment_mcp_roundtrip() -> None:
+    async def scenario() -> None:
+        operation="incidence.containment_profiles.compute"
+        async with Client(_server(operation), raise_exceptions=True) as client:
+            payload={"incidence":{"vertices":["a","b","c"],"edges":[["e1",["a","b"]],["e2",["a","b"]],["e3",[]]]},"t":2}
+            response=await client.call_tool(operation,payload)
+            assert response.structured_content is not None
+            assert response.structured_content["total_multiplicity"] == 2
+    asyncio.run(scenario())

--- a/tests/mcp/test_hypergraph_containment_profile.py
+++ b/tests/mcp/test_hypergraph_containment_profile.py
@@ -1,16 +1,36 @@
 import asyncio
+import json
 
 from tests.mcp.test_direct_operations import _server
 
+from jacobian.math.combinatorics.designs.incidence_structures.operations import (
+    containment_profile,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs import (
+    FiniteHypergraph,
+    parameters,
+)
 from mcp import Client
 
 
 def test_hypergraph_containment_mcp_roundtrip() -> None:
     async def scenario() -> None:
-        operation="incidence.containment_profiles.compute"
+        operation = "incidence.containment_profiles.compute"
         async with Client(_server(operation), raise_exceptions=True) as client:
-            payload={"incidence":{"vertices":["a","b","c"],"edges":[["e1",["a","b"]],["e2",["a","b"]],["e3",[]]]},"t":2}
-            response=await client.call_tool(operation,payload)
+            vertices = [f"v{i}" for i in range(256)]
+            edges = [[f"e{i}", [vertices[i % 256]]] for i in range(12000)]
+            payload = {"incidence": {"vertices": vertices, "edges": edges}, "t": 1}
+            response = await client.call_tool(operation, payload)
             assert response.structured_content is not None
-            assert response.structured_content["total_multiplicity"] == 2
+            result = response.structured_content
+            assert result["total_multiplicity"] == 12000
+            source = FiniteHypergraph.model_validate_json(
+                json.dumps(payload["incidence"])
+            )
+            native = containment_profile(source, 1)
+            restored = type(native).model_validate_json(json.dumps(result))
+            assert restored == native
+            assert isinstance(restored.incidence, FiniteHypergraph)
+            assert parameters(restored.incidence).vertex_count == 256
+
     asyncio.run(scenario())


### PR DESCRIPTION
## Problem

`incidence.containment_profiles.compute` cannot consume the canonical `FiniteHypergraph` produced by hypergraph operations. Callers must translate field names and decide how duplicate indexed edges and empty carriers should behave.

## Outcome

The existing operation accepts either `IncidenceStructure` or `FiniteHypergraph` unchanged and retains that exact source type in its result. Both use the same complete subset-containment kernel. Indexed duplicate edges contribute separately; every t-subset appears, including zero multiplicities. The result includes the histogram, total, extrema and constant-lambda status.

Order zero has one empty subset with multiplicity equal to the number of indexed blocks/edges. For t larger than the vertex count, the profile and histogram are empty, extrema are zero and constant lambda is zero. Empty hypergraphs and empty indexed edges retain these conventions. Existing `IncidenceStructure` bounds remain unchanged.

Closes #2494. No new operation ID or source-conversion operation is introduced.

## Validation

Final implementation: `7089210a0`.

- `make affected AFFECTED_BASE=origin/main`: all 6 commands passed in 84 seconds, including scoped Ruff/format, mypy, 89 mathematical tests, 156 catalog tests, catalog invocation examples and 76 MCP tests.
- `make import-contracts`: 4 kept. Architecture: 1,351 files checked. Scoped public-operation conformance: 1 passed, 882 deselected.
- Independent subset enumeration checks complete rows, histograms, totals and extrema. Explicit regressions cover t=0, empty vertices/edges, duplicate edges, t greater than the source axis, output refusal and an expired caller deadline.
- The accepted 256-vertex, 12,000-indexed-edge t=1 request executes through MCP, matches native output, round-trips through JSON and supplies its returned canonical hypergraph directly to the existing parameters consumer.

## Contract impact

The request/result source field becomes `IncidenceStructure | FiniteHypergraph`; t is 0..10. Result multiplicities admit the canonical hypergraph edge bound of 12,000. Hypergraph/codegree discovery terms and a degenerate invocation example are included.

Admission prices the complete subset count (at most 5,000), generated block subsets and membership work (at most 4,000,000 units), repeated source/subset label positions (at most 2^26), coordinate and integer slots (at most 1,048,576), and exact integer allocation (at most 16,777,216 bits) before enumeration. Histogram support is bounded by both source edge count and output subset count. All phases use the earlier caller deadline or a 60-second execution limit.

## Review closure

Independent review covered the generalized source contract and final allocation bounds. Constructors retain structural summary checks; the kernel establishes the mathematical counts. Native and MCP behavioral tests cover the final changed tree. Hosted required CI is the remaining publication check.
