### PR TITLE
fix(graphs): preserve degree axes in graph realization

### DIFF
--- a/src/jacobian/math/graphs/realization/operations.py
+++ b/src/jacobian/math/graphs/realization/operations.py
@@ -50,13 +50,25 @@ def graph_realization(sequence: DegreeSequence) -> GraphRealizationResult:
     degrees = sequence.degrees
     if not _is_graphical_erdos_gallai(degrees):
         return GraphRealizationResult(sequence=sequence, is_graphical=False)
-    graph = nx.havel_hakimi_graph(list(degrees))
+    # NetworkX's Havel--Hakimi implementation assigns its node labels only to
+    # nonzero entries in the input sequence.  Keep the public degree axis by
+    # mapping those compact labels back to their source positions; zero-degree
+    # positions remain isolated vertices of the returned indexed graph.
+    nonzero_positions = tuple(
+        index for index, degree in enumerate(degrees) if degree > 0
+    )
+    graph = nx.havel_hakimi_graph([degrees[index] for index in nonzero_positions])
     return GraphRealizationResult(
         sequence=sequence,
         is_graphical=True,
         graph=IndexedSimpleUndirectedGraph(
             vertex_count=len(degrees),
-            edges=tuple(sorted(tuple(sorted(edge)) for edge in graph.edges())),
+            edges=tuple(
+                sorted(
+                    tuple(sorted((nonzero_positions[left], nonzero_positions[right])))
+                    for left, right in graph.edges()
+                )
+            ),
         ),
     )
 

--- a/tests/math/graphs/test_graph_realization.py
+++ b/tests/math/graphs/test_graph_realization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from itertools import product
 
 import pytest
 from pydantic import ValidationError
@@ -139,6 +140,21 @@ class TestIsGraphical:
 
 
 class TestGraphRealization:
+    def test_realization_preserves_unsorted_degree_axis_with_isolate(self) -> None:
+        result = _realize([0, 1, 1])
+
+        assert result.is_graphical is True
+        assert result.graph is not None
+        assert result.graph.edges == ((1, 2),)
+        assert verify_graph_realization(
+            GraphRealizationResult.model_validate_json(result.model_dump_json())
+        )
+        checked = _check([0, 1, 1], 3, list(result.graph.edges))
+        assert checked.is_realization is True
+        assert verify_realization_check(
+            RealizationCheckResult.model_validate_json(checked.model_dump_json())
+        )
+
     def test_realizes_simple_path(self) -> None:
         result = _realize([1, 2, 2, 1])
         assert result.is_graphical is True
@@ -348,6 +364,54 @@ class TestRealizationCheck:
 
 
 class TestCrossConsistency:
+    def test_all_small_degree_axes_are_realized_on_their_original_indices(self) -> None:
+        """Compare construction to independently enumerated simple graphs."""
+
+        for vertex_count in range(1, 6):
+            edges = [
+                (left, right)
+                for left in range(vertex_count)
+                for right in range(left + 1, vertex_count)
+            ]
+            graphical_profiles = {
+                tuple(
+                    sum(vertex in edge for edge in selected_edges)
+                    for vertex in range(vertex_count)
+                )
+                for mask in range(1 << len(edges))
+                for selected_edges in (
+                    tuple(
+                        edge for index, edge in enumerate(edges) if mask & (1 << index)
+                    ),
+                )
+            }
+            for degrees in product(range(vertex_count), repeat=vertex_count):
+                realized = _realize(list(degrees))
+                assert realized.is_graphical == (degrees in graphical_profiles)
+                if realized.graph is None:
+                    continue
+                actual = tuple(
+                    sum(vertex in edge for edge in realized.graph.edges)
+                    for vertex in range(vertex_count)
+                )
+                assert actual == degrees
+                assert verify_graph_realization(realized)
+
+    def test_maximum_length_degree_axis_preserves_isolates_and_equal_degrees(
+        self,
+    ) -> None:
+        degrees = [0, *([2] * 62), 0]
+        realized = _realize(degrees)
+
+        assert realized.is_graphical is True
+        assert realized.graph is not None
+        actual = [0] * len(degrees)
+        for left, right in realized.graph.edges:
+            actual[left] += 1
+            actual[right] += 1
+        assert actual == degrees
+        assert verify_graph_realization(realized)
+
     def test_serialized_claim_verifiers_replay_retained_context(self) -> None:
         profile = _is_graphical([1, 2, 2, 1])
         assert verify_degree_sequence_profile(


### PR DESCRIPTION
## Problem

`graph.realization.construct.compute` returned edge (0,1) for degree sequence (0,1,1), producing degrees (1,1,0). The backend compacts nonzero entries, while the returned indexed graph claims the caller's original degree axis.

## Outcome

Run Havel–Hakimi on the nonzero subsequence and map its endpoints back to their original positions. Zero-degree positions remain isolated and every returned vertex has the requested degree.

## Validation

All affected-plan checks passed: scoped Ruff/mypy, 1,475 graph tests, 160 catalog tests, and 966 catalog integration/example tests. Interrupted stages were resumed through the same selected owner and catalog commands.

The new (0,1,1) regression fails on base `3f5f1334e` with the wrong edge. Tests independently enumerate graphical profiles through order five, cover 64 vertices with isolates and repeated degrees, and serialize the result into the real realization checker. An additional independent check reconstructed degree axes for 33,867 labelled graphs through order six.

Final tested head: `cf302a993`.

## Contract impact

IDs and wire fields are unchanged. The returned graph now satisfies its advertised indexed-degree relation. The existing 64-vertex envelope and maintained backend remain, with a linear coordinate map.

## Review closure

The complete diff was independently reviewed. All selected validation stages cover the final code; hosted checks passed on the tested head (11 successful, 14 intentionally skipped).
