### PR TITLE
Fix exact LP admission for short certificates

### DIFF
--- a/docs/reference/backend-known-defects.md
+++ b/docs/reference/backend-known-defects.md
@@ -26,7 +26,11 @@ alternatives include [SoPlex](https://soplex.zib.de/) and
 adopting either would require an additional native dependency. The finite basis
 families and conservative scalar-update/minor-height bounds are documented in
 `src/jacobian/math/optimization/_linear_basis.py` and exposed through inspection.
-They establish admission; timings do not.
+The complete-family basis and height bounds establish admission. A shared execution
+ledger reserves preprocessing, then charges each basis before exact FLINT work. This
+lets an early exact certificate complete even when exhaustive search would exceed
+the ledger; exhausting the ledger is an execution error and establishes no LP
+status. Timings do not establish either bound.
 
 On 2026-09-05, Python 3.12.13 / FLINT 0.9.0 on x86-64 completed five runs of the
 #3192 pair cover at objective 2 in 0.0048–0.0054 seconds for ten source variables
@@ -46,6 +50,15 @@ admitted coefficient regimes and host variation. It is cooperative between
 bounded FLINT primitives, not a hard interruption inside a native matrix call.
 Normalization, both searches, certificate construction and dispatch projection
 share the original request deadline; no phase receives a fresh allowance.
+
+On 2026-09-09, a nine-row grid-collision cover normalized to 18 columns had an
+exhaustive estimate of 324,709,800 updates but produced independently checked
+primal and dual certificates of value 8/3 in 0.036 seconds. This is the motivating
+certificate-prefix regression for the execution ledger. Reversing its source rows
+retains the same exact optimum. An eighteen-column Vandermonde control with
+negative RHS has no feasible original basis and deterministically exhausts the
+50,000,000-update ledger, demonstrating that the larger admitted prefix remains
+bounded.
 
 ## Adding an entry
 

--- a/src/jacobian/math/optimization/_linear_basis.py
+++ b/src/jacobian/math/optimization/_linear_basis.py
@@ -30,6 +30,8 @@ from typing import Any
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
 from jacobian._execution import (
+    ExecutionResource,
+    OperationResourceExhaustedError,
     bind_request_deadline,
     current_request_execution,
     request_checkpoint,
@@ -75,7 +77,27 @@ def linear_execution() -> Iterator[None]:
 class LinearAdmission:
     columns: tuple[int, ...]
     result_digits: int
+    initial_work: int
     components: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...] = ()
+
+
+@dataclass
+class _LinearWorkLedger:
+    consumed: int
+    limit: int = MAX_LINEAR_PROGRAM_SCALAR_UPDATES
+
+    def charge(self, work: int) -> None:
+        if work > self.limit - self.consumed:
+            raise OperationResourceExhaustedError(ExecutionResource.WORK)
+        self.consumed += work
+
+
+def _preprocessing_work(variables: int, equations: int) -> int:
+    return 8 * (equations + 1) ** 2 * (variables + equations + 2)
+
+
+def _basis_work(variables: int, rank: int) -> int:
+    return 4 * rank**3 + 2 * rank**2 * (variables + 2) + 4 * rank * (variables + 2)
 
 
 def basis_bounds(variables: int, equations: int) -> tuple[int, int]:
@@ -88,14 +110,12 @@ def basis_bounds(variables: int, equations: int) -> tuple[int, int]:
     elimination and matrix products have finite intermediate height bounded by
     (2*min(n,m)+4) times the conservative result-minor digit bound.
     """
-    preprocessing = 8 * (equations + 1) ** 2 * (variables + equations + 2)
+    preprocessing = _preprocessing_work(variables, equations)
     candidates = 1
     updates = preprocessing
     for rank in range(1, min(variables, equations) + 1):
         count = comb(variables + 1, rank)
-        per_basis = (
-            4 * rank**3 + 2 * rank**2 * (variables + 2) + 4 * rank * (variables + 2)
-        )
+        per_basis = _basis_work(variables, rank)
         candidates = max(candidates, count)
         updates = max(updates, preprocessing + count * per_basis)
     return candidates, updates
@@ -142,14 +162,17 @@ def admit_linear_program(program: StandardFormRationalLinearProgram) -> LinearAd
     rows = len(_active_equations(program))
     components = _constraint_components(program)
     if _has_trivial_inconsistent_row(program):
-        candidates, work = 0, 0
+        candidates, work, initial_work = 0, 0, 0
     else:
         bounds = [basis_bounds(len(cs), len(rs)) for rs, cs in components]
         candidates = sum(count for count, _ in bounds)
         # Source scans, subproblem projection and certificate assembly remain
         # in source coordinates; their dense work is charged independently.
-        work = sum(cost for _, cost in bounds) + 16 * (len(program.rhs) + 1) * (
-            len(program.variables) + 1
+        source_work = 16 * (len(program.rhs) + 1) * (len(program.variables) + 1)
+        work = sum(cost for _, cost in bounds) + source_work
+        initial_work = (
+            sum(_preprocessing_work(len(cs), len(rs)) for rs, cs in components)
+            + source_work
         )
 
     quantities = (
@@ -157,12 +180,13 @@ def admit_linear_program(program: StandardFormRationalLinearProgram) -> LinearAd
         f"normalized_rows={len(program.rhs)}, active_rows={rows}, "
         f"basis_estimate={candidates}, basis_limit={MAX_LINEAR_PROGRAM_BASES}, "
         f"work_estimate={work}, work_limit={MAX_LINEAR_PROGRAM_SCALAR_UPDATES}, "
+        f"initial_work={initial_work}, "
         f"result_digits={digits}, result_digit_limit={MAX_CANONICAL_RATIONAL_DIGITS}"
     )
     for reason, measured, limit in (
         ("result_height", digits, MAX_CANONICAL_RATIONAL_DIGITS),
         ("basis_bound", candidates, MAX_LINEAR_PROGRAM_BASES),
-        ("work_bound", work, MAX_LINEAR_PROGRAM_SCALAR_UPDATES),
+        ("work_bound", initial_work, MAX_LINEAR_PROGRAM_SCALAR_UPDATES),
     ):
         if measured > limit:
             raise OperationResourceAdmissionError(
@@ -170,7 +194,12 @@ def admit_linear_program(program: StandardFormRationalLinearProgram) -> LinearAd
                 code=f"optimization.linear.{reason}",
                 message=f"Exact LP {reason} exceeded: {quantities}.",
             )
-    return LinearAdmission(columns, digits, components)
+    return LinearAdmission(
+        columns=columns,
+        result_digits=digits,
+        initial_work=initial_work,
+        components=components,
+    )
 
 
 def independent_rows(a: Any, b: Any) -> tuple[tuple[int, ...], Any | None]:
@@ -205,7 +234,12 @@ def independent_rows(a: Any, b: Any) -> tuple[tuple[int, ...], Any | None]:
 
 
 def search_bases(
-    a: Any, b: Any, c: Any, *, artificial: bool = False
+    a: Any,
+    b: Any,
+    c: Any,
+    *,
+    ledger: _LinearWorkLedger,
+    artificial: bool = False,
 ) -> tuple[Any, Any, Any | None] | None:
     """Return a primal/dual pair or a primal/ray pair from one finite family."""
     from flint import fmpq_mat
@@ -218,6 +252,7 @@ def search_bases(
     )
     for basis in family:
         request_checkpoint("linear-program basis search")
+        ledger.charge(_basis_work(columns - int(artificial), rows))
         square = fmpq_mat([[a[i, j] for j in basis] for i in range(rows)])
         try:
             inverse = square.inv()

--- a/src/jacobian/math/optimization/_tools.py
+++ b/src/jacobian/math/optimization/_tools.py
@@ -27,12 +27,15 @@ _BASIS_ENVELOPE = (
     "For n remaining columns and m remaining rows, the basis estimate is "
     "max C(n+1,r) over 0<=r<=min(n,m); the work estimate is "
     "8(m+1)^2(n+m+2) + max C(n+1,r)[4r^3+2r^2(n+2)+4r(n+2)]. "
-    f"Limits are {MAX_LINEAR_PROGRAM_BASES} bases and "
-    f"{MAX_LINEAR_PROGRAM_SCALAR_UPDATES} scalar updates, plus source-derived "
-    "rational-minor height within the canonical rational digit limit. "
-    "Rejections report derived counts, estimates and limits; shape bounds alone "
-    "do not guarantee admission. Execution has one 600-second cooperative safety "
-    "deadline; expiration yields an execution error, never a mathematical conclusion."
+    f"The complete family must contain at most {MAX_LINEAR_PROGRAM_BASES} bases. "
+    "Execution tries bases in deterministic order and returns as soon as an exact "
+    f"certificate is found, charging at most {MAX_LINEAR_PROGRAM_SCALAR_UPDATES} "
+    "scalar updates across preprocessing, components, and both basis families. "
+    "Exhausting that execution allowance is an operational error, not a mathematical "
+    "conclusion. Source-derived rational-minor height must remain within the canonical "
+    "rational digit limit. Inspection reports the derived estimates and limits; shape "
+    "bounds alone do not guarantee completion. Execution has one 600-second cooperative "
+    "safety deadline; expiration yields an execution error."
 )
 
 

--- a/src/jacobian/math/optimization/operations.py
+++ b/src/jacobian/math/optimization/operations.py
@@ -9,6 +9,7 @@ from jacobian.canonical import format_canonical_integer
 from jacobian.math.optimization._arithmetic import rational_dot
 from jacobian.math.optimization._linear_basis import (
     LinearAdmission,
+    _LinearWorkLedger,
     admit_linear_program,
     independent_rows,
     linear_execution,
@@ -117,8 +118,16 @@ def _expand_vector(
     return tuple(expanded)
 
 
+def _work_ledger(
+    admission: LinearAdmission, ledger: _LinearWorkLedger | None
+) -> _LinearWorkLedger:
+    return ledger if ledger is not None else _LinearWorkLedger(admission.initial_work)
+
+
 def _component_programs(
-    program: StandardFormRationalLinearProgram, admission: LinearAdmission
+    program: StandardFormRationalLinearProgram,
+    admission: LinearAdmission,
+    ledger: _LinearWorkLedger,
 ) -> RationalLinearProgramResult:
     width, height = len(program.variables), len(program.rhs)
     point, dual = [Fraction()] * width, [Fraction()] * height
@@ -135,7 +144,12 @@ def _component_programs(
         )
         result = _linear_program_admitted(
             component,
-            LinearAdmission(tuple(range(len(columns))), admission.result_digits),
+            LinearAdmission(
+                columns=tuple(range(len(columns))),
+                result_digits=admission.result_digits,
+                initial_work=0,
+            ),
+            ledger=ledger,
         )
         if result.status == "INFEASIBLE":
             assert result.farkas_candidate is not None
@@ -174,10 +188,13 @@ def _component_programs(
 def _linear_program_admitted(
     program: StandardFormRationalLinearProgram,
     admission: LinearAdmission,
+    *,
+    ledger: _LinearWorkLedger | None = None,
 ) -> RationalLinearProgramResult:
     from flint import fmpq, fmpq_mat
 
     digits = admission.result_digits
+    ledger = _work_ledger(admission, ledger)
     width, height = len(program.variables), len(program.rhs)
     zero = Fraction()
     for i, (row, rhs) in enumerate(zip(program.coefficients, program.rhs, strict=True)):
@@ -186,7 +203,7 @@ def _linear_program_admitted(
             witness[i] = Fraction(1 if rhs.num < 0 else -1)
             return _certify_infeasible(program, tuple(witness), digits)
     if len(admission.components) > 1:
-        return _component_programs(program, admission)
+        return _component_programs(program, admission, ledger)
     columns = admission.columns
     active_rows = tuple(
         i for i, row in enumerate(program.coefficients) if any(v.num != 0 for v in row)
@@ -219,7 +236,7 @@ def _linear_program_admitted(
     reduced_a = fmpq_mat([[a[i, j] for j in range(len(columns))] for i in row_indices])
     reduced_b = fmpq_mat([[b[i, 0]] for i in row_indices])
     c = fmpq_mat([[scalar(program.objective[j]) for j in columns]])
-    solved = search_bases(reduced_a, reduced_b, c)
+    solved = search_bases(reduced_a, reduced_b, c, ledger=ledger)
     if solved is None:
         augmented = fmpq_mat(
             [
@@ -228,7 +245,11 @@ def _linear_program_admitted(
             ]
         )
         phase_one = search_bases(
-            augmented, reduced_b, fmpq_mat([[0] * len(columns) + [1]]), artificial=True
+            augmented,
+            reduced_b,
+            fmpq_mat([[0] * len(columns) + [1]]),
+            ledger=ledger,
+            artificial=True,
         )
         if phase_one is None:
             _execution_failure()

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -210,6 +210,15 @@ def _operation_error_boundary(operation_id: str) -> Iterator[None]:
                 hint = "Adjust rlimit within its admitted range; timeout_ms does not increase the work allowance."
             elif operation_id in {"sat.solve", "smt.solve"}:
                 hint = "timeout_ms does not increase the fixed work allowance."
+            elif operation_id in {
+                "optimization.linear.rational_optimum.compute",
+                "optimization.linear.rational_general_optimum.compute",
+            }:
+                hint = (
+                    "The exact basis search reached its fixed scalar-update allowance. "
+                    "If exact primal-dual candidates are available, submit them to "
+                    "optimization.linear.rational_optimality.check."
+                )
         raise _execution_tool_error(
             code="RESOURCE_EXHAUSTED",
             operation_id=operation_id,

--- a/tests/cli/test_execution_errors.py
+++ b/tests/cli/test_execution_errors.py
@@ -1,8 +1,10 @@
 """Native execution failures retain the CLI's nonzero, no-result path."""
 
+import json
 from typing import Never
 
 import pytest
+from tests.support.rationals import rational_payload as q
 from typer.testing import CliRunner
 
 from jacobian._execution import (
@@ -39,3 +41,27 @@ def test_cli_execution_failure_has_no_mathematical_output(
     assert not result.stdout.strip()
     assert "private marker" not in result.output
     assert str(error) in result.stderr
+
+
+def test_cli_lp_work_exhaustion_has_no_mathematical_output() -> None:
+    n, m = 18, 6
+    payload = {
+        "program": {
+            "variables": [f"x{i}" for i in range(n)],
+            "objective": [q(1)] * n,
+            "coefficients": [[q((j + 1) ** i) for j in range(n)] for i in range(m)],
+            "rhs": [q(-1)] * m,
+        }
+    }
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "optimization.linear.rational_optimum.compute",
+            "--json",
+            json.dumps(payload),
+        ],
+    )
+    assert result.exit_code != 0
+    assert not result.stdout.strip()
+    assert "operation exhausted its work allowance" in result.stderr

--- a/tests/math/optimization/test_linear_admission.py
+++ b/tests/math/optimization/test_linear_admission.py
@@ -8,7 +8,9 @@ from pydantic import ValidationError
 from tests.support.rationals import rational_payload as q
 
 from jacobian._execution import (
+    ExecutionResource,
     OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
     bind_request_deadline,
     current_request_execution,
     request_execution,
@@ -51,11 +53,8 @@ def test_scalar_envelope_agrees_for_native_and_json_components(sign: int) -> Non
         StandardFormRationalLinearProgram.model_validate_json(json.dumps(wire))
 
 
-@pytest.mark.parametrize(
-    ("n", "m", "code"), [(18, 6, "work_bound"), (24, 12, "basis_bound")]
-)
-def test_standard_admission_reports_measured_costs(n: int, m: int, code: str) -> None:
-    program = StandardFormRationalLinearProgram.model_validate_json(
+def _dense_program(n: int, m: int) -> StandardFormRationalLinearProgram:
+    return StandardFormRationalLinearProgram.model_validate_json(
         json.dumps(
             {
                 "variables": [f"x{i}" for i in range(n)],
@@ -67,14 +66,43 @@ def test_standard_admission_reports_measured_costs(n: int, m: int, code: str) ->
             }
         )
     )
+
+
+def test_exhaustive_work_estimate_does_not_prevent_short_certificate() -> None:
+    result = linear_program(_dense_program(18, 6))
+    assert result.status == "OPTIMAL"
+    assert result.primal_objective is not None
+    assert result.primal_objective.as_fraction().as_integer_ratio() == (6, 7)
+
+
+def test_standard_basis_admission_reports_measured_costs() -> None:
+    n, m = 24, 12
+    program = _dense_program(n, m)
     with pytest.raises(OperationResourceAdmissionError) as caught:
         linear_program(program)
-    assert caught.value.errors()[0]["type"] == f"optimization.linear.{code}"
+    assert caught.value.errors()[0]["type"] == "optimization.linear.basis_bound"
     count, work = basis_bounds(n, m)
     work += 16 * (m + 1) * (n + 1)
     assert f"basis_estimate={count}" in str(caught.value)
     assert f"work_estimate={work}" in str(caught.value)
     assert "input_value" not in str(caught.value)
+
+
+def test_search_exhaustion_is_an_execution_error() -> None:
+    n, m = 18, 6
+    program = StandardFormRationalLinearProgram.model_validate_json(
+        json.dumps(
+            {
+                "variables": [f"x{i}" for i in range(n)],
+                "objective": [q(1)] * n,
+                "coefficients": [[q((j + 1) ** i) for j in range(n)] for i in range(m)],
+                "rhs": [q(-1)] * m,
+            }
+        )
+    )
+    with pytest.raises(OperationResourceExhaustedError) as caught:
+        linear_program(program)
+    assert caught.value.resource is ExecutionResource.WORK
 
 
 def test_native_general_deadline_covers_normalization_and_respects_outer_deadline() -> (

--- a/tests/math/optimization/test_linear_certificates.py
+++ b/tests/math/optimization/test_linear_certificates.py
@@ -186,6 +186,48 @@ def test_pair_cover_original_and_trimmed_encodings(unused: bool) -> None:
     assert_cover_certificate(general_linear_program(cover_program(rows)))
 
 
+@pytest.mark.parametrize("reverse_rows", [False, True])
+def test_grid_collision_cover_finds_short_exact_certificate(
+    reverse_rows: bool,
+) -> None:
+    supports = [
+        (0, 1, 3),
+        (0, 1, 6),
+        (0, 2, 3),
+        (0, 2, 6),
+        (1, 2, 4),
+        (1, 2, 7),
+        (3, 4, 6),
+        (3, 5, 6),
+        (4, 5, 7),
+    ]
+    rows = [[int(j in support) for j in range(9)] for support in supports]
+    if reverse_rows:
+        rows.reverse()
+
+    result = general_linear_program(cover_program(rows))
+
+    assert result.status == "OPTIMAL"
+    assert result.primal_candidate is not None
+    assert result.constraint_dual is not None
+    point = tuple(value.as_fraction() for value in result.primal_candidate)
+    dual = tuple(value.as_fraction() for value in result.constraint_dual)
+    assert all(value >= 0 for value in (*point, *dual))
+    assert all(
+        sum(coefficient * value for coefficient, value in zip(row, point, strict=True))
+        >= 1
+        for row in rows
+    )
+    assert all(
+        sum(row[j] * value for row, value in zip(rows, dual, strict=True)) <= 1
+        for j in range(9)
+    )
+    assert sum(point) == sum(dual) == Fraction(8, 3)
+    assert result.primal_objective is not None
+    assert result.primal_objective.as_fraction() == Fraction(8, 3)
+    assert result.dual_objective == result.primal_objective
+
+
 @pytest.mark.parametrize(
     ("rows", "rhs", "objective", "status"),
     [

--- a/tests/mcp/test_linear_program_admission.py
+++ b/tests/mcp/test_linear_program_admission.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 from itertools import combinations
+from typing import Any
 
 import pytest
 from mcp.types import ContentBlock, TextContent
@@ -13,6 +14,7 @@ from jacobian.math.optimization._general_models import (
     GeneralRationalLinearProgramResult,
 )
 from jacobian.math.optimization._tools import TOOLS
+from jacobian.mcp.direct_tools import direct_operation_tools
 from jacobian.mcp.runtime import AppState
 from jacobian.mcp.server import _build_server
 from mcp import Client
@@ -24,6 +26,42 @@ def _content_text(block: ContentBlock) -> str:
 
 
 OPERATION = "optimization.linear.rational_general_optimum.compute"
+
+
+def _cover_payload(rows: list[list[int]]) -> dict[str, object]:
+    return {
+        "program": {
+            "variables": [
+                {"name": f"x{i}", "lower_bound": q(0)} for i in range(len(rows[0]))
+            ],
+            "objective": {
+                "sense": "MINIMIZE",
+                "coefficients": [q(1)] * len(rows[0]),
+            },
+            "constraints": [
+                {
+                    "label": f"row{i}",
+                    "coefficients": [q(value) for value in row],
+                    "relation": "GE",
+                    "rhs": q(1),
+                }
+                for i, row in enumerate(rows)
+            ],
+        }
+    }
+
+
+async def _invoke_lp(payload: dict[str, object], *, direct: bool) -> Any:
+    catalog = Catalog(TOOLS)
+    server = _build_server(
+        state=AppState(operation_catalog=catalog),
+        evaluation_tools=direct_operation_tools(catalog) if direct else (),
+    )
+    async with Client(server, raise_exceptions=False) as client:
+        return await client.call_tool(
+            OPERATION if direct else "math.run",
+            payload if direct else {"operation_id": OPERATION, "payload": payload},
+        )
 
 
 @pytest.mark.parametrize(
@@ -112,3 +150,68 @@ def test_lp_inspection_explains_derived_admission(
             assert "normalized_rows=66" in message
 
     asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("direct", [False, True])
+def test_lp_entry_points_distinguish_short_certificates_from_work_exhaustion(
+    direct: bool,
+) -> None:
+    supports = [
+        (0, 1, 3),
+        (0, 1, 6),
+        (0, 2, 3),
+        (0, 2, 6),
+        (1, 2, 4),
+        (1, 2, 7),
+        (3, 4, 6),
+        (3, 5, 6),
+        (4, 5, 7),
+    ]
+    grid_rows = [[int(j in support) for j in range(9)] for support in supports]
+    success = asyncio.run(_invoke_lp(_cover_payload(grid_rows), direct=direct))
+    assert not success.is_error
+    assert success.structured_content is not None
+    output = (
+        success.structured_content if direct else success.structured_content["output"]
+    )
+    parsed = GeneralRationalLinearProgramResult.model_validate_json(json.dumps(output))
+    assert parsed.status == "OPTIMAL"
+    assert parsed.primal_objective is not None
+    assert parsed.primal_objective.as_fraction().as_integer_ratio() == (8, 3)
+
+    n, m = 18, 6
+    exhaustion_rows = [[(j + 1) ** i for j in range(n)] for i in range(m)]
+    payload = {
+        "program": {
+            "variables": [f"x{i}" for i in range(n)],
+            "objective": [q(1)] * n,
+            "coefficients": [[q(value) for value in row] for row in exhaustion_rows],
+            "rhs": [q(-1)] * m,
+        }
+    }
+    standard_operation = "optimization.linear.rational_optimum.compute"
+
+    async def invoke_exhaustion() -> Any:
+        catalog = Catalog(TOOLS)
+        server = _build_server(
+            state=AppState(operation_catalog=catalog),
+            evaluation_tools=direct_operation_tools(catalog) if direct else (),
+        )
+        async with Client(server, raise_exceptions=False) as client:
+            return await client.call_tool(
+                standard_operation if direct else "math.run",
+                payload
+                if direct
+                else {"operation_id": standard_operation, "payload": payload},
+            )
+
+    failed = asyncio.run(invoke_exhaustion())
+    assert failed.is_error
+    assert failed.structured_content is None
+    diagnostic = json.loads(
+        _content_text(failed.content[0])[_content_text(failed.content[0]).index("{") :]
+    )
+    assert diagnostic["code"] == "RESOURCE_EXHAUSTED"
+    assert diagnostic["resource"] == "work"
+    assert diagnostic["operation_id"] == standard_operation
+    assert "fixed scalar-update allowance" in diagnostic["hint"]


### PR DESCRIPTION
The grid-collision cover LP is normalized to 18 columns and 9 rows. Its exhaustive basis estimate is 324,709,800 scalar updates, so the current admission check rejects it before FLINT can find the exact primal-dual certificate of value 8/3.

This change keeps the 50,000,000-update execution bound while moving basis work from an exhaustive preflight rejection to a shared deterministic ledger. Preprocessing is reserved at admission, every basis is charged before exact backend work, and one ledger spans disconnected components and both basis families. A short exact certificate can now complete; genuine exhaustion raises the existing work-resource execution error and never produces an LP status. The MCP error includes a concrete pointer to the exact optimality checker when the caller already has primal-dual candidates.

Regression coverage checks the motivating LP and its reversed row order against independent primal/dual invariants. A full-rank infeasible Vandermonde control proves native, CLI, `math.run`, and direct-tool exhaustion behavior. Inspection text and backend calibration documentation describe the certificate-prefix contract.

Validation:
- `make affected AFFECTED_BASE=origin/main` (13/13 commands passed)
- Independent exact-diff review: no findings

Closes #3568
