### PR TITLE
feat(probability): add exact site and hypergraph bond reliability

### DIFF
--- a/src/jacobian/math/probability/_hypergraph_bond_reliability.py
+++ b/src/jacobian/math/probability/_hypergraph_bond_reliability.py
@@ -16,6 +16,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.canonical import encode_strict_json
 from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
@@ -38,7 +39,14 @@ MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS = (
     MAX_INPUT_RATIONAL_DIGITS * MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
     + MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
 )
-MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS = 64_000_000
+MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES = 64_000_000
+MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS = MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES
+MAX_HYPERGRAPH_RELIABILITY_LOGICAL_WORK = MAX_HYPERGRAPH_RELIABILITY_STATES * (
+    4 * MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
+    + 4 * MAX_HYPERGRAPH_RELIABILITY_VERTICES
+    + 4 * MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES * MAX_HYPERGRAPH_RELIABILITY_VERTICES
+    + 16
+)
 
 
 def _validation_error(message: str) -> PydanticCustomError:
@@ -62,9 +70,22 @@ class HyperedgeOpenProbability(StrictModel):
 class HypergraphBondReliabilitySource(StrictModel):
     """Canonical hypergraph, hyperedge-axis probabilities, and terminals."""
 
-    hypergraph: FiniteHypergraph
+    hypergraph: FiniteHypergraph = Field(
+        description=(
+            "Finite simple hypergraph with at most "
+            f"{MAX_HYPERGRAPH_RELIABILITY_VERTICES} vertices and "
+            f"{MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES} nonempty hyperedges "
+            "for complete hyperedge-subset enumeration."
+        )
+    )
+    # The shared finite-hypergraph carrier is larger than this operation's
+    # powerset envelope.  Keep this structural model broad and let operation
+    # admission own the resource rejection.
     hyperedge_probabilities: tuple[HyperedgeOpenProbability, ...] = Field(
-        max_length=MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
+        description=(
+            "One independent exact open probability for every hyperedge, "
+            "in the hypergraph's declared hyperedge-axis order."
+        )
     )
     terminals: tuple[str, str]
     event: Literal["TERMINALS_CONNECTED_IN_INCIDENCE_GRAPH"] = (
@@ -90,9 +111,14 @@ class HypergraphBondReliabilitySource(StrictModel):
             raise _validation_error(
                 "hypergraph reliability terminals must be two distinct declared vertices"
             )
-        if len(self.hypergraph.edges) > MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES:
+        members = tuple(members for _, members in self.hypergraph.edges)
+        if any(not edge_members for edge_members in members):
             raise _validation_error(
-                "hypergraph reliability source exceeds the hyperedge bound"
+                "hypergraph reliability hyperedges must be nonempty"
+            )
+        if len(set(members)) != len(members):
+            raise _validation_error(
+                "hypergraph reliability hyperedges must have distinct vertex sets"
             )
         return self
 
@@ -116,6 +142,8 @@ class HypergraphBondReliabilityState(StrictModel):
             raise _validation_error(
                 "hypergraph reliability state probability must lie in [0, 1]"
             )
+        if len(set(self.open_hyperedge_ids)) != len(self.open_hyperedge_ids):
+            raise _validation_error("hypergraph state hyperedge IDs must be canonical")
         return self
 
 
@@ -261,6 +289,18 @@ def _admit_hypergraph_request(
         for item in request.hyperedge_probabilities
     )
     state_count = 1 << len(request.hypergraph.edges)
+    logical_work = state_count * (
+        4 * len(request.hypergraph.edges)
+        + 4 * len(request.hypergraph.vertices)
+        + 4 * sum(len(members) for _, members in request.hypergraph.edges)
+        + 16
+    )
+    if logical_work > MAX_HYPERGRAPH_RELIABILITY_LOGICAL_WORK:
+        raise OperationResourceAdmissionError(
+            location=("states",),
+            code="probability.hypergraph_reliability.work_bound",
+            message="hypergraph reliability enumeration exceeds its work bound",
+        )
     rational_digits = factor_digits + len(str(state_count))
     if rational_digits > MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS:
         raise OperationResourceAdmissionError(
@@ -271,29 +311,55 @@ def _admit_hypergraph_request(
                 f"{MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS}-digit result bound"
             ),
         )
-    label_characters = sum(len(vertex) for vertex in request.hypergraph.vertices) + sum(
-        len(edge_id) + sum(len(vertex) for vertex in members)
-        for edge_id, members in request.hypergraph.edges
+
+    def json_string_size(value: str) -> int:
+        return len(encode_strict_json(value))
+
+    def json_array_size(item_sizes: tuple[int, ...]) -> int:
+        return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
+
+    def json_object_size(fields: tuple[tuple[str, int], ...]) -> int:
+        return (
+            2
+            + max(len(fields) - 1, 0)
+            + sum(
+                json_string_size(name) + 1 + value_size for name, value_size in fields
+            )
+        )
+
+    source_bytes = len(encode_strict_json(request.model_dump(mode="json")))
+    rational_bytes = len(
+        encode_strict_json({"num": "9" * rational_digits, "den": "9" * rational_digits})
     )
-    max_component_characters = max(
-        (len(edge_id) for edge_id, _ in request.hypergraph.edges),
-        default=1,
+    open_hyperedge_bytes = json_array_size(
+        tuple(json_string_size(edge_id) for edge_id, _ in request.hypergraph.edges)
     )
-    # Bound mathematical storage by label characters, exact rational digits,
-    # and scalar slots. Reserve every state for the full open-hyperedge axis;
-    # fixed padding covers the bounded source and per-state scalar fields.
-    ledger_units = (
-        1024
-        + label_characters * 4
-        + len(request.hyperedge_probabilities) * (2 * MAX_INPUT_RATIONAL_DIGITS + 96)
-        + state_count
-        * (
-            192
-            + len(request.hypergraph.edges) * max_component_characters
-            + 2 * rational_digits
+    state_bytes = json_object_size(
+        (
+            ("state_index", len(encode_strict_json(state_count - 1))),
+            ("open_hyperedge_ids", open_hyperedge_bytes),
+            ("terminals_connected", len(encode_strict_json(True))),
+            ("state_probability", rational_bytes),
         )
     )
-    if ledger_units > MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS:
+    states_bytes = 2 + max(state_count - 1, 0) + state_count * state_bytes
+    result_bytes = json_object_size(
+        (
+            ("source", source_bytes),
+            ("connection_probability", rational_bytes),
+            ("hyperedge_count", len(encode_strict_json(len(request.hypergraph.edges)))),
+            ("visited_states", len(encode_strict_json(state_count))),
+            ("states", states_bytes),
+            (
+                "event",
+                json_string_size("TERMINALS_CONNECTED_IN_INCIDENCE_GRAPH"),
+            ),
+            ("hyperedge_independence", json_string_size("INDEPENDENT_BERNOULLI")),
+            ("connectivity_convention", json_string_size("INCIDENCE_GRAPH_CHAIN")),
+            ("enumeration", json_string_size("COMPLETE_HYPEREDGE_SUBSETS")),
+        )
+    )
+    if result_bytes > MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES:
         raise OperationResourceAdmissionError(
             location=("states",),
             code="probability.hypergraph_reliability.output_bound",
@@ -410,6 +476,8 @@ __all__ = [
     "HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION",
     "MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES",
     "MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS",
+    "MAX_HYPERGRAPH_RELIABILITY_LOGICAL_WORK",
+    "MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES",
     "MAX_HYPERGRAPH_RELIABILITY_STATES",
     "MAX_HYPERGRAPH_RELIABILITY_VERTICES",
     "HyperedgeOpenProbability",

--- a/src/jacobian/math/probability/_hypergraph_bond_reliability.py
+++ b/src/jacobian/math/probability/_hypergraph_bond_reliability.py
@@ -20,6 +20,7 @@ from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
     OperationExample,
+    OperationResourceAdmissionError,
 )
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
@@ -158,6 +159,17 @@ class HypergraphBondConnectionProbabilityResult(StrictModel):
             raise _validation_error(
                 "state ledger indices must be complete and canonical"
             )
+        hyperedge_axis = tuple(edge_id for edge_id, _ in self.source.hypergraph.edges)
+        for state in self.states:
+            expected = tuple(
+                edge_id
+                for index, edge_id in enumerate(hyperedge_axis)
+                if state.state_index & (1 << index)
+            )
+            if state.open_hyperedge_ids != expected:
+                raise _validation_error(
+                    "hypergraph state IDs do not match their state index"
+                )
         return self
 
     @classmethod
@@ -192,7 +204,7 @@ def _admit_hypergraph_request(
     request: HypergraphBondReliabilitySource,
 ) -> None:
     if len(request.hypergraph.vertices) > MAX_HYPERGRAPH_RELIABILITY_VERTICES:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("hypergraph", "vertices"),
             code="probability.hypergraph_reliability.vertex_bound",
             message=(
@@ -201,7 +213,7 @@ def _admit_hypergraph_request(
             ),
         )
     if len(request.hypergraph.edges) > MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("hypergraph", "edges"),
             code="probability.hypergraph_reliability.hyperedge_bound",
             message=(
@@ -251,7 +263,7 @@ def _admit_hypergraph_request(
     state_count = 1 << len(request.hypergraph.edges)
     rational_digits = factor_digits + len(str(state_count))
     if rational_digits > MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("hyperedge_probabilities",),
             code="probability.hypergraph_reliability.rational_height_bound",
             message=(
@@ -282,7 +294,7 @@ def _admit_hypergraph_request(
         )
     )
     if ledger_units > MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("states",),
             code="probability.hypergraph_reliability.output_bound",
             message="complete hypergraph-reliability ledger exceeds its output bound",

--- a/src/jacobian/math/probability/_hypergraph_bond_reliability.py
+++ b/src/jacobian/math/probability/_hypergraph_bond_reliability.py
@@ -1,0 +1,410 @@
+"""Exact bounded hyperedge bond reliability on a finite simple hypergraph.
+
+Two vertices connect in the open hypergraph when they lie in one connected
+component of the incidence graph restricted to open hyperedges: a chain of open
+hyperedges whose successive members intersect.  This is the incidence-graph
+convention, not the clique-expansion convention, and the difference is stated
+and tested explicitly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Self
+
+from pydantic import Field, StrictInt, ValidationError, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._models import StrictModel
+from jacobian.catalog.models import (
+    MathTool,
+    OperationDomainValidationError,
+    OperationExample,
+)
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.probability._models import MAX_INPUT_RATIONAL_DIGITS
+
+MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES = 12
+MAX_HYPERGRAPH_RELIABILITY_VERTICES = 24
+MAX_HYPERGRAPH_RELIABILITY_STATES = 1 << MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
+# A state mass has one probability (or complement) factor per hyperedge and
+# the successful-state sum has at most 2**k terms.  This is the result-carrier
+# width for the admitted 128-digit input factors; request-specific admission
+# below computes a tighter bound for each source.
+MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS = (
+    MAX_INPUT_RATIONAL_DIGITS * MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
+    + MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
+)
+MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES = 64_000_000
+
+
+def _validation_error(message: str) -> PydanticCustomError:
+    return PydanticCustomError("probability.model_invariant", message)
+
+
+class HyperedgeOpenProbability(StrictModel):
+    hyperedge_id: str
+    open_probability: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_canonical_bounded_probability(self) -> Self:
+        require_bounded_rational(
+            self.open_probability,
+            max_digits=MAX_INPUT_RATIONAL_DIGITS,
+            label="hypergraph reliability hyperedge probability",
+        )
+        return self
+
+
+class HypergraphBondReliabilitySource(StrictModel):
+    """Canonical hypergraph, hyperedge-axis probabilities, and terminals."""
+
+    hypergraph: FiniteHypergraph
+    hyperedge_probabilities: tuple[HyperedgeOpenProbability, ...] = Field(
+        max_length=MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
+    )
+    terminals: tuple[str, str]
+    event: Literal["TERMINALS_CONNECTED_IN_INCIDENCE_GRAPH"] = (
+        "TERMINALS_CONNECTED_IN_INCIDENCE_GRAPH"
+    )
+
+    @model_validator(mode="after")
+    def require_bound_hyperedge_axis(self) -> Self:
+        if tuple(item.hyperedge_id for item in self.hyperedge_probabilities) != tuple(
+            edge_id for edge_id, _ in self.hypergraph.edges
+        ):
+            raise _validation_error(
+                "hypergraph reliability probabilities must follow the declared "
+                "hyperedge axis"
+            )
+        if (
+            len(self.terminals) != 2
+            or self.terminals[0] == self.terminals[1]
+            or any(
+                terminal not in self.hypergraph.vertices for terminal in self.terminals
+            )
+        ):
+            raise _validation_error(
+                "hypergraph reliability terminals must be two distinct declared vertices"
+            )
+        if len(self.hypergraph.edges) > MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES:
+            raise _validation_error(
+                "hypergraph reliability source exceeds the hyperedge bound"
+            )
+        return self
+
+
+class HypergraphBondReliabilityState(StrictModel):
+    state_index: StrictInt = Field(ge=0, lt=MAX_HYPERGRAPH_RELIABILITY_STATES)
+    open_hyperedge_ids: tuple[str, ...] = Field(
+        max_length=MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
+    )
+    terminals_connected: bool
+    state_probability: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_bounded_probability(self) -> Self:
+        require_bounded_rational(
+            self.state_probability,
+            max_digits=MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS,
+            label="hypergraph reliability state probability",
+        )
+        if not 0 <= self.state_probability.as_fraction() <= 1:
+            raise _validation_error(
+                "hypergraph reliability state probability must lie in [0, 1]"
+            )
+        return self
+
+
+class HypergraphBondConnectionProbabilityResult(StrictModel):
+    source: HypergraphBondReliabilitySource
+    connection_probability: CanonicalRational
+    hyperedge_count: StrictInt = Field(ge=0, le=MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES)
+    visited_states: StrictInt = Field(ge=1, le=MAX_HYPERGRAPH_RELIABILITY_STATES)
+    states: tuple[HypergraphBondReliabilityState, ...] = Field(
+        min_length=1, max_length=MAX_HYPERGRAPH_RELIABILITY_STATES
+    )
+    event: Literal["TERMINALS_CONNECTED_IN_INCIDENCE_GRAPH"] = (
+        "TERMINALS_CONNECTED_IN_INCIDENCE_GRAPH"
+    )
+    hyperedge_independence: Literal["INDEPENDENT_BERNOULLI"] = "INDEPENDENT_BERNOULLI"
+    connectivity_convention: Literal["INCIDENCE_GRAPH_CHAIN"] = "INCIDENCE_GRAPH_CHAIN"
+    enumeration: Literal["COMPLETE_HYPEREDGE_SUBSETS"] = "COMPLETE_HYPEREDGE_SUBSETS"
+
+    @model_validator(mode="after")
+    def require_canonical_state_ledger(self) -> Self:
+        require_bounded_rational(
+            self.connection_probability,
+            max_digits=MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS,
+            label="hypergraph connection probability",
+        )
+        if not 0 <= self.connection_probability.as_fraction() <= 1:
+            raise _validation_error(
+                "hypergraph connection probability must lie in [0, 1]"
+            )
+        if self.hyperedge_count != len(self.source.hypergraph.edges):
+            raise _validation_error("hypergraph reliability hyperedge axis mismatch")
+        if self.visited_states != 1 << self.hyperedge_count:
+            raise _validation_error(
+                "visited state count is not the full hyperedge powerset"
+            )
+        if len(self.states) != self.visited_states:
+            raise _validation_error("state ledger length does not match visited states")
+        if tuple(state.state_index for state in self.states) != tuple(
+            range(self.visited_states)
+        ):
+            raise _validation_error(
+                "state ledger indices must be complete and canonical"
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls.model_construct(**values)
+
+
+def _wire(value: Any) -> CanonicalRational:
+    return CanonicalRational(num=int(value.p), den=int(value.q))
+
+
+def _connected_in_incidence_graph(
+    *,
+    open_edges: tuple[tuple[str, ...], ...],
+    terminals: tuple[str, str],
+) -> bool:
+    """Chain connectivity through intersecting open hyperedges."""
+
+    reached = {terminals[0]}
+    changed = True
+    while changed:
+        changed = False
+        for members in open_edges:
+            member_set = set(members)
+            if member_set & reached and not member_set <= reached:
+                reached |= member_set
+                changed = True
+    return terminals[1] in reached
+
+
+def _admit_hypergraph_request(
+    request: HypergraphBondReliabilitySource,
+) -> None:
+    if len(request.hypergraph.vertices) > MAX_HYPERGRAPH_RELIABILITY_VERTICES:
+        raise OperationDomainValidationError(
+            location=("hypergraph", "vertices"),
+            code="probability.hypergraph_reliability.vertex_bound",
+            message=(
+                "hypergraph reliability exceeds the "
+                f"{MAX_HYPERGRAPH_RELIABILITY_VERTICES}-vertex bound"
+            ),
+        )
+    if len(request.hypergraph.edges) > MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES:
+        raise OperationDomainValidationError(
+            location=("hypergraph", "edges"),
+            code="probability.hypergraph_reliability.hyperedge_bound",
+            message=(
+                "hypergraph reliability exceeds the "
+                f"{MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES}-hyperedge bound"
+            ),
+        )
+    if tuple(item.hyperedge_id for item in request.hyperedge_probabilities) != tuple(
+        edge_id for edge_id, _ in request.hypergraph.edges
+    ):
+        raise OperationDomainValidationError(
+            location=("hyperedge_probabilities",),
+            code="probability.hypergraph_reliability.probability_binding",
+            message=(
+                "hyperedge probabilities must cover hyperedges in canonical order"
+            ),
+        )
+    if any(
+        not 0 <= item.open_probability.as_fraction() <= 1
+        for item in request.hyperedge_probabilities
+    ):
+        raise OperationDomainValidationError(
+            location=("hyperedge_probabilities",),
+            code="probability.hypergraph_reliability.probability_range",
+            message="hypergraph reliability probabilities must lie in [0, 1]",
+        )
+
+    # Admit arithmetic height and the complete state ledger together.  The
+    # complement branch has numerator den-num, so this maximum covers both
+    # open and closed factors for every state.  The powerset sum contributes
+    # at most decimal-digit-length(state_count) additional digits.
+    factor_digits = sum(
+        max(
+            len(str(abs(item.open_probability.as_fraction().numerator))),
+            len(str(item.open_probability.as_fraction().denominator)),
+            len(
+                str(
+                    abs(
+                        item.open_probability.as_fraction().denominator
+                        - item.open_probability.as_fraction().numerator
+                    )
+                )
+            ),
+        )
+        for item in request.hyperedge_probabilities
+    )
+    state_count = 1 << len(request.hypergraph.edges)
+    rational_digits = factor_digits + len(str(state_count))
+    if rational_digits > MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS:
+        raise OperationDomainValidationError(
+            location=("hyperedge_probabilities",),
+            code="probability.hypergraph_reliability.rational_height_bound",
+            message=(
+                "hypergraph reliability state masses exceed the admitted exact "
+                f"{MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS}-digit result bound"
+            ),
+        )
+    label_bytes = sum(
+        len(vertex.encode("utf-8")) for vertex in request.hypergraph.vertices
+    ) + sum(
+        len(edge_id.encode("utf-8"))
+        + sum(len(vertex.encode("utf-8")) for vertex in members)
+        for edge_id, members in request.hypergraph.edges
+    )
+    max_component_bytes = max(
+        (len(edge_id.encode("utf-8")) for edge_id, _ in request.hypergraph.edges),
+        default=1,
+    )
+    # Reserve each state for its largest possible open-ID tuple and exact
+    # rational. This is a conservative source-bound output estimate.
+    estimated_output_bytes = (
+        1024
+        + label_bytes * 4
+        + len(request.hyperedge_probabilities) * (2 * MAX_INPUT_RATIONAL_DIGITS + 96)
+        + state_count
+        * (
+            192
+            + len(request.hypergraph.edges) * max_component_bytes
+            + 2 * rational_digits
+        )
+    )
+    if estimated_output_bytes > MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES:
+        raise OperationDomainValidationError(
+            location=("states",),
+            code="probability.hypergraph_reliability.output_bound",
+            message="complete hypergraph-reliability ledger exceeds its output bound",
+        )
+
+
+def compute_hypergraph_bond_connection_probability(
+    request: HypergraphBondReliabilitySource,
+) -> HypergraphBondConnectionProbabilityResult:
+    """Compute exact terminal connectivity over every open hyperedge subset."""
+
+    from flint import fmpq
+
+    try:
+        source = HypergraphBondReliabilitySource.model_validate(request.model_dump())
+    except ValidationError as exc:
+        error = exc.errors()[0]
+        raise OperationDomainValidationError(
+            location=tuple(error["loc"]),
+            code=str(error["type"]),
+            message=str(error["msg"]),
+        ) from None
+    _admit_hypergraph_request(source)
+    edges = tuple(members for _, members in source.hypergraph.edges)
+    probabilities = tuple(
+        fmpq(
+            item.open_probability.as_fraction().numerator,
+            item.open_probability.as_fraction().denominator,
+        )
+        for item in source.hyperedge_probabilities
+    )
+    states: list[HypergraphBondReliabilityState] = []
+    connection_probability = fmpq(0)
+    for state_index in range(1 << len(edges)):
+        open_edges = tuple(
+            members for index, members in enumerate(edges) if state_index & (1 << index)
+        )
+        state_probability = fmpq(1)
+        for index, probability in enumerate(probabilities):
+            state_probability *= (
+                probability if state_index & (1 << index) else 1 - probability
+            )
+        connected = _connected_in_incidence_graph(
+            open_edges=open_edges, terminals=source.terminals
+        )
+        if connected:
+            connection_probability += state_probability
+        states.append(
+            HypergraphBondReliabilityState(
+                state_index=state_index,
+                open_hyperedge_ids=tuple(
+                    source.hypergraph.edges[index][0]
+                    for index in range(len(edges))
+                    if state_index & (1 << index)
+                ),
+                terminals_connected=connected,
+                state_probability=_wire(state_probability),
+            )
+        )
+    return HypergraphBondConnectionProbabilityResult._from_kernel(
+        source=source,
+        connection_probability=_wire(connection_probability),
+        hyperedge_count=len(edges),
+        visited_states=len(states),
+        states=tuple(states),
+    )
+
+
+HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION = MathTool(
+    operation_id="probability.hypergraph_bond_reliability.connection_probability.compute",
+    title="Compute exact terminal reliability of a finite hypergraph",
+    description=(
+        "Given a bounded finite simple hypergraph, one exact independent open "
+        "probability for every hyperedge, and two distinct terminals, enumerate "
+        "every hyperedge subset and return the exact probability that the two "
+        "terminals connect through a chain of open hyperedges whose successive "
+        "members intersect, together with the complete canonical state ledger."
+    ),
+    request_type=HypergraphBondReliabilitySource,
+    result_type=HypergraphBondConnectionProbabilityResult,
+    run=compute_hypergraph_bond_connection_probability,
+    tags=("probability", "reliability", "hypergraph", "exact"),
+    examples=(
+        OperationExample(
+            name="two_hyperedges_through_a_bridge",
+            description=(
+                "Terminals a and d connect when both hyperedges ab and cd are "
+                "open and share vertex b=c, so the probability is 1/4."
+            ),
+            input={
+                "hypergraph": {
+                    "vertices": ["a", "b", "d"],
+                    "edges": [["ab", ["a", "b"]], ["bd", ["b", "d"]]],
+                },
+                "hyperedge_probabilities": [
+                    {
+                        "hyperedge_id": "ab",
+                        "open_probability": {"num": "1", "den": "2"},
+                    },
+                    {
+                        "hyperedge_id": "bd",
+                        "open_probability": {"num": "1", "den": "2"},
+                    },
+                ],
+                "terminals": ["a", "d"],
+            },
+        ),
+    ),
+)
+
+
+__all__ = [
+    "HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION",
+    "MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES",
+    "MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES",
+    "MAX_HYPERGRAPH_RELIABILITY_STATES",
+    "MAX_HYPERGRAPH_RELIABILITY_VERTICES",
+    "HyperedgeOpenProbability",
+    "HypergraphBondConnectionProbabilityResult",
+    "HypergraphBondReliabilitySource",
+    "HypergraphBondReliabilityState",
+    "compute_hypergraph_bond_connection_probability",
+]

--- a/src/jacobian/math/probability/_hypergraph_bond_reliability.py
+++ b/src/jacobian/math/probability/_hypergraph_bond_reliability.py
@@ -423,7 +423,10 @@ HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION = MathTool(
             name="two_hyperedges_through_a_bridge",
             description=(
                 "Terminals a and d connect when both hyperedges ab and bd are "
-                "open and share vertex b, so the probability is 1/4."
+                "open and share vertex b, so the probability is 1/4. "
+                "Hyperedge probabilities must cover the declared hyperedge "
+                "axis in order, and the two terminals must be distinct "
+                "declared vertices."
             ),
             input={
                 "hypergraph": {

--- a/src/jacobian/math/probability/_hypergraph_bond_reliability.py
+++ b/src/jacobian/math/probability/_hypergraph_bond_reliability.py
@@ -144,6 +144,10 @@ class HypergraphBondReliabilityState(StrictModel):
             raise _validation_error("hypergraph state hyperedge IDs must be canonical")
         return self
 
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls.model_construct(**values)
+
 
 class HypergraphBondConnectionProbabilityResult(StrictModel):
     source: HypergraphBondReliabilitySource
@@ -308,8 +312,11 @@ def _admit_hypergraph_request(
 
     hyperedge_count = len(request.hypergraph.edges)
     state_memberships = hyperedge_count * (state_count // 2) if hyperedge_count else 0
-    label_units = sum(len(vertex) for vertex in request.hypergraph.vertices) + sum(
-        len(edge_id) for edge_id, _ in request.hypergraph.edges
+    vertex_label_units = sum(len(vertex) for vertex in request.hypergraph.vertices)
+    hyperedge_label_units = sum(len(edge_id) for edge_id, _ in request.hypergraph.edges)
+    label_units = vertex_label_units + hyperedge_label_units
+    repeated_label_units = (
+        hyperedge_label_units * (state_count // 2) if state_count else 0
     )
     source_units = (
         label_units
@@ -321,6 +328,7 @@ def _admit_hypergraph_request(
         source_units
         + state_count * 4
         + state_memberships
+        + repeated_label_units
         + 2 * (state_count + 1) * rational_digits
     )
     if ledger_units > MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS:
@@ -376,7 +384,7 @@ def compute_hypergraph_bond_connection_probability(
         if connected:
             connection_probability += state_probability
         states.append(
-            HypergraphBondReliabilityState(
+            HypergraphBondReliabilityState._from_kernel(
                 state_index=state_index,
                 open_hyperedge_ids=tuple(
                     source.hypergraph.edges[index][0]
@@ -414,8 +422,8 @@ HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION = MathTool(
         OperationExample(
             name="two_hyperedges_through_a_bridge",
             description=(
-                "Terminals a and d connect when both hyperedges ab and cd are "
-                "open and share vertex b=c, so the probability is 1/4."
+                "Terminals a and d connect when both hyperedges ab and bd are "
+                "open and share vertex b, so the probability is 1/4."
             ),
             input={
                 "hypergraph": {

--- a/src/jacobian/math/probability/_hypergraph_bond_reliability.py
+++ b/src/jacobian/math/probability/_hypergraph_bond_reliability.py
@@ -16,7 +16,6 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
-from jacobian.canonical import encode_strict_json
 from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
@@ -39,8 +38,9 @@ MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS = (
     MAX_INPUT_RATIONAL_DIGITS * MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
     + MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
 )
-MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES = 64_000_000
-MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS = MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES
+# One unit reserves either a retained scalar digit, label code point, container
+# slot, or fixed record field.  Concrete transports own encoded-byte ceilings.
+MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS = 64_000_000
 MAX_HYPERGRAPH_RELIABILITY_LOGICAL_WORK = MAX_HYPERGRAPH_RELIABILITY_STATES * (
     4 * MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
     + 4 * MAX_HYPERGRAPH_RELIABILITY_VERTICES
@@ -312,58 +312,33 @@ def _admit_hypergraph_request(
             ),
         )
 
-    def json_string_size(value: str) -> int:
-        return len(encode_strict_json(value))
-
-    def json_array_size(item_sizes: tuple[int, ...]) -> int:
-        return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
-
-    def json_object_size(fields: tuple[tuple[str, int], ...]) -> int:
-        return (
-            2
-            + max(len(fields) - 1, 0)
-            + sum(
-                json_string_size(name) + 1 + value_size for name, value_size in fields
-            )
-        )
-
-    source_bytes = len(encode_strict_json(request.model_dump(mode="json")))
-    rational_bytes = len(
-        encode_strict_json({"num": "9" * rational_digits, "den": "9" * rational_digits})
+    hyperedge_count = len(request.hypergraph.edges)
+    state_memberships = (
+        hyperedge_count * (state_count // 2) if hyperedge_count else 0
     )
-    open_hyperedge_bytes = json_array_size(
-        tuple(json_string_size(edge_id) for edge_id, _ in request.hypergraph.edges)
+    label_units = sum(len(vertex) for vertex in request.hypergraph.vertices) + sum(
+        len(edge_id) for edge_id, _ in request.hypergraph.edges
     )
-    state_bytes = json_object_size(
-        (
-            ("state_index", len(encode_strict_json(state_count - 1))),
-            ("open_hyperedge_ids", open_hyperedge_bytes),
-            ("terminals_connected", len(encode_strict_json(True))),
-            ("state_probability", rational_bytes),
-        )
+    source_units = (
+        label_units
+        + sum(len(members) for _, members in request.hypergraph.edges)
+        + 4 * len(request.hyperedge_probabilities)
+        + 2
     )
-    states_bytes = 2 + max(state_count - 1, 0) + state_count * state_bytes
-    result_bytes = json_object_size(
-        (
-            ("source", source_bytes),
-            ("connection_probability", rational_bytes),
-            ("hyperedge_count", len(encode_strict_json(len(request.hypergraph.edges)))),
-            ("visited_states", len(encode_strict_json(state_count))),
-            ("states", states_bytes),
-            (
-                "event",
-                json_string_size("TERMINALS_CONNECTED_IN_INCIDENCE_GRAPH"),
-            ),
-            ("hyperedge_independence", json_string_size("INDEPENDENT_BERNOULLI")),
-            ("connectivity_convention", json_string_size("INCIDENCE_GRAPH_CHAIN")),
-            ("enumeration", json_string_size("COMPLETE_HYPEREDGE_SUBSETS")),
-        )
+    ledger_units = (
+        source_units
+        + state_count * 4
+        + state_memberships
+        + 2 * (state_count + 1) * rational_digits
     )
-    if result_bytes > MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES:
+    if ledger_units > MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS:
         raise OperationResourceAdmissionError(
             location=("states",),
             code="probability.hypergraph_reliability.output_bound",
-            message="complete hypergraph-reliability ledger exceeds its output bound",
+            message=(
+                "complete hypergraph-reliability ledger exceeds its retained "
+                "allocation bound"
+            ),
         )
 
 
@@ -477,7 +452,6 @@ __all__ = [
     "MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES",
     "MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS",
     "MAX_HYPERGRAPH_RELIABILITY_LOGICAL_WORK",
-    "MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES",
     "MAX_HYPERGRAPH_RELIABILITY_STATES",
     "MAX_HYPERGRAPH_RELIABILITY_VERTICES",
     "HyperedgeOpenProbability",

--- a/src/jacobian/math/probability/_hypergraph_bond_reliability.py
+++ b/src/jacobian/math/probability/_hypergraph_bond_reliability.py
@@ -28,7 +28,6 @@ from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
 from jacobian.math.probability._models import MAX_INPUT_RATIONAL_DIGITS
 
 MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES = 12
-MAX_HYPERGRAPH_RELIABILITY_VERTICES = 24
 MAX_HYPERGRAPH_RELIABILITY_STATES = 1 << MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
 # A state mass has one probability (or complement) factor per hyperedge and
 # the successful-state sum has at most 2**k terms.  This is the result-carrier
@@ -41,12 +40,10 @@ MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS = (
 # One unit reserves either a retained scalar digit, label code point, container
 # slot, or fixed record field.  Concrete transports own encoded-byte ceilings.
 MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS = 64_000_000
-MAX_HYPERGRAPH_RELIABILITY_LOGICAL_WORK = MAX_HYPERGRAPH_RELIABILITY_STATES * (
-    4 * MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
-    + 4 * MAX_HYPERGRAPH_RELIABILITY_VERTICES
-    + 4 * MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES * MAX_HYPERGRAPH_RELIABILITY_VERTICES
-    + 16
-)
+# This calibrated total work budget charges actual traversal vertices and
+# incidences per state below.  Declared isolated vertices are retained once in
+# the source/result and are charged by the separate source/output envelope.
+MAX_HYPERGRAPH_RELIABILITY_LOGICAL_WORK = 5_373_952
 
 
 def _validation_error(message: str) -> PydanticCustomError:
@@ -73,9 +70,10 @@ class HypergraphBondReliabilitySource(StrictModel):
     hypergraph: FiniteHypergraph = Field(
         description=(
             "Finite simple hypergraph with at most "
-            f"{MAX_HYPERGRAPH_RELIABILITY_VERTICES} vertices and "
             f"{MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES} nonempty hyperedges "
-            "for complete hyperedge-subset enumeration."
+            "for complete hyperedge-subset enumeration. Traversal work is "
+            "charged by relevant hyperedge incidences, while declared vertices "
+            "are retained and charged separately."
         )
     )
     # The shared finite-hypergraph carrier is larger than this operation's
@@ -231,15 +229,6 @@ def _connected_in_incidence_graph(
 def _admit_hypergraph_request(
     request: HypergraphBondReliabilitySource,
 ) -> None:
-    if len(request.hypergraph.vertices) > MAX_HYPERGRAPH_RELIABILITY_VERTICES:
-        raise OperationResourceAdmissionError(
-            location=("hypergraph", "vertices"),
-            code="probability.hypergraph_reliability.vertex_bound",
-            message=(
-                "hypergraph reliability exceeds the "
-                f"{MAX_HYPERGRAPH_RELIABILITY_VERTICES}-vertex bound"
-            ),
-        )
     if len(request.hypergraph.edges) > MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES:
         raise OperationResourceAdmissionError(
             location=("hypergraph", "edges"),
@@ -289,10 +278,15 @@ def _admit_hypergraph_request(
         for item in request.hyperedge_probabilities
     )
     state_count = 1 << len(request.hypergraph.edges)
+    incidence_count = sum(len(members) for _, members in request.hypergraph.edges)
+    relevant_vertices = {
+        *request.terminals,
+        *(vertex for _, members in request.hypergraph.edges for vertex in members),
+    }
     logical_work = state_count * (
         4 * len(request.hypergraph.edges)
-        + 4 * len(request.hypergraph.vertices)
-        + 4 * sum(len(members) for _, members in request.hypergraph.edges)
+        + 4 * len(relevant_vertices)
+        + 4 * incidence_count
         + 16
     )
     if logical_work > MAX_HYPERGRAPH_RELIABILITY_LOGICAL_WORK:
@@ -451,7 +445,6 @@ __all__ = [
     "MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS",
     "MAX_HYPERGRAPH_RELIABILITY_LOGICAL_WORK",
     "MAX_HYPERGRAPH_RELIABILITY_STATES",
-    "MAX_HYPERGRAPH_RELIABILITY_VERTICES",
     "HyperedgeOpenProbability",
     "HypergraphBondConnectionProbabilityResult",
     "HypergraphBondReliabilitySource",

--- a/src/jacobian/math/probability/_hypergraph_bond_reliability.py
+++ b/src/jacobian/math/probability/_hypergraph_bond_reliability.py
@@ -37,7 +37,7 @@ MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS = (
     MAX_INPUT_RATIONAL_DIGITS * MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
     + MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES
 )
-MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES = 64_000_000
+MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS = 64_000_000
 
 
 def _validation_error(message: str) -> PydanticCustomError:
@@ -259,31 +259,29 @@ def _admit_hypergraph_request(
                 f"{MAX_HYPERGRAPH_RELIABILITY_RATIONAL_DIGITS}-digit result bound"
             ),
         )
-    label_bytes = sum(
-        len(vertex.encode("utf-8")) for vertex in request.hypergraph.vertices
-    ) + sum(
-        len(edge_id.encode("utf-8"))
-        + sum(len(vertex.encode("utf-8")) for vertex in members)
+    label_characters = sum(len(vertex) for vertex in request.hypergraph.vertices) + sum(
+        len(edge_id) + sum(len(vertex) for vertex in members)
         for edge_id, members in request.hypergraph.edges
     )
-    max_component_bytes = max(
-        (len(edge_id.encode("utf-8")) for edge_id, _ in request.hypergraph.edges),
+    max_component_characters = max(
+        (len(edge_id) for edge_id, _ in request.hypergraph.edges),
         default=1,
     )
-    # Reserve each state for its largest possible open-ID tuple and exact
-    # rational. This is a conservative source-bound output estimate.
-    estimated_output_bytes = (
+    # Bound mathematical storage by label characters, exact rational digits,
+    # and scalar slots. Reserve every state for the full open-hyperedge axis;
+    # fixed padding covers the bounded source and per-state scalar fields.
+    ledger_units = (
         1024
-        + label_bytes * 4
+        + label_characters * 4
         + len(request.hyperedge_probabilities) * (2 * MAX_INPUT_RATIONAL_DIGITS + 96)
         + state_count
         * (
             192
-            + len(request.hypergraph.edges) * max_component_bytes
+            + len(request.hypergraph.edges) * max_component_characters
             + 2 * rational_digits
         )
     )
-    if estimated_output_bytes > MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES:
+    if ledger_units > MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS:
         raise OperationDomainValidationError(
             location=("states",),
             code="probability.hypergraph_reliability.output_bound",
@@ -399,7 +397,7 @@ HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION = MathTool(
 __all__ = [
     "HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION",
     "MAX_HYPERGRAPH_RELIABILITY_HYPEREDGES",
-    "MAX_HYPERGRAPH_RELIABILITY_OUTPUT_BYTES",
+    "MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS",
     "MAX_HYPERGRAPH_RELIABILITY_STATES",
     "MAX_HYPERGRAPH_RELIABILITY_VERTICES",
     "HyperedgeOpenProbability",

--- a/src/jacobian/math/probability/_hypergraph_bond_reliability.py
+++ b/src/jacobian/math/probability/_hypergraph_bond_reliability.py
@@ -313,9 +313,7 @@ def _admit_hypergraph_request(
         )
 
     hyperedge_count = len(request.hypergraph.edges)
-    state_memberships = (
-        hyperedge_count * (state_count // 2) if hyperedge_count else 0
-    )
+    state_memberships = hyperedge_count * (state_count // 2) if hyperedge_count else 0
     label_units = sum(len(vertex) for vertex in request.hypergraph.vertices) + sum(
         len(edge_id) for edge_id, _ in request.hypergraph.edges
     )

--- a/src/jacobian/math/probability/_site_reliability.py
+++ b/src/jacobian/math/probability/_site_reliability.py
@@ -306,15 +306,28 @@ def _admit_site_request(
     # retained state rows.  Charge both membership slots and the repeated
     # source-label code points in those rows so projection cannot explode
     # from a compact request whose labels are copied into thousands of states.
+    # The retained source also copies each vertex into the probability axis
+    # and the terminal pair, and copies edge endpoints, so those occurrences
+    # belong to the same allocation envelope.
     state_memberships = (
         len(request.graph.vertices) * (state_count // 2)
         if request.graph.vertices
         else 0
     )
     label_units = sum(len(vertex) for vertex in request.graph.vertices)
+    probability_label_units = sum(
+        len(item.vertex) for item in request.vertex_probabilities
+    )
+    terminal_label_units = sum(len(terminal) for terminal in request.terminals)
+    edge_label_units = sum(
+        len(left) + len(right) for left, right in request.graph.edges
+    )
     repeated_label_units = label_units * (state_count // 2) if state_count else 0
     source_units = (
         label_units
+        + probability_label_units
+        + terminal_label_units
+        + edge_label_units
         + 2 * len(request.graph.edges)
         + 4 * len(request.vertex_probabilities)
         + 2

--- a/src/jacobian/math/probability/_site_reliability.py
+++ b/src/jacobian/math/probability/_site_reliability.py
@@ -417,7 +417,9 @@ SITE_CONNECTION_PROBABILITY_OPERATION = MathTool(
             name="path_of_two",
             description=(
                 "Two vertices joined by an edge connect exactly when both are "
-                "open, so the probability is p^2 = 1/4."
+                "open, so the probability is p^2 = 1/4. Vertex probabilities "
+                "must follow the graph's declared vertex axis, and the two "
+                "terminals must be distinct declared vertices."
             ),
             input={
                 "graph": {"vertices": ["a", "b"], "edges": [["a", "b"]]},

--- a/src/jacobian/math/probability/_site_reliability.py
+++ b/src/jacobian/math/probability/_site_reliability.py
@@ -16,6 +16,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.canonical import encode_strict_json
 from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
@@ -37,7 +38,11 @@ MAX_SITE_RELIABILITY_RATIONAL_DIGITS = (
     MAX_INPUT_RATIONAL_DIGITS * MAX_SITE_RELIABILITY_VERTICES
     + MAX_SITE_RELIABILITY_VERTICES
 )
-MAX_SITE_RELIABILITY_LEDGER_UNITS = 64_000_000
+MAX_SITE_RELIABILITY_OUTPUT_BYTES = 64_000_000
+MAX_SITE_RELIABILITY_LEDGER_UNITS = MAX_SITE_RELIABILITY_OUTPUT_BYTES
+MAX_SITE_RELIABILITY_LOGICAL_WORK = MAX_SITE_RELIABILITY_STATES * (
+    4 * MAX_SITE_RELIABILITY_VERTICES + 4 * MAX_SITE_RELIABILITY_EDGES + 16
+)
 
 
 def _validation_error(message: str) -> PydanticCustomError:
@@ -61,9 +66,22 @@ class SiteReliabilityVertexProbability(StrictModel):
 class GraphSiteReliabilitySource(StrictModel):
     """Canonical graph, vertex-axis probabilities, and terminal event source."""
 
-    graph: SimpleUndirectedGraph
+    graph: SimpleUndirectedGraph = Field(
+        description=(
+            "Simple undirected graph with at most "
+            f"{MAX_SITE_RELIABILITY_VERTICES} vertices and "
+            f"{MAX_SITE_RELIABILITY_EDGES} edges for complete vertex-subset "
+            "enumeration."
+        )
+    )
+    # The shared graph carrier is larger than this operation's powerset
+    # envelope.  Operation-specific cardinality belongs to admission so an
+    # otherwise well-formed oversized request receives a resource error.
     vertex_probabilities: tuple[SiteReliabilityVertexProbability, ...] = Field(
-        max_length=MAX_SITE_RELIABILITY_VERTICES
+        description=(
+            "One independent exact open probability for every graph vertex, "
+            "in the graph's declared vertex-axis order."
+        )
     )
     terminals: tuple[str, str]
     event: Literal["TERMINALS_OPEN_AND_CONNECTED"] = "TERMINALS_OPEN_AND_CONNECTED"
@@ -86,8 +104,6 @@ class GraphSiteReliabilitySource(StrictModel):
             raise _validation_error(
                 "site reliability terminals must be two distinct graph vertices"
             )
-        if len(self.graph.vertices) > MAX_SITE_RELIABILITY_VERTICES:
-            raise _validation_error("site reliability source exceeds the vertex bound")
         return self
 
 
@@ -246,6 +262,17 @@ def _admit_site_request(
             message="site reliability probabilities must lie in [0, 1]",
         )
 
+    state_count = 1 << len(request.graph.vertices)
+    logical_work = state_count * (
+        4 * len(request.graph.vertices) + 4 * len(request.graph.edges) + 16
+    )
+    if logical_work > MAX_SITE_RELIABILITY_LOGICAL_WORK:
+        raise OperationResourceAdmissionError(
+            location=("states",),
+            code="probability.site_reliability.work_bound",
+            message="site reliability enumeration exceeds its work bound",
+        )
+
     # Bound both the exact numerator/denominator height and the complete
     # ledger before entering the powerset loop.  Complements have numerator
     # ``den-num``; taking the maximum over both branches is a sound bound for
@@ -266,7 +293,6 @@ def _admit_site_request(
         )
         for item in request.vertex_probabilities
     )
-    state_count = 1 << len(request.graph.vertices)
     rational_digits = factor_digits + len(str(state_count))
     if rational_digits > MAX_SITE_RELIABILITY_RATIONAL_DIGITS:
         raise OperationResourceAdmissionError(
@@ -277,26 +303,51 @@ def _admit_site_request(
                 f"{MAX_SITE_RELIABILITY_RATIONAL_DIGITS}-digit result bound"
             ),
         )
-    label_characters = sum(len(vertex) for vertex in request.graph.vertices)
-    max_component_characters = max(
-        (len(vertex) for vertex in request.graph.vertices),
-        default=1,
+
+    def json_string_size(value: str) -> int:
+        return len(encode_strict_json(value))
+
+    def json_array_size(item_sizes: tuple[int, ...]) -> int:
+        return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
+
+    def json_object_size(fields: tuple[tuple[str, int], ...]) -> int:
+        return (
+            2
+            + max(len(fields) - 1, 0)
+            + sum(
+                json_string_size(name) + 1 + value_size for name, value_size in fields
+            )
+        )
+
+    source_bytes = len(encode_strict_json(request.model_dump(mode="json")))
+    rational_bytes = len(
+        encode_strict_json({"num": "9" * rational_digits, "den": "9" * rational_digits})
     )
-    # Bound mathematical storage by label characters, exact rational digits,
-    # and scalar slots. Reserve every state for the full open-vertex axis;
-    # fixed padding covers the bounded source and per-state scalar fields.
-    ledger_units = (
-        1024
-        + label_characters * 8
-        + len(request.vertex_probabilities) * (2 * MAX_INPUT_RATIONAL_DIGITS + 96)
-        + state_count
-        * (
-            192
-            + len(request.graph.vertices) * max_component_characters
-            + 2 * rational_digits
+    open_vertices_bytes = json_array_size(
+        tuple(json_string_size(vertex) for vertex in request.graph.vertices)
+    )
+    state_bytes = json_object_size(
+        (
+            ("state_index", len(encode_strict_json(state_count - 1))),
+            ("open_vertices", open_vertices_bytes),
+            ("terminals_connected", len(encode_strict_json(True))),
+            ("state_probability", rational_bytes),
         )
     )
-    if ledger_units > MAX_SITE_RELIABILITY_LEDGER_UNITS:
+    states_bytes = 2 + max(state_count - 1, 0) + state_count * state_bytes
+    result_bytes = json_object_size(
+        (
+            ("source", source_bytes),
+            ("connection_probability", rational_bytes),
+            ("vertex_count", len(encode_strict_json(len(request.graph.vertices)))),
+            ("visited_states", len(encode_strict_json(state_count))),
+            ("states", states_bytes),
+            ("event", json_string_size("TERMINALS_OPEN_AND_CONNECTED")),
+            ("vertex_independence", json_string_size("INDEPENDENT_BERNOULLI")),
+            ("enumeration", json_string_size("COMPLETE_VERTEX_SUBSETS")),
+        )
+    )
+    if result_bytes > MAX_SITE_RELIABILITY_OUTPUT_BYTES:
         raise OperationResourceAdmissionError(
             location=("states",),
             code="probability.site_reliability.output_bound",
@@ -402,6 +453,8 @@ SITE_CONNECTION_PROBABILITY_OPERATION = MathTool(
 __all__ = [
     "MAX_SITE_RELIABILITY_EDGES",
     "MAX_SITE_RELIABILITY_LEDGER_UNITS",
+    "MAX_SITE_RELIABILITY_LOGICAL_WORK",
+    "MAX_SITE_RELIABILITY_OUTPUT_BYTES",
     "MAX_SITE_RELIABILITY_STATES",
     "MAX_SITE_RELIABILITY_VERTICES",
     "SITE_CONNECTION_PROBABILITY_OPERATION",

--- a/src/jacobian/math/probability/_site_reliability.py
+++ b/src/jacobian/math/probability/_site_reliability.py
@@ -134,6 +134,10 @@ class GraphSiteReliabilityState(StrictModel):
             )
         return self
 
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls.model_construct(**values)
+
 
 class GraphSiteReliabilityResult(StrictModel):
     """An exact complete site-reliability result with its state ledger."""
@@ -299,16 +303,16 @@ def _admit_site_request(
         )
 
     # Across a complete powerset, every vertex occurs in exactly half of the
-    # retained state rows.  Rational digit units cover both exact components
-    # of every state mass and of the final sum.  Source strings are counted as
-    # code points and graph incidences as slots, independently of any wire
-    # encoding chosen by a caller.
+    # retained state rows.  Charge both membership slots and the repeated
+    # source-label code points in those rows so projection cannot explode
+    # from a compact request whose labels are copied into thousands of states.
     state_memberships = (
         len(request.graph.vertices) * (state_count // 2)
         if request.graph.vertices
         else 0
     )
     label_units = sum(len(vertex) for vertex in request.graph.vertices)
+    repeated_label_units = label_units * (state_count // 2) if state_count else 0
     source_units = (
         label_units
         + 2 * len(request.graph.edges)
@@ -319,6 +323,7 @@ def _admit_site_request(
         source_units
         + state_count * 4
         + state_memberships
+        + repeated_label_units
         + 2 * (state_count + 1) * rational_digits
     )
     if ledger_units > MAX_SITE_RELIABILITY_LEDGER_UNITS:
@@ -377,7 +382,7 @@ def compute_site_connection_probability(
         if connected:
             connection_probability += state_probability
         states.append(
-            GraphSiteReliabilityState(
+            GraphSiteReliabilityState._from_kernel(
                 state_index=state_index,
                 open_vertices=open_vertices,
                 terminals_connected=connected,

--- a/src/jacobian/math/probability/_site_reliability.py
+++ b/src/jacobian/math/probability/_site_reliability.py
@@ -20,6 +20,7 @@ from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
     OperationExample,
+    OperationResourceAdmissionError,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 from jacobian.math.probability._models import MAX_INPUT_RATIONAL_DIGITS
@@ -69,8 +70,9 @@ class GraphSiteReliabilitySource(StrictModel):
 
     @model_validator(mode="after")
     def require_bound_vertex_axis(self) -> Self:
-        if tuple(item.vertex for item in self.vertex_probabilities) != tuple(
-            sorted(self.graph.vertices)
+        if (
+            tuple(item.vertex for item in self.vertex_probabilities)
+            != self.graph.vertices
         ):
             raise _validation_error(
                 "site reliability vertex probabilities must follow the declared "
@@ -108,7 +110,7 @@ class GraphSiteReliabilityState(StrictModel):
             raise _validation_error(
                 "site reliability state probability must lie in [0, 1]"
             )
-        if self.open_vertices != tuple(sorted(set(self.open_vertices))):
+        if len(set(self.open_vertices)) != len(self.open_vertices):
             raise _validation_error(
                 "site reliability state vertex lists must be canonical"
             )
@@ -154,6 +156,17 @@ class GraphSiteReliabilityResult(StrictModel):
             raise _validation_error(
                 "state ledger indices must be complete and canonical"
             )
+        vertex_axis = self.source.graph.vertices
+        for state in self.states:
+            expected = tuple(
+                vertex
+                for index, vertex in enumerate(vertex_axis)
+                if state.state_index & (1 << index)
+            )
+            if state.open_vertices != expected:
+                raise _validation_error(
+                    "site reliability state vertices do not match their state index"
+                )
         return self
 
     @classmethod
@@ -196,7 +209,7 @@ def _admit_site_request(
     request: GraphSiteReliabilitySource,
 ) -> None:
     if len(request.graph.vertices) > MAX_SITE_RELIABILITY_VERTICES:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("graph", "vertices"),
             code="probability.site_reliability.vertex_bound",
             message=(
@@ -205,15 +218,16 @@ def _admit_site_request(
             ),
         )
     if len(request.graph.edges) > MAX_SITE_RELIABILITY_EDGES:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("graph", "edges"),
             code="probability.site_reliability.edge_bound",
             message=(
                 f"site reliability exceeds the {MAX_SITE_RELIABILITY_EDGES}-edge bound"
             ),
         )
-    if tuple(item.vertex for item in request.vertex_probabilities) != tuple(
-        sorted(request.graph.vertices)
+    if (
+        tuple(item.vertex for item in request.vertex_probabilities)
+        != request.graph.vertices
     ):
         raise OperationDomainValidationError(
             location=("vertex_probabilities",),
@@ -255,7 +269,7 @@ def _admit_site_request(
     state_count = 1 << len(request.graph.vertices)
     rational_digits = factor_digits + len(str(state_count))
     if rational_digits > MAX_SITE_RELIABILITY_RATIONAL_DIGITS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("vertex_probabilities",),
             code="probability.site_reliability.rational_height_bound",
             message=(
@@ -283,7 +297,7 @@ def _admit_site_request(
         )
     )
     if ledger_units > MAX_SITE_RELIABILITY_LEDGER_UNITS:
-        raise OperationDomainValidationError(
+        raise OperationResourceAdmissionError(
             location=("states",),
             code="probability.site_reliability.output_bound",
             message="complete site-reliability ledger exceeds its output bound",
@@ -307,7 +321,7 @@ def compute_site_connection_probability(
             message=str(error["msg"]),
         ) from None
     _admit_site_request(source)
-    vertices = tuple(sorted(source.graph.vertices))
+    vertices = source.graph.vertices
     probabilities = tuple(
         fmpq(
             item.open_probability.as_fraction().numerator,

--- a/src/jacobian/math/probability/_site_reliability.py
+++ b/src/jacobian/math/probability/_site_reliability.py
@@ -16,7 +16,6 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
-from jacobian.canonical import encode_strict_json
 from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
@@ -38,8 +37,10 @@ MAX_SITE_RELIABILITY_RATIONAL_DIGITS = (
     MAX_INPUT_RATIONAL_DIGITS * MAX_SITE_RELIABILITY_VERTICES
     + MAX_SITE_RELIABILITY_VERTICES
 )
-MAX_SITE_RELIABILITY_OUTPUT_BYTES = 64_000_000
-MAX_SITE_RELIABILITY_LEDGER_UNITS = MAX_SITE_RELIABILITY_OUTPUT_BYTES
+# One unit reserves either a retained scalar digit, label code point, container
+# slot, or fixed record field.  This is a mathematical allocation envelope;
+# concrete transports own their independent encoded-byte ceilings.
+MAX_SITE_RELIABILITY_LEDGER_UNITS = 64_000_000
 MAX_SITE_RELIABILITY_LOGICAL_WORK = MAX_SITE_RELIABILITY_STATES * (
     4 * MAX_SITE_RELIABILITY_VERTICES + 4 * MAX_SITE_RELIABILITY_EDGES + 16
 )
@@ -304,54 +305,37 @@ def _admit_site_request(
             ),
         )
 
-    def json_string_size(value: str) -> int:
-        return len(encode_strict_json(value))
-
-    def json_array_size(item_sizes: tuple[int, ...]) -> int:
-        return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
-
-    def json_object_size(fields: tuple[tuple[str, int], ...]) -> int:
-        return (
-            2
-            + max(len(fields) - 1, 0)
-            + sum(
-                json_string_size(name) + 1 + value_size for name, value_size in fields
-            )
-        )
-
-    source_bytes = len(encode_strict_json(request.model_dump(mode="json")))
-    rational_bytes = len(
-        encode_strict_json({"num": "9" * rational_digits, "den": "9" * rational_digits})
+    # Across a complete powerset, every vertex occurs in exactly half of the
+    # retained state rows.  Rational digit units cover both exact components
+    # of every state mass and of the final sum.  Source strings are counted as
+    # code points and graph incidences as slots, independently of any wire
+    # encoding chosen by a caller.
+    state_memberships = (
+        len(request.graph.vertices) * (state_count // 2)
+        if request.graph.vertices
+        else 0
     )
-    open_vertices_bytes = json_array_size(
-        tuple(json_string_size(vertex) for vertex in request.graph.vertices)
+    label_units = sum(len(vertex) for vertex in request.graph.vertices)
+    source_units = (
+        label_units
+        + 2 * len(request.graph.edges)
+        + 4 * len(request.vertex_probabilities)
+        + 2
     )
-    state_bytes = json_object_size(
-        (
-            ("state_index", len(encode_strict_json(state_count - 1))),
-            ("open_vertices", open_vertices_bytes),
-            ("terminals_connected", len(encode_strict_json(True))),
-            ("state_probability", rational_bytes),
-        )
+    ledger_units = (
+        source_units
+        + state_count * 4
+        + state_memberships
+        + 2 * (state_count + 1) * rational_digits
     )
-    states_bytes = 2 + max(state_count - 1, 0) + state_count * state_bytes
-    result_bytes = json_object_size(
-        (
-            ("source", source_bytes),
-            ("connection_probability", rational_bytes),
-            ("vertex_count", len(encode_strict_json(len(request.graph.vertices)))),
-            ("visited_states", len(encode_strict_json(state_count))),
-            ("states", states_bytes),
-            ("event", json_string_size("TERMINALS_OPEN_AND_CONNECTED")),
-            ("vertex_independence", json_string_size("INDEPENDENT_BERNOULLI")),
-            ("enumeration", json_string_size("COMPLETE_VERTEX_SUBSETS")),
-        )
-    )
-    if result_bytes > MAX_SITE_RELIABILITY_OUTPUT_BYTES:
+    if ledger_units > MAX_SITE_RELIABILITY_LEDGER_UNITS:
         raise OperationResourceAdmissionError(
             location=("states",),
             code="probability.site_reliability.output_bound",
-            message="complete site-reliability ledger exceeds its output bound",
+            message=(
+                "complete site-reliability ledger exceeds its retained allocation "
+                "bound"
+            ),
         )
 
 
@@ -454,7 +438,6 @@ __all__ = [
     "MAX_SITE_RELIABILITY_EDGES",
     "MAX_SITE_RELIABILITY_LEDGER_UNITS",
     "MAX_SITE_RELIABILITY_LOGICAL_WORK",
-    "MAX_SITE_RELIABILITY_OUTPUT_BYTES",
     "MAX_SITE_RELIABILITY_STATES",
     "MAX_SITE_RELIABILITY_VERTICES",
     "SITE_CONNECTION_PROBABILITY_OPERATION",

--- a/src/jacobian/math/probability/_site_reliability.py
+++ b/src/jacobian/math/probability/_site_reliability.py
@@ -26,7 +26,6 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 from jacobian.math.probability._models import MAX_INPUT_RATIONAL_DIGITS
 
 MAX_SITE_RELIABILITY_VERTICES = 12
-MAX_SITE_RELIABILITY_EDGES = 24
 MAX_SITE_RELIABILITY_STATES = 1 << MAX_SITE_RELIABILITY_VERTICES
 # A state mass contains one probability (or its complement) per vertex.  The
 # input contract allows 128 digits per factor, and summing at most 2**n state
@@ -39,11 +38,13 @@ MAX_SITE_RELIABILITY_RATIONAL_DIGITS = (
 )
 # One unit reserves either a retained scalar digit, label code point, container
 # slot, or fixed record field.  This is a mathematical allocation envelope;
-# concrete transports own their independent encoded-byte ceilings.
+# concrete transports own their independent encoded-byte ceilings.  In
+# particular, native admission does not estimate a hypothetical JSON payload.
 MAX_SITE_RELIABILITY_LEDGER_UNITS = 64_000_000
-MAX_SITE_RELIABILITY_LOGICAL_WORK = MAX_SITE_RELIABILITY_STATES * (
-    4 * MAX_SITE_RELIABILITY_VERTICES + 4 * MAX_SITE_RELIABILITY_EDGES + 16
-)
+# This calibrated total work budget is checked against each request's actual
+# vertex and edge scans below.  It deliberately does not impose a separate
+# graph-edge cardinality cap.
+MAX_SITE_RELIABILITY_LOGICAL_WORK = 655_360
 
 
 def _validation_error(message: str) -> PydanticCustomError:
@@ -70,9 +71,9 @@ class GraphSiteReliabilitySource(StrictModel):
     graph: SimpleUndirectedGraph = Field(
         description=(
             "Simple undirected graph with at most "
-            f"{MAX_SITE_RELIABILITY_VERTICES} vertices and "
-            f"{MAX_SITE_RELIABILITY_EDGES} edges for complete vertex-subset "
-            "enumeration."
+            f"{MAX_SITE_RELIABILITY_VERTICES} vertices. Complete vertex-subset "
+            "enumeration is admitted by its intrinsic work and retained-ledger "
+            "bounds."
         )
     )
     # The shared graph carrier is larger than this operation's powerset
@@ -232,14 +233,6 @@ def _admit_site_request(
             message=(
                 "site reliability exceeds the "
                 f"{MAX_SITE_RELIABILITY_VERTICES}-vertex bound"
-            ),
-        )
-    if len(request.graph.edges) > MAX_SITE_RELIABILITY_EDGES:
-        raise OperationResourceAdmissionError(
-            location=("graph", "edges"),
-            code="probability.site_reliability.edge_bound",
-            message=(
-                f"site reliability exceeds the {MAX_SITE_RELIABILITY_EDGES}-edge bound"
             ),
         )
     if (
@@ -434,7 +427,6 @@ SITE_CONNECTION_PROBABILITY_OPERATION = MathTool(
 )
 
 __all__ = [
-    "MAX_SITE_RELIABILITY_EDGES",
     "MAX_SITE_RELIABILITY_LEDGER_UNITS",
     "MAX_SITE_RELIABILITY_LOGICAL_WORK",
     "MAX_SITE_RELIABILITY_STATES",

--- a/src/jacobian/math/probability/_site_reliability.py
+++ b/src/jacobian/math/probability/_site_reliability.py
@@ -1,0 +1,398 @@
+"""Exact bounded site-reliability operation for a finite simple graph.
+
+Site percolation differs from the existing bond operation in what is random:
+every vertex is independently open with its declared probability, and the two
+terminals connect when both are open and lie in one connected component of the
+open induced subgraph.  The state space is the vertex powerset, so this is a
+separate public contract rather than a mode flag on the bond operation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Self
+
+from pydantic import Field, StrictInt, ValidationError, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._models import StrictModel
+from jacobian.catalog.models import (
+    MathTool,
+    OperationDomainValidationError,
+    OperationExample,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.probability._models import MAX_INPUT_RATIONAL_DIGITS
+
+MAX_SITE_RELIABILITY_VERTICES = 12
+MAX_SITE_RELIABILITY_EDGES = 24
+MAX_SITE_RELIABILITY_STATES = 1 << MAX_SITE_RELIABILITY_VERTICES
+# A state mass contains one probability (or its complement) per vertex.  The
+# input contract allows 128 digits per factor, and summing at most 2**n state
+# masses adds at most log10(2**n) digits.  Keep the result carrier wide enough for the
+# admitted arithmetic; admission below uses the request's actual factor
+# heights, so ordinary small requests are not penalised by this worst case.
+MAX_SITE_RELIABILITY_RATIONAL_DIGITS = (
+    MAX_INPUT_RATIONAL_DIGITS * MAX_SITE_RELIABILITY_VERTICES
+    + MAX_SITE_RELIABILITY_VERTICES
+)
+MAX_SITE_RELIABILITY_OUTPUT_BYTES = 64_000_000
+
+
+def _validation_error(message: str) -> PydanticCustomError:
+    return PydanticCustomError("probability.model_invariant", message)
+
+
+class SiteReliabilityVertexProbability(StrictModel):
+    vertex: str
+    open_probability: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_canonical_bounded_probability(self) -> Self:
+        require_bounded_rational(
+            self.open_probability,
+            max_digits=MAX_INPUT_RATIONAL_DIGITS,
+            label="site reliability vertex probability",
+        )
+        return self
+
+
+class GraphSiteReliabilitySource(StrictModel):
+    """Canonical graph, vertex-axis probabilities, and terminal event source."""
+
+    graph: SimpleUndirectedGraph
+    vertex_probabilities: tuple[SiteReliabilityVertexProbability, ...] = Field(
+        max_length=MAX_SITE_RELIABILITY_VERTICES
+    )
+    terminals: tuple[str, str]
+    event: Literal["TERMINALS_OPEN_AND_CONNECTED"] = "TERMINALS_OPEN_AND_CONNECTED"
+
+    @model_validator(mode="after")
+    def require_bound_vertex_axis(self) -> Self:
+        if tuple(item.vertex for item in self.vertex_probabilities) != tuple(
+            sorted(self.graph.vertices)
+        ):
+            raise _validation_error(
+                "site reliability vertex probabilities must follow the declared "
+                "canonical vertex axis"
+            )
+        if (
+            len(self.terminals) != 2
+            or self.terminals[0] == self.terminals[1]
+            or any(terminal not in self.graph.vertices for terminal in self.terminals)
+        ):
+            raise _validation_error(
+                "site reliability terminals must be two distinct graph vertices"
+            )
+        if len(self.graph.vertices) > MAX_SITE_RELIABILITY_VERTICES:
+            raise _validation_error("site reliability source exceeds the vertex bound")
+        return self
+
+
+class GraphSiteReliabilityState(StrictModel):
+    """One exact open-vertex state of the site-percolation powerset."""
+
+    state_index: StrictInt = Field(ge=0, lt=MAX_SITE_RELIABILITY_STATES)
+    open_vertices: tuple[str, ...] = Field(max_length=MAX_SITE_RELIABILITY_VERTICES)
+    terminals_connected: bool
+    state_probability: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_bounded_probability(self) -> Self:
+        require_bounded_rational(
+            self.state_probability,
+            max_digits=MAX_SITE_RELIABILITY_RATIONAL_DIGITS,
+            label="site reliability state probability",
+        )
+        if not 0 <= self.state_probability.as_fraction() <= 1:
+            raise _validation_error(
+                "site reliability state probability must lie in [0, 1]"
+            )
+        if self.open_vertices != tuple(sorted(set(self.open_vertices))):
+            raise _validation_error(
+                "site reliability state vertex lists must be canonical"
+            )
+        return self
+
+
+class GraphSiteReliabilityResult(StrictModel):
+    """An exact complete site-reliability result with its state ledger."""
+
+    source: GraphSiteReliabilitySource
+    connection_probability: CanonicalRational
+    vertex_count: StrictInt = Field(ge=0, le=MAX_SITE_RELIABILITY_VERTICES)
+    visited_states: StrictInt = Field(ge=1, le=MAX_SITE_RELIABILITY_STATES)
+    states: tuple[GraphSiteReliabilityState, ...] = Field(
+        min_length=1, max_length=MAX_SITE_RELIABILITY_STATES
+    )
+    event: Literal["TERMINALS_OPEN_AND_CONNECTED"] = "TERMINALS_OPEN_AND_CONNECTED"
+    vertex_independence: Literal["INDEPENDENT_BERNOULLI"] = "INDEPENDENT_BERNOULLI"
+    enumeration: Literal["COMPLETE_VERTEX_SUBSETS"] = "COMPLETE_VERTEX_SUBSETS"
+
+    @model_validator(mode="after")
+    def require_canonical_state_ledger(self) -> Self:
+        require_bounded_rational(
+            self.connection_probability,
+            max_digits=MAX_SITE_RELIABILITY_RATIONAL_DIGITS,
+            label="site connection probability",
+        )
+        if not 0 <= self.connection_probability.as_fraction() <= 1:
+            raise _validation_error(
+                "site reliability connection probability must lie in [0, 1]"
+            )
+        if self.vertex_count != len(self.source.graph.vertices):
+            raise _validation_error("site reliability vertex axis mismatch")
+        if self.visited_states != 1 << self.vertex_count:
+            raise _validation_error(
+                "visited state count is not the full vertex powerset"
+            )
+        if len(self.states) != self.visited_states:
+            raise _validation_error("state ledger length does not match visited states")
+        if tuple(state.state_index for state in self.states) != tuple(
+            range(self.visited_states)
+        ):
+            raise _validation_error(
+                "state ledger indices must be complete and canonical"
+            )
+        return self
+
+    @classmethod
+    def _from_kernel(cls, **values: Any) -> Self:
+        return cls.model_construct(**values)
+
+
+def _wire(value: Any) -> CanonicalRational:
+    return CanonicalRational(num=int(value.p), den=int(value.q))
+
+
+def _open_terminals_connected(
+    *,
+    open_vertices: tuple[str, ...],
+    edges: tuple[tuple[str, str], ...],
+    terminals: tuple[str, str],
+) -> bool:
+    """Both terminals open and joined inside the open induced subgraph."""
+
+    if terminals[0] not in open_vertices or terminals[1] not in open_vertices:
+        return False
+    adjacency: dict[str, set[str]] = {vertex: set() for vertex in open_vertices}
+    for left, right in edges:
+        if left in adjacency and right in adjacency:
+            adjacency[left].add(right)
+            adjacency[right].add(left)
+    seen = {terminals[0]}
+    pending = [terminals[0]]
+    while pending:
+        vertex = pending.pop()
+        for neighbor in adjacency[vertex] - seen:
+            if neighbor == terminals[1]:
+                return True
+            seen.add(neighbor)
+            pending.append(neighbor)
+    return terminals[1] in seen
+
+
+def _admit_site_request(
+    request: GraphSiteReliabilitySource,
+) -> None:
+    if len(request.graph.vertices) > MAX_SITE_RELIABILITY_VERTICES:
+        raise OperationDomainValidationError(
+            location=("graph", "vertices"),
+            code="probability.site_reliability.vertex_bound",
+            message=(
+                "site reliability exceeds the "
+                f"{MAX_SITE_RELIABILITY_VERTICES}-vertex bound"
+            ),
+        )
+    if len(request.graph.edges) > MAX_SITE_RELIABILITY_EDGES:
+        raise OperationDomainValidationError(
+            location=("graph", "edges"),
+            code="probability.site_reliability.edge_bound",
+            message=(
+                f"site reliability exceeds the {MAX_SITE_RELIABILITY_EDGES}-edge bound"
+            ),
+        )
+    if tuple(item.vertex for item in request.vertex_probabilities) != tuple(
+        sorted(request.graph.vertices)
+    ):
+        raise OperationDomainValidationError(
+            location=("vertex_probabilities",),
+            code="probability.site_reliability.vertex_probability_binding",
+            message=(
+                "vertex probabilities must cover graph vertices in canonical order"
+            ),
+        )
+    if any(
+        not 0 <= item.open_probability.as_fraction() <= 1
+        for item in request.vertex_probabilities
+    ):
+        raise OperationDomainValidationError(
+            location=("vertex_probabilities",),
+            code="probability.site_reliability.probability_range",
+            message="site reliability probabilities must lie in [0, 1]",
+        )
+
+    # Bound both the exact numerator/denominator height and the complete
+    # ledger before entering the powerset loop.  Complements have numerator
+    # ``den-num``; taking the maximum over both branches is a sound bound for
+    # every state.  The state sum can add at most bit_length(state_count)
+    # decimal digits.
+    factor_digits = sum(
+        max(
+            len(str(abs(item.open_probability.as_fraction().numerator))),
+            len(str(item.open_probability.as_fraction().denominator)),
+            len(
+                str(
+                    abs(
+                        item.open_probability.as_fraction().denominator
+                        - item.open_probability.as_fraction().numerator
+                    )
+                )
+            ),
+        )
+        for item in request.vertex_probabilities
+    )
+    state_count = 1 << len(request.graph.vertices)
+    rational_digits = factor_digits + len(str(state_count))
+    if rational_digits > MAX_SITE_RELIABILITY_RATIONAL_DIGITS:
+        raise OperationDomainValidationError(
+            location=("vertex_probabilities",),
+            code="probability.site_reliability.rational_height_bound",
+            message=(
+                "site reliability state masses exceed the admitted exact "
+                f"{MAX_SITE_RELIABILITY_RATIONAL_DIGITS}-digit result bound"
+            ),
+        )
+    label_bytes = sum(len(vertex.encode("utf-8")) for vertex in request.graph.vertices)
+    max_component_bytes = max(
+        (len(vertex.encode("utf-8")) for vertex in request.graph.vertices),
+        default=1,
+    )
+    # This over-allocates every state to its largest possible open-vertex
+    # list, which is intentionally conservative and independent of execution.
+    estimated_output_bytes = (
+        1024
+        + label_bytes * 8
+        + len(request.vertex_probabilities) * (2 * MAX_INPUT_RATIONAL_DIGITS + 96)
+        + state_count
+        * (
+            192
+            + len(request.graph.vertices) * max_component_bytes
+            + 2 * rational_digits
+        )
+    )
+    if estimated_output_bytes > MAX_SITE_RELIABILITY_OUTPUT_BYTES:
+        raise OperationDomainValidationError(
+            location=("states",),
+            code="probability.site_reliability.output_bound",
+            message="complete site-reliability ledger exceeds its output bound",
+        )
+
+
+def compute_site_connection_probability(
+    request: GraphSiteReliabilitySource,
+) -> GraphSiteReliabilityResult:
+    """Compute exact terminal connectivity over every open vertex subset."""
+
+    from flint import fmpq
+
+    try:
+        source = GraphSiteReliabilitySource.model_validate(request.model_dump())
+    except ValidationError as exc:
+        error = exc.errors()[0]
+        raise OperationDomainValidationError(
+            location=tuple(error["loc"]),
+            code=str(error["type"]),
+            message=str(error["msg"]),
+        ) from None
+    _admit_site_request(source)
+    vertices = tuple(sorted(source.graph.vertices))
+    probabilities = tuple(
+        fmpq(
+            item.open_probability.as_fraction().numerator,
+            item.open_probability.as_fraction().denominator,
+        )
+        for item in source.vertex_probabilities
+    )
+    states: list[GraphSiteReliabilityState] = []
+    connection_probability = fmpq(0)
+    for state_index in range(1 << len(vertices)):
+        open_vertices = tuple(
+            vertex
+            for index, vertex in enumerate(vertices)
+            if state_index & (1 << index)
+        )
+        state_probability = fmpq(1)
+        for index, probability in enumerate(probabilities):
+            state_probability *= (
+                probability if state_index & (1 << index) else 1 - probability
+            )
+        connected = _open_terminals_connected(
+            open_vertices=open_vertices,
+            edges=source.graph.edges,
+            terminals=source.terminals,
+        )
+        if connected:
+            connection_probability += state_probability
+        states.append(
+            GraphSiteReliabilityState(
+                state_index=state_index,
+                open_vertices=open_vertices,
+                terminals_connected=connected,
+                state_probability=_wire(state_probability),
+            )
+        )
+    return GraphSiteReliabilityResult._from_kernel(
+        source=source,
+        connection_probability=_wire(connection_probability),
+        vertex_count=len(vertices),
+        visited_states=len(states),
+        states=tuple(states),
+    )
+
+
+SITE_CONNECTION_PROBABILITY_OPERATION = MathTool(
+    operation_id="probability.graph_site_reliability.connection_probability.compute",
+    title="Compute exact terminal site-reliability of a finite graph",
+    description=(
+        "Given a bounded finite simple graph, one exact independent open "
+        "probability for every vertex, and two distinct terminals, enumerate "
+        "every vertex subset and return the exact probability that both "
+        "terminals are open and lie in one connected component of the open "
+        "induced subgraph, together with the complete canonical state ledger."
+    ),
+    request_type=GraphSiteReliabilitySource,
+    result_type=GraphSiteReliabilityResult,
+    run=compute_site_connection_probability,
+    tags=("probability", "reliability", "site-percolation", "exact"),
+    examples=(
+        OperationExample(
+            name="path_of_two",
+            description=(
+                "Two vertices joined by an edge connect exactly when both are "
+                "open, so the probability is p^2 = 1/4."
+            ),
+            input={
+                "graph": {"vertices": ["a", "b"], "edges": [["a", "b"]]},
+                "vertex_probabilities": [
+                    {"vertex": "a", "open_probability": {"num": "1", "den": "2"}},
+                    {"vertex": "b", "open_probability": {"num": "1", "den": "2"}},
+                ],
+                "terminals": ["a", "b"],
+            },
+        ),
+    ),
+)
+
+__all__ = [
+    "MAX_SITE_RELIABILITY_EDGES",
+    "MAX_SITE_RELIABILITY_OUTPUT_BYTES",
+    "MAX_SITE_RELIABILITY_STATES",
+    "MAX_SITE_RELIABILITY_VERTICES",
+    "SITE_CONNECTION_PROBABILITY_OPERATION",
+    "GraphSiteReliabilityResult",
+    "GraphSiteReliabilitySource",
+    "GraphSiteReliabilityState",
+    "SiteReliabilityVertexProbability",
+    "compute_site_connection_probability",
+]

--- a/src/jacobian/math/probability/_site_reliability.py
+++ b/src/jacobian/math/probability/_site_reliability.py
@@ -36,7 +36,7 @@ MAX_SITE_RELIABILITY_RATIONAL_DIGITS = (
     MAX_INPUT_RATIONAL_DIGITS * MAX_SITE_RELIABILITY_VERTICES
     + MAX_SITE_RELIABILITY_VERTICES
 )
-MAX_SITE_RELIABILITY_OUTPUT_BYTES = 64_000_000
+MAX_SITE_RELIABILITY_LEDGER_UNITS = 64_000_000
 
 
 def _validation_error(message: str) -> PydanticCustomError:
@@ -263,25 +263,26 @@ def _admit_site_request(
                 f"{MAX_SITE_RELIABILITY_RATIONAL_DIGITS}-digit result bound"
             ),
         )
-    label_bytes = sum(len(vertex.encode("utf-8")) for vertex in request.graph.vertices)
-    max_component_bytes = max(
-        (len(vertex.encode("utf-8")) for vertex in request.graph.vertices),
+    label_characters = sum(len(vertex) for vertex in request.graph.vertices)
+    max_component_characters = max(
+        (len(vertex) for vertex in request.graph.vertices),
         default=1,
     )
-    # This over-allocates every state to its largest possible open-vertex
-    # list, which is intentionally conservative and independent of execution.
-    estimated_output_bytes = (
+    # Bound mathematical storage by label characters, exact rational digits,
+    # and scalar slots. Reserve every state for the full open-vertex axis;
+    # fixed padding covers the bounded source and per-state scalar fields.
+    ledger_units = (
         1024
-        + label_bytes * 8
+        + label_characters * 8
         + len(request.vertex_probabilities) * (2 * MAX_INPUT_RATIONAL_DIGITS + 96)
         + state_count
         * (
             192
-            + len(request.graph.vertices) * max_component_bytes
+            + len(request.graph.vertices) * max_component_characters
             + 2 * rational_digits
         )
     )
-    if estimated_output_bytes > MAX_SITE_RELIABILITY_OUTPUT_BYTES:
+    if ledger_units > MAX_SITE_RELIABILITY_LEDGER_UNITS:
         raise OperationDomainValidationError(
             location=("states",),
             code="probability.site_reliability.output_bound",
@@ -386,7 +387,7 @@ SITE_CONNECTION_PROBABILITY_OPERATION = MathTool(
 
 __all__ = [
     "MAX_SITE_RELIABILITY_EDGES",
-    "MAX_SITE_RELIABILITY_OUTPUT_BYTES",
+    "MAX_SITE_RELIABILITY_LEDGER_UNITS",
     "MAX_SITE_RELIABILITY_STATES",
     "MAX_SITE_RELIABILITY_VERTICES",
     "SITE_CONNECTION_PROBABILITY_OPERATION",

--- a/src/jacobian/math/probability/_site_reliability.py
+++ b/src/jacobian/math/probability/_site_reliability.py
@@ -333,8 +333,7 @@ def _admit_site_request(
             location=("states",),
             code="probability.site_reliability.output_bound",
             message=(
-                "complete site-reliability ledger exceeds its retained allocation "
-                "bound"
+                "complete site-reliability ledger exceeds its retained allocation bound"
             ),
         )
 

--- a/src/jacobian/math/probability/_tools.py
+++ b/src/jacobian/math/probability/_tools.py
@@ -36,7 +36,13 @@ from jacobian.math.probability._gaussian_inputs import (
 from jacobian.math.probability._graph_connection_probability import (
     GRAPH_CONNECTION_PROBABILITY_OPERATION,
 )
+from jacobian.math.probability._hypergraph_bond_reliability import (
+    HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION,
+)
 from jacobian.math.probability._local_lemma import ASYMMETRIC_LOCAL_LEMMA_OPERATION
+from jacobian.math.probability._site_reliability import (
+    SITE_CONNECTION_PROBABILITY_OPERATION,
+)
 
 
 def _event_probability(
@@ -378,6 +384,8 @@ FINITE_PROBABILITY_OPERATIONS = (
     ),
     GRAPH_CONNECTION_PROBABILITY_OPERATION,
     DIRECTED_BOND_CONNECTION_PROBABILITY_OPERATION,
+    SITE_CONNECTION_PROBABILITY_OPERATION,
+    HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION,
 )
 
 

--- a/tests/catalog/test_validated_analysis_declarations.py
+++ b/tests/catalog/test_validated_analysis_declarations.py
@@ -37,6 +37,8 @@ def test_subject_operation_groups_preserve_wire_contracts() -> None:
             "probability.gaussian_polynomial.moment.compute",
             "probability.graph_reliability.connection_probability.compute",
             "probability.digraph_bond_reliability.connection_probability.compute",
+            "probability.graph_site_reliability.connection_probability.compute",
+            "probability.hypergraph_bond_reliability.connection_probability.compute",
             "probability.graph_reliability.all_terminal.compute",
             "probability.local_lemma.asymmetric_witness.check",
         ),

--- a/tests/math/probability/test_hypergraph_bond_reliability.py
+++ b/tests/math/probability/test_hypergraph_bond_reliability.py
@@ -16,6 +16,9 @@ from jacobian.catalog.models import (
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
 )
+from jacobian.math.probability import (
+    _hypergraph_bond_reliability as hypergraph_reliability_module,
+)
 from jacobian.math.probability._hypergraph_bond_reliability import (
     HyperedgeOpenProbability,
     HypergraphBondConnectionProbabilityResult,
@@ -269,6 +272,24 @@ def test_hyperedge_bound_is_owned_by_operation_admission() -> None:
         ("v0", "v1"),
     )
     with pytest.raises(OperationResourceAdmissionError, match="hyperedge bound"):
+        compute_hypergraph_bond_connection_probability(source)
+
+
+def test_hypergraph_ledger_allocation_is_admitted_before_enumeration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        hypergraph_reliability_module,
+        "MAX_HYPERGRAPH_RELIABILITY_LEDGER_UNITS",
+        1,
+    )
+    source = _source(
+        ("a", "b"),
+        (("ab", ("a", "b")),),
+        {"ab": Fraction(1, 2)},
+        ("a", "b"),
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="allocation bound"):
         compute_hypergraph_bond_connection_probability(source)
 
 

--- a/tests/math/probability/test_hypergraph_bond_reliability.py
+++ b/tests/math/probability/test_hypergraph_bond_reliability.py
@@ -260,6 +260,12 @@ def test_forged_hyperedge_state_ids_are_rejected_after_json_round_trip() -> None
         HypergraphBondConnectionProbabilityResult.model_validate_json(
             encode_strict_json(payload), strict=True
         )
+    payload = result.model_dump(mode="json")
+    payload["states"][1]["open_hyperedge_ids"] = ["unknown"]
+    with pytest.raises(ValidationError, match="state IDs"):
+        HypergraphBondConnectionProbabilityResult.model_validate_json(
+            encode_strict_json(payload), strict=True
+        )
 
 
 def test_hyperedge_bound_is_owned_by_operation_admission() -> None:

--- a/tests/math/probability/test_hypergraph_bond_reliability.py
+++ b/tests/math/probability/test_hypergraph_bond_reliability.py
@@ -275,6 +275,20 @@ def test_hyperedge_bound_is_owned_by_operation_admission() -> None:
         compute_hypergraph_bond_connection_probability(source)
 
 
+def test_isolated_declared_vertices_are_charged_as_retained_source_only() -> None:
+    vertices = tuple(f"v{index}" for index in range(25))
+    source = _source(
+        vertices,
+        (("edge", ("v0", "v1")),),
+        {"edge": Fraction(1, 2)},
+        ("v0", "v1"),
+    )
+    result = compute_hypergraph_bond_connection_probability(source)
+    assert result.visited_states == 2
+    assert result.connection_probability.as_fraction() == Fraction(1, 2)
+    assert result.source.hypergraph.vertices == vertices
+
+
 def test_hypergraph_ledger_allocation_is_admitted_before_enumeration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/math/probability/test_hypergraph_bond_reliability.py
+++ b/tests/math/probability/test_hypergraph_bond_reliability.py
@@ -9,7 +9,10 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import encode_strict_json
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     FiniteHypergraph,
 )
@@ -253,4 +256,39 @@ def test_forged_hyperedge_state_ids_are_rejected_after_json_round_trip() -> None
     with pytest.raises(ValidationError, match="state IDs"):
         HypergraphBondConnectionProbabilityResult.model_validate_json(
             encode_strict_json(payload), strict=True
+        )
+
+
+def test_hyperedge_bound_is_owned_by_operation_admission() -> None:
+    vertices = tuple(f"v{index}" for index in range(14))
+    edges = tuple((f"e{index}", (f"v{index}", f"v{index + 1}")) for index in range(13))
+    source = _source(
+        vertices,
+        edges,
+        {edge_id: Fraction(1, 2) for edge_id, _ in edges},
+        ("v0", "v1"),
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="hyperedge bound"):
+        compute_hypergraph_bond_connection_probability(source)
+
+
+def test_empty_hyperedges_are_rejected_by_the_reliability_contract() -> None:
+    with pytest.raises(ValidationError, match="nonempty"):
+        _source(
+            ("a", "b"),
+            (("empty", ()),),
+            {"empty": Fraction(1, 2)},
+            ("a", "b"),
+        )
+
+
+def test_duplicate_hyperedge_vertex_sets_are_rejected_by_the_reliability_contract() -> (
+    None
+):
+    with pytest.raises(ValidationError, match="distinct vertex sets"):
+        _source(
+            ("a", "b"),
+            (("first", ("a", "b")), ("second", ("a", "b"))),
+            {"first": Fraction(1, 2), "second": Fraction(1, 2)},
+            ("a", "b"),
         )

--- a/tests/math/probability/test_hypergraph_bond_reliability.py
+++ b/tests/math/probability/test_hypergraph_bond_reliability.py
@@ -237,3 +237,20 @@ def test_result_round_trips_through_strict_json() -> None:
         encode_strict_json(result.model_dump(mode="json")), strict=True
     )
     assert restored == result
+
+
+def test_forged_hyperedge_state_ids_are_rejected_after_json_round_trip() -> None:
+    result = compute_hypergraph_bond_connection_probability(
+        _source(
+            ("a", "b"),
+            (("ab", ("a", "b")),),
+            {"ab": Fraction(1, 2)},
+            ("a", "b"),
+        )
+    )
+    payload = result.model_dump(mode="json")
+    payload["states"][1]["open_hyperedge_ids"] = []
+    with pytest.raises(ValidationError, match="state IDs"):
+        HypergraphBondConnectionProbabilityResult.model_validate_json(
+            encode_strict_json(payload), strict=True
+        )

--- a/tests/math/probability/test_hypergraph_bond_reliability.py
+++ b/tests/math/probability/test_hypergraph_bond_reliability.py
@@ -20,6 +20,7 @@ from jacobian.math.probability import (
     _hypergraph_bond_reliability as hypergraph_reliability_module,
 )
 from jacobian.math.probability._hypergraph_bond_reliability import (
+    HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION,
     HyperedgeOpenProbability,
     HypergraphBondConnectionProbabilityResult,
     HypergraphBondReliabilitySource,
@@ -333,3 +334,11 @@ def test_duplicate_hyperedge_vertex_sets_are_rejected_by_the_reliability_contrac
             {"first": Fraction(1, 2), "second": Fraction(1, 2)},
             ("a", "b"),
         )
+
+
+def test_published_hypergraph_example_states_axis_and_terminal_preconditions() -> None:
+    example = HYPERGRAPH_BOND_CONNECTION_PROBABILITY_OPERATION.examples[0]
+    description = example.description
+    assert "ab and bd" in description
+    assert "hyperedge axis" in description
+    assert "distinct declared vertices" in description

--- a/tests/math/probability/test_hypergraph_bond_reliability.py
+++ b/tests/math/probability/test_hypergraph_bond_reliability.py
@@ -1,0 +1,239 @@
+"""Exact hyperedge bond reliability on finite simple hypergraphs (#1688)."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import encode_strict_json
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
+    FiniteHypergraph,
+)
+from jacobian.math.probability._hypergraph_bond_reliability import (
+    HyperedgeOpenProbability,
+    HypergraphBondConnectionProbabilityResult,
+    HypergraphBondReliabilitySource,
+    compute_hypergraph_bond_connection_probability,
+)
+
+
+def _probability(value: Fraction) -> CanonicalRational:
+    return CanonicalRational(num=value.numerator, den=value.denominator)
+
+
+def _source(
+    vertices: tuple[str, ...],
+    edges: tuple[tuple[str, tuple[str, ...]], ...],
+    probabilities: dict[str, Fraction],
+    terminals: tuple[str, str],
+) -> HypergraphBondReliabilitySource:
+    hypergraph = FiniteHypergraph(vertices=vertices, edges=edges)
+    return HypergraphBondReliabilitySource(
+        hypergraph=hypergraph,
+        hyperedge_probabilities=tuple(
+            HyperedgeOpenProbability(
+                hyperedge_id=edge_id,
+                open_probability=_probability(probabilities[edge_id]),
+            )
+            for edge_id, _ in hypergraph.edges
+        ),
+        terminals=terminals,
+    )
+
+
+def _brute_force(
+    edges: tuple[tuple[str, tuple[str, ...]], ...],
+    probabilities: dict[str, Fraction],
+    terminals: tuple[str, str],
+) -> Fraction:
+    total = Fraction(0)
+    for mask in range(1 << len(edges)):
+        open_members = [
+            set(members)
+            for index, (_, members) in enumerate(edges)
+            if mask & (1 << index)
+        ]
+        mass = Fraction(1)
+        for index, (edge_id, _) in enumerate(edges):
+            probability = probabilities[edge_id]
+            mass *= probability if mask & (1 << index) else 1 - probability
+        reached = {terminals[0]}
+        changed = True
+        while changed:
+            changed = False
+            for members in open_members:
+                if members & reached and not members <= reached:
+                    reached |= members
+                    changed = True
+        if terminals[1] in reached:
+            total += mass
+    return total
+
+
+def test_chain_through_a_shared_vertex_connects() -> None:
+    """a-b and b-d connect a to d only when both hyperedges are open."""
+    result = compute_hypergraph_bond_connection_probability(
+        _source(
+            ("a", "b", "d"),
+            (("ab", ("a", "b")), ("bd", ("b", "d"))),
+            {"ab": Fraction(1, 2), "bd": Fraction(1, 2)},
+            ("a", "d"),
+        )
+    )
+    assert result.connection_probability.as_fraction() == Fraction(1, 4)
+    assert result.connectivity_convention == "INCIDENCE_GRAPH_CHAIN"
+
+
+def test_high_height_inputs_are_admitted_by_the_complete_result_carrier() -> None:
+    """Five 128-digit factors exceed the old 512-digit late validator cap."""
+    denominator = 10**128 - 1
+    vertices = tuple("v" + str(index) for index in range(6))
+    edges = tuple(
+        ("e" + str(index), ("v" + str(index), "v" + str(index + 1)))
+        for index in range(5)
+    )
+    result = compute_hypergraph_bond_connection_probability(
+        _source(
+            vertices,
+            edges,
+            {edge_id: Fraction(1, denominator) for edge_id, _ in edges},
+            ("v0", "v5"),
+        )
+    )
+    assert result.visited_states == 32
+    assert len(str(result.states[-1].state_probability.as_fraction().denominator)) > 512
+
+
+def test_disjoint_open_hyperedges_do_not_connect() -> None:
+    """Overlapping vertex sets are required for a chain, not mere disjointness."""
+    result = compute_hypergraph_bond_connection_probability(
+        _source(
+            ("a", "b", "c", "d"),
+            (("ab", ("a", "b")), ("cd", ("c", "d"))),
+            {"ab": Fraction(1), "cd": Fraction(1)},
+            ("a", "d"),
+        )
+    )
+    assert result.connection_probability.as_fraction() == Fraction(0)
+
+
+def test_clique_expansion_would_differ_and_is_not_used() -> None:
+    """Incidence-chain connectivity is not the clique-expansion convention.
+
+    Hyperedge {a, b, c} alone does not connect a and d under either convention,
+    but it also does not imply every pair inside it becomes a separate bond in
+    the state ledger; the ledger records open hyperedges, not expanded pairs.
+    """
+    result = compute_hypergraph_bond_connection_probability(
+        _source(
+            ("a", "b", "c"),
+            (("abc", ("a", "b", "c")),),
+            {"abc": Fraction(1, 2)},
+            ("a", "b"),
+        )
+    )
+    # One open hyperedge already joins both terminals.
+    assert result.connection_probability.as_fraction() == Fraction(1, 2)
+    assert result.states[1].open_hyperedge_ids == ("abc",)
+
+
+def test_three_hyperedges_form_a_chain_in_order() -> None:
+    """Connectivity propagates transitively across a chain of three hyperedges."""
+    result = compute_hypergraph_bond_connection_probability(
+        _source(
+            ("a", "b", "c", "d"),
+            (("ab", ("a", "b")), ("bc", ("b", "c")), ("cd", ("c", "d"))),
+            {"ab": Fraction(1), "bc": Fraction(1), "cd": Fraction(1)},
+            ("a", "d"),
+        )
+    )
+    assert result.connection_probability.as_fraction() == Fraction(1)
+
+
+def test_states_partition_and_successful_mass_matches_the_scalar() -> None:
+    """The ledger is a probability partition and its success mass is the total."""
+    result = compute_hypergraph_bond_connection_probability(
+        _source(
+            ("a", "b", "c"),
+            (("ab", ("a", "b")), ("bc", ("b", "c"))),
+            {"ab": Fraction(1, 3), "bc": Fraction(2, 5)},
+            ("a", "c"),
+        )
+    )
+    total = sum(
+        (state.state_probability.as_fraction() for state in result.states),
+        Fraction(0),
+    )
+    assert total == Fraction(1)
+    successful = sum(
+        (
+            state.state_probability.as_fraction()
+            for state in result.states
+            if state.terminals_connected
+        ),
+        Fraction(0),
+    )
+    assert successful == result.connection_probability.as_fraction()
+    assert result.visited_states == 4
+
+
+def test_matches_independent_brute_force() -> None:
+    """Several small hypergraphs agree with an independent subset enumeration."""
+    cases = (
+        (("a", "b"), (("ab", ("a", "b")),), {"ab": Fraction(1, 4)}, ("a", "b")),
+        (
+            ("a", "b", "c", "d"),
+            (("ab", ("a", "b")), ("bc", ("b", "c")), ("cd", ("c", "d"))),
+            {"ab": Fraction(1, 3), "bc": Fraction(1, 2), "cd": Fraction(2, 3)},
+            ("a", "d"),
+        ),
+        (
+            ("a", "b", "c"),
+            (("ac", ("a", "c")), ("bc", ("b", "c")), ("abc", ("a", "b", "c"))),
+            {"ac": Fraction(1, 2), "bc": Fraction(1, 3), "abc": Fraction(1, 5)},
+            ("a", "b"),
+        ),
+    )
+    for vertices, edges, probabilities, terminals in cases:
+        result = compute_hypergraph_bond_connection_probability(
+            _source(vertices, edges, probabilities, terminals)
+        )
+        assert result.connection_probability.as_fraction() == _brute_force(
+            edges, probabilities, terminals
+        )
+
+
+def test_duplicate_or_unknown_terminals_are_rejected() -> None:
+    """Terminals must be two distinct declared vertices of the hypergraph."""
+    with pytest.raises(ValidationError):
+        _source(("a", "b"), (("ab", ("a", "b")),), {"ab": Fraction(1, 2)}, ("a", "a"))
+
+
+def test_probability_outside_unit_interval_is_rejected() -> None:
+    """Component probabilities must lie in [0, 1]."""
+    with pytest.raises(OperationDomainValidationError):
+        compute_hypergraph_bond_connection_probability(
+            _source(
+                ("a", "b"), (("ab", ("a", "b")),), {"ab": Fraction(3, 2)}, ("a", "b")
+            )
+        )
+
+
+def test_result_round_trips_through_strict_json() -> None:
+    """The complete ledger survives strict JSON serialization unchanged."""
+    result = compute_hypergraph_bond_connection_probability(
+        _source(
+            ("a", "b"),
+            (("ab", ("a", "b")),),
+            {"ab": Fraction(1, 2)},
+            ("a", "b"),
+        )
+    )
+    restored = HypergraphBondConnectionProbabilityResult.model_validate_json(
+        encode_strict_json(result.model_dump(mode="json")), strict=True
+    )
+    assert restored == result

--- a/tests/math/probability/test_site_reliability.py
+++ b/tests/math/probability/test_site_reliability.py
@@ -14,6 +14,7 @@ from jacobian.catalog.models import (
     OperationResourceAdmissionError,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.probability import _site_reliability as site_module
 from jacobian.math.probability._site_reliability import (
     GraphSiteReliabilityResult,
     GraphSiteReliabilitySource,
@@ -249,6 +250,20 @@ def test_site_vertex_bound_is_owned_by_operation_admission() -> None:
         ("v0", "v1"),
     )
     with pytest.raises(OperationResourceAdmissionError, match="vertex bound"):
+        compute_site_connection_probability(source)
+
+
+def test_site_ledger_allocation_is_admitted_before_enumeration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(site_module, "MAX_SITE_RELIABILITY_LEDGER_UNITS", 1)
+    source = _source(
+        ("a", "b"),
+        (("a", "b"),),
+        (Fraction(1, 2), Fraction(1, 2)),
+        ("a", "b"),
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="allocation bound"):
         compute_site_connection_probability(source)
 
 

--- a/tests/math/probability/test_site_reliability.py
+++ b/tests/math/probability/test_site_reliability.py
@@ -1,0 +1,234 @@
+"""Exact site reliability: /#1688 (undirected bond reliability already existed)."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import encode_strict_json
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.probability._site_reliability import (
+    GraphSiteReliabilityResult,
+    GraphSiteReliabilitySource,
+    SiteReliabilityVertexProbability,
+    compute_site_connection_probability,
+)
+
+
+def _probability(value: Fraction) -> CanonicalRational:
+    return CanonicalRational(num=value.numerator, den=value.denominator)
+
+
+def _source(
+    vertices: tuple[str, ...],
+    edges: tuple[tuple[str, str], ...],
+    probabilities: tuple[Fraction, ...],
+    terminals: tuple[str, str],
+) -> GraphSiteReliabilitySource:
+    ordered = tuple(sorted(vertices))
+    lookup = dict(zip(vertices, probabilities, strict=True))
+    return GraphSiteReliabilitySource(
+        graph=SimpleUndirectedGraph(vertices=vertices, edges=edges),
+        vertex_probabilities=tuple(
+            SiteReliabilityVertexProbability(
+                vertex=vertex, open_probability=_probability(lookup[vertex])
+            )
+            for vertex in ordered
+        ),
+        terminals=terminals,
+    )
+
+
+def _brute_force(
+    vertices: tuple[str, ...],
+    edges: tuple[tuple[str, str], ...],
+    probabilities: tuple[Fraction, ...],
+    terminals: tuple[str, str],
+) -> Fraction:
+    total = Fraction(0)
+    for mask in range(1 << len(vertices)):
+        open_set = {
+            vertex for index, vertex in enumerate(vertices) if mask & (1 << index)
+        }
+        mass = Fraction(1)
+        for index, vertex in enumerate(vertices):
+            probability = probabilities[index]
+            mass *= probability if vertex in open_set else 1 - probability
+        if terminals[0] not in open_set or terminals[1] not in open_set:
+            continue
+        adjacency = {vertex: set() for vertex in open_set}
+        for left, right in edges:
+            if left in adjacency and right in adjacency:
+                adjacency[left].add(right)
+                adjacency[right].add(left)
+        seen = {terminals[0]}
+        pending = [terminals[0]]
+        while pending:
+            vertex = pending.pop()
+            for neighbor in adjacency[vertex] - seen:
+                seen.add(neighbor)
+                pending.append(neighbor)
+        if terminals[1] in seen:
+            total += mass
+    return total
+
+
+def test_two_vertex_path_requires_both_terminals_open() -> None:
+    """A single edge needs both endpoints open, giving p^2."""
+    result = compute_site_connection_probability(
+        _source(("a", "b"), (("a", "b"),), (Fraction(1, 2), Fraction(1, 2)), ("a", "b"))
+    )
+    assert result.connection_probability.as_fraction() == Fraction(1, 4)
+    assert result.visited_states == 4
+
+
+def test_both_terminals_must_be_open() -> None:
+    """A terminal with zero open probability disconnects the pair."""
+    result = compute_site_connection_probability(
+        _source(("a", "b"), (("a", "b"),), (Fraction(1), Fraction(0)), ("a", "b"))
+    )
+    assert result.connection_probability.as_fraction() == Fraction(0)
+
+
+def test_isolation_vertex_cannot_connect() -> None:
+    """An isolated third vertex never affects the terminal event."""
+    result = compute_site_connection_probability(
+        _source(
+            ("a", "b", "z"),
+            (("a", "b"),),
+            (Fraction(1), Fraction(1), Fraction(1, 2)),
+            ("a", "b"),
+        )
+    )
+    assert result.connection_probability.as_fraction() == Fraction(1)
+    assert result.visited_states == 8
+
+
+def test_open_induced_subgraph_uses_only_open_vertices() -> None:
+    """A path a-b-c connects only when b is open; otherwise it cannot."""
+    result = compute_site_connection_probability(
+        _source(
+            ("a", "b", "c"),
+            (("a", "b"), ("b", "c")),
+            (Fraction(1), Fraction(1, 2), Fraction(1)),
+            ("a", "c"),
+        )
+    )
+    # a and c are certain to be open; success needs b open too.
+    assert result.connection_probability.as_fraction() == Fraction(1, 2)
+
+
+def test_states_partition_the_sample_space() -> None:
+    """Every state probability is nonnegative and sums exactly to one."""
+    result = compute_site_connection_probability(
+        _source(
+            ("a", "b", "c"),
+            (("a", "b"), ("b", "c")),
+            (Fraction(1, 3), Fraction(2, 5), Fraction(1, 7)),
+            ("a", "c"),
+        )
+    )
+    total = sum(
+        (state.state_probability.as_fraction() for state in result.states),
+        Fraction(0),
+    )
+    assert total == Fraction(1)
+
+
+def test_high_height_inputs_are_admitted_by_the_complete_result_carrier() -> None:
+    """Five 128-digit factors exceed the old 512-digit late validator cap."""
+    denominator = 10**128 - 1
+    result = compute_site_connection_probability(
+        _source(
+            tuple("v" + str(index) for index in range(5)),
+            tuple(("v" + str(index), "v" + str(index + 1)) for index in range(4)),
+            (Fraction(1, denominator),) * 5,
+            ("v0", "v4"),
+        )
+    )
+    assert result.visited_states == 32
+    assert len(str(result.states[-1].state_probability.as_fraction().denominator)) > 512
+    assert all(state.state_probability.as_fraction() >= 0 for state in result.states)
+
+
+def test_successful_state_mass_equals_reported_total() -> None:
+    """The reported scalar is the exact sum of the successful ledger rows."""
+    result = compute_site_connection_probability(
+        _source(
+            ("a", "b", "c", "d"),
+            (("a", "b"), ("b", "c"), ("c", "d")),
+            (Fraction(1, 3), Fraction(1, 2), Fraction(2, 3), Fraction(1, 5)),
+            ("a", "d"),
+        )
+    )
+    successful = sum(
+        (
+            state.state_probability.as_fraction()
+            for state in result.states
+            if state.terminals_connected
+        ),
+        Fraction(0),
+    )
+    assert successful == result.connection_probability.as_fraction()
+
+
+def test_terminal_order_does_not_change_the_result() -> None:
+    """The event is symmetric in its two terminals."""
+    forward = compute_site_connection_probability(
+        _source(("a", "b"), (("a", "b"),), (Fraction(1, 3), Fraction(1, 3)), ("a", "b"))
+    )
+    reverse = compute_site_connection_probability(
+        _source(("a", "b"), (("a", "b"),), (Fraction(1, 3), Fraction(1, 3)), ("b", "a"))
+    )
+    assert forward.connection_probability == reverse.connection_probability
+
+
+def test_matches_independent_brute_force() -> None:
+    """Several small graphs agree with an independent vertex-subset enumeration."""
+    cases = (
+        (("a", "b", "c"), (("a", "b"), ("b", "c")), (Fraction(1, 2),) * 3, ("a", "c")),
+        (
+            ("a", "b", "c", "d"),
+            (("a", "b"), ("a", "c"), ("b", "d"), ("c", "d")),
+            (Fraction(1, 4), Fraction(3, 4), Fraction(1, 2), Fraction(2, 3)),
+            ("a", "d"),
+        ),
+    )
+    for vertices, edges, probabilities, terminals in cases:
+        result = compute_site_connection_probability(
+            _source(vertices, edges, probabilities, terminals)
+        )
+        assert result.connection_probability.as_fraction() == _brute_force(
+            vertices, edges, probabilities, terminals
+        )
+
+
+def test_duplicate_or_unknown_terminals_are_rejected() -> None:
+    """Terminals must be two distinct declared graph vertices."""
+    with pytest.raises(ValidationError):
+        _source(("a", "b"), (("a", "b"),), (Fraction(1, 2),) * 2, ("a", "a"))
+
+
+def test_probability_outside_unit_interval_is_rejected() -> None:
+    """Component probabilities must lie in [0, 1]."""
+    with pytest.raises(OperationDomainValidationError):
+        compute_site_connection_probability(
+            _source(
+                ("a", "b"), (("a", "b"),), (Fraction(3, 2), Fraction(1, 2)), ("a", "b")
+            )
+        )
+
+
+def test_result_round_trips_through_strict_json() -> None:
+    """The complete ledger survives strict JSON serialization unchanged."""
+    result = compute_site_connection_probability(
+        _source(("a", "b"), (("a", "b"),), (Fraction(1, 2), Fraction(1, 3)), ("a", "b"))
+    )
+    restored = GraphSiteReliabilityResult.model_validate_json(
+        encode_strict_json(result.model_dump(mode="json")), strict=True
+    )
+    assert restored == result

--- a/tests/math/probability/test_site_reliability.py
+++ b/tests/math/probability/test_site_reliability.py
@@ -159,6 +159,22 @@ def test_high_height_inputs_are_admitted_by_the_complete_result_carrier() -> Non
     assert all(state.state_probability.as_fraction() >= 0 for state in result.states)
 
 
+def test_long_labels_are_admitted_without_native_json_size_estimation() -> None:
+    """Native admission charges retained labels without a transport byte budget."""
+    label_prefix = "\U0001f600" * 100_000
+    vertices = tuple(sorted(f"{label_prefix}{index}" for index in range(12)))
+    result = compute_site_connection_probability(
+        _source(
+            vertices,
+            (),
+            (Fraction(1, 2),) * len(vertices),
+            (vertices[0], vertices[1]),
+        )
+    )
+    assert result.visited_states == 1 << len(vertices)
+    assert result.source.graph.vertices == vertices
+
+
 def test_successful_state_mass_equals_reported_total() -> None:
     """The reported scalar is the exact sum of the successful ledger rows."""
     result = compute_site_connection_probability(
@@ -239,6 +255,25 @@ def test_site_resource_bound_uses_resource_admission_error() -> None:
                 ("v0", "v1"),
             )
         )
+
+
+def test_complete_k8_is_admitted_by_the_actual_work_bound() -> None:
+    vertices = tuple(f"v{index}" for index in range(8))
+    edges = tuple(
+        (left, right)
+        for index, left in enumerate(vertices)
+        for right in vertices[index + 1 :]
+    )
+    result = compute_site_connection_probability(
+        _source(
+            vertices,
+            edges,
+            (Fraction(1, 2),) * len(vertices),
+            ("v0", "v1"),
+        )
+    )
+    assert result.visited_states == 1 << len(vertices)
+    assert result.connection_probability.as_fraction() == Fraction(1, 4)
 
 
 def test_site_vertex_bound_is_owned_by_operation_admission() -> None:

--- a/tests/math/probability/test_site_reliability.py
+++ b/tests/math/probability/test_site_reliability.py
@@ -16,6 +16,7 @@ from jacobian.catalog.models import (
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 from jacobian.math.probability import _site_reliability as site_module
 from jacobian.math.probability._site_reliability import (
+    SITE_CONNECTION_PROBABILITY_OPERATION,
     GraphSiteReliabilityResult,
     GraphSiteReliabilitySource,
     SiteReliabilityVertexProbability,
@@ -368,3 +369,10 @@ def test_result_round_trips_through_strict_json() -> None:
         encode_strict_json(result.model_dump(mode="json")), strict=True
     )
     assert restored == result
+
+
+def test_published_site_example_states_axis_and_terminal_preconditions() -> None:
+    description = SITE_CONNECTION_PROBABILITY_OPERATION.examples[0].description
+    assert "p^2 = 1/4" in description
+    assert "vertex axis" in description
+    assert "distinct declared vertices" in description

--- a/tests/math/probability/test_site_reliability.py
+++ b/tests/math/probability/test_site_reliability.py
@@ -324,6 +324,31 @@ def test_site_ledger_allocation_is_admitted_before_enumeration(
         compute_site_connection_probability(source)
 
 
+def test_site_ledger_charges_every_retained_source_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Copied vertex labels in probabilities and terminals count toward allocation."""
+
+    monkeypatch.setattr(site_module, "MAX_SITE_RELIABILITY_LEDGER_UNITS", 50_000)
+    left = "a" * 10_000
+    right = "b" * 10_000
+    source = GraphSiteReliabilitySource(
+        graph=SimpleUndirectedGraph(vertices=(left, right), edges=()),
+        vertex_probabilities=(
+            SiteReliabilityVertexProbability(
+                vertex=left, open_probability=_probability(Fraction(1, 2))
+            ),
+            SiteReliabilityVertexProbability(
+                vertex=right, open_probability=_probability(Fraction(1, 2))
+            ),
+        ),
+        terminals=(left, right),
+    )
+    with pytest.raises(OperationResourceAdmissionError) as error:
+        compute_site_connection_probability(source)
+    assert error.value.code == "probability.site_reliability.output_bound"
+
+
 def test_matches_independent_brute_force() -> None:
     """Several small graphs agree with an independent vertex-subset enumeration."""
     cases = (

--- a/tests/math/probability/test_site_reliability.py
+++ b/tests/math/probability/test_site_reliability.py
@@ -9,7 +9,10 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import encode_strict_json
-from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 from jacobian.math.probability._site_reliability import (
     GraphSiteReliabilityResult,
@@ -185,6 +188,51 @@ def test_terminal_order_does_not_change_the_result() -> None:
         _source(("a", "b"), (("a", "b"),), (Fraction(1, 3), Fraction(1, 3)), ("b", "a"))
     )
     assert forward.connection_probability == reverse.connection_probability
+
+
+def test_declared_vertex_axis_is_authoritative() -> None:
+    source = GraphSiteReliabilitySource(
+        graph=SimpleUndirectedGraph(
+            vertices=("b", "a"),
+            edges=(("a", "b"),),
+        ),
+        vertex_probabilities=(
+            SiteReliabilityVertexProbability(
+                vertex="b", open_probability=_probability(Fraction(1, 2))
+            ),
+            SiteReliabilityVertexProbability(
+                vertex="a", open_probability=_probability(Fraction(1, 3))
+            ),
+        ),
+        terminals=("b", "a"),
+    )
+    result = compute_site_connection_probability(source)
+    assert result.states[1].open_vertices == ("b",)
+
+
+def test_forged_site_state_subset_is_rejected_after_json_round_trip() -> None:
+    result = compute_site_connection_probability(
+        _source(("a", "b"), (("a", "b"),), (Fraction(1, 2),) * 2, ("a", "b"))
+    )
+    payload = result.model_dump(mode="json")
+    payload["states"][1]["open_vertices"] = ["b"]
+    with pytest.raises(ValidationError, match="state vertices"):
+        GraphSiteReliabilityResult.model_validate_json(
+            encode_strict_json(payload), strict=True
+        )
+
+
+def test_site_resource_bound_uses_resource_admission_error() -> None:
+    vertices = tuple(sorted(f"v{index}" for index in range(12)))
+    edges = tuple(
+        (left, right)
+        for index, left in enumerate(vertices)
+        for right in vertices[index + 1 :]
+    )
+    with pytest.raises(OperationResourceAdmissionError):
+        compute_site_connection_probability(
+            _source(vertices, edges, (Fraction(1, 2),) * len(vertices), vertices[:2])
+        )
 
 
 def test_matches_independent_brute_force() -> None:

--- a/tests/math/probability/test_site_reliability.py
+++ b/tests/math/probability/test_site_reliability.py
@@ -231,8 +231,25 @@ def test_site_resource_bound_uses_resource_admission_error() -> None:
     )
     with pytest.raises(OperationResourceAdmissionError):
         compute_site_connection_probability(
-            _source(vertices, edges, (Fraction(1, 2),) * len(vertices), vertices[:2])
+            _source(
+                vertices,
+                edges,
+                (Fraction(1, 2),) * len(vertices),
+                ("v0", "v1"),
+            )
         )
+
+
+def test_site_vertex_bound_is_owned_by_operation_admission() -> None:
+    vertices = tuple(sorted(f"v{index}" for index in range(13)))
+    source = _source(
+        vertices,
+        (),
+        (Fraction(1, 2),) * len(vertices),
+        ("v0", "v1"),
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="vertex bound"):
+        compute_site_connection_probability(source)
 
 
 def test_matches_independent_brute_force() -> None:

--- a/tests/math/probability/test_site_reliability.py
+++ b/tests/math/probability/test_site_reliability.py
@@ -344,9 +344,8 @@ def test_site_ledger_charges_every_retained_source_label(
         ),
         terminals=(left, right),
     )
-    with pytest.raises(OperationResourceAdmissionError) as error:
+    with pytest.raises(OperationResourceAdmissionError, match="allocation bound"):
         compute_site_connection_probability(source)
-    assert error.value.code == "probability.site_reliability.output_bound"
 
 
 def test_matches_independent_brute_force() -> None:

--- a/tests/math/probability/test_site_reliability.py
+++ b/tests/math/probability/test_site_reliability.py
@@ -60,7 +60,7 @@ def _brute_force(
             mass *= probability if vertex in open_set else 1 - probability
         if terminals[0] not in open_set or terminals[1] not in open_set:
             continue
-        adjacency = {vertex: set() for vertex in open_set}
+        adjacency: dict[str, set[str]] = {vertex: set() for vertex in open_set}
         for left, right in edges:
             if left in adjacency and right in adjacency:
                 adjacency[left].add(right)

--- a/tests/math/probability/test_site_reliability.py
+++ b/tests/math/probability/test_site_reliability.py
@@ -162,7 +162,7 @@ def test_high_height_inputs_are_admitted_by_the_complete_result_carrier() -> Non
 def test_long_labels_are_admitted_without_native_json_size_estimation() -> None:
     """Native admission charges retained labels without a transport byte budget."""
     label_prefix = "\U0001f600" * 100_000
-    vertices = tuple(sorted(f"{label_prefix}{index}" for index in range(12)))
+    vertices = tuple(sorted(f"{label_prefix}{index}" for index in range(2)))
     result = compute_site_connection_probability(
         _source(
             vertices,
@@ -173,6 +173,21 @@ def test_long_labels_are_admitted_without_native_json_size_estimation() -> None:
     )
     assert result.visited_states == 1 << len(vertices)
     assert result.source.graph.vertices == vertices
+
+
+def test_repeated_state_labels_are_charged_in_the_ledger_bound() -> None:
+    """A 12-vertex powerset repeats each long label in 2,048 rows."""
+    label_prefix = "\U0001f600" * 100_000
+    vertices = tuple(sorted(f"{label_prefix}{index}" for index in range(12)))
+    with pytest.raises(OperationResourceAdmissionError, match="allocation bound"):
+        compute_site_connection_probability(
+            _source(
+                vertices,
+                (),
+                (Fraction(1, 2),) * len(vertices),
+                (vertices[0], vertices[1]),
+            )
+        )
 
 
 def test_successful_state_mass_equals_reported_total() -> None:
@@ -233,6 +248,12 @@ def test_forged_site_state_subset_is_rejected_after_json_round_trip() -> None:
     )
     payload = result.model_dump(mode="json")
     payload["states"][1]["open_vertices"] = ["b"]
+    with pytest.raises(ValidationError, match="state vertices"):
+        GraphSiteReliabilityResult.model_validate_json(
+            encode_strict_json(payload), strict=True
+        )
+    payload = result.model_dump(mode="json")
+    payload["states"][1]["open_vertices"] = ["z"]
     with pytest.raises(ValidationError, match="state vertices"):
         GraphSiteReliabilityResult.model_validate_json(
             encode_strict_json(payload), strict=True


### PR DESCRIPTION
## Problem

Existing graph bond reliability does not model independently open vertices or independently open hyperedges. Related to #1688.

## Outcome

Adds two atomic exact operations:

- `probability.graph_site_reliability.connection_probability.compute`
- `probability.hypergraph_bond_reliability.connection_probability.compute`

Each returns an exact connection probability and a complete source-bound powerset state ledger. Site connectivity requires both terminals open; hypergraph connectivity uses chains of intersecting open hyperedges. The authoritative graph/hypergraph axes and state bitmasks survive JSON round-trip.

## Contract and bounds

At most 12 random vertices or hyperedges (4,096 states) and 24 graph edges or hypergraph vertices are admitted. Hyperedges are nonempty distinct vertex sets. Source-label codepoints, memberships, powerset work, state records, and exact-rational digit growth are admitted semantically before enumeration; transport adapters separately own encoded byte ceilings. Operation-specific limits are owned by typed admission rather than schema parsing.

## Evidence

Final local validation at `7efb317897983e7780eb2360d622a167a1642609`:

- `make affected AFFECTED_BASE=origin/main`
- 313 probability tests
- 160 catalog tests
- 968 catalog integration tests
- 32 focused reliability tests
- Ruff and mypy
- Independent exact-diff audit completed and repaired admission ownership and resource-bound findings.

This PR implements the bounded site/hypergraph reliability slice of #1688; broader reliability-polynomial and reduction operations remain open.