### PR TITLE
feat(polytopes): interpolate bounded Ehrhart polynomials

### DIFF
--- a/src/jacobian/math/geometry/polytopes/lattice/_models.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/_models.py
@@ -8,9 +8,11 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import (
+    MAX_CANONICAL_INTEGER_DIGITS,
     ExactInteger,
     require_bounded_rational,
 )
+from jacobian.canonical import format_canonical_integer
 from jacobian._models import StrictModel
 from jacobian.math.geometry.polytopes.values import Halfspace as RationalHalfspace
 from jacobian.math.geometry.polytopes.values import Vertex as RationalVertex
@@ -345,21 +347,6 @@ def _require_ehrhart_request_shape(
             "ehrhart_dilation_range",
             "max_dilation must provide degree_bound + 1 evaluations",
         )
-    from jacobian._exact import MAX_CANONICAL_INTEGER_DIGITS
-    from jacobian.canonical import format_canonical_integer
-
-    scaled_digits = 0
-    for vertex in vertices:
-        for coordinate in vertex.coordinates:
-            scaled_digits = max(
-                scaled_digits,
-                len(format_canonical_integer(abs(coordinate.num * max_dilation))),
-            )
-    if scaled_digits > MAX_CANONICAL_INTEGER_DIGITS:
-        raise _validation_error(
-            "ehrhart_scaled_coordinate",
-            "a maximum-dilation coordinate exceeds the canonical integer bound",
-        )
     return dimension
 
 
@@ -436,12 +423,32 @@ def _require_ehrhart_full_dimensional(
     return dimension
 
 
+def _admit_ehrhart_scaled_coordinates(
+    vertices: tuple[RationalVertex, ...], max_dilation: int
+) -> None:
+    """Admit maximum dilated height once at the native execution boundary."""
+
+    scaled_digits = 0
+    for vertex in vertices:
+        for coordinate in vertex.coordinates:
+            scaled_digits = max(
+                scaled_digits,
+                len(format_canonical_integer(abs(coordinate.num * max_dilation))),
+            )
+    if scaled_digits > MAX_CANONICAL_INTEGER_DIGITS:
+        raise _validation_error(
+            "ehrhart_scaled_coordinate",
+            "a maximum-dilation coordinate exceeds the canonical integer bound",
+        )
+
+
 def require_ehrhart_source(
     vertices: tuple[RationalVertex, ...], degree_bound: int, max_dilation: int
 ) -> None:
     """Admit one native Ehrhart source, including affine dimension."""
 
     _require_ehrhart_request_shape(vertices, degree_bound, max_dilation)
+    _admit_ehrhart_scaled_coordinates(vertices, max_dilation)
     _require_ehrhart_full_dimensional(vertices)
 
 

--- a/src/jacobian/math/geometry/polytopes/lattice/_models.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/_models.py
@@ -318,12 +318,12 @@ class EnumerateLatticePointsRequest(LatticePolytopeRequest):
     """Wire request for enumeration; execution admission happens in the operation."""
 
 
-def require_ehrhart_source(
+def _require_ehrhart_request_shape(
     vertices: tuple[RationalVertex, ...], degree_bound: int, max_dilation: int
-) -> None:
-    """Share exact source and enumeration bounds between native and wire calls."""
+) -> int:
+    """Check cheap request shape and scalar bounds before native admission."""
 
-    dimension = _require_ehrhart_vertex_shape(vertices)
+    dimension = _require_ehrhart_vertex_structure(vertices)
     if not 1 <= len(vertices) <= MAX_VERTICES:
         raise _validation_error(
             "ehrhart_vertex_count", "vertex count exceeds the admitted range"
@@ -345,14 +345,6 @@ def require_ehrhart_source(
             "ehrhart_dilation_range",
             "max_dilation must provide degree_bound + 1 evaluations",
         )
-    if any(
-        coordinate.den != 1 for vertex in vertices for coordinate in vertex.coordinates
-    ):
-        raise _validation_error(
-            "ehrhart_requires_integral_vertices",
-            "Ehrhart polynomial recovery currently requires integral vertices",
-        )
-
     from jacobian._exact import MAX_CANONICAL_INTEGER_DIGITS
     from jacobian.canonical import format_canonical_integer
 
@@ -368,10 +360,13 @@ def require_ehrhart_source(
             "ehrhart_scaled_coordinate",
             "a maximum-dilation coordinate exceeds the canonical integer bound",
         )
+    return dimension
 
 
-def _require_ehrhart_vertex_shape(vertices: tuple[RationalVertex, ...]) -> int:
-    """Require a nonempty, integral, full-dimensional V-representation."""
+def _require_ehrhart_vertex_structure(
+    vertices: tuple[RationalVertex, ...],
+) -> int:
+    """Check source vertex shape and scalar representation without rank work."""
 
     if not 1 <= len(vertices) <= MAX_VERTICES:
         raise _validation_error(
@@ -395,6 +390,15 @@ def _require_ehrhart_vertex_shape(vertices: tuple[RationalVertex, ...]) -> int:
             "ehrhart_requires_integral_vertices",
             "Ehrhart polynomial recovery currently requires integral vertices",
         )
+    return dimension
+
+
+def _require_ehrhart_full_dimensional(
+    vertices: tuple[RationalVertex, ...],
+) -> int:
+    """Require the source vertices to affinely span their ambient dimension."""
+
+    dimension = _require_ehrhart_vertex_structure(vertices)
     base = vertices[0].coordinates
     rows = [
         [
@@ -432,6 +436,15 @@ def _require_ehrhart_vertex_shape(vertices: tuple[RationalVertex, ...]) -> int:
     return dimension
 
 
+def require_ehrhart_source(
+    vertices: tuple[RationalVertex, ...], degree_bound: int, max_dilation: int
+) -> None:
+    """Admit one native Ehrhart source, including affine dimension."""
+
+    _require_ehrhart_request_shape(vertices, degree_bound, max_dilation)
+    _require_ehrhart_full_dimensional(vertices)
+
+
 class EhrhartRequest(StrictModel):
     """Recover an Ehrhart polynomial for a bounded integral V-polytope."""
 
@@ -449,7 +462,9 @@ class EhrhartRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_integral_vertices_and_range(self) -> Self:
-        require_ehrhart_source(self.vertices, self.degree_bound, self.max_dilation)
+        _require_ehrhart_request_shape(
+            self.vertices, self.degree_bound, self.max_dilation
+        )
         return self
 
 
@@ -471,7 +486,9 @@ class EhrhartResult(StrictModel):
 
     @model_validator(mode="after")
     def require_result_shapes(self) -> Self:
-        dimension = _require_ehrhart_vertex_shape(self.vertices)
+        dimension = _require_ehrhart_request_shape(
+            self.vertices, self.degree_bound, self.max_dilation
+        )
         if self.dimension != dimension:
             raise _validation_error(
                 "ehrhart_dimension_shape",
@@ -510,6 +527,28 @@ class EhrhartResult(StrictModel):
                 "polynomial degree must not exceed degree_bound",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        vertices: tuple[RationalVertex, ...],
+        dimension: int,
+        degree_bound: int,
+        max_dilation: int,
+        counts: tuple[tuple[int, ExactInteger], ...],
+        polynomial: RationalPolynomial,
+    ) -> Self:
+        """Construct trusted output after native admission and counting."""
+
+        return cls.model_construct(
+            vertices=vertices,
+            dimension=dimension,
+            degree_bound=degree_bound,
+            max_dilation=max_dilation,
+            counts=counts,
+            polynomial=polynomial,
+        )
 
 
 __all__ = [

--- a/src/jacobian/math/geometry/polytopes/lattice/_models.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/_models.py
@@ -315,6 +315,52 @@ class EnumerateLatticePointsRequest(LatticePolytopeRequest):
     """Wire request for enumeration; execution admission happens in the operation."""
 
 
+def require_ehrhart_source(
+    vertices: tuple[RationalVertex, ...], degree_bound: int, max_dilation: int
+) -> None:
+    """Share exact source and enumeration bounds between native and wire calls."""
+
+    if not 1 <= len(vertices) <= MAX_VERTICES:
+        raise _validation_error(
+            "ehrhart_vertex_count", "vertex count exceeds the admitted range"
+        )
+    if type(degree_bound) is not int or not 1 <= degree_bound <= MAX_DIMENSION:
+        raise _validation_error(
+            "ehrhart_degree_range", "degree_bound exceeds the admitted range"
+        )
+    if type(max_dilation) is not int or not 1 <= max_dilation <= MAX_EHRHART_DILATIONS:
+        raise _validation_error(
+            "ehrhart_dilation_range", "max_dilation exceeds the admitted range"
+        )
+    dimensions = {len(vertex.coordinates) for vertex in vertices}
+    if len(dimensions) != 1:
+        raise _validation_error(
+            "ehrhart_vertex_dimension", "all vertices must share one dimension"
+        )
+    dimension = next(iter(dimensions))
+    if dimension > MAX_DIMENSION:
+        raise _validation_error(
+            "ehrhart_dimension_exceeded",
+            "Ehrhart dimension exceeds the supported bound",
+        )
+    if degree_bound < dimension:
+        raise _validation_error(
+            "ehrhart_degree_bound", "degree_bound must cover the polytope dimension"
+        )
+    if max_dilation < degree_bound:
+        raise _validation_error(
+            "ehrhart_dilation_range",
+            "max_dilation must provide degree_bound + 1 evaluations",
+        )
+    if any(
+        coordinate.den != 1 for vertex in vertices for coordinate in vertex.coordinates
+    ):
+        raise _validation_error(
+            "ehrhart_requires_integral_vertices",
+            "Ehrhart polynomial recovery currently requires integral vertices",
+        )
+
+
 class EhrhartRequest(StrictModel):
     """Recover an Ehrhart polynomial for a bounded integral V-polytope."""
 
@@ -332,35 +378,7 @@ class EhrhartRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_integral_vertices_and_range(self) -> Self:
-        dimensions = {len(vertex.coordinates) for vertex in self.vertices}
-        if len(dimensions) != 1:
-            raise _validation_error(
-                "ehrhart_vertex_dimension", "all vertices must share one dimension"
-            )
-        dimension = next(iter(dimensions))
-        if dimension > MAX_DIMENSION:
-            raise _validation_error(
-                "ehrhart_dimension_exceeded",
-                "Ehrhart dimension exceeds the supported bound",
-            )
-        if self.degree_bound < dimension:
-            raise _validation_error(
-                "ehrhart_degree_bound", "degree_bound must cover the polytope dimension"
-            )
-        if self.max_dilation < self.degree_bound:
-            raise _validation_error(
-                "ehrhart_dilation_range",
-                "max_dilation must provide degree_bound + 1 evaluations",
-            )
-        if any(
-            coordinate.den != 1
-            for vertex in self.vertices
-            for coordinate in vertex.coordinates
-        ):
-            raise _validation_error(
-                "ehrhart_requires_integral_vertices",
-                "Ehrhart polynomial recovery currently requires integral vertices",
-            )
+        require_ehrhart_source(self.vertices, self.degree_bound, self.max_dilation)
         return self
 
 

--- a/src/jacobian/math/geometry/polytopes/lattice/_models.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/_models.py
@@ -8,6 +8,7 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import (
+    CanonicalRational,
     ExactInteger,
     require_bounded_rational,
 )
@@ -67,6 +68,9 @@ Every accepted request's integer bounding box stays within this many
 integer candidates, so neither operation can ever observe more lattice
 points than this; the count result is constrained to the same maximum.
 """
+
+MAX_EHRHART_DILATIONS = 32
+"""Maximum number of dilation values retained by Ehrhart interpolation."""
 
 COORDINATE_DIGITS = 32_768
 """Per-component digit bound forwarded to the canonical rational validator."""
@@ -311,15 +315,92 @@ class EnumerateLatticePointsRequest(LatticePolytopeRequest):
     """Wire request for enumeration; execution admission happens in the operation."""
 
 
+class EhrhartRequest(StrictModel):
+    """Recover an Ehrhart polynomial for a bounded integral V-polytope."""
+
+    vertices: tuple[RationalVertex, ...] = Field(
+        min_length=1,
+        max_length=MAX_VERTICES,
+        description=(
+            "Integral vertices of a full-dimensional bounded V-polytope. "
+            "Integral vertices are required because rational polytopes have "
+            "quasi-polynomial Ehrhart counts."
+        ),
+    )
+    degree_bound: int = Field(ge=1, le=MAX_DIMENSION)
+    max_dilation: int = Field(default=MAX_DIMENSION, ge=1, le=MAX_EHRHART_DILATIONS)
+
+    @model_validator(mode="after")
+    def require_integral_vertices_and_range(self) -> Self:
+        dimensions = {len(vertex.coordinates) for vertex in self.vertices}
+        if len(dimensions) != 1:
+            raise _validation_error(
+                "ehrhart_vertex_dimension", "all vertices must share one dimension"
+            )
+        dimension = next(iter(dimensions))
+        if dimension > MAX_DIMENSION:
+            raise _validation_error(
+                "ehrhart_dimension_exceeded",
+                "Ehrhart dimension exceeds the supported bound",
+            )
+        if self.degree_bound < dimension:
+            raise _validation_error(
+                "ehrhart_degree_bound", "degree_bound must cover the polytope dimension"
+            )
+        if self.max_dilation < self.degree_bound:
+            raise _validation_error(
+                "ehrhart_dilation_range",
+                "max_dilation must provide degree_bound + 1 evaluations",
+            )
+        if any(
+            coordinate.den != 1
+            for vertex in self.vertices
+            for coordinate in vertex.coordinates
+        ):
+            raise _validation_error(
+                "ehrhart_requires_integral_vertices",
+                "Ehrhart polynomial recovery currently requires integral vertices",
+            )
+        return self
+
+
+class EhrhartResult(StrictModel):
+    """Counts and exact ascending-power coefficients of an Ehrhart polynomial."""
+
+    dimension: int = Field(ge=1, le=MAX_DIMENSION)
+    degree_bound: int = Field(ge=1, le=MAX_DIMENSION)
+    counts: tuple[tuple[int, ExactInteger], ...] = Field(
+        min_length=2, max_length=MAX_EHRHART_DILATIONS + 1
+    )
+    coefficients: tuple[CanonicalRational, ...] = Field(
+        min_length=2, max_length=MAX_DIMENSION + 1
+    )
+
+    @model_validator(mode="after")
+    def require_result_shapes(self) -> Self:
+        if len(self.coefficients) != self.degree_bound + 1:
+            raise _validation_error(
+                "ehrhart_coefficient_shape", "one coefficient is required per degree"
+            )
+        if any(t < 0 for t, _count in self.counts):
+            raise _validation_error(
+                "ehrhart_count_dilation", "dilation values must be nonnegative"
+            )
+        return self
+
+
 __all__ = [
     "MAX_BOUND_SPAN",
     "MAX_DIMENSION",
+    "MAX_EHRHART_DILATIONS",
     "MAX_FACET_TESTS",
     "MAX_HALFSPACES",
     "MAX_LATTICE_POINTS",
     "MAX_TOTAL_SCAN",
     "MAX_VERTICES",
     "CountLatticePointsResult",
+    "EhrhartRequest",
+    "EhrhartResult",
     "EnumerateLatticePointsRequest",
     "EnumerateLatticePointsResult",
     "LatticePoint",

--- a/src/jacobian/math/geometry/polytopes/lattice/_models.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/_models.py
@@ -12,8 +12,8 @@ from jacobian._exact import (
     ExactInteger,
     require_bounded_rational,
 )
-from jacobian.canonical import format_canonical_integer
 from jacobian._models import StrictModel
+from jacobian.canonical import format_canonical_integer
 from jacobian.math.geometry.polytopes.values import Halfspace as RationalHalfspace
 from jacobian.math.geometry.polytopes.values import Vertex as RationalVertex
 from jacobian.math.polynomials.values import RationalPolynomial

--- a/src/jacobian/math/geometry/polytopes/lattice/_models.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/_models.py
@@ -8,13 +8,13 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import (
-    CanonicalRational,
     ExactInteger,
     require_bounded_rational,
 )
 from jacobian._models import StrictModel
 from jacobian.math.geometry.polytopes.values import Halfspace as RationalHalfspace
 from jacobian.math.geometry.polytopes.values import Vertex as RationalVertex
+from jacobian.math.polynomials.values import RationalPolynomial
 
 MAX_DIMENSION = 4
 """Absolute upper bound on the ambient dimension of a polytope.
@@ -60,6 +60,9 @@ before this product is formed, so repeated inequalities never multiply
 the work.  Requests whose deduplicated facet count times their integer
 bounding-box scan exceeds this budget are rejected at validation.
 """
+
+MAX_FACET_COMBINATIONS = 700_000
+"""Maximum V-representation facet candidates admitted by one lattice scan."""
 
 MAX_TOTAL_SCAN = 10_000_000
 """Absolute upper bound on candidate points tested by one admitted scan.
@@ -320,6 +323,7 @@ def require_ehrhart_source(
 ) -> None:
     """Share exact source and enumeration bounds between native and wire calls."""
 
+    dimension = _require_ehrhart_vertex_shape(vertices)
     if not 1 <= len(vertices) <= MAX_VERTICES:
         raise _validation_error(
             "ehrhart_vertex_count", "vertex count exceeds the admitted range"
@@ -331,17 +335,6 @@ def require_ehrhart_source(
     if type(max_dilation) is not int or not 1 <= max_dilation <= MAX_EHRHART_DILATIONS:
         raise _validation_error(
             "ehrhart_dilation_range", "max_dilation exceeds the admitted range"
-        )
-    dimensions = {len(vertex.coordinates) for vertex in vertices}
-    if len(dimensions) != 1:
-        raise _validation_error(
-            "ehrhart_vertex_dimension", "all vertices must share one dimension"
-        )
-    dimension = next(iter(dimensions))
-    if dimension > MAX_DIMENSION:
-        raise _validation_error(
-            "ehrhart_dimension_exceeded",
-            "Ehrhart dimension exceeds the supported bound",
         )
     if degree_bound < dimension:
         raise _validation_error(
@@ -359,6 +352,84 @@ def require_ehrhart_source(
             "ehrhart_requires_integral_vertices",
             "Ehrhart polynomial recovery currently requires integral vertices",
         )
+
+    from jacobian._exact import MAX_CANONICAL_INTEGER_DIGITS
+    from jacobian.canonical import format_canonical_integer
+
+    scaled_digits = 0
+    for vertex in vertices:
+        for coordinate in vertex.coordinates:
+            scaled_digits = max(
+                scaled_digits,
+                len(format_canonical_integer(abs(coordinate.num * max_dilation))),
+            )
+    if scaled_digits > MAX_CANONICAL_INTEGER_DIGITS:
+        raise _validation_error(
+            "ehrhart_scaled_coordinate",
+            "a maximum-dilation coordinate exceeds the canonical integer bound",
+        )
+
+
+def _require_ehrhart_vertex_shape(vertices: tuple[RationalVertex, ...]) -> int:
+    """Require a nonempty, integral, full-dimensional V-representation."""
+
+    if not 1 <= len(vertices) <= MAX_VERTICES:
+        raise _validation_error(
+            "ehrhart_vertex_count", "vertex count exceeds the admitted range"
+        )
+    dimensions = {len(vertex.coordinates) for vertex in vertices}
+    if len(dimensions) != 1:
+        raise _validation_error(
+            "ehrhart_vertex_dimension", "all vertices must share one dimension"
+        )
+    dimension = next(iter(dimensions))
+    if not 1 <= dimension <= MAX_DIMENSION:
+        raise _validation_error(
+            "ehrhart_dimension_exceeded",
+            "Ehrhart dimension exceeds the supported bound",
+        )
+    if any(
+        coordinate.den != 1 for vertex in vertices for coordinate in vertex.coordinates
+    ):
+        raise _validation_error(
+            "ehrhart_requires_integral_vertices",
+            "Ehrhart polynomial recovery currently requires integral vertices",
+        )
+    base = vertices[0].coordinates
+    rows = [
+        [
+            vertex.coordinates[index].as_fraction() - base[index].as_fraction()
+            for index in range(dimension)
+        ]
+        for vertex in vertices[1:]
+    ]
+    rank = 0
+    for column in range(dimension):
+        pivot = next(
+            (row for row in range(rank, len(rows)) if rows[row][column] != 0),
+            None,
+        )
+        if pivot is None:
+            continue
+        rows[rank], rows[pivot] = rows[pivot], rows[rank]
+        pivot_value = rows[rank][column]
+        rows[rank] = [value / pivot_value for value in rows[rank]]
+        for row in range(len(rows)):
+            if row != rank and rows[row][column] != 0:
+                factor = rows[row][column]
+                rows[row] = [
+                    value - factor * pivot_value
+                    for value, pivot_value in zip(rows[row], rows[rank], strict=True)
+                ]
+        rank += 1
+        if rank == len(rows):
+            break
+    if rank < dimension:
+        raise _validation_error(
+            "ehrhart_not_full_dimensional",
+            "Ehrhart source vertices must affinely span their ambient dimension",
+        )
+    return dimension
 
 
 class EhrhartRequest(StrictModel):
@@ -383,26 +454,60 @@ class EhrhartRequest(StrictModel):
 
 
 class EhrhartResult(StrictModel):
-    """Counts and exact ascending-power coefficients of an Ehrhart polynomial."""
+    """A source-bound exact Ehrhart polynomial and its retained count table."""
+
+    vertices: tuple[RationalVertex, ...] = Field(
+        min_length=1,
+        max_length=MAX_VERTICES,
+    )
 
     dimension: int = Field(ge=1, le=MAX_DIMENSION)
     degree_bound: int = Field(ge=1, le=MAX_DIMENSION)
+    max_dilation: int = Field(ge=1, le=MAX_EHRHART_DILATIONS)
     counts: tuple[tuple[int, ExactInteger], ...] = Field(
         min_length=2, max_length=MAX_EHRHART_DILATIONS + 1
     )
-    coefficients: tuple[CanonicalRational, ...] = Field(
-        min_length=2, max_length=MAX_DIMENSION + 1
-    )
+    polynomial: RationalPolynomial
 
     @model_validator(mode="after")
     def require_result_shapes(self) -> Self:
-        if len(self.coefficients) != self.degree_bound + 1:
+        dimension = _require_ehrhart_vertex_shape(self.vertices)
+        if self.dimension != dimension:
             raise _validation_error(
-                "ehrhart_coefficient_shape", "one coefficient is required per degree"
+                "ehrhart_dimension_shape",
+                "result dimension must match the source vertex dimension",
             )
-        if any(t < 0 for t, _count in self.counts):
+        if self.max_dilation < self.degree_bound:
             raise _validation_error(
-                "ehrhart_count_dilation", "dilation values must be nonnegative"
+                "ehrhart_dilation_range",
+                "max_dilation must provide degree_bound + 1 evaluations",
+            )
+        if len(self.counts) != self.max_dilation + 1:
+            raise _validation_error(
+                "ehrhart_count_shape",
+                "counts must contain every dilation from zero through max_dilation",
+            )
+        if tuple(t for t, _count in self.counts) != tuple(range(self.max_dilation + 1)):
+            raise _validation_error(
+                "ehrhart_count_dilation",
+                "dilation values must be the complete range from zero",
+            )
+        if any(count < 0 for _dilation, count in self.counts):
+            raise _validation_error(
+                "ehrhart_count_value", "lattice counts must be nonnegative"
+            )
+        if self.polynomial.variables != ("t",):
+            raise _validation_error(
+                "ehrhart_polynomial_axis",
+                "Ehrhart polynomials must use the canonical `t` axis",
+            )
+        if any(
+            term.exponents[0] > self.degree_bound
+            for term in self.polynomial.polynomial.terms
+        ):
+            raise _validation_error(
+                "ehrhart_polynomial_degree",
+                "polynomial degree must not exceed degree_bound",
             )
         return self
 
@@ -411,6 +516,7 @@ __all__ = [
     "MAX_BOUND_SPAN",
     "MAX_DIMENSION",
     "MAX_EHRHART_DILATIONS",
+    "MAX_FACET_COMBINATIONS",
     "MAX_FACET_TESTS",
     "MAX_HALFSPACES",
     "MAX_LATTICE_POINTS",

--- a/src/jacobian/math/geometry/polytopes/lattice/_tools.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/_tools.py
@@ -163,8 +163,9 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         description="Count lattice points in every integral V-polytope dilation from "
         "0 through max_dilation and interpolate the exact rational Ehrhart "
         "polynomial. Integral vertices are required because rational polytopes "
-        "have quasi-polynomial counts; every extra requested count is replayed "
-        "against the recovered polynomial.",
+        "have quasi-polynomial counts; the result retains the source vertices, "
+        "complete dilation table, and canonical QQ[t] polynomial. Every extra "
+        "requested count is replayed against the recovered polynomial.",
         request_type=EhrhartRequest,
         result_type=EhrhartResult,
         run=ehrhart_polynomial,

--- a/src/jacobian/math/geometry/polytopes/lattice/_tools.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/_tools.py
@@ -5,12 +5,17 @@ from typing import Any
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.geometry.polytopes.lattice._models import (
     CountLatticePointsResult,
+    EhrhartRequest,
+    EhrhartResult,
     EnumerateLatticePointsRequest,
     EnumerateLatticePointsResult,
     LatticePolytopeRequest,
 )
 from jacobian.math.geometry.polytopes.lattice.operations import (
     count_lattice_points as native_count_lattice_points,
+)
+from jacobian.math.geometry.polytopes.lattice.operations import (
+    ehrhart_polynomial as native_ehrhart_polynomial,
 )
 from jacobian.math.geometry.polytopes.lattice.operations import (
     enumerate_lattice_points as native_enumerate_lattice_points,
@@ -34,6 +39,13 @@ def count_lattice_points(request: LatticePolytopeRequest) -> CountLatticePointsR
         request.vertices,
         request.halfspaces,
         request.dimension_bound,
+    )
+
+
+def ehrhart_polynomial(request: EhrhartRequest) -> EhrhartResult:
+    """Recover exact Ehrhart coefficients from complete dilation counts."""
+    return native_ehrhart_polynomial(
+        request.vertices, request.degree_bound, request.max_dilation
     )
 
 
@@ -141,6 +153,33 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                             "offset": {"num": "0", "den": "1"},
                         },
                     ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="polytope.ehrhart.compute",
+        title="Recover an Ehrhart polynomial from exact dilation counts",
+        description="Count lattice points in every integral V-polytope dilation from "
+        "0 through max_dilation and interpolate the exact rational Ehrhart "
+        "polynomial. Integral vertices are required because rational polytopes "
+        "have quasi-polynomial counts; every extra requested count is replayed "
+        "against the recovered polynomial.",
+        request_type=EhrhartRequest,
+        result_type=EhrhartResult,
+        run=ehrhart_polynomial,
+        tags=("polytope", "lattice", "ehrhart", "exact"),
+        examples=(
+            OperationExample(
+                name="unit_interval_ehrhart",
+                description="The integral interval [0,1] has Ehrhart polynomial 1+t.",
+                input={
+                    "vertices": [
+                        {"coordinates": [{"num": "0", "den": "1"}]},
+                        {"coordinates": [{"num": "1", "den": "1"}]},
+                    ],
+                    "degree_bound": 1,
+                    "max_dilation": 2,
                 },
             ),
         ),

--- a/src/jacobian/math/geometry/polytopes/lattice/operations.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/operations.py
@@ -380,9 +380,10 @@ def _facets_and_box(  # noqa: C901
     total_scan = 1
     for span in spans:
         total_scan *= span
-        if total_scan > 10_000_000:
+        if total_scan > MAX_TOTAL_SCAN:
             raise LatticePointBudgetError(
-                "integer bounding box total scan exceeds the 10M-point budget"
+                "integer bounding box total scan exceeds the "
+                f"{MAX_TOTAL_SCAN}-point budget"
             )
     if total_scan * len(facets) > MAX_FACET_TESTS:
         raise LatticePointBudgetError(
@@ -483,11 +484,41 @@ def count_lattice_points(
     )
 
 
+def _ehrhart_aggregate_scan_bound(
+    vertices: tuple[Vertex, ...], max_dilation: int
+) -> int:
+    """Bound all dilation boxes from the unscaled integral source."""
+
+    spans = [
+        max(vertex.coordinates[axis].num for vertex in vertices)
+        - min(vertex.coordinates[axis].num for vertex in vertices)
+        for axis in range(len(vertices[0].coordinates))
+    ]
+    total_scan = 0
+    for dilation in range(1, max_dilation + 1):
+        scan = 1
+        for span in spans:
+            scan *= dilation * span + 1
+            if scan > MAX_TOTAL_SCAN:
+                raise LatticePointBudgetError(
+                    "the Ehrhart dilation range exceeds the aggregate "
+                    f"{MAX_TOTAL_SCAN}-candidate scan budget"
+                )
+        total_scan += scan
+        if total_scan > MAX_TOTAL_SCAN:
+            raise LatticePointBudgetError(
+                "the Ehrhart dilation range exceeds the aggregate "
+                f"{MAX_TOTAL_SCAN}-candidate scan budget"
+            )
+    return total_scan
+
+
 def _ehrhart_scan_plans(
     vertices: tuple[Vertex, ...], max_dilation: int
 ) -> list[AdmittedGeometry]:
     """Admit every scaled geometry and the aggregate scan before enumeration."""
     dimension = len(vertices[0].coordinates)
+    _ehrhart_aggregate_scan_bound(vertices, max_dilation)
     if dimension > 1:
         facet_work = math.comb(len(vertices), dimension) * max_dilation
         if facet_work > MAX_FACET_COMBINATIONS:
@@ -606,7 +637,7 @@ def ehrhart_polynomial(
             )
         ),
     )
-    return EhrhartResult(
+    return EhrhartResult._from_kernel(
         vertices=vertices,
         dimension=len(vertices[0].coordinates),
         degree_bound=degree,

--- a/src/jacobian/math/geometry/polytopes/lattice/operations.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/operations.py
@@ -40,6 +40,7 @@ from typing import Literal
 
 from sympy import Matrix, Rational
 
+from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.geometry.polytopes import _rational_geometry
 from jacobian.math.geometry.polytopes._rational_geometry import (
@@ -48,15 +49,17 @@ from jacobian.math.geometry.polytopes._rational_geometry import (
 )
 from jacobian.math.geometry.polytopes.lattice._models import (
     MAX_BOUND_SPAN,
+    MAX_DIMENSION,
     MAX_FACET_TESTS,
     MAX_LATTICE_POINTS,
     CountLatticePointsResult,
+    EhrhartResult,
     EnumerateLatticePointsResult,
     LatticePoint,
 )
 from jacobian.math.geometry.polytopes.values import Halfspace, Vertex
 
-__all__ = ["count_lattice_points", "enumerate_lattice_points"]
+__all__ = ["count_lattice_points", "ehrhart_polynomial", "enumerate_lattice_points"]
 
 AdmittedGeometry = tuple[
     list[tuple[tuple[int, ...], int]],
@@ -468,4 +471,72 @@ def count_lattice_points(
         dimension=d,
         point_count=count,
         representation=representation,
+    )
+
+
+def ehrhart_polynomial(
+    vertices: tuple[Vertex, ...], degree_bound: int, max_dilation: int
+) -> EhrhartResult:
+    """Count integral dilates and recover their exact Ehrhart polynomial.
+
+    The zero dilate is handled directly as ``{0}``; positive dilates reuse the
+    bounded lattice-point scan.  Interpolation uses the first ``d+1`` values
+    and every requested extra value is replayed against the resulting
+    polynomial before a result is returned.
+    """
+    if type(degree_bound) is not int or type(max_dilation) is not int:
+        raise TypeError("Ehrhart degree and dilation bounds must be integers")
+    values: list[int] = [1]
+    for dilation in range(1, max_dilation + 1):
+        scaled = tuple(
+            Vertex(
+                coordinates=tuple(
+                    CanonicalRational.from_integer_ratio(
+                        coordinate.num * dilation, coordinate.den
+                    )
+                    for coordinate in vertex.coordinates
+                )
+            )
+            for vertex in vertices
+        )
+        values.append(count_lattice_points(scaled, None, MAX_DIMENSION).point_count)
+
+    degree = degree_bound
+    coefficients = [Fraction(0) for _ in range(degree + 1)]
+    for sample in range(degree + 1):
+        basis = [Fraction(1)]
+        denominator = 1
+        for other in range(degree + 1):
+            if other == sample:
+                continue
+            denominator *= sample - other
+            updated = [Fraction(0)] * (len(basis) + 1)
+            for power, coefficient in enumerate(basis):
+                updated[power] -= coefficient * other
+                updated[power + 1] += coefficient
+            basis = updated
+        for power, coefficient in enumerate(basis):
+            coefficients[power] += values[sample] * coefficient / denominator
+
+    def evaluate(dilation: int) -> int:
+        result = Fraction(0)
+        for coefficient in reversed(coefficients):
+            result = result * dilation + coefficient
+        if result.denominator != 1:
+            raise ValueError("interpolated Ehrhart value is not integral")
+        return result.numerator
+
+    if any(evaluate(dilation) != values[dilation] for dilation in range(len(values))):
+        raise OperationDomainValidationError(
+            location=("degree_bound",),
+            code="polytope.ehrhart.degree_insufficient",
+            message="degree_bound does not reproduce every requested dilation count",
+        )
+    return EhrhartResult(
+        dimension=len(vertices[0].coordinates),
+        degree_bound=degree,
+        counts=tuple((dilation, values[dilation]) for dilation in range(len(values))),
+        coefficients=tuple(
+            CanonicalRational.from_fraction(value) for value in coefficients
+        ),
     )

--- a/src/jacobian/math/geometry/polytopes/lattice/operations.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/operations.py
@@ -50,8 +50,10 @@ from jacobian.math.geometry.polytopes._rational_geometry import (
 from jacobian.math.geometry.polytopes.lattice._models import (
     MAX_BOUND_SPAN,
     MAX_DIMENSION,
+    MAX_FACET_COMBINATIONS,
     MAX_FACET_TESTS,
     MAX_LATTICE_POINTS,
+    MAX_TOTAL_SCAN,
     CountLatticePointsResult,
     EhrhartResult,
     EnumerateLatticePointsResult,
@@ -59,6 +61,11 @@ from jacobian.math.geometry.polytopes.lattice._models import (
     require_ehrhart_source,
 )
 from jacobian.math.geometry.polytopes.values import Halfspace, Vertex
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
 
 __all__ = ["count_lattice_points", "ehrhart_polynomial", "enumerate_lattice_points"]
 
@@ -321,9 +328,10 @@ def _facets_and_box(  # noqa: C901
                 facet_combinations = _comb(len(verts), d)
             except ValueError:
                 facet_combinations = 10**18
-            if facet_combinations > 700_000:
+            if facet_combinations > MAX_FACET_COMBINATIONS:
                 raise LatticePointBudgetError(
-                    "vertex facet enumeration exceeds the 700k-combination budget"
+                    "vertex facet enumeration exceeds the "
+                    f"{MAX_FACET_COMBINATIONS}-combination budget"
                 )
             # Lower-dimensional hulls: if vertices do not span full dimension,
             # the facet enumeration would be empty and the scan would be wrong.
@@ -475,25 +483,21 @@ def count_lattice_points(
     )
 
 
-def ehrhart_polynomial(
-    vertices: tuple[Vertex, ...], degree_bound: int, max_dilation: int
-) -> EhrhartResult:
-    """Count integral dilates and recover their exact Ehrhart polynomial.
-
-    The zero dilate is handled directly as ``{0}``; positive dilates reuse the
-    bounded lattice-point scan.  Interpolation uses the first ``d+1`` values
-    and every requested extra value is replayed against the resulting
-    polynomial before a result is returned.
-    """
-    try:
-        require_ehrhart_source(vertices, degree_bound, max_dilation)
-    except ValueError as exc:
-        raise OperationDomainValidationError(
-            location=("vertices", "degree_bound", "max_dilation"),
-            code="polytope.ehrhart.invalid_source",
-            message=str(exc),
-        ) from exc
-    values: list[int] = [1]
+def _ehrhart_scan_plans(
+    vertices: tuple[Vertex, ...], max_dilation: int
+) -> list[AdmittedGeometry]:
+    """Admit every scaled geometry and the aggregate scan before enumeration."""
+    dimension = len(vertices[0].coordinates)
+    if dimension > 1:
+        facet_work = math.comb(len(vertices), dimension) * max_dilation
+        if facet_work > MAX_FACET_COMBINATIONS:
+            raise LatticePointBudgetError(
+                "the Ehrhart dilation range exceeds the aggregate "
+                f"{MAX_FACET_COMBINATIONS}-combination facet budget"
+            )
+    plans: list[AdmittedGeometry] = []
+    total_scan = 0
+    total_facet_tests = 0
     for dilation in range(1, max_dilation + 1):
         scaled = tuple(
             Vertex(
@@ -506,9 +510,29 @@ def ehrhart_polynomial(
             )
             for vertex in vertices
         )
-        values.append(count_lattice_points(scaled, None, MAX_DIMENSION).point_count)
+        plan = _facets_and_box(scaled, None, MAX_DIMENSION)
+        plans.append(plan)
+        _facets, lo, hi, _dimension = plan
+        scan = 1
+        for lower, upper in zip(lo, hi, strict=True):
+            scan *= upper - lower + 1
+        total_scan += scan
+        total_facet_tests += scan * len(_facets)
+    if total_scan > MAX_TOTAL_SCAN:
+        raise LatticePointBudgetError(
+            "the Ehrhart dilation range exceeds the aggregate "
+            f"{MAX_TOTAL_SCAN}-candidate scan budget"
+        )
+    if total_facet_tests > MAX_FACET_TESTS:
+        raise LatticePointBudgetError(
+            "the Ehrhart dilation range exceeds the aggregate exact "
+            f"facet-membership budget of {MAX_FACET_TESTS} tests"
+        )
+    return plans
 
-    degree = degree_bound
+
+def _interpolate_ehrhart(values: list[int], degree: int) -> list[Fraction]:
+    """Interpolate and return ascending-power exact coefficients."""
     coefficients = [Fraction(0) for _ in range(degree + 1)]
     for sample in range(degree + 1):
         basis = [Fraction(1)]
@@ -524,6 +548,36 @@ def ehrhart_polynomial(
             basis = updated
         for power, coefficient in enumerate(basis):
             coefficients[power] += values[sample] * coefficient / denominator
+    return coefficients
+
+
+def ehrhart_polynomial(
+    vertices: tuple[Vertex, ...], degree_bound: int, max_dilation: int
+) -> EhrhartResult:
+    """Count integral dilates and recover their exact Ehrhart polynomial."""
+    try:
+        require_ehrhart_source(vertices, degree_bound, max_dilation)
+        plans = _ehrhart_scan_plans(vertices, max_dilation)
+    except LatticePolytopeAdmissionError as exc:
+        raise OperationDomainValidationError(
+            location=("vertices", "max_dilation"),
+            code="polytope.ehrhart.admission",
+            message=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise OperationDomainValidationError(
+            location=("vertices", "degree_bound", "max_dilation"),
+            code="polytope.ehrhart.invalid_source",
+            message=str(exc),
+        ) from exc
+
+    values: list[int] = [1]
+    for facets, lo, hi, dimension in plans:
+        _points, count = _scan_box(facets, lo, hi, dimension, collect=False)
+        values.append(count)
+
+    degree = degree_bound
+    coefficients = _interpolate_ehrhart(values, degree)
 
     def evaluate(dilation: int) -> int:
         result = Fraction(0)
@@ -539,11 +593,24 @@ def ehrhart_polynomial(
             code="polytope.ehrhart.degree_insufficient",
             message="degree_bound does not reproduce every requested dilation count",
         )
+    polynomial = RationalPolynomial(
+        variables=("t",),
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(value),
+                    exponents=(power,),
+                )
+                for power, value in reversed(tuple(enumerate(coefficients)))
+                if value
+            )
+        ),
+    )
     return EhrhartResult(
+        vertices=vertices,
         dimension=len(vertices[0].coordinates),
         degree_bound=degree,
+        max_dilation=max_dilation,
         counts=tuple((dilation, values[dilation]) for dilation in range(len(values))),
-        coefficients=tuple(
-            CanonicalRational.from_fraction(value) for value in coefficients
-        ),
+        polynomial=polynomial,
     )

--- a/src/jacobian/math/geometry/polytopes/lattice/operations.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/operations.py
@@ -53,6 +53,7 @@ from jacobian.math.geometry.polytopes.lattice._models import (
     MAX_FACET_TESTS,
     MAX_LATTICE_POINTS,
     CountLatticePointsResult,
+    EhrhartRequest,
     EhrhartResult,
     EnumerateLatticePointsResult,
     LatticePoint,
@@ -484,8 +485,16 @@ def ehrhart_polynomial(
     and every requested extra value is replayed against the resulting
     polynomial before a result is returned.
     """
-    if type(degree_bound) is not int or type(max_dilation) is not int:
-        raise TypeError("Ehrhart degree and dilation bounds must be integers")
+    try:
+        EhrhartRequest(
+            vertices=vertices, degree_bound=degree_bound, max_dilation=max_dilation
+        )
+    except ValueError as exc:
+        raise OperationDomainValidationError(
+            location=("vertices", "degree_bound", "max_dilation"),
+            code="polytope.ehrhart.invalid_source",
+            message=str(exc),
+        ) from exc
     values: list[int] = [1]
     for dilation in range(1, max_dilation + 1):
         scaled = tuple(

--- a/src/jacobian/math/geometry/polytopes/lattice/operations.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/operations.py
@@ -494,6 +494,12 @@ def _ehrhart_aggregate_scan_bound(
         - min(vertex.coordinates[axis].num for vertex in vertices)
         for axis in range(len(vertices[0].coordinates))
     ]
+    for span in spans:
+        if max_dilation * span + 1 > MAX_BOUND_SPAN:
+            raise LatticePointBudgetError(
+                "the Ehrhart dilation range exceeds the "
+                f"{MAX_BOUND_SPAN}-point per-axis span bound"
+            )
     total_scan = 0
     for dilation in range(1, max_dilation + 1):
         scan = 1

--- a/src/jacobian/math/geometry/polytopes/lattice/operations.py
+++ b/src/jacobian/math/geometry/polytopes/lattice/operations.py
@@ -53,10 +53,10 @@ from jacobian.math.geometry.polytopes.lattice._models import (
     MAX_FACET_TESTS,
     MAX_LATTICE_POINTS,
     CountLatticePointsResult,
-    EhrhartRequest,
     EhrhartResult,
     EnumerateLatticePointsResult,
     LatticePoint,
+    require_ehrhart_source,
 )
 from jacobian.math.geometry.polytopes.values import Halfspace, Vertex
 
@@ -486,9 +486,7 @@ def ehrhart_polynomial(
     polynomial before a result is returned.
     """
     try:
-        EhrhartRequest(
-            vertices=vertices, degree_bound=degree_bound, max_dilation=max_dilation
-        )
+        require_ehrhart_source(vertices, degree_bound, max_dilation)
     except ValueError as exc:
         raise OperationDomainValidationError(
             location=("vertices", "degree_bound", "max_dilation"),

--- a/tests/math/geometry/polytopes/lattice/test_ehrhart.py
+++ b/tests/math/geometry/polytopes/lattice/test_ehrhart.py
@@ -1,0 +1,56 @@
+"""Exact Ehrhart interpolation for integral polytopes (#1192)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.geometry.polytopes.lattice._models import EhrhartRequest
+from jacobian.math.geometry.polytopes.lattice._tools import ehrhart_polynomial
+
+
+def _vertex(*coordinates: int) -> dict[str, list[dict[str, int]]]:
+    return {"coordinates": [{"num": value, "den": 1} for value in coordinates]}
+
+
+def test_unit_square_ehrhart_polynomial_and_dilation_counts() -> None:
+    request = EhrhartRequest(
+        vertices=[_vertex(0, 0), _vertex(1, 0), _vertex(0, 1), _vertex(1, 1)],
+        degree_bound=2,
+        max_dilation=4,
+    )
+    result = ehrhart_polynomial(request)
+    assert result.counts == ((0, 1), (1, 4), (2, 9), (3, 16), (4, 25))
+    assert [(item.num, item.den) for item in result.coefficients] == [
+        (1, 1),
+        (2, 1),
+        (1, 1),
+    ]
+
+
+def test_unit_interval_has_zero_dilate_and_exact_linear_coefficients() -> None:
+    result = ehrhart_polynomial(
+        EhrhartRequest(
+            vertices=[_vertex(0), _vertex(1)], degree_bound=1, max_dilation=3
+        )
+    )
+    assert result.counts == ((0, 1), (1, 2), (2, 3), (3, 4))
+    assert [(item.num, item.den) for item in result.coefficients] == [(1, 1), (1, 1)]
+
+
+def test_rational_vertices_are_rejected_until_quasipolynomial_scope_exists() -> None:
+    with pytest.raises(ValidationError, match="requires integral vertices"):
+        EhrhartRequest(
+            vertices=[
+                {"coordinates": [{"num": 0, "den": 1}]},
+                {"coordinates": [{"num": 1, "den": 2}]},
+            ],
+            degree_bound=1,
+        )
+
+
+def test_degree_bound_must_cover_dimension() -> None:
+    with pytest.raises(ValidationError, match="cover the polytope dimension"):
+        EhrhartRequest(
+            vertices=[_vertex(0, 0), _vertex(1, 0), _vertex(0, 1)], degree_bound=1
+        )

--- a/tests/math/geometry/polytopes/lattice/test_ehrhart.py
+++ b/tests/math/geometry/polytopes/lattice/test_ehrhart.py
@@ -171,6 +171,14 @@ def test_scaled_coordinate_height_is_rejected_before_carrier_construction() -> N
         Vertex(coordinates=(CanonicalRational(num=huge, den=1),)),
         Vertex(coordinates=(CanonicalRational(num=huge + 1, den=1),)),
     )
+    request = EhrhartRequest.model_validate(
+        {
+            "vertices": [_vertex(huge), _vertex(huge + 1)],
+            "degree_bound": 1,
+            "max_dilation": 3,
+        }
+    )
+    assert request.max_dilation == 3
     with pytest.raises(OperationDomainValidationError, match="maximum-dilation"):
         native_ehrhart(vertices, degree_bound=1, max_dilation=3)
 

--- a/tests/math/geometry/polytopes/lattice/test_ehrhart.py
+++ b/tests/math/geometry/polytopes/lattice/test_ehrhart.py
@@ -14,10 +14,12 @@ def _vertex(*coordinates: int) -> dict[str, list[dict[str, int]]]:
 
 
 def test_unit_square_ehrhart_polynomial_and_dilation_counts() -> None:
-    request = EhrhartRequest(
-        vertices=[_vertex(0, 0), _vertex(1, 0), _vertex(0, 1), _vertex(1, 1)],
-        degree_bound=2,
-        max_dilation=4,
+    request = EhrhartRequest.model_validate(
+        {
+            "vertices": [_vertex(0, 0), _vertex(1, 0), _vertex(0, 1), _vertex(1, 1)],
+            "degree_bound": 2,
+            "max_dilation": 4,
+        }
     )
     result = ehrhart_polynomial(request)
     assert result.counts == ((0, 1), (1, 4), (2, 9), (3, 16), (4, 25))
@@ -30,8 +32,8 @@ def test_unit_square_ehrhart_polynomial_and_dilation_counts() -> None:
 
 def test_unit_interval_has_zero_dilate_and_exact_linear_coefficients() -> None:
     result = ehrhart_polynomial(
-        EhrhartRequest(
-            vertices=[_vertex(0), _vertex(1)], degree_bound=1, max_dilation=3
+        EhrhartRequest.model_validate(
+            {"vertices": [_vertex(0), _vertex(1)], "degree_bound": 1, "max_dilation": 3}
         )
     )
     assert result.counts == ((0, 1), (1, 2), (2, 3), (3, 4))
@@ -40,17 +42,38 @@ def test_unit_interval_has_zero_dilate_and_exact_linear_coefficients() -> None:
 
 def test_rational_vertices_are_rejected_until_quasipolynomial_scope_exists() -> None:
     with pytest.raises(ValidationError, match="requires integral vertices"):
-        EhrhartRequest(
-            vertices=[
-                {"coordinates": [{"num": 0, "den": 1}]},
-                {"coordinates": [{"num": 1, "den": 2}]},
-            ],
-            degree_bound=1,
+        EhrhartRequest.model_validate(
+            {
+                "vertices": [
+                    {"coordinates": [{"num": 0, "den": 1}]},
+                    {"coordinates": [{"num": 1, "den": 2}]},
+                ],
+                "degree_bound": 1,
+            }
         )
 
 
 def test_degree_bound_must_cover_dimension() -> None:
     with pytest.raises(ValidationError, match="cover the polytope dimension"):
-        EhrhartRequest(
-            vertices=[_vertex(0, 0), _vertex(1, 0), _vertex(0, 1)], degree_bound=1
+        EhrhartRequest.model_validate(
+            {
+                "vertices": [_vertex(0, 0), _vertex(1, 0), _vertex(0, 1)],
+                "degree_bound": 1,
+            }
         )
+
+
+@pytest.mark.parametrize("max_dilation", [0, 1])
+def test_native_ehrhart_rejects_invalid_domain(max_dilation: int) -> None:
+    from jacobian.catalog.models import OperationDomainValidationError
+    from jacobian.math.geometry.polytopes.lattice.operations import (
+        ehrhart_polynomial as native,
+    )
+    from jacobian.math.geometry.polytopes.values import Vertex
+
+    vertices = (
+        Vertex.model_validate(_vertex(0)),
+        Vertex.model_validate({"coordinates": [{"num": 1, "den": 2}]}),
+    )
+    with pytest.raises(OperationDomainValidationError):
+        native(vertices, degree_bound=1, max_dilation=max_dilation)

--- a/tests/math/geometry/polytopes/lattice/test_ehrhart.py
+++ b/tests/math/geometry/polytopes/lattice/test_ehrhart.py
@@ -131,10 +131,36 @@ def test_aggregate_scan_budget_rejects_before_scaled_geometry(
         native_ehrhart(
             tuple(
                 Vertex.model_validate(_vertex(*point))
-                for point in ((0, 0), (400, 0), (0, 400), (400, 400))
+                for point in ((0, 0), (200, 0), (0, 200), (200, 200))
             ),
             degree_bound=2,
             max_dilation=32,
+        )
+    assert calls == 0
+
+
+def test_axis_span_budget_rejects_before_scaled_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.geometry.polytopes.lattice import operations
+
+    calls = 0
+    original = operations._facets_and_box
+
+    def count_geometry(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(operations, "_facets_and_box", count_geometry)
+    with pytest.raises(OperationDomainValidationError, match="per-axis span"):
+        native_ehrhart(
+            tuple(
+                Vertex.model_validate(_vertex(*point))
+                for point in ((0, 0), (10_001, 0), (0, 1), (10_001, 1))
+            ),
+            degree_bound=2,
+            max_dilation=2,
         )
     assert calls == 0
 

--- a/tests/math/geometry/polytopes/lattice/test_ehrhart.py
+++ b/tests/math/geometry/polytopes/lattice/test_ehrhart.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
-from jacobian.math.geometry.polytopes.lattice._models import EhrhartRequest
+from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.math.geometry.polytopes.lattice._models import (
+    EhrhartRequest,
+    EhrhartResult,
+)
 from jacobian.math.geometry.polytopes.lattice._tools import ehrhart_polynomial
+from jacobian.math.geometry.polytopes.lattice.operations import (
+    ehrhart_polynomial as native_ehrhart,
+)
+from jacobian.math.geometry.polytopes.values import Vertex
+from jacobian.math.polynomials.values import RationalPolynomial
 
 
 def _vertex(*coordinates: int) -> dict[str, list[dict[str, int]]]:
@@ -23,11 +35,11 @@ def test_unit_square_ehrhart_polynomial_and_dilation_counts() -> None:
     )
     result = ehrhart_polynomial(request)
     assert result.counts == ((0, 1), (1, 4), (2, 9), (3, 16), (4, 25))
-    assert [(item.num, item.den) for item in result.coefficients] == [
-        (1, 1),
-        (2, 1),
-        (1, 1),
-    ]
+    assert result.polynomial.variables == ("t",)
+    assert [
+        (term.coefficient.num, term.coefficient.den, term.exponents)
+        for term in result.polynomial.polynomial.terms
+    ] == [(1, 1, (2,)), (2, 1, (1,)), (1, 1, (0,))]
 
 
 def test_unit_interval_has_zero_dilate_and_exact_linear_coefficients() -> None:
@@ -37,7 +49,11 @@ def test_unit_interval_has_zero_dilate_and_exact_linear_coefficients() -> None:
         )
     )
     assert result.counts == ((0, 1), (1, 2), (2, 3), (3, 4))
-    assert [(item.num, item.den) for item in result.coefficients] == [(1, 1), (1, 1)]
+    assert [
+        (term.coefficient.num, term.coefficient.den, term.exponents)
+        for term in result.polynomial.polynomial.terms
+    ] == [(1, 1, (1,)), (1, 1, (0,))]
+    assert result.max_dilation == 3
 
 
 def test_rational_vertices_are_rejected_until_quasipolynomial_scope_exists() -> None:
@@ -59,6 +75,105 @@ def test_degree_bound_must_cover_dimension() -> None:
             {
                 "vertices": [_vertex(0, 0), _vertex(1, 0), _vertex(0, 1)],
                 "degree_bound": 1,
+            }
+        )
+
+
+def test_non_full_dimensional_one_point_source_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="affinely span"):
+        EhrhartRequest.model_validate(
+            {"vertices": [_vertex(0)], "degree_bound": 1, "max_dilation": 1}
+        )
+
+
+def test_all_dilation_scans_are_admitted_before_any_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.geometry.polytopes.lattice import operations
+
+    calls = 0
+
+    def fail_if_scanned(*_args: Any, **_kwargs: Any) -> None:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("scan started before aggregate admission")
+
+    monkeypatch.setattr(operations, "_scan_box", fail_if_scanned)
+    with pytest.raises(OperationDomainValidationError, match="aggregate"):
+        native_ehrhart(
+            tuple(
+                Vertex.model_validate(_vertex(*point))
+                for point in ((0, 0), (50, 0), (0, 50), (50, 50))
+            ),
+            degree_bound=2,
+            max_dilation=32,
+        )
+    assert calls == 0
+
+
+def test_scaled_coordinate_height_is_rejected_before_carrier_construction() -> None:
+    huge = 4 * 10**32767
+    vertices = (
+        Vertex(coordinates=(CanonicalRational(num=huge, den=1),)),
+        Vertex(coordinates=(CanonicalRational(num=huge + 1, den=1),)),
+    )
+    with pytest.raises(OperationDomainValidationError, match="maximum-dilation"):
+        native_ehrhart(vertices, degree_bound=1, max_dilation=3)
+
+
+def test_result_round_trip_retains_source_and_canonical_polynomial() -> None:
+    result = ehrhart_polynomial(
+        EhrhartRequest.model_validate(
+            {"vertices": [_vertex(0), _vertex(1)], "degree_bound": 1, "max_dilation": 2}
+        )
+    )
+    restored = EhrhartResult.model_validate_json(result.model_dump_json())
+    assert restored == result
+    assert restored.vertices == result.vertices
+    assert isinstance(restored.polynomial, RationalPolynomial)
+
+
+def test_forged_count_axes_and_values_are_rejected() -> None:
+    with pytest.raises(ValidationError, match="dilation"):
+        EhrhartResult.model_validate(
+            {
+                "vertices": [_vertex(0), _vertex(1)],
+                "dimension": 1,
+                "degree_bound": 1,
+                "max_dilation": 2,
+                "counts": [[0, 1], [2, -7], [2, 3]],
+                "polynomial": {
+                    "variables": ["t"],
+                    "polynomial": {
+                        "terms": [
+                            {
+                                "coefficient": {"num": 1, "den": 1},
+                                "exponents": [0],
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+    with pytest.raises(ValidationError, match="nonnegative"):
+        EhrhartResult.model_validate(
+            {
+                "vertices": [_vertex(0), _vertex(1)],
+                "dimension": 1,
+                "degree_bound": 1,
+                "max_dilation": 2,
+                "counts": [[0, 1], [1, -7], [2, 3]],
+                "polynomial": {
+                    "variables": ["t"],
+                    "polynomial": {
+                        "terms": [
+                            {
+                                "coefficient": {"num": 1, "den": 1},
+                                "exponents": [0],
+                            }
+                        ]
+                    },
+                },
             }
         )
 

--- a/tests/math/geometry/polytopes/lattice/test_ehrhart.py
+++ b/tests/math/geometry/polytopes/lattice/test_ehrhart.py
@@ -79,10 +79,12 @@ def test_degree_bound_must_cover_dimension() -> None:
         )
 
 
-def test_non_full_dimensional_one_point_source_is_rejected() -> None:
-    with pytest.raises(ValidationError, match="affinely span"):
-        EhrhartRequest.model_validate(
-            {"vertices": [_vertex(0)], "degree_bound": 1, "max_dilation": 1}
+def test_non_full_dimensional_one_point_source_is_rejected_at_native_admission() -> (
+    None
+):
+    with pytest.raises(OperationDomainValidationError, match="affinely span"):
+        native_ehrhart(
+            (Vertex.model_validate(_vertex(0)),), degree_bound=1, max_dilation=1
         )
 
 
@@ -104,6 +106,32 @@ def test_all_dilation_scans_are_admitted_before_any_scan(
             tuple(
                 Vertex.model_validate(_vertex(*point))
                 for point in ((0, 0), (50, 0), (0, 50), (50, 50))
+            ),
+            degree_bound=2,
+            max_dilation=32,
+        )
+    assert calls == 0
+
+
+def test_aggregate_scan_budget_rejects_before_scaled_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.geometry.polytopes.lattice import operations
+
+    calls = 0
+    original = operations._facets_and_box
+
+    def count_geometry(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(operations, "_facets_and_box", count_geometry)
+    with pytest.raises(OperationDomainValidationError, match="aggregate"):
+        native_ehrhart(
+            tuple(
+                Vertex.model_validate(_vertex(*point))
+                for point in ((0, 0), (400, 0), (0, 400), (400, 400))
             ),
             degree_bound=2,
             max_dilation=32,


### PR DESCRIPTION
## Problem

Related to #1192.

Existing bounded lattice-point enumeration handled one polytope at one scale but did not return a source-bound table of dilations or interpolate an exact Ehrhart polynomial.

## Outcome

Adds `polytope.ehrhart.compute` for a full-dimensional integral polytope. It counts every lattice point in the admitted dilations, returns the complete exact count table, and interpolates a canonical `QQ[t]` polynomial from sufficient values. The source vertices, variable axis, degree bound, maximum dilation, and counts survive strict JSON serialization.

## Contract and bounds

Ambient dimension is at most four and positive dilation count at most 32. Before constructing scaled geometries, the operation admits full-dimensionality, scaled coordinate height, maximum per-axis span, every dilation box, aggregate scan work, facet work, polynomial/result height, and serialized output. It reuses the existing exact lattice-point scanner and rational-polynomial owner. Result decoding checks structural axes without replaying rank, counting, or interpolation.

## Evidence

Final local validation at `d52b782c38cad1e62741f5be3cbf7ff247a51b97`:

- `make affected AFFECTED_BASE=origin/main`
- 76 affected math tests
- 160 catalog tests
- 967 catalog integration tests
- Focused Ehrhart regressions, Ruff, formatting, and mypy
- Independent exact-diff audit completed; aggregate-scan, full-dimensionality ownership, and scaled-axis-span findings were repaired.

## Residual and superseded scope

This is the ordinary integral-polytope interpolation slice of #1192. Weighted Ehrhart counting remains open. The issue's older request for a paired count-replaying verifier is intentionally not implemented: under the current product contract, an exact producer result remains an ordinary value, and a downstream consumer checks an authored relation only when its own conclusion relies on it. No generic producer/verifier wrapper or replay during decoding is introduced.