### PR TITLE
fix(logic): allow minute-scale solver deadlines

### DIFF
--- a/docs/how-to/invoke-domain-operations.md
+++ b/docs/how-to/invoke-domain-operations.md
@@ -64,7 +64,11 @@ exhaustion is an execution error, with no mathematical result. MCP reports
 `RESOURCE_EXHAUSTED`, `OPERATION_TIMEOUT`, `OPERATION_CANCELLED`, or
 `OPERATION_FAILED` in its model-visible error text. Backend details stay private.
 Increasing `timeout_ms` does not increase the fixed SAT/SMT work allowance;
-`smt.unsat_core` permits adjusting `rlimit` within its admitted range.
+`smt.unsat_core` permits adjusting `rlimit` within its admitted range. The three
+solver operations accept a full-lifecycle `timeout_ms` from 1 through 120,000
+milliseconds. Keep the one-second default for easy queries and select a longer
+value when the same admitted deterministic work needs more wall time. The MCP
+host's request deadline must also cover the selected value.
 
 Graph optimization may return valid bounds or an incumbent from an incomplete
 search before the parent deadline. A worker failure or parent deadline expiry

--- a/docs/how-to/invoke-domain-operations.md
+++ b/docs/how-to/invoke-domain-operations.md
@@ -66,7 +66,7 @@ exhaustion is an execution error, with no mathematical result. MCP reports
 Increasing `timeout_ms` does not increase the fixed SAT/SMT work allowance;
 `smt.unsat_core` permits adjusting `rlimit` within its admitted range. The three
 solver operations accept a full-lifecycle `timeout_ms` from 1 through 120,000
-milliseconds. Keep the one-second default for easy queries and select a longer
+milliseconds. The ten-second default covers ordinary queries; select a longer
 value when the same admitted deterministic work needs more wall time. The MCP
 host's request deadline must also cover the selected value.
 

--- a/docs/reference/operations/sat-smt/index.md
+++ b/docs/reference/operations/sat-smt/index.md
@@ -33,7 +33,7 @@ are unchanged. The `exhausted` field on SAT/SMT success results is now null.
 The work allowance of `sat.solve` and `smt.solve` is fixed: increasing
 `timeout_ms` does not increase it. `smt.unsat_core` exposes `rlimit`; callers
 may adjust it within the range advertised by its request schema. `timeout_ms`
-defaults to 1,000 milliseconds and admits values from 1 through 120,000
+defaults to 10,000 milliseconds and admits values from 1 through 120,000
 milliseconds for all three operations. It is a full-lifecycle wall limit: all
 mandatory phases share the parent deadline, including worker startup, parsing,
 solving, result validation, and projection. An earlier caller or transport

--- a/docs/reference/operations/sat-smt/index.md
+++ b/docs/reference/operations/sat-smt/index.md
@@ -32,8 +32,12 @@ are unchanged. The `exhausted` field on SAT/SMT success results is now null.
 
 The work allowance of `sat.solve` and `smt.solve` is fixed: increasing
 `timeout_ms` does not increase it. `smt.unsat_core` exposes `rlimit`; callers
-may adjust it within the range advertised by its request schema. All mandatory
-phases share the parent deadline, including worker startup and result validation.
+may adjust it within the range advertised by its request schema. `timeout_ms`
+defaults to 1,000 milliseconds and admits values from 1 through 120,000
+milliseconds for all three operations. It is a full-lifecycle wall limit: all
+mandatory phases share the parent deadline, including worker startup, parsing,
+solving, result validation, and projection. An earlier caller or transport
+deadline still wins.
 
 Native callers receive `OperationResourceExhaustedError` for work, memory, or
 output capacity, `OperationExecutionTimeoutError` for time expiry, and

--- a/src/jacobian/math/logic/_sat.py
+++ b/src/jacobian/math/logic/_sat.py
@@ -34,6 +34,7 @@ from jacobian.math.logic._cnf import (
     check_sat_assignment,
 )
 from jacobian.math.logic._smt import (
+    _DEFAULT_LOGIC_TIMEOUT_MS,
     _LOGIC_TIMEOUT_DESCRIPTION,
     _MAX_LOGIC_TIMEOUT_MS,
     _execution_deadline,
@@ -67,7 +68,7 @@ def _validation_error(code: str, message: str) -> PydanticCustomError:
 class SatSolveRequest(StrictModel):
     cnf: CanonicalCnf
     timeout_ms: StrictInt = Field(
-        default=1_000,
+        default=_DEFAULT_LOGIC_TIMEOUT_MS,
         ge=1,
         le=_MAX_LOGIC_TIMEOUT_MS,
         description=_LOGIC_TIMEOUT_DESCRIPTION,

--- a/src/jacobian/math/logic/_sat.py
+++ b/src/jacobian/math/logic/_sat.py
@@ -34,6 +34,8 @@ from jacobian.math.logic._cnf import (
     check_sat_assignment,
 )
 from jacobian.math.logic._smt import (
+    _LOGIC_TIMEOUT_DESCRIPTION,
+    _MAX_LOGIC_TIMEOUT_MS,
     _execution_deadline,
     _require_execution_deadline,
     _solver_settings,
@@ -64,7 +66,12 @@ def _validation_error(code: str, message: str) -> PydanticCustomError:
 
 class SatSolveRequest(StrictModel):
     cnf: CanonicalCnf
-    timeout_ms: StrictInt = Field(default=1_000, ge=1, le=10_000)
+    timeout_ms: StrictInt = Field(
+        default=1_000,
+        ge=1,
+        le=_MAX_LOGIC_TIMEOUT_MS,
+        description=_LOGIC_TIMEOUT_DESCRIPTION,
+    )
 
 
 class SatSolveResult(StrictModel):

--- a/src/jacobian/math/logic/_smt.py
+++ b/src/jacobian/math/logic/_smt.py
@@ -75,6 +75,12 @@ _MAX_SMTLIB_ARITHMETIC_WORK = _MAX_SMTLIB_NUMERAL_DIGITS**2 * 64
 # exhaustion surfaces as typed execution failure instead of host memory pressure.
 _SOLVER_RLIMIT = 20_000_000
 _SOLVER_MAX_MEMORY_MB = 1024
+_MAX_LOGIC_TIMEOUT_MS = 120_000
+_LOGIC_TIMEOUT_DESCRIPTION = (
+    "Full-lifecycle wall-clock limit in milliseconds, from 1 through 120000, "
+    "covering worker startup, parsing, solving, result validation, and projection. "
+    "This does not increase the operation's separate deterministic solver work limit."
+)
 _MAX_MODEL_BYTES = 64_000
 _SMT_WORKER = Path(__file__).with_name("_smt_worker.py")
 # JSON escaping can expand a model's UTF-8 spelling by almost twofold.  The
@@ -476,7 +482,12 @@ class SmtSolveRequest(StrictModel):
             "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)"
         ],
     )
-    timeout_ms: StrictInt = Field(default=1_000, ge=1, le=10_000)
+    timeout_ms: StrictInt = Field(
+        default=1_000,
+        ge=1,
+        le=_MAX_LOGIC_TIMEOUT_MS,
+        description=_LOGIC_TIMEOUT_DESCRIPTION,
+    )
 
     @model_validator(mode="after")
     def require_single_smtlib_query(self) -> Self:

--- a/src/jacobian/math/logic/_smt.py
+++ b/src/jacobian/math/logic/_smt.py
@@ -75,6 +75,7 @@ _MAX_SMTLIB_ARITHMETIC_WORK = _MAX_SMTLIB_NUMERAL_DIGITS**2 * 64
 # exhaustion surfaces as typed execution failure instead of host memory pressure.
 _SOLVER_RLIMIT = 20_000_000
 _SOLVER_MAX_MEMORY_MB = 1024
+_DEFAULT_LOGIC_TIMEOUT_MS = 10_000
 _MAX_LOGIC_TIMEOUT_MS = 120_000
 _LOGIC_TIMEOUT_DESCRIPTION = (
     "Full-lifecycle wall-clock limit in milliseconds, from 1 through 120000, "
@@ -483,7 +484,7 @@ class SmtSolveRequest(StrictModel):
         ],
     )
     timeout_ms: StrictInt = Field(
-        default=1_000,
+        default=_DEFAULT_LOGIC_TIMEOUT_MS,
         ge=1,
         le=_MAX_LOGIC_TIMEOUT_MS,
         description=_LOGIC_TIMEOUT_DESCRIPTION,

--- a/src/jacobian/math/logic/_tools.py
+++ b/src/jacobian/math/logic/_tools.py
@@ -54,7 +54,13 @@ TOOLS: MathTools = (
     MathTool(
         operation_id="sat.solve",
         title="Solve a bounded CNF",
-        description="Run the maintained Z3 Python binding on one canonical CNF. Resource exhaustion and backend failures raise execution errors; UNKNOWN denotes a healthy inconclusive solver answer.",
+        description=(
+            "Run the maintained Z3 Python binding on one canonical CNF. "
+            "timeout_ms provides up to 120 seconds for the full lifecycle without "
+            "increasing the fixed solver work limit. Resource exhaustion and backend "
+            "failures raise execution errors; UNKNOWN denotes a healthy inconclusive "
+            "solver answer."
+        ),
         request_type=SatSolveRequest,
         result_type=SatSolveResult,
         run=solve_sat,
@@ -73,7 +79,10 @@ TOOLS: MathTools = (
         description=(
             "Decide one bounded quantifier-free SMT-LIB query and return SAT, "
             "UNSAT, or UNKNOWN; SAT includes a satisfying model projection."
-            " Resource exhaustion and backend failures raise execution errors; UNKNOWN denotes a healthy inconclusive solver answer."
+            " timeout_ms provides up to 120 seconds for the full lifecycle without "
+            "increasing the fixed solver work limit. Resource exhaustion and backend "
+            "failures raise execution errors; UNKNOWN denotes a healthy inconclusive "
+            "solver answer."
         ),
         request_type=SmtSolveRequest,
         result_type=SmtSolveResult,

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -1491,8 +1491,10 @@ SMT_UNSAT_CORE_OPERATION = MathTool(
     description=(
         "Return SAT, UNKNOWN, or a deterministic backend-selected set of source-order "
         "assertion indices whose exact subsystem replays as UNSAT through the "
-        "maintained Z3 Python binding. The core need not be minimal."
-        " Resource exhaustion and backend failures raise execution errors; UNKNOWN denotes a healthy inconclusive solver answer."
+        "maintained Z3 Python binding. The core need not be minimal. timeout_ms "
+        "provides up to 120 seconds for the full lifecycle without increasing the "
+        "caller-selected rlimit. Resource exhaustion and backend failures raise "
+        "execution errors; UNKNOWN denotes a healthy inconclusive solver answer."
     ),
     request_type=SmtUnsatCoreRequest,
     result_type=SmtUnsatCoreResult,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -53,6 +53,52 @@ def test_cli_catalog_inspect_and_run_are_inline(
     }
 
 
+@pytest.mark.parametrize(
+    ("operation_id", "payload"),
+    [
+        (
+            "sat.solve",
+            {"cnf": {"variables": ["x"], "clauses": [[1]]}},
+        ),
+        (
+            "smt.solve",
+            {
+                "logic": "QF_LIA",
+                "smtlib": (
+                    "(set-logic QF_LIA)\n(declare-const x Int)\n"
+                    "(assert (> x 0))\n(check-sat)"
+                ),
+            },
+        ),
+        (
+            "smt.unsat_core",
+            {
+                "logic": "QF_LIA",
+                "smtlib": (
+                    "(set-logic QF_LIA)\n(declare-const x Int)\n"
+                    "(assert (> x 0))\n(assert (<= x 0))\n(check-sat)"
+                ),
+            },
+        ),
+    ],
+)
+def test_cli_solver_operations_accept_extended_wall_time(
+    operation_id: str, payload: dict[str, object]
+) -> None:
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            operation_id,
+            "--json",
+            json.dumps({**payload, "timeout_ms": 120_000}),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["output"]["source"]["timeout_ms"] == 120_000
+
+
 @pytest.mark.parametrize("arguments", [(), ("--json", "{}", "--file", "input.json")])
 def test_cli_run_requires_exactly_one_payload_source(
     arguments: tuple[str, ...],

--- a/tests/math/logic/test_solver_wall_time_scale.py
+++ b/tests/math/logic/test_solver_wall_time_scale.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import random
+from typing import cast
+
+import pytest
+
+from jacobian.math.logic._cnf import CnfCanonicalizeRequest, canonicalize_cnf
+from jacobian.math.logic._sat import SatSolveRequest, solve_sat
+
+
+def _threshold_3sat_request(*, timeout_ms: int) -> SatSolveRequest:
+    """Return one deterministic admitted UNSAT instance near the 3-SAT threshold."""
+
+    variable_count = 250
+    clause_count = round(4.27 * variable_count)
+    random_source = random.Random(3566)
+    clauses: list[tuple[int, int, int]] = []
+    seen: set[tuple[int, int, int]] = set()
+    while len(clauses) < clause_count:
+        variable_indices = sorted(random_source.sample(range(variable_count), 3))
+        clause = cast(
+            tuple[int, int, int],
+            tuple(
+                -(index + 1) if random_source.choice((False, True)) else index + 1
+                for index in variable_indices
+            ),
+        )
+        if clause in seen:
+            continue
+        seen.add(clause)
+        clauses.append(clause)
+    canonical = canonicalize_cnf(
+        CnfCanonicalizeRequest(
+            variable_names=tuple(f"x{index:04d}" for index in range(variable_count)),
+            clauses=tuple(clauses),
+        )
+    ).cnf
+    return SatSolveRequest(cnf=canonical, timeout_ms=timeout_ms)
+
+
+@pytest.mark.scale
+def test_sat_solver_finishes_near_threshold_work_with_extended_wall_time() -> None:
+    result = solve_sat(_threshold_3sat_request(timeout_ms=120_000))
+
+    assert result.outcome == "UNSAT"
+    assert result.assignment is None
+    assert result.source.cnf == _threshold_3sat_request(timeout_ms=1_000).cnf

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -158,7 +158,7 @@ def test_solver_schemas_publish_the_full_lifecycle_wall_time_range() -> None:
         timeout_schema = tools_by_id[operation_id].request_type.model_json_schema()[
             "properties"
         ]["timeout_ms"]
-        assert timeout_schema["default"] == 1_000
+        assert timeout_schema["default"] == 10_000
         assert timeout_schema["minimum"] == 1
         assert timeout_schema["maximum"] == 120_000
         assert "Full-lifecycle wall-clock limit" in timeout_schema["description"]

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -151,6 +151,20 @@ def test_smt_schema_publishes_commands_and_unsat_core_limits() -> None:
     assert "256 digits" in core_description
 
 
+def test_solver_schemas_publish_the_full_lifecycle_wall_time_range() -> None:
+    tools_by_id = {operation.operation_id: operation for operation in TOOLS}
+
+    for operation_id in ("sat.solve", "smt.solve", "smt.unsat_core"):
+        timeout_schema = tools_by_id[operation_id].request_type.model_json_schema()[
+            "properties"
+        ]["timeout_ms"]
+        assert timeout_schema["default"] == 1_000
+        assert timeout_schema["minimum"] == 1
+        assert timeout_schema["maximum"] == 120_000
+        assert "Full-lifecycle wall-clock limit" in timeout_schema["description"]
+        assert "does not increase" in timeout_schema["description"]
+
+
 @pytest.mark.parametrize("clauses, outcome", (((), "SAT"), (((),), "UNSAT")))
 def test_sat_solver_preserves_empty_formula_semantics(
     clauses: tuple[tuple[int, ...], ...], outcome: str

--- a/tests/mcp/test_execution_errors.py
+++ b/tests/mcp/test_execution_errors.py
@@ -26,6 +26,39 @@ from mcp import Client
 
 
 @pytest.mark.parametrize("direct", [False, True])
+@pytest.mark.parametrize("operation_id", ["sat.solve", "smt.solve", "smt.unsat_core"])
+def test_sdk_solver_entry_points_accept_extended_wall_time(
+    direct: bool, operation_id: str
+) -> None:
+    catalog = Catalog.open()
+    operation = catalog.operation(operation_id)
+    assert operation is not None
+    catalog = Catalog((operation,))
+    server = _build_server(
+        state=AppState(operation_catalog=catalog),
+        evaluation_tools=direct_operation_tools(catalog) if direct else (),
+    )
+    payload = {**operation.examples[0].input, "timeout_ms": 120_000}
+
+    async def scenario() -> Any:
+        async with Client(server, raise_exceptions=False) as client:
+            return await client.call_tool(
+                operation_id if direct else "math.run",
+                payload
+                if direct
+                else {"operation_id": operation_id, "payload": payload},
+            )
+
+    result = asyncio.run(scenario())
+    assert not result.is_error
+    assert result.structured_content is not None
+    output = (
+        result.structured_content if direct else result.structured_content["output"]
+    )
+    assert output["source"]["timeout_ms"] == 120_000
+
+
+@pytest.mark.parametrize("direct", [False, True])
 @pytest.mark.parametrize(
     ("error", "code", "tracebacks"),
     [


### PR DESCRIPTION
## Problem

`sat.solve`, `smt.solve`, and `smt.unsat_core` rejected every `timeout_ms` above 10 seconds even though their separately admitted Z3 work can require longer on a healthy host. A retained canonical 250-variable threshold 3-SAT instance timed out at 10 seconds after about 9.5 million resource units, then proved UNSAT in 13.9 seconds and about 12.8 million units with the same 20-million-unit work cap.

Closes #3565.

## Outcome

All three solver operations now admit a full-lifecycle wall limit from 1 through 120,000 milliseconds while using a ten-second default. The fixed SAT/SMT work and memory limits, the caller-selected UNSAT-core `rlimit`, source admission, result schemas, failure classification, and single parent deadline are unchanged.

Operation descriptions, field schemas, and invocation guidance now explain that increasing `timeout_ms` allows more wall time without increasing deterministic solver work. Both MCP entry points and the CLI exercise the widened value. Durable computation beyond a request lifetime remains separate in #3566.

## Validation

- `make affected AFFECTED_BASE=origin/main` — 7 planner-selected commands passed: static checks, 636 logic tests, 156 catalog tests, 938 catalog integration tests, 12 CLI tests, and 147 MCP tests.
- `uv run pytest -q -m scale --timeout=180 tests/math/logic/test_solver_wall_time_scale.py --durations=2` — 1 passed; the retained instance proved UNSAT in 14.12 seconds on the final tree.
- `make docs-linkcheck` — passed.
- Final head SHA tested: `dd8132547c602fed6c577865f841f962489de933`.

## Contract impact

- Public contract impact: `timeout_ms` maximum increases from 10,000 to 120,000 for `sat.solve`, `smt.solve`, and `smt.unsat_core`; descriptions now define its full-lifecycle wall semantics.
- [x] Schema and runtime accept/reject the same requests
- [x] Cheap malformed or over-budget input is rejected before expensive work
- [x] Exact results fit the complete canonical output boundary
- [x] All mandatory phases share one request deadline
- [x] Native and MCP behavior agree, where both are public
- [x] Defining invariant and adversarial regression are covered

## Review closure

- [x] Every substantive review finding has a fix and applicable regression evidence, or an evidence-backed explanation of why no change is needed
- [x] Merge conflicts were resolved against the intended base
- [x] Validation covers the final changed tree; checks invalidated by later edits or autofixes were rerun
- [x] CI evidence matches the final head SHA
- [x] The appropriate repository validation target and specialist lanes are listed above
- [x] Repository conventions were checked; no compatibility path or shared abstraction was added

## Operation boundary

- Changed stage and owner: request bounds and catalog descriptions in the logic owner models.
- Semantic admission and controlling quantities: the wall-time policy changed to a 10,000-millisecond default and a caller-selected range of `1..120000` milliseconds.
- Execution envelope: `sat.solve` and `smt.solve` retain a fixed 20,000,000-unit Z3 `rlimit` and 1 GiB Z3 memory ceiling. `smt.unsat_core` retains its admitted caller-selected `rlimit` up to 10,000,000 units per check. Existing source, process memory, output, and file-size caps remain in force.
- Backend or kernel path: unchanged isolated Z3 workers with one parent deadline across startup, parsing, solving, validation, and projection.
- Result construction: unchanged SAT, UNSAT, or healthy UNKNOWN result types; operational non-completion remains an execution error.
- Native/MCP parity: native, CLI, `math.run`, and direct MCP tools accept the widened value; MCP success remains structured and schema-valid.
- Serialized-result evidence: CLI and both MCP entry points retain `source.timeout_ms=120000` in successful results for all three operations.



