### PR TITLE
fix(search): return early exact witnesses within work limits

### DIFF
--- a/src/jacobian/_execution.py
+++ b/src/jacobian/_execution.py
@@ -166,6 +166,21 @@ class OperationResourceExhaustedError(Exception):
         super().__init__(f"operation exhausted its {resource.value} allowance")
 
 
+@dataclass(slots=True)
+class OperationWorkLedger:
+    """Charge deterministic kernel work before each bounded unit executes."""
+
+    limit: int
+    consumed: int = 0
+
+    def charge(self, units: int = 1) -> None:
+        if units < 0:
+            raise ValueError("work charge must be nonnegative")
+        if units > self.limit - self.consumed:
+            raise OperationResourceExhaustedError(ExecutionResource.WORK)
+        self.consumed += units
+
+
 class OperationBackendError(Exception):
     """A backend failed to establish a usable mathematical result."""
 
@@ -223,6 +238,7 @@ __all__ = [
     "OperationExecutionStage",
     "OperationExecutionTimeoutError",
     "OperationResourceExhaustedError",
+    "OperationWorkLedger",
     "RequestCancellationSignal",
     "RequestExecution",
     "bind_request_deadline",

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/_models.py
@@ -68,21 +68,16 @@ def _validate_coloring_envelope(
     edge_count = len(hypergraph.edges)
     has_forced_failure = any(len(members) <= 1 for _, members in hypergraph.edges)
     has_injective_witness = not has_forced_failure and palette_size >= vertex_count
-    work = (
+    exhaustive_work = (
         0
         if has_forced_failure or has_injective_witness
         else palette_size**vertex_count * edge_count
     )
-    if work > MAX_COLORING_WORK:
-        raise PydanticCustomError(
-            "hypergraph_coloring.work_too_large",
-            f"coloring search requires at most {MAX_COLORING_WORK} edge checks",
-        )
 
     return _ColoringAdmission(
         has_forced_failure=has_forced_failure,
         has_injective_witness=has_injective_witness,
-        work_budget=work,
+        work_budget=min(exhaustive_work, MAX_COLORING_WORK),
     )
 
 

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/_tools.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/_tools.py
@@ -24,7 +24,9 @@ TOOLS: MathTools = (
             "Given a finite hypergraph H and a positive palette size q, decide "
             "whether H has a vertex q-colouring in which no hyperedge is "
             "monochromatic. Returns COLORABLE with one witness colouring, or "
-            "NOT_COLORABLE."
+            "NOT_COLORABLE after complete search. Search checks at most 2,000,000 "
+            "coloring-edge pairs and returns immediately on a checked witness; "
+            "exhaustion is an execution error."
         ),
         request_type=NonmonochromaticColoringRequest,
         result_type=NonmonochromaticColoringResult,

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/operations.py
@@ -9,8 +9,10 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._execution import (
     OperationExecutionTimeoutError,
+    OperationWorkLedger,
     bind_request_deadline,
     current_request_execution,
+    request_checkpoint,
 )
 from jacobian.catalog.models import (
     OperationDomainValidationError,
@@ -82,6 +84,7 @@ def decide_nonmonochromatic_coloring(
     # An empty or singleton edge is monochromatic under every positive palette;
     # return the exact decision without charging or enumerating all colorings.
     if admission.has_forced_failure:
+        request_checkpoint("before hypergraph coloring result construction")
         return NonmonochromaticColoringResult(
             hypergraph=hypergraph,
             palette_size=palette_size,
@@ -90,6 +93,7 @@ def decide_nonmonochromatic_coloring(
 
     if not edges:
         witness = ColoringWitness(assignments=tuple((v, 0) for v in vertices))
+        request_checkpoint("before hypergraph coloring result construction")
         return NonmonochromaticColoringResult(
             hypergraph=hypergraph,
             palette_size=palette_size,
@@ -101,6 +105,7 @@ def decide_nonmonochromatic_coloring(
         witness = ColoringWitness(
             assignments=tuple((vertex, index) for index, vertex in enumerate(vertices))
         )
+        request_checkpoint("before hypergraph coloring result construction")
         return NonmonochromaticColoringResult(
             hypergraph=hypergraph,
             palette_size=palette_size,
@@ -109,14 +114,19 @@ def decide_nonmonochromatic_coloring(
         )
 
     n = len(vertices)
+    ledger = OperationWorkLedger(admission.work_budget)
+    request_checkpoint("before hypergraph coloring search")
     for index, coloring in enumerate(product(range(palette_size), repeat=n)):
-        if index % 1024 == 0 and deadline is not None and time.monotonic() >= deadline:
-            raise OperationExecutionTimeoutError(
-                "hypergraph coloring search exceeded its request deadline"
-            )
-        if _is_valid_coloring(coloring, edges, vertices, deadline):
+        if index % 1024 == 0:
+            request_checkpoint("during hypergraph coloring search")
+            if deadline is not None and time.monotonic() >= deadline:
+                raise OperationExecutionTimeoutError(
+                    "hypergraph coloring search exceeded its request deadline"
+                )
+        if _is_valid_coloring(coloring, edges, vertices, ledger, deadline):
             assignments = tuple((vertices[i], coloring[i]) for i in range(n))
             witness = ColoringWitness(assignments=assignments)
+            request_checkpoint("before hypergraph coloring result construction")
             return NonmonochromaticColoringResult(
                 hypergraph=hypergraph,
                 palette_size=palette_size,
@@ -124,6 +134,7 @@ def decide_nonmonochromatic_coloring(
                 witness=witness,
             )
 
+    request_checkpoint("before hypergraph coloring result construction")
     return NonmonochromaticColoringResult(
         hypergraph=hypergraph,
         palette_size=palette_size,
@@ -135,18 +146,18 @@ def _is_valid_coloring(
     coloring: tuple[int, ...],
     edges: list[tuple[str, tuple[str, ...]]],
     vertices: list[str],
+    ledger: OperationWorkLedger,
     deadline: float | None = None,
 ) -> bool:
     vertex_to_color = {vertices[i]: coloring[i] for i in range(len(coloring))}
     for edge_index, (_, members) in enumerate(edges):
-        if (
-            edge_index % 256 == 0
-            and deadline is not None
-            and time.monotonic() >= deadline
-        ):
-            raise OperationExecutionTimeoutError(
-                "hypergraph coloring edge checks exceeded its request deadline"
-            )
+        ledger.charge()
+        if edge_index % 256 == 0:
+            request_checkpoint("during hypergraph coloring edge checks")
+            if deadline is not None and time.monotonic() >= deadline:
+                raise OperationExecutionTimeoutError(
+                    "hypergraph coloring edge checks exceeded its request deadline"
+                )
         colors = {vertex_to_color[m] for m in members}
         if len(colors) < 2:
             return False

--- a/src/jacobian/math/graphs/morphisms/_models.py
+++ b/src/jacobian/math/graphs/morphisms/_models.py
@@ -166,19 +166,8 @@ class HomomorphismCheckResult(StrictModel):
 # Fixed-length cycle decision
 # ---------------------------------------------------------------------------
 
-# Worst-case DFS work for a k-cycle is bounded by the number of simple
-# directed paths of length k-1, at most n*(d_max)^(k-1) where d_max is the
-# maximum degree.  This product budget couples graph size with the requested
-# length so every accepted request terminates inside a tested bound.
 MAX_CYCLE_SEARCH_PATHS = 10_000_000
-
-
-def _canonical_max_degree(graph: SimpleUndirectedGraph) -> int:
-    degree: dict[str, int] = dict.fromkeys(graph.vertices, 0)
-    for u, v in graph.edges:
-        degree[u] += 1
-        degree[v] += 1
-    return max(degree.values(), default=0)
+MAX_SUBGRAPH_CANDIDATE_CHECKS = 10_000_000
 
 
 class FixedLengthCycleRequest(StrictModel):
@@ -189,9 +178,10 @@ class FixedLengthCycleRequest(StrictModel):
             "description": (
                 "Decide whether the canonical simple graph contains a simple "
                 "cycle of length `length` (3..64) in a graph with at most 64 "
-                "vertices. The request is rejected when "
-                "the worst-case exhaustive search would exceed the work budget, "
-                "or when the retained source graph plus witness labels exceed "
+                "vertices. Search visits at most 10,000,000 path extensions and "
+                "returns immediately on a checked witness. Exhaustion is an "
+                "execution error; a negative result follows only from completed "
+                "search. The retained source graph plus witness labels must fit "
                 "the owner-local representation bound. Accepts the domain-owned "
                 "`SimpleUndirectedGraph` so "
                 "callers can compose the output of `explicit_graph` or "
@@ -309,11 +299,11 @@ class FixedLengthCycleResult(StrictModel):
 class SubgraphPatternFindRequest(StrictModel):
     """Find an injective edge-preserving embedding of ``pattern`` in ``host``.
 
-    The pattern is capped at 64 vertices (``MORPHISM_MAX_VERTICES``), and the
-    request is rejected when the worst-case backtracking work - bounded by the
-    falling factorial of host vertices taken pattern-at-a-time times the
-    edge-choice branching - would exceed the search budget. Both graphs are
-    canonical ``SimpleUndirectedGraph`` values for direct composition.
+    The pattern is capped at 64 vertices (``MORPHISM_MAX_VERTICES``). Search
+    charges at most 10,000,000 host-candidate scans and returns immediately on
+    a checked witness. Exhaustion is an execution error; a negative result
+    follows only from completed search. Both graphs are canonical
+    ``SimpleUndirectedGraph`` values for direct composition.
     """
 
     model_config = ConfigDict(
@@ -322,10 +312,11 @@ class SubgraphPatternFindRequest(StrictModel):
                 "Find an injective edge-preserving embedding of `pattern` in "
                 "`host`. Both are canonical `SimpleUndirectedGraph` values so "
                 "callers can pass `explicit_graph` output directly. `pattern` "
-                "must have at most 64 vertices; requests whose worst-case "
-                "assignment search exceeds the per-pass work budget are "
-                "rejected. Admitted searches return a complete decision; returned "
-                "maps remain bounded by the admitted pattern cardinality."
+                "must have at most 64 vertices. Search visits at most 10,000,000 "
+                "host candidates and returns immediately on a checked witness. "
+                "Exhaustion is an execution error; negative decisions follow only "
+                "from complete search. Returned maps remain bounded by the admitted "
+                "pattern cardinality."
             )
         },
     )

--- a/src/jacobian/math/graphs/morphisms/_tools.py
+++ b/src/jacobian/math/graphs/morphisms/_tools.py
@@ -112,7 +112,10 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "the graph contains a simple cycle of exactly length k, returning an "
         "ordered cycle witness when one exists. The cycle is a subgraph and "
         "may have chords; this is distinct from girth (shortest cycle) and "
-        "from Hamiltonicity (spanning). Accepts the canonical "
+        "from Hamiltonicity (spanning). Search visits at most 10,000,000 path "
+        "extensions and returns immediately on a checked witness. Exhaustion is "
+        "an execution error; DOES_NOT_EXIST follows only from complete search. "
+        "Accepts the canonical "
         "`SimpleUndirectedGraph` so `explicit_graph` output composes directly.",
         request_type=FixedLengthCycleRequest,
         result_type=FixedLengthCycleResult,
@@ -124,7 +127,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 description=(
                     "A 4-cycle with a chord contains a 3-cycle (triangle); "
                     "length k is 3..vertex count. Preconditions: at most 64 "
-                    "vertices and inside the path-search budget."
+                    "vertices; a spent path-search allowance is an execution error."
                 ),
                 input=CYCLE_C4_WITH_CHORD,
             ),
@@ -132,7 +135,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 name="c4_plain_no_triangle",
                 description=(
                     "A plain 4-cycle has no 3-cycle. Preconditions: length 3..64 "
-                    "and at most the vertex count, and the per-pass path budget holds."
+                    "and at most the vertex count; the search must complete to "
+                    "establish absence."
                 ),
                 input=CYCLE_C4_PLAIN,
             ),
@@ -143,9 +147,9 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         title="Find a subgraph-pattern embedding",
         description="Given bounded canonical simple graphs pattern H and host G, find an "
         "injective non-induced embedding. Returns one vertex map in pattern order "
-        "when found. Assignment search is admission-bounded and every admitted "
-        "request returns a complete decision. Returned maps are bounded by the "
-        "admitted pattern cardinality.",
+        "when found. Search visits at most 10,000,000 host candidates. Exhaustion "
+        "is an execution error; DOES_NOT_EXIST follows only from complete search. "
+        "Returned maps are bounded by the admitted pattern cardinality.",
         request_type=SubgraphPatternFindRequest,
         result_type=SubgraphPatternFindResult,
         run=_compute_subgraph_pattern_find,
@@ -156,7 +160,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 description=(
                     "A triangle pattern embeds in a 4-cycle-with-chord host. "
                     "Preconditions: pattern at most 64 vertices, no larger than "
-                    "host and inside the assignment budget."
+                    "the host; a spent candidate allowance is an execution error."
                 ),
                 input=SUBGRAPH_TRIANGLE_IN_C4_CHORD,
             ),
@@ -165,7 +169,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 description=(
                     "A path P3 does not embed in two disjoint host edges. "
                     "Preconditions: at most 64 pattern vertices, no larger than "
-                    "the host, and the per-pass budget holds."
+                    "the host; the search must complete to establish absence."
                 ),
                 input=SUBGRAPH_P3_NOT_IN_MATCHING,
             ),

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_tools.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_tools.py
@@ -14,7 +14,7 @@ TOOLS: MathTools = (
     MathTool(
         operation_id="graph.edge_colored_subgraph_pattern.find",
         title="Find an edge-color-preserving subgraph embedding",
-        description="Decide ordinary non-induced containment of one edge-colored pattern in an edge-colored host, returning one injective host-label map in the pattern vertex order. Both sources must have nonempty total edge colorings and no vertex colors. Negative decisions follow complete admitted search or a source-count obstruction; execution interruption establishes no decision.",
+        description="Decide ordinary non-induced containment of one edge-colored pattern in an edge-colored host, returning one injective host-label map in the pattern vertex order. Both sources must have nonempty total edge colorings and no vertex colors. Search charges at most 10,000,000 assignments and 50,000,000 work units, returning immediately on a checked witness. Negative decisions follow complete search or a source-count obstruction; exhaustion establishes no decision.",
         request_type=EdgeColoredPatternRequest,
         result_type=EdgeColoredPatternResult,
         run=_run,

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/operations.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/operations.py
@@ -3,11 +3,11 @@
 import time
 from collections import Counter
 from itertools import permutations
-from math import perm
 
 from pydantic_core import PydanticCustomError
 
 from jacobian._execution import (
+    OperationWorkLedger,
     bind_request_deadline,
     current_request_execution,
     request_checkpoint,
@@ -88,23 +88,20 @@ def edge_colored_subgraph_pattern_find(
         host_edges.get(edge) == color
         for edge, color in zip(pattern.graph.edges, pattern.edge_colors, strict=True)
     )
-    assignments = 0 if impossible or identity else perm(n, k)
-    # itertools constructs k-entry injections; each candidate checks at most
-    # every pattern edge. Colors are interned once so search compares integers.
-    work = (
-        retained + len(host.graph.edges) + assignments * (k + len(pattern.graph.edges))
-    )
-    if assignments > MAX_ASSIGNMENTS or work > MAX_WORK:
-        _reject(
-            "search",
-            "complete injective assignment search exceeds its admitted work bound",
-        )
-    request_checkpoint("after complete colored embedding admission")
+    setup_work = retained + len(host.graph.edges)
+    if setup_work > MAX_WORK:
+        _reject("work", "colored embedding setup exceeds its admitted work bound")
+    request_checkpoint("after colored embedding admission")
     found: tuple[str, ...] | None = None
     if identity and not impossible:
         found = pattern.graph.vertices
     elif not impossible:
-        found = _search(pattern, host)
+        found = _search(
+            pattern,
+            host,
+            candidate_ledger=OperationWorkLedger(MAX_ASSIGNMENTS),
+            work_ledger=OperationWorkLedger(MAX_WORK, consumed=setup_work),
+        )
     request_checkpoint("before colored embedding result construction")
     return EdgeColoredPatternResult(
         pattern=pattern,
@@ -115,7 +112,11 @@ def edge_colored_subgraph_pattern_find(
 
 
 def _search(
-    pattern: ColoredUndirectedGraph, host: ColoredUndirectedGraph
+    pattern: ColoredUndirectedGraph,
+    host: ColoredUndirectedGraph,
+    *,
+    candidate_ledger: OperationWorkLedger | None = None,
+    work_ledger: OperationWorkLedger | None = None,
 ) -> tuple[str, ...] | None:
     pattern_index = {label: i for i, label in enumerate(pattern.graph.vertices)}
     host_index = {label: i for i, label in enumerate(host.graph.vertices)}
@@ -135,9 +136,16 @@ def _search(
         ]
         for (u, v), color in zip(host.graph.edges, host.edge_colors, strict=True)
     }
+    if candidate_ledger is None:
+        candidate_ledger = OperationWorkLedger(MAX_ASSIGNMENTS)
+    if work_ledger is None:
+        work_ledger = OperationWorkLedger(MAX_WORK)
+    per_candidate_work = len(pattern.graph.vertices) + len(pattern.graph.edges)
     for assignment in permutations(
         range(len(host.graph.vertices)), len(pattern.graph.vertices)
     ):
+        candidate_ledger.charge()
+        work_ledger.charge(per_candidate_work)
         request_checkpoint("during colored embedding search")
         if all(
             available.get(

--- a/src/jacobian/math/graphs/morphisms/operations.py
+++ b/src/jacobian/math/graphs/morphisms/operations.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from jacobian._execution import OperationWorkLedger, request_checkpoint
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.morphisms._models import (
     MAX_CYCLE_SEARCH_PATHS,
+    MAX_SUBGRAPH_CANDIDATE_CHECKS,
     MORPHISM_MAX_VERTICES,
     FixedLengthCycleResult,
     GraphHomomorphism,
@@ -12,7 +14,6 @@ from jacobian.math.graphs.morphisms._models import (
     GraphVertexMap,
     HomomorphismCheckResult,
     SubgraphPatternFindResult,
-    _canonical_max_degree,
     _cycle_source_edges,
     _first_homomorphism_obstruction,
     _validate_cycle_witness,
@@ -67,16 +68,6 @@ def _admit_cycle_request(graph: SimpleUndirectedGraph, length: int) -> None:
             code="graph.cycle.length_bound",
             message="cycle length must not exceed the vertex count",
         )
-    work = n * (_canonical_max_degree(graph) ** (length - 1))
-    if work > MAX_CYCLE_SEARCH_PATHS:
-        raise OperationDomainValidationError(
-            location=("length",),
-            code="graph.cycle.search_bound",
-            message=(
-                "fixed-length cycle search exceeds the "
-                f"{MAX_CYCLE_SEARCH_PATHS}-path work budget"
-            ),
-        )
     _admit_cycle_retained(graph, length)
 
 
@@ -123,18 +114,6 @@ def _admit_subgraph_request(
             code="graph.subgraph.pattern_size_bound",
             message="pattern must not have more vertices than the host",
         )
-    assignments = 1
-    for step in range(pattern_size):
-        assignments *= len(host.vertices) - step
-        if assignments > MAX_CYCLE_SEARCH_PATHS:
-            raise OperationDomainValidationError(
-                location=("pattern", "host"),
-                code="graph.subgraph.search_bound",
-                message=(
-                    "subgraph-pattern search exceeds the "
-                    f"{MAX_CYCLE_SEARCH_PATHS}-assignment work budget"
-                ),
-            )
     _admit_subgraph_retained(pattern, host)
 
 
@@ -207,6 +186,8 @@ def _find_cycle_of_length(
     vertices: tuple[str, ...],
     edges: tuple[tuple[str, str], ...],
     length: int,
+    *,
+    max_search_paths: int = MAX_CYCLE_SEARCH_PATHS,
 ) -> tuple[int, ...] | None:
     """Return one simple cycle of exactly ``length`` vertices, or ``None``.
 
@@ -216,6 +197,8 @@ def _find_cycle_of_length(
     """
     _, adj = _canonical_label_adjacency(vertices, edges)
     n = len(vertices)
+    ledger = OperationWorkLedger(max_search_paths)
+    request_checkpoint("before fixed-length cycle search")
 
     # To avoid reporting rotations, fix the smallest vertex of the cycle as the
     # start and restrict every other vertex to be strictly larger than the
@@ -229,6 +212,9 @@ def _find_cycle_of_length(
         for nxt in range(start + 1, n):
             if nxt not in adj[last] or nxt in path:
                 continue
+            ledger.charge()
+            if ledger.consumed % 1024 == 0:
+                request_checkpoint("during fixed-length cycle search")
             path.append(nxt)
             if dfs(start, nxt):
                 return True
@@ -255,7 +241,10 @@ def fixed_length_cycle(
     """
     _admit_cycle_request(graph, length)
     k = length
-    found = _find_cycle_of_length(graph.vertices, graph.edges, k)
+    found = _find_cycle_of_length(
+        graph.vertices, graph.edges, k, max_search_paths=MAX_CYCLE_SEARCH_PATHS
+    )
+    request_checkpoint("before fixed-length cycle result construction")
     if found is not None:
         return FixedLengthCycleResult._from_kernel(
             graph=graph,
@@ -283,20 +272,16 @@ def verify_fixed_length_cycle(claim: FixedLengthCycleResult) -> bool:
             return False
         _admit_cycle_request(claim.graph, claim.length)
         return (
-            _find_cycle_of_length(claim.graph.vertices, claim.graph.edges, claim.length)
+            _find_cycle_of_length(
+                claim.graph.vertices,
+                claim.graph.edges,
+                claim.length,
+                max_search_paths=MAX_CYCLE_SEARCH_PATHS,
+            )
             is None
         )
     except (TypeError, ValueError):
         return False
-
-
-class SearchBudgetExceededError(RuntimeError):
-    """The bounded search exhausted its candidate-check budget.
-
-    A search stopped at its budget establishes nothing: it is neither a
-    witness nor a negative decision, so callers must surface the typed
-    non-conclusion instead of projecting it into a decision.
-    """
 
 
 def _candidate_preserves_pattern_edges(
@@ -321,20 +306,15 @@ def _backtrack_subgraph_embedding(
     host_adj: list[set[int]],
     vertex_map_idx: list[int],
     used_host_idx: set[int],
-    budget: int | None,
-    candidate_checks: list[int],
+    ledger: OperationWorkLedger,
 ) -> bool:
     if position == len(pattern_order):
         return True
     pattern_idx = pattern_order[position]
     for host_idx in candidate_domains[pattern_idx]:
-        if budget is not None:
-            candidate_checks[0] += 1
-            if candidate_checks[0] > budget:
-                raise SearchBudgetExceededError(
-                    f"subgraph-pattern search exceeded its "
-                    f"{budget}-candidate-check per-pass budget"
-                )
+        ledger.charge()
+        if ledger.consumed % 1024 == 0:
+            request_checkpoint("during subgraph-pattern search")
         if host_idx in used_host_idx:
             continue
         if not _candidate_preserves_pattern_edges(
@@ -351,8 +331,7 @@ def _backtrack_subgraph_embedding(
             host_adj,
             vertex_map_idx,
             used_host_idx,
-            budget,
-            candidate_checks,
+            ledger,
         ):
             return True
         used_host_idx.discard(host_idx)
@@ -365,16 +344,14 @@ def _find_subgraph_embedding(
     pattern_edges: tuple[tuple[str, str], ...],
     host_vertices: tuple[str, ...],
     host_edges: tuple[tuple[str, str], ...],
-    max_candidate_checks: int | None = None,
+    max_candidate_checks: int = MAX_SUBGRAPH_CANDIDATE_CHECKS,
 ) -> tuple[int, ...] | None:
     """Return host indices ordered by pattern vertex order, or ``None``.
 
-    Ordinary (non-induced) subgraph containment via exhaustive bounded
-    backtracking.  Callers must enforce the request's assignment-count
-    admission before invoking this kernel.  Every host-candidate scan at an
-    eligible host-candidate scan at an internal backtracking node is charged
-    against ``max_candidate_checks`` when given; exceeding it raises
-    ``SearchBudgetExceededError`` so a partially searched space can never
+    Ordinary (non-induced) subgraph containment via bounded backtracking.
+    Every host-candidate scan at an internal backtracking node is charged
+    against ``max_candidate_checks`` before it executes. Exhausting that
+    allowance raises an execution error, so a partial search can never
     masquerade as a negative decision.
     """
     # Normalize host labels to indices once, as the cycle kernel does: the
@@ -397,10 +374,8 @@ def _find_subgraph_embedding(
     pattern_edge_idx = tuple(
         (pattern_index[u], pattern_index[v]) for u, v in pattern_edges
     )
-    candidate_checks = [0]
-    # Every admitted request declares this bound; explicit verification uses
-    # the same charged accounting as execution.
-    budget = max_candidate_checks if max_candidate_checks is not None else None
+    ledger = OperationWorkLedger(max_candidate_checks)
+    request_checkpoint("before subgraph-pattern search")
 
     vertex_map_idx: list[int] = [-1] * p_n  # pattern idx -> host idx
     used_host_idx: set[int] = set()
@@ -426,8 +401,7 @@ def _find_subgraph_embedding(
         host_adj,
         vertex_map_idx,
         used_host_idx,
-        budget,
-        candidate_checks,
+        ledger,
     ):
         return tuple(vertex_map_idx[i] for i in range(p_n))
     return None
@@ -449,8 +423,9 @@ def subgraph_pattern_find(
         pattern.edges,
         host.vertices,
         host.edges,
-        max_candidate_checks=None,
+        max_candidate_checks=MAX_SUBGRAPH_CANDIDATE_CHECKS,
     )
+    request_checkpoint("before subgraph-pattern result construction")
     if found is not None:
         return SubgraphPatternFindResult._from_kernel(
             pattern=pattern,
@@ -482,7 +457,7 @@ def verify_subgraph_pattern_find(claim: SubgraphPatternFindResult) -> bool:
                 claim.pattern.edges,
                 claim.host.vertices,
                 claim.host.edges,
-                max_candidate_checks=None,
+                max_candidate_checks=MAX_SUBGRAPH_CANDIDATE_CHECKS,
             )
             is None
         )

--- a/src/jacobian/math/graphs/regular_subgraph/_tools.py
+++ b/src/jacobian/math/graphs/regular_subgraph/_tools.py
@@ -21,8 +21,9 @@ TOOLS: MathTools = (
         description=(
             "Find a nonempty k-regular subgraph of a simple undirected "
             "graph: a vertex set and edge set where every used vertex has "
-            "degree exactly k. Returns a witness or found=false. "
-            "Exhaustive edge-subset enumeration."
+            "degree exactly k. Returns the first checked witness found within "
+            "524,288 selected-edge checks. Returns found=false only after complete "
+            "search; exhausting the work allowance is an execution error."
         ),
         request_type=RegularSubgraphRequest,
         result_type=RegularSubgraphResult,

--- a/src/jacobian/math/graphs/regular_subgraph/operations.py
+++ b/src/jacobian/math/graphs/regular_subgraph/operations.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 from itertools import combinations
 
-from jacobian.catalog.models import (
-    OperationDomainValidationError,
-    OperationResourceAdmissionError,
-)
+from jacobian._execution import OperationWorkLedger, request_checkpoint
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.regular_subgraph._models import (
     RegularSubgraphResult,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
-MAX_REGULAR_SUBGRAPH_EDGES = 16
+# The previous 16-edge envelope could visit every edge in every subset:
+# 16 * 2**15 selected-edge visits. Runtime accounting keeps that ceiling while
+# allowing an early witness in a larger source graph.
+MAX_REGULAR_SUBGRAPH_WORK = 16 * (1 << 15)
 
 
 def find_k_regular_subgraph(
@@ -46,6 +47,7 @@ def find_k_regular_subgraph(
 
     # Trivial witnesses do not require enumerating edge subsets.
     if k == 0 and n_vertices > 0:
+        request_checkpoint("before k-regular subgraph result construction")
         return RegularSubgraphResult(
             graph=graph,
             k=k,
@@ -57,22 +59,13 @@ def find_k_regular_subgraph(
         left_label, right_label = edges[0]
         if left_label > right_label:
             left_label, right_label = right_label, left_label
+        request_checkpoint("before k-regular subgraph result construction")
         return RegularSubgraphResult(
             graph=graph,
             k=k,
             found=True,
             vertices=tuple(sorted((left_label, right_label))),
             edges=((left_label, right_label),),
-        )
-
-    if n_edges > MAX_REGULAR_SUBGRAPH_EDGES:
-        raise OperationResourceAdmissionError(
-            location=("graph",),
-            code="graphs.regular_subgraph.edge_subset_work",
-            message=(
-                "k-regular subgraph search exceeds the admitted complete-search "
-                f"bound of {MAX_REGULAR_SUBGRAPH_EDGES} edges"
-            ),
         )
 
     vertex_to_idx = {v: i for i, v in enumerate(vertices)}
@@ -85,9 +78,14 @@ def find_k_regular_subgraph(
     # Try edge subsets in increasing size. A nonempty subgraph with at least one
     # vertex of positive degree requires at least k+1 vertices and ceil(k*|V|/2) edges.
     min_edges_needed = (k + 1) * k // 2 if k > 0 else 0
+    ledger = OperationWorkLedger(MAX_REGULAR_SUBGRAPH_WORK)
+    request_checkpoint("before k-regular subgraph search")
 
     for edge_count in range(max(1, min_edges_needed), n_edges + 1):
         for edge_combo in combinations(range(n_edges), edge_count):
+            ledger.charge(edge_count)
+            if ledger.consumed % 1024 == 0:
+                request_checkpoint("during k-regular subgraph search")
             selected_edges = [edge_pairs[i] for i in edge_combo]
             used_vertices: set[int] = set()
             for left_idx, right_idx in selected_edges:
@@ -114,6 +112,7 @@ def find_k_regular_subgraph(
                         if left_label <= right_label
                         else (right_label, left_label)
                     )
+                request_checkpoint("before k-regular subgraph result construction")
                 return RegularSubgraphResult(
                     graph=graph,
                     k=k,
@@ -122,6 +121,7 @@ def find_k_regular_subgraph(
                     edges=tuple(sorted(used_edge_list)),
                 )
 
+    request_checkpoint("before k-regular subgraph result construction")
     return RegularSubgraphResult(graph=graph, k=k, found=False)
 
 
@@ -130,7 +130,7 @@ def verify_k_regular_subgraph(claim: RegularSubgraphResult) -> bool:
     if not claim.found:
         try:
             return not find_k_regular_subgraph(claim.graph, claim.k).found
-        except (OperationDomainValidationError, OperationResourceAdmissionError):
+        except OperationDomainValidationError:
             return False
     vertices = set(claim.vertices)
     if not vertices or len(vertices) != len(claim.vertices):

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -219,6 +219,18 @@ def _operation_error_boundary(operation_id: str) -> Iterator[None]:
                     "If exact primal-dual candidates are available, submit them to "
                     "optimization.linear.rational_optimality.check."
                 )
+            elif operation_id in {
+                "graph.k_regular_subgraph.find",
+                "graph.cycle.fixed_length.decide",
+                "graph.subgraph_pattern.find",
+                "graph.edge_colored_subgraph_pattern.find",
+                "hypergraph.nonmonochromatic_vertex_coloring.q_decide",
+            }:
+                hint = (
+                    "The bounded search prefix found no witness; this does not "
+                    "establish a negative result. Reduce the search space enough "
+                    "for the operation to complete within its fixed work allowance."
+                )
         raise _execution_tool_error(
             code="RESOURCE_EXHAUSTED",
             operation_id=operation_id,

--- a/tests/math/combinatorics/finite_structures/hypergraph_coloring/test_nonmonochromatic_coloring.py
+++ b/tests/math/combinatorics/finite_structures/hypergraph_coloring/test_nonmonochromatic_coloring.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 import pytest
 
 from jacobian._execution import OperationResourceExhaustedError
@@ -13,7 +15,9 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 )
 
 
-def _hg(vertices, edges):
+def _hg(
+    vertices: Iterable[str], edges: Iterable[tuple[str, Iterable[str]]]
+) -> FiniteHypergraph:
     return FiniteHypergraph(
         vertices=tuple(vertices),
         edges=tuple((eid, tuple(m)) for eid, m in edges),
@@ -98,6 +102,7 @@ def test_witness_replay() -> None:
     )
     result = decide_nonmonochromatic_coloring(h, 2)
     assert result.outcome == "COLORABLE"
+    assert result.witness is not None
     color_map = dict(result.witness.assignments)
     for _, members in h.edges:
         colors = {color_map[m] for m in members}

--- a/tests/math/combinatorics/finite_structures/hypergraph_coloring/test_nonmonochromatic_coloring.py
+++ b/tests/math/combinatorics/finite_structures/hypergraph_coloring/test_nonmonochromatic_coloring.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian._execution import OperationResourceExhaustedError
 from jacobian.math.combinatorics.finite_structures.hypergraph_coloring.operations import (
     decide_nonmonochromatic_coloring,
     verify_coloring_witness,
@@ -177,10 +177,16 @@ def test_singleton_edge_not_colorable() -> None:
     assert result.outcome == "NOT_COLORABLE"
 
 
-def test_native_admission_matches_request_bounds() -> None:
-    h = _hg([str(i) for i in range(256)], [("e0", ("0", "1"))])
-    with pytest.raises(OperationDomainValidationError, match="edge checks"):
-        decide_nonmonochromatic_coloring(h, 16)
+def test_native_search_exhaustion_is_not_a_negative_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    h = _hg(["a", "b", "c"], [("edge", ("a", "b"))])
+    monkeypatch.setattr(
+        "jacobian.math.combinatorics.finite_structures.hypergraph_coloring._models.MAX_COLORING_WORK",
+        1,
+    )
+    with pytest.raises(OperationResourceExhaustedError, match="work allowance"):
+        decide_nonmonochromatic_coloring(h, 2)
 
 
 def test_large_carrier_with_cheap_search_is_admitted() -> None:
@@ -189,8 +195,19 @@ def test_large_carrier_with_cheap_search_is_admitted() -> None:
     assert result.outcome == "NOT_COLORABLE"
 
 
-def test_rejects_search_work_before_enumeration() -> None:
+def test_injective_presolve_precedes_search_work() -> None:
     h = _hg([str(i) for i in range(16)], [("e0", ("0", "1"))])
     result = decide_nonmonochromatic_coloring(h, 16)
     assert result.outcome == "COLORABLE"
     assert result.witness is not None
+
+
+def test_early_coloring_witness_precedes_oversized_complete_search() -> None:
+    vertices = [f"v{index:02d}" for index in range(22)]
+    result = decide_nonmonochromatic_coloring(
+        _hg(vertices, [("edge", tuple(vertices))]), 2
+    )
+    assert result.outcome == "COLORABLE"
+    assert result.witness is not None
+    colors = dict(result.witness.assignments)
+    assert len({colors[vertex] for vertex in vertices}) == 2

--- a/tests/math/combinatorics/finite_structures/hypergraph_coloring/test_verification_execution.py
+++ b/tests/math/combinatorics/finite_structures/hypergraph_coloring/test_verification_execution.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian._execution import OperationResourceExhaustedError
 from jacobian.math.combinatorics.finite_structures.hypergraph_coloring import (
     _models,
     operations,
@@ -33,7 +33,7 @@ def test_noncolorability_resource_refusal_is_not_a_false_claim(
     claim = operations.decide_nonmonochromatic_coloring(_cycle(3), 2)
     assert operations.verify_non_colorable(claim)
     monkeypatch.setattr(_models, "MAX_COLORING_WORK", 0)
-    with pytest.raises(OperationResourceAdmissionError):
+    with pytest.raises(OperationResourceExhaustedError):
         operations.verify_non_colorable(claim)
 
 

--- a/tests/math/graphs/morphisms/edge_colored_pattern/test_embedding.py
+++ b/tests/math/graphs/morphisms/edge_colored_pattern/test_embedding.py
@@ -8,13 +8,11 @@ from pydantic import ValidationError
 
 from jacobian._execution import (
     OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
     bind_request_deadline,
     request_execution,
 )
-from jacobian.catalog.models import (
-    OperationDomainValidationError,
-    OperationResourceAdmissionError,
-)
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.morphisms.edge_colored_pattern import (
     edge_colored_subgraph_pattern_find,
 )
@@ -124,7 +122,7 @@ def test_color_domain_and_shared_deadline() -> None:
             edge_colored_subgraph_pattern_find(valid, valid)
 
 
-def test_large_identity_presolve_and_unadmitted_search() -> None:
+def test_large_identity_and_early_isomorphic_witnesses() -> None:
     vertices = tuple(f"v{i:02}" for i in range(64))
     edges = tuple((vertices[i], vertices[i + 1]) for i in range(63))
     pattern = colored(vertices, edges, ("red",) * 63)
@@ -138,5 +136,38 @@ def test_large_identity_presolve_and_unadmitted_search() -> None:
         tuple((host_vertices[i], host_vertices[i + 1]) for i in range(63)),
         ("red",) * 63,
     )
-    with pytest.raises(OperationResourceAdmissionError):
+    renamed = edge_colored_subgraph_pattern_find(pattern, host)
+    assert renamed.decision == "EXISTS"
+    assert renamed.vertex_map == host_vertices
+
+
+def test_search_exhaustion_is_not_a_negative_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pattern = colored(("p0", "p1"), (("p0", "p1"),), ("red",))
+    host = colored(("h0", "h1", "h2"), (("h1", "h2"),), ("red",))
+    monkeypatch.setattr(
+        "jacobian.math.graphs.morphisms.edge_colored_pattern.operations.MAX_ASSIGNMENTS",
+        1,
+    )
+    with pytest.raises(OperationResourceExhaustedError):
+        edge_colored_subgraph_pattern_find(pattern, host)
+
+
+def test_search_work_units_exhaust_independently_of_candidate_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.graphs.morphisms.edge_colored_pattern import operations
+
+    pattern = colored(("p0", "p1"), (("p0", "p1"),), ("red",))
+    host = colored(("h0", "h1", "h2"), (("h1", "h2"),), ("red",))
+    retained = (
+        operations._graph_label_characters(pattern.graph)
+        + operations._graph_label_characters(host.graph)
+        + sum(map(len, pattern.edge_colors))
+        + sum(map(len, host.edge_colors))
+        + len(pattern.graph.vertices) * max(map(len, host.graph.vertices))
+    )
+    monkeypatch.setattr(operations, "MAX_WORK", retained + len(host.graph.edges) + 2)
+    with pytest.raises(OperationResourceExhaustedError):
         edge_colored_subgraph_pattern_find(pattern, host)

--- a/tests/math/graphs/morphisms/edge_colored_pattern/test_embedding.py
+++ b/tests/math/graphs/morphisms/edge_colored_pattern/test_embedding.py
@@ -161,9 +161,15 @@ def test_search_work_units_exhaust_independently_of_candidate_count(
 
     pattern = colored(("p0", "p1"), (("p0", "p1"),), ("red",))
     host = colored(("h0", "h1", "h2"), (("h1", "h2"),), ("red",))
+
+    def label_characters(graph: SimpleUndirectedGraph) -> int:
+        return sum(map(len, graph.vertices)) + sum(
+            len(left) + len(right) for left, right in graph.edges
+        )
+
     retained = (
-        operations._graph_label_characters(pattern.graph)
-        + operations._graph_label_characters(host.graph)
+        label_characters(pattern.graph)
+        + label_characters(host.graph)
         + sum(map(len, pattern.edge_colors))
         + sum(map(len, host.edge_colors))
         + len(pattern.graph.vertices) * max(map(len, host.graph.vertices))

--- a/tests/math/graphs/morphisms/test_graph_morphisms.py
+++ b/tests/math/graphs/morphisms/test_graph_morphisms.py
@@ -3,6 +3,13 @@
 import pytest
 from pydantic import ValidationError
 
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
+    OperationWorkLedger,
+    bind_request_deadline,
+    request_execution,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.morphisms._models import (
     GraphHomomorphism,
@@ -335,6 +342,44 @@ class TestFixedLengthCycle:
         assert result.decision == "EXISTS"
         assert len(result.cycle) == 4
 
+    def test_early_cycle_witness_precedes_oversized_path_estimate(self) -> None:
+        from itertools import combinations
+
+        labels = [f"v{i:02d}" for i in range(64)]
+        graph = self._g(labels, [list(edge) for edge in combinations(labels, 2)])
+        result = fixed_length_cycle(graph, 4)
+        assert result.decision == "EXISTS"
+        assert result.cycle == tuple(labels[:4])
+        assert verify_fixed_length_cycle(result)
+
+    def test_cycle_search_exhaustion_is_not_a_negative_decision(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        graph = self._g(["a", "b", "c"], [["a", "b"], ["a", "c"], ["b", "c"]])
+        monkeypatch.setattr(
+            "jacobian.math.graphs.morphisms.operations.MAX_CYCLE_SEARCH_PATHS", 1
+        )
+        with pytest.raises(OperationResourceExhaustedError):
+            fixed_length_cycle(graph, 3)
+
+    def test_cycle_checks_parent_deadline_after_final_candidate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        clock = {"now": 0.0}
+        original_charge = OperationWorkLedger.charge
+
+        def charge_and_expire(ledger: OperationWorkLedger, units: int = 1) -> None:
+            original_charge(ledger, units)
+            clock["now"] = 2.0
+
+        monkeypatch.setattr(OperationWorkLedger, "charge", charge_and_expire)
+        monkeypatch.setattr("jacobian._execution.time.monotonic", lambda: clock["now"])
+        graph = self._g(["a", "b", "c"], [["a", "b"], ["a", "c"], ["b", "c"]])
+        with request_execution(0.0):
+            bind_request_deadline(1.0)
+            with pytest.raises(OperationExecutionTimeoutError):
+                fixed_length_cycle(graph, 3)
+
     def test_distinct_from_girth(self) -> None:
         # A graph with a 3-cycle and a 4-cycle: asking for length 4 still finds
         # the 4-cycle even though the girth is 3.
@@ -538,6 +583,54 @@ class TestSubgraphPatternFind:
             SubgraphPatternFindRequest(pattern=pat, host=host),
         )
         assert result.decision == "EXISTS"
+
+    def test_early_embedding_precedes_oversized_assignment_family(self) -> None:
+        from itertools import combinations
+
+        pattern_labels = [f"p{i:02d}" for i in range(6)]
+        host_labels = [f"h{i:02d}" for i in range(64)]
+        pattern = self._g(
+            pattern_labels,
+            [list(edge) for edge in combinations(pattern_labels, 2)],
+        )
+        host = self._g(
+            host_labels, [list(edge) for edge in combinations(host_labels, 2)]
+        )
+        result = subgraph_pattern_find(pattern, host)
+        assert result.decision == "EXISTS"
+        assert result.vertex_map == tuple(host_labels[:6])
+        assert verify_subgraph_pattern_find(result)
+
+    def test_embedding_search_exhaustion_is_not_a_negative_decision(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pattern = self._g(["p", "q"], [["p", "q"]])
+        host = self._g(["a", "b"], [["a", "b"]])
+        monkeypatch.setattr(
+            "jacobian.math.graphs.morphisms.operations.MAX_SUBGRAPH_CANDIDATE_CHECKS",
+            1,
+        )
+        with pytest.raises(OperationResourceExhaustedError):
+            subgraph_pattern_find(pattern, host)
+
+    def test_embedding_checks_parent_deadline_after_final_candidate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        clock = {"now": 0.0}
+        original_charge = OperationWorkLedger.charge
+
+        def charge_and_expire(ledger: OperationWorkLedger, units: int = 1) -> None:
+            original_charge(ledger, units)
+            clock["now"] = 2.0
+
+        monkeypatch.setattr(OperationWorkLedger, "charge", charge_and_expire)
+        monkeypatch.setattr("jacobian._execution.time.monotonic", lambda: clock["now"])
+        pattern = self._g(["p", "q"], [["p", "q"]])
+        host = self._g(["a", "b"], [["a", "b"]])
+        with request_execution(0.0):
+            bind_request_deadline(1.0)
+            with pytest.raises(OperationExecutionTimeoutError):
+                subgraph_pattern_find(pattern, host)
 
     def test_rejects_pattern_larger_than_host(self) -> None:
         from jacobian.math.graphs.morphisms._models import (

--- a/tests/math/graphs/test_regular_subgraph.py
+++ b/tests/math/graphs/test_regular_subgraph.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian._execution import (
+    OperationExecutionTimeoutError,
+    OperationResourceExhaustedError,
+    OperationWorkLedger,
+    bind_request_deadline,
+    request_execution,
+)
 from jacobian.math.graphs.regular_subgraph._models import RegularSubgraphResult
 from jacobian.math.graphs.regular_subgraph.operations import (
     find_k_regular_subgraph,
@@ -106,11 +112,11 @@ def test_serialized_witness_claim_is_verified_against_its_graph() -> None:
     assert not verify_k_regular_subgraph(RegularSubgraphResult.model_validate(forged))
 
 
-def test_widened_path_is_refused_before_edge_subset_enumeration() -> None:
+def test_widened_path_exhaustion_is_not_a_negative_decision() -> None:
     vertices = tuple(f"v{index:03d}" for index in range(257))
     edges = [(vertices[index], vertices[index + 1]) for index in range(256)]
     graph = _graph(list(vertices), edges)
-    with pytest.raises(OperationResourceAdmissionError, match="16 edges"):
+    with pytest.raises(OperationResourceExhaustedError, match="work allowance"):
         find_k_regular_subgraph(graph, 2)
 
 
@@ -125,3 +131,40 @@ def test_k0_and_k1_on_a_long_path_do_not_require_edge_subset_search() -> None:
     matching = find_k_regular_subgraph(graph, 1)
     assert matching.found
     assert matching.edges == ((vertices[0], vertices[1]),)
+
+
+def test_triangle_witness_precedes_oversized_complete_search() -> None:
+    vertices = [f"v{index:02d}" for index in range(18)]
+    edges = [("v00", "v01"), ("v00", "v02"), ("v01", "v02")]
+    edges.extend((vertices[index], vertices[index + 1]) for index in range(3, 17))
+    result = find_k_regular_subgraph(_graph(vertices, edges), 2)
+    assert result.found
+    assert result.vertices == ("v00", "v01", "v02")
+    assert result.edges == (("v00", "v01"), ("v00", "v02"), ("v01", "v02"))
+
+
+def test_dense_large_subsets_charge_their_selected_edge_work() -> None:
+    left = [f"l{index:02d}" for index in range(16)]
+    right = [f"r{index:02d}" for index in range(16)]
+    graph = _graph(left + right, [(u, v) for u in left for v in right])
+    with pytest.raises(OperationResourceExhaustedError, match="work allowance"):
+        find_k_regular_subgraph(graph, 16)
+
+
+def test_search_checks_parent_deadline_after_final_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = {"now": 0.0}
+    original_charge = OperationWorkLedger.charge
+
+    def charge_and_expire(ledger: OperationWorkLedger, units: int = 1) -> None:
+        original_charge(ledger, units)
+        clock["now"] = 2.0
+
+    monkeypatch.setattr(OperationWorkLedger, "charge", charge_and_expire)
+    monkeypatch.setattr("jacobian._execution.time.monotonic", lambda: clock["now"])
+    graph = _graph(["a", "b", "c"], [("a", "b"), ("a", "c"), ("b", "c")])
+    with request_execution(0.0):
+        bind_request_deadline(1.0)
+        with pytest.raises(OperationExecutionTimeoutError):
+            find_k_regular_subgraph(graph, 2)

--- a/tests/mcp/test_search_certificate_prefix.py
+++ b/tests/mcp/test_search_certificate_prefix.py
@@ -1,0 +1,235 @@
+"""Search prefixes may establish witnesses; exhaustion establishes no decision."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+from itertools import combinations
+from typing import Any
+
+import jsonschema
+import pytest
+from mcp.types import TextContent
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.mcp.direct_tools import direct_operation_tools
+from jacobian.mcp.runtime import AppState
+from jacobian.mcp.server import _build_server
+from mcp import Client
+
+
+def _complete_graph(prefix: str, order: int) -> dict[str, object]:
+    vertices = [f"{prefix}{index:02d}" for index in range(order)]
+    return {
+        "vertices": vertices,
+        "edges": [list(edge) for edge in combinations(vertices, 2)],
+    }
+
+
+def _positive_cases() -> list[tuple[str, dict[str, object], str, object]]:
+    regular_vertices = [f"v{index:02d}" for index in range(18)]
+    regular_edges = [["v00", "v01"], ["v00", "v02"], ["v01", "v02"]]
+    regular_edges.extend(
+        [regular_vertices[index], regular_vertices[index + 1]] for index in range(3, 17)
+    )
+    pattern = _complete_graph("p", 6)
+    pattern_edges = pattern["edges"]
+    assert isinstance(pattern_edges, list)
+    host = _complete_graph("h", 64)
+    host_edges = host["edges"]
+    assert isinstance(host_edges, list)
+    colored_pattern = {
+        "graph": pattern,
+        "edge_colors": ["red"] * len(pattern_edges),
+    }
+    colored_host = {
+        "graph": host,
+        "edge_colors": ["red"] * len(host_edges),
+    }
+    hypergraph_vertices = [f"v{index:02d}" for index in range(22)]
+    return [
+        (
+            "graph.k_regular_subgraph.find",
+            {
+                "graph": {"vertices": regular_vertices, "edges": regular_edges},
+                "k": 2,
+            },
+            "found",
+            True,
+        ),
+        (
+            "graph.cycle.fixed_length.decide",
+            {"graph": host, "length": 4},
+            "decision",
+            "EXISTS",
+        ),
+        (
+            "graph.subgraph_pattern.find",
+            {"pattern": pattern, "host": host},
+            "decision",
+            "EXISTS",
+        ),
+        (
+            "graph.edge_colored_subgraph_pattern.find",
+            {"pattern": colored_pattern, "host": colored_host},
+            "decision",
+            "EXISTS",
+        ),
+        (
+            "hypergraph.nonmonochromatic_vertex_coloring.q_decide",
+            {
+                "hypergraph": {
+                    "vertices": hypergraph_vertices,
+                    "edges": [["edge", hypergraph_vertices]],
+                },
+                "palette_size": 2,
+            },
+            "outcome",
+            "COLORABLE",
+        ),
+    ]
+
+
+async def _invoke(
+    operation_id: str, payload: dict[str, object], *, direct: bool
+) -> Any:
+    operation = Catalog.open().operation(operation_id)
+    assert operation is not None
+    catalog = Catalog((operation,))
+    server = _build_server(
+        state=AppState(operation_catalog=catalog),
+        evaluation_tools=direct_operation_tools(catalog) if direct else (),
+    )
+    async with Client(server, raise_exceptions=False) as client:
+        return await client.call_tool(
+            operation_id if direct else "math.run",
+            payload if direct else {"operation_id": operation_id, "payload": payload},
+        )
+
+
+@pytest.mark.parametrize("direct", [False, True])
+@pytest.mark.parametrize(
+    ("operation_id", "payload", "field", "expected"), _positive_cases()
+)
+def test_early_witnesses_reach_both_mcp_entry_points(
+    direct: bool,
+    operation_id: str,
+    payload: dict[str, object],
+    field: str,
+    expected: object,
+) -> None:
+    result = asyncio.run(_invoke(operation_id, payload, direct=direct))
+    assert not result.is_error
+    assert result.structured_content is not None
+    output = (
+        result.structured_content if direct else result.structured_content["output"]
+    )
+    operation = Catalog.open().operation(operation_id)
+    assert operation is not None
+    jsonschema.validate(
+        output, operation.result_type.model_json_schema(mode="serialization")
+    )
+    assert output[field] == expected
+
+
+_EXHAUSTION_CASES = (
+    (
+        "graph.k_regular_subgraph.find",
+        "jacobian.math.graphs.regular_subgraph.operations",
+        "MAX_REGULAR_SUBGRAPH_WORK",
+        3,
+        {
+            "graph": {
+                "vertices": ["a", "b", "c", "d", "e"],
+                "edges": [["a", "b"], ["b", "c"], ["c", "d"], ["d", "e"]],
+            },
+            "k": 2,
+        },
+    ),
+    (
+        "graph.cycle.fixed_length.decide",
+        "jacobian.math.graphs.morphisms.operations",
+        "MAX_CYCLE_SEARCH_PATHS",
+        1,
+        {
+            "graph": {
+                "vertices": ["a", "b", "c"],
+                "edges": [["a", "b"], ["a", "c"], ["b", "c"]],
+            },
+            "length": 3,
+        },
+    ),
+    (
+        "graph.subgraph_pattern.find",
+        "jacobian.math.graphs.morphisms.operations",
+        "MAX_SUBGRAPH_CANDIDATE_CHECKS",
+        1,
+        {
+            "pattern": {"vertices": ["p", "q"], "edges": [["p", "q"]]},
+            "host": {"vertices": ["a", "b"], "edges": [["a", "b"]]},
+        },
+    ),
+    (
+        "graph.edge_colored_subgraph_pattern.find",
+        "jacobian.math.graphs.morphisms.edge_colored_pattern.operations",
+        "MAX_ASSIGNMENTS",
+        1,
+        {
+            "pattern": {
+                "graph": {"vertices": ["p", "q"], "edges": [["p", "q"]]},
+                "edge_colors": ["red"],
+            },
+            "host": {
+                "graph": {
+                    "vertices": ["a", "b", "c"],
+                    "edges": [["b", "c"]],
+                },
+                "edge_colors": ["red"],
+            },
+        },
+    ),
+    (
+        "hypergraph.nonmonochromatic_vertex_coloring.q_decide",
+        "jacobian.math.combinatorics.finite_structures.hypergraph_coloring._models",
+        "MAX_COLORING_WORK",
+        1,
+        {
+            "hypergraph": {
+                "vertices": ["a", "b", "c"],
+                "edges": [
+                    ["ab", ["a", "b"]],
+                    ["ac", ["a", "c"]],
+                    ["bc", ["b", "c"]],
+                ],
+            },
+            "palette_size": 2,
+        },
+    ),
+)
+
+
+@pytest.mark.parametrize("direct", [False, True])
+@pytest.mark.parametrize(
+    ("operation_id", "module", "limit", "limit_value", "payload"),
+    _EXHAUSTION_CASES,
+)
+def test_exhausted_prefixes_are_mcp_errors_without_mathematical_output(
+    monkeypatch: pytest.MonkeyPatch,
+    direct: bool,
+    operation_id: str,
+    module: str,
+    limit: str,
+    limit_value: int,
+    payload: dict[str, object],
+) -> None:
+    monkeypatch.setattr(importlib.import_module(module), limit, limit_value)
+    result = asyncio.run(_invoke(operation_id, payload, direct=direct))
+    assert result.is_error
+    assert result.structured_content is None
+    assert isinstance(result.content[0], TextContent)
+    diagnostic = json.loads(result.content[0].text[result.content[0].text.index("{") :])
+    assert diagnostic["code"] == "RESOURCE_EXHAUSTED"
+    assert diagnostic["operation_id"] == operation_id
+    assert diagnostic["resource"] == "work"
+    assert "does not establish a negative result" in diagnostic["hint"]


### PR DESCRIPTION
## Problem

Several finite graph and hypergraph decisions rejected requests from the size of the complete search space even when the deterministic search prefix contained an immediate exact witness. That coupled positive certificate discovery to the cost of proving absence and exposed the stop as a validation error. Closes #3570.

## Outcome

The five affected searches now charge deterministic work as they run and return a checked positive witness immediately. They return a negative result only after completing the search space; consuming the fixed allowance first raises `OperationResourceExhaustedError`, which both MCP entry points project as `RESOURCE_EXHAUSTED` with no mathematical structured result and a recovery hint.

Source, retained-output, and exact-growth admission remain in place. Fixed-length cycle and subgraph embedding each retain a 10,000,000-extension/candidate limit, colored embedding retains its 10,000,000-assignment and 50,000,000-work limits, hypergraph coloring retains 2,000,000 coloring-edge checks, and regular-subgraph search preserves the former 524,288 selected-edge-work ceiling. Final checkpoints prevent a witness or negative result from crossing an expired parent deadline.

## Validation

- Commands run: `make affected AFFECTED_BASE=origin/main`
- Final head SHA tested: `d91ff6b3c28a0b0b13bd27bbe4cc4eec3587501e`
- Relevant CI checks or links: local affected planner completed all 13 selected commands in 674.8s, including 10,058 math tests, catalog and 938 catalog examples, CLI, dispatch, integration, tooling, 169 MCP tests, 477 process tests, Singular, and QEPCAD.

## Contract impact

- Public contract impact: requests with early exact witnesses may now succeed even when proving absence would exceed the fixed work allowance. Operational exhaustion is an execution error rather than a validation error or mathematical negative.
- [ ] Schema and runtime accept/reject the same requests
- [ ] Cheap malformed or over-budget input is rejected before expensive work
- [x] Exact results fit the complete canonical output boundary
- [x] All mandatory phases share one request deadline
- [x] Native and MCP behavior agree, where both are public
- [ ] Producer → serialization → consumer composition was tested
- [x] Defining invariant and adversarial regression are covered

## Review closure

- [x] Every substantive review finding has a fix and applicable regression evidence, or an evidence-backed explanation of why no change is needed
- [x] Merge conflicts were resolved against the intended base
- [x] Validation covers the final changed tree; checks invalidated by later edits or autofixes were rerun
- [ ] CI evidence matches the final head SHA
- [x] The appropriate repository validation target and any specialist lane are listed above (normally `make affected`; docs use `make docs-linkcheck`)
- [x] Repository conventions were checked: no compatibility or shadow paths were added; if a shared abstraction was introduced, two existing paths already share its mechanics and contract

## Conditional detail

### Operation boundary

- Changed stage and owner: graph/hypergraph request bounds, exact search kernels, result construction, and MCP error projection.
- Semantic admission and controlling quantities: source and retained-result bounds remain pre-admitted; candidate/path/edge-check work is charged immediately before each bounded unit.
- Execution envelope: fixed limits are 524,288 regular-subgraph selected-edge checks; 10,000,000 cycle path extensions; 10,000,000 uncolored embedding host-candidate scans; 10,000,000 colored assignments plus 50,000,000 colored work units; and 2,000,000 hypergraph coloring-edge checks. Parent deadline and cancellation checks cover search and final result construction.
- Backend or kernel path: existing deterministic in-process enumerators and backtracking kernels, with one shared execution work ledger.
- Result construction: existing canonical result types; negative branches are constructed only after complete search.
- Caller-supplied claim recognition (if applicable): existing source-bound verifiers retain witness checks, and negative verifiers propagate operational exhaustion.
- Native/MCP parity: native calls raise typed execution exhaustion; `math.run` and direct tools return MCP errors without structured mathematical output.
- Serialized-result and round-trip evidence: successful MCP results are validated against each operation's advertised serialization schema.

### Canonical value audit

- [x] Existing canonical value searched; owner or intentional distinction recorded
- [x] Advertised codomain is closed under the result types, including required parent, embedding, branch, orientation, basis, or coordinate data
- [ ] Producer→consumer serialization tested
- [x] Theorem-dependent preconditions and validated input subtype are covered, or marked not applicable with a reason
- Structurally valid but mathematically invalid fixture and outcome: a consumed incomplete prefix raises execution exhaustion and emits no result value.
- Serialized-subtype trust boundary: existing source-bound bounded verifiers check positive witnesses and recompute negative claims within the same operational allowance.
- Exact-success defining invariant: selected edges are k-regular; cycle vertices close through graph edges; embeddings preserve source edges and colors; and every hyperedge contains at least two witness colors.
- Discriminated result schema and impossible combinations: existing result schemas and witness/negative branch constraints are unchanged.
