### PR TITLE
perf(combinatorics): compute Bell numbers with FLINT

### DIFF
--- a/src/jacobian/math/combinatorics/operations.py
+++ b/src/jacobian/math/combinatorics/operations.py
@@ -341,9 +341,20 @@ def compositions(n: int, k: int) -> int:
 def bell_number(n: int) -> int:
     """Return the nth Bell number."""
 
-    import sympy
+    # The exponential generating function is exp(exp(x) - 1), whose
+    # nonnegative coefficients give, at r = 7,
+    #
+    # B_n <= n! exp(exp(7) - 1) / 7**n.
+    #
+    # The n = 0 result is 1. For 1 <= n <= 10_000, n! <= n**n, exp(7) <
+    # 1100, exp(1099) < 10**478, and (n / 7)**n < 1500**10_000 <
+    # 10**32_000. Thus every admitted result is below 10**32_478, inside the
+    # 32_768-digit canonical scalar envelope. This is an output bound, not a
+    # runtime estimate.
+    index = _bounded_counting_index(n, name="n")
+    from flint import fmpz
 
-    return int(sympy.bell(_nonnegative(n, name="n")))
+    return int(fmpz.bell_number(index))
 
 
 def bernoulli_number(n: int) -> Fraction:

--- a/tests/math/combinatorics/test_native_operations.py
+++ b/tests/math/combinatorics/test_native_operations.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import json
 from fractions import Fraction
 
 import pytest
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.dispatch import invoke_operation
 from jacobian.math.combinatorics import (
     bell_number,
     bernoulli_number,
@@ -13,6 +16,30 @@ from jacobian.math.combinatorics import (
     integer_partitions,
     stirling_second,
 )
+from jacobian.math.combinatorics.operations import MAX_COUNTING_INDEX
+
+
+def _bell_by_stirling_recurrence(n: int) -> int:
+    """Count set partitions by their number of blocks, without the Bell kernel."""
+
+    stirling_row = [1]
+    for size in range(1, n + 1):
+        next_row = [0] * (size + 1)
+        for blocks in range(1, size + 1):
+            next_row[blocks] = (
+                blocks * stirling_row[blocks] if blocks < len(stirling_row) else 0
+            ) + stirling_row[blocks - 1]
+        stirling_row = next_row
+    return sum(stirling_row)
+
+
+def _bell_modulo_by_touchard_recurrence(limit: int, prime: int) -> list[int]:
+    """Compute Bell residues from small Stirling rows and Touchard's congruence."""
+
+    residues = [_bell_by_stirling_recurrence(n) % prime for n in range(prime)]
+    for n in range(prime, limit + 1):
+        residues.append((residues[n - prime] + residues[n - prime + 1]) % prime)
+    return residues
 
 
 def test_classical_numbers_remain_available_without_catalog_slots() -> None:
@@ -22,11 +49,60 @@ def test_classical_numbers_remain_available_without_catalog_slots() -> None:
     assert integer_partitions(4, max_parts=2) == ((4,), (3, 1), (2, 2))
 
 
+def test_bell_numbers_match_the_independent_stirling_recurrence() -> None:
+    assert [bell_number(n) for n in range(20)] == [
+        _bell_by_stirling_recurrence(n) for n in range(20)
+    ]
+
+
+def test_large_bell_numbers_match_touchard_residues() -> None:
+    prime = 13
+    n = MAX_COUNTING_INDEX - prime
+    residues = _bell_modulo_by_touchard_recurrence(MAX_COUNTING_INDEX, prime)
+
+    bell_n = bell_number(n)
+    bell_n_plus_one = bell_number(n + 1)
+    bell_n_plus_prime = bell_number(n + prime)
+
+    assert bell_n % prime == residues[n]
+    assert bell_n_plus_one % prime == residues[n + 1]
+    assert bell_n_plus_prime % prime == residues[n + prime]
+    assert bell_n_plus_prime % prime == (bell_n + bell_n_plus_one) % prime
+
+
+def test_largest_bell_number_projects_as_a_canonical_public_json_integer() -> None:
+    catalog = Catalog.open()
+    operation = catalog.operation("combinatorics.compute.bell")
+    assert operation is not None
+
+    result = invoke_operation(
+        operation.operation_id, {"n": MAX_COUNTING_INDEX}, catalog
+    )
+
+    assert isinstance(result.output["value"], str)
+    assert len(result.output["value"]) == 27_665
+    assert (
+        operation.result_type.model_validate_json(json.dumps(result.output)).model_dump(
+            mode="json"
+        )
+        == result.output
+    )
+
+
 def test_native_classical_numbers_reject_noninteger_or_negative_indices() -> None:
     with pytest.raises(OperationDomainValidationError, match="nonnegative integer"):
         bell_number(-1)
     with pytest.raises(OperationDomainValidationError, match="nonnegative integer"):
         bell_number(True)
+
+
+def test_bell_number_enforces_the_native_counting_index_bound() -> None:
+    with pytest.raises(OperationDomainValidationError) as raised:
+        bell_number(MAX_COUNTING_INDEX + 1)
+
+    assert (
+        raised.value.errors()[0]["type"] == "combinatorics.counting_index_out_of_range"
+    )
 
 
 def test_native_recurrence_admission_uses_typed_domain_errors() -> None:


### PR DESCRIPTION
## Problem

`combinatorics.compute.bell` admits indices through 10,000, but the SymPy implementation exceeded a 15-second diagnostic limit at n=2,000. The native entry point also lacked the public counting-index bound.

## Outcome

Use the existing FLINT backend's exact Bell-number implementation. A local sample computed and converted B_10000 in approximately 0.33 seconds; this is an observation on a concurrently loaded host, not a latency guarantee.

Admission precedes backend work. The exponential generating function gives `B_n <= n! exp(exp(7)-1) / 7^n`. For 1 <= n <= 10,000 this is below `10^32478`, inside the canonical 32,768-digit scalar envelope; B_0 is 1. The bound is independent of the timing measurement.

## Validation

`make affected` completed all five selected commands: scoped Ruff/mypy, 1,644 combinatorics tests, 160 catalog tests, and 966 catalog integration/example tests.

Small values are checked against an independent Stirling recurrence. Near-boundary values are checked against an independently computed Touchard recurrence modulo 13. The actual public dispatch at n=10,000 produces a 27,665-digit canonical decimal result that survives JSON decoding. Native n=10,001 is rejected with the typed counting-index error.

Final tested head: `589aa57b3`.

## Contract impact

The operation ID, public index range, and result encoding are unchanged. The native function now enforces the same n <= 10,000 bound. No dependency is added. Modular checks supplement, rather than constitute, a proof of every output digit; exactness relies on the maintained mathematical backend and the independent small-value comparisons.

## Review closure

The complete diff and output-bound argument were independently reviewed. All selected checks cover the final code; hosted checks passed on the tested head (11 successful, 14 intentionally skipped).
