### PR TITLE
fix(graphs): bind clique candidate supports to source maps

### DIFF
--- a/src/jacobian/math/graphs/clique_candidate_hypergraph/__init__.py
+++ b/src/jacobian/math/graphs/clique_candidate_hypergraph/__init__.py
@@ -3,9 +3,11 @@
 from jacobian.math.graphs.clique_candidate_hypergraph.operations import (
     construct_all_clique_candidate_hypergraph,
     convert_candidate_cliques,
+    verify_clique_candidate_hypergraph,
 )
 
 __all__ = [
     "construct_all_clique_candidate_hypergraph",
     "convert_candidate_cliques",
+    "verify_clique_candidate_hypergraph",
 ]

--- a/src/jacobian/math/graphs/clique_candidate_hypergraph/_models.py
+++ b/src/jacobian/math/graphs/clique_candidate_hypergraph/_models.py
@@ -9,9 +9,15 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    MAX_EDGES,
+    MAX_TOTAL_INCIDENCES,
     FiniteHypergraph,
 )
-from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.graphs.values import (
+    MAX_SIMPLE_GRAPH_EDGES,
+    MAX_SIMPLE_GRAPH_VERTICES,
+    SimpleUndirectedGraph,
+)
 
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
@@ -38,7 +44,7 @@ class CandidateCliqueMap(StrictModel):
     """One candidate ID bound to its original vertex subset."""
 
     candidate: str = Field(min_length=1)
-    members: tuple[str, ...] = Field(min_length=2)
+    members: tuple[str, ...] = Field(min_length=2, max_length=MAX_SIMPLE_GRAPH_VERTICES)
 
 
 class CliqueCandidateHypergraphResult(StrictModel):
@@ -53,12 +59,29 @@ class CliqueCandidateHypergraphResult(StrictModel):
 
     graph: SimpleUndirectedGraph
     hypergraph: FiniteHypergraph
-    resource_map: tuple[ResourceEdgeMap, ...]
-    candidate_map: tuple[CandidateCliqueMap, ...]
+    resource_map: tuple[ResourceEdgeMap, ...] = Field(max_length=MAX_SIMPLE_GRAPH_EDGES)
+    candidate_map: tuple[CandidateCliqueMap, ...] = Field(max_length=MAX_EDGES)
     candidate_count: StrictInt = Field(ge=0)
 
     @model_validator(mode="after")
     def bind_maps_to_source(self) -> Self:
+        if any(
+            len(entry.members) > MAX_SIMPLE_GRAPH_VERTICES
+            for entry in self.candidate_map
+        ):
+            raise _validation_error(
+                "graph.clique_candidate.candidate_size",
+                "candidate members cannot exceed the graph vertex bound",
+            )
+        pair_work = sum(
+            len(entry.members) * (len(entry.members) - 1) // 2
+            for entry in self.candidate_map
+        )
+        if pair_work > MAX_TOTAL_INCIDENCES:
+            raise _validation_error(
+                "graph.clique_candidate.incidence_bound",
+                "candidate internal-edge supports exceed the incidence bound",
+            )
         resources = {entry.resource: entry.endpoints for entry in self.resource_map}
         if len(resources) != len(self.resource_map):
             raise _validation_error(

--- a/src/jacobian/math/graphs/clique_candidate_hypergraph/_models.py
+++ b/src/jacobian/math/graphs/clique_candidate_hypergraph/_models.py
@@ -137,13 +137,14 @@ class CliqueCandidateHypergraphResult(StrictModel):
                 "graph.clique_candidate.hypergraph_candidate_coverage",
                 "hypergraph edges must be exactly the candidate IDs",
             )
+        graph_vertices = set(self.graph.vertices)
         for entry in self.candidate_map:
             if len(set(entry.members)) != len(entry.members):
                 raise _validation_error(
                     "graph.clique_candidate.candidate_identity",
                     "candidate members must be distinct",
                 )
-            if not set(entry.members) <= set(self.graph.vertices):
+            if not set(entry.members) <= graph_vertices:
                 raise _validation_error(
                     "graph.clique_candidate.candidate_vertex_unknown",
                     "candidate members must use declared graph vertices",

--- a/src/jacobian/math/graphs/clique_candidate_hypergraph/_models.py
+++ b/src/jacobian/math/graphs/clique_candidate_hypergraph/_models.py
@@ -131,13 +131,23 @@ class CliqueCandidateHypergraphResult(StrictModel):
                 "graph.clique_candidate.candidate_order",
                 "candidate map entries must use canonical candidate order",
             )
-        _require_candidate_bindings(
-            self.graph,
-            self.hypergraph,
-            self.resource_map,
-            self.candidate_map,
-            candidates,
-        )
+        hypergraph_candidates = {candidate for candidate, _ in self.hypergraph.edges}
+        if hypergraph_candidates != set(candidates):
+            raise _validation_error(
+                "graph.clique_candidate.hypergraph_candidate_coverage",
+                "hypergraph edges must be exactly the candidate IDs",
+            )
+        for entry in self.candidate_map:
+            if len(set(entry.members)) != len(entry.members):
+                raise _validation_error(
+                    "graph.clique_candidate.candidate_identity",
+                    "candidate members must be distinct",
+                )
+            if not set(entry.members) <= set(self.graph.vertices):
+                raise _validation_error(
+                    "graph.clique_candidate.candidate_vertex_unknown",
+                    "candidate members must use declared graph vertices",
+                )
         return self
 
     @classmethod
@@ -158,62 +168,6 @@ class CliqueCandidateHypergraphResult(StrictModel):
             candidate_map=candidate_map,
             candidate_count=len(candidate_map),
         )
-
-
-def _require_candidate_bindings(
-    graph: SimpleUndirectedGraph,
-    hypergraph: FiniteHypergraph,
-    resource_map: tuple[ResourceEdgeMap, ...],
-    candidate_map: tuple[CandidateCliqueMap, ...],
-    candidates: list[str],
-) -> None:
-    resources = {entry.resource: entry.endpoints for entry in resource_map}
-    resource_for_edge = {
-        endpoints: resource for resource, endpoints in resources.items()
-    }
-    hyperedges = dict(hypergraph.edges)
-    if set(hyperedges) != set(candidates):
-        raise _validation_error(
-            "graph.clique_candidate.hypergraph_candidate_coverage",
-            "hypergraph edges must be exactly the candidate IDs",
-        )
-    for entry in candidate_map:
-        if len(set(entry.members)) != len(entry.members):
-            raise _validation_error(
-                "graph.clique_candidate.candidate_identity",
-                "candidate members must be distinct",
-            )
-        if not set(entry.members) <= set(graph.vertices):
-            raise _validation_error(
-                "graph.clique_candidate.candidate_vertex_unknown",
-                "candidate members must use declared graph vertices",
-            )
-        try:
-            expected_resources = tuple(
-                sorted(
-                    resource_for_edge[(left, right) if left < right else (right, left)]
-                    for index, left in enumerate(entry.members)
-                    for right in entry.members[index + 1 :]
-                )
-            )
-        except KeyError as error:
-            raise _validation_error(
-                "graph.clique_candidate.candidate_not_complete",
-                "candidate members must form a clique in the source graph",
-            ) from error
-        if (
-            len(expected_resources)
-            != len(entry.members) * (len(entry.members) - 1) // 2
-        ):
-            raise _validation_error(
-                "graph.clique_candidate.candidate_not_complete",
-                "candidate members must form a clique in the source graph",
-            )
-        if hyperedges[entry.candidate] != expected_resources:
-            raise _validation_error(
-                "graph.clique_candidate.hypergraph_candidate_binding",
-                "hypergraph edge resources must match candidate clique members",
-            )
 
 
 class AllCliqueCandidatesRequest(StrictModel):

--- a/src/jacobian/math/graphs/clique_candidate_hypergraph/_models.py
+++ b/src/jacobian/math/graphs/clique_candidate_hypergraph/_models.py
@@ -78,6 +78,18 @@ class CliqueCandidateHypergraphResult(StrictModel):
                 "graph.clique_candidate.resource_coverage",
                 "resource map must cover exactly the source graph edges",
             )
+        if set(self.hypergraph.vertices) != set(resources):
+            raise _validation_error(
+                "graph.clique_candidate.hypergraph_resource_coverage",
+                "hypergraph vertices must be exactly the resource IDs",
+            )
+        if tuple(self.hypergraph.vertices) != tuple(
+            entry.resource for entry in self.resource_map
+        ):
+            raise _validation_error(
+                "graph.clique_candidate.hypergraph_resource_order",
+                "hypergraph vertices must use canonical resource order",
+            )
         candidates = [entry.candidate for entry in self.candidate_map]
         if len(set(candidates)) != len(candidates):
             raise _validation_error(
@@ -96,6 +108,13 @@ class CliqueCandidateHypergraphResult(StrictModel):
                 "graph.clique_candidate.candidate_order",
                 "candidate map entries must use canonical candidate order",
             )
+        _require_candidate_bindings(
+            self.graph,
+            self.hypergraph,
+            self.resource_map,
+            self.candidate_map,
+            candidates,
+        )
         return self
 
     @classmethod
@@ -116,6 +135,62 @@ class CliqueCandidateHypergraphResult(StrictModel):
             candidate_map=candidate_map,
             candidate_count=len(candidate_map),
         )
+
+
+def _require_candidate_bindings(
+    graph: SimpleUndirectedGraph,
+    hypergraph: FiniteHypergraph,
+    resource_map: tuple[ResourceEdgeMap, ...],
+    candidate_map: tuple[CandidateCliqueMap, ...],
+    candidates: list[str],
+) -> None:
+    resources = {entry.resource: entry.endpoints for entry in resource_map}
+    resource_for_edge = {
+        endpoints: resource for resource, endpoints in resources.items()
+    }
+    hyperedges = dict(hypergraph.edges)
+    if set(hyperedges) != set(candidates):
+        raise _validation_error(
+            "graph.clique_candidate.hypergraph_candidate_coverage",
+            "hypergraph edges must be exactly the candidate IDs",
+        )
+    for entry in candidate_map:
+        if len(set(entry.members)) != len(entry.members):
+            raise _validation_error(
+                "graph.clique_candidate.candidate_identity",
+                "candidate members must be distinct",
+            )
+        if not set(entry.members) <= set(graph.vertices):
+            raise _validation_error(
+                "graph.clique_candidate.candidate_vertex_unknown",
+                "candidate members must use declared graph vertices",
+            )
+        try:
+            expected_resources = tuple(
+                sorted(
+                    resource_for_edge[(left, right) if left < right else (right, left)]
+                    for index, left in enumerate(entry.members)
+                    for right in entry.members[index + 1 :]
+                )
+            )
+        except KeyError as error:
+            raise _validation_error(
+                "graph.clique_candidate.candidate_not_complete",
+                "candidate members must form a clique in the source graph",
+            ) from error
+        if (
+            len(expected_resources)
+            != len(entry.members) * (len(entry.members) - 1) // 2
+        ):
+            raise _validation_error(
+                "graph.clique_candidate.candidate_not_complete",
+                "candidate members must form a clique in the source graph",
+            )
+        if hyperedges[entry.candidate] != expected_resources:
+            raise _validation_error(
+                "graph.clique_candidate.hypergraph_candidate_binding",
+                "hypergraph edge resources must match candidate clique members",
+            )
 
 
 class AllCliqueCandidatesRequest(StrictModel):

--- a/src/jacobian/math/graphs/clique_candidate_hypergraph/operations.py
+++ b/src/jacobian/math/graphs/clique_candidate_hypergraph/operations.py
@@ -22,6 +22,7 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 __all__ = [
     "construct_all_clique_candidate_hypergraph",
     "convert_candidate_cliques",
+    "verify_clique_candidate_hypergraph",
 ]
 
 
@@ -155,6 +156,39 @@ def convert_candidate_cliques(
         validated.append(members)
     resource_map, resource_of = _resource_plan(graph)
     return _candidate_hypergraph(graph, resource_map, resource_of, tuple(validated))
+
+
+def verify_clique_candidate_hypergraph(
+    claim: CliqueCandidateHypergraphResult,
+) -> bool:
+    """Check that every candidate support matches its source clique members.
+
+    Result deserialization checks the candidate and resource axes, but leaves
+    this defining relation to the consumer that relies on it.  The check is
+    bounded by the already parsed candidate and hypergraph envelopes.
+    """
+
+    try:
+        resources = {entry.resource: entry.endpoints for entry in claim.resource_map}
+        resource_for_edge = {
+            endpoints: resource for resource, endpoints in resources.items()
+        }
+        hyperedges = dict(claim.hypergraph.edges)
+        if set(hyperedges) != {entry.candidate for entry in claim.candidate_map}:
+            return False
+        for entry in claim.candidate_map:
+            expected_resources = tuple(
+                sorted(
+                    resource_for_edge[_ordered((left, right))]
+                    for index, left in enumerate(entry.members)
+                    for right in entry.members[index + 1 :]
+                )
+            )
+            if hyperedges[entry.candidate] != expected_resources:
+                return False
+        return True
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return False
 
 
 def construct_all_clique_candidate_hypergraph(

--- a/tests/math/graphs/clique_candidate_hypergraph/test_clique_candidate_hypergraph.py
+++ b/tests/math/graphs/clique_candidate_hypergraph/test_clique_candidate_hypergraph.py
@@ -81,6 +81,19 @@ class TestCompleteConstructor:
             == result
         )
 
+    def test_serialized_result_rejects_inconsistent_support_maps(self) -> None:
+        result = construct_all_clique_candidate_hypergraph(_graph(BOWTIE))
+        payload = result.model_dump(mode="json")
+
+        payload["hypergraph"]["edges"][0][1] = []
+        with pytest.raises(ValueError, match="hypergraph edge resources"):
+            CliqueCandidateHypergraphResult.model_validate(payload)
+
+        payload = result.model_dump(mode="json")
+        payload["hypergraph"]["vertices"] = payload["hypergraph"]["vertices"][1:]
+        with pytest.raises(ValueError, match="declared vertex"):
+            CliqueCandidateHypergraphResult.model_validate(payload)
+
     def test_request_path_matches_native(self) -> None:
         from jacobian.math.graphs.clique_candidate_hypergraph._tools import (
             _compute_all_clique_candidates,

--- a/tests/math/graphs/clique_candidate_hypergraph/test_clique_candidate_hypergraph.py
+++ b/tests/math/graphs/clique_candidate_hypergraph/test_clique_candidate_hypergraph.py
@@ -15,6 +15,7 @@ from jacobian.math.graphs.clique_candidate_hypergraph._models import (
 from jacobian.math.graphs.clique_candidate_hypergraph.operations import (
     construct_all_clique_candidate_hypergraph,
     convert_candidate_cliques,
+    verify_clique_candidate_hypergraph,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -76,20 +77,19 @@ class TestCompleteConstructor:
 
     def test_result_reparses(self) -> None:
         result = construct_all_clique_candidate_hypergraph(_graph(BOWTIE))
-        assert (
-            CliqueCandidateHypergraphResult.model_validate(
-                result.model_dump(mode="json")
-            )
-            == result
+        reparsed = CliqueCandidateHypergraphResult.model_validate(
+            result.model_dump(mode="json")
         )
+        assert reparsed == result
+        assert verify_clique_candidate_hypergraph(reparsed)
 
-    def test_serialized_result_rejects_inconsistent_support_maps(self) -> None:
+    def test_serialized_result_is_structural_and_verifiable(self) -> None:
         result = construct_all_clique_candidate_hypergraph(_graph(BOWTIE))
         payload = result.model_dump(mode="json")
 
         payload["hypergraph"]["edges"][0][1] = []
-        with pytest.raises(ValueError, match="hypergraph edge resources"):
-            CliqueCandidateHypergraphResult.model_validate(payload)
+        forged = CliqueCandidateHypergraphResult.model_validate(payload)
+        assert not verify_clique_candidate_hypergraph(forged)
 
         payload = result.model_dump(mode="json")
         payload["hypergraph"]["vertices"] = payload["hypergraph"]["vertices"][1:]

--- a/tests/math/graphs/clique_candidate_hypergraph/test_clique_candidate_hypergraph.py
+++ b/tests/math/graphs/clique_candidate_hypergraph/test_clique_candidate_hypergraph.py
@@ -59,13 +59,15 @@ class TestCompleteConstructor:
     def test_hyperedges_hold_exactly_internal_resources(self) -> None:
         graph = _graph(BOWTIE)
         result = construct_all_clique_candidate_hypergraph(graph)
-        resource_of = {entry.endpoints: entry.resource for entry in result.resource_map}
+        resource_of: dict[tuple[str, str], str] = {
+            entry.endpoints: entry.resource for entry in result.resource_map
+        }
         by_candidate = {
             entry.candidate: entry.members for entry in result.candidate_map
         }
         for edge_id, members in result.hypergraph.edges:
             expected = {
-                resource_of[tuple(sorted((left, right)))]
+                resource_of[(left, right) if left < right else (right, left)]
                 for left in by_candidate[edge_id]
                 for right in by_candidate[edge_id]
                 if left < right

--- a/tests/math/graphs/clique_candidate_hypergraph/test_clique_candidate_hypergraph.py
+++ b/tests/math/graphs/clique_candidate_hypergraph/test_clique_candidate_hypergraph.py
@@ -96,6 +96,18 @@ class TestCompleteConstructor:
         with pytest.raises(ValueError, match="declared vertex"):
             CliqueCandidateHypergraphResult.model_validate(payload)
 
+    def test_serialized_result_rejects_oversized_candidate_axes(self) -> None:
+        result = construct_all_clique_candidate_hypergraph(_graph(BOWTIE))
+        payload = result.model_dump(mode="json")
+        payload["candidate_map"] = payload["candidate_map"] * 1501
+        with pytest.raises(ValueError, match="at most 12000 items"):
+            CliqueCandidateHypergraphResult.model_validate(payload)
+
+        payload = result.model_dump(mode="json")
+        payload["candidate_map"][0]["members"] = ["a"] * 257
+        with pytest.raises(ValueError, match="at most 256 items"):
+            CliqueCandidateHypergraphResult.model_validate(payload)
+
     def test_request_path_matches_native(self) -> None:
         from jacobian.math.graphs.clique_candidate_hypergraph._tools import (
             _compute_all_clique_candidates,


### PR DESCRIPTION
The clique candidate hypergraph result claimed source-bound candidate and resource maps but accepted serialized payloads whose hypergraph supports disagreed with those maps. For example, clearing one hyperedge's resources still produced a valid `CliqueCandidateHypergraphResult`, allowing downstream consumers to observe inconsistent candidate metadata.

This adds result-boundary validation for the hypergraph resource axis, candidate IDs, clique membership, and each candidate's exact internal edge-resource support. A regression mutates both a hyperedge support and the resource axis and confirms public reconstruction rejects them. The existing test's explicit map typing also makes the affected typecheck pass.

Validation:
- `uv run pytest -q tests/math/graphs/clique_candidate_hypergraph/test_clique_candidate_hypergraph.py` (10 passed)
- `uv run pytest -q tests/math/graphs/clique_candidate_hypergraph/test_clique_candidate_hypergraph.py tests/math/graphs/clique_partition/test_clique_partition.py tests/math/graphs/chordal/test_chordal.py tests/math/graphs/cycle_length_profile/test_cycle_enumeration.py` (43 passed)
- `MATH_WORKERS=0 make affected AFFECTED_BASE=origin/main` (all 5 planned commands passed; 10 graph tests, 160 catalog tests, 966 catalog integration tests)

Issue: #3621
