### PR TITLE
fix(graphs): admit exhaustive morphism searches

### DIFF
--- a/src/jacobian/math/graphs/morphisms/_models.py
+++ b/src/jacobian/math/graphs/morphisms/_models.py
@@ -178,10 +178,11 @@ class FixedLengthCycleRequest(StrictModel):
             "description": (
                 "Decide whether the canonical simple graph contains a simple "
                 "cycle of length `length` (3..64) in a graph with at most 64 "
-                "vertices. Search visits at most 10,000,000 path extensions and "
-                "returns immediately on a checked witness. Exhaustion is an "
-                "execution error; a negative result follows only from completed "
-                "search. The retained source graph plus witness labels must fit "
+                "vertices. A bounded witness presolve returns immediately on a "
+                "checked cycle. If exhaustive search remains necessary, every "
+                "possible path extension must fit the 10,000,000-path admission "
+                "bound before search begins. A negative result follows only from "
+                "completed search. The retained source graph plus witness labels must fit "
                 "the owner-local representation bound. Accepts the domain-owned "
                 "`SimpleUndirectedGraph` so "
                 "callers can compose the output of `explicit_graph` or "
@@ -300,9 +301,10 @@ class SubgraphPatternFindRequest(StrictModel):
     """Find an injective edge-preserving embedding of ``pattern`` in ``host``.
 
     The pattern is capped at 64 vertices (``MORPHISM_MAX_VERTICES``). Search
-    charges at most 10,000,000 host-candidate scans and returns immediately on
-    a checked witness. Exhaustion is an execution error; a negative result
-    follows only from completed search. Both graphs are canonical
+    first runs a bounded witness presolve. If exhaustive search remains necessary,
+    every possible host-candidate scan must fit the 10,000,000-candidate admission
+    bound before search begins. A negative result follows only from completed
+    search. Both graphs are canonical
     ``SimpleUndirectedGraph`` values for direct composition.
     """
 
@@ -312,10 +314,11 @@ class SubgraphPatternFindRequest(StrictModel):
                 "Find an injective edge-preserving embedding of `pattern` in "
                 "`host`. Both are canonical `SimpleUndirectedGraph` values so "
                 "callers can pass `explicit_graph` output directly. `pattern` "
-                "must have at most 64 vertices. Search visits at most 10,000,000 "
-                "host candidates and returns immediately on a checked witness. "
-                "Exhaustion is an execution error; negative decisions follow only "
-                "from complete search. Returned maps remain bounded by the admitted "
+                "must have at most 64 vertices. A bounded witness presolve returns "
+                "immediately on a checked embedding. If exhaustive search remains "
+                "necessary, every possible host-candidate scan must fit the "
+                "10,000,000-candidate admission bound before search begins. Negative "
+                "decisions follow only from complete search. Returned maps remain bounded by the admitted "
                 "pattern cardinality."
             )
         },

--- a/src/jacobian/math/graphs/morphisms/_tools.py
+++ b/src/jacobian/math/graphs/morphisms/_tools.py
@@ -112,9 +112,10 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "the graph contains a simple cycle of exactly length k, returning an "
         "ordered cycle witness when one exists. The cycle is a subgraph and "
         "may have chords; this is distinct from girth (shortest cycle) and "
-        "from Hamiltonicity (spanning). Search visits at most 10,000,000 path "
-        "extensions and returns immediately on a checked witness. Exhaustion is "
-        "an execution error; DOES_NOT_EXIST follows only from complete search. "
+        "from Hamiltonicity (spanning). A bounded presolve returns an early "
+        "witness. Any remaining exhaustive search is admitted only when all path "
+        "extensions fit the 10,000,000-path budget; DOES_NOT_EXIST follows only "
+        "from complete search. "
         "Accepts the canonical "
         "`SimpleUndirectedGraph` so `explicit_graph` output composes directly.",
         request_type=FixedLengthCycleRequest,
@@ -127,7 +128,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 description=(
                     "A 4-cycle with a chord contains a 3-cycle (triangle); "
                     "length k is 3..vertex count. Preconditions: at most 64 "
-                    "vertices; a spent path-search allowance is an execution error."
+                    "vertices; exhaustive search must fit the path budget."
                 ),
                 input=CYCLE_C4_WITH_CHORD,
             ),
@@ -147,8 +148,9 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         title="Find a subgraph-pattern embedding",
         description="Given bounded canonical simple graphs pattern H and host G, find an "
         "injective non-induced embedding. Returns one vertex map in pattern order "
-        "when found. Search visits at most 10,000,000 host candidates. Exhaustion "
-        "is an execution error; DOES_NOT_EXIST follows only from complete search. "
+        "when found. A bounded presolve returns an early witness. Any remaining "
+        "exhaustive search is admitted only when all host-candidate scans fit the "
+        "10,000,000-candidate budget; DOES_NOT_EXIST follows only from complete search. "
         "Returned maps are bounded by the admitted pattern cardinality.",
         request_type=SubgraphPatternFindRequest,
         result_type=SubgraphPatternFindResult,
@@ -160,7 +162,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 description=(
                     "A triangle pattern embeds in a 4-cycle-with-chord host. "
                     "Preconditions: pattern at most 64 vertices, no larger than "
-                    "the host; a spent candidate allowance is an execution error."
+                    "the host; exhaustive search must fit the candidate budget."
                 ),
                 input=SUBGRAPH_TRIANGLE_IN_C4_CHORD,
             ),

--- a/src/jacobian/math/graphs/morphisms/operations.py
+++ b/src/jacobian/math/graphs/morphisms/operations.py
@@ -321,6 +321,8 @@ def verify_fixed_length_cycle(claim: FixedLengthCycleResult) -> bool:
             return False
         _admit_cycle_request(claim.graph, claim.length)
         return _decide_cycle_indices(claim.graph, claim.length) is None
+    except OperationResourceAdmissionError:
+        raise
     except (TypeError, ValueError):
         return False
 
@@ -550,5 +552,7 @@ def verify_subgraph_pattern_find(claim: SubgraphPatternFindResult) -> bool:
             return False
         _admit_subgraph_request(claim.pattern, claim.host)
         return _decide_subgraph_embedding(claim.pattern, claim.host) is None
+    except OperationResourceAdmissionError:
+        raise
     except (TypeError, ValueError):
         return False

--- a/src/jacobian/math/graphs/morphisms/operations.py
+++ b/src/jacobian/math/graphs/morphisms/operations.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
-from jacobian._execution import OperationWorkLedger, request_checkpoint
-from jacobian.catalog.models import OperationDomainValidationError
+from dataclasses import dataclass
+
+from jacobian._execution import (
+    OperationResourceExhaustedError,
+    OperationWorkLedger,
+    request_checkpoint,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.graphs.morphisms._models import (
     MAX_CYCLE_SEARCH_PATHS,
     MAX_SUBGRAPH_CANDIDATE_CHECKS,
@@ -31,6 +40,7 @@ __all__ = [
 ]
 
 MAX_MORPHISM_RETAINED_LABEL_CHARACTERS = 10_000_000
+_WITNESS_PRESOLVE_WORK = 1_024
 
 
 def _graph_label_characters(graph: SimpleUndirectedGraph) -> int:
@@ -69,6 +79,26 @@ def _admit_cycle_request(graph: SimpleUndirectedGraph, length: int) -> None:
             message="cycle length must not exceed the vertex count",
         )
     _admit_cycle_retained(graph, length)
+
+
+def _admit_complete_cycle_search(adjacency: list[set[int]], length: int) -> None:
+    """Admit every charged DFS prefix needed for a negative decision."""
+
+    maximum_degree = max(map(len, adjacency), default=0)
+    work = 0
+    paths_at_depth = len(adjacency)
+    for _ in range(1, length):
+        paths_at_depth *= maximum_degree
+        work += paths_at_depth
+        if work > MAX_CYCLE_SEARCH_PATHS:
+            raise OperationResourceAdmissionError(
+                location=("length",),
+                code="graph.cycle.search_bound",
+                message=(
+                    "complete fixed-length cycle search exceeds the "
+                    f"{MAX_CYCLE_SEARCH_PATHS}-path work budget"
+                ),
+            )
 
 
 def _admit_cycle_retained(graph: SimpleUndirectedGraph, length: int) -> None:
@@ -184,7 +214,7 @@ def _canonical_label_adjacency(
 
 def _find_cycle_of_length(
     vertices: tuple[str, ...],
-    edges: tuple[tuple[str, str], ...],
+    adjacency: list[set[int]],
     length: int,
     *,
     max_search_paths: int = MAX_CYCLE_SEARCH_PATHS,
@@ -193,7 +223,7 @@ def _find_cycle_of_length(
 
     Exhaustive search over vertex indices with a runtime path-count budget.
     """
-    _, adj = _canonical_label_adjacency(vertices, edges)
+    adj = adjacency
     n = len(vertices)
     ledger = OperationWorkLedger(max_search_paths)
     request_checkpoint("before fixed-length cycle search")
@@ -226,6 +256,29 @@ def _find_cycle_of_length(
     return None
 
 
+def _decide_cycle_indices(
+    graph: SimpleUndirectedGraph, length: int
+) -> tuple[int, ...] | None:
+    """Run a bounded witness presolve, then an admitted complete search."""
+
+    _, adjacency = _canonical_label_adjacency(graph.vertices, graph.edges)
+    try:
+        return _find_cycle_of_length(
+            graph.vertices,
+            adjacency,
+            length,
+            max_search_paths=min(_WITNESS_PRESOLVE_WORK, MAX_CYCLE_SEARCH_PATHS),
+        )
+    except OperationResourceExhaustedError:
+        _admit_complete_cycle_search(adjacency, length)
+        return _find_cycle_of_length(
+            graph.vertices,
+            adjacency,
+            length,
+            max_search_paths=MAX_CYCLE_SEARCH_PATHS,
+        )
+
+
 def fixed_length_cycle(
     graph: SimpleUndirectedGraph, length: int
 ) -> FixedLengthCycleResult:
@@ -239,9 +292,7 @@ def fixed_length_cycle(
     """
     _admit_cycle_request(graph, length)
     k = length
-    found = _find_cycle_of_length(
-        graph.vertices, graph.edges, k, max_search_paths=MAX_CYCLE_SEARCH_PATHS
-    )
+    found = _decide_cycle_indices(graph, k)
     request_checkpoint("before fixed-length cycle result construction")
     if found is not None:
         return FixedLengthCycleResult._from_kernel(
@@ -269,15 +320,7 @@ def verify_fixed_length_cycle(claim: FixedLengthCycleResult) -> bool:
         if claim.cycle:
             return False
         _admit_cycle_request(claim.graph, claim.length)
-        return (
-            _find_cycle_of_length(
-                claim.graph.vertices,
-                claim.graph.edges,
-                claim.length,
-                max_search_paths=MAX_CYCLE_SEARCH_PATHS,
-            )
-            is None
-        )
+        return _decide_cycle_indices(claim.graph, claim.length) is None
     except (TypeError, ValueError):
         return False
 
@@ -285,9 +328,9 @@ def verify_fixed_length_cycle(claim: FixedLengthCycleResult) -> bool:
 def _candidate_preserves_pattern_edges(
     candidate_idx: int,
     pattern_idx: int,
-    pattern_adj: list[list[int]],
+    pattern_adj: tuple[tuple[int, ...], ...],
     vertex_map_idx: list[int],
-    host_adj: list[set[int]],
+    host_adj: tuple[set[int], ...],
 ) -> bool:
     for neighbor_idx in pattern_adj[pattern_idx]:
         mapped_idx = vertex_map_idx[neighbor_idx]
@@ -298,10 +341,10 @@ def _candidate_preserves_pattern_edges(
 
 def _backtrack_subgraph_embedding(
     position: int,
-    pattern_order: list[int],
-    pattern_adj: list[list[int]],
-    candidate_domains: list[tuple[int, ...]],
-    host_adj: list[set[int]],
+    pattern_order: tuple[int, ...],
+    pattern_adj: tuple[tuple[int, ...], ...],
+    candidate_domains: tuple[tuple[int, ...], ...],
+    host_adj: tuple[set[int], ...],
     vertex_map_idx: list[int],
     used_host_idx: set[int],
     ledger: OperationWorkLedger,
@@ -337,21 +380,22 @@ def _backtrack_subgraph_embedding(
     return False
 
 
-def _find_subgraph_embedding(
+@dataclass(frozen=True)
+class _SubgraphSearchPlan:
+    pattern_order: tuple[int, ...]
+    pattern_adjacency: tuple[tuple[int, ...], ...]
+    candidate_domains: tuple[tuple[int, ...], ...]
+    host_adjacency: tuple[set[int], ...]
+
+
+def _build_subgraph_search_plan(
     pattern_vertices: tuple[str, ...],
     pattern_edges: tuple[tuple[str, str], ...],
     host_vertices: tuple[str, ...],
     host_edges: tuple[tuple[str, str], ...],
-    max_candidate_checks: int = MAX_SUBGRAPH_CANDIDATE_CHECKS,
-) -> tuple[int, ...] | None:
-    """Return host indices ordered by pattern vertex order, or ``None``.
+) -> _SubgraphSearchPlan:
+    """Build the degree-filtered plan shared by presolve and full search."""
 
-    Ordinary (non-induced) subgraph containment via bounded backtracking.
-    Every host-candidate scan at an internal backtracking node is charged
-    against ``max_candidate_checks`` before it executes. Exhausting that
-    allowance raises an execution error, so a partial search can never
-    masquerade as a negative decision.
-    """
     # Normalize host labels to indices once, as the cycle kernel does: the
     # assignment-count admission bounds search paths, so every per-check
     # cost must be index work rather than label-length-dependent string
@@ -365,44 +409,106 @@ def _find_subgraph_embedding(
     for u, v in pattern_edges:
         pattern_degree[u] += 1
         pattern_degree[v] += 1
-    pattern_order = sorted(
-        range(p_n), key=lambda i: -pattern_degree[pattern_vertices[i]]
+    pattern_order = tuple(
+        sorted(range(p_n), key=lambda i: -pattern_degree[pattern_vertices[i]])
     )
     # Pattern edges as pairs of indices in pattern vertex order.
     pattern_edge_idx = tuple(
         (pattern_index[u], pattern_index[v]) for u, v in pattern_edges
     )
-    ledger = OperationWorkLedger(max_candidate_checks)
-    request_checkpoint("before subgraph-pattern search")
-
-    vertex_map_idx: list[int] = [-1] * p_n  # pattern idx -> host idx
-    used_host_idx: set[int] = set()
     # Pattern adjacency for quick neighbor checks.
     pattern_adj: list[list[int]] = [[] for _ in range(p_n)]
     for u_idx, v_idx in pattern_edge_idx:
         pattern_adj[u_idx].append(v_idx)
         pattern_adj[v_idx].append(u_idx)
-    candidate_domains = [
+    candidate_domains = tuple(
         tuple(
             host_idx
             for host_idx, neighbors in enumerate(host_adj)
             if len(neighbors) >= len(pattern_adj[pattern_idx])
         )
         for pattern_idx in range(p_n)
-    ]
+    )
+    return _SubgraphSearchPlan(
+        pattern_order=pattern_order,
+        pattern_adjacency=tuple(tuple(row) for row in pattern_adj),
+        candidate_domains=candidate_domains,
+        host_adjacency=tuple(host_adj),
+    )
+
+
+def _admit_complete_subgraph_search(plan: _SubgraphSearchPlan) -> None:
+    """Admit every candidate scan in the degree-filtered search plan."""
+
+    host_size = len(plan.host_adjacency)
+    partial_assignments = 1
+    work = 0
+    for depth, pattern_index in enumerate(plan.pattern_order):
+        domain_size = len(plan.candidate_domains[pattern_index])
+        work += partial_assignments * domain_size
+        if work > MAX_SUBGRAPH_CANDIDATE_CHECKS:
+            raise OperationResourceAdmissionError(
+                location=("pattern", "host"),
+                code="graph.subgraph.search_bound",
+                message=(
+                    "complete subgraph-pattern search exceeds the "
+                    f"{MAX_SUBGRAPH_CANDIDATE_CHECKS}-candidate work budget"
+                ),
+            )
+        partial_assignments *= min(domain_size, host_size - depth)
+
+
+def _find_subgraph_embedding(
+    plan: _SubgraphSearchPlan,
+    max_candidate_checks: int = MAX_SUBGRAPH_CANDIDATE_CHECKS,
+) -> tuple[int, ...] | None:
+    """Return host indices ordered by pattern vertex order, or ``None``."""
+
+    ledger = OperationWorkLedger(max_candidate_checks)
+    request_checkpoint("before subgraph-pattern search")
+    vertex_map_idx: list[int] = [-1] * len(plan.pattern_order)
+    used_host_idx: set[int] = set()
 
     if _backtrack_subgraph_embedding(
         0,
-        pattern_order,
-        pattern_adj,
-        candidate_domains,
-        host_adj,
+        plan.pattern_order,
+        plan.pattern_adjacency,
+        plan.candidate_domains,
+        plan.host_adjacency,
         vertex_map_idx,
         used_host_idx,
         ledger,
     ):
-        return tuple(vertex_map_idx[i] for i in range(p_n))
+        return tuple(vertex_map_idx)
     return None
+
+
+def _decide_subgraph_embedding(
+    pattern: SimpleUndirectedGraph, host: SimpleUndirectedGraph
+) -> tuple[int, ...] | None:
+    """Run a bounded witness presolve, then an admitted complete search."""
+
+    plan = _build_subgraph_search_plan(
+        pattern.vertices, pattern.edges, host.vertices, host.edges
+    )
+    candidate_union = {
+        host_index for domain in plan.candidate_domains for host_index in domain
+    }
+    if len(candidate_union) < len(plan.pattern_order):
+        return None
+    try:
+        return _find_subgraph_embedding(
+            plan,
+            max_candidate_checks=min(
+                _WITNESS_PRESOLVE_WORK, MAX_SUBGRAPH_CANDIDATE_CHECKS
+            ),
+        )
+    except OperationResourceExhaustedError:
+        _admit_complete_subgraph_search(plan)
+        return _find_subgraph_embedding(
+            plan,
+            max_candidate_checks=MAX_SUBGRAPH_CANDIDATE_CHECKS,
+        )
 
 
 def subgraph_pattern_find(
@@ -416,13 +522,7 @@ def subgraph_pattern_find(
     order) or ``DOES_NOT_EXIST`` after exhaustive bounded search.
     """
     _admit_subgraph_request(pattern, host)
-    found = _find_subgraph_embedding(
-        pattern.vertices,
-        pattern.edges,
-        host.vertices,
-        host.edges,
-        max_candidate_checks=MAX_SUBGRAPH_CANDIDATE_CHECKS,
-    )
+    found = _decide_subgraph_embedding(pattern, host)
     request_checkpoint("before subgraph-pattern result construction")
     if found is not None:
         return SubgraphPatternFindResult._from_kernel(
@@ -449,15 +549,6 @@ def verify_subgraph_pattern_find(claim: SubgraphPatternFindResult) -> bool:
         if claim.vertex_map:
             return False
         _admit_subgraph_request(claim.pattern, claim.host)
-        return (
-            _find_subgraph_embedding(
-                claim.pattern.vertices,
-                claim.pattern.edges,
-                claim.host.vertices,
-                claim.host.edges,
-                max_candidate_checks=MAX_SUBGRAPH_CANDIDATE_CHECKS,
-            )
-            is None
-        )
+        return _decide_subgraph_embedding(claim.pattern, claim.host) is None
     except (TypeError, ValueError):
         return False

--- a/tests/math/graphs/morphisms/test_graph_morphisms.py
+++ b/tests/math/graphs/morphisms/test_graph_morphisms.py
@@ -9,7 +9,10 @@ from jacobian._execution import (
     bind_request_deadline,
     request_execution,
 )
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.graphs.morphisms._models import (
     GraphHomomorphism,
     GraphHomomorphismObstruction,
@@ -364,11 +367,18 @@ class TestFixedLengthCycle:
     def test_large_bipartite_odd_cycle_is_rejected_before_complete_search(
         self,
     ) -> None:
+        from jacobian.math.graphs.morphisms._models import FixedLengthCycleResult
+
         left = [f"a{index:02d}" for index in range(32)]
         right = [f"b{index:02d}" for index in range(32)]
         graph = self._g(left + right, [[u, v] for u in left for v in right])
         with pytest.raises(OperationDomainValidationError, match="path work budget"):
             fixed_length_cycle(graph, 63)
+        claim = FixedLengthCycleResult(
+            graph=graph, decision="DOES_NOT_EXIST", length=63, cycle=()
+        )
+        with pytest.raises(OperationResourceAdmissionError, match="path work budget"):
+            verify_fixed_length_cycle(claim)
 
     def test_cycle_checks_parent_deadline_after_final_candidate(
         self, monkeypatch: pytest.MonkeyPatch
@@ -628,6 +638,8 @@ class TestSubgraphPatternFind:
     ) -> None:
         from itertools import combinations
 
+        from jacobian.math.graphs.morphisms._models import SubgraphPatternFindResult
+
         pattern_labels = [f"p{index}" for index in range(8)]
         pattern = self._g(
             pattern_labels, [list(edge) for edge in combinations(pattern_labels, 2)]
@@ -645,6 +657,13 @@ class TestSubgraphPatternFind:
             OperationDomainValidationError, match="candidate work budget"
         ):
             subgraph_pattern_find(pattern, host)
+        claim = SubgraphPatternFindResult(
+            pattern=pattern, host=host, decision="DOES_NOT_EXIST", vertex_map=()
+        )
+        with pytest.raises(
+            OperationResourceAdmissionError, match="candidate work budget"
+        ):
+            verify_subgraph_pattern_find(claim)
 
     def test_embedding_checks_parent_deadline_after_final_candidate(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/math/graphs/morphisms/test_graph_morphisms.py
+++ b/tests/math/graphs/morphisms/test_graph_morphisms.py
@@ -5,7 +5,6 @@ from pydantic import ValidationError
 
 from jacobian._execution import (
     OperationExecutionTimeoutError,
-    OperationResourceExhaustedError,
     OperationWorkLedger,
     bind_request_deadline,
     request_execution,
@@ -352,15 +351,24 @@ class TestFixedLengthCycle:
         assert result.cycle == tuple(labels[:4])
         assert verify_fixed_length_cycle(result)
 
-    def test_cycle_search_exhaustion_is_not_a_negative_decision(
+    def test_cycle_search_requires_complete_work_admission(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         graph = self._g(["a", "b", "c"], [["a", "b"], ["a", "c"], ["b", "c"]])
         monkeypatch.setattr(
             "jacobian.math.graphs.morphisms.operations.MAX_CYCLE_SEARCH_PATHS", 1
         )
-        with pytest.raises(OperationResourceExhaustedError):
+        with pytest.raises(OperationDomainValidationError, match="path work budget"):
             fixed_length_cycle(graph, 3)
+
+    def test_large_bipartite_odd_cycle_is_rejected_before_complete_search(
+        self,
+    ) -> None:
+        left = [f"a{index:02d}" for index in range(32)]
+        right = [f"b{index:02d}" for index in range(32)]
+        graph = self._g(left + right, [[u, v] for u in left for v in right])
+        with pytest.raises(OperationDomainValidationError, match="path work budget"):
+            fixed_length_cycle(graph, 63)
 
     def test_cycle_checks_parent_deadline_after_final_candidate(
         self, monkeypatch: pytest.MonkeyPatch
@@ -601,7 +609,7 @@ class TestSubgraphPatternFind:
         assert result.vertex_map == tuple(host_labels[:6])
         assert verify_subgraph_pattern_find(result)
 
-    def test_embedding_search_exhaustion_is_not_a_negative_decision(
+    def test_embedding_search_requires_complete_work_admission(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         pattern = self._g(["p", "q"], [["p", "q"]])
@@ -610,7 +618,32 @@ class TestSubgraphPatternFind:
             "jacobian.math.graphs.morphisms.operations.MAX_SUBGRAPH_CANDIDATE_CHECKS",
             1,
         )
-        with pytest.raises(OperationResourceExhaustedError):
+        with pytest.raises(
+            OperationDomainValidationError, match="candidate work budget"
+        ):
+            subgraph_pattern_find(pattern, host)
+
+    def test_large_partite_clique_obstruction_is_rejected_before_complete_search(
+        self,
+    ) -> None:
+        from itertools import combinations
+
+        pattern_labels = [f"p{index}" for index in range(8)]
+        pattern = self._g(
+            pattern_labels, [list(edge) for edge in combinations(pattern_labels, 2)]
+        )
+        parts = [[f"h{part}{index:02d}" for index in range(9)] for part in range(7)]
+        host_labels = [vertex for part in parts for vertex in part]
+        host_edges = [
+            [left, right]
+            for left_part, right_part in combinations(parts, 2)
+            for left in left_part
+            for right in right_part
+        ]
+        host = self._g(host_labels, host_edges)
+        with pytest.raises(
+            OperationDomainValidationError, match="candidate work budget"
+        ):
             subgraph_pattern_find(pattern, host)
 
     def test_embedding_checks_parent_deadline_after_final_candidate(

--- a/tests/mcp/test_search_certificate_prefix.py
+++ b/tests/mcp/test_search_certificate_prefix.py
@@ -1,4 +1,4 @@
-"""Search prefixes may establish witnesses; exhaustion establishes no decision."""
+"""Search prefixes may establish witnesses before complete-work admission."""
 
 from __future__ import annotations
 
@@ -214,7 +214,7 @@ _EXHAUSTION_CASES = (
     ("operation_id", "module", "limit", "limit_value", "payload"),
     _EXHAUSTION_CASES,
 )
-def test_exhausted_prefixes_are_mcp_errors_without_mathematical_output(
+def test_incomplete_searches_are_mcp_errors_without_mathematical_output(
     monkeypatch: pytest.MonkeyPatch,
     direct: bool,
     operation_id: str,
@@ -229,7 +229,16 @@ def test_exhausted_prefixes_are_mcp_errors_without_mathematical_output(
     assert result.structured_content is None
     assert isinstance(result.content[0], TextContent)
     diagnostic = json.loads(result.content[0].text[result.content[0].text.index("{") :])
-    assert diagnostic["code"] == "RESOURCE_EXHAUSTED"
     assert diagnostic["operation_id"] == operation_id
-    assert diagnostic["resource"] == "work"
-    assert "does not establish a negative result" in diagnostic["hint"]
+    admission_codes = {
+        "graph.cycle.fixed_length.decide": "graph.cycle.search_bound",
+        "graph.subgraph_pattern.find": "graph.subgraph.search_bound",
+    }
+    if operation_id in admission_codes:
+        assert diagnostic["code"] == "RESOURCE_ADMISSION_REJECTED"
+        assert diagnostic["stage"] == "resource_admission"
+        assert diagnostic["errors"][0]["code"] == admission_codes[operation_id]
+    else:
+        assert diagnostic["code"] == "RESOURCE_EXHAUSTED"
+        assert diagnostic["resource"] == "work"
+        assert "does not establish a negative result" in diagnostic["hint"]


### PR DESCRIPTION
## Problem

The runtime-ledger restoration in #3581 preserved early witnesses but left two exhaustive negative paths without sound pre-admission. A 63-cycle request on `K₃₂,₃₂` and an 8-clique request against a 63-vertex complete 7-partite host both enter search, consume their runtime allowance, and fail operationally instead of being rejected before complete search begins.

## Outcome

Fixed-cycle and subgraph-pattern decisions now run a separately bounded 1,024-step witness presolve. If that presolve does not establish a result, the operation admits a complete search before restarting it:

- cycle admission sums a conservative maximum-degree path bound over every DFS depth;
- subgraph admission builds the degree-filtered search plan once and sums a conservative candidate-scan recurrence over every backtracking depth.

A global degree-domain obstruction retains cheap negative subgraph decisions when the compatible host vertices cannot cover the pattern. Early `K4` cycle and `K6`-in-`K64` witnesses remain accepted. The two reported negative cases now raise `OperationResourceAdmissionError` in milliseconds, projected as `RESOURCE_ADMISSION_REJECTED` by both MCP entry points. Negative-claim verifiers propagate the same resource refusal rather than converting it into the mathematical verdict `False`.

This addresses the post-merge review findings on #3581.

## Validation

- Commands run:
  - `make affected AFFECTED_BASE=origin/main` — all 6 selected commands passed: scoped lint and types; 47 morphism tests; 156 catalog tests; 938 catalog invocation tests; 169 MCP tests.
  - Direct review-counterexample probe — cycle and subgraph requests produced `graph.cycle.search_bound` and `graph.subgraph.search_bound` resource-admission failures in approximately 7 ms and 2 ms locally; retained positive controls returned exact witnesses.
- Final head SHA tested: `a396503780d3184a48333736bd84edb4a1f51a24`
- Relevant CI checks or links: hosted required, static, math, catalog, catalog examples, MCP boundary, container build, and benchmark validation checks passed on the final head

## Contract impact

- Public contract impact: exhaustive negative searches that cannot fit their proven work envelope now fail during resource admission; operation IDs and request/result schemas are unchanged.
- [x] Schema and runtime accept/reject the same requests
- [x] Cheap malformed or over-budget input is rejected before expensive work
- [x] Exact results fit the complete canonical output boundary
- [x] All mandatory phases share one request deadline
- [x] Native and MCP behavior agree, where both are public
- [x] Producer → serialization → consumer composition was tested
- [x] Defining invariant and adversarial regression are covered

## Review closure

- [x] Every substantive review finding has a fix and applicable regression evidence, or an evidence-backed explanation of why no change is needed
- [x] Merge conflicts were resolved against the intended base
- [x] Validation covers the final changed tree; checks invalidated by later edits or autofixes were rerun
- [x] CI evidence matches the final head SHA
- [x] The appropriate repository validation target and any specialist lane are listed above
- [x] Repository conventions were checked: no compatibility or shadow paths were added; if a shared abstraction was introduced, two existing paths already share its mechanics and contract

## Conditional detail

### Operation boundary

- Changed stage and owner: semantic resource admission and owner-local graph-morphism search.
- Semantic admission and controlling quantities: vertex count, cycle length, maximum degree, degree-compatible candidate-domain sizes, search depth, and host size.
- Execution envelope: a 1,024-step positive presolve followed, when needed, by a proven complete-search envelope of at most 10,000,000 charged path extensions or host-candidate scans. All phases share the existing request deadline and retained-output bound.
- Backend or kernel path: owner-local DFS and degree-filtered backtracking; the admitted search plan is reused without recomputing candidate domains.
- Result construction: unchanged canonical graph-bound decisions and witnesses.
- Caller-supplied claim recognition: valid negative claims outside the verifier work envelope raise `OperationResourceAdmissionError`; malformed claims still return `False`.
- Native/MCP parity: native resource-admission exceptions project to sanitized `RESOURCE_ADMISSION_REJECTED` errors through `math.run` and direct tools.
- Serialized-result and round-trip evidence: affected owner, catalog invocation, and MCP suites passed on the final head.

