### PR TITLE
fix(search): scale structural graph and hypergraph cases

### DIFF
--- a/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/_models.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/_models.py
@@ -31,6 +31,7 @@ class _ColoringAdmission:
 
     has_forced_failure: bool
     has_injective_witness: bool
+    active_vertices: tuple[str, ...]
     work_budget: int
 
 
@@ -64,19 +65,27 @@ def _validate_coloring_envelope(
 ) -> _ColoringAdmission:
     """Admit the decision search after checking its bounded source."""
     _validate_coloring_source(hypergraph, palette_size)
-    vertex_count = len(hypergraph.vertices)
     edge_count = len(hypergraph.edges)
     has_forced_failure = any(len(members) <= 1 for _, members in hypergraph.edges)
-    has_injective_witness = not has_forced_failure and palette_size >= vertex_count
+    active_vertex_set = {
+        vertex for _, members in hypergraph.edges for vertex in members
+    }
+    active_vertices = tuple(
+        vertex for vertex in hypergraph.vertices if vertex in active_vertex_set
+    )
+    has_injective_witness = not has_forced_failure and palette_size >= len(
+        active_vertices
+    )
     exhaustive_work = (
         0
         if has_forced_failure or has_injective_witness
-        else palette_size**vertex_count * edge_count
+        else palette_size ** len(active_vertices) * edge_count
     )
 
     return _ColoringAdmission(
         has_forced_failure=has_forced_failure,
         has_injective_witness=has_injective_witness,
+        active_vertices=active_vertices,
         work_budget=min(exhaustive_work, MAX_COLORING_WORK),
     )
 

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/_tools.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/_tools.py
@@ -24,9 +24,10 @@ TOOLS: MathTools = (
             "Given a finite hypergraph H and a positive palette size q, decide "
             "whether H has a vertex q-colouring in which no hyperedge is "
             "monochromatic. Returns COLORABLE with one witness colouring, or "
-            "NOT_COLORABLE after complete search. Search checks at most 2,000,000 "
-            "coloring-edge pairs and returns immediately on a checked witness; "
-            "exhaustion is an execution error."
+            "NOT_COLORABLE after complete search. Search projects away isolated "
+            "vertices, checks at most 2,000,000 active-coloring/edge pairs, and "
+            "returns immediately on a checked witness; exhaustion is an execution "
+            "error."
         ),
         request_type=NonmonochromaticColoringRequest,
         result_type=NonmonochromaticColoringResult,

--- a/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/operations.py
+++ b/src/jacobian/math/combinatorics/finite_structures/hypergraph_coloring/operations.py
@@ -79,6 +79,7 @@ def decide_nonmonochromatic_coloring(
         deadline = time.monotonic() + max(60.0, work_budget / 100_000)
 
     vertices = list(hypergraph.vertices)
+    active_vertices = list(admission.active_vertices)
     edges = list(hypergraph.edges)
 
     # An empty or singleton edge is monochromatic under every positive palette;
@@ -102,8 +103,11 @@ def decide_nonmonochromatic_coloring(
         )
 
     if admission.has_injective_witness:
+        active_colors = {vertex: index for index, vertex in enumerate(active_vertices)}
         witness = ColoringWitness(
-            assignments=tuple((vertex, index) for index, vertex in enumerate(vertices))
+            assignments=tuple(
+                (vertex, active_colors.get(vertex, 0)) for vertex in vertices
+            )
         )
         request_checkpoint("before hypergraph coloring result construction")
         return NonmonochromaticColoringResult(
@@ -113,7 +117,7 @@ def decide_nonmonochromatic_coloring(
             witness=witness,
         )
 
-    n = len(vertices)
+    n = len(active_vertices)
     ledger = OperationWorkLedger(admission.work_budget)
     request_checkpoint("before hypergraph coloring search")
     for index, coloring in enumerate(product(range(palette_size), repeat=n)):
@@ -123,8 +127,11 @@ def decide_nonmonochromatic_coloring(
                 raise OperationExecutionTimeoutError(
                     "hypergraph coloring search exceeded its request deadline"
                 )
-        if _is_valid_coloring(coloring, edges, vertices, ledger, deadline):
-            assignments = tuple((vertices[i], coloring[i]) for i in range(n))
+        if _is_valid_coloring(coloring, edges, active_vertices, ledger, deadline):
+            active_colors = dict(zip(active_vertices, coloring, strict=True))
+            assignments = tuple(
+                (vertex, active_colors.get(vertex, 0)) for vertex in vertices
+            )
             witness = ColoringWitness(assignments=assignments)
             request_checkpoint("before hypergraph coloring result construction")
             return NonmonochromaticColoringResult(

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_tools.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/_tools.py
@@ -14,7 +14,7 @@ TOOLS: MathTools = (
     MathTool(
         operation_id="graph.edge_colored_subgraph_pattern.find",
         title="Find an edge-color-preserving subgraph embedding",
-        description="Decide ordinary non-induced containment of one edge-colored pattern in an edge-colored host, returning one injective host-label map in the pattern vertex order. Both sources must have nonempty total edge colorings and no vertex colors. Search charges at most 10,000,000 assignments and 50,000,000 work units, returning immediately on a checked witness. Negative decisions follow complete search or a source-count obstruction; exhaustion establishes no decision.",
+        description="Decide ordinary non-induced containment of one edge-colored pattern in an edge-colored host, returning one injective host-label map in the pattern vertex order. Both sources must have nonempty total edge colorings and no vertex colors. Degree- and color-filtered backtracking charges at most 10,000,000 host-candidate scans and 50,000,000 setup/constraint work units, returning immediately on a checked witness. Negative decisions follow complete search or a source-count obstruction; exhaustion establishes no decision.",
         request_type=EdgeColoredPatternRequest,
         result_type=EdgeColoredPatternResult,
         run=_run,

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/operations.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/operations.py
@@ -1,8 +1,7 @@
-"""Exhaustive admitted edge-coloured monomorphism search."""
+"""Bounded edge-coloured monomorphism search."""
 
 import time
 from collections import Counter
-from itertools import permutations
 
 from pydantic_core import PydanticCustomError
 
@@ -88,7 +87,12 @@ def edge_colored_subgraph_pattern_find(
         host_edges.get(edge) == color
         for edge, color in zip(pattern.graph.edges, pattern.edge_colors, strict=True)
     )
-    setup_work = retained + len(host.graph.edges)
+    setup_work = (
+        retained
+        + 3 * len(pattern.graph.edges)
+        + 3 * len(host.graph.edges)
+        + n * (k + 2 * len(pattern.graph.edges))
+    )
     if setup_work > MAX_WORK:
         _reject("work", "colored embedding setup exceeds its admitted work bound")
     request_checkpoint("after colored embedding admission")
@@ -126,33 +130,96 @@ def _search(
             dict.fromkeys((*pattern.edge_colors, *host.edge_colors))
         )
     }
-    required = tuple(
-        (pattern_index[u], pattern_index[v], palette[color])
-        for (u, v), color in zip(pattern.graph.edges, pattern.edge_colors, strict=True)
-    )
+    pattern_adjacency: list[dict[int, int]] = [{} for _ in pattern.graph.vertices]
+    pattern_color_degrees: list[Counter[int]] = [
+        Counter() for _ in pattern.graph.vertices
+    ]
+    for (u, v), color in zip(pattern.graph.edges, pattern.edge_colors, strict=True):
+        u_index, v_index, color_index = (
+            pattern_index[u],
+            pattern_index[v],
+            palette[color],
+        )
+        pattern_adjacency[u_index][v_index] = color_index
+        pattern_adjacency[v_index][u_index] = color_index
+        pattern_color_degrees[u_index][color_index] += 1
+        pattern_color_degrees[v_index][color_index] += 1
     available = {
         (min(host_index[u], host_index[v]), max(host_index[u], host_index[v])): palette[
             color
         ]
         for (u, v), color in zip(host.graph.edges, host.edge_colors, strict=True)
     }
+    host_color_degrees: list[Counter[int]] = [Counter() for _ in host.graph.vertices]
+    for (u, v), color in zip(host.graph.edges, host.edge_colors, strict=True):
+        u_index, v_index, color_index = host_index[u], host_index[v], palette[color]
+        host_color_degrees[u_index][color_index] += 1
+        host_color_degrees[v_index][color_index] += 1
+    host_degrees = [sum(color_degrees.values()) for color_degrees in host_color_degrees]
     if candidate_ledger is None:
         candidate_ledger = OperationWorkLedger(MAX_ASSIGNMENTS)
     if work_ledger is None:
         work_ledger = OperationWorkLedger(MAX_WORK)
-    per_candidate_work = len(pattern.graph.vertices) + len(pattern.graph.edges)
-    for assignment in permutations(
-        range(len(host.graph.vertices)), len(pattern.graph.vertices)
-    ):
-        candidate_ledger.charge()
-        work_ledger.charge(per_candidate_work)
-        request_checkpoint("during colored embedding search")
-        if all(
-            available.get(
-                (min(assignment[u], assignment[v]), max(assignment[u], assignment[v]))
+    candidate_domains = [
+        tuple(
+            host_vertex
+            for host_vertex, host_color_degree in enumerate(host_color_degrees)
+            if host_degrees[host_vertex] >= len(pattern_adjacency[pattern_vertex])
+            and all(
+                host_color_degree[color] >= count
+                for color, count in pattern_color_degrees[pattern_vertex].items()
             )
-            == color
-            for u, v, color in required
-        ):
-            return tuple(host.graph.vertices[i] for i in assignment)
-    return None
+        )
+        for pattern_vertex in range(len(pattern.graph.vertices))
+    ]
+    pattern_order = sorted(
+        range(len(pattern.graph.vertices)),
+        key=lambda vertex: (
+            len(candidate_domains[vertex]),
+            -len(pattern_adjacency[vertex]),
+            vertex,
+        ),
+    )
+    assignment = [-1] * len(pattern.graph.vertices)
+    used_host_vertices: set[int] = set()
+
+    def backtrack(position: int) -> bool:
+        if position == len(pattern_order):
+            return True
+        pattern_vertex = pattern_order[position]
+        for host_vertex in candidate_domains[pattern_vertex]:
+            candidate_ledger.charge()
+            work_ledger.charge()
+            request_checkpoint("during colored embedding search")
+            if host_vertex in used_host_vertices:
+                continue
+            compatible = True
+            for neighbor, color in pattern_adjacency[pattern_vertex].items():
+                mapped_neighbor = assignment[neighbor]
+                if mapped_neighbor == -1:
+                    continue
+                work_ledger.charge()
+                if (
+                    available.get(
+                        (
+                            min(host_vertex, mapped_neighbor),
+                            max(host_vertex, mapped_neighbor),
+                        )
+                    )
+                    != color
+                ):
+                    compatible = False
+                    break
+            if not compatible:
+                continue
+            assignment[pattern_vertex] = host_vertex
+            used_host_vertices.add(host_vertex)
+            if backtrack(position + 1):
+                return True
+            used_host_vertices.remove(host_vertex)
+            assignment[pattern_vertex] = -1
+        return False
+
+    if not backtrack(0):
+        return None
+    return tuple(host.graph.vertices[index] for index in assignment)

--- a/src/jacobian/math/graphs/morphisms/edge_colored_pattern/operations.py
+++ b/src/jacobian/math/graphs/morphisms/edge_colored_pattern/operations.py
@@ -87,19 +87,19 @@ def edge_colored_subgraph_pattern_find(
         host_edges.get(edge) == color
         for edge, color in zip(pattern.graph.edges, pattern.edge_colors, strict=True)
     )
-    setup_work = (
-        retained
-        + 3 * len(pattern.graph.edges)
-        + 3 * len(host.graph.edges)
-        + n * (k + 2 * len(pattern.graph.edges))
-    )
-    if setup_work > MAX_WORK:
-        _reject("work", "colored embedding setup exceeds its admitted work bound")
-    request_checkpoint("after colored embedding admission")
     found: tuple[str, ...] | None = None
     if identity and not impossible:
         found = pattern.graph.vertices
     elif not impossible:
+        setup_work = (
+            retained
+            + 3 * len(pattern.graph.edges)
+            + 3 * len(host.graph.edges)
+            + n * (k + 2 * len(pattern.graph.edges))
+        )
+        if setup_work > MAX_WORK:
+            _reject("work", "colored embedding setup exceeds its admitted work bound")
+        request_checkpoint("after colored embedding admission")
         found = _search(
             pattern,
             host,
@@ -180,6 +180,18 @@ def _search(
             vertex,
         ),
     )
+    pattern_position = {
+        pattern_vertex: position
+        for position, pattern_vertex in enumerate(pattern_order)
+    }
+    earlier_neighbors = [
+        tuple(
+            (neighbor, color)
+            for neighbor, color in pattern_adjacency[pattern_vertex].items()
+            if pattern_position[neighbor] < pattern_position[pattern_vertex]
+        )
+        for pattern_vertex in range(len(pattern.graph.vertices))
+    ]
     assignment = [-1] * len(pattern.graph.vertices)
     used_host_vertices: set[int] = set()
 
@@ -194,10 +206,8 @@ def _search(
             if host_vertex in used_host_vertices:
                 continue
             compatible = True
-            for neighbor, color in pattern_adjacency[pattern_vertex].items():
+            for neighbor, color in earlier_neighbors[pattern_vertex]:
                 mapped_neighbor = assignment[neighbor]
-                if mapped_neighbor == -1:
-                    continue
                 work_ledger.charge()
                 if (
                     available.get(

--- a/src/jacobian/math/graphs/morphisms/operations.py
+++ b/src/jacobian/math/graphs/morphisms/operations.py
@@ -33,19 +33,6 @@ __all__ = [
 MAX_MORPHISM_RETAINED_LABEL_CHARACTERS = 10_000_000
 
 
-def _canonical_max_degree(graph: SimpleUndirectedGraph) -> int:
-    """Maximum vertex degree of the canonical source graph.
-
-    Owner-local admission helper: the cycle work estimate must be computed
-    from canonical values without replaying the search kernel.
-    """
-    degree: dict[str, int] = dict.fromkeys(graph.vertices, 0)
-    for u, v in graph.edges:
-        degree[u] += 1
-        degree[v] += 1
-    return max(degree.values(), default=0)
-
-
 def _graph_label_characters(graph: SimpleUndirectedGraph) -> int:
     return sum(len(vertex) for vertex in graph.vertices) + sum(
         len(left) + len(right) for left, right in graph.edges
@@ -80,22 +67,6 @@ def _admit_cycle_request(graph: SimpleUndirectedGraph, length: int) -> None:
             location=("length",),
             code="graph.cycle.length_bound",
             message="cycle length must not exceed the vertex count",
-        )
-    # Conservative full-negative-case admission: worst-case DFS work for a
-    # k-cycle is bounded by the number of simple directed paths of length
-    # k-1, at most n*(d_max)^(k-1). Every accepted request must terminate
-    # inside the tested bound even when no witness exists, so this estimate
-    # is enforced before enumeration begins; the runtime ledger remains only
-    # as defense-in-depth and never as the primary admission.
-    work = n * (_canonical_max_degree(graph) ** (length - 1))
-    if work > MAX_CYCLE_SEARCH_PATHS:
-        raise OperationDomainValidationError(
-            location=("length",),
-            code="graph.cycle.search_bound",
-            message=(
-                "fixed-length cycle search exceeds the "
-                f"{MAX_CYCLE_SEARCH_PATHS}-path work budget"
-            ),
         )
     _admit_cycle_retained(graph, length)
 
@@ -143,24 +114,6 @@ def _admit_subgraph_request(
             code="graph.subgraph.pattern_size_bound",
             message="pattern must not have more vertices than the host",
         )
-    # Conservative full-negative-case admission: worst-case backtracking work
-    # is bounded by the falling factorial of host vertices taken
-    # pattern-at-a-time. A negative decision requires the complete search, so
-    # requests whose exhaustive family exceeds the candidate budget are
-    # rejected before enumeration begins; the runtime ledger remains only as
-    # defense-in-depth.
-    assignments = 1
-    for step in range(pattern_size):
-        assignments *= len(host.vertices) - step
-        if assignments > MAX_SUBGRAPH_CANDIDATE_CHECKS:
-            raise OperationDomainValidationError(
-                location=("pattern", "host"),
-                code="graph.subgraph.search_bound",
-                message=(
-                    "subgraph-pattern search exceeds the "
-                    f"{MAX_SUBGRAPH_CANDIDATE_CHECKS}-assignment work budget"
-                ),
-            )
     _admit_subgraph_retained(pattern, host)
 
 
@@ -238,9 +191,7 @@ def _find_cycle_of_length(
 ) -> tuple[int, ...] | None:
     """Return one simple cycle of exactly ``length`` vertices, or ``None``.
 
-    Exhaustive bounded search over vertex indices.  Callers must enforce
-    the request's path-count admission before invoking this kernel so the
-    search terminates inside a tested budget.
+    Exhaustive search over vertex indices with a runtime path-count budget.
     """
     _, adj = _canonical_label_adjacency(vertices, edges)
     n = len(vertices)

--- a/src/jacobian/math/graphs/regular_subgraph/_tools.py
+++ b/src/jacobian/math/graphs/regular_subgraph/_tools.py
@@ -21,9 +21,10 @@ TOOLS: MathTools = (
         description=(
             "Find a nonempty k-regular subgraph of a simple undirected "
             "graph: a vertex set and edge set where every used vertex has "
-            "degree exactly k. Returns the first checked witness found within "
-            "524,288 selected-edge checks. Returns found=false only after complete "
-            "search; exhausting the work allowance is an execution error."
+            "degree exactly k. The k=2 case uses linear cycle detection; larger "
+            "k searches within 524,288 edge-work units. Returns found=false only "
+            "after complete search; exhausting the work allowance is an execution "
+            "error."
         ),
         request_type=RegularSubgraphRequest,
         result_type=RegularSubgraphResult,

--- a/src/jacobian/math/graphs/regular_subgraph/operations.py
+++ b/src/jacobian/math/graphs/regular_subgraph/operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from itertools import combinations
 
 from jacobian._execution import OperationWorkLedger, request_checkpoint
@@ -17,6 +18,96 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 MAX_REGULAR_SUBGRAPH_WORK = 16 * (1 << 15)
 
 
+def _trivial_result(
+    graph: SimpleUndirectedGraph,
+    k: int,
+    edges: list[tuple[str, str]],
+) -> RegularSubgraphResult | None:
+    """Return a constant-work result for k=0 or k=1 when available."""
+
+    if k == 0 and graph.vertices:
+        return RegularSubgraphResult(
+            graph=graph,
+            k=k,
+            found=True,
+            vertices=(graph.vertices[0],),
+            edges=(),
+        )
+    if k == 1 and edges:
+        left_label, right_label = edges[0]
+        edge = (
+            (left_label, right_label)
+            if left_label <= right_label
+            else (right_label, left_label)
+        )
+        return RegularSubgraphResult(
+            graph=graph,
+            k=k,
+            found=True,
+            vertices=edge,
+            edges=(edge,),
+        )
+    return None
+
+
+def _find_cycle_edge_indices(
+    edge_pairs: list[tuple[int, int]],
+    vertex_count: int,
+    ledger: OperationWorkLedger,
+) -> tuple[int, ...] | None:
+    """Return one cycle's edge indices using an incrementally built forest."""
+
+    parents = list(range(vertex_count))
+    ranks = [0] * vertex_count
+    forest: list[list[tuple[int, int]]] = [[] for _ in range(vertex_count)]
+
+    def root(vertex: int) -> int:
+        while parents[vertex] != vertex:
+            parents[vertex] = parents[parents[vertex]]
+            vertex = parents[vertex]
+        return vertex
+
+    for edge_index, (left, right) in enumerate(edge_pairs):
+        ledger.charge()
+        if ledger.consumed % 1024 == 0:
+            request_checkpoint("during 2-regular cycle search")
+        left_root, right_root = root(left), root(right)
+        if left_root != right_root:
+            if ranks[left_root] < ranks[right_root]:
+                left_root, right_root = right_root, left_root
+            parents[right_root] = left_root
+            if ranks[left_root] == ranks[right_root]:
+                ranks[left_root] += 1
+            forest[left].append((right, edge_index))
+            forest[right].append((left, edge_index))
+            continue
+
+        previous: dict[int, tuple[int, int] | None] = {left: None}
+        pending = deque([left])
+        while pending:
+            vertex = pending.popleft()
+            if vertex == right:
+                break
+            for neighbor, forest_edge_index in forest[vertex]:
+                ledger.charge()
+                if ledger.consumed % 1024 == 0:
+                    request_checkpoint("during 2-regular cycle reconstruction")
+                if neighbor not in previous:
+                    previous[neighbor] = (vertex, forest_edge_index)
+                    pending.append(neighbor)
+
+        path_edges: list[int] = []
+        vertex = right
+        previous_step = previous[vertex]
+        while previous_step is not None:
+            vertex, forest_edge_index = previous_step
+            path_edges.append(forest_edge_index)
+            previous_step = previous[vertex]
+        path_edges.append(edge_index)
+        return tuple(path_edges)
+    return None
+
+
 def find_k_regular_subgraph(
     graph: SimpleUndirectedGraph,
     k: int,
@@ -24,8 +115,8 @@ def find_k_regular_subgraph(
     """Return a nonempty k-regular subgraph (vertex set and edge set) or found=false.
 
     A subgraph is k-regular when every *used* vertex has degree exactly k in the
-    selected edge set. We enumerate edge subsets in increasing size order and
-    return the first feasible solution. For k=0, any single vertex suffices.
+    selected edge set. The k=2 regime uses exact cycle detection; larger k uses
+    bounded edge-subset enumeration. For k=0, any single vertex suffices.
     """
 
     if k < 0:
@@ -46,27 +137,10 @@ def find_k_regular_subgraph(
     n_edges = len(edges)
 
     # Trivial witnesses do not require enumerating edge subsets.
-    if k == 0 and n_vertices > 0:
+    trivial_result = _trivial_result(graph, k, edges)
+    if trivial_result is not None:
         request_checkpoint("before k-regular subgraph result construction")
-        return RegularSubgraphResult(
-            graph=graph,
-            k=k,
-            found=True,
-            vertices=(vertices[0],),
-            edges=(),
-        )
-    if k == 1 and n_edges > 0:
-        left_label, right_label = edges[0]
-        if left_label > right_label:
-            left_label, right_label = right_label, left_label
-        request_checkpoint("before k-regular subgraph result construction")
-        return RegularSubgraphResult(
-            graph=graph,
-            k=k,
-            found=True,
-            vertices=tuple(sorted((left_label, right_label))),
-            edges=((left_label, right_label),),
-        )
+        return trivial_result
 
     vertex_to_idx = {v: i for i, v in enumerate(vertices)}
 
@@ -75,11 +149,28 @@ def find_k_regular_subgraph(
     for left_label, right_label in edges:
         edge_pairs.append((vertex_to_idx[left_label], vertex_to_idx[right_label]))
 
+    ledger = OperationWorkLedger(MAX_REGULAR_SUBGRAPH_WORK)
+    request_checkpoint("before k-regular subgraph search")
+    if k == 2:
+        cycle_edges = _find_cycle_edge_indices(edge_pairs, n_vertices, ledger)
+        request_checkpoint("before k-regular subgraph result construction")
+        if cycle_edges is None:
+            return RegularSubgraphResult(graph=graph, k=k, found=False)
+        selected_labels = [edges[index] for index in cycle_edges]
+        used_labels = tuple(
+            sorted({label for edge in selected_labels for label in edge})
+        )
+        return RegularSubgraphResult(
+            graph=graph,
+            k=k,
+            found=True,
+            vertices=used_labels,
+            edges=tuple(sorted(selected_labels)),
+        )
+
     # Try edge subsets in increasing size. A nonempty subgraph with at least one
     # vertex of positive degree requires at least k+1 vertices and ceil(k*|V|/2) edges.
     min_edges_needed = (k + 1) * k // 2 if k > 0 else 0
-    ledger = OperationWorkLedger(MAX_REGULAR_SUBGRAPH_WORK)
-    request_checkpoint("before k-regular subgraph search")
 
     for edge_count in range(max(1, min_edges_needed), n_edges + 1):
         for edge_combo in combinations(range(n_edges), edge_count):

--- a/tests/math/combinatorics/finite_structures/hypergraph_coloring/test_nonmonochromatic_coloring.py
+++ b/tests/math/combinatorics/finite_structures/hypergraph_coloring/test_nonmonochromatic_coloring.py
@@ -185,7 +185,10 @@ def test_singleton_edge_not_colorable() -> None:
 def test_native_search_exhaustion_is_not_a_negative_decision(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    h = _hg(["a", "b", "c"], [("edge", ("a", "b"))])
+    h = _hg(
+        ["a", "b", "c"],
+        [("ab", ("a", "b")), ("ac", ("a", "c")), ("bc", ("b", "c"))],
+    )
     monkeypatch.setattr(
         "jacobian.math.combinatorics.finite_structures.hypergraph_coloring._models.MAX_COLORING_WORK",
         1,
@@ -216,3 +219,17 @@ def test_early_coloring_witness_precedes_oversized_complete_search() -> None:
     assert result.witness is not None
     colors = dict(result.witness.assignments)
     assert len({colors[vertex] for vertex in vertices}) == 2
+
+
+def test_isolated_vertices_do_not_expand_coloring_search() -> None:
+    vertices = [f"v{index:02d}" for index in range(23)]
+    result = decide_nonmonochromatic_coloring(
+        _hg(vertices, [("edge", ("v00", "v01"))]), 2
+    )
+    assert result.outcome == "COLORABLE"
+    assert result.witness is not None
+    colors = dict(result.witness.assignments)
+    assert tuple(colors) == tuple(vertices)
+    assert colors["v00"] != colors["v01"]
+    assert all(colors[vertex] == 0 for vertex in vertices[2:])
+    assert verify_coloring_witness(result)

--- a/tests/math/graphs/morphisms/edge_colored_pattern/test_embedding.py
+++ b/tests/math/graphs/morphisms/edge_colored_pattern/test_embedding.py
@@ -163,6 +163,19 @@ def test_degree_filter_finds_forced_star_embedding_at_source_limit() -> None:
     assert all(mapping[leaf] in host_leaves for leaf in pattern_vertices[1:])
 
 
+def test_large_identity_witness_does_not_reserve_unused_search_setup() -> None:
+    pattern_vertices = tuple(f"v{index:05d}" for index in range(64))
+    pattern_edges = tuple(combinations(pattern_vertices, 2))
+    host_vertices = pattern_vertices + tuple(
+        f"z{index:05d}" for index in range(64, 12_256)
+    )
+    pattern = colored(pattern_vertices, pattern_edges, ("red",) * len(pattern_edges))
+    host = colored(host_vertices, pattern_edges, ("red",) * len(pattern_edges))
+    result = edge_colored_subgraph_pattern_find(pattern, host)
+    assert result.decision == "EXISTS"
+    assert result.vertex_map == pattern_vertices
+
+
 def test_search_exhaustion_is_not_a_negative_decision(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/math/graphs/morphisms/edge_colored_pattern/test_embedding.py
+++ b/tests/math/graphs/morphisms/edge_colored_pattern/test_embedding.py
@@ -138,7 +138,29 @@ def test_large_identity_and_early_isomorphic_witnesses() -> None:
     )
     renamed = edge_colored_subgraph_pattern_find(pattern, host)
     assert renamed.decision == "EXISTS"
-    assert renamed.vertex_map == host_vertices
+    mapping = dict(zip(pattern.graph.vertices, renamed.vertex_map, strict=True))
+    host_edges = dict(zip(host.graph.edges, host.edge_colors, strict=True))
+    assert len(set(renamed.vertex_map)) == len(pattern.graph.vertices)
+    assert all(
+        host_edges[(min(mapping[u], mapping[v]), max(mapping[u], mapping[v]))] == color
+        for (u, v), color in zip(pattern.graph.edges, pattern.edge_colors, strict=True)
+    )
+
+
+def test_degree_filter_finds_forced_star_embedding_at_source_limit() -> None:
+    pattern_vertices = tuple(f"p{index}" for index in range(6))
+    pattern_edges = tuple(("p0", f"p{index}") for index in range(1, 6))
+    host_leaves = tuple(f"h{index:02d}" for index in range(63))
+    host_vertices = (*host_leaves, "hz")
+    host_edges = tuple((leaf, "hz") for leaf in host_leaves)
+    pattern = colored(pattern_vertices, pattern_edges, ("red",) * 5)
+    host = colored(host_vertices, host_edges, ("red",) * 63)
+    result = edge_colored_subgraph_pattern_find(pattern, host)
+    assert result.decision == "EXISTS"
+    mapping = dict(zip(pattern_vertices, result.vertex_map, strict=True))
+    assert mapping["p0"] == "hz"
+    assert len(set(result.vertex_map)) == len(pattern_vertices)
+    assert all(mapping[leaf] in host_leaves for leaf in pattern_vertices[1:])
 
 
 def test_search_exhaustion_is_not_a_negative_decision(
@@ -174,6 +196,13 @@ def test_search_work_units_exhaust_independently_of_candidate_count(
         + sum(map(len, host.edge_colors))
         + len(pattern.graph.vertices) * max(map(len, host.graph.vertices))
     )
-    monkeypatch.setattr(operations, "MAX_WORK", retained + len(host.graph.edges) + 2)
+    setup_work = (
+        retained
+        + 3 * len(pattern.graph.edges)
+        + 3 * len(host.graph.edges)
+        + len(host.graph.vertices)
+        * (len(pattern.graph.vertices) + 2 * len(pattern.graph.edges))
+    )
+    monkeypatch.setattr(operations, "MAX_WORK", setup_work + 1)
     with pytest.raises(OperationResourceExhaustedError):
         edge_colored_subgraph_pattern_find(pattern, host)

--- a/tests/math/graphs/test_regular_subgraph.py
+++ b/tests/math/graphs/test_regular_subgraph.py
@@ -112,12 +112,13 @@ def test_serialized_witness_claim_is_verified_against_its_graph() -> None:
     assert not verify_k_regular_subgraph(RegularSubgraphResult.model_validate(forged))
 
 
-def test_widened_path_exhaustion_is_not_a_negative_decision() -> None:
+def test_widened_path_uses_exact_linear_k2_regime() -> None:
     vertices = tuple(f"v{index:03d}" for index in range(257))
     edges = [(vertices[index], vertices[index + 1]) for index in range(256)]
     graph = _graph(list(vertices), edges)
-    with pytest.raises(OperationResourceExhaustedError, match="work allowance"):
-        find_k_regular_subgraph(graph, 2)
+    result = find_k_regular_subgraph(graph, 2)
+    assert not result.found
+    assert verify_k_regular_subgraph(result)
 
 
 def test_k0_and_k1_on_a_long_path_do_not_require_edge_subset_search() -> None:


### PR DESCRIPTION
## Problem

Several bounded graph and hypergraph searches reject or exhaust on instances whose mathematical structure makes them easy:

- hypergraph coloring enumerates colors for isolated vertices;
- edge-colored embedding enumerates raw injective maps without degree or color constraints;
- `k=2` regular-subgraph search enumerates edge subsets even though the question is exactly cycle existence.

A follow-up commit on `main` also restored coarse full-negative admission estimates for fixed-cycle and uncolored subgraph searches, rejecting early witnesses that the runtime-ledger implementation from #3571 can find within budget.

Closes #3572.
Closes #3573.
Closes #3574.

## Outcome

Hypergraph coloring now searches only vertices contained in an edge and extends a successful coloring canonically with color 0 on isolated vertices. Edge-colored embedding now builds degree- and per-color candidate domains, orders constrained pattern vertices first, and checks only constraints to earlier assigned vertices while charging every candidate and constraint inspection. The `k=2` regular-subgraph regime now uses exact linear cycle detection; `k>=3` retains bounded edge-subset enumeration.

Identity and source-count presolves still return before search-specific admission, and existing result schemas, retained source data, deadlines, and work caps remain unchanged. Fixed-cycle and uncolored subgraph searches again admit by source/result bounds and enforce actual search work with their runtime ledgers.

On the issue fixtures, the final tree produced verified results locally in under 1 ms each. The prior implementations exhausted 2,000,000 coloring work units, exhausted 50,000,000 colored-embedding work units, and exhausted 524,288 regular-subgraph work units respectively. A 12,256-host-vertex identity embedding also remains an immediate exact witness without reserving unused search setup.

## Validation

- Commands run:
  - `make affected AFFECTED_BASE=origin/main` — all 5 selected commands passed: scoped lint and types; 1,473 affected math tests; 156 catalog tests; 938 catalog invocation tests.
  - Direct issue-fixture probe — verified `COLORABLE`, forced colored embedding, and exact negative 2-regular result; each completed in under 1 ms locally.
- Final head SHA tested: `ba0c0bea1a4df8cc8ad98f6e5c9a9a8792e68ed6`
- Relevant CI checks or links: hosted checks pending

## Contract impact

- Public contract impact: operation descriptions and accepted execution envelope are widened for structurally easy requests; operation IDs and request/result schemas are unchanged.
- [x] Schema and runtime accept/reject the same requests
- [x] Cheap malformed or over-budget input is rejected before expensive work
- [x] Exact results fit the complete canonical output boundary
- [x] All mandatory phases share one request deadline
- [x] Native and MCP behavior agree, where both are public
- [x] Producer → serialization → consumer composition was tested
- [x] Defining invariant and adversarial regression are covered

## Review closure

- [x] Every substantive review finding has a fix and applicable regression evidence, or an evidence-backed explanation of why no change is needed
- [x] Merge conflicts were resolved against the intended base
- [x] Validation covers the final changed tree; checks invalidated by later edits or autofixes were rerun
- [ ] CI evidence matches the final head SHA
- [x] The appropriate repository validation target and any specialist lane are listed above (normally `make affected`; docs use `make docs-linkcheck`)
- [x] Repository conventions were checked: no compatibility or shadow paths were added; if a shared abstraction was introduced, two existing paths already share its mechanics and contract

## Conditional detail

### Operation boundary

- Changed stage and owner: semantic admission and owner-local search kernels for hypergraph coloring, graph morphisms, edge-colored pattern embedding, and regular subgraphs.
- Semantic admission and controlling quantities: active edge support for coloring; retained source size plus pattern/host adjacency and candidate-domain work for colored embedding; cycle existence for `k=2`; actual runtime path/candidate counts for uncolored morphisms.
- Execution envelope: existing 2,000,000 coloring work, 10,000,000 colored host-candidate scans, 50,000,000 colored setup/constraint work, 524,288 larger-`k` regular-subgraph work, and existing morphism runtime ledgers. Existing request deadlines and retained-output limits remain in force.
- Backend or kernel path: owner-local exact search; union-find plus forest-path reconstruction returns a cycle witness for `k=2`.
- Result construction: full canonical source axes are retained; projected coloring witnesses restore isolated vertices in source order with color 0.
- Caller-supplied claim recognition (if applicable): existing witness and negative-claim verifiers are unchanged and exercised against the new results.
- Native/MCP parity: both paths use the same operations; catalog invocation examples passed.
- Serialized-result and round-trip evidence: affected owner and catalog invocation suites passed on the final head.

### Canonical value audit

- [x] Existing canonical value searched; owner or intentional distinction recorded
- [x] Advertised codomain is closed under the result types, including required parent, embedding, branch, orientation, basis, or coordinate data
- [x] Producer→consumer serialization tested
- [x] Theorem-dependent preconditions and validated input subtype are covered, or marked not applicable with a reason
- Structurally valid but mathematically invalid fixture and outcome: forged coloring and regular-subgraph witnesses remain rejected by their bounded verifiers.
- Serialized-subtype trust boundary: source-bound constructors and existing operation-specific verifiers.
- Exact-success defining invariant: every hyperedge is non-monochromatic; every mapped pattern edge exists with the same color; each returned cycle gives degree 2 at every used vertex.
- Discriminated result schema and impossible combinations: unchanged.
