### PR TITLE
feat(finite-fields): expose exact polynomial point evaluation

### DIFF
--- a/src/jacobian/math/finite_fields/_models.py
+++ b/src/jacobian/math/finite_fields/_models.py
@@ -10,8 +10,10 @@ from jacobian.math.finite_fields.values import (
     Axis,
     DirectionRankLedger,
     FiniteDimensionalSubspace,
+    FiniteFieldElement,
     FiniteFieldPresentation,
     FiniteMapTable,
+    FinitePolynomial,
     FinitePolynomialMap,
     PrimeFieldLinearAction,
     ProjectiveLine,
@@ -122,6 +124,13 @@ class FiniteMapTableRequest(_FiniteFieldRequest):
     polynomial_map: FinitePolynomialMap
 
 
+class FinitePolynomialEvaluationRequest(_FiniteFieldRequest):
+    """Evaluate one bounded polynomial at one element of its exact field."""
+
+    polynomial: FinitePolynomial
+    value: FiniteFieldElement
+
+
 class FiberPartitionRequest(_FiniteFieldRequest):
     table: FiniteMapTable
 
@@ -143,6 +152,7 @@ __all__ = [
     "DirectionRankLedgerRequest",
     "FiberPartitionRequest",
     "FiniteMapTableRequest",
+    "FinitePolynomialEvaluationRequest",
     "HomogeneousFixedSubspaceRequest",
     "LinearMapRankRequest",
     "OrbitDistributionRequest",

--- a/src/jacobian/math/finite_fields/_tools.py
+++ b/src/jacobian/math/finite_fields/_tools.py
@@ -3,7 +3,6 @@
 from jacobian.catalog.models import (
     MathTool,
     MathTools,
-    OperationDomainValidationError,
     OperationExample,
 )
 from jacobian.math.finite_fields import (
@@ -202,12 +201,6 @@ def _finite_map_table(request: FiniteMapTableRequest) -> FiniteMapTable:
 def _finite_polynomial_evaluation(
     request: FinitePolynomialEvaluationRequest,
 ) -> FiniteFieldElement:
-    if request.value.presentation != request.polynomial.presentation:
-        raise OperationDomainValidationError(
-            location=("value", "presentation"),
-            code="finite_field.finite_polynomial_evaluation_parent_mismatch",
-            message="polynomial and value must share their exact presentation",
-        )
     return evaluate_finite_polynomial(request.polynomial, request.value)
 
 

--- a/src/jacobian/math/finite_fields/_tools.py
+++ b/src/jacobian/math/finite_fields/_tools.py
@@ -1,6 +1,11 @@
 """Finite-field catalog projections and immutable tool declarations."""
 
-from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.catalog.models import (
+    MathTool,
+    MathTools,
+    OperationDomainValidationError,
+    OperationExample,
+)
 from jacobian.math.finite_fields import (
     Axis,
     AxisBoundMatrix,
@@ -20,6 +25,7 @@ from jacobian.math.finite_fields import (
     analyze_collisions,
     analyze_permutation,
     direction_rank_ledger,
+    evaluate_finite_polynomial,
     fiber_partition,
     finite_map_table,
     homogeneous_fixed_subspace,
@@ -38,6 +44,7 @@ from jacobian.math.finite_fields._models import (
     DirectionRankLedgerRequest,
     FiberPartitionRequest,
     FiniteMapTableRequest,
+    FinitePolynomialEvaluationRequest,
     HomogeneousFixedSubspaceRequest,
     LinearMapRankRequest,
     OrbitDistributionRequest,
@@ -192,6 +199,25 @@ def _finite_map_table(request: FiniteMapTableRequest) -> FiniteMapTable:
     return finite_map_table(request.polynomial_map)
 
 
+def _finite_polynomial_evaluation(
+    request: FinitePolynomialEvaluationRequest,
+) -> FiniteFieldElement:
+    if request.value.presentation != request.polynomial.presentation:
+        raise OperationDomainValidationError(
+            location=("value", "presentation"),
+            code="finite_field.finite_polynomial_evaluation_parent_mismatch",
+            message="polynomial and value must share their exact presentation",
+        )
+    from jacobian.math.finite_fields._admission import require_field
+    from jacobian.math.finite_fields.operations import (
+        _admit_polynomial_point_evaluation,
+    )
+
+    require_field(request.polynomial.presentation)
+    _admit_polynomial_point_evaluation(request.polynomial, location=("polynomial",))
+    return evaluate_finite_polynomial(request.polynomial, request.value)
+
+
 def _fiber_partition(request: FiberPartitionRequest) -> FiberPartition:
     return fiber_partition(request.table)
 
@@ -282,6 +308,28 @@ def _build_tools() -> MathTools:
                 name="cubic_map_over_gf_four",
                 description="Evaluate x³ on every element of GF(4).",
                 input={"polynomial_map": _POLYNOMIAL_MAP},
+            ),
+        ),
+    )
+    point_evaluation_operation = MathTool(
+        operation_id="finite_field.polynomial.evaluate.compute",
+        request_type=FinitePolynomialEvaluationRequest,
+        result_type=FiniteFieldElement,
+        run=_finite_polynomial_evaluation,
+        title="Evaluate a finite-field polynomial at one exact element",
+        description=(
+            "Return one exact value without enumerating the field. The polynomial "
+            "and evaluation point must share one admitted finite-field presentation."
+        ),
+        tags=("finite-field", "polynomial", "evaluation", "exact"),
+        examples=(
+            OperationExample(
+                name="cubic_map_at_zero",
+                description="Evaluate x³ at the zero element of GF(4).",
+                input={
+                    "polynomial": _POLYNOMIAL_MAP["polynomial"],
+                    "value": _ZERO,
+                },
             ),
         ),
     )
@@ -437,6 +485,7 @@ def _build_tools() -> MathTools:
         rank_operation,
         ledger_operation,
         orbit_operation,
+        point_evaluation_operation,
         table_operation,
         fiber_operation,
         collision_operation,

--- a/src/jacobian/math/finite_fields/_tools.py
+++ b/src/jacobian/math/finite_fields/_tools.py
@@ -208,13 +208,6 @@ def _finite_polynomial_evaluation(
             code="finite_field.finite_polynomial_evaluation_parent_mismatch",
             message="polynomial and value must share their exact presentation",
         )
-    from jacobian.math.finite_fields._admission import require_field
-    from jacobian.math.finite_fields.operations import (
-        _admit_polynomial_point_evaluation,
-    )
-
-    require_field(request.polynomial.presentation)
-    _admit_polynomial_point_evaluation(request.polynomial, location=("polynomial",))
     return evaluate_finite_polynomial(request.polynomial, request.value)
 
 

--- a/src/jacobian/math/finite_fields/operations.py
+++ b/src/jacobian/math/finite_fields/operations.py
@@ -988,6 +988,7 @@ def evaluate_finite_polynomial(
 
     if value.presentation != polynomial.presentation:
         raise ValueError("polynomial and value must share their exact presentation")
+    _admit_polynomial_point_evaluation(polynomial, location=("polynomial",))
     from jacobian.math.finite_fields import _flint
 
     return FiniteFieldElement(

--- a/src/jacobian/math/finite_fields/operations.py
+++ b/src/jacobian/math/finite_fields/operations.py
@@ -987,7 +987,11 @@ def evaluate_finite_polynomial(
     """Evaluate with Python-FLINT while preserving the exact parent."""
 
     if value.presentation != polynomial.presentation:
-        raise ValueError("polynomial and value must share their exact presentation")
+        raise OperationDomainValidationError(
+            location=("value", "presentation"),
+            code="finite_field.finite_polynomial_evaluation_parent_mismatch",
+            message="polynomial and value must share their exact presentation",
+        )
     _admit_polynomial_point_evaluation(polynomial, location=("polynomial",))
     from jacobian.math.finite_fields import _flint
 

--- a/src/jacobian/math/finite_fields/operations.py
+++ b/src/jacobian/math/finite_fields/operations.py
@@ -996,6 +996,22 @@ def evaluate_finite_polynomial(
     )
 
 
+def _admit_polynomial_point_evaluation(
+    polynomial: FinitePolynomial,
+    *,
+    location: tuple[str, ...],
+) -> None:
+    """Admit one-point evaluation without charging complete-field enumeration."""
+
+    work = len(polynomial.coefficients) * polynomial.presentation.degree
+    if work > _MAX_FINITE_MAP_WORK:
+        raise OperationResourceAdmissionError(
+            location=location,
+            code="finite_field.finite_polynomial_evaluation_exceeds_operation_work_budget",
+            message="finite polynomial evaluation exceeds the operation work budget",
+        )
+
+
 def _admit_map_evaluation(
     polynomial_map: FinitePolynomialMap, *, location: tuple[str, ...]
 ) -> None:

--- a/tests/math/finite_fields/test_polynomial_maps.py
+++ b/tests/math/finite_fields/test_polynomial_maps.py
@@ -114,6 +114,25 @@ def test_native_point_evaluation_rejects_maximum_degree_work() -> None:
     )
 
 
+def test_native_point_evaluation_rejects_mismatched_parent_with_typed_error() -> None:
+    field = finite_field(2, (1, 1, 1))
+    other = finite_field(3, (0, 1))
+    polynomial = finite_polynomial(
+        field, (element(field, (1, 0)), element(field, (1, 0)))
+    )
+
+    with pytest.raises(OperationDomainValidationError) as error:
+        evaluate_finite_polynomial(polynomial, element(other, (0,)))
+
+    assert error.value.errors() == (
+        {
+            "loc": ("value", "presentation"),
+            "type": "finite_field.finite_polynomial_evaluation_parent_mismatch",
+            "msg": "polynomial and value must share their exact presentation",
+        },
+    )
+
+
 def test_frobenius_map_is_a_permutation() -> None:
     table = finite_map_table(_map(2))
 

--- a/tests/math/finite_fields/test_polynomial_maps.py
+++ b/tests/math/finite_fields/test_polynomial_maps.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from typing import Any
 
 import pytest
 
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.finite_fields import (
+    FiniteFieldElement,
+    FiniteFieldPresentation,
     FiniteMapTable,
     FinitePolynomialMap,
     analyze_collisions,
@@ -24,6 +30,16 @@ from jacobian.math.finite_fields import (
 )
 
 pytestmark = pytest.mark.requires_backend("flint")
+
+
+def _max_point_evaluation() -> tuple[FinitePolynomialMap, FiniteFieldElement]:
+    presentation = finite_field(
+        2,
+        (1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1),
+    )
+    one = element(presentation, (1,) + (0,) * 15)
+    polynomial = finite_polynomial(presentation, (one,) * 65_536)
+    return finite_polynomial_map(polynomial), element(presentation, (0,) * 16)
 
 
 def _map(*exponents: int) -> FinitePolynomialMap:
@@ -57,6 +73,44 @@ def test_complete_table_and_fibers_reuse_exact_slice_a_field_identity() -> None:
     assert tuple(target for _source, target in table.entries) == tuple(
         evaluate_finite_polynomial(polynomial_map.polynomial, source)
         for source, _target in table.entries
+    )
+
+
+def test_native_point_evaluation_recognizes_field_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.finite_fields import _admission
+
+    polynomial_map = _map(3)
+    calls = 0
+    original = _admission.require_field
+
+    def tracked(presentation: FiniteFieldPresentation) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(presentation)
+
+    monkeypatch.setattr(_admission, "require_field", tracked)
+
+    assert evaluate_finite_polynomial(
+        polynomial_map.polynomial,
+        element(polynomial_map.domain, (0, 1)),
+    ).coordinates == (1, 0)
+    assert calls == 1
+
+
+def test_native_point_evaluation_rejects_maximum_degree_work() -> None:
+    polynomial_map, value = _max_point_evaluation()
+
+    with pytest.raises(OperationResourceAdmissionError) as error:
+        evaluate_finite_polynomial(polynomial_map.polynomial, value)
+
+    assert error.value.errors() == (
+        {
+            "loc": ("polynomial",),
+            "type": "finite_field.finite_polynomial_evaluation_exceeds_operation_work_budget",
+            "msg": "finite polynomial evaluation exceeds the operation work budget",
+        },
     )
 
 

--- a/tests/math/finite_fields/test_tools.py
+++ b/tests/math/finite_fields/test_tools.py
@@ -6,6 +6,7 @@ from jacobian.math.finite_fields import (
     Axis,
     AxisBoundMatrix,
     FiniteDimensionalSubspace,
+    FiniteFieldElement,
     FiniteFieldPresentation,
     FiniteLinearMap,
     FiniteMapTable,
@@ -23,6 +24,7 @@ from jacobian.math.finite_fields import (
 from jacobian.math.finite_fields._models import (
     DirectionRankLedgerRequest,
     FiniteMapTableRequest,
+    FinitePolynomialEvaluationRequest,
     PaleyTournamentRequest,
     ProjectiveLineRequest,
 )
@@ -39,6 +41,7 @@ def test_bundle_declares_atomic_inline_typed_operations() -> None:
         "finite_field.linear_map.rank.compute",
         "finite_field.direction_rank_ledger.compute",
         "finite_field.orbit_distribution.compute",
+        "finite_field.polynomial.evaluate.compute",
         "finite_field.polynomial_map.table.compute",
         "finite_field.polynomial_map.fibers.compute",
         "finite_field.polynomial_map.collision.analyze",
@@ -53,6 +56,7 @@ def test_bundle_declares_atomic_inline_typed_operations() -> None:
         rank_operation,
         _,
         _,
+        point_evaluation,
         table,
         _,
         _,
@@ -68,6 +72,8 @@ def test_bundle_declares_atomic_inline_typed_operations() -> None:
     assert restrict_operation.result_type is FiniteLinearMap
     assert rank_operation.result_type is RankResult
     assert table.result_type is FiniteMapTable
+    assert point_evaluation.request_type is FinitePolynomialEvaluationRequest
+    assert point_evaluation.result_type is FiniteFieldElement
     assert paley.request_type is PaleyTournamentRequest
     assert fixed.result_type is HomogeneousFixedSubspace
 
@@ -178,3 +184,68 @@ def test_axis_beyond_shared_matrix_bound_rejects_during_request_parsing() -> Non
         error.value.errors()[0]["type"]
         == "finite_field.axis_exceeds_supported_label_bound"
     )
+
+
+def test_point_evaluation_has_no_complete_field_enumeration_factor() -> None:
+    presentation = finite_field(2, (1, 1, 0, 1, 1, 0, 0, 0, 1))
+    one = element(presentation, (1,) + (0,) * 7)
+    polynomial = finite_polynomial(presentation, (one,) * 512)
+    request = FinitePolynomialEvaluationRequest(
+        polynomial=polynomial,
+        value=element(presentation, (0,) * 8),
+    )
+    # 512 coefficients * degree 8 is admitted; the complete table's extra
+    # factor of |F| is intentionally not charged by this operation.
+    operation = next(
+        operation
+        for operation in TOOLS
+        if operation.operation_id == "finite_field.polynomial.evaluate.compute"
+    )
+    restored_request = operation.request_type.model_validate_json(
+        request.model_dump_json(), strict=True
+    )
+    result = operation.run(restored_request)
+    assert result == one
+    assert (
+        FiniteFieldElement.model_validate_json(result.model_dump_json(), strict=True)
+        == result
+    )
+
+
+def test_point_evaluation_rejects_mismatched_parent() -> None:
+    field = finite_field(2, (1, 1, 1))
+    other = finite_field(3, (0, 1))
+    polynomial = finite_polynomial(
+        field, (element(field, (1, 0)), element(field, (1, 0)))
+    )
+    request = FinitePolynomialEvaluationRequest(
+        polynomial=polynomial,
+        value=element(other, (0,)),
+    )
+    operation = next(
+        operation
+        for operation in TOOLS
+        if operation.operation_id == "finite_field.polynomial.evaluate.compute"
+    )
+    with pytest.raises(OperationDomainValidationError) as error:
+        operation.run(request)
+    assert error.value.errors()[0]["type"] == (
+        "finite_field.finite_polynomial_evaluation_parent_mismatch"
+    )
+
+
+def test_point_evaluation_preserves_extension_field_coordinates() -> None:
+    field = finite_field(23, (1, 18, 1), generator="v")
+    coefficients = tuple(
+        element(field, (coefficient, 0)) for coefficient in (0, 18, 16, 16, 18)
+    )
+    request = FinitePolynomialEvaluationRequest(
+        polynomial=finite_polynomial(field, coefficients, variable="X"),
+        value=element(field, (0, 1)),
+    )
+    operation = next(
+        operation
+        for operation in TOOLS
+        if operation.operation_id == "finite_field.polynomial.evaluate.compute"
+    )
+    assert operation.run(request).coordinates == (1, 22)

--- a/tests/math/finite_fields/test_tools.py
+++ b/tests/math/finite_fields/test_tools.py
@@ -249,3 +249,28 @@ def test_point_evaluation_preserves_extension_field_coordinates() -> None:
         if operation.operation_id == "finite_field.polynomial.evaluate.compute"
     )
     assert operation.run(request).coordinates == (1, 22)
+
+
+@pytest.mark.parametrize("constant", [0, 1])
+def test_point_evaluation_handles_zero_and_constant_polynomials_and_matches_table(
+    constant: int,
+) -> None:
+    field = finite_field(2, (1, 1, 1))
+    zero = element(field, (0, 0))
+    one = element(field, (1, 0))
+    polynomial = finite_polynomial(field, (zero if constant == 0 else one,))
+    value = element(field, (0, 1))
+    operation = next(
+        operation
+        for operation in TOOLS
+        if operation.operation_id == "finite_field.polynomial.evaluate.compute"
+    )
+
+    result = operation.run(
+        FinitePolynomialEvaluationRequest(polynomial=polynomial, value=value)
+    )
+    table = finite_map_table(finite_polynomial_map(polynomial))
+    table_value = next(target for source, target in table.entries if source == value)
+
+    assert result == (zero if constant == 0 else one)
+    assert result == table_value

--- a/tests/math/finite_fields/test_tools.py
+++ b/tests/math/finite_fields/test_tools.py
@@ -1,7 +1,13 @@
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
-from jacobian.catalog.models import MathTool, OperationDomainValidationError
+from jacobian.catalog.models import (
+    MathTool,
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.finite_fields import (
     Axis,
     AxisBoundMatrix,
@@ -29,6 +35,28 @@ from jacobian.math.finite_fields._models import (
     ProjectiveLineRequest,
 )
 from jacobian.math.finite_fields._tools import TOOLS
+
+
+def _point_evaluation_operation() -> MathTool[
+    FinitePolynomialEvaluationRequest, FiniteFieldElement
+]:
+    return next(
+        operation
+        for operation in TOOLS
+        if operation.operation_id == "finite_field.polynomial.evaluate.compute"
+    )
+
+
+def _max_point_evaluation_request() -> FinitePolynomialEvaluationRequest:
+    presentation = finite_field(
+        2,
+        (1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1),
+    )
+    one = element(presentation, (1,) + (0,) * 15)
+    return FinitePolynomialEvaluationRequest(
+        polynomial=finite_polynomial(presentation, (one,) * 65_536),
+        value=element(presentation, (0,) * 16),
+    )
 
 
 def test_bundle_declares_atomic_inline_typed_operations() -> None:
@@ -196,11 +224,7 @@ def test_point_evaluation_has_no_complete_field_enumeration_factor() -> None:
     )
     # 512 coefficients * degree 8 is admitted; the complete table's extra
     # factor of |F| is intentionally not charged by this operation.
-    operation = next(
-        operation
-        for operation in TOOLS
-        if operation.operation_id == "finite_field.polynomial.evaluate.compute"
-    )
+    operation = _point_evaluation_operation()
     restored_request = operation.request_type.model_validate_json(
         request.model_dump_json(), strict=True
     )
@@ -210,6 +234,44 @@ def test_point_evaluation_has_no_complete_field_enumeration_factor() -> None:
         FiniteFieldElement.model_validate_json(result.model_dump_json(), strict=True)
         == result
     )
+
+
+def test_catalog_point_evaluation_recognizes_field_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.finite_fields import _admission
+
+    field = finite_field(2, (1, 1, 1))
+    one = element(field, (1, 0))
+    request = FinitePolynomialEvaluationRequest(
+        polynomial=finite_polynomial(field, (one,)),
+        value=element(field, (0, 1)),
+    )
+    calls = 0
+    original = _admission.require_field
+
+    def tracked(presentation: FiniteFieldPresentation) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(presentation)
+
+    monkeypatch.setattr(_admission, "require_field", tracked)
+
+    assert _point_evaluation_operation().run(request) == one
+    assert calls == 1
+
+
+def test_catalog_point_evaluation_has_same_typed_resource_refusal_as_native() -> None:
+    from jacobian.math.finite_fields import evaluate_finite_polynomial
+
+    request = _max_point_evaluation_request()
+
+    with pytest.raises(OperationResourceAdmissionError) as native_error:
+        evaluate_finite_polynomial(request.polynomial, request.value)
+    with pytest.raises(OperationResourceAdmissionError) as catalog_error:
+        _point_evaluation_operation().run(request)
+
+    assert catalog_error.value.errors() == native_error.value.errors()
 
 
 def test_point_evaluation_rejects_mismatched_parent() -> None:


### PR DESCRIPTION
## Problem

Evaluating one finite-field polynomial at one supplied element should not require constructing the complete value table over the field.

## Outcome

Publishes `finite_field.polynomial.evaluate.compute` over the existing canonical `FinitePolynomial` and `FiniteFieldElement` values. The operation preserves the exact field presentation, rejects parent mismatches, and returns the canonical presentation-bound element directly.

This is the univariate single-point slice requested in the latest comment on #1796. It is related to #1796 and intentionally does not close the broader issue: multivariate polynomial/map carriers, affine and projective zero sets, fibers, base change, and extension point counts remain open.

## Contract and scale

The operation reuses the existing FLINT-backed exact evaluator and finite-field recognition. Admission charges polynomial coefficient count times extension degree, without the full-field-cardinality factor required by complete table enumeration.

The regression suite covers:

- the reported GF(23²) fixture;
- a 512-coefficient polynomial over GF(256);
- zero and constant polynomials;
- exact agreement with the corresponding complete-table row;
- extension-field coordinates and strict result round trips;
- mismatched field presentations.

## Validation

- `make affected AFFECTED_BASE=origin/main` passed locally at `01403e4c2312849e4734298d02ed3f40f5b6e148`: lint, mypy, 32 finite-field tests, 160 catalog tests, and 967 catalog examples.
- An independent exact-diff review found no mathematical or contract defect; its requested degenerate and composition evidence is included in the final commit.
- Hosted required CI passed at the final head.

## Catalog impact

New operation ID:

- `finite_field.polynomial.evaluate.compute`

The declaration adds to the catalog and does not replace an existing operation ID.