### PR TITLE
fix(codes): defer canonicalization orbit expansion (follow-up)

### DIFF
--- a/src/jacobian/math/combinatorics/codes/linear/_canonicalization.py
+++ b/src/jacobian/math/combinatorics/codes/linear/_canonicalization.py
@@ -4,7 +4,8 @@ from itertools import permutations
 from math import factorial
 from typing import Literal, Self
 
-from pydantic import model_validator
+from pydantic import StrictInt, model_validator
+from pydantic_core import PydanticCustomError
 from sympy import isprime
 
 from jacobian._exact import ExactInteger
@@ -44,10 +45,70 @@ class LinearCodeCanonicalizationRequest(StrictModel):
 class LinearCodeCanonicalizationResult(StrictModel):
     source: LinearCodeCanonicalizationRequest
     canonical_encoder: PrimeFieldLinearEncoder
-    transporter: tuple[int, ...]
+    transporter: tuple[StrictInt, ...]
     transported_axis: tuple[str, ...]
     orbit_size: ExactInteger
     stabilizer_size: ExactInteger
+
+    @model_validator(mode="after")
+    def require_structural_canonicalization(self) -> Self:
+        """Check result wiring without replaying finite-field elimination."""
+
+        source_encoder = self.source.encoder
+        width = len(source_encoder.coordinate_axis)
+        if len(self.transporter) != width or sorted(self.transporter) != list(
+            range(width)
+        ):
+            raise PydanticCustomError(
+                "code_linear.canonicalization_transporter_not_permutation",
+                "transporter must be a permutation of the source coordinates",
+            )
+        expected_axis = tuple(
+            source_encoder.coordinate_axis[index] for index in self.transporter
+        )
+        if self.transported_axis != expected_axis:
+            raise PydanticCustomError(
+                "code_linear.canonicalization_transported_axis_mismatch",
+                "transported axis must follow the transporter",
+            )
+        if self.canonical_encoder.field_order != source_encoder.field_order:
+            raise PydanticCustomError(
+                "code_linear.canonicalization_field_mismatch",
+                "canonical encoder must retain the source field",
+            )
+        if self.canonical_encoder.coordinate_axis != self.transported_axis:
+            raise PydanticCustomError(
+                "code_linear.canonicalization_axis_mismatch",
+                "canonical encoder must retain the transported coordinate axis",
+            )
+        if len(self.canonical_encoder.generator_matrix) != len(
+            source_encoder.generator_matrix
+        ):
+            raise PydanticCustomError(
+                "code_linear.canonicalization_dimension_mismatch",
+                "canonical encoder must retain the source dimension",
+            )
+        if self.canonical_encoder.message_axis != tuple(
+            f"m{index}" for index in range(len(self.canonical_encoder.generator_matrix))
+        ):
+            raise PydanticCustomError(
+                "code_linear.canonicalization_message_axis",
+                "canonical encoder message labels must be m0, m1, and so on",
+            )
+        if self.orbit_size < 1 or self.stabilizer_size < 1:
+            raise PydanticCustomError(
+                "code_linear.canonicalization_orbit_stabilizer_positive",
+                "orbit and stabilizer sizes must be positive",
+            )
+        if (
+            self.orbit_size * self.stabilizer_size
+            > MAX_CODE_CANONICALIZATION_ACTION_ORDER
+        ):
+            raise PydanticCustomError(
+                "code_linear.canonicalization_orbit_stabilizer_bound",
+                "orbit-stabilizer product exceeds the admitted action bound",
+            )
+        return self
 
 
 def _rref(
@@ -93,7 +154,7 @@ def canonicalize_linear_code(
                 code="code.canonicalization.factorial_bound",
                 message="full symmetric coordinate action exceeds its factorial bound",
             )
-        elements = tuple(permutations(range(width)))
+        backend = None
     else:
         assert request.permutation_group is not None
         backend = _backend_group(request.permutation_group)
@@ -104,17 +165,24 @@ def canonicalize_linear_code(
                 code="code.canonicalization.group_order_bound",
                 message="generated coordinate group exceeds its enumeration bound",
             )
-        elements = tuple(
-            sorted(
-                _full_permutation_form(element, width) for element in backend.elements
-            )
-        )
     work = order * max(1, len(encoder.message_axis)) * max(1, width * width)
     if work > MAX_CODE_CANONICALIZATION_RREF_WORK:
         raise OperationResourceAdmissionError(
             location=("encoder",),
             code="code.canonicalization.rref_work_bound",
             message="coordinate-action RREF traversal exceeds its admitted work bound",
+        )
+    # Do not materialize an action orbit until the complete traversal has been
+    # admitted. In particular, S_10 has 3.6M elements but is rejected by the
+    # RREF-work bound for every nontrivial encoder before tuple construction.
+    if request.action == "FULL_SYMMETRIC":
+        elements = tuple(permutations(range(width)))
+    else:
+        assert backend is not None
+        elements = tuple(
+            sorted(
+                _full_permutation_form(element, width) for element in backend.elements
+            )
         )
     candidates: list[
         tuple[tuple[tuple[int, ...], ...], tuple[int, ...], tuple[str, ...]]

--- a/tests/math/combinatorics/codes/linear/test_canonicalization.py
+++ b/tests/math/combinatorics/codes/linear/test_canonicalization.py
@@ -1,7 +1,13 @@
 """Prime-field linear-code canonicalization tests."""
 
+import pytest
+from pydantic import ValidationError
+
+from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.combinatorics.codes.linear import _canonicalization
 from jacobian.math.combinatorics.codes.linear._canonicalization import (
     LinearCodeCanonicalizationRequest,
+    LinearCodeCanonicalizationResult,
     canonicalize_linear_code,
 )
 from jacobian.math.combinatorics.codes.linear._models import GeneratorMatrixRequest
@@ -86,3 +92,32 @@ def test_zero_code_and_full_space_keep_degenerate_rref_shapes() -> None:
     assert full_result.canonical_encoder.generator_matrix == ((1, 0), (0, 1))
     assert full_result.orbit_size == 1
     assert full_result.stabilizer_size == 2
+
+
+def test_structural_result_validation_does_not_accept_a_bad_transporter() -> None:
+    source = _encoder()
+    result = canonicalize_linear_code(LinearCodeCanonicalizationRequest(encoder=source))
+    payload = result.model_dump()
+    payload["transporter"] = (0, 0, 1)
+    with pytest.raises(ValidationError):
+        LinearCodeCanonicalizationResult.model_validate(payload)
+
+
+def test_full_symmetric_action_is_admitted_before_orbit_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = PrimeFieldLinearEncoder(
+        field_order=2,
+        message_axis=("m",),
+        coordinate_axis=tuple(f"x{index}" for index in range(10)),
+        generator_matrix=((1, 0, 0, 0, 0, 0, 0, 0, 0, 0),),
+    )
+
+    def orbit_must_not_be_materialized(_width: int) -> object:
+        raise AssertionError("permutation orbit was materialized before admission")
+
+    monkeypatch.setattr(
+        _canonicalization, "permutations", orbit_must_not_be_materialized
+    )
+    with pytest.raises(OperationResourceAdmissionError):
+        canonicalize_linear_code(LinearCodeCanonicalizationRequest(encoder=source))

--- a/tests/math/combinatorics/codes/linear/test_canonicalization.py
+++ b/tests/math/combinatorics/codes/linear/test_canonicalization.py
@@ -103,6 +103,27 @@ def test_structural_result_validation_does_not_accept_a_bad_transporter() -> Non
         LinearCodeCanonicalizationResult.model_validate(payload)
 
 
+def test_result_round_trip_keeps_transporter_composable() -> None:
+    source = _encoder()
+    result = canonicalize_linear_code(LinearCodeCanonicalizationRequest(encoder=source))
+    decoded = LinearCodeCanonicalizationResult.model_validate_json(
+        result.model_dump_json()
+    )
+    assert decoded == result
+    permuted = tuple(
+        tuple(row[index] for index in decoded.transporter)
+        for row in source.generator_matrix
+    )
+    replayed = compute_from_generator(
+        GeneratorMatrixRequest(
+            field_order=source.field_order,
+            generator_matrix=permuted,
+            coordinate_axis=decoded.transported_axis,
+        )
+    )
+    assert replayed.encoder == decoded.canonical_encoder
+
+
 def test_full_symmetric_action_is_admitted_before_orbit_materialization(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -121,3 +142,40 @@ def test_full_symmetric_action_is_admitted_before_orbit_materialization(
     )
     with pytest.raises(OperationResourceAdmissionError):
         canonicalize_linear_code(LinearCodeCanonicalizationRequest(encoder=source))
+
+
+def test_supplied_action_is_admitted_before_orbit_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = PrimeFieldLinearEncoder(
+        field_order=2,
+        message_axis=("m",),
+        coordinate_axis=tuple(f"x{index}" for index in range(64)),
+        generator_matrix=((1,) + (0,) * 63,),
+    )
+
+    def cycle(start: int, length: int) -> tuple[int, ...]:
+        permutation = list(range(64))
+        for offset in range(length):
+            permutation[start + offset] = start + (offset + 1) % length
+        return tuple(permutation)
+
+    generators = (*tuple(cycle(5 * block, 5) for block in range(6)), cycle(30, 2))
+    group = PermutationGroup(degree=64, generators=generators)
+
+    def orbit_must_not_be_materialized(_element: object, _width: int) -> object:
+        raise AssertionError(
+            "supplied permutation orbit was materialized before admission"
+        )
+
+    monkeypatch.setattr(
+        _canonicalization, "_full_permutation_form", orbit_must_not_be_materialized
+    )
+    with pytest.raises(OperationResourceAdmissionError):
+        canonicalize_linear_code(
+            LinearCodeCanonicalizationRequest(
+                encoder=source,
+                action="SUPPLIED_GROUP",
+                permutation_group=group,
+            )
+        )


### PR DESCRIPTION
Related #3597; Follow-up to #3639.

## Scope

This follow-up closes the admission and structural-validation slice around prime-field linear-code coordinate canonicalization:

- defer full-symmetric and supplied-group permutation orbit materialization until action-order and RREF-work admission passes;
- validate transporter permutation shape, transported-axis alignment, source field/axis context, canonical dimension/message labels, and bounded result scalars without replaying finite-field elimination;
- preserve typed composition through JSON serialization and the existing generator operation.

This is a bounded follow-up to the merged row-reduction change. It does not claim closure of the broader #3597 request (which remains open).

## Evidence

- `3a3c93afff097a1495ad282baf536c7befc407c7` — implementation and structural validation.
- `29acff3a46a53ade79748baad50c9ce15ef89bcd` — supplied/full admission regressions and serialized composition test.
- `make affected AFFECTED_BASE=origin/main` passed after fetch: Ruff, mypy, and 69 linear-code tests.
- Focused math validation passed: 8 canonicalization tests.

No operation IDs were added or removed.