### PR TITLE
fix(probability): drop wire request from public edge-count moments exports

### DIFF
--- a/src/jacobian/math/probability/hypergraph_edge_count_moments/__init__.py
+++ b/src/jacobian/math/probability/hypergraph_edge_count_moments/__init__.py
@@ -1,13 +1,11 @@
 from ._models import (
     EdgeOverlapMomentRow,
-    HypergraphEdgeCountMomentsRequest,
     HypergraphEdgeCountMomentsResult,
 )
 from .operations import compute_hypergraph_edge_count_moments
 
 __all__ = [
     "EdgeOverlapMomentRow",
-    "HypergraphEdgeCountMomentsRequest",
     "HypergraphEdgeCountMomentsResult",
     "compute_hypergraph_edge_count_moments",
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
`#3545` published `HypergraphEdgeCountMomentsRequest` on `jacobian.math.probability.hypergraph_edge_count_moments.__all__`. That violates the public-math rule that native packages do not export wire `Request`/`Input` models. GitHub PR CI merges `main` into each head, so `tests/math/public_api/test_namespace.py` now fails on otherwise unrelated open PRs (for example `#3530`, `#3531`, `#3534`).

## Outcome
The request type stays on the private `_models` / catalog `_tools` path. Public exports are the result value, overlap rows, and `compute_hypergraph_edge_count_moments`. Operation ID, schemas, and kernel behavior are unchanged.

## Validation
- Commands run: `PYTHONPATH=src python -m pytest tests/math/public_api/test_namespace.py tests/math/probability/hypergraph_edge_count_moments/test_operations.py`
- Result: 12 passed
- Final head SHA tested: `474d2bc2acf6f347b3d24552d651c3b0636e7c4e`

Contributor quick path:

```sh
make setup
make affected AFFECTED_BASE=origin/main
```

## Contract impact
- Public contract impact: native package `__all__` no longer includes `HypergraphEdgeCountMomentsRequest`. Catalog/MCP still use the private request type.
- [x] Native and MCP behavior agree, where both are public
- [x] Producer → serialization → consumer composition was tested

## Review closure
- [ ] Every substantive review finding has a fix and applicable regression evidence, or an evidence-backed explanation of why no change is needed
- [ ] Merge conflicts were resolved against the intended base
- [x] Validation covers the final changed tree; checks invalidated by later edits or autofixes were rerun
- [ ] CI evidence matches the final head SHA
- [ ] The appropriate repository validation target and any specialist lane are listed above
- [x] Repository conventions were checked: no compatibility or shadow paths were added

## Conditional detail

### Operation boundary
- Changed stage and owner: native public exports only
- Semantic admission and controlling quantities: unchanged
- Execution envelope: not applicable
- Backend or kernel path: unchanged
- Result construction: unchanged
- Native/MCP parity: catalog still binds `request_type=HypergraphEdgeCountMomentsRequest`
- Serialized-result and round-trip evidence: existing operations tests still import the request from `_models`

### Canonical value audit
- [x] Existing canonical value searched; owner or intentional distinction recorded
- Structurally valid but mathematically invalid fixture and outcome: not applicable
- Exact-success defining invariant: not applicable; export-surface repair only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4530562c-2d92-48ad-94ae-d099bf8228a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4530562c-2d92-48ad-94ae-d099bf8228a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

