### PR TITLE
feat(semigroups): profile regular and nilpotent elements

### DIFF
--- a/src/jacobian/math/finite_semigroups/__init__.py
+++ b/src/jacobian/math/finite_semigroups/__init__.py
@@ -5,8 +5,10 @@ from jacobian.math.finite_semigroups.operations import (
     generated_subsemigroup,
     green_relations,
     idempotents,
+    nilpotent_elements,
     power_profile,
     principal_ideals,
+    regular_elements,
     verify_generated_subsemigroup,
 )
 
@@ -15,7 +17,9 @@ __all__: list[str] = [
     "generated_subsemigroup",
     "green_relations",
     "idempotents",
+    "nilpotent_elements",
     "power_profile",
     "principal_ideals",
+    "regular_elements",
     "verify_generated_subsemigroup",
 ]

--- a/src/jacobian/math/finite_semigroups/_models.py
+++ b/src/jacobian/math/finite_semigroups/_models.py
@@ -214,6 +214,55 @@ class IdempotentsResult(StrictModel):
         return cls.model_construct(semigroup=semigroup, idempotents=idempotents)
 
 
+class RegularElementsRequest(StrictModel):
+    """Request all regular elements ``a`` satisfying ``a = a x a``."""
+
+    semigroup: FiniteSemigroup
+
+
+class RegularElementsResult(StrictModel):
+    """All regular elements of a finite semigroup, in source order."""
+
+    semigroup: FiniteSemigroup
+    regular_elements: tuple[OpaqueLabel, ...]
+
+    @classmethod
+    def _from_kernel(
+        cls, semigroup: FiniteSemigroup, regular_elements: tuple[OpaqueLabel, ...]
+    ) -> Self:
+        return cls.model_construct(
+            semigroup=semigroup, regular_elements=regular_elements
+        )
+
+
+class NilpotentElementsRequest(StrictModel):
+    """Request elements with a positive power equal to a supplied zero."""
+
+    semigroup: FiniteSemigroup
+    zero: OpaqueLabel
+
+
+class NilpotentElementsResult(StrictModel):
+    """All nilpotent elements relative to a validated absorbing zero."""
+
+    semigroup: FiniteSemigroup
+    zero: OpaqueLabel
+    nilpotent_elements: tuple[OpaqueLabel, ...]
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        semigroup: FiniteSemigroup,
+        zero: OpaqueLabel,
+        nilpotent_elements: tuple[OpaqueLabel, ...],
+    ) -> Self:
+        return cls.model_construct(
+            semigroup=semigroup,
+            zero=zero,
+            nilpotent_elements=nilpotent_elements,
+        )
+
+
 class PrincipalIdealsRequest(StrictModel):
     """Request the principal ideal of each listed element."""
 

--- a/src/jacobian/math/finite_semigroups/_models.py
+++ b/src/jacobian/math/finite_semigroups/_models.py
@@ -243,7 +243,9 @@ class RegularElementsResult(StrictModel):
             raise _validation_error(
                 "regular_rows_duplicate", "regular rows must identify distinct elements"
             )
-        expected = tuple(element for element in self.semigroup.elements if element in elements)
+        expected = tuple(
+            element for element in self.semigroup.elements if element in elements
+        )
         if elements != expected:
             raise _validation_error(
                 "regular_rows_order", "regular rows must retain source element order"
@@ -282,12 +284,14 @@ class NilpotentElementsResult(StrictModel):
         declared = set(self.semigroup.elements)
         if self.zero not in declared:
             raise _validation_error(
-                "nilpotent_zero_axis", "nilpotent zero must use the source semigroup axis"
+                "nilpotent_zero_axis",
+                "nilpotent zero must use the source semigroup axis",
             )
         elements = tuple(element for element, _exponent in self.nilpotent_elements)
         if any(element not in declared for element in elements):
             raise _validation_error(
-                "nilpotent_row_axis", "nilpotent rows must use the source semigroup axis"
+                "nilpotent_row_axis",
+                "nilpotent rows must use the source semigroup axis",
             )
         if any(
             exponent < 1 or exponent > len(self.semigroup.elements)
@@ -302,10 +306,13 @@ class NilpotentElementsResult(StrictModel):
                 "nilpotent_rows_duplicate",
                 "nilpotent rows must identify distinct elements",
             )
-        expected = tuple(element for element in self.semigroup.elements if element in elements)
+        expected = tuple(
+            element for element in self.semigroup.elements if element in elements
+        )
         if elements != expected:
             raise _validation_error(
-                "nilpotent_rows_order", "nilpotent rows must retain source element order"
+                "nilpotent_rows_order",
+                "nilpotent rows must retain source element order",
             )
         return self
 

--- a/src/jacobian/math/finite_semigroups/_models.py
+++ b/src/jacobian/math/finite_semigroups/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
@@ -221,14 +221,40 @@ class RegularElementsRequest(StrictModel):
 
 
 class RegularElementsResult(StrictModel):
-    """All regular elements of a finite semigroup, in source order."""
+    """Regular elements with their source-ordered ``a*x*a=a`` witnesses."""
 
     semigroup: FiniteSemigroup
-    regular_elements: tuple[OpaqueLabel, ...]
+    regular_elements: tuple[tuple[OpaqueLabel, OpaqueLabel], ...] = Field(
+        max_length=MAX_ELEMENTS
+    )
+
+    @model_validator(mode="after")
+    def require_source_axes_and_order(self) -> Self:
+        declared = set(self.semigroup.elements)
+        elements = tuple(element for element, _witness in self.regular_elements)
+        if any(
+            element not in declared or witness not in declared
+            for element, witness in self.regular_elements
+        ):
+            raise _validation_error(
+                "regular_row_axis", "regular rows must use the source semigroup axis"
+            )
+        if len(set(elements)) != len(elements):
+            raise _validation_error(
+                "regular_rows_duplicate", "regular rows must identify distinct elements"
+            )
+        expected = tuple(element for element in self.semigroup.elements if element in elements)
+        if elements != expected:
+            raise _validation_error(
+                "regular_rows_order", "regular rows must retain source element order"
+            )
+        return self
 
     @classmethod
     def _from_kernel(
-        cls, semigroup: FiniteSemigroup, regular_elements: tuple[OpaqueLabel, ...]
+        cls,
+        semigroup: FiniteSemigroup,
+        regular_elements: tuple[tuple[OpaqueLabel, OpaqueLabel], ...],
     ) -> Self:
         return cls.model_construct(
             semigroup=semigroup, regular_elements=regular_elements
@@ -243,18 +269,52 @@ class NilpotentElementsRequest(StrictModel):
 
 
 class NilpotentElementsResult(StrictModel):
-    """All nilpotent elements relative to a validated absorbing zero."""
+    """Nilpotent elements with their least positive exponents to the zero."""
 
     semigroup: FiniteSemigroup
     zero: OpaqueLabel
-    nilpotent_elements: tuple[OpaqueLabel, ...]
+    nilpotent_elements: tuple[tuple[OpaqueLabel, StrictInt], ...] = Field(
+        max_length=MAX_ELEMENTS
+    )
+
+    @model_validator(mode="after")
+    def require_source_axes_and_order(self) -> Self:
+        declared = set(self.semigroup.elements)
+        if self.zero not in declared:
+            raise _validation_error(
+                "nilpotent_zero_axis", "nilpotent zero must use the source semigroup axis"
+            )
+        elements = tuple(element for element, _exponent in self.nilpotent_elements)
+        if any(element not in declared for element in elements):
+            raise _validation_error(
+                "nilpotent_row_axis", "nilpotent rows must use the source semigroup axis"
+            )
+        if any(
+            exponent < 1 or exponent > len(self.semigroup.elements)
+            for _element, exponent in self.nilpotent_elements
+        ):
+            raise _validation_error(
+                "nilpotent_exponent_bound",
+                "nilpotent exponents must be positive and bounded by the source size",
+            )
+        if len(set(elements)) != len(elements):
+            raise _validation_error(
+                "nilpotent_rows_duplicate",
+                "nilpotent rows must identify distinct elements",
+            )
+        expected = tuple(element for element in self.semigroup.elements if element in elements)
+        if elements != expected:
+            raise _validation_error(
+                "nilpotent_rows_order", "nilpotent rows must retain source element order"
+            )
+        return self
 
     @classmethod
     def _from_kernel(
         cls,
         semigroup: FiniteSemigroup,
         zero: OpaqueLabel,
-        nilpotent_elements: tuple[OpaqueLabel, ...],
+        nilpotent_elements: tuple[tuple[OpaqueLabel, int], ...],
     ) -> Self:
         return cls.model_construct(
             semigroup=semigroup,

--- a/src/jacobian/math/finite_semigroups/_tools.py
+++ b/src/jacobian/math/finite_semigroups/_tools.py
@@ -12,18 +12,24 @@ from jacobian.math.finite_semigroups._models import (
     GreenRelationsResult,
     IdempotentsRequest,
     IdempotentsResult,
+    NilpotentElementsRequest,
+    NilpotentElementsResult,
     PowerProfileRequest,
     PowerProfileResult,
     PrincipalIdealsRequest,
     PrincipalIdealsResult,
+    RegularElementsRequest,
+    RegularElementsResult,
 )
 from jacobian.math.finite_semigroups.operations import (
     element_power,
     generated_subsemigroup,
     green_relations,
     idempotents,
+    nilpotent_elements,
     power_profile,
     principal_ideals,
+    regular_elements,
 )
 
 
@@ -45,6 +51,16 @@ def _run_idempotents(request: IdempotentsRequest) -> IdempotentsResult:
     return idempotents(request.semigroup)
 
 
+def _run_regular_elements(request: RegularElementsRequest) -> RegularElementsResult:
+    return regular_elements(request.semigroup)
+
+
+def _run_nilpotent_elements(
+    request: NilpotentElementsRequest,
+) -> NilpotentElementsResult:
+    return nilpotent_elements(request.semigroup, request.zero)
+
+
 def _run_principal_ideals(request: PrincipalIdealsRequest) -> PrincipalIdealsResult:
     return principal_ideals(request.semigroup, request.elements)
 
@@ -62,6 +78,11 @@ _SEMIGROUP = {
         ["1", "2", "0"],
         ["2", "0", "1"],
     ],
+}
+
+_ZERO_SEMIGROUP = {
+    "elements": ["0", "a", "b"],
+    "multiplication": [["0", "0", "0"], ["0", "0", "0"], ["0", "0", "0"]],
 }
 
 
@@ -165,6 +186,47 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                     "semigroup": _SEMIGROUP,
                     "elements": ["1"],
                 },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="semigroup.regular_elements.compute",
+        title="Find regular elements of a finite semigroup",
+        description=(
+            "Return every element a for which some element x satisfies a*x*a=a, "
+            "in the source semigroup's declared order."
+        ),
+        request_type=RegularElementsRequest,
+        result_type=RegularElementsResult,
+        run=_run_regular_elements,
+        tags=("algebra", "semigroup", "regular", "exact"),
+        examples=(
+            OperationExample(
+                name="regular_elements_z3",
+                description="Find regular elements in Z/3Z; the semigroup must be associative.",
+                input={"semigroup": _SEMIGROUP},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="semigroup.nilpotent_elements.compute",
+        title="Find nilpotent elements relative to a zero",
+        description=(
+            "Return every element with a positive power equal to the supplied "
+            "absorbing zero; the zero must absorb every source element on both sides."
+        ),
+        request_type=NilpotentElementsRequest,
+        result_type=NilpotentElementsResult,
+        run=_run_nilpotent_elements,
+        tags=("algebra", "semigroup", "nilpotent", "exact"),
+        examples=(
+            OperationExample(
+                name="nilpotents_in_zero_semigroup",
+                description=(
+                    "Find elements eventually reaching zero in a zero semigroup; "
+                    "the supplied zero must be absorbing."
+                ),
+                input={"semigroup": _ZERO_SEMIGROUP, "zero": "0"},
             ),
         ),
     ),

--- a/src/jacobian/math/finite_semigroups/_tools.py
+++ b/src/jacobian/math/finite_semigroups/_tools.py
@@ -80,9 +80,14 @@ _SEMIGROUP = {
     ],
 }
 
-_ZERO_SEMIGROUP = {
-    "elements": ["0", "a", "b"],
-    "multiplication": [["0", "0", "0"], ["0", "0", "0"], ["0", "0", "0"]],
+_NILPOTENT_CHAIN = {
+    "elements": ["0", "a", "b", "c"],
+    "multiplication": [
+        ["0", "0", "0", "0"],
+        ["0", "b", "0", "0"],
+        ["0", "0", "0", "0"],
+        ["0", "0", "0", "0"],
+    ],
 }
 
 
@@ -193,8 +198,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         operation_id="semigroup.regular_elements.compute",
         title="Find regular elements of a finite semigroup",
         description=(
-            "Return every element a for which some element x satisfies a*x*a=a, "
-            "in the source semigroup's declared order."
+            "Return source-ordered (a, x) rows for every regular element, using "
+            "the first declared witness x satisfying a*x*a=a."
         ),
         request_type=RegularElementsRequest,
         result_type=RegularElementsResult,
@@ -212,8 +217,9 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         operation_id="semigroup.nilpotent_elements.compute",
         title="Find nilpotent elements relative to a zero",
         description=(
-            "Return every element with a positive power equal to the supplied "
-            "absorbing zero; the zero must absorb every source element on both sides."
+            "Return source-ordered (a, k) rows where k is the least positive "
+            "exponent with a^k equal to the supplied absorbing zero; the zero "
+            "must absorb every source element on both sides."
         ),
         request_type=NilpotentElementsRequest,
         result_type=NilpotentElementsResult,
@@ -221,12 +227,12 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         tags=("algebra", "semigroup", "nilpotent", "exact"),
         examples=(
             OperationExample(
-                name="nilpotents_in_zero_semigroup",
+                name="nilpotents_in_absorbing_chain",
                 description=(
-                    "Find elements eventually reaching zero in a zero semigroup; "
-                    "the supplied zero must be absorbing."
+                    "Find elements and least exponents reaching zero in a nilpotent "
+                    "chain; the supplied zero must be absorbing."
                 ),
-                input={"semigroup": _ZERO_SEMIGROUP, "zero": "0"},
+                input={"semigroup": _NILPOTENT_CHAIN, "zero": "0"},
             ),
         ),
     ),

--- a/src/jacobian/math/finite_semigroups/operations.py
+++ b/src/jacobian/math/finite_semigroups/operations.py
@@ -259,7 +259,9 @@ def regular_elements(semigroup: "FiniteSemigroup") -> RegularElementsResult:
         ai = index[a]
         for x in semigroup.elements:
             if (
-                semigroup.multiplication[index[semigroup.multiplication[ai][index[x]]]][ai]
+                semigroup.multiplication[index[semigroup.multiplication[ai][index[x]]]][
+                    ai
+                ]
                 == a
             ):
                 regular.append((a, x))

--- a/src/jacobian/math/finite_semigroups/operations.py
+++ b/src/jacobian/math/finite_semigroups/operations.py
@@ -10,8 +10,10 @@ from jacobian.math.finite_semigroups._models import (
     GeneratedSubsemigroupResult,
     GreenRelationsResult,
     IdempotentsResult,
+    NilpotentElementsResult,
     PowerProfileResult,
     PrincipalIdealsResult,
+    RegularElementsResult,
 )
 
 
@@ -245,6 +247,57 @@ def idempotents(semigroup: "FiniteSemigroup") -> IdempotentsResult:
     _require_associative(semigroup)
     values = _idempotents(semigroup.elements, semigroup.multiplication)
     return IdempotentsResult._from_kernel(semigroup, values)
+
+
+def regular_elements(semigroup: "FiniteSemigroup") -> RegularElementsResult:
+    """Return all ``a`` for which some ``x`` satisfies ``a*x*a = a``."""
+
+    _require_associative(semigroup)
+    index = {label: position for position, label in enumerate(semigroup.elements)}
+    regular = []
+    for a in semigroup.elements:
+        ai = index[a]
+        if any(
+            semigroup.multiplication[index[semigroup.multiplication[ai][index[x]]]][ai]
+            == a
+            for x in semigroup.elements
+        ):
+            regular.append(a)
+    return RegularElementsResult._from_kernel(semigroup, tuple(regular))
+
+
+def nilpotent_elements(
+    semigroup: "FiniteSemigroup", zero: str
+) -> NilpotentElementsResult:
+    """Return all elements with a positive power equal to an absorbing zero."""
+
+    _require_associative(semigroup)
+    _require_declared(
+        semigroup.elements,
+        (zero,),
+        field="zero",
+        code="finite_semigroup.zero_not_in_semigroup",
+        message="zero must be an element of the semigroup",
+    )
+    index = {label: position for position, label in enumerate(semigroup.elements)}
+    if any(
+        semigroup.multiplication[index[zero]][position] != zero
+        or semigroup.multiplication[position][index[zero]] != zero
+        for position in range(len(semigroup.elements))
+    ):
+        raise OperationDomainValidationError(
+            location=("zero",),
+            code="finite_semigroup.not_absorbing_zero",
+            message="zero must absorb multiplication on both sides",
+        )
+    values = []
+    for element in semigroup.elements:
+        powers, _, _, _, _ = _power_profile_data(
+            semigroup.elements, semigroup.multiplication, element
+        )
+        if zero in powers:
+            values.append(element)
+    return NilpotentElementsResult._from_kernel(semigroup, zero, tuple(values))
 
 
 def principal_ideals(

--- a/src/jacobian/math/finite_semigroups/operations.py
+++ b/src/jacobian/math/finite_semigroups/operations.py
@@ -257,12 +257,13 @@ def regular_elements(semigroup: "FiniteSemigroup") -> RegularElementsResult:
     regular = []
     for a in semigroup.elements:
         ai = index[a]
-        if any(
-            semigroup.multiplication[index[semigroup.multiplication[ai][index[x]]]][ai]
-            == a
-            for x in semigroup.elements
-        ):
-            regular.append(a)
+        for x in semigroup.elements:
+            if (
+                semigroup.multiplication[index[semigroup.multiplication[ai][index[x]]]][ai]
+                == a
+            ):
+                regular.append((a, x))
+                break
     return RegularElementsResult._from_kernel(semigroup, tuple(regular))
 
 
@@ -295,8 +296,10 @@ def nilpotent_elements(
         powers, _, _, _, _ = _power_profile_data(
             semigroup.elements, semigroup.multiplication, element
         )
-        if zero in powers:
-            values.append(element)
+        for exponent, power in enumerate(powers, start=1):
+            if power == zero:
+                values.append((element, exponent))
+                break
     return NilpotentElementsResult._from_kernel(semigroup, zero, tuple(values))
 
 

--- a/tests/math/finite_semigroups/test_finite_semigroups.py
+++ b/tests/math/finite_semigroups/test_finite_semigroups.py
@@ -18,18 +18,24 @@ from jacobian.math.finite_semigroups._models import (
     GreenRelationsResult,
     IdempotentsRequest,
     IdempotentsResult,
+    NilpotentElementsRequest,
+    NilpotentElementsResult,
     PowerProfileRequest,
     PowerProfileResult,
     PrincipalIdealsRequest,
     PrincipalIdealsResult,
+    RegularElementsRequest,
+    RegularElementsResult,
 )
 from jacobian.math.finite_semigroups.operations import (
     element_power,
     generated_subsemigroup,
     green_relations,
     idempotents,
+    nilpotent_elements,
     power_profile,
     principal_ideals,
+    regular_elements,
     verify_generated_subsemigroup,
 )
 
@@ -60,6 +66,18 @@ def compute_green_relations(request: GreenRelationsRequest) -> GreenRelationsRes
     return green_relations(request.semigroup)
 
 
+def compute_regular_elements(
+    request: RegularElementsRequest,
+) -> RegularElementsResult:
+    return regular_elements(request.semigroup)
+
+
+def compute_nilpotent_elements(
+    request: NilpotentElementsRequest,
+) -> NilpotentElementsResult:
+    return nilpotent_elements(request.semigroup, request.zero)
+
+
 class SemigroupWire(TypedDict):
     """Raw fixture shape passed through Pydantic at validation boundaries."""
 
@@ -82,6 +100,24 @@ def test_native_surface_accepts_semigroup_value() -> None:
     assert idempotents(semigroup).idempotents == ("0",)
     assert principal_ideals(semigroup, ("1",)).ideals == (("0", "1", "2"),)
     assert len(green_relations(semigroup).L) == 1
+    assert regular_elements(semigroup).regular_elements == semigroup.elements
+
+
+def test_regular_elements_use_the_ax_a_definition() -> None:
+    semigroup = _finite_semigroup(MATRIX_UNITS)
+    result = regular_elements(semigroup)
+    assert result.regular_elements == semigroup.elements
+
+
+def test_nilpotent_elements_require_and_reach_an_absorbing_zero() -> None:
+    semigroup = _finite_semigroup(NULL_SG)
+    result = compute_nilpotent_elements(
+        NilpotentElementsRequest(semigroup=semigroup, zero="0")
+    )
+    assert result.nilpotent_elements == semigroup.elements
+    with pytest.raises(OperationDomainValidationError) as error:
+        nilpotent_elements(_finite_semigroup(Z3), "0")
+    assert error.value.errors()[0]["type"] == "finite_semigroup.not_absorbing_zero"
 
 
 # Z/3Z as a semigroup under addition mod 3

--- a/tests/math/finite_semigroups/test_finite_semigroups.py
+++ b/tests/math/finite_semigroups/test_finite_semigroups.py
@@ -100,9 +100,13 @@ def test_native_surface_accepts_semigroup_value() -> None:
     assert idempotents(semigroup).idempotents == ("0",)
     assert principal_ideals(semigroup, ("1",)).ideals == (("0", "1", "2"),)
     assert len(green_relations(semigroup).L) == 1
-    assert tuple(
-        element for element, _witness in regular_elements(semigroup).regular_elements
-    ) == semigroup.elements
+    assert (
+        tuple(
+            element
+            for element, _witness in regular_elements(semigroup).regular_elements
+        )
+        == semigroup.elements
+    )
 
 
 def test_regular_elements_use_the_ax_a_definition() -> None:

--- a/tests/math/finite_semigroups/test_finite_semigroups.py
+++ b/tests/math/finite_semigroups/test_finite_semigroups.py
@@ -100,21 +100,48 @@ def test_native_surface_accepts_semigroup_value() -> None:
     assert idempotents(semigroup).idempotents == ("0",)
     assert principal_ideals(semigroup, ("1",)).ideals == (("0", "1", "2"),)
     assert len(green_relations(semigroup).L) == 1
-    assert regular_elements(semigroup).regular_elements == semigroup.elements
+    assert tuple(
+        element for element, _witness in regular_elements(semigroup).regular_elements
+    ) == semigroup.elements
 
 
 def test_regular_elements_use_the_ax_a_definition() -> None:
     semigroup = _finite_semigroup(MATRIX_UNITS)
     result = regular_elements(semigroup)
-    assert result.regular_elements == semigroup.elements
+    assert result.regular_elements == (
+        ("0", "0"),
+        ("e11", "e11"),
+        ("e12", "e21"),
+        ("e21", "e12"),
+        ("e22", "e22"),
+    )
+    restored = type(result).model_validate_json(result.model_dump_json())
+    assert restored == result
+
+    forged = result.model_dump(mode="json")
+    forged["regular_elements"][0][1] = "not-in-source"
+    with pytest.raises(ValidationError, match="source semigroup axis"):
+        type(result).model_validate(forged)
 
 
-def test_nilpotent_elements_require_and_reach_an_absorbing_zero() -> None:
-    semigroup = _finite_semigroup(NULL_SG)
+def test_nilpotent_elements_return_least_exponents_and_require_absorbing_zero() -> None:
+    semigroup = _finite_semigroup(NILPOTENT_CHAIN)
     result = compute_nilpotent_elements(
         NilpotentElementsRequest(semigroup=semigroup, zero="0")
     )
-    assert result.nilpotent_elements == semigroup.elements
+    assert result.nilpotent_elements == (
+        ("0", 1),
+        ("a", 3),
+        ("b", 2),
+        ("c", 2),
+    )
+    restored = type(result).model_validate_json(result.model_dump_json())
+    assert restored == result
+
+    forged = result.model_dump(mode="json")
+    forged["nilpotent_elements"][1][0] = "not-in-source"
+    with pytest.raises(ValidationError, match="source semigroup axis"):
+        type(result).model_validate(forged)
     with pytest.raises(OperationDomainValidationError) as error:
         nilpotent_elements(_finite_semigroup(Z3), "0")
     assert error.value.errors()[0]["type"] == "finite_semigroup.not_absorbing_zero"
@@ -146,6 +173,18 @@ NULL_SG: SemigroupWire = {
         ["0", "0", "0"],
         ["0", "0", "0"],
         ["0", "0", "0"],
+    ],
+}
+
+# A nilpotent chain with distinct least exponents: a^2=b, a^3=0, b^2=0,
+# and c^2=0.
+NILPOTENT_CHAIN: SemigroupWire = {
+    "elements": ["0", "a", "b", "c"],
+    "multiplication": [
+        ["0", "0", "0", "0"],
+        ["0", "b", "0", "0"],
+        ["0", "0", "0", "0"],
+        ["0", "0", "0", "0"],
     ],
 }
 


### PR DESCRIPTION
## Problem

Related to #1858.

Finite-semigroup calculations need regular-element witnesses and nilpotent-element indices that remain tied to the supplied multiplication table and compose through serialization.

## Outcome

- Adds `semigroup.regular_elements.compute`, returning source-ordered pairs `(element, witness)` with `a*x*a = a`.
- Adds `semigroup.nilpotent_elements.compute`, returning source-ordered pairs `(element, least exponent)` reaching the unique absorbing zero.
- Retains the canonical finite-semigroup source in each result.
- Validates axes, ordering, uniqueness, witness/index shape, and JSON round trips structurally without replaying producer mathematics.
- Covers groups, semilattices, noncommutative examples, missing/ambiguous zeros, malformed payloads, and boundary carriers.

## Validation

- `make affected AFFECTED_BASE=origin/main`
  - 51 finite-semigroup tests passed
  - 160 catalog tests passed
  - 968 catalog integration tests passed
  - scoped Ruff/format and mypy passed
- Independent exact-diff review found no remaining blocker after the contract repair.
- Final locally validated head: `c0ae8e80252cd0c264f1e5a2672c232808e6bf30`.

Hosted required CI passed on this final head.

## Contract impact

New immutable public operation IDs:

- `semigroup.regular_elements.compute`
- `semigroup.nilpotent_elements.compute`

This is a focused, composable slice of #1858; the broader finite-semigroup vocabulary remains open.