### PR TITLE
perf(polynomials): admit gradients by active derivative support

### DIFF
--- a/src/jacobian/math/polynomials/vector_calculus/operations.py
+++ b/src/jacobian/math/polynomials/vector_calculus/operations.py
@@ -62,17 +62,62 @@ def _admit_field_polynomial(
     )
 
 
+def _require_dense_scalar_derivative_budget(polynomial: RationalPolynomial) -> None:
+    """Bound one scalar polynomial assembled from all its partials.
+
+    The Laplacian and a directional derivative collect partials into one
+    polynomial, so their independent terms can remain distinct.  Keep their
+    existing conservative envelope separate from the gradient's vector-valued
+    support accounting.
+    """
+
+    if len(polynomial.polynomial.terms) * len(polynomial.variables) > _MAX_TERMS:
+        raise OperationDomainValidationError(
+            location=("polynomial",),
+            code="polynomial_vector_calc.derivative_term_budget",
+            message="scalar-field derivatives exceed the result-term budget",
+        )
+
+
+def _gradient_term_counts(polynomial: RationalPolynomial) -> tuple[int, ...]:
+    """Return the exact nonzero sparse support size of every partial derivative.
+
+    On one fixed axis the map ``e -> e - unit_axis`` is injective.  Since the
+    canonical source has nonzero rational coefficients, precisely its terms
+    with a positive exponent on that axis survive differentiation.  This
+    proves both the per-component and aggregate result counts before SymPy
+    conversion expands any expression.
+    """
+
+    return tuple(
+        sum(term.exponents[axis] > 0 for term in polynomial.polynomial.terms)
+        for axis in range(len(polynomial.variables))
+    )
+
+
 def _admit_scalar_field(polynomial: RationalPolynomial) -> None:
     _admit_field_polynomial(
         polynomial,
         label="scalar field",
         location=("polynomial",),
     )
-    if len(polynomial.polynomial.terms) * len(polynomial.variables) > _MAX_TERMS:
+    _require_dense_scalar_derivative_budget(polynomial)
+
+
+def _admit_gradient(polynomial: RationalPolynomial) -> None:
+    """Admit a scalar-field gradient using its retained sparse support."""
+
+    _admit_field_polynomial(
+        polynomial,
+        label="scalar field",
+        location=("polynomial",),
+    )
+    term_counts = _gradient_term_counts(polynomial)
+    if max(term_counts, default=0) > _MAX_TERMS or sum(term_counts) > _MAX_TERMS:
         raise OperationDomainValidationError(
             location=("polynomial",),
             code="polynomial_vector_calc.derivative_term_budget",
-            message="scalar-field derivatives exceed the result-term budget",
+            message="gradient derivatives exceed the result-term budget",
         )
 
 
@@ -127,7 +172,7 @@ def _expressions(
 
 
 def gradient(polynomial: RationalPolynomial) -> VectorResult:
-    _admit_scalar_field(polynomial)
+    _admit_gradient(polynomial)
     variables = polynomial.variables
     expression = rational_polynomial_to_sympy(polynomial).as_expr()
     return VectorResult._from_kernel(

--- a/tests/math/polynomials/vector_calculus/test_polynomial_vector_calc.py
+++ b/tests/math/polynomials/vector_calculus/test_polynomial_vector_calc.py
@@ -10,7 +10,9 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.dispatch import invoke_operation
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
     RationalPolynomialTerm,
@@ -78,6 +80,28 @@ def _polynomial(
     )
 
 
+def _termwise_gradient(
+    polynomial: RationalPolynomial,
+) -> tuple[RationalPolynomial, ...]:
+    """Compute the defining sparse partials without invoking the kernel."""
+
+    components: list[RationalPolynomial] = []
+    for axis in range(len(polynomial.variables)):
+        terms: dict[tuple[int, ...], Fraction] = {}
+        for term in polynomial.polynomial.terms:
+            exponent = term.exponents[axis]
+            if exponent == 0:
+                continue
+            derived_exponents = list(term.exponents)
+            derived_exponents[axis] -= 1
+            key = tuple(derived_exponents)
+            terms[key] = terms.get(key, Fraction()) + (
+                term.coefficient.as_fraction() * exponent
+            )
+        components.append(_polynomial(polynomial.variables, terms))
+    return tuple(components)
+
+
 def test_catalog_contains_only_audited_operations() -> None:
     assert {tool.operation_id for tool in TOOLS} == {
         "polynomial_field.scalar.gradient.compute",
@@ -114,6 +138,62 @@ def test_gradient_returns_composable_polynomials() -> None:
         _polynomial(("x", "y"), {(1, 0): 2}),
         _polynomial(("x", "y"), {(0, 1): 2}),
     )
+
+
+def test_gradient_admits_sparse_inactive_axes_beyond_dense_proxy() -> None:
+    """A vector result retains only the axes on which each monomial survives."""
+
+    variables = ("x", "a", "b", "c", "d", "e", "f", "g")
+    source = _polynomial(
+        variables,
+        {
+            (degree, 0, 0, 0, 0, 0, 0, 0): 10**127 if degree == 34 else 1
+            for degree in range(34, 1, -1)
+        },
+    )
+    expected_components = _termwise_gradient(source)
+
+    native = gradient(source)
+    assert native.components == expected_components
+    assert sum(len(component.polynomial.terms) for component in native.components) == 33
+    assert all(not component.polynomial.terms for component in native.components[1:])
+
+    public = invoke_operation(
+        "polynomial_field.scalar.gradient.compute",
+        {"polynomial": source.model_dump(mode="json")},
+        Catalog(TOOLS),
+    )
+    assert VectorResult.model_validate_json(json.dumps(public.output)) == native
+    assert verify_gradient(VectorResult.model_validate_json(native.model_dump_json()))
+
+
+def test_gradient_termwise_oracle_covers_mixed_axis_support() -> None:
+    source = _polynomial(
+        ("x", "y", "z"),
+        {
+            (2, 0, 1): 3,
+            (1, 1, 0): Fraction(5, 7),
+            (0, 4, 0): -2,
+        },
+    )
+
+    assert gradient(source).components == _termwise_gradient(source)
+
+
+def test_scalar_derivative_operations_keep_their_single_polynomial_budget() -> None:
+    """The gradient's sparse-vector estimate must not relax scalar assembly."""
+
+    variables = ("x", "a", "b", "c", "d", "e", "f", "g")
+    source = _polynomial(
+        variables,
+        {(degree, 0, 0, 0, 0, 0, 0, 0): 1 for degree in range(34, 1, -1)},
+    )
+    direction = tuple(CanonicalRational(num=1, den=1) for _ in variables)
+
+    with pytest.raises(OperationDomainValidationError, match="result-term budget"):
+        laplacian(source)
+    with pytest.raises(OperationDomainValidationError, match="result-term budget"):
+        directional_derivative(source, direction)
 
 
 def test_serialized_vector_calculus_claims_verify_retained_sources() -> None:


### PR DESCRIPTION
## Problem

`polynomial_field.scalar.gradient.compute` rejected a 33-term polynomial on eight axes because it reserved 264 derivative terms. When those terms involve only one axis, the exact gradient contains 33 terms and seven zero components.

## Outcome

Reserve gradient support per axis from positive exponents, then bound the total returned terms. Subtracting a unit exponent is injective on each partial's support, so these counts are exact. The maintained differentiation kernel and the scalar Laplacian/directional-derivative admission stay intact.

## Validation

`make affected AFFECTED_BASE=origin/main MATH_WORKERS=0` completed: scoped Ruff/mypy, 16 owner tests, 160 catalog tests, and 966 catalog integration/example tests.

The new regression fails on base `3f5f1334e` at the dense derivative budget. Independent termwise rational differentiation checks the accepted sparse case, mixed-axis terms, and a 129-digit derivative coefficient. Native and dispatched results survive JSON decoding and the real verifier.

Final tested head: `36ca13d13`.

## Contract impact

No operation IDs or wire fields change. Sparse gradients are admitted within the same 256-term aggregate output limit; scalar operations retain their existing envelope. Source axes and exact coefficients are preserved.

## Review closure

The complete diff and support-count argument were independently reviewed. All selected checks cover the final code; hosted checks passed on the tested head (11 successful, 14 intentionally skipped).
