### PR TITLE
fix(group-actions): report tuple-family orbit completeness

### DIFF
--- a/src/jacobian/math/groups/tuple_orbits/_models.py
+++ b/src/jacobian/math/groups/tuple_orbits/_models.py
@@ -38,3 +38,4 @@ class TupleOrbitRow(StrictModel):
 class TupleFamilyOrbitResult(StrictModel):
     source: TupleFamilyOrbitSource
     rows: tuple[TupleOrbitRow, ...] = Field(max_length=4096)
+    is_union_of_complete_ambient_orbits: bool

--- a/src/jacobian/math/groups/tuple_orbits/operations.py
+++ b/src/jacobian/math/groups/tuple_orbits/operations.py
@@ -32,6 +32,7 @@ def tuple_family_orbit_profile(
     )
     source_by_representative: dict[tuple[int, ...], list[int]] = {}
     orbit_data: dict[tuple[int, ...], tuple[int, tuple[int, ...]]] = {}
+    source_members = {tuple(member) for member in request.family}
     for source_index, member in enumerate(request.family):
         images = {tuple(element[value] for value in member) for element in elements}
         representative = min(images)
@@ -53,7 +54,16 @@ def tuple_family_orbit_profile(
         )
         for representative in sorted(source_by_representative)
     )
-    return TupleFamilyOrbitResult(source=request, rows=rows)
+    return TupleFamilyOrbitResult(
+        source=request,
+        rows=rows,
+        is_union_of_complete_ambient_orbits=all(
+            {
+                tuple(element[value] for value in member) for element in elements
+            }.issubset(source_members)
+            for member in source_members
+        ),
+    )
 
 
 __all__ = ["tuple_family_orbit_profile"]

--- a/src/jacobian/math/groups/tuple_orbits/operations.py
+++ b/src/jacobian/math/groups/tuple_orbits/operations.py
@@ -33,8 +33,10 @@ def tuple_family_orbit_profile(
     source_by_representative: dict[tuple[int, ...], list[int]] = {}
     orbit_data: dict[tuple[int, ...], tuple[int, tuple[int, ...]]] = {}
     source_members = {tuple(member) for member in request.family}
+    complete_orbits = True
     for source_index, member in enumerate(request.family):
         images = {tuple(element[value] for value in member) for element in elements}
+        complete_orbits = complete_orbits and images.issubset(source_members)
         representative = min(images)
         source_by_representative.setdefault(representative, []).append(source_index)
         if representative not in orbit_data:
@@ -57,12 +59,7 @@ def tuple_family_orbit_profile(
     return TupleFamilyOrbitResult(
         source=request,
         rows=rows,
-        is_union_of_complete_ambient_orbits=all(
-            {
-                tuple(element[value] for value in member) for element in elements
-            }.issubset(source_members)
-            for member in source_members
-        ),
+        is_union_of_complete_ambient_orbits=complete_orbits,
     )
 
 

--- a/tests/math/groups/tuple_orbits/test_tuple_orbits.py
+++ b/tests/math/groups/tuple_orbits/test_tuple_orbits.py
@@ -16,6 +16,17 @@ def test_repeated_coordinates_and_duplicate_sources_are_retained() -> None:
     assert result.rows[0].source_indices == (0, 1)
     assert result.rows[1].source_indices == (2, 3, 4)
     assert all(row.orbit_size == 3 and row.stabilizer_size == 1 for row in result.rows)
+    assert result.is_union_of_complete_ambient_orbits is False
+
+
+def test_complete_ambient_orbits_are_reported() -> None:
+    request = TupleFamilyOrbitSource(
+        group=PermutationGroup(degree=3, generators=((1, 2, 0),)),
+        arity=2,
+        family=((0, 0), (1, 1), (2, 2)),
+    )
+    result = tuple_family_orbit_profile(request)
+    assert result.is_union_of_complete_ambient_orbits is True
 
 
 def test_empty_family_has_empty_profile() -> None:


### PR DESCRIPTION
## Problem

Tuple-family orbit profiles do not state whether the supplied family contains every member of each represented ambient orbit. Related to #3607.

## Outcome

Adds `is_union_of_complete_ambient_orbits` while retaining duplicate source indices and ambient orbit/stabilizer data.

## Validation

- Hosted required CI passed on `cf1829625643ab0fa2363ae121d6721f6032212d`.
- Focused local lint/type and regression checks passed. Final full validation is supplied by hosted CI; broad local catalog runs were interrupted under system memory pressure.
- Independent scoped review found no remaining actionable defects.

## Contract impact


No operation IDs are added or removed. The outcome above describes changes to existing behavior or result validation.

## Review closure

- [x] Exact changed scope reviewed. Local validation evidence and gaps are listed above.
- [x] No unresolved findings from the scoped review.
- [x] CI evidence matches the final head.

## Operation boundary

The existing finite action admission bounds source tuples and enumerated group elements. Completeness reuses image sets produced during orbit grouping, avoiding a second action traversal.

This PR addresses the described slice of #3607; it does not automatically close the broader issue.
