### PR TITLE
feat(graphs): find edge-color-preserving subgraph embeddings

### DIFF
--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/__init__.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/__init__.py
@@ -1,0 +1,6 @@
+"""Exact edge-colour-preserving subgraph embeddings."""
+
+from ._models import EdgeColoredPatternResult
+from .operations import edge_colored_subgraph_pattern_find
+
+__all__ = ["EdgeColoredPatternResult", "edge_colored_subgraph_pattern_find"]

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_models.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_models.py
@@ -24,20 +24,20 @@ def require_edge_colors(value: ColoredUndirectedGraph) -> None:
 class EdgeColoredPatternRequest(StrictModel):
     """An edge-color-preserving embedding request.
 
-    Both sources require a nonempty total edge coloring (a bijection from
-    the nonempty edge set onto its color set) and the empty vertex coloring.
+    Both sources require a nonempty total edge coloring (one color on every
+    edge, with colors allowed to repeat) and the empty vertex coloring.
     """
 
     pattern: ColoredUndirectedGraph = Field(
         description=(
-            "Pattern graph. The total edge coloring is a bijection from the "
-            "nonempty edge set onto its colors, and vertex colors must be empty."
+            "Pattern graph. The total edge coloring assigns one color to every "
+            "edge, and vertex colors must be empty."
         ),
     )
     host: ColoredUndirectedGraph = Field(
         description=(
-            "Host graph. The total edge coloring is a bijection from the "
-            "nonempty edge set onto its colors, and vertex colors must be empty."
+            "Host graph. The total edge coloring assigns one color to every "
+            "edge, and vertex colors must be empty."
         ),
     )
 

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_models.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_models.py
@@ -1,0 +1,56 @@
+"""Source-bound edge-colour-preserving subgraph decisions."""
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+from jacobian.math.graphs.values import ColoredUndirectedGraph
+
+
+def require_edge_colors(value: ColoredUndirectedGraph) -> None:
+    if (
+        value.vertex_colors
+        or not value.edge_colors
+        or len(value.edge_colors) != len(value.graph.edges)
+    ):
+        raise PydanticCustomError(
+            "graph.edge_colored_pattern.color_domain",
+            "sources require a nonempty total edge coloring and no vertex coloring",
+        )
+
+
+class EdgeColoredPatternRequest(StrictModel):
+    pattern: ColoredUndirectedGraph
+    host: ColoredUndirectedGraph
+
+    @model_validator(mode="after")
+    def require_color_domain(self) -> Self:
+        require_edge_colors(self.pattern)
+        require_edge_colors(self.host)
+        return self
+
+
+class EdgeColoredPatternResult(StrictModel):
+    pattern: ColoredUndirectedGraph
+    host: ColoredUndirectedGraph
+    decision: Literal["EXISTS", "DOES_NOT_EXIST"]
+    vertex_map: tuple[str, ...] = Field(default=(), max_length=64)
+
+    @model_validator(mode="after")
+    def require_witness_shape(self) -> Self:
+        require_edge_colors(self.pattern)
+        require_edge_colors(self.host)
+        if self.decision == "DOES_NOT_EXIST":
+            if self.vertex_map:
+                raise ValueError("a negative decision cannot carry a witness")
+        elif (
+            len(self.vertex_map) != len(self.pattern.graph.vertices)
+            or len(set(self.vertex_map)) != len(self.vertex_map)
+            or not set(self.vertex_map) <= set(self.host.graph.vertices)
+        ):
+            raise ValueError(
+                "an embedding must inject the complete pattern axis into the host"
+            )
+        return self

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_models.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_models.py
@@ -22,8 +22,24 @@ def require_edge_colors(value: ColoredUndirectedGraph) -> None:
 
 
 class EdgeColoredPatternRequest(StrictModel):
-    pattern: ColoredUndirectedGraph
-    host: ColoredUndirectedGraph
+    """An edge-color-preserving embedding request.
+
+    Both sources require a nonempty total edge coloring (a bijection from
+    the nonempty edge set onto its color set) and the empty vertex coloring.
+    """
+
+    pattern: ColoredUndirectedGraph = Field(
+        description=(
+            "Pattern graph. The total edge coloring is a bijection from the "
+            "nonempty edge set onto its colors, and vertex colors must be empty."
+        ),
+    )
+    host: ColoredUndirectedGraph = Field(
+        description=(
+            "Host graph. The total edge coloring is a bijection from the "
+            "nonempty edge set onto its colors, and vertex colors must be empty."
+        ),
+    )
 
     @model_validator(mode="after")
     def require_color_domain(self) -> Self:

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_tools.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_tools.py
@@ -22,7 +22,7 @@ TOOLS: MathTools = (
         examples=(
             OperationExample(
                 name="mixed_color_path",
-                description="A red-blue path occurs with both required colors preserved.",
+                description="A red-blue path occurs with both required colors preserved. Both sources need nonempty total edge colorings and empty vertex-color axes.",
                 input={
                     "pattern": {
                         "graph": {

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_tools.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_tools.py
@@ -1,0 +1,45 @@
+"""Immutable declaration for coloured subgraph containment."""
+
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+
+from ._models import EdgeColoredPatternRequest, EdgeColoredPatternResult
+from .operations import edge_colored_subgraph_pattern_find
+
+
+def _run(request: EdgeColoredPatternRequest) -> EdgeColoredPatternResult:
+    return edge_colored_subgraph_pattern_find(request.pattern, request.host)
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="graph.edge_colored_subgraph_pattern.find",
+        title="Find an edge-color-preserving subgraph embedding",
+        description="Decide ordinary non-induced containment of one edge-colored pattern in an edge-colored host, returning one injective host-label map in the pattern vertex order. Both sources must have nonempty total edge colorings and no vertex colors. Negative decisions follow complete admitted search or a source-count obstruction; execution interruption establishes no decision.",
+        request_type=EdgeColoredPatternRequest,
+        result_type=EdgeColoredPatternResult,
+        run=_run,
+        tags=("graph", "edge-colored", "embedding", "subgraph", "exact"),
+        examples=(
+            OperationExample(
+                name="mixed_color_path",
+                description="A red-blue path occurs with both required colors preserved.",
+                input={
+                    "pattern": {
+                        "graph": {
+                            "vertices": ["a", "b", "c"],
+                            "edges": [["a", "b"], ["b", "c"]],
+                        },
+                        "edge_colors": ["red", "blue"],
+                    },
+                    "host": {
+                        "graph": {
+                            "vertices": ["x", "y", "z"],
+                            "edges": [["x", "y"], ["y", "z"]],
+                        },
+                        "edge_colors": ["red", "blue"],
+                    },
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/operations.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/operations.py
@@ -1,0 +1,150 @@
+"""Exhaustive admitted edge-coloured monomorphism search."""
+
+import time
+from collections import Counter
+from itertools import permutations
+from math import perm
+
+from pydantic_core import PydanticCustomError
+
+from jacobian._execution import (
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.graphs.morphisms.operations import _graph_label_characters
+from jacobian.math.graphs.values import ColoredUndirectedGraph
+
+from ._models import EdgeColoredPatternResult, require_edge_colors
+
+MAX_ASSIGNMENTS = 10_000_000
+MAX_WORK = 50_000_000
+MAX_RETAINED_CHARACTERS = 20_000_000
+
+
+def _reject(reason: str, message: str) -> None:
+    raise OperationResourceAdmissionError(
+        location=("pattern", "host"),
+        code=f"graph.edge_colored_pattern.{reason}",
+        message=message,
+    )
+
+
+def edge_colored_subgraph_pattern_find(
+    pattern: ColoredUndirectedGraph, host: ColoredUndirectedGraph
+) -> EdgeColoredPatternResult:
+    for name, value in (("pattern", pattern), ("host", host)):
+        if not isinstance(value, ColoredUndirectedGraph):
+            raise TypeError(f"{name} must be a ColoredUndirectedGraph")
+        try:
+            require_edge_colors(value)
+        except PydanticCustomError as exc:
+            raise OperationDomainValidationError(
+                location=(name,),
+                code="graph.edge_colored_pattern.color_domain",
+                message=str(exc),
+            ) from exc
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return edge_colored_subgraph_pattern_find(pattern, host)
+    deadline = execution.started_at + 60
+    bind_request_deadline(
+        min(deadline, execution.deadline)
+        if execution.deadline is not None
+        else deadline
+    )
+    request_checkpoint("before colored embedding admission")
+    k, n = len(pattern.graph.vertices), len(host.graph.vertices)
+    if k > 64:
+        _reject("pattern_order", "pattern must have at most 64 vertices")
+    retained = (
+        _graph_label_characters(pattern.graph)
+        + _graph_label_characters(host.graph)
+        + sum(map(len, pattern.edge_colors))
+        + sum(map(len, host.edge_colors))
+        + k * max(map(len, host.graph.vertices), default=0)
+    )
+    if retained > MAX_RETAINED_CHARACTERS:
+        _reject(
+            "output", "retained sources and witness exceed their label allocation bound"
+        )
+    # The canonical source envelope bounds these linear presolves independently
+    # of search. An injective edge map preserves each color's edge cardinality.
+    pattern_counts, host_counts = (
+        Counter(pattern.edge_colors),
+        Counter(host.edge_colors),
+    )
+    impossible = k > n or any(
+        count > host_counts[color] for color, count in pattern_counts.items()
+    )
+    host_edges = dict(zip(host.graph.edges, host.edge_colors, strict=True))
+    identity = set(pattern.graph.vertices) <= set(host.graph.vertices) and all(
+        host_edges.get(edge) == color
+        for edge, color in zip(pattern.graph.edges, pattern.edge_colors, strict=True)
+    )
+    assignments = 0 if impossible or identity else perm(n, k)
+    # itertools constructs k-entry injections; each candidate checks at most
+    # every pattern edge. Colors are interned once so search compares integers.
+    work = (
+        retained + len(host.graph.edges) + assignments * (k + len(pattern.graph.edges))
+    )
+    if assignments > MAX_ASSIGNMENTS or work > MAX_WORK:
+        _reject(
+            "search",
+            "complete injective assignment search exceeds its admitted work bound",
+        )
+    request_checkpoint("after complete colored embedding admission")
+    found: tuple[str, ...] | None = None
+    if identity and not impossible:
+        found = pattern.graph.vertices
+    elif not impossible:
+        found = _search(pattern, host)
+    request_checkpoint("before colored embedding result construction")
+    return EdgeColoredPatternResult(
+        pattern=pattern,
+        host=host,
+        decision="EXISTS" if found is not None else "DOES_NOT_EXIST",
+        vertex_map=found if found is not None else (),
+    )
+
+
+def _search(
+    pattern: ColoredUndirectedGraph, host: ColoredUndirectedGraph
+) -> tuple[str, ...] | None:
+    pattern_index = {label: i for i, label in enumerate(pattern.graph.vertices)}
+    host_index = {label: i for i, label in enumerate(host.graph.vertices)}
+    palette = {
+        color: i
+        for i, color in enumerate(
+            dict.fromkeys((*pattern.edge_colors, *host.edge_colors))
+        )
+    }
+    required = tuple(
+        (pattern_index[u], pattern_index[v], palette[color])
+        for (u, v), color in zip(pattern.graph.edges, pattern.edge_colors, strict=True)
+    )
+    available = {
+        (min(host_index[u], host_index[v]), max(host_index[u], host_index[v])): palette[
+            color
+        ]
+        for (u, v), color in zip(host.graph.edges, host.edge_colors, strict=True)
+    }
+    for assignment in permutations(
+        range(len(host.graph.vertices)), len(pattern.graph.vertices)
+    ):
+        request_checkpoint("during colored embedding search")
+        if all(
+            available.get(
+                (min(assignment[u], assignment[v]), max(assignment[u], assignment[v]))
+            )
+            == color
+            for u, v, color in required
+        ):
+            return tuple(host.graph.vertices[i] for i in assignment)
+    return None

--- a/tests/math/graphs/morphisms/edge_colored_pattern/test_embedding.py
+++ b/tests/math/graphs/morphisms/edge_colored_pattern/test_embedding.py
@@ -1,0 +1,142 @@
+"""Independent finite-map checks for colored containment."""
+
+import time
+from itertools import combinations, permutations, product
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    bind_request_deadline,
+    request_execution,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.graphs.morphisms.edge_colored_pattern import (
+    edge_colored_subgraph_pattern_find,
+)
+from jacobian.math.graphs.morphisms.edge_colored_pattern._models import (
+    EdgeColoredPatternRequest,
+)
+from jacobian.math.graphs.values import ColoredUndirectedGraph, SimpleUndirectedGraph
+
+
+def colored(
+    vertices: tuple[str, ...],
+    edges: tuple[tuple[str, str], ...],
+    colors: tuple[str, ...],
+) -> ColoredUndirectedGraph:
+    return ColoredUndirectedGraph(
+        graph=SimpleUndirectedGraph(vertices=vertices, edges=edges), edge_colors=colors
+    )
+
+
+def oracle(pattern: ColoredUndirectedGraph, host: ColoredUndirectedGraph) -> bool:
+    host_edges = dict(zip(host.graph.edges, host.edge_colors, strict=True))
+    return any(
+        all(
+            host_edges.get((min(mapping[u], mapping[v]), max(mapping[u], mapping[v])))
+            == color
+            for (u, v), color in zip(
+                pattern.graph.edges, pattern.edge_colors, strict=True
+            )
+        )
+        for image in permutations(host.graph.vertices, len(pattern.graph.vertices))
+        for mapping in (dict(zip(pattern.graph.vertices, image, strict=True)),)
+    )
+
+
+def test_exhaustive_small_mixed_color_patterns() -> None:
+    vertices = ("x", "y", "z")
+    all_edges = tuple(combinations(vertices, 2))
+    for pattern_colors in product(("red", "blue"), repeat=2):
+        pattern = colored(("a", "b", "c"), (("a", "b"), ("b", "c")), pattern_colors)
+        for edge_states in product((None, "red", "blue"), repeat=3):
+            retained = tuple(
+                (edge, color)
+                for edge, color in zip(all_edges, edge_states, strict=True)
+                if color is not None
+            )
+            if not retained:
+                continue
+            host = colored(
+                vertices,
+                tuple(edge for edge, _ in retained),
+                tuple(color for _, color in retained),
+            )
+            result = edge_colored_subgraph_pattern_find(pattern, host)
+            assert (result.decision == "EXISTS") == oracle(pattern, host)
+            assert type(result).model_validate_json(result.model_dump_json()) == result
+            if result.decision == "EXISTS":
+                mapping = dict(
+                    zip(pattern.graph.vertices, result.vertex_map, strict=True)
+                )
+                assert len(set(result.vertex_map)) == 3
+                edges = dict(zip(host.graph.edges, host.edge_colors, strict=True))
+                assert all(
+                    edges[(min(mapping[u], mapping[v]), max(mapping[u], mapping[v]))]
+                    == c
+                    for (u, v), c in zip(
+                        pattern.graph.edges, pattern.edge_colors, strict=True
+                    )
+                )
+
+
+def test_triangle_color_change_and_edge_axis_permutation() -> None:
+    pattern = colored(
+        ("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c")), ("red",) * 3
+    )
+    host = colored(("x", "y", "z"), (("x", "y"), ("x", "z"), ("y", "z")), ("red",) * 3)
+    assert edge_colored_subgraph_pattern_find(pattern, host).decision == "EXISTS"
+    changed = host.model_copy(update={"edge_colors": ("red", "blue", "red")})
+    assert (
+        edge_colored_subgraph_pattern_find(pattern, changed).decision
+        == "DOES_NOT_EXIST"
+    )
+    reversed_axis = colored(
+        host.graph.vertices,
+        tuple(reversed(host.graph.edges)),
+        tuple(reversed(host.edge_colors)),
+    )
+    assert (
+        edge_colored_subgraph_pattern_find(pattern, reversed_axis).decision == "EXISTS"
+    )
+
+
+def test_color_domain_and_shared_deadline() -> None:
+    valid = colored(("a", "b"), (("a", "b"),), ("red",))
+    uncolored = ColoredUndirectedGraph(graph=valid.graph)
+    with pytest.raises(ValidationError):
+        EdgeColoredPatternRequest(pattern=uncolored, host=valid)
+    with pytest.raises(OperationDomainValidationError):
+        edge_colored_subgraph_pattern_find(uncolored, valid)
+    with pytest.raises(ValidationError):
+        colored(valid.graph.vertices, valid.graph.edges, ("red", "blue"))
+    vertex_colored = valid.model_copy(update={"vertex_colors": ("red", "red")})
+    with pytest.raises(OperationDomainValidationError):
+        edge_colored_subgraph_pattern_find(valid, vertex_colored)
+    with request_execution(time.monotonic()):
+        bind_request_deadline(time.monotonic() - 1)
+        with pytest.raises(OperationExecutionTimeoutError):
+            edge_colored_subgraph_pattern_find(valid, valid)
+
+
+def test_large_identity_presolve_and_unadmitted_search() -> None:
+    vertices = tuple(f"v{i:02}" for i in range(64))
+    edges = tuple((vertices[i], vertices[i + 1]) for i in range(63))
+    pattern = colored(vertices, edges, ("red",) * 63)
+    result = edge_colored_subgraph_pattern_find(pattern, pattern)
+    assert result.vertex_map == vertices
+    decoded = type(result).model_validate_json(result.model_dump_json())
+    assert edge_colored_subgraph_pattern_find(decoded.pattern, decoded.host) == result
+    host_vertices = tuple(f"x{i:02}" for i in range(64))
+    host = colored(
+        host_vertices,
+        tuple((host_vertices[i], host_vertices[i + 1]) for i in range(63)),
+        ("red",) * 63,
+    )
+    with pytest.raises(OperationResourceAdmissionError):
+        edge_colored_subgraph_pattern_find(pattern, host)

--- a/tests/mcp/test_edge_colored_pattern.py
+++ b/tests/mcp/test_edge_colored_pattern.py
@@ -1,0 +1,28 @@
+"""MCP parity for the edge-colored embedding operation."""
+
+import asyncio
+import json
+
+from tests.mcp.test_direct_operations import _server
+
+from jacobian.math.graphs.morphisms.edge_colored_pattern._tools import TOOLS
+from mcp import Client
+
+
+def test_colored_pattern_live_mcp_parity() -> None:
+    async def scenario() -> None:
+        tool = TOOLS[0]
+        payload = tool.examples[0].input
+        request = tool.request_type.model_validate_json(json.dumps(payload))
+        expected = tool.run(request)
+        async with Client(_server(tool.operation_id), raise_exceptions=True) as client:
+            response = await client.call_tool(tool.operation_id, payload)
+            assert response.structured_content is not None
+            assert (
+                tool.result_type.model_validate_json(
+                    json.dumps(response.structured_content)
+                )
+                == expected
+            )
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Uncolored subgraph matching cannot preserve a mixed edge-color relation. Filtering one host color loses the original colored source and cannot express the red-blue path in #2810.

## Outcome

Add `graph.edge_colored_subgraph_pattern.find`. It retains canonical `ColoredUndirectedGraph` sources and returns `EXISTS` with one injective host-label tuple in pattern vertex order, or `DOES_NOT_EXIST`. Every pattern edge must map to a host edge of the same color; additional host edges are allowed. Sources require nonempty total edge-color axes and empty vertex-color axes.

The exact kernel enumerates admitted injections using integer vertex/color indices. A source color-count obstruction can establish a negative result immediately, and a recognized same-label embedding can supply a witness without enumeration. Execution interruption never becomes a negative decision.

Closes #2810.

## Validation

Final head: `f92608969`.

- `make affected AFFECTED_BASE=origin/main`: all 6 commands passed, including scoped Ruff/format and mypy, mathematical tests, 156 catalog tests, 917 catalog integration tests and 76 MCP tests.
- Five focused native/MCP tests cover 104 independently enumerated small mixed-color cases, red-triangle recoloring, simultaneous edge/color-axis permutation, witness replay, malformed color axes, shared deadline expiry, and search refusal.
- A 64-vertex identity instance bypasses an otherwise enormous permutation space, serializes its actual result and reuses both retained colored sources unchanged in another embedding computation.
- Import contracts: 4 kept. Architecture: 1,355 files checked. Scoped public-operation conformance: 1 passed, 883 deselected.

## Contract impact

This is a separate edge-color-preserving relation alongside the existing uncolored containment and rainbow-profile operations. No existing operation is superseded. The result constructor checks source domains and structural witness shape; the producer establishes edge/color preservation.

The initial envelope admits at most 64 pattern vertices, 10,000,000 injections, 50,000,000 weighted setup/candidate checks and 20,000,000 retained source/witness label positions. Complete work is bounded by `P(host_order, pattern_order) * (pattern_order + pattern_edges)` plus source setup after the bounded linear presolves. Exact output contains only the retained sources and one witness. All phases share the earlier caller deadline or a 60-second execution limit. Larger generic searches remain an explicit admission limitation.

## Review closure

Independent exact-diff review found no unresolved mathematical or admission defects. Behavioral tests cover the issue and its implementation comment, and the final changed tree passed the affected and specialist checks. Hosted CI remains the final publication check.
