### PR TITLE
fix(polynomials): validate native vector field shapes

### DIFF
--- a/src/jacobian/math/polynomials/vector_calculus/operations.py
+++ b/src/jacobian/math/polynomials/vector_calculus/operations.py
@@ -77,12 +77,31 @@ def _admit_scalar_field(polynomial: RationalPolynomial) -> None:
 
 
 def _admit_vector_field(components: tuple[RationalPolynomial, ...]) -> None:
+    if not components:
+        raise OperationDomainValidationError(
+            location=("components",),
+            code="polynomial_vector_calc.empty_vector_field",
+            message="vector field must contain at least one component",
+        )
+    variables = components[0].variables
+    if len(components) != len(variables):
+        raise OperationDomainValidationError(
+            location=("components",),
+            code="polynomial_vector_calc.component_count",
+            message="vector field must have one component per variable",
+        )
     for index, component in enumerate(components):
         _admit_field_polynomial(
             component,
             label="vector-field component",
             location=("components", index),
         )
+        if component.variables != variables:
+            raise OperationDomainValidationError(
+                location=("components", index),
+                code="polynomial_vector_calc.ordered_ring",
+                message="vector-field components must use one ordered ring",
+            )
     if sum(len(item.polynomial.terms) for item in components) > _MAX_TERMS:
         raise OperationDomainValidationError(
             location=("components",),
@@ -142,6 +161,12 @@ def curl(components: tuple[RationalPolynomial, ...]) -> VectorResult:
 
     _admit_vector_field(components)
     variables = components[0].variables
+    if len(variables) != 3:
+        raise OperationDomainValidationError(
+            location=("components",),
+            code="polynomial_vector_calc.curl_dimensions",
+            message="curl requires exactly three variables and components",
+        )
     x, y, z = symbols_for_variables(variables)
     fx, fy, fz = _expressions(components)
     return VectorResult._from_kernel(

--- a/tests/math/polynomials/vector_calculus/test_polynomial_vector_calc.py
+++ b/tests/math/polynomials/vector_calculus/test_polynomial_vector_calc.py
@@ -88,6 +88,23 @@ def test_catalog_contains_only_audited_operations() -> None:
     }
 
 
+def test_native_vector_operations_reject_malformed_fields_at_admission() -> None:
+    with pytest.raises(OperationDomainValidationError, match="at least one component"):
+        divergence(())
+
+    x = _polynomial(("x", "y", "z"), {(1, 0, 0): 1})
+    with pytest.raises(OperationDomainValidationError, match="one component per variable"):
+        divergence((x, x))
+
+    planar = _polynomial(("x", "y"), {(1, 0): 1})
+    with pytest.raises(OperationDomainValidationError, match="exactly three variables"):
+        curl((planar, planar))
+
+    y = _polynomial(("y", "x", "z"), {(0, 1, 0): 1})
+    with pytest.raises(OperationDomainValidationError, match="one ordered ring"):
+        divergence((x, y, x))
+
+
 def test_gradient_returns_composable_polynomials() -> None:
     source = _polynomial(("x", "y"), {(2, 0): 1, (0, 2): 1})
     result = _run_gradient(ScalarFieldRequest(polynomial=source))

--- a/tests/math/polynomials/vector_calculus/test_polynomial_vector_calc.py
+++ b/tests/math/polynomials/vector_calculus/test_polynomial_vector_calc.py
@@ -93,7 +93,9 @@ def test_native_vector_operations_reject_malformed_fields_at_admission() -> None
         divergence(())
 
     x = _polynomial(("x", "y", "z"), {(1, 0, 0): 1})
-    with pytest.raises(OperationDomainValidationError, match="one component per variable"):
+    with pytest.raises(
+        OperationDomainValidationError, match="one component per variable"
+    ):
         divergence((x, x))
 
     planar = _polynomial(("x", "y"), {(1, 0): 1})


### PR DESCRIPTION
## Problem
The native polynomial vector calculus operations accepted component tuples directly, but shared admission dereferenced the first component before checking that the field was nonempty and did not establish component count or common ordered axes. Empty fields leaked `IndexError`; mismatched fields leaked `ValueError` and unpacking errors.

## Change
- validate nonempty vector fields at native admission
- require one component per variable and a common ordered ring
- reject non-three-dimensional native curl requests with a typed domain error
- add behavioral regressions for empty, count, dimension, and axis mismatches

Issue: #3620

## Validation
- `PYTHONPATH=src pytest -q tests/math/polynomials/vector_calculus/test_polynomial_vector_calc.py` (13 passed)
- prior focused polynomial suite: 278 passed
- `git diff --check`
