### PR TITLE
fix(finite-geometry): enforce projective sequence normalization

### DIFF
--- a/src/jacobian/math/geometry/finite/values.py
+++ b/src/jacobian/math/geometry/finite/values.py
@@ -111,7 +111,7 @@ class ProjectivePointSequence(StrictModel):
     @model_validator(mode="after")
     def require_structural_coordinates(self) -> Self:
         for coordinates in self.coordinates:
-            _validate_vector(coordinates, self.space)
+            _require_projective_representative(coordinates, self.space)
         return self
 
     def __len__(self) -> int:

--- a/tests/math/geometry/finite/test_finite_geometry.py
+++ b/tests/math/geometry/finite/test_finite_geometry.py
@@ -393,7 +393,7 @@ def test_enumerate_admission_bounds_axis_label_characters() -> None:
 
 
 def test_sequence_normalization_is_an_explicit_claim() -> None:
-    """Sequence coordinate normalization is checked by its verifier."""
+    """Sequence coordinates are canonical at the typed value boundary."""
     result = projective_space_enumerate(_space(3, ("x", "y")))
     assert result.sequence.coordinates == ((0, 1), (1, 0), (1, 1), (1, 2))
 
@@ -402,8 +402,8 @@ def test_sequence_normalization_is_an_explicit_claim() -> None:
         (2, 1),
         *payload["sequence"]["coordinates"][1:],
     )
-    forged = ProjectiveSpaceEnumerateResult.model_validate(payload)
-    assert verify_projective_point_sequence(forged.sequence) is False
+    with pytest.raises(ValidationError):
+        ProjectiveSpaceEnumerateResult.model_validate(payload)
 
 
 def test_enumeration_sequence_claim_verifier_rejects_duplicates_and_wrong_counts() -> (


### PR DESCRIPTION
Projective point sequences are documented as complete lists of canonical homogeneous representatives, but their typed value validator previously checked only field residues. On the base, both `ProjectivePointSequence(space=F3^2, coordinates=((0, 0),))` and `ProjectivePointSequence(space=F3^2, coordinates=((2, 1),))` were accepted. The first is the zero vector; the second is a scaled, non-normalized representative. Iterating either through the typed `ProjectivePoint` boundary then fails or admits a non-canonical projective claim.

The sequence validator now applies the shared canonical representative invariant: every tuple has the right residue shape, is nonzero, and has first nonzero coordinate equal to one. The forged serialized payload regression changes `((0, 1), ...)` to `((2, 1), ...)` and proves `ProjectiveSpaceEnumerateResult.model_validate(payload)` rejects it at construction.

Validation:
- `PYTHONPATH=src pytest -q tests/math/geometry/euclidean tests/math/geometry/exact tests/math/geometry/finite tests/math/geometry/framework tests/math/geometry/gaussian_projective_line tests/math/geometry/metric_spaces tests/math/geometry/polygon_kernel tests/math/geometry/polytopes tests/math/geometry/projective` (459 passed)
- `MATH_WORKERS=0 make affected AFFECTED_BASE=origin/main` (lint, mypy, finite geometry tests, catalog, and catalog examples passed)
- Final head `c2b3c7befa11218dbb3cb193dc30eb57c228d1cd`; worktree clean and branch tracks `origin/codex/kernel-audit-geometry-e-z`.
