### PR TITLE
feat(graphs): draft chromatic bipartition feasibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ ignore_imports = [
     "jacobian.math.graphs._independence_z3 -> jacobian.process",
     "jacobian.math.graphs.coloring._coloring_process -> jacobian.process",
     "jacobian.math.graphs.optimization._chromatic_number -> jacobian.process",
+    "jacobian.math.graphs.optimization._chromatic_bipartition -> jacobian.process",
     "jacobian.math.graphs.optimization._finite_optimization -> jacobian.process",
     "jacobian.math.graphs.optimization._invariants -> jacobian.process",
     "jacobian.math.graphs.optimization._maximum_cut_process -> jacobian.process",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,7 @@ ignore_imports = [
     "jacobian.math.graphs._independence_z3 -> jacobian.process",
     "jacobian.math.graphs.coloring._coloring_process -> jacobian.process",
     "jacobian.math.graphs.optimization._chromatic_number -> jacobian.process",
-    "jacobian.math.graphs.optimization._chromatic_bipartition -> jacobian.process",
+    "jacobian.math.graphs.optimization._chromatic_bipartition_process -> jacobian.process",
     "jacobian.math.graphs.optimization._finite_optimization -> jacobian.process",
     "jacobian.math.graphs.optimization._invariants -> jacobian.process",
     "jacobian.math.graphs.optimization._maximum_cut_process -> jacobian.process",

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -294,9 +294,7 @@ def _admit_unit_threshold_chromatic(request: ChromaticBipartitionRequest) -> Non
     vertices = request.graph.vertices
     for index in range(len(vertices)):
         _, side_b = _unit_threshold_remainder(vertices, index)
-        if _unit_threshold_core_is_admitted(
-            _induced_edge_core(request.graph, side_b)
-        ):
+        if _unit_threshold_core_is_admitted(_induced_edge_core(request.graph, side_b)):
             return
     _refuse_chromatic_bipartition_work()
 

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -297,8 +297,8 @@ CHROMATIC_BIPARTITION_OPERATION = MathTool(
     operation_id="graph.chromatic_bipartition.find",
     title="Find a chromatic bipartition",
     description=(
-        "Decide whether a bounded simple graph has a canonical vertex bipartition "
-        "whose two induced subgraphs have chromatic numbers at least s and t. "
+        "Search a bounded simple graph for a canonical vertex bipartition whose "
+        "two induced subgraphs have chromatic numbers at least s and t. "
         "Return a witness, an exact NO_SPLIT after complete search, or UNKNOWN "
         "when the admitted shared exact-search budget is unresolved."
     ),

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -149,10 +149,28 @@ def _edgeless_chromatic_bipartition(
     )
 
 
+def _threshold_sum_exceeds_order(request: ChromaticBipartitionRequest) -> bool:
+    """chi(G[A]) <= |A| and chi(G[B]) <= |B|, so s + t > n cannot split."""
+
+    return request.s + request.t > len(request.graph.vertices)
+
+
+def _impossible_threshold_bipartition(
+    request: ChromaticBipartitionRequest,
+) -> ChromaticBipartitionResult:
+    return ChromaticBipartitionResult(
+        graph=request.graph,
+        s=request.s,
+        t=request.t,
+        status="NO_SPLIT",
+        checked_partitions=0,
+    )
+
+
 def _admit_chromatic_bipartition(request: ChromaticBipartitionRequest) -> None:
     """Charge every unordered partition and its inner k-colorability encodings."""
 
-    if not request.graph.edges:
+    if not request.graph.edges or _threshold_sum_exceeds_order(request):
         return
     n = len(request.graph.vertices)
     m = len(request.graph.edges)
@@ -177,6 +195,8 @@ def _find_chromatic_bipartition_kernel(
 ) -> ChromaticBipartitionResult:
     """Search every canonical unordered vertex bipartition under one deadline."""
     graph = request.graph
+    if _threshold_sum_exceeds_order(request):
+        return _impossible_threshold_bipartition(request)
     if not graph.edges:
         return _edgeless_chromatic_bipartition(request)
     source_vertices = graph.vertices

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -167,19 +167,69 @@ def _impossible_threshold_bipartition(
     )
 
 
+def _is_bipartite(graph: SimpleUndirectedGraph) -> bool:
+    color: dict[str, int] = {}
+    adjacency: dict[str, list[str]] = {vertex: [] for vertex in graph.vertices}
+    for left, right in graph.edges:
+        adjacency[left].append(right)
+        adjacency[right].append(left)
+    for start in graph.vertices:
+        if start in color:
+            continue
+        color[start] = 0
+        queue = [start]
+        for vertex in queue:
+            for neighbor in adjacency[vertex]:
+                assigned = color.get(neighbor)
+                if assigned is None:
+                    color[neighbor] = 1 - color[vertex]
+                    queue.append(neighbor)
+                elif assigned == color[vertex]:
+                    return False
+    return True
+
+
+def _exact_induced_chromatic(
+    graph: SimpleUndirectedGraph,
+    vertices: tuple[str, ...],
+    request: ChromaticBipartitionRequest,
+    started: float,
+) -> int | None:
+    induced = _induced_graph(graph, vertices)
+    if len(vertices) <= 1 or not induced.edges:
+        return 1
+    if _is_bipartite(induced):
+        return 2
+    return _chromatic_number(induced, request, started)
+
+
 def _unit_threshold_bipartition(
     request: ChromaticBipartitionRequest,
 ) -> ChromaticBipartitionResult:
+    """Split off a singleton and report exact induced chromatic numbers."""
+
     vertices = request.graph.vertices
+    side_a = (vertices[0],)
+    side_b = vertices[1:]
+    started = time.monotonic()
+    chromatic_b = _exact_induced_chromatic(request.graph, side_b, request, started)
+    if chromatic_b is None:
+        return ChromaticBipartitionResult(
+            graph=request.graph,
+            s=request.s,
+            t=request.t,
+            status="UNKNOWN",
+            checked_partitions=0,
+        )
     return ChromaticBipartitionResult(
         graph=request.graph,
         s=request.s,
         t=request.t,
         status="SPLIT",
-        side_a=(vertices[0],),
-        side_b=vertices[1:],
+        side_a=side_a,
+        side_b=side_b,
         chromatic_a=1,
-        chromatic_b=1,
+        chromatic_b=chromatic_b,
         checked_partitions=0,
     )
 

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -1,0 +1,338 @@
+"""Bounded exact chromatic bipartition feasibility."""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._execution import OperationExecutionCancelledError, request_checkpoint
+from jacobian._models import StrictModel
+from jacobian.catalog.models import (
+    MathTool,
+    OperationExample,
+)
+from jacobian.math.graphs.optimization._budget import remaining_ms
+from jacobian.math.graphs.optimization._chromatic_kernel import (
+    build_simple_graph,
+    solve_chromatic_number,
+)
+from jacobian.math.graphs.optimization._coloring_models import ChromaticNumberBudget
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+MAX_CHROMATIC_BIPARTITION_WORK = 2_000_000
+_BIPARTITION_WORKER = Path(__file__).with_name("_chromatic_bipartition_worker.py")
+_WORKER_OUTPUT_BYTES = 128 * 1024
+_WORKER_ERROR_BYTES = 16_384
+
+
+class ChromaticBipartitionRequest(StrictModel):
+    """Decide whether both sides of a vertex bipartition meet chromatic thresholds."""
+
+    graph: SimpleUndirectedGraph
+    s: StrictInt = Field(ge=1, le=32)
+    t: StrictInt = Field(ge=1, le=32)
+    resource_budget: ChromaticNumberBudget = Field(
+        default_factory=ChromaticNumberBudget
+    )
+
+    @model_validator(mode="after")
+    def admit_complete_partition_search(self) -> Self:
+        n = len(self.graph.vertices)
+        partitions = 1 << max(0, n - 1)
+        work = partitions * (n + len(self.graph.edges) + 1)
+        if work > MAX_CHROMATIC_BIPARTITION_WORK:
+            raise PydanticCustomError(
+                "graph.chromatic_bipartition_exact_work_exceeds",
+                "chromatic bipartition search exceeds the admitted complete-search work bound",
+            )
+        return self
+
+
+class ChromaticBipartitionResult(StrictModel):
+    """Exact split, exact negative result, or operationally unresolved search."""
+
+    graph: SimpleUndirectedGraph
+    s: StrictInt = Field(ge=1, le=32)
+    t: StrictInt = Field(ge=1, le=32)
+    status: Literal["SPLIT", "NO_SPLIT", "UNKNOWN"]
+    side_a: tuple[str, ...] | None = None
+    side_b: tuple[str, ...] | None = None
+    chromatic_a: StrictInt | None = Field(default=None, ge=0, le=32)
+    chromatic_b: StrictInt | None = Field(default=None, ge=0, le=32)
+    checked_partitions: StrictInt = Field(ge=0)
+
+    @model_validator(mode="after")
+    def bind_result_to_source(self) -> Self:
+        if self.status == "SPLIT":
+            if self.side_a is None or self.side_b is None:
+                raise PydanticCustomError(
+                    "graph.chromatic_bipartition_witness_required",
+                    "a split result requires both sides",
+                )
+            if self.chromatic_a is None or self.chromatic_b is None:
+                raise PydanticCustomError(
+                    "graph.chromatic_bipartition_values_required",
+                    "a split result requires both chromatic values",
+                )
+            if not self.side_a or not self.side_b:
+                raise PydanticCustomError(
+                    "graph.chromatic_bipartition_sides_nonempty",
+                    "a split must have two nonempty sides",
+                )
+            if (
+                len(set(self.side_a)) != len(self.side_a)
+                or len(set(self.side_b)) != len(self.side_b)
+                or len(self.side_a) + len(self.side_b) != len(self.graph.vertices)
+                or set(self.side_a) & set(self.side_b)
+                or set(self.side_a) | set(self.side_b) != set(self.graph.vertices)
+                or any(
+                    vertex not in self.graph.vertices
+                    for vertex in self.side_a + self.side_b
+                )
+            ):
+                raise PydanticCustomError(
+                    "graph.chromatic_bipartition_must_partition_vertices",
+                    "split sides must partition graph vertices exactly once",
+                )
+            if self.graph.vertices[0] not in self.side_a:
+                raise PydanticCustomError(
+                    "graph.chromatic_bipartition_side_a_anchor",
+                    "side_a must contain the first source vertex",
+                )
+            if self.chromatic_a < self.s or self.chromatic_b < self.t:
+                raise PydanticCustomError(
+                    "graph.chromatic_bipartition_thresholds_not_met",
+                    "reported chromatic values must meet the requested thresholds",
+                )
+        elif (
+            self.side_a is not None
+            or self.side_b is not None
+            or self.chromatic_a is not None
+            or self.chromatic_b is not None
+        ):
+            raise PydanticCustomError(
+                "graph.chromatic_bipartition_non_split_must_not_claim_witness",
+                "non-split results cannot carry a witness or chromatic values",
+            )
+        return self
+
+
+def _induced_graph(
+    graph: SimpleUndirectedGraph, vertices: tuple[str, ...]
+) -> SimpleUndirectedGraph:
+    selected = set(vertices)
+    return SimpleUndirectedGraph(
+        vertices=vertices,
+        edges=tuple(
+            (left, right)
+            for left, right in graph.edges
+            if left in selected and right in selected
+        ),
+    )
+
+
+def _find_chromatic_bipartition_kernel(
+    request: ChromaticBipartitionRequest,
+) -> ChromaticBipartitionResult:
+    """Search every canonical unordered vertex bipartition under one deadline."""
+    graph = request.graph
+    source_vertices = graph.vertices
+    started = time.monotonic()
+    checked = 0
+    anchor = 1
+    for mask in range(1, 1 << len(source_vertices)):
+        if not mask & anchor:
+            continue
+        side_a = tuple(
+            vertex
+            for index, vertex in enumerate(source_vertices)
+            if mask & (1 << index)
+        )
+        side_b = tuple(
+            vertex
+            for index, vertex in enumerate(source_vertices)
+            if not mask & (1 << index)
+        )
+        checked += 1
+        if remaining_ms(started, request.resource_budget.wall_seconds) <= 0:
+            return ChromaticBipartitionResult(
+                graph=graph,
+                s=request.s,
+                t=request.t,
+                status="UNKNOWN",
+                checked_partitions=checked,
+            )
+        if len(side_a) < request.s or len(side_b) < request.t:
+            continue
+        chromatic_a = _chromatic_number(_induced_graph(graph, side_a), request, started)
+        if chromatic_a is None:
+            return ChromaticBipartitionResult(
+                graph=graph,
+                s=request.s,
+                t=request.t,
+                status="UNKNOWN",
+                checked_partitions=checked,
+            )
+        if chromatic_a < request.s:
+            continue
+        chromatic_b = _chromatic_number(_induced_graph(graph, side_b), request, started)
+        if chromatic_b is None:
+            return ChromaticBipartitionResult(
+                graph=graph,
+                s=request.s,
+                t=request.t,
+                status="UNKNOWN",
+                checked_partitions=checked,
+            )
+        if chromatic_b >= request.t:
+            return ChromaticBipartitionResult(
+                graph=graph,
+                s=request.s,
+                t=request.t,
+                status="SPLIT",
+                side_a=side_a,
+                side_b=side_b,
+                chromatic_a=chromatic_a,
+                chromatic_b=chromatic_b,
+                checked_partitions=checked,
+            )
+    return ChromaticBipartitionResult(
+        graph=graph,
+        s=request.s,
+        t=request.t,
+        status="NO_SPLIT",
+        checked_partitions=checked,
+    )
+
+
+def _unknown_result(request: ChromaticBipartitionRequest) -> ChromaticBipartitionResult:
+    return ChromaticBipartitionResult(
+        graph=request.graph,
+        s=request.s,
+        t=request.t,
+        status="UNKNOWN",
+        checked_partitions=0,
+    )
+
+
+def find_chromatic_bipartition(
+    request: ChromaticBipartitionRequest,
+) -> ChromaticBipartitionResult:
+    """Run the aggregate search in a killable worker with one request deadline."""
+    deadline = time.monotonic() + request.resource_budget.wall_seconds
+    try:
+        with TemporaryDirectory(prefix="jacobian-graph-bipartition-") as directory:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return _unknown_result(request)
+            completed = run_bounded_process(
+                [sys.executable, str(_BIPARTITION_WORKER)],
+                input_bytes=json.dumps(
+                    request.model_dump(mode="json"),
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ).encode("utf-8"),
+                timeout_seconds=remaining_seconds,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_WORKER_OUTPUT_BYTES,
+                stderr_limit=_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(request.resource_budget.wall_seconds)),
+                    address_space_bytes=1_536 * 1024 * 1024,
+                    file_size_bytes=1_024 * 1_024,
+                ),
+                cwd=directory,
+            )
+    except OSError:
+        return _unknown_result(request)
+    request_checkpoint("after chromatic bipartition worker")
+    if completed.cancelled:
+        raise OperationExecutionCancelledError("chromatic bipartition worker cancelled")
+    if (
+        completed.timed_out
+        or completed.returncode != 0
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+    ):
+        return _unknown_result(request)
+    if time.monotonic() >= deadline:
+        return _unknown_result(request)
+    try:
+        result = ChromaticBipartitionResult.model_validate(
+            json.loads(completed.stdout.decode("utf-8"))
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return _unknown_result(request)
+    request_checkpoint("after chromatic bipartition response validation")
+    return result
+
+
+def _chromatic_number(
+    graph: SimpleUndirectedGraph, request: ChromaticBipartitionRequest, started: float
+) -> int | None:
+    output = solve_chromatic_number(
+        build_simple_graph(graph),
+        graph=graph,
+        vertices=graph.vertices,
+        wall_seconds=request.resource_budget.wall_seconds,
+        started=started,
+    )
+    return output.chromatic_number if output.status == "EXACT" else None
+
+
+CHROMATIC_BIPARTITION_OPERATION = MathTool(
+    operation_id="graph.chromatic_bipartition.find",
+    title="Find a chromatic bipartition",
+    description=(
+        "Decide whether a bounded simple graph has a canonical vertex bipartition "
+        "whose two induced subgraphs have chromatic numbers at least s and t. "
+        "Return a witness, an exact NO_SPLIT after complete search, or UNKNOWN "
+        "when the admitted shared exact-search budget is unresolved."
+    ),
+    request_type=ChromaticBipartitionRequest,
+    result_type=ChromaticBipartitionResult,
+    run=find_chromatic_bipartition,
+    tags=("graph", "chromatic", "bipartition", "exact", "bounded"),
+    examples=(
+        OperationExample(
+            name="k4_two_two_split",
+            description="K4 splits into two induced K2 graphs, each of chromatic number 2.",
+            input={
+                "graph": {
+                    "vertices": ["a", "b", "c", "d"],
+                    "edges": [
+                        ["a", "b"],
+                        ["a", "c"],
+                        ["a", "d"],
+                        ["b", "c"],
+                        ["b", "d"],
+                        ["c", "d"],
+                    ],
+                },
+                "s": 2,
+                "t": 2,
+            },
+        ),
+    ),
+)
+
+__all__ = [
+    "CHROMATIC_BIPARTITION_OPERATION",
+    "MAX_CHROMATIC_BIPARTITION_WORK",
+    "ChromaticBipartitionRequest",
+    "ChromaticBipartitionResult",
+    "find_chromatic_bipartition",
+]

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -23,6 +23,7 @@ from jacobian.math.graphs.optimization._coloring_models import ChromaticNumberBu
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 MAX_CHROMATIC_BIPARTITION_WORK = 2_000_000
+MAX_CHROMATIC_BACKEND_ORDER = 32
 
 
 class ChromaticBipartitionRequest(StrictModel):
@@ -189,18 +190,41 @@ def _is_bipartite(graph: SimpleUndirectedGraph) -> bool:
     return True
 
 
+def _chromatic_search_work(order: int, edge_count: int) -> int:
+    """Charge one bounded k-colorability sweep of an induced core."""
+
+    encoding = order * order + edge_count * order * order
+    return order * (encoding + order + edge_count + 1)
+
+
+def _induced_edge_core(
+    graph: SimpleUndirectedGraph, vertices: tuple[str, ...]
+) -> SimpleUndirectedGraph:
+    """Drop isolates; they do not change chromatic number of a nonempty side."""
+
+    induced = _induced_graph(graph, vertices)
+    if not induced.edges:
+        return induced
+    support = {endpoint for edge in induced.edges for endpoint in edge}
+    return _induced_graph(
+        induced, tuple(vertex for vertex in vertices if vertex in support)
+    )
+
+
 def _exact_induced_chromatic(
     graph: SimpleUndirectedGraph,
     vertices: tuple[str, ...],
     request: ChromaticBipartitionRequest,
     started: float,
 ) -> int | None:
-    induced = _induced_graph(graph, vertices)
-    if len(vertices) <= 1 or not induced.edges:
+    core = _induced_edge_core(graph, vertices)
+    if len(core.vertices) <= 1 or not core.edges:
         return 1
-    if _is_bipartite(induced):
+    if _is_bipartite(core):
         return 2
-    return _chromatic_number(induced, request, started)
+    if len(core.vertices) > MAX_CHROMATIC_BACKEND_ORDER:
+        return None
+    return _chromatic_number(core, request, started)
 
 
 def _unit_threshold_bipartition(
@@ -234,32 +258,47 @@ def _unit_threshold_bipartition(
     )
 
 
+def _refuse_chromatic_bipartition_work() -> None:
+    raise OperationResourceAdmissionError(
+        location=("graph",),
+        code="graph.chromatic_bipartition_exact_work_exceeds",
+        message=(
+            "chromatic bipartition search exceeds the admitted complete-search "
+            "work bound"
+        ),
+    )
+
+
+def _admit_unit_threshold_chromatic(request: ChromaticBipartitionRequest) -> None:
+    """Charge the singleton-versus-rest coloring search before the worker."""
+
+    core = _induced_edge_core(request.graph, request.graph.vertices[1:])
+    if not core.edges or _is_bipartite(core):
+        return
+    if len(core.vertices) > MAX_CHROMATIC_BACKEND_ORDER:
+        _refuse_chromatic_bipartition_work()
+    work = _chromatic_search_work(len(core.vertices), len(core.edges))
+    if work > MAX_CHROMATIC_BIPARTITION_WORK:
+        _refuse_chromatic_bipartition_work()
+
+
 def _admit_chromatic_bipartition(request: ChromaticBipartitionRequest) -> None:
     """Charge every unordered partition and its inner k-colorability encodings."""
 
     order = len(request.graph.vertices)
-    if (
-        not request.graph.edges
-        or _threshold_sum_exceeds_order(request)
-        or (request.s == 1 and request.t == 1 and order >= 2)
-    ):
+    if not request.graph.edges or _threshold_sum_exceeds_order(request):
+        return
+    if request.s == 1 and request.t == 1 and order >= 2:
+        _admit_unit_threshold_chromatic(request)
         return
     n = len(request.graph.vertices)
     m = len(request.graph.edges)
     partitions = _unordered_partition_count(n)
     # Two induced graphs, each trying up to n color counts. One encoding of
     # order n and k<=n uses n*k vertex literals plus m*k^2 edge separations.
-    encoding = n * n + m * n * n
-    work = partitions * 2 * n * (encoding + n + m + 1)
+    work = partitions * 2 * _chromatic_search_work(n, m)
     if work > MAX_CHROMATIC_BIPARTITION_WORK:
-        raise OperationResourceAdmissionError(
-            location=("graph",),
-            code="graph.chromatic_bipartition_exact_work_exceeds",
-            message=(
-                "chromatic bipartition search exceeds the admitted complete-search "
-                "work bound"
-            ),
-        )
+        _refuse_chromatic_bipartition_work()
 
 
 def _find_chromatic_bipartition_kernel(

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -12,6 +12,7 @@ from jacobian._models import StrictModel
 from jacobian.catalog.models import (
     MathTool,
     OperationExample,
+    OperationResourceAdmissionError,
 )
 from jacobian.math.graphs.optimization._budget import remaining_ms
 from jacobian.math.graphs.optimization._chromatic_kernel import (
@@ -33,18 +34,6 @@ class ChromaticBipartitionRequest(StrictModel):
     resource_budget: ChromaticNumberBudget = Field(
         default_factory=ChromaticNumberBudget
     )
-
-    @model_validator(mode="after")
-    def admit_complete_partition_search(self) -> Self:
-        n = len(self.graph.vertices)
-        partitions = 1 << max(0, n - 1)
-        work = partitions * (n + len(self.graph.edges) + 1)
-        if work > MAX_CHROMATIC_BIPARTITION_WORK:
-            raise PydanticCustomError(
-                "graph.chromatic_bipartition_exact_work_exceeds",
-                "chromatic bipartition search exceeds the admitted complete-search work bound",
-            )
-        return self
 
 
 class ChromaticBipartitionResult(StrictModel):
@@ -93,11 +82,6 @@ class ChromaticBipartitionResult(StrictModel):
                     "graph.chromatic_bipartition_must_partition_vertices",
                     "split sides must partition graph vertices exactly once",
                 )
-            if self.graph.vertices[0] not in self.side_a:
-                raise PydanticCustomError(
-                    "graph.chromatic_bipartition_side_a_anchor",
-                    "side_a must contain the first source vertex",
-                )
             if self.chromatic_a < self.s or self.chromatic_b < self.t:
                 raise PydanticCustomError(
                     "graph.chromatic_bipartition_thresholds_not_met",
@@ -130,6 +114,27 @@ def _induced_graph(
     )
 
 
+def _admit_chromatic_bipartition(request: ChromaticBipartitionRequest) -> None:
+    """Charge every canonical partition and its inner k-colorability encodings."""
+
+    n = len(request.graph.vertices)
+    m = len(request.graph.edges)
+    partitions = max(0, (1 << n) - 2)
+    # Two induced graphs, each trying up to n color counts. One encoding of
+    # order n and k<=n uses n*k vertex literals plus m*k^2 edge separations.
+    encoding = n * n + m * n * n
+    work = partitions * 2 * n * (encoding + n + m + 1)
+    if work > MAX_CHROMATIC_BIPARTITION_WORK:
+        raise OperationResourceAdmissionError(
+            location=("graph",),
+            code="graph.chromatic_bipartition_exact_work_exceeds",
+            message=(
+                "chromatic bipartition search exceeds the admitted complete-search "
+                "work bound"
+            ),
+        )
+
+
 def _find_chromatic_bipartition_kernel(
     request: ChromaticBipartitionRequest,
 ) -> ChromaticBipartitionResult:
@@ -138,9 +143,10 @@ def _find_chromatic_bipartition_kernel(
     source_vertices = graph.vertices
     started = time.monotonic()
     checked = 0
-    anchor = 1
-    for mask in range(1, 1 << len(source_vertices)):
-        if not mask & anchor:
+    order = len(source_vertices)
+    for mask in range(1, 1 << order):
+        complement = ((1 << order) - 1) ^ mask
+        if complement == 0:
             continue
         side_a = tuple(
             vertex
@@ -161,8 +167,6 @@ def _find_chromatic_bipartition_kernel(
                 status="UNKNOWN",
                 checked_partitions=checked,
             )
-        if len(side_a) < request.s or len(side_b) < request.t:
-            continue
         chromatic_a = _chromatic_number(_induced_graph(graph, side_a), request, started)
         if chromatic_a is None:
             return ChromaticBipartitionResult(
@@ -172,8 +176,6 @@ def _find_chromatic_bipartition_kernel(
                 status="UNKNOWN",
                 checked_partitions=checked,
             )
-        if chromatic_a < request.s:
-            continue
         chromatic_b = _chromatic_number(_induced_graph(graph, side_b), request, started)
         if chromatic_b is None:
             return ChromaticBipartitionResult(
@@ -183,7 +185,7 @@ def _find_chromatic_bipartition_kernel(
                 status="UNKNOWN",
                 checked_partitions=checked,
             )
-        if chromatic_b >= request.t:
+        if chromatic_a >= request.s and chromatic_b >= request.t:
             return ChromaticBipartitionResult(
                 graph=graph,
                 s=request.s,
@@ -193,6 +195,22 @@ def _find_chromatic_bipartition_kernel(
                 side_b=side_b,
                 chromatic_a=chromatic_a,
                 chromatic_b=chromatic_b,
+                checked_partitions=checked,
+            )
+        if (
+            request.s != request.t
+            and chromatic_a >= request.t
+            and chromatic_b >= request.s
+        ):
+            return ChromaticBipartitionResult(
+                graph=graph,
+                s=request.s,
+                t=request.t,
+                status="SPLIT",
+                side_a=side_b,
+                side_b=side_a,
+                chromatic_a=chromatic_b,
+                chromatic_b=chromatic_a,
                 checked_partitions=checked,
             )
     return ChromaticBipartitionResult(
@@ -219,6 +237,7 @@ def find_chromatic_bipartition(
 ) -> ChromaticBipartitionResult:
     """Run the aggregate search in a killable worker with one request deadline."""
 
+    _admit_chromatic_bipartition(request)
     # Circular: the process owner imports this module's request and result types.
     from jacobian.math.graphs.optimization._chromatic_bipartition_process import (
         find_chromatic_bipartition as run_worker,

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -2,18 +2,12 @@
 
 from __future__ import annotations
 
-import json
-import math
-import sys
 import time
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._execution import OperationExecutionCancelledError, request_checkpoint
 from jacobian._models import StrictModel
 from jacobian.catalog.models import (
     MathTool,
@@ -26,16 +20,8 @@ from jacobian.math.graphs.optimization._chromatic_kernel import (
 )
 from jacobian.math.graphs.optimization._coloring_models import ChromaticNumberBudget
 from jacobian.math.graphs.values import SimpleUndirectedGraph
-from jacobian.process import (
-    ProcessResourceLimits,
-    run_bounded_process,
-    worker_environment,
-)
 
 MAX_CHROMATIC_BIPARTITION_WORK = 2_000_000
-_BIPARTITION_WORKER = Path(__file__).with_name("_chromatic_bipartition_worker.py")
-_WORKER_OUTPUT_BYTES = 128 * 1024
-_WORKER_ERROR_BYTES = 16_384
 
 
 class ChromaticBipartitionRequest(StrictModel):
@@ -232,52 +218,13 @@ def find_chromatic_bipartition(
     request: ChromaticBipartitionRequest,
 ) -> ChromaticBipartitionResult:
     """Run the aggregate search in a killable worker with one request deadline."""
-    deadline = time.monotonic() + request.resource_budget.wall_seconds
-    try:
-        with TemporaryDirectory(prefix="jacobian-graph-bipartition-") as directory:
-            remaining_seconds = deadline - time.monotonic()
-            if remaining_seconds <= 0:
-                return _unknown_result(request)
-            completed = run_bounded_process(
-                [sys.executable, str(_BIPARTITION_WORKER)],
-                input_bytes=json.dumps(
-                    request.model_dump(mode="json"),
-                    separators=(",", ":"),
-                    ensure_ascii=False,
-                ).encode("utf-8"),
-                timeout_seconds=remaining_seconds,
-                environment=worker_environment(locale="C.UTF-8"),
-                stdout_limit=_WORKER_OUTPUT_BYTES,
-                stderr_limit=_WORKER_ERROR_BYTES,
-                resource_limits=ProcessResourceLimits(
-                    cpu_seconds=max(1, math.ceil(request.resource_budget.wall_seconds)),
-                    address_space_bytes=1_536 * 1024 * 1024,
-                    file_size_bytes=1_024 * 1_024,
-                ),
-                cwd=directory,
-            )
-    except OSError:
-        return _unknown_result(request)
-    request_checkpoint("after chromatic bipartition worker")
-    if completed.cancelled:
-        raise OperationExecutionCancelledError("chromatic bipartition worker cancelled")
-    if (
-        completed.timed_out
-        or completed.returncode != 0
-        or completed.stdout_exceeded
-        or completed.stderr_exceeded
-    ):
-        return _unknown_result(request)
-    if time.monotonic() >= deadline:
-        return _unknown_result(request)
-    try:
-        result = ChromaticBipartitionResult.model_validate(
-            json.loads(completed.stdout.decode("utf-8"))
-        )
-    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
-        return _unknown_result(request)
-    request_checkpoint("after chromatic bipartition response validation")
-    return result
+
+    # Circular: the process owner imports this module's request and result types.
+    from jacobian.math.graphs.optimization._chromatic_bipartition_process import (
+        find_chromatic_bipartition as run_worker,
+    )
+
+    return run_worker(request)
 
 
 def _chromatic_number(

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -114,12 +114,49 @@ def _induced_graph(
     )
 
 
-def _admit_chromatic_bipartition(request: ChromaticBipartitionRequest) -> None:
-    """Charge every canonical partition and its inner k-colorability encodings."""
+def _unordered_partition_count(order: int) -> int:
+    """Count nonempty proper subsets with a strictly smaller complement mask."""
 
+    if order < 2:
+        return 0
+    return (1 << (order - 1)) - 1
+
+
+def _edgeless_chromatic_bipartition(
+    request: ChromaticBipartitionRequest,
+) -> ChromaticBipartitionResult:
+    """Decide an edgeless instance without enumerating 2^{n-1} partitions."""
+
+    vertices = request.graph.vertices
+    if len(vertices) < 2 or request.s > 1 or request.t > 1:
+        return ChromaticBipartitionResult(
+            graph=request.graph,
+            s=request.s,
+            t=request.t,
+            status="NO_SPLIT",
+            checked_partitions=0,
+        )
+    return ChromaticBipartitionResult(
+        graph=request.graph,
+        s=request.s,
+        t=request.t,
+        status="SPLIT",
+        side_a=(vertices[0],),
+        side_b=vertices[1:],
+        chromatic_a=1,
+        chromatic_b=1,
+        checked_partitions=0,
+    )
+
+
+def _admit_chromatic_bipartition(request: ChromaticBipartitionRequest) -> None:
+    """Charge every unordered partition and its inner k-colorability encodings."""
+
+    if not request.graph.edges:
+        return
     n = len(request.graph.vertices)
     m = len(request.graph.edges)
-    partitions = max(0, (1 << n) - 2)
+    partitions = _unordered_partition_count(n)
     # Two induced graphs, each trying up to n color counts. One encoding of
     # order n and k<=n uses n*k vertex literals plus m*k^2 edge separations.
     encoding = n * n + m * n * n
@@ -140,13 +177,15 @@ def _find_chromatic_bipartition_kernel(
 ) -> ChromaticBipartitionResult:
     """Search every canonical unordered vertex bipartition under one deadline."""
     graph = request.graph
+    if not graph.edges:
+        return _edgeless_chromatic_bipartition(request)
     source_vertices = graph.vertices
     started = time.monotonic()
     checked = 0
     order = len(source_vertices)
     for mask in range(1, 1 << order):
         complement = ((1 << order) - 1) ^ mask
-        if complement == 0:
+        if complement == 0 or mask > complement:
             continue
         side_a = tuple(
             vertex

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -227,33 +227,52 @@ def _exact_induced_chromatic(
     return _chromatic_number(core, request, started)
 
 
+def _unit_threshold_remainder(
+    vertices: tuple[str, ...], index: int
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    side_a = (vertices[index],)
+    side_b = vertices[:index] + vertices[index + 1 :]
+    return side_a, side_b
+
+
+def _unit_threshold_core_is_admitted(core: SimpleUndirectedGraph) -> bool:
+    if not core.edges or _is_bipartite(core):
+        return True
+    if len(core.vertices) > MAX_CHROMATIC_BACKEND_ORDER:
+        return False
+    return _chromatic_search_work(len(core.vertices), len(core.edges)) <= (
+        MAX_CHROMATIC_BIPARTITION_WORK
+    )
+
+
 def _unit_threshold_bipartition(
     request: ChromaticBipartitionRequest,
 ) -> ChromaticBipartitionResult:
-    """Split off a singleton and report exact induced chromatic numbers."""
+    """Split off a singleton whose remainder has an exact cheap chromatic number."""
 
     vertices = request.graph.vertices
-    side_a = (vertices[0],)
-    side_b = vertices[1:]
     started = time.monotonic()
-    chromatic_b = _exact_induced_chromatic(request.graph, side_b, request, started)
-    if chromatic_b is None:
+    for index in range(len(vertices)):
+        side_a, side_b = _unit_threshold_remainder(vertices, index)
+        chromatic_b = _exact_induced_chromatic(request.graph, side_b, request, started)
+        if chromatic_b is None:
+            continue
         return ChromaticBipartitionResult(
             graph=request.graph,
             s=request.s,
             t=request.t,
-            status="UNKNOWN",
+            status="SPLIT",
+            side_a=side_a,
+            side_b=side_b,
+            chromatic_a=1,
+            chromatic_b=chromatic_b,
             checked_partitions=0,
         )
     return ChromaticBipartitionResult(
         graph=request.graph,
         s=request.s,
         t=request.t,
-        status="SPLIT",
-        side_a=side_a,
-        side_b=side_b,
-        chromatic_a=1,
-        chromatic_b=chromatic_b,
+        status="UNKNOWN",
         checked_partitions=0,
     )
 
@@ -270,16 +289,16 @@ def _refuse_chromatic_bipartition_work() -> None:
 
 
 def _admit_unit_threshold_chromatic(request: ChromaticBipartitionRequest) -> None:
-    """Charge the singleton-versus-rest coloring search before the worker."""
+    """Admit a singleton split whose remainder is cheaply colorable."""
 
-    core = _induced_edge_core(request.graph, request.graph.vertices[1:])
-    if not core.edges or _is_bipartite(core):
-        return
-    if len(core.vertices) > MAX_CHROMATIC_BACKEND_ORDER:
-        _refuse_chromatic_bipartition_work()
-    work = _chromatic_search_work(len(core.vertices), len(core.edges))
-    if work > MAX_CHROMATIC_BIPARTITION_WORK:
-        _refuse_chromatic_bipartition_work()
+    vertices = request.graph.vertices
+    for index in range(len(vertices)):
+        _, side_b = _unit_threshold_remainder(vertices, index)
+        if _unit_threshold_core_is_admitted(
+            _induced_edge_core(request.graph, side_b)
+        ):
+            return
+    _refuse_chromatic_bipartition_work()
 
 
 def _admit_chromatic_bipartition(request: ChromaticBipartitionRequest) -> None:

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -167,10 +167,32 @@ def _impossible_threshold_bipartition(
     )
 
 
+def _unit_threshold_bipartition(
+    request: ChromaticBipartitionRequest,
+) -> ChromaticBipartitionResult:
+    vertices = request.graph.vertices
+    return ChromaticBipartitionResult(
+        graph=request.graph,
+        s=request.s,
+        t=request.t,
+        status="SPLIT",
+        side_a=(vertices[0],),
+        side_b=vertices[1:],
+        chromatic_a=1,
+        chromatic_b=1,
+        checked_partitions=0,
+    )
+
+
 def _admit_chromatic_bipartition(request: ChromaticBipartitionRequest) -> None:
     """Charge every unordered partition and its inner k-colorability encodings."""
 
-    if not request.graph.edges or _threshold_sum_exceeds_order(request):
+    order = len(request.graph.vertices)
+    if (
+        not request.graph.edges
+        or _threshold_sum_exceeds_order(request)
+        or (request.s == 1 and request.t == 1 and order >= 2)
+    ):
         return
     n = len(request.graph.vertices)
     m = len(request.graph.edges)
@@ -195,8 +217,10 @@ def _find_chromatic_bipartition_kernel(
 ) -> ChromaticBipartitionResult:
     """Search every canonical unordered vertex bipartition under one deadline."""
     graph = request.graph
-    if _threshold_sum_exceeds_order(request):
+    if _threshold_sum_exceeds_order(request) or len(graph.vertices) < 2:
         return _impossible_threshold_bipartition(request)
+    if request.s == 1 and request.t == 1:
+        return _unit_threshold_bipartition(request)
     if not graph.edges:
         return _edgeless_chromatic_bipartition(request)
     source_vertices = graph.vertices

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition.py
@@ -254,6 +254,9 @@ def _unit_threshold_bipartition(
     started = time.monotonic()
     for index in range(len(vertices)):
         side_a, side_b = _unit_threshold_remainder(vertices, index)
+        core = _induced_edge_core(request.graph, side_b)
+        if not _unit_threshold_core_is_admitted(core):
+            continue
         chromatic_b = _exact_induced_chromatic(request.graph, side_b, request, started)
         if chromatic_b is None:
             continue

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
@@ -71,11 +71,11 @@ def find_chromatic_bipartition(
         raise RuntimeError(
             "bounded chromatic bipartition worker could not be started"
         ) from exc
-    request_checkpoint("after chromatic bipartition worker")
     if completed.cancelled:
         raise OperationExecutionCancelledError("chromatic bipartition worker cancelled")
     if completed.timed_out:
         return _unknown_result(request)
+    request_checkpoint("after chromatic bipartition worker")
     if completed.stdout_exceeded or completed.stderr_exceeded:
         raise RuntimeError(
             "bounded chromatic bipartition worker exceeded an output cap"

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
@@ -9,7 +9,13 @@ import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from jacobian._execution import OperationExecutionCancelledError, request_checkpoint
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    bind_request_deadline,
+    current_request_execution,
+    request_checkpoint,
+    request_execution,
+)
 from jacobian.math.graphs.optimization._chromatic_bipartition import (
     ChromaticBipartitionRequest,
     ChromaticBipartitionResult,
@@ -30,7 +36,14 @@ def find_chromatic_bipartition(
     request: ChromaticBipartitionRequest,
 ) -> ChromaticBipartitionResult:
     """Run the aggregate search in a killable worker with one request deadline."""
-    deadline = time.monotonic() + request.resource_budget.wall_seconds
+    execution = current_request_execution()
+    if execution is None:
+        with request_execution(time.monotonic()):
+            return find_chromatic_bipartition(request)
+    deadline = execution.started_at + request.resource_budget.wall_seconds
+    if execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
     try:
         with TemporaryDirectory(prefix="jacobian-graph-bipartition-") as directory:
             remaining_seconds = deadline - time.monotonic()
@@ -75,4 +88,6 @@ def find_chromatic_bipartition(
     except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
         return _unknown_result(request)
     request_checkpoint("after chromatic bipartition response validation")
-    return result
+    return result.model_copy(
+        update={"graph": request.graph, "s": request.s, "t": request.t}
+    )

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
@@ -20,6 +20,7 @@ from jacobian.math.graphs.optimization._chromatic_bipartition import (
     ChromaticBipartitionRequest,
     ChromaticBipartitionResult,
     _unknown_result,
+    _unordered_partition_count,
 )
 from jacobian.process import (
     ProcessResourceLimits,
@@ -28,8 +29,43 @@ from jacobian.process import (
 )
 
 _BIPARTITION_WORKER = Path(__file__).with_name("_chromatic_bipartition_worker.py")
-_WORKER_OUTPUT_BYTES = 128 * 1024
 _WORKER_ERROR_BYTES = 16_384
+_WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
+
+
+def _chromatic_bipartition_worker_stdout_limit(
+    request: ChromaticBipartitionRequest,
+) -> int:
+    """Measure the largest admitted canonical worker result for this request."""
+
+    vertices = request.graph.vertices
+    if len(vertices) < 2:
+        result = ChromaticBipartitionResult(
+            graph=request.graph,
+            s=request.s,
+            t=request.t,
+            status="NO_SPLIT",
+            checked_partitions=0,
+        )
+    else:
+        result = ChromaticBipartitionResult(
+            graph=request.graph,
+            s=request.s,
+            t=request.t,
+            status="SPLIT",
+            side_a=(vertices[0],),
+            side_b=vertices[1:],
+            chromatic_a=request.s,
+            chromatic_b=request.t,
+            checked_partitions=_unordered_partition_count(len(vertices)),
+        )
+    return len(
+        json.dumps(
+            result.model_dump(mode="json"),
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+    )
 
 
 def find_chromatic_bipartition(
@@ -49,6 +85,7 @@ def find_chromatic_bipartition(
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
                 return _unknown_result(request)
+            stdout_limit = _chromatic_bipartition_worker_stdout_limit(request)
             completed = run_bounded_process(
                 [sys.executable, str(_BIPARTITION_WORKER)],
                 input_bytes=json.dumps(
@@ -58,12 +95,12 @@ def find_chromatic_bipartition(
                 ).encode("utf-8"),
                 timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
-                stdout_limit=_WORKER_OUTPUT_BYTES,
+                stdout_limit=stdout_limit,
                 stderr_limit=_WORKER_ERROR_BYTES,
                 resource_limits=ProcessResourceLimits(
                     cpu_seconds=max(1, math.ceil(request.resource_budget.wall_seconds)),
                     address_space_bytes=1_536 * 1024 * 1024,
-                    file_size_bytes=1_024 * 1_024,
+                    file_size_bytes=max(_WORKER_FILE_SIZE_BYTES, stdout_limit),
                 ),
                 cwd=directory,
             )

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
@@ -67,27 +67,36 @@ def find_chromatic_bipartition(
                 ),
                 cwd=directory,
             )
-    except OSError:
-        return _unknown_result(request)
+    except OSError as exc:
+        raise RuntimeError(
+            "bounded chromatic bipartition worker could not be started"
+        ) from exc
     request_checkpoint("after chromatic bipartition worker")
     if completed.cancelled:
         raise OperationExecutionCancelledError("chromatic bipartition worker cancelled")
-    if (
-        completed.timed_out
-        or completed.returncode != 0
-        or completed.stdout_exceeded
-        or completed.stderr_exceeded
-    ):
+    if completed.timed_out:
         return _unknown_result(request)
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        raise RuntimeError(
+            "bounded chromatic bipartition worker exceeded an output cap"
+        )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "bounded chromatic bipartition worker did not establish an outcome"
+        )
     if time.monotonic() >= deadline:
         return _unknown_result(request)
     try:
         result = ChromaticBipartitionResult.model_validate(
             json.loads(completed.stdout.decode("utf-8"))
         )
-    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
-        return _unknown_result(request)
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "bounded chromatic bipartition worker returned malformed output"
+        ) from exc
+    if result.graph != request.graph or result.s != request.s or result.t != request.t:
+        raise RuntimeError(
+            "chromatic bipartition worker result is not bound to the submitted request"
+        )
     request_checkpoint("after chromatic bipartition response validation")
-    return result.model_copy(
-        update={"graph": request.graph, "s": request.s, "t": request.t}
-    )
+    return result

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
@@ -1,0 +1,78 @@
+"""Killable owner for the chromatic-bipartition complete-search worker."""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from jacobian._execution import OperationExecutionCancelledError, request_checkpoint
+from jacobian.math.graphs.optimization._chromatic_bipartition import (
+    ChromaticBipartitionRequest,
+    ChromaticBipartitionResult,
+    _unknown_result,
+)
+from jacobian.process import (
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
+
+_BIPARTITION_WORKER = Path(__file__).with_name("_chromatic_bipartition_worker.py")
+_WORKER_OUTPUT_BYTES = 128 * 1024
+_WORKER_ERROR_BYTES = 16_384
+
+
+def find_chromatic_bipartition(
+    request: ChromaticBipartitionRequest,
+) -> ChromaticBipartitionResult:
+    """Run the aggregate search in a killable worker with one request deadline."""
+    deadline = time.monotonic() + request.resource_budget.wall_seconds
+    try:
+        with TemporaryDirectory(prefix="jacobian-graph-bipartition-") as directory:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return _unknown_result(request)
+            completed = run_bounded_process(
+                [sys.executable, str(_BIPARTITION_WORKER)],
+                input_bytes=json.dumps(
+                    request.model_dump(mode="json"),
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ).encode("utf-8"),
+                timeout_seconds=remaining_seconds,
+                environment=worker_environment(locale="C.UTF-8"),
+                stdout_limit=_WORKER_OUTPUT_BYTES,
+                stderr_limit=_WORKER_ERROR_BYTES,
+                resource_limits=ProcessResourceLimits(
+                    cpu_seconds=max(1, math.ceil(request.resource_budget.wall_seconds)),
+                    address_space_bytes=1_536 * 1024 * 1024,
+                    file_size_bytes=1_024 * 1_024,
+                ),
+                cwd=directory,
+            )
+    except OSError:
+        return _unknown_result(request)
+    request_checkpoint("after chromatic bipartition worker")
+    if completed.cancelled:
+        raise OperationExecutionCancelledError("chromatic bipartition worker cancelled")
+    if (
+        completed.timed_out
+        or completed.returncode != 0
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+    ):
+        return _unknown_result(request)
+    if time.monotonic() >= deadline:
+        return _unknown_result(request)
+    try:
+        result = ChromaticBipartitionResult.model_validate(
+            json.loads(completed.stdout.decode("utf-8"))
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return _unknown_result(request)
+    request_checkpoint("after chromatic bipartition response validation")
+    return result

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition_process.py
@@ -33,32 +33,7 @@ _WORKER_ERROR_BYTES = 16_384
 _WORKER_FILE_SIZE_BYTES = 1_024 * 1_024
 
 
-def _chromatic_bipartition_worker_stdout_limit(
-    request: ChromaticBipartitionRequest,
-) -> int:
-    """Measure the largest admitted canonical worker result for this request."""
-
-    vertices = request.graph.vertices
-    if len(vertices) < 2:
-        result = ChromaticBipartitionResult(
-            graph=request.graph,
-            s=request.s,
-            t=request.t,
-            status="NO_SPLIT",
-            checked_partitions=0,
-        )
-    else:
-        result = ChromaticBipartitionResult(
-            graph=request.graph,
-            s=request.s,
-            t=request.t,
-            status="SPLIT",
-            side_a=(vertices[0],),
-            side_b=vertices[1:],
-            chromatic_a=request.s,
-            chromatic_b=request.t,
-            checked_partitions=_unordered_partition_count(len(vertices)),
-        )
+def _serialized_result_bytes(result: ChromaticBipartitionResult) -> int:
     return len(
         json.dumps(
             result.model_dump(mode="json"),
@@ -66,6 +41,46 @@ def _chromatic_bipartition_worker_stdout_limit(
             ensure_ascii=False,
         ).encode("utf-8")
     )
+
+
+def _chromatic_bipartition_worker_stdout_limit(
+    request: ChromaticBipartitionRequest,
+) -> int:
+    """Measure the largest admitted canonical worker result for this request."""
+
+    vertices = request.graph.vertices
+    checked = _unordered_partition_count(len(vertices))
+    envelopes = [
+        ChromaticBipartitionResult(
+            graph=request.graph,
+            s=request.s,
+            t=request.t,
+            status="NO_SPLIT",
+            checked_partitions=checked,
+        ),
+        ChromaticBipartitionResult(
+            graph=request.graph,
+            s=request.s,
+            t=request.t,
+            status="UNKNOWN",
+            checked_partitions=checked,
+        ),
+    ]
+    if len(vertices) >= 2:
+        envelopes.append(
+            ChromaticBipartitionResult(
+                graph=request.graph,
+                s=request.s,
+                t=request.t,
+                status="SPLIT",
+                side_a=(vertices[0],),
+                side_b=vertices[1:],
+                chromatic_a=request.s,
+                chromatic_b=request.t,
+                checked_partitions=checked,
+            )
+        )
+    return max(_serialized_result_bytes(result) for result in envelopes)
 
 
 def find_chromatic_bipartition(

--- a/src/jacobian/math/graphs/optimization/_chromatic_bipartition_worker.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_bipartition_worker.py
@@ -1,0 +1,33 @@
+"""Isolated worker for the bounded chromatic bipartition operation."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from jacobian.math.graphs.optimization._chromatic_bipartition import (
+    ChromaticBipartitionRequest,
+    _find_chromatic_bipartition_kernel,
+)
+
+
+def main() -> int:
+    try:
+        request = ChromaticBipartitionRequest.model_validate(
+            json.loads(sys.stdin.buffer.read())
+        )
+        result = _find_chromatic_bipartition_kernel(request)
+        sys.stdout.write(
+            json.dumps(
+                result.model_dump(mode="json"),
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/graphs/optimization/_tools.py
+++ b/src/jacobian/math/graphs/optimization/_tools.py
@@ -1,6 +1,9 @@
 """Bounded graph-optimization operations."""
 
 from jacobian.catalog.models import MathTools
+from jacobian.math.graphs.optimization._chromatic_bipartition import (
+    CHROMATIC_BIPARTITION_OPERATION,
+)
 from jacobian.math.graphs.optimization._chromatic_number import (
     CHROMATIC_NUMBER_OPERATION,
 )
@@ -28,6 +31,7 @@ from jacobian.math.graphs.optimization._minimum_spanning_tree import (
 __all__ = ["TOOLS"]
 
 TOOLS: MathTools = (
+    CHROMATIC_BIPARTITION_OPERATION,
     CHROMATIC_NUMBER_OPERATION,
     MAXIMUM_CUT_OPERATION,
     *FINITE_GRAPH_OPTIMIZATION_OPERATIONS,

--- a/tests/math/graphs/test_chromatic_bipartition.py
+++ b/tests/math/graphs/test_chromatic_bipartition.py
@@ -135,6 +135,18 @@ def test_eight_vertex_path_fits_the_unordered_partition_bound() -> None:
     assert not set(result.side_a or ()) & set(result.side_b or ())
 
 
+def test_impossible_threshold_sum_is_exact_no_split_before_search() -> None:
+    vertices = tuple(f"v{i}" for i in range(20))
+    source = graph(vertices, (("v0", "v1"),))
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=11, t=10)
+    )
+    assert result.status == "NO_SPLIT"
+    assert result.side_a is None and result.chromatic_a is None
+    assert result.checked_partitions == 0
+    assert result.model_validate_json(result.model_dump_json()) == result
+
+
 def test_complete_search_bound_still_rejects_a_dense_twenty_vertex_graph() -> None:
     vertices = tuple(f"v{i}" for i in range(20))
     source = graph(vertices, (("v0", "v1"),))
@@ -243,3 +255,24 @@ def test_split_below_submitted_thresholds_cannot_bind() -> None:
             chromatic_b=1,
             checked_partitions=1,
         )
+
+
+def test_long_nfc_labels_on_k2_return_split_through_the_worker() -> None:
+    left = "a" * 30_000
+    right = "b" * 30_000
+    source = graph((left, right), ((left, right),))
+    request = ChromaticBipartitionRequest(graph=source, s=1, t=1)
+    limit = process_owner._chromatic_bipartition_worker_stdout_limit(request)
+    assert limit > 128 * 1024
+    result = find_chromatic_bipartition(request)
+    assert result.status == "SPLIT"
+    assert result.side_a == (left,)
+    assert result.side_b == (right,)
+    assert (result.chromatic_a, result.chromatic_b) == (1, 1)
+    dumped = json.dumps(
+        result.model_dump(mode="json"),
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    assert len(dumped) <= limit
+    assert result.model_validate_json(result.model_dump_json()) == result

--- a/tests/math/graphs/test_chromatic_bipartition.py
+++ b/tests/math/graphs/test_chromatic_bipartition.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.graphs.optimization import _chromatic_bipartition as operation
 from jacobian.math.graphs.optimization import (
     _chromatic_bipartition_process as process_owner,
@@ -41,8 +41,21 @@ def test_k3_has_exact_no_split() -> None:
         ChromaticBipartitionRequest(graph=source, s=2, t=2)
     )
     assert result.status == "NO_SPLIT"
-    assert result.checked_partitions == 4
     assert result.side_a is None
+
+
+def test_unequal_thresholds_accept_the_opposite_orientation() -> None:
+    source = graph(
+        ("a", "b", "c", "d", "e"),
+        (("a", "b"), ("c", "d"), ("c", "e"), ("d", "e")),
+    )
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=3, t=2)
+    )
+    assert result.status == "SPLIT"
+    assert set(result.side_a) == {"c", "d", "e"}
+    assert set(result.side_b) == {"a", "b"}
+    assert (result.chromatic_a, result.chromatic_b) == (3, 2)
 
 
 def test_timeout_is_unknown_without_negative_claim(
@@ -62,8 +75,9 @@ def test_timeout_is_unknown_without_negative_claim(
 
 def test_complete_search_bound_is_source_admission() -> None:
     source = graph(tuple(f"v{i}" for i in range(20)), ())
-    with pytest.raises(ValidationError, match="complete-search work bound"):
-        ChromaticBipartitionRequest(graph=source, s=1, t=1)
+    request = ChromaticBipartitionRequest(graph=source, s=1, t=1)
+    with pytest.raises(OperationResourceAdmissionError, match="complete-search work"):
+        find_chromatic_bipartition(request)
 
 
 def test_worker_noncompletion_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/math/graphs/test_chromatic_bipartition.py
+++ b/tests/math/graphs/test_chromatic_bipartition.py
@@ -44,7 +44,30 @@ def test_k4_returns_canonical_split_and_exact_induced_values() -> None:
     assert result.model_validate_json(result.model_dump_json()) == result
 
 
-def test_k3_has_exact_no_split() -> None:
+def test_k3_unit_thresholds_report_the_induced_k2_chromatic_number() -> None:
+    source = graph(("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c")))
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=1, t=1)
+    )
+    assert result.status == "SPLIT"
+    assert result.side_a == ("a",)
+    assert result.side_b == ("b", "c")
+    assert (result.chromatic_a, result.chromatic_b) == (1, 2)
+    assert result.model_validate_json(result.model_dump_json()) == result
+
+
+def test_k4_unit_thresholds_report_the_induced_k3_chromatic_number() -> None:
+    source = graph(
+        ("a", "b", "c", "d"),
+        (("a", "b"), ("a", "c"), ("a", "d"), ("b", "c"), ("b", "d"), ("c", "d")),
+    )
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=1, t=1)
+    )
+    assert result.status == "SPLIT"
+    assert result.side_a == ("a",)
+    assert result.side_b == ("b", "c", "d")
+    assert (result.chromatic_a, result.chromatic_b) == (1, 3)
     source = graph(("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c")))
     result = find_chromatic_bipartition(
         ChromaticBipartitionRequest(graph=source, s=2, t=2)

--- a/tests/math/graphs/test_chromatic_bipartition.py
+++ b/tests/math/graphs/test_chromatic_bipartition.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
-import pytest
+import json
+import time
 
+import pytest
+from pydantic import ValidationError
+
+from jacobian._execution import bind_request_deadline, request_execution
 from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.graphs.optimization import _chromatic_bipartition as operation
 from jacobian.math.graphs.optimization import (
@@ -9,9 +14,12 @@ from jacobian.math.graphs.optimization import (
 )
 from jacobian.math.graphs.optimization._chromatic_bipartition import (
     ChromaticBipartitionRequest,
+    ChromaticBipartitionResult,
     find_chromatic_bipartition,
 )
+from jacobian.math.graphs.optimization._coloring_models import ChromaticNumberBudget
 from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.process import BoundedProcessResult
 
 
 def graph(
@@ -32,6 +40,7 @@ def test_k4_returns_canonical_split_and_exact_induced_values() -> None:
     assert result.side_a == ("a", "b")
     assert result.side_b == ("c", "d")
     assert (result.chromatic_a, result.chromatic_b) == (2, 2)
+    assert result.checked_partitions == 3
     assert result.model_validate_json(result.model_dump_json()) == result
 
 
@@ -42,6 +51,7 @@ def test_k3_has_exact_no_split() -> None:
     )
     assert result.status == "NO_SPLIT"
     assert result.side_a is None
+    assert result.checked_partitions == 3
 
 
 def test_unequal_thresholds_accept_the_opposite_orientation() -> None:
@@ -58,7 +68,7 @@ def test_unequal_thresholds_accept_the_opposite_orientation() -> None:
     assert (result.chromatic_a, result.chromatic_b) == (3, 2)
 
 
-def test_timeout_is_unknown_without_negative_claim(
+def test_kernel_timeout_is_unknown_without_a_negative_claim(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source = graph(
@@ -67,36 +77,169 @@ def test_timeout_is_unknown_without_negative_claim(
     )
     request = ChromaticBipartitionRequest(graph=source, s=2, t=2)
     monkeypatch.setattr(operation, "remaining_ms", lambda *_args: 0)
-    result = find_chromatic_bipartition(request)
-    assert result.status in {"SPLIT", "UNKNOWN"}
-    if result.status == "UNKNOWN":
-        assert result.side_a is None and result.chromatic_a is None
+    result = operation._find_chromatic_bipartition_kernel(request)
+    assert result.status == "UNKNOWN"
+    assert result.side_a is None and result.chromatic_a is None
+    assert result.checked_partitions == 1
 
 
-def test_complete_search_bound_is_source_admission() -> None:
+def test_worker_deadline_times_out_across_the_process_boundary() -> None:
+    source = graph(
+        ("a", "b", "c", "d"),
+        (("a", "b"), ("a", "c"), ("a", "d"), ("b", "c"), ("b", "d"), ("c", "d")),
+    )
+    request = ChromaticBipartitionRequest(
+        graph=source,
+        s=2,
+        t=2,
+        resource_budget=ChromaticNumberBudget(wall_seconds=5),
+    )
+    with request_execution(time.monotonic()):
+        bind_request_deadline(time.monotonic() + 0.02)
+        result = process_owner.find_chromatic_bipartition(request)
+    assert result.status == "UNKNOWN"
+    assert result.side_a is None and result.chromatic_a is None
+
+
+def test_edgeless_twenty_vertex_request_is_exactly_decidable() -> None:
     source = graph(tuple(f"v{i}" for i in range(20)), ())
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=1, t=1)
+    )
+    assert result.status == "SPLIT"
+    assert result.side_a == ("v0",)
+    assert result.side_b == tuple(f"v{i}" for i in range(1, 20))
+    assert (result.chromatic_a, result.chromatic_b) == (1, 1)
+    assert result.model_validate_json(result.model_dump_json()) == result
+
+
+def test_edgeless_graph_has_no_split_above_chromatic_one() -> None:
+    source = graph(tuple(f"v{i}" for i in range(20)), ())
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=2, t=1)
+    )
+    assert result.status == "NO_SPLIT"
+    assert result.side_a is None
+
+
+def test_eight_vertex_path_fits_the_unordered_partition_bound() -> None:
+    vertices = tuple(f"v{i}" for i in range(8))
+    edges = tuple((vertices[index], vertices[index + 1]) for index in range(7))
+    source = graph(vertices, edges)
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=2, t=2)
+    )
+    assert result.status == "SPLIT"
+    assert result.chromatic_a == 2 and result.chromatic_b == 2
+    assert set(result.side_a or ()) | set(result.side_b or ()) == set(vertices)
+    assert not set(result.side_a or ()) & set(result.side_b or ())
+
+
+def test_complete_search_bound_still_rejects_a_dense_twenty_vertex_graph() -> None:
+    vertices = tuple(f"v{i}" for i in range(20))
+    source = graph(vertices, (("v0", "v1"),))
     request = ChromaticBipartitionRequest(graph=source, s=1, t=1)
     with pytest.raises(OperationResourceAdmissionError, match="complete-search work"):
         find_chromatic_bipartition(request)
 
 
-def test_worker_noncompletion_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+def _completed(
+    *,
+    returncode: int | None = 0,
+    stdout: bytes = b"",
+    timed_out: bool = False,
+    stdout_exceeded: bool = False,
+    stderr_exceeded: bool = False,
+) -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=b"",
+        stdout_exceeded=stdout_exceeded,
+        stderr_exceeded=stderr_exceeded,
+        timed_out=timed_out,
+    )
+
+
+def test_worker_timeout_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
     source = graph(("a", "b"), (("a", "b"),))
-
-    class TimedOut:
-        timed_out = True
-        cancelled = False
-        returncode = None
-        stdout_exceeded = False
-        stderr_exceeded = False
-        stdout = b""
-        stderr = b""
-
     monkeypatch.setattr(
-        process_owner, "run_bounded_process", lambda *_args, **_kwargs: TimedOut()
+        process_owner,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: _completed(returncode=None, timed_out=True),
     )
     result = operation.find_chromatic_bipartition(
         ChromaticBipartitionRequest(graph=source, s=1, t=1)
     )
     assert result.status == "UNKNOWN"
     assert result.side_a is None and result.side_b is None
+
+
+@pytest.mark.parametrize(
+    ("completed", "message"),
+    [
+        (_completed(returncode=1), "did not establish an outcome"),
+        (_completed(stdout_exceeded=True), "exceeded an output cap"),
+        (_completed(stderr_exceeded=True), "exceeded an output cap"),
+        (_completed(stdout=b"not-json"), "malformed output"),
+    ],
+)
+def test_worker_failures_are_operational_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    completed: BoundedProcessResult,
+    message: str,
+) -> None:
+    source = graph(("a", "b"), (("a", "b"),))
+    monkeypatch.setattr(
+        process_owner,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: completed,
+    )
+    with pytest.raises(RuntimeError, match=message):
+        operation.find_chromatic_bipartition(
+            ChromaticBipartitionRequest(graph=source, s=1, t=1)
+        )
+
+
+def test_worker_result_must_echo_the_submitted_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = graph(("a", "b", "c"), (("a", "b"), ("b", "c")))
+    echoed = ChromaticBipartitionResult(
+        graph=graph(("x", "y"), (("x", "y"),)),
+        s=1,
+        t=1,
+        status="SPLIT",
+        side_a=("x",),
+        side_b=("y",),
+        chromatic_a=1,
+        chromatic_b=2,
+        checked_partitions=1,
+    )
+    monkeypatch.setattr(
+        process_owner,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: _completed(
+            stdout=json.dumps(echoed.model_dump(mode="json")).encode("utf-8")
+        ),
+    )
+    with pytest.raises(RuntimeError, match="not bound to the submitted request"):
+        operation.find_chromatic_bipartition(
+            ChromaticBipartitionRequest(graph=source, s=2, t=2)
+        )
+
+
+def test_split_below_submitted_thresholds_cannot_bind() -> None:
+    source = graph(("a", "b", "c"), (("a", "b"), ("b", "c")))
+    with pytest.raises(ValidationError):
+        ChromaticBipartitionResult(
+            graph=source,
+            s=2,
+            t=2,
+            status="SPLIT",
+            side_a=("a", "b"),
+            side_b=("c",),
+            chromatic_a=2,
+            chromatic_b=1,
+            checked_partitions=1,
+        )

--- a/tests/math/graphs/test_chromatic_bipartition.py
+++ b/tests/math/graphs/test_chromatic_bipartition.py
@@ -197,7 +197,7 @@ def test_unit_threshold_triangle_plus_isolates_is_exact_without_backend_overflow
     None
 ):
     isolates = tuple(f"u{i:02d}" for i in range(31))
-    source = graph(isolates + ("x", "y", "z"), (("x", "y"), ("x", "z"), ("y", "z")))
+    source = graph((*isolates, "x", "y", "z"), (("x", "y"), ("x", "z"), ("y", "z")))
     result = find_chromatic_bipartition(
         ChromaticBipartitionRequest(graph=source, s=1, t=1)
     )
@@ -208,15 +208,31 @@ def test_unit_threshold_triangle_plus_isolates_is_exact_without_backend_overflow
     assert result.model_validate_json(result.model_dump_json()) == result
 
 
-def test_unit_threshold_core_above_backend_order_is_refused() -> None:
+def test_unit_threshold_tries_another_singleton_before_backend_overflow() -> None:
     isolated = "iso"
     cycle = tuple(f"c{i:02d}" for i in range(33))
-    edges = tuple((cycle[index], cycle[index + 1]) for index in range(32)) + (
+    edges = (
+        *((cycle[index], cycle[index + 1]) for index in range(32)),
         (cycle[0], cycle[32]),
     )
-    request = ChromaticBipartitionRequest(
-        graph=graph((isolated,) + cycle, edges), s=1, t=1
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=graph((isolated, *cycle), edges), s=1, t=1)
     )
+    assert result.status == "SPLIT"
+    assert result.chromatic_a == 1
+    assert result.chromatic_b == 2
+    assert len(result.side_a) == 1
+    assert result.model_validate_json(result.model_dump_json()) == result
+
+
+def test_unit_threshold_nonbipartite_core_above_backend_order_is_refused() -> None:
+    vertices = tuple(f"v{i:02d}" for i in range(34))
+    edges = tuple(
+        (vertices[left], vertices[right])
+        for left in range(34)
+        for right in range(left + 1, 34)
+    )
+    request = ChromaticBipartitionRequest(graph=graph(vertices, edges), s=1, t=1)
     with pytest.raises(OperationResourceAdmissionError, match="complete-search work"):
         find_chromatic_bipartition(request)
 

--- a/tests/math/graphs/test_chromatic_bipartition.py
+++ b/tests/math/graphs/test_chromatic_bipartition.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.optimization import _chromatic_bipartition as operation
+from jacobian.math.graphs.optimization._chromatic_bipartition import (
+    ChromaticBipartitionRequest,
+    find_chromatic_bipartition,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def graph(
+    vertices: tuple[str, ...], edges: tuple[tuple[str, str], ...]
+) -> SimpleUndirectedGraph:
+    return SimpleUndirectedGraph(vertices=vertices, edges=edges)
+
+
+def test_k4_returns_canonical_split_and_exact_induced_values() -> None:
+    source = graph(
+        ("a", "b", "c", "d"),
+        (("a", "b"), ("a", "c"), ("a", "d"), ("b", "c"), ("b", "d"), ("c", "d")),
+    )
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=2, t=2)
+    )
+    assert result.status == "SPLIT"
+    assert result.side_a == ("a", "b")
+    assert result.side_b == ("c", "d")
+    assert (result.chromatic_a, result.chromatic_b) == (2, 2)
+    assert result.model_validate_json(result.model_dump_json()) == result
+
+
+def test_k3_has_exact_no_split() -> None:
+    source = graph(("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c")))
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=2, t=2)
+    )
+    assert result.status == "NO_SPLIT"
+    assert result.checked_partitions == 4
+    assert result.side_a is None
+
+
+def test_timeout_is_unknown_without_negative_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = graph(
+        ("a", "b", "c", "d"),
+        (("a", "b"), ("a", "c"), ("a", "d"), ("b", "c"), ("b", "d"), ("c", "d")),
+    )
+    request = ChromaticBipartitionRequest(graph=source, s=2, t=2)
+    monkeypatch.setattr(operation, "remaining_ms", lambda started, seconds: 0)
+    result = find_chromatic_bipartition(request)
+    assert result.status in {"SPLIT", "UNKNOWN"}
+    if result.status == "UNKNOWN":
+        assert result.side_a is None and result.chromatic_a is None
+
+
+def test_complete_search_bound_is_source_admission() -> None:
+    source = graph(tuple(f"v{i}" for i in range(20)), ())
+    with pytest.raises(ValidationError, match="complete-search work bound"):
+        ChromaticBipartitionRequest(graph=source, s=1, t=1)
+
+
+def test_worker_noncompletion_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = graph(("a", "b"), (("a", "b"),))
+
+    class TimedOut:
+        timed_out = True
+        cancelled = False
+        returncode = None
+        stdout_exceeded = False
+        stderr_exceeded = False
+        stdout = b""
+        stderr = b""
+
+    monkeypatch.setattr(
+        operation, "run_bounded_process", lambda *args, **kwargs: TimedOut()
+    )
+    result = operation.find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=1, t=1)
+    )
+    assert result.status == "UNKNOWN"
+    assert result.side_a is None and result.side_b is None

--- a/tests/math/graphs/test_chromatic_bipartition.py
+++ b/tests/math/graphs/test_chromatic_bipartition.py
@@ -51,7 +51,7 @@ def test_k3_has_exact_no_split() -> None:
     )
     assert result.status == "NO_SPLIT"
     assert result.side_a is None
-    assert result.checked_partitions == 3
+    assert result.checked_partitions == 0
 
 
 def test_unequal_thresholds_accept_the_opposite_orientation() -> None:
@@ -150,7 +150,7 @@ def test_impossible_threshold_sum_is_exact_no_split_before_search() -> None:
 def test_complete_search_bound_still_rejects_a_dense_twenty_vertex_graph() -> None:
     vertices = tuple(f"v{i}" for i in range(20))
     source = graph(vertices, (("v0", "v1"),))
-    request = ChromaticBipartitionRequest(graph=source, s=1, t=1)
+    request = ChromaticBipartitionRequest(graph=source, s=2, t=2)
     with pytest.raises(OperationResourceAdmissionError, match="complete-search work"):
         find_chromatic_bipartition(request)
 

--- a/tests/math/graphs/test_chromatic_bipartition.py
+++ b/tests/math/graphs/test_chromatic_bipartition.py
@@ -4,6 +4,9 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.graphs.optimization import _chromatic_bipartition as operation
+from jacobian.math.graphs.optimization import (
+    _chromatic_bipartition_process as process_owner,
+)
 from jacobian.math.graphs.optimization._chromatic_bipartition import (
     ChromaticBipartitionRequest,
     find_chromatic_bipartition,
@@ -76,7 +79,7 @@ def test_worker_noncompletion_is_unknown(monkeypatch: pytest.MonkeyPatch) -> Non
         stderr = b""
 
     monkeypatch.setattr(
-        operation, "run_bounded_process", lambda *_args, **_kwargs: TimedOut()
+        process_owner, "run_bounded_process", lambda *_args, **_kwargs: TimedOut()
     )
     result = operation.find_chromatic_bipartition(
         ChromaticBipartitionRequest(graph=source, s=1, t=1)

--- a/tests/math/graphs/test_chromatic_bipartition.py
+++ b/tests/math/graphs/test_chromatic_bipartition.py
@@ -50,7 +50,7 @@ def test_timeout_is_unknown_without_negative_claim(
         (("a", "b"), ("a", "c"), ("a", "d"), ("b", "c"), ("b", "d"), ("c", "d")),
     )
     request = ChromaticBipartitionRequest(graph=source, s=2, t=2)
-    monkeypatch.setattr(operation, "remaining_ms", lambda started, seconds: 0)
+    monkeypatch.setattr(operation, "remaining_ms", lambda *_args: 0)
     result = find_chromatic_bipartition(request)
     assert result.status in {"SPLIT", "UNKNOWN"}
     if result.status == "UNKNOWN":
@@ -76,7 +76,7 @@ def test_worker_noncompletion_is_unknown(monkeypatch: pytest.MonkeyPatch) -> Non
         stderr = b""
 
     monkeypatch.setattr(
-        operation, "run_bounded_process", lambda *args, **kwargs: TimedOut()
+        operation, "run_bounded_process", lambda *_args, **_kwargs: TimedOut()
     )
     result = operation.find_chromatic_bipartition(
         ChromaticBipartitionRequest(graph=source, s=1, t=1)

--- a/tests/math/graphs/test_chromatic_bipartition.py
+++ b/tests/math/graphs/test_chromatic_bipartition.py
@@ -68,6 +68,9 @@ def test_k4_unit_thresholds_report_the_induced_k3_chromatic_number() -> None:
     assert result.side_a == ("a",)
     assert result.side_b == ("b", "c", "d")
     assert (result.chromatic_a, result.chromatic_b) == (1, 3)
+
+
+def test_k3_has_exact_no_split() -> None:
     source = graph(("a", "b", "c"), (("a", "b"), ("a", "c"), ("b", "c")))
     result = find_chromatic_bipartition(
         ChromaticBipartitionRequest(graph=source, s=2, t=2)
@@ -174,6 +177,46 @@ def test_complete_search_bound_still_rejects_a_dense_twenty_vertex_graph() -> No
     vertices = tuple(f"v{i}" for i in range(20))
     source = graph(vertices, (("v0", "v1"),))
     request = ChromaticBipartitionRequest(graph=source, s=2, t=2)
+    with pytest.raises(OperationResourceAdmissionError, match="complete-search work"):
+        find_chromatic_bipartition(request)
+
+
+def test_unit_threshold_dense_thirty_two_vertex_graph_is_admitted_as_work() -> None:
+    vertices = tuple(f"v{i:02d}" for i in range(32))
+    edges = tuple(
+        (vertices[left], vertices[right])
+        for left in range(32)
+        for right in range(left + 1, 32)
+    )
+    request = ChromaticBipartitionRequest(graph=graph(vertices, edges), s=1, t=1)
+    with pytest.raises(OperationResourceAdmissionError, match="complete-search work"):
+        find_chromatic_bipartition(request)
+
+
+def test_unit_threshold_triangle_plus_isolates_is_exact_without_backend_overflow() -> (
+    None
+):
+    isolates = tuple(f"u{i:02d}" for i in range(31))
+    source = graph(isolates + ("x", "y", "z"), (("x", "y"), ("x", "z"), ("y", "z")))
+    result = find_chromatic_bipartition(
+        ChromaticBipartitionRequest(graph=source, s=1, t=1)
+    )
+    assert result.status == "SPLIT"
+    assert result.side_a == ("u00",)
+    assert result.chromatic_a == 1
+    assert result.chromatic_b == 3
+    assert result.model_validate_json(result.model_dump_json()) == result
+
+
+def test_unit_threshold_core_above_backend_order_is_refused() -> None:
+    isolated = "iso"
+    cycle = tuple(f"c{i:02d}" for i in range(33))
+    edges = tuple((cycle[index], cycle[index + 1]) for index in range(32)) + (
+        (cycle[0], cycle[32]),
+    )
+    request = ChromaticBipartitionRequest(
+        graph=graph((isolated,) + cycle, edges), s=1, t=1
+    )
     with pytest.raises(OperationResourceAdmissionError, match="complete-search work"):
         find_chromatic_bipartition(request)
 

--- a/tests/mcp/test_chromatic_bipartition.py
+++ b/tests/mcp/test_chromatic_bipartition.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from jacobian.math.graphs.optimization._chromatic_bipartition import (
+    CHROMATIC_BIPARTITION_OPERATION,
+    ChromaticBipartitionRequest,
+)
+from jacobian.mcp.server import create_server
+from mcp import Client
+
+
+def test_live_mcp_split_round_trip_and_chromatic_consumers() -> None:
+    async def scenario() -> None:
+        payload = CHROMATIC_BIPARTITION_OPERATION.examples[0].input
+        request = ChromaticBipartitionRequest.model_validate(payload)
+        expected = CHROMATIC_BIPARTITION_OPERATION.run(request).model_dump(mode="json")
+        async with Client(create_server(), raise_exceptions=False) as client:
+            response = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": CHROMATIC_BIPARTITION_OPERATION.operation_id,
+                    "payload": payload,
+                },
+            )
+            assert not response.is_error
+            assert response.structured_content is not None
+            output = response.structured_content["output"]
+            assert output == expected
+            round_trip = json.loads(json.dumps(output))
+            assert round_trip == output
+            for side in (output["side_a"], output["side_b"]):
+                induced_edges = [
+                    edge
+                    for edge in output["graph"]["edges"]
+                    if edge[0] in side and edge[1] in side
+                ]
+                consumed = await client.call_tool(
+                    "math.run",
+                    {
+                        "operation_id": "graph.invariant.chromatic_number.compute",
+                        "payload": {
+                            "graph": {"vertices": side, "edges": induced_edges}
+                        },
+                    },
+                )
+                assert not consumed.is_error
+                assert consumed.structured_content is not None
+                assert consumed.structured_content["output"]["status"] == "EXACT"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

Issue #2813 asks for one source-bound decision about complementary induced subgraphs meeting two chromatic thresholds. Repeating whole-graph chromatic-number calls does not own the outer partition search or its incomplete outcomes.

## Outcome

Draft implementation of `graph.chromatic_bipartition.find`, with `SPLIT`, `NO_SPLIT`, and `UNKNOWN` results. Split results retain the graph, two sides and reported exact chromatic values. A bounded child process contains the partition search and existing chromatic kernel.

Refs #2813.

## Validation

Head: `8b7a50724`.

The implementation author ran 6 focused mathematical/MCP tests and scoped Ruff/mypy after introducing the worker. An earlier revision passed 122 catalog/isolation/coloring tests. These results do not replace final affected validation or independent review of the complete final diff.

## Contract impact

Adds a public graph-domain decision and source-bound split result. The current request derives an outer partition/reconstruction work bound and carries the existing chromatic resource budget. Worker noncompletion maps to `UNKNOWN`.

## Review closure

This PR is intentionally a draft. Required work before readiness:

- Complete independent exact-diff mathematical and boundary review.
- Correct or prove handling of unequal thresholds when fixing the first vertex in side A; an unordered partition may need its opposite orientation.
- Validate aggregate inner-coloring admission, caller-deadline propagation, and process import boundaries.
- Run the final affected and specialist validation, then resolve hosted CI findings.

The current draft must not be treated as a completed exact negative-decision contract.
