### PR TITLE
fix(posets): authenticate canonical claims before consumers

### DIFF
--- a/src/jacobian/math/combinatorics/posets/antichain_enumeration/_models.py
+++ b/src/jacobian/math/combinatorics/posets/antichain_enumeration/_models.py
@@ -24,7 +24,9 @@ def require_antichain_enumeration_envelope(
     try:
         n = len(poset.elements)
     except (AttributeError, TypeError) as error:
-        raise ValueError("antichain enumeration requires a finite poset carrier") from error
+        raise ValueError(
+            "antichain enumeration requires a finite poset carrier"
+        ) from error
     if n > MAX_ELEMENTS:
         raise ValueError(
             f"antichain enumeration supports at most {MAX_ELEMENTS} elements"

--- a/src/jacobian/math/combinatorics/posets/antichain_enumeration/_models.py
+++ b/src/jacobian/math/combinatorics/posets/antichain_enumeration/_models.py
@@ -21,7 +21,10 @@ def require_antichain_enumeration_envelope(
     min_cardinality: int,
     max_cardinality: int,
 ) -> int:
-    n = len(poset.elements)
+    try:
+        n = len(poset.elements)
+    except (AttributeError, TypeError) as error:
+        raise ValueError("antichain enumeration requires a finite poset carrier") from error
     if n > MAX_ELEMENTS:
         raise ValueError(
             f"antichain enumeration supports at most {MAX_ELEMENTS} elements"

--- a/src/jacobian/math/combinatorics/posets/antichain_enumeration/operations.py
+++ b/src/jacobian/math/combinatorics/posets/antichain_enumeration/operations.py
@@ -25,6 +25,7 @@ def enumerate_antichains(
     An antichain is a set of pairwise incomparable elements. Uses a bitset
     comparability lookup for efficient rejection.
     """
+    _admit_canonical_poset(poset)
     try:
         require_antichain_enumeration_envelope(poset, min_cardinality, max_cardinality)
     except ValueError as exc:
@@ -33,7 +34,6 @@ def enumerate_antichains(
             code="poset.antichain_enumeration_envelope_exceeded",
             message=str(exc),
         ) from exc
-    _admit_canonical_poset(poset)
     elements = poset.elements
     n = len(elements)
     element_index = {e: i for i, e in enumerate(elements)}

--- a/src/jacobian/math/combinatorics/posets/antichain_enumeration/operations.py
+++ b/src/jacobian/math/combinatorics/posets/antichain_enumeration/operations.py
@@ -10,6 +10,7 @@ from jacobian.math.combinatorics.posets.antichain_enumeration._models import (
     require_antichain_enumeration_envelope,
 )
 from jacobian.math.combinatorics.posets.core._models import FinitePoset
+from jacobian.math.combinatorics.posets.core.operations import _admit_canonical_poset
 
 __all__ = ["enumerate_antichains"]
 
@@ -32,6 +33,7 @@ def enumerate_antichains(
             code="poset.antichain_enumeration_envelope_exceeded",
             message=str(exc),
         ) from exc
+    _admit_canonical_poset(poset)
     elements = poset.elements
     n = len(elements)
     element_index = {e: i for i, e in enumerate(elements)}

--- a/src/jacobian/math/combinatorics/posets/antichain_enumeration/operations.py
+++ b/src/jacobian/math/combinatorics/posets/antichain_enumeration/operations.py
@@ -25,15 +25,20 @@ def enumerate_antichains(
     An antichain is a set of pairwise incomparable elements. Uses a bitset
     comparability lookup for efficient rejection.
     """
-    _admit_canonical_poset(poset)
     try:
         require_antichain_enumeration_envelope(poset, min_cardinality, max_cardinality)
+    except (AttributeError, TypeError):
+        _admit_canonical_poset(poset)
     except ValueError as exc:
-        raise OperationDomainValidationError(
-            location=("min_cardinality", "max_cardinality"),
-            code="poset.antichain_enumeration_envelope_exceeded",
-            message=str(exc),
-        ) from exc
+        if "finite poset carrier" in str(exc):
+            _admit_canonical_poset(poset)
+        else:
+            raise OperationDomainValidationError(
+                location=("min_cardinality", "max_cardinality"),
+                code="poset.antichain_enumeration_envelope_exceeded",
+                message=str(exc),
+            ) from exc
+    _admit_canonical_poset(poset)
     elements = poset.elements
     n = len(elements)
     element_index = {e: i for i, e in enumerate(elements)}

--- a/src/jacobian/math/combinatorics/posets/core/_maximal_chains.py
+++ b/src/jacobian/math/combinatorics/posets/core/_maximal_chains.py
@@ -232,7 +232,7 @@ def _admit_typed_source(poset: FinitePoset) -> int:
     )
 
     request_checkpoint("before maximal-chain source admission")
-    if not isinstance(poset, FinitePoset):
+    if type(poset) is not FinitePoset:
         raise OperationDomainValidationError(
             location=("poset",),
             code="poset.maximal_chains.request_type",

--- a/src/jacobian/math/combinatorics/posets/core/_models.py
+++ b/src/jacobian/math/combinatorics/posets/core/_models.py
@@ -319,6 +319,12 @@ def _validate_poset_incomparable_pairs(
         for right in elements[index + 1 :]
         if (left, right) not in closure and (right, left) not in closure
     )
+    for pair in incomparable_pairs:
+        if type(pair) is not IncomparablePair:
+            raise _validation_error(
+                "canonical_incomparable_pairs",
+                "incomparable_pairs must use the canonical IncomparablePair type",
+            )
     actual_incomparable = tuple((pair.left, pair.right) for pair in incomparable_pairs)
     if actual_incomparable != expected_incomparable:
         raise _validation_error(

--- a/src/jacobian/math/combinatorics/posets/core/_models.py
+++ b/src/jacobian/math/combinatorics/posets/core/_models.py
@@ -330,6 +330,11 @@ def _validate_poset_incomparable_pairs(
                 "canonical_incomparable_pairs",
                 "incomparable_pairs must use the canonical IncomparablePair type",
             )
+        if type(pair.left) is not str or type(pair.right) is not str:
+            raise _validation_error(
+                "canonical_incomparable_pairs",
+                "incomparable pair labels must be canonical strings",
+            )
     actual_incomparable = tuple((pair.left, pair.right) for pair in incomparable_pairs)
     if actual_incomparable != expected_incomparable:
         raise _validation_error(

--- a/src/jacobian/math/combinatorics/posets/core/_models.py
+++ b/src/jacobian/math/combinatorics/posets/core/_models.py
@@ -356,11 +356,22 @@ def _compute_poset_extremal_elements(
 
 
 def _validate_poset_extremal_elements(
-    minimal_elements: tuple[str, ...],
-    maximal_elements: tuple[str, ...],
+    minimal_elements: object,
+    maximal_elements: object,
     expected_minimal: tuple[str, ...],
     expected_maximal: tuple[str, ...],
 ) -> None:
+    if type(minimal_elements) is not tuple or type(maximal_elements) is not tuple:
+        raise _validation_error(
+            "canonical_extremal_elements",
+            "extremal elements must be tuples",
+        )
+    for entry in (*minimal_elements, *maximal_elements):
+        if type(entry) is not str:
+            raise _validation_error(
+                "canonical_extremal_elements",
+                "extremal elements must be canonical strings",
+            )
     if minimal_elements != expected_minimal or maximal_elements != expected_maximal:
         raise _validation_error(
             "extremal_elements_complete", "minimal or maximal elements are incomplete"

--- a/src/jacobian/math/combinatorics/posets/core/_models.py
+++ b/src/jacobian/math/combinatorics/posets/core/_models.py
@@ -310,9 +310,14 @@ def _validate_canonical_poset_elements_and_pairs(
 
 def _validate_poset_incomparable_pairs(
     elements: tuple[str, ...],
-    incomparable_pairs: tuple[IncomparablePair, ...],
+    incomparable_pairs: object,
     closure: set[tuple[str, str]],
 ) -> None:
+    if type(incomparable_pairs) is not tuple:
+        raise _validation_error(
+            "canonical_incomparable_pairs",
+            "incomparable_pairs must be a tuple",
+        )
     expected_incomparable = tuple(
         (left, right)
         for index, left in enumerate(elements)

--- a/src/jacobian/math/combinatorics/posets/core/_models.py
+++ b/src/jacobian/math/combinatorics/posets/core/_models.py
@@ -6,7 +6,7 @@ import hashlib
 from enum import StrEnum
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, StrictInt, StringConstraints, model_validator
+from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._digest import Sha256Digest
@@ -412,7 +412,7 @@ class FinitePoset(StrictModel):
     )
     minimal_elements: tuple[ElementLabel, ...] = ()
     maximal_elements: tuple[ElementLabel, ...] = ()
-    graded: bool
+    graded: StrictBool
     ranks: tuple[ElementRank, ...] | None = None
     poset_digest: Sha256Digest
 

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -223,7 +223,13 @@ def _canonical_claims_match(
 ) -> bool:
     try:
         _canonical_carrier_elements(poset.elements)
-    except (AttributeError, PydanticCustomError, TypeError, ValidationError, ValueError):
+    except (
+        AttributeError,
+        PydanticCustomError,
+        TypeError,
+        ValidationError,
+        ValueError,
+    ):
         return False
     if tuple(sorted(set(poset.elements))) != poset.elements:
         return False

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -145,11 +145,11 @@ def _revalidated_ranks(ranks: object) -> tuple[ElementRank, ...] | None:
         return None
     if type(ranks) is not tuple:
         raise TypeError("ranks must be a tuple")
+    for entry in ranks:
+        if type(entry) is not ElementRank:
+            raise TypeError("rank entries must use the canonical ElementRank type")
     return tuple(
-        ElementRank.model_validate(
-            {"element": entry.element, "rank": entry.rank},
-            strict=True,
-        )
+        ElementRank.model_validate(entry.model_dump(mode="python"), strict=True)
         for entry in ranks
     )
 

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -39,6 +39,7 @@ from jacobian.math.combinatorics.posets.core._models import (
     MAX_ANTICHAIN_PROFILE_ELEMENTS,
     MAX_LINEAR_EXTENSION_ELEMENTS,
     AntichainProfileResult,
+    ElementLabel,
     ElementRank,
     FinitePoset,
     IncidenceConvolutionResult,
@@ -99,7 +100,7 @@ def _admit_finite_poset(
 
 def _admit_canonical_poset(poset: FinitePoset) -> None:
     """Admit the partial-order relation before running a consumer kernel."""
-    if not isinstance(poset, FinitePoset):
+    if type(poset) is not FinitePoset:
         raise OperationDomainValidationError(
             location=("poset",),
             code="poset.invalid_canonical_value",
@@ -156,6 +157,7 @@ def _revalidated_ranks(ranks: object) -> tuple[ElementRank, ...] | None:
 
 
 _SHA256_DIGEST = TypeAdapter(Sha256Digest)
+_ELEMENT_LABEL = TypeAdapter(ElementLabel)
 
 
 def _canonical_ordered_pairs(pairs: object) -> tuple[OrderedPair, ...]:
@@ -173,6 +175,17 @@ def _canonical_poset_digest(digest: object) -> str:
     if type(digest) is not str:
         raise TypeError("poset_digest must be a canonical sha256 string")
     return _SHA256_DIGEST.validate_python(digest, strict=True)
+
+
+def _canonical_element_labels(labels: object) -> tuple[str, ...]:
+    if type(labels) is not tuple:
+        raise TypeError("extremal labels must be a tuple")
+    canonical: list[str] = []
+    for entry in labels:
+        if type(entry) is not str:
+            raise TypeError("extremal labels must be canonical strings")
+        canonical.append(_ELEMENT_LABEL.validate_python(entry, strict=True))
+    return tuple(canonical)
 
 
 def _canonical_claims_match(
@@ -207,8 +220,8 @@ def _canonical_claims_match(
             poset.elements, strict
         )
         _validate_poset_extremal_elements(
-            poset.minimal_elements,
-            poset.maximal_elements,
+            _canonical_element_labels(poset.minimal_elements),
+            _canonical_element_labels(poset.maximal_elements),
             expected_minimal,
             expected_maximal,
         )
@@ -271,6 +284,8 @@ def induced_subposet(
 def verify_finite_poset(poset: FinitePoset) -> bool:
     """Verify all retained canonical order/profile claims of a poset value."""
     try:
+        if type(poset) is not FinitePoset:
+            return False
         if tuple(sorted(set(poset.elements))) != poset.elements:
             return False
         if type(poset.graded) is not bool:
@@ -303,8 +318,8 @@ def verify_finite_poset(poset: FinitePoset) -> bool:
             poset.elements, strict
         )
         _validate_poset_extremal_elements(
-            poset.minimal_elements,
-            poset.maximal_elements,
+            _canonical_element_labels(poset.minimal_elements),
+            _canonical_element_labels(poset.maximal_elements),
             expected_minimal,
             expected_maximal,
         )

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -147,7 +147,7 @@ def _revalidated_ranks(ranks: object) -> tuple[ElementRank, ...] | None:
         raise TypeError("ranks must be a tuple")
     return tuple(
         ElementRank.model_validate(
-            {"element": getattr(entry, "element"), "rank": getattr(entry, "rank")},
+            {"element": entry.element, "rank": entry.rank},
             strict=True,
         )
         for entry in ranks

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -164,7 +164,7 @@ def _canonical_claims_match(
             expected_maximal,
             reduction,
         )
-    except (PydanticCustomError, TypeError, ValueError):
+    except (AttributeError, PydanticCustomError, TypeError, ValueError):
         return False
     return (
         finite_poset_digest(
@@ -262,7 +262,13 @@ def verify_finite_poset(poset: FinitePoset) -> bool:
             )
             == poset.poset_digest
         )
-    except (OperationDomainValidationError, PydanticCustomError, TypeError, ValueError):
+    except (
+        AttributeError,
+        OperationDomainValidationError,
+        PydanticCustomError,
+        TypeError,
+        ValueError,
+    ):
         return False
 
 

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -38,6 +38,7 @@ from jacobian.math.combinatorics.posets.core._models import (
     MAX_ANTICHAIN_PROFILE_ELEMENTS,
     MAX_LINEAR_EXTENSION_ELEMENTS,
     AntichainProfileResult,
+    ElementRank,
     FinitePoset,
     IncidenceConvolutionResult,
     IncomparablePair,
@@ -139,6 +140,20 @@ def _admit_canonical_poset(poset: FinitePoset) -> None:
         )
 
 
+def _revalidated_ranks(ranks: object) -> tuple[ElementRank, ...] | None:
+    if ranks is None:
+        return None
+    if type(ranks) is not tuple:
+        raise TypeError("ranks must be a tuple")
+    return tuple(
+        ElementRank.model_validate(
+            {"element": getattr(entry, "element"), "rank": getattr(entry, "rank")},
+            strict=True,
+        )
+        for entry in ranks
+    )
+
+
 def _canonical_claims_match(
     poset: FinitePoset,
     strict: set[tuple[str, str]],
@@ -173,7 +188,7 @@ def _canonical_claims_match(
         _validate_poset_rank_structure(
             poset.elements,
             poset.graded,
-            poset.ranks,
+            _revalidated_ranks(poset.ranks),
             expected_ranks,
             expected_minimal,
             expected_maximal,
@@ -258,7 +273,7 @@ def verify_finite_poset(poset: FinitePoset) -> bool:
         _validate_poset_rank_structure(
             poset.elements,
             poset.graded,
-            poset.ranks,
+            _revalidated_ranks(poset.ranks),
             expected_ranks,
             expected_minimal,
             expected_maximal,

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -96,8 +96,14 @@ def _admit_finite_poset(
 
 def _admit_canonical_poset(poset: FinitePoset) -> None:
     """Admit the partial-order relation before running a consumer kernel."""
-    _run_admission(
-        lambda: _validated_presentation(
+    if not isinstance(poset, FinitePoset):
+        raise OperationDomainValidationError(
+            location=("poset",),
+            code="poset.invalid_canonical_value",
+            message="poset claims do not describe its canonical finite poset",
+        )
+    try:
+        strict, reduction = _validated_presentation(
             poset.elements,
             tuple(
                 PresentationPair(lower=pair.lower, upper=pair.upper)
@@ -106,6 +112,70 @@ def _admit_canonical_poset(poset: FinitePoset) -> None:
             RelationInterpretation.COMPARABLE_PAIRS,
             ReflexivePairPolicy.FORBIDDEN,
         )
+    except PydanticCustomError as exc:
+        raise OperationDomainValidationError(
+            location=("poset",), code=exc.type, message=exc.message()
+        ) from exc
+    if not _canonical_claims_match(poset, strict, reduction):
+        raise OperationDomainValidationError(
+            location=("poset",),
+            code="poset.invalid_canonical_value",
+            message="poset claims do not describe its canonical finite poset",
+        )
+
+
+def _canonical_claims_match(
+    poset: FinitePoset,
+    strict: set[tuple[str, str]],
+    reduction: set[tuple[str, str]],
+) -> bool:
+    if (
+        tuple(OrderedPair(lower=a, upper=b) for a, b in sorted(strict))
+        != poset.strict_order_pairs
+    ):
+        return False
+    if (
+        tuple(OrderedPair(lower=a, upper=b) for a, b in sorted(reduction))
+        != poset.cover_relations
+    ):
+        return False
+    try:
+        _validate_poset_incomparable_pairs(
+            poset.elements, poset.incomparable_pairs, strict
+        )
+        expected_minimal, expected_maximal = _compute_poset_extremal_elements(
+            poset.elements, strict
+        )
+        _validate_poset_extremal_elements(
+            poset.minimal_elements,
+            poset.maximal_elements,
+            expected_minimal,
+            expected_maximal,
+        )
+        expected_ranks = canonical_poset_ranks(poset.elements, reduction)
+        _validate_poset_rank_structure(
+            poset.elements,
+            poset.graded,
+            poset.ranks,
+            expected_ranks,
+            expected_minimal,
+            expected_maximal,
+            reduction,
+        )
+    except (PydanticCustomError, TypeError, ValueError):
+        return False
+    return (
+        finite_poset_digest(
+            elements=poset.elements,
+            strict_order_pairs=poset.strict_order_pairs,
+            cover_relations=poset.cover_relations,
+            incomparable_pairs=poset.incomparable_pairs,
+            minimal_elements=poset.minimal_elements,
+            maximal_elements=poset.maximal_elements,
+            graded=poset.graded,
+            ranks=poset.ranks,
+        )
+        == poset.poset_digest
     )
 
 

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -123,7 +123,15 @@ def _admit_canonical_poset(poset: FinitePoset) -> None:
             code="poset.invalid_canonical_value",
             message="poset claims do not describe its canonical finite poset",
         ) from exc
-    if not _canonical_claims_match(poset, strict, reduction):
+    try:
+        claims_match = _canonical_claims_match(poset, strict, reduction)
+    except (AttributeError, TypeError, ValidationError, ValueError) as exc:
+        raise OperationDomainValidationError(
+            location=("poset",),
+            code="poset.invalid_canonical_value",
+            message="poset claims do not describe its canonical finite poset",
+        ) from exc
+    if not claims_match:
         raise OperationDomainValidationError(
             location=("poset",),
             code="poset.invalid_canonical_value",

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import importlib
 from typing import Any, Literal
 
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 from pydantic_core import PydanticCustomError
 
+from jacobian._digest import Sha256Digest
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.posets.core._closure_kernel import (
     dual_poset as _dual_poset_kernel,
@@ -154,6 +155,9 @@ def _revalidated_ranks(ranks: object) -> tuple[ElementRank, ...] | None:
     )
 
 
+_SHA256_DIGEST = TypeAdapter(Sha256Digest)
+
+
 def _canonical_ordered_pairs(pairs: object) -> tuple[OrderedPair, ...]:
     if type(pairs) is not tuple:
         raise TypeError("order pairs must be a tuple")
@@ -163,6 +167,12 @@ def _canonical_ordered_pairs(pairs: object) -> tuple[OrderedPair, ...]:
             raise TypeError("order pairs must use the canonical OrderedPair type")
         canonical.append(entry)
     return tuple(canonical)
+
+
+def _canonical_poset_digest(digest: object) -> str:
+    if type(digest) is not str:
+        raise TypeError("poset_digest must be a canonical sha256 string")
+    return _SHA256_DIGEST.validate_python(digest, strict=True)
 
 
 def _canonical_claims_match(
@@ -212,7 +222,14 @@ def _canonical_claims_match(
             expected_maximal,
             reduction,
         )
-    except (AttributeError, PydanticCustomError, TypeError, ValueError):
+        authored_digest = _canonical_poset_digest(poset.poset_digest)
+    except (
+        AttributeError,
+        PydanticCustomError,
+        TypeError,
+        ValidationError,
+        ValueError,
+    ):
         return False
     return (
         finite_poset_digest(
@@ -225,7 +242,7 @@ def _canonical_claims_match(
             graded=poset.graded,
             ranks=poset.ranks,
         )
-        == poset.poset_digest
+        == authored_digest
     )
 
 
@@ -301,19 +318,16 @@ def verify_finite_poset(poset: FinitePoset) -> bool:
             expected_maximal,
             reduction,
         )
-        return (
-            finite_poset_digest(
-                elements=poset.elements,
-                strict_order_pairs=poset.strict_order_pairs,
-                cover_relations=poset.cover_relations,
-                incomparable_pairs=poset.incomparable_pairs,
-                minimal_elements=poset.minimal_elements,
-                maximal_elements=poset.maximal_elements,
-                graded=poset.graded,
-                ranks=poset.ranks,
-            )
-            == poset.poset_digest
-        )
+        return finite_poset_digest(
+            elements=poset.elements,
+            strict_order_pairs=poset.strict_order_pairs,
+            cover_relations=poset.cover_relations,
+            incomparable_pairs=poset.incomparable_pairs,
+            minimal_elements=poset.minimal_elements,
+            maximal_elements=poset.maximal_elements,
+            graded=poset.graded,
+            ranks=poset.ranks,
+        ) == _canonical_poset_digest(poset.poset_digest)
     except (
         AttributeError,
         OperationDomainValidationError,

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -150,6 +150,11 @@ def _revalidated_ranks(ranks: object) -> tuple[ElementRank, ...] | None:
     for entry in ranks:
         if type(entry) is not ElementRank:
             raise TypeError("rank entries must use the canonical ElementRank type")
+        if type(entry.element) is not str:
+            raise TypeError("rank labels must be canonical strings")
+        if type(entry.rank) is not int:
+            raise TypeError("rank values must be canonical integers")
+        _ELEMENT_LABEL.validate_python(entry.element, strict=True)
     return tuple(
         ElementRank.model_validate(entry.model_dump(mode="python"), strict=True)
         for entry in ranks
@@ -160,6 +165,25 @@ _SHA256_DIGEST = TypeAdapter(Sha256Digest)
 _ELEMENT_LABEL = TypeAdapter(ElementLabel)
 
 
+def _canonical_carrier_elements(elements: object) -> tuple[str, ...]:
+    """Strictly revalidate the in-memory carrier before matching claims.
+
+    ``model_copy``/``model_construct`` bypass Pydantic validation, so a
+    ``str`` subclass with identical text would otherwise pass the
+    ordering/equality check while digest canonicalization normalizes it to
+    an ordinary string.  Require the exact ``tuple`` container and exact
+    ``str`` labels here; callers map failures to ``False``/domain errors.
+    """
+
+    if type(elements) is not tuple:
+        raise TypeError("elements must be a tuple")
+    for entry in elements:
+        if type(entry) is not str:
+            raise TypeError("carrier labels must be canonical strings")
+        _ELEMENT_LABEL.validate_python(entry, strict=True)
+    return elements  # type: ignore[return-value]
+
+
 def _canonical_ordered_pairs(pairs: object) -> tuple[OrderedPair, ...]:
     if type(pairs) is not tuple:
         raise TypeError("order pairs must be a tuple")
@@ -167,6 +191,10 @@ def _canonical_ordered_pairs(pairs: object) -> tuple[OrderedPair, ...]:
     for entry in pairs:
         if type(entry) is not OrderedPair:
             raise TypeError("order pairs must use the canonical OrderedPair type")
+        if type(entry.lower) is not str or type(entry.upper) is not str:
+            raise TypeError("order pair labels must be canonical strings")
+        _ELEMENT_LABEL.validate_python(entry.lower, strict=True)
+        _ELEMENT_LABEL.validate_python(entry.upper, strict=True)
         canonical.append(entry)
     return tuple(canonical)
 
@@ -193,6 +221,10 @@ def _canonical_claims_match(
     strict: set[tuple[str, str]],
     reduction: set[tuple[str, str]],
 ) -> bool:
+    try:
+        _canonical_carrier_elements(poset.elements)
+    except (AttributeError, PydanticCustomError, TypeError, ValidationError, ValueError):
+        return False
     if tuple(sorted(set(poset.elements))) != poset.elements:
         return False
     if type(poset.graded) is not bool:
@@ -286,6 +318,7 @@ def verify_finite_poset(poset: FinitePoset) -> bool:
     try:
         if type(poset) is not FinitePoset:
             return False
+        _canonical_carrier_elements(poset.elements)
         if tuple(sorted(set(poset.elements))) != poset.elements:
             return False
         if type(poset.graded) is not bool:

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -161,6 +161,8 @@ def _canonical_claims_match(
 ) -> bool:
     if tuple(sorted(set(poset.elements))) != poset.elements:
         return False
+    if type(poset.graded) is not bool:
+        return False
     if (
         tuple(OrderedPair(lower=a, upper=b) for a, b in sorted(strict))
         != poset.strict_order_pairs
@@ -237,6 +239,8 @@ def verify_finite_poset(poset: FinitePoset) -> bool:
     """Verify all retained canonical order/profile claims of a poset value."""
     try:
         if tuple(sorted(set(poset.elements))) != poset.elements:
+            return False
+        if type(poset.graded) is not bool:
             return False
         strict, reduction = _validated_presentation(
             poset.elements,

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -129,6 +129,8 @@ def _canonical_claims_match(
     strict: set[tuple[str, str]],
     reduction: set[tuple[str, str]],
 ) -> bool:
+    if tuple(sorted(set(poset.elements))) != poset.elements:
+        return False
     if (
         tuple(OrderedPair(lower=a, upper=b) for a, b in sorted(strict))
         != poset.strict_order_pairs
@@ -204,6 +206,8 @@ def induced_subposet(
 def verify_finite_poset(poset: FinitePoset) -> bool:
     """Verify all retained canonical order/profile claims of a poset value."""
     try:
+        if tuple(sorted(set(poset.elements))) != poset.elements:
+            return False
         strict, reduction = _validated_presentation(
             poset.elements,
             tuple(

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 from typing import Any, Literal
 
+from pydantic import ValidationError
 from pydantic_core import PydanticCustomError
 
 from jacobian.catalog.models import OperationDomainValidationError
@@ -115,6 +116,12 @@ def _admit_canonical_poset(poset: FinitePoset) -> None:
     except PydanticCustomError as exc:
         raise OperationDomainValidationError(
             location=("poset",), code=exc.type, message=exc.message()
+        ) from exc
+    except (AttributeError, TypeError, ValidationError, ValueError) as exc:
+        raise OperationDomainValidationError(
+            location=("poset",),
+            code="poset.invalid_canonical_value",
+            message="poset claims do not describe its canonical finite poset",
         ) from exc
     if not _canonical_claims_match(poset, strict, reduction):
         raise OperationDomainValidationError(
@@ -267,6 +274,7 @@ def verify_finite_poset(poset: FinitePoset) -> bool:
         OperationDomainValidationError,
         PydanticCustomError,
         TypeError,
+        ValidationError,
         ValueError,
     ):
         return False

--- a/src/jacobian/math/combinatorics/posets/core/operations.py
+++ b/src/jacobian/math/combinatorics/posets/core/operations.py
@@ -154,6 +154,17 @@ def _revalidated_ranks(ranks: object) -> tuple[ElementRank, ...] | None:
     )
 
 
+def _canonical_ordered_pairs(pairs: object) -> tuple[OrderedPair, ...]:
+    if type(pairs) is not tuple:
+        raise TypeError("order pairs must be a tuple")
+    canonical: list[OrderedPair] = []
+    for entry in pairs:
+        if type(entry) is not OrderedPair:
+            raise TypeError("order pairs must use the canonical OrderedPair type")
+        canonical.append(entry)
+    return tuple(canonical)
+
+
 def _canonical_claims_match(
     poset: FinitePoset,
     strict: set[tuple[str, str]],
@@ -163,14 +174,19 @@ def _canonical_claims_match(
         return False
     if type(poset.graded) is not bool:
         return False
+    try:
+        authored_strict = _canonical_ordered_pairs(poset.strict_order_pairs)
+        authored_covers = _canonical_ordered_pairs(poset.cover_relations)
+    except TypeError:
+        return False
     if (
         tuple(OrderedPair(lower=a, upper=b) for a, b in sorted(strict))
-        != poset.strict_order_pairs
+        != authored_strict
     ):
         return False
     if (
         tuple(OrderedPair(lower=a, upper=b) for a, b in sorted(reduction))
-        != poset.cover_relations
+        != authored_covers
     ):
         return False
     try:
@@ -242,23 +258,25 @@ def verify_finite_poset(poset: FinitePoset) -> bool:
             return False
         if type(poset.graded) is not bool:
             return False
+        authored_strict = _canonical_ordered_pairs(poset.strict_order_pairs)
+        authored_covers = _canonical_ordered_pairs(poset.cover_relations)
         strict, reduction = _validated_presentation(
             poset.elements,
             tuple(
                 PresentationPair(lower=pair.lower, upper=pair.upper)
-                for pair in poset.strict_order_pairs
+                for pair in authored_strict
             ),
             RelationInterpretation.COMPARABLE_PAIRS,
             ReflexivePairPolicy.FORBIDDEN,
         )
         if (
             tuple(OrderedPair(lower=a, upper=b) for a, b in sorted(strict))
-            != poset.strict_order_pairs
+            != authored_strict
         ):
             return False
         if (
             tuple(OrderedPair(lower=a, upper=b) for a, b in sorted(reduction))
-            != poset.cover_relations
+            != authored_covers
         ):
             return False
         _validate_poset_incomparable_pairs(

--- a/tests/math/combinatorics/posets/antichain_enumeration/test_antichain_enumeration.py
+++ b/tests/math/combinatorics/posets/antichain_enumeration/test_antichain_enumeration.py
@@ -12,6 +12,7 @@ from jacobian.math.combinatorics.posets.antichain_enumeration.operations import 
 )
 from jacobian.math.combinatorics.posets.core._models import (
     FinitePoset,
+    IncomparablePair,
     PresentationPair,
     ReflexivePairPolicy,
     RelationInterpretation,
@@ -135,3 +136,17 @@ def test_request_retains_intrinsic_cardinality_range_shape() -> None:
         AntichainEnumerationRequest(
             poset=_make_chain(3), min_cardinality=2, max_cardinality=1
         )
+
+
+def test_rejects_forged_poset_relation_claims() -> None:
+    poset = _make_chain(2)
+    forged = poset.model_copy(
+        update={
+            "strict_order_pairs": (),
+            "cover_relations": (),
+            "incomparable_pairs": (IncomparablePair(left="0", right="1"),),
+        }
+    )
+
+    with pytest.raises(OperationDomainValidationError):
+        enumerate_antichains(forged, 1, 2)

--- a/tests/math/combinatorics/posets/antichain_enumeration/test_antichain_enumeration.py
+++ b/tests/math/combinatorics/posets/antichain_enumeration/test_antichain_enumeration.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 from pydantic import ValidationError
 
@@ -150,3 +152,13 @@ def test_rejects_forged_poset_relation_claims() -> None:
 
     with pytest.raises(OperationDomainValidationError):
         enumerate_antichains(forged, 1, 2)
+
+
+def test_enumeration_admits_before_inspecting_the_carrier() -> None:
+    poset = _make_chain(2)
+    malformed = poset.model_copy(update={"elements": object()})
+
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        enumerate_antichains(malformed, 1, 1)
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        enumerate_antichains(cast(FinitePoset, object()), 1, 1)

--- a/tests/math/combinatorics/posets/antichain_enumeration/test_antichain_enumeration.py
+++ b/tests/math/combinatorics/posets/antichain_enumeration/test_antichain_enumeration.py
@@ -178,7 +178,5 @@ def test_enumeration_rejects_size_bound_before_strict_closure(
     monkeypatch.setattr(poset_models, "_validated_presentation", fail_presentation)
     monkeypatch.setattr(poset_operations, "_validated_presentation", fail_presentation)
     monkeypatch.setattr(poset_models, "_strict_closure", fail_presentation)
-    with pytest.raises(
-        OperationDomainValidationError, match="at most 24 elements"
-    ):
+    with pytest.raises(OperationDomainValidationError, match="at most 24 elements"):
         enumerate_antichains(poset, 1, 1)

--- a/tests/math/combinatorics/posets/antichain_enumeration/test_antichain_enumeration.py
+++ b/tests/math/combinatorics/posets/antichain_enumeration/test_antichain_enumeration.py
@@ -162,3 +162,23 @@ def test_enumeration_admits_before_inspecting_the_carrier() -> None:
         enumerate_antichains(malformed, 1, 1)
     with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
         enumerate_antichains(cast(FinitePoset, object()), 1, 1)
+
+
+def test_enumeration_rejects_size_bound_before_strict_closure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.combinatorics.posets.core import _models as poset_models
+    from jacobian.math.combinatorics.posets.core import operations as poset_operations
+
+    poset = _make_antichain_poset(25)
+
+    def fail_presentation(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("presentation ran before the enumeration bound")
+
+    monkeypatch.setattr(poset_models, "_validated_presentation", fail_presentation)
+    monkeypatch.setattr(poset_operations, "_validated_presentation", fail_presentation)
+    monkeypatch.setattr(poset_models, "_strict_closure", fail_presentation)
+    with pytest.raises(
+        OperationDomainValidationError, match="at most 24 elements"
+    ):
+        enumerate_antichains(poset, 1, 1)

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -203,6 +203,38 @@ def test_consumers_reject_integer_graded_flag_as_domain_errors() -> None:
         width(forged)
 
 
+def test_consumers_reject_foreign_ordered_pair_models_as_domain_errors() -> None:
+    class ForeignOrderedPair(OrderedPair):
+        extra: str = "foreign"
+
+    poset = _materialize(["a", "b"], [("a", "b")])
+    forged_pairs = tuple(
+        ForeignOrderedPair(lower=pair.lower, upper=pair.upper)
+        for pair in poset.strict_order_pairs
+    )
+    forged = poset.model_copy(
+        update={
+            "strict_order_pairs": forged_pairs,
+            "poset_digest": finite_poset_digest(
+                elements=poset.elements,
+                strict_order_pairs=forged_pairs,
+                cover_relations=poset.cover_relations,
+                incomparable_pairs=poset.incomparable_pairs,
+                minimal_elements=poset.minimal_elements,
+                maximal_elements=poset.maximal_elements,
+                graded=poset.graded,
+                ranks=poset.ranks,
+            ),
+        }
+    )
+
+    assert all(isinstance(pair, OrderedPair) for pair in forged.strict_order_pairs)
+    assert any(type(pair) is not OrderedPair for pair in forged.strict_order_pairs)
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+
+
 def test_consumers_reject_foreign_rank_models_as_domain_errors() -> None:
     class ForeignRank(ElementRank):
         extra: str = "foreign"

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -174,7 +174,7 @@ def test_consumers_reject_mixed_carrier_elements_as_domain_errors() -> None:
 
     assert verify_finite_poset(malformed) is False
     with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
-            width(malformed)
+        width(malformed)
 
 
 def test_consumers_reject_boolean_rank_claims_as_domain_errors() -> None:

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -148,11 +148,24 @@ def test_consumers_reject_forged_noncanonical_carrier_order() -> None:
 
 def test_consumers_reject_model_bypassed_nested_claims_as_domain_errors() -> None:
     poset = _materialize(["a", "b"], [])
-    malformed = poset.model_copy(update={"incomparable_pairs": (object(),)})
+    malformed_claims = (
+        poset.model_copy(update={"incomparable_pairs": (object(),)}),
+        poset.model_copy(update={"strict_order_pairs": (object(),)}),
+        poset.model_copy(
+            update={
+                "strict_order_pairs": (
+                    OrderedPair.model_construct(lower=object(), upper="b"),
+                )
+            }
+        ),
+    )
 
-    assert verify_finite_poset(malformed) is False
-    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
-        width(malformed)
+    for malformed in malformed_claims:
+        assert verify_finite_poset(malformed) is False
+        with pytest.raises(
+            OperationDomainValidationError, match="canonical finite poset"
+        ):
+            width(malformed)
 
 
 def test_comparable_pairs_require_complete_transitive_relation() -> None:

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -263,6 +263,46 @@ def test_consumers_reject_foreign_incomparable_pair_models_as_domain_errors() ->
         width(forged)
 
 
+def test_consumers_reject_foreign_ordered_pair_models_as_domain_errors() -> None:
+    class ForeignOrder:
+        def __init__(self, lower: str, upper: str) -> None:
+            self.lower = lower
+            self.upper = upper
+
+        def model_dump(self, mode: str = "json") -> dict[str, str]:
+            return {"lower": self.lower, "upper": self.upper, "extra": "foreign"}
+
+        def __eq__(self, other: object) -> bool:
+            return (
+                getattr(other, "lower", None) == self.lower
+                and getattr(other, "upper", None) == self.upper
+            )
+
+    poset = _materialize(["a", "b"], [("a", "b")])
+    forged_pairs = tuple(
+        ForeignOrder(pair.lower, pair.upper) for pair in poset.strict_order_pairs
+    )
+    forged = poset.model_copy(
+        update={
+            "strict_order_pairs": forged_pairs,
+            "cover_relations": forged_pairs,
+            "poset_digest": finite_poset_digest(
+                elements=poset.elements,
+                strict_order_pairs=forged_pairs,  # type: ignore[arg-type]
+                cover_relations=forged_pairs,  # type: ignore[arg-type]
+                incomparable_pairs=poset.incomparable_pairs,
+                minimal_elements=poset.minimal_elements,
+                maximal_elements=poset.maximal_elements,
+                graded=poset.graded,
+                ranks=poset.ranks,
+            ),
+        }
+    )
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+
+
 def test_consumers_reject_boolean_rank_claims_as_domain_errors() -> None:
     poset = _materialize(["a", "b"], [("a", "b")])
     forged_ranks = tuple(

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -174,7 +174,22 @@ def test_consumers_reject_mixed_carrier_elements_as_domain_errors() -> None:
 
     assert verify_finite_poset(malformed) is False
     with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
-        width(malformed)
+            width(malformed)
+
+
+def test_consumers_reject_boolean_rank_claims_as_domain_errors() -> None:
+    poset = _materialize(["a", "b"], [("a", "b")])
+    forged_ranks = tuple(
+        ElementRank.model_construct(element=entry.element, rank=False)
+        if entry.rank == 0
+        else entry
+        for entry in poset.ranks or ()
+    )
+    forged = poset.model_copy(update={"ranks": forged_ranks})
+
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
 
 
 def test_comparable_pairs_require_complete_transitive_relation() -> None:

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -168,6 +168,15 @@ def test_consumers_reject_model_bypassed_nested_claims_as_domain_errors() -> Non
             width(malformed)
 
 
+def test_consumers_reject_mixed_carrier_elements_as_domain_errors() -> None:
+    poset = _materialize(["a"], [])
+    malformed = poset.model_copy(update={"elements": ("a", object())})
+
+    assert verify_finite_poset(malformed) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(malformed)
+
+
 def test_comparable_pairs_require_complete_transitive_relation() -> None:
     with pytest.raises(OperationDomainValidationError) as exc:
         _materialize_request(

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -179,6 +179,118 @@ def test_consumers_reject_mixed_carrier_elements_as_domain_errors() -> None:
         width(malformed)
 
 
+def test_consumers_reject_str_subclass_carrier_labels_as_domain_errors() -> None:
+    class CarrierSubclass(str):
+        pass
+
+    poset = _materialize(["a", "b"], [("a", "b")])
+    forged_elements = tuple(CarrierSubclass(element) for element in poset.elements)
+    assert forged_elements == poset.elements
+    assert any(type(element) is not str for element in forged_elements)
+    forged = poset.model_copy(
+        update={
+            "elements": forged_elements,
+            "poset_digest": finite_poset_digest(
+                elements=forged_elements,
+                strict_order_pairs=poset.strict_order_pairs,
+                cover_relations=poset.cover_relations,
+                incomparable_pairs=poset.incomparable_pairs,
+                minimal_elements=poset.minimal_elements,
+                maximal_elements=poset.maximal_elements,
+                graded=poset.graded,
+                ranks=poset.ranks,
+            ),
+        }
+    )
+
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+
+
+def test_consumers_reject_str_subclass_pair_labels_as_domain_errors() -> None:
+    class LabelSubclass(str):
+        pass
+
+    poset = _materialize(["a", "b"], [("a", "b")])
+    forged_order = tuple(
+        OrderedPair.model_construct(
+            lower=LabelSubclass(pair.lower), upper=LabelSubclass(pair.upper)
+        )
+        for pair in poset.strict_order_pairs
+    )
+    forged = poset.model_copy(
+        update={
+            "strict_order_pairs": forged_order,
+            "cover_relations": forged_order,
+            "poset_digest": finite_poset_digest(
+                elements=poset.elements,
+                strict_order_pairs=forged_order,
+                cover_relations=forged_order,
+                incomparable_pairs=poset.incomparable_pairs,
+                minimal_elements=poset.minimal_elements,
+                maximal_elements=poset.maximal_elements,
+                graded=poset.graded,
+                ranks=poset.ranks,
+            ),
+        }
+    )
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+
+    antichain = _materialize(["a", "b"], [])
+    forged_incomparable = tuple(
+        IncomparablePair.model_construct(
+            left=LabelSubclass(pair.left), right=LabelSubclass(pair.right)
+        )
+        for pair in antichain.incomparable_pairs
+    )
+    forged_antichain = antichain.model_copy(
+        update={
+            "incomparable_pairs": forged_incomparable,
+            "poset_digest": finite_poset_digest(
+                elements=antichain.elements,
+                strict_order_pairs=antichain.strict_order_pairs,
+                cover_relations=antichain.cover_relations,
+                incomparable_pairs=forged_incomparable,
+                minimal_elements=antichain.minimal_elements,
+                maximal_elements=antichain.maximal_elements,
+                graded=antichain.graded,
+                ranks=antichain.ranks,
+            ),
+        }
+    )
+    assert verify_finite_poset(forged_antichain) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged_antichain)
+
+    forged_ranks = tuple(
+        ElementRank.model_construct(
+            element=LabelSubclass(entry.element), rank=entry.rank
+        )
+        for entry in poset.ranks or ()
+    )
+    forged_ranked = poset.model_copy(
+        update={
+            "ranks": forged_ranks,
+            "poset_digest": finite_poset_digest(
+                elements=poset.elements,
+                strict_order_pairs=poset.strict_order_pairs,
+                cover_relations=poset.cover_relations,
+                incomparable_pairs=poset.incomparable_pairs,
+                minimal_elements=poset.minimal_elements,
+                maximal_elements=poset.maximal_elements,
+                graded=poset.graded,
+                ranks=forged_ranks,
+            ),
+        }
+    )
+    assert verify_finite_poset(forged_ranked) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged_ranked)
+
+
 def test_consumers_reject_integer_graded_flag_as_domain_errors() -> None:
     poset = _materialize(["a", "b"], [("a", "b")])
     forged = poset.model_copy(

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -146,6 +146,15 @@ def test_consumers_reject_forged_noncanonical_carrier_order() -> None:
         lower_closure(LowerClosureRequest.model_construct(poset=forged, subset=("b",)))
 
 
+def test_consumers_reject_model_bypassed_nested_claims_as_domain_errors() -> None:
+    poset = _materialize(["a", "b"], [])
+    malformed = poset.model_copy(update={"incomparable_pairs": (object(),)})
+
+    assert verify_finite_poset(malformed) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(malformed)
+
+
 def test_comparable_pairs_require_complete_transitive_relation() -> None:
     with pytest.raises(OperationDomainValidationError) as exc:
         _materialize_request(

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -335,6 +335,26 @@ def test_consumers_reject_duck_typed_ordered_pair_carriers_as_domain_errors() ->
         width(forged)
 
 
+def test_consumers_reject_equality_forging_digest_subclasses_as_domain_errors() -> None:
+    class AlwaysEqualDigest(str):
+        def __eq__(self, other: object) -> bool:
+            return True
+
+        def __hash__(self) -> int:
+            return hash(str(self))
+
+    poset = _materialize(["a", "b"], [("a", "b")])
+    forged_digest = AlwaysEqualDigest("sha256:" + "0" * 64)
+    forged = poset.model_copy(update={"poset_digest": forged_digest})
+
+    assert type(forged.poset_digest) is not str
+    assert forged.poset_digest == poset.poset_digest
+    assert poset.poset_digest != "sha256:" + "0" * 64
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+
+
 def test_consumers_reject_boolean_rank_claims_as_domain_errors() -> None:
     poset = _materialize(["a", "b"], [("a", "b")])
     forged_ranks = tuple(

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -19,6 +19,7 @@ from jacobian.math.combinatorics.posets.core.operations import (
     finite_poset_digest,
     linear_extension_count,
     materialize_finite_poset,
+    maximal_chains,
     verify_finite_poset,
     width,
 )
@@ -365,6 +366,57 @@ def test_consumers_reject_equality_forging_digest_subclasses_as_domain_errors() 
     assert verify_finite_poset(forged) is False
     with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
         width(forged)
+
+
+def test_consumers_reject_equality_forging_extremal_label_subclasses() -> None:
+    class ForeignMinimum(str):
+        def __eq__(self, other: object) -> bool:
+            return other == "a"
+
+        def __hash__(self) -> int:
+            return hash("a")
+
+    poset = _materialize(["a", "b"], [("a", "b")])
+    forged_minimal = (ForeignMinimum("x"),)
+    assert forged_minimal == poset.minimal_elements
+    assert "x" not in poset.elements
+    forged = poset.model_copy(
+        update={
+            "minimal_elements": forged_minimal,
+            "poset_digest": finite_poset_digest(
+                elements=poset.elements,
+                strict_order_pairs=poset.strict_order_pairs,
+                cover_relations=poset.cover_relations,
+                incomparable_pairs=poset.incomparable_pairs,
+                minimal_elements=forged_minimal,
+                maximal_elements=poset.maximal_elements,
+                graded=poset.graded,
+                ranks=poset.ranks,
+            ),
+        }
+    )
+
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+    with pytest.raises(OperationDomainValidationError, match="canonical"):
+        maximal_chains(forged)
+
+
+def test_consumers_reject_finite_poset_subclasses_as_domain_errors() -> None:
+    class ForeignPoset(FinitePoset):
+        extra: str = "foreign"
+
+    poset = _materialize(["a", "b"], [("a", "b")])
+    forged = ForeignPoset(**poset.model_dump(mode="python"), extra="foreign")
+
+    assert isinstance(forged, FinitePoset)
+    assert type(forged) is not FinitePoset
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+    with pytest.raises(OperationDomainValidationError, match="typed finite poset"):
+        maximal_chains(forged)
 
 
 def test_consumers_reject_boolean_rank_claims_as_domain_errors() -> None:

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -295,7 +295,7 @@ def test_consumers_reject_foreign_incomparable_pair_models_as_domain_errors() ->
         width(forged)
 
 
-def test_consumers_reject_foreign_ordered_pair_models_as_domain_errors() -> None:
+def test_consumers_reject_duck_typed_ordered_pair_carriers_as_domain_errors() -> None:
     class ForeignOrder:
         def __init__(self, lower: str, upper: str) -> None:
             self.lower = lower

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -7,12 +7,15 @@ from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.combinatorics.posets.core._closure_models import LowerClosureRequest
 from jacobian.math.combinatorics.posets.core._closure_tools import lower_closure
 from jacobian.math.combinatorics.posets.core._models import (
+    ElementRank,
     FinitePoset,
     FinitePosetRequest,
     LinearExtensionRequest,
     MobiusFunctionRequest,
+    OrderedPair,
 )
 from jacobian.math.combinatorics.posets.core.operations import (
+    finite_poset_digest,
     linear_extension_count,
     materialize_finite_poset,
     verify_finite_poset,
@@ -109,6 +112,38 @@ def test_serialized_poset_keeps_order_profile_as_a_claim() -> None:
         width(poset)
     with pytest.raises(OperationDomainValidationError, match="antisymmetric"):
         lower_closure(LowerClosureRequest.model_construct(poset=poset, subset=("a",)))
+
+
+def test_consumers_reject_forged_noncanonical_carrier_order() -> None:
+    poset = _materialize(["a", "b"], [("a", "b")])
+    assert verify_finite_poset(poset) is True
+    strict_order_pairs = (OrderedPair(lower="a", upper="b"),)
+    cover_relations = (OrderedPair(lower="a", upper="b"),)
+    ranks = (ElementRank(element="b", rank=1), ElementRank(element="a", rank=0))
+    forged = FinitePoset.model_construct(
+        elements=("b", "a"),
+        strict_order_pairs=strict_order_pairs,
+        cover_relations=cover_relations,
+        incomparable_pairs=(),
+        minimal_elements=("a",),
+        maximal_elements=("b",),
+        graded=True,
+        ranks=ranks,
+        poset_digest=finite_poset_digest(
+            elements=("b", "a"),
+            strict_order_pairs=strict_order_pairs,
+            cover_relations=cover_relations,
+            incomparable_pairs=(),
+            minimal_elements=("a",),
+            maximal_elements=("b",),
+            graded=True,
+            ranks=ranks,
+        ),
+    )
+
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        lower_closure(LowerClosureRequest.model_construct(poset=forged, subset=("b",)))
 
 
 def test_comparable_pairs_require_complete_transitive_relation() -> None:

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -10,6 +10,7 @@ from jacobian.math.combinatorics.posets.core._models import (
     ElementRank,
     FinitePoset,
     FinitePosetRequest,
+    IncomparablePair,
     LinearExtensionRequest,
     MobiusFunctionRequest,
     OrderedPair,
@@ -197,6 +198,66 @@ def test_consumers_reject_integer_graded_flag_as_domain_errors() -> None:
 
     assert type(forged.graded) is int
     assert forged.graded == 1
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+
+
+def test_consumers_reject_foreign_rank_models_as_domain_errors() -> None:
+    class ForeignRank(ElementRank):
+        extra: str = "foreign"
+
+    poset = _materialize(["a", "b"], [("a", "b")])
+    forged_ranks = tuple(
+        ForeignRank(element=entry.element, rank=entry.rank)
+        for entry in poset.ranks or ()
+    )
+    forged = poset.model_copy(
+        update={
+            "ranks": forged_ranks,
+            "poset_digest": finite_poset_digest(
+                elements=poset.elements,
+                strict_order_pairs=poset.strict_order_pairs,
+                cover_relations=poset.cover_relations,
+                incomparable_pairs=poset.incomparable_pairs,
+                minimal_elements=poset.minimal_elements,
+                maximal_elements=poset.maximal_elements,
+                graded=poset.graded,
+                ranks=forged_ranks,
+            ),
+        }
+    )
+
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+
+
+def test_consumers_reject_foreign_incomparable_pair_models_as_domain_errors() -> None:
+    class ForeignPair(IncomparablePair):
+        extra: str = "foreign"
+
+    poset = _materialize(["a", "b"], [])
+    forged_pairs = tuple(
+        ForeignPair(left=pair.left, right=pair.right)
+        for pair in poset.incomparable_pairs
+    )
+    forged = poset.model_copy(
+        update={
+            "incomparable_pairs": forged_pairs,
+            "poset_digest": finite_poset_digest(
+                elements=poset.elements,
+                strict_order_pairs=poset.strict_order_pairs,
+                cover_relations=poset.cover_relations,
+                incomparable_pairs=forged_pairs,
+                minimal_elements=poset.minimal_elements,
+                maximal_elements=poset.maximal_elements,
+                graded=poset.graded,
+                ranks=poset.ranks,
+            ),
+        }
+    )
+
     assert verify_finite_poset(forged) is False
     with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
         width(forged)

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -295,6 +295,18 @@ def test_consumers_reject_foreign_incomparable_pair_models_as_domain_errors() ->
         width(forged)
 
 
+def test_consumers_reject_list_incomparable_pair_containers_as_domain_errors() -> None:
+    poset = _materialize(["a", "b"], [])
+    forged = poset.model_copy(
+        update={"incomparable_pairs": list(poset.incomparable_pairs)}
+    )
+
+    assert type(forged.incomparable_pairs) is list
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+
+
 def test_consumers_reject_duck_typed_ordered_pair_carriers_as_domain_errors() -> None:
     class ForeignOrder:
         def __init__(self, lower: str, upper: str) -> None:

--- a/tests/math/combinatorics/posets/core/test_models.py
+++ b/tests/math/combinatorics/posets/core/test_models.py
@@ -177,6 +177,31 @@ def test_consumers_reject_mixed_carrier_elements_as_domain_errors() -> None:
         width(malformed)
 
 
+def test_consumers_reject_integer_graded_flag_as_domain_errors() -> None:
+    poset = _materialize(["a", "b"], [("a", "b")])
+    forged = poset.model_copy(
+        update={
+            "graded": 1,
+            "poset_digest": finite_poset_digest(
+                elements=poset.elements,
+                strict_order_pairs=poset.strict_order_pairs,
+                cover_relations=poset.cover_relations,
+                incomparable_pairs=poset.incomparable_pairs,
+                minimal_elements=poset.minimal_elements,
+                maximal_elements=poset.maximal_elements,
+                graded=1,  # type: ignore[arg-type]
+                ranks=poset.ranks,
+            ),
+        }
+    )
+
+    assert type(forged.graded) is int
+    assert forged.graded == 1
+    assert verify_finite_poset(forged) is False
+    with pytest.raises(OperationDomainValidationError, match="canonical finite poset"):
+        width(forged)
+
+
 def test_consumers_reject_boolean_rank_claims_as_domain_errors() -> None:
     poset = _materialize(["a", "b"], [("a", "b")])
     forged_ranks = tuple(

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -15,7 +15,6 @@ from pydantic import ValidationError
 
 from jacobian._execution import OperationExecutionCancelledError, request_cancellation
 from jacobian.canonical import encode_strict_json
-from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
@@ -803,16 +802,6 @@ def test_range_profile_observes_request_cancellation_inside_row_loop(
     ):
         range_profile((2,), 3, 4)
     assert calls == 1
-
-
-def test_record_minima_remains_native_only() -> None:
-    """Record extraction composes the public range operation in native code."""
-    assert (
-        Catalog.open().operation(
-            "number_theory.simultaneous_approximation.record_minima.compute"
-        )
-        is None
-    )
 
 
 def test_surd_request_schemas_describe_radical_axis_constraints() -> None:

--- a/tests/math/number_theory/sequences/core/test_autocorrelation.py
+++ b/tests/math/number_theory/sequences/core/test_autocorrelation.py
@@ -9,12 +9,10 @@ from pydantic import ValidationError
 
 from jacobian._exact import MAX_CANONICAL_INTEGER_DIGITS, CanonicalRational
 from jacobian.canonical import parse_canonical_integer
-from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
 )
-from jacobian.dispatch import invoke_operation
 from jacobian.math.number_theory.sequences.core._models import (
     AutocorrelationCell,
     AutocorrelationResult,
@@ -238,21 +236,6 @@ def test_constant_sequence_peak_scan_is_linear() -> None:
     assert result.weak_unimodal_peak_positions == tuple(range(10_000))
 
 
-def test_catalog_accepts_serialized_integer_sequence_source() -> None:
-    source = sequence_order_shape(FiniteIntegerSequence(values=(1, 2, 3))).source
-    payload = json.loads(source.model_dump_json())
-    result = invoke_operation(
-        "sequence.autocorrelation.aperiodic.compute",
-        payload,
-        Catalog.open(),
-    )
-    native = aperiodic_autocorrelation(source)
-    assert result.output == native.model_dump(mode="json")
-    restored = AutocorrelationResult.model_validate_json(json.dumps(result.output))
-    assert isinstance(restored.source, FiniteIntegerSequence)
-    assert restored.source.values == (1, 2, 3)
-
-
 def test_wide_rational_cyclic_work_is_rejected_before_kernel() -> None:
     denominator = 10**15_999
     source = FiniteRationalSequence(
@@ -281,13 +264,6 @@ def test_oversized_integer_wire_entries_are_rejected_before_parsing() -> None:
         FiniteRationalSequence.model_validate(payload)
 
 
-def test_autocorrelation_catalog_schema_registers_canonical_rational_defs() -> None:
+def test_autocorrelation_value_schema_registers_canonical_rational_defs() -> None:
     schema = FiniteSequence.model_json_schema()
     assert "CanonicalRational" in json.dumps(schema)
-    catalog = Catalog.open()
-    descriptor = next(
-        operation
-        for operation in catalog.snapshot().operations
-        if operation.operation_id == "sequence.autocorrelation.aperiodic.compute"
-    )
-    assert "CanonicalRational" in json.dumps(descriptor.input_schema)

--- a/tests/math/polynomials/test_laurent_multiply.py
+++ b/tests/math/polynomials/test_laurent_multiply.py
@@ -3,7 +3,6 @@
 import pytest
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
@@ -80,30 +79,6 @@ def test_exponent_growth_is_rejected_before_convolution() -> None:
     )
     with pytest.raises(OperationResourceAdmissionError) as error:
         rational_laurent_multiply(left, right)
-    assert error.value.errors()[0]["type"] == "polynomial.laurent.exponent_growth"
-
-
-def test_catalog_admits_exponent_growth_before_convolution_bound() -> None:
-    operation = Catalog.open().operation("polynomial.laurent.rational.multiply.compute")
-    assert operation is not None
-
-    left_count = 65
-    right_count = 64
-    left = RationalLaurentPolynomial(
-        variables=("x",),
-        terms=tuple(
-            term(1, MAX_POLYNOMIAL_EXPONENT - index) for index in range(left_count)
-        ),
-    )
-    right = RationalLaurentPolynomial(
-        variables=("x",),
-        terms=tuple(term(1, index) for index in range(right_count - 1, -1, -1)),
-    )
-    request = operation.request_type(left=left, right=right)
-
-    with pytest.raises(OperationResourceAdmissionError) as error:
-        operation.run(request)
-
     assert error.value.errors()[0]["type"] == "polynomial.laurent.exponent_growth"
 
 


### PR DESCRIPTION
## Problem

Poset consumers could trust semantically inconsistent `FinitePoset` claims. The antichain enumeration operation checked its cardinality envelope but did not authenticate the retained relation, profile, and digest, so a forged source could produce antichains for a different order.

## Change

- Require canonical admission for antichain enumeration.
- Strengthen shared canonical poset admission to validate the complete retained value: strict order, covers, incomparables, extrema, graded ranks, and digest.
- Add a behavioral regression using a forged two-element chain claim.

Fixes #3619.

## Validation

- `uv run pytest -q tests/math/combinatorics/finite_structures tests/math/combinatorics/posets` (470 passed)
- `MATH_WORKERS=0 make affected AFFECTED_BASE=eaa4f3d6fdaca75ba5082e9197a6dc3dbd400318` (all 5 planned commands passed: scoped lint, mypy, 40 math tests, 160 catalog tests, 966 catalog integration tests)

The audit covered 56 public tools in the finite structures and posets owned paths, including seven dynamically registered tools: minimal transversal enumeration, weighted independent selection, four poset closure tools, and maximal-chain enumeration.