### PR TITLE
fix(semidefinite): bound scalar lists and inactive off-diagonals

### DIFF
--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -114,7 +114,7 @@ def _scan_and_install_scalars(
         collected.append(item)
         extra += _raw_rational_digits(item)
         if extra > remaining or len(collected) > _MAX_EQUALITIES:
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, (list, tuple)) and len(collected) > _MAX_EQUALITIES:
                 raise ValueError(
                     "source equalities exceed the admitted 8192-item envelope"
                 )

--- a/src/jacobian/math/matrices/semidefinite/_models.py
+++ b/src/jacobian/math/matrices/semidefinite/_models.py
@@ -114,6 +114,10 @@ def _scan_and_install_scalars(
         collected.append(item)
         extra += _raw_rational_digits(item)
         if extra > remaining or len(collected) > _MAX_EQUALITIES:
+            if isinstance(value, (list, tuple)):
+                raise ValueError(
+                    "source equalities exceed the admitted 8192-item envelope"
+                )
             break
     if not isinstance(value, (list, tuple)):
         container[key] = collected

--- a/src/jacobian/math/matrices/semidefinite/operations.py
+++ b/src/jacobian/math/matrices/semidefinite/operations.py
@@ -59,9 +59,14 @@ def _admit(
         *system.rhs,
         *multipliers,
     )
-    diagonal = all(
+    exposing = tuple(
+        matrix
+        for multiplier, matrix in zip(multipliers, system.matrices, strict=True)
+        if multiplier.num
+    )
+    diagonal = bool(exposing) and all(
         not entry.num
-        for matrix in system.matrices
+        for matrix in exposing
         for i, row in enumerate(matrix.entries)
         for j, entry in enumerate(row)
         if i != j

--- a/tests/math/matrices/test_semidefinite_face.py
+++ b/tests/math/matrices/test_semidefinite_face.py
@@ -118,6 +118,21 @@ def test_full_rank_face_retains_contradictory_equalities_and_empty_axes() -> Non
     )
 
 
+def test_inactive_off_diagonal_constraint_keeps_the_diagonal_regime() -> None:
+    huge = Fraction(1, 10**20_000)
+    system = RationalSemidefiniteSystem(
+        order=2,
+        matrices=(
+            _matrix([[1, 0], [0, 1]]),
+            rational_matrix_from_fractions(((0, huge), (huge, 0))),
+        ),
+        rhs=(_q(0), _q(0)),
+    )
+    result = reduce_exposed_face(system, (_q(1), _q(0)))
+    _identities(result)
+    assert result.reduced.order == 0
+
+
 def test_serialized_reduced_system_supports_another_supplied_step() -> None:
     system = _system(
         (
@@ -248,6 +263,21 @@ def test_raw_request_preflight_rejects_over_budget_cells() -> None:
                     "rhs": [{"num": "0", "den": "1"}] * 128,
                 },
                 "multipliers": [{"num": "1", "den": "1"}] * 128,
+            }
+        )
+
+
+def test_raw_request_preflight_rejects_oversized_scalar_lists() -> None:
+    zero = {"num": "0", "den": "1"}
+    with pytest.raises(ValidationError, match="8192-item"):
+        SemidefiniteFaceReductionRequest.model_validate(
+            {
+                "system": {
+                    "order": 1,
+                    "matrices": [{"entries": [[zero]]}],
+                    "rhs": [zero] * 10_000,
+                },
+                "multipliers": [zero],
             }
         )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Follow-up to merged #3521. Oversized concrete `rhs`/`multipliers` lists still reached recursive canonicalization, and inactive off-diagonal constraints forced the general height regime.

## Outcome
Concrete lists longer than 8192 items are rejected at preflight. Diagonality is decided from matrices with nonzero multipliers. Digit-overflow generators still hit the aggregate digit envelope.

## Validation
- Commands run: `PYTHONPATH=src pytest -q tests/math/matrices/test_semidefinite_face.py`
- Final head SHA tested: 2bde70409
- Relevant CI checks or links: python math / static on this PR

Contributor quick path:

```sh
make setup
make affected AFFECTED_BASE=origin/main
```

## Contract impact
- Public contract impact: same request schema; stricter deserialization rejection for oversized scalar lists; more requests admitted on the diagonal fast path
- [x] Schema and runtime accept/reject the same requests
- [x] Cheap malformed or over-budget input is rejected before expensive work
- [x] Exact results fit the complete canonical output boundary
- [x] All mandatory phases share one request deadline
- [x] Native and MCP behavior agree, where both are public
- [x] Producer → serialization → consumer composition was tested
- [x] Defining invariant and adversarial regression are covered

## Review closure
- [x] Every substantive review finding has a fix and applicable regression evidence, or an evidence-backed explanation of why no change is needed
- [ ] Merge conflicts were resolved against the intended base
- [x] Validation covers the final changed tree; checks invalidated by later edits or autofixes were rerun
- [ ] CI evidence matches the final head SHA
- [ ] The appropriate repository validation target and any specialist lane are listed above (normally `make affected`; docs use `make docs-linkcheck`)
- [x] Repository conventions were checked: no compatibility or shadow paths were added; if a shared abstraction was introduced, two existing paths already share its mechanics and contract

## Conditional detail
### Operation boundary
- Changed stage and owner: request parsing / request bounds
- Semantic admission and controlling quantities: 8192 equalities; exposing-matrix diagonality
- Execution envelope: unchanged cell/digit envelopes
- Backend or kernel path: unchanged
- Result construction: unchanged
- Caller-supplied claim recognition (if applicable): not applicable
- Native/MCP parity: request model shared
- Serialized-result and round-trip evidence: existing face identities plus new tests

### Canonical value audit
- [x] Existing canonical value searched; owner or intentional distinction recorded
- Structurally valid but mathematically invalid fixture and outcome: 10_000-item rhs rejected
- Exact-success defining invariant: exposing-face identities in `_identities`

### Catalog admission (publication changes only)
not applicable

### Residual scope (parent issue only)
none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49522d60-a128-4ebf-aa9e-ca8ecf36f3ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49522d60-a128-4ebf-aa9e-ca8ecf36f3ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

