### PR TITLE
fix(graphs): widen block-cut tree vertex envelope

### DIFF
--- a/src/jacobian/math/graphs/decomposition/_models.py
+++ b/src/jacobian/math/graphs/decomposition/_models.py
@@ -18,6 +18,8 @@ from jacobian._models import StrictModel
 from jacobian.math.graphs.multigraph._models import MAX_EDGES, LooplessMultigraph
 from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
+MAX_BLOCK_CUT_TREE_VERTICES = 256
+
 
 def _require_decomposition_graph(
     graph: IndexedSimpleUndirectedGraph,
@@ -36,8 +38,27 @@ _DecompositionGraph = Annotated[
 ]
 
 
+def _require_block_cut_graph(
+    graph: IndexedSimpleUndirectedGraph,
+) -> IndexedSimpleUndirectedGraph:
+    """Admit the linear block-cut construction up to the shared graph axis."""
+    if not 1 <= graph.vertex_count <= MAX_BLOCK_CUT_TREE_VERTICES:
+        raise PydanticCustomError(
+            "graph.block_cut_tree_vertex_count",
+            "block-cut tree requires between 1 and "
+            f"{MAX_BLOCK_CUT_TREE_VERTICES} vertices",
+        )
+    return graph
+
+
+_BlockCutGraph = Annotated[
+    IndexedSimpleUndirectedGraph,
+    AfterValidator(_require_block_cut_graph),
+]
+
+
 class BlockCutTreeRequest(StrictModel):
-    graph: _DecompositionGraph
+    graph: _BlockCutGraph
 
 
 class BlockCutTreeResult(StrictModel):

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -73,8 +73,19 @@ class TestBlockCutTreeRequest:
     def test_vertex_count_too_large(self) -> None:
         with pytest.raises(ValidationError):
             BlockCutTreeRequest(
-                graph=IndexedSimpleUndirectedGraph(vertex_count=65, edges=())
+                graph=IndexedSimpleUndirectedGraph(vertex_count=257, edges=())
             )
+
+    def test_linear_path_above_legacy_cap_is_admitted_and_round_trips(self) -> None:
+        graph = IndexedSimpleUndirectedGraph(
+            vertex_count=65, edges=tuple((index, index + 1) for index in range(64))
+        )
+        request = BlockCutTreeRequest(graph=graph)
+        result = block_cut_tree(request.graph)
+        assert len(result.blocks) == 64
+        assert len(result.articulation_points) == 63
+        assert len(result.tree) == 126
+        assert type(result).model_validate(result.model_dump()) == result
 
     def test_vertex_count_too_small(self) -> None:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
The initial repair for #3630 separated block-cut construction from the generic 64-vertex decomposition envelope. It admitted the motivating 65-vertex path under a temporary operation-local 256-vertex runtime bound while preserving the 64-vertex limits on the other decomposition operations. A 257-vertex request and malformed edge endpoints remained rejected, and the 65-vertex result round-tripped through serialization.

Follow-up #3633 publishes and enforces the full 1024-vertex indexed carrier envelope, aligns JSON Schema with runtime admission, and replaces the quadratic block/articulation incidence scan with output-proportional construction.

Validation for this initial step:

- `uv run pytest -q tests/math/graphs/test_graph_decomposition.py` (31 passed)
- `MATH_WORKERS=0 make affected AFFECTED_BASE=origin/main` (all 5 commands passed: 69 math tests, 160 catalog tests, 966 catalog integration tests, lint/format, and mypy)
