### PR TITLE
feat(number-theory): add bounded quadratic-surd approximation

### DIFF
--- a/src/jacobian/math/number_theory/diophantine_approximation/__init__.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/__init__.py
@@ -3,7 +3,21 @@
 from jacobian.math.number_theory.diophantine_approximation.operations import (
     continued_fraction,
     convergents,
+    nearest_integer_distance,
+    range_profile,
+    record_minima,
+    scaled_floor,
+    simultaneous_product,
     solve_pell,
 )
 
-__all__ = ["continued_fraction", "convergents", "solve_pell"]
+__all__ = [
+    "continued_fraction",
+    "convergents",
+    "nearest_integer_distance",
+    "range_profile",
+    "record_minima",
+    "scaled_floor",
+    "simultaneous_product",
+    "solve_pell",
+]

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
@@ -13,29 +13,27 @@ from math import isqrt
 from typing import Literal
 
 from jacobian._exact import CanonicalRational
+from jacobian._execution import request_checkpoint
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
 )
 from jacobian.math.analysis.intervals import ClosedRationalInterval
 from jacobian.math.number_theory.diophantine_approximation._surd_models import (
+    MAX_RANGE_LENGTH,
+    MAX_SIMULTANEOUS_RADICANDS,
     MAX_SURD_MULTIPLIER_BITS,
     MAX_SURD_RADICAND,
     MAX_SURD_RANGE_ALLOCATION_UNITS,
     MAX_SURD_RANGE_INTERMEDIATE_BITS,
     MAX_SURD_RANGE_WORK,
     MAX_SURD_SCALE_BITS,
-    NearestIntegerDistanceRequest,
     NearestIntegerDistanceValue,
-    RangeProfileRequest,
     RangeProfileResult,
     RangeProfileRow,
-    RecordMinimaRequest,
     RecordMinimaResult,
     RecordMinimumValue,
-    ScaledFloorRequest,
     ScaledFloorValue,
-    SimultaneousProductRequest,
     SimultaneousProductResult,
     bound_enclosure,
     is_surd_radicand,
@@ -50,7 +48,13 @@ __all__ = [
 ]
 
 
-def _require_request_multiplier(multiplier: int) -> None:
+def _require_multiplier(multiplier: int) -> None:
+    if type(multiplier) is not int:
+        raise OperationDomainValidationError(
+            location=("multiplier",),
+            code="diophantine.multiplier_type",
+            message="multiplier must be a strict integer",
+        )
     if multiplier.bit_length() > MAX_SURD_MULTIPLIER_BITS:
         raise OperationResourceAdmissionError(
             location=("multiplier",),
@@ -66,7 +70,11 @@ def _require_request_multiplier(multiplier: int) -> None:
 
 
 def _require_surd_radicand(radicand: int, *, location: tuple[str, ...]) -> None:
-    if not (2 <= radicand <= MAX_SURD_RADICAND) or not is_surd_radicand(radicand):
+    if (
+        type(radicand) is not int
+        or not (2 <= radicand <= MAX_SURD_RADICAND)
+        or not is_surd_radicand(radicand)
+    ):
         raise OperationDomainValidationError(
             location=location,
             code="diophantine.surd_radicand_must_not_be_square",
@@ -75,12 +83,31 @@ def _require_surd_radicand(radicand: int, *, location: tuple[str, ...]) -> None:
 
 
 def _require_surd_axis(radicands: tuple[int, ...]) -> None:
+    if (
+        type(radicands) is not tuple
+        or not 1 <= len(radicands) <= MAX_SIMULTANEOUS_RADICANDS
+    ):
+        raise OperationDomainValidationError(
+            location=("radicands",),
+            code="diophantine.surd_radicands_out_of_range",
+            message="radicands must be a tuple with one through eight entries",
+        )
     for index, radicand in enumerate(radicands):
         _require_surd_radicand(radicand, location=("radicands", str(index)))
+    if len(set(radicands)) != len(radicands):
+        raise OperationDomainValidationError(
+            location=("radicands",),
+            code="diophantine.surd_radicands_must_be_distinct",
+            message="an ordered radicand axis requires distinct radicands",
+        )
 
 
 def _require_scale_bits(scale_bits: int) -> None:
-    if scale_bits < 1 or scale_bits > MAX_SURD_SCALE_BITS:
+    if (
+        type(scale_bits) is not int
+        or scale_bits < 1
+        or scale_bits > MAX_SURD_SCALE_BITS
+    ):
         raise OperationDomainValidationError(
             location=("scale_bits",),
             code="diophantine.scale_bits_out_of_range",
@@ -108,7 +135,7 @@ def _scaled_floor_row(multiplier: int, radicand: int) -> ScaledFloorValue:
             code="diophantine.scaled_floor_must_be_irrational",
             message="a scaled quadratic-surd floor requires a nonsquare radicand",
         )
-    return ScaledFloorValue(
+    return ScaledFloorValue._from_kernel(
         multiplier=multiplier,
         radicand=radicand,
         floor=floor,
@@ -152,35 +179,29 @@ def _distance_value(
     ceiling_distance_lower = Fraction(row.ceiling) - radical_upper
     ceiling_distance_upper = Fraction(row.ceiling) - radical_lower
 
-    # Strict separation is required: touching enclosures leave the branch
-    # mathematically undecided, so they must not be read as a tie-break.
+    # The midpoint comparison is exact.  The radical cannot equal this
+    # rational midpoint because the radicand is nonsquare, so even a coarse
+    # dyadic bracket can choose the nearest branch without guessing.
     side: Literal["FLOOR", "CEILING"]
-    if floor_distance_upper < ceiling_distance_lower:
+    radical_square_twice = 4 * radicand * multiplier * multiplier
+    midpoint_square = (2 * row.floor + 1) * (2 * row.floor + 1)
+    if radical_square_twice < midpoint_square:
         side = "FLOOR"
         lower, upper = floor_distance_lower, floor_distance_upper
         upper_scaled = scaled_floor + 1 - row.floor * scale
-    elif ceiling_distance_upper < floor_distance_lower:
+    elif radical_square_twice > midpoint_square:
         side = "CEILING"
         lower, upper = ceiling_distance_lower, ceiling_distance_upper
         upper_scaled = row.ceiling * scale - scaled_floor
     else:
-        # Overlapping branches mean the requested precision cannot separate the
-        # nearest integer; that is a caller error, never a guessed branch.
-        raise OperationDomainValidationError(
-            location=("scale_bits",),
-            code="diophantine.nearest_integer_branch_unresolved",
-            message=(
-                "the requested scale_bits does not separate the nearest integer "
-                "branch for this multiplier and radicand"
-            ),
-        )
+        raise AssertionError("a nonsquare quadratic radical cannot equal a midpoint")
 
     # The distance enclosure is nonnegative and ordered; both endpoints are
     # exact rationals, and neither endpoint is negative by construction.
     interval = bound_enclosure(
         _interval(max(lower, Fraction(0)), upper), label="nearest-integer distance"
     )
-    return NearestIntegerDistanceValue(
+    return NearestIntegerDistanceValue._from_kernel(
         multiplier=multiplier,
         radicand=radicand,
         floor=row.floor,
@@ -211,22 +232,22 @@ def _product_enclosure(
     return bound_enclosure(_interval(lower, upper), label="simultaneous product")
 
 
-def _range_admission(request: RangeProfileRequest) -> None:
+def _range_admission(radicands: tuple[int, ...], limit: int, scale_bits: int) -> None:
     """Admit complete range expansion before allocating any result rows."""
 
-    _require_request_multiplier(request.limit)
-    radicand_count = len(request.radicands)
-    multiplier_bits = request.limit.bit_length()
+    _require_multiplier(limit)
+    radicand_count = len(radicands)
+    multiplier_bits = limit.bit_length()
     radicand_bits = MAX_SURD_RADICAND.bit_length()
     scalar_bits = max(
-        radicand_bits + 2 * multiplier_bits + request.scale_bits + 2,
-        request.scale_bits + 2,
+        radicand_bits + 2 * multiplier_bits + scale_bits + 2,
+        scale_bits + 2,
     )
-    product_bits = multiplier_bits + radicand_count * (request.scale_bits + 2)
-    work = request.limit * radicand_count * (request.scale_bits + scalar_bits)
-    intermediate_bits = request.limit * radicand_count * scalar_bits
+    product_bits = multiplier_bits + radicand_count * (scale_bits + 2)
+    work = limit * radicand_count * (scale_bits + scalar_bits)
+    intermediate_bits = limit * radicand_count * scalar_bits
     row_units = radicand_count * (12 * scalar_bits + 512) + 4 * product_bits + 1_024
-    allocation_units = request.limit * row_units + radicand_count * 32 + 256
+    allocation_units = limit * row_units + radicand_count * 32 + 256
     if work > MAX_SURD_RANGE_WORK:
         raise OperationResourceAdmissionError(
             location=("limit", "scale_bits"),
@@ -249,127 +270,115 @@ def _range_admission(request: RangeProfileRequest) -> None:
         )
 
 
-def scaled_floor(request: ScaledFloorRequest) -> ScaledFloorValue:
+def scaled_floor(multiplier: int, radicand: int) -> ScaledFloorValue:
     """Return one exact ``floor``/``ceiling`` value derived from integer squares."""
 
-    _require_request_multiplier(request.multiplier)
-    _require_surd_radicand(request.radicand, location=("radicand",))
-    return _scaled_floor_row(request.multiplier, request.radicand)
+    _require_multiplier(multiplier)
+    _require_surd_radicand(radicand, location=("radicand",))
+    return _scaled_floor_row(multiplier, radicand)
 
 
 def nearest_integer_distance(
-    request: NearestIntegerDistanceRequest,
+    multiplier: int,
+    radicand: int,
+    scale_bits: int,
 ) -> NearestIntegerDistanceValue:
     """Certify the distance from ``n sqrt(d)`` to its nearest integer."""
 
-    _require_request_multiplier(request.multiplier)
-    _require_scale_bits(request.scale_bits)
-    _require_surd_radicand(request.radicand, location=("radicand",))
-    return _distance_value(request.multiplier, request.radicand, request.scale_bits)
+    _require_multiplier(multiplier)
+    _require_scale_bits(scale_bits)
+    _require_surd_radicand(radicand, location=("radicand",))
+    return _distance_value(multiplier, radicand, scale_bits)
 
 
 def simultaneous_product(
-    request: SimultaneousProductRequest,
+    multiplier: int,
+    radicands: tuple[int, ...],
+    scale_bits: int,
 ) -> SimultaneousProductResult:
     """Certify ``n * prod_i ||n sqrt(d_i)||`` and every factor row."""
 
-    _require_request_multiplier(request.multiplier)
-    _require_scale_bits(request.scale_bits)
-    _require_surd_axis(request.radicands)
+    _require_multiplier(multiplier)
+    _require_scale_bits(scale_bits)
+    _require_surd_axis(radicands)
     factors = tuple(
-        _distance_value(request.multiplier, radicand, request.scale_bits)
-        for radicand in request.radicands
+        _distance_value(multiplier, radicand, scale_bits) for radicand in radicands
     )
-    return SimultaneousProductResult(
-        multiplier=request.multiplier,
-        radicands=request.radicands,
-        scale_bits=request.scale_bits,
+    return SimultaneousProductResult._from_kernel(
+        multiplier=multiplier,
+        radicands=radicands,
+        scale_bits=scale_bits,
         factors=factors,
-        product_enclosure=_product_enclosure(request.multiplier, factors),
+        product_enclosure=_product_enclosure(multiplier, factors),
     )
 
 
-def _compute_range_profile(request: RangeProfileRequest) -> RangeProfileResult:
+def _compute_range_profile(
+    radicands: tuple[int, ...], limit: int, scale_bits: int
+) -> RangeProfileResult:
     rows = []
-    for multiplier in range(1, request.limit + 1):
-        try:
-            factors = tuple(
-                _distance_value(multiplier, radicand, request.scale_bits)
-                for radicand in request.radicands
-            )
-        except OperationDomainValidationError as error:
-            if error.errors()[0]["type"] != (
-                "diophantine.nearest_integer_branch_unresolved"
-            ):
-                raise
-            # Completeness is a contract: reject the whole range with the
-            # first unresolvable row instead of returning a short profile.
-            raise OperationDomainValidationError(
-                location=("scale_bits",),
-                code="diophantine.range_profile_unresolved_row",
-                message=(
-                    "the declared scale_bits cannot resolve the nearest-integer "
-                    f"branch of row n={multiplier}; raise scale_bits or lower limit"
-                ),
-            ) from error
+    for multiplier in range(1, limit + 1):
+        request_checkpoint("during quadratic-surd range profile")
+        factors = tuple(
+            _distance_value(multiplier, radicand, scale_bits) for radicand in radicands
+        )
+        product_enclosure = _product_enclosure(multiplier, factors)
         rows.append(
-            RangeProfileRow(
+            RangeProfileRow._from_kernel(
                 multiplier=multiplier,
                 factors=factors,
-                product_enclosure=_product_enclosure(multiplier, factors),
+                product_enclosure=product_enclosure,
             )
         )
-    return RangeProfileResult(
-        radicands=request.radicands,
-        limit=request.limit,
-        scale_bits=request.scale_bits,
+    return RangeProfileResult._from_kernel(
+        radicands=radicands,
+        limit=limit,
+        scale_bits=scale_bits,
         rows=tuple(rows),
     )
 
 
-def range_profile(request: RangeProfileRequest) -> RangeProfileResult:
+def range_profile(
+    radicands: tuple[int, ...], limit: int, scale_bits: int
+) -> RangeProfileResult:
     """Return a complete certified row for every ``1 <= n <= limit``."""
 
-    _require_scale_bits(request.scale_bits)
-    _require_surd_axis(request.radicands)
-    _range_admission(request)
-    return _compute_range_profile(request)
+    _require_scale_bits(scale_bits)
+    _require_surd_axis(radicands)
+    if type(limit) is not int or not 1 <= limit <= MAX_RANGE_LENGTH:
+        raise OperationDomainValidationError(
+            location=("limit",),
+            code="diophantine.limit_out_of_range",
+            message=(f"limit must be an integer between 1 and {MAX_RANGE_LENGTH}"),
+        )
+    _range_admission(radicands, limit, scale_bits)
+    return _compute_range_profile(radicands, limit, scale_bits)
 
 
-def record_minima(request: RecordMinimaRequest) -> RecordMinimaResult:
+def record_minima(
+    radicands: tuple[int, ...], limit: int, scale_bits: int
+) -> RecordMinimaResult:
     """Extract strict record minima, or report the first unseparated comparison.
 
-    A new strict record requires its product enclosure to lie strictly below
-    every prior incumbent enclosure.  When an enclosure overlaps the incumbent
-    the comparison is mathematically undecided at this precision, so the result
-    reports ``UNRESOLVED`` with both enclosures instead of guessing an order.
+    A new strict record requires its product enclosure to lie at or below the
+    prior incumbent's lower endpoint.  Equality is sufficient because the
+    irrational products lie strictly inside their outward enclosures.  When
+    the enclosures overlap beyond that endpoint the comparison is undecided at
+    this precision, so the result reports ``UNRESOLVED`` instead of guessing.
     """
 
-    _require_scale_bits(request.scale_bits)
-    _require_surd_axis(request.radicands)
-    profile_request = RangeProfileRequest(
-        radicands=request.radicands,
-        limit=request.limit,
-        scale_bits=request.scale_bits,
-    )
-    _range_admission(profile_request)
-    profile = _compute_range_profile(
-        RangeProfileRequest(
-            radicands=request.radicands,
-            limit=request.limit,
-            scale_bits=request.scale_bits,
-        )
-    )
+    profile = range_profile(radicands, limit, scale_bits)
     records: list[RecordMinimumValue] = []
     incumbent: ClosedRationalInterval | None = None
     incumbent_lower = Fraction(0)
     for row in profile.rows:
+        request_checkpoint("during quadratic-surd record scan")
         candidate = row.product_enclosure
         candidate_lower = candidate.lower.as_fraction()
         candidate_upper = candidate.upper.as_fraction()
         if incumbent is None:
             records.append(
-                RecordMinimumValue(
+                RecordMinimumValue._from_kernel(
                     multiplier=row.multiplier,
                     product_enclosure=candidate,
                     incumbent_enclosure=candidate,
@@ -378,9 +387,9 @@ def record_minima(request: RecordMinimaRequest) -> RecordMinimaResult:
             incumbent = candidate
             incumbent_lower = candidate_lower
             continue
-        if candidate_upper < incumbent_lower:
+        if candidate_upper <= incumbent_lower:
             records.append(
-                RecordMinimumValue(
+                RecordMinimumValue._from_kernel(
                     multiplier=row.multiplier,
                     product_enclosure=candidate,
                     incumbent_enclosure=incumbent,
@@ -391,17 +400,16 @@ def record_minima(request: RecordMinimaRequest) -> RecordMinimaResult:
             continue
         incumbent_upper = incumbent.upper.as_fraction()
         if incumbent_upper <= candidate_lower:
-            # The candidate is provably no smaller than the incumbent.  This
-            # includes touching intervals: equality is not a strict record.
+            # The candidate is provably no smaller than the incumbent.
             continue
         # The intervals overlap (or the candidate reaches below the incumbent
         # while its lower endpoint does not establish a new record).  Either
         # ordering is possible at this precision, so make no record claim.
         if candidate_lower < incumbent_upper:
-            return RecordMinimaResult(
-                radicands=request.radicands,
-                limit=request.limit,
-                scale_bits=request.scale_bits,
+            return RecordMinimaResult._from_kernel(
+                radicands=radicands,
+                limit=limit,
+                scale_bits=scale_bits,
                 outcome="UNRESOLVED",
                 records=tuple(records),
                 unresolved_multiplier=row.multiplier,
@@ -409,10 +417,10 @@ def record_minima(request: RecordMinimaRequest) -> RecordMinimaResult:
                 unresolved_incumbent_enclosure=incumbent,
             )
         raise AssertionError("record interval comparison was not classified")
-    return RecordMinimaResult(
-        radicands=request.radicands,
-        limit=request.limit,
-        scale_bits=request.scale_bits,
+    return RecordMinimaResult._from_kernel(
+        radicands=radicands,
+        limit=limit,
+        scale_bits=scale_bits,
         outcome="COMPLETE",
         records=tuple(records),
         finite_argmin=records[-1].multiplier,

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
@@ -20,6 +20,10 @@ from jacobian.catalog.models import (
 from jacobian.math.analysis.intervals import ClosedRationalInterval
 from jacobian.math.number_theory.diophantine_approximation._surd_models import (
     MAX_SURD_MULTIPLIER_BITS,
+    MAX_SURD_RADICAND,
+    MAX_SURD_RANGE_INTERMEDIATE_BITS,
+    MAX_SURD_RANGE_OUTPUT_BYTES,
+    MAX_SURD_RANGE_WORK,
     MAX_SURD_SCALE_BITS,
     NearestIntegerDistanceRequest,
     NearestIntegerDistanceValue,
@@ -30,11 +34,11 @@ from jacobian.math.number_theory.diophantine_approximation._surd_models import (
     RecordMinimaResult,
     RecordMinimumValue,
     ScaledFloorRequest,
-    ScaledFloorResult,
     ScaledFloorValue,
     SimultaneousProductRequest,
     SimultaneousProductResult,
     bound_enclosure,
+    is_surd_radicand,
 )
 
 __all__ = [
@@ -59,6 +63,20 @@ def _require_request_multiplier(multiplier: int) -> None:
             code="diophantine.multiplier_out_of_range",
             message="multiplier must be at least 1",
         )
+
+
+def _require_surd_radicand(radicand: int, *, location: tuple[str, ...]) -> None:
+    if not (2 <= radicand <= MAX_SURD_RADICAND) or not is_surd_radicand(radicand):
+        raise OperationDomainValidationError(
+            location=location,
+            code="diophantine.surd_radicand_must_not_be_square",
+            message="a quadratic irrational requires a nonsquare radicand",
+        )
+
+
+def _require_surd_axis(radicands: tuple[int, ...]) -> None:
+    for index, radicand in enumerate(radicands):
+        _require_surd_radicand(radicand, location=("radicands", str(index)))
 
 
 def _require_scale_bits(scale_bits: int) -> None:
@@ -193,13 +211,48 @@ def _product_enclosure(
     return bound_enclosure(_interval(lower, upper), label="simultaneous product")
 
 
-def scaled_floor(request: ScaledFloorRequest) -> ScaledFloorResult:
-    """Return exact ``floor``/``ceiling`` rows derived from integer squares."""
+def _range_admission(request: RangeProfileRequest) -> None:
+    """Admit complete range expansion before allocating any result rows."""
+
+    _require_request_multiplier(request.limit)
+    radicand_count = len(request.radicands)
+    multiplier_bits = request.limit.bit_length()
+    radicand_bits = MAX_SURD_RADICAND.bit_length()
+    scalar_bits = max(
+        radicand_bits + 2 * multiplier_bits + request.scale_bits + 2,
+        request.scale_bits + 2,
+    )
+    product_bits = multiplier_bits + radicand_count * (request.scale_bits + 2)
+    work = request.limit * radicand_count * (request.scale_bits + scalar_bits)
+    intermediate_bits = request.limit * radicand_count * scalar_bits
+    row_bytes = radicand_count * (12 * scalar_bits + 512) + 4 * product_bits + 1_024
+    output_bytes = request.limit * row_bytes + radicand_count * 32 + 256
+    if work > MAX_SURD_RANGE_WORK:
+        raise OperationResourceAdmissionError(
+            location=("limit", "scale_bits"),
+            code="diophantine.range_profile_work_bound",
+            message="range expansion exceeds the admitted exact-work bound",
+        )
+    if intermediate_bits > MAX_SURD_RANGE_INTERMEDIATE_BITS:
+        raise OperationResourceAdmissionError(
+            location=("limit", "scale_bits"),
+            code="diophantine.range_profile_intermediate_bound",
+            message="range expansion exceeds the admitted intermediate-size bound",
+        )
+    if output_bytes > MAX_SURD_RANGE_OUTPUT_BYTES:
+        raise OperationResourceAdmissionError(
+            location=("limit", "scale_bits"),
+            code="diophantine.range_profile_output_bound",
+            message="the complete serialized range exceeds the admitted output bound",
+        )
+
+
+def scaled_floor(request: ScaledFloorRequest) -> ScaledFloorValue:
+    """Return one exact ``floor``/``ceiling`` value derived from integer squares."""
 
     _require_request_multiplier(request.multiplier)
-    return ScaledFloorResult(
-        rows=(_scaled_floor_row(request.multiplier, request.radicand),)
-    )
+    _require_surd_radicand(request.radicand, location=("radicand",))
+    return _scaled_floor_row(request.multiplier, request.radicand)
 
 
 def nearest_integer_distance(
@@ -209,6 +262,7 @@ def nearest_integer_distance(
 
     _require_request_multiplier(request.multiplier)
     _require_scale_bits(request.scale_bits)
+    _require_surd_radicand(request.radicand, location=("radicand",))
     return _distance_value(request.multiplier, request.radicand, request.scale_bits)
 
 
@@ -219,6 +273,7 @@ def simultaneous_product(
 
     _require_request_multiplier(request.multiplier)
     _require_scale_bits(request.scale_bits)
+    _require_surd_axis(request.radicands)
     factors = tuple(
         _distance_value(request.multiplier, radicand, request.scale_bits)
         for radicand in request.radicands
@@ -232,10 +287,7 @@ def simultaneous_product(
     )
 
 
-def range_profile(request: RangeProfileRequest) -> RangeProfileResult:
-    """Return a complete certified row for every ``1 <= n <= limit``."""
-
-    _require_scale_bits(request.scale_bits)
+def _compute_range_profile(request: RangeProfileRequest) -> RangeProfileResult:
     rows = []
     for multiplier in range(1, request.limit + 1):
         try:
@@ -273,6 +325,15 @@ def range_profile(request: RangeProfileRequest) -> RangeProfileResult:
     )
 
 
+def range_profile(request: RangeProfileRequest) -> RangeProfileResult:
+    """Return a complete certified row for every ``1 <= n <= limit``."""
+
+    _require_scale_bits(request.scale_bits)
+    _require_surd_axis(request.radicands)
+    _range_admission(request)
+    return _compute_range_profile(request)
+
+
 def record_minima(request: RecordMinimaRequest) -> RecordMinimaResult:
     """Extract strict record minima, or report the first unseparated comparison.
 
@@ -282,7 +343,15 @@ def record_minima(request: RecordMinimaRequest) -> RecordMinimaResult:
     reports ``UNRESOLVED`` with both enclosures instead of guessing an order.
     """
 
-    profile = range_profile(
+    _require_scale_bits(request.scale_bits)
+    _require_surd_axis(request.radicands)
+    profile_request = RangeProfileRequest(
+        radicands=request.radicands,
+        limit=request.limit,
+        scale_bits=request.scale_bits,
+    )
+    _range_admission(profile_request)
+    profile = _compute_range_profile(
         RangeProfileRequest(
             radicands=request.radicands,
             limit=request.limit,

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
@@ -1,0 +1,336 @@
+"""Certified finite quadratic-surd arithmetic on exact integer squares.
+
+Every enclosure below is derived from ``isqrt`` of an exact integer, so the
+bounds are exact rationals rather than floating-point approximations, and the
+only irrational input is a nonsquare radicand.  Refinement is monotone because
+a larger binary scale only subdivides the same integer-square bracket.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from math import isqrt
+
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+from jacobian.math.number_theory.diophantine_approximation._surd_models import (
+    MAX_SURD_SCALE_BITS,
+    NearestIntegerDistanceRequest,
+    NearestIntegerDistanceValue,
+    RangeProfileRequest,
+    RangeProfileResult,
+    RangeProfileRow,
+    RecordMinimaRequest,
+    RecordMinimaResult,
+    RecordMinimumValue,
+    ScaledFloorRequest,
+    ScaledFloorResult,
+    ScaledFloorValue,
+    SimultaneousProductRequest,
+    SimultaneousProductResult,
+    bound_enclosure,
+)
+
+__all__ = [
+    "nearest_integer_distance",
+    "range_profile",
+    "record_minima",
+    "scaled_floor",
+    "simultaneous_product",
+]
+
+
+def _require_request_multiplier(multiplier: int) -> None:
+    if multiplier < 1:
+        raise OperationDomainValidationError(
+            location=("multiplier",),
+            code="diophantine.multiplier_out_of_range",
+            message="multiplier must be at least 1",
+        )
+
+
+def _require_scale_bits(scale_bits: int) -> None:
+    if scale_bits < 1 or scale_bits > MAX_SURD_SCALE_BITS:
+        raise OperationDomainValidationError(
+            location=("scale_bits",),
+            code="diophantine.scale_bits_out_of_range",
+            message="scale_bits must lie in the admitted binary precision range",
+        )
+
+
+def _rational(value: Fraction) -> CanonicalRational:
+    return CanonicalRational(num=value.numerator, den=value.denominator)
+
+
+def _interval(lower: Fraction, upper: Fraction) -> ClosedRationalInterval:
+    return ClosedRationalInterval(lower=_rational(lower), upper=_rational(upper))
+
+
+def _scaled_floor_row(multiplier: int, radicand: int) -> ScaledFloorValue:
+    """Exact ``floor(n sqrt(d))`` from ``isqrt(d n^2)``; the radical is nonsquare."""
+
+    square: int = radicand * multiplier * multiplier
+    floor: int = isqrt(square)
+    if floor * floor == square:
+        # Only possible for a square radicand, which admission already rejects.
+        raise OperationDomainValidationError(
+            location=("radicand",),
+            code="diophantine.scaled_floor_must_be_irrational",
+            message="a scaled quadratic-surd floor requires a nonsquare radicand",
+        )
+    return ScaledFloorValue(
+        multiplier=multiplier,
+        radicand=radicand,
+        floor=floor,
+        ceiling=floor + 1,
+        square_lower=floor * floor,
+        square_upper=(floor + 1) * (floor + 1),
+    )
+
+
+def _distance_value(
+    multiplier: int,
+    radicand: int,
+    scale_bits: int,
+) -> NearestIntegerDistanceValue:
+    """A certified enclosure of ``||n sqrt(d)||`` at ``2**-scale_bits``.
+
+    ``sqrt(d n^2)`` lies strictly between ``floor`` and ``floor + 1``.  Scaling
+    the integer square by ``4**scale_bits`` and taking its integer square root
+    gives the scaled radical bracket ``[scaled_floor, scaled_floor + 1] / 2**s``
+    with no floating point and no half-integer ambiguity, because the radical is
+    irrational.
+    """
+
+    row = _scaled_floor_row(multiplier, radicand)
+    scaled_square: int = radicand * multiplier * multiplier * 4**scale_bits
+    scaled_floor: int = isqrt(scaled_square)
+    if scaled_floor * scaled_floor == scaled_square:
+        raise OperationDomainValidationError(
+            location=("radicand",),
+            code="diophantine.scaled_floor_must_be_irrational",
+            message="a scaled quadratic-surd floor requires a nonsquare radicand",
+        )
+    scale: int = 2**scale_bits
+    radical_lower = Fraction(scaled_floor, scale)
+    radical_upper = Fraction(scaled_floor + 1, scale)
+
+    floor_distance_lower = radical_lower - row.floor
+    # The floor-branch distance stays strictly positive because the radical
+    # exceeds its integer floor; the upper bound is a strict over-estimate.
+    floor_distance_upper = radical_upper - row.floor
+    ceiling_distance_lower = Fraction(row.ceiling) - radical_upper
+    ceiling_distance_upper = Fraction(row.ceiling) - radical_lower
+
+    # Strict separation is required: touching enclosures leave the branch
+    # mathematically undecided, so they must not be read as a tie-break.
+    if floor_distance_upper < ceiling_distance_lower:
+        side = "FLOOR"
+        lower, upper = floor_distance_lower, floor_distance_upper
+        upper_scaled = scaled_floor + 1 - row.floor * scale
+    elif ceiling_distance_upper < floor_distance_lower:
+        side = "CEILING"
+        lower, upper = ceiling_distance_lower, ceiling_distance_upper
+        upper_scaled = row.ceiling * scale - scaled_floor
+    else:
+        # Overlapping branches mean the requested precision cannot separate the
+        # nearest integer; that is a caller error, never a guessed branch.
+        raise OperationDomainValidationError(
+            location=("scale_bits",),
+            code="diophantine.nearest_integer_branch_unresolved",
+            message=(
+                "the requested scale_bits does not separate the nearest integer "
+                "branch for this multiplier and radicand"
+            ),
+        )
+
+    # The distance enclosure is nonnegative and ordered; both endpoints are
+    # exact rationals, and neither endpoint is negative by construction.
+    interval = bound_enclosure(
+        _interval(max(lower, Fraction(0)), upper), label="nearest-integer distance"
+    )
+    return NearestIntegerDistanceValue(
+        multiplier=multiplier,
+        radicand=radicand,
+        floor=row.floor,
+        ceiling=row.ceiling,
+        nearest_integer=row.floor if side == "FLOOR" else row.ceiling,
+        side=side,
+        scale_bits=scale_bits,
+        distance_enclosure=interval,
+        distance_upper_scaled=upper_scaled,
+    )
+
+
+def _product_enclosure(
+    multiplier: int,
+    factors: tuple[NearestIntegerDistanceValue, ...],
+) -> ClosedRationalInterval:
+    """Exact interval for ``n * prod_i ||n sqrt(d_i)||``.
+
+    Every distance enclosure is nonnegative, so the outer multiplier scales
+    both endpoints exactly and preserves the interval order.
+    """
+
+    lower = Fraction(multiplier)
+    upper = Fraction(multiplier)
+    for factor in factors:
+        lower *= factor.distance_enclosure.lower.as_fraction()
+        upper *= factor.distance_enclosure.upper.as_fraction()
+    return bound_enclosure(_interval(lower, upper), label="simultaneous product")
+
+
+def scaled_floor(request: ScaledFloorRequest) -> ScaledFloorResult:
+    """Return exact ``floor``/``ceiling`` rows derived from integer squares."""
+
+    _require_request_multiplier(request.multiplier)
+    return ScaledFloorResult(
+        rows=(_scaled_floor_row(request.multiplier, request.radicand),)
+    )
+
+
+def nearest_integer_distance(
+    request: NearestIntegerDistanceRequest,
+) -> NearestIntegerDistanceValue:
+    """Certify the distance from ``n sqrt(d)`` to its nearest integer."""
+
+    _require_request_multiplier(request.multiplier)
+    _require_scale_bits(request.scale_bits)
+    return _distance_value(request.multiplier, request.radicand, request.scale_bits)
+
+
+def simultaneous_product(
+    request: SimultaneousProductRequest,
+) -> SimultaneousProductResult:
+    """Certify ``n * prod_i ||n sqrt(d_i)||`` and every factor row."""
+
+    _require_request_multiplier(request.multiplier)
+    _require_scale_bits(request.scale_bits)
+    factors = tuple(
+        _distance_value(request.multiplier, radicand, request.scale_bits)
+        for radicand in request.radicands
+    )
+    return SimultaneousProductResult(
+        multiplier=request.multiplier,
+        radicands=request.radicands,
+        scale_bits=request.scale_bits,
+        factors=factors,
+        product_enclosure=_product_enclosure(request.multiplier, factors),
+    )
+
+
+def range_profile(request: RangeProfileRequest) -> RangeProfileResult:
+    """Return a complete certified row for every ``1 <= n <= limit``."""
+
+    _require_scale_bits(request.scale_bits)
+    rows = []
+    for multiplier in range(1, request.limit + 1):
+        try:
+            factors = tuple(
+                _distance_value(multiplier, radicand, request.scale_bits)
+                for radicand in request.radicands
+            )
+        except OperationDomainValidationError as error:
+            if error.errors()[0]["type"] != (
+                "diophantine.nearest_integer_branch_unresolved"
+            ):
+                raise
+            # Completeness is a contract: reject the whole range with the
+            # first unresolvable row instead of returning a short profile.
+            raise OperationDomainValidationError(
+                location=("scale_bits",),
+                code="diophantine.range_profile_unresolved_row",
+                message=(
+                    "the declared scale_bits cannot resolve the nearest-integer "
+                    f"branch of row n={multiplier}; raise scale_bits or lower limit"
+                ),
+            ) from error
+        rows.append(
+            RangeProfileRow(
+                multiplier=multiplier,
+                factors=factors,
+                product_enclosure=_product_enclosure(multiplier, factors),
+            )
+        )
+    return RangeProfileResult(
+        radicands=request.radicands,
+        limit=request.limit,
+        scale_bits=request.scale_bits,
+        rows=tuple(rows),
+    )
+
+
+def record_minima(request: RecordMinimaRequest) -> RecordMinimaResult:
+    """Extract strict record minima, or report the first unseparated comparison.
+
+    A new strict record requires its product enclosure to lie strictly below
+    every prior incumbent enclosure.  When an enclosure overlaps the incumbent
+    the comparison is mathematically undecided at this precision, so the result
+    reports ``UNRESOLVED`` with both enclosures instead of guessing an order.
+    """
+
+    profile = range_profile(
+        RangeProfileRequest(
+            radicands=request.radicands,
+            limit=request.limit,
+            scale_bits=request.scale_bits,
+        )
+    )
+    records: list[RecordMinimumValue] = []
+    incumbent: ClosedRationalInterval | None = None
+    incumbent_lower = Fraction(0)
+    for row in profile.rows:
+        candidate = row.product_enclosure
+        candidate_lower = candidate.lower.as_fraction()
+        candidate_upper = candidate.upper.as_fraction()
+        if incumbent is None:
+            records.append(
+                RecordMinimumValue(
+                    multiplier=row.multiplier,
+                    product_enclosure=candidate,
+                    incumbent_enclosure=candidate,
+                )
+            )
+            incumbent = candidate
+            incumbent_lower = candidate_lower
+            continue
+        if candidate_upper < incumbent_lower:
+            records.append(
+                RecordMinimumValue(
+                    multiplier=row.multiplier,
+                    product_enclosure=candidate,
+                    incumbent_enclosure=incumbent,
+                )
+            )
+            incumbent = candidate
+            incumbent_lower = candidate_lower
+            continue
+        incumbent_upper = incumbent.upper.as_fraction()
+        if incumbent_upper <= candidate_lower:
+            # The candidate is provably no smaller than the incumbent.  This
+            # includes touching intervals: equality is not a strict record.
+            continue
+        # The intervals overlap (or the candidate reaches below the incumbent
+        # while its lower endpoint does not establish a new record).  Either
+        # ordering is possible at this precision, so make no record claim.
+        if candidate_lower < incumbent_upper:
+            return RecordMinimaResult(
+                radicands=request.radicands,
+                limit=request.limit,
+                scale_bits=request.scale_bits,
+                outcome="UNRESOLVED",
+                records=tuple(records),
+                unresolved_multiplier=row.multiplier,
+                unresolved_product_enclosure=candidate,
+                unresolved_incumbent_enclosure=incumbent,
+            )
+        raise AssertionError("record interval comparison was not classified")
+    return RecordMinimaResult(
+        radicands=request.radicands,
+        limit=request.limit,
+        scale_bits=request.scale_bits,
+        outcome="COMPLETE",
+        records=tuple(records),
+        finite_argmin=records[-1].multiplier,
+    )

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
@@ -21,8 +21,8 @@ from jacobian.math.analysis.intervals import ClosedRationalInterval
 from jacobian.math.number_theory.diophantine_approximation._surd_models import (
     MAX_SURD_MULTIPLIER_BITS,
     MAX_SURD_RADICAND,
+    MAX_SURD_RANGE_ALLOCATION_UNITS,
     MAX_SURD_RANGE_INTERMEDIATE_BITS,
-    MAX_SURD_RANGE_OUTPUT_BYTES,
     MAX_SURD_RANGE_WORK,
     MAX_SURD_SCALE_BITS,
     NearestIntegerDistanceRequest,
@@ -225,8 +225,8 @@ def _range_admission(request: RangeProfileRequest) -> None:
     product_bits = multiplier_bits + radicand_count * (request.scale_bits + 2)
     work = request.limit * radicand_count * (request.scale_bits + scalar_bits)
     intermediate_bits = request.limit * radicand_count * scalar_bits
-    row_bytes = radicand_count * (12 * scalar_bits + 512) + 4 * product_bits + 1_024
-    output_bytes = request.limit * row_bytes + radicand_count * 32 + 256
+    row_units = radicand_count * (12 * scalar_bits + 512) + 4 * product_bits + 1_024
+    allocation_units = request.limit * row_units + radicand_count * 32 + 256
     if work > MAX_SURD_RANGE_WORK:
         raise OperationResourceAdmissionError(
             location=("limit", "scale_bits"),
@@ -239,11 +239,13 @@ def _range_admission(request: RangeProfileRequest) -> None:
             code="diophantine.range_profile_intermediate_bound",
             message="range expansion exceeds the admitted intermediate-size bound",
         )
-    if output_bytes > MAX_SURD_RANGE_OUTPUT_BYTES:
+    if allocation_units > MAX_SURD_RANGE_ALLOCATION_UNITS:
         raise OperationResourceAdmissionError(
             location=("limit", "scale_bits"),
             code="diophantine.range_profile_output_bound",
-            message="the complete serialized range exceeds the admitted output bound",
+            message=(
+                "the complete range exceeds the admitted retained-allocation bound"
+            ),
         )
 
 

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
@@ -10,11 +10,16 @@ from __future__ import annotations
 
 from fractions import Fraction
 from math import isqrt
+from typing import Literal
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.analysis.intervals import ClosedRationalInterval
 from jacobian.math.number_theory.diophantine_approximation._surd_models import (
+    MAX_SURD_MULTIPLIER_BITS,
     MAX_SURD_SCALE_BITS,
     NearestIntegerDistanceRequest,
     NearestIntegerDistanceValue,
@@ -42,6 +47,12 @@ __all__ = [
 
 
 def _require_request_multiplier(multiplier: int) -> None:
+    if multiplier.bit_length() > MAX_SURD_MULTIPLIER_BITS:
+        raise OperationResourceAdmissionError(
+            location=("multiplier",),
+            code="diophantine.multiplier_bit_bound",
+            message="multiplier exceeds the 4096-bit exact-work bound",
+        )
     if multiplier < 1:
         raise OperationDomainValidationError(
             location=("multiplier",),
@@ -125,6 +136,7 @@ def _distance_value(
 
     # Strict separation is required: touching enclosures leave the branch
     # mathematically undecided, so they must not be read as a tie-break.
+    side: Literal["FLOOR", "CEILING"]
     if floor_distance_upper < ceiling_distance_lower:
         side = "FLOOR"
         lower, upper = floor_distance_lower, floor_distance_upper

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_kernel.py
@@ -55,17 +55,17 @@ def _require_multiplier(multiplier: int) -> None:
             code="diophantine.multiplier_type",
             message="multiplier must be a strict integer",
         )
-    if multiplier.bit_length() > MAX_SURD_MULTIPLIER_BITS:
-        raise OperationResourceAdmissionError(
-            location=("multiplier",),
-            code="diophantine.multiplier_bit_bound",
-            message="multiplier exceeds the 4096-bit exact-work bound",
-        )
     if multiplier < 1:
         raise OperationDomainValidationError(
             location=("multiplier",),
             code="diophantine.multiplier_out_of_range",
             message="multiplier must be at least 1",
+        )
+    if multiplier.bit_length() > MAX_SURD_MULTIPLIER_BITS:
+        raise OperationResourceAdmissionError(
+            location=("multiplier",),
+            code="diophantine.multiplier_bit_bound",
+            message="multiplier exceeds the 4096-bit exact-work bound",
         )
 
 

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -9,9 +9,9 @@ deterministic integer arithmetic rather than a floating-point round.
 from __future__ import annotations
 
 from math import isqrt
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
-from pydantic import Field, StrictInt, model_validator
+from pydantic import AfterValidator, Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import ExactInteger, require_bounded_rational
@@ -45,6 +45,25 @@ _POSITIVE_MULTIPLIER_PATTERN = r"^[1-9][0-9]*$"
 _POSITIVE_MULTIPLIER_DESCRIPTION = (
     "Positive exact multiplier; computation admits at most 4096 bits."
 )
+
+
+def _require_positive_multiplier(value: int) -> int:
+    if value < 1:
+        raise PydanticCustomError(
+            "diophantine.multiplier_must_be_positive",
+            "multiplier must be a positive exact integer",
+        )
+    return value
+
+
+PositiveExactMultiplier = Annotated[
+    ExactInteger,
+    AfterValidator(_require_positive_multiplier),
+    Field(
+        description=_POSITIVE_MULTIPLIER_DESCRIPTION,
+        json_schema_extra={"pattern": _POSITIVE_MULTIPLIER_PATTERN},
+    ),
+]
 
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
@@ -92,11 +111,7 @@ def bound_enclosure(
 class ScaledFloorRequest(StrictModel):
     """Exact floor/ceiling of ``n * sqrt(d)`` for positive ``n`` and nonsquare ``d``."""
 
-    multiplier: ExactInteger = Field(
-        ge=1,
-        description=_POSITIVE_MULTIPLIER_DESCRIPTION,
-        json_schema_extra={"pattern": _POSITIVE_MULTIPLIER_PATTERN},
-    )
+    multiplier: PositiveExactMultiplier
     radicand: StrictInt = Field(
         ge=2,
         le=MAX_SURD_RADICAND,
@@ -157,11 +172,7 @@ class ScaledFloorValue(StrictModel):
 class NearestIntegerDistanceRequest(StrictModel):
     """Certify ``||n sqrt(d)||`` at a requested binary precision."""
 
-    multiplier: ExactInteger = Field(
-        ge=1,
-        description=_POSITIVE_MULTIPLIER_DESCRIPTION,
-        json_schema_extra={"pattern": _POSITIVE_MULTIPLIER_PATTERN},
-    )
+    multiplier: PositiveExactMultiplier
     radicand: StrictInt = Field(
         ge=2,
         le=MAX_SURD_RADICAND,
@@ -251,11 +262,7 @@ class NearestIntegerDistanceValue(StrictModel):
 class SimultaneousProductRequest(StrictModel):
     """Certify ``n * prod_i ||n sqrt(d_i)||`` over an ordered radicand axis."""
 
-    multiplier: ExactInteger = Field(
-        ge=1,
-        description=_POSITIVE_MULTIPLIER_DESCRIPTION,
-        json_schema_extra={"pattern": _POSITIVE_MULTIPLIER_PATTERN},
-    )
+    multiplier: PositiveExactMultiplier
     radicands: tuple[StrictInt, ...] = Field(
         min_length=1,
         max_length=MAX_SIMULTANEOUS_RADICANDS,

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -26,6 +26,11 @@ MAX_SIMULTANEOUS_RADICANDS = 8
 # a 4096-bit integer keeps both components below 16384 decimal digits.
 MAX_SURD_MULTIPLIER_BITS = 4_096
 MAX_ENCLOSURE_COMPONENT_DIGITS = 16_384
+# Complete range operations expand a rectangular table.  Admit work and
+# output before any row or exact interval is materialized.
+MAX_SURD_RANGE_WORK = 32_000_000
+MAX_SURD_RANGE_INTERMEDIATE_BITS = 64_000_000
+MAX_SURD_RANGE_OUTPUT_BYTES = 16 * 1024 * 1024
 
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
@@ -79,15 +84,6 @@ class ScaledFloorRequest(StrictModel):
     )
     radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
 
-    @model_validator(mode="after")
-    def require_non_square_radicand(self) -> Self:
-        if not is_surd_radicand(self.radicand):
-            raise _validation_error(
-                "diophantine.surd_radicand_must_not_be_square",
-                "a quadratic irrational requires a nonsquare radicand",
-            )
-        return self
-
 
 class ScaledFloorValue(StrictModel):
     """One exact floor/ceiling row derived from integer squares only."""
@@ -102,32 +98,6 @@ class ScaledFloorValue(StrictModel):
     square_lower: ExactInteger
     square_upper: ExactInteger
 
-    @model_validator(mode="after")
-    def require_exact_square_bracket(self) -> Self:
-        if self.ceiling != self.floor + 1:
-            raise _validation_error(
-                "diophantine.scaled_floor_not_unit_bracket",
-                "an irrational scaled floor must have ceiling equal to floor + 1",
-            )
-        if not (
-            self.floor >= 0
-            and self.square_lower == self.floor * self.floor
-            and self.square_upper == self.ceiling * self.ceiling
-        ):
-            raise _validation_error(
-                "diophantine.scaled_floor_square_mismatch",
-                "square_lower/square_upper must be the exact endpoint squares",
-            )
-        return self
-
-
-class ScaledFloorResult(StrictModel):
-    """A bounded carrier of exact scaled floors over an ordered radicand axis."""
-
-    rows: tuple[ScaledFloorValue, ...] = Field(
-        min_length=1, max_length=MAX_RANGE_LENGTH
-    )
-
 
 class NearestIntegerDistanceRequest(StrictModel):
     """Certify ``||n sqrt(d)||`` at a requested binary precision."""
@@ -138,15 +108,6 @@ class NearestIntegerDistanceRequest(StrictModel):
     )
     radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
     scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
-
-    @model_validator(mode="after")
-    def require_non_square_radicand(self) -> Self:
-        if not is_surd_radicand(self.radicand):
-            raise _validation_error(
-                "diophantine.surd_radicand_must_not_be_square",
-                "a quadratic irrational requires a nonsquare radicand",
-            )
-        return self
 
 
 class NearestIntegerDistanceValue(StrictModel):
@@ -165,26 +126,6 @@ class NearestIntegerDistanceValue(StrictModel):
     distance_enclosure: ClosedRationalInterval
     distance_upper_scaled: ExactInteger
 
-    @model_validator(mode="after")
-    def require_nearest_branch(self) -> Self:
-        if self.ceiling != self.floor + 1 or self.floor < 0:
-            raise _validation_error(
-                "diophantine.nearest_integer_not_unit_bracket",
-                "nearest-integer distance requires a nonnegative unit bracket",
-            )
-        expected_nearest = self.floor if self.side == "FLOOR" else self.ceiling
-        if self.nearest_integer != expected_nearest:
-            raise _validation_error(
-                "diophantine.nearest_integer_branch_mismatch",
-                "nearest_integer must be the declared bracket endpoint",
-            )
-        if self.distance_upper_scaled < 0:
-            raise _validation_error(
-                "diophantine.nearest_integer_negative_scale",
-                "distance_upper_scaled is a nonnegative integer numerator",
-            )
-        return self
-
 
 class SimultaneousProductRequest(StrictModel):
     """Certify ``n * prod_i ||n sqrt(d_i)||`` over an ordered radicand axis."""
@@ -199,12 +140,7 @@ class SimultaneousProductRequest(StrictModel):
     scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
 
     @model_validator(mode="after")
-    def require_distinct_non_square_radicands(self) -> Self:
-        if any(not is_surd_radicand(radicand) for radicand in self.radicands):
-            raise _validation_error(
-                "diophantine.surd_radicand_must_not_be_square",
-                "every radicand must be a nonsquare integer in the admitted range",
-            )
+    def require_distinct_radicands(self) -> Self:
         if len(set(self.radicands)) != len(self.radicands):
             raise _validation_error(
                 "diophantine.surd_radicands_must_be_distinct",
@@ -241,6 +177,11 @@ class SimultaneousProductResult(StrictModel):
                 "diophantine.product_factor_multiplier_mismatch",
                 "every factor row must share the request multiplier",
             )
+        if any(factor.scale_bits != self.scale_bits for factor in self.factors):
+            raise _validation_error(
+                "diophantine.product_factor_scale_mismatch",
+                "every factor row must share the requested precision",
+            )
         return self
 
 
@@ -254,12 +195,7 @@ class RangeProfileRequest(StrictModel):
     scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
 
     @model_validator(mode="after")
-    def require_distinct_non_square_radicands(self) -> Self:
-        if any(not is_surd_radicand(radicand) for radicand in self.radicands):
-            raise _validation_error(
-                "diophantine.surd_radicand_must_not_be_square",
-                "every radicand must be a nonsquare integer in the admitted range",
-            )
+    def require_distinct_radicands(self) -> Self:
         if len(set(self.radicands)) != len(self.radicands):
             raise _validation_error(
                 "diophantine.surd_radicands_must_be_distinct",
@@ -279,6 +215,15 @@ class RangeProfileRow(StrictModel):
         min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
     )
     product_enclosure: ClosedRationalInterval
+
+    @model_validator(mode="after")
+    def require_factor_multiplier_alignment(self) -> Self:
+        if any(factor.multiplier != self.multiplier for factor in self.factors):
+            raise _validation_error(
+                "diophantine.range_profile_factor_multiplier_mismatch",
+                "every row factor must share its row multiplier",
+            )
+        return self
 
 
 class RangeProfileResult(StrictModel):
@@ -311,6 +256,11 @@ class RangeProfileResult(StrictModel):
                     "diophantine.range_profile_factor_axis_mismatch",
                     "every row must follow the declared radicand axis",
                 )
+            if any(factor.scale_bits != self.scale_bits for factor in row.factors):
+                raise _validation_error(
+                    "diophantine.range_profile_factor_scale_mismatch",
+                    "every row factor must share the profile precision",
+                )
         return self
 
 
@@ -324,12 +274,7 @@ class RecordMinimaRequest(StrictModel):
     scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
 
     @model_validator(mode="after")
-    def require_distinct_non_square_radicands(self) -> Self:
-        if any(not is_surd_radicand(radicand) for radicand in self.radicands):
-            raise _validation_error(
-                "diophantine.surd_radicand_must_not_be_square",
-                "every radicand must be a nonsquare integer in the admitted range",
-            )
+    def require_distinct_radicands(self) -> Self:
         if len(set(self.radicands)) != len(self.radicands):
             raise _validation_error(
                 "diophantine.surd_radicands_must_be_distinct",
@@ -360,7 +305,7 @@ class RecordMinimaResult(StrictModel):
     outcome: Literal["COMPLETE", "UNRESOLVED"]
     records: tuple[RecordMinimumValue, ...] = Field(max_length=MAX_RANGE_LENGTH)
     finite_argmin: StrictInt | None = None
-    unresolved_multiplier: StrictInt | None = None
+    unresolved_multiplier: ExactInteger | None = None
     unresolved_product_enclosure: ClosedRationalInterval | None = None
     unresolved_incumbent_enclosure: ClosedRationalInterval | None = None
 
@@ -381,25 +326,31 @@ class RecordMinimaResult(StrictModel):
                     "diophantine.complete_record_missing_first_row",
                     "a complete record sequence contains at least the first row",
                 )
+            if any(record.multiplier > self.limit for record in self.records):
+                raise _validation_error(
+                    "diophantine.complete_record_multiplier_out_of_range",
+                    "every record multiplier must lie in the declared range",
+                )
+            if any(
+                current.multiplier <= previous.multiplier
+                for previous, current in zip(
+                    self.records, self.records[1:], strict=False
+                )
+            ):
+                raise _validation_error(
+                    "diophantine.complete_record_order",
+                    "record multipliers must be strictly increasing",
+                )
             if self.finite_argmin != self.records[-1].multiplier:
                 raise _validation_error(
                     "diophantine.complete_record_argmin_mismatch",
                     "finite_argmin must be the last certified record multiplier",
                 )
-            for previous, current in zip(self.records, self.records[1:], strict=False):
-                if current.multiplier <= previous.multiplier:
-                    raise _validation_error(
-                        "diophantine.complete_record_order",
-                        "certified record multipliers must be strictly increasing",
-                    )
-                if not (
-                    current.product_enclosure.upper.as_fraction()
-                    < current.incumbent_enclosure.lower.as_fraction()
-                ):
-                    raise _validation_error(
-                        "diophantine.complete_record_not_separated",
-                        "every reported record must lie strictly below its incumbent",
-                    )
+            if self.finite_argmin > self.limit:
+                raise _validation_error(
+                    "diophantine.complete_record_argmin_out_of_range",
+                    "finite_argmin must lie in the declared range",
+                )
         else:
             if self.finite_argmin is not None:
                 raise _validation_error(
@@ -415,6 +366,11 @@ class RecordMinimaResult(StrictModel):
                     "diophantine.unresolved_record_missing_evidence",
                     "an unresolved record search names the first overlapping row",
                 )
+            if self.unresolved_multiplier > self.limit:
+                raise _validation_error(
+                    "diophantine.unresolved_record_multiplier_out_of_range",
+                    "the unresolved multiplier must lie in the declared range",
+                )
             if (
                 self.records
                 and self.unresolved_multiplier <= self.records[-1].multiplier
@@ -423,16 +379,6 @@ class RecordMinimaResult(StrictModel):
                     "diophantine.unresolved_record_order",
                     "the unresolved multiplier must follow all certified records",
                 )
-            candidate = self.unresolved_product_enclosure
-            incumbent = self.unresolved_incumbent_enclosure
-            if (
-                candidate.upper.as_fraction() < incumbent.lower.as_fraction()
-                or incumbent.upper.as_fraction() <= candidate.lower.as_fraction()
-            ):
-                raise _validation_error(
-                    "diophantine.unresolved_record_separated",
-                    "an unresolved comparison must retain overlapping enclosures",
-                )
         return self
 
 
@@ -440,7 +386,11 @@ __all__ = [
     "MAX_ENCLOSURE_COMPONENT_DIGITS",
     "MAX_RANGE_LENGTH",
     "MAX_SIMULTANEOUS_RADICANDS",
+    "MAX_SURD_MULTIPLIER_BITS",
     "MAX_SURD_RADICAND",
+    "MAX_SURD_RANGE_INTERMEDIATE_BITS",
+    "MAX_SURD_RANGE_OUTPUT_BYTES",
+    "MAX_SURD_RANGE_WORK",
     "MAX_SURD_SCALE_BITS",
     "NearestIntegerDistanceRequest",
     "NearestIntegerDistanceValue",
@@ -452,7 +402,6 @@ __all__ = [
     "RecordMinimaResult",
     "RecordMinimumValue",
     "ScaledFloorRequest",
-    "ScaledFloorResult",
     "ScaledFloorValue",
     "SimultaneousProductRequest",
     "SimultaneousProductResult",

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -1,0 +1,434 @@
+"""Certified finite quadratic-surd and simultaneous-approximation values.
+
+These values keep exact integer structure and carry a certified rational
+enclosure whenever the underlying real number is irrational.  Precision is
+requested as a binary scale ``2**-scale_bits`` so every refinement step is
+deterministic integer arithmetic rather than a floating-point round.
+"""
+
+from __future__ import annotations
+
+from math import isqrt
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import ExactInteger, require_bounded_rational
+from jacobian._models import StrictModel
+from jacobian.math.analysis.intervals import ClosedRationalInterval
+
+MAX_SURD_RADICAND = 1_000_000
+MAX_SURD_SCALE_BITS = 4_096
+MAX_RANGE_LENGTH = 4_096
+MAX_SIMULTANEOUS_RADICANDS = 8
+MAX_ENCLOSURE_COMPONENT_DIGITS = 4_096
+
+
+def _validation_error(code: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(code, message)
+
+
+def is_surd_radicand(radicand: int) -> bool:
+    """A bounded positive nonsquare radicand has an irrational square root."""
+
+    if radicand < 2 or radicand > MAX_SURD_RADICAND:
+        return False
+    root = isqrt(radicand)
+    return root * root != radicand
+
+
+class PositiveQuadraticIrrational(StrictModel):
+    """The positive square root of one bounded nonsquare integer radicand."""
+
+    radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
+
+    @model_validator(mode="after")
+    def require_non_square_radicand(self) -> Self:
+        if not is_surd_radicand(self.radicand):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "a quadratic irrational requires a nonsquare radicand",
+            )
+        return self
+
+
+def bound_enclosure(
+    interval: ClosedRationalInterval, *, label: str
+) -> ClosedRationalInterval:
+    """Reject an enclosure whose canonical components exceed the digit bound."""
+
+    require_bounded_rational(
+        interval.lower, max_digits=MAX_ENCLOSURE_COMPONENT_DIGITS, label=label
+    )
+    require_bounded_rational(
+        interval.upper, max_digits=MAX_ENCLOSURE_COMPONENT_DIGITS, label=label
+    )
+    return interval
+
+
+class ScaledFloorRequest(StrictModel):
+    """Exact floor/ceiling of ``n * sqrt(d)`` for positive ``n`` and nonsquare ``d``."""
+
+    multiplier: StrictInt = Field(ge=1)
+    radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
+
+    @model_validator(mode="after")
+    def require_non_square_radicand(self) -> Self:
+        if not is_surd_radicand(self.radicand):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "a quadratic irrational requires a nonsquare radicand",
+            )
+        return self
+
+
+class ScaledFloorValue(StrictModel):
+    """One exact floor/ceiling row derived from integer squares only."""
+
+    multiplier: StrictInt = Field(ge=1)
+    radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
+    floor: ExactInteger
+    ceiling: ExactInteger
+    square_lower: ExactInteger
+    square_upper: ExactInteger
+
+    @model_validator(mode="after")
+    def require_exact_square_bracket(self) -> Self:
+        if self.ceiling != self.floor + 1:
+            raise _validation_error(
+                "diophantine.scaled_floor_not_unit_bracket",
+                "an irrational scaled floor must have ceiling equal to floor + 1",
+            )
+        if not (
+            self.floor >= 0
+            and self.square_lower == self.floor * self.floor
+            and self.square_upper == self.ceiling * self.ceiling
+        ):
+            raise _validation_error(
+                "diophantine.scaled_floor_square_mismatch",
+                "square_lower/square_upper must be the exact endpoint squares",
+            )
+        return self
+
+
+class ScaledFloorResult(StrictModel):
+    """A bounded carrier of exact scaled floors over an ordered radicand axis."""
+
+    rows: tuple[ScaledFloorValue, ...] = Field(
+        min_length=1, max_length=MAX_RANGE_LENGTH
+    )
+
+
+class NearestIntegerDistanceRequest(StrictModel):
+    """Certify ``||n sqrt(d)||`` at a requested binary precision."""
+
+    multiplier: StrictInt = Field(ge=1)
+    radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
+    scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
+
+    @model_validator(mode="after")
+    def require_non_square_radicand(self) -> Self:
+        if not is_surd_radicand(self.radicand):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "a quadratic irrational requires a nonsquare radicand",
+            )
+        return self
+
+
+class NearestIntegerDistanceValue(StrictModel):
+    """Exact nearest-integer data plus a certified distance enclosure."""
+
+    multiplier: StrictInt = Field(ge=1)
+    radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
+    floor: ExactInteger
+    ceiling: ExactInteger
+    nearest_integer: ExactInteger
+    side: Literal["FLOOR", "CEILING"]
+    scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
+    distance_enclosure: ClosedRationalInterval
+    distance_upper_scaled: ExactInteger
+
+    @model_validator(mode="after")
+    def require_nearest_branch(self) -> Self:
+        if self.ceiling != self.floor + 1 or self.floor < 0:
+            raise _validation_error(
+                "diophantine.nearest_integer_not_unit_bracket",
+                "nearest-integer distance requires a nonnegative unit bracket",
+            )
+        expected_nearest = self.floor if self.side == "FLOOR" else self.ceiling
+        if self.nearest_integer != expected_nearest:
+            raise _validation_error(
+                "diophantine.nearest_integer_branch_mismatch",
+                "nearest_integer must be the declared bracket endpoint",
+            )
+        if self.distance_upper_scaled < 0:
+            raise _validation_error(
+                "diophantine.nearest_integer_negative_scale",
+                "distance_upper_scaled is a nonnegative integer numerator",
+            )
+        return self
+
+
+class SimultaneousProductRequest(StrictModel):
+    """Certify ``n * prod_i ||n sqrt(d_i)||`` over an ordered radicand axis."""
+
+    multiplier: StrictInt = Field(ge=1)
+    radicands: tuple[StrictInt, ...] = Field(
+        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+    )
+    scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
+
+    @model_validator(mode="after")
+    def require_distinct_non_square_radicands(self) -> Self:
+        if any(not is_surd_radicand(radicand) for radicand in self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "every radicand must be a nonsquare integer in the admitted range",
+            )
+        if len(set(self.radicands)) != len(self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicands_must_be_distinct",
+                "an ordered radicand axis requires distinct radicands",
+            )
+        return self
+
+
+class SimultaneousProductResult(StrictModel):
+    """Per-factor nearest-integer rows and the certified product enclosure."""
+
+    multiplier: StrictInt = Field(ge=1)
+    radicands: tuple[StrictInt, ...] = Field(
+        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+    )
+    scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
+    factors: tuple[NearestIntegerDistanceValue, ...] = Field(
+        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+    )
+    product_enclosure: ClosedRationalInterval
+
+    @model_validator(mode="after")
+    def require_factor_axis_alignment(self) -> Self:
+        if tuple(factor.radicand for factor in self.factors) != self.radicands:
+            raise _validation_error(
+                "diophantine.product_factor_axis_mismatch",
+                "factor rows must follow the declared radicand axis",
+            )
+        if any(factor.multiplier != self.multiplier for factor in self.factors):
+            raise _validation_error(
+                "diophantine.product_factor_multiplier_mismatch",
+                "every factor row must share the request multiplier",
+            )
+        return self
+
+
+class RangeProfileRequest(StrictModel):
+    """A complete certified row for every ``1 <= n <= limit``."""
+
+    radicands: tuple[StrictInt, ...] = Field(
+        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+    )
+    limit: StrictInt = Field(ge=1, le=MAX_RANGE_LENGTH)
+    scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
+
+    @model_validator(mode="after")
+    def require_distinct_non_square_radicands(self) -> Self:
+        if any(not is_surd_radicand(radicand) for radicand in self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "every radicand must be a nonsquare integer in the admitted range",
+            )
+        if len(set(self.radicands)) != len(self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicands_must_be_distinct",
+                "an ordered radicand axis requires distinct radicands",
+            )
+        return self
+
+
+class RangeProfileRow(StrictModel):
+    """One complete certified row: factor enclosures and their product."""
+
+    multiplier: StrictInt = Field(ge=1)
+    factors: tuple[NearestIntegerDistanceValue, ...] = Field(
+        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+    )
+    product_enclosure: ClosedRationalInterval
+
+
+class RangeProfileResult(StrictModel):
+    """Every row of the declared range with no silent omission."""
+
+    radicands: tuple[StrictInt, ...] = Field(
+        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+    )
+    limit: StrictInt = Field(ge=1, le=MAX_RANGE_LENGTH)
+    scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
+    rows: tuple[RangeProfileRow, ...] = Field(max_length=MAX_RANGE_LENGTH)
+
+    @model_validator(mode="after")
+    def require_complete_range(self) -> Self:
+        if len(self.rows) != self.limit:
+            raise _validation_error(
+                "diophantine.range_profile_incomplete",
+                "the range profile must contain exactly one row per integer",
+            )
+        if tuple(row.multiplier for row in self.rows) != tuple(
+            range(1, self.limit + 1)
+        ):
+            raise _validation_error(
+                "diophantine.range_profile_multiplier_order",
+                "range rows must be ordered by multiplier starting at one",
+            )
+        for row in self.rows:
+            if tuple(factor.radicand for factor in row.factors) != self.radicands:
+                raise _validation_error(
+                    "diophantine.range_profile_factor_axis_mismatch",
+                    "every row must follow the declared radicand axis",
+                )
+        return self
+
+
+class RecordMinimaRequest(StrictModel):
+    """Extract strict record minima from a certified simultaneous range."""
+
+    radicands: tuple[StrictInt, ...] = Field(
+        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+    )
+    limit: StrictInt = Field(ge=1, le=MAX_RANGE_LENGTH)
+    scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
+
+    @model_validator(mode="after")
+    def require_distinct_non_square_radicands(self) -> Self:
+        if any(not is_surd_radicand(radicand) for radicand in self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "every radicand must be a nonsquare integer in the admitted range",
+            )
+        if len(set(self.radicands)) != len(self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicands_must_be_distinct",
+                "an ordered radicand axis requires distinct radicands",
+            )
+        return self
+
+
+class RecordMinimumValue(StrictModel):
+    """One certified strict-record row."""
+
+    multiplier: StrictInt = Field(ge=1)
+    product_enclosure: ClosedRationalInterval
+    incumbent_enclosure: ClosedRationalInterval
+
+
+class RecordMinimaResult(StrictModel):
+    """Certified strict record minima, or an explicit non-conclusion."""
+
+    radicands: tuple[StrictInt, ...] = Field(
+        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+    )
+    limit: StrictInt = Field(ge=1, le=MAX_RANGE_LENGTH)
+    scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
+    outcome: Literal["COMPLETE", "UNRESOLVED"]
+    records: tuple[RecordMinimumValue, ...] = Field(max_length=MAX_RANGE_LENGTH)
+    finite_argmin: StrictInt | None = None
+    unresolved_multiplier: StrictInt | None = None
+    unresolved_product_enclosure: ClosedRationalInterval | None = None
+    unresolved_incumbent_enclosure: ClosedRationalInterval | None = None
+
+    @model_validator(mode="after")
+    def require_outcome_shape(self) -> Self:
+        if self.outcome == "COMPLETE":
+            if (
+                self.unresolved_multiplier is not None
+                or self.unresolved_product_enclosure is not None
+                or self.unresolved_incumbent_enclosure is not None
+            ):
+                raise _validation_error(
+                    "diophantine.complete_record_has_unresolved_fields",
+                    "a complete record result cannot carry unresolved fields",
+                )
+            if not self.records:
+                raise _validation_error(
+                    "diophantine.complete_record_missing_first_row",
+                    "a complete record sequence contains at least the first row",
+                )
+            if self.finite_argmin != self.records[-1].multiplier:
+                raise _validation_error(
+                    "diophantine.complete_record_argmin_mismatch",
+                    "finite_argmin must be the last certified record multiplier",
+                )
+            for previous, current in zip(self.records, self.records[1:], strict=False):
+                if current.multiplier <= previous.multiplier:
+                    raise _validation_error(
+                        "diophantine.complete_record_order",
+                        "certified record multipliers must be strictly increasing",
+                    )
+                if not (
+                    current.product_enclosure.upper.as_fraction()
+                    < current.incumbent_enclosure.lower.as_fraction()
+                ):
+                    raise _validation_error(
+                        "diophantine.complete_record_not_separated",
+                        "every reported record must lie strictly below its incumbent",
+                    )
+        else:
+            if self.finite_argmin is not None:
+                raise _validation_error(
+                    "diophantine.unresolved_record_has_argmin",
+                    "an unresolved record search makes no argmin claim",
+                )
+            if (
+                self.unresolved_multiplier is None
+                or self.unresolved_product_enclosure is None
+                or self.unresolved_incumbent_enclosure is None
+            ):
+                raise _validation_error(
+                    "diophantine.unresolved_record_missing_evidence",
+                    "an unresolved record search names the first overlapping row",
+                )
+            if (
+                self.records
+                and self.unresolved_multiplier <= self.records[-1].multiplier
+            ):
+                raise _validation_error(
+                    "diophantine.unresolved_record_order",
+                    "the unresolved multiplier must follow all certified records",
+                )
+            candidate = self.unresolved_product_enclosure
+            incumbent = self.unresolved_incumbent_enclosure
+            if (
+                candidate.upper.as_fraction() < incumbent.lower.as_fraction()
+                or incumbent.upper.as_fraction() <= candidate.lower.as_fraction()
+            ):
+                raise _validation_error(
+                    "diophantine.unresolved_record_separated",
+                    "an unresolved comparison must retain overlapping enclosures",
+                )
+        return self
+
+
+__all__ = [
+    "MAX_ENCLOSURE_COMPONENT_DIGITS",
+    "MAX_RANGE_LENGTH",
+    "MAX_SIMULTANEOUS_RADICANDS",
+    "MAX_SURD_RADICAND",
+    "MAX_SURD_SCALE_BITS",
+    "NearestIntegerDistanceRequest",
+    "NearestIntegerDistanceValue",
+    "PositiveQuadraticIrrational",
+    "RangeProfileRequest",
+    "RangeProfileResult",
+    "RangeProfileRow",
+    "RecordMinimaRequest",
+    "RecordMinimaResult",
+    "RecordMinimumValue",
+    "ScaledFloorRequest",
+    "ScaledFloorResult",
+    "ScaledFloorValue",
+    "SimultaneousProductRequest",
+    "SimultaneousProductResult",
+    "bound_enclosure",
+    "is_surd_radicand",
+]

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -552,6 +552,10 @@ class RecordMinimaResult(StrictModel):
             record.product_enclosure.lower.num < 0
             or record.incumbent_enclosure.lower.num < 0
             for record in self.records
+        ) or (
+            self.outcome == "UNRESOLVED"
+            and self.unresolved_product_enclosure is not None
+            and self.unresolved_product_enclosure.lower.num < 0
         ):
             raise _validation_error(
                 "diophantine.record_negative_product_enclosure",

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -39,8 +39,7 @@ _SURD_AXIS_DESCRIPTION = (
     f"range 2..{MAX_SURD_RADICAND}."
 )
 _SURD_SCALAR_RADICAND_DESCRIPTION = (
-    "Nonsquare integer radicand in the admitted range "
-    f"2..{MAX_SURD_RADICAND}."
+    f"Nonsquare integer radicand in the admitted range 2..{MAX_SURD_RADICAND}."
 )
 
 

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -38,6 +38,10 @@ _SURD_AXIS_DESCRIPTION = (
     "Ordered tuple of distinct nonsquare integer radicands in the admitted "
     f"range 2..{MAX_SURD_RADICAND}."
 )
+_SURD_SCALAR_RADICAND_DESCRIPTION = (
+    "Nonsquare integer radicand in the admitted range "
+    f"2..{MAX_SURD_RADICAND}."
+)
 
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
@@ -89,7 +93,11 @@ class ScaledFloorRequest(StrictModel):
         ge=1,
         description="Positive exact multiplier; computation admits at most 4096 bits.",
     )
-    radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
+    radicand: StrictInt = Field(
+        ge=2,
+        le=MAX_SURD_RADICAND,
+        description=_SURD_SCALAR_RADICAND_DESCRIPTION,
+    )
 
 
 class ScaledFloorValue(StrictModel):
@@ -116,14 +124,6 @@ class ScaledFloorValue(StrictModel):
             raise _validation_error(
                 "diophantine.scaled_floor_bracket_shape",
                 "floor and ceiling must be consecutive nonnegative integers",
-            )
-        if (
-            self.square_lower != self.floor * self.floor
-            or self.square_upper != self.ceiling * self.ceiling
-        ):
-            raise _validation_error(
-                "diophantine.scaled_floor_square_shape",
-                "endpoint squares must match the retained floor and ceiling",
             )
         return self
 
@@ -157,7 +157,11 @@ class NearestIntegerDistanceRequest(StrictModel):
         ge=1,
         description="Positive exact multiplier; computation admits at most 4096 bits.",
     )
-    radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
+    radicand: StrictInt = Field(
+        ge=2,
+        le=MAX_SURD_RADICAND,
+        description=_SURD_SCALAR_RADICAND_DESCRIPTION,
+    )
     scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
 
 

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -8,7 +8,6 @@ deterministic integer arithmetic rather than a floating-point round.
 
 from __future__ import annotations
 
-from fractions import Fraction
 from math import isqrt
 from typing import Literal, Self
 
@@ -34,6 +33,11 @@ MAX_ENCLOSURE_COMPONENT_DIGITS = 16_384
 MAX_SURD_RANGE_WORK = 32_000_000
 MAX_SURD_RANGE_INTERMEDIATE_BITS = 64_000_000
 MAX_SURD_RANGE_ALLOCATION_UNITS = 16 * 1024 * 1024
+
+_SURD_AXIS_DESCRIPTION = (
+    "Ordered tuple of distinct nonsquare integer radicands in the admitted "
+    f"range 2..{MAX_SURD_RADICAND}."
+)
 
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
@@ -123,6 +127,28 @@ class ScaledFloorValue(StrictModel):
             )
         return self
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        multiplier: int,
+        radicand: int,
+        floor: int,
+        ceiling: int,
+        square_lower: int,
+        square_upper: int,
+    ) -> Self:
+        """Construct an exact row after the owner kernel established it."""
+
+        return cls.model_construct(
+            multiplier=multiplier,
+            radicand=radicand,
+            floor=floor,
+            ceiling=ceiling,
+            square_lower=square_lower,
+            square_upper=square_upper,
+        )
+
 
 class NearestIntegerDistanceRequest(StrictModel):
     """Certify ``||n sqrt(d)||`` at a requested binary precision."""
@@ -169,20 +195,48 @@ class NearestIntegerDistanceValue(StrictModel):
                 "diophantine.nearest_integer_side_mismatch",
                 "nearest_integer must agree with the certified branch",
             )
-        if self.distance_enclosure.lower.as_fraction() < 0:
+        if self.distance_enclosure.lower.num < 0:
             raise _validation_error(
                 "diophantine.nearest_integer_negative_distance",
                 "a nearest-integer distance enclosure must be nonnegative",
             )
-        expected_upper = Fraction(self.distance_upper_scaled, 2**self.scale_bits)
+        upper = self.distance_enclosure.upper
         if self.distance_upper_scaled < 1 or (
-            self.distance_enclosure.upper.as_fraction() != expected_upper
+            upper.num * (2**self.scale_bits) != self.distance_upper_scaled * upper.den
         ):
             raise _validation_error(
                 "diophantine.nearest_integer_upper_mismatch",
                 "distance_upper_scaled must retain the enclosure upper endpoint",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        multiplier: int,
+        radicand: int,
+        floor: int,
+        ceiling: int,
+        nearest_integer: int,
+        side: Literal["FLOOR", "CEILING"],
+        scale_bits: int,
+        distance_enclosure: ClosedRationalInterval,
+        distance_upper_scaled: int,
+    ) -> Self:
+        """Construct a distance value after the exact kernel established it."""
+
+        return cls.model_construct(
+            multiplier=multiplier,
+            radicand=radicand,
+            floor=floor,
+            ceiling=ceiling,
+            nearest_integer=nearest_integer,
+            side=side,
+            scale_bits=scale_bits,
+            distance_enclosure=distance_enclosure,
+            distance_upper_scaled=distance_upper_scaled,
+        )
 
 
 class SimultaneousProductRequest(StrictModel):
@@ -193,7 +247,9 @@ class SimultaneousProductRequest(StrictModel):
         description="Positive exact multiplier; computation admits at most 4096 bits.",
     )
     radicands: tuple[StrictInt, ...] = Field(
-        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+        min_length=1,
+        max_length=MAX_SIMULTANEOUS_RADICANDS,
+        description=_SURD_AXIS_DESCRIPTION,
     )
     scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
 
@@ -250,19 +306,41 @@ class SimultaneousProductResult(StrictModel):
                 "diophantine.product_factor_scale_mismatch",
                 "every factor row must share the requested precision",
             )
-        if self.product_enclosure.lower.as_fraction() < 0:
+        if self.product_enclosure.lower.num < 0:
             raise _validation_error(
                 "diophantine.product_negative_enclosure",
                 "a simultaneous product enclosure must be nonnegative",
             )
         return self
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        multiplier: int,
+        radicands: tuple[int, ...],
+        scale_bits: int,
+        factors: tuple[NearestIntegerDistanceValue, ...],
+        product_enclosure: ClosedRationalInterval,
+    ) -> Self:
+        """Construct a product result after the owner kernel established it."""
+
+        return cls.model_construct(
+            multiplier=multiplier,
+            radicands=radicands,
+            scale_bits=scale_bits,
+            factors=factors,
+            product_enclosure=product_enclosure,
+        )
+
 
 class RangeProfileRequest(StrictModel):
     """A complete certified row for every ``1 <= n <= limit``."""
 
     radicands: tuple[StrictInt, ...] = Field(
-        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+        min_length=1,
+        max_length=MAX_SIMULTANEOUS_RADICANDS,
+        description=_SURD_AXIS_DESCRIPTION,
     )
     limit: StrictInt = Field(ge=1, le=MAX_RANGE_LENGTH)
     scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
@@ -297,6 +375,22 @@ class RangeProfileRow(StrictModel):
                 "every row factor must share its row multiplier",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        multiplier: int,
+        factors: tuple[NearestIntegerDistanceValue, ...],
+        product_enclosure: ClosedRationalInterval,
+    ) -> Self:
+        """Construct a row after the owner kernel established its bindings."""
+
+        return cls.model_construct(
+            multiplier=multiplier,
+            factors=factors,
+            product_enclosure=product_enclosure,
+        )
 
 
 class RangeProfileResult(StrictModel):
@@ -344,19 +438,39 @@ class RangeProfileResult(StrictModel):
                     "diophantine.range_profile_factor_scale_mismatch",
                     "every row factor must share the profile precision",
                 )
-            if row.product_enclosure.lower.as_fraction() < 0:
+            if row.product_enclosure.lower.num < 0:
                 raise _validation_error(
                     "diophantine.range_profile_negative_product",
                     "a range product enclosure must be nonnegative",
                 )
         return self
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        radicands: tuple[int, ...],
+        limit: int,
+        scale_bits: int,
+        rows: tuple[RangeProfileRow, ...],
+    ) -> Self:
+        """Construct a complete profile after the owner kernel established it."""
+
+        return cls.model_construct(
+            radicands=radicands,
+            limit=limit,
+            scale_bits=scale_bits,
+            rows=rows,
+        )
+
 
 class RecordMinimaRequest(StrictModel):
     """Extract strict record minima from a certified simultaneous range."""
 
     radicands: tuple[StrictInt, ...] = Field(
-        min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
+        min_length=1,
+        max_length=MAX_SIMULTANEOUS_RADICANDS,
+        description=_SURD_AXIS_DESCRIPTION,
     )
     limit: StrictInt = Field(ge=1, le=MAX_RANGE_LENGTH)
     scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
@@ -380,6 +494,22 @@ class RecordMinimumValue(StrictModel):
     )
     product_enclosure: ClosedRationalInterval
     incumbent_enclosure: ClosedRationalInterval
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        multiplier: int,
+        product_enclosure: ClosedRationalInterval,
+        incumbent_enclosure: ClosedRationalInterval,
+    ) -> Self:
+        """Construct one record after the owner kernel established it."""
+
+        return cls.model_construct(
+            multiplier=multiplier,
+            product_enclosure=product_enclosure,
+            incumbent_enclosure=incumbent_enclosure,
+        )
 
 
 class RecordMinimaResult(StrictModel):
@@ -419,8 +549,8 @@ class RecordMinimaResult(StrictModel):
                 "a finite record sequence must retain its first row at multiplier one",
             )
         if any(
-            record.product_enclosure.lower.as_fraction() < 0
-            or record.incumbent_enclosure.lower.as_fraction() < 0
+            record.product_enclosure.lower.num < 0
+            or record.incumbent_enclosure.lower.num < 0
             for record in self.records
         ):
             raise _validation_error(
@@ -459,30 +589,10 @@ class RecordMinimaResult(StrictModel):
                     "diophantine.complete_record_missing_first_row",
                     "a complete record sequence contains at least the first row",
                 )
-            if any(record.multiplier > self.limit for record in self.records):
-                raise _validation_error(
-                    "diophantine.complete_record_multiplier_out_of_range",
-                    "every record multiplier must lie in the declared range",
-                )
-            if any(
-                current.multiplier <= previous.multiplier
-                for previous, current in zip(
-                    self.records, self.records[1:], strict=False
-                )
-            ):
-                raise _validation_error(
-                    "diophantine.complete_record_order",
-                    "record multipliers must be strictly increasing",
-                )
             if self.finite_argmin != self.records[-1].multiplier:
                 raise _validation_error(
                     "diophantine.complete_record_argmin_mismatch",
                     "finite_argmin must be the last certified record multiplier",
-                )
-            if self.finite_argmin > self.limit:
-                raise _validation_error(
-                    "diophantine.complete_record_argmin_out_of_range",
-                    "finite_argmin must lie in the declared range",
                 )
         else:
             if self.finite_argmin is not None:
@@ -515,32 +625,78 @@ class RecordMinimaResult(StrictModel):
         return self
 
     @model_validator(mode="after")
-    def require_complete_record_separation(self) -> Self:
-        if self.outcome == "COMPLETE" and any(
-            current.product_enclosure.upper.as_fraction()
-            >= current.incumbent_enclosure.lower.as_fraction()
-            for current in self.records[1:]
+    def require_common_record_axis(self) -> Self:
+        """Validate record provenance shared by complete and unresolved results."""
+
+        if any(record.multiplier > self.limit for record in self.records):
+            raise _validation_error(
+                (
+                    "diophantine.complete_record_multiplier_out_of_range"
+                    if self.outcome == "COMPLETE"
+                    else "diophantine.record_multiplier_out_of_range"
+                ),
+                "every record multiplier must lie in the declared range",
+            )
+        if any(
+            current.multiplier <= previous.multiplier
+            for previous, current in zip(self.records, self.records[1:], strict=False)
         ):
             raise _validation_error(
-                "diophantine.record_not_strictly_separated",
-                "each retained record must be strictly below its incumbent",
+                (
+                    "diophantine.complete_record_order"
+                    if self.outcome == "COMPLETE"
+                    else "diophantine.record_order"
+                ),
+                "record multipliers must be strictly increasing",
             )
-        return self
-
-    @model_validator(mode="after")
-    def require_unresolved_overlap(self) -> Self:
+        if (
+            self.outcome == "COMPLETE"
+            and self.finite_argmin is not None
+            and self.finite_argmin > self.limit
+        ):
+            raise _validation_error(
+                "diophantine.complete_record_argmin_out_of_range",
+                "finite_argmin must lie in the declared range",
+            )
         if self.outcome == "UNRESOLVED":
-            assert self.unresolved_product_enclosure is not None
             assert self.unresolved_incumbent_enclosure is not None
             if (
-                self.unresolved_product_enclosure.lower.as_fraction()
-                >= self.unresolved_incumbent_enclosure.upper.as_fraction()
+                self.unresolved_incumbent_enclosure
+                != self.records[-1].product_enclosure
             ):
                 raise _validation_error(
-                    "diophantine.unresolved_record_not_overlapping",
-                    "an unresolved comparison must retain overlapping enclosures",
+                    "diophantine.unresolved_record_incumbent_mismatch",
+                    "the unresolved incumbent must equal the last retained product",
                 )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        radicands: tuple[int, ...],
+        limit: int,
+        scale_bits: int,
+        outcome: Literal["COMPLETE", "UNRESOLVED"],
+        records: tuple[RecordMinimumValue, ...],
+        finite_argmin: int | None = None,
+        unresolved_multiplier: int | None = None,
+        unresolved_product_enclosure: ClosedRationalInterval | None = None,
+        unresolved_incumbent_enclosure: ClosedRationalInterval | None = None,
+    ) -> Self:
+        """Construct a result after the owner kernel established its claims."""
+
+        return cls.model_construct(
+            radicands=radicands,
+            limit=limit,
+            scale_bits=scale_bits,
+            outcome=outcome,
+            records=records,
+            finite_argmin=finite_argmin,
+            unresolved_multiplier=unresolved_multiplier,
+            unresolved_product_enclosure=unresolved_product_enclosure,
+            unresolved_incumbent_enclosure=unresolved_incumbent_enclosure,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -8,6 +8,7 @@ deterministic integer arithmetic rather than a floating-point round.
 
 from __future__ import annotations
 
+from fractions import Fraction
 from math import isqrt
 from typing import Literal, Self
 
@@ -98,6 +99,28 @@ class ScaledFloorValue(StrictModel):
     square_lower: ExactInteger
     square_upper: ExactInteger
 
+    @model_validator(mode="after")
+    def require_canonical_bracket_shape(self) -> Self:
+        if not is_surd_radicand(self.radicand):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "a quadratic irrational requires a nonsquare radicand",
+            )
+        if self.floor < 0 or self.ceiling != self.floor + 1:
+            raise _validation_error(
+                "diophantine.scaled_floor_bracket_shape",
+                "floor and ceiling must be consecutive nonnegative integers",
+            )
+        if (
+            self.square_lower != self.floor * self.floor
+            or self.square_upper != self.ceiling * self.ceiling
+        ):
+            raise _validation_error(
+                "diophantine.scaled_floor_square_shape",
+                "endpoint squares must match the retained floor and ceiling",
+            )
+        return self
+
 
 class NearestIntegerDistanceRequest(StrictModel):
     """Certify ``||n sqrt(d)||`` at a requested binary precision."""
@@ -125,6 +148,39 @@ class NearestIntegerDistanceValue(StrictModel):
     scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
     distance_enclosure: ClosedRationalInterval
     distance_upper_scaled: ExactInteger
+
+    @model_validator(mode="after")
+    def require_canonical_distance_shape(self) -> Self:
+        if not is_surd_radicand(self.radicand):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "a quadratic irrational requires a nonsquare radicand",
+            )
+        if self.floor < 0 or self.ceiling != self.floor + 1:
+            raise _validation_error(
+                "diophantine.nearest_integer_bracket_shape",
+                "floor and ceiling must be consecutive nonnegative integers",
+            )
+        expected_nearest = self.floor if self.side == "FLOOR" else self.ceiling
+        if self.nearest_integer != expected_nearest:
+            raise _validation_error(
+                "diophantine.nearest_integer_side_mismatch",
+                "nearest_integer must agree with the certified branch",
+            )
+        if self.distance_enclosure.lower.as_fraction() < 0:
+            raise _validation_error(
+                "diophantine.nearest_integer_negative_distance",
+                "a nearest-integer distance enclosure must be nonnegative",
+            )
+        expected_upper = Fraction(self.distance_upper_scaled, 2**self.scale_bits)
+        if self.distance_upper_scaled < 1 or (
+            self.distance_enclosure.upper.as_fraction() != expected_upper
+        ):
+            raise _validation_error(
+                "diophantine.nearest_integer_upper_mismatch",
+                "distance_upper_scaled must retain the enclosure upper endpoint",
+            )
+        return self
 
 
 class SimultaneousProductRequest(StrictModel):
@@ -167,6 +223,16 @@ class SimultaneousProductResult(StrictModel):
 
     @model_validator(mode="after")
     def require_factor_axis_alignment(self) -> Self:
+        if any(not is_surd_radicand(radicand) for radicand in self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "a quadratic irrational requires nonsquare radicands",
+            )
+        if len(set(self.radicands)) != len(self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicands_must_be_distinct",
+                "an ordered radicand axis requires distinct radicands",
+            )
         if tuple(factor.radicand for factor in self.factors) != self.radicands:
             raise _validation_error(
                 "diophantine.product_factor_axis_mismatch",
@@ -238,6 +304,16 @@ class RangeProfileResult(StrictModel):
 
     @model_validator(mode="after")
     def require_complete_range(self) -> Self:
+        if any(not is_surd_radicand(radicand) for radicand in self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "a quadratic irrational requires nonsquare radicands",
+            )
+        if len(set(self.radicands)) != len(self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicands_must_be_distinct",
+                "an ordered radicand axis requires distinct radicands",
+            )
         if len(self.rows) != self.limit:
             raise _validation_error(
                 "diophantine.range_profile_incomplete",
@@ -310,6 +386,51 @@ class RecordMinimaResult(StrictModel):
     unresolved_incumbent_enclosure: ClosedRationalInterval | None = None
 
     @model_validator(mode="after")
+    def require_surd_axis(self) -> Self:
+        if any(not is_surd_radicand(radicand) for radicand in self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicand_must_not_be_square",
+                "a quadratic irrational requires nonsquare radicands",
+            )
+        if len(set(self.radicands)) != len(self.radicands):
+            raise _validation_error(
+                "diophantine.surd_radicands_must_be_distinct",
+                "an ordered radicand axis requires distinct radicands",
+            )
+        return self
+
+    @model_validator(mode="after")
+    def require_record_history(self) -> Self:
+        if not self.records or self.records[0].multiplier != 1:
+            raise _validation_error(
+                "diophantine.record_sequence_must_start_at_one",
+                "a finite record sequence must retain its first row at multiplier one",
+            )
+        if any(
+            record.product_enclosure.lower.as_fraction() < 0
+            or record.incumbent_enclosure.lower.as_fraction() < 0
+            for record in self.records
+        ):
+            raise _validation_error(
+                "diophantine.record_negative_product_enclosure",
+                "record product enclosures must be nonnegative",
+            )
+        if self.records[0].incumbent_enclosure != self.records[0].product_enclosure:
+            raise _validation_error(
+                "diophantine.first_record_incumbent_mismatch",
+                "the first record's incumbent enclosure must equal its product",
+            )
+        if any(
+            current.incumbent_enclosure != previous.product_enclosure
+            for previous, current in zip(self.records, self.records[1:], strict=False)
+        ):
+            raise _validation_error(
+                "diophantine.record_incumbent_source_mismatch",
+                "each record must retain the prior record's product enclosure",
+            )
+        return self
+
+    @model_validator(mode="after")
     def require_outcome_shape(self) -> Self:
         if self.outcome == "COMPLETE":
             if (
@@ -378,6 +499,34 @@ class RecordMinimaResult(StrictModel):
                 raise _validation_error(
                     "diophantine.unresolved_record_order",
                     "the unresolved multiplier must follow all certified records",
+                )
+        return self
+
+    @model_validator(mode="after")
+    def require_complete_record_separation(self) -> Self:
+        if self.outcome == "COMPLETE" and any(
+            current.product_enclosure.upper.as_fraction()
+            >= current.incumbent_enclosure.lower.as_fraction()
+            for current in self.records[1:]
+        ):
+            raise _validation_error(
+                "diophantine.record_not_strictly_separated",
+                "each retained record must be strictly below its incumbent",
+            )
+        return self
+
+    @model_validator(mode="after")
+    def require_unresolved_overlap(self) -> Self:
+        if self.outcome == "UNRESOLVED":
+            assert self.unresolved_product_enclosure is not None
+            assert self.unresolved_incumbent_enclosure is not None
+            if (
+                self.unresolved_product_enclosure.lower.as_fraction()
+                >= self.unresolved_incumbent_enclosure.upper.as_fraction()
+            ):
+                raise _validation_error(
+                    "diophantine.unresolved_record_not_overlapping",
+                    "an unresolved comparison must retain overlapping enclosures",
                 )
         return self
 

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -41,7 +41,7 @@ _SURD_AXIS_DESCRIPTION = (
 _SURD_SCALAR_RADICAND_DESCRIPTION = (
     f"Nonsquare integer radicand in the admitted range 2..{MAX_SURD_RADICAND}."
 )
-_POSITIVE_MULTIPLIER_PATTERN = r"^[1-9][0-9]*$"
+_POSITIVE_MULTIPLIER_PATTERN = r"^[1-9][0-9]*(?![\s\S])"
 _POSITIVE_MULTIPLIER_DESCRIPTION = (
     "Positive exact multiplier; computation admits at most 4096 bits."
 )

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -248,6 +248,11 @@ class SimultaneousProductResult(StrictModel):
                 "diophantine.product_factor_scale_mismatch",
                 "every factor row must share the requested precision",
             )
+        if self.product_enclosure.lower.as_fraction() < 0:
+            raise _validation_error(
+                "diophantine.product_negative_enclosure",
+                "a simultaneous product enclosure must be nonnegative",
+            )
         return self
 
 
@@ -336,6 +341,11 @@ class RangeProfileResult(StrictModel):
                 raise _validation_error(
                     "diophantine.range_profile_factor_scale_mismatch",
                     "every row factor must share the profile precision",
+                )
+            if row.product_enclosure.lower.as_fraction() < 0:
+                raise _validation_error(
+                    "diophantine.range_profile_negative_product",
+                    "a range product enclosure must be nonnegative",
                 )
         return self
 

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -28,10 +28,12 @@ MAX_SIMULTANEOUS_RADICANDS = 8
 MAX_SURD_MULTIPLIER_BITS = 4_096
 MAX_ENCLOSURE_COMPONENT_DIGITS = 16_384
 # Complete range operations expand a rectangular table.  Admit work and
-# output before any row or exact interval is materialized.
+# retained allocation before any row or exact interval is materialized.  One
+# allocation unit conservatively reserves an exact scalar bit or a fixed
+# structural slot; transports own their encoded-byte ceilings separately.
 MAX_SURD_RANGE_WORK = 32_000_000
 MAX_SURD_RANGE_INTERMEDIATE_BITS = 64_000_000
-MAX_SURD_RANGE_OUTPUT_BYTES = 16 * 1024 * 1024
+MAX_SURD_RANGE_ALLOCATION_UNITS = 16 * 1024 * 1024
 
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
@@ -547,8 +549,8 @@ __all__ = [
     "MAX_SIMULTANEOUS_RADICANDS",
     "MAX_SURD_MULTIPLIER_BITS",
     "MAX_SURD_RADICAND",
+    "MAX_SURD_RANGE_ALLOCATION_UNITS",
     "MAX_SURD_RANGE_INTERMEDIATE_BITS",
-    "MAX_SURD_RANGE_OUTPUT_BYTES",
     "MAX_SURD_RANGE_WORK",
     "MAX_SURD_SCALE_BITS",
     "NearestIntegerDistanceRequest",

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -41,6 +41,10 @@ _SURD_AXIS_DESCRIPTION = (
 _SURD_SCALAR_RADICAND_DESCRIPTION = (
     f"Nonsquare integer radicand in the admitted range 2..{MAX_SURD_RADICAND}."
 )
+_POSITIVE_MULTIPLIER_PATTERN = r"^[1-9][0-9]*$"
+_POSITIVE_MULTIPLIER_DESCRIPTION = (
+    "Positive exact multiplier; computation admits at most 4096 bits."
+)
 
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
@@ -90,7 +94,8 @@ class ScaledFloorRequest(StrictModel):
 
     multiplier: ExactInteger = Field(
         ge=1,
-        description="Positive exact multiplier; computation admits at most 4096 bits.",
+        description=_POSITIVE_MULTIPLIER_DESCRIPTION,
+        json_schema_extra={"pattern": _POSITIVE_MULTIPLIER_PATTERN},
     )
     radicand: StrictInt = Field(
         ge=2,
@@ -154,7 +159,8 @@ class NearestIntegerDistanceRequest(StrictModel):
 
     multiplier: ExactInteger = Field(
         ge=1,
-        description="Positive exact multiplier; computation admits at most 4096 bits.",
+        description=_POSITIVE_MULTIPLIER_DESCRIPTION,
+        json_schema_extra={"pattern": _POSITIVE_MULTIPLIER_PATTERN},
     )
     radicand: StrictInt = Field(
         ge=2,
@@ -247,7 +253,8 @@ class SimultaneousProductRequest(StrictModel):
 
     multiplier: ExactInteger = Field(
         ge=1,
-        description="Positive exact multiplier; computation admits at most 4096 bits.",
+        description=_POSITIVE_MULTIPLIER_DESCRIPTION,
+        json_schema_extra={"pattern": _POSITIVE_MULTIPLIER_PATTERN},
     )
     radicands: tuple[StrictInt, ...] = Field(
         min_length=1,

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_models.py
@@ -22,7 +22,10 @@ MAX_SURD_RADICAND = 1_000_000
 MAX_SURD_SCALE_BITS = 4_096
 MAX_RANGE_LENGTH = 4_096
 MAX_SIMULTANEOUS_RADICANDS = 8
-MAX_ENCLOSURE_COMPONENT_DIGITS = 4_096
+# A product denominator has at most 8 * 4096 binary places; multiplying by
+# a 4096-bit integer keeps both components below 16384 decimal digits.
+MAX_SURD_MULTIPLIER_BITS = 4_096
+MAX_ENCLOSURE_COMPONENT_DIGITS = 16_384
 
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
@@ -70,7 +73,10 @@ def bound_enclosure(
 class ScaledFloorRequest(StrictModel):
     """Exact floor/ceiling of ``n * sqrt(d)`` for positive ``n`` and nonsquare ``d``."""
 
-    multiplier: StrictInt = Field(ge=1)
+    multiplier: ExactInteger = Field(
+        ge=1,
+        description="Positive exact multiplier; computation admits at most 4096 bits.",
+    )
     radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
 
     @model_validator(mode="after")
@@ -86,7 +92,10 @@ class ScaledFloorRequest(StrictModel):
 class ScaledFloorValue(StrictModel):
     """One exact floor/ceiling row derived from integer squares only."""
 
-    multiplier: StrictInt = Field(ge=1)
+    multiplier: ExactInteger = Field(
+        ge=1,
+        description="Positive exact multiplier; computation admits at most 4096 bits.",
+    )
     radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
     floor: ExactInteger
     ceiling: ExactInteger
@@ -123,7 +132,10 @@ class ScaledFloorResult(StrictModel):
 class NearestIntegerDistanceRequest(StrictModel):
     """Certify ``||n sqrt(d)||`` at a requested binary precision."""
 
-    multiplier: StrictInt = Field(ge=1)
+    multiplier: ExactInteger = Field(
+        ge=1,
+        description="Positive exact multiplier; computation admits at most 4096 bits.",
+    )
     radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
     scale_bits: StrictInt = Field(ge=1, le=MAX_SURD_SCALE_BITS)
 
@@ -140,7 +152,10 @@ class NearestIntegerDistanceRequest(StrictModel):
 class NearestIntegerDistanceValue(StrictModel):
     """Exact nearest-integer data plus a certified distance enclosure."""
 
-    multiplier: StrictInt = Field(ge=1)
+    multiplier: ExactInteger = Field(
+        ge=1,
+        description="Positive exact multiplier; computation admits at most 4096 bits.",
+    )
     radicand: StrictInt = Field(ge=2, le=MAX_SURD_RADICAND)
     floor: ExactInteger
     ceiling: ExactInteger
@@ -174,7 +189,10 @@ class NearestIntegerDistanceValue(StrictModel):
 class SimultaneousProductRequest(StrictModel):
     """Certify ``n * prod_i ||n sqrt(d_i)||`` over an ordered radicand axis."""
 
-    multiplier: StrictInt = Field(ge=1)
+    multiplier: ExactInteger = Field(
+        ge=1,
+        description="Positive exact multiplier; computation admits at most 4096 bits.",
+    )
     radicands: tuple[StrictInt, ...] = Field(
         min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
     )
@@ -198,7 +216,10 @@ class SimultaneousProductRequest(StrictModel):
 class SimultaneousProductResult(StrictModel):
     """Per-factor nearest-integer rows and the certified product enclosure."""
 
-    multiplier: StrictInt = Field(ge=1)
+    multiplier: ExactInteger = Field(
+        ge=1,
+        description="Positive exact multiplier; computation admits at most 4096 bits.",
+    )
     radicands: tuple[StrictInt, ...] = Field(
         min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
     )
@@ -250,7 +271,10 @@ class RangeProfileRequest(StrictModel):
 class RangeProfileRow(StrictModel):
     """One complete certified row: factor enclosures and their product."""
 
-    multiplier: StrictInt = Field(ge=1)
+    multiplier: ExactInteger = Field(
+        ge=1,
+        description="Positive exact multiplier; computation admits at most 4096 bits.",
+    )
     factors: tuple[NearestIntegerDistanceValue, ...] = Field(
         min_length=1, max_length=MAX_SIMULTANEOUS_RADICANDS
     )
@@ -317,7 +341,10 @@ class RecordMinimaRequest(StrictModel):
 class RecordMinimumValue(StrictModel):
     """One certified strict-record row."""
 
-    multiplier: StrictInt = Field(ge=1)
+    multiplier: ExactInteger = Field(
+        ge=1,
+        description="Positive exact multiplier; computation admits at most 4096 bits.",
+    )
     product_enclosure: ClosedRationalInterval
     incumbent_enclosure: ClosedRationalInterval
 

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_tools.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_tools.py
@@ -34,7 +34,7 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             OperationExample(
                 name="three_sqrt_two",
                 description="floor(3*sqrt(2)) = 4 and ceiling 5.",
-                input={"multiplier": 3, "radicand": 2},
+                input={"multiplier": "3", "radicand": 2},
             ),
         ),
     ),
@@ -56,7 +56,7 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             OperationExample(
                 name="sqrt_two_distance",
                 description="||sqrt(2)|| is enclosed near 0.414 at 32-bit precision.",
-                input={"multiplier": 1, "radicand": 2, "scale_bits": 32},
+                input={"multiplier": "1", "radicand": 2, "scale_bits": 32},
             ),
         ),
     ),
@@ -76,7 +76,7 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             OperationExample(
                 name="sqrt_two_sqrt_three",
                 description="Product factor for sqrt(2) and sqrt(3) at n = 1.",
-                input={"multiplier": 1, "radicands": [2, 3], "scale_bits": 32},
+                input={"multiplier": "1", "radicands": [2, 3], "scale_bits": 32},
             ),
         ),
     ),

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_tools.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_tools.py
@@ -9,13 +9,44 @@ from jacobian.math.number_theory.diophantine_approximation._surd_models import (
     NearestIntegerDistanceValue,
     RangeProfileRequest,
     RangeProfileResult,
-    RecordMinimaRequest,
-    RecordMinimaResult,
     ScaledFloorRequest,
     ScaledFloorValue,
     SimultaneousProductRequest,
     SimultaneousProductResult,
 )
+
+
+def _scaled_floor(request: ScaledFloorRequest) -> ScaledFloorValue:
+    return native.scaled_floor(request.multiplier, request.radicand)
+
+
+def _nearest_integer_distance(
+    request: NearestIntegerDistanceRequest,
+) -> NearestIntegerDistanceValue:
+    return native.nearest_integer_distance(
+        request.multiplier,
+        request.radicand,
+        request.scale_bits,
+    )
+
+
+def _simultaneous_product(
+    request: SimultaneousProductRequest,
+) -> SimultaneousProductResult:
+    return native.simultaneous_product(
+        request.multiplier,
+        request.radicands,
+        request.scale_bits,
+    )
+
+
+def _range_profile(request: RangeProfileRequest) -> RangeProfileResult:
+    return native.range_profile(
+        request.radicands,
+        request.limit,
+        request.scale_bits,
+    )
+
 
 SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     MathTool(
@@ -28,7 +59,7 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         ),
         request_type=ScaledFloorRequest,
         result_type=ScaledFloorValue,
-        run=native.scaled_floor,
+        run=_scaled_floor,
         tags=("number-theory", "quadratic-surd", "floor", "exact"),
         examples=(
             OperationExample(
@@ -46,13 +77,13 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         description=(
             "Return the exact floor, ceiling, nearest integer, and branch of "
             "n*sqrt(d) together with a certified rational enclosure of the "
-            "distance ||n*sqrt(d)|| at the requested binary scale. A precision "
-            "that cannot separate the two branches is rejected rather than "
-            "guessed."
+            "distance ||n*sqrt(d)|| at the requested binary scale. The nearest "
+            "branch is selected by an exact midpoint comparison, even when the "
+            "requested dyadic enclosure touches the midpoint."
         ),
         request_type=NearestIntegerDistanceRequest,
         result_type=NearestIntegerDistanceValue,
-        run=native.nearest_integer_distance,
+        run=_nearest_integer_distance,
         tags=("number-theory", "quadratic-surd", "certified", "enclosure"),
         examples=(
             OperationExample(
@@ -75,7 +106,7 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         ),
         request_type=SimultaneousProductRequest,
         result_type=SimultaneousProductResult,
-        run=native.simultaneous_product,
+        run=_simultaneous_product,
         tags=("number-theory", "simultaneous-approximation", "certified"),
         examples=(
             OperationExample(
@@ -98,7 +129,7 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         ),
         request_type=RangeProfileRequest,
         result_type=RangeProfileResult,
-        run=native.range_profile,
+        run=_range_profile,
         tags=("number-theory", "simultaneous-approximation", "range", "certified"),
         examples=(
             OperationExample(
@@ -108,30 +139,6 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                     "2 and 3 up to 10."
                 ),
                 input={"radicands": [2, 3], "limit": 10, "scale_bits": 32},
-            ),
-        ),
-    ),
-    MathTool(
-        operation_id="number_theory.simultaneous_approximation.record_minima.compute",
-        title="Extract strict certified record minima from a finite range",
-        description=(
-            "Return the strict record-minimum sequence and the finite argmin of "
-            "n*prod_i||n*sqrt(d_i)|| over a complete certified range, or an "
-            "explicit UNRESOLVED row with both enclosures when the declared "
-            "precision cannot strictly separate a comparison."
-        ),
-        request_type=RecordMinimaRequest,
-        result_type=RecordMinimaResult,
-        run=native.record_minima,
-        tags=("number-theory", "simultaneous-approximation", "records", "certified"),
-        examples=(
-            OperationExample(
-                name="records_sqrt_two_sqrt_three",
-                description=(
-                    "Strict records for distinct nonsquare radicands 2 and 3 "
-                    "with n <= 50."
-                ),
-                input={"radicands": [2, 3], "limit": 50, "scale_bits": 64},
             ),
         ),
     ),

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_tools.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_tools.py
@@ -1,0 +1,125 @@
+"""Certified finite quadratic-surd operation declarations."""
+
+from typing import Any
+
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.number_theory.diophantine_approximation import _surd_kernel as native
+from jacobian.math.number_theory.diophantine_approximation._surd_models import (
+    NearestIntegerDistanceRequest,
+    NearestIntegerDistanceValue,
+    RangeProfileRequest,
+    RangeProfileResult,
+    RecordMinimaRequest,
+    RecordMinimaResult,
+    ScaledFloorRequest,
+    ScaledFloorResult,
+    SimultaneousProductRequest,
+    SimultaneousProductResult,
+)
+
+SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="number_theory.quadratic_surd.scaled_floor.compute",
+        title="Compute the exact floor and ceiling of n*sqrt(d)",
+        description=(
+            "Return floor(n*sqrt(d)) = isqrt(d*n^2) and its ceiling for a "
+            "positive multiplier and a nonsquare integer radicand, together "
+            "with the exact endpoint squares that replay the bracket."
+        ),
+        request_type=ScaledFloorRequest,
+        result_type=ScaledFloorResult,
+        run=native.scaled_floor,
+        tags=("number-theory", "quadratic-surd", "floor", "exact"),
+        examples=(
+            OperationExample(
+                name="three_sqrt_two",
+                description="floor(3*sqrt(2)) = 4 and ceiling 5.",
+                input={"multiplier": 3, "radicand": 2},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="number_theory.quadratic_surd.nearest_integer_distance.compute",
+        title="Certify the distance from n*sqrt(d) to the nearest integer",
+        description=(
+            "Return the exact floor, ceiling, nearest integer, and branch of "
+            "n*sqrt(d) together with a certified rational enclosure of the "
+            "distance ||n*sqrt(d)|| at the requested binary scale. A precision "
+            "that cannot separate the two branches is rejected rather than "
+            "guessed."
+        ),
+        request_type=NearestIntegerDistanceRequest,
+        result_type=NearestIntegerDistanceValue,
+        run=native.nearest_integer_distance,
+        tags=("number-theory", "quadratic-surd", "certified", "enclosure"),
+        examples=(
+            OperationExample(
+                name="sqrt_two_distance",
+                description="||sqrt(2)|| is enclosed near 0.414 at 32-bit precision.",
+                input={"multiplier": 1, "radicand": 2, "scale_bits": 32},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="number_theory.simultaneous_approximation.product_enclosure.compute",
+        title="Certify n times a product of quadratic-surd distances",
+        description=(
+            "Return every per-factor nearest-integer row and a certified "
+            "rational enclosure of n*prod_i||n*sqrt(d_i)|| over an ordered "
+            "radicand axis."
+        ),
+        request_type=SimultaneousProductRequest,
+        result_type=SimultaneousProductResult,
+        run=native.simultaneous_product,
+        tags=("number-theory", "simultaneous-approximation", "certified"),
+        examples=(
+            OperationExample(
+                name="sqrt_two_sqrt_three",
+                description="Product factor for sqrt(2) and sqrt(3) at n = 1.",
+                input={"multiplier": 1, "radicands": [2, 3], "scale_bits": 32},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="number_theory.simultaneous_approximation.range_profile.compute",
+        title="Return a complete certified simultaneous-approximation range",
+        description=(
+            "Return one certified row for every integer 1 <= n <= limit, with "
+            "floors, nearest integers, per-factor enclosure intervals, and the "
+            "product interval. Every row of the declared range is present; the "
+            "operation never omits a difficult row silently."
+        ),
+        request_type=RangeProfileRequest,
+        result_type=RangeProfileResult,
+        run=native.range_profile,
+        tags=("number-theory", "simultaneous-approximation", "range", "certified"),
+        examples=(
+            OperationExample(
+                name="sqrt_two_sqrt_three_to_ten",
+                description="Complete certified range for sqrt(2), sqrt(3) up to 10.",
+                input={"radicands": [2, 3], "limit": 10, "scale_bits": 32},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="number_theory.simultaneous_approximation.record_minima.compute",
+        title="Extract strict certified record minima from a finite range",
+        description=(
+            "Return the strict record-minimum sequence and the finite argmin of "
+            "n*prod_i||n*sqrt(d_i)|| over a complete certified range, or an "
+            "explicit UNRESOLVED row with both enclosures when the declared "
+            "precision cannot strictly separate a comparison."
+        ),
+        request_type=RecordMinimaRequest,
+        result_type=RecordMinimaResult,
+        run=native.record_minima,
+        tags=("number-theory", "simultaneous-approximation", "records", "certified"),
+        examples=(
+            OperationExample(
+                name="records_sqrt_two_sqrt_three",
+                description="Strict records of n*||n*sqrt(2)||*||n*sqrt(3)|| for n <= 50.",
+                input={"radicands": [2, 3], "limit": 50, "scale_bits": 64},
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/number_theory/diophantine_approximation/_surd_tools.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_surd_tools.py
@@ -12,7 +12,7 @@ from jacobian.math.number_theory.diophantine_approximation._surd_models import (
     RecordMinimaRequest,
     RecordMinimaResult,
     ScaledFloorRequest,
-    ScaledFloorResult,
+    ScaledFloorValue,
     SimultaneousProductRequest,
     SimultaneousProductResult,
 )
@@ -27,13 +27,15 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             "with the exact endpoint squares that replay the bracket."
         ),
         request_type=ScaledFloorRequest,
-        result_type=ScaledFloorResult,
+        result_type=ScaledFloorValue,
         run=native.scaled_floor,
         tags=("number-theory", "quadratic-surd", "floor", "exact"),
         examples=(
             OperationExample(
                 name="three_sqrt_two",
-                description="floor(3*sqrt(2)) = 4 and ceiling 5.",
+                description=(
+                    "For the nonsquare radicand 2, floor(3*sqrt(2)) = 4 and ceiling 5."
+                ),
                 input={"multiplier": "3", "radicand": 2},
             ),
         ),
@@ -55,7 +57,10 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             OperationExample(
                 name="sqrt_two_distance",
-                description="||sqrt(2)|| is enclosed near 0.414 at 32-bit precision.",
+                description=(
+                    "For nonsquare radicand 2, ||sqrt(2)|| is enclosed near "
+                    "0.414 at 32-bit precision."
+                ),
                 input={"multiplier": "1", "radicand": 2, "scale_bits": 32},
             ),
         ),
@@ -75,7 +80,9 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             OperationExample(
                 name="sqrt_two_sqrt_three",
-                description="Product factor for sqrt(2) and sqrt(3) at n = 1.",
+                description=(
+                    "Product factor for distinct nonsquare radicands 2 and 3 at n = 1."
+                ),
                 input={"multiplier": "1", "radicands": [2, 3], "scale_bits": 32},
             ),
         ),
@@ -96,7 +103,10 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             OperationExample(
                 name="sqrt_two_sqrt_three_to_ten",
-                description="Complete certified range for sqrt(2), sqrt(3) up to 10.",
+                description=(
+                    "Complete certified range for distinct nonsquare radicands "
+                    "2 and 3 up to 10."
+                ),
                 input={"radicands": [2, 3], "limit": 10, "scale_bits": 32},
             ),
         ),
@@ -117,7 +127,10 @@ SURD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             OperationExample(
                 name="records_sqrt_two_sqrt_three",
-                description="Strict records of n*||n*sqrt(2)||*||n*sqrt(3)|| for n <= 50.",
+                description=(
+                    "Strict records for distinct nonsquare radicands 2 and 3 "
+                    "with n <= 50."
+                ),
                 input={"radicands": [2, 3], "limit": 50, "scale_bits": 64},
             ),
         ),

--- a/src/jacobian/math/number_theory/diophantine_approximation/_tools.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/_tools.py
@@ -12,6 +12,9 @@ from jacobian.math.number_theory.diophantine_approximation._models import (
     PellEquationRequest,
     PellEquationResult,
 )
+from jacobian.math.number_theory.diophantine_approximation._surd_tools import (
+    SURD_OPERATIONS,
+)
 
 
 def compute_continued_fraction(
@@ -29,6 +32,7 @@ def compute_pell_equation(request: PellEquationRequest) -> PellEquationResult:
 
 
 TOOLS: tuple[MathTool[Any, Any], ...] = (
+    *SURD_OPERATIONS,
     MathTool(
         operation_id="diophantine.continued_fraction.compute",
         title="Compute the continued fraction expansion of sqrt(D)",

--- a/src/jacobian/math/number_theory/diophantine_approximation/operations.py
+++ b/src/jacobian/math/number_theory/diophantine_approximation/operations.py
@@ -12,8 +12,24 @@ from jacobian.math.number_theory.diophantine_approximation._models import (
     ConvergentValue,
     PellEquationResult,
 )
+from jacobian.math.number_theory.diophantine_approximation._surd_kernel import (
+    nearest_integer_distance,
+    range_profile,
+    record_minima,
+    scaled_floor,
+    simultaneous_product,
+)
 
-__all__ = ["continued_fraction", "convergents", "solve_pell"]
+__all__ = [
+    "continued_fraction",
+    "convergents",
+    "nearest_integer_distance",
+    "range_profile",
+    "record_minima",
+    "scaled_floor",
+    "simultaneous_product",
+    "solve_pell",
+]
 
 
 def _require_periodic_discriminant(discriminant: int) -> None:

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -522,9 +522,9 @@ def test_scaled_floor_deserialization_does_not_replay_endpoint_squares() -> None
     value = scaled_floor(3, 2)
     restored = ScaledFloorValue.model_validate_json(value.model_dump_json())
     assert restored == value
-    payload = value.model_dump(mode="json")
+    payload = json.loads(value.model_dump_json())
     payload["square_lower"] = str(int(payload["square_lower"]) + 1)
-    authored = ScaledFloorValue.model_validate(payload)
+    authored = ScaledFloorValue.model_validate_json(json.dumps(payload))
     assert authored.square_lower != authored.floor * authored.floor
     assert authored.square_upper == value.square_upper
 

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -517,6 +517,37 @@ def test_scaled_floor_rejects_square_radicand() -> None:
         scaled_floor(2, 9)
 
 
+def test_surd_request_schemas_encode_positive_multipliers() -> None:
+    """Wire JSON for multipliers is a positive decimal string, not ExactInteger zero."""
+    payloads = (
+        (ScaledFloorRequest, '{"multiplier":"0","radicand":2}'),
+        (
+            NearestIntegerDistanceRequest,
+            '{"multiplier":"0","radicand":2,"scale_bits":1}',
+        ),
+        (
+            SimultaneousProductRequest,
+            '{"multiplier":"0","radicands":[2],"scale_bits":1}',
+        ),
+    )
+    negative = (
+        (ScaledFloorRequest, '{"multiplier":"-1","radicand":2}'),
+        (
+            NearestIntegerDistanceRequest,
+            '{"multiplier":"-1","radicand":2,"scale_bits":1}',
+        ),
+        (
+            SimultaneousProductRequest,
+            '{"multiplier":"-1","radicands":[2],"scale_bits":1}',
+        ),
+    )
+    for request_type, payload in (*payloads, *negative):
+        schema = request_type.model_json_schema()["properties"]["multiplier"]
+        assert schema["pattern"] == r"^[1-9][0-9]*$"
+        with pytest.raises(ValidationError):
+            request_type.model_validate_json(payload)
+
+
 def test_scaled_floor_deserialization_does_not_replay_endpoint_squares() -> None:
     """Endpoint squares are authored claims; decoding must not recompute them."""
     value = scaled_floor(3, 2)

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -39,6 +39,7 @@ from jacobian.math.number_theory.diophantine_approximation._models import (
     PellEquationRequest,
 )
 from jacobian.math.number_theory.diophantine_approximation._surd_models import (
+    NearestIntegerDistanceRequest,
     NearestIntegerDistanceValue,
     RangeProfileRequest,
     RangeProfileResult,
@@ -514,6 +515,26 @@ def test_scaled_floor_rejects_square_radicand() -> None:
     """A perfect-square radicand is outside the irrational contract."""
     with pytest.raises(OperationDomainValidationError):
         scaled_floor(2, 9)
+
+
+def test_scaled_floor_deserialization_does_not_replay_endpoint_squares() -> None:
+    """Endpoint squares are authored claims; decoding must not recompute them."""
+    value = scaled_floor(3, 2)
+    restored = ScaledFloorValue.model_validate_json(value.model_dump_json())
+    assert restored == value
+    payload = value.model_dump(mode="json")
+    payload["square_lower"] = str(int(payload["square_lower"]) + 1)
+    authored = ScaledFloorValue.model_validate(payload)
+    assert authored.square_lower != authored.floor * authored.floor
+    assert authored.square_upper == value.square_upper
+
+
+def test_scalar_surd_requests_advertise_the_nonsquare_radicand_constraint() -> None:
+    """Schema-driven callers see the nonsquare constraint before execution."""
+    for model in (ScaledFloorRequest, NearestIntegerDistanceRequest):
+        description = model.model_fields["radicand"].description
+        assert description is not None
+        assert "nonsquare" in description.lower()
 
 
 def test_native_multiplier_domain_precedes_bit_admission() -> None:

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -39,6 +39,7 @@ from jacobian.math.number_theory.diophantine_approximation._surd_models import (
     ScaledFloorRequest,
     ScaledFloorValue,
     SimultaneousProductRequest,
+    SimultaneousProductResult,
 )
 from jacobian.math.number_theory.diophantine_approximation._tools import (
     compute_continued_fraction,
@@ -779,6 +780,16 @@ def test_serialized_surd_values_reject_forged_structural_fields() -> None:
     with pytest.raises(ValidationError):
         NearestIntegerDistanceValue.model_validate_json(
             encode_strict_json(distance_payload), strict=True
+        )
+
+    product = simultaneous_product(
+        SimultaneousProductRequest(multiplier=1, radicands=(2, 3), scale_bits=32)
+    )
+    product_payload = product.model_dump(mode="json")
+    product_payload["product_enclosure"]["lower"] = {"num": "-1", "den": "1"}
+    with pytest.raises(ValidationError):
+        SimultaneousProductResult.model_validate_json(
+            encode_strict_json(product_payload), strict=True
         )
 
 

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -516,6 +516,13 @@ def test_scaled_floor_rejects_square_radicand() -> None:
         scaled_floor(2, 9)
 
 
+def test_native_multiplier_domain_precedes_bit_admission() -> None:
+    """An invalid sign remains a domain error regardless of its magnitude."""
+    with pytest.raises(OperationDomainValidationError) as error:
+        scaled_floor(-(1 << 4096), 2)
+    assert error.value.errors()[0]["type"] == "diophantine.multiplier_out_of_range"
+
+
 def test_nearest_integer_distance_branches_on_both_sides() -> None:
     """The nearest integer can come from either endpoint of the bracket."""
     floor_side = nearest_integer_distance(1, 2, 48)
@@ -859,6 +866,19 @@ def test_serialized_unresolved_record_result_rejects_impossible_history() -> Non
         RecordMinimaResult.model_validate_json(
             encode_strict_json(malformed_incumbent), strict=True
         )
+
+    malformed_product = result.model_dump(mode="json")
+    malformed_product["unresolved_product_enclosure"]["lower"] = {
+        "num": "-1",
+        "den": "1",
+    }
+    with pytest.raises(ValidationError) as error:
+        RecordMinimaResult.model_validate_json(
+            encode_strict_json(malformed_product), strict=True
+        )
+    assert error.value.errors()[0]["type"] == (
+        "diophantine.record_negative_product_enclosure"
+    )
 
 
 def test_large_multiplier_uses_exact_json_integer_encoding() -> None:

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -543,9 +543,11 @@ def test_surd_request_schemas_encode_positive_multipliers() -> None:
     )
     for request_type, payload in (*payloads, *negative):
         schema = request_type.model_json_schema()["properties"]["multiplier"]
-        assert schema["pattern"] == r"^[1-9][0-9]*$"
+        assert schema["pattern"] == r"^[1-9][0-9]*(?![\s\S])"
         with pytest.raises(ValidationError):
             request_type.model_validate_json(payload)
+    with pytest.raises(ValidationError):
+        ScaledFloorRequest.model_validate_json('{"multiplier":"1\\n","radicand":2}')
 
 
 def test_scaled_floor_deserialization_does_not_replay_endpoint_squares() -> None:

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -761,6 +761,51 @@ def test_nearest_integer_distance_round_trips_through_strict_json() -> None:
     assert restored == result
 
 
+def test_serialized_surd_values_reject_forged_structural_fields() -> None:
+    """Canonical carriers retain their domain and branch bindings on decode."""
+    floor = scaled_floor(ScaledFloorRequest(multiplier=6, radicand=3))
+    floor_payload = floor.model_dump(mode="json")
+    floor_payload["radicand"] = 4
+    with pytest.raises(ValidationError):
+        ScaledFloorValue.model_validate_json(
+            encode_strict_json(floor_payload), strict=True
+        )
+
+    distance = nearest_integer_distance(
+        NearestIntegerDistanceRequest(multiplier=5, radicand=7, scale_bits=32)
+    )
+    distance_payload = distance.model_dump(mode="json")
+    distance_payload["nearest_integer"] = distance.ceiling
+    with pytest.raises(ValidationError):
+        NearestIntegerDistanceValue.model_validate_json(
+            encode_strict_json(distance_payload), strict=True
+        )
+
+
+def test_serialized_record_result_rejects_missing_or_unbound_history() -> None:
+    """A record result cannot lose its first row or incumbent source binding."""
+    result = record_minima(
+        RecordMinimaRequest(radicands=(2, 3), limit=20, scale_bits=64)
+    )
+    assert result.outcome == "COMPLETE"
+
+    missing_first = result.model_dump(mode="json")
+    missing_first["records"] = []
+    with pytest.raises(ValidationError):
+        RecordMinimaResult.model_validate_json(
+            encode_strict_json(missing_first), strict=True
+        )
+
+    unbound_incumbent = result.model_dump(mode="json")
+    unbound_incumbent["records"][1]["incumbent_enclosure"] = unbound_incumbent[
+        "records"
+    ][1]["product_enclosure"]
+    with pytest.raises(ValidationError):
+        RecordMinimaResult.model_validate_json(
+            encode_strict_json(unbound_incumbent), strict=True
+        )
+
+
 def test_large_multiplier_uses_exact_json_integer_encoding() -> None:
     request = ScaledFloorRequest(multiplier=2**53, radicand=2)
     result = scaled_floor(request)

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -13,7 +13,13 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.canonical import encode_strict_json
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.number_theory.diophantine_approximation import (
+    _surd_kernel as surd_kernel,
+)
 from jacobian.math.number_theory.diophantine_approximation import (
     continued_fraction,
     convergents,
@@ -645,6 +651,14 @@ def test_range_profile_rejects_aggregate_output_before_expansion() -> None:
         "diophantine.range_profile_intermediate_bound",
         "diophantine.range_profile_work_bound",
     }
+
+
+def test_range_profile_admits_retained_allocation_before_expansion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(surd_kernel, "MAX_SURD_RANGE_ALLOCATION_UNITS", 1)
+    with pytest.raises(OperationResourceAdmissionError, match="allocation bound"):
+        range_profile(RangeProfileRequest(radicands=(2, 3), limit=2, scale_bits=32))
 
 
 def test_serialized_range_rejects_forged_factor_axes() -> None:

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import decimal
 import json
 import math
+import threading
 from collections.abc import Callable
 from decimal import Decimal
 from fractions import Fraction
@@ -12,7 +13,9 @@ from fractions import Fraction
 import pytest
 from pydantic import ValidationError
 
+from jacobian._execution import OperationExecutionCancelledError, request_cancellation
 from jacobian.canonical import encode_strict_json
+from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
@@ -36,7 +39,6 @@ from jacobian.math.number_theory.diophantine_approximation._models import (
     PellEquationRequest,
 )
 from jacobian.math.number_theory.diophantine_approximation._surd_models import (
-    NearestIntegerDistanceRequest,
     NearestIntegerDistanceValue,
     RangeProfileRequest,
     RangeProfileResult,
@@ -501,9 +503,7 @@ def _high_precision_sqrt(radicand: int, digits: int = 80) -> str:
 def test_scaled_floor_matches_integer_square_definition() -> None:
     """floor(n*sqrt(d)) is isqrt(d*n^2) for a nonsquare radicand."""
     for multiplier, radicand in ((3, 2), (1, 2), (7, 3), (10, 5), (12, 6)):
-        value = scaled_floor(
-            ScaledFloorRequest(multiplier=multiplier, radicand=radicand)
-        )
+        value = scaled_floor(multiplier, radicand)
         assert value.floor == math.isqrt(radicand * multiplier * multiplier)
         assert value.ceiling == value.floor + 1
         assert value.square_lower == value.floor * value.floor
@@ -513,17 +513,13 @@ def test_scaled_floor_matches_integer_square_definition() -> None:
 def test_scaled_floor_rejects_square_radicand() -> None:
     """A perfect-square radicand is outside the irrational contract."""
     with pytest.raises(OperationDomainValidationError):
-        scaled_floor(ScaledFloorRequest(multiplier=2, radicand=9))
+        scaled_floor(2, 9)
 
 
 def test_nearest_integer_distance_branches_on_both_sides() -> None:
     """The nearest integer can come from either endpoint of the bracket."""
-    floor_side = nearest_integer_distance(
-        NearestIntegerDistanceRequest(multiplier=1, radicand=2, scale_bits=48)
-    )
-    ceiling_side = nearest_integer_distance(
-        NearestIntegerDistanceRequest(multiplier=1, radicand=3, scale_bits=48)
-    )
+    floor_side = nearest_integer_distance(1, 2, 48)
+    ceiling_side = nearest_integer_distance(1, 3, 48)
     assert floor_side.side == "FLOOR"
     assert floor_side.nearest_integer == floor_side.floor
     assert ceiling_side.side == "CEILING"
@@ -533,11 +529,7 @@ def test_nearest_integer_distance_branches_on_both_sides() -> None:
 def test_nearest_integer_distance_encloses_the_true_distance() -> None:
     """Independent high-precision square roots must lie inside the enclosure."""
     for multiplier, radicand in ((1, 2), (2, 3), (5, 7), (9, 11), (31, 13)):
-        value = nearest_integer_distance(
-            NearestIntegerDistanceRequest(
-                multiplier=multiplier, radicand=radicand, scale_bits=64
-            )
-        )
+        value = nearest_integer_distance(multiplier, radicand, 64)
         true_distance = abs(
             Decimal(multiplier) * Decimal(_high_precision_sqrt(radicand))
             - Decimal(value.nearest_integer)
@@ -546,25 +538,19 @@ def test_nearest_integer_distance_encloses_the_true_distance() -> None:
         assert Fraction(true_distance) <= value.distance_enclosure.upper.as_fraction()
 
 
-def test_insufficient_precision_is_reported_not_guessed() -> None:
-    """Overlapping branches must be rejected, never tie-broken arbitrarily."""
-    with pytest.raises(OperationDomainValidationError) as error:
-        nearest_integer_distance(
-            NearestIntegerDistanceRequest(multiplier=1, radicand=2, scale_bits=1)
-        )
-    assert error.value.errors()[0]["type"] == (
-        "diophantine.nearest_integer_branch_unresolved"
-    )
+def test_midpoint_branch_is_decided_by_exact_integer_ordering() -> None:
+    """A coarse bracket still selects the exact nearest branch at a midpoint."""
+    value = nearest_integer_distance(1, 2, 1)
+    assert value.side == "FLOOR"
+    assert value.nearest_integer == value.floor == 1
+    assert value.distance_enclosure.lower.as_fraction() == 0
+    assert value.distance_enclosure.upper.as_fraction() == Fraction(1, 2)
 
 
 def test_refinement_tightens_without_reversing_a_separated_order() -> None:
     """A larger scale subdivides the same bracket and never reverses order."""
-    coarse = nearest_integer_distance(
-        NearestIntegerDistanceRequest(multiplier=1, radicand=2, scale_bits=8)
-    )
-    fine = nearest_integer_distance(
-        NearestIntegerDistanceRequest(multiplier=1, radicand=2, scale_bits=64)
-    )
+    coarse = nearest_integer_distance(1, 2, 8)
+    fine = nearest_integer_distance(1, 2, 64)
     assert coarse.side == fine.side == "FLOOR"
     coarse_width = (
         coarse.distance_enclosure.upper.as_fraction()
@@ -585,17 +571,11 @@ def test_refinement_tightens_without_reversing_a_separated_order() -> None:
 
 def test_product_enclosure_includes_the_outer_factor_and_contains_the_value() -> None:
     """n * prod_i ||n sqrt(d_i)|| is enclosed, not the bare product of distances."""
-    result = simultaneous_product(
-        SimultaneousProductRequest(multiplier=4, radicands=(2, 3), scale_bits=64)
-    )
+    result = simultaneous_product(4, (2, 3), 64)
     assert tuple(f.radicand for f in result.factors) == (2, 3)
     true_product = Decimal(4)
     for radicand in (2, 3):
-        per_factor = nearest_integer_distance(
-            NearestIntegerDistanceRequest(
-                multiplier=4, radicand=radicand, scale_bits=64
-            )
-        )
+        per_factor = nearest_integer_distance(4, radicand, 64)
         true_product *= abs(
             Decimal(4) * Decimal(_high_precision_sqrt(radicand))
             - Decimal(per_factor.nearest_integer)
@@ -606,46 +586,31 @@ def test_product_enclosure_includes_the_outer_factor_and_contains_the_value() ->
 
 def test_product_enclosure_is_radicand_permutation_invariant() -> None:
     """Reordering the radicand axis permutes rows but preserves the product."""
-    forward = simultaneous_product(
-        SimultaneousProductRequest(multiplier=3, radicands=(2, 3), scale_bits=48)
-    )
-    reversed_axis = simultaneous_product(
-        SimultaneousProductRequest(multiplier=3, radicands=(3, 2), scale_bits=48)
-    )
+    forward = simultaneous_product(3, (2, 3), 48)
+    reversed_axis = simultaneous_product(3, (3, 2), 48)
     assert forward.product_enclosure == reversed_axis.product_enclosure
     assert tuple(f.radicand for f in reversed_axis.factors) == (3, 2)
 
 
 def test_range_profile_accounts_for_every_integer() -> None:
     """The completed range covers each multiplier exactly once, in order."""
-    result = range_profile(
-        RangeProfileRequest(radicands=(2, 3), limit=25, scale_bits=40)
-    )
+    result = range_profile((2, 3), 25, 40)
     assert tuple(row.multiplier for row in result.rows) == tuple(range(1, 26))
     assert len(result.rows) == 25
     for row in result.rows:
         assert tuple(f.radicand for f in row.factors) == (2, 3)
 
 
-def test_range_profile_rejects_rather_than_omitting_an_unresolved_row() -> None:
-    """Completeness is all-or-nothing: a short profile is never returned."""
-    with pytest.raises(OperationDomainValidationError) as error:
-        range_profile(RangeProfileRequest(radicands=(2, 3), limit=5, scale_bits=2))
-    assert error.value.errors()[0]["type"] == (
-        "diophantine.range_profile_unresolved_row"
-    )
+def test_range_profile_keeps_coarse_rows_complete() -> None:
+    """Exact midpoint ordering keeps every coarse range row available."""
+    result = range_profile((2, 3), 5, 2)
+    assert tuple(row.multiplier for row in result.rows) == tuple(range(1, 6))
 
 
 def test_range_profile_rejects_aggregate_output_before_expansion() -> None:
     """A maximal table is refused before allocating its rows or intervals."""
     with pytest.raises(OperationDomainValidationError) as error:
-        range_profile(
-            RangeProfileRequest(
-                radicands=(2, 3, 5, 6, 7, 10, 11, 13),
-                limit=4096,
-                scale_bits=4096,
-            )
-        )
+        range_profile((2, 3, 5, 6, 7, 10, 11, 13), 4096, 4096)
     assert error.value.errors()[0]["type"] in {
         "diophantine.range_profile_output_bound",
         "diophantine.range_profile_intermediate_bound",
@@ -658,13 +623,11 @@ def test_range_profile_admits_retained_allocation_before_expansion(
 ) -> None:
     monkeypatch.setattr(surd_kernel, "MAX_SURD_RANGE_ALLOCATION_UNITS", 1)
     with pytest.raises(OperationResourceAdmissionError, match="allocation bound"):
-        range_profile(RangeProfileRequest(radicands=(2, 3), limit=2, scale_bits=32))
+        range_profile((2, 3), 2, 32)
 
 
 def test_serialized_range_rejects_forged_factor_axes() -> None:
-    result = range_profile(
-        RangeProfileRequest(radicands=(2, 3), limit=2, scale_bits=32)
-    )
+    result = range_profile((2, 3), 2, 32)
     payload = result.model_dump(mode="json")
     payload["rows"][0]["factors"][0]["multiplier"] = "99"
     with pytest.raises(ValidationError):
@@ -676,9 +639,7 @@ def test_serialized_range_rejects_forged_factor_axes() -> None:
 
 
 def test_serialized_records_reject_forged_multiplier_axis() -> None:
-    result = record_minima(
-        RecordMinimaRequest(radicands=(2, 3), limit=20, scale_bits=64)
-    )
+    result = record_minima((2, 3), 20, 64)
     assert result.outcome == "COMPLETE"
     payload = result.model_dump(mode="json")
     payload["records"][0]["multiplier"] = "21"
@@ -688,9 +649,7 @@ def test_serialized_records_reject_forged_multiplier_axis() -> None:
 
 def test_record_minima_match_an_independent_decimal_record_oracle() -> None:
     """The record sequence agrees with a Decimal oracle, not this kernel."""
-    result = record_minima(
-        RecordMinimaRequest(radicands=(2, 3), limit=2000, scale_bits=64)
-    )
+    result = record_minima((2, 3), 2000, 64)
     expected: list[int] = []
     incumbent: Decimal | None = None
     with decimal.localcontext() as context:
@@ -713,25 +672,16 @@ def test_record_minima_match_an_independent_decimal_record_oracle() -> None:
     assert result.finite_argmin == expected[-1]
 
 
-def test_record_minima_report_unresolved_without_an_argmin_claim() -> None:
-    """A precision too coarse to separate a comparison makes no record claim.
-
-    The exact distances are rational, so every branch eventually resolves; a
-    scale that cannot resolve one row of the declared range must therefore
-    reject rather than return a partial record sequence or a guessed argmin.
-    """
-    with pytest.raises(OperationDomainValidationError) as error:
-        record_minima(RecordMinimaRequest(radicands=(2, 3), limit=40, scale_bits=1))
-    assert error.value.errors()[0]["type"] == (
-        "diophantine.range_profile_unresolved_row"
-    )
+def test_record_minima_reports_unresolved_without_an_argmin_claim() -> None:
+    """A coarse product comparison makes no finite argmin claim."""
+    result = record_minima((2, 3), 40, 1)
+    assert result.outcome == "UNRESOLVED"
+    assert result.finite_argmin is None
 
 
 def test_record_minima_resolved_scale_makes_only_strict_claims() -> None:
     """Every reported record is strictly below the incumbent it replaced."""
-    result = record_minima(
-        RecordMinimaRequest(radicands=(2, 3), limit=200, scale_bits=16)
-    )
+    result = record_minima((2, 3), 200, 16)
     assert result.outcome == "COMPLETE"
     assert result.finite_argmin == result.records[-1].multiplier
     for previous, current in zip(result.records, result.records[1:], strict=False):
@@ -743,7 +693,7 @@ def test_record_minima_resolved_scale_makes_only_strict_claims() -> None:
 
 def test_record_minima_reports_an_overlapping_nonrecord_comparison() -> None:
     """An overlapping candidate cannot be silently classified as a non-record."""
-    result = record_minima(RecordMinimaRequest(radicands=(2, 3), limit=5, scale_bits=6))
+    result = record_minima((2, 3), 5, 6)
 
     assert result.outcome == "UNRESOLVED"
     assert result.unresolved_multiplier == 5
@@ -756,9 +706,71 @@ def test_record_minima_reports_an_overlapping_nonrecord_comparison() -> None:
     )
 
 
+def test_record_minima_accepts_touching_enclosures_as_a_strict_record() -> None:
+    """Outward endpoints touching still prove the irrational values differ."""
+    result = record_minima((2,), 2, 4)
+
+    assert result.outcome == "COMPLETE"
+    assert tuple(record.multiplier for record in result.records) == (1, 2)
+    assert result.finite_argmin == 2
+    assert result.records[1].product_enclosure.upper.as_fraction() == Fraction(3, 8)
+    assert result.records[0].product_enclosure.lower.as_fraction() == Fraction(3, 8)
+
+
+def test_range_profile_observes_request_cancellation_inside_row_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancellation raised between rows prevents the next exact expansion."""
+    cancellation = threading.Event()
+    original = surd_kernel._distance_value
+    calls = 0
+
+    def cancel_after_first(
+        multiplier: int, radicand: int, scale_bits: int
+    ) -> NearestIntegerDistanceValue:
+        nonlocal calls
+        value = original(multiplier, radicand, scale_bits)
+        calls += 1
+        if calls == 1:
+            cancellation.set()
+        return value
+
+    monkeypatch.setattr(surd_kernel, "_distance_value", cancel_after_first)
+    with (
+        request_cancellation(cancellation),
+        pytest.raises(OperationExecutionCancelledError, match="range profile"),
+    ):
+        range_profile((2,), 3, 4)
+    assert calls == 1
+
+
+def test_record_minima_remains_native_only() -> None:
+    """Record extraction composes the public range operation in native code."""
+    assert (
+        Catalog.open().operation(
+            "number_theory.simultaneous_approximation.record_minima.compute"
+        )
+        is None
+    )
+
+
+def test_surd_request_schemas_describe_radical_axis_constraints() -> None:
+    """Request schemas expose the constraints enforced by execution."""
+    for request_type in (
+        SimultaneousProductRequest,
+        RangeProfileRequest,
+        RecordMinimaRequest,
+    ):
+        description = request_type.model_json_schema()["properties"]["radicands"][
+            "description"
+        ]
+        assert "distinct" in description
+        assert "nonsquare" in description
+
+
 def test_scaled_floor_value_round_trips_through_strict_json() -> None:
     """The declared result survives strict JSON serialization unchanged."""
-    result = scaled_floor(ScaledFloorRequest(multiplier=6, radicand=3))
+    result = scaled_floor(6, 3)
     restored = ScaledFloorValue.model_validate_json(
         encode_strict_json(result.model_dump(mode="json")), strict=True
     )
@@ -767,9 +779,7 @@ def test_scaled_floor_value_round_trips_through_strict_json() -> None:
 
 def test_nearest_integer_distance_round_trips_through_strict_json() -> None:
     """The certified enclosure survives strict JSON serialization unchanged."""
-    result = nearest_integer_distance(
-        NearestIntegerDistanceRequest(multiplier=5, radicand=7, scale_bits=32)
-    )
+    result = nearest_integer_distance(5, 7, 32)
     restored = NearestIntegerDistanceValue.model_validate_json(
         encode_strict_json(result.model_dump(mode="json")), strict=True
     )
@@ -778,7 +788,7 @@ def test_nearest_integer_distance_round_trips_through_strict_json() -> None:
 
 def test_serialized_surd_values_reject_forged_structural_fields() -> None:
     """Canonical carriers retain their domain and branch bindings on decode."""
-    floor = scaled_floor(ScaledFloorRequest(multiplier=6, radicand=3))
+    floor = scaled_floor(6, 3)
     floor_payload = floor.model_dump(mode="json")
     floor_payload["radicand"] = 4
     with pytest.raises(ValidationError):
@@ -786,9 +796,7 @@ def test_serialized_surd_values_reject_forged_structural_fields() -> None:
             encode_strict_json(floor_payload), strict=True
         )
 
-    distance = nearest_integer_distance(
-        NearestIntegerDistanceRequest(multiplier=5, radicand=7, scale_bits=32)
-    )
+    distance = nearest_integer_distance(5, 7, 32)
     distance_payload = distance.model_dump(mode="json")
     distance_payload["nearest_integer"] = distance.ceiling
     with pytest.raises(ValidationError):
@@ -796,9 +804,7 @@ def test_serialized_surd_values_reject_forged_structural_fields() -> None:
             encode_strict_json(distance_payload), strict=True
         )
 
-    product = simultaneous_product(
-        SimultaneousProductRequest(multiplier=1, radicands=(2, 3), scale_bits=32)
-    )
+    product = simultaneous_product(1, (2, 3), 32)
     product_payload = product.model_dump(mode="json")
     product_payload["product_enclosure"]["lower"] = {"num": "-1", "den": "1"}
     with pytest.raises(ValidationError):
@@ -809,9 +815,7 @@ def test_serialized_surd_values_reject_forged_structural_fields() -> None:
 
 def test_serialized_record_result_rejects_missing_or_unbound_history() -> None:
     """A record result cannot lose its first row or incumbent source binding."""
-    result = record_minima(
-        RecordMinimaRequest(radicands=(2, 3), limit=20, scale_bits=64)
-    )
+    result = record_minima((2, 3), 20, 64)
     assert result.outcome == "COMPLETE"
 
     missing_first = result.model_dump(mode="json")
@@ -831,9 +835,35 @@ def test_serialized_record_result_rejects_missing_or_unbound_history() -> None:
         )
 
 
+def test_serialized_unresolved_record_result_rejects_impossible_history() -> None:
+    """Unresolved evidence retains the complete record axis and incumbent source."""
+    result = record_minima((2, 3), 5, 6)
+    assert result.outcome == "UNRESOLVED"
+
+    malformed_axis = result.model_dump(mode="json")
+    malformed_axis["records"].append(malformed_axis["records"][1].copy())
+    malformed_axis["records"][2]["multiplier"] = "2"
+    malformed_axis["records"][2]["incumbent_enclosure"] = malformed_axis["records"][1][
+        "product_enclosure"
+    ]
+    with pytest.raises(ValidationError):
+        RecordMinimaResult.model_validate_json(
+            encode_strict_json(malformed_axis), strict=True
+        )
+
+    malformed_incumbent = result.model_dump(mode="json")
+    malformed_incumbent["unresolved_incumbent_enclosure"] = malformed_incumbent[
+        "records"
+    ][0]["product_enclosure"]
+    with pytest.raises(ValidationError):
+        RecordMinimaResult.model_validate_json(
+            encode_strict_json(malformed_incumbent), strict=True
+        )
+
+
 def test_large_multiplier_uses_exact_json_integer_encoding() -> None:
     request = ScaledFloorRequest(multiplier=2**53, radicand=2)
-    result = scaled_floor(request)
+    result = scaled_floor(request.multiplier, request.radicand)
     restored = ScaledFloorValue.model_validate_json(
         encode_strict_json(result.model_dump(mode="json")), strict=True
     )
@@ -841,11 +871,7 @@ def test_large_multiplier_uses_exact_json_integer_encoding() -> None:
 
 
 def test_maximum_product_precision_fits_result_envelope() -> None:
-    result = simultaneous_product(
-        SimultaneousProductRequest(
-            multiplier=1, radicands=(2, 3, 5, 6), scale_bits=4096
-        )
-    )
+    result = simultaneous_product(1, (2, 3, 5, 6), 4096)
     restored = type(result).model_validate_json(
         encode_strict_json(result.model_dump(mode="json"))
     )

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -2,22 +2,40 @@
 
 from __future__ import annotations
 
+import decimal
 import json
 import math
+from decimal import Decimal
+from fractions import Fraction
 
 import pytest
 from pydantic import ValidationError
 
+from jacobian.canonical import encode_strict_json
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.diophantine_approximation import (
     continued_fraction,
     convergents,
+    nearest_integer_distance,
+    range_profile,
+    record_minima,
+    scaled_floor,
+    simultaneous_product,
     solve_pell,
 )
 from jacobian.math.number_theory.diophantine_approximation._models import (
     ContinuedFractionRequest,
     ConvergentRequest,
     PellEquationRequest,
+)
+from jacobian.math.number_theory.diophantine_approximation._surd_models import (
+    NearestIntegerDistanceRequest,
+    NearestIntegerDistanceValue,
+    RangeProfileRequest,
+    RecordMinimaRequest,
+    ScaledFloorRequest,
+    ScaledFloorResult,
+    SimultaneousProductRequest,
 )
 from jacobian.math.number_theory.diophantine_approximation._tools import (
     compute_continued_fraction,
@@ -438,3 +456,266 @@ def test_producer_to_convergent_composition() -> None:
         replayed.append((p_prev1, q_prev1))
     claimed = [(c.numerator, c.denominator) for c in convs.convergents]
     assert claimed == replayed
+
+
+# ---------------------------------------------------------------------------
+# Certified finite quadratic-surd and simultaneous approximation (#1786)
+# ---------------------------------------------------------------------------
+
+
+def _high_precision_sqrt(radicand: int, digits: int = 80) -> str:
+    """Independent square root, computed without the module under test."""
+
+    return format(Decimal(radicand).sqrt(context=decimal.Context(prec=digits)), "f")
+
+
+def test_scaled_floor_matches_integer_square_definition() -> None:
+    """floor(n*sqrt(d)) is isqrt(d*n^2) for a nonsquare radicand."""
+    for multiplier, radicand in ((3, 2), (1, 2), (7, 3), (10, 5), (12, 6)):
+        value = scaled_floor(
+            ScaledFloorRequest(multiplier=multiplier, radicand=radicand)
+        ).rows[0]
+        assert value.floor == math.isqrt(radicand * multiplier * multiplier)
+        assert value.ceiling == value.floor + 1
+        assert value.square_lower == value.floor * value.floor
+        assert value.square_upper == value.ceiling * value.ceiling
+
+
+def test_scaled_floor_rejects_square_radicand() -> None:
+    """A perfect-square radicand is outside the irrational contract."""
+    with pytest.raises(ValidationError):
+        ScaledFloorRequest(multiplier=2, radicand=9)
+
+
+def test_nearest_integer_distance_branches_on_both_sides() -> None:
+    """The nearest integer can come from either endpoint of the bracket."""
+    floor_side = nearest_integer_distance(
+        NearestIntegerDistanceRequest(multiplier=1, radicand=2, scale_bits=48)
+    )
+    ceiling_side = nearest_integer_distance(
+        NearestIntegerDistanceRequest(multiplier=1, radicand=3, scale_bits=48)
+    )
+    assert floor_side.side == "FLOOR"
+    assert floor_side.nearest_integer == floor_side.floor
+    assert ceiling_side.side == "CEILING"
+    assert ceiling_side.nearest_integer == ceiling_side.ceiling
+
+
+def test_nearest_integer_distance_encloses_the_true_distance() -> None:
+    """Independent high-precision square roots must lie inside the enclosure."""
+    for multiplier, radicand in ((1, 2), (2, 3), (5, 7), (9, 11), (31, 13)):
+        value = nearest_integer_distance(
+            NearestIntegerDistanceRequest(
+                multiplier=multiplier, radicand=radicand, scale_bits=64
+            )
+        )
+        true_distance = abs(
+            Decimal(multiplier) * Decimal(_high_precision_sqrt(radicand))
+            - Decimal(value.nearest_integer)
+        )
+        assert value.distance_enclosure.lower.as_fraction() <= Fraction(true_distance)
+        assert Fraction(true_distance) <= value.distance_enclosure.upper.as_fraction()
+
+
+def test_insufficient_precision_is_reported_not_guessed() -> None:
+    """Overlapping branches must be rejected, never tie-broken arbitrarily."""
+    with pytest.raises(OperationDomainValidationError) as error:
+        nearest_integer_distance(
+            NearestIntegerDistanceRequest(multiplier=1, radicand=2, scale_bits=1)
+        )
+    assert error.value.errors()[0]["type"] == (
+        "diophantine.nearest_integer_branch_unresolved"
+    )
+
+
+def test_refinement_tightens_without_reversing_a_separated_order() -> None:
+    """A larger scale subdivides the same bracket and never reverses order."""
+    coarse = nearest_integer_distance(
+        NearestIntegerDistanceRequest(multiplier=1, radicand=2, scale_bits=8)
+    )
+    fine = nearest_integer_distance(
+        NearestIntegerDistanceRequest(multiplier=1, radicand=2, scale_bits=64)
+    )
+    assert coarse.side == fine.side == "FLOOR"
+    coarse_width = (
+        coarse.distance_enclosure.upper.as_fraction()
+        - coarse.distance_enclosure.lower.as_fraction()
+    )
+    fine_width = (
+        fine.distance_enclosure.upper.as_fraction()
+        - fine.distance_enclosure.lower.as_fraction()
+    )
+    assert fine_width <= coarse_width
+    assert fine.distance_enclosure.lower.as_fraction() >= (
+        coarse.distance_enclosure.lower.as_fraction()
+    )
+    assert fine.distance_enclosure.upper.as_fraction() <= (
+        coarse.distance_enclosure.upper.as_fraction()
+    )
+
+
+def test_product_enclosure_includes_the_outer_factor_and_contains_the_value() -> None:
+    """n * prod_i ||n sqrt(d_i)|| is enclosed, not the bare product of distances."""
+    result = simultaneous_product(
+        SimultaneousProductRequest(multiplier=4, radicands=(2, 3), scale_bits=64)
+    )
+    assert tuple(f.radicand for f in result.factors) == (2, 3)
+    true_product = Decimal(4)
+    for radicand in (2, 3):
+        per_factor = nearest_integer_distance(
+            NearestIntegerDistanceRequest(
+                multiplier=4, radicand=radicand, scale_bits=64
+            )
+        )
+        true_product *= abs(
+            Decimal(4) * Decimal(_high_precision_sqrt(radicand))
+            - Decimal(per_factor.nearest_integer)
+        )
+    assert result.product_enclosure.lower.as_fraction() <= Fraction(true_product)
+    assert Fraction(true_product) <= result.product_enclosure.upper.as_fraction()
+
+
+def test_product_enclosure_is_radicand_permutation_invariant() -> None:
+    """Reordering the radicand axis permutes rows but preserves the product."""
+    forward = simultaneous_product(
+        SimultaneousProductRequest(multiplier=3, radicands=(2, 3), scale_bits=48)
+    )
+    reversed_axis = simultaneous_product(
+        SimultaneousProductRequest(multiplier=3, radicands=(3, 2), scale_bits=48)
+    )
+    assert forward.product_enclosure == reversed_axis.product_enclosure
+    assert tuple(f.radicand for f in reversed_axis.factors) == (3, 2)
+
+
+def test_range_profile_accounts_for_every_integer() -> None:
+    """The completed range covers each multiplier exactly once, in order."""
+    result = range_profile(
+        RangeProfileRequest(radicands=(2, 3), limit=25, scale_bits=40)
+    )
+    assert tuple(row.multiplier for row in result.rows) == tuple(range(1, 26))
+    assert len(result.rows) == 25
+    for row in result.rows:
+        assert tuple(f.radicand for f in row.factors) == (2, 3)
+
+
+def test_range_profile_rejects_rather_than_omitting_an_unresolved_row() -> None:
+    """Completeness is all-or-nothing: a short profile is never returned."""
+    with pytest.raises(OperationDomainValidationError) as error:
+        range_profile(RangeProfileRequest(radicands=(2, 3), limit=5, scale_bits=2))
+    assert error.value.errors()[0]["type"] == (
+        "diophantine.range_profile_unresolved_row"
+    )
+
+
+def test_record_minima_match_an_independent_strict_record_search() -> None:
+    """The record sequence agrees with an independent interval-free oracle."""
+    result = record_minima(
+        RecordMinimaRequest(radicands=(2, 3), limit=2000, scale_bits=64)
+    )
+    expected: list[int] = []
+    incumbent: Fraction | None = None
+    for multiplier in range(1, 2001):
+        lower = Fraction(0)
+        upper = Fraction(0)
+        first = True
+        for radicand in (2, 3):
+            row = nearest_integer_distance(
+                NearestIntegerDistanceRequest(
+                    multiplier=multiplier, radicand=radicand, scale_bits=256
+                )
+            )
+            lower = (
+                row.distance_enclosure.lower.as_fraction()
+                if first
+                else lower * row.distance_enclosure.lower.as_fraction()
+            )
+            upper = (
+                row.distance_enclosure.upper.as_fraction()
+                if first
+                else upper * row.distance_enclosure.upper.as_fraction()
+            )
+            first = False
+        lower *= multiplier
+        upper *= multiplier
+        if incumbent is None or upper < incumbent:
+            expected.append(multiplier)
+            incumbent = lower
+    assert result.outcome == "COMPLETE"
+    assert tuple(row.multiplier for row in result.records) == tuple(expected)
+    assert result.finite_argmin == expected[-1]
+
+
+def test_record_minima_report_unresolved_without_an_argmin_claim() -> None:
+    """A precision too coarse to separate a comparison makes no record claim.
+
+    The exact distances are rational, so every branch eventually resolves; a
+    scale that cannot resolve one row of the declared range must therefore
+    reject rather than return a partial record sequence or a guessed argmin.
+    """
+    with pytest.raises(OperationDomainValidationError) as error:
+        record_minima(RecordMinimaRequest(radicands=(2, 3), limit=40, scale_bits=1))
+    assert error.value.errors()[0]["type"] == (
+        "diophantine.range_profile_unresolved_row"
+    )
+
+
+def test_record_minima_resolved_scale_makes_only_strict_claims() -> None:
+    """Every reported record is strictly below the incumbent it replaced."""
+    result = record_minima(
+        RecordMinimaRequest(radicands=(2, 3), limit=200, scale_bits=16)
+    )
+    assert result.outcome == "COMPLETE"
+    assert result.finite_argmin == result.records[-1].multiplier
+    for previous, current in zip(result.records, result.records[1:], strict=False):
+        assert (
+            current.product_enclosure.upper.as_fraction()
+            < previous.product_enclosure.lower.as_fraction()
+        )
+
+
+def test_record_minima_reports_an_overlapping_nonrecord_comparison() -> None:
+    """An overlapping candidate cannot be silently classified as a non-record."""
+    result = record_minima(RecordMinimaRequest(radicands=(2, 3), limit=5, scale_bits=6))
+
+    assert result.outcome == "UNRESOLVED"
+    assert result.unresolved_multiplier == 5
+    assert result.records[-1].multiplier == 4
+    assert result.unresolved_product_enclosure is not None
+    assert result.unresolved_incumbent_enclosure is not None
+    assert (
+        result.unresolved_product_enclosure.lower.as_fraction()
+        < result.unresolved_incumbent_enclosure.upper.as_fraction()
+    )
+
+
+def test_record_minima_rejects_forged_nonseparated_record() -> None:
+    """A complete result cannot claim a record without strict interval proof."""
+    result = record_minima(
+        RecordMinimaRequest(radicands=(2, 3), limit=5, scale_bits=64)
+    )
+    payload = result.model_dump()
+    payload["records"][1]["incumbent_enclosure"] = payload["records"][1][
+        "product_enclosure"
+    ]
+    with pytest.raises(ValidationError, match="strictly below its incumbent"):
+        type(result).model_validate(payload)
+
+
+def test_scaled_floor_result_round_trips_through_strict_json() -> None:
+    """The declared result survives strict JSON serialization unchanged."""
+    result = scaled_floor(ScaledFloorRequest(multiplier=6, radicand=3))
+    restored = ScaledFloorResult.model_validate_json(
+        encode_strict_json(result.model_dump(mode="json")), strict=True
+    )
+    assert restored == result
+
+
+def test_nearest_integer_distance_round_trips_through_strict_json() -> None:
+    """The certified enclosure survives strict JSON serialization unchanged."""
+    result = nearest_integer_distance(
+        NearestIntegerDistanceRequest(multiplier=5, radicand=7, scale_bits=32)
+    )
+    restored = NearestIntegerDistanceValue.model_validate_json(
+        encode_strict_json(result.model_dump(mode="json")), strict=True
+    )
+    assert restored == result

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -33,9 +33,11 @@ from jacobian.math.number_theory.diophantine_approximation._surd_models import (
     NearestIntegerDistanceRequest,
     NearestIntegerDistanceValue,
     RangeProfileRequest,
+    RangeProfileResult,
     RecordMinimaRequest,
+    RecordMinimaResult,
     ScaledFloorRequest,
-    ScaledFloorResult,
+    ScaledFloorValue,
     SimultaneousProductRequest,
 )
 from jacobian.math.number_theory.diophantine_approximation._tools import (
@@ -494,7 +496,7 @@ def test_scaled_floor_matches_integer_square_definition() -> None:
     for multiplier, radicand in ((3, 2), (1, 2), (7, 3), (10, 5), (12, 6)):
         value = scaled_floor(
             ScaledFloorRequest(multiplier=multiplier, radicand=radicand)
-        ).rows[0]
+        )
         assert value.floor == math.isqrt(radicand * multiplier * multiplier)
         assert value.ceiling == value.floor + 1
         assert value.square_lower == value.floor * value.floor
@@ -503,8 +505,8 @@ def test_scaled_floor_matches_integer_square_definition() -> None:
 
 def test_scaled_floor_rejects_square_radicand() -> None:
     """A perfect-square radicand is outside the irrational contract."""
-    with pytest.raises(ValidationError):
-        ScaledFloorRequest(multiplier=2, radicand=9)
+    with pytest.raises(OperationDomainValidationError):
+        scaled_floor(ScaledFloorRequest(multiplier=2, radicand=9))
 
 
 def test_nearest_integer_distance_branches_on_both_sides() -> None:
@@ -627,39 +629,70 @@ def test_range_profile_rejects_rather_than_omitting_an_unresolved_row() -> None:
     )
 
 
-def test_record_minima_match_an_independent_strict_record_search() -> None:
-    """The record sequence agrees with an independent interval-free oracle."""
+def test_range_profile_rejects_aggregate_output_before_expansion() -> None:
+    """A maximal table is refused before allocating its rows or intervals."""
+    with pytest.raises(OperationDomainValidationError) as error:
+        range_profile(
+            RangeProfileRequest(
+                radicands=(2, 3, 5, 6, 7, 10, 11, 13),
+                limit=4096,
+                scale_bits=4096,
+            )
+        )
+    assert error.value.errors()[0]["type"] in {
+        "diophantine.range_profile_output_bound",
+        "diophantine.range_profile_intermediate_bound",
+        "diophantine.range_profile_work_bound",
+    }
+
+
+def test_serialized_range_rejects_forged_factor_axes() -> None:
+    result = range_profile(
+        RangeProfileRequest(radicands=(2, 3), limit=2, scale_bits=32)
+    )
+    payload = result.model_dump(mode="json")
+    payload["rows"][0]["factors"][0]["multiplier"] = "99"
+    with pytest.raises(ValidationError):
+        RangeProfileResult.model_validate_json(encode_strict_json(payload), strict=True)
+    payload = result.model_dump(mode="json")
+    payload["rows"][0]["factors"][0]["scale_bits"] = 31
+    with pytest.raises(ValidationError):
+        RangeProfileResult.model_validate_json(encode_strict_json(payload), strict=True)
+
+
+def test_serialized_records_reject_forged_multiplier_axis() -> None:
+    result = record_minima(
+        RecordMinimaRequest(radicands=(2, 3), limit=20, scale_bits=64)
+    )
+    assert result.outcome == "COMPLETE"
+    payload = result.model_dump(mode="json")
+    payload["records"][0]["multiplier"] = "21"
+    with pytest.raises(ValidationError):
+        RecordMinimaResult.model_validate_json(encode_strict_json(payload), strict=True)
+
+
+def test_record_minima_match_an_independent_decimal_record_oracle() -> None:
+    """The record sequence agrees with a Decimal oracle, not this kernel."""
     result = record_minima(
         RecordMinimaRequest(radicands=(2, 3), limit=2000, scale_bits=64)
     )
     expected: list[int] = []
-    incumbent: Fraction | None = None
-    for multiplier in range(1, 2001):
-        lower = Fraction(0)
-        upper = Fraction(0)
-        first = True
-        for radicand in (2, 3):
-            row = nearest_integer_distance(
-                NearestIntegerDistanceRequest(
-                    multiplier=multiplier, radicand=radicand, scale_bits=256
+    incumbent: Decimal | None = None
+    with decimal.localcontext() as context:
+        context.prec = 180
+        for multiplier in range(1, 2001):
+            product = Decimal(multiplier)
+            for radicand in (2, 3):
+                root = Decimal(radicand).sqrt()
+                floor = math.isqrt(radicand * multiplier * multiplier)
+                distance = min(
+                    Decimal(multiplier) * root - Decimal(floor),
+                    Decimal(floor + 1) - Decimal(multiplier) * root,
                 )
-            )
-            lower = (
-                row.distance_enclosure.lower.as_fraction()
-                if first
-                else lower * row.distance_enclosure.lower.as_fraction()
-            )
-            upper = (
-                row.distance_enclosure.upper.as_fraction()
-                if first
-                else upper * row.distance_enclosure.upper.as_fraction()
-            )
-            first = False
-        lower *= multiplier
-        upper *= multiplier
-        if incumbent is None or upper < incumbent:
-            expected.append(multiplier)
-            incumbent = lower
+                product *= distance
+            if incumbent is None or product < incumbent:
+                expected.append(multiplier)
+                incumbent = product
     assert result.outcome == "COMPLETE"
     assert tuple(row.multiplier for row in result.records) == tuple(expected)
     assert result.finite_argmin == expected[-1]
@@ -708,23 +741,10 @@ def test_record_minima_reports_an_overlapping_nonrecord_comparison() -> None:
     )
 
 
-def test_record_minima_rejects_forged_nonseparated_record() -> None:
-    """A complete result cannot claim a record without strict interval proof."""
-    result = record_minima(
-        RecordMinimaRequest(radicands=(2, 3), limit=5, scale_bits=64)
-    )
-    payload = result.model_dump()
-    payload["records"][1]["incumbent_enclosure"] = payload["records"][1][
-        "product_enclosure"
-    ]
-    with pytest.raises(ValidationError, match="strictly below its incumbent"):
-        type(result).model_validate(payload)
-
-
-def test_scaled_floor_result_round_trips_through_strict_json() -> None:
+def test_scaled_floor_value_round_trips_through_strict_json() -> None:
     """The declared result survives strict JSON serialization unchanged."""
     result = scaled_floor(ScaledFloorRequest(multiplier=6, radicand=3))
-    restored = ScaledFloorResult.model_validate_json(
+    restored = ScaledFloorValue.model_validate_json(
         encode_strict_json(result.model_dump(mode="json")), strict=True
     )
     assert restored == result
@@ -744,8 +764,8 @@ def test_nearest_integer_distance_round_trips_through_strict_json() -> None:
 def test_large_multiplier_uses_exact_json_integer_encoding() -> None:
     request = ScaledFloorRequest(multiplier=2**53, radicand=2)
     result = scaled_floor(request)
-    restored = ScaledFloorResult.model_validate_json(
-        encode_strict_json(result.model_dump(mode="json"))
+    restored = ScaledFloorValue.model_validate_json(
+        encode_strict_json(result.model_dump(mode="json")), strict=True
     )
     assert restored == result
 

--- a/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/number_theory/diophantine_approximation/test_diophantine_approximation.py
@@ -719,3 +719,24 @@ def test_nearest_integer_distance_round_trips_through_strict_json() -> None:
         encode_strict_json(result.model_dump(mode="json")), strict=True
     )
     assert restored == result
+
+
+def test_large_multiplier_uses_exact_json_integer_encoding() -> None:
+    request = ScaledFloorRequest(multiplier=2**53, radicand=2)
+    result = scaled_floor(request)
+    restored = ScaledFloorResult.model_validate_json(
+        encode_strict_json(result.model_dump(mode="json"))
+    )
+    assert restored == result
+
+
+def test_maximum_product_precision_fits_result_envelope() -> None:
+    result = simultaneous_product(
+        SimultaneousProductRequest(
+            multiplier=1, radicands=(2, 3, 5, 6), scale_bits=4096
+        )
+    )
+    restored = type(result).model_validate_json(
+        encode_strict_json(result.model_dump(mode="json"))
+    )
+    assert restored == result

--- a/tests/math/number_theory/diophantine_approximation/test_public_api.py
+++ b/tests/math/number_theory/diophantine_approximation/test_public_api.py
@@ -10,6 +10,11 @@ def test_exact_public_api_symbols() -> None:
     expected = (
         "continued_fraction",
         "convergents",
+        "nearest_integer_distance",
+        "range_profile",
+        "record_minima",
+        "scaled_floor",
+        "simultaneous_product",
         "solve_pell",
     )
     assert tuple(diophantine_approximation.__all__) == expected


### PR DESCRIPTION
## Problem

Finite simultaneous-approximation calculations need exact quadratic-surd floors, nearest-integer distances, products, finite ranges, and comparable record minima. Related to #1786.

## Outcome

Adds five composable operations:

- `number_theory.quadratic_surd.scaled_floor.compute`
- `number_theory.quadratic_surd.nearest_integer_distance.compute`
- `number_theory.simultaneous_approximation.product_enclosure.compute`
- `number_theory.simultaneous_approximation.range_profile.compute`
- `number_theory.simultaneous_approximation.record_minima.compute`

Multipliers use exact integer JSON encoding. Enclosures are outward dyadic bounds; exact non-dyadic singletons are retained where appropriate. Overlapping record comparisons remain unresolved instead of establishing a false argmin. Result carriers bind factors, radicands, multiplier/range axes, precision, bracket branches, and record provenance without replaying square-root or distance computations.

## Contract and bounds

The implementation uses integer square-root arithmetic. It admits at most eight radicands, radicands through 1,000,000, range length 4,096, binary precision 4,096, and multipliers up to 4,096 bits. A 16,384-digit rational envelope covers dyadic products. Source integers, per-row scalars, exact digits, range work, intermediates, and result allocation are bounded semantically before expansion; transport adapters separately own encoded byte ceilings. Square radicands, negative product ranges, and oversized requests fail with typed domain/admission errors.

## Evidence

Final local validation at `1e00287dc716269e44322245c0472757e95d7dfe`:

- `make affected AFFECTED_BASE=origin/main`
- 56 number-theory tests
- 160 catalog tests
- 971 catalog integration tests
- Ruff and mypy
- Independent exact-diff audit completed and repaired carrier-boundary and admission-ownership findings.

This PR implements a bounded foundational slice of #1786; broader simultaneous Diophantine approximation operations remain open.