### PR TITLE
perf(codes): admit generator reduction by matrix bounds

### DIFF
--- a/src/jacobian/math/combinatorics/codes/linear/operations.py
+++ b/src/jacobian/math/combinatorics/codes/linear/operations.py
@@ -31,7 +31,9 @@ from jacobian.math.combinatorics.codes.linear._models import (
     _validate_coordinate_axis,
 )
 from jacobian.math.combinatorics.codes.linear.values import (
+    MAX_LINEAR_CODE_DIMENSION,
     MAX_LINEAR_CODE_LENGTH,
+    MAX_LINEAR_FIELD_ORDER,
     PrimeFieldLinearEncoder,
 )
 from jacobian.math.matrices.finite_fields.linear_algebra import (
@@ -48,6 +50,20 @@ def _validate_prime_matrix(
 
     from sympy import isprime
 
+    if type(field_order) is not int or not 2 <= field_order <= MAX_LINEAR_FIELD_ORDER:
+        raise PydanticCustomError(
+            "code_linear.field_order_out_of_bounds",
+            "field_order must be between 2 and the supported prime-field bound",
+        )
+    if (
+        not isinstance(generator_matrix, tuple)
+        or not 1 <= len(generator_matrix) <= MAX_LINEAR_CODE_DIMENSION
+        or any(not isinstance(row, tuple) for row in generator_matrix)
+    ):
+        raise PydanticCustomError(
+            "code_linear.generator_matrix_row_count",
+            "generator matrix must contain a bounded nonempty tuple of rows",
+        )
     if not isprime(field_order):
         raise PydanticCustomError(
             "code_linear.field_order_must_be_prime", "field_order must be prime"
@@ -496,13 +512,9 @@ def from_generator(
         _validate_coordinate_axis(coordinate_axis, width=width)
     except PydanticCustomError as error:
         _domain_error(("generator_matrix", "coordinate_axis"), error)
-    if field_order ** len(generator_matrix) > MAX_CODEWORDS:
-        raise OperationDomainValidationError(
-            location=("generator_matrix",),
-            code="code_linear.generator_matrix_exceeds_exact_enumeration_bound",
-            message="generator matrix exceeds exact enumeration bound",
-        )
     matrix = [list(row) for row in generator_matrix]
+    # This operation reduces a bounded matrix; codeword enumeration is admitted
+    # separately by consumers that actually perform it.
     canonical = _canonical_generator(matrix, field_order)
     return FromGeneratorResult(
         encoder=_canonical_encoder(

--- a/src/jacobian/math/combinatorics/codes/linear/operations.py
+++ b/src/jacobian/math/combinatorics/codes/linear/operations.py
@@ -509,9 +509,17 @@ def from_generator(
 ) -> FromGeneratorResult:
     try:
         width = _validate_prime_matrix(field_order, generator_matrix)
+    except PydanticCustomError as error:
+        location = (
+            ("field_order",)
+            if error.type.startswith("code_linear.field_order_")
+            else ("generator_matrix",)
+        )
+        _domain_error(location, error)
+    try:
         _validate_coordinate_axis(coordinate_axis, width=width)
     except PydanticCustomError as error:
-        _domain_error(("generator_matrix", "coordinate_axis"), error)
+        _domain_error(("coordinate_axis",), error)
     matrix = [list(row) for row in generator_matrix]
     # This operation reduces a bounded matrix; codeword enumeration is admitted
     # separately by consumers that actually perform it.

--- a/tests/math/combinatorics/codes/linear/test_code_linear.py
+++ b/tests/math/combinatorics/codes/linear/test_code_linear.py
@@ -7,7 +7,9 @@ import pytest
 import sympy
 from pydantic import ValidationError
 
+from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.dispatch import invoke_operation
 from jacobian.math.combinatorics.codes.linear._models import (
     CodeEqualRequest,
     CodewordCheckRequest,
@@ -31,6 +33,7 @@ from jacobian.math.combinatorics.codes.linear._tools import (
     compute_shorten,
     compute_syndrome,
 )
+from jacobian.math.combinatorics.codes.linear.operations import from_generator
 from jacobian.math.combinatorics.codes.linear.values import PrimeFieldLinearEncoder
 
 
@@ -98,6 +101,114 @@ def test_from_generator_canonicalizes_dependent_rows() -> None:
     assert result.encoder.generator_matrix == ((1, 1),)
     assert result.encoder.message_axis == ("m0",)
     assert result.encoder.coordinate_axis == ("left", "right")
+
+
+@pytest.mark.parametrize(
+    ("field_order", "generator_matrix", "expected_generator"),
+    (
+        # This is the motivating regression: both 2**20 and 3**11 exceed the
+        # former enumeration cap, although row reduction establishes ranks 20
+        # and 1 respectively without enumerating a codeword.
+        (
+            2,
+            tuple(
+                tuple(int(row == column) for column in range(20)) for row in range(20)
+            ),
+            tuple(
+                tuple(int(row == column) for column in range(20)) for row in range(20)
+            ),
+        ),
+        (2, tuple((1,) + (0,) * 19 for _ in range(20)), ((1,) + (0,) * 19,)),
+        (
+            3,
+            tuple((value, 0, 0, 0) for value in (1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1)),
+            ((1, 0, 0, 0),),
+        ),
+        (2, tuple((0,) * 20 for _ in range(20)), ()),
+    ),
+)
+def test_from_generator_admits_large_row_presentations_by_rref_rank(
+    field_order: int,
+    generator_matrix: tuple[tuple[int, ...], ...],
+    expected_generator: tuple[tuple[int, ...], ...],
+) -> None:
+    coordinate_axis = tuple(f"x{index}" for index in range(len(generator_matrix[0])))
+    request = GeneratorMatrixRequest(
+        field_order=field_order,
+        generator_matrix=generator_matrix,
+        coordinate_axis=coordinate_axis,
+    )
+
+    # Native and declared public adapters establish the same canonical rowspace.
+    native = from_generator(field_order, generator_matrix, coordinate_axis)
+    public = compute_from_generator(request)
+    assert native == public
+    assert public.encoder.generator_matrix == expected_generator
+    assert public.encoder.codeword_count == field_order ** len(expected_generator)
+
+
+def test_from_generator_scale_regression_dispatches_and_composes() -> None:
+    identity = [[int(row == column) for column in range(20)] for row in range(20)]
+    payload = {
+        "field_order": 2,
+        "generator_matrix": identity,
+        "coordinate_axis": [f"x{index}" for index in range(20)],
+    }
+    dispatched = invoke_operation(
+        "code.linear.from_generator.compute", payload, Catalog.open()
+    )
+    assert dispatched.output is not None
+    produced = compute_from_generator(GeneratorMatrixRequest.model_validate(payload))
+    replayed = type(produced).model_validate(dispatched.output)
+    assert replayed == produced
+    assert replayed.encoder.codeword_count == 2**20
+
+    # The encoder remains a composable bounded matrix value even though a
+    # codeword-enumerating consumer would refuse this cardinality.
+    serialized_encoder = replayed.model_dump(mode="json")["encoder"]
+    dual = compute_dual_code(
+        DualCodeRequest.model_validate({"encoder": serialized_encoder})
+    )
+    parity = compute_parity_check(
+        ParityCheckRequest.model_validate({"encoder": serialized_encoder})
+    )
+    member = compute_codeword_check(
+        CodewordCheckRequest.model_validate(
+            {"encoder": serialized_encoder, "word": [1] + [0] * 19}
+        )
+    )
+    assert dual.encoder.generator_matrix == ()
+    assert parity.parity_check.rows == ()
+    assert member.is_member
+    assert member.coefficients == (1,) + (0,) * 19
+
+
+@pytest.mark.parametrize(
+    ("field_order", "generator_matrix", "coordinate_axis", "error"),
+    (
+        (2, (), (), "row_count"),
+        (2, tuple((1,) for _ in range(65)), ("x",), "row_count"),
+        (257, ((1,),), ("x",), "field_order_out_of_bounds"),
+    ),
+)
+def test_from_generator_native_admits_shape_before_rref(
+    field_order: int,
+    generator_matrix: tuple[tuple[int, ...], ...],
+    coordinate_axis: tuple[str, ...],
+    error: str,
+) -> None:
+    with _operation_error(error):
+        from_generator(field_order, generator_matrix, coordinate_axis)
+
+
+def test_from_generator_native_accepts_row_and_field_boundary() -> None:
+    result = from_generator(
+        251,
+        tuple((1,) for _ in range(64)),
+        ("x",),
+    )
+    assert result.encoder.field_order == 251
+    assert result.encoder.generator_matrix == ((1,),)
 
 
 def test_code_equal_admits_each_encoder_field_once(

--- a/tests/math/combinatorics/codes/linear/test_code_linear.py
+++ b/tests/math/combinatorics/codes/linear/test_code_linear.py
@@ -184,11 +184,18 @@ def test_from_generator_scale_regression_dispatches_and_composes() -> None:
 
 
 @pytest.mark.parametrize(
-    ("field_order", "generator_matrix", "coordinate_axis", "error"),
+    ("field_order", "generator_matrix", "coordinate_axis", "error", "location"),
     (
-        (2, (), (), "row_count"),
-        (2, tuple((1,) for _ in range(65)), ("x",), "row_count"),
-        (257, ((1,),), ("x",), "field_order_out_of_bounds"),
+        (2, (), (), "row_count", ("generator_matrix",)),
+        (2, tuple((1,) for _ in range(65)), ("x",), "row_count", ("generator_matrix",)),
+        (257, ((1,),), ("x",), "field_order_out_of_bounds", ("field_order",)),
+        (
+            2,
+            ((1,),),
+            (),
+            "coordinate_axis",
+            ("coordinate_axis",),
+        ),
     ),
 )
 def test_from_generator_native_admits_shape_before_rref(
@@ -196,9 +203,12 @@ def test_from_generator_native_admits_shape_before_rref(
     generator_matrix: tuple[tuple[int, ...], ...],
     coordinate_axis: tuple[str, ...],
     error: str,
+    location: tuple[str, ...],
 ) -> None:
-    with _operation_error(error):
+    with pytest.raises(OperationDomainValidationError) as exc_info:
         from_generator(field_order, generator_matrix, coordinate_axis)
+    assert error in exc_info.value.errors()[0]["type"]
+    assert exc_info.value.errors()[0]["loc"] == location
 
 
 def test_from_generator_native_accepts_row_and_field_boundary() -> None:


### PR DESCRIPTION
## Problem

`code.linear.from_generator.compute` rejected a 20×20 binary identity matrix because it priced all 2^20 codewords, although construction only reduces a matrix. Dependent and zero-row presentations had the same unnecessary restriction.

## Outcome

Admit generator construction by its matrix bounds and retain codeword limits in the operations that enumerate words. Native calls establish the prime-field range and nonempty ≤64-row shape before primality testing and row reduction. The canonical encoder and coordinate axes are preserved.

## Validation

All affected-plan checks passed: scoped Ruff/mypy, 74 linear-code tests, 160 catalog tests, and 966 catalog integration/example tests. The interrupted final integration stage was completed with `make test-integration TESTS=tests/integration/catalog/`.

The new public rank-20 regression fails on base `3f5f1334e` at the former enumeration guard. Tests independently check identity, dependent, ternary, and zero row spaces and serialize the encoder into dual, parity-check, and codeword consumers.

Final tested head: `0239f7c1f`.

## Contract impact

The existing operation accepts larger matrix presentations; IDs and wire fields are unchanged. Native malformed or over-limit presentations receive the owner's structured domain errors. At most 64×64 entries over GF(p), p≤251, reach row reduction; no codeword enumeration is introduced.

## Review closure

The complete diff and mathematical admission were independently reviewed. All selected validation stages cover the final code; hosted checks passed on the tested head (11 successful, 14 intentionally skipped).
