### PR TITLE
perf(combinatorics): count progression edges from torsion

### DIFF
--- a/src/jacobian/math/combinatorics/_progression_hypergraph_models.py
+++ b/src/jacobian/math/combinatorics/_progression_hypergraph_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from math import gcd, prod
+
 from jacobian._models import StrictModel
 from jacobian.math.combinatorics.finite_structures.hypergraphs._models import (
     MAX_VERTICES,
@@ -13,27 +15,37 @@ from jacobian.math.groups.finite_abelian import (
 )
 
 
-def _cyclic_progression_edge_count(group_order: int) -> int:
-    """Return the exact number of distinct 3-AP edges in ``Z/group_order Z``.
+def _torsion_cardinality(group: FiniteAbelianProductGroup, order: int) -> int:
+    """Return the cardinality of the subgroup killed by ``order``.
 
-    The ordered construction has two encodings for an ordinary edge.  When
-    three divides the group order, each coset of the order-three subgroup has
-    six encodings, so those exceptional edges require a correction.
+    In one cyclic factor ``Z/mZ``, precisely ``gcd(order, m)`` elements solve
+    ``order * x = 0``.  The product formula keeps this pre-enumeration count
+    exact without materializing any group elements.
     """
-    valid_differences = group_order - 2 if group_order % 2 == 0 else group_order - 1
-    ordered_progressions = group_order * valid_differences
-    edge_count = ordered_progressions // 2
-    if group_order % 3 == 0:
-        edge_count -= 2 * (group_order // 3)
-    return edge_count
+
+    return prod(gcd(order, modulus) for modulus in group.moduli)
 
 
 def progression_edge_bound(group: FiniteAbelianProductGroup) -> int:
-    """Return a sound pre-enumeration edge bound for the supplied group."""
+    """Return the exact number of nondegenerate unordered 3-AP edges.
 
-    if len(group.moduli) == 1:
-        return _cyclic_progression_edge_count(group.order)
-    return group.order * (group.order - 1) // 2
+    An ordered pair ``(a, d)`` yields a nondegenerate progression exactly when
+    ``2d != 0``, giving ``|G| (|G| - |G[2]|)`` encodings.  Such an edge has two
+    encodings from reversal, except when ``3d = 0``: its nonzero order-three
+    difference gives all three vertices as possible centers and therefore six
+    encodings.  There are ``|G| (|G[3]| - 1)`` encodings in that exceptional
+    class, so subtracting its two-encoding contribution and restoring its
+    six-encoding contribution gives the formula below.
+    """
+
+    group_order = group.order
+    two_torsion = _torsion_cardinality(group, 2)
+    three_torsion = _torsion_cardinality(group, 3)
+    ordinary_encodings = group_order * (group_order - two_torsion)
+    order_three_encodings = group_order * (three_torsion - 1)
+    return (
+        ordinary_encodings - order_three_encodings
+    ) // 2 + order_three_encodings // 6
 
 
 MAX_GROUP_ORDER = MAX_VERTICES

--- a/src/jacobian/math/combinatorics/operations.py
+++ b/src/jacobian/math/combinatorics/operations.py
@@ -473,8 +473,20 @@ def progression_hypergraph(
     coordinates = tuple(product(*(range(modulus) for modulus in group.moduli)))
     labels = {element: f"v{index}" for index, element in enumerate(coordinates)}
     edge_sets: set[frozenset[tuple[int, ...]]] = set()
+    # A step killed by two produces ``a, a + d, a`` and can never contribute
+    # an edge.  Filtering it first also makes elementary 2-groups linear in
+    # their retained vertex output instead of needlessly traversing |G|**2
+    # degenerate pairs.
+    nondegenerate_steps = tuple(
+        step
+        for step in coordinates
+        if any(
+            (2 * coordinate) % modulus
+            for coordinate, modulus in zip(step, group.moduli, strict=True)
+        )
+    )
     for start in coordinates:
-        for step in coordinates:
+        for step in nondegenerate_steps:
             progression = frozenset(
                 tuple(
                     (start[index] + multiple * step[index]) % group.moduli[index]

--- a/tests/math/combinatorics/test_progression_hypergraph.py
+++ b/tests/math/combinatorics/test_progression_hypergraph.py
@@ -1,17 +1,44 @@
 """Tests for 3-term progression hypergraph construction."""
 
+from itertools import product
+
 import pytest
 
 from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.combinatorics import progression_hypergraph
+from jacobian.math.combinatorics._progression_hypergraph import (
+    PROGRESSION_HYPERGRAPH_OPERATION,
+)
 from jacobian.math.combinatorics._progression_hypergraph_models import (
     MAX_GROUP_ORDER,
+    ProgressionHypergraphRequest,
+    ProgressionHypergraphResult,
+    progression_edge_bound,
 )
+from jacobian.math.combinatorics.finite_structures.hypergraphs import parameters
 from jacobian.math.groups.finite_abelian import FiniteAbelianProductGroup
 
 
 def _group(*moduli: int) -> FiniteAbelianProductGroup:
     return FiniteAbelianProductGroup(moduli=moduli)
+
+
+def _exhaustive_3term_edge_count(moduli: tuple[int, ...]) -> int:
+    """Independently enumerate unordered nondegenerate 3-AP vertex sets."""
+
+    elements = tuple(product(*(range(modulus) for modulus in moduli)))
+    edges = {
+        frozenset(
+            tuple(
+                (start[axis] + multiple * step[axis]) % moduli[axis]
+                for axis in range(len(moduli))
+            )
+            for multiple in range(3)
+        )
+        for start in elements
+        for step in elements
+    }
+    return sum(len(edge) == 3 for edge in edges)
 
 
 def test_z3() -> None:
@@ -65,6 +92,35 @@ def test_product_group_progressions_are_complete() -> None:
             )
             for middle, left, right in ((0, 1, 2), (1, 0, 2), (2, 0, 1))
         )
+
+
+@pytest.mark.parametrize(
+    "moduli",
+    ((2, 2), (2, 3), (3, 3), (4, 3), (5, 5), (2, 2, 3), (4, 4)),
+)
+def test_product_group_edge_bound_matches_independent_enumeration(
+    moduli: tuple[int, ...],
+) -> None:
+    """Mixed 2- and 3-torsion groups distinguish the edge multiplicities."""
+
+    assert progression_edge_bound(_group(*moduli)) == _exhaustive_3term_edge_count(
+        moduli
+    )
+
+
+def test_elementary_two_group_at_vertex_boundary_is_admitted_and_composable() -> None:
+    """The exact empty-edge output, rather than a dense proxy, controls admission."""
+
+    request = ProgressionHypergraphRequest(group=_group(*(2,) * 8))
+    result = PROGRESSION_HYPERGRAPH_OPERATION.run(request)
+
+    assert len(result.vertex_elements) == MAX_GROUP_ORDER
+    assert result.hypergraph.edges == ()
+    decoded = ProgressionHypergraphResult.model_validate_json(result.model_dump_json())
+    profile = parameters(decoded.hypergraph)
+    assert profile.vertex_count == MAX_GROUP_ORDER
+    assert profile.edge_count == 0
+    assert profile.total_incidences == 0
 
 
 def test_product_group_over_sound_edge_bound_is_rejected() -> None:


### PR DESCRIPTION
## Problem

`combinatorics.finite_abelian.3term_progression_hypergraph.construct` rejected C2^8 using a coarse pair bound, although every progression is degenerate and its exact output has 256 vertices and no edges.

## Outcome

Use the exact edge count for any finite abelian product G:

`|G|(|G|−|G[2]|)/2 − |G|(|G[3]|−1)/3`.

Two encodings represent ordinary edges; three-torsion edges have six encodings. Torsion cardinalities are products of gcds, so the count is available before enumeration. Filtering steps killed by two also makes elementary two-groups linear in their retained vertex output.

## Validation

All affected-plan checks passed: scoped Ruff/mypy, 1,648 combinatorics tests, 160 catalog tests, and 966 catalog integration/example tests. The interrupted final integration stage was completed with `make test-integration TESTS=tests/integration/catalog/`.

The new C2^8 public regression fails on base `3f5f1334e`. Mixed two-/three-torsion tests compare complete edge sets to independent enumeration; a separate exhaustive check covered 156 products. The accepted result survives JSON decoding into the hypergraph parameters consumer. Oversized exact output remains rejected.

Final tested head: `f6bef71eb`.

## Contract impact

IDs and wire fields are unchanged. The existing group-order and hypergraph output bounds remain; the pre-enumeration edge reservation becomes exact, and degenerate steps are omitted without weakening the result.

## Review closure

The complete diff and counting proof were independently reviewed. All selected validation stages cover the final code; hosted checks passed on the tested head (11 successful, 14 intentionally skipped).
