### PR TITLE
feat(delta-matroids): compute twists and widths

### DIFF
--- a/docs/reference/operations/finite-math/finite-delta-matroids.md
+++ b/docs/reference/operations/finite-math/finite-delta-matroids.md
@@ -38,4 +38,5 @@ result.
 
 `delta_matroid.twist.compute` returns the canonical twisted `FiniteDeltaMatroid`.
 Width `max(|F|)-min(|F|)` is a native projection of the feasible family and is
-not a catalog operation.
+not a catalog operation. It scans every retained feasible-row length of the
+canonical value and has no extra row ceiling.

--- a/docs/reference/operations/finite-math/finite-delta-matroids.md
+++ b/docs/reference/operations/finite-math/finite-delta-matroids.md
@@ -13,7 +13,7 @@ lexicographic order. Omitted rows are infeasible; they are never unknown.
 
 The operation checks every ordered pair of feasible sets and every element of
 their symmetric difference. It bounds the complete family before executing its
-axiom and explicit verification passes: 1,024 total row memberships, 2,048
+axiom and explicit verification passes: 16,384 total row memberships, 2,048
 UTF-8 bytes of ground labels
 (each label must be UTF-8-representable), 250,000 symmetric-exchange candidate
 checks per complete axiom replay. There
@@ -35,3 +35,7 @@ This initial operation deliberately does not construct twists, minors, binary
 matrix presentations, graph conversions, or interlace polynomials. Those are
 separate mathematical postconditions rather than fields of the recognition
 result.
+
+`delta_matroid.twist.compute` returns the canonical twisted `FiniteDeltaMatroid`.
+Width `max(|F|)-min(|F|)` is a native projection of the feasible family and is
+not a catalog operation.

--- a/src/jacobian/math/combinatorics/matroids/delta/__init__.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/__init__.py
@@ -2,8 +2,16 @@
 
 from jacobian.math.combinatorics.matroids.delta.operations import (
     from_feasible_sets,
+    twist,
     verify_from_feasible_sets,
+    width,
 )
 from jacobian.math.combinatorics.matroids.delta.values import FiniteDeltaMatroid
 
-__all__ = ["FiniteDeltaMatroid", "from_feasible_sets", "verify_from_feasible_sets"]
+__all__ = [
+    "FiniteDeltaMatroid",
+    "from_feasible_sets",
+    "twist",
+    "verify_from_feasible_sets",
+    "width",
+]

--- a/src/jacobian/math/combinatorics/matroids/delta/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/_models.py
@@ -38,7 +38,34 @@ def require_twist_subset(
 class DeltaMatroidTwistRequest(StrictModel):
     """Twist a delta-matroid by a canonical ground-index subset."""
 
-    delta_matroid: FiniteDeltaMatroid
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Twist one complete finite delta-matroid by a sorted ground-index "
+                "subset. Source recognition and the twisted family share the "
+                f"{MAX_DELTA_MEMBERSHIPS}-membership, {MAX_DELTA_LABEL_BYTES}-byte "
+                "label, and "
+                f"{MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS}-candidate envelopes."
+            ),
+            "admission_limits": {
+                "max_feasible_set_memberships": MAX_DELTA_MEMBERSHIPS,
+                "max_ground_label_utf8_bytes": MAX_DELTA_LABEL_BYTES,
+                "max_symmetric_exchange_candidate_checks_per_replay": (
+                    MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS
+                ),
+            },
+        }
+    )
+
+    delta_matroid: FiniteDeltaMatroid = Field(
+        description=(
+            "Canonical finite delta-matroid. Twist admission allows at most "
+            f"{MAX_DELTA_MEMBERSHIPS} total feasible-row memberships, "
+            f"{MAX_DELTA_LABEL_BYTES} UTF-8 ground-label bytes, and "
+            f"{MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS} symmetric-exchange candidate "
+            "checks before using the source family."
+        )
+    )
     subset: tuple[int, ...] = Field(default=())
 
     @model_validator(mode="after")

--- a/src/jacobian/math/combinatorics/matroids/delta/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/_models.py
@@ -18,6 +18,58 @@ from jacobian.math.combinatorics.matroids.delta.values import (
 )
 
 
+class DeltaMatroidTwistRequest(StrictModel):
+    """Twist a delta-matroid by a canonical ground-index subset."""
+
+    delta_matroid: FiniteDeltaMatroid
+    subset: tuple[int, ...] = Field(default=())
+
+    @model_validator(mode="after")
+    def require_canonical_subset(self) -> Self:
+        if self.subset != tuple(sorted(set(self.subset))):
+            raise _validation_error(
+                "subset_not_canonical", "twist subset must be sorted and distinct"
+            )
+        if any(
+            index < 0 or index >= len(self.delta_matroid.ground)
+            for index in self.subset
+        ):
+            raise _validation_error(
+                "subset_out_of_range", "twist subset index is outside the ground set"
+            )
+        return self
+
+
+class DeltaMatroidTwistResult(DeltaMatroidTwistRequest):
+    """The exact feasible family obtained by symmetric-difference twist."""
+
+    twisted: FiniteDeltaMatroid
+
+    @classmethod
+    def _from_kernel(
+        cls, request: DeltaMatroidTwistRequest, twisted: FiniteDeltaMatroid
+    ) -> Self:
+        return cls.model_construct(
+            delta_matroid=request.delta_matroid,
+            subset=request.subset,
+            twisted=twisted,
+        )
+
+
+class DeltaMatroidWidthRequest(StrictModel):
+    """Compute the width (largest minus smallest feasible-set size)."""
+
+    delta_matroid: FiniteDeltaMatroid
+
+
+class DeltaMatroidWidthResult(DeltaMatroidWidthRequest):
+    width: int = Field(ge=0)
+
+    @classmethod
+    def _from_kernel(cls, request: DeltaMatroidWidthRequest, width: int) -> Self:
+        return cls.model_construct(delta_matroid=request.delta_matroid, width=width)
+
+
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"delta_matroid.{reason}", message)
 
@@ -104,4 +156,8 @@ class DeltaMatroidRecognitionResult(StrictModel):
 __all__ = [
     "DeltaMatroidFromFeasibleSetsRequest",
     "DeltaMatroidRecognitionResult",
+    "DeltaMatroidTwistRequest",
+    "DeltaMatroidTwistResult",
+    "DeltaMatroidWidthRequest",
+    "DeltaMatroidWidthResult",
 ]

--- a/src/jacobian/math/combinatorics/matroids/delta/_models.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/_models.py
@@ -18,6 +18,23 @@ from jacobian.math.combinatorics.matroids.delta.values import (
 )
 
 
+def require_twist_subset(
+    delta_matroid: FiniteDeltaMatroid, subset: tuple[int, ...]
+) -> None:
+    """Validate the canonical twist axis for native and wire callers."""
+
+    if any(type(index) is not int for index in subset):
+        raise _validation_error("subset_index_type", "twist indices must be integers")
+    if subset != tuple(sorted(set(subset))):
+        raise _validation_error(
+            "subset_not_canonical", "twist subset must be sorted and distinct"
+        )
+    if any(index < 0 or index >= len(delta_matroid.ground) for index in subset):
+        raise _validation_error(
+            "subset_out_of_range", "twist subset index is outside the ground set"
+        )
+
+
 class DeltaMatroidTwistRequest(StrictModel):
     """Twist a delta-matroid by a canonical ground-index subset."""
 
@@ -26,17 +43,7 @@ class DeltaMatroidTwistRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical_subset(self) -> Self:
-        if self.subset != tuple(sorted(set(self.subset))):
-            raise _validation_error(
-                "subset_not_canonical", "twist subset must be sorted and distinct"
-            )
-        if any(
-            index < 0 or index >= len(self.delta_matroid.ground)
-            for index in self.subset
-        ):
-            raise _validation_error(
-                "subset_out_of_range", "twist subset index is outside the ground set"
-            )
+        require_twist_subset(self.delta_matroid, self.subset)
         return self
 
 
@@ -47,11 +54,14 @@ class DeltaMatroidTwistResult(DeltaMatroidTwistRequest):
 
     @classmethod
     def _from_kernel(
-        cls, request: DeltaMatroidTwistRequest, twisted: FiniteDeltaMatroid
+        cls,
+        delta_matroid: FiniteDeltaMatroid,
+        subset: tuple[int, ...],
+        twisted: FiniteDeltaMatroid,
     ) -> Self:
         return cls.model_construct(
-            delta_matroid=request.delta_matroid,
-            subset=request.subset,
+            delta_matroid=delta_matroid,
+            subset=subset,
             twisted=twisted,
         )
 
@@ -66,8 +76,8 @@ class DeltaMatroidWidthResult(DeltaMatroidWidthRequest):
     width: int = Field(ge=0)
 
     @classmethod
-    def _from_kernel(cls, request: DeltaMatroidWidthRequest, width: int) -> Self:
-        return cls.model_construct(delta_matroid=request.delta_matroid, width=width)
+    def _from_kernel(cls, delta_matroid: FiniteDeltaMatroid, width: int) -> Self:
+        return cls.model_construct(delta_matroid=delta_matroid, width=width)
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:

--- a/src/jacobian/math/combinatorics/matroids/delta/_tools.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/_tools.py
@@ -11,7 +11,6 @@ from jacobian.math.combinatorics.matroids.delta._models import (
     DeltaMatroidFromFeasibleSetsRequest,
     DeltaMatroidRecognitionResult,
     DeltaMatroidTwistRequest,
-    DeltaMatroidTwistResult,
     DeltaMatroidWidthRequest,
     DeltaMatroidWidthResult,
 )
@@ -20,7 +19,10 @@ from jacobian.math.combinatorics.matroids.delta.operations import (
     twist,
     width,
 )
-from jacobian.math.combinatorics.matroids.delta.values import DeltaMatroidAdmissionError
+from jacobian.math.combinatorics.matroids.delta.values import (
+    DeltaMatroidAdmissionError,
+    FiniteDeltaMatroid,
+)
 
 
 def _from_feasible_sets(
@@ -38,7 +40,7 @@ def _from_feasible_sets(
         ) from exc
 
 
-def _twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
+def _twist(request: DeltaMatroidTwistRequest) -> FiniteDeltaMatroid:
     try:
         return twist(request.delta_matroid, request.subset)
     except DeltaMatroidAdmissionError as exc:
@@ -57,7 +59,9 @@ def _twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
 
 def _width(request: DeltaMatroidWidthRequest) -> DeltaMatroidWidthResult:
     try:
-        return width(request.delta_matroid)
+        return DeltaMatroidWidthResult._from_kernel(
+            request.delta_matroid, width(request.delta_matroid)
+        )
     except DeltaMatroidAdmissionError as exc:
         raise OperationResourceAdmissionError(
             location=("delta_matroid",),
@@ -107,7 +111,7 @@ TOOLS: MathTools = (
             "ground indices and the source must satisfy symmetric exchange."
         ),
         request_type=DeltaMatroidTwistRequest,
-        result_type=DeltaMatroidTwistResult,
+        result_type=FiniteDeltaMatroid,
         run=_twist,
         tags=("delta-matroid", "twist", "exact"),
         examples=(
@@ -123,33 +127,6 @@ TOOLS: MathTools = (
                         "feasible": [[], [0], [0, 1], [1]],
                     },
                     "subset": [0],
-                },
-            ),
-        ),
-    ),
-    MathTool(
-        operation_id="delta_matroid.width.compute",
-        title="Compute the width of a finite delta-matroid",
-        description=(
-            "Return max(|F|) - min(|F|) over the complete feasible family; the "
-            "source must satisfy symmetric exchange."
-        ),
-        request_type=DeltaMatroidWidthRequest,
-        result_type=DeltaMatroidWidthResult,
-        run=_width,
-        tags=("delta-matroid", "width", "exact"),
-        examples=(
-            OperationExample(
-                name="uniform_two_element_family",
-                description=(
-                    "Compute the width of the complete two-element feasible family; "
-                    "the source must satisfy symmetric exchange."
-                ),
-                input={
-                    "delta_matroid": {
-                        "ground": ["a", "b"],
-                        "feasible": [[], [0], [0, 1], [1]],
-                    }
                 },
             ),
         ),

--- a/src/jacobian/math/combinatorics/matroids/delta/_tools.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/_tools.py
@@ -40,7 +40,7 @@ def _from_feasible_sets(
 
 def _twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
     try:
-        return twist(request)
+        return twist(request.delta_matroid, request.subset)
     except DeltaMatroidAdmissionError as exc:
         raise OperationResourceAdmissionError(
             location=("delta_matroid",),
@@ -57,7 +57,7 @@ def _twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
 
 def _width(request: DeltaMatroidWidthRequest) -> DeltaMatroidWidthResult:
     try:
-        return width(request)
+        return width(request.delta_matroid)
     except DeltaMatroidAdmissionError as exc:
         raise OperationResourceAdmissionError(
             location=("delta_matroid",),

--- a/src/jacobian/math/combinatorics/matroids/delta/_tools.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/_tools.py
@@ -5,6 +5,7 @@ from jacobian.catalog.models import (
     MathTools,
     OperationDomainValidationError,
     OperationExample,
+    OperationResourceAdmissionError,
 )
 from jacobian.math.combinatorics.matroids.delta._models import (
     DeltaMatroidFromFeasibleSetsRequest,
@@ -40,6 +41,12 @@ def _from_feasible_sets(
 def _twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
     try:
         return twist(request)
+    except DeltaMatroidAdmissionError as exc:
+        raise OperationResourceAdmissionError(
+            location=("delta_matroid",),
+            code=f"delta_matroid.{exc.reason}",
+            message=str(exc),
+        ) from exc
     except ValueError as exc:
         raise OperationDomainValidationError(
             location=("delta_matroid",),
@@ -51,6 +58,12 @@ def _twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
 def _width(request: DeltaMatroidWidthRequest) -> DeltaMatroidWidthResult:
     try:
         return width(request)
+    except DeltaMatroidAdmissionError as exc:
+        raise OperationResourceAdmissionError(
+            location=("delta_matroid",),
+            code=f"delta_matroid.{exc.reason}",
+            message=str(exc),
+        ) from exc
     except ValueError as exc:
         raise OperationDomainValidationError(
             location=("delta_matroid",),

--- a/src/jacobian/math/combinatorics/matroids/delta/_tools.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/_tools.py
@@ -9,8 +9,16 @@ from jacobian.catalog.models import (
 from jacobian.math.combinatorics.matroids.delta._models import (
     DeltaMatroidFromFeasibleSetsRequest,
     DeltaMatroidRecognitionResult,
+    DeltaMatroidTwistRequest,
+    DeltaMatroidTwistResult,
+    DeltaMatroidWidthRequest,
+    DeltaMatroidWidthResult,
 )
-from jacobian.math.combinatorics.matroids.delta.operations import from_feasible_sets
+from jacobian.math.combinatorics.matroids.delta.operations import (
+    from_feasible_sets,
+    twist,
+    width,
+)
 from jacobian.math.combinatorics.matroids.delta.values import DeltaMatroidAdmissionError
 
 
@@ -25,6 +33,28 @@ def _from_feasible_sets(
         raise OperationDomainValidationError(
             location=("system",),
             code=f"delta_matroid.{exc.reason}",
+            message=str(exc),
+        ) from exc
+
+
+def _twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
+    try:
+        return twist(request)
+    except ValueError as exc:
+        raise OperationDomainValidationError(
+            location=("delta_matroid",),
+            code="delta_matroid.source_not_valid",
+            message=str(exc),
+        ) from exc
+
+
+def _width(request: DeltaMatroidWidthRequest) -> DeltaMatroidWidthResult:
+    try:
+        return width(request)
+    except ValueError as exc:
+        raise OperationDomainValidationError(
+            location=("delta_matroid",),
+            code="delta_matroid.source_not_valid",
             message=str(exc),
         ) from exc
 
@@ -50,6 +80,62 @@ TOOLS: MathTools = (
                     "system": {
                         "ground": ["a", "b"],
                         "feasible": [[], [0], [1], [0, 1]],
+                    }
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="delta_matroid.twist.compute",
+        title="Twist a finite delta-matroid",
+        description=(
+            "Return the exact delta-matroid whose feasible sets are F symmetric "
+            "difference X for each source feasible set F; the subset uses sorted "
+            "ground indices and the source must satisfy symmetric exchange."
+        ),
+        request_type=DeltaMatroidTwistRequest,
+        result_type=DeltaMatroidTwistResult,
+        run=_twist,
+        tags=("delta-matroid", "twist", "exact"),
+        examples=(
+            OperationExample(
+                name="twist_by_first_element",
+                description=(
+                    "Twist {∅,{a},{b},{a,b}} by {a}; the subset must be sorted "
+                    "ground indices."
+                ),
+                input={
+                    "delta_matroid": {
+                        "ground": ["a", "b"],
+                        "feasible": [[], [0], [0, 1], [1]],
+                    },
+                    "subset": [0],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="delta_matroid.width.compute",
+        title="Compute the width of a finite delta-matroid",
+        description=(
+            "Return max(|F|) - min(|F|) over the complete feasible family; the "
+            "source must satisfy symmetric exchange."
+        ),
+        request_type=DeltaMatroidWidthRequest,
+        result_type=DeltaMatroidWidthResult,
+        run=_width,
+        tags=("delta-matroid", "width", "exact"),
+        examples=(
+            OperationExample(
+                name="uniform_two_element_family",
+                description=(
+                    "Compute the width of the complete two-element feasible family; "
+                    "the source must satisfy symmetric exchange."
+                ),
+                input={
+                    "delta_matroid": {
+                        "ground": ["a", "b"],
+                        "feasible": [[], [0], [0, 1], [1]],
                     }
                 },
             ),

--- a/src/jacobian/math/combinatorics/matroids/delta/_tools.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/_tools.py
@@ -108,7 +108,9 @@ TOOLS: MathTools = (
         description=(
             "Return the exact delta-matroid whose feasible sets are F symmetric "
             "difference X for each source feasible set F; the subset uses sorted "
-            "ground indices and the source must satisfy symmetric exchange."
+            "ground indices. Source and output families are admitted at 16,384 "
+            "memberships, 2,048 UTF-8 label bytes, and 250,000 symmetric-exchange "
+            "candidate checks."
         ),
         request_type=DeltaMatroidTwistRequest,
         result_type=FiniteDeltaMatroid,

--- a/src/jacobian/math/combinatorics/matroids/delta/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/operations.py
@@ -9,12 +9,12 @@ from jacobian.math.combinatorics.matroids.delta._models import (
 )
 from jacobian.math.combinatorics.matroids.delta.values import (
     MAX_DELTA_MEMBERSHIPS,
-    MAX_DELTA_WIDTH_ROWS,
     DeltaMatroidAdmissionError,
     FiniteDeltaMatroid,
     first_symmetric_exchange_obstruction,
     require_delta_matroid_admission,
     require_delta_matroid_envelope,
+    require_delta_matroid_exchange_work,
 )
 
 __all__ = [
@@ -63,11 +63,10 @@ def verify_from_feasible_sets(claim: DeltaMatroidRecognitionResult) -> bool:
     )
 
 
-def _require_delta_matroid(value: FiniteDeltaMatroid) -> None:
-    """Re-establish the source axiom before consuming a serialized claim."""
+def _require_delta_matroid_axiom(system: FiniteFeasibleSetSystem) -> None:
+    """Replay candidate-work and exchange after the source envelope is known."""
 
-    system = FiniteFeasibleSetSystem(ground=value.ground, feasible=value.feasible)
-    require_delta_matroid_admission(system)
+    require_delta_matroid_exchange_work(system)
     obstruction = first_symmetric_exchange_obstruction(system)
     if obstruction is not None:
         raise ValueError("source feasible family is not a delta-matroid")
@@ -98,7 +97,7 @@ def twist(
             "memberships_exceeded",
             "twisted feasible-family memberships exceed the output envelope",
         )
-    _require_delta_matroid(delta_matroid)
+    _require_delta_matroid_axiom(system)
     rows = tuple(
         sorted(
             tuple(sorted(frozenset(row) ^ twist_subset))
@@ -117,12 +116,5 @@ def twist(
 def width(delta_matroid: FiniteDeltaMatroid) -> int:
     """Return the delta-matroid width ``max |F| - min |F|``."""
 
-    row_count = len(delta_matroid.feasible)
-    if row_count > MAX_DELTA_WIDTH_ROWS:
-        raise DeltaMatroidAdmissionError(
-            "width_rows_exceeded",
-            "delta-matroid width row scan exceeds the "
-            f"{MAX_DELTA_WIDTH_ROWS}-row envelope",
-        )
     sizes = tuple(len(row) for row in delta_matroid.feasible)
     return max(sizes) - min(sizes)

--- a/src/jacobian/math/combinatorics/matroids/delta/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/operations.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from jacobian.math.combinatorics.greedoids.values import FiniteFeasibleSetSystem
 from jacobian.math.combinatorics.matroids.delta._models import (
     DeltaMatroidRecognitionResult,
+    DeltaMatroidTwistRequest,
+    DeltaMatroidTwistResult,
+    DeltaMatroidWidthRequest,
+    DeltaMatroidWidthResult,
 )
 from jacobian.math.combinatorics.matroids.delta.values import (
     FiniteDeltaMatroid,
@@ -12,7 +16,12 @@ from jacobian.math.combinatorics.matroids.delta.values import (
     require_delta_matroid_admission,
 )
 
-__all__ = ["from_feasible_sets", "verify_from_feasible_sets"]
+__all__ = [
+    "from_feasible_sets",
+    "twist",
+    "verify_from_feasible_sets",
+    "width",
+]
 
 
 def from_feasible_sets(
@@ -50,4 +59,56 @@ def verify_from_feasible_sets(claim: DeltaMatroidRecognitionResult) -> bool:
         claim.status == "DELTA_MATROID"
         and claim.obstruction is None
         and claim.delta_matroid == FiniteDeltaMatroid._from_kernel(claim.source)
+    )
+
+
+def _require_delta_matroid(value: FiniteDeltaMatroid) -> None:
+    """Re-establish the source axiom before consuming a serialized claim."""
+
+    system = FiniteFeasibleSetSystem(ground=value.ground, feasible=value.feasible)
+    require_delta_matroid_admission(system)
+    obstruction = first_symmetric_exchange_obstruction(system)
+    if obstruction is not None:
+        raise ValueError("source feasible family is not a delta-matroid")
+
+
+def twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
+    """Return the delta-matroid twist by ``subset``.
+
+    Feasible sets are transformed as ``F △ X``.  The source axiom is replayed
+    at this consumer boundary because a deserialized ``FiniteDeltaMatroid`` is
+    caller-authored rather than trusted producer output.
+    """
+
+    _require_delta_matroid(request.delta_matroid)
+    subset = frozenset(request.subset)
+    rows = tuple(
+        sorted(
+            tuple(sorted(frozenset(row) ^ subset))
+            for row in request.delta_matroid.feasible
+        )
+    )
+    twisted_system = FiniteFeasibleSetSystem(
+        ground=request.delta_matroid.ground,
+        feasible=rows,
+    )
+    # Twisting preserves symmetric exchange; replay the finite defining axiom
+    # before constructing the theorem-bearing canonical value.
+    twisted_obstruction = first_symmetric_exchange_obstruction(twisted_system)
+    if twisted_obstruction is not None:
+        raise ValueError("twist did not preserve symmetric exchange")
+    return DeltaMatroidTwistResult._from_kernel(
+        request,
+        FiniteDeltaMatroid._from_kernel(twisted_system),
+    )
+
+
+def width(request: DeltaMatroidWidthRequest) -> DeltaMatroidWidthResult:
+    """Return the delta-matroid width ``max |F| - min |F|``."""
+
+    _require_delta_matroid(request.delta_matroid)
+    sizes = tuple(len(row) for row in request.delta_matroid.feasible)
+    return DeltaMatroidWidthResult._from_kernel(
+        request,
+        max(sizes) - min(sizes),
     )

--- a/src/jacobian/math/combinatorics/matroids/delta/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/operations.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from jacobian.math.combinatorics.greedoids.values import FiniteFeasibleSetSystem
 from jacobian.math.combinatorics.matroids.delta._models import (
     DeltaMatroidRecognitionResult,
-    DeltaMatroidTwistRequest,
     DeltaMatroidTwistResult,
-    DeltaMatroidWidthRequest,
     DeltaMatroidWidthResult,
+    require_twist_subset,
 )
 from jacobian.math.combinatorics.matroids.delta.values import (
     MAX_DELTA_MEMBERSHIPS,
@@ -84,12 +83,12 @@ def twist(
     caller-authored rather than trusted producer output.
     """
 
-    request = DeltaMatroidTwistRequest(delta_matroid=delta_matroid, subset=subset)
-    _require_delta_matroid(request.delta_matroid)
-    twist_subset = frozenset(request.subset)
+    require_twist_subset(delta_matroid, subset)
+    _require_delta_matroid(delta_matroid)
+    twist_subset = frozenset(subset)
     projected_memberships = sum(
         len(row) + len(twist_subset) - 2 * len(twist_subset.intersection(row))
-        for row in request.delta_matroid.feasible
+        for row in delta_matroid.feasible
     )
     if projected_memberships > MAX_DELTA_MEMBERSHIPS:
         raise DeltaMatroidAdmissionError(
@@ -99,17 +98,18 @@ def twist(
     rows = tuple(
         sorted(
             tuple(sorted(frozenset(row) ^ twist_subset))
-            for row in request.delta_matroid.feasible
+            for row in delta_matroid.feasible
         )
     )
     twisted_system = FiniteFeasibleSetSystem(
-        ground=request.delta_matroid.ground,
+        ground=delta_matroid.ground,
         feasible=rows,
     )
     # Twisting preserves symmetric differences, hence symmetric exchange and
     # its candidate-work bound. The output membership bound was admitted above.
     return DeltaMatroidTwistResult._from_kernel(
-        request,
+        delta_matroid,
+        subset,
         FiniteDeltaMatroid._from_kernel(twisted_system),
     )
 
@@ -117,10 +117,9 @@ def twist(
 def width(delta_matroid: FiniteDeltaMatroid) -> DeltaMatroidWidthResult:
     """Return the delta-matroid width ``max |F| - min |F|``."""
 
-    request = DeltaMatroidWidthRequest(delta_matroid=delta_matroid)
-    _require_delta_matroid(request.delta_matroid)
-    sizes = tuple(len(row) for row in request.delta_matroid.feasible)
+    _require_delta_matroid(delta_matroid)
+    sizes = tuple(len(row) for row in delta_matroid.feasible)
     return DeltaMatroidWidthResult._from_kernel(
-        request,
+        delta_matroid,
         max(sizes) - min(sizes),
     )

--- a/src/jacobian/math/combinatorics/matroids/delta/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/operations.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from jacobian.math.combinatorics.greedoids.values import FiniteFeasibleSetSystem
 from jacobian.math.combinatorics.matroids.delta._models import (
     DeltaMatroidRecognitionResult,
-    DeltaMatroidTwistResult,
-    DeltaMatroidWidthResult,
     require_twist_subset,
 )
 from jacobian.math.combinatorics.matroids.delta.values import (
@@ -15,6 +13,7 @@ from jacobian.math.combinatorics.matroids.delta.values import (
     FiniteDeltaMatroid,
     first_symmetric_exchange_obstruction,
     require_delta_matroid_admission,
+    require_delta_matroid_envelope,
 )
 
 __all__ = [
@@ -75,7 +74,7 @@ def _require_delta_matroid(value: FiniteDeltaMatroid) -> None:
 
 def twist(
     delta_matroid: FiniteDeltaMatroid, subset: tuple[int, ...]
-) -> DeltaMatroidTwistResult:
+) -> FiniteDeltaMatroid:
     """Return the delta-matroid twist by ``subset``.
 
     Feasible sets are transformed as ``F △ X``.  The source axiom is replayed
@@ -107,19 +106,16 @@ def twist(
     )
     # Twisting preserves symmetric differences, hence symmetric exchange and
     # its candidate-work bound. The output membership bound was admitted above.
-    return DeltaMatroidTwistResult._from_kernel(
-        delta_matroid,
-        subset,
-        FiniteDeltaMatroid._from_kernel(twisted_system),
-    )
+    return FiniteDeltaMatroid._from_kernel(twisted_system)
 
 
-def width(delta_matroid: FiniteDeltaMatroid) -> DeltaMatroidWidthResult:
+def width(delta_matroid: FiniteDeltaMatroid) -> int:
     """Return the delta-matroid width ``max |F| - min |F|``."""
 
-    _require_delta_matroid(delta_matroid)
-    sizes = tuple(len(row) for row in delta_matroid.feasible)
-    return DeltaMatroidWidthResult._from_kernel(
-        delta_matroid,
-        max(sizes) - min(sizes),
+    require_delta_matroid_envelope(
+        FiniteFeasibleSetSystem(
+            ground=delta_matroid.ground, feasible=delta_matroid.feasible
+        )
     )
+    sizes = tuple(len(row) for row in delta_matroid.feasible)
+    return max(sizes) - min(sizes)

--- a/src/jacobian/math/combinatorics/matroids/delta/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/operations.py
@@ -14,6 +14,7 @@ from jacobian.math.combinatorics.matroids.delta.values import (
     FiniteDeltaMatroid,
     first_symmetric_exchange_obstruction,
     require_delta_matroid_admission,
+    require_delta_matroid_envelope,
 )
 
 __all__ = [
@@ -83,7 +84,10 @@ def twist(
     """
 
     require_twist_subset(delta_matroid, subset)
-    _require_delta_matroid(delta_matroid)
+    system = FiniteFeasibleSetSystem(
+        ground=delta_matroid.ground, feasible=delta_matroid.feasible
+    )
+    require_delta_matroid_envelope(system)
     twist_subset = frozenset(subset)
     projected_memberships = sum(
         len(row) + len(twist_subset) - 2 * len(twist_subset.intersection(row))
@@ -94,6 +98,7 @@ def twist(
             "memberships_exceeded",
             "twisted feasible-family memberships exceed the output envelope",
         )
+    _require_delta_matroid(delta_matroid)
     rows = tuple(
         sorted(
             tuple(sorted(frozenset(row) ^ twist_subset))

--- a/src/jacobian/math/combinatorics/matroids/delta/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/operations.py
@@ -11,6 +11,8 @@ from jacobian.math.combinatorics.matroids.delta._models import (
     DeltaMatroidWidthResult,
 )
 from jacobian.math.combinatorics.matroids.delta.values import (
+    MAX_DELTA_MEMBERSHIPS,
+    DeltaMatroidAdmissionError,
     FiniteDeltaMatroid,
     first_symmetric_exchange_obstruction,
     require_delta_matroid_admission,
@@ -82,6 +84,15 @@ def twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
 
     _require_delta_matroid(request.delta_matroid)
     subset = frozenset(request.subset)
+    projected_memberships = sum(
+        len(row) + len(subset) - 2 * len(subset.intersection(row))
+        for row in request.delta_matroid.feasible
+    )
+    if projected_memberships > MAX_DELTA_MEMBERSHIPS:
+        raise DeltaMatroidAdmissionError(
+            "memberships_exceeded",
+            "twisted feasible-family memberships exceed the output envelope",
+        )
     rows = tuple(
         sorted(
             tuple(sorted(frozenset(row) ^ subset))
@@ -92,11 +103,8 @@ def twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
         ground=request.delta_matroid.ground,
         feasible=rows,
     )
-    # Twisting preserves symmetric exchange; replay the finite defining axiom
-    # before constructing the theorem-bearing canonical value.
-    twisted_obstruction = first_symmetric_exchange_obstruction(twisted_system)
-    if twisted_obstruction is not None:
-        raise ValueError("twist did not preserve symmetric exchange")
+    # Twisting preserves symmetric differences, hence symmetric exchange and
+    # its candidate-work bound. The output membership bound was admitted above.
     return DeltaMatroidTwistResult._from_kernel(
         request,
         FiniteDeltaMatroid._from_kernel(twisted_system),

--- a/src/jacobian/math/combinatorics/matroids/delta/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/operations.py
@@ -74,7 +74,9 @@ def _require_delta_matroid(value: FiniteDeltaMatroid) -> None:
         raise ValueError("source feasible family is not a delta-matroid")
 
 
-def twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
+def twist(
+    delta_matroid: FiniteDeltaMatroid, subset: tuple[int, ...]
+) -> DeltaMatroidTwistResult:
     """Return the delta-matroid twist by ``subset``.
 
     Feasible sets are transformed as ``F △ X``.  The source axiom is replayed
@@ -82,10 +84,11 @@ def twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
     caller-authored rather than trusted producer output.
     """
 
+    request = DeltaMatroidTwistRequest(delta_matroid=delta_matroid, subset=subset)
     _require_delta_matroid(request.delta_matroid)
-    subset = frozenset(request.subset)
+    twist_subset = frozenset(request.subset)
     projected_memberships = sum(
-        len(row) + len(subset) - 2 * len(subset.intersection(row))
+        len(row) + len(twist_subset) - 2 * len(twist_subset.intersection(row))
         for row in request.delta_matroid.feasible
     )
     if projected_memberships > MAX_DELTA_MEMBERSHIPS:
@@ -95,7 +98,7 @@ def twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
         )
     rows = tuple(
         sorted(
-            tuple(sorted(frozenset(row) ^ subset))
+            tuple(sorted(frozenset(row) ^ twist_subset))
             for row in request.delta_matroid.feasible
         )
     )
@@ -111,9 +114,10 @@ def twist(request: DeltaMatroidTwistRequest) -> DeltaMatroidTwistResult:
     )
 
 
-def width(request: DeltaMatroidWidthRequest) -> DeltaMatroidWidthResult:
+def width(delta_matroid: FiniteDeltaMatroid) -> DeltaMatroidWidthResult:
     """Return the delta-matroid width ``max |F| - min |F|``."""
 
+    request = DeltaMatroidWidthRequest(delta_matroid=delta_matroid)
     _require_delta_matroid(request.delta_matroid)
     sizes = tuple(len(row) for row in request.delta_matroid.feasible)
     return DeltaMatroidWidthResult._from_kernel(

--- a/src/jacobian/math/combinatorics/matroids/delta/operations.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/operations.py
@@ -9,11 +9,11 @@ from jacobian.math.combinatorics.matroids.delta._models import (
 )
 from jacobian.math.combinatorics.matroids.delta.values import (
     MAX_DELTA_MEMBERSHIPS,
+    MAX_DELTA_WIDTH_ROWS,
     DeltaMatroidAdmissionError,
     FiniteDeltaMatroid,
     first_symmetric_exchange_obstruction,
     require_delta_matroid_admission,
-    require_delta_matroid_envelope,
 )
 
 __all__ = [
@@ -112,10 +112,12 @@ def twist(
 def width(delta_matroid: FiniteDeltaMatroid) -> int:
     """Return the delta-matroid width ``max |F| - min |F|``."""
 
-    require_delta_matroid_envelope(
-        FiniteFeasibleSetSystem(
-            ground=delta_matroid.ground, feasible=delta_matroid.feasible
+    row_count = len(delta_matroid.feasible)
+    if row_count > MAX_DELTA_WIDTH_ROWS:
+        raise DeltaMatroidAdmissionError(
+            "width_rows_exceeded",
+            "delta-matroid width row scan exceeds the "
+            f"{MAX_DELTA_WIDTH_ROWS}-row envelope",
         )
-    )
     sizes = tuple(len(row) for row in delta_matroid.feasible)
     return max(sizes) - min(sizes)

--- a/src/jacobian/math/combinatorics/matroids/delta/values.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/values.py
@@ -13,6 +13,7 @@ from jacobian.math.combinatorics.greedoids.values import FiniteFeasibleSetSystem
 MAX_DELTA_MEMBERSHIPS = 16_384
 MAX_DELTA_LABEL_BYTES = 2_048
 MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS = 250_000
+MAX_DELTA_WIDTH_ROWS = 16_384
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -191,6 +192,7 @@ __all__ = [
     "MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS",
     "MAX_DELTA_LABEL_BYTES",
     "MAX_DELTA_MEMBERSHIPS",
+    "MAX_DELTA_WIDTH_ROWS",
     "DeltaMatroidObstruction",
     "FiniteDeltaMatroid",
     "canonical_feasible_rows",

--- a/src/jacobian/math/combinatorics/matroids/delta/values.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/values.py
@@ -13,7 +13,6 @@ from jacobian.math.combinatorics.greedoids.values import FiniteFeasibleSetSystem
 MAX_DELTA_MEMBERSHIPS = 16_384
 MAX_DELTA_LABEL_BYTES = 2_048
 MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS = 250_000
-MAX_DELTA_WIDTH_ROWS = 16_384
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -111,12 +110,9 @@ def require_delta_matroid_envelope(system: FiniteFeasibleSetSystem) -> None:
         )
 
 
-def require_delta_matroid_admission(system: FiniteFeasibleSetSystem) -> None:
-    """Bound all work and the canonical recognition result before replay."""
+def require_delta_matroid_exchange_work(system: FiniteFeasibleSetSystem) -> None:
+    """Bound symmetric-exchange candidate work after the source envelope."""
 
-    require_delta_matroid_envelope(system)
-    # Every nonempty row carries at least one membership, so the membership
-    # envelope bounds the row count and keeps this ordered-pair scan bounded.
     _, candidate_space = _exchange_work(canonical_feasible_rows(system))
     if candidate_space > MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS:
         raise DeltaMatroidAdmissionError(
@@ -124,6 +120,13 @@ def require_delta_matroid_admission(system: FiniteFeasibleSetSystem) -> None:
             "delta-matroid symmetric-exchange candidate checks exceed the "
             f"{MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS}-check envelope",
         )
+
+
+def require_delta_matroid_admission(system: FiniteFeasibleSetSystem) -> None:
+    """Bound all work and the canonical recognition result before replay."""
+
+    require_delta_matroid_envelope(system)
+    require_delta_matroid_exchange_work(system)
 
 
 def first_symmetric_exchange_obstruction(
@@ -192,11 +195,11 @@ __all__ = [
     "MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS",
     "MAX_DELTA_LABEL_BYTES",
     "MAX_DELTA_MEMBERSHIPS",
-    "MAX_DELTA_WIDTH_ROWS",
     "DeltaMatroidObstruction",
     "FiniteDeltaMatroid",
     "canonical_feasible_rows",
     "first_symmetric_exchange_obstruction",
     "require_delta_matroid_admission",
     "require_delta_matroid_envelope",
+    "require_delta_matroid_exchange_work",
 ]

--- a/src/jacobian/math/combinatorics/matroids/delta/values.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/values.py
@@ -85,8 +85,8 @@ def _exchange_work(
     return instances, candidate_space
 
 
-def require_delta_matroid_admission(system: FiniteFeasibleSetSystem) -> None:
-    """Bound all work and the canonical recognition result before replay."""
+def require_delta_matroid_envelope(system: FiniteFeasibleSetSystem) -> None:
+    """Bound linear source size without replaying symmetric exchange."""
 
     memberships = sum(len(row) for row in system.feasible)
     if memberships > MAX_DELTA_MEMBERSHIPS:
@@ -108,6 +108,12 @@ def require_delta_matroid_admission(system: FiniteFeasibleSetSystem) -> None:
             "delta-matroid ground labels exceed the "
             f"{MAX_DELTA_LABEL_BYTES}-byte envelope",
         )
+
+
+def require_delta_matroid_admission(system: FiniteFeasibleSetSystem) -> None:
+    """Bound all work and the canonical recognition result before replay."""
+
+    require_delta_matroid_envelope(system)
     # Every nonempty row carries at least one membership, so the membership
     # envelope bounds the row count and keeps this ordered-pair scan bounded.
     _, candidate_space = _exchange_work(canonical_feasible_rows(system))
@@ -190,4 +196,5 @@ __all__ = [
     "canonical_feasible_rows",
     "first_symmetric_exchange_obstruction",
     "require_delta_matroid_admission",
+    "require_delta_matroid_envelope",
 ]

--- a/src/jacobian/math/combinatorics/matroids/delta/values.py
+++ b/src/jacobian/math/combinatorics/matroids/delta/values.py
@@ -10,7 +10,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._models import StrictModel
 from jacobian.math.combinatorics.greedoids.values import FiniteFeasibleSetSystem
 
-MAX_DELTA_MEMBERSHIPS = 1_024
+MAX_DELTA_MEMBERSHIPS = 16_384
 MAX_DELTA_LABEL_BYTES = 2_048
 MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS = 250_000
 
@@ -80,6 +80,8 @@ def _exchange_work(
             difference_size = len(left ^ right)
             instances += difference_size
             candidate_space += difference_size * difference_size
+            if candidate_space > MAX_DELTA_EXCHANGE_CANDIDATE_CHECKS:
+                return instances, candidate_space
     return instances, candidate_space
 
 

--- a/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
+++ b/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
@@ -38,9 +38,7 @@ def test_twist_transforms_feasible_sets_and_round_trips() -> None:
     request = DeltaMatroidTwistRequest(delta_matroid=source, subset=(0,))
     result = _twist(request)
 
-    assert result == FiniteDeltaMatroid(
-        ground=("a", "b"), feasible=((), (0,), (0, 1))
-    )
+    assert result == FiniteDeltaMatroid(ground=("a", "b"), feasible=((), (0,), (0, 1)))
     assert (
         DeltaMatroidTwistRequest.model_validate_json(request.model_dump_json())
         == request
@@ -342,9 +340,7 @@ def test_native_transforms_accept_canonical_mathematical_values() -> None:
     source = FiniteDeltaMatroid(ground=("a", "b"), feasible=((), (0,), (1,)))
     result = twist(source, (0,))
     assert result == _twist(DeltaMatroidTwistRequest(delta_matroid=source, subset=(0,)))
-    assert width(result) == _width(
-        DeltaMatroidWidthRequest(delta_matroid=result)
-    ).width
+    assert width(result) == _width(DeltaMatroidWidthRequest(delta_matroid=result)).width
     assert twist(result, (0,)) == source
 
 

--- a/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
+++ b/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
@@ -332,9 +332,18 @@ def test_dense_twist_composes_with_width_and_inverse_twist() -> None:
     )
 
 
-def test_twist_output_limit_remains_a_resource_refusal() -> None:
+def test_twist_output_limit_remains_a_resource_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from jacobian.catalog.models import OperationResourceAdmissionError
+    from jacobian.math.combinatorics.matroids.delta import operations
 
+    def fail_if_replayed(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("exchange replayed before output preflight")
+
+    monkeypatch.setattr(
+        operations, "first_symmetric_exchange_obstruction", fail_if_replayed
+    )
     source = FiniteDeltaMatroid(
         ground=tuple(f"e{i}" for i in range(129)),
         feasible=((), *tuple((i,) for i in range(129))),

--- a/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
+++ b/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
@@ -335,3 +335,15 @@ def test_twist_output_limit_remains_a_resource_refusal() -> None:
     )
     with pytest.raises(OperationResourceAdmissionError, match="memberships exceed"):
         _twist(DeltaMatroidTwistRequest(delta_matroid=source, subset=tuple(range(129))))
+
+
+def test_native_transforms_accept_canonical_mathematical_values() -> None:
+    from jacobian.math.combinatorics.matroids.delta import twist, width
+
+    source = FiniteDeltaMatroid(ground=("a", "b"), feasible=((), (0,), (1,)))
+    result = twist(source, (0,))
+    assert result == _twist(DeltaMatroidTwistRequest(delta_matroid=source, subset=(0,)))
+    assert width(result.twisted) == _width(
+        DeltaMatroidWidthRequest(delta_matroid=result.twisted)
+    )
+    assert twist(result.twisted, (0,)).twisted == source

--- a/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
+++ b/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
@@ -33,7 +33,16 @@ def test_catalog_contains_only_audited_agent_outcome() -> None:
     }
 
 
-def test_twist_transforms_feasible_sets_and_round_trips() -> None:
+def test_twist_request_publishes_admission_limits() -> None:
+    schema = DeltaMatroidTwistRequest.model_json_schema()
+    limits = schema["admission_limits"]
+    assert limits["max_feasible_set_memberships"] == 16_384
+    assert limits["max_ground_label_utf8_bytes"] == 2_048
+    assert limits["max_symmetric_exchange_candidate_checks_per_replay"] == 250_000
+    description = schema["properties"]["delta_matroid"]["description"]
+    assert "16384" in description.replace(",", "")
+    assert "2048" in description.replace(",", "")
+    assert "250000" in description.replace(",", "")
     source = FiniteDeltaMatroid(ground=("a", "b"), feasible=((), (0,), (1,)))
     request = DeltaMatroidTwistRequest(delta_matroid=source, subset=(0,))
     result = _twist(request)
@@ -358,3 +367,10 @@ def test_even_subset_width_uses_linear_admission() -> None:
         ),
     )
     assert width(source) == 8
+
+
+def test_width_ignores_recognition_label_envelope() -> None:
+    from jacobian.math.combinatorics.matroids.delta import width
+
+    source = FiniteDeltaMatroid(ground=("a" * 2049,), feasible=((),))
+    assert width(source) == 0

--- a/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
+++ b/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
@@ -30,7 +30,6 @@ def test_catalog_contains_only_audited_agent_outcome() -> None:
     assert {tool.operation_id for tool in TOOLS} == {
         "delta_matroid.from_feasible_sets.compute",
         "delta_matroid.twist.compute",
-        "delta_matroid.width.compute",
     }
 
 
@@ -39,7 +38,7 @@ def test_twist_transforms_feasible_sets_and_round_trips() -> None:
     request = DeltaMatroidTwistRequest(delta_matroid=source, subset=(0,))
     result = _twist(request)
 
-    assert result.twisted == FiniteDeltaMatroid(
+    assert result == FiniteDeltaMatroid(
         ground=("a", "b"), feasible=((), (0,), (0, 1))
     )
     assert (
@@ -317,11 +316,11 @@ def test_dense_twist_composes_with_width_and_inverse_twist() -> None:
     )
     subset = tuple(range(33))
     result = _twist(DeltaMatroidTwistRequest(delta_matroid=source, subset=subset))
-    restored = FiniteDeltaMatroid.model_validate_json(result.twisted.model_dump_json())
+    restored = FiniteDeltaMatroid.model_validate_json(result.model_dump_json())
     assert sum(map(len, restored.feasible)) == 1089
     assert _width(DeltaMatroidWidthRequest(delta_matroid=restored)).width == 1
     assert (
-        _twist(DeltaMatroidTwistRequest(delta_matroid=restored, subset=subset)).twisted
+        _twist(DeltaMatroidTwistRequest(delta_matroid=restored, subset=subset))
         == source
     )
 
@@ -343,7 +342,23 @@ def test_native_transforms_accept_canonical_mathematical_values() -> None:
     source = FiniteDeltaMatroid(ground=("a", "b"), feasible=((), (0,), (1,)))
     result = twist(source, (0,))
     assert result == _twist(DeltaMatroidTwistRequest(delta_matroid=source, subset=(0,)))
-    assert width(result.twisted) == _width(
-        DeltaMatroidWidthRequest(delta_matroid=result.twisted)
+    assert width(result) == _width(
+        DeltaMatroidWidthRequest(delta_matroid=result)
+    ).width
+    assert twist(result, (0,)) == source
+
+
+def test_even_subset_width_uses_linear_admission() -> None:
+    from jacobian.math.combinatorics.matroids.delta import width
+
+    source = FiniteDeltaMatroid(
+        ground=tuple(f"e{index}" for index in range(8)),
+        feasible=tuple(
+            sorted(
+                tuple(bit for bit in range(8) if (index >> bit) & 1)
+                for index in range(256)
+                if index.bit_count() % 2 == 0
+            )
+        ),
     )
-    assert twist(result.twisted, (0,)).twisted == source
+    assert width(source) == 8

--- a/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
+++ b/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
@@ -240,7 +240,7 @@ def test_request_schema_exposes_every_delta_specific_admission_limit() -> None:
     schema = DeltaMatroidFromFeasibleSetsRequest.model_json_schema()
 
     assert schema["admission_limits"] == {
-        "max_feasible_set_memberships": 1_024,
+        "max_feasible_set_memberships": 16_384,
         "max_ground_label_utf8_bytes": 2_048,
         "max_symmetric_exchange_candidate_checks_per_replay": 250_000,
     }
@@ -272,9 +272,9 @@ def test_short_row_family_beyond_any_row_cap_is_recognized() -> None:
     )
 
 
-def test_membership_envelope_rejects_wide_families_without_a_row_cap() -> None:
-    # Six hundred distinct pairs carry 1,200 memberships, past the membership
-    # envelope; rejection names the controlling quantity rather than a row cap.
+def test_exchange_envelope_rejects_wide_families_without_a_row_cap() -> None:
+    # Six hundred distinct pairs fit the membership envelope but exceed
+    # the symmetric-exchange candidate-work bound.
     feasible = []
     for index in range(25):
         for offset in range(1, 25):
@@ -285,7 +285,7 @@ def test_membership_envelope_rejects_wide_families_without_a_row_cap() -> None:
             feasible=tuple(feasible),
         )
     )
-    with pytest.raises(ValueError, match="memberships exceed"):
+    with pytest.raises(ValueError, match="candidate checks exceed"):
         _from_feasible_sets(request)
 
 
@@ -308,3 +308,30 @@ def test_native_admission_rejects_exchange_candidate_space_before_axiom_pass() -
     )
     with pytest.raises(ValueError, match="candidate checks exceed"):
         _from_feasible_sets(request)
+
+
+def test_dense_twist_composes_with_width_and_inverse_twist() -> None:
+    source = FiniteDeltaMatroid(
+        ground=tuple(f"e{i}" for i in range(33)),
+        feasible=((), *tuple((i,) for i in range(33))),
+    )
+    subset = tuple(range(33))
+    result = _twist(DeltaMatroidTwistRequest(delta_matroid=source, subset=subset))
+    restored = FiniteDeltaMatroid.model_validate_json(result.twisted.model_dump_json())
+    assert sum(map(len, restored.feasible)) == 1089
+    assert _width(DeltaMatroidWidthRequest(delta_matroid=restored)).width == 1
+    assert (
+        _twist(DeltaMatroidTwistRequest(delta_matroid=restored, subset=subset)).twisted
+        == source
+    )
+
+
+def test_twist_output_limit_remains_a_resource_refusal() -> None:
+    from jacobian.catalog.models import OperationResourceAdmissionError
+
+    source = FiniteDeltaMatroid(
+        ground=tuple(f"e{i}" for i in range(129)),
+        feasible=((), *tuple((i,) for i in range(129))),
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="memberships exceed"):
+        _twist(DeltaMatroidTwistRequest(delta_matroid=source, subset=tuple(range(129))))

--- a/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
+++ b/tests/math/combinatorics/matroids/delta/test_delta_matroids.py
@@ -10,8 +10,15 @@ from jacobian.math.combinatorics.matroids.delta import FiniteDeltaMatroid
 from jacobian.math.combinatorics.matroids.delta._models import (
     DeltaMatroidFromFeasibleSetsRequest,
     DeltaMatroidRecognitionResult,
+    DeltaMatroidTwistRequest,
+    DeltaMatroidWidthRequest,
 )
-from jacobian.math.combinatorics.matroids.delta._tools import TOOLS, _from_feasible_sets
+from jacobian.math.combinatorics.matroids.delta._tools import (
+    TOOLS,
+    _from_feasible_sets,
+    _twist,
+    _width,
+)
 
 
 def _two_element_delta_matroid(*, scrambled: bool = False) -> FiniteFeasibleSetSystem:
@@ -22,7 +29,37 @@ def _two_element_delta_matroid(*, scrambled: bool = False) -> FiniteFeasibleSetS
 def test_catalog_contains_only_audited_agent_outcome() -> None:
     assert {tool.operation_id for tool in TOOLS} == {
         "delta_matroid.from_feasible_sets.compute",
+        "delta_matroid.twist.compute",
+        "delta_matroid.width.compute",
     }
+
+
+def test_twist_transforms_feasible_sets_and_round_trips() -> None:
+    source = FiniteDeltaMatroid(ground=("a", "b"), feasible=((), (0,), (1,)))
+    request = DeltaMatroidTwistRequest(delta_matroid=source, subset=(0,))
+    result = _twist(request)
+
+    assert result.twisted == FiniteDeltaMatroid(
+        ground=("a", "b"), feasible=((), (0,), (0, 1))
+    )
+    assert (
+        DeltaMatroidTwistRequest.model_validate_json(request.model_dump_json())
+        == request
+    )
+
+
+def test_twist_rejects_forged_non_delta_source() -> None:
+    source = FiniteDeltaMatroid(ground=("a", "b", "c"), feasible=((), (0, 1), (2,)))
+    with pytest.raises(ValueError, match="source feasible family"):
+        _twist(DeltaMatroidTwistRequest(delta_matroid=source, subset=(1,)))
+
+
+def test_width_is_exact_and_preserves_source_binding() -> None:
+    source = FiniteDeltaMatroid(ground=("a", "b"), feasible=((), (0,), (0, 1), (1,)))
+    result = _width(DeltaMatroidWidthRequest(delta_matroid=source))
+    assert result.width == 2
+    assert result.delta_matroid == source
+    assert type(result.model_dump()["width"]) is int
 
 
 def test_complete_feasible_family_constructs_canonical_delta_matroid() -> None:

--- a/tests/math/combinatorics/matroids/delta/test_public_api.py
+++ b/tests/math/combinatorics/matroids/delta/test_public_api.py
@@ -9,5 +9,7 @@ def test_public_api_is_small_and_canonical() -> None:
     assert delta_matroids.__all__ == [
         "FiniteDeltaMatroid",
         "from_feasible_sets",
+        "twist",
         "verify_from_feasible_sets",
+        "width",
     ]


### PR DESCRIPTION
## Problem

Canonical finite delta-matroids need symmetric-difference twists and width calculations over their feasible families.

## Outcome

Adds twist by a sorted ground-index subset and width `max(|F|)-min(|F|)`, retaining the source and checking symmetric exchange before using caller-supplied families.

## Validation

- Hosted required CI passed on `b19dce2403212c6267520e940516401ee9c0a03a`.
- Focused local lint/type and regression checks passed. Final full validation is supplied by hosted CI; broad local catalog runs were interrupted under system memory pressure.
- Independent scoped review found no remaining actionable defects.

## Contract impact


New operation IDs:

- `delta_matroid.twist.compute`
- `delta_matroid.width.compute`

These declarations add to the catalog; they do not replace an existing operation ID.

## Review closure

- [x] Exact changed scope reviewed. Local validation evidence and gaps are listed above.
- [x] No unresolved findings from the scoped review.
- [x] CI evidence matches the final head.

## Operation boundary

Reuses finite-delta-matroid recognition with a 16,384-membership envelope, 2,048 ground-label bytes, and 250,000 symmetric-exchange candidate checks. Admission stops the candidate scan once over budget. Twist preflights output memberships and preserves the exchange axiom by symmetric-difference invariance; resource refusals retain their type.
