### PR TITLE
fix(number-theory): bound native Diophantine approximation requests

### DIFF
--- a/src/jacobian/math/number_theory/diophantine_approximation/operations.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/operations.py
@@ -7,6 +7,8 @@ from math import isqrt
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.arithmetic._integer_predicates import is_square_free
 from jacobian.math.number_theory.diophantine_approximation._models import (
+    _MAX_DISCRIMINANT,
+    _MAX_TERMS,
     ContinuedFractionResult,
     ConvergentResult,
     ConvergentValue,
@@ -18,11 +20,14 @@ __all__ = ["continued_fraction", "convergents", "solve_pell"]
 
 def _require_periodic_discriminant(discriminant: int) -> None:
     """Reject discriminants whose sqrt is not a periodic quadratic surd."""
-    if discriminant < 2:
+    if type(discriminant) is not int or not 2 <= discriminant <= _MAX_DISCRIMINANT:
         raise OperationDomainValidationError(
             location=("discriminant",),
             code="diophantine.discriminant_out_of_range",
-            message="discriminant must be at least 2",
+            message=(
+                "discriminant must be an integer between 2 and "
+                f"{_MAX_DISCRIMINANT}"
+            ),
         )
     root = isqrt(discriminant)
     if root * root == discriminant:
@@ -78,11 +83,11 @@ def continued_fraction(
     term_count: int,
 ) -> ContinuedFractionResult:
     """Return the continued fraction expansion of sqrt(D)."""
-    if term_count < 1:
+    if type(term_count) is not int or not 1 <= term_count <= _MAX_TERMS:
         raise OperationDomainValidationError(
             location=("term_count",),
             code="diophantine.term_count_out_of_range",
-            message="term_count must be at least 1",
+            message=f"term_count must be between 1 and {_MAX_TERMS}",
         )
     preperiod, period = _cf_coefficients(discriminant)
     return ContinuedFractionResult._from_kernel(
@@ -96,11 +101,11 @@ def continued_fraction(
 
 def convergents(discriminant: int, count: int) -> ConvergentResult:
     """Return the first count convergents (index, p_n, q_n) of sqrt(D)."""
-    if count < 1:
+    if type(count) is not int or not 1 <= count <= _MAX_TERMS:
         raise OperationDomainValidationError(
             location=("count",),
             code="diophantine.convergent_count_out_of_range",
-            message="count must be at least 1",
+            message=f"count must be between 1 and {_MAX_TERMS}",
         )
     preperiod, period = _cf_coefficients(discriminant)
     coefficients = _coefficients(preperiod, period, count)

--- a/src/jacobian/math/number_theory/diophantine_approximation/operations.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/operations.py
@@ -25,8 +25,7 @@ def _require_periodic_discriminant(discriminant: int) -> None:
             location=("discriminant",),
             code="diophantine.discriminant_out_of_range",
             message=(
-                "discriminant must be an integer between 2 and "
-                f"{_MAX_DISCRIMINANT}"
+                f"discriminant must be an integer between 2 and {_MAX_DISCRIMINANT}"
             ),
         )
     root = isqrt(discriminant)

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -214,6 +214,23 @@ def test_public_kernels_reject_perfect_square() -> None:
         solve_pell(16)
 
 
+@pytest.mark.parametrize(
+    ("operation", "argument"),
+    [(continued_fraction, 5_001), (convergents, 5_001)],
+)
+def test_public_kernels_reject_unbounded_prefix_requests(operation, argument) -> None:
+    """Native callers share the materialized-prefix bound of the public models."""
+    with pytest.raises(OperationDomainValidationError, match="between 1 and 5000"):
+        operation(2, argument)
+
+
+def test_public_kernels_reject_unbounded_discriminants() -> None:
+    with pytest.raises(OperationDomainValidationError, match="between 2 and 1000000"):
+        continued_fraction(1_000_001, 1)
+    with pytest.raises(OperationDomainValidationError, match="between 2 and 1000000"):
+        solve_pell(1_000_001)
+
+
 def test_public_kernels_return_typed_values() -> None:
     fraction = continued_fraction(2, 3)
     assert fraction.coefficients == (1, 2, 2)

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+from collections.abc import Callable
 
 import pytest
 from pydantic import ValidationError
@@ -218,7 +219,9 @@ def test_public_kernels_reject_perfect_square() -> None:
     ("operation", "argument"),
     [(continued_fraction, 5_001), (convergents, 5_001)],
 )
-def test_public_kernels_reject_unbounded_prefix_requests(operation, argument) -> None:
+def test_public_kernels_reject_unbounded_prefix_requests(
+    operation: Callable[[int, int], object], argument: int
+) -> None:
     """Native callers share the materialized-prefix bound of the public models."""
     with pytest.raises(OperationDomainValidationError, match="between 1 and 5000"):
         operation(2, argument)


### PR DESCRIPTION
Direct native Diophantine approximation calls could bypass the public request envelope: continued-fraction and convergent prefixes had no upper term bound, and all three operations accepted arbitrarily large discriminants before invoking SymPy. This allowed unbounded materialized output or backend work through the native API.

The native operations now share the request model limits (discriminants 2..1,000,000 and materialized prefixes 1..5,000), with strict integer checks and the existing stable error codes. Regression tests cover oversized prefixes and discriminants.

Validation: `uv run pytest tests/math/number_theory/arithmetic tests/math/number_theory/arithmetic_functions tests/math/number_theory/characters tests/math/number_theory/counting tests/math/number_theory/diophantine_approximation tests/math/number_theory/elliptic_curves tests/math/number_theory/galois tests/math/number_theory/algebraic_numbers tests/math/number_theory/prime_affine_forms tests/math/number_theory/test_interval_profiles.py -q` (419 passed).