### PR TITLE
fix(codes): reuse canonical finite-field row reduction

### DIFF
--- a/src/jacobian/math/combinatorics/codes/linear/_canonicalization.py
+++ b/src/jacobian/math/combinatorics/codes/linear/_canonicalization.py
@@ -16,6 +16,10 @@ from jacobian.catalog.models import (
 from jacobian.math.combinatorics.codes.linear.values import PrimeFieldLinearEncoder
 from jacobian.math.groups._models import PermutationGroup
 from jacobian.math.groups.operations import _backend_group, _full_permutation_form
+from jacobian.math.matrices.finite_fields.linear_algebra import (
+    PrimeFieldMatrix,
+    _rref_admitted,
+)
 
 MAX_CODE_CANONICALIZATION_ACTION_ORDER = 100_000
 MAX_CODE_CANONICALIZATION_RREF_WORK = 20_000_000
@@ -47,33 +51,16 @@ class LinearCodeCanonicalizationResult(StrictModel):
 
 
 def _rref(
-    matrix: tuple[tuple[int, ...], ...], prime: int
-) -> tuple[tuple[int, ...], ...]:
-    rows = [list(row) for row in matrix]
-    pivot = 0
-    width = len(rows[0]) if rows else 0
-    for column in range(width):
-        selected = next(
-            (row for row in range(pivot, len(rows)) if rows[row][column] % prime),
-            None,
-        )
-        if selected is None:
-            continue
-        rows[pivot], rows[selected] = rows[selected], rows[pivot]
-        inverse = pow(rows[pivot][column], -1, prime)
-        rows[pivot] = [value * inverse % prime for value in rows[pivot]]
-        for row in range(len(rows)):
-            if row == pivot:
-                continue
-            factor = rows[row][column]
-            rows[row] = [
-                (left - factor * right) % prime
-                for left, right in zip(rows[row], rows[pivot], strict=True)
-            ]
-        pivot += 1
-        if pivot == len(rows):
-            break
-    return tuple(tuple(row) for row in rows)
+    matrix: tuple[tuple[int, ...], ...], prime: int, width: int
+) -> tuple[tuple[tuple[int, ...], ...], tuple[int, ...]]:
+    """Reduce through the canonical prime-field matrix carrier.
+
+    Keeping this operation on the shared carrier is important for composition:
+    the same FLINT/SymPy exact backend and empty-axis convention used by the
+    other code-linear operations define every canonical representative here.
+    """
+
+    return _rref_admitted(PrimeFieldMatrix(prime=prime, entries=matrix, columns=width))
 
 
 def canonicalize_linear_code(
@@ -86,8 +73,12 @@ def canonicalize_linear_code(
             code="code.canonicalization.prime_field",
             message="linear-code canonicalization requires a prime field order",
         )
-    source_rref = _rref(encoder.generator_matrix, encoder.field_order)
-    if any(not any(row) for row in source_rref):
+    _, pivots = _rref(
+        encoder.generator_matrix,
+        encoder.field_order,
+        len(encoder.coordinate_axis),
+    )
+    if len(pivots) != len(encoder.generator_matrix):
         raise OperationDomainValidationError(
             location=("encoder", "generator_matrix"),
             code="code.canonicalization.full_row_rank",
@@ -134,7 +125,20 @@ def canonicalize_linear_code(
             tuple(row[element[column]] for column in range(width))
             for row in encoder.generator_matrix
         )
-        reduced = _rref(permuted, encoder.field_order)
+        reduced, pivots = _rref(
+            permuted,
+            encoder.field_order,
+            width,
+        )
+        # Coordinate permutations preserve rank. Keep the assertion local to
+        # the producer so a future action adapter cannot silently emit a
+        # malformed canonical encoder.
+        if len(pivots) != len(encoder.generator_matrix):
+            raise OperationDomainValidationError(
+                location=("encoder", "generator_matrix"),
+                code="code.canonicalization.transported_rank",
+                message="a coordinate action must preserve generator rank",
+            )
         distinct.add(reduced)
         candidates.append(
             (

--- a/tests/math/combinatorics/codes/linear/test_canonicalization.py
+++ b/tests/math/combinatorics/codes/linear/test_canonicalization.py
@@ -4,6 +4,8 @@ from jacobian.math.combinatorics.codes.linear._canonicalization import (
     LinearCodeCanonicalizationRequest,
     canonicalize_linear_code,
 )
+from jacobian.math.combinatorics.codes.linear._models import GeneratorMatrixRequest
+from jacobian.math.combinatorics.codes.linear._tools import compute_from_generator
 from jacobian.math.combinatorics.codes.linear.values import PrimeFieldLinearEncoder
 from jacobian.math.groups._models import PermutationGroup
 
@@ -39,3 +41,48 @@ def test_supplied_cyclic_action_is_respected() -> None:
     )
     assert result.orbit_size == 3
     assert result.stabilizer_size == 1
+
+
+def test_transporter_replays_through_the_public_generator_operation() -> None:
+    source = _encoder()
+    result = canonicalize_linear_code(LinearCodeCanonicalizationRequest(encoder=source))
+    permuted = tuple(
+        tuple(row[index] for index in result.transporter)
+        for row in source.generator_matrix
+    )
+    replayed = compute_from_generator(
+        GeneratorMatrixRequest(
+            field_order=source.field_order,
+            generator_matrix=permuted,
+            coordinate_axis=result.transported_axis,
+        )
+    )
+    assert replayed.encoder == result.canonical_encoder
+
+
+def test_zero_code_and_full_space_keep_degenerate_rref_shapes() -> None:
+    zero = PrimeFieldLinearEncoder(
+        field_order=3,
+        message_axis=(),
+        coordinate_axis=("x0", "x1"),
+        generator_matrix=(),
+    )
+    zero_result = canonicalize_linear_code(
+        LinearCodeCanonicalizationRequest(encoder=zero)
+    )
+    assert zero_result.canonical_encoder.generator_matrix == ()
+    assert zero_result.orbit_size == 1
+    assert zero_result.stabilizer_size == 2
+
+    full = PrimeFieldLinearEncoder(
+        field_order=3,
+        message_axis=("m0", "m1"),
+        coordinate_axis=("x0", "x1"),
+        generator_matrix=((1, 0), (0, 1)),
+    )
+    full_result = canonicalize_linear_code(
+        LinearCodeCanonicalizationRequest(encoder=full)
+    )
+    assert full_result.canonical_encoder.generator_matrix == ((1, 0), (0, 1))
+    assert full_result.orbit_size == 1
+    assert full_result.stabilizer_size == 2


### PR DESCRIPTION
## Problem

Coordinate-permutation code canonicalization carries a separate row-reduction implementation instead of using the domain’s canonical finite-field matrix path. Related to #3597.

## Outcome

Reuses the shared prime-field matrix carrier and admitted exact row reduction, preserving rank checks, transporter coordinates, empty codes, and full spaces.

## Validation

- `make affected AFFECTED_BASE=e99e4cc5840d82bacb73ff45b5ea64a13487e4be` passed on `d845b7b330fdc3017dbe2abff0c0a8bfa2c01c40`.
- Scoped lint/format and type checks passed; the affected planner ran the selected owner and catalog/boundary lanes.
- 65 passed in 5.82s

## Contract impact

Existing permutation-action and RREF work bounds remain. The returned generator matrix is compared with the public generator operation after applying the transporter.

No operation IDs are added or removed. The outcome above describes changes to existing behavior or result validation.

## Review closure

- [x] Exact changed scope reviewed; applicable local validation passed.
- [x] No unresolved findings from the scoped review.
- [ ] CI evidence matches the final head.

## Operation boundary

Existing permutation-action and RREF work bounds remain. The returned generator matrix is compared with the public generator operation after applying the transporter.

This PR addresses the described slice of #3597; it does not automatically close the broader issue.
