### PR TITLE
fix(majorization): validate weak check direction

### DIFF
--- a/src/jacobian/math/analysis/majorization/operations.py
+++ b/src/jacobian/math/analysis/majorization/operations.py
@@ -149,6 +149,12 @@ def weak_majorization_check(
     (using ascending sort)
     """
     _require_same_dimension(x, y)
+    if direction not in ("sub", "super"):
+        raise OperationDomainValidationError(
+            location=("direction",),
+            code="majorization.direction",
+            message="direction must be 'sub' or 'super'",
+        )
     x_vals = x.as_fractions()
     y_vals = y.as_fractions()
     n = len(x_vals)

--- a/tests/math/analysis/majorization/test_majorization.py
+++ b/tests/math/analysis/majorization/test_majorization.py
@@ -23,6 +23,7 @@ from jacobian.math.analysis.majorization._tools import (
     _t_transform_sequence,
     _weak_majorization_check,
 )
+from jacobian.math.analysis.majorization.operations import weak_majorization_check
 from jacobian.math.matrices.values import RationalMatrix, rational_matrix_from_fractions
 
 
@@ -94,6 +95,14 @@ class TestMajorizationCheck:
 
 
 class TestWeakMajorization:
+    def test_native_rejects_invalid_direction_with_typed_error(self) -> None:
+        vector = rv(["a"], [(1, 1)])
+
+        with pytest.raises(OperationDomainValidationError) as error:
+            weak_majorization_check(vector, vector, "invalid")  # type: ignore[arg-type]
+
+        assert error.value.errors()[0]["type"] == "majorization.direction"
+
     def test_weak_sub_holds(self) -> None:
         """Weak submajorization holds when x >= y in prefix sums."""
         result = _weak_majorization_check(


### PR DESCRIPTION
## Problem

The public native operation `weak_majorization_check(x, y, direction)` accepts `direction` at runtime, but Python type annotations do not enforce its `Literal["sub", "super"]` domain. An invalid value therefore reached the computation and result construction.

## Exact reproduction on the base revision

```text
PYTHONPATH=src python -c 'from jacobian.math.analysis.majorization.operations import weak_majorization_check; from jacobian.math.analysis.majorization._models import RationalVector; from jacobian._exact import CanonicalRational; v=RationalVector(labels=("a",), values=(CanonicalRational(num=1, den=1),)); weak_majorization_check(v, v, "invalid")'
```

The base raises a raw Pydantic `ValidationError` while constructing `WeakMajorizationCheckResult`, after treating the invalid direction as the supermajorization branch. This violates the public operation error contract: domain-invalid native arguments must raise the typed `OperationDomainValidationError` with an owner diagnostic.

## Change

Validate `direction` at the operation boundary and raise `OperationDomainValidationError` with the stable `majorization.direction` diagnostic. A behavioral regression test covers the native call.

Fixes #3618

## Validation

- `PYTHONPATH=src pytest -q tests/math/analysis/majorization/test_majorization.py` — 22 passed
- `MATH_WORKERS=0 make affected AFFECTED_BASE=origin/main` — all 5 selected commands passed: lint, mypy, 25 math tests, 160 catalog tests, and 966 integration tests