### PR TITLE
docs(matrices): document polynomial inertia cells

### DIFF
--- a/docs/reference/operations/matrix/index.md
+++ b/docs/reference/operations/matrix/index.md
@@ -14,5 +14,6 @@ the matrices needed to inspect (D = UAV) in the returned value; it does not
 publish a record or require later retrieval.
 
 - [Exact rational matrix determinants](matrix-rational-determinant.md)
+- [Exact inertia cells for polynomial matrices](polynomial-inertia-cells.md)
 - [Exact subsystem-aware Hermitian matrices](subsystem-hermitian-matrices.md)
 - [Exact symbolic matrix products](matrix-symbolic-products.md)

--- a/docs/reference/operations/matrix/polynomial-inertia-cells.md
+++ b/docs/reference/operations/matrix/polynomial-inertia-cells.md
@@ -1,0 +1,39 @@
+# Exact inertia cells for polynomial matrices
+
+[Documentation home](../../../index.md) · [Matrix operations](index.md) ·
+[Tool surface](../../tools.md)
+
+`matrix.polynomial.inertia_cells.compute` returns the complete exact inertia
+profile of one symmetric matrix over `QQ[t]` on a closed rational interval.
+The result is source-bound: it echoes the polynomial matrix and interval and
+alternates singleton point cells with open interval cells. Every domain
+endpoint is a point cell, every rank-drop parameter is retained as a point
+cell, and each cell carries `(n_positive, n_negative, n_zero)` whose sum is the
+matrix order.
+
+The input uses the canonical `RationalPolynomialMatrix` and
+`ClosedRationalInterval` values. Matrix entries must use one univariate
+variable and the matrix must be square and symmetric. Empty and zero matrices,
+constant matrices, tangential roots such as `t²`, persistent nullspaces, and a
+singleton interval are supported within the operation's admitted envelope.
+
+Irrational transition parameters are represented by a primitive real-algebraic
+root identity (`RealAlgebraicValue`) together with a rational isolating
+interval. Rational transitions use canonical rational values and singleton
+isolating intervals. The partition is exact; it is not a sampled eigenvalue
+plot. In particular, `diag(t² - 2, 0)` on `[-2, 2]` retains both `±√2` even
+though its determinant is identically zero.
+
+The kernel first bounds the source, characteristic-polynomial growth,
+transition isolation, exact coefficient-sign work, sampling, and output size.
+It then processes disconnected support blocks independently, isolates all roots
+of the lowest nonzero characteristic coefficient, and uses exact specialization
+at point cells. The eigenvalue signs are obtained from the real-rooted
+characteristic polynomial's Descartes sign variations; no floating-point
+eigenvalue calculation is used. A request that exceeds any admitted bound or
+does not complete exactly is rejected rather than returning a partial profile.
+
+The operation is available natively as
+`jacobian.math.matrices.inertia_cells.compute_inertia_cells` and through
+`math.find`/`math.run`. Its catalog example is the persistent-nullspace
+`diag(t² - 2, 0)` fixture.

--- a/docs/reference/operations/matrix/polynomial-inertia-cells.md
+++ b/docs/reference/operations/matrix/polynomial-inertia-cells.md
@@ -24,14 +24,11 @@ isolating intervals. The partition is exact; it is not a sampled eigenvalue
 plot. In particular, `diag(t² - 2, 0)` on `[-2, 2]` retains both `±√2` even
 though its determinant is identically zero.
 
-The kernel first bounds the source, characteristic-polynomial growth,
-transition isolation, exact coefficient-sign work, sampling, and output size.
-It then processes disconnected support blocks independently, isolates all roots
-of the lowest nonzero characteristic coefficient, and uses exact specialization
-at point cells. The eigenvalue signs are obtained from the real-rooted
-characteristic polynomial's Descartes sign variations; no floating-point
-eigenvalue calculation is used. A request that exceeds any admitted bound or
-does not complete exactly is rejected rather than returning a partial profile.
+The operation admits a request only when its source representation, exact
+computation, intermediate growth, and materialized profile fit the declared
+bounds. Accepted requests return a complete exact profile. A request that
+exceeds an admitted bound or cannot complete exactly is rejected rather than
+returning a partial profile.
 
 The operation is available natively as
 `jacobian.math.matrices.inertia_cells.compute_inertia_cells` and through


### PR DESCRIPTION
## Summary

Closes #3456.

The exact `matrix.polynomial.inertia_cells.compute` operation, native kernel,
canonical carriers, bounded admission, independent exact fixtures, and MCP
parity are already present on `main` through the merged polynomial-matrix
change. This PR completes the public operation reference surface by documenting
its exact alternating point/open partition, algebraic boundary representation,
degenerate cases, admission boundary, and native/MCP entry points, and links it
from the matrix-operation index.

## Validation

- `make docs-linkcheck`
- `make quick-scoped LANE=math TESTS=tests/math/matrices/inertia_cells/test_inertia_cells.py PATHS="src/jacobian/math/matrices/inertia_cells tests/math/matrices/inertia_cells tests/mcp/test_polynomial_inertia_cells.py docs/reference/operations/matrix"`
- `make quick-scoped LANE=catalog TESTS="tests/mcp/test_polynomial_inertia_cells.py tests/integration/catalog/test_public_operation_contract_conformance.py" PATHS="src/jacobian/math/matrices/inertia_cells tests/mcp/test_polynomial_inertia_cells.py docs/reference/operations/matrix"`
- `uv run pytest -q -o addopts='' -m exhaustive tests/integration/catalog/test_public_operation_contract_conformance.py -k matrix.polynomial.inertia_cells.compute`
- `make lint typecheck`
