### PR TITLE
perf(matrices): admit Hadamard products by carrier capacity

### DIFF
--- a/src/jacobian/math/matrices/combinatorial/operations.py
+++ b/src/jacobian/math/matrices/combinatorial/operations.py
@@ -13,13 +13,12 @@ from ._models import (
     SignProfileResult,
     SylvesterResult,
 )
-from .values import HadamardMatrix, SignMatrix
+from .values import MAX_HADAMARD_ORDER, HadamardMatrix, SignMatrix
 
 # Cube-root of the Gram multiply-add work budget.
 MAX_GRAM_PROFILE_AXIS = 512
 MAX_GRAM_PROFILE_MULTIPLY_ADDS = MAX_GRAM_PROFILE_AXIS**3
 MAX_GRAM_PROFILE_ENTRIES = 1_000_000
-MAX_KRONECKER_ORDER = 128
 
 
 def _require_gram_profile_admission(matrix: SignMatrix) -> None:
@@ -71,6 +70,30 @@ def _sign_matrix_from_hadamard(hadamard: HadamardMatrix) -> SignMatrix:
     """Reuse structurally validated Hadamard rows as a sign-matrix carrier."""
 
     return SignMatrix.model_construct(rows=hadamard.rows)
+
+
+def _require_kronecker_admission(
+    left: HadamardMatrix, right: HadamardMatrix
+) -> tuple[int, int]:
+    """Admit the bounded Hadamard-product carrier before recognition.
+
+    For positive factor orders, ``n^3 + m^3 <= (n*m)^3 + 1``; therefore
+    ``n*m <= N`` bounds the two exact recognitions by ``N^3 + 1`` and the
+    materialized product by ``N^2`` entries.
+    """
+
+    n, m = len(left.rows), len(right.rows)
+    product_order = n * m
+    if product_order > MAX_HADAMARD_ORDER:
+        raise OperationDomainValidationError(
+            location=("left", "rows"),
+            code="combinatorial_matrix.kronecker_output_order",
+            message=(
+                "Kronecker product order exceeds the "
+                f"{MAX_HADAMARD_ORDER}-order Hadamard carrier bound"
+            ),
+        )
+    return n, m
 
 
 __all__ = [
@@ -188,11 +211,7 @@ def kronecker(left: HadamardMatrix, right: HadamardMatrix) -> KroneckerProductRe
     """Return the Kronecker product of two Hadamard matrices as a Hadamard
     matrix, factor-to-product row/column maps, and the exact Gram
     factorization."""
-    n, m = len(left.rows), len(right.rows)
-    if n * m > MAX_KRONECKER_ORDER:
-        raise ValueError(
-            f"Kronecker product order {n * m} exceeds maximum {MAX_KRONECKER_ORDER}"
-        )
+    n, m = _require_kronecker_admission(left, right)
     left_h = recognize_hadamard(_sign_matrix_from_hadamard(left))
     right_h = recognize_hadamard(_sign_matrix_from_hadamard(right))
     a = [list(row) for row in left_h.rows]

--- a/tests/math/matrices/combinatorial/test_combinatorial_matrices.py
+++ b/tests/math/matrices/combinatorial/test_combinatorial_matrices.py
@@ -14,6 +14,7 @@ from jacobian.math.matrices.combinatorial import HadamardMatrix, SignMatrix
 from jacobian.math.matrices.combinatorial._models import (
     DeterminantProfileRequest,
     GramProfileRequest,
+    KroneckerProductResult,
     NormalizeRequest,
     SignProfileRequest,
     SylvesterRequest,
@@ -32,6 +33,7 @@ from jacobian.math.matrices.combinatorial.operations import (
     gram_profile,
     kronecker,
     recognize_hadamard,
+    sylvester,
 )
 from jacobian.math.matrices.combinatorial.values import (
     MAX_MATERIALIZED_SIGN_MATRIX_AXIS,
@@ -296,6 +298,113 @@ def test_kronecker_returns_a_canonical_hadamard_matrix() -> None:
     assert isinstance(result.product, HadamardMatrix)
     assert result.row_map == ((0, 0), (0, 1), (1, 0), (1, 1))
     assert result.column_map == result.row_map
+
+
+def test_kronecker_admits_previously_rejected_order_256_and_round_trips_to_consumer() -> (
+    None
+):
+    result = kronecker(sylvester(4).matrix, sylvester(4).matrix)
+
+    assert len(result.product.rows) == 256
+    restored = KroneckerProductResult.model_validate_json(result.model_dump_json())
+    profile = determinant_profile(restored.product)
+    assert profile.order == 256
+    assert profile.determinant_magnitude**2 == profile.gram_determinant
+
+
+def test_kronecker_admits_the_hadamard_carrier_order_boundary() -> None:
+    result = kronecker(sylvester(4).matrix, sylvester(5).matrix)
+
+    assert len(result.product.rows) == 512
+    assert len(result.product.rows[0]) == 512
+    assert result.row_map[0] == (0, 0)
+    assert result.row_map[-1] == (15, 31)
+    assert result.column_map == result.row_map
+
+
+def test_kronecker_preserves_factor_coordinates_and_hadamard_gram() -> None:
+    left_source = sylvester(1).matrix.rows
+    right_source = sylvester(2).matrix.rows
+    left_row_order, left_column_order = (1, 0), (1, 0)
+    left_row_signs, left_column_signs = (-1, 1), (1, -1)
+    right_row_order, right_column_order = (2, 0, 3, 1), (1, 3, 0, 2)
+    right_row_signs, right_column_signs = (1, -1, 1, -1), (-1, 1, 1, -1)
+    left_rows = tuple(
+        tuple(
+            left_row_signs[i]
+            * left_source[left_row_order[i]][left_column_order[j]]
+            * left_column_signs[j]
+            for j in range(len(left_source))
+        )
+        for i in range(len(left_source))
+    )
+    right_rows = tuple(
+        tuple(
+            right_row_signs[i]
+            * right_source[right_row_order[i]][right_column_order[j]]
+            * right_column_signs[j]
+            for j in range(len(right_source))
+        )
+        for i in range(len(right_source))
+    )
+    left = recognize_hadamard(SignMatrix(rows=left_rows))
+    right = recognize_hadamard(SignMatrix(rows=right_rows))
+
+    result = kronecker(left, right)
+    expected = tuple(
+        tuple(
+            left_rows[i][column_i] * right_rows[j][column_j]
+            for column_i in range(len(left_rows))
+            for column_j in range(len(right_rows))
+        )
+        for i in range(len(left_rows))
+        for j in range(len(right_rows))
+    )
+
+    assert result.row_map == tuple(
+        (i, j) for i in range(len(left_rows)) for j in range(len(right_rows))
+    )
+    assert result.column_map == result.row_map
+    assert result.product.rows == expected
+    assert all(
+        sum(
+            entry * other_entry
+            for entry, other_entry in zip(row, other_row, strict=True)
+        )
+        == (len(expected) if row_index == other_index else 0)
+        for row_index, row in enumerate(expected)
+        for other_index, other_row in enumerate(expected)
+    )
+
+
+def test_kronecker_rejects_a_forged_hadamard_factor() -> None:
+    forged = HadamardMatrix(rows=((1, 1), (1, 1)))
+
+    with pytest.raises(OperationDomainValidationError) as exc_info:
+        kronecker(forged, sylvester(1).matrix)
+    assert (
+        exc_info.value.errors()[0]["type"]
+        == "combinatorial_matrix.orthogonality_violation"
+    )
+
+
+def test_kronecker_refuses_an_overbound_product_before_factor_recognition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.matrices.combinatorial import operations
+
+    def recognition_must_not_run(*_args: object) -> None:
+        raise AssertionError("factor recognition must follow Kronecker admission")
+
+    monkeypatch.setattr(operations, "integer_gram", recognition_must_not_run)
+    overbound = HadamardMatrix(rows=((1,) * 512,) * 512)
+
+    with pytest.raises(OperationDomainValidationError) as exc_info:
+        kronecker(overbound, sylvester(1).matrix)
+    assert (
+        exc_info.value.errors()[0]["type"]
+        == "combinatorial_matrix.kronecker_output_order"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The native Hadamard `kronecker` operation rejected two order-16 factors because of a fixed order-128 product ceiling, although the canonical Hadamard carrier supports order 512.

## Outcome

Admit products through the existing order-512 carrier before recognizing either factor. For positive factor orders n and m, `n^3 + m^3 <= (nm)^3 + 1`; therefore the product-order bound limits both exact factor recognition and the quadratic materialized output. Mathematical recognition remains mandatory for caller-supplied factors.

## Validation

`make affected` completed all five selected commands: scoped Ruff/mypy, 34 combinatorial-matrix tests, 160 catalog tests, and 966 catalog integration/example tests.

An order-256 product survives JSON decoding into the real determinant consumer. The order-512 boundary is accepted. Independently signed and permuted factors are checked entry by entry and by their exact Gram matrix. A forged factor fails recognition, and an order-1,024 product is rejected before factor recognition.

Final tested head: `46b194f6f`.

## Contract impact

This remains a native-only operation; no catalog operation or public symbol is added. Existing result fields and factor-to-product coordinates are preserved. The accepted product order increases from 128 to 512, and oversized products now report a typed domain error.

## Review closure

The complete diff, admission inequality, and independent mathematical tests were reviewed. All selected checks cover the final code; hosted checks passed on the tested head (11 successful, 14 intentionally skipped).
