### PR TITLE
fix(symmetric-functions): retain Schur evaluation context

### DIFF
--- a/src/jacobian/math/combinatorics/symmetric_functions/_models.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, Self
 
-from pydantic import Field, WithJsonSchema, model_validator
+from pydantic import Field, StrictInt, WithJsonSchema, model_validator
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
@@ -31,7 +31,7 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 
 
 PointCoordinate = Annotated[
-    int,
+    StrictInt,
     Field(
         ge=-_MAX_POINT_COORDINATE_ABS,
         le=_MAX_POINT_COORDINATE_ABS,

--- a/src/jacobian/math/combinatorics/symmetric_functions/_models.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, Self
 
-from pydantic import Field, WithJsonSchema, model_validator
+from pydantic import Field, StringConstraints, WithJsonSchema, model_validator
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
@@ -20,6 +20,7 @@ _MAX_POINT_COORDINATE_DIGITS = 6
 _MAX_POINT_COORDINATE_ABS = 10**_MAX_POINT_COORDINATE_DIGITS - 1
 _MAX_SCHUR_RESULT_DIGITS = 4000
 _MAX_SCHUR_PARTITION_LENGTH = 50
+_MAX_SCHUR_VARIABLE_NAME_LENGTH = 64
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -40,6 +41,17 @@ PointCoordinate = Annotated[
     ),
 ]
 """One bounded evaluation coordinate: ``abs(value) <= 10**6 - 1``."""
+
+
+SchurVariableName = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=_MAX_SCHUR_VARIABLE_NAME_LENGTH,
+        strict=True,
+    ),
+]
+"""One bounded variable label retained in a Schur evaluation context."""
 
 
 def _schur_partition_schema() -> JsonSchemaValue:
@@ -84,12 +96,13 @@ class SchurExpansionRequest(StrictModel):
             "parts for the admitted Jacobi-Trudi determinant."
         )
     )
-    variables: tuple[str, ...] = Field(
+    variables: tuple[SchurVariableName, ...] = Field(
         min_length=1,
         max_length=20,
         description=(
             "Distinct variable names; the length must equal the length of "
-            "point (between 1 and 20)."
+            "point (between 1 and 20), and each name must contain at most "
+            f"{_MAX_SCHUR_VARIABLE_NAME_LENGTH} characters."
         ),
         json_schema_extra={"uniqueItems": True},
     )
@@ -126,9 +139,13 @@ class SchurExpansionRequest(StrictModel):
 
 class SchurExpansionResult(StrictModel):
     partition: IntegerPartition
-    variables: tuple[str, ...] = Field(
+    variables: tuple[SchurVariableName, ...] = Field(
         min_length=1,
         max_length=20,
+        description=(
+            "Distinct variable names, each containing at most "
+            f"{_MAX_SCHUR_VARIABLE_NAME_LENGTH} characters."
+        ),
         json_schema_extra={"uniqueItems": True},
     )
     point: tuple[PointCoordinate, ...] = Field(min_length=1, max_length=20)
@@ -160,4 +177,5 @@ __all__ = [
     "PartitionRequest",
     "SchurExpansionRequest",
     "SchurExpansionResult",
+    "SchurVariableName",
 ]

--- a/src/jacobian/math/combinatorics/symmetric_functions/_models.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/_models.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from typing import Annotated, Self
 
-from pydantic import Field, StringConstraints, WithJsonSchema, model_validator
+from pydantic import Field, WithJsonSchema, model_validator
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import ExactInteger
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer
+from jacobian.math._labels import MAX_OPAQUE_LABEL_LENGTH, OpaqueLabel
 from jacobian.math.combinatorics.symmetric_functions.values import (
     MAX_PARTITION_SIZE,
     IntegerPartition,
@@ -20,7 +21,7 @@ _MAX_POINT_COORDINATE_DIGITS = 6
 _MAX_POINT_COORDINATE_ABS = 10**_MAX_POINT_COORDINATE_DIGITS - 1
 _MAX_SCHUR_RESULT_DIGITS = 4000
 _MAX_SCHUR_PARTITION_LENGTH = 50
-_MAX_SCHUR_VARIABLE_NAME_LENGTH = 64
+_MAX_SCHUR_VARIABLE_NAME_LENGTH = MAX_OPAQUE_LABEL_LENGTH
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -43,15 +44,8 @@ PointCoordinate = Annotated[
 """One bounded evaluation coordinate: ``abs(value) <= 10**6 - 1``."""
 
 
-SchurVariableName = Annotated[
-    str,
-    StringConstraints(
-        min_length=1,
-        max_length=_MAX_SCHUR_VARIABLE_NAME_LENGTH,
-        strict=True,
-    ),
-]
-"""One bounded variable label retained in a Schur evaluation context."""
+SchurVariableName = OpaqueLabel
+"""One canonical bounded variable label retained in a Schur context."""
 
 
 def _schur_partition_schema() -> JsonSchemaValue:

--- a/src/jacobian/math/combinatorics/symmetric_functions/_models.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/_models.py
@@ -125,10 +125,27 @@ class SchurExpansionRequest(StrictModel):
 
 
 class SchurExpansionResult(StrictModel):
+    partition: IntegerPartition
+    variables: tuple[str, ...] = Field(
+        min_length=1,
+        max_length=20,
+        json_schema_extra={"uniqueItems": True},
+    )
+    point: tuple[PointCoordinate, ...] = Field(min_length=1, max_length=20)
     value: ExactInteger
 
     @model_validator(mode="after")
-    def require_bounded_value(self) -> Self:
+    def require_bounded_result(self) -> Self:
+        if len(self.variables) != len(self.point):
+            raise _validation_error(
+                "schur_dimensions_mismatch",
+                "variables and point must have the same length",
+            )
+        if len(set(self.variables)) != len(self.variables):
+            raise _validation_error(
+                "schur_variables_not_distinct",
+                "variables must be distinct (duplicate axis)",
+            )
         if len(format_canonical_integer(abs(self.value))) > _MAX_SCHUR_RESULT_DIGITS:
             raise _validation_error(
                 "schur_value_digits_exceeded",

--- a/src/jacobian/math/combinatorics/symmetric_functions/_tools.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/_tools.py
@@ -11,7 +11,7 @@ from jacobian.math.combinatorics.symmetric_functions.operations import schur_eva
 
 
 def _run_schur_evaluation(request: SchurExpansionRequest) -> SchurExpansionResult:
-    return schur_evaluation(request.partition, request.point)
+    return schur_evaluation(request.partition, request.point, request.variables)
 
 
 TOOLS: tuple[MathTool[Any, Any], ...] = (

--- a/src/jacobian/math/combinatorics/symmetric_functions/operations.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/operations.py
@@ -73,8 +73,10 @@ def schur_evaluation(
             message="point must contain 1..20 bounded integer coordinates",
         )
 
-    variables = variables if variables is not None else tuple(
-        f"x{i}" for i in range(len(point))
+    variables = (
+        variables
+        if variables is not None
+        else tuple(f"x{i}" for i in range(len(point)))
     )
     if len(variables) != len(point):
         raise OperationDomainValidationError(

--- a/src/jacobian/math/combinatorics/symmetric_functions/operations.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/operations.py
@@ -164,9 +164,10 @@ def verify_schur_evaluation(claim: object) -> bool:
             return False
         if not 1 <= len(variables) <= 20 or not 1 <= len(point) <= 20:
             return False
+        partition = claim.partition
         canonical_claim = SchurExpansionResult.model_validate(
             {
-                "partition": claim.partition,
+                "partition": {"parts": partition.parts},
                 "variables": variables,
                 "point": point,
                 "value": claim.value,

--- a/src/jacobian/math/combinatorics/symmetric_functions/operations.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/operations.py
@@ -133,10 +133,7 @@ def _determinant(matrix: list[list[int]]) -> int:
 def verify_schur_evaluation(claim: SchurExpansionResult) -> bool:
     if not isinstance(claim, SchurExpansionResult):
         return False
-    try:
-        expected = schur_evaluation(claim.partition, claim.point, claim.variables)
-    except (OperationDomainValidationError, TypeError, ValueError):
-        return False
+    expected = schur_evaluation(claim.partition, claim.point, claim.variables)
     return expected == claim
 
 

--- a/src/jacobian/math/combinatorics/symmetric_functions/operations.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/operations.py
@@ -8,8 +8,10 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.symmetric_functions._models import (
     _MAX_POINT_COORDINATE_ABS,
     _MAX_SCHUR_PARTITION_LENGTH,
+    _MAX_SCHUR_VARIABLE_NAME_LENGTH,
     IntegerPartition,
     SchurExpansionResult,
+    SchurVariableName,
 )
 
 
@@ -46,7 +48,7 @@ def _complete_homogeneous(variables: Sequence[int], k: int) -> int:
 def schur_evaluation(
     partition: IntegerPartition,
     point: tuple[int, ...],
-    variables: tuple[str, ...] | None = None,
+    variables: tuple[SchurVariableName, ...] | None = None,
 ) -> SchurExpansionResult:
     """Evaluate a Schur function s_lambda at a point using the Jacobi-Trudi formula.
 
@@ -78,6 +80,19 @@ def schur_evaluation(
         if variables is not None
         else tuple(f"x{i}" for i in range(len(point)))
     )
+    if any(
+        type(variable) is not str
+        or not 1 <= len(variable) <= _MAX_SCHUR_VARIABLE_NAME_LENGTH
+        for variable in variables
+    ):
+        raise OperationDomainValidationError(
+            location=("variables",),
+            code="symmetric_function.schur_variable_name_bounded",
+            message=(
+                "variable names must be nonempty strings of at most "
+                f"{_MAX_SCHUR_VARIABLE_NAME_LENGTH} characters"
+            ),
+        )
     if len(variables) != len(point):
         raise OperationDomainValidationError(
             location=("variables",),
@@ -130,7 +145,7 @@ def _determinant(matrix: list[list[int]]) -> int:
     return int(Matrix(matrix).det())
 
 
-def verify_schur_evaluation(claim: SchurExpansionResult) -> bool:
+def verify_schur_evaluation(claim: object) -> bool:
     if not isinstance(claim, SchurExpansionResult):
         return False
     expected = schur_evaluation(claim.partition, claim.point, claim.variables)

--- a/src/jacobian/math/combinatorics/symmetric_functions/operations.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/operations.py
@@ -79,11 +79,23 @@ def schur_evaluation(
             message="point must contain 1..20 bounded integer coordinates",
         )
 
-    variables = (
-        variables
-        if variables is not None
-        else tuple(f"x{i}" for i in range(len(point)))
-    )
+    if variables is None:
+        variables = tuple(f"x{i}" for i in range(len(point)))
+    else:
+        try:
+            variable_count = len(variables)
+        except TypeError as error:
+            raise OperationDomainValidationError(
+                location=("variables",),
+                code="symmetric_function.schur_dimensions_mismatch",
+                message="variables and point must have the same length",
+            ) from error
+        if variable_count != len(point):
+            raise OperationDomainValidationError(
+                location=("variables",),
+                code="symmetric_function.schur_dimensions_mismatch",
+                message="variables and point must have the same length",
+            )
     for variable in variables:
         try:
             _SCHUR_VARIABLE_NAME_ADAPTER.validate_python(variable, strict=True)
@@ -96,12 +108,6 @@ def schur_evaluation(
                     f"{_MAX_SCHUR_VARIABLE_NAME_LENGTH} characters"
                 ),
             ) from error
-    if len(variables) != len(point):
-        raise OperationDomainValidationError(
-            location=("variables",),
-            code="symmetric_function.schur_dimensions_mismatch",
-            message="variables and point must have the same length",
-        )
     if len(set(variables)) != len(variables):
         raise OperationDomainValidationError(
             location=("variables",),
@@ -152,8 +158,20 @@ def verify_schur_evaluation(claim: object) -> bool:
     if not isinstance(claim, SchurExpansionResult):
         return False
     try:
+        variables = claim.variables
+        point = claim.point
+        if type(variables) is not tuple or type(point) is not tuple:
+            return False
+        if not 1 <= len(variables) <= 20 or not 1 <= len(point) <= 20:
+            return False
         canonical_claim = SchurExpansionResult.model_validate(
-            claim.model_dump(mode="python"), strict=True
+            {
+                "partition": claim.partition,
+                "variables": variables,
+                "point": point,
+                "value": claim.value,
+            },
+            strict=True,
         )
     except (AttributeError, TypeError, ValueError):
         return False

--- a/src/jacobian/math/combinatorics/symmetric_functions/operations.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/operations.py
@@ -46,6 +46,7 @@ def _complete_homogeneous(variables: Sequence[int], k: int) -> int:
 def schur_evaluation(
     partition: IntegerPartition,
     point: tuple[int, ...],
+    variables: tuple[str, ...] | None = None,
 ) -> SchurExpansionResult:
     """Evaluate a Schur function s_lambda at a point using the Jacobi-Trudi formula.
 
@@ -72,10 +73,28 @@ def schur_evaluation(
             message="point must contain 1..20 bounded integer coordinates",
         )
 
+    variables = variables if variables is not None else tuple(
+        f"x{i}" for i in range(len(point))
+    )
+    if len(variables) != len(point):
+        raise OperationDomainValidationError(
+            location=("variables",),
+            code="symmetric_function.schur_dimensions_mismatch",
+            message="variables and point must have the same length",
+        )
+    if len(set(variables)) != len(variables):
+        raise OperationDomainValidationError(
+            location=("variables",),
+            code="symmetric_function.schur_variables_not_distinct",
+            message="variables must be distinct (duplicate axis)",
+        )
+
     parts = list(partition.parts)
     n = len(parts)
     if not parts:
-        return SchurExpansionResult(value=1)
+        return SchurExpansionResult(
+            partition=partition, variables=variables, point=point, value=1
+        )
 
     def h(k: int) -> int:
         if k < 0:
@@ -89,7 +108,9 @@ def schur_evaluation(
             matrix[i][j] = h(parts[i] - (i + 1) + (j + 1))
 
     result = _determinant(matrix)
-    return SchurExpansionResult(value=result)
+    return SchurExpansionResult(
+        partition=partition, variables=variables, point=point, value=result
+    )
 
 
 def _determinant(matrix: list[list[int]]) -> int:
@@ -108,7 +129,13 @@ def _determinant(matrix: list[list[int]]) -> int:
 
 
 def verify_schur_evaluation(claim: SchurExpansionResult) -> bool:
-    return type(claim.value) is int
+    if not isinstance(claim, SchurExpansionResult):
+        return False
+    try:
+        expected = schur_evaluation(claim.partition, claim.point, claim.variables)
+    except (OperationDomainValidationError, TypeError, ValueError):
+        return False
+    return expected == claim
 
 
 __all__ = [

--- a/src/jacobian/math/combinatorics/symmetric_functions/operations.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/operations.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from pydantic import TypeAdapter, ValidationError
+
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.symmetric_functions._models import (
     _MAX_POINT_COORDINATE_ABS,
@@ -13,6 +15,8 @@ from jacobian.math.combinatorics.symmetric_functions._models import (
     SchurExpansionResult,
     SchurVariableName,
 )
+
+_SCHUR_VARIABLE_NAME_ADAPTER = TypeAdapter(SchurVariableName)
 
 
 def partition_conjugate(partition: IntegerPartition) -> IntegerPartition:
@@ -80,19 +84,18 @@ def schur_evaluation(
         if variables is not None
         else tuple(f"x{i}" for i in range(len(point)))
     )
-    if any(
-        type(variable) is not str
-        or not 1 <= len(variable) <= _MAX_SCHUR_VARIABLE_NAME_LENGTH
-        for variable in variables
-    ):
-        raise OperationDomainValidationError(
-            location=("variables",),
-            code="symmetric_function.schur_variable_name_bounded",
-            message=(
-                "variable names must be nonempty strings of at most "
-                f"{_MAX_SCHUR_VARIABLE_NAME_LENGTH} characters"
-            ),
-        )
+    for variable in variables:
+        try:
+            _SCHUR_VARIABLE_NAME_ADAPTER.validate_python(variable, strict=True)
+        except ValidationError as error:
+            raise OperationDomainValidationError(
+                location=("variables",),
+                code="symmetric_function.schur_variable_name_bounded",
+                message=(
+                    "variable names must be canonical nonempty labels of at most "
+                    f"{_MAX_SCHUR_VARIABLE_NAME_LENGTH} characters"
+                ),
+            ) from error
     if len(variables) != len(point):
         raise OperationDomainValidationError(
             location=("variables",),

--- a/src/jacobian/math/combinatorics/symmetric_functions/operations.py
+++ b/src/jacobian/math/combinatorics/symmetric_functions/operations.py
@@ -151,8 +151,18 @@ def _determinant(matrix: list[list[int]]) -> int:
 def verify_schur_evaluation(claim: object) -> bool:
     if not isinstance(claim, SchurExpansionResult):
         return False
-    expected = schur_evaluation(claim.partition, claim.point, claim.variables)
-    return expected == claim
+    try:
+        canonical_claim = SchurExpansionResult.model_validate(
+            claim.model_dump(mode="python"), strict=True
+        )
+    except (AttributeError, TypeError, ValueError):
+        return False
+    expected = schur_evaluation(
+        canonical_claim.partition,
+        canonical_claim.point,
+        canonical_claim.variables,
+    )
+    return expected == canonical_claim
 
 
 __all__ = [

--- a/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
@@ -277,7 +277,29 @@ def test_native_schur_rejects_variable_name_exceeding_length_bound() -> None:
     variable = "x" * (_MAX_SCHUR_VARIABLE_NAME_LENGTH + 1)
     with pytest.raises(
         OperationDomainValidationError,
-        match="variable names must be nonempty strings",
+        match="canonical nonempty labels",
+    ):
+        schur_evaluation(IntegerPartition(parts=(1,)), (1,), (variable,))
+
+
+@pytest.mark.parametrize("variable", (" x", "x ", "x\x00"))
+def test_schur_rejects_noncanonical_variable_name(variable: str) -> None:
+    with pytest.raises(ValidationError):
+        SchurExpansionRequest(
+            partition=IntegerPartition(parts=(1,)),
+            variables=(variable,),
+            point=(1,),
+        )
+    with pytest.raises(ValidationError):
+        SchurExpansionResult(
+            partition=IntegerPartition(parts=(1,)),
+            variables=(variable,),
+            point=(1,),
+            value=1,
+        )
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="canonical nonempty labels",
     ):
         schur_evaluation(IntegerPartition(parts=(1,)), (1,), (variable,))
 

--- a/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
@@ -63,9 +63,7 @@ def test_schur_result_is_bound_and_verifiable() -> None:
 def test_native_schur_rejects_oversized_variable_axis_before_label_validation() -> None:
     labels = tuple(f"x{index}" for index in range(21))
 
-    with pytest.raises(
-        OperationDomainValidationError, match="same length"
-    ):
+    with pytest.raises(OperationDomainValidationError, match="same length"):
         schur_evaluation(IntegerPartition(parts=(1,)), (1,), labels)
 
 

--- a/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.symmetric_functions._models import (
     _MAX_SCHUR_PARTITION_LENGTH,
+    _MAX_SCHUR_VARIABLE_NAME_LENGTH,
     IntegerPartition,
     PartitionConjugateResult,
     PartitionRequest,
@@ -228,6 +229,8 @@ def test_request_schema_publishes_schur_invariants() -> None:
     assert "length must equal the length of point" in variables_description
     assert variables.get("uniqueItems") is True
     assert variables["minItems"] == 1 and variables["maxItems"] == 20
+    assert variables["items"]["maxLength"] == _MAX_SCHUR_VARIABLE_NAME_LENGTH
+    assert f"{_MAX_SCHUR_VARIABLE_NAME_LENGTH} characters" in variables["description"]
     assert point["items"]["minimum"] == -999_999
     assert point["items"]["maximum"] == 999_999
     assert "decimal digits" in point["items"]["description"]
@@ -248,6 +251,35 @@ def test_schur_rejects_coordinate_exceeding_digit_bound() -> None:
             variables=("x1",),
             point=(1_000_000,),
         )
+
+
+def test_schur_rejects_variable_name_exceeding_length_bound() -> None:
+    variable = "x" * (_MAX_SCHUR_VARIABLE_NAME_LENGTH + 1)
+    with pytest.raises(ValidationError) as request_error:
+        SchurExpansionRequest(
+            partition=IntegerPartition(parts=(1,)),
+            variables=(variable,),
+            point=(1,),
+        )
+    assert request_error.value.errors()[0]["type"] == "string_too_long"
+
+    with pytest.raises(ValidationError) as result_error:
+        SchurExpansionResult(
+            partition=IntegerPartition(parts=(1,)),
+            variables=(variable,),
+            point=(1,),
+            value=1,
+        )
+    assert result_error.value.errors()[0]["type"] == "string_too_long"
+
+
+def test_native_schur_rejects_variable_name_exceeding_length_bound() -> None:
+    variable = "x" * (_MAX_SCHUR_VARIABLE_NAME_LENGTH + 1)
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="variable names must be nonempty strings",
+    ):
+        schur_evaluation(IntegerPartition(parts=(1,)), (1,), (variable,))
 
 
 def test_schur_accepts_boundary_coordinate() -> None:

--- a/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
@@ -85,6 +85,39 @@ def test_schur_verifier_rejects_forged_nested_partition_parts() -> None:
     assert not verify_schur_evaluation(forged)
 
 
+def test_schur_result_rejects_non_integer_point_coordinates() -> None:
+    result = schur_evaluation(IntegerPartition(parts=(1,)), (1,), ("x",))
+    with pytest.raises(ValidationError):
+        SchurExpansionResult(
+            partition=result.partition,
+            variables=result.variables,
+            point=(True,),
+            value=result.value,
+        )
+    with pytest.raises(ValidationError):
+        SchurExpansionResult(
+            partition=result.partition,
+            variables=result.variables,
+            point=(1.0,),
+            value=result.value,
+        )
+    with pytest.raises(ValidationError):
+        SchurExpansionResult(
+            partition=result.partition,
+            variables=result.variables,
+            point=("1",),
+            value=result.value,
+        )
+    for coordinate in (True, 1.0, "1"):
+        forged = SchurExpansionResult.model_construct(
+            partition=result.partition,
+            variables=result.variables,
+            point=(coordinate,),
+            value=result.value,
+        )
+        assert not verify_schur_evaluation(forged)
+
+
 def test_schur_verifier_rejects_unvalidated_claim_copies() -> None:
     result = schur_evaluation(IntegerPartition(parts=(1,)), (1,), ("x",))
     invalid_copies = (

--- a/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.symmetric_functions._models import (
     _MAX_SCHUR_PARTITION_LENGTH,
     IntegerPartition,
@@ -55,6 +56,49 @@ def test_schur_result_is_bound_and_verifiable() -> None:
     assert verify_schur_evaluation(result)
     forged = result.model_copy(update={"value": 3})
     assert not verify_schur_evaluation(forged)
+    assert not verify_schur_evaluation(object())
+
+
+def test_schur_verifier_propagates_claim_outside_execution_envelope() -> None:
+    claim = SchurExpansionResult(
+        partition=IntegerPartition(parts=(1,) * 51),
+        variables=("x",),
+        point=(1,),
+        value=0,
+    )
+
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="partition length must not exceed 50",
+    ):
+        verify_schur_evaluation(claim)
+
+
+def test_schur_verifier_accepts_boundary_execution_envelope() -> None:
+    claim = SchurExpansionResult(
+        partition=IntegerPartition(parts=(1,) * 50),
+        variables=("x",),
+        point=(0,),
+        value=0,
+    )
+
+    assert verify_schur_evaluation(claim)
+
+
+def test_schur_verifier_propagates_computation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    claim = schur_evaluation(IntegerPartition(parts=(1,)), (1,), ("x",))
+
+    def fail(*args: object, **kwargs: object) -> SchurExpansionResult:
+        raise RuntimeError("computation failed")
+
+    monkeypatch.setattr(
+        "jacobian.math.combinatorics.symmetric_functions.operations.schur_evaluation",
+        fail,
+    )
+    with pytest.raises(RuntimeError, match="computation failed"):
+        verify_schur_evaluation(claim)
 
 
 def test_conjugate_self_conjugate_partition() -> None:

--- a/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
@@ -76,6 +76,15 @@ def test_schur_verifier_rejects_oversized_constructed_axes_without_dumping() -> 
     assert not verify_schur_evaluation(claim)
 
 
+def test_schur_verifier_rejects_forged_nested_partition_parts() -> None:
+    result = schur_evaluation(IntegerPartition(parts=(1,)), (1,), ("x",))
+    forged = result.model_copy(
+        update={"partition": IntegerPartition.model_construct(parts=(0,))}
+    )
+
+    assert not verify_schur_evaluation(forged)
+
+
 def test_schur_verifier_rejects_unvalidated_claim_copies() -> None:
     result = schur_evaluation(IntegerPartition(parts=(1,)), (1,), ("x",))
     invalid_copies = (

--- a/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
@@ -60,6 +60,21 @@ def test_schur_result_is_bound_and_verifiable() -> None:
     assert not verify_schur_evaluation(object())
 
 
+def test_schur_verifier_rejects_unvalidated_claim_copies() -> None:
+    result = schur_evaluation(IntegerPartition(parts=(1,)), (1,), ("x",))
+    invalid_copies = (
+        result.model_copy(update={"variables": ()}),
+        SchurExpansionResult.model_construct(
+            partition=result.partition,
+            variables=result.variables,
+            point=result.point,
+            value=True,
+        ),
+    )
+
+    assert all(not verify_schur_evaluation(claim) for claim in invalid_copies)
+
+
 def test_schur_verifier_propagates_claim_outside_execution_envelope() -> None:
     claim = SchurExpansionResult(
         partition=IntegerPartition(parts=(1,) * 51),

--- a/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
@@ -60,6 +60,24 @@ def test_schur_result_is_bound_and_verifiable() -> None:
     assert not verify_schur_evaluation(object())
 
 
+def test_native_schur_rejects_oversized_variable_axis_before_label_validation() -> None:
+    labels = tuple(f"x{index}" for index in range(21))
+
+    with pytest.raises(
+        OperationDomainValidationError, match="same length"
+    ):
+        schur_evaluation(IntegerPartition(parts=(1,)), (1,), labels)
+
+
+def test_schur_verifier_rejects_oversized_constructed_axes_without_dumping() -> None:
+    result = schur_evaluation(IntegerPartition(parts=(1,)), (1,), ("x",))
+    claim = result.model_copy(
+        update={"variables": tuple(f"x{index}" for index in range(10_000))}
+    )
+
+    assert not verify_schur_evaluation(claim)
+
+
 def test_schur_verifier_rejects_unvalidated_claim_copies() -> None:
     result = schur_evaluation(IntegerPartition(parts=(1,)), (1,), ("x",))
     invalid_copies = (

--- a/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
@@ -17,6 +17,7 @@ from jacobian.math.combinatorics.symmetric_functions._tools import TOOLS
 from jacobian.math.combinatorics.symmetric_functions.operations import (
     partition_conjugate,
     schur_evaluation,
+    verify_schur_evaluation,
 )
 from jacobian.math.combinatorics.symmetric_functions.values import (
     MAX_PARTITION_SIZE,
@@ -44,6 +45,18 @@ def test_native_surface_accepts_canonical_partition_values() -> None:
 
     assert partition_conjugate(partition).parts == (2, 1)
     assert schur_evaluation(partition, (1, 1)).value == 2
+
+
+def test_schur_result_is_bound_and_verifiable() -> None:
+    result = schur_evaluation(
+        IntegerPartition(parts=(1,)), (1, 1), ("x1", "x2")
+    )
+    assert result.partition.parts == (1,)
+    assert result.variables == ("x1", "x2")
+    assert result.point == (1, 1)
+    assert verify_schur_evaluation(result)
+    forged = result.model_copy(update={"value": 3})
+    assert not verify_schur_evaluation(forged)
 
 
 def test_conjugate_self_conjugate_partition() -> None:

--- a/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/combinatorics/symmetric_functions/test_symmetric_functions.py
@@ -48,9 +48,7 @@ def test_native_surface_accepts_canonical_partition_values() -> None:
 
 
 def test_schur_result_is_bound_and_verifiable() -> None:
-    result = schur_evaluation(
-        IntegerPartition(parts=(1,)), (1, 1), ("x1", "x2")
-    )
+    result = schur_evaluation(IntegerPartition(parts=(1,)), (1, 1), ("x1", "x2"))
     assert result.partition.parts == (1,)
     assert result.variables == ("x1", "x2")
     assert result.point == (1, 1)


### PR DESCRIPTION
## Problem
`SchurExpansionResult` retained only an integer value, and its verifier accepted every integer claim. Serialized Schur evaluations therefore lost the partition, ordered variable axes, and evaluation point needed to identify or verify the mathematical claim. This is a regression of the requirement tracked in #3391.

## Outcome
Results now retain the partition, variables, and point, while preserving the native scalar value. The verifier recomputes the exact evaluation against that retained context and rejects forged values.

## Validation
- Commands run: `PYTHONPATH=src pytest -q tests/math/combinatorics/symmetric_functions tests/dispatch/test_algebraic_combinatorics_dispatch.py` (32 passed); `PYTHONPATH=src pytest -q tests/math/combinatorics/additive tests/math/combinatorics/algebraic tests/math/combinatorics/arithmetic_progression_hypergraph tests/math/combinatorics/extremal_sets tests/math/combinatorics/greedoids tests/math/combinatorics/matroids tests/math/combinatorics/symmetric_functions tests/math/combinatorics/word_cubes` (666 passed).
- Final head SHA tested: `05a69fb4e`.

## Contract impact
- Public result schema gains the source context required for exact verification. Request admission and mathematical evaluation remain unchanged.
- Producer → serialization → consumer context is covered by the bound result and forged-value regression.
- Defining invariant and adversarial regression are covered.

### Operation boundary
- Changed stage and owner: result construction and source-bound claim verification in symmetric functions.
- Semantic admission and controlling quantities: existing partition, point, and output digit bounds remain controlling.
- Backend or kernel path: existing Jacobi–Trudi computation.
- Result construction: canonical partition, ordered variable axis, point, and exact integer are retained.
- Caller-supplied claim recognition: `verify_schur_evaluation` recomputes the retained evaluation.
- Native/MCP parity: catalog runner now passes request variables into the same native operation.
- Serialized-result and round-trip evidence: focused test checks retained context and rejects a tampered value.