### PR TITLE
fix(graphs): publish full block-cut carrier envelope

### DIFF
--- a/src/jacobian/math/graphs/decomposition/_models.py
+++ b/src/jacobian/math/graphs/decomposition/_models.py
@@ -11,14 +11,18 @@ from __future__ import annotations
 
 from typing import Annotated, Literal, Self
 
-from pydantic import AfterValidator, Field, model_validator
+from pydantic import AfterValidator, Field, WithJsonSchema, model_validator
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.multigraph._models import MAX_EDGES, LooplessMultigraph
-from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+from jacobian.math.graphs.values import (
+    MAX_INDEXED_SIMPLE_GRAPH_VERTICES,
+    IndexedSimpleUndirectedGraph,
+)
 
-MAX_BLOCK_CUT_TREE_VERTICES = 256
+MAX_BLOCK_CUT_TREE_VERTICES = MAX_INDEXED_SIMPLE_GRAPH_VERTICES
 
 
 def _require_decomposition_graph(
@@ -51,9 +55,22 @@ def _require_block_cut_graph(
     return graph
 
 
+def _block_cut_graph_schema() -> JsonSchemaValue:
+    schema = IndexedSimpleUndirectedGraph.model_json_schema()
+    schema["description"] = (
+        "A finite simple indexed graph accepted by block-cut decomposition: "
+        f"at most {MAX_BLOCK_CUT_TREE_VERTICES} vertices."
+    )
+    schema["properties"]["vertex_count"].update(
+        maximum=MAX_BLOCK_CUT_TREE_VERTICES,
+    )
+    return schema
+
+
 _BlockCutGraph = Annotated[
     IndexedSimpleUndirectedGraph,
     AfterValidator(_require_block_cut_graph),
+    WithJsonSchema(_block_cut_graph_schema()),
 ]
 
 

--- a/src/jacobian/math/graphs/decomposition/_models.py
+++ b/src/jacobian/math/graphs/decomposition/_models.py
@@ -2,9 +2,9 @@
 
 All operations in this module act on an undirected simple graph supplied as
 a vertex count and a tuple of ``(source, target)`` integer edges.  Vertices
-are labelled ``0..vertex_count-1``; the vertex axis holds at most 64
-vertices, so a simple graph admits up to ``C(64, 2) = 2016`` edges, matching
-the shared multigraph carrier bounds.
+are labelled ``0..vertex_count-1``. Most decomposition operations use a
+64-vertex execution envelope; block-cut construction uses the full indexed
+graph carrier envelope because its incidence construction is output-linear.
 """
 
 from __future__ import annotations

--- a/src/jacobian/math/graphs/decomposition/_models.py
+++ b/src/jacobian/math/graphs/decomposition/_models.py
@@ -62,6 +62,7 @@ def _block_cut_graph_schema() -> JsonSchemaValue:
         f"at most {MAX_BLOCK_CUT_TREE_VERTICES} vertices."
     )
     schema["properties"]["vertex_count"].update(
+        minimum=1,
         maximum=MAX_BLOCK_CUT_TREE_VERTICES,
     )
     return schema

--- a/src/jacobian/math/graphs/decomposition/operations.py
+++ b/src/jacobian/math/graphs/decomposition/operations.py
@@ -56,15 +56,18 @@ def block_cut_tree(graph: IndexedSimpleUndirectedGraph) -> BlockCutTreeResult:
         for component in nx.biconnected_components(g)
     ]
     articulation_points = sorted(nx.articulation_points(g))
+    canonical_blocks = tuple(tuple(sorted(block)) for block in blocks)
 
-    tree_edges: list[tuple[int, int]] = []
-    for block_index, block in enumerate(blocks):
-        for vertex in articulation_points:
-            if vertex in block:
-                tree_edges.append((block_index, vertex))
+    articulation_set = set(articulation_points)
+    tree_edges: list[tuple[int, int]] = [
+        (block_index, vertex)
+        for block_index, block in enumerate(canonical_blocks)
+        for vertex in block
+        if vertex in articulation_set
+    ]
 
     return BlockCutTreeResult(
-        blocks=tuple(tuple(sorted(block)) for block in blocks),
+        blocks=canonical_blocks,
         articulation_points=tuple(articulation_points),
         tree=tuple(tree_edges),
     )

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -73,7 +73,7 @@ class TestBlockCutTreeRequest:
     def test_vertex_count_too_large(self) -> None:
         with pytest.raises(ValidationError):
             BlockCutTreeRequest(
-                graph=IndexedSimpleUndirectedGraph(vertex_count=257, edges=())
+                graph=IndexedSimpleUndirectedGraph(vertex_count=1025, edges=())
             )
 
     def test_linear_path_above_legacy_cap_is_admitted_and_round_trips(self) -> None:
@@ -86,6 +86,43 @@ class TestBlockCutTreeRequest:
         assert len(result.articulation_points) == 63
         assert len(result.tree) == 126
         assert type(result).model_validate(result.model_dump()) == result
+
+    def test_full_indexed_vertex_envelope_and_schema_parity(self) -> None:
+        schema = BlockCutTreeRequest.model_json_schema()
+        graph_schema = schema["properties"]["graph"]
+        assert graph_schema["properties"]["vertex_count"]["maximum"] == 1024
+        graph = IndexedSimpleUndirectedGraph(
+            vertex_count=1024,
+            edges=tuple((index, index + 1) for index in range(1023)),
+        )
+        result = block_cut_tree(BlockCutTreeRequest(graph=graph).graph)
+        assert len(result.blocks) == 1023
+        assert len(result.articulation_points) == 1022
+        assert len(result.tree) == 2044
+
+    def test_full_indexed_star_envelope_is_admitted(self) -> None:
+        graph = IndexedSimpleUndirectedGraph(
+            vertex_count=1024,
+            edges=tuple((0, index) for index in range(1, 1024)),
+        )
+        result = block_cut_tree(BlockCutTreeRequest(graph=graph).graph)
+        assert len(result.blocks) == 1023
+        assert result.articulation_points == (0,)
+        assert len(result.tree) == 1023
+
+    def test_near_edge_carrier_bound_is_admitted(self) -> None:
+        edges = []
+        for left in range(1024):
+            for right in range(left + 1, 1024):
+                edges.append((left, right))
+                if len(edges) == 65_536:
+                    break
+            if len(edges) == 65_536:
+                break
+        graph = IndexedSimpleUndirectedGraph(vertex_count=1024, edges=tuple(edges))
+        result = block_cut_tree(BlockCutTreeRequest(graph=graph).graph)
+        assert len(result.blocks) == 1
+        assert result.articulation_points == ()
 
     def test_vertex_count_too_small(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import pytest
+from jsonschema import Draft202012Validator
+from jsonschema import ValidationError as JSONSchemaValidationError
 from pydantic import ValidationError
 
 from jacobian.math.graphs.decomposition._models import (
@@ -90,6 +92,7 @@ class TestBlockCutTreeRequest:
     def test_full_indexed_vertex_envelope_and_schema_parity(self) -> None:
         schema = BlockCutTreeRequest.model_json_schema()
         graph_schema = schema["properties"]["graph"]
+        assert graph_schema["properties"]["vertex_count"]["minimum"] == 1
         assert graph_schema["properties"]["vertex_count"]["maximum"] == 1024
         graph = IndexedSimpleUndirectedGraph(
             vertex_count=1024,
@@ -99,6 +102,12 @@ class TestBlockCutTreeRequest:
         assert len(result.blocks) == 1023
         assert len(result.articulation_points) == 1022
         assert len(result.tree) == 2044
+
+    def test_schema_rejects_empty_graph_vertex_count(self) -> None:
+        validator = Draft202012Validator(BlockCutTreeRequest.model_json_schema())
+        validator.validate({"graph": {"vertex_count": 1, "edges": []}})
+        with pytest.raises(JSONSchemaValidationError):
+            validator.validate({"graph": {"vertex_count": 0, "edges": []}})
 
     def test_full_indexed_star_envelope_is_admitted(self) -> None:
         graph = IndexedSimpleUndirectedGraph(


### PR DESCRIPTION
Follow-up to #3632 and #3630.

The block-cut request now publishes and enforces the full 1024-vertex indexed carrier envelope. The incidence kernel canonicalizes each block once and scans only block memberships against an articulation set, making sparse-path work proportional to block incidence rather than scanning every block against every articulation point. A 65,536-edge near-carrier-bound graph remains admitted; 1025 vertices and malformed endpoints remain rejected.

Same harness, seven runs per size, median incidence-only timings on paths (old nested scan → membership scan): 128 vertices 0.385 ms → 0.048 ms; 256 1.221 → 0.070; 512 5.187 → 0.157; 1024 20.312 → 0.326. These timings are diagnostic evidence; the contract relies on the derived incidence bound.

Validation:

- `uv run pytest -q tests/math/graphs/test_graph_decomposition.py` (34 passed)
- `MATH_WORKERS=0 make affected AFFECTED_BASE=origin/main` (all 5 commands passed: 72 math tests, 160 catalog tests, 966 catalog integration tests, lint/format, and mypy)