### PR TITLE
perf(number-theory): aggregate congruence boxes by residue

### DIFF
--- a/src/jacobian/math/number_theory/counting/_models.py
+++ b/src/jacobian/math/number_theory/counting/_models.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Annotated, Self
 
 from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._exact import ExactInteger
+from jacobian._exact import DecimalIntegerEncoding, ExactInteger
 from jacobian._models import StrictModel
 
 # The floor-sum kernel is the Euclidean-like recursion (O(log m * log a/m)
@@ -17,9 +17,19 @@ from jacobian._models import StrictModel
 # the exact output digits.
 _MAX_FLOOR_SUM_N = 10**15
 _MAX_FLOOR_SUM_PARAM = 1_000_000
-_MAX_BOX_COORD = 10_000
+# The residue aggregation kernel visits one class modulo ``modulus``, not one
+# lattice point or coordinate value.  Thirty-two decimal digits leave a
+# compact, explicit bound for both the endpoint arithmetic and the exact
+# count: a box has fewer than 4 * 10**64 points.
+_MAX_BOX_COORD_DIGITS = 32
 _MAX_BOX_LINEAR_COEFFICIENT = 10**15
 _MAX_BOX_MODULUS = 10_000
+
+BoxCoordinate = Annotated[int, DecimalIntegerEncoding(max_digits=_MAX_BOX_COORD_DIGITS)]
+_BOX_COORDINATE_DESCRIPTION = (
+    "Exact signed coordinate with at most 32 decimal digits; use a canonical "
+    "decimal string in JSON."
+)
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -60,10 +70,10 @@ class FloorSumResult(StrictModel):
 class CongruenceBoxCountRequest(StrictModel):
     """Count lattice points in a box satisfying a linear congruence."""
 
-    x_lo: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
-    x_hi: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
-    y_lo: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
-    y_hi: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
+    x_lo: BoxCoordinate = Field(description=_BOX_COORDINATE_DESCRIPTION)
+    x_hi: BoxCoordinate = Field(description=_BOX_COORDINATE_DESCRIPTION)
+    y_lo: BoxCoordinate = Field(description=_BOX_COORDINATE_DESCRIPTION)
+    y_hi: BoxCoordinate = Field(description=_BOX_COORDINATE_DESCRIPTION)
     u: int = Field(
         ge=-_MAX_BOX_LINEAR_COEFFICIENT,
         le=_MAX_BOX_LINEAR_COEFFICIENT,
@@ -90,14 +100,14 @@ class CongruenceBoxCountRequest(StrictModel):
 class CongruenceBoxCountResult(StrictModel):
     """Count and residue-class ledger."""
 
-    x_lo: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
-    x_hi: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
-    y_lo: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
-    y_hi: int = Field(ge=-_MAX_BOX_COORD, le=_MAX_BOX_COORD)
+    x_lo: BoxCoordinate = Field(description=_BOX_COORDINATE_DESCRIPTION)
+    x_hi: BoxCoordinate = Field(description=_BOX_COORDINATE_DESCRIPTION)
+    y_lo: BoxCoordinate = Field(description=_BOX_COORDINATE_DESCRIPTION)
+    y_hi: BoxCoordinate = Field(description=_BOX_COORDINATE_DESCRIPTION)
     u: int = Field(ge=-_MAX_BOX_LINEAR_COEFFICIENT, le=_MAX_BOX_LINEAR_COEFFICIENT)
     v: int = Field(ge=-_MAX_BOX_LINEAR_COEFFICIENT, le=_MAX_BOX_LINEAR_COEFFICIENT)
     c: int = Field(ge=-_MAX_BOX_LINEAR_COEFFICIENT, le=_MAX_BOX_LINEAR_COEFFICIENT)
-    count: int = Field(ge=0)
+    count: ExactInteger = Field(ge=0)
     modulus: int = Field(ge=1, le=_MAX_BOX_MODULUS)
 
 

--- a/src/jacobian/math/number_theory/counting/_models.py
+++ b/src/jacobian/math/number_theory/counting/_models.py
@@ -22,6 +22,8 @@ _MAX_FLOOR_SUM_PARAM = 1_000_000
 # compact, explicit bound for both the endpoint arithmetic and the exact
 # count: a box has fewer than 4 * 10**64 points.
 _MAX_BOX_COORD_DIGITS = 32
+# A box with 32-digit endpoints has fewer than 4 * 10**64 lattice points.
+_MAX_BOX_COUNT_DIGITS = 65
 _MAX_BOX_LINEAR_COEFFICIENT = 10**15
 _MAX_BOX_MODULUS = 10_000
 
@@ -30,6 +32,21 @@ _BOX_COORDINATE_DESCRIPTION = (
     "Exact signed coordinate with at most 32 decimal digits; use a canonical "
     "decimal string in JSON."
 )
+
+BoxCount = Annotated[
+    int,
+    DecimalIntegerEncoding(max_digits=_MAX_BOX_COUNT_DIGITS),
+    Field(
+        ge=0,
+        description=(
+            "Canonical nonnegative decimal count of lattice points in the box."
+        ),
+        json_schema_extra={
+            "pattern": rf"^(?:0|[1-9][0-9]{{0,{_MAX_BOX_COUNT_DIGITS - 1}}})(?![\s\S])",
+            "maxLength": _MAX_BOX_COUNT_DIGITS,
+        },
+    ),
+]
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -107,7 +124,7 @@ class CongruenceBoxCountResult(StrictModel):
     u: int = Field(ge=-_MAX_BOX_LINEAR_COEFFICIENT, le=_MAX_BOX_LINEAR_COEFFICIENT)
     v: int = Field(ge=-_MAX_BOX_LINEAR_COEFFICIENT, le=_MAX_BOX_LINEAR_COEFFICIENT)
     c: int = Field(ge=-_MAX_BOX_LINEAR_COEFFICIENT, le=_MAX_BOX_LINEAR_COEFFICIENT)
-    count: ExactInteger = Field(ge=0)
+    count: BoxCount
     modulus: int = Field(ge=1, le=_MAX_BOX_MODULUS)
 
 

--- a/src/jacobian/math/number_theory/counting/_tools.py
+++ b/src/jacobian/math/number_theory/counting/_tools.py
@@ -72,7 +72,11 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
     MathTool(
         operation_id="integer.counting.congruence_box.compute",
         title="Count congruence-constrained lattice points",
-        description="Count lattice points in a bounded box satisfying u*x + v*y = c (mod modulus).",
+        description=(
+            "Count lattice points in a bounded box satisfying u*x + v*y = c "
+            "(mod modulus). Coordinates use canonical decimal strings with "
+            "up to 32 digits; the modulus is at most 10,000."
+        ),
         request_type=CongruenceBoxCountRequest,
         result_type=CongruenceBoxCountResult,
         run=compute_congruence_box_count,
@@ -82,10 +86,10 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 name="simple_congruence",
                 description="Count (x+y)=0 mod 3 in [0,5]^2.",
                 input={
-                    "x_lo": 0,
-                    "x_hi": 5,
-                    "y_lo": 0,
-                    "y_hi": 5,
+                    "x_lo": "0",
+                    "x_hi": "5",
+                    "y_lo": "0",
+                    "y_hi": "5",
                     "u": 1,
                     "v": 1,
                     "c": 0,

--- a/src/jacobian/math/number_theory/counting/operations.py
+++ b/src/jacobian/math/number_theory/counting/operations.py
@@ -4,7 +4,7 @@ from math import gcd
 
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_theory.counting._models import (
-    _MAX_BOX_COORD,
+    _MAX_BOX_COORD_DIGITS,
     _MAX_BOX_LINEAR_COEFFICIENT,
     _MAX_BOX_MODULUS,
     _MAX_FLOOR_SUM_N,
@@ -66,30 +66,35 @@ def congruence_box_count(
 ) -> int:
     """Count points in a bounded box satisfying one linear congruence."""
 
-    for name, value in (
+    coordinates = (
         ("x_lo", x_lo),
         ("x_hi", x_hi),
         ("y_lo", y_lo),
         ("y_hi", y_hi),
-    ):
-        if not -_MAX_BOX_COORD <= value <= _MAX_BOX_COORD:
+    )
+    for name, value in coordinates:
+        if type(value) is not int:
+            _reject((name,), f"{name}_type", f"{name} must be an exact integer")
+        if abs(value) >= 10**_MAX_BOX_COORD_DIGITS:
             _reject(
                 (name,),
                 f"{name}_out_of_range",
-                f"{name} is outside the admitted range",
+                f"{name} exceeds the {_MAX_BOX_COORD_DIGITS}-digit bound",
             )
     if x_lo > x_hi:
         _reject(("x_lo", "x_hi"), "x_interval_invalid", "x_lo must be <= x_hi")
     if y_lo > y_hi:
         _reject(("y_lo", "y_hi"), "y_interval_invalid", "y_lo must be <= y_hi")
-    if not 1 <= modulus <= _MAX_BOX_MODULUS:
+    if type(modulus) is not int or not 1 <= modulus <= _MAX_BOX_MODULUS:
         _reject(
             ("modulus",),
             "modulus_out_of_range",
             "modulus is outside the admitted range",
         )
     for name, value in (("u", u), ("v", v), ("c", c)):
-        if not -_MAX_BOX_LINEAR_COEFFICIENT <= value <= _MAX_BOX_LINEAR_COEFFICIENT:
+        if type(value) is not int or not (
+            -_MAX_BOX_LINEAR_COEFFICIENT <= value <= _MAX_BOX_LINEAR_COEFFICIENT
+        ):
             _reject(
                 (name,),
                 f"{name}_out_of_range",
@@ -100,6 +105,7 @@ def congruence_box_count(
     y_length = y_hi - y_lo + 1
     if y_length < x_length:
         x_lo, x_hi, y_lo, y_hi = y_lo, y_hi, x_lo, x_hi
+        x_length = y_length
         u, v = v, u
 
     divisor = gcd(v, modulus)
@@ -107,13 +113,23 @@ def congruence_box_count(
     inverse = 0 if reduced_modulus == 1 else pow(v // divisor, -1, reduced_modulus)
 
     count = 0
-    for x in range(x_lo, x_hi + 1):
-        right_hand_side = c - u * x
+    # A short axis exposes fewer than one full period, so visiting its actual
+    # representatives avoids turning a one-column box into a modulus-sized
+    # scan.  Otherwise one representative per residue captures all distinct
+    # congruence behavior and the multiplicity formula accounts for repeats.
+    residues = range(x_lo, x_hi + 1) if x_length < modulus else range(modulus)
+    for representative in residues:
+        residue = representative % modulus
+        x_count = (x_hi - residue) // modulus - (x_lo - 1 - residue) // modulus
+        if not x_count:
+            continue
+        right_hand_side = c - u * residue
         if right_hand_side % divisor:
             continue
-        residue = (right_hand_side // divisor * inverse) % reduced_modulus
-        count += (y_hi - residue) // reduced_modulus
-        count -= (y_lo - 1 - residue) // reduced_modulus
+        y_residue = (right_hand_side // divisor * inverse) % reduced_modulus
+        y_count = (y_hi - y_residue) // reduced_modulus
+        y_count -= (y_lo - 1 - y_residue) // reduced_modulus
+        count += x_count * y_count
     return count
 
 

--- a/tests/math/number_theory/counting/test_arithmetic_counting.py
+++ b/tests/math/number_theory/counting/test_arithmetic_counting.py
@@ -4,6 +4,9 @@ import json
 from itertools import product
 from typing import TypedDict
 
+import pytest
+from pydantic import ValidationError
+
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import invoke_operation
 from jacobian.math.number_theory.counting import congruence_box_count, floor_sum
@@ -169,6 +172,31 @@ class TestCongruenceBoxCount:
         assert not verify_congruence_box_count(
             CongruenceBoxCountResult.model_validate_json(json.dumps(forged))
         )
+
+    @pytest.mark.parametrize("count", ["-1", "01", "1\n"])
+    def test_count_schema_and_decoder_reject_invalid_decimal_counts(
+        self, count: str
+    ) -> None:
+        request = CongruenceBoxCountRequest(
+            x_lo=0,
+            x_hi=5,
+            y_lo=0,
+            y_hi=5,
+            u=1,
+            v=1,
+            c=0,
+            modulus=3,
+        )
+        result = compute_congruence_box_count(request)
+        payload = result.model_dump(mode="json")
+        from jsonschema import Draft202012Validator
+
+        validator = Draft202012Validator(CongruenceBoxCountResult.model_json_schema())
+        assert not list(validator.iter_errors(payload))
+        payload["count"] = count
+        assert list(validator.iter_errors(payload))
+        with pytest.raises(ValidationError):
+            CongruenceBoxCountResult.model_validate_json(json.dumps(payload))
 
     def test_admits_full_coordinate_box(self) -> None:
         request = CongruenceBoxCountRequest.model_validate(

--- a/tests/math/number_theory/counting/test_arithmetic_counting.py
+++ b/tests/math/number_theory/counting/test_arithmetic_counting.py
@@ -4,6 +4,8 @@ import json
 from itertools import product
 from typing import TypedDict
 
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import invoke_operation
 from jacobian.math.number_theory.counting import congruence_box_count, floor_sum
 from jacobian.math.number_theory.counting._models import (
     _MAX_BOX_LINEAR_COEFFICIENT,
@@ -165,7 +167,7 @@ class TestCongruenceBoxCount:
         forged = restored.model_dump(mode="json")
         forged["modulus"] = 5
         assert not verify_congruence_box_count(
-            CongruenceBoxCountResult.model_validate(forged)
+            CongruenceBoxCountResult.model_validate_json(json.dumps(forged))
         )
 
     def test_admits_full_coordinate_box(self) -> None:
@@ -182,6 +184,68 @@ class TestCongruenceBoxCount:
             )
         )
         assert compute_congruence_box_count(request).count == 40_040
+
+    def test_large_exact_public_count_uses_periodic_residue_oracle(self) -> None:
+        """The O(modulus) kernel must not inherit a coordinate-width cap."""
+
+        endpoint = 10**20
+        modulus = 97
+        payload: dict[str, object] = {
+            "x_lo": str(-endpoint),
+            "x_hi": str(endpoint),
+            "y_lo": str(-endpoint),
+            "y_hi": str(endpoint),
+            "u": 17,
+            "v": 19,
+            "c": 23,
+            "modulus": modulus,
+        }
+
+        def residue_count(lower: int, upper: int, residue: int) -> int:
+            return (upper - residue) // modulus - (lower - 1 - residue) // modulus
+
+        # A period decomposition independent of the single-residue solver in
+        # the kernel: count the exact Cartesian multiplicity of every one of
+        # the 97^2 coordinate residue pairs.
+        expected = sum(
+            residue_count(-endpoint, endpoint, x_residue)
+            * residue_count(-endpoint, endpoint, y_residue)
+            for x_residue, y_residue in product(range(modulus), repeat=2)
+            if (17 * x_residue + 19 * y_residue - 23) % modulus == 0
+        )
+
+        public = invoke_operation(
+            "integer.counting.congruence_box.compute", payload, Catalog.open()
+        ).output
+        result = CongruenceBoxCountResult.model_validate_json(json.dumps(public))
+        assert result.count == expected
+        assert result.count > 2**53
+        assert public["count"] == str(expected)
+        assert public["x_lo"] == str(-endpoint)
+        assert verify_congruence_box_count(result)
+
+    def test_narrow_axis_avoids_a_full_modulus_scan(self) -> None:
+        endpoint = 10**20
+        modulus = 9_991
+        x_value = endpoint + 17
+        y_residue = ((23 - 17 * x_value) * pow(19, -1, modulus)) % modulus
+        expected = (endpoint - y_residue) // modulus - (
+            -endpoint - 1 - y_residue
+        ) // modulus
+
+        assert (
+            congruence_box_count(
+                x_lo=x_value,
+                x_hi=x_value,
+                y_lo=-endpoint,
+                y_hi=endpoint,
+                u=17,
+                v=19,
+                c=23,
+                modulus=modulus,
+            )
+            == expected
+        )
 
     def test_matches_exhaustive_small_boxes(self) -> None:
         intervals = ((-2, 2), (-1, -1), (0, 2))


### PR DESCRIPTION
## Problem

`integer.counting.congruence_box.compute` was limited to endpoints within ±10,000 because it scanned the shorter coordinate interval. Large boxes with a small modulus remained cheap mathematically but were refused. This extends the earlier partial counting repair in #2986.

## Outcome

Aggregate exact residue multiplicities and solve the remaining one-variable congruence using gcd reduction. Visit at most min(box width, box height, modulus) representatives, retaining the short-interval regime. Coordinates admit up to 32 decimal digits, and the exact count has at most 65 digits.

## Validation

All affected-plan checks passed: scoped Ruff/mypy, 16 counting tests, 160 catalog tests, and 966 catalog integration/example tests. The declared example was migrated to the new decimal encoding, then the affected catalog stages were rerun.

Independent brute-force boxes cover signed and non-coprime coefficients. A separate residue-pair oracle checks the dispatched ±10^20 box modulo 97; its count exceeds 2^53 and survives JSON decoding into the real verifier. Tests cover narrow boxes with modulus 9991. Additional checks exercised 160 small boxes and the full 32-digit boundary. The new public scale regression fails on base `3f5f1334e`.

Final tested head: `9f8554214`.

## Contract impact

The operation ID is unchanged. The four coordinate fields now use canonical decimal strings in JSON, and the result count is also an exact decimal string. Native fields remain integers. Coefficient limits and modulus ≤10,000 remain. Admission bounds coordinate arithmetic and output before the loop; auxiliary storage is constant.

## Review closure

The complete diff and residue argument were independently reviewed. All selected checks cover the final code; hosted checks passed on the tested head (11 successful, 14 intentionally skipped).
