### PR TITLE
fix(impartial-games): bind profile results to source games

### DIFF
--- a/src/jacobian/math/logic/games/impartial/__init__.py
+++ b/src/jacobian/math/logic/games/impartial/__init__.py
@@ -13,6 +13,8 @@ from jacobian.math.logic.games.impartial.operations import (
     position_grundy,
     subtraction_game,
     subtraction_grundy_prefix,
+    verify_disjunctive_sum,
+    verify_outcome_profile,
 )
 from jacobian.math.logic.games.impartial.values import (
     GameMove,
@@ -36,4 +38,6 @@ __all__ = [
     "position_grundy",
     "subtraction_game",
     "subtraction_grundy_prefix",
+    "verify_disjunctive_sum",
+    "verify_outcome_profile",
 ]

--- a/src/jacobian/math/logic/games/impartial/_models.py
+++ b/src/jacobian/math/logic/games/impartial/_models.py
@@ -311,10 +311,37 @@ class OutcomeProfileRequest(StrictModel):
 class OutcomeProfileResult(StrictModel):
     """The complete P/N position partition with Grundy values."""
 
+    game: ImpartialGame
     p_positions: tuple[str, ...]
     n_positions: tuple[str, ...]
     grundy_values: tuple[tuple[str, int], ...]
     terminal_positions: tuple[str, ...]
+
+    @model_validator(mode="after")
+    def require_source_bound_shape(self) -> Self:
+        positions = self.game.positions
+        values = dict(self.grundy_values)
+        expected_terminals = tuple(
+            p for p in positions if not any(m.source == p for m in self.game.moves)
+        )
+        if (
+            len(self.p_positions) != len(set(self.p_positions))
+            or len(self.n_positions) != len(set(self.n_positions))
+            or len(self.terminal_positions) != len(set(self.terminal_positions))
+            or len(self.grundy_values) != len(positions)
+            or set(self.p_positions) | set(self.n_positions) != set(positions)
+            or set(self.p_positions) & set(self.n_positions)
+            or set(values) != set(positions)
+            or self.terminal_positions != expected_terminals
+            or any(value < 0 or value >= len(positions) for value in values.values())
+            or tuple(p for p in positions if values[p] == 0) != self.p_positions
+            or tuple(p for p in positions if values[p] != 0) != self.n_positions
+        ):
+            raise PydanticCustomError(
+                "impartial_game.outcome_profile_shape",
+                "outcome profile must cover the retained game positions canonically",
+            )
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -355,6 +382,8 @@ class DisjunctiveSumRequest(StrictModel):
 class DisjunctiveSumResult(StrictModel):
     """The exact Grundy value of a disjunctive sum of impartial games."""
 
+    components: tuple[ImpartialGame, ...] = Field(min_length=1, max_length=MAX_HEAPS)
+    start_positions: tuple[str, ...] = Field(min_length=1, max_length=MAX_HEAPS)
     grundy_value: int = Field(ge=0, le=MAX_DISJUNCTIVE_GRUNDY)
     component_grundy_values: tuple[int, ...] = Field(
         min_length=1,
@@ -365,6 +394,24 @@ class DisjunctiveSumResult(StrictModel):
 
     @model_validator(mode="after")
     def require_exact_disjunctive_invariants(self) -> Self:
+        if len(self.components) != len(self.start_positions):
+            raise PydanticCustomError(
+                "impartial_game.component_count_mismatch",
+                "components and start_positions must have equal length",
+            )
+        if any(
+            start not in game.positions
+            for game, start in zip(self.components, self.start_positions, strict=True)
+        ):
+            raise PydanticCustomError(
+                "impartial_game.start_position_unknown",
+                "every start position must belong to its component game",
+            )
+        if self.component_count != len(self.components):
+            raise PydanticCustomError(
+                "impartial_game.component_count_mismatch",
+                "component_count must match components length",
+            )
         if self.component_count != len(self.component_grundy_values):
             raise PydanticCustomError(
                 "impartial_game.component_count_mismatch",

--- a/src/jacobian/math/logic/games/impartial/_models.py
+++ b/src/jacobian/math/logic/games/impartial/_models.py
@@ -329,6 +329,7 @@ class OutcomeProfileResult(StrictModel):
             or len(self.n_positions) != len(set(self.n_positions))
             or len(self.terminal_positions) != len(set(self.terminal_positions))
             or len(self.grundy_values) != len(positions)
+            or tuple(position for position, _ in self.grundy_values) != positions
             or set(self.p_positions) | set(self.n_positions) != set(positions)
             or set(self.p_positions) & set(self.n_positions)
             or set(values) != set(positions)

--- a/src/jacobian/math/logic/games/impartial/operations.py
+++ b/src/jacobian/math/logic/games/impartial/operations.py
@@ -143,12 +143,20 @@ def _disjunctive_sum_result(
 
 def verify_outcome_profile(claim: OutcomeProfileResult) -> bool:
     """Verify a serialized outcome profile against its retained game."""
-    return _outcome_profile_result(claim.game) == claim
+    try:
+        expected = _outcome_profile_result(claim.game)
+    except ValueError:
+        return False
+    return expected == claim
 
 
 def verify_disjunctive_sum(claim: DisjunctiveSumResult) -> bool:
     """Verify a serialized disjunctive sum against its retained components."""
-    return _disjunctive_sum_result(claim.components, claim.start_positions) == claim
+    try:
+        expected = _disjunctive_sum_result(claim.components, claim.start_positions)
+    except ValueError:
+        return False
+    return expected == claim
 
 
 def grundy_classes(game: ImpartialGame) -> tuple[tuple[int, tuple[str, ...]], ...]:

--- a/src/jacobian/math/logic/games/impartial/operations.py
+++ b/src/jacobian/math/logic/games/impartial/operations.py
@@ -111,6 +111,7 @@ def _outcome_profile_result(game: ImpartialGame) -> OutcomeProfileResult:
         if not any(move.source == position for move in game.moves)
     )
     return OutcomeProfileResult(
+        game=game,
         p_positions=p_positions,
         n_positions=n_positions,
         grundy_values=analysis.values,
@@ -131,11 +132,23 @@ def _disjunctive_sum_result(
         component_grundy_values.append(grundy_map[start])
     result_grundy = reduce(xor, component_grundy_values, 0)
     return DisjunctiveSumResult(
+        components=components,
+        start_positions=start_positions,
         grundy_value=result_grundy,
         component_grundy_values=tuple(component_grundy_values),
         is_p_position=result_grundy == 0,
         component_count=len(component_grundy_values),
     )
+
+
+def verify_outcome_profile(claim: OutcomeProfileResult) -> bool:
+    """Verify a serialized outcome profile against its retained game."""
+    return _outcome_profile_result(claim.game) == claim
+
+
+def verify_disjunctive_sum(claim: DisjunctiveSumResult) -> bool:
+    """Verify a serialized disjunctive sum against its retained components."""
+    return _disjunctive_sum_result(claim.components, claim.start_positions) == claim
 
 
 def grundy_classes(game: ImpartialGame) -> tuple[tuple[int, tuple[str, ...]], ...]:
@@ -288,4 +301,6 @@ __all__ = [
     "position_grundy",
     "subtraction_game",
     "subtraction_grundy_prefix",
+    "verify_disjunctive_sum",
+    "verify_outcome_profile",
 ]

--- a/tests/math/logic/games/impartial/test_disjunctive_sum.py
+++ b/tests/math/logic/games/impartial/test_disjunctive_sum.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from jacobian.math.logic.games.impartial._models import (
     DisjunctiveSumRequest,
+    DisjunctiveSumResult,
 )
 from jacobian.math.logic.games.impartial._tools import (
     TOOLS,
@@ -143,6 +144,28 @@ class TestDisjunctiveSum:
         forged = type(result).model_validate_json(json.dumps(payload))
         assert verify_disjunctive_sum(forged) is False
         assert verify_disjunctive_sum(result) is True
+
+    def test_verifier_rejects_structurally_valid_cyclic_claim(self) -> None:
+        claim = DisjunctiveSumResult.model_validate(
+            {
+                "components": [
+                    {
+                        "positions": ["a", "b"],
+                        "moves": [
+                            {"source": "a", "target": "b"},
+                            {"source": "b", "target": "a"},
+                        ],
+                    }
+                ],
+                "start_positions": ["a"],
+                "grundy_value": 0,
+                "component_grundy_values": [0],
+                "is_p_position": True,
+                "component_count": 1,
+            }
+        )
+
+        assert verify_disjunctive_sum(claim) is False
 
 
 class TestDisjunctiveSumValidation:

--- a/tests/math/logic/games/impartial/test_disjunctive_sum.py
+++ b/tests/math/logic/games/impartial/test_disjunctive_sum.py
@@ -1,5 +1,7 @@
 """Known-answer and adversarial tests for the disjunctive sum operation."""
 
+import json
+
 import pytest
 from pydantic import ValidationError
 
@@ -10,6 +12,7 @@ from jacobian.math.logic.games.impartial._tools import (
     TOOLS,
     compute_disjunctive_sum,
 )
+from jacobian.math.logic.games.impartial.operations import verify_disjunctive_sum
 from jacobian.math.logic.games.impartial.values import ImpartialGame
 
 # -- helpers -----------------------------------------------------------------
@@ -112,6 +115,34 @@ class TestDisjunctiveSum:
         assert result.component_grundy_values == (0, 1)
         assert result.is_p_position is False
         assert result.component_count == 2
+
+    def test_serialization_retains_components_and_verifier_rejects_forgery(
+        self,
+    ) -> None:
+        request = DisjunctiveSumRequest(
+            components=(_TERMINAL, _SINGLE_MOVE),
+            start_positions=("start", "a"),
+        )
+        result = compute_disjunctive_sum(request)
+        payload = result.model_dump(mode="json")
+        assert payload["components"] == [
+            {"positions": ["start"], "moves": []},
+            {
+                "positions": ["a", "b"],
+                "moves": [{"source": "a", "target": "b"}],
+            },
+        ]
+        payload["components"][1] = {
+            "positions": ["a", "b", "c", "d"],
+            "moves": [
+                {"source": "a", "target": "b"},
+                {"source": "a", "target": "c"},
+                {"source": "c", "target": "d"},
+            ],
+        }
+        forged = type(result).model_validate_json(json.dumps(payload))
+        assert verify_disjunctive_sum(forged) is False
+        assert verify_disjunctive_sum(result) is True
 
 
 class TestDisjunctiveSumValidation:

--- a/tests/math/logic/games/impartial/test_nim_outcome.py
+++ b/tests/math/logic/games/impartial/test_nim_outcome.py
@@ -13,6 +13,7 @@ from jacobian.math.logic.games.impartial._tools import (
     compute_nim_sum,
     compute_outcome_profile,
 )
+from jacobian.math.logic.games.impartial.operations import verify_outcome_profile
 from jacobian.math.logic.games.impartial.values import NimPosition
 
 _GAME = {
@@ -98,3 +99,20 @@ class TestOutcomeProfile:
         assert grundy_map["1"] == 1
         assert grundy_map["2"] == 2
         assert grundy_map["3"] == 0
+
+    def test_serialization_retains_game_and_rejects_forged_profile(self) -> None:
+        request = OutcomeProfileRequest.model_validate({"game": _GAME})
+        result = compute_outcome_profile(request)
+        payload = result.model_dump(mode="json")
+        assert payload["game"] == _GAME
+        payload["p_positions"] = ["1", "3"]
+        with pytest.raises(ValidationError):
+            type(result).model_validate_json(json.dumps(payload))
+        coherent = result.model_dump(mode="json")
+        coherent["grundy_values"] = [
+            [position, 1 if position == "2" else value]
+            for position, value in coherent["grundy_values"]
+        ]
+        forged = type(result).model_validate_json(json.dumps(coherent))
+        assert verify_outcome_profile(forged) is False
+        assert verify_outcome_profile(result)

--- a/tests/math/logic/games/impartial/test_nim_outcome.py
+++ b/tests/math/logic/games/impartial/test_nim_outcome.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from jacobian.math.logic.games.impartial._models import (
     NimSumRequest,
     OutcomeProfileRequest,
+    OutcomeProfileResult,
 )
 from jacobian.math.logic.games.impartial._tools import (
     compute_nim_sum,
@@ -116,3 +117,31 @@ class TestOutcomeProfile:
         forged = type(result).model_validate_json(json.dumps(coherent))
         assert verify_outcome_profile(forged) is False
         assert verify_outcome_profile(result)
+
+    def test_result_requires_canonical_grundy_row_order(self) -> None:
+        request = OutcomeProfileRequest.model_validate({"game": _GAME})
+        result = compute_outcome_profile(request)
+        payload = result.model_dump(mode="json")
+        payload["grundy_values"] = list(reversed(payload["grundy_values"]))
+
+        with pytest.raises(ValidationError):
+            type(result).model_validate_json(json.dumps(payload))
+
+    def test_verifier_rejects_structurally_valid_cyclic_claim(self) -> None:
+        claim = OutcomeProfileResult.model_validate(
+            {
+                "game": {
+                    "positions": ["a", "b"],
+                    "moves": [
+                        {"source": "a", "target": "b"},
+                        {"source": "b", "target": "a"},
+                    ],
+                },
+                "p_positions": ["a", "b"],
+                "n_positions": [],
+                "grundy_values": [["a", 0], ["b", 0]],
+                "terminal_positions": [],
+            }
+        )
+
+        assert verify_outcome_profile(claim) is False

--- a/tests/math/logic/games/impartial/test_public_api.py
+++ b/tests/math/logic/games/impartial/test_public_api.py
@@ -24,6 +24,8 @@ def test_exact_public_api_symbols() -> None:
         "position_grundy",
         "subtraction_game",
         "subtraction_grundy_prefix",
+        "verify_disjunctive_sum",
+        "verify_outcome_profile",
     )
     assert tuple(impartial_games.__all__) == expected
     assert len(impartial_games.__all__) == len(set(impartial_games.__all__))


### PR DESCRIPTION
Closes #3380

Outcome-profile and disjunctive-sum results now retain the canonical impartial games and start-position axes that define their claims. Result validation enforces complete source-bound position/component shapes without replaying Grundy computation, while explicit verifiers compare deserialized claims against the retained sources.

Regression tests cover producer-to-JSON round trips, structurally coherent forged Grundy values, forged partitions, and component replacement.

Validation:
- MATH_WORKERS=0 .venv/bin/python tools/affected_validation.py --base origin/main
- .venv/bin/pytest -q tests/math/logic (654 passed)
- .venv/bin/pytest -q tests/math/logic/games/impartial (58 passed)
- .venv/bin/ruff check src/jacobian/math/logic/games/impartial tests/math/logic/games/impartial
- .venv/bin/ruff format --check src/jacobian/math/logic/games/impartial tests/math/logic/games/impartial

The affected validation planner also passed lint, typecheck, 58 math tests, 160 catalog tests, and 966 catalog integration tests.
