### PR TITLE
fix(geometry): point Laplace diagnostics at metric and scalar fields

### DIFF
--- a/src/jacobian/math/geometry/differential/_recognition_process.py
+++ b/src/jacobian/math/geometry/differential/_recognition_process.py
@@ -35,9 +35,13 @@ _RECOGNITION_STDERR_BYTES = 64 * 1024
 _RECOGNITION_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
 
 
+type RecognitionOwner = Literal["vector_field", "tensor", "metric", "scalar"]
+_RECOGNITION_OWNERS = ("vector_field", "tensor", "metric", "scalar")
+
+
 @dataclass(frozen=True, slots=True)
 class RationalFunctionRecognitionCandidate:
-    owner: Literal["vector_field", "tensor"]
+    owner: RecognitionOwner
     component: int
     value: RationalFunction
 
@@ -239,7 +243,7 @@ def recognize_canonical_rational_functions(
     if status == "NOT_COPRIME":
         owner = response.get("owner")
         component = response.get("component")
-        if owner not in ("vector_field", "tensor") or type(component) is not int:
+        if owner not in _RECOGNITION_OWNERS or type(component) is not int:
             raise RuntimeError(
                 "bounded rational-function recognition worker returned malformed output"
             )

--- a/src/jacobian/math/geometry/differential/_recognition_worker.py
+++ b/src/jacobian/math/geometry/differential/_recognition_worker.py
@@ -48,7 +48,7 @@ def _run(payload: dict[str, Any]) -> dict[str, Any]:
         component = candidate["component"]
         variable_count = candidate["variable_count"]
         if (
-            owner not in ("vector_field", "tensor")
+            owner not in ("vector_field", "tensor", "metric", "scalar")
             or type(component) is not int
             or component < 0
             or type(variable_count) is not int

--- a/src/jacobian/math/geometry/differential/laplace_beltrami/_plan.py
+++ b/src/jacobian/math/geometry/differential/laplace_beltrami/_plan.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, replace
 from fractions import Fraction
 from typing import NoReturn
 
@@ -48,13 +49,25 @@ def _laplace_singular_metric() -> OperationDomainValidationError:
     )
 
 
+def _laplace_reject_at(
+    location: tuple[str, ...],
+) -> Callable[[str, str], NoReturn]:
+    def reject(reason: str, message: str) -> NoReturn:
+        raise OperationResourceAdmissionError(
+            location=location,
+            code=f"differential_geometry.laplace_beltrami.{reason}",
+            message=message,
+        )
+
+    return reject
+
+
+_laplace_metric_reject = _laplace_reject_at(("metric",))
+_laplace_scalar_reject = _laplace_reject_at(("scalar",))
+
+
 def _laplace_reject(reason: str, message: str) -> NoReturn:
-    location = ("scalar",) if reason == "result_exponent" else ("metric",)
-    raise OperationResourceAdmissionError(
-        location=location,
-        code=f"differential_geometry.laplace_beltrami.{reason}",
-        message=message,
-    )
+    _laplace_metric_reject(reason, message)
 
 
 @dataclass(frozen=True)
@@ -91,11 +104,16 @@ def build_plan(metric: RationalCoordinateMetric, scalar: RationalFunction) -> Pl
     dimension = len(metric.tensor.coordinate_axis)
     connection_plan = build_connection_plan(
         metric,
-        admission_reject=_laplace_reject,
+        admission_reject=_laplace_metric_reject,
         label="Laplace--Beltrami",
         singular_metric=_laplace_singular_metric,
     )
     dag = connection_plan.dag
+    dag.ledger.limits = replace(
+        dag.ledger.limits,
+        reject=_laplace_scalar_reject,
+        label="Laplace--Beltrami",
+    )
     field = dag.fraction(scalar)
     axes = tuple(range(dimension))
     value_terms: list[Expression] = []
@@ -197,7 +215,7 @@ def build_plan(metric: RationalCoordinateMetric, scalar: RationalFunction) -> Pl
         or bits > MAX_LAPLACE_OUTPUT_BITS
         or slots > MAX_LAPLACE_OUTPUT_SLOTS
     ):
-        _laplace_reject(
+        _laplace_scalar_reject(
             "output",
             "Laplace--Beltrami source and result exceed polynomial term, "
             "coefficient-bit, or coordinate allocation bounds",

--- a/src/jacobian/math/geometry/differential/laplace_beltrami/operations.py
+++ b/src/jacobian/math/geometry/differential/laplace_beltrami/operations.py
@@ -20,7 +20,8 @@ from jacobian.math.geometry.differential.laplace_beltrami._models import (
     RationalLaplaceBeltramiResult,
 )
 from jacobian.math.geometry.differential.laplace_beltrami._plan import (
-    _laplace_reject,
+    _laplace_metric_reject,
+    _laplace_scalar_reject,
     build_plan,
 )
 from jacobian.math.geometry.differential.metrics._dag import admit_recognition_work
@@ -40,27 +41,48 @@ def _singular_metric() -> OperationDomainValidationError:
     )
 
 
+def _recognition_location(
+    failure: RationalFunctionRecognitionCandidate,
+) -> tuple[str | int, ...]:
+    if failure.owner == "scalar":
+        return ("scalar",)
+    return ("metric", "tensor", "components", failure.component)
+
+
 def _recognize_source(
     metric: RationalCoordinateMetric, scalar: RationalFunction, deadline: float
 ) -> None:
-    sources = gcd_recognition_values((*metric.tensor.components, scalar))
-    admit_recognition_work(
-        sources,
-        reject=_laplace_reject,
-        label="Laplace--Beltrami",
-    )
-    candidates = tuple(
-        RationalFunctionRecognitionCandidate(
-            owner="tensor", component=index, value=source
+    candidates: list[RationalFunctionRecognitionCandidate] = []
+    seen: set[RationalFunction] = set()
+    for index, component in enumerate(metric.tensor.components):
+        if component in seen or not gcd_recognition_values((component,)):
+            continue
+        seen.add(component)
+        candidates.append(
+            RationalFunctionRecognitionCandidate(
+                owner="metric", component=index, value=component
+            )
         )
-        for index, source in enumerate(sources)
-    )
-    if not candidates:
+    if scalar not in seen and gcd_recognition_values((scalar,)):
+        candidates.append(
+            RationalFunctionRecognitionCandidate(
+                owner="scalar", component=0, value=scalar
+            )
+        )
+    owned = tuple(candidates)
+    if not owned:
         return
-    recognition = recognize_canonical_rational_functions(candidates, deadline=deadline)
+    admit_recognition_work(
+        tuple(candidate.value for candidate in owned),
+        label="Laplace--Beltrami",
+        reject_for=lambda value: (
+            _laplace_scalar_reject if value == scalar else _laplace_metric_reject
+        ),
+    )
+    recognition = recognize_canonical_rational_functions(owned, deadline=deadline)
     if recognition.non_coprime is not None:
         raise OperationDomainValidationError(
-            location=("laplace_beltrami",),
+            location=_recognition_location(recognition.non_coprime),
             code="differential_geometry.laplace_beltrami.noncanonical_source",
             message="metric and scalar must be reduced canonical rational functions",
         )

--- a/src/jacobian/math/geometry/differential/metrics/_dag.py
+++ b/src/jacobian/math/geometry/differential/metrics/_dag.py
@@ -71,17 +71,21 @@ def admit_recognition_work(
     *,
     reject: Callable[[str, str], NoReturn] | None = None,
     label: str | None = None,
+    reject_for: Callable[[RationalFunction], Callable[[str, str], NoReturn]]
+    | None = None,
 ) -> None:
     """Charge coprimality work against the shared 50,000,000-unit envelope."""
 
     ledger = Ledger()
-    if reject is not None or label is not None:
+    if reject is not None or label is not None or reject_for is not None:
         ledger.limits = replace(
             ledger.limits,
             reject=reject or ledger.limits.reject,
             label=label or ledger.limits.label,
         )
     for value in dict.fromkeys(values):
+        if reject_for is not None:
+            ledger.limits = replace(ledger.limits, reject=reject_for(value))
         bound = _fraction_bound(value, ledger)
         ledger.charge("recognition", _recognition_work_units(bound))
 

--- a/tests/math/geometry/differential/laplace_beltrami/test_operations.py
+++ b/tests/math/geometry/differential/laplace_beltrami/test_operations.py
@@ -191,7 +191,31 @@ def test_nonreduced_scalar_is_a_domain_error_before_admission() -> None:
     )
     with pytest.raises(OperationDomainValidationError) as rejected:
         laplace_beltrami(metric, scalar)
-    assert rejected.value.errors()[0]["type"].endswith("noncanonical_source")
+    error = rejected.value.errors()[0]
+    assert error["type"].endswith("noncanonical_source")
+    assert error["loc"] == ("scalar",)
+
+
+def test_nonreduced_metric_component_keeps_its_request_path() -> None:
+    x = symbols("x")
+    unreduced = RationalFunction(
+        variables=("x",),
+        numerator=_scalar(x**64 - 1, ("x",)).numerator,
+        denominator=_scalar(x**32 - 1, ("x",)).numerator,
+    )
+    metric = RationalCoordinateMetric(
+        tensor=RationalCoordinateTensor(
+            coordinate_axis=("x",),
+            variance=("COVARIANT", "COVARIANT"),
+            components=(unreduced,),
+            retained_nonzero_denominators=(unreduced.denominator,),
+        )
+    )
+    with pytest.raises(OperationDomainValidationError) as rejected:
+        laplace_beltrami(metric, _scalar(1, ("x",)))
+    error = rejected.value.errors()[0]
+    assert error["type"].endswith("noncanonical_source")
+    assert error["loc"] == ("metric", "tensor", "components", 0)
 
 
 def test_monic_powered_result_denominator_reuses_inherited_guards() -> None:
@@ -241,8 +265,21 @@ def test_recognition_work_is_rejected_before_the_gcd_worker(
             "recognition worker must follow work admission"
         ),
     )
-    with pytest.raises(OperationResourceAdmissionError, match="work"):
+    with pytest.raises(OperationResourceAdmissionError, match="work") as rejected:
         laplace_beltrami(metric, scalar)
+    error = rejected.value.errors()[0]
+    assert error["type"].endswith(".work")
+    assert error["loc"] == ("scalar",)
+
+
+def test_scalar_derivative_bounds_report_the_scalar_field() -> None:
+    x = symbols("x")
+    metric = _metric((1,), ("x",))
+    with pytest.raises(OperationResourceAdmissionError) as rejected:
+        laplace_beltrami(metric, _scalar(1 / (x**64 + 1), ("x",)))
+    error = rejected.value.errors()[0]
+    assert error["loc"] == ("scalar",)
+    assert error["type"].endswith("result_exponent")
 
 
 def test_result_locus_guard_budget_is_bounded() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
After #3544 merged, Codex noted two P2s: noncanonical recognition used a synthetic `laplace_beltrami` location that is not a request field, and most scalar-caused admission failures still blamed `metric`.

## Outcome
- Coprimality failures report `scalar` or `metric.tensor.components[i]`.
- Recognition work, derivative bounds, and result output admission after the connection plan use the scalar-owned rejection callback.
- Connection, determinant-locus, and inherited-locus checks remain on `metric`.

## Validation
- Commands run: `PYTHONPATH=src python -m pytest tests/math/geometry/differential/laplace_beltrami/test_operations.py tests/math/geometry/differential/laplace_beltrami/test_laplace_beltrami.py tests/process/test_lie_derivative_recognition.py`
- Final head SHA tested: `cca1217e66669da5749a05bb6fa7511e872e39b8`
- Relevant CI checks or links: hosted CI on this branch

Contributor quick path:

```sh
make setup
make affected AFFECTED_BASE=origin/main
```

## Contract impact
- Public contract impact: MCP/native diagnostics for Laplace–Beltrami domain and resource errors now name request fields; operation ID and result schema are unchanged.
- [x] Schema and runtime accept/reject the same requests
- [x] Cheap malformed or over-budget input is rejected before expensive work
- [x] Exact results fit the complete canonical output boundary
- [x] All mandatory phases share one request deadline
- [x] Native and MCP behavior agree, where both are public
- [ ] Producer → serialization → consumer composition was tested
- [x] Defining invariant and adversarial regression are covered

## Review closure
- [x] Every substantive review finding has a fix and applicable regression evidence, or an evidence-backed explanation of why no change is needed
- [x] Merge conflicts were resolved against the intended base
- [x] Validation covers the final changed tree; checks invalidated by later edits or autofixes were rerun
- [ ] CI evidence matches the final head SHA
- [ ] The appropriate repository validation target and any specialist lane are listed above (normally `make affected`; docs use `make docs-linkcheck`)
- [x] Repository conventions were checked: no compatibility or shadow paths were added; if a shared abstraction was introduced, two existing paths already share its mechanics and contract

## Conditional detail

### Operation boundary
- Changed stage and owner: request bounds / recognition for `differential_geometry.laplace_beltrami`
- Semantic admission and controlling quantities: coprimality work still uses the 50,000,000-unit envelope; result exponent/support/height and DAG work after the connection plan are attributed to `scalar`
- Execution envelope: unchanged numerical limits
- Backend or kernel path: recognition worker owner vocabulary now includes `metric` and `scalar`
- Result construction: unchanged
- Caller-supplied claim recognition (if applicable): not applicable
- Native/MCP parity: same `loc` tuples on `OperationDomainValidationError` / `OperationResourceAdmissionError`
- Serialized-result and round-trip evidence: not applicable

Follow-up to merged #3544.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49522d60-a128-4ebf-aa9e-ca8ecf36f3ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49522d60-a128-4ebf-aa9e-ca8ecf36f3ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

