### PR TITLE
feat(matrices): compute polynomial remainders modulo minimal polynomials

### DIFF
--- a/src/jacobian/math/matrices/canonical_forms/__init__.py
+++ b/src/jacobian/math/matrices/canonical_forms/__init__.py
@@ -3,6 +3,7 @@
 from jacobian.math.matrices.canonical_forms._models import (
     InvariantFactorEntry,
     MatrixPolynomialEvaluationResult,
+    MatrixPolynomialRemainderResult,
     MinimalPolynomialResult,
     MonicPolynomial,
     PrimaryDecompositionResult,
@@ -14,6 +15,7 @@ from jacobian.math.matrices.canonical_forms.operations import (
     invariant_factors,
     minimal_polynomial,
     primary_decomposition,
+    reduce_matrix_polynomial,
     verify_minimal_polynomial,
     verify_primary_decomposition,
     verify_rational_canonical_form,
@@ -22,6 +24,7 @@ from jacobian.math.matrices.canonical_forms.operations import (
 __all__ = [
     "InvariantFactorEntry",
     "MatrixPolynomialEvaluationResult",
+    "MatrixPolynomialRemainderResult",
     "MinimalPolynomialResult",
     "MonicPolynomial",
     "PrimaryDecompositionResult",
@@ -31,6 +34,7 @@ __all__ = [
     "invariant_factors",
     "minimal_polynomial",
     "primary_decomposition",
+    "reduce_matrix_polynomial",
     "verify_minimal_polynomial",
     "verify_primary_decomposition",
     "verify_rational_canonical_form",

--- a/src/jacobian/math/matrices/canonical_forms/_models.py
+++ b/src/jacobian/math/matrices/canonical_forms/_models.py
@@ -1414,6 +1414,10 @@ class MatrixPolynomialRemainderResult(StrictModel):
 
     @model_validator(mode="after")
     def require_division_shape(self) -> Self:
+        if self.source_matrix.row_count == 0:
+            raise _validation_error(
+                "shape_mismatch", "source matrix must be nonempty"
+            )
         if self.source_matrix.row_count != self.source_matrix.column_count:
             raise _validation_error("shape_mismatch", "source matrix must be square")
         variable = self.polynomial.variables

--- a/src/jacobian/math/matrices/canonical_forms/_models.py
+++ b/src/jacobian/math/matrices/canonical_forms/_models.py
@@ -1415,9 +1415,7 @@ class MatrixPolynomialRemainderResult(StrictModel):
     @model_validator(mode="after")
     def require_division_shape(self) -> Self:
         if self.source_matrix.row_count == 0:
-            raise _validation_error(
-                "shape_mismatch", "source matrix must be nonempty"
-            )
+            raise _validation_error("shape_mismatch", "source matrix must be nonempty")
         if self.source_matrix.row_count != self.source_matrix.column_count:
             raise _validation_error("shape_mismatch", "source matrix must be square")
         variable = self.polynomial.variables

--- a/src/jacobian/math/matrices/canonical_forms/_models.py
+++ b/src/jacobian/math/matrices/canonical_forms/_models.py
@@ -37,6 +37,10 @@ MATRIX_POLYNOMIAL_EVALUATION_PASSES = 2
 # costs about 33 billion proxy units and 1.5 seconds; a 1x1 degree-327 request
 # with a 32,701-digit denominator costs about 700 billion units and one second.
 MAX_MATRIX_POLYNOMIAL_DIGIT_WORK = 1_000_000_000_000
+# Polynomial division can repeatedly multiply by every non-leading modulus
+# coefficient.  Charge the source degree and the resulting component width
+# before materializing the quotient, rather than discovering growth midway.
+MAX_MATRIX_POLYNOMIAL_REMAINDER_DIGIT_WORK = 1_000_000_000_000
 
 # Admission may materialize bounded powers to prove shared numerator factors
 # before digit budgets are charged. Eight bits per canonical digit sits far
@@ -1383,6 +1387,75 @@ class MatrixPolynomialEvaluationResult(StrictModel):
         )
 
 
+class MatrixPolynomialRemainderRequest(StrictModel):
+    """Reduce one exact univariate polynomial modulo a matrix's minimal polynomial."""
+
+    matrix: RationalMatrix = Field(
+        description="Nonempty square rational matrix whose minimal polynomial supplies the modulus."
+    )
+    polynomial: RationalPolynomial = Field(
+        description="Sparse univariate rational polynomial; its declared variable is retained in every result polynomial."
+    )
+
+
+class MatrixPolynomialRemainderResult(StrictModel):
+    """Exact Euclidean division by the matrix minimal polynomial.
+
+    The quotient and remainder establish the defining relation
+    ``polynomial = quotient * minimal_polynomial + remainder`` and the
+    remainder has degree strictly below the minimal-polynomial degree.
+    """
+
+    source_matrix: RationalMatrix
+    polynomial: RationalPolynomial
+    minimal_polynomial: MonicPolynomial
+    quotient: RationalPolynomial
+    remainder: RationalPolynomial
+
+    @model_validator(mode="after")
+    def require_division_shape(self) -> Self:
+        if self.source_matrix.row_count != self.source_matrix.column_count:
+            raise _validation_error("shape_mismatch", "source matrix must be square")
+        variable = self.polynomial.variables
+        if self.minimal_polynomial.variables != variable:
+            raise _validation_error(
+                "invariant_mismatch", "minimal polynomial must use the source variable"
+            )
+        if self.quotient.variables != variable or self.remainder.variables != variable:
+            raise _validation_error(
+                "invariant_mismatch", "division outputs must use the source variable"
+            )
+        minimal_degree = self.minimal_polynomial.polynomial.terms[0].exponents[0]
+        remainder_degree = max(
+            (term.exponents[0] for term in self.remainder.polynomial.terms),
+            default=-1,
+        )
+        if remainder_degree >= minimal_degree:
+            raise _validation_error(
+                "invariant_mismatch",
+                "remainder degree must be smaller than the minimal-polynomial degree",
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        matrix: RationalMatrix,
+        polynomial: RationalPolynomial,
+        minimal_polynomial: MonicPolynomial,
+        quotient: RationalPolynomial,
+        remainder: RationalPolynomial,
+    ) -> Self:
+        return cls.model_construct(
+            source_matrix=matrix,
+            polynomial=polynomial,
+            minimal_polynomial=minimal_polynomial,
+            quotient=quotient,
+            remainder=remainder,
+        )
+
+
 class SquareMatrixRequest(StrictModel):
     """One square rational matrix bounded for canonical-form computation."""
 
@@ -1534,10 +1607,13 @@ __all__ = [
     "MAX_CANONICAL_FORM_DIMENSION",
     "MAX_CANONICAL_FORM_SCALAR_DIGITS",
     "MAX_MATRIX_POLYNOMIAL_DIGIT_WORK",
+    "MAX_MATRIX_POLYNOMIAL_REMAINDER_DIGIT_WORK",
     "MAX_MATRIX_POLYNOMIAL_SCALAR_PRODUCTS",
     "InvariantFactorEntry",
     "MatrixPolynomialEvaluationRequest",
     "MatrixPolynomialEvaluationResult",
+    "MatrixPolynomialRemainderRequest",
+    "MatrixPolynomialRemainderResult",
     "MinimalPolynomialResult",
     "MonicPolynomial",
     "PrimaryDecompositionResult",

--- a/src/jacobian/math/matrices/canonical_forms/_tools.py
+++ b/src/jacobian/math/matrices/canonical_forms/_tools.py
@@ -4,6 +4,8 @@ from jacobian.catalog.models import MathTool, MathTools, OperationExample
 from jacobian.math.matrices.canonical_forms._models import (
     MatrixPolynomialEvaluationRequest,
     MatrixPolynomialEvaluationResult,
+    MatrixPolynomialRemainderRequest,
+    MatrixPolynomialRemainderResult,
     MinimalPolynomialResult,
     PrimaryDecompositionResult,
     RationalCanonicalFormResult,
@@ -14,6 +16,7 @@ from jacobian.math.matrices.canonical_forms.operations import (
     _primary_decomposition_components,
     _rational_canonical_components,
     evaluate_matrix_polynomial_value,
+    reduce_matrix_polynomial,
 )
 from jacobian.math.matrices.values import RationalMatrix
 from jacobian.math.polynomials.values import RationalPolynomial
@@ -27,6 +30,20 @@ def compute_matrix_polynomial_evaluation(
         matrix=matrix,
         polynomial=polynomial,
         value=evaluate_matrix_polynomial_value(matrix, polynomial),
+    )
+
+
+def compute_matrix_polynomial_remainder(
+    matrix: RationalMatrix,
+    polynomial: RationalPolynomial,
+) -> MatrixPolynomialRemainderResult:
+    minimal, quotient, remainder = reduce_matrix_polynomial(matrix, polynomial)
+    return MatrixPolynomialRemainderResult._from_kernel(
+        matrix=matrix,
+        polynomial=polynomial,
+        minimal_polynomial=minimal,
+        quotient=quotient,
+        remainder=remainder,
     )
 
 
@@ -68,6 +85,12 @@ def _run_matrix_polynomial_evaluation(
     return compute_matrix_polynomial_evaluation(request.matrix, request.polynomial)
 
 
+def _run_matrix_polynomial_remainder(
+    request: MatrixPolynomialRemainderRequest,
+) -> MatrixPolynomialRemainderResult:
+    return compute_matrix_polynomial_remainder(request.matrix, request.polynomial)
+
+
 def _run_minimal_polynomial(request: SquareMatrixRequest) -> MinimalPolynomialResult:
     return compute_minimal_polynomial(request.matrix)
 
@@ -85,6 +108,58 @@ def _run_primary_decomposition(
 
 
 TOOLS: MathTools = (
+    MathTool(
+        operation_id="matrix.polynomial.remainder.compute",
+        title="Reduce a rational polynomial modulo a matrix minimal polynomial",
+        description=(
+            "Compute the exact Euclidean quotient and remainder of a univariate "
+            "QQ polynomial by the source matrix's minimal polynomial. The "
+            "returned source variable is retained and the remainder degree is "
+            "strictly smaller than the minimal-polynomial degree."
+        ),
+        request_type=MatrixPolynomialRemainderRequest,
+        result_type=MatrixPolynomialRemainderResult,
+        run=_run_matrix_polynomial_remainder,
+        tags=("matrix", "polynomial", "minimal-polynomial", "remainder", "exact"),
+        examples=(
+            OperationExample(
+                name="nilpotent_reduction",
+                description=(
+                    "Reduce t^3+2t+1 modulo the minimal polynomial t^2 of a "
+                    "nilpotent Jordan block; the matrix must be nonempty and "
+                    "square and the polynomial must be univariate."
+                ),
+                input={
+                    "matrix": {
+                        "domain": "QQ",
+                        "entries": [
+                            [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}],
+                            [{"num": "0", "den": "1"}, {"num": "0", "den": "1"}],
+                        ],
+                    },
+                    "polynomial": {
+                        "variables": ["t"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [3],
+                                },
+                                {
+                                    "coefficient": {"num": "2", "den": "1"},
+                                    "exponents": [1],
+                                },
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                },
+            ),
+        ),
+    ),
     MathTool(
         operation_id="matrix.polynomial.evaluate.compute",
         title="Evaluate an exact rational polynomial at a square matrix",

--- a/src/jacobian/math/matrices/canonical_forms/operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/operations.py
@@ -256,12 +256,8 @@ def _evaluate_polynomial(
     )
 
 
-def minimal_polynomial(entries: RationalEntries) -> CoefficientList:
-    """Compute the minimal polynomial via the Krylov/nullspace method.
-
-    Returns the monic minimal polynomial as coefficient list [a_0, ..., a_n].
-    """
-
+def _minimal_polynomial_coefficients(entries: RationalEntries) -> CoefficientList:
+    """Compute bounded raw minimal-polynomial coefficients for one matrix."""
     from sympy import Matrix, eye
 
     n = _square_dimension(entries)
@@ -287,6 +283,17 @@ def minimal_polynomial(entries: RationalEntries) -> CoefficientList:
         *(Fraction(-reduced[index, degree]) for index in range(degree)),
         Fraction(1),
     )
+
+
+def minimal_polynomial(entries: RationalEntries) -> CoefficientList:
+    """Return raw increasing-degree minimal-polynomial coefficients.
+
+    This compatibility-facing native helper delegates to the private
+    coefficient kernel. Typed matrix operations that construct canonical
+    polynomial carriers call the private kernel directly so they cannot
+    accidentally consume a future public result contract.
+    """
+    return _minimal_polynomial_coefficients(entries)
 
 
 def invariant_factors(entries: RationalEntries) -> tuple[CoefficientList, ...]:
@@ -326,7 +333,7 @@ def primary_decomposition(entries: RationalEntries) -> tuple[CoefficientList, ..
     from sympy import Poly, Symbol, factor_list
 
     x = Symbol("x")
-    minimal_coefficients = minimal_polynomial(entries)
+    minimal_coefficients = _minimal_polynomial_coefficients(entries)
     minimal_expression = sum(
         coefficient * x**index for index, coefficient in enumerate(minimal_coefficients)
     )
@@ -596,7 +603,7 @@ def reduce_matrix_polynomial(
     # polynomial, which is part of this operation's result, before returning
     # the source polynomial unchanged as the remainder.
     if source_degree == 0:
-        minimal_coefficients = minimal_polynomial(_matrix_entries(matrix))
+        minimal_coefficients = _minimal_polynomial_coefficients(_matrix_entries(matrix))
         minimal = _to_monic_polynomial(
             minimal_coefficients, variable=polynomial.variables[0]
         )
@@ -646,7 +653,7 @@ def reduce_matrix_polynomial(
             code="matrix.polynomial.remainder.output",
             message="polynomial remainder quotient growth exceeds the admitted exact-arithmetic bound",
         )
-    minimal_coefficients = minimal_polynomial(_matrix_entries(matrix))
+    minimal_coefficients = _minimal_polynomial_coefficients(_matrix_entries(matrix))
     minimal = _to_monic_polynomial(
         minimal_coefficients, variable=polynomial.variables[0]
     )
@@ -662,7 +669,7 @@ def _minimal_polynomial_components(
     _admit_square(matrix)
     entries = _matrix_entries(matrix)
     return (
-        _to_monic_polynomial(minimal_polynomial(entries)),
+        _to_monic_polynomial(_minimal_polynomial_coefficients(entries)),
         _to_monic_polynomial(characteristic_polynomial(entries)),
     )
 
@@ -675,7 +682,7 @@ def _rational_canonical_components(
     _admit_square(matrix)
     entries = _matrix_entries(matrix)
     factors = invariant_factors(entries)
-    minimal = minimal_polynomial(entries)
+    minimal = _minimal_polynomial_coefficients(entries)
     characteristic = characteristic_polynomial(entries)
     invariant_entries = tuple(
         InvariantFactorEntry(

--- a/src/jacobian/math/matrices/canonical_forms/operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/operations.py
@@ -630,6 +630,118 @@ def _division_support_bound(
     return len(quotient_support)
 
 
+def _bounded_exact_division_presolve(
+    dividend: RationalPolynomial, divisor: MonicPolynomial
+) -> tuple[RationalPolynomial, RationalPolynomial] | None:
+    """Try exact division while bounding every presolve intermediate.
+
+    The support ledger deliberately ignores coefficients, so it can reject a
+    sparse quotient whose high-degree cancellations are obvious from the
+    source. This presolve recovers those cases without admitting unrestricted
+    exact arithmetic: every product and sum must fit one canonical rational
+    component, and the accumulated digit-work charge must stay within the
+    remainder-operation budget. ``None`` leaves the conservative support and
+    growth admission in charge.
+    """
+
+    variable = dividend.variables[0]
+    remaining = {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in dividend.polynomial.terms
+    }
+    divisor_coefficients = {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in divisor.polynomial.terms
+    }
+    divisor_degree = divisor.polynomial.terms[0].exponents[0]
+    quotient: dict[int, Fraction] = {}
+    digit_work = 0
+
+    while remaining and max(remaining) >= divisor_degree:
+        degree = max(remaining)
+        shift = degree - divisor_degree
+        factor = remaining[degree]
+        quotient[shift] = factor
+        if len(quotient) > MAX_POLYNOMIAL_TERMS:
+            return None
+        factor_digits = max(
+            _integer_decimal_digits(abs(factor.numerator)),
+            _integer_decimal_digits(factor.denominator),
+        )
+        for divisor_exponent, divisor_coefficient in divisor_coefficients.items():
+            old = remaining.get(divisor_exponent + shift)
+            coefficient_digits = max(
+                _integer_decimal_digits(abs(divisor_coefficient.numerator)),
+                _integer_decimal_digits(divisor_coefficient.denominator),
+            )
+            old_digits = (
+                max(
+                    _integer_decimal_digits(abs(old.numerator)),
+                    _integer_decimal_digits(old.denominator),
+                )
+                if old is not None
+                else 1
+            )
+            operation_digits = factor_digits + coefficient_digits + old_digits
+            digit_work += operation_digits**2
+            if digit_work > MAX_MATRIX_POLYNOMIAL_REMAINDER_DIGIT_WORK:
+                return None
+            # The product's unreduced components are bounded by the operand
+            # component sums. Refuse before materializing a wider integer.
+            if factor_digits + coefficient_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+                return None
+            product = factor * divisor_coefficient
+            if old is None:
+                value = -product
+            else:
+                # Clearing both denominators gives a component bound before
+                # Fraction performs the exact reduction or cancellation.
+                if (
+                    max(
+                        _integer_decimal_digits(abs(old.numerator))
+                        + _integer_decimal_digits(product.denominator)
+                        + 1,
+                        _integer_decimal_digits(abs(product.numerator))
+                        + _integer_decimal_digits(old.denominator)
+                        + 1,
+                        _integer_decimal_digits(old.denominator)
+                        + _integer_decimal_digits(product.denominator),
+                    )
+                    > MAX_CANONICAL_RATIONAL_DIGITS
+                ):
+                    return None
+                value = old - product
+            if value:
+                if (
+                    max(
+                        _integer_decimal_digits(abs(value.numerator)),
+                        _integer_decimal_digits(value.denominator),
+                    )
+                    > MAX_CANONICAL_RATIONAL_DIGITS
+                ):
+                    return None
+                remaining[divisor_exponent + shift] = value
+            else:
+                remaining.pop(divisor_exponent + shift, None)
+
+    return (
+        _polynomial_from_coefficients(
+            [
+                quotient.get(index, Fraction(0))
+                for index in range(max(quotient, default=-1) + 1)
+            ],
+            variable,
+        ),
+        _polynomial_from_coefficients(
+            [
+                remaining.get(index, Fraction(0))
+                for index in range(max(remaining, default=-1) + 1)
+            ],
+            variable,
+        ),
+    )
+
+
 def reduce_matrix_polynomial(
     matrix: RationalMatrix, polynomial: RationalPolynomial
 ) -> tuple[MonicPolynomial, RationalPolynomial, RationalPolynomial]:
@@ -694,17 +806,18 @@ def reduce_matrix_polynomial(
     # through the source exponent. In particular, t^D divided by t has one
     # quotient term for any admitted exponent D.
     quotient_support = _division_support_bound(polynomial, minimal)
-    if quotient_support > MAX_POLYNOMIAL_TERMS:
-        raise OperationResourceAdmissionError(
-            location=("polynomial",),
-            code="matrix.polynomial.remainder.output",
-            message="polynomial remainder quotient support exceeds the canonical term bound",
-        )
+    support_rejected = quotient_support > MAX_POLYNOMIAL_TERMS
 
     # A monomial modulus only shifts source terms. There are no coefficient
     # products or accumulations to charge, so high exponents retain the source
     # component bound and the support ledger above is sufficient.
     if len(minimal_terms) == 1:
+        if support_rejected:
+            raise OperationResourceAdmissionError(
+                location=("polynomial",),
+                code="matrix.polynomial.remainder.output",
+                message="polynomial remainder quotient support exceeds the canonical term bound",
+            )
         quotient, remainder = _divide_polynomials(polynomial, minimal)
         return minimal, quotient, remainder
 
@@ -738,9 +851,21 @@ def reduce_matrix_polynomial(
         * max(1, nonleading_support)
         * (estimated_digits**2)
     )
-    if estimated_digits > MAX_CANONICAL_RATIONAL_DIGITS or (
+    growth_rejected = estimated_digits > MAX_CANONICAL_RATIONAL_DIGITS or (
         digit_work > MAX_MATRIX_POLYNOMIAL_REMAINDER_DIGIT_WORK
-    ):
+    )
+    if support_rejected or growth_rejected:
+        presolved = _bounded_exact_division_presolve(polynomial, minimal)
+        if presolved is not None:
+            quotient, remainder = presolved
+            return minimal, quotient, remainder
+    if support_rejected:
+        raise OperationResourceAdmissionError(
+            location=("polynomial",),
+            code="matrix.polynomial.remainder.output",
+            message="polynomial remainder quotient support exceeds the canonical term bound",
+        )
+    if growth_rejected:
         raise OperationResourceAdmissionError(
             location=("polynomial",),
             code="matrix.polynomial.remainder.output",

--- a/src/jacobian/math/matrices/canonical_forms/operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/operations.py
@@ -591,6 +591,20 @@ def reduce_matrix_polynomial(
         ),
         default=1,
     )
+    # A zero or constant source needs no Euclidean quotient-growth work.  Keep
+    # the square-matrix admission above and still compute the minimal
+    # polynomial, which is part of this operation's result, before returning
+    # the source polynomial unchanged as the remainder.
+    if source_degree == 0:
+        minimal_coefficients = minimal_polynomial(_matrix_entries(matrix))
+        minimal = _to_monic_polynomial(
+            minimal_coefficients, variable=polynomial.variables[0]
+        )
+        return (
+            minimal,
+            _polynomial_from_coefficients((), polynomial.variables[0]),
+            polynomial,
+        )
     # Euclidean division can fill every degree from zero through the leading
     # quotient degree. Reject a quotient whose canonical sparse carrier could
     # not hold that complete support before computing the matrix modulus.

--- a/src/jacobian/math/matrices/canonical_forms/operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/operations.py
@@ -19,6 +19,7 @@ from jacobian.catalog.models import (
     OperationResourceAdmissionError,
 )
 from jacobian.math.matrices.canonical_forms._models import (
+    _MAX_RESULT_COMPONENT,
     MATRIX_POLYNOMIAL_EVALUATION_PASSES,
     MAX_CANONICAL_FORM_DIMENSION,
     MAX_CANONICAL_FORM_SCALAR_DIGITS,
@@ -30,6 +31,9 @@ from jacobian.math.matrices.canonical_forms._models import (
     MonicPolynomial,
     PrimaryDecompositionResult,
     RationalCanonicalFormResult,
+    _capped_add,
+    _capped_lcm,
+    _capped_multiply,
     _polynomial_degree,
     _require_matrix_polynomial_output_budget,
     _validation_error,
@@ -562,6 +566,70 @@ def _divide_polynomials(
     )
 
 
+def _coefficient_growth_digits(
+    terms: Sequence[RationalPolynomialTerm],
+) -> int | None:
+    """Bound one coefficient family's common-denominator aggregate height.
+
+    A quotient coefficient can collect contributions from several source
+    coefficients. Charging only the largest source component therefore misses
+    the product of unrelated denominators (and the corresponding sum of
+    lifted numerators). Keep the common denominator and absolute lifted
+    numerator sum capped at one canonical rational component; callers reject a
+    saturated result before division starts.
+    """
+
+    common_denominator = _capped_lcm(term.coefficient.den for term in terms)
+    if common_denominator > _MAX_RESULT_COMPONENT:
+        return None
+    aggregate_numerator = 0
+    for term in terms:
+        coefficient = term.coefficient
+        lifted = _capped_multiply(
+            abs(coefficient.num), common_denominator // coefficient.den
+        )
+        aggregate_numerator = _capped_add(aggregate_numerator, lifted)
+        if aggregate_numerator > _MAX_RESULT_COMPONENT:
+            return None
+    return max(
+        _integer_decimal_digits(common_denominator),
+        _integer_decimal_digits(aggregate_numerator),
+        max(
+            (canonical_rational_component_digits(term.coefficient) for term in terms),
+            default=1,
+        ),
+    )
+
+
+def _division_support_bound(
+    polynomial: RationalPolynomial, divisor: MonicPolynomial
+) -> int:
+    """Return an upper bound on quotient support before rational division.
+
+    Long division can create a lower-degree term at every cancellation. A
+    support-only simulation follows those possible shifts while ignoring
+    coefficient cancellation, so its count safely bounds the canonical
+    quotient carrier without materializing any exact rational intermediate.
+    Monomial moduli take the particularly useful fast path: their support has
+    no lower shifts, so a high-degree monomial remains one quotient term.
+    """
+
+    remaining = {term.exponents[0] for term in polynomial.polynomial.terms}
+    divisor_terms = divisor.polynomial.terms
+    divisor_degree = divisor_terms[0].exponents[0]
+    lower_support = {term.exponents[0] for term in divisor_terms[1:]}
+    quotient_support: set[int] = set()
+    while remaining:
+        degree = max(remaining)
+        if degree < divisor_degree:
+            break
+        remaining.remove(degree)
+        shift = degree - divisor_degree
+        quotient_support.add(shift)
+        remaining.update(shift + exponent for exponent in lower_support)
+    return len(quotient_support)
+
+
 def reduce_matrix_polynomial(
     matrix: RationalMatrix, polynomial: RationalPolynomial
 ) -> tuple[MonicPolynomial, RationalPolynomial, RationalPolynomial]:
@@ -591,13 +659,6 @@ def reduce_matrix_polynomial(
     source_degree = max(
         (term.exponents[0] for term in polynomial.polynomial.terms), default=0
     )
-    source_digits = max(
-        (
-            canonical_rational_component_digits(term.coefficient)
-            for term in polynomial.polynomial.terms
-        ),
-        default=1,
-    )
     # A zero or constant source needs no Euclidean quotient-growth work.  Keep
     # the square-matrix admission above and still compute the minimal
     # polynomial, which is part of this operation's result, before returning
@@ -612,38 +673,70 @@ def reduce_matrix_polynomial(
             _polynomial_from_coefficients((), polynomial.variables[0]),
             polynomial,
         )
-    # Euclidean division can fill every degree from zero through the leading
-    # quotient degree. Reject a quotient whose canonical sparse carrier could
-    # not hold that complete support before computing the matrix modulus.
-    if source_degree > MAX_POLYNOMIAL_TERMS:
+    # The matrix admission above bounds the Krylov computation. Compute this
+    # operation's actual modulus before estimating quotient growth: its degree
+    # and nonzero support, rather than the dense characteristic envelope, are
+    # the quantities the Euclidean division will use.
+    minimal_coefficients = _minimal_polynomial_coefficients(_matrix_entries(matrix))
+    minimal = _to_monic_polynomial(
+        minimal_coefficients, variable=polynomial.variables[0]
+    )
+    minimal_terms = minimal.polynomial.terms
+    minimal_degree = minimal_terms[0].exponents[0]
+    if source_degree < minimal_degree:
+        return (
+            minimal,
+            _polynomial_from_coefficients((), polynomial.variables[0]),
+            polynomial,
+        )
+
+    # The support-only division ledger is tighter than charging every degree
+    # through the source exponent. In particular, t^D divided by t has one
+    # quotient term for any admitted exponent D.
+    quotient_support = _division_support_bound(polynomial, minimal)
+    if quotient_support > MAX_POLYNOMIAL_TERMS:
         raise OperationResourceAdmissionError(
             location=("polynomial",),
             code="matrix.polynomial.remainder.output",
             message="polynomial remainder quotient support exceeds the canonical term bound",
         )
-    # The characteristic polynomial bounds the minimal polynomial degree by n.
-    # Clearing all n-entry products gives a coefficient-height bound of
-    # n*(entry-height + 2) + ceil(log10(n+1)); the larger additive slack also
-    # covers rational Krylov elimination used by the private producer.
-    dimension = matrix.row_count
-    matrix_digits = max(
-        (
-            canonical_rational_component_digits(entry)
-            for row in matrix.entries
-            for entry in row
-        ),
-        default=1,
-    )
-    minimal_digits_bound = dimension * (matrix_digits + 2) + dimension.bit_length() + 2
-    # A recurrence step adds at most one minimal-polynomial coefficient times
-    # a previous quotient coefficient. This is intentionally an upper bound:
-    # it charges every source-degree step even when the source is sparse or
-    # cancellation later reduces the exact result.
-    estimated_digits = source_digits + (source_degree + 1) * (
-        minimal_digits_bound + dimension.bit_length() + 2
+
+    # A monomial modulus only shifts source terms. There are no coefficient
+    # products or accumulations to charge, so high exponents retain the source
+    # component bound and the support ledger above is sufficient.
+    if len(minimal_terms) == 1:
+        quotient, remainder = _divide_polynomials(polynomial, minimal)
+        return minimal, quotient, remainder
+
+    source_height = _coefficient_growth_digits(polynomial.polynomial.terms)
+    modulus_height = _coefficient_growth_digits(minimal_terms)
+    if source_height is None or modulus_height is None:
+        raise OperationResourceAdmissionError(
+            location=("polynomial",),
+            code="matrix.polynomial.remainder.output",
+            message=(
+                "matrix polynomial coefficient common-denominator or aggregate "
+                "growth exceeds the canonical "
+                f"{MAX_CANONICAL_RATIONAL_DIGITS:,}-digit exact-arithmetic bound"
+            ),
+        )
+
+    quotient_degree = source_degree - minimal_degree
+    division_steps = quotient_degree + 1
+    nonleading_support = len(minimal_terms) - 1
+    support_digits = _integer_decimal_digits(max(1, nonleading_support))
+    # Each recurrence step multiplies by at most one modulus coefficient and
+    # may collect the supported lower shifts. The common-denominator and
+    # aggregate numerator heights account for unrelated source/modulus
+    # denominators before this recurrence charge is applied.
+    estimated_digits = source_height + division_steps * (
+        modulus_height + support_digits + 1
     )
     digit_work = (
-        len(polynomial.polynomial.terms) * (source_degree + 1) * (estimated_digits**2)
+        len(polynomial.polynomial.terms)
+        * division_steps
+        * max(1, nonleading_support)
+        * (estimated_digits**2)
     )
     if estimated_digits > MAX_CANONICAL_RATIONAL_DIGITS or (
         digit_work > MAX_MATRIX_POLYNOMIAL_REMAINDER_DIGIT_WORK
@@ -653,10 +746,6 @@ def reduce_matrix_polynomial(
             code="matrix.polynomial.remainder.output",
             message="polynomial remainder quotient growth exceeds the admitted exact-arithmetic bound",
         )
-    minimal_coefficients = _minimal_polynomial_coefficients(_matrix_entries(matrix))
-    minimal = _to_monic_polynomial(
-        minimal_coefficients, variable=polynomial.variables[0]
-    )
     quotient, remainder = _divide_polynomials(polynomial, minimal)
     return minimal, quotient, remainder
 

--- a/src/jacobian/math/matrices/canonical_forms/operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/operations.py
@@ -9,7 +9,11 @@ from typing import Any
 
 from pydantic_core import PydanticCustomError
 
-from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
+from jacobian._exact import (
+    MAX_CANONICAL_RATIONAL_DIGITS,
+    CanonicalRational,
+    canonical_rational_component_digits,
+)
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
@@ -19,6 +23,7 @@ from jacobian.math.matrices.canonical_forms._models import (
     MAX_CANONICAL_FORM_DIMENSION,
     MAX_CANONICAL_FORM_SCALAR_DIGITS,
     MAX_MATRIX_POLYNOMIAL_DIGIT_WORK,
+    MAX_MATRIX_POLYNOMIAL_REMAINDER_DIGIT_WORK,
     MAX_MATRIX_POLYNOMIAL_SCALAR_PRODUCTS,
     InvariantFactorEntry,
     MinimalPolynomialResult,
@@ -38,6 +43,8 @@ from jacobian.math.polynomials.values import (
     MAX_POLYNOMIAL_EXPONENT,
     MAX_POLYNOMIAL_TERMS,
     RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
     require_polynomial_budget,
 )
 
@@ -47,6 +54,7 @@ __all__ = [
     "invariant_factors",
     "minimal_polynomial",
     "primary_decomposition",
+    "reduce_matrix_polynomial",
     "verify_minimal_polynomial",
     "verify_primary_decomposition",
     "verify_rational_canonical_form",
@@ -438,13 +446,16 @@ def _matrix_entries(
     return tuple(tuple(value.as_fraction() for value in row) for row in matrix.entries)
 
 
-def _to_monic_polynomial(coefficients: Sequence[Fraction]) -> MonicPolynomial:
+def _to_monic_polynomial(
+    coefficients: Sequence[Fraction], *, variable: str = "t"
+) -> MonicPolynomial:
     from jacobian.math.polynomials.values import monic_polynomial_from_coefficients
 
     return monic_polynomial_from_coefficients(
         tuple(
             CanonicalRational.from_fraction(coefficient) for coefficient in coefficients
-        )
+        ),
+        variable=variable,
     )
 
 
@@ -478,6 +489,155 @@ def _evaluate_matrix_polynomial_value(
         _dense_polynomial_coefficients(polynomial),
     )
     return rational_matrix_from_fractions(evaluated)
+
+
+def _polynomial_from_coefficients(
+    coefficients: Sequence[Fraction], variable: str
+) -> RationalPolynomial:
+    """Encode increasing-degree coefficients in the canonical sparse form."""
+
+    terms = tuple(
+        RationalPolynomialTerm(
+            coefficient=CanonicalRational.from_fraction(coefficient),
+            exponents=(degree,),
+        )
+        for degree, coefficient in reversed(tuple(enumerate(coefficients)))
+        if coefficient
+    )
+    return RationalPolynomial(
+        variables=(variable,), polynomial=SparseRationalPolynomial(terms=terms)
+    )
+
+
+def _divide_polynomials(
+    dividend: RationalPolynomial, divisor: MonicPolynomial
+) -> tuple[RationalPolynomial, RationalPolynomial]:
+    """Perform exact univariate Euclidean division over QQ."""
+
+    variable = dividend.variables[0]
+    remainder = {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in dividend.polynomial.terms
+    }
+    divisor_coefficients = {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in divisor.polynomial.terms
+    }
+    divisor_degree = divisor.polynomial.terms[0].exponents[0]
+    quotient: dict[int, Fraction] = {}
+    while remainder and max(remainder) >= divisor_degree:
+        degree = max(remainder)
+        shift = degree - divisor_degree
+        factor = remainder[degree]  # the divisor is monic
+        quotient[shift] = quotient.get(shift, Fraction(0)) + factor
+        for divisor_exponent, divisor_coefficient in divisor_coefficients.items():
+            exponent = divisor_exponent + shift
+            value = remainder.get(exponent, Fraction(0)) - factor * divisor_coefficient
+            if value:
+                remainder[exponent] = value
+            else:
+                remainder.pop(exponent, None)
+    return (
+        _polynomial_from_coefficients(
+            [
+                quotient.get(index, Fraction(0))
+                for index in range(max(quotient, default=-1) + 1)
+            ],
+            variable,
+        ),
+        _polynomial_from_coefficients(
+            [
+                remainder.get(index, Fraction(0))
+                for index in range(max(remainder, default=-1) + 1)
+            ],
+            variable,
+        ),
+    )
+
+
+def reduce_matrix_polynomial(
+    matrix: RationalMatrix, polynomial: RationalPolynomial
+) -> tuple[MonicPolynomial, RationalPolynomial, RationalPolynomial]:
+    """Return the minimal polynomial and exact quotient/remainder of ``polynomial``."""
+
+    _admit_square(matrix)
+    if len(polynomial.variables) != 1:
+        raise OperationDomainValidationError(
+            location=("polynomial",),
+            code="matrix.polynomial.remainder.variable",
+            message="polynomial reduction requires exactly one variable",
+        )
+    try:
+        require_polynomial_budget(
+            polynomial,
+            maximum_terms=MAX_POLYNOMIAL_TERMS,
+            maximum_exponent=MAX_POLYNOMIAL_EXPONENT,
+            maximum_coefficient_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+            label="matrix polynomial remainder",
+        )
+    except ValueError as exc:
+        raise OperationDomainValidationError(
+            location=("polynomial",),
+            code="matrix.polynomial.remainder.budget",
+            message=str(exc),
+        ) from exc
+    source_degree = max(
+        (term.exponents[0] for term in polynomial.polynomial.terms), default=0
+    )
+    source_digits = max(
+        (
+            canonical_rational_component_digits(term.coefficient)
+            for term in polynomial.polynomial.terms
+        ),
+        default=1,
+    )
+    # Euclidean division can fill every degree from zero through the leading
+    # quotient degree. Reject a quotient whose canonical sparse carrier could
+    # not hold that complete support before computing the matrix modulus.
+    if source_degree > MAX_POLYNOMIAL_TERMS:
+        raise OperationResourceAdmissionError(
+            location=("polynomial",),
+            code="matrix.polynomial.remainder.output",
+            message="polynomial remainder quotient support exceeds the canonical term bound",
+        )
+    # The characteristic polynomial bounds the minimal polynomial degree by n.
+    # Clearing all n-entry products gives a coefficient-height bound of
+    # n*(entry-height + 2) + ceil(log10(n+1)); the larger additive slack also
+    # covers rational Krylov elimination used by the private producer.
+    dimension = matrix.row_count
+    matrix_digits = max(
+        (
+            canonical_rational_component_digits(entry)
+            for row in matrix.entries
+            for entry in row
+        ),
+        default=1,
+    )
+    minimal_digits_bound = dimension * (matrix_digits + 2) + dimension.bit_length() + 2
+    # A recurrence step adds at most one minimal-polynomial coefficient times
+    # a previous quotient coefficient. This is intentionally an upper bound:
+    # it charges every source-degree step even when the source is sparse or
+    # cancellation later reduces the exact result.
+    estimated_digits = source_digits + (source_degree + 1) * (
+        minimal_digits_bound + dimension.bit_length() + 2
+    )
+    digit_work = (
+        len(polynomial.polynomial.terms) * (source_degree + 1) * (estimated_digits**2)
+    )
+    if estimated_digits > MAX_CANONICAL_RATIONAL_DIGITS or (
+        digit_work > MAX_MATRIX_POLYNOMIAL_REMAINDER_DIGIT_WORK
+    ):
+        raise OperationResourceAdmissionError(
+            location=("polynomial",),
+            code="matrix.polynomial.remainder.output",
+            message="polynomial remainder quotient growth exceeds the admitted exact-arithmetic bound",
+        )
+    minimal_coefficients = minimal_polynomial(_matrix_entries(matrix))
+    minimal = _to_monic_polynomial(
+        minimal_coefficients, variable=polynomial.variables[0]
+    )
+    quotient, remainder = _divide_polynomials(polynomial, minimal)
+    return minimal, quotient, remainder
 
 
 def _minimal_polynomial_components(

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -249,6 +249,30 @@ def test_matrix_polynomial_remainder_accepts_sparse_zero_modulus_at_high_degree(
     assert result.remainder.polynomial.terms == ()
 
 
+def test_matrix_polynomial_remainder_preserves_high_degree_source_cancellation() -> (
+    None
+):
+    matrix = _diagonal(1)
+    polynomial = RationalPolynomial(
+        variables=("t",),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(
+                    coefficient=R(num=1, den=1), exponents=(32_768,)
+                ),
+                RationalPolynomialTerm(
+                    coefficient=R(num=-1, den=1), exponents=(32_767,)
+                ),
+            )
+        ),
+    )
+    result = compute_matrix_polynomial_remainder(matrix, polynomial)
+    assert result.quotient.polynomial.terms == (
+        RationalPolynomialTerm(coefficient=R(num=1, den=1), exponents=(32_767,)),
+    )
+    assert result.remainder.polynomial.terms == ()
+
+
 def test_matrix_polynomial_remainder_accepts_maximum_size_constant() -> None:
     coefficient = R(num=10**32_767, den=1)
     polynomial = RationalPolynomial(

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -205,6 +205,50 @@ def test_matrix_polynomial_remainder_accepts_bounded_high_degree_prefix() -> Non
     assert result.remainder.polynomial.terms[0].coefficient == R(num=1, den=1)
 
 
+def test_matrix_polynomial_remainder_rejects_cumulative_source_denominator_growth() -> (
+    None
+):
+    """Unrelated source denominators are admitted as one aggregate bound."""
+    from math import lcm
+
+    denominator_base = 10**164 * lcm(*range(1, 201))
+    denominators = tuple(denominator_base * index + 1 for index in range(1, 201))
+    polynomial = RationalPolynomial(
+        variables=("t",),
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=R(num=1, den=denominator),
+                    exponents=(index,),
+                )
+                for index, denominator in reversed(tuple(enumerate(denominators)))
+            )
+        ),
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="denominator"):
+        compute_matrix_polynomial_remainder(_diagonal(1), polynomial)
+
+
+def test_matrix_polynomial_remainder_accepts_sparse_zero_modulus_at_high_degree() -> (
+    None
+):
+    matrix = _diagonal(0)
+    polynomial = RationalPolynomial(
+        variables=("t",),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(coefficient=R(num=1, den=1), exponents=(2_311,)),
+            )
+        ),
+    )
+    result = compute_matrix_polynomial_remainder(matrix, polynomial)
+    assert _coeffs(result.minimal_polynomial) == [Fraction(0), Fraction(1)]
+    assert result.quotient.polynomial.terms == (
+        RationalPolynomialTerm(coefficient=R(num=1, den=1), exponents=(2_310,)),
+    )
+    assert result.remainder.polynomial.terms == ()
+
+
 def test_matrix_polynomial_remainder_accepts_maximum_size_constant() -> None:
     coefficient = R(num=10**32_767, den=1)
     polynomial = RationalPolynomial(

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -8,7 +8,10 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.matrices.canonical_forms import (
     invariant_factors,
     minimal_polynomial,
@@ -20,16 +23,23 @@ from jacobian.math.matrices.canonical_forms import (
 from jacobian.math.matrices.canonical_forms import operations as canonical_operations
 from jacobian.math.matrices.canonical_forms._models import (
     InvariantFactorEntry,
+    MatrixPolynomialRemainderResult,
     MonicPolynomial,
     RationalCanonicalFormResult,
 )
 from jacobian.math.matrices.canonical_forms._tools import (
+    compute_matrix_polynomial_remainder,
     compute_minimal_polynomial,
     compute_primary_decomposition,
     compute_rational_canonical_form,
 )
 from jacobian.math.matrices.values import RationalMatrix
-from jacobian.math.polynomials.values import monic_polynomial_from_coefficients
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+    monic_polynomial_from_coefficients,
+)
 
 R = CanonicalRational
 
@@ -95,6 +105,75 @@ def test_nilpotent_jordan_block_minimal_polynomial_is_t_squared() -> None:
     result = compute_minimal_polynomial(req)
     assert _coeffs(result.minimal_polynomial) == [Fraction(0), Fraction(0), Fraction(1)]
     assert result.degree == 2
+
+
+def test_matrix_polynomial_remainder_retains_variable_and_reconstructs_source() -> None:
+    req = _mat(
+        (_pair(0, 1), _pair(1, 1)),
+        (_pair(0, 1), _pair(0, 1)),
+    )
+    polynomial = RationalPolynomial(
+        variables=("u",),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(coefficient=R(num=1, den=1), exponents=(5,)),
+                RationalPolynomialTerm(coefficient=R(num=3, den=2), exponents=(2,)),
+                RationalPolynomialTerm(coefficient=R(num=-1, den=1), exponents=(0,)),
+            )
+        ),
+    )
+    result = compute_matrix_polynomial_remainder(req, polynomial)
+    assert isinstance(result, MatrixPolynomialRemainderResult)
+    assert result.minimal_polynomial.variables == ("u",)
+    assert result.quotient.variables == result.remainder.variables == ("u",)
+    assert result.remainder.polynomial.terms[0].exponents[0] < 2
+    import sympy
+
+    u = sympy.Symbol("u")
+
+    def expr(value: RationalPolynomial) -> sympy.Expr:
+        return sum(
+            sympy.Rational(term.coefficient.num, term.coefficient.den)
+            * u ** term.exponents[0]
+            for term in value.polynomial.terms
+        )
+
+    assert sympy.expand(expr(result.polynomial)) == sympy.expand(
+        expr(result.quotient) * expr(result.minimal_polynomial) + expr(result.remainder)
+    )
+    assert result == MatrixPolynomialRemainderResult.model_validate_json(
+        result.model_dump_json()
+    )
+
+
+def test_matrix_polynomial_remainder_rejects_unbounded_quotient_growth() -> None:
+    matrix = _diagonal(1)
+    polynomial = RationalPolynomial(
+        variables=("t",),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(
+                    coefficient=R(num=1, den=1), exponents=(32_768,)
+                ),
+            )
+        ),
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="support"):
+        compute_matrix_polynomial_remainder(matrix, polynomial)
+
+
+def test_matrix_polynomial_remainder_accepts_bounded_high_degree_prefix() -> None:
+    matrix = _diagonal(1)
+    polynomial = RationalPolynomial(
+        variables=("t",),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(coefficient=R(num=1, den=1), exponents=(1_800,)),
+            )
+        ),
+    )
+    result = compute_matrix_polynomial_remainder(matrix, polynomial)
+    assert result.remainder.polynomial.terms[0].coefficient == R(num=1, den=1)
 
 
 def test_trusted_canonical_form_producers_run_each_kernel_once(

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -146,6 +146,35 @@ def test_matrix_polynomial_remainder_retains_variable_and_reconstructs_source() 
     )
 
 
+def test_matrix_polynomial_remainder_handles_nonconstant_minimal_polynomial() -> None:
+    """A diagonal matrix supplies a nonconstant modulus to exact division."""
+    polynomial = RationalPolynomial(
+        variables=("u",),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(coefficient=R(num=1, den=1), exponents=(3,)),
+                RationalPolynomialTerm(coefficient=R(num=2, den=1), exponents=(1,)),
+                RationalPolynomialTerm(coefficient=R(num=1, den=1), exponents=(0,)),
+            )
+        ),
+    )
+    result = compute_matrix_polynomial_remainder(_diagonal(2, 3), polynomial)
+
+    assert _coeffs(result.minimal_polynomial) == [
+        Fraction(6),
+        Fraction(-5),
+        Fraction(1),
+    ]
+    assert {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in result.quotient.polynomial.terms
+    } == {1: Fraction(1), 0: Fraction(5)}
+    assert {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in result.remainder.polynomial.terms
+    } == {1: Fraction(21), 0: Fraction(-29)}
+
+
 def test_matrix_polynomial_remainder_rejects_unbounded_quotient_growth() -> None:
     matrix = _diagonal(1)
     polynomial = RationalPolynomial(
@@ -218,7 +247,7 @@ def test_trusted_canonical_form_producers_run_each_kernel_once(
     request = _diagonal(2, 3)
     names = (
         "invariant_factors",
-        "minimal_polynomial",
+        "_minimal_polynomial_coefficients",
         "characteristic_polynomial",
         "primary_decomposition",
     )
@@ -241,7 +270,7 @@ def test_trusted_canonical_form_producers_run_each_kernel_once(
     compute_minimal_polynomial(request)
     assert calls == {
         "invariant_factors": 0,
-        "minimal_polynomial": 1,
+        "_minimal_polynomial_coefficients": 1,
         "characteristic_polynomial": 1,
         "primary_decomposition": 0,
     }
@@ -251,7 +280,7 @@ def test_trusted_canonical_form_producers_run_each_kernel_once(
     compute_rational_canonical_form(request)
     assert calls == {
         "invariant_factors": 1,
-        "minimal_polynomial": 1,
+        "_minimal_polynomial_coefficients": 1,
         "characteristic_polynomial": 1,
         "primary_decomposition": 0,
     }
@@ -261,7 +290,7 @@ def test_trusted_canonical_form_producers_run_each_kernel_once(
     compute_primary_decomposition(request)
     assert calls == {
         "invariant_factors": 0,
-        "minimal_polynomial": 1,
+        "_minimal_polynomial_coefficients": 1,
         "characteristic_polynomial": 0,
         "primary_decomposition": 1,
     }

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -181,9 +181,7 @@ def test_matrix_polynomial_remainder_accepts_maximum_size_constant() -> None:
     polynomial = RationalPolynomial(
         variables=("t",),
         polynomial=SparseRationalPolynomial(
-            terms=(
-                RationalPolynomialTerm(coefficient=coefficient, exponents=(0,)),
-            )
+            terms=(RationalPolynomialTerm(coefficient=coefficient, exponents=(0,)),)
         ),
     )
     result = compute_matrix_polynomial_remainder(_diagonal(0), polynomial)

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -176,6 +176,44 @@ def test_matrix_polynomial_remainder_accepts_bounded_high_degree_prefix() -> Non
     assert result.remainder.polynomial.terms[0].coefficient == R(num=1, den=1)
 
 
+def test_matrix_polynomial_remainder_accepts_maximum_size_constant() -> None:
+    coefficient = R(num=10**32_767, den=1)
+    polynomial = RationalPolynomial(
+        variables=("t",),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(coefficient=coefficient, exponents=(0,)),
+            )
+        ),
+    )
+    result = compute_matrix_polynomial_remainder(_diagonal(0), polynomial)
+    assert result.quotient.polynomial.terms == ()
+    assert result.remainder == polynomial
+
+
+def test_matrix_polynomial_remainder_accepts_zero_polynomial() -> None:
+    polynomial = RationalPolynomial(
+        variables=("t",), polynomial=SparseRationalPolynomial(terms=())
+    )
+    result = compute_matrix_polynomial_remainder(_diagonal(0), polynomial)
+    assert result.quotient == polynomial
+    assert result.remainder == polynomial
+
+
+def test_matrix_polynomial_remainder_result_rejects_empty_source() -> None:
+    zero = RationalPolynomial(
+        variables=("t",), polynomial=SparseRationalPolynomial(terms=())
+    )
+    with pytest.raises(ValidationError, match="source matrix must be nonempty"):
+        MatrixPolynomialRemainderResult(
+            source_matrix=RationalMatrix(entries=()),
+            polynomial=zero,
+            minimal_polynomial=_mono(0, 1),
+            quotient=zero,
+            remainder=zero,
+        )
+
+
 def test_trusted_canonical_form_producers_run_each_kernel_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem

Related to #1818 and #1801.

Matrix-polynomial calculations need a canonical exact remainder modulo the matrix minimal polynomial, with enough reconstruction data to compose with later canonical-form and module-structure operations.

## Outcome

- Adds `matrix.polynomial.remainder.compute`.
- Retains the source matrix, polynomial variable, canonical minimal polynomial, quotient, and remainder.
- Handles empty matrices, zero and constant polynomials, and nonconstant reductions.
- Uses the private coefficient kernel directly, avoiding an incompatible call through the public typed minimal-polynomial wrapper.
- Pre-admits source degree, matrix/minimal-polynomial work, quotient coefficient growth, result digits, and the bounded division envelope.
- Enforces exact source reconstruction and canonical quotient/remainder degrees through serialization.

## Validation

- `make affected AFFECTED_BASE=origin/main`
  - 831 matrix tests passed
  - 160 catalog tests passed
  - 967 catalog integration tests passed
  - scoped Ruff/format and mypy passed
- Focused canonical-form tests: 36 passed.
- Final autoreview: clean, with no actionable findings.
- Final locally validated head: `807d4478495b44b3790e3cb3bd125d9e554ad0e6`.

Hosted required CI passed on this final head.

## Contract impact

New immutable public operation ID:

- `matrix.polynomial.remainder.compute`

This is a focused primitive for the broader matrix module-structure requests; invariant factors, rational canonical forms, primary projectors, and Jordan profiles remain separate scope.