### PR TITLE
fix(runtime): surface operational solver failures

### DIFF
--- a/docs/how-to/invoke-domain-operations.md
+++ b/docs/how-to/invoke-domain-operations.md
@@ -59,11 +59,20 @@ or workspace documents.
 
 A successful tool call returns the operation's own mathematical result model.
 For `sat.solve`, `SAT` and `UNSAT` have their stated meanings, while `UNKNOWN`
-is a non-conclusion; its `exhausted` field may say whether a time, work, or
-memory budget was exhausted. A malformed payload or unknown operation ID is a
+is a healthy inconclusive solver answer. Known work, memory, output, or time
+exhaustion is an execution error, with no mathematical result. MCP reports
+`RESOURCE_EXHAUSTED`, `OPERATION_TIMEOUT`, `OPERATION_CANCELLED`, or
+`OPERATION_FAILED` in its model-visible error text. Backend details stay private.
+Increasing `timeout_ms` does not increase the fixed SAT/SMT work allowance;
+`smt.unsat_core` permits adjusting `rlimit` within its admitted range.
+
+Graph optimization may return valid bounds or an incumbent from an incomplete
+search before the parent deadline. A worker failure or parent deadline expiry
+is an execution error, even when trivial bounds could be constructed afterward.
+A malformed payload or unknown operation ID is a
 tool error, not a mathematical result. A client timeout aborts transport and is
 also not a conclusion. Preserve the selected operation, exact payload or digest,
-and the changed budget, backend, representation, or partition before retrying.
+and the concrete change in budget, backend, or representation before retrying.
 
 ## Use the same contract from the CLI
 

--- a/docs/reference/operations/sat-smt/index.md
+++ b/docs/reference/operations/sat-smt/index.md
@@ -10,10 +10,13 @@ The logic tools take and return bounded inline values.
 - `sat.solve` solves one canonical CNF with the maintained Z3 Python binding.
 - `smt.solve` solves one bounded QF_UF, QF_LIA, or QF_LRA SMT-LIB query with
   the same binding.
+- `smt.unsat_core` returns SAT, UNKNOWN, or an indexed UNSAT core of its source
+  assertions.
 
-The solver result is `SAT`, `UNSAT`, or `UNKNOWN`. A SAT result contains a
-bounded model; `UNKNOWN` makes no mathematical conclusion. There are no CNF,
-model, proof, or solver-result URIs.
+The solver result is `SAT`, `UNSAT`, or `UNKNOWN`. For SAT, `sat.solve`
+returns an assignment and `smt.solve` returns a bounded model projection;
+`smt.unsat_core` returns no core. `UNKNOWN` makes no mathematical conclusion.
+There are no CNF, model, proof, or solver-result URIs.
 
 ## Solver budgets
 
@@ -22,7 +25,28 @@ nesting depth, compound terms, declared symbols, and decimal numeral width.
 Each budget names the quantity that controls parser work, solver
 preprocessing, symbol-table size, or big-integer expansion. Both solvers give
 Z3 a complete request-scoped budget: wall-clock time, a deterministic work
-limit (`rlimit`), and a memory ceiling (`max_memory`). Exhausting any of them,
-or exceeding the bounded model size, returns `UNKNOWN` with an `exhausted`
-value of `time`, `work`, or `memory` where applicable; it never raises a host
-exception or yields a mathematical conclusion.
+limit (`rlimit`), and a memory ceiling (`max_memory`). Known work, memory,
+time, or result-output exhaustion raises an execution exception. A healthy
+inconclusive solver answer remains `UNKNOWN`; the existing success schemas
+are unchanged. The `exhausted` field on SAT/SMT success results is now null.
+
+The work allowance of `sat.solve` and `smt.solve` is fixed: increasing
+`timeout_ms` does not increase it. `smt.unsat_core` exposes `rlimit`; callers
+may adjust it within the range advertised by its request schema. All mandatory
+phases share the parent deadline, including worker startup and result validation.
+
+Native callers receive `OperationResourceExhaustedError` for work, memory, or
+output capacity, `OperationExecutionTimeoutError` for time expiry, and
+`OperationBackendError` for initialization, startup, abnormal exit, malformed
+response, or invalid backend mathematics. Cancellation preserves
+`OperationExecutionCancelledError`. These transport-independent exceptions
+have safe messages; their private causes are not mathematical output.
+
+MCP uses the SDK's
+[ToolError handling](https://py.sdk.modelcontextprotocol.io/servers/handling-errors/):
+`is_error=True`, model-visible text, and no error `structured_content`. Text
+contains `RESOURCE_EXHAUSTED`, `OPERATION_TIMEOUT`, `OPERATION_CANCELLED`, or
+`OPERATION_FAILED`, with the operation ID, stage, safe message, and applicable
+resource and recovery hint. Backend defects and unexpected exceptions receive
+one private traceback at the adapter boundary. Expected resource, timeout,
+cancellation, and validation failures do not receive crash tracebacks.

--- a/src/jacobian/_execution.py
+++ b/src/jacobian/_execution.py
@@ -138,6 +138,48 @@ class OperationExecutionCancelledError(Exception):
         super().__init__(message)
 
 
+class ExecutionResource(StrEnum):
+    WORK = "work"
+    MEMORY = "memory"
+    OUTPUT = "output"
+
+
+class BackendFailureReason(StrEnum):
+    INITIALIZATION = "initialization"
+    STARTUP = "startup"
+    ABNORMAL_EXIT = "abnormal_exit"
+    MALFORMED_RESPONSE = "malformed_response"
+    INVALID_OUTPUT = "invalid_output"
+
+
+class OperationResourceExhaustedError(Exception):
+    """An admitted execution exhausted an operational capacity."""
+
+    def __init__(
+        self,
+        resource: ExecutionResource,
+        *,
+        stage: OperationExecutionStage = OperationExecutionStage.OPERATION_EXECUTION,
+    ) -> None:
+        self.resource = resource
+        self.stage = stage
+        super().__init__(f"operation exhausted its {resource.value} allowance")
+
+
+class OperationBackendError(Exception):
+    """A backend failed to establish a usable mathematical result."""
+
+    def __init__(
+        self,
+        reason: BackendFailureReason,
+        *,
+        stage: OperationExecutionStage = OperationExecutionStage.OPERATION_EXECUTION,
+    ) -> None:
+        self.reason = reason
+        self.stage = stage
+        super().__init__(f"operation backend failed ({reason.value})")
+
+
 def bind_request_deadline(deadline: float) -> None:
     """Attach an owner-derived deadline to the current request envelope."""
 
@@ -146,17 +188,51 @@ def bind_request_deadline(deadline: float) -> None:
         _REQUEST_EXECUTION.set(replace(context, deadline=deadline))
 
 
+def execution_deadline(seconds: float) -> float:
+    """Bind the owner's allowance once, including earlier dispatch phases."""
+    execution = current_request_execution()
+    start = execution.started_at if execution is not None else time.monotonic()
+    deadline = start + seconds
+    if execution is not None and execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    require_execution_deadline(deadline)
+    return deadline
+
+
+def require_execution_deadline(deadline: float) -> None:
+    request_checkpoint("during operation execution")
+    if time.monotonic() >= deadline:
+        raise OperationExecutionTimeoutError("operation deadline expired")
+
+
+def remaining_timeout_ms(timeout_ms: int) -> int:
+    """Give a mandatory solver phase only the unspent request allowance."""
+    request_checkpoint("before solver phase")
+    execution = current_request_execution()
+    if execution is None or execution.deadline is None:
+        return timeout_ms
+    return min(timeout_ms, max(1, int((execution.deadline - time.monotonic()) * 1000)))
+
+
 __all__ = [
+    "BackendFailureReason",
+    "ExecutionResource",
+    "OperationBackendError",
     "OperationExecutionCancelledError",
     "OperationExecutionStage",
     "OperationExecutionTimeoutError",
+    "OperationResourceExhaustedError",
     "RequestCancellationSignal",
     "RequestExecution",
     "bind_request_deadline",
     "current_request_cancellation",
     "current_request_execution",
+    "execution_deadline",
+    "remaining_timeout_ms",
     "request_cancellation",
     "request_cancelled",
     "request_checkpoint",
     "request_execution",
+    "require_execution_deadline",
 ]

--- a/src/jacobian/_worker_errors.py
+++ b/src/jacobian/_worker_errors.py
@@ -1,0 +1,95 @@
+"""Private execution-error branch for bounded mathematical workers."""
+
+from __future__ import annotations
+
+import json
+import math
+import traceback
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from jacobian._execution import (
+    BackendFailureReason,
+    ExecutionResource,
+    OperationBackendError,
+    OperationExecutionCancelledError,
+    OperationExecutionStage,
+    OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
+)
+
+
+@contextmanager
+def worker_execution_errors() -> Iterator[None]:
+    """Encode classified failures; retain bounded backend causes privately."""
+    try:
+        try:
+            yield
+        except ImportError as exc:
+            raise OperationBackendError(BackendFailureReason.INITIALIZATION) from exc
+        except MemoryError as exc:
+            raise OperationResourceExhaustedError(ExecutionResource.MEMORY) from exc
+    except (
+        OperationBackendError,
+        OperationResourceExhaustedError,
+        OperationExecutionTimeoutError,
+        OperationExecutionCancelledError,
+    ) as exc:
+        error = {"kind": "execution_error", "stage": exc.stage.value}
+        if isinstance(exc, OperationBackendError):
+            error["reason"] = exc.reason.value
+            error["diagnostic"] = "".join(traceback.format_exception(exc))[-1024:]
+        elif isinstance(exc, OperationResourceExhaustedError):
+            error["resource"] = exc.resource.value
+        else:
+            error["reason"] = (
+                "timeout"
+                if isinstance(exc, OperationExecutionTimeoutError)
+                else "cancelled"
+            )
+        print(json.dumps(error, separators=(",", ":")))
+
+
+def decode_worker_execution_error(response: object) -> None:
+    """Raise a validated private execution branch, leaving mathematics to owners."""
+    if not isinstance(response, dict) or response.get("kind") != "execution_error":
+        return
+    try:
+        stage = OperationExecutionStage(response["stage"])
+        if set(response) == {"kind", "stage", "resource"}:
+            raise OperationResourceExhaustedError(
+                ExecutionResource(response["resource"]), stage=stage
+            )
+        if set(response) == {"kind", "stage", "reason"}:
+            if response["reason"] == "timeout":
+                raise OperationExecutionTimeoutError(
+                    "operation worker deadline expired", stage=stage
+                )
+            if response["reason"] == "cancelled":
+                raise OperationExecutionCancelledError(
+                    "operation worker cancelled", stage=stage
+                )
+        if set(response) == {"kind", "stage", "reason", "diagnostic"}:
+            reason = BackendFailureReason(response["reason"])
+            diagnostic = response["diagnostic"]
+            if not isinstance(diagnostic, str) or len(diagnostic) > 1024:
+                raise ValueError("invalid private diagnostic")
+            error = OperationBackendError(reason, stage=stage)
+            error.add_note(diagnostic)
+            raise error
+        raise ValueError("invalid execution-error branch")
+    except (KeyError, TypeError, ValueError) as exc:
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE) from exc
+
+
+def bind_worker_deadline(payload: object) -> None:
+    """Consume the private parent deadline before parsing mathematical input."""
+    from jacobian._execution import bind_request_deadline, request_checkpoint
+
+    if not isinstance(payload, dict):
+        raise ValueError("worker payload must be an object")
+    deadline = payload.pop("_deadline", None)
+    if type(deadline) not in (float, int) or not math.isfinite(deadline):
+        raise ValueError("worker payload requires a finite deadline")
+    bind_request_deadline(deadline)
+    request_checkpoint("before worker request parsing")

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_independence_z3.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_independence_z3.py
@@ -11,10 +11,13 @@ from tempfile import TemporaryDirectory
 from typing import Any, cast
 
 from jacobian._execution import (
-    OperationExecutionCancelledError,
-    OperationExecutionTimeoutError,
-    request_checkpoint,
+    BackendFailureReason,
+    OperationBackendError,
+    execution_deadline,
+    remaining_timeout_ms,
+    require_execution_deadline,
 )
+from jacobian._worker_errors import decode_worker_execution_error
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
     HypergraphIndependenceBudget,
@@ -26,6 +29,7 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 )
 from jacobian.process import (
     ProcessResourceLimits,
+    check_bounded_process_result,
     run_bounded_process,
     worker_environment,
 )
@@ -74,7 +78,7 @@ def _check_threshold(
         remaining_ms = _remaining_ms(started, wall_seconds)
         if remaining_ms <= 0:
             return z3.unknown, (), "the wall-clock budget expired during encoding"
-        solver.set(timeout=max(1, remaining_ms))
+        solver.set(timeout=remaining_timeout_ms(max(1, remaining_ms)))
         status = solver.check()
         if status != z3.sat:
             reason = solver.reason_unknown() if status == z3.unknown else ""
@@ -189,18 +193,7 @@ def _solve_independence_number_kernel(
     try:
         solver, selected, cardinality = _build_solver(source)
     except z3.Z3Exception as exc:
-        return _result(
-            source,
-            resource_budget,
-            status="UNKNOWN",
-            independence_number=None,
-            incumbent=incumbent,
-            upper_bound=source_upper_bound,
-            solver_calls=0,
-            wall_budget_exhausted=False,
-            termination_reason="SOLVER_ERROR",
-            detail=f"the exact backend rejected the admitted encoding: {str(exc)[:800]}",
-        )
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
     solver_calls = 0
     lower_bound = len(incumbent)
@@ -245,18 +238,7 @@ def _solve_independence_number_kernel(
                 vertices,
             )
         except z3.Z3Exception as exc:
-            return _result(
-                source,
-                resource_budget,
-                status="UNKNOWN",
-                independence_number=None,
-                incumbent=incumbent,
-                upper_bound=source_upper_bound,
-                solver_calls=solver_calls,
-                wall_budget_exhausted=False,
-                termination_reason="SOLVER_ERROR",
-                detail=f"the exact backend failed during a threshold query: {str(exc)[:800]}",
-            )
+            raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
         if solver_status == z3.unsat:
             upper_bound = threshold - 1
             continue
@@ -266,21 +248,7 @@ def _solve_independence_number_kernel(
             ) < threshold or not _solver_witness_is_canonical_and_independent(
                 source, candidate
             ):
-                return _result(
-                    source,
-                    resource_budget,
-                    status="UNKNOWN",
-                    independence_number=None,
-                    incumbent=incumbent,
-                    upper_bound=source_upper_bound,
-                    solver_calls=solver_calls,
-                    wall_budget_exhausted=False,
-                    termination_reason="SOLVER_ERROR",
-                    detail=(
-                        "the exact backend returned a satisfying witness below "
-                        f"the submitted threshold {threshold}"
-                    ),
-                )
+                raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
             if len(candidate) > len(incumbent):
                 incumbent = candidate
                 lower_bound = max(lower_bound, len(candidate))
@@ -322,11 +290,11 @@ def _solve_independence_number_kernel(
     )
 
 
-def _run_independence_worker(
-    payload: dict[str, object], *, timeout_seconds: float
-) -> object | None:
+def _run_independence_worker(payload: dict[str, object], *, deadline: float) -> object:
     """Run one complete Z3 kernel in an isolated bounded owner process."""
 
+    require_execution_deadline(deadline)
+    timeout_seconds = deadline - time.monotonic()
     try:
         with TemporaryDirectory(
             prefix="jacobian-hypergraph-independence-"
@@ -334,7 +302,9 @@ def _run_independence_worker(
             completed = run_bounded_process(
                 [sys.executable, str(_INDEPENDENCE_WORKER)],
                 input_bytes=json.dumps(
-                    payload, separators=(",", ":"), ensure_ascii=False
+                    {"_deadline": deadline, **payload},
+                    separators=(",", ":"),
+                    ensure_ascii=False,
                 ).encode("utf-8"),
                 timeout_seconds=timeout_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
@@ -347,25 +317,19 @@ def _run_independence_worker(
                 ),
                 cwd=directory,
             )
-    except OSError:
-        return None
-    request_checkpoint("after hypergraph independence worker")
-    if completed.cancelled:
-        raise OperationExecutionCancelledError(
-            "hypergraph independence worker cancelled"
-        )
-    if completed.timed_out:
-        raise OperationExecutionTimeoutError("hypergraph independence worker expired")
-    if (
-        completed.stdout_exceeded
-        or completed.stderr_exceeded
-        or completed.returncode != 0
-    ):
-        return None
+    except OSError as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.STARTUP) from exc
+    check_bounded_process_result(completed)
+    require_execution_deadline(deadline)
     try:
-        return cast(object, json.loads(completed.stdout.decode("utf-8")))
-    except (UnicodeDecodeError, json.JSONDecodeError):
-        return None
+        response = json.loads(completed.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE) from exc
+    require_execution_deadline(deadline)
+    decode_worker_execution_error(response)
+    return cast(object, response)
 
 
 def solve_independence_number(
@@ -374,78 +338,23 @@ def solve_independence_number(
 ) -> HypergraphIndependenceResult:
     """Run every Z3 phase under one process and resource envelope."""
 
-    source_upper_bound = _independence_upper_bound(source)
-    incumbent = _greedy_independent_vertices(source)
-    started = time.monotonic()
-    remaining_seconds = _remaining_ms(started, resource_budget.wall_seconds) / 1_000
-    if remaining_seconds <= 0:
-        return _result(
-            source,
-            resource_budget,
-            status="UNKNOWN",
-            independence_number=None,
-            incumbent=incumbent,
-            upper_bound=source_upper_bound,
-            solver_calls=0,
-            wall_budget_exhausted=True,
-            termination_reason="WALL_TIME",
-            detail="the hypergraph independence request expired before worker startup",
-        )
+    deadline = execution_deadline(resource_budget.wall_seconds)
+    response = _run_independence_worker(
+        {
+            "kind": "solve",
+            "hypergraph": source.model_dump(mode="json"),
+            "resource_budget": resource_budget.model_dump(mode="json"),
+        },
+        deadline=deadline,
+    )
+    require_execution_deadline(deadline)
+    if (
+        not isinstance(response, dict)
+        or "hypergraph" in response
+        or "resource_budget" in response
+    ):
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE)
     try:
-        response = _run_independence_worker(
-            {
-                "kind": "solve",
-                "hypergraph": source.model_dump(mode="json"),
-                "resource_budget": resource_budget.model_dump(mode="json"),
-            },
-            timeout_seconds=remaining_seconds,
-        )
-    except OperationExecutionTimeoutError:
-        return _result(
-            source,
-            resource_budget,
-            status="UNKNOWN",
-            independence_number=None,
-            incumbent=incumbent,
-            upper_bound=source_upper_bound,
-            solver_calls=0,
-            wall_budget_exhausted=True,
-            termination_reason="WALL_TIME",
-            detail="the hypergraph independence worker expired",
-        )
-    request_checkpoint("after hypergraph independence worker response")
-    remaining = _remaining_ms(started, resource_budget.wall_seconds)
-    if not isinstance(response, dict) and remaining > 0:
-        return _result(
-            source,
-            resource_budget,
-            status="UNKNOWN",
-            independence_number=None,
-            incumbent=incumbent,
-            upper_bound=source_upper_bound,
-            solver_calls=0,
-            wall_budget_exhausted=False,
-            termination_reason="SOLVER_ERROR",
-            detail="the bounded hypergraph independence worker did not establish an outcome",
-        )
-    if remaining <= 0:
-        return _result(
-            source,
-            resource_budget,
-            status="UNKNOWN",
-            independence_number=None,
-            incumbent=incumbent,
-            upper_bound=source_upper_bound,
-            solver_calls=0,
-            wall_budget_exhausted=True,
-            termination_reason="WALL_TIME",
-            detail="the hypergraph independence request expired before response validation",
-        )
-    assert isinstance(response, dict)
-    try:
-        # The worker returns only its bounded outcome projection.  Retained
-        # source data belongs to this parent request and must not consume the
-        # worker channel or be trusted from child output.
         result = HypergraphIndependenceResult.model_validate(
             {
                 **response,
@@ -453,39 +362,10 @@ def solve_independence_number(
                 "resource_budget": resource_budget.model_dump(mode="json"),
             }
         )
-    except (TypeError, ValueError):
-        request_checkpoint("during hypergraph independence response validation")
-        expired = _remaining_ms(started, resource_budget.wall_seconds) <= 0
-        return _result(
-            source,
-            resource_budget,
-            status="UNKNOWN",
-            independence_number=None,
-            incumbent=incumbent,
-            upper_bound=source_upper_bound,
-            solver_calls=0,
-            wall_budget_exhausted=expired,
-            termination_reason="WALL_TIME" if expired else "SOLVER_ERROR",
-            detail=(
-                "the hypergraph independence request expired during response validation"
-                if expired
-                else "the bounded hypergraph independence worker returned malformed output"
-            ),
-        )
-    request_checkpoint("after hypergraph independence response validation")
-    if _remaining_ms(started, resource_budget.wall_seconds) <= 0:
-        return _result(
-            source,
-            resource_budget,
-            status="UNKNOWN",
-            independence_number=None,
-            incumbent=incumbent,
-            upper_bound=source_upper_bound,
-            solver_calls=0,
-            wall_budget_exhausted=True,
-            termination_reason="WALL_TIME",
-            detail="the hypergraph independence request expired during response validation",
-        )
+    except (TypeError, ValueError) as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
+    require_execution_deadline(deadline)
     return result
 
 

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_independence_z3_worker.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_independence_z3_worker.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from typing import Any
 
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    request_execution,
+)
+from jacobian._worker_errors import bind_worker_deadline, worker_execution_errors
 from jacobian.math.combinatorics.finite_structures.hypergraphs._independence_z3 import (
     _solve_independence_number_kernel,
 )
@@ -18,6 +25,7 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 def main() -> int:
     try:
         payload: Any = json.loads(sys.stdin.buffer.read())
+        bind_worker_deadline(payload)
         if not isinstance(payload, dict):
             raise ValueError("worker payload must be an object")
         kind = payload["kind"]
@@ -42,9 +50,10 @@ def main() -> int:
             )
             return 0
         raise ValueError("worker payload has invalid kind")
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-        return 2
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    with worker_execution_errors(), request_execution(time.monotonic()):
+        raise SystemExit(main())

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_tools.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraphs/_tools.py
@@ -129,7 +129,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         description="Compute a maximum vertex subset containing no complete hyperedge. "
         "Return either the exact independence number and a maximizing witness, "
         "or a source-bound feasible incumbent with sound lower and upper bounds "
-        "when the bounded exact threshold search does not finish.",
+        "when the bounded exact threshold search does not finish."
+        " Worker failures and parent deadline expiry raise execution errors; a valid partial result must arrive before that deadline.",
         request_type=HypergraphIndependenceRequest,
         result_type=HypergraphIndependenceResult,
         run=_compute_independence_number,

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -10,7 +10,16 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Literal
 
-from jacobian._execution import OperationExecutionCancelledError, request_checkpoint
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    OperationExecutionTimeoutError,
+    execution_deadline,
+    remaining_timeout_ms,
+    request_checkpoint,
+    require_execution_deadline,
+)
+from jacobian._worker_errors import decode_worker_execution_error
 from jacobian.math.graphs.independence import (
     IndependenceNumberBudget,
     IndependenceNumberResult,
@@ -18,6 +27,7 @@ from jacobian.math.graphs.independence import (
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 from jacobian.process import (
     ProcessResourceLimits,
+    check_bounded_process_result,
     run_bounded_process,
     worker_environment,
 )
@@ -43,10 +53,13 @@ def _independence_worker_stdout_limit(graph: SimpleUndirectedGraph) -> int:
         "detail": "x" * 1_024,
         "convention": "MAXIMUM_EDGE_FREE_VERTEX_SUBSET",
     }
-    return len(
-        json.dumps(projection, separators=(",", ":"), ensure_ascii=False).encode(
-            "utf-8"
-        )
+    return max(
+        8192,
+        len(
+            json.dumps(projection, separators=(",", ":"), ensure_ascii=False).encode(
+                "utf-8"
+            )
+        ),
     )
 
 
@@ -100,7 +113,7 @@ def _solve_independence_number_values_kernel(
     import z3
 
     optimizer = z3.Optimize()
-    optimizer.set(timeout=max(1, remaining_ms))
+    optimizer.set(timeout=remaining_timeout_ms(max(1, remaining_ms)))
     selected = {
         vertex: z3.Bool(f"selected_{index}") for index, vertex in enumerate(vertices)
     }
@@ -137,16 +150,7 @@ def _solve_independence_number_values_kernel(
                 detail="bounded Z3 optimization seeded by a NetworkX feasible witness",
             )
     elif status == z3.unsat:
-        return IndependenceNumberResult._from_kernel(
-            graph=graph,
-            status="UNKNOWN",
-            optimum_value=None,
-            upper_bound=len(vertices),
-            incumbent_vertices=incumbent,
-            termination_reason="SOLVER_UNSAT",
-            detail="bounded Z3 optimization returned unsat, which is unexpected "
-            "for an independence-number problem that always has a feasible witness",
-        )
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
     termination: Literal["WALL_TIME", "SOLVER_UNKNOWN"] = (
         "WALL_TIME"
         if time.monotonic() - started >= resource_budget.wall_seconds
@@ -169,32 +173,17 @@ def solve_independence_number_values(
 ) -> IndependenceNumberResult:
     """Run Z3 optimization in one bounded owner worker and decode its result."""
 
-    incumbent = () if not graph.vertices else (min(graph.vertices),)
-
-    def fallback(detail: str, *, wall_time: bool = False) -> IndependenceNumberResult:
-        return IndependenceNumberResult._from_kernel(
-            graph=graph,
-            status="UNKNOWN",
-            optimum_value=None,
-            upper_bound=len(graph.vertices),
-            incumbent_vertices=incumbent,
-            termination_reason="WALL_TIME" if wall_time else "SOLVER_UNKNOWN",
-            detail=detail,
-        )
-
-    deadline = time.monotonic() + resource_budget.wall_seconds
+    deadline = execution_deadline(resource_budget.wall_seconds)
     try:
         with TemporaryDirectory(prefix="jacobian-graph-independence-") as directory:
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
-                return fallback(
-                    "the graph independence request expired before worker startup",
-                    wall_time=True,
-                )
+                raise OperationExecutionTimeoutError("operation deadline expired")
             completed = run_bounded_process(
                 [sys.executable, str(_INDEPENDENCE_WORKER)],
                 input_bytes=json.dumps(
                     {
+                        "_deadline": deadline,
                         "graph": graph.model_dump(mode="json"),
                         "resource_budget": resource_budget.model_dump(mode="json"),
                     },
@@ -212,48 +201,27 @@ def solve_independence_number_values(
                 ),
                 cwd=directory,
             )
-    except OSError:
-        return fallback("the bounded graph independence worker could not be started")
-    request_checkpoint("after graph independence worker")
-    if completed.cancelled:
-        raise OperationExecutionCancelledError("graph independence worker cancelled")
-    if completed.timed_out:
-        return fallback("the graph independence worker expired", wall_time=True)
-    if (
-        completed.stdout_exceeded
-        or completed.stderr_exceeded
-        or completed.returncode != 0
-    ):
-        return fallback(
-            "the bounded graph independence worker did not establish an outcome"
-        )
-    if time.monotonic() >= deadline:
-        return fallback(
-            "the graph independence request expired before response validation",
-            wall_time=True,
-        )
+    except OSError as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.STARTUP) from exc
+    check_bounded_process_result(completed)
+    require_execution_deadline(deadline)
     try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+        require_execution_deadline(deadline)
+        decode_worker_execution_error(response)
+        if not isinstance(response, dict) or "graph" in response:
+            raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE)
         result = IndependenceNumberResult.model_validate(
             {
-                **json.loads(completed.stdout.decode("utf-8")),
+                **response,
                 "graph": graph.model_dump(mode="json"),
             }
         )
         request_checkpoint("after graph independence response validation")
-        return (
-            result
-            if time.monotonic() < deadline
-            else fallback(
-                "the graph independence request expired during response validation",
-                wall_time=True,
-            )
-        )
-    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        require_execution_deadline(deadline)
+        return result
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
         request_checkpoint("during graph independence response validation")
-        expired = time.monotonic() >= deadline
-        return fallback(
-            "the graph independence request expired during response validation"
-            if expired
-            else "the bounded graph independence worker returned malformed output",
-            wall_time=expired,
-        )
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE) from exc

--- a/src/jacobian/math/graphs/_independence_z3_worker.py
+++ b/src/jacobian/math/graphs/_independence_z3_worker.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from typing import Any
 
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    request_execution,
+)
+from jacobian._worker_errors import bind_worker_deadline, worker_execution_errors
 from jacobian.math.graphs._independence_z3 import (
     _solve_independence_number_values_kernel,
 )
@@ -16,6 +23,7 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 def main() -> int:
     try:
         payload: Any = json.loads(sys.stdin.buffer.read())
+        bind_worker_deadline(payload)
         if not isinstance(payload, dict):
             raise ValueError("worker payload must be an object")
         graph = SimpleUndirectedGraph.model_validate(payload["graph"])
@@ -31,9 +39,10 @@ def main() -> int:
             )
         )
         return 0
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-        return 2
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    with worker_execution_errors(), request_execution(time.monotonic()):
+        raise SystemExit(main())

--- a/src/jacobian/math/graphs/optimization/_chromatic_kernel.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_kernel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from jacobian._execution import remaining_timeout_ms
 from jacobian.math.graphs.optimization._budget import remaining_ms as _remaining_ms
 from jacobian.math.graphs.optimization._coloring_models import (
     ChromaticGraph,
@@ -149,7 +150,7 @@ def solve_chromatic_number(
                 detail="the chromatic-number wall-clock budget expired",
             )
         solver = z3.Solver()
-        solver.set(timeout=max(1, remaining_ms))
+        solver.set(timeout=remaining_timeout_ms(max(1, remaining_ms)))
         variable_names, clauses = coloring_cnf(encoded_graph, colors)
         variables = {
             index: z3.Bool(name) for index, name in enumerate(variable_names, start=1)

--- a/src/jacobian/math/graphs/optimization/_chromatic_number.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_number.py
@@ -9,7 +9,15 @@ import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from jacobian._execution import OperationExecutionCancelledError, request_checkpoint
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    OperationExecutionTimeoutError,
+    execution_deadline,
+    request_checkpoint,
+    require_execution_deadline,
+)
+from jacobian._worker_errors import decode_worker_execution_error
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.graphs.optimization._chromatic_kernel import (
     build_simple_graph,
@@ -21,6 +29,7 @@ from jacobian.math.graphs.optimization._coloring_models import (
 )
 from jacobian.process import (
     ProcessResourceLimits,
+    check_bounded_process_result,
     run_bounded_process,
     worker_environment,
 )
@@ -50,56 +59,21 @@ def _search_chromatic_number_kernel(
     return output
 
 
-def _chromatic_worker_failure(
-    request: GraphChromaticNumberRequest, detail: str
-) -> GraphChromaticNumberOutput:
-    """Return a source-derived unknown when the bounded worker fails."""
-
-    vertices = request.graph.vertices
-    if not vertices:
-        return GraphChromaticNumberOutput(
-            status="EXACT",
-            vertices=vertices,
-            order=0,
-            chromatic_number=0,
-            lower_bound=0,
-            upper_bound=0,
-            coloring={},
-            solver_status="SPECIAL_CASE",
-            tested=(),
-            detail="the empty graph requires zero colors",
-        )
-    return GraphChromaticNumberOutput(
-        status="UNKNOWN",
-        vertices=vertices,
-        order=len(vertices),
-        lower_bound=2 if request.graph.edges else 1,
-        upper_bound=len(vertices),
-        coloring={vertex: index for index, vertex in enumerate(vertices)},
-        solver_status="UNKNOWN",
-        tested=(),
-        detail=detail,
-    )
-
-
 def _search_chromatic_number(
     request: GraphChromaticNumberRequest,
 ) -> GraphChromaticNumberOutput:
     """Run the complete Z3 chromatic search in a bounded owner worker."""
 
-    deadline = time.monotonic() + request.resource_budget.wall_seconds
+    deadline = execution_deadline(request.resource_budget.wall_seconds)
     try:
         with TemporaryDirectory(prefix="jacobian-graph-chromatic-") as directory:
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
-                return _chromatic_worker_failure(
-                    request,
-                    "the chromatic-number request expired before worker startup",
-                )
+                raise OperationExecutionTimeoutError("operation deadline expired")
             completed = run_bounded_process(
                 [sys.executable, str(_CHROMATIC_NUMBER_WORKER)],
                 input_bytes=json.dumps(
-                    request.model_dump(mode="json"),
+                    {"_deadline": deadline, **request.model_dump(mode="json")},
                     separators=(",", ":"),
                     ensure_ascii=False,
                 ).encode("utf-8"),
@@ -114,31 +88,18 @@ def _search_chromatic_number(
                 ),
                 cwd=directory,
             )
-    except OSError:
-        return _chromatic_worker_failure(
-            request, "the bounded chromatic-number worker could not be started"
-        )
-    request_checkpoint("after chromatic-number worker")
-    if completed.cancelled:
-        raise OperationExecutionCancelledError("chromatic-number worker cancelled")
-    if completed.timed_out:
-        return _chromatic_worker_failure(request, "the chromatic-number worker expired")
-    if (
-        completed.stdout_exceeded
-        or completed.stderr_exceeded
-        or completed.returncode != 0
-    ):
-        return _chromatic_worker_failure(
-            request, "the bounded chromatic-number worker did not establish an outcome"
-        )
-    if time.monotonic() >= deadline:
-        return _chromatic_worker_failure(
-            request, "the chromatic-number request expired before response validation"
-        )
+    except OSError as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.STARTUP) from exc
+    check_bounded_process_result(completed)
+    require_execution_deadline(deadline)
     try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+        require_execution_deadline(deadline)
+        decode_worker_execution_error(response)
         result = GraphChromaticNumberOutput.model_validate(
             {
-                **json.loads(completed.stdout.decode("utf-8")),
+                **response,
                 "vertices": list(request.graph.vertices),
             }
         )
@@ -149,22 +110,15 @@ def _search_chromatic_number(
                 for left, right in request.graph.edges
             )
         ):
-            raise ValueError("worker result is not bound to the submitted graph")
-    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+            require_execution_deadline(deadline)
+            raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
         request_checkpoint("during chromatic-number response validation")
-        if time.monotonic() >= deadline:
-            return _chromatic_worker_failure(
-                request,
-                "the chromatic-number request expired during response validation",
-            )
-        return _chromatic_worker_failure(
-            request, "the bounded chromatic-number worker returned malformed output"
-        )
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE) from exc
     request_checkpoint("after chromatic-number response validation")
     if time.monotonic() >= deadline:
-        return _chromatic_worker_failure(
-            request, "the chromatic-number request expired during response validation"
-        )
+        raise OperationExecutionTimeoutError("operation deadline expired")
     return result
 
 
@@ -173,8 +127,9 @@ CHROMATIC_NUMBER_OPERATION = MathTool(
     title="Exact chromatic number",
     description=(
         "Compute the exact chromatic number of a bounded simple undirected "
-        "graph by bounded Z3 k-colorability decisions. A timeout returns "
-        "an UNKNOWN result with the tested bounds and search trace."
+        "graph by bounded Z3 k-colorability decisions. An incomplete search can return "
+        "an UNKNOWN result with established bounds and the search trace."
+        " Worker failures and parent deadline expiry raise execution errors; a valid partial result must arrive before that deadline."
     ),
     request_type=GraphChromaticNumberRequest,
     result_type=GraphChromaticNumberOutput,

--- a/src/jacobian/math/graphs/optimization/_chromatic_number_worker.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_number_worker.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from typing import Any
 
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    request_execution,
+)
+from jacobian._worker_errors import bind_worker_deadline, worker_execution_errors
 from jacobian.math.graphs.optimization._chromatic_number import (
     _search_chromatic_number_kernel,
 )
@@ -17,6 +24,7 @@ from jacobian.math.graphs.optimization._coloring_models import (
 def main() -> int:
     try:
         payload: Any = json.loads(sys.stdin.buffer.read())
+        bind_worker_deadline(payload)
         request = GraphChromaticNumberRequest.model_validate(payload)
         result = _search_chromatic_number_kernel(request)
         sys.stdout.write(
@@ -27,9 +35,10 @@ def main() -> int:
             )
         )
         return 0
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return 2
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    with worker_execution_errors(), request_execution(time.monotonic()):
+        raise SystemExit(main())

--- a/src/jacobian/math/graphs/optimization/_exact_search.py
+++ b/src/jacobian/math/graphs/optimization/_exact_search.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from jacobian._execution import remaining_timeout_ms
 from jacobian.math.graphs.optimization._budget import remaining_ms as _remaining_ms
 from jacobian.math.graphs.optimization._coloring_models import ChromaticGraph
 from jacobian.math.graphs.optimization._models import (
@@ -186,7 +187,7 @@ def _check_after_encoding(
     remaining_ms = _remaining_ms(started, budget.wall_seconds)
     if remaining_ms <= 0:
         return z3.unknown
-    solver.set(timeout=max(1, remaining_ms))
+    solver.set(timeout=remaining_timeout_ms(max(1, remaining_ms)))
     status = solver.check()
     return z3.unknown if _remaining_ms(started, budget.wall_seconds) <= 0 else status
 

--- a/src/jacobian/math/graphs/optimization/_finite_optimization.py
+++ b/src/jacobian/math/graphs/optimization/_finite_optimization.py
@@ -11,8 +11,16 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, cast
 
-from jacobian._execution import OperationExecutionCancelledError, request_checkpoint
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    OperationExecutionTimeoutError,
+    execution_deadline,
+    request_checkpoint,
+    require_execution_deadline,
+)
 from jacobian._models import StrictModel
+from jacobian._worker_errors import decode_worker_execution_error
 from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
@@ -36,6 +44,7 @@ from jacobian.math.graphs.optimization._models import (
 )
 from jacobian.process import (
     ProcessResourceLimits,
+    check_bounded_process_result,
     run_bounded_process,
     worker_environment,
 )
@@ -119,64 +128,6 @@ def _valid_witness(graph: Any, result: StrictModel) -> bool:
     return validate(graph, result) if validate else False
 
 
-def _fallback_unknown[ResultT: StrictModel](
-    graph: Any,
-    request: GraphOptimizationRequest,
-    result_type: type[ResultT],
-    detail: str,
-    *,
-    wall_time: bool = False,
-) -> ResultT:
-    """Return a source-derived feasible incumbent without an optimum claim."""
-
-    vertices = tuple(sorted(request.graph.vertices))
-    common: dict[str, object] = {
-        "status": "UNKNOWN",
-        "order": len(vertices),
-        "optimum_value": None,
-        "tested": (),
-        "termination_reason": "WALL_TIME" if wall_time else "SOLVER_UNKNOWN",
-        "detail": detail,
-    }
-    if result_type is GraphDominationMinimumOutput:
-        return result_type.model_validate(
-            {
-                **common,
-                "incumbent_value": len(vertices),
-                "lower_bound": 0 if not vertices else 1,
-                "upper_bound": len(vertices),
-                "witness_vertices": vertices,
-            }
-        )
-    if result_type is GraphMinimumMaximalMatchingOutput:
-        used: set[str] = set()
-        selected: list[tuple[str, str]] = []
-        for left, right in sorted(graph.edges):
-            if left not in used and right not in used:
-                selected.append((left, right) if left < right else (right, left))
-                used.update((left, right))
-        edges = tuple(selected)
-        return result_type.model_validate(
-            {
-                **common,
-                "incumbent_value": len(edges),
-                "lower_bound": 0,
-                "upper_bound": len(edges),
-                "witness_edges": edges,
-            }
-        )
-    witness = () if not vertices else (vertices[0],)
-    return result_type.model_validate(
-        {
-            **common,
-            "incumbent_value": len(witness),
-            "lower_bound": len(witness),
-            "upper_bound": len(vertices),
-            "witness_vertices": witness,
-        }
-    )
-
-
 def _execute[ResultT: StrictModel](
     operation_id: str,
     request: GraphOptimizationRequest,
@@ -190,23 +141,18 @@ def _execute[ResultT: StrictModel](
             code="graph.optimization.max_order_budget",
             message="graph order exceeds the declared max_order budget",
         )
+    deadline = execution_deadline(request.resource_budget.wall_seconds)
     graph = cast(Any, build_simple_graph(request.graph))
-    deadline = time.monotonic() + request.resource_budget.wall_seconds
     try:
         with TemporaryDirectory(prefix="jacobian-graph-optimization-") as directory:
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
-                return _fallback_unknown(
-                    graph,
-                    request,
-                    result_type,
-                    "the graph optimization request expired before worker startup",
-                    wall_time=True,
-                )
+                raise OperationExecutionTimeoutError("operation deadline expired")
             completed = run_bounded_process(
                 [sys.executable, str(_OPTIMIZATION_WORKER)],
                 input_bytes=json.dumps(
                     {
+                        "_deadline": deadline,
                         "operation_id": operation_id,
                         "request": request.model_dump(mode="json"),
                     },
@@ -223,78 +169,28 @@ def _execute[ResultT: StrictModel](
                 ),
                 cwd=directory,
             )
-    except OSError:
-        return _fallback_unknown(
-            graph,
-            request,
-            result_type,
-            "the bounded graph optimization worker could not be started",
-        )
-    request_checkpoint("after graph optimization worker")
-    if completed.cancelled:
-        raise OperationExecutionCancelledError("graph optimization worker cancelled")
-    if completed.timed_out:
-        return _fallback_unknown(
-            graph,
-            request,
-            result_type,
-            "the graph optimization worker expired",
-            wall_time=True,
-        )
-    if (
-        completed.stdout_exceeded
-        or completed.stderr_exceeded
-        or completed.returncode != 0
-    ):
-        return _fallback_unknown(
-            graph,
-            request,
-            result_type,
-            "the bounded graph optimization worker did not establish an outcome",
-        )
-    if time.monotonic() >= deadline:
-        return _fallback_unknown(
-            graph,
-            request,
-            result_type,
-            "the graph optimization request expired before response validation",
-            wall_time=True,
-        )
+    except OSError as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.STARTUP) from exc
+    check_bounded_process_result(completed)
+    require_execution_deadline(deadline)
     try:
-        result = result_type.model_validate(
-            json.loads(completed.stdout.decode("utf-8"))
-        )
-    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        response = json.loads(completed.stdout.decode("utf-8"))
+        require_execution_deadline(deadline)
+        decode_worker_execution_error(response)
+        result = result_type.model_validate(response)
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
         request_checkpoint("during graph optimization response validation")
-        expired = time.monotonic() >= deadline
-        return _fallback_unknown(
-            graph,
-            request,
-            result_type,
-            "the graph optimization request expired during response validation"
-            if expired
-            else "the bounded graph optimization worker returned malformed output",
-            wall_time=expired,
-        )
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE) from exc
     valid_witness = getattr(result, "order", None) == len(
         request.graph.vertices
     ) and _valid_witness(graph, result)
     request_checkpoint("after graph optimization response validation")
     if time.monotonic() >= deadline:
-        return _fallback_unknown(
-            graph,
-            request,
-            result_type,
-            "the graph optimization request expired during response validation",
-            wall_time=True,
-        )
+        raise OperationExecutionTimeoutError("operation deadline expired")
     if not valid_witness:
-        return _fallback_unknown(
-            graph,
-            request,
-            result_type,
-            "the bounded graph optimization worker returned an invalid witness",
-        )
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
     return result
 
 
@@ -309,7 +205,8 @@ def _operation[ResultT: StrictModel](
     return MathTool(
         operation_id=operation_id,
         title=title,
-        description=description,
+        description=description
+        + " Worker failures and parent deadline expiry raise execution errors; a valid partial result must arrive before that deadline.",
         request_type=GraphOptimizationRequest,
         result_type=result_type,
         run=lambda request: _execute(operation_id, request, result_type),
@@ -470,5 +367,5 @@ def _run_worker_kernel(
     else:
         raise ValueError("unknown graph optimization operation")
     if not _valid_witness(graph, result):
-        raise ValueError("graph optimization kernel returned an invalid witness")
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
     return result

--- a/src/jacobian/math/graphs/optimization/_finite_optimization_worker.py
+++ b/src/jacobian/math/graphs/optimization/_finite_optimization_worker.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from typing import Any
 
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    request_execution,
+)
+from jacobian._worker_errors import bind_worker_deadline, worker_execution_errors
 from jacobian.math.graphs.optimization._finite_optimization import _run_worker_kernel
 from jacobian.math.graphs.optimization._models import GraphOptimizationRequest
 
@@ -13,6 +20,7 @@ from jacobian.math.graphs.optimization._models import GraphOptimizationRequest
 def main() -> int:
     try:
         payload: Any = json.loads(sys.stdin.buffer.read())
+        bind_worker_deadline(payload)
         if not isinstance(payload, dict):
             raise ValueError("worker payload must be an object")
         operation_id = payload["operation_id"]
@@ -24,9 +32,10 @@ def main() -> int:
             json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
         )
         return 0
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-        return 2
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    with worker_execution_errors(), request_execution(time.monotonic()):
+        raise SystemExit(main())

--- a/src/jacobian/math/graphs/optimization/_independence.py
+++ b/src/jacobian/math/graphs/optimization/_independence.py
@@ -15,7 +15,8 @@ INDEPENDENCE_NUMBER_OPERATION = MathTool(
     description=(
         "Compute a maximum independent set (independence number) through order "
         "128. Return either the exact optimum or a feasible incumbent with "
-        "explicit lower and upper bounds when the wall-clock budget expires."
+        "explicit lower and upper bounds from an incomplete search."
+        " Worker failures and parent deadline expiry raise execution errors; a valid partial result must arrive before that deadline."
     ),
     request_type=IndependenceNumberRequest,
     result_type=IndependenceNumberResult,

--- a/src/jacobian/math/graphs/optimization/_invariants.py
+++ b/src/jacobian/math/graphs/optimization/_invariants.py
@@ -14,8 +14,17 @@ from typing import Any, cast
 
 from pydantic_core import PydanticCustomError
 
-from jacobian._execution import OperationExecutionCancelledError, request_checkpoint
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    OperationExecutionTimeoutError,
+    execution_deadline,
+    remaining_timeout_ms,
+    request_checkpoint,
+    require_execution_deadline,
+)
 from jacobian._models import StrictModel
+from jacobian._worker_errors import decode_worker_execution_error
 from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
@@ -49,6 +58,7 @@ from jacobian.math.graphs.optimization._models import (
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 from jacobian.process import (
     ProcessResourceLimits,
+    check_bounded_process_result,
     run_bounded_process,
     worker_environment,
 )
@@ -334,7 +344,7 @@ def _clique_execute_kernel(
             termination = "WALL_TIME"
             break
         solver = z3.Solver()
-        solver.set(timeout=max(1, remaining_ms))
+        solver.set(timeout=remaining_timeout_ms(max(1, remaining_ms)))
         selected = {
             vertex: z3.Bool(f"selected_{index}")
             for index, vertex in enumerate(vertices)
@@ -405,31 +415,6 @@ def _clique_execute_kernel(
     )
 
 
-def _clique_worker_failure(
-    request: GraphOptimizationRequest,
-    detail: str,
-    *,
-    wall_time: bool = False,
-) -> GraphCliqueNumberResult:
-    """Return a source-derived unknown result when the isolated worker fails."""
-
-    vertices = tuple(request.graph.vertices)
-    witness = () if not vertices else (min(vertices),)
-    return GraphCliqueNumberResult(
-        graph=request.graph,
-        status="UNKNOWN",
-        order=len(vertices),
-        optimum_value=None,
-        incumbent_value=len(witness),
-        lower_bound=len(witness),
-        upper_bound=len(vertices),
-        witness_vertices=witness,
-        tested=(),
-        termination_reason="WALL_TIME" if wall_time else "SOLVER_UNKNOWN",
-        detail=detail,
-    )
-
-
 def _clique_execute(
     request: GraphOptimizationRequest,
 ) -> GraphCliqueNumberResult:
@@ -441,20 +426,17 @@ def _clique_execute(
             code="graph.clique_number.max_order_budget",
             message="graph order exceeds the declared max_order budget",
         )
-    deadline = time.monotonic() + request.resource_budget.wall_seconds
+    deadline = execution_deadline(request.resource_budget.wall_seconds)
     try:
         with TemporaryDirectory(prefix="jacobian-graph-clique-") as directory:
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
-                return _clique_worker_failure(
-                    request,
-                    "the clique request expired before worker startup",
-                    wall_time=True,
-                )
+                raise OperationExecutionTimeoutError("operation deadline expired")
             completed = run_bounded_process(
                 [sys.executable, str(_INVARIANTS_WORKER)],
                 input_bytes=json.dumps(
-                    request.model_dump(mode="json"), separators=(",", ":")
+                    {"_deadline": deadline, **request.model_dump(mode="json")},
+                    separators=(",", ":"),
                 ).encode("utf-8"),
                 timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
@@ -467,35 +449,16 @@ def _clique_execute(
                 ),
                 cwd=directory,
             )
-    except OSError:
-        return _clique_worker_failure(
-            request, "the bounded clique worker could not be started"
-        )
-    request_checkpoint("after clique worker")
-    if completed.cancelled:
-        raise OperationExecutionCancelledError("clique worker cancelled")
-    if completed.timed_out:
-        return _clique_worker_failure(
-            request, "the clique worker expired", wall_time=True
-        )
-    if (
-        completed.stdout_exceeded
-        or completed.stderr_exceeded
-        or completed.returncode != 0
-    ):
-        return _clique_worker_failure(
-            request, "the bounded clique worker did not establish an outcome"
-        )
-    if time.monotonic() >= deadline:
-        return _clique_worker_failure(
-            request,
-            "the clique request expired before response validation",
-            wall_time=True,
-        )
+    except OSError as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.STARTUP) from exc
+    check_bounded_process_result(completed)
+    require_execution_deadline(deadline)
     try:
-        result = GraphCliqueNumberResult.model_validate(
-            json.loads(completed.stdout.decode("utf-8"))
-        )
+        response = json.loads(completed.stdout.decode("utf-8"))
+        require_execution_deadline(deadline)
+        decode_worker_execution_error(response)
+        result = GraphCliqueNumberResult.model_validate(response)
         source_vertices = set(request.graph.vertices)
         source_edges = {tuple(sorted(edge)) for edge in request.graph.edges}
         if (
@@ -507,32 +470,22 @@ def _clique_execute(
                 for edge in combinations(result.witness_vertices, 2)
             )
         ):
-            raise ValueError("worker result is not bound to the submitted graph")
-    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+            require_execution_deadline(deadline)
+            raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
         request_checkpoint("during clique response validation")
-        if time.monotonic() >= deadline:
-            return _clique_worker_failure(
-                request,
-                "the clique request expired during response validation",
-                wall_time=True,
-            )
-        return _clique_worker_failure(
-            request, "the bounded clique worker returned malformed output"
-        )
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE) from exc
     request_checkpoint("after clique response validation")
     if time.monotonic() >= deadline:
-        return _clique_worker_failure(
-            request,
-            "the clique request expired during response validation",
-            wall_time=True,
-        )
+        raise OperationExecutionTimeoutError("operation deadline expired")
     return result
 
 
 CLIQUE_NUMBER_OPERATION = MathTool(
     operation_id="graph.invariant.clique_number.compute",
     title="Clique number",
-    description="Compute a maximum clique under explicit finite search budgets.",
+    description="Compute a maximum clique under explicit finite search budgets. Worker failures and parent deadline expiry raise execution errors; a valid partial result must arrive before that deadline.",
     request_type=GraphOptimizationRequest,
     result_type=GraphCliqueNumberResult,
     run=_clique_execute,

--- a/src/jacobian/math/graphs/optimization/_invariants_worker.py
+++ b/src/jacobian/math/graphs/optimization/_invariants_worker.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from typing import Any
 
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    request_execution,
+)
+from jacobian._worker_errors import bind_worker_deadline, worker_execution_errors
 from jacobian.math.graphs.optimization._invariants import _clique_execute_kernel
 from jacobian.math.graphs.optimization._models import GraphOptimizationRequest
 
@@ -13,15 +20,17 @@ from jacobian.math.graphs.optimization._models import GraphOptimizationRequest
 def main() -> int:
     try:
         payload: Any = json.loads(sys.stdin.buffer.read())
+        bind_worker_deadline(payload)
         request = GraphOptimizationRequest.model_validate(payload)
         result = _clique_execute_kernel(request)
         sys.stdout.write(
             json.dumps(result.model_dump(mode="json"), separators=(",", ":"))
         )
         return 0
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return 2
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    with worker_execution_errors(), request_execution(time.monotonic()):
+        raise SystemExit(main())

--- a/src/jacobian/math/logic/_sat.py
+++ b/src/jacobian/math/logic/_sat.py
@@ -19,10 +19,14 @@ from pydantic import (
 from pydantic_core import PydanticCustomError
 
 from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
     OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
+    require_execution_deadline,
 )
 from jacobian._models import StrictModel
+from jacobian._worker_errors import decode_worker_execution_error
 from jacobian.math.logic._cnf import (
     _MAX_VARIABLES,
     CanonicalCnf,
@@ -30,16 +34,19 @@ from jacobian.math.logic._cnf import (
     check_sat_assignment,
 )
 from jacobian.math.logic._smt import (
-    _EXHAUSTION_DETAILS,
-    _classify_exhaustion,
     _execution_deadline,
-    _project_unknown,
     _require_execution_deadline,
     _solver_settings,
+)
+from jacobian.math.logic._solver_errors import (
+    _classify_exhaustion,
+    _project_unknown,
+    _raise_exhaustion,
     _UnknownResource,
 )
 from jacobian.process import (
     ProcessResourceLimits,
+    check_bounded_process_result,
     run_bounded_process,
     worker_environment,
 )
@@ -99,12 +106,7 @@ def _solve_sat_kernel(*, cnf: CanonicalCnf, timeout_ms: int) -> dict[str, object
     try:
         import z3
     except (ImportError, OSError) as exc:
-        return {
-            "outcome": "UNKNOWN",
-            "assignment": None,
-            "exhausted": None,
-            "detail": f"the Z3 backend could not initialize: {exc}"[:1_024],
-        }
+        raise OperationBackendError(BackendFailureReason.INITIALIZATION) from exc
 
     try:
         variables = tuple(z3.Bool(name) for name in cnf.variables)
@@ -138,22 +140,13 @@ def _solve_sat_kernel(*, cnf: CanonicalCnf, timeout_ms: int) -> dict[str, object
                 "exhausted": None,
                 "detail": None,
             }
+    except (OperationExecutionTimeoutError, OperationExecutionCancelledError):
+        raise
     except (OSError, z3.Z3Exception) as exc:
         exhausted = _classify_exhaustion(str(exc))
         if exhausted is not None:
-            return {
-                "outcome": "UNKNOWN",
-                "assignment": None,
-                "exhausted": exhausted,
-                "detail": _EXHAUSTION_DETAILS[exhausted],
-            }
-        detail = f"the Z3 backend failed during the bounded solve: {exc}"
-        return {
-            "outcome": "UNKNOWN",
-            "assignment": None,
-            "exhausted": None,
-            "detail": detail[:1_024],
-        }
+            _raise_exhaustion(exhausted, cause=exc)
+        raise OperationBackendError(BackendFailureReason.ABNORMAL_EXIT) from exc
     exhausted, detail = _project_unknown(solver.reason_unknown())
     return {
         "outcome": "UNKNOWN",
@@ -161,23 +154,6 @@ def _solve_sat_kernel(*, cnf: CanonicalCnf, timeout_ms: int) -> dict[str, object
         "exhausted": exhausted,
         "detail": detail,
     }
-
-
-def _result(request: SatSolveRequest, **values: object) -> SatSolveResult:
-    """Bind every projected worker outcome to its exact admitted source."""
-
-    return SatSolveResult.model_validate(
-        {"source": request.model_dump(mode="json"), **values}
-    )
-
-
-def _time_exhausted_result(request: SatSolveRequest) -> SatSolveResult:
-    return _result(
-        request,
-        outcome="UNKNOWN",
-        exhausted="time",
-        detail=_EXHAUSTION_DETAILS["time"],
-    )
 
 
 def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
@@ -194,7 +170,8 @@ def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
             completed = run_bounded_process(
                 [sys.executable, str(_SAT_WORKER)],
                 input_bytes=json.dumps(
-                    request.model_dump(mode="json"), separators=(",", ":")
+                    {"_deadline": deadline, **request.model_dump(mode="json")},
+                    separators=(",", ":"),
                 ).encode("utf-8"),
                 timeout_seconds=remaining_seconds,
                 environment=worker_environment(locale="C.UTF-8"),
@@ -209,34 +186,15 @@ def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
             )
     except (OperationExecutionCancelledError, OperationExecutionTimeoutError):
         raise
-    except OSError:
-        _require_execution_deadline(deadline, "after SAT worker startup")
-        return _result(
-            request,
-            outcome="UNKNOWN",
-            detail="the bounded Z3 worker could not be started",
-        )
-    if completed.timed_out:
-        raise OperationExecutionTimeoutError(
-            "request deadline expired during SAT worker"
-        )
-    if completed.cancelled:
-        raise OperationExecutionCancelledError("request cancelled during SAT worker")
-    if completed.stdout_exceeded or completed.stderr_exceeded:
-        return _result(
-            request,
-            outcome="UNKNOWN",
-            detail="the bounded Z3 worker exceeded its output limit",
-        )
-    if completed.returncode != 0:
-        return _result(
-            request,
-            outcome="UNKNOWN",
-            detail="the bounded Z3 worker failed before returning a result",
-        )
-    _require_execution_deadline(deadline, "after SAT worker")
+    except OSError as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.STARTUP) from exc
+    check_bounded_process_result(completed)
+    require_execution_deadline(deadline)
     try:
         response = json.loads(completed.stdout.decode("utf-8"))
+        require_execution_deadline(deadline)
+        decode_worker_execution_error(response)
         if not isinstance(response, dict) or "source" in response:
             raise TypeError("worker response must not replace the retained source")
         result = SatSolveResult.model_validate(
@@ -250,22 +208,14 @@ def _run_sat_worker(request: SatSolveRequest) -> SatSolveResult:
         ):
             # The parent-side scan may have consumed the remaining budget.
             _require_execution_deadline(deadline, "after SAT assignment check")
-            return _result(
-                request,
-                outcome="UNKNOWN",
-                detail=(
-                    "the Z3 worker returned an assignment that does not satisfy "
-                    "the canonical CNF"
-                ),
-            )
+            raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
+        if result.exhausted is not None:
+            _raise_exhaustion(result.exhausted)
         _require_execution_deadline(deadline, "after SAT result projection")
         return result
-    except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
-        return _result(
-            request,
-            outcome="UNKNOWN",
-            detail="the bounded Z3 worker returned malformed output",
-        )
+    except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE) from exc
 
 
 def solve_sat(request: SatSolveRequest) -> SatSolveResult:

--- a/src/jacobian/math/logic/_sat_worker.py
+++ b/src/jacobian/math/logic/_sat_worker.py
@@ -4,21 +4,30 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from typing import Any
 
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    request_execution,
+)
+from jacobian._worker_errors import bind_worker_deadline, worker_execution_errors
 from jacobian.math.logic._sat import SatSolveRequest, _solve_sat_kernel
 
 
 def main() -> int:
     try:
         payload: Any = json.loads(sys.stdin.buffer.read())
+        bind_worker_deadline(payload)
         request = SatSolveRequest.model_validate(payload)
         response = _solve_sat_kernel(cnf=request.cnf, timeout_ms=request.timeout_ms)
         sys.stdout.write(json.dumps(response, separators=(",", ":")))
         return 0
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return 2
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    with worker_execution_errors(), request_execution(time.monotonic()):
+        raise SystemExit(main())

--- a/src/jacobian/math/logic/_smt.py
+++ b/src/jacobian/math/logic/_smt.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import math
-import re
 import sys
 import time
 from enum import StrEnum
@@ -21,16 +20,31 @@ from pydantic import (
 from pydantic_core import PydanticCustomError
 
 from jacobian._execution import (
+    BackendFailureReason,
+    ExecutionResource,
+    OperationBackendError,
     OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
     bind_request_deadline,
     current_request_execution,
+    remaining_timeout_ms,
     request_checkpoint,
+    require_execution_deadline,
 )
 from jacobian._models import StrictModel
+from jacobian._worker_errors import decode_worker_execution_error
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.logic._solver_errors import (
+    _Z3_SOURCE_DIAGNOSTIC,
+    _classify_exhaustion,
+    _project_unknown,
+    _raise_exhaustion,
+    _UnknownResource,
+)
 from jacobian.process import (
     ProcessResourceLimits,
+    check_bounded_process_result,
     run_bounded_process,
     worker_environment,
 )
@@ -58,7 +72,7 @@ _MAX_SMTLIB_ARITHMETIC_WORK = _MAX_SMTLIB_NUMERAL_DIGITS**2 * 64
 # or speed. The ceiling is orders of magnitude above admitted easy queries
 # (measured <1k units) while cutting runaway search within seconds at a
 # measured ~0.2-5M units/s across QF regimes. max_memory caps Z3's own arena so
-# exhaustion surfaces as typed UNKNOWN instead of host memory pressure.
+# exhaustion surfaces as typed execution failure instead of host memory pressure.
 _SOLVER_RLIMIT = 20_000_000
 _SOLVER_MAX_MEMORY_MB = 1024
 _MAX_MODEL_BYTES = 64_000
@@ -79,7 +93,6 @@ _SUPPORTED_SMTLIB_COMMANDS = frozenset(
 _SUPPORTED_SMTLIB_COMMANDS_DESCRIPTION = (
     "set-logic, declare-const, declare-fun, assert, and check-sat"
 )
-_UnknownResource = Literal["time", "work", "memory"]
 
 
 def _execution_deadline(timeout_ms: int, stage: str) -> float:
@@ -417,9 +430,6 @@ def _smtlib_structure(source: str) -> _SmtLibStructure:
     return _SmtLibStructure(max_depth, compound_terms, numeral_digits)
 
 
-_Z3_SOURCE_DIAGNOSTIC = re.compile(r'\(error "line \d+ column \d+: ')
-
-
 def _exception_message(exc: Exception) -> str:
     message = exc.args[0] if exc.args else ""
     if isinstance(message, bytes):
@@ -576,54 +586,11 @@ class SmtSolveResult(StrictModel):
         return self
 
 
-_EXHAUSTION_DETAILS: dict[_UnknownResource, str] = {
-    "work": "the bounded solver work budget was exhausted",
-    "memory": "the bounded solver memory budget was exhausted",
-    "time": "the bounded solver time budget was exhausted",
-}
-
-
-def _classify_exhaustion(message: str) -> _UnknownResource | None:
-    """Classify one Z3 reason or exception message onto the exhausted budgets.
-
-    Exhaustion keywords classify only backend conditions, which carry no
-    source locator. A message containing a located ``(error "line ...
-    column ...: ...")`` diagnostic is never classified as exhaustion, even
-    when its text mentions a resource keyword: the diagnostic quotes
-    caller-controlled source spellings, so an undeclared identifier named
-    ``memory`` or a comment mentioning ``timeout`` must not report an
-    exhausted budget.
-    """
-
-    if _Z3_SOURCE_DIAGNOSTIC.search(message) is not None:
-        return None
-    lowered = message.strip().lower()
-    if "resource limit" in lowered or "canceled" in lowered:
-        return "work"
-    if "memory" in lowered:
-        return "memory"
-    if "timeout" in lowered or "time limit" in lowered:
-        return "time"
-    return None
-
-
-def _project_unknown(reason: str | None) -> tuple[_UnknownResource | None, str]:
-    """Project one Z3 unknown reason onto the typed exhausted-budget taxonomy."""
-
-    text = (reason or "").strip()
-    classified = _classify_exhaustion(text)
-    if classified is not None:
-        return classified, _EXHAUSTION_DETAILS[classified]
-    if not text:
-        return None, "the solver returned no completeness evidence"
-    return None, text[:1_024]
-
-
 def _solver_settings(timeout_ms: int) -> dict[str, int]:
     """Return the full request-scoped Z3 budget: wall time, work, and memory."""
 
     return {
-        "timeout": timeout_ms,
+        "timeout": remaining_timeout_ms(timeout_ms),
         "rlimit": _SOLVER_RLIMIT,
         "max_memory": _SOLVER_MAX_MEMORY_MB,
     }
@@ -721,25 +688,6 @@ def _probe_declared_logic(
         raise ValueError(f"SMT terms must belong to the declared {logic} fragment")
 
 
-def _result(request: SmtSolveRequest, **values: object) -> SmtSolveResult:
-    """Bind every projected worker outcome to its exact admitted source."""
-
-    return SmtSolveResult.model_validate(
-        {"source": request.model_dump(mode="json"), **values}
-    )
-
-
-def _time_exhausted_result(request: SmtSolveRequest) -> SmtSolveResult:
-    """Project expiry of the admitted owner envelope as a non-conclusion."""
-
-    return _result(
-        request,
-        outcome="UNKNOWN",
-        exhausted="time",
-        detail=_EXHAUSTION_DETAILS["time"],
-    )
-
-
 def _solve_smt_kernel(
     *, logic: str, smtlib: str, timeout_ms: int
 ) -> dict[str, str | None]:
@@ -748,12 +696,7 @@ def _solve_smt_kernel(
     try:
         import z3
     except (ImportError, OSError) as exc:
-        return {
-            "outcome": "UNKNOWN",
-            "model_smtlib": None,
-            "exhausted": None,
-            "detail": f"the Z3 backend could not initialize: {exc}"[:1_024],
-        }
+        raise OperationBackendError(BackendFailureReason.INITIALIZATION) from exc
 
     try:
         assertions = z3.parse_smt2_string(smtlib)
@@ -771,23 +714,10 @@ def _solve_smt_kernel(
                 z3.is_true(model.eval(assertion, model_completion=True))
                 for assertion in assertions
             ):
-                return {
-                    "outcome": "UNKNOWN",
-                    "model_smtlib": None,
-                    "exhausted": None,
-                    "detail": (
-                        "the Z3 backend returned a model that does not satisfy the "
-                        "admitted SMT-LIB assertions"
-                    ),
-                }
+                raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
             model_smtlib = model.sexpr()
             if len(model_smtlib.encode("utf-8")) > _MAX_MODEL_BYTES:
-                return {
-                    "outcome": "UNKNOWN",
-                    "model_smtlib": None,
-                    "exhausted": None,
-                    "detail": "the satisfying model exceeds the bounded result limit",
-                }
+                raise OperationResourceExhaustedError(ExecutionResource.OUTPUT)
             return {
                 "outcome": "SAT",
                 "model_smtlib": model_smtlib,
@@ -801,6 +731,8 @@ def _solve_smt_kernel(
                 "exhausted": None,
                 "detail": None,
             }
+    except (OperationExecutionTimeoutError, OperationExecutionCancelledError):
+        raise
     except (OSError, z3.Z3Exception) as exc:
         if isinstance(exc, z3.Z3Exception) and _is_smtlib_source_diagnostic(exc):
             return {
@@ -809,19 +741,8 @@ def _solve_smt_kernel(
             }
         exhausted = _classify_exhaustion(str(exc))
         if exhausted is not None:
-            return {
-                "outcome": "UNKNOWN",
-                "model_smtlib": None,
-                "exhausted": exhausted,
-                "detail": _EXHAUSTION_DETAILS[exhausted],
-            }
-        detail = f"the Z3 backend failed during the bounded solve: {exc}"
-        return {
-            "outcome": "UNKNOWN",
-            "model_smtlib": None,
-            "exhausted": None,
-            "detail": detail[:1_024],
-        }
+            _raise_exhaustion(exhausted, cause=exc)
+        raise OperationBackendError(BackendFailureReason.ABNORMAL_EXIT) from exc
     exhausted, detail = _project_unknown(solver.reason_unknown())
     return {
         "outcome": "UNKNOWN",
@@ -849,6 +770,7 @@ def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
                 [sys.executable, str(_SMT_WORKER)],
                 input_bytes=json.dumps(
                     {
+                        "_deadline": deadline,
                         "logic": request.logic.value,
                         "smtlib": request.smtlib,
                         "timeout_ms": request.timeout_ms,
@@ -868,34 +790,15 @@ def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
             )
     except (OperationExecutionCancelledError, OperationExecutionTimeoutError):
         raise
-    except OSError:
-        _require_execution_deadline(deadline, "after SMT worker startup")
-        return _result(
-            request,
-            outcome="UNKNOWN",
-            detail="the bounded Z3 worker could not be started",
-        )
-    if completed.timed_out:
-        raise OperationExecutionTimeoutError(
-            "request deadline expired during SMT worker"
-        )
-    if completed.cancelled:
-        raise OperationExecutionCancelledError("request cancelled during SMT worker")
-    if completed.stdout_exceeded or completed.stderr_exceeded:
-        return _result(
-            request,
-            outcome="UNKNOWN",
-            detail="the bounded Z3 worker exceeded its output limit",
-        )
-    if completed.returncode != 0:
-        return _result(
-            request,
-            outcome="UNKNOWN",
-            detail="the bounded Z3 worker failed before returning a result",
-        )
-    _require_execution_deadline(deadline, "after SMT worker")
+    except OSError as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.STARTUP) from exc
+    check_bounded_process_result(completed)
+    require_execution_deadline(deadline)
     try:
         response = json.loads(completed.stdout.decode("utf-8"))
+        require_execution_deadline(deadline)
+        decode_worker_execution_error(response)
         if not isinstance(response, dict):
             raise TypeError("worker response must be an object")
         if "source" in response:
@@ -914,16 +817,15 @@ def _run_smt_worker(request: SmtSolveRequest) -> SmtSolveResult:
         result = SmtSolveResult.model_validate(
             {"source": request.model_dump(mode="json"), **response}
         )
+        if result.exhausted is not None:
+            _raise_exhaustion(result.exhausted)
         _require_execution_deadline(deadline, "after SMT result projection")
         return result
     except OperationDomainValidationError:
         raise
-    except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
-        return _result(
-            request,
-            outcome="UNKNOWN",
-            detail="the bounded Z3 worker returned malformed output",
-        )
+    except (TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE) from exc
 
 
 def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
@@ -933,7 +835,6 @@ def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
 
 
 __all__ = [
-    "_EXHAUSTION_DETAILS",
     "SmtLogic",
     "SmtSolveRequest",
     "SmtSolveResult",

--- a/src/jacobian/math/logic/_smt_worker.py
+++ b/src/jacobian/math/logic/_smt_worker.py
@@ -4,14 +4,22 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from typing import Any
 
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    request_execution,
+)
+from jacobian._worker_errors import bind_worker_deadline, worker_execution_errors
 from jacobian.math.logic._smt import _solve_smt_kernel
 
 
 def main() -> int:
     try:
         payload: Any = json.loads(sys.stdin.buffer.read())
+        bind_worker_deadline(payload)
         if not isinstance(payload, dict):
             raise ValueError("worker payload must be an object")
         logic = payload["logic"]
@@ -28,9 +36,10 @@ def main() -> int:
         )
         sys.stdout.write(json.dumps(response, separators=(",", ":")))
         return 0
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-        return 2
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    with worker_execution_errors(), request_execution(time.monotonic()):
+        raise SystemExit(main())

--- a/src/jacobian/math/logic/_solver_errors.py
+++ b/src/jacobian/math/logic/_solver_errors.py
@@ -1,0 +1,59 @@
+"""Shared Z3 execution classification, excluding caller source diagnostics."""
+
+import re
+from typing import Literal, Never
+
+from jacobian._execution import (
+    ExecutionResource,
+    OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
+)
+
+_UnknownResource = Literal["time", "work", "memory"]
+_Z3_SOURCE_DIAGNOSTIC = re.compile(r'\(error "line \d+ column \d+: ')
+
+
+def _raise_exhaustion(
+    resource: _UnknownResource, *, cause: Exception | None = None
+) -> Never:
+    if resource == "time":
+        raise OperationExecutionTimeoutError(
+            "operation solver time allowance expired"
+        ) from cause
+    raise OperationResourceExhaustedError(ExecutionResource(resource)) from cause
+
+
+def _classify_exhaustion(message: str) -> _UnknownResource | None:
+    """Classify one Z3 reason or exception message onto the exhausted budgets.
+
+    Exhaustion keywords classify only backend conditions, which carry no
+    source locator. A message containing a located ``(error "line ...
+    column ...: ...")`` diagnostic is never classified as exhaustion, even
+    when its text mentions a resource keyword: the diagnostic quotes
+    caller-controlled source spellings, so an undeclared identifier named
+    ``memory`` or a comment mentioning ``timeout`` must not report an
+    exhausted budget.
+    """
+
+    if _Z3_SOURCE_DIAGNOSTIC.search(message) is not None:
+        return None
+    lowered = message.strip().lower()
+    if "resource limit" in lowered or "canceled" in lowered:
+        return "work"
+    if "memory" in lowered:
+        return "memory"
+    if "timeout" in lowered or "time limit" in lowered:
+        return "time"
+    return None
+
+
+def _project_unknown(reason: str | None) -> tuple[_UnknownResource | None, str]:
+    """Project one Z3 unknown reason onto the typed exhausted-budget taxonomy."""
+
+    text = (reason or "").strip()
+    classified = _classify_exhaustion(text)
+    if classified is not None:
+        _raise_exhaustion(classified)
+    if not text:
+        return None, "the solver returned no completeness evidence"
+    return None, "the solver returned an inconclusive answer"

--- a/src/jacobian/math/logic/_tools.py
+++ b/src/jacobian/math/logic/_tools.py
@@ -54,7 +54,7 @@ TOOLS: MathTools = (
     MathTool(
         operation_id="sat.solve",
         title="Solve a bounded CNF",
-        description="Run the maintained Z3 Python binding on one canonical CNF.",
+        description="Run the maintained Z3 Python binding on one canonical CNF. Resource exhaustion and backend failures raise execution errors; UNKNOWN denotes a healthy inconclusive solver answer.",
         request_type=SatSolveRequest,
         result_type=SatSolveResult,
         run=solve_sat,
@@ -73,6 +73,7 @@ TOOLS: MathTools = (
         description=(
             "Decide one bounded quantifier-free SMT-LIB query and return SAT, "
             "UNSAT, or UNKNOWN; SAT includes a satisfying model projection."
+            " Resource exhaustion and backend failures raise execution errors; UNKNOWN denotes a healthy inconclusive solver answer."
         ),
         request_type=SmtSolveRequest,
         result_type=SmtSolveResult,

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -6,6 +6,7 @@ import json
 import math
 import re
 import sys
+import time
 from fractions import Fraction
 from math import lcm
 from pathlib import Path
@@ -15,8 +16,17 @@ from typing import Any, Literal, NamedTuple, Self
 from pydantic import ConfigDict, Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._execution import OperationExecutionCancelledError, request_checkpoint
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    execution_deadline,
+    remaining_timeout_ms,
+    require_execution_deadline,
+)
 from jacobian._models import StrictModel
+from jacobian._worker_errors import decode_worker_execution_error
 from jacobian.canonical import format_canonical_integer
 from jacobian.catalog.models import (
     MathTool,
@@ -32,8 +42,14 @@ from jacobian.math.logic._smt import (
     _tokenize_smtlib,
     _top_level_smtlib_commands,
 )
+from jacobian.math.logic._solver_errors import (
+    _classify_exhaustion,
+    _project_unknown,
+    _raise_exhaustion,
+)
 from jacobian.process import (
     ProcessResourceLimits,
+    check_bounded_process_result,
     run_bounded_process,
     worker_environment,
 )
@@ -379,11 +395,8 @@ def _parsed_request_error(
 
     try:
         import z3
-    except (ImportError, OSError):
-        # Backend absence provides no information about caller-controlled
-        # source. Leave this accepted request for execution to report as its
-        # typed UNKNOWN outcome.
-        return None
+    except (ImportError, OSError) as exc:
+        raise OperationBackendError(BackendFailureReason.INITIALIZATION) from exc
 
     try:
         assertions = _parse_assertions(smtlib)
@@ -396,10 +409,13 @@ def _parsed_request_error(
                 f"{_MAX_CORE_AST_NODES} distinct AST nodes"
             )
         _require_declared_logic(assertions, logic)
-    except (OSError, z3.Z3Exception):
-        # A deferred backend failure carries no evidence about this source;
-        # execution reports it through the typed UNKNOWN outcome.
-        return None
+    except (OperationExecutionTimeoutError, OperationExecutionCancelledError):
+        raise
+    except (OSError, z3.Z3Exception) as exc:
+        resource = _classify_exhaustion(str(exc))
+        if resource is not None:
+            _raise_exhaustion(resource, cause=exc)
+        raise OperationBackendError(BackendFailureReason.ABNORMAL_EXIT) from exc
     except ValueError as exc:
         return str(exc)
     return None
@@ -1258,7 +1274,7 @@ def _configured_solver(source: SmtUnsatCoreRequest, *, context: Any) -> Any:
 
     solver = z3.SolverFor(source.logic.value, ctx=context)
     solver.set(
-        timeout=source.timeout_ms,
+        timeout=remaining_timeout_ms(source.timeout_ms),
         rlimit=source.rlimit,
         random_seed=0,
         unsat_core=True,
@@ -1276,8 +1292,8 @@ def _bounded_outcome(
         return "SAT", None
     if outcome == z3.unsat:
         return "UNSAT", None
-    detail = solver.reason_unknown().strip() or "Z3 returned UNKNOWN."
-    return "UNKNOWN", detail[:1_024]
+    _, detail = _project_unknown(solver.reason_unknown())
+    return "UNKNOWN", detail
 
 
 def _extract_source_core(
@@ -1286,7 +1302,7 @@ def _extract_source_core(
     try:
         import z3
     except (ImportError, OSError) as exc:
-        return "UNKNOWN", (), f"the Z3 backend could not initialize: {exc}"[:1_024]
+        raise OperationBackendError(BackendFailureReason.INITIALIZATION) from exc
 
     try:
         context = z3.Context()
@@ -1302,15 +1318,20 @@ def _extract_source_core(
         core_ids = {literal.get_id() for literal in solver.unsat_core()}
         tracker_ids = {tracker.get_id() for tracker in trackers}
         if not core_ids or not core_ids <= tracker_ids:
-            return "UNKNOWN", (), "Z3 returned an unusable UNSAT core."
+            raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
         core_indices = tuple(
             index
             for index, tracker in enumerate(trackers)
             if tracker.get_id() in core_ids
         )
         return "UNSAT", core_indices, None
-    except (OSError, ValueError, z3.Z3Exception):
-        return "UNKNOWN", (), "Z3 could not complete the bounded source check."
+    except (OperationExecutionTimeoutError, OperationExecutionCancelledError):
+        raise
+    except (OSError, ValueError, z3.Z3Exception) as exc:
+        resource = _classify_exhaustion(str(exc))
+        if resource is not None:
+            _raise_exhaustion(resource, cause=exc)
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
 
 def _classify_source_for_execution(source: SmtUnsatCoreRequest) -> str | None:
@@ -1330,7 +1351,7 @@ def _replay_source(
     try:
         import z3
     except (ImportError, OSError) as exc:
-        return "UNKNOWN", f"the Z3 backend could not initialize: {exc}"[:1_024]
+        raise OperationBackendError(BackendFailureReason.INITIALIZATION) from exc
 
     try:
         context = z3.Context()
@@ -1343,8 +1364,13 @@ def _replay_source(
         solver = _configured_solver(source, context=context)
         solver.add(*(assertions[index] for index in selected))
         return _bounded_outcome(solver)
-    except (OSError, ValueError, z3.Z3Exception):
-        return "UNKNOWN", "Z3 could not complete the bounded source replay."
+    except (OperationExecutionTimeoutError, OperationExecutionCancelledError):
+        raise
+    except (OSError, ValueError, z3.Z3Exception) as exc:
+        resource = _classify_exhaustion(str(exc))
+        if resource is not None:
+            _raise_exhaustion(resource, cause=exc)
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
 
 def _unsat_core_worker_kernel(
@@ -1373,10 +1399,13 @@ def _run_unsat_core_worker(
     source: SmtUnsatCoreRequest,
     *,
     selected_indices: tuple[int, ...] | None = None,
-) -> dict[str, object] | None:
+    deadline: float | None = None,
+) -> dict[str, object]:
     """Execute one semantic core phase in an isolated, bounded Z3 worker."""
 
-    request_checkpoint("before SMT unsat-core worker")
+    if deadline is None:
+        deadline = execution_deadline(source.timeout_ms / 1000)
+    require_execution_deadline(deadline)
     payload: dict[str, object] = {
         "request": source.model_dump(mode="json"),
         "selected_indices": list(selected_indices)
@@ -1387,8 +1416,10 @@ def _run_unsat_core_worker(
         with TemporaryDirectory(prefix="jacobian-unsat-core-") as worker_directory:
             completed = run_bounded_process(
                 [sys.executable, str(_UNSAT_CORE_WORKER)],
-                input_bytes=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
-                timeout_seconds=source.timeout_ms / 1_000,
+                input_bytes=json.dumps(
+                    {"_deadline": deadline, **payload}, separators=(",", ":")
+                ).encode("utf-8"),
+                timeout_seconds=max(0, deadline - time.monotonic()),
                 environment=worker_environment(locale="C.UTF-8"),
                 stdout_limit=_UNSAT_CORE_WORKER_OUTPUT_BYTES,
                 stderr_limit=_UNSAT_CORE_WORKER_ERROR_BYTES,
@@ -1399,52 +1430,47 @@ def _run_unsat_core_worker(
                 ),
                 cwd=worker_directory,
             )
-    except OSError:
-        return None
-    request_checkpoint("after SMT unsat-core worker")
-    if completed.cancelled:
-        raise OperationExecutionCancelledError("SMT unsat-core worker cancelled")
-    if (
-        completed.timed_out
-        or completed.stdout_exceeded
-        or completed.stderr_exceeded
-        or completed.returncode != 0
-    ):
-        return None
+    except OSError as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.STARTUP) from exc
+    check_bounded_process_result(completed)
+    require_execution_deadline(deadline)
     try:
         response = json.loads(completed.stdout.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
-        request_checkpoint("during SMT unsat-core response validation")
-        return None
-    request_checkpoint("after SMT unsat-core response validation")
-    return response if isinstance(response, dict) else None
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE) from exc
+    require_execution_deadline(deadline)
+    decode_worker_execution_error(response)
+    if not isinstance(response, dict):
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE)
+    return response
 
 
 def compute_smt_unsat_core(request: SmtUnsatCoreRequest) -> SmtUnsatCoreResult:
     """Return a bounded core of source-assertion indices when Z3 proves UNSAT."""
 
-    response = _run_unsat_core_worker(request)
-    if response is None:
-        return SmtUnsatCoreResult(
-            source=request,
-            outcome="UNKNOWN",
-            detail="the bounded SMT core worker did not establish an outcome",
-        )
+    deadline = execution_deadline(request.timeout_ms / 1000)
+    response = _run_unsat_core_worker(request, deadline=deadline)
     detail = response.get("detail")
-    if response.get("kind") == "invalid" and isinstance(detail, str):
+    if (
+        set(response) == {"kind", "detail"}
+        and response.get("kind") == "invalid"
+        and isinstance(detail, str)
+        and 0 < len(detail) <= 1024
+    ):
         raise OperationDomainValidationError(
             location=("smtlib",),
             code="logic.unsat_core_contract",
-            message=detail[:1_024],
+            message=detail,
         )
-    if response.get("kind") != "result":
-        return SmtUnsatCoreResult(
-            source=request,
-            outcome="UNKNOWN",
-            detail="the bounded SMT core worker returned malformed output",
-        )
+    if (
+        set(response) != {"kind", "outcome", "core_indices", "detail"}
+        or response.get("kind") != "result"
+    ):
+        raise OperationBackendError(BackendFailureReason.MALFORMED_RESPONSE)
     try:
-        return SmtUnsatCoreResult.model_validate(
+        result = SmtUnsatCoreResult.model_validate(
             {
                 "source": request,
                 "outcome": response["outcome"],
@@ -1452,12 +1478,11 @@ def compute_smt_unsat_core(request: SmtUnsatCoreRequest) -> SmtUnsatCoreResult:
                 "detail": response["detail"],
             }
         )
-    except (KeyError, TypeError, ValueError):
-        return SmtUnsatCoreResult(
-            source=request,
-            outcome="UNKNOWN",
-            detail="the bounded SMT core worker returned malformed output",
-        )
+    except (KeyError, TypeError, ValueError) as exc:
+        require_execution_deadline(deadline)
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
+    require_execution_deadline(deadline)
+    return result
 
 
 SMT_UNSAT_CORE_OPERATION = MathTool(
@@ -1467,6 +1492,7 @@ SMT_UNSAT_CORE_OPERATION = MathTool(
         "Return SAT, UNKNOWN, or a deterministic backend-selected set of source-order "
         "assertion indices whose exact subsystem replays as UNSAT through the "
         "maintained Z3 Python binding. The core need not be minimal."
+        " Resource exhaustion and backend failures raise execution errors; UNKNOWN denotes a healthy inconclusive solver answer."
     ),
     request_type=SmtUnsatCoreRequest,
     result_type=SmtUnsatCoreResult,

--- a/src/jacobian/math/logic/_unsat_core_worker.py
+++ b/src/jacobian/math/logic/_unsat_core_worker.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from typing import Any
 
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    request_execution,
+)
+from jacobian._worker_errors import bind_worker_deadline, worker_execution_errors
 from jacobian.math.logic._unsat_core import (
     SmtUnsatCoreRequest,
     _unsat_core_worker_kernel,
@@ -15,6 +22,7 @@ from jacobian.math.logic._unsat_core import (
 def main() -> int:
     try:
         payload: Any = json.loads(sys.stdin.buffer.read())
+        bind_worker_deadline(payload)
         if not isinstance(payload, dict):
             raise ValueError("worker payload must be an object")
         request = SmtUnsatCoreRequest.model_validate(payload["request"])
@@ -34,9 +42,10 @@ def main() -> int:
         )
         sys.stdout.write(json.dumps(response, separators=(",", ":")))
         return 0
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-        return 2
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT) from exc
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    with worker_execution_errors(), request_execution(time.monotonic()):
+        raise SystemExit(main())

--- a/src/jacobian/mcp/direct_tools.py
+++ b/src/jacobian/mcp/direct_tools.py
@@ -6,30 +6,20 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from mcp.server.mcpserver import Context
-from mcp.server.mcpserver.exceptions import ToolError
 from mcp.server.mcpserver.tools import Tool
 from mcp.server.mcpserver.utilities.func_metadata import ArgModelBase, FuncMetadata
-from mcp.shared.exceptions import MCPError
 from mcp.shared.tool_name_validation import validate_tool_name
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
-from jacobian._execution import (
-    OperationExecutionCancelledError,
-)
-from jacobian.backends import BackendUnavailableError
 from jacobian.canonical import encode_strict_json
 from jacobian.catalog.catalog import Catalog
-from jacobian.catalog.models import MathTool, OperationDomainValidationError
+from jacobian.catalog.models import MathTool
 from jacobian.dispatch import (
-    OperationExecutionTimeoutError,
-    OperationRequestValidationError,
     execute_operation,
 )
 from jacobian.mcp.runtime import AppState, _authorize
 from jacobian.mcp.tools import (
-    _backend_unavailable_error,
-    _execution_tool_error,
-    _invalid_request_error,
+    _operation_error_boundary,
     _request_cancellation,
 )
 
@@ -75,7 +65,7 @@ def _direct_operation_tool(
     ) -> CallToolResult:
         _authorize(ctx)
         cancellation = _request_cancellation(ctx)
-        try:
+        with _operation_error_boundary(operation_id):
 
             def project(
                 _operation_id: str, result: Any, _started: float
@@ -94,22 +84,6 @@ def _direct_operation_tool(
                 projector=project,
                 cancellation_signal=cancellation,
             )
-        except (OperationRequestValidationError, OperationDomainValidationError) as exc:
-            raise _invalid_request_error(operation_id, exc) from exc
-        except OperationExecutionTimeoutError as exc:
-            raise _execution_tool_error(
-                code="OPERATION_TIMEOUT", operation_id=operation_id, stage=exc.stage
-            ) from exc
-        except OperationExecutionCancelledError as exc:
-            raise _execution_tool_error(
-                code="OPERATION_CANCELLED", operation_id=operation_id, stage=exc.stage
-            ) from exc
-        except BackendUnavailableError as exc:
-            raise _backend_unavailable_error(operation_id, exc) from exc
-        except (MCPError, ToolError):
-            raise
-        except Exception as exc:
-            raise ToolError("operation execution failed") from exc
 
     metadata = FuncMetadata(
         arg_model=_direct_argument_model(operation),

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -8,7 +8,8 @@ import json
 import logging
 import secrets
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from typing import Any
 
 from mcp.server.mcpserver import Context
@@ -16,7 +17,9 @@ from mcp.server.mcpserver.exceptions import ToolError
 from mcp.shared.exceptions import MCPError
 
 from jacobian._execution import (
+    OperationBackendError,
     OperationExecutionCancelledError,
+    OperationResourceExhaustedError,
     RequestCancellationSignal,
 )
 from jacobian.backends import BackendUnavailableError, check_backend
@@ -167,7 +170,7 @@ def math_run(
     _authorize(ctx)
     catalog = _catalog(ctx)
     cancellation = _request_cancellation(ctx)
-    try:
+    with _operation_error_boundary(operation_id):
         try:
             return execute_operation(
                 operation_id,
@@ -182,6 +185,14 @@ def math_run(
             )
         except _OperationResolutionError as exc:
             raise ToolError(str(exc)) from exc
+
+
+@contextmanager
+def _operation_error_boundary(operation_id: str) -> Iterator[None]:
+    """Translate and privately log failures once for both SDK entry points."""
+
+    try:
+        yield
     except (OperationRequestValidationError, OperationDomainValidationError) as exc:
         raise _invalid_request_error(operation_id, exc) from exc
     except OperationExecutionTimeoutError as exc:
@@ -192,13 +203,35 @@ def math_run(
         raise _execution_tool_error(
             code="OPERATION_CANCELLED", operation_id=operation_id, stage=exc.stage
         ) from exc
+    except OperationResourceExhaustedError as exc:
+        hint = None
+        if exc.resource == "work":
+            if operation_id == "smt.unsat_core":
+                hint = "Adjust rlimit within its admitted range; timeout_ms does not increase the work allowance."
+            elif operation_id in {"sat.solve", "smt.solve"}:
+                hint = "timeout_ms does not increase the fixed work allowance."
+        raise _execution_tool_error(
+            code="RESOURCE_EXHAUSTED",
+            operation_id=operation_id,
+            stage=exc.stage,
+            resource=exc.resource,
+            hint=hint,
+        ) from exc
+    except OperationBackendError as exc:
+        logger.exception(
+            "operation backend failure operation_id=%s reason=%s",
+            operation_id,
+            exc.reason,
+        )
+        raise _execution_tool_error(
+            code="OPERATION_FAILED", operation_id=operation_id, stage=exc.stage
+        ) from exc
     except BackendUnavailableError as exc:
         raise _backend_unavailable_error(operation_id, exc) from exc
     except (MCPError, ToolError):
         raise
     except Exception as exc:
-        # Keep backend details inside the owner while guaranteeing the SDK
-        # receives a bounded tool error instead of an unhandled worker failure.
+        logger.exception("unexpected operation failure operation_id=%s", operation_id)
         raise ToolError("operation execution failed") from exc
 
 
@@ -243,12 +276,35 @@ def _backend_unavailable_error(
     )
 
 
-def _execution_tool_error(*, code: str, operation_id: str, stage: str) -> ToolError:
+def _execution_tool_error(
+    *,
+    code: str,
+    operation_id: str,
+    stage: str,
+    resource: str | None = None,
+    hint: str | None = None,
+) -> ToolError:
     """Project bounded operation context through the SDK's text-only tool error."""
 
+    messages = {
+        "OPERATION_TIMEOUT": "operation deadline expired",
+        "OPERATION_CANCELLED": "operation was cancelled",
+        "RESOURCE_EXHAUSTED": "operation exhausted its resource allowance",
+        "OPERATION_FAILED": "operation backend failed",
+    }
+    diagnostic = {
+        "code": code,
+        "operation_id": operation_id,
+        "stage": stage,
+        "message": messages[code],
+    }
+    if resource is not None:
+        diagnostic["resource"] = resource
+    if hint is not None:
+        diagnostic["hint"] = hint
     return ToolError(
         json.dumps(
-            {"code": code, "operation_id": operation_id, "stage": stage},
+            diagnostic,
             separators=(",", ":"),
             sort_keys=True,
         )

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -33,6 +33,12 @@ from pathlib import Path
 from typing import BinaryIO, Never, cast
 
 from jacobian._execution import (
+    BackendFailureReason,
+    ExecutionResource,
+    OperationBackendError,
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
     RequestCancellationSignal,
     current_request_cancellation,
     current_request_execution,
@@ -48,6 +54,7 @@ __all__ = [
     "ProcessPlatformTools",
     "ProcessResourceLimits",
     "bounded_process_cancellation",
+    "check_bounded_process_result",
     "run_bounded_process",
     "run_bounded_worker_dialogue",
     "worker_environment",
@@ -67,6 +74,21 @@ class BoundedProcessResult:
     stderr_exceeded: bool
     timed_out: bool
     cancelled: bool = False
+
+
+def check_bounded_process_result(result: BoundedProcessResult) -> None:
+    """Opt in to execution exceptions without interpreting worker mathematics."""
+
+    if result.cancelled:
+        raise OperationExecutionCancelledError("operation worker cancelled")
+    if result.timed_out:
+        raise OperationExecutionTimeoutError("operation worker deadline expired")
+    if result.stdout_exceeded or result.stderr_exceeded:
+        raise OperationResourceExhaustedError(ExecutionResource.OUTPUT)
+    if result.returncode != 0:
+        error = OperationBackendError(BackendFailureReason.ABNORMAL_EXIT)
+        error.add_note(repr(result.stderr[:16384]))
+        raise error
 
 
 class BoundedWorkerDialogueErrorReason(StrEnum):

--- a/tests/cli/test_execution_errors.py
+++ b/tests/cli/test_execution_errors.py
@@ -1,0 +1,41 @@
+"""Native execution failures retain the CLI's nonzero, no-result path."""
+
+from typing import Never
+
+import pytest
+from typer.testing import CliRunner
+
+from jacobian._execution import (
+    BackendFailureReason,
+    ExecutionResource,
+    OperationBackendError,
+    OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
+)
+from jacobian.cli import app
+from jacobian.math.logic import _sat
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        OperationBackendError(BackendFailureReason.STARTUP),
+        OperationResourceExhaustedError(ExecutionResource.WORK),
+        OperationExecutionTimeoutError("operation deadline expired"),
+    ],
+)
+def test_cli_execution_failure_has_no_mathematical_output(
+    monkeypatch: pytest.MonkeyPatch, error: Exception
+) -> None:
+    def fail(*args: object, **kwargs: object) -> Never:
+        raise error from RuntimeError("private marker")
+
+    monkeypatch.setattr(_sat, "_run_sat_worker", fail)
+    result = CliRunner().invoke(
+        app,
+        ["run", "sat.solve", "--json", '{"cnf":{"variables":["x"],"clauses":[[1]]}}'],
+    )
+    assert result.exit_code != 0
+    assert not result.stdout.strip()
+    assert "private marker" not in result.output
+    assert str(error) in result.stderr

--- a/tests/dispatch/test_logic_dispatch.py
+++ b/tests/dispatch/test_logic_dispatch.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from jacobian._execution import (
+    OperationBackendError,
+    OperationResourceExhaustedError,
+)
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import OperationRequestValidationError, invoke_operation
 from jacobian.math.logic import _sat, _smt, _unsat_core
@@ -40,9 +44,8 @@ def _smt_worker_memory_exhaustion() -> BoundedProcessResult:
     return BoundedProcessResult(
         returncode=0,
         stdout=(
-            b'{"outcome":"UNKNOWN","model_smtlib":null,'
-            b'"exhausted":"memory","detail":"the bounded solver memory '
-            b'budget was exhausted"}'
+            b'{"kind":"execution_error","stage":"operation_execution",'
+            b'"resource":"memory"}'
         ),
         stderr=b"",
         stdout_exceeded=False,
@@ -55,9 +58,8 @@ def _sat_worker_memory_exhaustion() -> BoundedProcessResult:
     return BoundedProcessResult(
         returncode=0,
         stdout=(
-            b'{"outcome":"UNKNOWN","assignment":null,'
-            b'"exhausted":"memory","detail":"the bounded solver memory '
-            b'budget was exhausted"}'
+            b'{"kind":"execution_error","stage":"operation_execution",'
+            b'"resource":"memory"}'
         ),
         stderr=b"",
         stdout_exceeded=False,
@@ -68,12 +70,12 @@ def _sat_worker_memory_exhaustion() -> BoundedProcessResult:
 
 def _unsat_core_worker_unavailable() -> BoundedProcessResult:
     return BoundedProcessResult(
-        returncode=None,
+        returncode=2,
         stdout=b"",
         stderr=b"",
         stdout_exceeded=False,
         stderr_exceeded=False,
-        timed_out=True,
+        timed_out=False,
     )
 
 
@@ -85,14 +87,14 @@ def _unsat_core_worker_unavailable() -> BoundedProcessResult:
         ("smt.unsat_core", _contradictory_bounds_core()),
     ],
 )
-def test_dispatch_types_parser_resource_failure_as_execution_unknown(
+def test_dispatch_types_parser_resource_failure_as_execution_failure(
     monkeypatch: pytest.MonkeyPatch, operation_id: str, payload: dict[str, object]
 ) -> None:
     """A fresh request validation cannot claim parser exhaustion is malformed.
 
     ``math.run`` revalidates every payload. Backend parsing happens only in
     the bounded owner worker, so a resource failure remains admissible and
-    surfaces as typed execution UNKNOWN instead of
+    surfaces as typed execution failure instead of
     ``OperationRequestValidationError``.
     """
 
@@ -116,14 +118,16 @@ def test_dispatch_types_parser_resource_failure_as_execution_unknown(
         )
 
     try:
-        result = invoke_operation(operation_id, payload, Catalog.open())
+        with pytest.raises(
+            OperationBackendError
+            if operation_id == "smt.unsat_core"
+            else OperationResourceExhaustedError
+        ):
+            invoke_operation(operation_id, payload, Catalog.open())
     except OperationRequestValidationError as exc:
         raise AssertionError(
             f"{operation_id} rejected a parser resource failure as caller error"
         ) from exc
-
-    assert result.operation_id == operation_id
-    assert result.output["outcome"] == "UNKNOWN"
 
 
 def test_dispatch_reports_memory_exhaustion_for_smt_solve(
@@ -137,10 +141,9 @@ def test_dispatch_reports_memory_exhaustion_for_smt_solve(
         lambda *_args, **_kwargs: _smt_worker_memory_exhaustion(),
     )
 
-    result = invoke_operation("smt.solve", _positive_integer_query(), Catalog.open())
-
-    assert result.output["outcome"] == "UNKNOWN"
-    assert result.output["exhausted"] == "memory"
+    with pytest.raises(OperationResourceExhaustedError) as caught:
+        invoke_operation("smt.solve", _positive_integer_query(), Catalog.open())
+    assert caught.value.resource == "memory"
 
 
 def test_dispatch_reports_memory_exhaustion_for_sat_solve(
@@ -152,13 +155,12 @@ def test_dispatch_reports_memory_exhaustion_for_sat_solve(
         lambda *_args, **_kwargs: _sat_worker_memory_exhaustion(),
     )
 
-    result = invoke_operation("sat.solve", _positive_cnf_query(), Catalog.open())
+    with pytest.raises(OperationResourceExhaustedError) as caught:
+        invoke_operation("sat.solve", _positive_cnf_query(), Catalog.open())
+    assert caught.value.resource == "memory"
 
-    assert result.output["outcome"] == "UNKNOWN"
-    assert result.output["exhausted"] == "memory"
 
-
-def test_dispatch_types_unsat_core_initialization_failure_as_unknown(
+def test_dispatch_types_unsat_core_initialization_failure_as_execution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A failed core worker must not turn an accepted request into an import error."""
@@ -169,13 +171,5 @@ def test_dispatch_types_unsat_core_initialization_failure_as_unknown(
         lambda *_args, **_kwargs: _unsat_core_worker_unavailable(),
     )
 
-    result = invoke_operation(
-        "smt.unsat_core", _contradictory_bounds_core(), Catalog.open()
-    )
-
-    assert result.output["outcome"] == "UNKNOWN"
-    assert result.output["core_indices"] == []
-    assert (
-        result.output["detail"]
-        == "the bounded SMT core worker did not establish an outcome"
-    )
+    with pytest.raises(OperationBackendError):
+        invoke_operation("smt.unsat_core", _contradictory_bounds_core(), Catalog.open())

--- a/tests/math/combinatorics/finite_structures/hypergraphs/test_independence.py
+++ b/tests/math/combinatorics/finite_structures/hypergraphs/test_independence.py
@@ -8,6 +8,9 @@ import pytest
 import z3
 from pydantic import ValidationError
 
+from jacobian._execution import (
+    OperationBackendError,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     MAX_EDGES,
@@ -576,10 +579,8 @@ def test_independence_worker_projection_cannot_replace_the_submitted_request(
         ),
     )
 
-    result = independence_number(request.hypergraph, request.resource_budget)
-
-    assert result.status == "UNKNOWN"
-    assert result.hypergraph == request.hypergraph
+    with pytest.raises(OperationBackendError):
+        independence_number(request.hypergraph, request.resource_budget)
 
 
 def test_threshold_encoding_rechecks_the_wall_budget_before_solver_check(
@@ -655,7 +656,7 @@ def test_interrupted_solver_returns_unknown(monkeypatch: pytest.MonkeyPatch) -> 
     assert result.termination_reason == "SOLVER_UNKNOWN"
 
 
-def test_backend_exception_returns_typed_unknown(
+def test_backend_exception_raises_execution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from jacobian.math.combinatorics.finite_structures.hypergraphs import (
@@ -666,15 +667,13 @@ def test_backend_exception_returns_typed_unknown(
         raise z3.Z3Exception("forced backend failure")
 
     monkeypatch.setattr(_independence_z3, "_check_threshold", fail)
-    result = _kernel_compute(
-        {
-            "vertices": ["a", "b", "c"],
-            "edges": [["triple", ["a", "b", "c"]]],
-        }
-    )
-    assert result.status == "UNKNOWN"
-    assert result.independence_number is None
-    assert result.termination_reason == "SOLVER_ERROR"
+    with pytest.raises(OperationBackendError):
+        _kernel_compute(
+            {
+                "vertices": ["a", "b", "c"],
+                "edges": [["triple", ["a", "b", "c"]]],
+            }
+        )
 
 
 def test_produced_result_reparses_structurally() -> None:
@@ -701,14 +700,13 @@ def test_producer_rejects_infeasible_backend_witness(
         return z3.sat, ("a", "b", "c"), ""
 
     monkeypatch.setattr(_independence_z3, "_check_threshold", regressed)
-    result = _kernel_compute(
-        {
-            "vertices": ["a", "b", "c"],
-            "edges": [["triple", ["a", "b", "c"]]],
-        }
-    )
-    assert result.status == "UNKNOWN"
-    assert result.termination_reason == "SOLVER_ERROR"
+    with pytest.raises(OperationBackendError):
+        _kernel_compute(
+            {
+                "vertices": ["a", "b", "c"],
+                "edges": [["triple", ["a", "b", "c"]]],
+            }
+        )
 
 
 def test_producer_rejects_forged_optimum_below_greedy_incumbent(
@@ -722,18 +720,13 @@ def test_producer_rejects_forged_optimum_below_greedy_incumbent(
         return z3.sat, ("a",), ""
 
     monkeypatch.setattr(_independence_z3, "_check_threshold", regressed)
-    result = _kernel_compute(
-        {
-            "vertices": ["a", "b", "c"],
-            "edges": [["triple", ["a", "b", "c"]]],
-        }
-    )
-    assert result.status == "UNKNOWN"
-    assert result.independence_number is None
-    assert result.incumbent_vertices == ("a", "b")
-    assert result.upper_bound == 3
-    assert result.solver_calls == 1
-    assert result.termination_reason == "SOLVER_ERROR"
+    with pytest.raises(OperationBackendError):
+        _kernel_compute(
+            {
+                "vertices": ["a", "b", "c"],
+                "edges": [["triple", ["a", "b", "c"]]],
+            }
+        )
 
 
 def test_producer_rejects_solver_calls_inconsistent_with_established_bounds(
@@ -747,21 +740,17 @@ def test_producer_rejects_solver_calls_inconsistent_with_established_bounds(
         return z3.sat, ("b", "c"), ""
 
     monkeypatch.setattr(_independence_z3, "_check_threshold", regressed)
-    result = _kernel_compute(
-        {
-            "vertices": ["a", "b", "c", "d"],
-            "edges": [
-                ["ab", ["a", "b"]],
-                ["ac", ["a", "c"]],
-                ["ad", ["a", "d"]],
-            ],
-        }
-    )
-    assert result.status == "UNKNOWN"
-    assert result.independence_number is None
-    assert result.upper_bound == 4
-    assert result.solver_calls == 1
-    assert result.termination_reason == "SOLVER_ERROR"
+    with pytest.raises(OperationBackendError):
+        _kernel_compute(
+            {
+                "vertices": ["a", "b", "c", "d"],
+                "edges": [
+                    ["ab", ["a", "b"]],
+                    ["ac", ["a", "c"]],
+                    ["ad", ["a", "d"]],
+                ],
+            }
+        )
 
 
 def test_producer_projects_solver_error_when_witness_misses_threshold(
@@ -786,25 +775,17 @@ def test_producer_projects_solver_error_when_witness_misses_threshold(
         return z3.sat, ("c",), ""
 
     monkeypatch.setattr(_independence_z3, "_check_threshold", regressed)
-    result = _kernel_compute(
-        {
-            "vertices": ["c", "a", "b"],
-            "edges": [["ca", ["c", "a"]], ["cb", ["c", "b"]]],
-        }
-    )
+    with pytest.raises(OperationBackendError):
+        _kernel_compute(
+            {
+                "vertices": ["c", "a", "b"],
+                "edges": [["ca", ["c", "a"]], ["cb", ["c", "b"]]],
+            }
+        )
     # Binary search on (lo=1, hi=3) first queries mid=2, where the mocked
     # backend returns a below-threshold witness, so the run stops after
     # one call (linear descent would query 3 first, then 2).
     assert thresholds == [2]
-    assert result.status == "UNKNOWN"
-    assert result.independence_number is None
-    assert result.incumbent_vertices == ("c",)
-    assert result.lower_bound == 1
-    assert result.upper_bound == 3
-    assert result.solver_calls == 1
-    assert not result.wall_budget_exhausted
-    assert result.termination_reason == "SOLVER_ERROR"
-    assert HypergraphIndependenceResult.model_validate_json(result.model_dump_json())
 
 
 def test_produced_exact_result_meets_the_queried_threshold() -> None:

--- a/tests/math/graphs/test_independence_source_binding.py
+++ b/tests/math/graphs/test_independence_source_binding.py
@@ -10,6 +10,10 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from jacobian._execution import (
+    OperationBackendError,
+    OperationExecutionTimeoutError,
+)
 from jacobian.math.graphs import _independence_z3 as z3_backend
 from jacobian.math.graphs.independence import (
     IndependenceNumberBudget,
@@ -383,11 +387,8 @@ def test_independence_worker_failure_is_not_an_exact_claim(
         ),
     )
 
-    result = solve_independence_number(IndependenceNumberRequest(graph=_path_graph()))
-
-    assert result.status == "UNKNOWN"
-    assert result.optimum_value is None
-    assert result.upper_bound == result.order
+    with pytest.raises(OperationExecutionTimeoutError):
+        solve_independence_number(IndependenceNumberRequest(graph=_path_graph()))
 
 
 def test_independence_worker_projection_cannot_replace_the_submitted_graph(
@@ -414,10 +415,8 @@ def test_independence_worker_projection_cannot_replace_the_submitted_graph(
         ),
     )
 
-    result = solve_independence_number(request)
-
-    assert result.status == "UNKNOWN"
-    assert result.graph == request.graph
+    with pytest.raises(OperationBackendError):
+        solve_independence_number(request)
 
 
 def test_native_result_does_not_inherit_canonical_output_limit() -> None:

--- a/tests/math/graphs/test_optimization_wall_budget.py
+++ b/tests/math/graphs/test_optimization_wall_budget.py
@@ -8,6 +8,7 @@ import networkx as nx
 import pytest
 import z3
 
+from jacobian._execution import OperationExecutionTimeoutError
 from jacobian.math.graphs import _independence_z3
 from jacobian.math.graphs.independence import (
     IndependenceNumberBudget,
@@ -195,13 +196,10 @@ def test_graph_optimization_worker_failure_cannot_claim_an_optimum(
         ),
     )
 
-    result = _finite_optimization.DOMINATION_MINIMUM_OPERATION.run(
-        GraphOptimizationRequest(graph=_graph())
-    )
-
-    assert result.status == "UNKNOWN"
-    assert result.optimum_value is None
-    assert result.termination_reason == "WALL_TIME"
+    with pytest.raises(OperationExecutionTimeoutError):
+        _finite_optimization.DOMINATION_MINIMUM_OPERATION.run(
+            GraphOptimizationRequest(graph=_graph())
+        )
 
 
 def test_threshold_solver_does_not_start_or_finish_after_encoding_expires(

--- a/tests/math/graphs/test_response_validation_expiry.py
+++ b/tests/math/graphs/test_response_validation_expiry.py
@@ -6,7 +6,11 @@ from typing import Any
 
 import pytest
 
-from jacobian._execution import OperationExecutionCancelledError, request_cancellation
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    request_cancellation,
+)
 from jacobian.math.graphs.optimization import _chromatic_number, _invariants
 from jacobian.math.graphs.optimization._coloring_models import (
     GraphChromaticNumberRequest,
@@ -64,12 +68,8 @@ def test_control_expiry_after_real_response_validation(
             with pytest.raises(OperationExecutionCancelledError):
                 execute(request)
         else:
-            result = execute(request)
-            assert result.status == "UNKNOWN"
-            assert "expired during response validation" in result.detail
-            assert "malformed" not in result.detail
-            if kind == "clique":
-                assert result.termination_reason == "WALL_TIME"
+            with pytest.raises(OperationExecutionTimeoutError):
+                execute(request)
 
 
 def test_augmentation_noop_expiry_has_a_modeled_outcome(
@@ -119,7 +119,9 @@ def test_hypergraph_response_validation_control_outcome(
     monkeypatch.setattr(
         module,
         "_run_independence_worker",
-        lambda *a, **_kwargs: expected.model_dump(mode="json"),
+        lambda *a, **_kwargs: expected.model_dump(
+            mode="json", exclude={"hypergraph", "resource_budget"}
+        ),
     )
     now = [0.0]
     event = Event()
@@ -142,10 +144,8 @@ def test_hypergraph_response_validation_control_outcome(
             with pytest.raises(OperationExecutionCancelledError):
                 module.solve_independence_number(source, budget)
         else:
-            result = module.solve_independence_number(source, budget)
-            assert result.termination_reason == "WALL_TIME"
-            assert result.wall_budget_exhausted
-            assert "malformed" not in result.detail
+            with pytest.raises(OperationExecutionTimeoutError):
+                module.solve_independence_number(source, budget)
 
 
 def test_hypergraph_worker_timeout_is_not_solver_error(
@@ -172,10 +172,10 @@ def test_hypergraph_worker_timeout_is_not_solver_error(
             timed_out=True,
         ),
     )
-    result = module.solve_independence_number(
-        source, HypergraphIndependenceBudget(wall_seconds=1)
-    )
-    assert result.termination_reason == "WALL_TIME"
+    with pytest.raises(OperationExecutionTimeoutError):
+        module.solve_independence_number(
+            source, HypergraphIndependenceBudget(wall_seconds=1)
+        )
 
 
 @pytest.mark.parametrize("cancel", [False, True])
@@ -219,6 +219,5 @@ def test_expiry_during_finite_graph_witness_check_precedes_invalid_witness(
             with pytest.raises(OperationExecutionCancelledError):
                 operation.run(request)
         else:
-            result = operation.run(request)
-            assert result.termination_reason == "WALL_TIME"
-            assert "invalid witness" not in result.detail
+            with pytest.raises(OperationExecutionTimeoutError):
+                operation.run(request)

--- a/tests/math/logic/test_solver_inconclusive.py
+++ b/tests/math/logic/test_solver_inconclusive.py
@@ -1,0 +1,94 @@
+"""A healthy inconclusive solver answer remains a successful mathematical result."""
+
+import json
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import pytest
+import z3
+
+from jacobian.math.logic import _sat, _smt, _unsat_core
+from jacobian.math.logic._cnf import CanonicalCnf
+from jacobian.process import BoundedProcessResult
+
+
+@pytest.mark.parametrize("operation_id", ["sat.solve", "smt.solve", "smt.unsat_core"])
+def test_healthy_unknown_survives_worker_decoding(
+    monkeypatch: pytest.MonkeyPatch, operation_id: str
+) -> None:
+    monkeypatch.setattr(z3.Solver, "check", lambda *args: z3.unknown)
+    monkeypatch.setattr(z3.Solver, "reason_unknown", lambda *args: "incomplete theory")
+    owner: Any
+    request: Any
+    solve: Callable[[Any], Any]
+    response: Mapping[str, object]
+    if operation_id == "sat.solve":
+        owner = _sat
+        request = _sat.SatSolveRequest(
+            cnf=CanonicalCnf(variables=("x",), clauses=((1,),))
+        )
+        solve = _sat.solve_sat
+        response = _sat._solve_sat_kernel(
+            cnf=request.cnf, timeout_ms=request.timeout_ms
+        )
+    elif operation_id == "smt.solve":
+        owner = _smt
+        request = _smt.SmtSolveRequest(
+            logic=_smt.SmtLogic.QF_LIA,
+            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+        )
+        solve = _smt.solve_smt
+        response = _smt._solve_smt_kernel(
+            logic=request.logic.value,
+            smtlib=request.smtlib,
+            timeout_ms=request.timeout_ms,
+        )
+    else:
+        owner = _unsat_core
+        request = _unsat_core.SmtUnsatCoreRequest(
+            logic=_smt.SmtLogic.QF_LIA,
+            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+        )
+        solve = _unsat_core.compute_smt_unsat_core
+        response = _unsat_core._unsat_core_worker_kernel(request)
+    monkeypatch.setattr(
+        owner,
+        "run_bounded_process",
+        lambda *args, **kwargs: BoundedProcessResult(
+            0, json.dumps(response).encode(), b"", False, False, False
+        ),
+    )
+    result = solve(request)
+    assert result.outcome == "UNKNOWN"
+    assert result.detail == "the solver returned an inconclusive answer"
+    assert result.model_dump().get("assignment") is None
+    assert result.model_dump().get("model_smtlib") is None
+    assert not result.model_dump().get("core_indices")
+
+
+@pytest.mark.parametrize("sat", [False, True])
+def test_solver_phase_preserves_parent_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    sat: bool,
+) -> None:
+    from jacobian._execution import OperationExecutionTimeoutError
+
+    error = OperationExecutionTimeoutError("operation deadline expired")
+
+    def timeout(*args: object, **kwargs: object) -> None:
+        raise error
+
+    monkeypatch.setattr(_sat if sat else _smt, "_solver_settings", timeout)
+    with pytest.raises(OperationExecutionTimeoutError) as caught:
+        if sat:
+            _sat._solve_sat_kernel(
+                cnf=CanonicalCnf(variables=("x",), clauses=((1,),)),
+                timeout_ms=1000,
+            )
+        else:
+            _smt._solve_smt_kernel(
+                logic="QF_LIA",
+                smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+                timeout_ms=1000,
+            )
+    assert caught.value is error

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -14,8 +14,10 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._execution import (
+    OperationBackendError,
     OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
     request_cancellation,
     request_execution,
 )
@@ -273,15 +275,8 @@ def test_sat_solver_does_not_promote_a_malformed_backend_model(
         ),
     )
 
-    result = solve_sat(
-        SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.assignment is None
-    assert result.detail == (
-        "the Z3 worker returned an assignment that does not satisfy the canonical CNF"
-    )
+    with pytest.raises(OperationBackendError):
+        solve_sat(SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),))))
 
 
 def test_sat_solver_invalid_model_cannot_outlive_request_deadline(
@@ -340,24 +335,18 @@ def test_smt_solver_does_not_promote_a_malformed_backend_model(
 
     monkeypatch.setattr(z3, "SolverFor", lambda _logic: MisreportingSolver())
 
-    result = _solve_smt_kernel(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib=(
-                "(set-logic QF_LIA)\n"
-                "(declare-const x Int)\n"
-                "(assert (> x 0))\n"
-                "(check-sat)"
-            ),
+    with pytest.raises(OperationBackendError):
+        _solve_smt_kernel(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib=(
+                    "(set-logic QF_LIA)\n"
+                    "(declare-const x Int)\n"
+                    "(assert (> x 0))\n"
+                    "(check-sat)"
+                ),
+            )
         )
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.model_smtlib is None
-    assert result.detail == (
-        "the Z3 backend returned a model that does not satisfy the admitted "
-        "SMT-LIB assertions"
-    )
 
 
 def test_smt_solver_uses_the_inline_smtlib_query() -> None:
@@ -924,15 +913,17 @@ def test_sat_worker_never_projects_transport_failure_as_a_math_verdict(
                 SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
             )
     else:
-        result = solve_sat(
-            SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
-        )
-        assert result.outcome == "UNKNOWN"
-        assert result.exhausted is None
-        assert detail in (result.detail or "")
+        with pytest.raises(
+            OperationResourceExhaustedError
+            if completed.stdout_exceeded
+            else OperationBackendError
+        ):
+            solve_sat(
+                SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
+            )
 
 
-def test_sat_worker_start_failure_is_a_typed_unknown(
+def test_sat_worker_start_failure_is_an_execution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def unavailable(*_args: object, **_kwargs: object) -> BoundedProcessResult:
@@ -940,13 +931,8 @@ def test_sat_worker_start_failure_is_a_typed_unknown(
 
     monkeypatch.setattr(sat, "run_bounded_process", unavailable)
 
-    result = solve_sat(
-        SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted is None
-    assert result.detail == "the bounded Z3 worker could not be started"
+    with pytest.raises(OperationBackendError):
+        solve_sat(SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),))))
 
 
 @pytest.mark.parametrize(
@@ -979,18 +965,20 @@ def test_smt_worker_never_projects_transport_failure_as_a_math_verdict(
                 )
             )
     else:
-        result = solve_smt(
-            SmtSolveRequest(
-                logic=SmtLogic.QF_LIA,
-                smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+        with pytest.raises(
+            OperationResourceExhaustedError
+            if completed.stdout_exceeded
+            else OperationBackendError
+        ):
+            solve_smt(
+                SmtSolveRequest(
+                    logic=SmtLogic.QF_LIA,
+                    smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+                )
             )
-        )
-        assert result.outcome == "UNKNOWN"
-        assert result.exhausted is None
-        assert detail in (result.detail or "")
 
 
-def test_smt_worker_start_failure_is_a_typed_unknown(
+def test_smt_worker_start_failure_is_an_execution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def unavailable(*_args: object, **_kwargs: object) -> BoundedProcessResult:
@@ -998,19 +986,16 @@ def test_smt_worker_start_failure_is_a_typed_unknown(
 
     monkeypatch.setattr(smt, "run_bounded_process", unavailable)
 
-    result = solve_smt(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+    with pytest.raises(OperationBackendError):
+        solve_smt(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+            )
         )
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted is None
-    assert result.detail == "the bounded Z3 worker could not be started"
 
 
-def test_smt_parse_stage_expiry_is_a_typed_unknown(
+def test_smt_parse_stage_expiry_is_an_execution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Parser work cannot outlive the hard parent-to-worker deadline."""
@@ -1062,65 +1047,54 @@ def test_native_smt_caller_cancellation_stops_before_worker_launch(
         solve_smt(request)
 
 
-def test_smt_solver_projects_exhausted_work_budget_as_typed_unknown(
+def test_smt_solver_projects_exhausted_work_budget_as_execution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(smt, "_SOLVER_RLIMIT", 1)
-    result = _solve_smt_kernel(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+    with pytest.raises(OperationResourceExhaustedError) as caught:
+        _solve_smt_kernel(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+            )
         )
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted == "work"
-    assert result.model_smtlib is None
-    assert result.detail is not None and "work budget" in result.detail
+    assert caught.value.resource == "work"
 
 
-def test_sat_solver_projects_exhausted_work_budget_as_typed_unknown(
+def test_sat_solver_projects_exhausted_work_budget_as_execution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(smt, "_SOLVER_RLIMIT", 1)
-    result = _solve_sat_kernel(
-        SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted == "work"
-    assert result.assignment is None
-    assert result.detail is not None and "work budget" in result.detail
+    with pytest.raises(OperationResourceExhaustedError) as caught:
+        _solve_sat_kernel(
+            SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
+        )
+    assert caught.value.resource == "work"
 
 
-def test_smt_solver_projects_exhausted_memory_budget_as_typed_unknown(
+def test_smt_solver_projects_exhausted_memory_budget_as_execution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(smt, "_SOLVER_MAX_MEMORY_MB", 2)
-    result = _solve_smt_kernel(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib=_pigeonhole_smtlib(8, 7),
+    with pytest.raises(OperationResourceExhaustedError) as caught:
+        _solve_smt_kernel(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib=_pigeonhole_smtlib(8, 7),
+            )
         )
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted == "memory"
-    assert result.detail is not None and "memory budget" in result.detail
+    assert caught.value.resource == "memory"
 
 
-def test_smt_solver_projects_exhausted_time_budget_as_typed_unknown() -> None:
-    result = _solve_smt_kernel(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib=_pigeonhole_smtlib(8, 7),
-            timeout_ms=1,
+def test_smt_solver_projects_exhausted_time_budget_as_execution_failure() -> None:
+    with pytest.raises(OperationExecutionTimeoutError):
+        _solve_smt_kernel(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib=_pigeonhole_smtlib(8, 7),
+                timeout_ms=1,
+            )
         )
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted == "time"
-    assert result.detail is not None and "time budget" in result.detail
 
 
 def test_smt_solver_wraps_backend_failure_during_the_solve(
@@ -1139,16 +1113,13 @@ def test_smt_solver_wraps_backend_failure_during_the_solve(
             raise z3.Z3Exception("backend exploded")
 
     monkeypatch.setattr(z3, "SolverFor", lambda _logic: ExplodingSolver())
-    result = _solve_smt_kernel(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+    with pytest.raises(OperationBackendError):
+        _solve_smt_kernel(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+            )
         )
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted is None
-    assert result.detail is not None and "backend exploded" in result.detail
 
 
 @pytest.mark.parametrize(
@@ -1179,14 +1150,17 @@ def test_sat_solver_projects_exhaustion_messages_from_z3_exceptions(
             raise AssertionError("check must not run after a failed assertion add")
 
     monkeypatch.setattr(z3, "Solver", ExhaustingSolver)
-    result = _solve_sat_kernel(
-        SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted == exhausted
-    assert result.assignment is None
-    assert result.detail == smt._EXHAUSTION_DETAILS[exhausted]
+    with pytest.raises(
+        OperationExecutionTimeoutError
+        if exhausted == "time"
+        else OperationResourceExhaustedError
+    ) as caught:
+        _solve_sat_kernel(
+            SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
+        )
+    if exhausted != "time":
+        assert isinstance(caught.value, OperationResourceExhaustedError)
+        assert caught.value.resource == exhausted
 
 
 @pytest.mark.parametrize(
@@ -1215,17 +1189,20 @@ def test_smt_solver_projects_exhaustion_messages_from_z3_exceptions(
             raise AssertionError("check must not run after a failed assertion add")
 
     monkeypatch.setattr(z3, "SolverFor", lambda _logic: ExhaustingSolver())
-    result = _solve_smt_kernel(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+    with pytest.raises(
+        OperationExecutionTimeoutError
+        if exhausted == "time"
+        else OperationResourceExhaustedError
+    ) as caught:
+        _solve_smt_kernel(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+            )
         )
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted == exhausted
-    assert result.model_smtlib is None
-    assert result.detail == smt._EXHAUSTION_DETAILS[exhausted]
+    if exhausted != "time":
+        assert isinstance(caught.value, OperationResourceExhaustedError)
+        assert caught.value.resource == exhausted
 
 
 def test_smt_solver_projects_exhaustion_from_model_serialization(
@@ -1254,16 +1231,14 @@ def test_smt_solver_projects_exhaustion_from_model_serialization(
             return ExhaustingModel()
 
     monkeypatch.setattr(z3, "SolverFor", lambda _logic: SolvingThenExhaustingSolver())
-    result = _solve_smt_kernel(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+    with pytest.raises(OperationResourceExhaustedError) as caught:
+        _solve_smt_kernel(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+            )
         )
-    )
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted == "memory"
-    assert result.detail == "the bounded solver memory budget was exhausted"
+    assert caught.value.resource == "memory"
 
 
 def test_solver_wraps_unrecognized_z3_exceptions_without_typed_exhaustion(
@@ -1282,24 +1257,17 @@ def test_solver_wraps_unrecognized_z3_exceptions_without_typed_exhaustion(
             raise AssertionError("check must not run after a failed assertion add")
 
     monkeypatch.setattr(z3, "Solver", ExplodingSolver)
-    sat_result = _solve_sat_kernel(
-        SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
-    )
-    monkeypatch.setattr(z3, "SolverFor", lambda _logic: ExplodingSolver())
-    smt_result = _solve_smt_kernel(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+    with pytest.raises(OperationBackendError):
+        _solve_sat_kernel(
+            SatSolveRequest(cnf=CanonicalCnf(variables=("x",), clauses=((1,),)))
         )
-    )
-
-    for result in (sat_result, smt_result):
-        assert result.outcome == "UNKNOWN"
-        assert result.exhausted is None
-        assert result.detail is not None
-        assert (
-            "the Z3 backend failed during the bounded solve: backend exploded"
-            in result.detail
+    monkeypatch.setattr(z3, "SolverFor", lambda _logic: ExplodingSolver())
+    with pytest.raises(OperationBackendError):
+        _solve_smt_kernel(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+            )
         )
 
 
@@ -1326,7 +1294,7 @@ def test_solver_wraps_unrecognized_z3_exceptions_without_typed_exhaustion(
         ),
     ),
 )
-def test_z3_initialization_failure_is_a_typed_unknown(
+def test_z3_initialization_failure_is_an_execution_failure(
     operation: Callable[[object], SatSolveResult | SmtSolveResult],
     accepted_request: object,
     monkeypatch: pytest.MonkeyPatch,
@@ -1335,13 +1303,8 @@ def test_z3_initialization_failure_is_a_typed_unknown(
 
     monkeypatch.setitem(sys.modules, "z3", None)
 
-    result = operation(accepted_request)
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted is None
-    assert result.detail is not None
-    assert "could not initialize" in result.detail
-    assert type(result).model_validate(result.model_dump()) == result
+    with pytest.raises(OperationBackendError):
+        operation(accepted_request)
 
 
 def test_smt_request_admission_skips_grammar_rejection_without_the_backend(
@@ -1355,12 +1318,8 @@ def test_smt_request_admission_skips_grammar_rejection_without_the_backend(
         smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
     )
 
-    result = _solve_smt_kernel(admitted)
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted is None
-    assert result.detail is not None
-    assert "could not initialize" in result.detail
+    with pytest.raises(OperationBackendError):
+        _solve_smt_kernel(admitted)
 
 
 def test_smt_request_does_not_parse_before_execution(
@@ -1405,10 +1364,10 @@ def test_smt_execution_reports_undeclared_identifiers_without_resource_claims(
         )
 
 
-def test_smt_solver_types_parse_stage_backend_failures_as_unknown(
+def test_smt_solver_types_parse_stage_backend_failures_as_execution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A backend parser failure on an admitted source is execution UNKNOWN."""
+    """A backend parser failure on an admitted source is execution failure."""
 
     import z3
 
@@ -1420,11 +1379,9 @@ def test_smt_solver_types_parse_stage_backend_failures_as_unknown(
         smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
     )
     monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
-    result = _solve_smt_kernel(admitted)
-
-    assert result.outcome == "UNKNOWN"
-    assert result.exhausted == "memory"
-    assert result.detail == smt._EXHAUSTION_DETAILS["memory"]
+    with pytest.raises(OperationResourceExhaustedError) as caught:
+        _solve_smt_kernel(admitted)
+    assert caught.value.resource == "memory"
 
 
 def test_smt_solver_never_classifies_located_source_text_as_exhaustion(
@@ -1498,7 +1455,7 @@ def test_smt_execution_projects_located_parser_diagnostics(
         },
     ),
 )
-def test_smt_rejects_malformed_invalid_worker_envelopes_as_unknown(
+def test_smt_rejects_malformed_invalid_worker_envelopes_as_execution_failure(
     monkeypatch: pytest.MonkeyPatch, response: dict[str, object]
 ) -> None:
     monkeypatch.setattr(
@@ -1508,14 +1465,13 @@ def test_smt_rejects_malformed_invalid_worker_envelopes_as_unknown(
             stdout=json.dumps(response).encode("utf-8")
         ),
     )
-    result = solve_smt(
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib="(set-logic QF_LIA)\n(check-sat)",
+    with pytest.raises(OperationBackendError):
+        solve_smt(
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib="(set-logic QF_LIA)\n(check-sat)",
+            )
         )
-    )
-    assert result.outcome == "UNKNOWN"
-    assert result.detail == "the bounded Z3 worker returned malformed output"
 
 
 def test_smt_request_admission_defers_parse_stage_os_errors(
@@ -1526,7 +1482,7 @@ def test_smt_request_admission_defers_parse_stage_os_errors(
     ``math.run`` validates the request before calling the solver, so admission
     must not let a native ``OSError`` from ``parse_smt2_string`` escape as a
     host exception; it carries no evidence about the source and defers to
-    execution, which reports it through the typed UNKNOWN translation.
+    execution, which reports it through the typed execution failure translation.
     """
 
     import z3
@@ -1537,9 +1493,8 @@ def test_smt_request_admission_defers_parse_stage_os_errors(
     source = "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)"
     monkeypatch.setattr(z3, "parse_smt2_string", failing_parser)
     admitted = SmtSolveRequest(logic=SmtLogic.QF_LIA, smtlib=source)
-    result = _solve_smt_kernel(admitted)
-
-    assert result.outcome == "UNKNOWN"
+    with pytest.raises(OperationBackendError):
+        _solve_smt_kernel(admitted)
 
 
 @pytest.mark.parametrize(
@@ -1564,16 +1519,20 @@ def test_every_concrete_smt_request_keeps_grammar_validation_structural(
 
 
 def test_unknown_projection_maps_every_exhausted_resource() -> None:
-    assert smt._project_unknown("max. resource limit exceeded") == (
-        "work",
-        "the bounded solver work budget was exhausted",
+    for reason, resource in (
+        ("max. resource limit exceeded", "work"),
+        ("canceled", "work"),
+        ("max. memory exceeded", "memory"),
+    ):
+        with pytest.raises(OperationResourceExhaustedError) as caught:
+            smt._project_unknown(reason)
+        assert caught.value.resource == resource
+    with pytest.raises(OperationExecutionTimeoutError):
+        smt._project_unknown("timeout")
+    assert smt._project_unknown("max. engine depth reached") == (
+        None,
+        "the solver returned an inconclusive answer",
     )
-    assert smt._project_unknown("canceled")[0] == "work"
-    assert smt._project_unknown("max. memory exceeded")[0] == "memory"
-    assert smt._project_unknown("timeout")[0] == "time"
-    passthrough = smt._project_unknown("max. engine depth reached")
-    assert passthrough[0] is None
-    assert passthrough[1] == "max. engine depth reached"
     assert smt._project_unknown(None)[1].endswith("no completeness evidence")
 
 

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -9,6 +9,10 @@ import pytest
 import z3
 from pydantic import ValidationError
 
+from jacobian._execution import (
+    OperationBackendError,
+    OperationResourceExhaustedError,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.logic import _unsat_core as unsat_core
 from jacobian.math.logic._smt import SmtLogic
@@ -126,12 +130,10 @@ def test_empty_assertion_collection_is_satisfiable() -> None:
     assert result.detail is None
 
 
-def test_resource_exhaustion_is_unknown_not_unsat() -> None:
-    result = compute_smt_unsat_core(_request(rlimit=1))
-
-    assert result.outcome == "UNKNOWN"
-    assert result.core_indices == ()
-    assert result.detail
+def test_resource_exhaustion_raises() -> None:
+    with pytest.raises(OperationResourceExhaustedError) as caught:
+        compute_smt_unsat_core(_request(rlimit=1))
+    assert caught.value.resource == "work"
 
 
 def test_core_worker_bounds_parsing_and_solving_in_one_parent_envelope(
@@ -152,7 +154,8 @@ def test_core_worker_bounds_parsing_and_solving_in_one_parent_envelope(
     result = compute_smt_unsat_core(request)
 
     assert result.outcome == "UNSAT"
-    assert recorded["timeout_seconds"] == 2.5
+    assert isinstance(recorded["timeout_seconds"], float)
+    assert 0 < recorded["timeout_seconds"] <= 2.5
     assert Path(str(recorded["cwd"])).name.startswith("jacobian-unsat-core-")
     limits = recorded["resource_limits"]
     assert isinstance(limits, ProcessResourceLimits)
@@ -182,14 +185,15 @@ def test_core_worker_failures_never_project_a_math_verdict(
         lambda *_args, **_kwargs: completed,
     )
 
-    result = compute_smt_unsat_core(_request())
+    with pytest.raises(
+        OperationResourceExhaustedError
+        if completed.stdout_exceeded
+        else OperationBackendError
+    ):
+        compute_smt_unsat_core(_request())
 
-    assert result.outcome == "UNKNOWN"
-    assert result.core_indices == ()
-    assert detail in (result.detail or "")
 
-
-def test_core_extraction_failure_is_a_typed_unknown(
+def test_core_extraction_failure_is_an_execution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fail_core_extraction(_solver: object) -> None:
@@ -197,14 +201,8 @@ def test_core_extraction_failure_is_a_typed_unknown(
 
     monkeypatch.setattr(z3.Solver, "unsat_core", fail_core_extraction)
 
-    response = unsat_core._unsat_core_worker_kernel(_request())
-
-    assert response == {
-        "kind": "result",
-        "outcome": "UNKNOWN",
-        "core_indices": [],
-        "detail": "Z3 could not complete the bounded source check.",
-    }
+    with pytest.raises(OperationBackendError):
+        unsat_core._unsat_core_worker_kernel(_request())
 
 
 def test_kernel_producer_does_not_replay_its_established_core(
@@ -484,7 +482,7 @@ def test_core_bounds_reject_before_any_backend_parse(
 def test_core_admission_defers_parser_resource_failures_to_execution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A parser resource failure is typed UNKNOWN, not a contract rejection."""
+    """A parser resource failure is typed execution failure, not a contract rejection."""
 
     def exhausting_parser(_source: str, **_kwargs: object) -> object:
         raise z3.Z3Exception("out of memory")
@@ -492,10 +490,9 @@ def test_core_admission_defers_parser_resource_failures_to_execution(
     monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
     admitted = SmtUnsatCoreRequest(logic="QF_LIA", smtlib=CONTRADICTORY_LIA)
 
-    response = unsat_core._unsat_core_worker_kernel(admitted)
-
-    assert response["outcome"] == "UNKNOWN"
-    assert response["core_indices"] == []
+    with pytest.raises(OperationResourceExhaustedError) as caught:
+        unsat_core._unsat_core_worker_kernel(admitted)
+    assert caught.value.resource == "memory"
 
 
 def test_request_bounds_numeric_coefficient_digits() -> None:
@@ -1621,3 +1618,26 @@ def test_request_schema_explains_validator_owned_indexing() -> None:
     assert "owner-local bounded Z3 worker" in schema["description"]
     assert "Boolean-sorted" in schema["properties"]["logic"]["description"]
     assert schema["examples"]
+
+
+@pytest.mark.parametrize("replay", [False, True])
+@pytest.mark.parametrize("phase", ["_bounded_outcome", "_configured_solver"])
+def test_core_preserves_execution_timeout_before_backend_os_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    replay: bool,
+    phase: str,
+) -> None:
+    from jacobian._execution import OperationExecutionTimeoutError
+
+    error = OperationExecutionTimeoutError("operation solver time allowance expired")
+
+    def timeout(*args: object, **kwargs: object) -> None:
+        raise error
+
+    monkeypatch.setattr(unsat_core, phase, timeout)
+    with pytest.raises(OperationExecutionTimeoutError) as caught:
+        if replay:
+            unsat_core._replay_source(_request(), (0, 1))
+        else:
+            unsat_core._extract_source_core(_request())
+    assert caught.value is error

--- a/tests/mcp/test_direct_operations.py
+++ b/tests/mcp/test_direct_operations.py
@@ -409,6 +409,7 @@ def test_direct_calls_preserve_owner_cancellation_diagnosis() -> None:
         )
         assert diagnostic == {
             "code": "OPERATION_CANCELLED",
+            "message": "operation was cancelled",
             "operation_id": operation.operation_id,
             "stage": "operation_execution",
         }
@@ -472,6 +473,9 @@ def test_calls_preserve_bounded_operation_failure_context(
         )
         assert diagnostic == {
             "code": code,
+            "message": "operation deadline expired"
+            if code == "OPERATION_TIMEOUT"
+            else "operation was cancelled",
             "operation_id": operation.operation_id,
             "stage": "operation_execution",
         }

--- a/tests/mcp/test_execution_errors.py
+++ b/tests/mcp/test_execution_errors.py
@@ -1,0 +1,249 @@
+"""Both SDK entry points expose sanitized failures and retain private tracebacks."""
+
+import asyncio
+import importlib
+import json
+import logging
+from typing import Any, Never
+
+import pytest
+from mcp.types import TextContent
+
+from jacobian._execution import (
+    BackendFailureReason,
+    ExecutionResource,
+    OperationBackendError,
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
+)
+from jacobian.catalog.catalog import Catalog
+from jacobian.math.logic import _sat
+from jacobian.mcp.direct_tools import direct_operation_tools
+from jacobian.mcp.runtime import AppState
+from jacobian.mcp.server import _build_server
+from mcp import Client
+
+
+@pytest.mark.parametrize("direct", [False, True])
+@pytest.mark.parametrize(
+    ("error", "code", "tracebacks"),
+    [
+        (RuntimeError("private failure marker"), None, 1),
+        (
+            OperationBackendError(BackendFailureReason.INVALID_OUTPUT),
+            "OPERATION_FAILED",
+            1,
+        ),
+        (
+            OperationResourceExhaustedError(ExecutionResource.WORK),
+            "RESOURCE_EXHAUSTED",
+            0,
+        ),
+        (
+            OperationExecutionTimeoutError("private failure marker"),
+            "OPERATION_TIMEOUT",
+            0,
+        ),
+        (
+            OperationExecutionCancelledError("private failure marker"),
+            "OPERATION_CANCELLED",
+            0,
+        ),
+    ],
+)
+def test_sdk_execution_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    direct: bool,
+    error: Exception,
+    code: str | None,
+    tracebacks: int,
+) -> None:
+    def fail(*args: object, **kwargs: object) -> Never:
+        raise error
+
+    monkeypatch.setattr(_sat, "_run_sat_worker", fail)
+    catalog = Catalog.open()
+    operation = catalog.operation("sat.solve")
+    assert operation is not None
+    catalog = Catalog((operation,))
+    server = _build_server(
+        state=AppState(operation_catalog=catalog),
+        evaluation_tools=direct_operation_tools(catalog) if direct else (),
+    )
+
+    async def scenario() -> Any:
+        async with Client(server, raise_exceptions=False) as client:
+            return await client.call_tool(
+                "sat.solve" if direct else "math.run",
+                operation.examples[0].input
+                if direct
+                else {
+                    "operation_id": "sat.solve",
+                    "payload": operation.examples[0].input,
+                },
+            )
+
+    with caplog.at_level(logging.ERROR, logger="jacobian.mcp.tools"):
+        result = asyncio.run(scenario())
+    assert result.is_error
+    assert result.structured_content is None
+    assert isinstance(result.content[0], TextContent)
+    text = result.content[0].text
+    assert "private failure marker" not in text
+    if code:
+        data = json.loads(text[text.index("{") :])
+        assert data["code"] == code
+        assert data["operation_id"] == "sat.solve"
+        assert data["stage"] == "operation_execution"
+        assert data["message"]
+        if code == "RESOURCE_EXHAUSTED":
+            assert data["resource"] == "work"
+            assert "timeout_ms does not increase" in data["hint"]
+    else:
+        assert text.endswith("operation execution failed")
+    records = [
+        r for r in caplog.records if r.name == "jacobian.mcp.tools" and r.exc_info
+    ]
+    assert len(records) == tracebacks
+    if code is None:
+        assert "private failure marker" in caplog.text
+
+
+@pytest.mark.parametrize("direct", [False, True])
+@pytest.mark.parametrize("operation_id", ["sat.solve", "smt.solve", "smt.unsat_core"])
+def test_success_and_resource_errors_keep_distinct_sdk_shapes(
+    monkeypatch: pytest.MonkeyPatch, direct: bool, operation_id: str
+) -> None:
+    import jsonschema
+
+    from jacobian.math.logic import _sat, _smt, _unsat_core
+
+    catalog = Catalog.open()
+    operation = catalog.operation(operation_id)
+    assert operation is not None
+    catalog = Catalog((operation,))
+    server = _build_server(
+        state=AppState(operation_catalog=catalog),
+        evaluation_tools=direct_operation_tools(catalog) if direct else (),
+    )
+
+    async def invoke() -> Any:
+        async with Client(server, raise_exceptions=False) as client:
+            return await client.call_tool(
+                operation_id if direct else "math.run",
+                operation.examples[0].input
+                if direct
+                else {
+                    "operation_id": operation_id,
+                    "payload": operation.examples[0].input,
+                },
+            )
+
+    success = asyncio.run(invoke())
+    assert not success.is_error
+    assert success.structured_content is not None
+    output = (
+        success.structured_content if direct else success.structured_content["output"]
+    )
+    jsonschema.validate(
+        output, operation.result_type.model_json_schema(mode="serialization")
+    )
+    assert output["outcome"] in {"SAT", "UNSAT"}
+
+    def exhausted(*args: object, **kwargs: object) -> Never:
+        raise OperationResourceExhaustedError(ExecutionResource.WORK)
+
+    owner = {"sat.solve": _sat, "smt.solve": _smt, "smt.unsat_core": _unsat_core}[
+        operation_id
+    ]
+    monkeypatch.setattr(owner, "run_bounded_process", exhausted)
+    failed = asyncio.run(invoke())
+    assert failed.is_error
+    assert failed.structured_content is None
+    assert isinstance(failed.content[0], TextContent)
+    text = failed.content[0].text
+    diagnostic = json.loads(text[text.index("{") :])
+    assert diagnostic["resource"] == "work"
+    if operation_id == "smt.unsat_core":
+        assert "rlimit within its admitted range" in diagnostic["hint"]
+    else:
+        assert "fixed work allowance" in diagnostic["hint"]
+
+
+OWNERS = [
+    ("sat.solve", "jacobian.math.logic._sat"),
+    ("smt.solve", "jacobian.math.logic._smt"),
+    ("smt.unsat_core", "jacobian.math.logic._unsat_core"),
+    *[
+        (name, "jacobian.math.graphs.optimization._finite_optimization")
+        for name in (
+            "graph.domination.minimum.compute",
+            "graph.induced_bipartite.maximum.compute",
+            "graph.induced_forest.maximum.compute",
+            "graph.induced_tree.maximum.compute",
+            "graph.matching.maximal.minimum.compute",
+        )
+    ],
+    (
+        "graph.invariant.clique_number.compute",
+        "jacobian.math.graphs.optimization._invariants",
+    ),
+    (
+        "graph.invariant.chromatic_number.compute",
+        "jacobian.math.graphs.optimization._chromatic_number",
+    ),
+    (
+        "graph.invariant.independence_number.compute",
+        "jacobian.math.graphs._independence_z3",
+    ),
+    (
+        "hypergraph.independence_number.compute",
+        "jacobian.math.combinatorics.finite_structures.hypergraphs._independence_z3",
+    ),
+]
+
+
+@pytest.mark.parametrize(("operation_id", "module"), OWNERS)
+@pytest.mark.parametrize("direct", [False, True])
+def test_each_owner_startup_failure_is_visible_to_the_model(
+    monkeypatch: pytest.MonkeyPatch,
+    operation_id: str,
+    module: str,
+    direct: bool,
+) -> None:
+    operation = Catalog.open().operation(operation_id)
+    assert operation is not None
+    catalog = Catalog((operation,))
+    server = _build_server(
+        state=AppState(operation_catalog=catalog),
+        evaluation_tools=direct_operation_tools(catalog) if direct else (),
+    )
+
+    def fail(*args: object, **kwargs: object) -> Never:
+        raise OSError("private worker startup marker")
+
+    monkeypatch.setattr(importlib.import_module(module), "run_bounded_process", fail)
+
+    async def scenario() -> None:
+        async with Client(server, raise_exceptions=False) as client:
+            result = await client.call_tool(
+                operation_id if direct else "math.run",
+                operation.examples[0].input
+                if direct
+                else {
+                    "operation_id": operation_id,
+                    "payload": operation.examples[0].input,
+                },
+            )
+        assert result.is_error
+        assert result.structured_content is None
+        assert isinstance(result.content[0], TextContent)
+        text = result.content[0].text
+        assert "private worker startup marker" not in text
+        data = json.loads(text[text.index("{") :])
+        assert data["code"] == "OPERATION_FAILED"
+        assert data["operation_id"] == operation_id
+
+    asyncio.run(scenario())

--- a/tests/process/test_solver_execution_failures.py
+++ b/tests/process/test_solver_execution_failures.py
@@ -1,0 +1,266 @@
+"""Failed worker execution must not establish a mathematical outcome (#3560-3562)."""
+
+import importlib
+from typing import Any, Never
+
+import pytest
+
+from jacobian._execution import (
+    OperationBackendError,
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
+)
+from jacobian.catalog.catalog import Catalog
+from jacobian.process import BoundedProcessResult
+
+OWNERS = [
+    ("sat.solve", "jacobian.math.logic._sat"),
+    ("smt.solve", "jacobian.math.logic._smt"),
+    ("smt.unsat_core", "jacobian.math.logic._unsat_core"),
+    *[
+        (name, "jacobian.math.graphs.optimization._finite_optimization")
+        for name in (
+            "graph.domination.minimum.compute",
+            "graph.induced_bipartite.maximum.compute",
+            "graph.induced_forest.maximum.compute",
+            "graph.induced_tree.maximum.compute",
+            "graph.matching.maximal.minimum.compute",
+        )
+    ],
+    (
+        "graph.invariant.clique_number.compute",
+        "jacobian.math.graphs.optimization._invariants",
+    ),
+    (
+        "graph.invariant.chromatic_number.compute",
+        "jacobian.math.graphs.optimization._chromatic_number",
+    ),
+    (
+        "graph.invariant.independence_number.compute",
+        "jacobian.math.graphs._independence_z3",
+    ),
+    (
+        "hypergraph.independence_number.compute",
+        "jacobian.math.combinatorics.finite_structures.hypergraphs._independence_z3",
+    ),
+]
+
+
+@pytest.mark.parametrize(("operation_id", "module"), OWNERS)
+def test_startup_failure_raises(
+    monkeypatch: pytest.MonkeyPatch, operation_id: str, module: str
+) -> None:
+    operation = Catalog.open().operation(operation_id)
+    assert operation is not None
+    request = operation.request_type.model_validate(operation.examples[0].input)
+
+    def fail(*args: object, **kwargs: object) -> Never:
+        raise OSError("private startup marker")
+
+    monkeypatch.setattr(importlib.import_module(module), "run_bounded_process", fail)
+    with pytest.raises(OperationBackendError) as caught:
+        operation.run(request)
+    assert caught.value.reason == "startup"
+    assert isinstance(caught.value.__cause__, OSError)
+
+
+@pytest.mark.parametrize(("operation_id", "module"), OWNERS)
+@pytest.mark.parametrize(
+    ("changes", "expected"),
+    [
+        ({"returncode": 2}, OperationBackendError),
+        ({"stdout_exceeded": True}, OperationResourceExhaustedError),
+        ({"stderr_exceeded": True}, OperationResourceExhaustedError),
+        ({"stdout": b"not JSON"}, OperationBackendError),
+        ({"stdout": b'{"invalid":"result"}'}, OperationBackendError),
+        ({"cancelled": True, "timed_out": True}, OperationExecutionCancelledError),
+        ({"timed_out": True, "stdout_exceeded": True}, OperationExecutionTimeoutError),
+        (
+            {
+                "stdout": b'{"kind":"execution_error","stage":"operation_execution","resource":"memory"}'
+            },
+            OperationResourceExhaustedError,
+        ),
+        (
+            {
+                "stdout": b'{"kind":"execution_error","stage":"operation_execution","resource":"forged"}'
+            },
+            OperationBackendError,
+        ),
+    ],
+)
+def test_worker_failure_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    operation_id: str,
+    module: str,
+    changes: dict[str, Any],
+    expected: type[Exception],
+) -> None:
+    operation = Catalog.open().operation(operation_id)
+    assert operation is not None
+    request = operation.request_type.model_validate(operation.examples[0].input)
+    values: dict[str, Any] = {
+        "returncode": 0,
+        "stdout": b"{}",
+        "stderr": b"",
+        "stdout_exceeded": False,
+        "stderr_exceeded": False,
+        "timed_out": False,
+    }
+    values.update(changes)
+    monkeypatch.setattr(
+        importlib.import_module(module),
+        "run_bounded_process",
+        lambda *args, **kwargs: BoundedProcessResult(**values),
+    )
+    with pytest.raises(expected):
+        operation.run(request)
+
+
+@pytest.mark.parametrize(("operation_id", "module"), OWNERS)
+def test_decode_cannot_finish_after_parent_deadline(
+    monkeypatch: pytest.MonkeyPatch, operation_id: str, module: str
+) -> None:
+    import time
+
+    from jacobian._execution import request_execution
+
+    owner = importlib.import_module(module)
+    operation = Catalog.open().operation(operation_id)
+    assert operation is not None
+    request = operation.request_type.model_validate(operation.examples[0].input)
+    now = time.monotonic()
+    clock = [now]
+
+    def complete(*args: object, **kwargs: object) -> BoundedProcessResult:
+        clock[0] += 1000
+        return BoundedProcessResult(0, b"{}", b"", False, False, False)
+
+    monkeypatch.setattr(owner, "run_bounded_process", complete)
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+    with request_execution(now), pytest.raises(OperationExecutionTimeoutError):
+        operation.run(request)
+
+
+@pytest.mark.parametrize(
+    ("operation_id", "optimum", "witness_kind"),
+    [
+        ("graph.domination.minimum.compute", 2, "domination"),
+        ("graph.matching.maximal.minimum.compute", 3, "matching"),
+        ("graph.induced_forest.maximum.compute", 4, "forest"),
+        ("graph.induced_tree.maximum.compute", 4, "tree"),
+        ("graph.induced_bipartite.maximum.compute", 4, "bipartite"),
+        ("graph.invariant.clique_number.compute", 2, "clique"),
+    ],
+)
+def test_worker_search_limit_preserves_valid_partial_bounds(
+    operation_id: str,
+    optimum: int,
+    witness_kind: str,
+) -> None:
+    from itertools import combinations
+
+    import networkx as nx
+
+    operation = Catalog.open().operation(operation_id)
+    assert operation is not None
+    graph = nx.cycle_graph(list("abcdefg" if witness_kind == "matching" else "abcde"))
+    request = operation.request_type.model_validate(
+        {
+            "graph": {"vertices": list(graph), "edges": list(graph.edges)},
+            "resource_budget": {"wall_seconds": 5, "max_solver_calls": 1},
+        }
+    )
+    result = operation.run(request)
+    assert result.status == "UNKNOWN"
+    assert result.optimum_value is None
+    assert result.lower_bound <= optimum <= result.upper_bound
+    if witness_kind == "matching":
+        assert nx.is_maximal_matching(graph, result.witness_edges)
+        assert result.incumbent_value == len(result.witness_edges)
+    else:
+        witness = result.witness_vertices
+        assert set(witness) <= set(graph)
+        assert result.incumbent_value == len(witness)
+        if witness_kind == "domination":
+            assert nx.is_dominating_set(graph, witness)
+        elif witness_kind == "forest":
+            assert not witness or nx.is_forest(graph.subgraph(witness))
+        elif witness_kind == "tree":
+            assert nx.is_tree(graph.subgraph(witness))
+        elif witness_kind == "bipartite":
+            assert nx.is_bipartite(graph.subgraph(witness))
+        else:
+            assert all(graph.has_edge(a, b) for a, b in combinations(witness, 2))
+
+
+def test_hypergraph_preserves_unspent_dispatch_allowance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+    import time
+
+    from jacobian._execution import request_execution
+    from jacobian.math.combinatorics.finite_structures.hypergraphs import (
+        _independence_z3 as owner,
+    )
+
+    operation = Catalog.open().operation("hypergraph.independence_number.compute")
+    assert operation is not None
+    request = operation.request_type.model_validate(
+        {**operation.examples[0].input, "resource_budget": {"wall_seconds": 10}}
+    )
+    expected = owner._solve_independence_number_kernel(
+        request.hypergraph, request.resource_budget
+    )
+    projection = expected.model_dump(
+        mode="json", exclude={"hypergraph", "resource_budget"}
+    )
+    recorded: dict[str, Any] = {}
+
+    def complete(*args: object, **kwargs: Any) -> BoundedProcessResult:
+        recorded.update(kwargs)
+        return BoundedProcessResult(
+            0, json.dumps(projection).encode(), b"", False, False, False
+        )
+
+    monkeypatch.setattr(owner, "run_bounded_process", complete)
+    monkeypatch.setattr(time, "monotonic", lambda: 106.0)
+    with request_execution(100.0):
+        assert operation.run(request) == expected
+    assert recorded["timeout_seconds"] == 4.0
+    assert json.loads(recorded["input_bytes"])["_deadline"] == 110.0
+
+
+def test_hypergraph_error_decoding_preserves_parent_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+    import time
+
+    from jacobian.math.combinatorics.finite_structures.hypergraphs import (
+        _independence_z3 as owner,
+    )
+
+    now = [106.0]
+    original_loads = json.loads
+
+    def delayed_loads(*args: Any, **kwargs: Any) -> Any:
+        response = original_loads(*args, **kwargs)
+        now[0] = 111.0
+        return response
+
+    completed = BoundedProcessResult(
+        0,
+        b'{"kind":"execution_error","stage":"operation_execution","resource":"work"}',
+        b"",
+        False,
+        False,
+        False,
+    )
+    monkeypatch.setattr(owner, "run_bounded_process", lambda *args, **kwargs: completed)
+    monkeypatch.setattr(json, "loads", delayed_loads)
+    monkeypatch.setattr(time, "monotonic", lambda: now[0])
+    with pytest.raises(OperationExecutionTimeoutError):
+        owner._run_independence_worker({}, deadline=110.0)

--- a/tests/process/test_worker_execution_errors.py
+++ b/tests/process/test_worker_execution_errors.py
@@ -1,0 +1,78 @@
+"""Private IPC preserves classifications and rejects malformed error branches."""
+
+import json
+
+import pytest
+
+from jacobian._execution import (
+    BackendFailureReason,
+    ExecutionResource,
+    OperationBackendError,
+    OperationExecutionCancelledError,
+    OperationExecutionStage,
+    OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
+)
+from jacobian._worker_errors import (
+    decode_worker_execution_error,
+    worker_execution_errors,
+)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        *[OperationBackendError(reason) for reason in BackendFailureReason],
+        *[OperationResourceExhaustedError(resource) for resource in ExecutionResource],
+        OperationExecutionCancelledError("private marker"),
+        OperationExecutionTimeoutError(
+            "private marker", stage=OperationExecutionStage.RESULT_PROJECTION
+        ),
+    ],
+)
+def test_private_error_roundtrip(
+    capsys: pytest.CaptureFixture[str],
+    error: OperationBackendError
+    | OperationResourceExhaustedError
+    | OperationExecutionTimeoutError
+    | OperationExecutionCancelledError,
+) -> None:
+    with worker_execution_errors():
+        raise error from RuntimeError("private cause marker")
+    branch = json.loads(capsys.readouterr().out)
+    with pytest.raises(type(error)) as caught:
+        decode_worker_execution_error(branch)
+    assert caught.value.stage == error.stage
+    if isinstance(error, OperationBackendError):
+        assert isinstance(caught.value, OperationBackendError)
+        assert caught.value.reason == error.reason
+        assert "private cause marker" in "".join(caught.value.__notes__)
+    elif isinstance(error, OperationResourceExhaustedError):
+        assert isinstance(caught.value, OperationResourceExhaustedError)
+        assert caught.value.resource == error.resource
+    assert "private" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        {},
+        {"stage": None},
+        {"stage": []},
+        {"stage": "result_projection", "reason": "unknown"},
+        {"stage": "operation_execution", "resource": "time"},
+        {"stage": "operation_execution", "resource": "work", "extra": True},
+        {"stage": "operation_execution", "reason": "startup", "diagnostic": 1},
+        {"stage": "operation_execution", "reason": "startup", "diagnostic": "x" * 1025},
+    ],
+)
+def test_malformed_execution_branch_is_backend_failure(
+    branch: dict[str, object],
+) -> None:
+    with pytest.raises(OperationBackendError) as caught:
+        decode_worker_execution_error({"kind": "execution_error", **branch})
+    assert caught.value.reason == "malformed_response"
+
+
+def test_mathematical_unknown_is_not_an_execution_branch() -> None:
+    decode_worker_execution_error({"outcome": "UNKNOWN", "detail": "inconclusive"})


### PR DESCRIPTION
## Problem

Worker startup failures, abnormal exits, malformed responses, and invalid backend witnesses were converted into successful `UNKNOWN` results across SAT/SMT and finite graph optimization operations. MCP therefore exposed operational failures as mathematical success, and unexpected adapter exceptions lost their traceback logging.

Fixes #3560, #3561, and #3562.

## Outcome

Operational failures now cross operation and worker boundaries as transport-independent execution exceptions. SAT/SMT work, memory, time, and output exhaustion are errors; a healthy inconclusive solver response remains a successful `UNKNOWN`. Graph workers may still return valid partial bounds or incumbents, but a parent no longer constructs fallback mathematics after worker failure.

Both `math.run` and direct MCP tools use one SDK `ToolError` boundary. It preserves existing validation, availability, timeout, and cancellation codes; adds `RESOURCE_EXHAUSTED` and `OPERATION_FAILED`; emits bounded recovery guidance; and logs backend defects or unexpected exceptions once without exposing private diagnostics. Operation IDs, request limits, and mathematical success schemas are unchanged.

## Validation

- Commands run:
  - `make affected AFFECTED_BASE=origin/main` (planner-selected lint/type, math, catalog, catalog-example, CLI, dispatch, integration, tooling, MCP, process, Singular, and QEPCAD lanes completed; focused reruns followed test-only corrections)
  - `make test-tooling`
  - `make test-mcp TESTS=tests/mcp/test_direct_operations.py`
  - `make docs-linkcheck`
- Final head SHA tested: `fa75b690001071896e3c4e9cccd010cc5a1cd3ff`
- Relevant CI checks or links: pending on this PR

The completed lanes included 10,040 math tests, 156 catalog tests, 938 catalog examples, 9 CLI tests, 130 dispatch tests, 455 integration tests, 477 process tests, 1,160 Singular tests, and 27 QEPCAD tests. The final focused MCP rerun passed 18 tests after assertion-only updates.

## Contract impact

- Public contract impact: known operational exhaustion and backend failures now fail natively and through MCP instead of returning mathematical `UNKNOWN`; successful result schemas remain unchanged.
- [x] Schema and runtime accept/reject the same requests
- [x] Exact results fit the complete canonical output boundary
- [x] All mandatory phases share one request deadline
- [x] Native and MCP behavior agree, where both are public
- [x] Producer → serialization → consumer composition was tested
- [x] Defining invariant and adversarial regression are covered

## Review closure

- [x] Every substantive review finding has a fix and applicable regression evidence, or an evidence-backed explanation of why no change is needed
- [x] Merge conflicts were resolved against the intended base
- [x] Validation covers the final changed tree; checks invalidated by later edits or autofixes were rerun
- [ ] CI evidence matches the final head SHA
- [x] The appropriate repository validation target and any specialist lane are listed above (normally `make affected`; docs use `make docs-linkcheck`)
- [x] Repository conventions were checked: no compatibility or shadow paths were added; if a shared abstraction was introduced, two existing paths already share its mechanics and contract

## Conditional detail

### Operation boundary

- Changed stage and owner: operation execution, worker decoding and validation, backend adaptation, and MCP transport projection.
- Semantic admission and controlling quantities: existing request admission and mathematical limits are unchanged; the repair distinguishes operational non-completion from mathematical results.
- Execution envelope: one parent deadline covers worker startup, decoding, validation, and projection. Existing work and memory limits remain in force, bounded stdout/stderr overflow is classified as output exhaustion, and cancellation or deadline expiry keeps its existing exception type.
- Backend or kernel path: isolated Z3 and finite-search workers encode known execution failures in a validated private IPC branch; parents reconstruct the classification and reject malformed branches.
- Result construction: valid exact results, healthy inconclusive answers, and worker-produced graph partial results retain their existing canonical construction. Invalid or unavailable worker output raises before result construction.
- Caller-supplied claim recognition (if applicable): SMT source diagnostics remain source-bound and cannot be classified as exhaustion merely because caller text contains resource words.
- Native/MCP parity: native APIs raise the execution exceptions; MCP maps the same classifications to SDK `ToolError` text with transport-specific codes and safe context.
- Serialized-result and round-trip evidence: MCP tests cover both entry points, successful advertised schemas, error text and context, absence of error structured content, and redaction of private exception markers.
