### PR TITLE
feat(sequences): extend autocorrelation to exact rationals

### DIFF
--- a/docs/reference/operations/number-theory/finite-sequence-autocorrelation.md
+++ b/docs/reference/operations/number-theory/finite-sequence-autocorrelation.md
@@ -1,0 +1,31 @@
+# Exact finite-sequence autocorrelation
+
+The sequence catalog publishes two bounded exact transforms over a finite real
+rational sequence:
+
+- `sequence.autocorrelation.aperiodic.compute` returns coefficients at the
+  signed lag axis `-(n-1), ..., 0, ..., n-1`, with no wraparound:
+
+  `c_k = sum_j a_(j+k) a_j` for every pair of indices that remains in the
+  sequence.
+
+- `sequence.autocorrelation.cyclic.compute` returns one complete residue axis
+  `0, ..., n-1`, with indices interpreted modulo `n`:
+
+  `c_k = sum_(j mod n) a_(j+k mod n) a_j`.
+
+The result includes the explicit `convention` field (`"aperiodic"` or
+`"cyclic"`), so the lag axis remains self-describing after transport. The
+source sequence is retained in the result. Integer wire entries are canonical
+denominator-one rationals; native integer callers may use the finite-integer
+carrier directly and receive compact exact integer cells.
+Rational cells use `CanonicalRational`. Empty sequences return an empty cell
+axis for either convention. Complex coefficients are outside this real-rational
+contract; conjugation is therefore not an option hidden behind the operation.
+
+Both operations admit the complete source, multiplication work, exact
+coefficient growth, and materialized output before constructing the quadratic
+coefficient table. Oversized requests return the operation's typed domain or
+resource admission error rather than partially computed rows.
+
+[Number-theory operations](index.md) · [Tool reference](../../tools.md)

--- a/docs/reference/operations/number-theory/index.md
+++ b/docs/reference/operations/number-theory/index.md
@@ -12,3 +12,4 @@ and finite abelian-group decompositions are separate catalog entries.
 - [Integer prime factorization](integer-prime-factorization-verification.md)
 - [Simple number-field embeddings](number-field-embeddings.md)
 - [Real-embedded binary power-sum gap profiles](binary-power-sum-gap-profile.md)
+- [Exact finite-sequence autocorrelation](finite-sequence-autocorrelation.md)

--- a/src/jacobian/math/number_theory/sequences/__init__.py
+++ b/src/jacobian/math/number_theory/sequences/__init__.py
@@ -1,1 +1,19 @@
-"""Integer sequences and recurrence solving."""
+"""Finite exact sequences and recurrence solving."""
+
+from jacobian.math.number_theory.sequences.core import (
+    AutocorrelationCell,
+    AutocorrelationResult,
+    FiniteIntegerSequence,
+    FiniteRationalSequence,
+    aperiodic_autocorrelation,
+    cyclic_autocorrelation,
+)
+
+__all__ = [
+    "AutocorrelationCell",
+    "AutocorrelationResult",
+    "FiniteIntegerSequence",
+    "FiniteRationalSequence",
+    "aperiodic_autocorrelation",
+    "cyclic_autocorrelation",
+]

--- a/src/jacobian/math/number_theory/sequences/core/__init__.py
+++ b/src/jacobian/math/number_theory/sequences/core/__init__.py
@@ -1,5 +1,11 @@
-"""Finite integer-sequence values and native operations."""
+"""Finite exact-sequence values and native operations."""
 
+from jacobian.math.number_theory.sequences.core._models import (
+    AutocorrelationCell,
+    AutocorrelationResult,
+    FiniteIntegerSequence,
+    FiniteRationalSequence,
+)
 from jacobian.math.number_theory.sequences.core.operations import (
     aperiodic_autocorrelation,
     cyclic_autocorrelation,
@@ -37,6 +43,10 @@ from jacobian.math.number_theory.sequences.core.operations import (
 from jacobian.math.number_theory.sequences.core.values import IntegerSequence
 
 __all__ = [
+    "AutocorrelationCell",
+    "AutocorrelationResult",
+    "FiniteIntegerSequence",
+    "FiniteRationalSequence",
     "IntegerSequence",
     "aperiodic_autocorrelation",
     "cyclic_autocorrelation",

--- a/src/jacobian/math/number_theory/sequences/core/_models.py
+++ b/src/jacobian/math/number_theory/sequences/core/_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, ValidationInfo, model_validator
-from pydantic_core import PydanticCustomError
+from pydantic_core import PydanticCustomError, core_schema
 
 from jacobian._exact import (
     MAX_CANONICAL_RATIONAL_DIGITS,
@@ -102,7 +102,11 @@ class IntegerSequenceBooleanResult(StrictModel):
     holds: bool
 
 
-class FiniteIntegerSequence(StrictModel):
+class FiniteSequence(StrictModel):
+    """Catalog request base for canonical integer or rational sequences."""
+
+
+class FiniteIntegerSequence(FiniteSequence):
     """A possibly empty finite integer sequence."""
 
     domain: Literal["integer"] = "integer"
@@ -124,7 +128,7 @@ class FiniteIntegerSequence(StrictModel):
         return self
 
 
-class FiniteRationalSequence(StrictModel):
+class FiniteRationalSequence(FiniteSequence):
     """A possibly empty finite sequence of canonical real rationals.
 
     Integer wire entries are accepted as denominator-one rationals.  The
@@ -243,3 +247,37 @@ class SequenceOrderShapeResult(StrictModel):
     )
     is_nonnegative: bool
     has_internal_zero: bool
+
+
+@classmethod
+def _finite_sequence_core_schema(
+    cls, source_type: Any, handler: Any
+) -> core_schema.CoreSchema:
+    if cls is not FiniteSequence:
+        return handler(source_type)
+    return core_schema.union_schema(
+        [
+            handler.generate_schema(FiniteRationalSequence),
+            handler.generate_schema(FiniteIntegerSequence),
+        ]
+    )
+
+
+@classmethod
+def _finite_sequence_json_schema(
+    cls, core_schema_obj: Any, handler: Any
+) -> dict[str, Any]:
+    if cls is not FiniteSequence:
+        return handler(core_schema_obj)
+    return {
+        "type": "object",
+        "anyOf": [
+            FiniteIntegerSequence.model_json_schema(mode=handler.mode),
+            FiniteRationalSequence.model_json_schema(mode=handler.mode),
+        ],
+    }
+
+
+FiniteSequence.__get_pydantic_core_schema__ = _finite_sequence_core_schema
+FiniteSequence.__get_pydantic_json_schema__ = _finite_sequence_json_schema
+FiniteSequence.model_rebuild(force=True)

--- a/src/jacobian/math/number_theory/sequences/core/_models.py
+++ b/src/jacobian/math/number_theory/sequences/core/_models.py
@@ -1,17 +1,50 @@
-"""Typed wire contracts for finite integer-sequence operations."""
+"""Typed wire contracts for finite exact-sequence operations."""
 
 from __future__ import annotations
 
-from pydantic import Field
+from typing import Any, Literal, Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
 
 from jacobian._exact import (
+    MAX_CANONICAL_RATIONAL_DIGITS,
     CanonicalRational,
     ExactInteger,
 )
 from jacobian._models import StrictModel
+from jacobian.canonical import format_canonical_integer
 from jacobian.math.number_theory.sequences.core.values import (
     MAX_SEQUENCE_LENGTH,
+    MAX_SEQUENCE_TOTAL_DIGITS,
 )
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"sequences.{reason}", message)
+
+
+def _rational_sequence_schema(schema: dict[str, Any]) -> None:
+    """Publish denominator-one integer wire entries beside rational objects."""
+
+    rational_schema = schema["items"]
+    schema["items"] = {
+        "oneOf": [
+            rational_schema,
+            {
+                "type": "string",
+                "pattern": (
+                    rf"^(?:0|-?[1-9][0-9]{{0,{MAX_CANONICAL_RATIONAL_DIGITS - 1}}})"
+                    r"(?![\s\S])"
+                ),
+                "maxLength": MAX_CANONICAL_RATIONAL_DIGITS + 1,
+                "description": (
+                    "Canonical integer wire entry, interpreted as a "
+                    "denominator-one rational."
+                ),
+            },
+        ]
+    }
 
 
 class IntegerSequenceValueResult(StrictModel):
@@ -76,17 +109,109 @@ class FiniteIntegerSequence(StrictModel):
         min_length=0, max_length=MAX_SEQUENCE_LENGTH
     )
 
+    @model_validator(mode="after")
+    def require_bounded_representation(self) -> Self:
+        total_digits = sum(
+            len(format_canonical_integer(abs(value))) for value in self.values
+        )
+        if total_digits > MAX_SEQUENCE_TOTAL_DIGITS:
+            raise _validation_error(
+                "representation_too_large",
+                "integer sequence exceeds the "
+                f"{MAX_SEQUENCE_TOTAL_DIGITS}-digit representation bound",
+            )
+        return self
+
+
+class FiniteRationalSequence(StrictModel):
+    """A possibly empty finite sequence of canonical real rationals.
+
+    Integer wire entries are accepted as denominator-one rationals.  The
+    parsed value is always a canonical rational, so rational consumers do not
+    have to infer a coefficient domain from an empty or degenerate sequence.
+    """
+
+    values: tuple[CanonicalRational, ...] = Field(
+        min_length=0,
+        max_length=MAX_SEQUENCE_LENGTH,
+        json_schema_extra=_rational_sequence_schema,
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def accept_integer_wire_entries(cls, data: object) -> object:
+        if not isinstance(data, dict) or not isinstance(
+            data.get("values"), (list, tuple)
+        ):
+            return data
+        converted: list[object] = []
+        for value in data["values"]:
+            if isinstance(value, int) and not isinstance(value, bool):
+                converted.append({"num": value, "den": 1})
+                continue
+            if isinstance(value, str):
+                try:
+                    integer = int(value)
+                except ValueError:
+                    pass
+                else:
+                    if value == str(integer):
+                        converted.append({"num": value, "den": "1"})
+                        continue
+            converted.append(value)
+        return {**data, "values": tuple(converted)}
+
+    @model_validator(mode="after")
+    def require_bounded_representation(self) -> Self:
+        total_digits = sum(
+            len(format_canonical_integer(abs(value.num)))
+            + len(format_canonical_integer(value.den))
+            for value in self.values
+        )
+        if total_digits > MAX_SEQUENCE_TOTAL_DIGITS:
+            raise _validation_error(
+                "representation_too_large",
+                "rational sequence exceeds the "
+                f"{MAX_SEQUENCE_TOTAL_DIGITS}-digit representation bound",
+            )
+        return self
+
 
 class AutocorrelationCell(StrictModel):
     lag: int
-    value: ExactInteger
+    value: ExactInteger | CanonicalRational = Field(union_mode="left_to_right")
 
 
 class AutocorrelationResult(StrictModel):
-    source: FiniteIntegerSequence
+    convention: Literal["aperiodic", "cyclic"]
+    source: FiniteIntegerSequence | FiniteRationalSequence = Field(
+        union_mode="left_to_right"
+    )
     cells: tuple[AutocorrelationCell, ...] = Field(
         min_length=0, max_length=2 * MAX_SEQUENCE_LENGTH - 1
     )
+
+    @model_validator(mode="after")
+    def require_canonical_axis_and_domain(self) -> Self:
+        size = len(self.source.values)
+        expected_lags = (
+            range(-(size - 1), size) if self.convention == "aperiodic" else range(size)
+        )
+        if tuple(cell.lag for cell in self.cells) != tuple(expected_lags):
+            raise _validation_error(
+                "invalid_lag_axis",
+                f"{self.convention} autocorrelation must retain its canonical lag axis",
+            )
+        integer_source = isinstance(self.source, FiniteIntegerSequence)
+        if any(
+            isinstance(cell.value, CanonicalRational) is integer_source
+            for cell in self.cells
+        ):
+            raise _validation_error(
+                "mixed_coefficient_domain",
+                "autocorrelation cells must retain the source coefficient domain",
+            )
+        return self
 
 
 class SequenceLogConcavityRow(StrictModel):

--- a/src/jacobian/math/number_theory/sequences/core/_models.py
+++ b/src/jacobian/math/number_theory/sequences/core/_models.py
@@ -8,6 +8,7 @@ from pydantic import Field, ValidationInfo, model_validator
 from pydantic_core import PydanticCustomError, core_schema
 
 from jacobian._exact import (
+    MAX_CANONICAL_INTEGER_DIGITS,
     MAX_CANONICAL_RATIONAL_DIGITS,
     CanonicalRational,
     ExactInteger,
@@ -156,6 +157,13 @@ class FiniteRationalSequence(FiniteSequence):
                 converted.append({"num": value, "den": 1})
                 continue
             if isinstance(value, str):
+                digits = value[1:] if value.startswith("-") else value
+                if digits.isdigit() and len(digits) > MAX_CANONICAL_INTEGER_DIGITS:
+                    raise _validation_error(
+                        "integer_digits_exceeded",
+                        "canonical integer entries exceed the "
+                        f"{MAX_CANONICAL_INTEGER_DIGITS}-digit bound",
+                    )
                 try:
                     integer = parse_canonical_integer(value)
                 except ValueError:

--- a/src/jacobian/math/number_theory/sequences/core/_models.py
+++ b/src/jacobian/math/number_theory/sequences/core/_models.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, ValidationInfo, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import (
@@ -13,7 +13,7 @@ from jacobian._exact import (
     ExactInteger,
 )
 from jacobian._models import StrictModel
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.number_theory.sequences.core.values import (
     MAX_SEQUENCE_LENGTH,
     MAX_SEQUENCE_TOTAL_DIGITS,
@@ -105,6 +105,7 @@ class IntegerSequenceBooleanResult(StrictModel):
 class FiniteIntegerSequence(StrictModel):
     """A possibly empty finite integer sequence."""
 
+    domain: Literal["integer"] = "integer"
     values: tuple[ExactInteger, ...] = Field(
         min_length=0, max_length=MAX_SEQUENCE_LENGTH
     )
@@ -131,6 +132,7 @@ class FiniteRationalSequence(StrictModel):
     have to infer a coefficient domain from an empty or degenerate sequence.
     """
 
+    domain: Literal["rational"] = "rational"
     values: tuple[CanonicalRational, ...] = Field(
         min_length=0,
         max_length=MAX_SEQUENCE_LENGTH,
@@ -139,7 +141,7 @@ class FiniteRationalSequence(StrictModel):
 
     @model_validator(mode="before")
     @classmethod
-    def accept_integer_wire_entries(cls, data: object) -> object:
+    def accept_integer_wire_entries(cls, data: object, info: ValidationInfo) -> object:
         if not isinstance(data, dict) or not isinstance(
             data.get("values"), (list, tuple)
         ):
@@ -151,12 +153,15 @@ class FiniteRationalSequence(StrictModel):
                 continue
             if isinstance(value, str):
                 try:
-                    integer = int(value)
+                    integer = parse_canonical_integer(value)
                 except ValueError:
                     pass
                 else:
-                    if value == str(integer):
-                        converted.append({"num": value, "den": "1"})
+                    if value == format_canonical_integer(integer):
+                        if info.mode == "json":
+                            converted.append({"num": value, "den": "1"})
+                        else:
+                            converted.append({"num": integer, "den": 1})
                         continue
             converted.append(value)
         return {**data, "values": tuple(converted)}
@@ -184,9 +189,10 @@ class AutocorrelationCell(StrictModel):
 
 class AutocorrelationResult(StrictModel):
     convention: Literal["aperiodic", "cyclic"]
-    source: FiniteIntegerSequence | FiniteRationalSequence = Field(
-        union_mode="left_to_right"
-    )
+    source: Annotated[
+        FiniteIntegerSequence | FiniteRationalSequence,
+        Field(discriminator="domain"),
+    ]
     cells: tuple[AutocorrelationCell, ...] = Field(
         min_length=0, max_length=2 * MAX_SEQUENCE_LENGTH - 1
     )

--- a/src/jacobian/math/number_theory/sequences/core/_models.py
+++ b/src/jacobian/math/number_theory/sequences/core/_models.py
@@ -269,13 +269,10 @@ def _finite_sequence_json_schema(
 ) -> dict[str, Any]:
     if cls is not FiniteSequence:
         return handler(core_schema_obj)
-    return {
-        "type": "object",
-        "anyOf": [
-            FiniteIntegerSequence.model_json_schema(mode=handler.mode),
-            FiniteRationalSequence.model_json_schema(mode=handler.mode),
-        ],
-    }
+    schema = dict(handler(core_schema_obj))
+    if "type" not in schema:
+        schema["type"] = "object"
+    return schema
 
 
 FiniteSequence.__get_pydantic_core_schema__ = _finite_sequence_core_schema

--- a/src/jacobian/math/number_theory/sequences/core/_tools.py
+++ b/src/jacobian/math/number_theory/sequences/core/_tools.py
@@ -6,6 +6,7 @@ from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.number_theory.sequences.core._models import (
     AutocorrelationResult,
     FiniteIntegerSequence,
+    FiniteRationalSequence,
     IntegerSequenceBooleanResult,
     IntegerSequenceFrequenciesResult,
     IntegerSequenceIndexListResult,
@@ -77,13 +78,16 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         operation_id="sequence.autocorrelation.aperiodic.compute",
         title="Compute exact aperiodic autocorrelation",
         description=(
-            "Compute the exact integer autocorrelation at lags -(n-1) through "
-            "n-1 without wraparound. An empty sequence returns an empty profile."
+            "Compute the exact real-rational autocorrelation at lags -(n-1) "
+            "through n-1 without wraparound. Integer wire entries are accepted "
+            "as denominator-one rationals, and an empty sequence returns an "
+            "empty profile."
         ),
-        request_type=FiniteIntegerSequence,
+        request_type=FiniteRationalSequence,
         result_type=AutocorrelationResult,
         run=aperiodic_autocorrelation,
         tags=("sequence", "autocorrelation", "aperiodic", "exact"),
+        discovery_terms=("aperiodic autocorrelation", "non-cyclic correlation"),
         examples=(
             OperationExample(
                 name="three_terms",
@@ -96,13 +100,16 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         operation_id="sequence.autocorrelation.cyclic.compute",
         title="Compute exact cyclic autocorrelation",
         description=(
-            "Compute the exact integer autocorrelation with indices modulo n at "
-            "lags 0 through n-1. An empty sequence returns an empty profile."
+            "Compute the exact real-rational autocorrelation with indices modulo "
+            "n at lags 0 through n-1. Integer wire entries are accepted as "
+            "denominator-one rationals, and an empty sequence returns an empty "
+            "profile."
         ),
-        request_type=FiniteIntegerSequence,
+        request_type=FiniteRationalSequence,
         result_type=AutocorrelationResult,
         run=cyclic_autocorrelation,
         tags=("sequence", "autocorrelation", "cyclic", "exact"),
+        discovery_terms=("cyclic autocorrelation", "periodic correlation"),
         examples=(
             OperationExample(
                 name="three_terms",

--- a/src/jacobian/math/number_theory/sequences/core/_tools.py
+++ b/src/jacobian/math/number_theory/sequences/core/_tools.py
@@ -6,7 +6,7 @@ from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.number_theory.sequences.core._models import (
     AutocorrelationResult,
     FiniteIntegerSequence,
-    FiniteRationalSequence,
+    FiniteSequence,
     IntegerSequenceBooleanResult,
     IntegerSequenceFrequenciesResult,
     IntegerSequenceIndexListResult,
@@ -83,7 +83,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
             "as denominator-one rationals, and an empty sequence returns an "
             "empty profile."
         ),
-        request_type=FiniteRationalSequence,
+        request_type=FiniteSequence,
         result_type=AutocorrelationResult,
         run=aperiodic_autocorrelation,
         tags=("sequence", "autocorrelation", "aperiodic", "exact"),
@@ -105,7 +105,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
             "denominator-one rationals, and an empty sequence returns an empty "
             "profile."
         ),
-        request_type=FiniteRationalSequence,
+        request_type=FiniteSequence,
         result_type=AutocorrelationResult,
         run=cyclic_autocorrelation,
         tags=("sequence", "autocorrelation", "cyclic", "exact"),

--- a/src/jacobian/math/number_theory/sequences/core/operations.py
+++ b/src/jacobian/math/number_theory/sequences/core/operations.py
@@ -165,12 +165,19 @@ def _admit_autocorrelation(
             code="sequences.autocorrelation_result_digits_exceeded",
             message="autocorrelation values exceed the exact rational digit bound",
         )
-    common_numerators = tuple(
-        abs(value.numerator) * (common_denominator // value.denominator)
-        for value in fractions
-    )
+    widest_numerator: dict[int, int] = {}
+    for value in fractions:
+        numerator = abs(value.numerator)
+        current = widest_numerator.get(value.denominator)
+        if current is None or numerator > current:
+            widest_numerator[value.denominator] = numerator
     common_numerator_digits = max(
-        len(format_canonical_integer(value)) for value in common_numerators
+        len(
+            format_canonical_integer(
+                numerator * (common_denominator // denominator)
+            )
+        )
+        for denominator, numerator in widest_numerator.items()
     )
     denominator_digits = len(format_canonical_integer(common_denominator))
     term_count_digits = len(str(len(fractions)))

--- a/src/jacobian/math/number_theory/sequences/core/operations.py
+++ b/src/jacobian/math/number_theory/sequences/core/operations.py
@@ -7,6 +7,7 @@ from collections import Counter
 from fractions import Fraction
 from functools import reduce
 from itertools import pairwise
+from math import gcd
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import format_canonical_integer
@@ -18,6 +19,7 @@ from jacobian.math.number_theory.sequences.core._models import (
     AutocorrelationCell,
     AutocorrelationResult,
     FiniteIntegerSequence,
+    FiniteRationalSequence,
     FrequencyEntry,
     IntegerSequenceBooleanResult,
     IntegerSequenceFrequenciesResult,
@@ -34,6 +36,7 @@ from jacobian.math.number_theory.sequences.core.values import (
 )
 
 MAX_AUTOCORRELATION_MULTIPLICATIONS = 4_000_000
+MAX_AUTOCORRELATION_ADDITIONS = 4_000_000
 
 
 def _admit(
@@ -101,7 +104,99 @@ def _value_result(value: int) -> IntegerSequenceValueResult:
     return IntegerSequenceValueResult(value=value)
 
 
-def _admit_autocorrelation(request: FiniteIntegerSequence) -> tuple[int, ...]:
+def _admit_autocorrelation(
+    request: FiniteIntegerSequence | FiniteRationalSequence,
+    *,
+    output_items: int,
+) -> tuple[tuple[Fraction, ...], int]:
+    """Admit source, intermediate, and output bounds before expansion.
+
+    A common denominator gives a sound width bound without computing any
+    pairwise products.  Every coefficient is a sum of at most ``n`` products
+    whose denominator divides ``D**2``, where ``D`` is the lcm of source
+    denominators.  This also keeps cheap repeated rational inputs from being
+    rejected merely because their syntactic denominators are nontrivial.
+    """
+
+    if isinstance(request, FiniteIntegerSequence):
+        fractions = tuple(Fraction(value) for value in request.values)
+    else:
+        fractions = tuple(value.as_fraction() for value in request.values)
+    if not fractions:
+        return fractions, 1
+
+    denominators = tuple(value.denominator for value in fractions)
+    common_denominator = 1
+    common_denominator_digits = 1
+    for denominator in denominators:
+        denominator_digits = len(format_canonical_integer(denominator))
+        if denominator_digits > MAX_CANONICAL_RATIONAL_DIGITS // 2:
+            raise OperationDomainValidationError(
+                location=("values",),
+                code="sequences.autocorrelation_result_digits_exceeded",
+                message="autocorrelation denominators exceed the exact rational digit bound",
+            )
+        divisor = gcd(common_denominator, denominator)
+        quotient = denominator // divisor
+        quotient_digits = len(format_canonical_integer(quotient))
+        if common_denominator_digits + quotient_digits > (
+            MAX_CANONICAL_RATIONAL_DIGITS // 2 + 1
+        ):
+            raise OperationDomainValidationError(
+                location=("values",),
+                code="sequences.autocorrelation_result_digits_exceeded",
+                message="autocorrelation denominators exceed the exact rational digit bound",
+            )
+        common_denominator *= quotient
+        common_denominator_digits = len(format_canonical_integer(common_denominator))
+        if common_denominator_digits > MAX_CANONICAL_RATIONAL_DIGITS // 2:
+            raise OperationDomainValidationError(
+                location=("values",),
+                code="sequences.autocorrelation_result_digits_exceeded",
+                message="autocorrelation denominators exceed the exact rational digit bound",
+            )
+    if any(
+        len(format_canonical_integer(abs(value.numerator))) + common_denominator_digits
+        > MAX_CANONICAL_RATIONAL_DIGITS
+        for value in fractions
+    ):
+        raise OperationDomainValidationError(
+            location=("values",),
+            code="sequences.autocorrelation_result_digits_exceeded",
+            message="autocorrelation values exceed the exact rational digit bound",
+        )
+    common_numerators = tuple(
+        abs(value.numerator) * (common_denominator // value.denominator)
+        for value in fractions
+    )
+    common_numerator_digits = max(
+        len(format_canonical_integer(value)) for value in common_numerators
+    )
+    denominator_digits = len(format_canonical_integer(common_denominator))
+    term_count_digits = len(str(len(fractions)))
+    result_digits = max(
+        2 * common_numerator_digits + term_count_digits,
+        2 * denominator_digits,
+    )
+    if result_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        raise OperationDomainValidationError(
+            location=("values",),
+            code="sequences.autocorrelation_result_digits_exceeded",
+            message="autocorrelation values exceed the exact rational digit bound",
+        )
+
+    if output_items * result_digits > MAX_SEQUENCE_TOTAL_DIGITS:
+        raise OperationDomainValidationError(
+            location=("values",),
+            code="sequences.autocorrelation.result_representation_too_large",
+            message="autocorrelation output exceeds the exact representation bound",
+        )
+    return fractions, result_digits
+
+
+def _admit_integer_sequence_for_shape(
+    request: FiniteIntegerSequence,
+) -> tuple[int, ...]:
     values = tuple(request.values)
     if not values:
         return values
@@ -116,20 +211,45 @@ def _admit_autocorrelation(request: FiniteIntegerSequence) -> tuple[int, ...]:
     return values
 
 
-def aperiodic_autocorrelation(request: FiniteIntegerSequence) -> AutocorrelationResult:
-    values = _admit_autocorrelation(request)
-    size = len(values)
-    if size * (size + 1) // 2 > MAX_AUTOCORRELATION_MULTIPLICATIONS:
+def _autocorrelation_scalar(
+    value: Fraction,
+    *,
+    rational_output: bool,
+) -> int | CanonicalRational:
+    if rational_output or value.denominator != 1:
+        return CanonicalRational.from_fraction(value)
+    return value.numerator
+
+
+def aperiodic_autocorrelation(
+    request: FiniteIntegerSequence | FiniteRationalSequence,
+) -> AutocorrelationResult:
+    size = len(request.values)
+    multiplications = size * (size + 1) // 2
+    additions = size * (size - 1) // 2
+    if (
+        multiplications > MAX_AUTOCORRELATION_MULTIPLICATIONS
+        or additions > MAX_AUTOCORRELATION_ADDITIONS
+    ):
         raise OperationResourceAdmissionError(
             location=("values",),
             code="sequences.autocorrelation.work_bound",
-            message="aperiodic autocorrelation exceeds the admitted multiplication bound",
+            message="aperiodic autocorrelation exceeds the admitted arithmetic-work bound",
         )
+    values, _ = _admit_autocorrelation(request, output_items=max(2 * size - 1, 0))
+    rational_output = isinstance(request, FiniteRationalSequence)
     cells = tuple(
         AutocorrelationCell(
             lag=lag,
-            value=sum(
-                values[index] * values[index + lag] for index in range(size - lag)
+            value=_autocorrelation_scalar(
+                sum(
+                    (
+                        values[index] * values[index + lag]
+                        for index in range(size - lag)
+                    ),
+                    Fraction(0),
+                ),
+                rational_output=rational_output,
             ),
         )
         for lag in range(size)
@@ -138,26 +258,43 @@ def aperiodic_autocorrelation(request: FiniteIntegerSequence) -> Autocorrelation
         AutocorrelationCell(lag=-cell.lag, value=cell.value)
         for cell in reversed(cells[1:])
     )
-    return AutocorrelationResult(source=request, cells=negative + cells)
+    return AutocorrelationResult(
+        convention="aperiodic", source=request, cells=negative + cells
+    )
 
 
-def cyclic_autocorrelation(request: FiniteIntegerSequence) -> AutocorrelationResult:
-    values = _admit_autocorrelation(request)
-    size = len(values)
-    if size * size > MAX_AUTOCORRELATION_MULTIPLICATIONS:
+def cyclic_autocorrelation(
+    request: FiniteIntegerSequence | FiniteRationalSequence,
+) -> AutocorrelationResult:
+    size = len(request.values)
+    multiplications = size * size
+    additions = size * max(size - 1, 0)
+    if (
+        multiplications > MAX_AUTOCORRELATION_MULTIPLICATIONS
+        or additions > MAX_AUTOCORRELATION_ADDITIONS
+    ):
         raise OperationResourceAdmissionError(
             location=("values",),
             code="sequences.autocorrelation.work_bound",
-            message="cyclic autocorrelation exceeds the admitted multiplication bound",
+            message="cyclic autocorrelation exceeds the admitted arithmetic-work bound",
         )
+    values, _ = _admit_autocorrelation(request, output_items=size)
+    rational_output = isinstance(request, FiniteRationalSequence)
     return AutocorrelationResult(
+        convention="cyclic",
         source=request,
         cells=tuple(
             AutocorrelationCell(
                 lag=lag,
-                value=sum(
-                    values[index] * values[(index + lag) % size]
-                    for index in range(size)
+                value=_autocorrelation_scalar(
+                    sum(
+                        (
+                            values[index] * values[(index + lag) % size]
+                            for index in range(size)
+                        ),
+                        Fraction(0),
+                    ),
+                    rational_output=rational_output,
                 ),
             )
             for lag in range(size)
@@ -166,7 +303,7 @@ def cyclic_autocorrelation(request: FiniteIntegerSequence) -> AutocorrelationRes
 
 
 def sequence_order_shape(request: FiniteIntegerSequence) -> SequenceOrderShapeResult:
-    values = _admit_autocorrelation(request)
+    values = _admit_integer_sequence_for_shape(request)
     nondecreasing_violation = next(
         (
             index

--- a/src/jacobian/math/number_theory/sequences/core/operations.py
+++ b/src/jacobian/math/number_theory/sequences/core/operations.py
@@ -172,11 +172,7 @@ def _admit_autocorrelation(
         if current is None or numerator > current:
             widest_numerator[value.denominator] = numerator
     common_numerator_digits = max(
-        len(
-            format_canonical_integer(
-                numerator * (common_denominator // denominator)
-            )
-        )
+        len(format_canonical_integer(numerator * (common_denominator // denominator)))
         for denominator, numerator in widest_numerator.items()
     )
     denominator_digits = len(format_canonical_integer(common_denominator))

--- a/src/jacobian/math/number_theory/sequences/core/operations.py
+++ b/src/jacobian/math/number_theory/sequences/core/operations.py
@@ -174,10 +174,9 @@ def _admit_autocorrelation(
     )
     denominator_digits = len(format_canonical_integer(common_denominator))
     term_count_digits = len(str(len(fractions)))
-    result_digits = max(
-        2 * common_numerator_digits + term_count_digits,
-        2 * denominator_digits,
-    )
+    result_numerator_digits = 2 * common_numerator_digits + term_count_digits
+    result_denominator_digits = 2 * denominator_digits
+    result_digits = max(result_numerator_digits, result_denominator_digits)
     if result_digits > MAX_CANONICAL_RATIONAL_DIGITS:
         raise OperationDomainValidationError(
             location=("values",),
@@ -185,7 +184,12 @@ def _admit_autocorrelation(
             message="autocorrelation values exceed the exact rational digit bound",
         )
 
-    if output_items * result_digits > MAX_SEQUENCE_TOTAL_DIGITS:
+    result_representation_digits = (
+        result_numerator_digits + result_denominator_digits
+        if isinstance(request, FiniteRationalSequence)
+        else result_numerator_digits
+    )
+    if output_items * result_representation_digits > MAX_SEQUENCE_TOTAL_DIGITS:
         raise OperationDomainValidationError(
             location=("values",),
             code="sequences.autocorrelation.result_representation_too_large",

--- a/src/jacobian/math/number_theory/sequences/core/operations.py
+++ b/src/jacobian/math/number_theory/sequences/core/operations.py
@@ -108,7 +108,7 @@ def _admit_autocorrelation(
     request: FiniteIntegerSequence | FiniteRationalSequence,
     *,
     output_items: int,
-) -> tuple[tuple[Fraction, ...], int]:
+) -> tuple[tuple[Fraction, ...], int, int]:
     """Admit source, intermediate, and output bounds before expansion.
 
     A common denominator gives a sound width bound without computing any
@@ -123,7 +123,7 @@ def _admit_autocorrelation(
     else:
         fractions = tuple(value.as_fraction() for value in request.values)
     if not fractions:
-        return fractions, 1
+        return fractions, 1, 1
 
     denominators = tuple(value.denominator for value in fractions)
     common_denominator = 1
@@ -195,7 +195,8 @@ def _admit_autocorrelation(
             code="sequences.autocorrelation.result_representation_too_large",
             message="autocorrelation output exceeds the exact representation bound",
         )
-    return fractions, result_digits
+    operand_width = max(1, common_numerator_digits + denominator_digits)
+    return fractions, result_digits, operand_width
 
 
 def _admit_integer_sequence_for_shape(
@@ -225,22 +226,34 @@ def _autocorrelation_scalar(
     return value.numerator
 
 
+def _require_autocorrelation_work(
+    multiplications: int, additions: int, operand_width: int, *, convention: str
+) -> None:
+    if (
+        multiplications * operand_width > MAX_AUTOCORRELATION_MULTIPLICATIONS
+        or additions * operand_width > MAX_AUTOCORRELATION_ADDITIONS
+    ):
+        raise OperationResourceAdmissionError(
+            location=("values",),
+            code="sequences.autocorrelation.work_bound",
+            message=(
+                f"{convention} autocorrelation exceeds the admitted arithmetic-work bound"
+            ),
+        )
+
+
 def aperiodic_autocorrelation(
     request: FiniteIntegerSequence | FiniteRationalSequence,
 ) -> AutocorrelationResult:
     size = len(request.values)
     multiplications = size * (size + 1) // 2
     additions = size * (size - 1) // 2
-    if (
-        multiplications > MAX_AUTOCORRELATION_MULTIPLICATIONS
-        or additions > MAX_AUTOCORRELATION_ADDITIONS
-    ):
-        raise OperationResourceAdmissionError(
-            location=("values",),
-            code="sequences.autocorrelation.work_bound",
-            message="aperiodic autocorrelation exceeds the admitted arithmetic-work bound",
-        )
-    values, _ = _admit_autocorrelation(request, output_items=max(2 * size - 1, 0))
+    values, _, operand_width = _admit_autocorrelation(
+        request, output_items=max(2 * size - 1, 0)
+    )
+    _require_autocorrelation_work(
+        multiplications, additions, operand_width, convention="aperiodic"
+    )
     rational_output = isinstance(request, FiniteRationalSequence)
     cells = tuple(
         AutocorrelationCell(
@@ -273,16 +286,10 @@ def cyclic_autocorrelation(
     size = len(request.values)
     multiplications = size * size
     additions = size * max(size - 1, 0)
-    if (
-        multiplications > MAX_AUTOCORRELATION_MULTIPLICATIONS
-        or additions > MAX_AUTOCORRELATION_ADDITIONS
-    ):
-        raise OperationResourceAdmissionError(
-            location=("values",),
-            code="sequences.autocorrelation.work_bound",
-            message="cyclic autocorrelation exceeds the admitted arithmetic-work bound",
-        )
-    values, _ = _admit_autocorrelation(request, output_items=size)
+    values, _, operand_width = _admit_autocorrelation(request, output_items=size)
+    _require_autocorrelation_work(
+        multiplications, additions, operand_width, convention="cyclic"
+    )
     rational_output = isinstance(request, FiniteRationalSequence)
     return AutocorrelationResult(
         convention="cyclic",

--- a/tests/dispatch/test_sequence_core_dispatch.py
+++ b/tests/dispatch/test_sequence_core_dispatch.py
@@ -43,6 +43,8 @@ def test_sequence_core_manifest_publishes_every_recovered_operation() -> None:
         "sequence.decide.strictly_increasing",
         "sequence.compute.frequencies",
         "sequence.compute.zero_indices",
+        "sequence.autocorrelation.aperiodic.compute",
+        "sequence.autocorrelation.cyclic.compute",
     } <= ids
 
 
@@ -55,3 +57,18 @@ def test_dispatch_matches_native_sum_value() -> None:
     )
 
     assert dispatched.output == native.model_dump(mode="json")
+
+
+def test_dispatch_accepts_exact_rational_autocorrelation_input() -> None:
+    dispatched = invoke_operation(
+        "sequence.autocorrelation.aperiodic.compute",
+        {"values": [{"num": "1", "den": "2"}, {"num": "1", "den": "3"}]},
+        Catalog.open(),
+    )
+
+    assert dispatched.output["convention"] == "aperiodic"
+    assert dispatched.output["cells"] == [
+        {"lag": -1, "value": {"num": "1", "den": "6"}},
+        {"lag": 0, "value": {"num": "13", "den": "36"}},
+        {"lag": 1, "value": {"num": "1", "den": "6"}},
+    ]

--- a/tests/math/number_theory/sequences/core/test_autocorrelation.py
+++ b/tests/math/number_theory/sequences/core/test_autocorrelation.py
@@ -1,13 +1,18 @@
 """Exact aperiodic and cyclic autocorrelation contracts."""
 
+import json
 from collections.abc import Callable
+from fractions import Fraction
 
 import pytest
+from pydantic import ValidationError
 
+from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.number_theory.sequences.core._models import (
     AutocorrelationResult,
     FiniteIntegerSequence,
+    FiniteRationalSequence,
 )
 from jacobian.math.number_theory.sequences.core.operations import (
     aperiodic_autocorrelation,
@@ -16,19 +21,131 @@ from jacobian.math.number_theory.sequences.core.operations import (
 )
 
 
-def values(result: AutocorrelationResult) -> list[tuple[int, int]]:
+def values(result: AutocorrelationResult) -> list[tuple[int, object]]:
     return [(cell.lag, cell.value) for cell in result.cells]
 
 
 def test_aperiodic_uses_signed_nonwrapping_lags() -> None:
     result = aperiodic_autocorrelation(FiniteIntegerSequence(values=(1, 2, 3)))
+    assert result.convention == "aperiodic"
     assert values(result) == [(-2, 3), (-1, 8), (0, 14), (1, 8), (2, 3)]
     assert result.source.values == (1, 2, 3)
 
 
 def test_cyclic_uses_one_complete_residue_axis() -> None:
     result = cyclic_autocorrelation(FiniteIntegerSequence(values=(1, 2, 3)))
+    assert result.convention == "cyclic"
     assert values(result) == [(0, 14), (1, 11), (2, 11)]
+
+
+def test_rational_coefficients_retain_exact_domain_and_source() -> None:
+    source = FiniteRationalSequence(
+        values=(
+            CanonicalRational(num=1, den=2),
+            CanonicalRational(num=1, den=3),
+            CanonicalRational(num=-1, den=2),
+        )
+    )
+    result = aperiodic_autocorrelation(source)
+
+    assert result.source is source
+    assert values(result) == [
+        (-2, CanonicalRational(num=-1, den=4)),
+        (-1, CanonicalRational(num=0, den=1)),
+        (0, CanonicalRational(num=11, den=18)),
+        (1, CanonicalRational(num=0, den=1)),
+        (2, CanonicalRational(num=-1, den=4)),
+    ]
+
+
+def test_serialized_integer_result_retains_integer_source_domain() -> None:
+    result = aperiodic_autocorrelation(FiniteIntegerSequence(values=(1, 2, 3)))
+
+    restored = AutocorrelationResult.model_validate_json(result.model_dump_json())
+
+    assert isinstance(restored.source, FiniteIntegerSequence)
+    assert all(isinstance(cell.value, int) for cell in restored.cells)
+
+
+def test_serialized_rational_integer_entries_retain_rational_domain() -> None:
+    source = FiniteRationalSequence.model_validate_json(
+        json.dumps({"values": ["1", "2", "3"]})
+    )
+
+    restored = AutocorrelationResult.model_validate_json(
+        aperiodic_autocorrelation(source).model_dump_json()
+    )
+
+    assert isinstance(restored.source, FiniteRationalSequence)
+    assert all(isinstance(cell.value, CanonicalRational) for cell in restored.cells)
+
+
+def test_result_rejects_noncanonical_lag_axis_without_recomputing_coefficients() -> (
+    None
+):
+    with pytest.raises(ValidationError, match="invalid_lag_axis"):
+        AutocorrelationResult(
+            convention="cyclic",
+            source=FiniteIntegerSequence(values=(1, 2)),
+            cells=(
+                {"lag": 0, "value": 5},
+                {"lag": 2, "value": 5},
+            ),
+        )
+
+
+def test_rational_wire_entries_normalize_integer_strings() -> None:
+    source = FiniteRationalSequence.model_validate_json(
+        '{"values":["1",{"num":"1","den":"2"}]}'
+    )
+
+    assert source.values == (
+        CanonicalRational(num=1, den=1),
+        CanonicalRational(num=1, den=2),
+    )
+
+
+def test_complex_entries_are_rejected_by_real_rational_contract() -> None:
+    with pytest.raises(ValidationError):
+        FiniteRationalSequence.model_validate({"values": [{"real": 1, "imaginary": 2}]})
+
+
+def test_aperiodic_matches_defining_sum_for_signed_rational_lags() -> None:
+    source = FiniteRationalSequence(
+        values=tuple(
+            CanonicalRational.from_fraction(Fraction(value, 5))
+            for value in (2, -1, 3, 0)
+        )
+    )
+    expected = {
+        lag: sum(
+            Fraction(source.values[index].num, source.values[index].den)
+            * Fraction(
+                source.values[index + lag].num,
+                source.values[index + lag].den,
+            )
+            for index in range(len(source.values) - lag)
+        )
+        for lag in range(len(source.values))
+    }
+    expected.update({-lag: value for lag, value in expected.items() if lag})
+
+    result = aperiodic_autocorrelation(source)
+    assert [cell.lag for cell in result.cells] == list(range(-3, 4))
+    assert [Fraction(cell.value.num, cell.value.den) for cell in result.cells] == [
+        expected[lag] for lag in range(-3, 4)
+    ]
+
+
+def test_reversing_source_preserves_aperiodic_profile() -> None:
+    source = FiniteIntegerSequence(values=(2, -1, 3, 0))
+
+    result = aperiodic_autocorrelation(source)
+    reversed_result = aperiodic_autocorrelation(
+        FiniteIntegerSequence(values=tuple(reversed(source.values)))
+    )
+
+    assert values(reversed_result) == values(result)
 
 
 def test_empty_sequence_has_empty_profiles() -> None:

--- a/tests/math/number_theory/sequences/core/test_autocorrelation.py
+++ b/tests/math/number_theory/sequences/core/test_autocorrelation.py
@@ -9,10 +9,12 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import parse_canonical_integer
+from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
 )
+from jacobian.dispatch import invoke_operation
 from jacobian.math.number_theory.sequences.core._models import (
     AutocorrelationCell,
     AutocorrelationResult,
@@ -233,3 +235,18 @@ def test_constant_sequence_peak_scan_is_linear() -> None:
     source = FiniteIntegerSequence(values=(1,) * 10_000)
     result = sequence_order_shape(source)
     assert result.weak_unimodal_peak_positions == tuple(range(10_000))
+
+
+def test_catalog_accepts_serialized_integer_sequence_source() -> None:
+    source = sequence_order_shape(FiniteIntegerSequence(values=(1, 2, 3))).source
+    payload = json.loads(source.model_dump_json())
+    result = invoke_operation(
+        "sequence.autocorrelation.aperiodic.compute",
+        payload,
+        Catalog.open(),
+    )
+    native = aperiodic_autocorrelation(source)
+    assert result.output == native.model_dump(mode="json")
+    restored = AutocorrelationResult.model_validate_json(json.dumps(result.output))
+    assert isinstance(restored.source, FiniteIntegerSequence)
+    assert restored.source.values == (1, 2, 3)

--- a/tests/math/number_theory/sequences/core/test_autocorrelation.py
+++ b/tests/math/number_theory/sequences/core/test_autocorrelation.py
@@ -20,6 +20,7 @@ from jacobian.math.number_theory.sequences.core._models import (
     AutocorrelationResult,
     FiniteIntegerSequence,
     FiniteRationalSequence,
+    FiniteSequence,
 )
 from jacobian.math.number_theory.sequences.core.operations import (
     aperiodic_autocorrelation,
@@ -250,3 +251,24 @@ def test_catalog_accepts_serialized_integer_sequence_source() -> None:
     restored = AutocorrelationResult.model_validate_json(json.dumps(result.output))
     assert isinstance(restored.source, FiniteIntegerSequence)
     assert restored.source.values == (1, 2, 3)
+
+
+def test_wide_rational_cyclic_work_is_rejected_before_kernel() -> None:
+    denominator = 10**15_999
+    source = FiniteRationalSequence(
+        values=(CanonicalRational(num=1, den=denominator),) * 153
+    )
+    with pytest.raises(OperationResourceAdmissionError, match="work"):
+        cyclic_autocorrelation(source)
+
+
+def test_autocorrelation_catalog_schema_registers_canonical_rational_defs() -> None:
+    schema = FiniteSequence.model_json_schema()
+    assert "CanonicalRational" in json.dumps(schema)
+    catalog = Catalog.open()
+    descriptor = next(
+        operation
+        for operation in catalog.snapshot().operations
+        if operation.operation_id == "sequence.autocorrelation.aperiodic.compute"
+    )
+    assert "CanonicalRational" in json.dumps(descriptor.input_schema)

--- a/tests/math/number_theory/sequences/core/test_autocorrelation.py
+++ b/tests/math/number_theory/sequences/core/test_autocorrelation.py
@@ -7,7 +7,7 @@ from fractions import Fraction
 import pytest
 from pydantic import ValidationError
 
-from jacobian._exact import CanonicalRational, MAX_CANONICAL_INTEGER_DIGITS
+from jacobian._exact import MAX_CANONICAL_INTEGER_DIGITS, CanonicalRational
 from jacobian.canonical import parse_canonical_integer
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
@@ -273,7 +273,10 @@ def test_mixed_denominator_widths_are_preflighted_without_scaled_copies() -> Non
 
 
 def test_oversized_integer_wire_entries_are_rejected_before_parsing() -> None:
-    payload = {"domain": "rational", "values": ["1" * (MAX_CANONICAL_INTEGER_DIGITS + 1)]}
+    payload = {
+        "domain": "rational",
+        "values": ["1" * (MAX_CANONICAL_INTEGER_DIGITS + 1)],
+    }
     with pytest.raises(ValidationError, match="digit"):
         FiniteRationalSequence.model_validate(payload)
 

--- a/tests/math/number_theory/sequences/core/test_autocorrelation.py
+++ b/tests/math/number_theory/sequences/core/test_autocorrelation.py
@@ -8,7 +8,11 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.canonical import parse_canonical_integer
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.number_theory.sequences.core._models import (
     AutocorrelationCell,
     AutocorrelationResult,
@@ -79,6 +83,25 @@ def test_serialized_rational_integer_entries_retain_rational_domain() -> None:
 
     assert isinstance(restored.source, FiniteRationalSequence)
     assert all(isinstance(cell.value, CanonicalRational) for cell in restored.cells)
+
+
+def test_serialized_empty_rational_source_retains_rational_domain() -> None:
+    source = FiniteRationalSequence(values=())
+
+    restored = AutocorrelationResult.model_validate_json(
+        aperiodic_autocorrelation(source).model_dump_json()
+    )
+
+    assert isinstance(restored.source, FiniteRationalSequence)
+
+
+def test_rational_wire_entries_accept_full_width_integer_strings() -> None:
+    value = "1" * 4_301
+
+    source = FiniteRationalSequence.model_validate_json(json.dumps({"values": [value]}))
+
+    assert source.values[0].num == parse_canonical_integer(value)
+    assert source.values[0].den == 1
 
 
 def test_result_rejects_noncanonical_lag_axis_without_recomputing_coefficients() -> (
@@ -189,6 +212,21 @@ def test_large_quadratic_autocorrelation_is_rejected(
     source = FiniteIntegerSequence(values=(1,) * 3_000)
     with pytest.raises(OperationResourceAdmissionError):
         operation(source)
+
+
+def test_rational_autocorrelation_admission_counts_both_output_components() -> None:
+    width = 5_000
+    numerator = parse_canonical_integer("1" + "0" * (width - 1))
+    denominator = parse_canonical_integer("1" + "2" * (width - 1))
+    source = FiniteRationalSequence(
+        values=(CanonicalRational.from_integer_ratio(numerator, denominator),) * 126
+    )
+
+    with pytest.raises(
+        OperationDomainValidationError,
+        match="autocorrelation output exceeds the exact representation bound",
+    ):
+        aperiodic_autocorrelation(source)
 
 
 def test_constant_sequence_peak_scan_is_linear() -> None:

--- a/tests/math/number_theory/sequences/core/test_autocorrelation.py
+++ b/tests/math/number_theory/sequences/core/test_autocorrelation.py
@@ -7,7 +7,7 @@ from fractions import Fraction
 import pytest
 from pydantic import ValidationError
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import CanonicalRational, MAX_CANONICAL_INTEGER_DIGITS
 from jacobian.canonical import parse_canonical_integer
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
@@ -260,6 +260,22 @@ def test_wide_rational_cyclic_work_is_rejected_before_kernel() -> None:
     )
     with pytest.raises(OperationResourceAdmissionError, match="work"):
         cyclic_autocorrelation(source)
+
+
+def test_mixed_denominator_widths_are_preflighted_without_scaled_copies() -> None:
+    wide = CanonicalRational(num=1, den=10**15_999)
+    ones = (CanonicalRational(num=1, den=1),) * 2_000
+    source = FiniteRationalSequence(values=(wide, *ones))
+    with pytest.raises(
+        (OperationResourceAdmissionError, OperationDomainValidationError)
+    ):
+        cyclic_autocorrelation(source)
+
+
+def test_oversized_integer_wire_entries_are_rejected_before_parsing() -> None:
+    payload = {"domain": "rational", "values": ["1" * (MAX_CANONICAL_INTEGER_DIGITS + 1)]}
+    with pytest.raises(ValidationError, match="digit"):
+        FiniteRationalSequence.model_validate(payload)
 
 
 def test_autocorrelation_catalog_schema_registers_canonical_rational_defs() -> None:

--- a/tests/math/number_theory/sequences/core/test_autocorrelation.py
+++ b/tests/math/number_theory/sequences/core/test_autocorrelation.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.number_theory.sequences.core._models import (
+    AutocorrelationCell,
     AutocorrelationResult,
     FiniteIntegerSequence,
     FiniteRationalSequence,
@@ -88,8 +89,8 @@ def test_result_rejects_noncanonical_lag_axis_without_recomputing_coefficients()
             convention="cyclic",
             source=FiniteIntegerSequence(values=(1, 2)),
             cells=(
-                {"lag": 0, "value": 5},
-                {"lag": 2, "value": 5},
+                AutocorrelationCell(lag=0, value=5),
+                AutocorrelationCell(lag=2, value=5),
             ),
         )
 
@@ -132,9 +133,11 @@ def test_aperiodic_matches_defining_sum_for_signed_rational_lags() -> None:
 
     result = aperiodic_autocorrelation(source)
     assert [cell.lag for cell in result.cells] == list(range(-3, 4))
-    assert [Fraction(cell.value.num, cell.value.den) for cell in result.cells] == [
-        expected[lag] for lag in range(-3, 4)
-    ]
+    actual = []
+    for cell in result.cells:
+        assert isinstance(cell.value, CanonicalRational)
+        actual.append(cell.value.as_fraction())
+    assert actual == [expected[lag] for lag in range(-3, 4)]
 
 
 def test_reversing_source_preserves_aperiodic_profile() -> None:


### PR DESCRIPTION
## Summary

Extends the existing exact aperiodic and cyclic finite-sequence autocorrelation operations from integer-only inputs to bounded real-rational sequences.

- Accepts canonical rational coefficients and denominator-one integer wire entries.
- Retains exact source domain, explicit `convention`, and canonical lag axes through JSON round trips.
- Admits source representation, multiplication/addition work, common-denominator growth, exact output width, and materialized output before the quadratic kernel.
- Publishes schema/docs/examples and tests native, dispatch, catalog, and serialization behavior.

This completes the rational portion of #3588; the integer operation IDs were previously published by the merged operation work.

## Validation

Final head: `ba14e9ea1d748ad6000d6488ec61839fb1c455c0`

`make affected AFFECTED_BASE=origin/main` passed on the final tree after merging latest `origin/main` (`e4088473159e32424e5cb725ed56d5b457ca116b`):

- scoped Ruff check and format check
- scoped mypy
- 42 number-theory sequence math tests
- 161 catalog tests
- 968 catalog integration tests
- 132 dispatch tests

The independent exact-diff review found no remaining correctness or contract findings. No backend or MCP boundary is changed.
