### PR TITLE
docs(math): qualify native admission migration guidance

### DIFF
--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -30,18 +30,22 @@ enumerate candidates, select a kernel, reserve result work, or retain an
 execution plan in a Pydantic private attribute. The owner admission function
 runs after parsing and is shared by native and MCP execution.
 
-Every native callable that backs a public operation is also an admission
-boundary. Python type annotations and Pydantic field declarations do not
-validate values supplied directly to that callable. Validate strict runtime
-types, shape, axes, domain, work, intermediate growth, and materialized output
-before indexing, unpacking, backend work, or result allocation. Equivalent
-native and catalog invocations must use the same owner admission helper.
-Expected invalid native values raise `OperationDomainValidationError` or the
-operation's declared subtype while preserving its stable owner code and
-domain/resource classification. Use `OperationResourceAdmissionError` when the
-operation contract distinguishes execution-envelope refusal from other domain
+When a native callable is being published or audited as the implementation of a
+public operation, treat it as the admission boundary. Python type annotations
+and Pydantic field declarations do not validate values supplied directly to
+that callable. The implementation must validate strict runtime types, shape,
+axes, domain, work, intermediate growth, and materialized output before
+indexing, unpacking, backend work, or result allocation. Equivalent native and
+catalog invocations must use the same owner admission helper. Expected invalid
+native values raise `OperationDomainValidationError` or the operation's
+declared subtype while preserving its stable owner code and domain/resource
+classification. Use `OperationResourceAdmissionError` when the operation
+contract distinguishes execution-envelope refusal from other domain
 rejections. Neither path may leak helper `ValueError`, `IndexError`,
-tuple-unpacking errors, or Pydantic validation exceptions.
+tuple-unpacking errors, or Pydantic validation exceptions. This is the
+migration target for public operations; legacy native-only helpers may still
+require migration and must not be described as satisfying this boundary until
+audited.
 
 Every built-in `MathTool` declaration must publish at least one small valid
 invocation example. An example is part of the public contract: it must validate

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -30,22 +30,24 @@ enumerate candidates, select a kernel, reserve result work, or retain an
 execution plan in a Pydantic private attribute. The owner admission function
 runs after parsing and is shared by native and MCP execution.
 
-When a native callable is being published or audited as the implementation of a
-public operation, treat it as the admission boundary. Python type annotations
-and Pydantic field declarations do not validate values supplied directly to
-that callable. The implementation must validate strict runtime types, shape,
-axes, domain, work, intermediate growth, and materialized output before
-indexing, unpacking, backend work, or result allocation. Equivalent native and
-catalog invocations must use the same owner admission helper. Expected invalid
-native values raise `OperationDomainValidationError` or the operation's
-declared subtype while preserving its stable owner code and domain/resource
-classification. Use `OperationResourceAdmissionError` when the operation
-contract distinguishes execution-envelope refusal from other domain
-rejections. Neither path may leak helper `ValueError`, `IndexError`,
-tuple-unpacking errors, or Pydantic validation exceptions. This is the
-migration target for public operations; legacy native-only helpers may still
-require migration and must not be described as satisfying this boundary until
-audited.
+Every native callable that backs a public operation is itself an admission
+boundary. Python type annotations and Pydantic field declarations do not
+validate values supplied directly to that callable. The implementation must
+validate strict runtime types, shape, axes, and domain; enforce the same
+owner-defined work and intermediate limits; and enforce the same exact-output
+or materialization bounds before indexing, unpacking, backend work, or result
+allocation. Equivalent native and catalog invocations must use the same owner
+admission helper. Expected invalid native values, shapes, axes, and dimensions
+raise `OperationDomainValidationError` or the operation's declared subtype
+while preserving its stable owner code and domain/resource classification. Use
+`OperationResourceAdmissionError` when the operation contract distinguishes
+execution-envelope refusal from other domain rejections. Neither path may leak
+helper `ValueError`, `IndexError`, tuple-unpacking errors, or Pydantic
+validation exceptions.
+
+Legacy native-only helpers that have not yet been audited may violate this
+boundary; each such violation is migration debt. Audit and repair them before
+publishing them as public-operation implementations.
 
 Every built-in `MathTool` declaration must publish at least one small valid
 invocation example. An example is part of the public contract: it must validate

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -64,20 +64,24 @@ than constructing a wire Pydantic model. Native and wire parity tests should
 assert equal exact results and typed outcomes, and should document any
 difference as an explicit transport-only constraint.
 
-When a native function is being published or audited as the implementation of a
-public operation, treat it as the admitted boundary. Its implementation must
-apply strict Python type and domain checks, the same owner-defined work and
-intermediate limits, and the same exact-output or materialization bounds before
-calling a backend or allocating expanded results. Put reusable admission in one
-owner helper used by native and catalog paths. Expected invalid values, shapes,
-axes, and dimensions produce `OperationDomainValidationError` or the
-operation's declared subtype while preserving its stable owner code and
-domain/resource classification. Use `OperationResourceAdmissionError` when the
-operation distinguishes execution-envelope refusal from other domain
-rejections. Neither path may leak raw `IndexError`, tuple-unpacking errors,
-helper `ValueError`, or Pydantic validation exceptions. This is the migration
-target for public operations; legacy native-only helpers may still require
-migration and must not be described as satisfying this boundary until audited.
+Every native callable that backs a public operation is itself an admission
+boundary. Python type annotations and Pydantic field declarations do not
+validate values supplied directly to that callable. The implementation must
+validate strict runtime types, shape, axes, and domain; enforce the same
+owner-defined work and intermediate limits; and enforce the same exact-output
+or materialization bounds before indexing, unpacking, backend work, or result
+allocation. Equivalent native and catalog invocations must use the same owner
+admission helper. Expected invalid native values, shapes, axes, and dimensions
+raise `OperationDomainValidationError` or the operation's declared subtype
+while preserving its stable owner code and domain/resource classification. Use
+`OperationResourceAdmissionError` when the operation contract distinguishes
+execution-envelope refusal from other domain rejections. Neither path may leak
+helper `ValueError`, `IndexError`, tuple-unpacking errors, or Pydantic
+validation exceptions.
+
+Legacy native-only helpers that have not yet been audited may violate this
+boundary; each such violation is migration debt. Audit and repair them before
+publishing them as public-operation implementations.
 
 Pydantic request models are transport contracts, not containers for hidden
 execution state. They may enforce typed shape, canonical representation, and

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -64,17 +64,20 @@ than constructing a wire Pydantic model. Native and wire parity tests should
 assert equal exact results and typed outcomes, and should document any
 difference as an explicit transport-only constraint.
 
-Every native function that backs a public operation is itself an admitted
-boundary. It applies strict Python type and domain checks, the same owner-defined
-work and intermediate limits, and the same exact-output or materialization
-bounds before calling a backend or allocating expanded results. Put reusable
-admission in one owner helper used by native and catalog paths. Expected invalid
-values, shapes, axes, and dimensions produce `OperationDomainValidationError`
-or the operation's declared subtype while preserving its stable owner code and
+When a native function is being published or audited as the implementation of a
+public operation, treat it as the admitted boundary. Its implementation must
+apply strict Python type and domain checks, the same owner-defined work and
+intermediate limits, and the same exact-output or materialization bounds before
+calling a backend or allocating expanded results. Put reusable admission in one
+owner helper used by native and catalog paths. Expected invalid values, shapes,
+axes, and dimensions produce `OperationDomainValidationError` or the
+operation's declared subtype while preserving its stable owner code and
 domain/resource classification. Use `OperationResourceAdmissionError` when the
 operation distinguishes execution-envelope refusal from other domain
 rejections. Neither path may leak raw `IndexError`, tuple-unpacking errors,
-helper `ValueError`, or Pydantic validation exceptions.
+helper `ValueError`, or Pydantic validation exceptions. This is the migration
+target for public operations; legacy native-only helpers may still require
+migration and must not be described as satisfying this boundary until audited.
 
 Pydantic request models are transport contracts, not containers for hidden
 execution state. They may enforce typed shape, canonical representation, and


### PR DESCRIPTION
## Problem

Merged #3659 documents strict admission behavior for native functions backing public operations, but its universal wording can imply that every legacy native helper already satisfies that contract. Some existing direct native calls still leak raw exceptions before owner admission.

## Change

- Qualify the Python API and domain-operation guidance to apply when a native function is being published or audited as a public-operation implementation.
- Explicitly identify the strict boundary language as a migration target.
- Warn that legacy native-only helpers must not be described as compliant until audited and migrated.

This is a documentation-only follow-up to merged PR #3659; no runtime, operation, schema, catalog, or MCP behavior changes.

## Validation

- `make docs-linkcheck`
- `git diff --check origin/main...HEAD`
- Final head: `8f3a1d96d`