### PR TITLE
fix(regular-languages): bound DFA equivalence contract

### DIFF
--- a/docs/reference/operations/index.md
+++ b/docs/reference/operations/index.md
@@ -11,6 +11,7 @@ Additional references document mathematical contracts or external boundaries
 that need more context than an operation card:
 
 - [Combinatorics on words](words/index.md)
+- [Regular languages](regular-languages.md)
 - [SAT and SMT](sat-smt/index.md)
 - [Exact quadratic forms](quadratic-forms.md)
 - [Homogeneous monomial systems on algebraic tori](algebraic-torus-monomial-systems.md)

--- a/docs/reference/operations/regular-languages.md
+++ b/docs/reference/operations/regular-languages.md
@@ -1,0 +1,22 @@
+# Regular-language operations
+
+[Documentation home](../../index.md) · [Tool surface](../tools.md)
+
+`regular_language.dfa.equivalence.decide` compares two total deterministic
+finite automata over the same ordered integer alphabet. It explores only the
+reachable product of their initial states and returns `equivalent=true` when
+every reachable pair agrees on acceptance.
+
+For inequivalent DFAs the result retains both source DFAs, the shortest
+distinguishing word, and one state trace per source automaton. Product
+successors are expanded in ascending alphabet order, so the witness is the
+lexicographically least word among all shortest witnesses. The empty word is
+considered first. A zero-symbol alphabet is valid and has only the empty word;
+DFAs with a positive alphabet must still provide exactly one transition for
+every state-symbol pair.
+
+Product-state, transition, predecessor, witness, work, and result-allocation
+envelopes are admitted before traversal. Resource refusal is not an equivalence
+result. The result model checks witness and trace shape without replaying the
+automata; use `regular_language.run.check` when an independent run result is
+needed.

--- a/src/jacobian/math/logic/languages/regular/_models.py
+++ b/src/jacobian/math/logic/languages/regular/_models.py
@@ -12,6 +12,7 @@ from jacobian._models import StrictModel
 from jacobian.math.logic.languages.regular.values import (
     DFA,
     MAX_COUNT_WORD_LENGTH,
+    MAX_DFA_EQUIVALENCE_WITNESS_LENGTH,
     MAX_DFA_STATES,
     MAX_LABELED_AUTOMATON_STATES,
     MAX_TRANSITION_PROFILE_PATH_LENGTH,
@@ -47,8 +48,18 @@ class ComplementRequest(StrictModel):
 class EquivalenceRequest(StrictModel):
     """Two total DFAs over one common ordered alphabet."""
 
-    left: DFA
-    right: DFA
+    left: DFA = Field(
+        description=(
+            "Complete deterministic finite automaton; it must use the same "
+            "ordered alphabet axis as right."
+        )
+    )
+    right: DFA = Field(
+        description=(
+            "Complete deterministic finite automaton; it must use the same "
+            "ordered alphabet axis as left."
+        )
+    )
 
 
 class EquivalenceResult(StrictModel):
@@ -58,13 +69,18 @@ class EquivalenceResult(StrictModel):
     right: DFA
     equivalent: bool
     distinguishing_word: tuple[int, ...] | None = Field(
-        default=None, max_length=MAX_DFA_STATES * MAX_DFA_STATES
+        default=None, max_length=MAX_DFA_EQUIVALENCE_WITNESS_LENGTH
     )
     left_state_trace: tuple[int, ...] | None = None
     right_state_trace: tuple[int, ...] | None = None
 
     @model_validator(mode="after")
     def require_counterexample_shape(self) -> Self:
+        if self.left.alphabet_size != self.right.alphabet_size:
+            raise _validation_error(
+                "alphabet_mismatch",
+                "equivalence results must retain DFAs over one common alphabet",
+            )
         fields = (
             self.distinguishing_word,
             self.left_state_trace,
@@ -93,6 +109,31 @@ class EquivalenceResult(StrictModel):
             raise _validation_error(
                 "counterexample_trace_length",
                 "each counterexample trace must contain one state per word prefix",
+            )
+        if self.distinguishing_word is not None and any(
+            not 0 <= symbol < self.left.alphabet_size
+            for symbol in self.distinguishing_word
+        ):
+            raise _validation_error(
+                "counterexample_symbol_out_of_range",
+                "distinguishing word contains a symbol outside the common alphabet",
+            )
+        if (
+            self.left_state_trace[0] != self.left.initial_state
+            or self.right_state_trace[0] != self.right.initial_state
+            or any(
+                not 0 <= state < self.left.state_count
+                for state in self.left_state_trace
+            )
+            or any(
+                not 0 <= state < self.right.state_count
+                for state in self.right_state_trace
+            )
+        ):
+            raise _validation_error(
+                "counterexample_trace_state",
+                "counterexample traces must start at each initial state and stay on "
+                "their source state axes",
             )
         return self
 

--- a/src/jacobian/math/logic/languages/regular/_symbol_parikh.py
+++ b/src/jacobian/math/logic/languages/regular/_symbol_parikh.py
@@ -52,6 +52,16 @@ def symbol_parikh_profile(
             if target not in reachable:
                 reachable.add(target)
                 frontier.append(target)
+    if alphabet_size == 0:
+        total = count_accepted_words(dfa, length)
+        cells = (SymbolParikhCell(symbol_counts=(), multiplicity=1),) if total else ()
+        return SymbolParikhProfileResult(
+            dfa=dfa,
+            alphabet=(),
+            word_length=length,
+            cells=cells,
+            total_accepted_words=total,
+        )
     output_bound = comb(length + alphabet_size - 1, alphabet_size - 1)
     state_bound = len(reachable) * comb(length + alphabet_size, alphabet_size)
     work_bound = alphabet_size * state_bound

--- a/src/jacobian/math/logic/languages/regular/_tools.py
+++ b/src/jacobian/math/logic/languages/regular/_tools.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from jacobian._execution import request_checkpoint
 from jacobian.catalog.models import (
     MathTool,
     OperationDomainValidationError,
@@ -68,6 +69,7 @@ def compute_complement(request: ComplementRequest) -> ComplementResult:
 
 def compute_equivalence(request: EquivalenceRequest) -> EquivalenceResult:
     word, left_trace, right_trace = dfa_equivalence(request.left, request.right)
+    request_checkpoint("before DFA equivalence result construction")
     return EquivalenceResult(
         left=request.left,
         right=request.right,
@@ -136,7 +138,11 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             OperationExample(
                 name="different_empty_word_acceptance",
-                description="Distinguish a DFA from its complement using the empty word.",
+                description=(
+                    "Decide that these two total DFAs differ and return the empty-word "
+                    "witness; both must share one ordered alphabet and a complete "
+                    "state-symbol transition table."
+                ),
                 input={
                     "left": _DFA_EXAMPLE["dfa"],
                     "right": {**_DFA_EXAMPLE["dfa"], "accepting_states": [0]},

--- a/src/jacobian/math/logic/languages/regular/operations.py
+++ b/src/jacobian/math/logic/languages/regular/operations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import deque
 
+from jacobian._execution import OperationWorkLedger, request_checkpoint
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
@@ -18,7 +19,18 @@ from jacobian.math.logic.languages.regular.values import (
     MAX_COUNT_MATRIX_BIT_WORK,
     MAX_COUNT_RESULT_DIGITS,
     MAX_COUNT_WORD_LENGTH,
+    MAX_DFA_ALPHABET,
+    MAX_DFA_EQUIVALENCE_INTERMEDIATE_ALLOCATION,
+    MAX_DFA_EQUIVALENCE_OUTPUT_ALLOCATION,
+    MAX_DFA_EQUIVALENCE_PRODUCT_STATES,
+    MAX_DFA_EQUIVALENCE_PRODUCT_TRANSITIONS,
+    MAX_DFA_EQUIVALENCE_TRACE_ROWS,
+    MAX_DFA_EQUIVALENCE_WITNESS_LENGTH,
+    MAX_DFA_EQUIVALENCE_WORK,
+    MAX_DFA_STATES,
+    MAX_DFA_TRANSITIONS,
     AutomatonTransition,
+    DFATransition,
     FiniteLabeledAutomaton,
     TransitionParikhCell,
     TransitionParikhProfile,
@@ -213,17 +225,152 @@ def dfa_complement(dfa: DFA) -> DFA:
     )
 
 
-def dfa_equivalence(
-    left: DFA, right: DFA
-) -> tuple[tuple[int, ...] | None, tuple[int, ...] | None, tuple[int, ...] | None]:
-    """Return the shortest lexicographically least distinguishing word and traces."""
+def _require_equivalence_dfa(value: object, location: str) -> int:
+    """Guard the native entry point against unvalidated or partial DFAs."""
 
+    if type(value) is not DFA:
+        raise OperationDomainValidationError(
+            location=(location,),
+            code=f"regular_language.equivalence.{location}_not_dfa",
+            message=f"{location} must be a canonical DFA value",
+        )
+    state_count = getattr(value, "state_count", None)
+    alphabet_size = getattr(value, "alphabet_size", None)
+    initial_state = getattr(value, "initial_state", None)
+    accepting_states = getattr(value, "accepting_states", None)
+    transitions = getattr(value, "transitions", None)
+    if (
+        type(state_count) is not int
+        or not 1 <= state_count <= MAX_DFA_STATES
+        or type(alphabet_size) is not int
+        or not 0 <= alphabet_size <= MAX_DFA_ALPHABET
+        or type(initial_state) is not int
+        or not 0 <= initial_state < state_count
+        or type(accepting_states) is not tuple
+        or len(accepting_states) > MAX_DFA_STATES
+        or any(
+            type(state) is not int or not 0 <= state < state_count
+            for state in accepting_states
+        )
+        or len(set(accepting_states)) != len(accepting_states)
+        or type(transitions) is not tuple
+        or len(transitions) > MAX_DFA_TRANSITIONS
+    ):
+        raise OperationDomainValidationError(
+            location=(location,),
+            code="regular_language.equivalence.invalid_dfa",
+            message=f"{location} is not a structurally valid DFA",
+        )
+    keys: set[tuple[int, int]] = set()
+    for transition in transitions:
+        source = getattr(transition, "source", None)
+        symbol = getattr(transition, "symbol", None)
+        target = getattr(transition, "target", None)
+        if (
+            type(transition) is not DFATransition
+            or type(source) is not int
+            or type(symbol) is not int
+            or type(target) is not int
+            or not 0 <= source < state_count
+            or not 0 <= target < state_count
+            or not 0 <= symbol < alphabet_size
+        ):
+            raise OperationDomainValidationError(
+                location=(location, "transitions"),
+                code="regular_language.equivalence.invalid_dfa",
+                message=f"{location} contains an invalid transition",
+            )
+        key = (source, symbol)
+        if key in keys:
+            raise OperationDomainValidationError(
+                location=(location, "transitions"),
+                code="regular_language.equivalence.partial_dfa",
+                message=f"{location} must have one transition for every state-symbol pair",
+            )
+        keys.add(key)
+    expected = state_count * alphabet_size
+    if len(keys) != expected:
+        raise OperationDomainValidationError(
+            location=(location, "transitions"),
+            code="regular_language.equivalence.partial_dfa",
+            message=f"{location} must have one transition for every state-symbol pair",
+        )
+    return len(transitions) + len(accepting_states) + 4
+
+
+def _admit_dfa_equivalence(left: DFA, right: DFA) -> tuple[int, int]:
+    """Admit every BFS materialization before the product search begins."""
+
+    source_work = _require_equivalence_dfa(left, "left")
+    source_work += _require_equivalence_dfa(right, "right")
     if left.alphabet_size != right.alphabet_size:
         raise OperationDomainValidationError(
             location=("right", "alphabet_size"),
             code="regular_language.equivalence.alphabet_mismatch",
             message="DFA equivalence requires the same ordered alphabet",
         )
+    product_states = left.state_count * right.state_count
+    product_transitions = product_states * left.alphabet_size
+    witness_length = product_states - 1
+    predecessor_allocation = product_states * 4
+    trace_rows = 2 * (witness_length + 1)
+    reconstruction_work = witness_length + trace_rows
+    work = source_work + product_transitions + product_states + reconstruction_work
+    output_allocation = (
+        2
+        * (
+            left.state_count
+            + right.state_count
+            + left.alphabet_size
+            + len(left.transitions)
+            + len(right.transitions)
+            + len(left.accepting_states)
+            + len(right.accepting_states)
+        )
+        + witness_length
+        + trace_rows
+        + 8
+    )
+    bounds = (
+        ("product_states", product_states, MAX_DFA_EQUIVALENCE_PRODUCT_STATES),
+        (
+            "product_transitions",
+            product_transitions,
+            MAX_DFA_EQUIVALENCE_PRODUCT_TRANSITIONS,
+        ),
+        ("witness_length", witness_length, MAX_DFA_EQUIVALENCE_WITNESS_LENGTH),
+        ("trace_rows", trace_rows, MAX_DFA_EQUIVALENCE_TRACE_ROWS),
+        (
+            "intermediate_cells",
+            predecessor_allocation,
+            MAX_DFA_EQUIVALENCE_INTERMEDIATE_ALLOCATION,
+        ),
+        ("work", work, MAX_DFA_EQUIVALENCE_WORK),
+        ("output_allocation", output_allocation, MAX_DFA_EQUIVALENCE_OUTPUT_ALLOCATION),
+    )
+    for resource, observed, admitted in bounds:
+        if observed > admitted:
+            raise OperationResourceAdmissionError(
+                location=("left", "right"),
+                code=f"regular_language.equivalence.{resource}_bound",
+                message=(
+                    f"DFA equivalence {resource} exceeds the admitted "
+                    f"bound of {admitted}"
+                ),
+            )
+    return source_work, work
+
+
+def dfa_equivalence(
+    left: DFA, right: DFA
+) -> tuple[tuple[int, ...] | None, tuple[int, ...] | None, tuple[int, ...] | None]:
+    """Return the shortest lexicographically least distinguishing word and traces."""
+
+    request_checkpoint("before DFA equivalence admission")
+    source_work, admitted_work = _admit_dfa_equivalence(left, right)
+    request_checkpoint("after DFA equivalence admission")
+    ledger = OperationWorkLedger(admitted_work)
+    ledger.charge(source_work)
     left_transitions = _transition_map(left)
     right_transitions = _transition_map(right)
     initial = (left.initial_state, right.initial_state)
@@ -232,6 +379,8 @@ def dfa_equivalence(
         initial: None
     }
     while queue:
+        ledger.charge()
+        request_checkpoint("during DFA equivalence product search")
         pair = queue.popleft()
         left_accepts = pair[0] in left.accepting_states
         right_accepts = pair[1] in right.accepting_states
@@ -240,18 +389,22 @@ def dfa_equivalence(
             symbols: list[int] = []
             link = predecessor[pairs[-1]]
             while link is not None:
+                ledger.charge()
+                request_checkpoint("during DFA equivalence witness reconstruction")
                 parent, symbol = link
                 symbols.append(symbol)
                 pairs.append(parent)
                 link = predecessor[parent]
             pairs.reverse()
             symbols.reverse()
+            request_checkpoint("before DFA equivalence result construction")
             return (
                 tuple(symbols),
                 tuple(state[0] for state in pairs),
                 tuple(state[1] for state in pairs),
             )
         for symbol in range(left.alphabet_size):
+            ledger.charge()
             target = (
                 left_transitions[(pair[0], symbol)],
                 right_transitions[(pair[1], symbol)],
@@ -259,6 +412,7 @@ def dfa_equivalence(
             if target not in predecessor:
                 predecessor[target] = (pair, symbol)
                 queue.append(target)
+    request_checkpoint("before DFA equivalence result construction")
     return None, None, None
 
 

--- a/src/jacobian/math/logic/languages/regular/values.py
+++ b/src/jacobian/math/logic/languages/regular/values.py
@@ -18,6 +18,18 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 MAX_DFA_STATES = 64
 MAX_DFA_ALPHABET = 32
 MAX_DFA_TRANSITIONS = 4096
+# Equivalence explores a reachable subset of the Cartesian product. These
+# bounds are derived from the carrier limits so admission can account for the
+# whole product before allocating BFS state.
+MAX_DFA_EQUIVALENCE_PRODUCT_STATES = MAX_DFA_STATES * MAX_DFA_STATES
+MAX_DFA_EQUIVALENCE_PRODUCT_TRANSITIONS = (
+    MAX_DFA_EQUIVALENCE_PRODUCT_STATES * MAX_DFA_ALPHABET
+)
+MAX_DFA_EQUIVALENCE_WORK = 2_000_000
+MAX_DFA_EQUIVALENCE_INTERMEDIATE_ALLOCATION = 4_000_000
+MAX_DFA_EQUIVALENCE_OUTPUT_ALLOCATION = 100_000
+MAX_DFA_EQUIVALENCE_WITNESS_LENGTH = MAX_DFA_EQUIVALENCE_PRODUCT_STATES - 1
+MAX_DFA_EQUIVALENCE_TRACE_ROWS = 2 * MAX_DFA_EQUIVALENCE_PRODUCT_STATES
 MAX_WORD_LENGTH = 1000
 # Raw JSON integers remain exactly interoperable through this exponent. FLINT
 # accepts the full range, while owner-local work and result admission narrow it.
@@ -61,7 +73,7 @@ class DFA(StrictModel):
     """
 
     state_count: int = Field(ge=1, le=MAX_DFA_STATES)
-    alphabet_size: int = Field(ge=1, le=MAX_DFA_ALPHABET)
+    alphabet_size: int = Field(ge=0, le=MAX_DFA_ALPHABET)
     transitions: tuple[DFATransition, ...] = Field(
         min_length=0,
         max_length=MAX_DFA_TRANSITIONS,

--- a/tests/catalog/test_regular_language_discovery.py
+++ b/tests/catalog/test_regular_language_discovery.py
@@ -1,0 +1,17 @@
+"""Discovery coverage for exact DFA language equivalence."""
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationMatchRequest
+
+
+def test_dfa_equivalence_need_routes_to_the_decision_operation() -> None:
+    result = Catalog.open().match(
+        OperationMatchRequest(
+            need="exact deterministic finite automata language equivalence "
+            "shortest distinguishing word",
+            limit=5,
+        )
+    )
+
+    assert result.matches
+    assert result.matches[0].operation_id == ("regular_language.dfa.equivalence.decide")

--- a/tests/math/logic/languages/regular/test_dfa_equivalence.py
+++ b/tests/math/logic/languages/regular/test_dfa_equivalence.py
@@ -1,11 +1,23 @@
 """Exact DFA equivalence and least distinguishing words."""
 
 import itertools
+from typing import cast
 
 import pytest
 
-from jacobian.catalog.models import OperationDomainValidationError
-from jacobian.math.logic.languages.regular._models import EquivalenceRequest
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    request_execution,
+)
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
+from jacobian.math.logic.languages.regular import operations
+from jacobian.math.logic.languages.regular._models import (
+    EquivalenceRequest,
+    EquivalenceResult,
+)
 from jacobian.math.logic.languages.regular._tools import compute_equivalence
 from jacobian.math.logic.languages.regular.operations import dfa_run
 from jacobian.math.logic.languages.regular.values import DFA, DFATransition
@@ -73,3 +85,136 @@ def test_alphabet_mismatch_is_a_domain_error() -> None:
     unary = dfa(((0, 0, 0),), (), alphabet_size=1)
     with pytest.raises(OperationDomainValidationError, match="same ordered alphabet"):
         compute_equivalence(EquivalenceRequest(left=binary, right=unary))
+
+
+def test_empty_alphabet_has_only_the_empty_word() -> None:
+    accepting = DFA(
+        state_count=2,
+        alphabet_size=0,
+        transitions=(),
+        initial_state=0,
+        accepting_states=(0,),
+    )
+    rejecting = accepting.model_copy(update={"accepting_states": ()})
+    equivalent = compute_equivalence(
+        EquivalenceRequest(left=accepting, right=accepting)
+    )
+    assert equivalent.equivalent
+    result = compute_equivalence(EquivalenceRequest(left=accepting, right=rejecting))
+    assert not result.equivalent
+    assert result.distinguishing_word == ()
+    assert result.left_state_trace == result.right_state_trace == (0,)
+
+
+def test_reachable_product_ignores_different_unreachable_states() -> None:
+    left = DFA(
+        state_count=3,
+        alphabet_size=1,
+        transitions=(
+            DFATransition(source=0, symbol=0, target=0),
+            DFATransition(source=1, symbol=0, target=1),
+            DFATransition(source=2, symbol=0, target=2),
+        ),
+        initial_state=0,
+        accepting_states=(),
+    )
+    right = left.model_copy(
+        update={
+            "accepting_states": (1, 2),
+            "transitions": (
+                DFATransition(source=0, symbol=0, target=0),
+                DFATransition(source=1, symbol=0, target=2),
+                DFATransition(source=2, symbol=0, target=1),
+            ),
+        }
+    )
+    assert compute_equivalence(EquivalenceRequest(left=left, right=right)).equivalent
+
+
+def test_native_guard_rejects_partial_and_untyped_dfas() -> None:
+    partial = DFA.model_construct(
+        state_count=2,
+        alphabet_size=1,
+        transitions=(DFATransition(source=0, symbol=0, target=0),),
+        initial_state=0,
+        accepting_states=(),
+    )
+    valid = DFA(
+        state_count=2,
+        alphabet_size=1,
+        transitions=(
+            DFATransition(source=0, symbol=0, target=0),
+            DFATransition(source=1, symbol=0, target=1),
+        ),
+        initial_state=0,
+        accepting_states=(),
+    )
+    with pytest.raises(OperationDomainValidationError, match="one transition"):
+        operations.dfa_equivalence(partial, valid)
+    with pytest.raises(OperationDomainValidationError, match="canonical DFA"):
+        operations.dfa_equivalence(cast(DFA, {"not": "a DFA"}), valid)
+
+
+def test_native_guard_rejects_incompletely_constructed_values() -> None:
+    valid = dfa(((0, 0, 0), (0, 1, 0)), ())
+    incomplete = DFA.model_construct()
+    incomplete_transition = DFA.model_construct(
+        state_count=1,
+        alphabet_size=1,
+        transitions=(DFATransition.model_construct(),),
+        initial_state=0,
+        accepting_states=(),
+    )
+    with pytest.raises(OperationDomainValidationError) as incomplete_error:
+        operations.dfa_equivalence(incomplete, valid)
+    assert "structurally valid" in str(incomplete_error.value)
+    with pytest.raises(OperationDomainValidationError) as transition_error:
+        operations.dfa_equivalence(incomplete_transition, valid)
+    assert "invalid transition" in str(transition_error.value)
+
+
+def test_equivalence_honors_request_cancellation_before_execution() -> None:
+    class Cancelled:
+        def is_set(self) -> bool:
+            return True
+
+    left = dfa(((0, 0, 0), (0, 1, 0)), ())
+    with (
+        request_execution(0.0, cancellation_signal=Cancelled()),
+        pytest.raises(OperationExecutionCancelledError),
+    ):
+        operations.dfa_equivalence(left, left)
+
+
+def test_equivalence_admits_before_product_bfs(monkeypatch: pytest.MonkeyPatch) -> None:
+    left = dfa(
+        ((0, 0, 0), (0, 1, 0), (1, 0, 1), (1, 1, 1)),
+        (),
+    )
+    right = left
+    monkeypatch.setattr(operations, "MAX_DFA_EQUIVALENCE_PRODUCT_STATES", 1)
+    with pytest.raises(OperationResourceAdmissionError, match="product_states"):
+        operations.dfa_equivalence(left, right)
+
+
+def test_result_shape_checks_are_structural_and_do_not_replay() -> None:
+    left = dfa(((0, 0, 0), (0, 1, 0)), ())
+    right = left
+    with pytest.raises(ValueError, match="symbol outside"):
+        EquivalenceResult(
+            left=left,
+            right=right,
+            equivalent=False,
+            distinguishing_word=(2,),
+            left_state_trace=(0, 0),
+            right_state_trace=(0, 0),
+        )
+    with pytest.raises(ValueError, match="start at each initial"):
+        EquivalenceResult(
+            left=left,
+            right=right,
+            equivalent=False,
+            distinguishing_word=(0,),
+            left_state_trace=(1, 0),
+            right_state_trace=(0, 0),
+        )

--- a/tests/math/logic/languages/regular/test_symbol_parikh_profile.py
+++ b/tests/math/logic/languages/regular/test_symbol_parikh_profile.py
@@ -47,3 +47,17 @@ def test_length_zero_retains_empty_count_vector() -> None:
     )
     assert accepted.cells[0].symbol_counts == (0, 0)
     assert accepted.cells[0].multiplicity == 1
+
+
+def test_empty_alphabet_has_only_the_empty_word() -> None:
+    dfa = DFA(
+        state_count=1,
+        alphabet_size=0,
+        transitions=(),
+        initial_state=0,
+        accepting_states=(0,),
+    )
+    result = symbol_parikh_profile(SymbolParikhProfileRequest(dfa=dfa, word_length=0))
+    assert result.alphabet == ()
+    assert result.cells[0].symbol_counts == ()
+    assert result.total_accepted_words == 1


### PR DESCRIPTION
Closes #3590.

## Outcome

Hardens the existing `regular_language.dfa.equivalence.decide` operation into a bounded, typed, composable DFA equivalence primitive. It now admits canonical total DFAs, common ordered alphabets, reachable-product work, predecessor/intermediate cells, witness length, traces, and semantic result allocation before traversal. BFS remains deterministic: the first mismatch is the shortest lexicographically least distinguishing word, including the empty word.

The native path rejects forged or partially constructed DFA values with typed domain errors, shares request cancellation/deadline checkpoints and a work ledger, and constructs results without replaying the automata. Zero-symbol DFAs are represented canonically and compose through run/count/profile paths. Request schema guidance, operation documentation, catalog discovery coverage, and boundary regressions are included.

## Validation

- `make affected AFFECTED_BASE=origin/main` passed: scoped Ruff/format, mypy, 74 regular-language tests, 161 catalog tests, and 968 catalog integration tests.
- `make import-contracts architecture` passed.
- Final validated head: `e7cb069ffbe6af5f2aa0ceb977e381c3b52f7fe3`.

## Contract notes

- The established operation ID `regular_language.dfa.equivalence.decide` is retained; no duplicate ID is introduced.
- The implementation is Jacobian-owned BFS over the finite reachable product; no external backend is needed for this admitted envelope.
- Resource refusal is typed and never reported as equivalence.