### PR TITLE
perf(graphs): decide equitable two-coloring by component balance

### DIFF
--- a/src/jacobian/math/graphs/coloring/equitable_k_coloring/operations.py
+++ b/src/jacobian/math/graphs/coloring/equitable_k_coloring/operations.py
@@ -18,7 +18,7 @@ __all__ = ["decide_equitable_k_coloring", "verify_equitable_coloring"]
 
 
 def _admit(graph: SimpleUndirectedGraph, k: int) -> None:
-    """Admit the bounded search once at the native operation boundary."""
+    """Admit the bounded generic-search or bipartite-DP envelope once."""
     if k <= 0:
         raise OperationDomainValidationError(
             location=("k",),
@@ -29,7 +29,7 @@ def _admit(graph: SimpleUndirectedGraph, k: int) -> None:
     needs_search = bool(graph.edges) and 0 < k < n and not _is_complete(graph) and k > 1
     if needs_search and (
         n > MAX_EQUITABLE_COLORING_SEARCH_DEPTH
-        or k**n > MAX_EQUITABLE_COLORING_SEARCH_NODES
+        or (k != 2 and k**n > MAX_EQUITABLE_COLORING_SEARCH_NODES)
     ):
         raise OperationDomainValidationError(
             location=("graph", "k"),
@@ -66,6 +66,8 @@ def decide_equitable_k_coloring(
     direct_result = _direct_result(graph, k)
     if direct_result is not None:
         return direct_result
+    if k == 2:
+        return _bipartite_equitable_result(graph)
     n = len(graph.vertices)
     if n > MAX_EQUITABLE_COLORING_SEARCH_DEPTH:
         raise OperationDomainValidationError(
@@ -76,6 +78,14 @@ def decide_equitable_k_coloring(
                 f"{MAX_EQUITABLE_COLORING_SEARCH_DEPTH} vertices"
             ),
         )
+    return _backtracking_result(graph, k)
+
+
+def _backtracking_result(
+    graph: SimpleUndirectedGraph, k: int
+) -> EquitableColoringResult:
+    """Run the admitted generic equitable-colouring search."""
+    n = len(graph.vertices)
     nx_graph: nx.Graph[str] = nx.Graph()
     for v in graph.vertices:
         nx_graph.add_node(v)
@@ -124,6 +134,82 @@ def decide_equitable_k_coloring(
     if result_colors is not None:
         return _result(graph, k, True, tuple(result_colors))
     return _result(graph, k, False)
+
+
+def _bipartite_equitable_result(
+    graph: SimpleUndirectedGraph,
+) -> EquitableColoringResult:
+    """Decide equitable 2-colourability from bipartite component orientations.
+
+    A connected bipartite component has exactly two proper 2-colourings, which
+    exchange its two bipartition classes.  Selecting one orientation per
+    component is therefore sufficient and necessary.  The dynamic program
+    records achievable size-zero classes, using at most ``n * (n + 1)``
+    states; the graph carrier bounds ``n`` by the admitted search depth.
+    A non-bipartite graph has no proper 2-colouring and therefore returns the
+    exact negative decision without entering the generic search.
+    """
+    vertices = graph.vertices
+    index_of = {vertex: index for index, vertex in enumerate(vertices)}
+    adjacency: list[list[int]] = [[] for _ in vertices]
+    for left, right in graph.edges:
+        left_index = index_of[left]
+        right_index = index_of[right]
+        adjacency[left_index].append(right_index)
+        adjacency[right_index].append(left_index)
+
+    parity = [-1] * len(vertices)
+    components: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    for start in range(len(vertices)):
+        if parity[start] != -1:
+            continue
+        parity[start] = 0
+        stack = [start]
+        sides: tuple[list[int], list[int]] = ([], [])
+        while stack:
+            vertex = stack.pop()
+            sides[parity[vertex]].append(vertex)
+            for neighbor in adjacency[vertex]:
+                if parity[neighbor] == -1:
+                    parity[neighbor] = 1 - parity[vertex]
+                    stack.append(neighbor)
+                elif parity[neighbor] == parity[vertex]:
+                    return _result(graph, 2, False)
+        components.append((tuple(sides[0]), tuple(sides[1])))
+
+    target_sizes = (len(vertices) // 2, (len(vertices) + 1) // 2)
+    reachable_sizes = {0}
+    predecessors: list[dict[int, tuple[int, bool]]] = []
+    for first_side, second_side in components:
+        next_predecessors: dict[int, tuple[int, bool]] = {}
+        for size in reachable_sizes:
+            next_predecessors.setdefault(size + len(first_side), (size, True))
+            next_predecessors.setdefault(size + len(second_side), (size, False))
+        predecessors.append(next_predecessors)
+        reachable_sizes = set(next_predecessors)
+
+    target = next(
+        (target for target in target_sizes if target in reachable_sizes),
+        None,
+    )
+    if target is None:
+        return _result(graph, 2, False)
+
+    orientations: list[bool] = []
+    for predecessor_map in reversed(predecessors):
+        target, first_is_zero = predecessor_map[target]
+        orientations.append(first_is_zero)
+    orientations.reverse()
+
+    coloring = [0] * len(vertices)
+    for (first_side, second_side), first_is_zero in zip(
+        components, orientations, strict=True
+    ):
+        for vertex in first_side:
+            coloring[vertex] = 0 if first_is_zero else 1
+        for vertex in second_side:
+            coloring[vertex] = 1 if first_is_zero else 0
+    return _result(graph, 2, True, tuple(coloring))
 
 
 def _direct_result(

--- a/tests/math/graphs/coloring/equitable_k_coloring/test_equitable_k_coloring.py
+++ b/tests/math/graphs/coloring/equitable_k_coloring/test_equitable_k_coloring.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from itertools import combinations, product
 
 import pytest
 
+from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.dispatch import invoke_operation
+from jacobian.math.graphs.coloring.equitable_k_coloring._models import (
+    EquitableColoringResult,
+)
 from jacobian.math.graphs.coloring.equitable_k_coloring.operations import (
     decide_equitable_k_coloring,
+    verify_equitable_coloring,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -72,11 +79,124 @@ def test_edgeless_graph_uses_direct_balanced_class_construction() -> None:
     assert result.coloring.coloring.count(1) == 10
 
 
-def test_exponential_search_is_rejected_before_backtracking() -> None:
-    graph = _graph([str(index) for index in range(20)], [["0", "1"]])
+def test_bipartite_path_above_generic_search_bound_is_accepted() -> None:
+    vertices = [f"v{index:03d}" for index in range(256)]
+    graph = _graph(
+        vertices, [[vertices[index], vertices[index + 1]] for index in range(255)]
+    )
 
-    with pytest.raises(OperationDomainValidationError, match="search bound"):
-        decide_equitable_k_coloring(graph, 2)
+    result = decide_equitable_k_coloring(graph, 2)
+
+    assert result.colorable
+    assert result.coloring is not None
+    assert result.coloring.coloring.count(0) == 128
+    assert result.coloring.coloring.count(1) == 128
+    assert verify_equitable_coloring(result)
+
+
+def test_bipartite_component_orientations_handle_disconnected_graphs_and_isolates() -> (
+    None
+):
+    graph = _graph(
+        ["a", "b", "c", "d", "e", "f"],
+        [["a", "b"], ["a", "c"], ["d", "e"]],
+    )
+
+    result = decide_equitable_k_coloring(graph, 2)
+
+    assert result.colorable
+    assert result.coloring is not None
+    assert result.coloring.coloring.count(0) == 3
+    assert result.coloring.coloring.count(1) == 3
+    assert verify_equitable_coloring(result)
+
+
+def test_bipartite_but_imbalanced_graph_is_not_equitably_two_colorable() -> None:
+    graph = _graph(
+        ["a", "b", "c", "d", "e", "f"],
+        [["a", "b"], ["a", "c"], ["a", "d"], ["a", "e"], ["a", "f"]],
+    )
+
+    result = decide_equitable_k_coloring(graph, 2)
+
+    assert not result.colorable
+    assert result.coloring is None
+
+
+def test_odd_cycle_is_not_two_colorable() -> None:
+    graph = _graph(
+        ["a", "b", "c", "d", "e"],
+        [["a", "b"], ["b", "c"], ["c", "d"], ["d", "e"], ["a", "e"]],
+    )
+
+    assert not decide_equitable_k_coloring(graph, 2).colorable
+
+
+def test_large_nonbipartite_graph_is_decided_without_generic_search() -> None:
+    vertices = tuple(f"v{index:03d}" for index in range(256))
+    graph = _graph(
+        vertices,
+        [
+            [vertices[0], vertices[1]],
+            [vertices[1], vertices[2]],
+            [vertices[0], vertices[2]],
+            *[[vertices[index], vertices[index + 1]] for index in range(2, 255)],
+        ],
+    )
+
+    result = decide_equitable_k_coloring(graph, 2)
+
+    assert not result.colorable
+    assert result.coloring is None
+
+
+def test_bipartite_decision_matches_independent_bruteforce_on_all_graphs_through_order_four() -> (
+    None
+):
+    for order in range(5):
+        vertices = tuple(chr(ord("a") + index) for index in range(order))
+        possible_edges = tuple(combinations(vertices, 2))
+        for edge_mask in range(1 << len(possible_edges)):
+            graph = SimpleUndirectedGraph(
+                vertices=vertices,
+                edges=tuple(
+                    edge
+                    for index, edge in enumerate(possible_edges)
+                    if edge_mask & (1 << index)
+                ),
+            )
+            expected = any(
+                max(colors.count(0), colors.count(1))
+                - min(colors.count(0), colors.count(1))
+                <= 1
+                and all(
+                    colors[vertices.index(left)] != colors[vertices.index(right)]
+                    for left, right in graph.edges
+                )
+                for colors in product((0, 1), repeat=order)
+            )
+            result = decide_equitable_k_coloring(graph, 2)
+            assert result.colorable is expected
+            if result.colorable:
+                assert verify_equitable_coloring(result)
+
+
+def test_public_tool_dispatch_serializes_and_verifies_newly_accepted_boundary() -> None:
+    vertices = tuple(f"v{index:03d}" for index in range(20))
+    graph = SimpleUndirectedGraph(
+        vertices=vertices,
+        edges=tuple((vertices[index], vertices[index + 1]) for index in range(19)),
+    )
+
+    dispatched = invoke_operation(
+        "graph.coloring.equitable_k_colorability.decide",
+        {"graph": graph.model_dump(mode="json"), "k": 2},
+        Catalog.open(),
+    )
+
+    decoded = EquitableColoringResult.model_validate(dispatched.output)
+    assert decoded.colorable
+    assert verify_equitable_coloring(decoded)
 
 
 def test_one_edge_k1_is_decided_without_recursion() -> None:


### PR DESCRIPTION
## Problem

`graph.coloring.equitable_k_colorability.decide` rejected a 20-vertex path for two colors because generic admission priced 2^20 assignments. The existing carrier supports 256 vertices.

## Outcome

For two colors, bipartition each component and use a dynamic program to choose component orientations whose color-class sizes differ by at most one. This decides the entire two-color case exactly in O(n² + m) work and O(n²) storage. Non-bipartite graphs return an exact negative. Higher palettes retain their existing bounded search.

## Validation

All affected-plan checks passed: scoped Ruff/mypy, 16 owner tests, 160 catalog tests, and 966 catalog integration/example tests. The interrupted final integration stage was completed with `make test-integration TESTS=tests/integration/catalog/`.

New public acceptance fails on base `3f5f1334e`. Tests include a 256-vertex path, a large odd-cycle graph, disconnected components, isolates, impossible balance, an independent exhaustive coloring oracle through order four, and dispatched JSON passed to the real verifier.

Final tested head: `d50e20b13`.

## Contract impact

No ID, request, or result fields change. The two-color execution envelope widens to the existing 256-vertex carrier. The dynamic program retains at most n(n+1) states, and witnesses retain the original vertex axis.

## Review closure

The complete diff was independently reviewed; the odd-cycle fallback finding was fixed and regression-tested. All selected validation stages cover the final code; hosted checks passed on the tested head (11 successful, 14 intentionally skipped).
