### PR TITLE
fix(polynomials): preflight Laurent product exponent growth

### DIFF
--- a/src/jacobian/math/polynomials/_laurent.py
+++ b/src/jacobian/math/polynomials/_laurent.py
@@ -43,20 +43,16 @@ def rational_laurent_multiply(
             code="polynomial.laurent.convolution_bound",
             message=f"sparse convolution requires {work} term products; maximum is {MAX_POLYNOMIAL_TERMS}",
         )
-    # Check the full exponent envelope before entering the convolution.  This
-    # keeps a mathematically invalid product from doing partial exact work and
-    # makes the admission decision independent of cancellation in the result.
-    max_left = tuple(
-        max(abs(term.exponents[index]) for term in left.terms)
-        for index in range(len(left.variables))
-    )
-    max_right = tuple(
-        max(abs(term.exponents[index]) for term in right.terms)
-        for index in range(len(right.variables))
-    )
+    # Signed extrema bound every convolution exponent without excluding
+    # products whose opposite-sign source exponents cancel.
     if any(
-        left_bound + right_bound > MAX_POLYNOMIAL_EXPONENT
-        for left_bound, right_bound in zip(max_left, max_right, strict=True)
+        min(term.exponents[index] for term in left.terms)
+        + min(term.exponents[index] for term in right.terms)
+        < -MAX_POLYNOMIAL_EXPONENT
+        or max(term.exponents[index] for term in left.terms)
+        + max(term.exponents[index] for term in right.terms)
+        > MAX_POLYNOMIAL_EXPONENT
+        for index in range(len(left.variables))
     ):
         raise OperationResourceAdmissionError(
             location=("right", "terms"),

--- a/src/jacobian/math/polynomials/_laurent.py
+++ b/src/jacobian/math/polynomials/_laurent.py
@@ -36,13 +36,6 @@ def rational_laurent_multiply(
         )
     if not left.terms or not right.terms:
         return RationalLaurentPolynomial(variables=left.variables, terms=())
-    work = len(left.terms) * len(right.terms)
-    if work > MAX_POLYNOMIAL_TERMS:
-        raise OperationResourceAdmissionError(
-            location=("right", "terms"),
-            code="polynomial.laurent.convolution_bound",
-            message=f"sparse convolution requires {work} term products; maximum is {MAX_POLYNOMIAL_TERMS}",
-        )
     # Signed extrema bound every convolution exponent without excluding
     # products whose opposite-sign source exponents cancel.
     if any(
@@ -58,6 +51,13 @@ def rational_laurent_multiply(
             location=("right", "terms"),
             code="polynomial.laurent.exponent_growth",
             message="product exponent may exceed the Laurent representation bound",
+        )
+    work = len(left.terms) * len(right.terms)
+    if work > MAX_POLYNOMIAL_TERMS:
+        raise OperationResourceAdmissionError(
+            location=("right", "terms"),
+            code="polynomial.laurent.convolution_bound",
+            message=f"sparse convolution requires {work} term products; maximum is {MAX_POLYNOMIAL_TERMS}",
         )
     coefficient_digits = work * (
         max(

--- a/src/jacobian/math/polynomials/_laurent.py
+++ b/src/jacobian/math/polynomials/_laurent.py
@@ -43,6 +43,26 @@ def rational_laurent_multiply(
             code="polynomial.laurent.convolution_bound",
             message=f"sparse convolution requires {work} term products; maximum is {MAX_POLYNOMIAL_TERMS}",
         )
+    # Check the full exponent envelope before entering the convolution.  This
+    # keeps a mathematically invalid product from doing partial exact work and
+    # makes the admission decision independent of cancellation in the result.
+    max_left = tuple(
+        max(abs(term.exponents[index]) for term in left.terms)
+        for index in range(len(left.variables))
+    )
+    max_right = tuple(
+        max(abs(term.exponents[index]) for term in right.terms)
+        for index in range(len(right.variables))
+    )
+    if any(
+        left_bound + right_bound > MAX_POLYNOMIAL_EXPONENT
+        for left_bound, right_bound in zip(max_left, max_right, strict=True)
+    ):
+        raise OperationResourceAdmissionError(
+            location=("right", "terms"),
+            code="polynomial.laurent.exponent_growth",
+            message="product exponent may exceed the Laurent representation bound",
+        )
     coefficient_digits = work * (
         max(
             canonical_rational_component_digits(term.coefficient) for term in left.terms
@@ -65,12 +85,6 @@ def rational_laurent_multiply(
                 a + b
                 for a, b in zip(left_term.exponents, right_term.exponents, strict=True)
             )
-            if any(abs(exponent) > MAX_POLYNOMIAL_EXPONENT for exponent in exponents):
-                raise OperationResourceAdmissionError(
-                    location=("right", "terms"),
-                    code="polynomial.laurent.exponent_growth",
-                    message="product exponent exceeds the Laurent representation bound",
-                )
             coefficients[exponents] = coefficients.get(exponents, Fraction()) + (
                 left_term.coefficient.as_fraction()
                 * right_term.coefficient.as_fraction()

--- a/tests/math/polynomials/test_laurent_multiply.py
+++ b/tests/math/polynomials/test_laurent_multiply.py
@@ -10,6 +10,8 @@ from jacobian.catalog.models import (
 )
 from jacobian.math.polynomials._laurent import rational_laurent_multiply
 from jacobian.math.polynomials.values import (
+    MAX_POLYNOMIAL_EXPONENT,
+    MAX_POLYNOMIAL_TERMS,
     RationalLaurentPolynomial,
     RationalLaurentPolynomialTerm,
 )
@@ -60,22 +62,43 @@ def test_coefficient_growth_is_rejected_before_convolution() -> None:
 
 
 def test_exponent_growth_is_rejected_before_convolution() -> None:
-    limit = 32_768
-    left = RationalLaurentPolynomial(variables=("x",), terms=(term(1, limit),))
-    right = RationalLaurentPolynomial(variables=("x",), terms=(term(1, 1),))
-    with pytest.raises(OperationResourceAdmissionError, match="exponent"):
+    # Convolution work is 65 * 64 = 4160 > MAX_POLYNOMIAL_TERMS, so a guard
+    # that still lived inside the product loop would raise convolution_bound
+    # first. The extrema check must win with exponent_growth.
+    left_count = 65
+    right_count = 64
+    assert left_count * right_count > MAX_POLYNOMIAL_TERMS
+    left = RationalLaurentPolynomial(
+        variables=("x",),
+        terms=tuple(
+            term(1, MAX_POLYNOMIAL_EXPONENT - index) for index in range(left_count)
+        ),
+    )
+    right = RationalLaurentPolynomial(
+        variables=("x",),
+        terms=tuple(term(1, index) for index in range(right_count)),
+    )
+    with pytest.raises(OperationResourceAdmissionError) as error:
         rational_laurent_multiply(left, right)
+    assert error.value.errors()[0]["type"] == "polynomial.laurent.exponent_growth"
 
 
 def test_catalog_admits_exponent_growth_before_convolution_bound() -> None:
     operation = Catalog.open().operation("polynomial.laurent.rational.multiply.compute")
     assert operation is not None
 
+    left_count = 65
+    right_count = 64
     left = RationalLaurentPolynomial(
         variables=("x",),
-        terms=tuple(term(1, exponent) for exponent in range(32_768, 30_719, -1)),
+        terms=tuple(
+            term(1, MAX_POLYNOMIAL_EXPONENT - index) for index in range(left_count)
+        ),
     )
-    right = RationalLaurentPolynomial(variables=("x",), terms=(term(1, 1), term(1, 0)))
+    right = RationalLaurentPolynomial(
+        variables=("x",),
+        terms=tuple(term(1, index) for index in range(right_count)),
+    )
     request = operation.request_type(left=left, right=right)
 
     with pytest.raises(OperationResourceAdmissionError) as error:

--- a/tests/math/polynomials/test_laurent_multiply.py
+++ b/tests/math/polynomials/test_laurent_multiply.py
@@ -76,7 +76,7 @@ def test_exponent_growth_is_rejected_before_convolution() -> None:
     )
     right = RationalLaurentPolynomial(
         variables=("x",),
-        terms=tuple(term(1, index) for index in range(right_count)),
+        terms=tuple(term(1, index) for index in range(right_count - 1, -1, -1)),
     )
     with pytest.raises(OperationResourceAdmissionError) as error:
         rational_laurent_multiply(left, right)
@@ -97,7 +97,7 @@ def test_catalog_admits_exponent_growth_before_convolution_bound() -> None:
     )
     right = RationalLaurentPolynomial(
         variables=("x",),
-        terms=tuple(term(1, index) for index in range(right_count)),
+        terms=tuple(term(1, index) for index in range(right_count - 1, -1, -1)),
     )
     request = operation.request_type(left=left, right=right)
 

--- a/tests/math/polynomials/test_laurent_multiply.py
+++ b/tests/math/polynomials/test_laurent_multiply.py
@@ -64,3 +64,12 @@ def test_exponent_growth_is_rejected_before_convolution() -> None:
     right = RationalLaurentPolynomial(variables=("x",), terms=(term(1, 1),))
     with pytest.raises(OperationResourceAdmissionError, match="exponent"):
         rational_laurent_multiply(left, right)
+
+
+def test_opposite_boundary_exponents_multiply_to_one() -> None:
+    left = RationalLaurentPolynomial(variables=("x",), terms=(term(1, 32_768),))
+    right = RationalLaurentPolynomial(variables=("x",), terms=(term(1, -32_768),))
+    result = rational_laurent_multiply(left, right)
+    assert result == RationalLaurentPolynomial(variables=("x",), terms=(term(1, 0),))
+    restored = RationalLaurentPolynomial.model_validate_json(result.model_dump_json())
+    assert rational_laurent_multiply(restored, left) == left

--- a/tests/math/polynomials/test_laurent_multiply.py
+++ b/tests/math/polynomials/test_laurent_multiply.py
@@ -56,3 +56,11 @@ def test_coefficient_growth_is_rejected_before_convolution() -> None:
     right = RationalLaurentPolynomial(variables=("x",), terms=(term(coefficient, 0),))
     with pytest.raises(OperationResourceAdmissionError):
         rational_laurent_multiply(left, right)
+
+
+def test_exponent_growth_is_rejected_before_convolution() -> None:
+    limit = 32_768
+    left = RationalLaurentPolynomial(variables=("x",), terms=(term(1, limit),))
+    right = RationalLaurentPolynomial(variables=("x",), terms=(term(1, 1),))
+    with pytest.raises(OperationResourceAdmissionError, match="exponent"):
+        rational_laurent_multiply(left, right)

--- a/tests/math/polynomials/test_laurent_multiply.py
+++ b/tests/math/polynomials/test_laurent_multiply.py
@@ -75,9 +75,7 @@ def test_catalog_admits_exponent_growth_before_convolution_bound() -> None:
         variables=("x",),
         terms=tuple(term(1, exponent) for exponent in range(32_768, 30_719, -1)),
     )
-    right = RationalLaurentPolynomial(
-        variables=("x",), terms=(term(1, 1), term(1, 0))
-    )
+    right = RationalLaurentPolynomial(variables=("x",), terms=(term(1, 1), term(1, 0)))
     request = operation.request_type(left=left, right=right)
 
     with pytest.raises(OperationResourceAdmissionError) as error:

--- a/tests/math/polynomials/test_laurent_multiply.py
+++ b/tests/math/polynomials/test_laurent_multiply.py
@@ -91,3 +91,16 @@ def test_opposite_boundary_exponents_multiply_to_one() -> None:
     assert result == RationalLaurentPolynomial(variables=("x",), terms=(term(1, 0),))
     restored = RationalLaurentPolynomial.model_validate_json(result.model_dump_json())
     assert rational_laurent_multiply(restored, left) == left
+
+
+def test_multiaxis_opposite_boundary_exponents_preserve_cancellation() -> None:
+    left = RationalLaurentPolynomial(
+        variables=("x", "y"), terms=(term(1, 32_768, -32_768),)
+    )
+    right = RationalLaurentPolynomial(
+        variables=("x", "y"), terms=(term(1, -32_768, 32_768),)
+    )
+
+    assert rational_laurent_multiply(left, right) == RationalLaurentPolynomial(
+        variables=("x", "y"), terms=(term(1, 0, 0),)
+    )

--- a/tests/math/polynomials/test_laurent_multiply.py
+++ b/tests/math/polynomials/test_laurent_multiply.py
@@ -3,6 +3,7 @@
 import pytest
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
@@ -64,6 +65,25 @@ def test_exponent_growth_is_rejected_before_convolution() -> None:
     right = RationalLaurentPolynomial(variables=("x",), terms=(term(1, 1),))
     with pytest.raises(OperationResourceAdmissionError, match="exponent"):
         rational_laurent_multiply(left, right)
+
+
+def test_catalog_admits_exponent_growth_before_convolution_bound() -> None:
+    operation = Catalog.open().operation("polynomial.laurent.rational.multiply.compute")
+    assert operation is not None
+
+    left = RationalLaurentPolynomial(
+        variables=("x",),
+        terms=tuple(term(1, exponent) for exponent in range(32_768, 30_719, -1)),
+    )
+    right = RationalLaurentPolynomial(
+        variables=("x",), terms=(term(1, 1), term(1, 0))
+    )
+    request = operation.request_type(left=left, right=right)
+
+    with pytest.raises(OperationResourceAdmissionError) as error:
+        operation.run(request)
+
+    assert error.value.errors()[0]["type"] == "polynomial.laurent.exponent_growth"
 
 
 def test_opposite_boundary_exponents_multiply_to_one() -> None:


### PR DESCRIPTION
## Problem

Laurent multiplication checks exponent overflow after beginning sparse convolution. Related to #3615.

## Outcome

Moves exponent-growth refusal before convolution using signed minimum/maximum sums on each axis, preserving opposite-sign boundary products such as `x^32768*x^-32768=1`.

## Validation

- Hosted required CI passed on `97af6726e1107172b4880894b03739b269eaa43b`.
- Focused local lint/type and regression checks passed. Final full validation is supplied by hosted CI; broad local catalog runs were interrupted under system memory pressure.
- Independent scoped review found no remaining actionable defects.

## Contract impact


No operation IDs are added or removed. The outcome above describes changes to existing behavior or result validation.

## Review closure

- [x] Exact changed scope reviewed. Local validation evidence and gaps are listed above.
- [x] No unresolved findings from the scoped review.
- [x] CI evidence matches the final head.

## Operation boundary

The shared Laurent exponent limit is 32,768; existing term-product and rational-height admission remain in place.

This PR addresses the described slice of #3615; it does not automatically close the broader issue.
