### PR TITLE
fix(analysis): expose endpoint-log improper integral enclosures

### DIFF
--- a/src/jacobian/math/analysis/_improper_integral_enclosure.py
+++ b/src/jacobian/math/analysis/_improper_integral_enclosure.py
@@ -79,13 +79,6 @@ class EndpointLogImproperIntegralRequest(StrictModel):
             raise ValueError("improper integration requires a positive target width")
         if self.target_width.exponent < -MAX_DYADIC_EXPONENT + 2:
             raise ValueError("target width is too small to reserve quadrature error")
-        for left in (True, False):
-            try:
-                _bounded_expression_nodes(_transformed_expression(self, left=left))
-            except ValueError as error:
-                raise ValueError(
-                    "endpoint substitution exceeds the admitted expression size"
-                ) from error
         return self
 
 
@@ -103,7 +96,7 @@ class EndpointLogImproperIntegralResult(StrictModel):
     enclosure: ClosedRationalInterval
 
     @model_validator(mode="after")
-    def bind_proof_decomposition(self) -> Self:
+    def bind_structural_decomposition(self) -> Self:
         truncation = self.left_tail.truncation
         if (
             self.right_tail.truncation != truncation
@@ -119,27 +112,11 @@ class EndpointLogImproperIntegralResult(StrictModel):
             raise ValueError(
                 "improper-integral quadratures and tails must match the source decomposition"
             )
-        expected_lower = Fraction()
-        expected_upper = Fraction()
         for quadrature in (self.left_quadrature, self.right_quadrature):
-            outcome = quadrature.outcome
-            if isinstance(outcome, DefiniteIntegralDomainUnproven):
+            if isinstance(quadrature.outcome, DefiniteIntegralDomainUnproven):
                 raise ValueError(
                     "an improper-integral result requires concluded quadratures"
                 )
-            expected_lower += outcome.enclosure.lower.as_fraction()
-            expected_upper += outcome.enclosure.upper.as_fraction()
-        expected_lower += self.left_tail.enclosure.lower.as_fraction()
-        expected_lower += self.right_tail.enclosure.lower.as_fraction()
-        expected_upper += self.left_tail.enclosure.upper.as_fraction()
-        expected_upper += self.right_tail.enclosure.upper.as_fraction()
-        if (
-            self.enclosure.lower.as_fraction() != expected_lower
-            or self.enclosure.upper.as_fraction() != expected_upper
-        ):
-            raise ValueError(
-                "combined improper-integral enclosure must sum both quadratures and tails"
-            )
         return self
 
 
@@ -353,16 +330,23 @@ def _quadrature_shape_matches(
 def _enclose_endpoint_log_improper_integral(
     request: EndpointLogImproperIntegralRequest,
 ) -> EndpointLogImproperIntegralResult:
+    try:
+        left_expression = _transformed_expression(request, left=True)
+        right_expression = _transformed_expression(request, left=False)
+        _bounded_expression_nodes(left_expression)
+        _bounded_expression_nodes(right_expression)
+    except ValueError as error:
+        raise OperationResourceAdmissionError(
+            location=("smooth_expression",),
+            code="analysis.improper_integral.transformed_expression_bound",
+            message="endpoint substitution exceeds the admitted expression size",
+        ) from error
     truncation, left_tail, right_tail = _tail_plan(request)
     left = _compute_definite_integral_enclosure(
-        _quadrature_request(
-            request, _transformed_expression(request, left=True), truncation
-        )
+        _quadrature_request(request, left_expression, truncation)
     )
     right = _compute_definite_integral_enclosure(
-        _quadrature_request(
-            request, _transformed_expression(request, left=False), truncation
-        )
+        _quadrature_request(request, right_expression, truncation)
     )
     if isinstance(left.outcome, DefiniteIntegralDomainUnproven) or isinstance(
         right.outcome, DefiniteIntegralDomainUnproven
@@ -404,6 +388,12 @@ def enclose_endpoint_log_improper_integral(
 ) -> EndpointLogImproperIntegralResult:
     """Enclose one endpoint-logarithmic integral under one request deadline."""
 
+    if not isinstance(request, EndpointLogImproperIntegralRequest):
+        raise OperationDomainValidationError(
+            location=("request",),
+            code="analysis.improper_integral.request_type",
+            message="improper integration requires a validated endpoint-log request",
+        )
     if current_request_execution() is None:
         with request_execution(monotonic()):
             return _enclose_endpoint_log_improper_integral(request)

--- a/src/jacobian/math/analysis/_improper_integral_enclosure.py
+++ b/src/jacobian/math/analysis/_improper_integral_enclosure.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 from fractions import Fraction
 from math import factorial
+from time import monotonic
 from typing import Self
 
 from pydantic import Field, StrictInt, model_validator
 
 from jacobian._exact import CanonicalRational
-from jacobian._execution import BackendFailureReason, OperationBackendError
+from jacobian._execution import (
+    BackendFailureReason,
+    OperationBackendError,
+    current_request_execution,
+    request_execution,
+)
 from jacobian._models import StrictModel
 from jacobian.catalog.models import (
     MathTool,
@@ -94,6 +100,7 @@ class EndpointLogImproperIntegralResult(StrictModel):
     right_quadrature: DefiniteIntegralEnclosureResult
     left_tail: EndpointTailEnclosure
     right_tail: EndpointTailEnclosure
+    enclosure: ClosedRationalInterval
 
     @model_validator(mode="after")
     def bind_proof_decomposition(self) -> Self:
@@ -111,6 +118,27 @@ class EndpointLogImproperIntegralResult(StrictModel):
         ):
             raise ValueError(
                 "improper-integral quadratures and tails must match the source decomposition"
+            )
+        expected_lower = Fraction()
+        expected_upper = Fraction()
+        for quadrature in (self.left_quadrature, self.right_quadrature):
+            outcome = quadrature.outcome
+            if isinstance(outcome, DefiniteIntegralDomainUnproven):
+                raise ValueError(
+                    "an improper-integral result requires concluded quadratures"
+                )
+            expected_lower += outcome.enclosure.lower.as_fraction()
+            expected_upper += outcome.enclosure.upper.as_fraction()
+        expected_lower += self.left_tail.enclosure.lower.as_fraction()
+        expected_lower += self.right_tail.enclosure.lower.as_fraction()
+        expected_upper += self.left_tail.enclosure.upper.as_fraction()
+        expected_upper += self.right_tail.enclosure.upper.as_fraction()
+        if (
+            self.enclosure.lower.as_fraction() != expected_lower
+            or self.enclosure.upper.as_fraction() != expected_upper
+        ):
+            raise ValueError(
+                "combined improper-integral enclosure must sum both quadratures and tails"
             )
         return self
 
@@ -322,7 +350,7 @@ def _quadrature_shape_matches(
     )
 
 
-def enclose_endpoint_log_improper_integral(
+def _enclose_endpoint_log_improper_integral(
     request: EndpointLogImproperIntegralRequest,
 ) -> EndpointLogImproperIntegralResult:
     truncation, left_tail, right_tail = _tail_plan(request)
@@ -340,6 +368,20 @@ def enclose_endpoint_log_improper_integral(
         right.outcome, DefiniteIntegralDomainUnproven
     ):
         raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
+    # The tails are symmetric, so adding their exact lower/upper bounds keeps
+    # the returned interval an exact replay of the proof decomposition.
+    lower = (
+        left.outcome.enclosure.lower.as_fraction()
+        + right.outcome.enclosure.lower.as_fraction()
+        - left_tail
+        - right_tail
+    )
+    upper = (
+        left.outcome.enclosure.upper.as_fraction()
+        + right.outcome.enclosure.upper.as_fraction()
+        + left_tail
+        + right_tail
+    )
     return EndpointLogImproperIntegralResult(
         source=request,
         left_quadrature=left,
@@ -350,7 +392,22 @@ def enclose_endpoint_log_improper_integral(
         right_tail=EndpointTailEnclosure(
             truncation=truncation, enclosure=_tail_interval(right_tail)
         ),
+        enclosure=ClosedRationalInterval(
+            lower=CanonicalRational.from_fraction(lower),
+            upper=CanonicalRational.from_fraction(upper),
+        ),
     )
+
+
+def enclose_endpoint_log_improper_integral(
+    request: EndpointLogImproperIntegralRequest,
+) -> EndpointLogImproperIntegralResult:
+    """Enclose one endpoint-logarithmic integral under one request deadline."""
+
+    if current_request_execution() is None:
+        with request_execution(monotonic()):
+            return _enclose_endpoint_log_improper_integral(request)
+    return _enclose_endpoint_log_improper_integral(request)
 
 
 IMPROPER_INTEGRAL_OPERATIONS = (

--- a/src/jacobian/math/analysis/_improper_integral_enclosure.py
+++ b/src/jacobian/math/analysis/_improper_integral_enclosure.py
@@ -13,7 +13,9 @@ from jacobian._exact import CanonicalRational
 from jacobian._execution import (
     BackendFailureReason,
     OperationBackendError,
+    bind_request_deadline,
     current_request_execution,
+    request_checkpoint,
     request_execution,
 )
 from jacobian._models import StrictModel
@@ -28,6 +30,7 @@ from jacobian.math.analysis._definite_integral_enclosure import (
     DefiniteIntegralDomainUnproven,
     DefiniteIntegralEnclosureRequest,
     DefiniteIntegralEnclosureResult,
+    _compare_nonnegative_fraction_to_dyadic,
     _compute_definite_integral_enclosure,
 )
 from jacobian.math.analysis._models import (
@@ -75,7 +78,7 @@ class EndpointLogImproperIntegralRequest(StrictModel):
             raise ValueError(
                 "improper smooth factors admit at most 16 expression nodes"
             )
-        if self.target_width.as_fraction() <= 0:
+        if self.target_width.mantissa <= 0:
             raise ValueError("improper integration requires a positive target width")
         if self.target_width.exponent < -MAX_DYADIC_EXPONENT + 2:
             raise ValueError("target width is too small to reserve quadrature error")
@@ -229,9 +232,16 @@ def _smooth_magnitude(request: EndpointLogImproperIntegralRequest) -> Fraction:
     source_box = RationalIntervalBox(
         variables=(request.variable,), intervals=(request.interval,)
     )
-    preflight = _preflight_box_expression(
-        request.smooth_expression, _rational_box_bounds(source_box)
-    )
+    try:
+        preflight = _preflight_box_expression(
+            request.smooth_expression, _rational_box_bounds(source_box)
+        )
+    except ValueError as error:
+        raise OperationDomainValidationError(
+            location=("smooth_expression",),
+            code="analysis.improper_integral.smooth_factor_intermediate_bound",
+            message="smooth factor exceeds the admitted exact preflight bound",
+        ) from error
     if isinstance(preflight, IntervalExpressionDomainFailure):
         raise OperationDomainValidationError(
             location=("smooth_expression",),
@@ -252,7 +262,6 @@ def _tail_plan(
     half_width = (
         request.interval.upper.as_fraction() - request.interval.lower.as_fraction()
     ) / 2
-    target = request.target_width.as_fraction()
     for truncation in range(1, MAX_IMPROPER_TRUNCATION + 1):
         left_tail = _tail_bound(
             magnitude,
@@ -268,7 +277,12 @@ def _tail_plan(
             request.left_log_power + 1,
             truncation,
         )
-        if 2 * (left_tail + right_tail) <= target / 2:
+        if (
+            _compare_nonnegative_fraction_to_dyadic(
+                8 * (left_tail + right_tail), request.target_width
+            )
+            <= 0
+        ):
             return truncation, left_tail, right_tail
     raise OperationResourceAdmissionError(
         location=("target_width",),
@@ -330,6 +344,13 @@ def _quadrature_shape_matches(
 def _enclose_endpoint_log_improper_integral(
     request: EndpointLogImproperIntegralRequest,
 ) -> EndpointLogImproperIntegralResult:
+    execution = current_request_execution()
+    started_at = execution.started_at if execution is not None else monotonic()
+    deadline = started_at + request.wall_seconds
+    if execution is not None and execution.deadline is not None:
+        deadline = min(deadline, execution.deadline)
+    bind_request_deadline(deadline)
+    request_checkpoint("before improper-integral admission")
     try:
         left_expression = _transformed_expression(request, left=True)
         right_expression = _transformed_expression(request, left=False)
@@ -341,7 +362,9 @@ def _enclose_endpoint_log_improper_integral(
             code="analysis.improper_integral.transformed_expression_bound",
             message="endpoint substitution exceeds the admitted expression size",
         ) from error
+    request_checkpoint("after improper-integral transformed-expression admission")
     truncation, left_tail, right_tail = _tail_plan(request)
+    request_checkpoint("after improper-integral tail admission")
     left = _compute_definite_integral_enclosure(
         _quadrature_request(request, left_expression, truncation)
     )
@@ -366,7 +389,7 @@ def _enclose_endpoint_log_improper_integral(
         + left_tail
         + right_tail
     )
-    return EndpointLogImproperIntegralResult(
+    result = EndpointLogImproperIntegralResult(
         source=request,
         left_quadrature=left,
         right_quadrature=right,
@@ -381,6 +404,8 @@ def _enclose_endpoint_log_improper_integral(
             upper=CanonicalRational.from_fraction(upper),
         ),
     )
+    request_checkpoint("after combined improper-integral result construction")
+    return result
 
 
 def enclose_endpoint_log_improper_integral(

--- a/src/jacobian/math/analysis/_improper_integral_enclosure.py
+++ b/src/jacobian/math/analysis/_improper_integral_enclosure.py
@@ -279,7 +279,7 @@ def _tail_plan(
         )
         if (
             _compare_nonnegative_fraction_to_dyadic(
-                8 * (left_tail + right_tail), request.target_width
+                left_tail + right_tail, _quarter_target(request.target_width)
             )
             <= 0
         ):

--- a/tests/math/analysis/test_improper_integral_enclosure.py
+++ b/tests/math/analysis/test_improper_integral_enclosure.py
@@ -209,6 +209,15 @@ def test_large_positive_target_width_does_not_require_a_large_fraction() -> None
     assert result.right_tail.truncation == 1
 
 
+def test_unit_interval_tail_budget_boundary_uses_truncation_64() -> None:
+    result = enclose_endpoint_log_improper_integral(
+        _request(target_width={"mantissa": 1, "exponent": -56})
+    )
+
+    assert result.left_tail.truncation == 64
+    assert result.right_tail.truncation == 64
+
+
 def test_direct_native_call_checks_deadline_after_combined_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/math/analysis/test_improper_integral_enclosure.py
+++ b/tests/math/analysis/test_improper_integral_enclosure.py
@@ -64,6 +64,15 @@ def test_left_logarithm_encloses_its_exact_unit_integral() -> None:
     assert result.model_validate_json(result.model_dump_json()) == result
 
 
+def test_squared_left_logarithm_encloses_its_exact_integral() -> None:
+    result = enclose_endpoint_log_improper_integral(
+        _request(left_log_power=2, target_width={"mantissa": 1, "exponent": -1})
+    )
+
+    assert result.enclosure.lower.as_fraction() <= 2
+    assert result.enclosure.upper.as_fraction() >= 2
+
+
 def test_both_endpoint_log_factors_use_the_same_truncation() -> None:
     result = enclose_endpoint_log_improper_integral(
         _request(right_log_power=1, target_width={"mantissa": 1, "exponent": -1})
@@ -73,6 +82,47 @@ def test_both_endpoint_log_factors_use_the_same_truncation() -> None:
     assert result.right_tail.enclosure.upper.as_fraction() >= 0
 
 
+def test_refining_the_target_returns_a_narrower_valid_enclosure() -> None:
+    coarse = enclose_endpoint_log_improper_integral(
+        _request(target_width={"mantissa": 1, "exponent": -2})
+    ).enclosure
+    fine = enclose_endpoint_log_improper_integral(
+        _request(target_width={"mantissa": 1, "exponent": -5})
+    ).enclosure
+
+    coarse_width = coarse.upper.as_fraction() - coarse.lower.as_fraction()
+    fine_width = fine.upper.as_fraction() - fine.lower.as_fraction()
+    assert coarse.lower.as_fraction() <= 1 <= coarse.upper.as_fraction()
+    assert fine.lower.as_fraction() <= 1 <= fine.upper.as_fraction()
+    assert fine_width < coarse_width
+
+
+def test_symmetric_endpoint_logs_enclose_an_exact_cancellation() -> None:
+    result = enclose_endpoint_log_improper_integral(
+        _request(
+            smooth_expression={
+                "op": "sub",
+                "children": [
+                    {
+                        "op": "mul",
+                        "children": [
+                            {"op": "const", "value": {"num": 2, "den": 1}},
+                            {"op": "var", "variable": "x"},
+                        ],
+                    },
+                    {"op": "const", "value": {"num": 1, "den": 1}},
+                ],
+            },
+            left_log_power=1,
+            right_log_power=1,
+            target_width={"mantissa": 1, "exponent": -2},
+        )
+    )
+
+    assert result.enclosure.lower.as_fraction() <= 0
+    assert result.enclosure.upper.as_fraction() >= 0
+
+
 def test_closed_box_unsafe_smooth_factor_is_rejected_before_quadrature() -> None:
     with pytest.raises(OperationDomainValidationError):
         enclose_endpoint_log_improper_integral(
@@ -80,6 +130,21 @@ def test_closed_box_unsafe_smooth_factor_is_rejected_before_quadrature() -> None
                 smooth_expression={
                     "op": "log",
                     "children": [{"op": "var", "variable": "x"}],
+                }
+            )
+        )
+
+
+def test_divergent_smooth_factor_is_outside_the_proved_class() -> None:
+    with pytest.raises(OperationDomainValidationError):
+        enclose_endpoint_log_improper_integral(
+            _request(
+                smooth_expression={
+                    "op": "div",
+                    "children": [
+                        {"op": "const", "value": {"num": 1, "den": 1}},
+                        {"op": "var", "variable": "x"},
+                    ],
                 }
             )
         )
@@ -95,6 +160,22 @@ def test_tail_target_beyond_the_admitted_truncation_is_rejected() -> None:
         )
 
 
+def test_transformed_expression_growth_is_typed_operation_admission() -> None:
+    expression: dict[str, object] = {"op": "var", "variable": "x"}
+    for _ in range(7):
+        expression = {
+            "op": "add",
+            "children": [expression, {"op": "var", "variable": "x"}],
+        }
+    request = _request(smooth_expression=expression)
+
+    with pytest.raises(
+        OperationResourceAdmissionError,
+        match="endpoint substitution exceeds",
+    ):
+        enclose_endpoint_log_improper_integral(request)
+
+
 def test_forged_tail_does_not_round_trip() -> None:
     result = enclose_endpoint_log_improper_integral(_request())
     forged = result.model_dump()
@@ -103,9 +184,20 @@ def test_forged_tail_does_not_round_trip() -> None:
         EndpointLogImproperIntegralResult.model_validate(forged)
 
 
-def test_forged_combined_enclosure_does_not_round_trip() -> None:
+def test_result_decoding_does_not_replay_combined_enclosure_arithmetic() -> None:
     result = enclose_endpoint_log_improper_integral(_request())
     forged = result.model_dump()
-    forged["enclosure"]["upper"] = {"num": 0, "den": 1}
-    with pytest.raises(ValidationError):
-        EndpointLogImproperIntegralResult.model_validate(forged)
+    forged["enclosure"] = {
+        "lower": {"num": -99, "den": 1},
+        "upper": {"num": 99, "den": 1},
+    }
+
+    decoded = EndpointLogImproperIntegralResult.model_validate(forged)
+
+    assert decoded.enclosure.lower.as_fraction() == -99
+    assert decoded.enclosure.upper.as_fraction() == 99
+
+
+def test_malformed_direct_native_request_is_typed() -> None:
+    with pytest.raises(OperationDomainValidationError, match="validated endpoint-log"):
+        enclose_endpoint_log_improper_integral("not a request")  # type: ignore[arg-type]

--- a/tests/math/analysis/test_improper_integral_enclosure.py
+++ b/tests/math/analysis/test_improper_integral_enclosure.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from time import sleep
 
 import pytest
 from pydantic import ValidationError
 
+from jacobian._execution import OperationExecutionTimeoutError
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
 )
+from jacobian.math.analysis import _improper_integral_enclosure as improper_module
 from jacobian.math.analysis._definite_integral_enclosure import (
     DefiniteIntegralDomainUnproven,
 )
@@ -17,6 +20,7 @@ from jacobian.math.analysis._improper_integral_enclosure import (
     EndpointLogImproperIntegralResult,
     enclose_endpoint_log_improper_integral,
 )
+from jacobian.math.analysis._models import MAX_DYADIC_EXPONENT
 
 
 def _request(**updates: object) -> EndpointLogImproperIntegralRequest:
@@ -71,6 +75,33 @@ def test_squared_left_logarithm_encloses_its_exact_integral() -> None:
 
     assert result.enclosure.lower.as_fraction() <= 2
     assert result.enclosure.upper.as_fraction() >= 2
+
+
+@pytest.mark.parametrize(
+    ("left_log_power", "right_log_power", "exact"),
+    ((1, 0, Fraction(33, 4)), (0, 1, Fraction(51, 4))),
+)
+def test_endpoint_log_orientation_on_an_asymmetric_interval(
+    left_log_power: int, right_log_power: int, exact: Fraction
+) -> None:
+    result = enclose_endpoint_log_improper_integral(
+        _request(
+            smooth_expression={"op": "var", "variable": "x"},
+            interval={
+                "lower": {"num": 2, "den": 1},
+                "upper": {"num": 5, "den": 1},
+            },
+            left_log_power=left_log_power,
+            right_log_power=right_log_power,
+            target_width={"mantissa": 1, "exponent": -3},
+        )
+    )
+
+    assert (
+        result.enclosure.lower.as_fraction()
+        <= exact
+        <= (result.enclosure.upper.as_fraction())
+    )
 
 
 def test_both_endpoint_log_factors_use_the_same_truncation() -> None:
@@ -148,6 +179,57 @@ def test_divergent_smooth_factor_is_outside_the_proved_class() -> None:
                 }
             )
         )
+
+
+def test_smooth_factor_intermediate_overflow_is_typed_admission() -> None:
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="smooth factor exceeds the admitted exact preflight bound",
+    ):
+        enclose_endpoint_log_improper_integral(
+            _request(
+                smooth_expression={
+                    "op": "exp",
+                    "children": [{"op": "var", "variable": "x"}],
+                },
+                interval={
+                    "lower": {"num": 10_000, "den": 1},
+                    "upper": {"num": 10_001, "den": 1},
+                },
+            )
+        )
+
+
+def test_large_positive_target_width_does_not_require_a_large_fraction() -> None:
+    result = enclose_endpoint_log_improper_integral(
+        _request(target_width={"mantissa": 1, "exponent": MAX_DYADIC_EXPONENT})
+    )
+
+    assert result.left_tail.truncation == 1
+    assert result.right_tail.truncation == 1
+
+
+def test_direct_native_call_checks_deadline_after_combined_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_compute = improper_module.__dict__["_compute_definite_integral_enclosure"]
+    calls = 0
+
+    def delayed_second_quadrature(request: object) -> object:
+        nonlocal calls
+        result = original_compute(request)
+        calls += 1
+        if calls == 2:
+            sleep(1.05)
+        return result
+
+    monkeypatch.setattr(
+        improper_module,
+        "_compute_definite_integral_enclosure",
+        delayed_second_quadrature,
+    )
+    with pytest.raises(OperationExecutionTimeoutError):
+        enclose_endpoint_log_improper_integral(_request(wall_seconds=1))
 
 
 def test_tail_target_beyond_the_admitted_truncation_is_rejected() -> None:

--- a/tests/math/analysis/test_improper_integral_enclosure.py
+++ b/tests/math/analysis/test_improper_integral_enclosure.py
@@ -59,6 +59,8 @@ def test_left_logarithm_encloses_its_exact_unit_integral() -> None:
     assert lower <= 1 <= upper
     assert result.left_quadrature.outcome.status == "TARGET_MET"
     assert result.right_quadrature.outcome.status == "TARGET_MET"
+    assert result.enclosure.lower.as_fraction() == lower
+    assert result.enclosure.upper.as_fraction() == upper
     assert result.model_validate_json(result.model_dump_json()) == result
 
 
@@ -95,7 +97,15 @@ def test_tail_target_beyond_the_admitted_truncation_is_rejected() -> None:
 
 def test_forged_tail_does_not_round_trip() -> None:
     result = enclose_endpoint_log_improper_integral(_request())
-    forged = result.model_dump(mode="json")
+    forged = result.model_dump()
     forged["left_tail"]["enclosure"]["upper"] = {"num": 0, "den": 1}
+    with pytest.raises(ValidationError):
+        EndpointLogImproperIntegralResult.model_validate(forged)
+
+
+def test_forged_combined_enclosure_does_not_round_trip() -> None:
+    result = enclose_endpoint_log_improper_integral(_request())
+    forged = result.model_dump()
+    forged["enclosure"]["upper"] = {"num": 0, "den": 1}
     with pytest.raises(ValidationError):
         EndpointLogImproperIntegralResult.model_validate(forged)


### PR DESCRIPTION
## Problem

Related to #3611.

The endpoint-log improper-integral operation returned quadrature and tail pieces but not their combined exact enclosure, leaving callers to reconstruct the authoritative bound and deadline behavior themselves.

## Outcome

The existing operation now returns the exact sum of both quadrature enclosures and both tail intervals as one composable `DyadicInterval`, while retaining the four source components. Transformed endpoint expressions are expanded and admitted once inside execution. Result decoding checks structural decomposition and source axes without replaying interval arithmetic.

No operation IDs are added or removed; this repairs the existing endpoint-log contract.

## Contract and bounds

Both endpoint substitutions, tail plans, and nested quadratures share one request execution context. The deadline is checked before admission and after final-result construction. Target refinement, transformed-expression growth, exact preflight overflow, and dyadic output conversion fail through typed operation/admission errors. The implementation avoids materializing huge dyadics as Python `Fraction` values.

## Evidence

Final local validation at `f985bdf496488bf5e258a2e0d07cd871218211a8`:

- `make affected AFFECTED_BASE=origin/main`
- 426 analysis tests
- 17 focused endpoint-log tests
- Ruff and mypy
- Independent mathematical audit completed; deadline, overflow, orientation, and exact-materialization findings were repaired.

Fixtures cover `log²` integration, divergent `1/x` rejection, symmetric cancellation, asymmetric orientation, maximum targets, transformed-expression growth, typed overflow, result decoding without arithmetic replay, and native deadline expiry.

This PR addresses the bounded endpoint-log enclosure slice of #3611; general symbolic improper integration remains outside the contract.