### PR TITLE
fix(graphs): make maximum induced matching canonical and bounded

### DIFF
--- a/docs/reference/operations/graphs/graph-induced-matching.md
+++ b/docs/reference/operations/graphs/graph-induced-matching.md
@@ -1,0 +1,24 @@
+# Maximum induced matching
+
+[Documentation home](../../../index.md) · [Graph operations](index.md) · [Tool surface](../../tools.md)
+
+`graph.induced_matching.maximum.compute` computes a bounded exact maximum
+induced matching of a finite simple graph. It returns the incumbent cardinality
+and bounds, a canonical source-edge axis (`e0`, `e1`, …), the selected edge-ID
+family, and the complete source subgraph on the selected endpoints.
+
+Two selected source edges must be vertex-disjoint, and no other source edge may
+join their endpoints. Internally the operation builds the square of the line
+graph and invokes the existing bounded exact independence-number kernel; that
+reduction is private and the result remains source-graph edges.
+
+Source edges are sorted lexicographically before IDs are assigned. Among equal
+cardinality optima, the selected ID family is lexicographically smallest. The
+endpoint graph has sorted vertex and edge axes, independent of input row order.
+The request admits at most 128 source edges and bounds conflict-pair and
+intermediate graph-cell construction. An incomplete solver outcome is reported
+with its feasible lower bound and safe upper bound; it is not an optimum claim.
+
+This operation is distinct from ordinary maximum matching, induced bipartite
+vertex-subgraph selection, strong edge coloring, weighted induced matching, and
+minimum maximal matching.

--- a/docs/reference/operations/graphs/index.md
+++ b/docs/reference/operations/graphs/index.md
@@ -10,6 +10,7 @@ there is no graph artifact carrier or invariant-batch registry.
 - [Graph metric operations](graph-distance-matrix.md)
 - [Graph invariants](graph-invariant-batch.md)
 - [Maximum matching](graph-maximum-matching.md)
+- [Maximum induced matching](graph-induced-matching.md)
 - [Diameter and radius](graph-metric-verification.md)
 - [Exact weighted minimum spanning tree](graph-minimum-spanning-tree.md)
 - [Small exact graph reliability](graph-reliability.md)

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -157,55 +157,65 @@ def _solve_independence_number_values_kernel(
         if lower_bound == upper_bound == len(incumbent) and (
             _closed_objective_value(objective) == len(incumbent)
         ):
-            if canonicalize_witness:
-                remaining_ms = int(
-                    (resource_budget.wall_seconds - (time.monotonic() - started)) * 1000
+            if not canonicalize_witness:
+                return IndependenceNumberResult._from_kernel(
+                    graph=graph,
+                    status="EXACT",
+                    optimum_value=len(incumbent),
+                    upper_bound=len(incumbent),
+                    incumbent_vertices=incumbent,
+                    termination_reason="OPTIMUM_ESTABLISHED",
+                    detail="bounded Z3 optimization seeded by a NetworkX feasible witness",
                 )
-                if remaining_ms > 0:
-                    lex_optimizer = z3.Optimize()
-                    lex_optimizer.set(priority="lex")
-                    lex_optimizer.set(
-                        timeout=remaining_timeout_ms(max(1, remaining_ms))
-                    )
-                    lex_selected = {
-                        vertex: z3.Bool(f"lex_{index}")
-                        for index, vertex in enumerate(vertices)
-                    }
-                    for left, right in graph.edges:
-                        lex_optimizer.add(
-                            z3.Or(
-                                z3.Not(lex_selected[left]),
-                                z3.Not(lex_selected[right]),
-                            )
-                        )
-                    lex_optimizer.add(
-                        z3.Sum(
-                            [z3.If(lex_selected[vertex], 1, 0) for vertex in vertices]
-                        )
-                        == len(incumbent)
-                    )
-                    for vertex in vertices:
-                        lex_optimizer.maximize(z3.If(lex_selected[vertex], 1, 0))
-                    if lex_optimizer.check() == z3.sat:
-                        lex_model = lex_optimizer.model()
-                        incumbent = tuple(
-                            sorted(
-                                vertex
-                                for vertex, variable in lex_selected.items()
-                                if z3.is_true(
-                                    lex_model.eval(variable, model_completion=True)
-                                )
-                            )
-                        )
-            return IndependenceNumberResult._from_kernel(
-                graph=graph,
-                status="EXACT",
-                optimum_value=len(incumbent),
-                upper_bound=len(incumbent),
-                incumbent_vertices=incumbent,
-                termination_reason="OPTIMUM_ESTABLISHED",
-                detail="bounded Z3 optimization seeded by a NetworkX feasible witness",
+            remaining_ms = int(
+                (resource_budget.wall_seconds - (time.monotonic() - started)) * 1000
             )
+            if remaining_ms > 0:
+                lex_optimizer = z3.Optimize()
+                lex_optimizer.set(priority="lex")
+                lex_optimizer.set(timeout=remaining_timeout_ms(max(1, remaining_ms)))
+                lex_selected = {
+                    vertex: z3.Bool(f"lex_{index}")
+                    for index, vertex in enumerate(vertices)
+                }
+                for left, right in graph.edges:
+                    lex_optimizer.add(
+                        z3.Or(
+                            z3.Not(lex_selected[left]),
+                            z3.Not(lex_selected[right]),
+                        )
+                    )
+                lex_optimizer.add(
+                    z3.Sum([z3.If(lex_selected[vertex], 1, 0) for vertex in vertices])
+                    == len(incumbent)
+                )
+                lex_objectives = [
+                    lex_optimizer.maximize(z3.If(lex_selected[vertex], 1, 0))
+                    for vertex in vertices
+                ]
+                if lex_optimizer.check() == z3.sat and all(
+                    _closed_objective_value(objective) is not None
+                    for objective in lex_objectives
+                ):
+                    lex_model = lex_optimizer.model()
+                    incumbent = tuple(
+                        sorted(
+                            vertex
+                            for vertex, variable in lex_selected.items()
+                            if z3.is_true(
+                                lex_model.eval(variable, model_completion=True)
+                            )
+                        )
+                    )
+                    return IndependenceNumberResult._from_kernel(
+                        graph=graph,
+                        status="EXACT",
+                        optimum_value=len(incumbent),
+                        upper_bound=len(incumbent),
+                        incumbent_vertices=incumbent,
+                        termination_reason="OPTIMUM_ESTABLISHED",
+                        detail="bounded Z3 optimization seeded by a NetworkX feasible witness",
+                    )
     elif status == z3.unsat:
         raise OperationBackendError(BackendFailureReason.INVALID_OUTPUT)
     termination: Literal["WALL_TIME", "SOLVER_UNKNOWN"] = (

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -85,6 +85,8 @@ def _closed_objective_value(objective: Any) -> int | None:
 def _solve_independence_number_values_kernel(
     graph: SimpleUndirectedGraph,
     resource_budget: IndependenceNumberBudget,
+    *,
+    canonicalize_witness: bool = False,
 ) -> IndependenceNumberResult:
     """Run one wall-clock-bounded exact maximum independent-set optimization.
 
@@ -133,16 +135,8 @@ def _solve_independence_number_values_kernel(
     }
     for left, right in graph.edges:
         optimizer.add(z3.Or(z3.Not(selected[left]), z3.Not(selected[right])))
-    objective = optimizer.maximize(
-        z3.Sum([z3.If(selected[vertex], 1, 0) for vertex in vertices])
-    )
-    # With a fixed cardinality, maximizing each membership bit in canonical
-    # vertex order yields the lexicographically smallest sorted witness.
-    # Keep cardinality as the authoritative objective handle below, but retain
-    # every membership handle so an exact result also proves its tie-break.
-    tie_break_objectives = [
-        optimizer.maximize(z3.If(selected[vertex], 1, 0)) for vertex in vertices
-    ]
+    cardinality = z3.Sum([z3.If(selected[vertex], 1, 0) for vertex in vertices])
+    objective = optimizer.maximize(cardinality)
 
     status = optimizer.check()
     if status == z3.sat:
@@ -160,14 +154,51 @@ def _solve_independence_number_values_kernel(
         upper = objective.upper()
         lower_bound = max(len(incumbent), _integer_bound(lower, len(incumbent)))
         upper_bound = max(lower_bound, min(order, _integer_bound(upper, order)))
-        if (
-            lower_bound == upper_bound == len(incumbent)
-            and _closed_objective_value(objective) == len(incumbent)
-            and all(
-                _closed_objective_value(tie_break) is not None
-                for tie_break in tie_break_objectives
-            )
+        if lower_bound == upper_bound == len(incumbent) and (
+            _closed_objective_value(objective) == len(incumbent)
         ):
+            if canonicalize_witness:
+                remaining_ms = int(
+                    (resource_budget.wall_seconds - (time.monotonic() - started))
+                    * 1000
+                )
+                if remaining_ms > 0:
+                    lex_optimizer = z3.Optimize()
+                    lex_optimizer.set(priority="lex")
+                    lex_optimizer.set(timeout=remaining_timeout_ms(max(1, remaining_ms)))
+                    lex_selected = {
+                        vertex: z3.Bool(f"lex_{index}")
+                        for index, vertex in enumerate(vertices)
+                    }
+                    for left, right in graph.edges:
+                        lex_optimizer.add(
+                            z3.Or(
+                                z3.Not(lex_selected[left]),
+                                z3.Not(lex_selected[right]),
+                            )
+                        )
+                    lex_optimizer.add(
+                        z3.Sum(
+                            [
+                                z3.If(lex_selected[vertex], 1, 0)
+                                for vertex in vertices
+                            ]
+                        )
+                        == len(incumbent)
+                    )
+                    for vertex in vertices:
+                        lex_optimizer.maximize(z3.If(lex_selected[vertex], 1, 0))
+                    if lex_optimizer.check() == z3.sat:
+                        lex_model = lex_optimizer.model()
+                        incumbent = tuple(
+                            sorted(
+                                vertex
+                                for vertex, variable in lex_selected.items()
+                                if z3.is_true(
+                                    lex_model.eval(variable, model_completion=True)
+                                )
+                            )
+                        )
             return IndependenceNumberResult._from_kernel(
                 graph=graph,
                 status="EXACT",
@@ -198,6 +229,8 @@ def _solve_independence_number_values_kernel(
 def solve_independence_number_values(
     graph: SimpleUndirectedGraph,
     resource_budget: IndependenceNumberBudget,
+    *,
+    canonicalize_witness: bool = False,
 ) -> IndependenceNumberResult:
     """Run Z3 optimization in one bounded owner worker and decode its result."""
 
@@ -220,6 +253,7 @@ def solve_independence_number_values(
                         "_deadline": lease.backend_deadline,
                         "graph": graph.model_dump(mode="json"),
                         "resource_budget": resource_budget.model_dump(mode="json"),
+                        "canonicalize_witness": canonicalize_witness,
                     },
                     separators=(",", ":"),
                     ensure_ascii=False,

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -159,13 +159,14 @@ def _solve_independence_number_values_kernel(
         ):
             if canonicalize_witness:
                 remaining_ms = int(
-                    (resource_budget.wall_seconds - (time.monotonic() - started))
-                    * 1000
+                    (resource_budget.wall_seconds - (time.monotonic() - started)) * 1000
                 )
                 if remaining_ms > 0:
                     lex_optimizer = z3.Optimize()
                     lex_optimizer.set(priority="lex")
-                    lex_optimizer.set(timeout=remaining_timeout_ms(max(1, remaining_ms)))
+                    lex_optimizer.set(
+                        timeout=remaining_timeout_ms(max(1, remaining_ms))
+                    )
                     lex_selected = {
                         vertex: z3.Bool(f"lex_{index}")
                         for index, vertex in enumerate(vertices)
@@ -179,10 +180,7 @@ def _solve_independence_number_values_kernel(
                         )
                     lex_optimizer.add(
                         z3.Sum(
-                            [
-                                z3.If(lex_selected[vertex], 1, 0)
-                                for vertex in vertices
-                            ]
+                            [z3.If(lex_selected[vertex], 1, 0) for vertex in vertices]
                         )
                         == len(incumbent)
                     )

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -121,6 +121,11 @@ def _solve_independence_number_values_kernel(
     objective = optimizer.maximize(
         z3.Sum([z3.If(selected[vertex], 1, 0) for vertex in vertices])
     )
+    # With a fixed cardinality, maximizing each membership bit in canonical
+    # vertex order yields the lexicographically smallest sorted witness.
+    # Keep cardinality as the authoritative objective handle below.
+    for vertex in vertices:
+        optimizer.maximize(z3.If(selected[vertex], 1, 0))
 
     status = optimizer.check()
     if status == z3.sat:

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -68,6 +68,20 @@ def _integer_bound(value: Any, fallback: int) -> int:
     return value.as_long() if z3.is_int_value(value) else fallback
 
 
+def _closed_objective_value(objective: Any) -> int | None:
+    """Return an objective value only when both Optimize bounds are closed."""
+
+    import z3
+
+    lower = objective.lower()
+    upper = objective.upper()
+    if not (z3.is_int_value(lower) and z3.is_int_value(upper)):
+        return None
+    lower_value = lower.as_long()
+    upper_value = upper.as_long()
+    return lower_value if lower_value == upper_value else None
+
+
 def _solve_independence_number_values_kernel(
     graph: SimpleUndirectedGraph,
     resource_budget: IndependenceNumberBudget,
@@ -124,9 +138,11 @@ def _solve_independence_number_values_kernel(
     )
     # With a fixed cardinality, maximizing each membership bit in canonical
     # vertex order yields the lexicographically smallest sorted witness.
-    # Keep cardinality as the authoritative objective handle below.
-    for vertex in vertices:
-        optimizer.maximize(z3.If(selected[vertex], 1, 0))
+    # Keep cardinality as the authoritative objective handle below, but retain
+    # every membership handle so an exact result also proves its tie-break.
+    tie_break_objectives = [
+        optimizer.maximize(z3.If(selected[vertex], 1, 0)) for vertex in vertices
+    ]
 
     status = optimizer.check()
     if status == z3.sat:
@@ -144,7 +160,14 @@ def _solve_independence_number_values_kernel(
         upper = objective.upper()
         lower_bound = max(len(incumbent), _integer_bound(lower, len(incumbent)))
         upper_bound = max(lower_bound, min(order, _integer_bound(upper, order)))
-        if lower_bound == upper_bound == len(incumbent):
+        if (
+            lower_bound == upper_bound == len(incumbent)
+            and _closed_objective_value(objective) == len(incumbent)
+            and all(
+                _closed_objective_value(tie_break) is not None
+                for tie_break in tie_break_objectives
+            )
+        ):
             return IndependenceNumberResult._from_kernel(
                 graph=graph,
                 status="EXACT",

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -112,6 +112,7 @@ def _solve_independence_number_values_kernel(
     import z3
 
     optimizer = z3.Optimize()
+    optimizer.set(priority="lex")
     optimizer.set(timeout=remaining_timeout_ms(max(1, remaining_ms)))
     selected = {
         vertex: z3.Bool(f"selected_{index}") for index, vertex in enumerate(vertices)

--- a/src/jacobian/math/graphs/_independence_z3_worker.py
+++ b/src/jacobian/math/graphs/_independence_z3_worker.py
@@ -31,7 +31,11 @@ def main() -> int:
         resource_budget = IndependenceNumberBudget.model_validate(
             payload["resource_budget"]
         )
-        result = _solve_independence_number_values_kernel(graph, resource_budget)
+        result = _solve_independence_number_values_kernel(
+            graph,
+            resource_budget,
+            canonicalize_witness=bool(payload.get("canonicalize_witness", False)),
+        )
         sys.stdout.buffer.write(
             encode_worker_result_frame(
                 result.model_dump(mode="json", exclude={"graph"}),

--- a/src/jacobian/math/graphs/induced_matching/_models.py
+++ b/src/jacobian/math/graphs/induced_matching/_models.py
@@ -1,6 +1,7 @@
 """Typed contracts for maximum induced matching."""
 
-from pydantic import Field, StrictInt
+from pydantic import Field, StrictInt, StrictStr, model_validator
+from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.independence import (
@@ -9,25 +10,122 @@ from jacobian.math.graphs.independence import (
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
+MAX_INDUCED_MATCHING_EDGES = 128
+MAX_INDUCED_MATCHING_CONFLICT_PAIRS = (
+    MAX_INDUCED_MATCHING_EDGES * (MAX_INDUCED_MATCHING_EDGES - 1) // 2
+)
+MAX_INDUCED_MATCHING_CONFLICT_GRAPH_CELLS = (
+    MAX_INDUCED_MATCHING_EDGES + MAX_INDUCED_MATCHING_CONFLICT_PAIRS
+)
+
 
 class MaximumInducedMatchingRequest(StrictModel):
-    graph: SimpleUndirectedGraph
+    graph: SimpleUndirectedGraph = Field(
+        description=(
+            "Canonical finite simple graph. Its source edge count must not exceed "
+            "resource_budget.max_order because one conflict vertex is created per edge."
+        )
+    )
     resource_budget: IndependenceNumberBudget = Field(
-        default_factory=IndependenceNumberBudget
+        default_factory=IndependenceNumberBudget,
+        description=(
+            "Bounded exact-independence search envelope for the private conflict "
+            "graph; max_order must cover the source edge count."
+        ),
     )
 
 
 class SourceEdgeBinding(StrictModel):
-    edge_id: str
-    endpoints: tuple[str, str]
+    edge_id: StrictStr = Field(pattern=r"^e(?:0|[1-9][0-9]*)$")
+    endpoints: tuple[StrictStr, StrictStr] = Field(
+        description="Canonical source edge endpoints in lexicographic order."
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_endpoints(self) -> "SourceEdgeBinding":
+        if self.endpoints[0] >= self.endpoints[1]:
+            raise PydanticCustomError(
+                "graph.induced_matching.edge_endpoints_must_be_canonical",
+                "source edge endpoints must be distinct and lexicographically ordered",
+            )
+        return self
 
 
 class MaximumInducedMatchingResult(StrictModel):
     graph: SimpleUndirectedGraph
-    source_edges: tuple[SourceEdgeBinding, ...]
+    source_edges: tuple[SourceEdgeBinding, ...] = Field(
+        max_length=MAX_INDUCED_MATCHING_EDGES
+    )
     status: IndependenceSearchStatus
-    cardinality: StrictInt = Field(ge=0, le=128)
-    lower_bound: StrictInt = Field(ge=0, le=128)
-    upper_bound: StrictInt = Field(ge=0, le=128)
-    selected_edge_ids: tuple[str, ...] = Field(max_length=128)
+    cardinality: StrictInt = Field(ge=0, le=MAX_INDUCED_MATCHING_EDGES)
+    lower_bound: StrictInt = Field(ge=0, le=MAX_INDUCED_MATCHING_EDGES)
+    upper_bound: StrictInt = Field(ge=0, le=MAX_INDUCED_MATCHING_EDGES)
+    selected_edge_ids: tuple[StrictStr, ...] = Field(
+        max_length=MAX_INDUCED_MATCHING_EDGES
+    )
     induced_endpoint_graph: SimpleUndirectedGraph
+
+    @model_validator(mode="after")
+    def bind_source_and_witness(self) -> "MaximumInducedMatchingResult":
+        source_edges = tuple(sorted(self.graph.edges))
+        bindings = tuple(binding.endpoints for binding in self.source_edges)
+        expected_ids = tuple(f"e{index}" for index in range(len(source_edges)))
+        actual_ids = tuple(binding.edge_id for binding in self.source_edges)
+        if bindings != source_edges or actual_ids != expected_ids:
+            raise PydanticCustomError(
+                "graph.induced_matching.source_edge_axis_must_be_complete",
+                "source_edges must contain every source edge in canonical order with contiguous IDs",
+            )
+
+        if self.selected_edge_ids != tuple(sorted(set(self.selected_edge_ids))):
+            raise PydanticCustomError(
+                "graph.induced_matching.selected_edge_ids_must_be_sorted_unique",
+                "selected edge IDs must be unique and lexicographically sorted",
+            )
+        source_by_id = dict(zip(actual_ids, bindings, strict=True))
+        if any(edge_id not in source_by_id for edge_id in self.selected_edge_ids):
+            raise PydanticCustomError(
+                "graph.induced_matching.selected_edge_must_belong_to_source",
+                "every selected edge ID must belong to source_edges",
+            )
+        selected_edges = tuple(
+            source_by_id[edge_id] for edge_id in self.selected_edge_ids
+        )
+        selected_vertices = {vertex for edge in selected_edges for vertex in edge}
+        if len(selected_vertices) != 2 * len(selected_edges):
+            raise PydanticCustomError(
+                "graph.induced_matching.selected_edges_must_be_vertex_disjoint",
+                "selected source edges must be pairwise vertex-disjoint",
+            )
+        expected_endpoint_edges = tuple(
+            edge
+            for edge in source_edges
+            if edge[0] in selected_vertices and edge[1] in selected_vertices
+        )
+        expected_endpoint_vertices = tuple(sorted(selected_vertices))
+        if (
+            self.induced_endpoint_graph.vertices != expected_endpoint_vertices
+            or self.induced_endpoint_graph.edges != expected_endpoint_edges
+        ):
+            raise PydanticCustomError(
+                "graph.induced_matching.endpoint_graph_must_be_complete",
+                "induced_endpoint_graph must be the complete canonical source subgraph on selected endpoints",
+            )
+        if self.cardinality != len(self.selected_edge_ids):
+            raise PydanticCustomError(
+                "graph.induced_matching.cardinality_must_match_witness",
+                "cardinality must equal the number of selected edge IDs",
+            )
+        if self.lower_bound != self.cardinality or not (
+            self.lower_bound <= self.upper_bound <= len(source_edges)
+        ):
+            raise PydanticCustomError(
+                "graph.induced_matching.bounds_must_contain_incumbent",
+                "bounds must contain the returned feasible cardinality",
+            )
+        if self.status == "EXACT" and self.upper_bound != self.cardinality:
+            raise PydanticCustomError(
+                "graph.induced_matching.exact_bounds_must_coincide",
+                "an exact induced matching result must have coincident bounds",
+            )
+        return self

--- a/src/jacobian/math/graphs/induced_matching/_models.py
+++ b/src/jacobian/math/graphs/induced_matching/_models.py
@@ -102,6 +102,11 @@ class MaximumInducedMatchingResult(StrictModel):
             for edge in source_edges
             if edge[0] in selected_vertices and edge[1] in selected_vertices
         )
+        if set(expected_endpoint_edges) != set(selected_edges):
+            raise PydanticCustomError(
+                "graph.induced_matching.selected_edges_must_induce_no_cross_edges",
+                "selected source edges must be the complete source subgraph on their endpoints",
+            )
         expected_endpoint_vertices = tuple(sorted(selected_vertices))
         if (
             self.induced_endpoint_graph.vertices != expected_endpoint_vertices
@@ -127,5 +132,10 @@ class MaximumInducedMatchingResult(StrictModel):
             raise PydanticCustomError(
                 "graph.induced_matching.exact_bounds_must_coincide",
                 "an exact induced matching result must have coincident bounds",
+            )
+        if self.status == "UNKNOWN" and self.upper_bound != len(source_edges):
+            raise PydanticCustomError(
+                "graph.induced_matching.unknown_upper_bound_must_be_source_edge_count",
+                "an incomplete induced matching result must report the source edge count as its safe upper bound",
             )
         return self

--- a/src/jacobian/math/graphs/induced_matching/_tools.py
+++ b/src/jacobian/math/graphs/induced_matching/_tools.py
@@ -18,7 +18,12 @@ TOOLS: MathTools = (
     MathTool(
         operation_id="graph.induced_matching.maximum.compute",
         title="Compute a maximum induced matching",
-        description="Reduce source edges to an admitted conflict graph and return an exact or bounded induced matching with its induced endpoint graph.",
+        description=(
+            "Reduce source edges to a private conflict graph and return an exact "
+            "or bounded maximum induced matching with its complete endpoint "
+            "subgraph; the input must be a canonical finite simple graph with "
+            "no more than the declared conflict-graph edge-order budget."
+        ),
         request_type=MaximumInducedMatchingRequest,
         result_type=MaximumInducedMatchingResult,
         run=_compute,
@@ -26,7 +31,11 @@ TOOLS: MathTools = (
         examples=(
             OperationExample(
                 name="path_four",
-                description="The three-edge path has induced matching number one.",
+                description=(
+                    "Compute the maximum induced matching of the three-edge path; "
+                    "the graph is a canonical finite simple graph and fits the "
+                    "declared conflict-graph order budget."
+                ),
                 input={
                     "graph": {
                         "vertices": ["0", "1", "2", "3"],

--- a/src/jacobian/math/graphs/induced_matching/operations.py
+++ b/src/jacobian/math/graphs/induced_matching/operations.py
@@ -9,9 +9,10 @@ from jacobian.catalog.models import (
     OperationDomainValidationError,
     OperationResourceAdmissionError,
 )
+from jacobian.math.graphs import _independence_z3
 from jacobian.math.graphs.independence import (
     IndependenceNumberBudget,
-    independence_number,
+    _require_admitted_request,
 )
 from jacobian.math.graphs.induced_matching._models import (
     MAX_INDUCED_MATCHING_CONFLICT_GRAPH_CELLS,
@@ -113,12 +114,16 @@ def maximum_induced_matching(
     budget = resource_budget or IndependenceNumberBudget()
     plan = _admit_and_build_plan(graph, budget)
     conflict_graph = SimpleUndirectedGraph(
-        # The independence kernel's canonical tie-break follows this axis;
-        # sort IDs lexicographically to match the public selected-ID family.
+        # Canonical selected-edge IDs follow this sorted axis. Tie-breaking is
+        # confined to this operation so independence-number exactness does not
+        # depend on membership objectives.
         vertices=tuple(sorted(binding.edge_id for binding in plan.bindings)),
         edges=plan.conflict_edges,
     )
-    independence = independence_number(conflict_graph, resource_budget=budget)
+    _require_admitted_request(conflict_graph, budget)
+    independence = _independence_z3.solve_independence_number_values(
+        conflict_graph, budget, canonicalize_witness=True
+    )
     selected_ids = independence.witness_vertices
     selected = {
         endpoint

--- a/src/jacobian/math/graphs/induced_matching/operations.py
+++ b/src/jacobian/math/graphs/induced_matching/operations.py
@@ -1,38 +1,87 @@
 """Maximum induced matching through a private conflict graph."""
 
-from jacobian.catalog.models import OperationResourceAdmissionError
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jacobian._execution import request_checkpoint
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.graphs.independence import (
     IndependenceNumberBudget,
     independence_number,
 )
 from jacobian.math.graphs.induced_matching._models import (
+    MAX_INDUCED_MATCHING_CONFLICT_GRAPH_CELLS,
+    MAX_INDUCED_MATCHING_CONFLICT_PAIRS,
+    MAX_INDUCED_MATCHING_EDGES,
     MaximumInducedMatchingResult,
     SourceEdgeBinding,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 
-def maximum_induced_matching(
-    graph: SimpleUndirectedGraph,
-    *,
-    resource_budget: IndependenceNumberBudget | None = None,
-) -> MaximumInducedMatchingResult:
-    """Return an exact or rigorously bounded maximum induced matching."""
+@dataclass(frozen=True, slots=True)
+class _InducedMatchingPlan:
+    """Canonical source axis and one materialized private conflict graph."""
 
-    budget = resource_budget or IndependenceNumberBudget()
-    if len(graph.edges) > budget.max_order:
+    canonical_edges: tuple[tuple[str, str], ...]
+    bindings: tuple[SourceEdgeBinding, ...]
+    conflict_edges: tuple[tuple[str, str], ...]
+
+
+def _admit_and_build_plan(
+    graph: SimpleUndirectedGraph, budget: IndependenceNumberBudget
+) -> _InducedMatchingPlan:
+    if not isinstance(graph, SimpleUndirectedGraph):
+        raise OperationDomainValidationError(
+            location=("graph",),
+            code="graph.induced_matching.graph_type",
+            message="graph must be a SimpleUndirectedGraph",
+        )
+
+    # The edge axis is the source identity for this operation. Canonicalize
+    # before assigning IDs so input row order is never part of the witness.
+    canonical_edges = tuple(sorted(graph.edges))
+    edge_count = len(canonical_edges)
+    if edge_count > MAX_INDUCED_MATCHING_EDGES:
+        raise OperationResourceAdmissionError(
+            location=("graph", "edges"),
+            code="graph.induced_matching.source_edge_bound",
+            message="source edge count exceeds the admitted induced-matching bound",
+        )
+    if edge_count > budget.max_order:
         raise OperationResourceAdmissionError(
             location=("graph", "edges"),
             code="graph.induced_matching.conflict_graph_order_bound",
             message="source edge count exceeds the admitted conflict-graph order",
         )
+
+    # The complete conflict-pair envelope is C(m, 2), independent of labels.
+    # Check it before materializing any pair rows.
+    conflict_pair_bound = edge_count * (edge_count - 1) // 2
+    if conflict_pair_bound > MAX_INDUCED_MATCHING_CONFLICT_PAIRS:
+        raise OperationResourceAdmissionError(
+            location=("graph", "edges"),
+            code="graph.induced_matching.conflict_pair_bound",
+            message="conflict-pair construction exceeds its admitted work envelope",
+        )
+    if edge_count + conflict_pair_bound > MAX_INDUCED_MATCHING_CONFLICT_GRAPH_CELLS:
+        raise OperationResourceAdmissionError(
+            location=("graph", "edges"),
+            code="graph.induced_matching.conflict_graph_cell_bound",
+            message="conflict graph cells exceed the admitted intermediate envelope",
+        )
     bindings = tuple(
         SourceEdgeBinding(edge_id=f"e{index}", endpoints=edge)
-        for index, edge in enumerate(graph.edges)
+        for index, edge in enumerate(canonical_edges)
     )
-    source_edge_set = {frozenset(edge) for edge in graph.edges}
+    source_edge_set = {frozenset(edge) for edge in canonical_edges}
     conflicts: list[tuple[str, str]] = []
     for left_index, left in enumerate(bindings):
+        request_checkpoint("during induced-matching conflict construction")
         left_endpoints = set(left.endpoints)
         for right in bindings[left_index + 1 :]:
             right_endpoints = set(right.endpoints)
@@ -47,27 +96,47 @@ def maximum_induced_matching(
                     if left.edge_id < right.edge_id
                     else (right.edge_id, left.edge_id)
                 )
+    return _InducedMatchingPlan(
+        canonical_edges=canonical_edges,
+        bindings=bindings,
+        conflict_edges=tuple(conflicts),
+    )
+
+
+def maximum_induced_matching(
+    graph: SimpleUndirectedGraph,
+    *,
+    resource_budget: IndependenceNumberBudget | None = None,
+) -> MaximumInducedMatchingResult:
+    """Return an exact or rigorously bounded maximum induced matching."""
+
+    budget = resource_budget or IndependenceNumberBudget()
+    plan = _admit_and_build_plan(graph, budget)
     conflict_graph = SimpleUndirectedGraph(
-        vertices=tuple(binding.edge_id for binding in bindings),
-        edges=tuple(conflicts),
+        # The independence kernel's canonical tie-break follows this axis;
+        # sort IDs lexicographically to match the public selected-ID family.
+        vertices=tuple(sorted(binding.edge_id for binding in plan.bindings)),
+        edges=plan.conflict_edges,
     )
     independence = independence_number(conflict_graph, resource_budget=budget)
     selected_ids = independence.witness_vertices
     selected = {
         endpoint
-        for binding in bindings
+        for binding in plan.bindings
         if binding.edge_id in selected_ids
         for endpoint in binding.endpoints
     }
     endpoint_graph = SimpleUndirectedGraph(
-        vertices=tuple(vertex for vertex in graph.vertices if vertex in selected),
+        vertices=tuple(sorted(selected)),
         edges=tuple(
-            edge for edge in graph.edges if edge[0] in selected and edge[1] in selected
+            edge
+            for edge in plan.canonical_edges
+            if edge[0] in selected and edge[1] in selected
         ),
     )
     return MaximumInducedMatchingResult(
         graph=graph,
-        source_edges=bindings,
+        source_edges=plan.bindings,
         status=independence.status,
         cardinality=independence.incumbent_value,
         lower_bound=independence.lower_bound,

--- a/tests/math/graphs/induced_matching/test_induced_matching.py
+++ b/tests/math/graphs/induced_matching/test_induced_matching.py
@@ -1,8 +1,12 @@
 """Maximum induced matching tests."""
 
+from itertools import combinations
+
 import pytest
+from pydantic import ValidationError
 
 from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.math.graphs.induced_matching._models import MaximumInducedMatchingResult
 from jacobian.math.graphs.induced_matching.operations import maximum_induced_matching
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -25,6 +29,141 @@ def test_empty_graph_has_empty_induced_matching() -> None:
     assert result.cardinality == 0
     assert result.selected_edge_ids == ()
     assert result.induced_endpoint_graph.vertices == ()
+
+
+def test_source_edge_and_endpoint_axes_ignore_input_row_order() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("f", "e", "d", "c", "b", "a"),
+        edges=(("e", "f"), ("a", "b"), ("c", "d")),
+    )
+    result = maximum_induced_matching(graph)
+    assert tuple(binding.edge_id for binding in result.source_edges) == (
+        "e0",
+        "e1",
+        "e2",
+    )
+    assert tuple(binding.endpoints for binding in result.source_edges) == (
+        ("a", "b"),
+        ("c", "d"),
+        ("e", "f"),
+    )
+    assert result.selected_edge_ids == ("e0", "e1", "e2")
+    assert result.induced_endpoint_graph.vertices == (
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+    )
+    assert result.induced_endpoint_graph.edges == (
+        ("a", "b"),
+        ("c", "d"),
+        ("e", "f"),
+    )
+
+
+def test_lexicographically_smallest_maximum_witness_is_returned() -> None:
+    # A six-vertex path has maximum induced matchings (e0,e3), (e0,e4), and
+    # (e1,e4); the first edge-ID family is the canonical tie-break.
+    graph = SimpleUndirectedGraph(
+        vertices=tuple(str(index) for index in range(6)),
+        edges=tuple((str(index), str(index + 1)) for index in range(5)),
+    )
+    result = maximum_induced_matching(graph)
+    assert result.status == "EXACT"
+    assert result.selected_edge_ids == ("e0", "e3")
+
+
+def test_complete_bipartite_graph_has_one_edge_induced_matching() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("a0", "a1", "b0", "b1"),
+        edges=(("a0", "b0"), ("a0", "b1"), ("a1", "b0"), ("a1", "b1")),
+    )
+    result = maximum_induced_matching(graph)
+    assert result.status == "EXACT"
+    assert result.cardinality == 1
+    assert result.selected_edge_ids == ("e0",)
+    assert result.induced_endpoint_graph.edges == (("a0", "b0"),)
+
+
+def test_cycle_and_star_have_the_expected_induced_matching_numbers() -> None:
+    cycle = SimpleUndirectedGraph(
+        vertices=("0", "1", "2", "3", "4"),
+        edges=(
+            ("0", "1"),
+            ("0", "4"),
+            ("1", "2"),
+            ("2", "3"),
+            ("3", "4"),
+        ),
+    )
+    star = SimpleUndirectedGraph(
+        vertices=("c", "a", "b", "d"),
+        edges=(("a", "c"), ("b", "c"), ("c", "d")),
+    )
+    assert maximum_induced_matching(cycle).cardinality == 1
+    assert maximum_induced_matching(star).cardinality == 1
+
+
+def test_small_graph_matches_exhaustive_edge_subset_enumeration() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("0", "1", "2", "3", "4"),
+        edges=(
+            ("0", "1"),
+            ("0", "2"),
+            ("1", "2"),
+            ("1", "3"),
+            ("2", "4"),
+        ),
+    )
+    feasible_sizes: list[int] = []
+    for size in range(len(graph.edges) + 1):
+        for selected_edges in combinations(graph.edges, size):
+            endpoints = {vertex for edge in selected_edges for vertex in edge}
+            if len(endpoints) != 2 * size:
+                continue
+            induced_edges = tuple(
+                edge
+                for edge in graph.edges
+                if edge[0] in endpoints and edge[1] in endpoints
+            )
+            if induced_edges == selected_edges:
+                feasible_sizes.append(size)
+    result = maximum_induced_matching(graph)
+    assert result.status == "EXACT"
+    assert result.cardinality == max(feasible_sizes)
+
+
+def test_disjoint_union_additivity_and_complete_endpoint_subgraph() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("a", "b", "c", "d", "e", "f"),
+        edges=(("a", "b"), ("c", "d"), ("d", "e"), ("e", "f")),
+    )
+    result = maximum_induced_matching(graph)
+    assert result.cardinality == 2
+    selected = {
+        binding.endpoints
+        for binding in result.source_edges
+        if binding.edge_id in result.selected_edge_ids
+    }
+    assert selected == {("a", "b"), ("c", "d")}
+    assert result.induced_endpoint_graph.edges == (("a", "b"), ("c", "d"))
+
+
+def test_result_rejects_incomplete_endpoint_subgraph() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("a", "b", "c", "d"),
+        edges=(("a", "b"), ("c", "d")),
+    )
+    result = maximum_induced_matching(graph)
+    payload = result.model_dump(mode="python")
+    payload["induced_endpoint_graph"] = {
+        "vertices": ["a", "b"],
+        "edges": [],
+    }
+    with pytest.raises(ValidationError):
+        MaximumInducedMatchingResult.model_validate(payload)
 
 
 def test_double_digit_conflict_ids_are_canonically_oriented() -> None:

--- a/tests/math/graphs/induced_matching/test_induced_matching.py
+++ b/tests/math/graphs/induced_matching/test_induced_matching.py
@@ -189,6 +189,44 @@ def test_result_rejects_incomplete_endpoint_subgraph() -> None:
         MaximumInducedMatchingResult.model_validate(payload)
 
 
+def test_result_rejects_cross_edges_between_selected_edges() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("a", "b", "c", "d"),
+        edges=(("a", "b"), ("a", "c"), ("c", "d")),
+    )
+    payload = maximum_induced_matching(graph).model_dump(mode="python")
+    payload["status"] = "EXACT"
+    payload["selected_edge_ids"] = ["e0", "e2"]
+    payload["cardinality"] = 2
+    payload["lower_bound"] = 2
+    payload["upper_bound"] = 2
+    payload["induced_endpoint_graph"] = {
+        "vertices": ["a", "b", "c", "d"],
+        "edges": [["a", "b"], ["a", "c"], ["c", "d"]],
+    }
+    with pytest.raises(ValidationError):
+        MaximumInducedMatchingResult.model_validate(payload)
+
+
+def test_unknown_result_must_use_source_edge_count_as_upper_bound() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=("a", "b", "c", "d"),
+        edges=(("a", "b"), ("c", "d")),
+    )
+    payload = maximum_induced_matching(graph).model_dump(mode="python")
+    payload["status"] = "UNKNOWN"
+    payload["selected_edge_ids"] = ["e0"]
+    payload["cardinality"] = 1
+    payload["lower_bound"] = 1
+    payload["upper_bound"] = 1
+    payload["induced_endpoint_graph"] = {
+        "vertices": ["a", "b"],
+        "edges": [["a", "b"]],
+    }
+    with pytest.raises(ValidationError):
+        MaximumInducedMatchingResult.model_validate(payload)
+
+
 def test_double_digit_conflict_ids_are_canonically_oriented() -> None:
     vertices = tuple(f"v{i}" for i in range(12))
     graph = SimpleUndirectedGraph(

--- a/tests/math/graphs/induced_matching/test_induced_matching.py
+++ b/tests/math/graphs/induced_matching/test_induced_matching.py
@@ -75,6 +75,29 @@ def test_lexicographically_smallest_maximum_witness_is_returned() -> None:
     assert result.selected_edge_ids == ("e0", "e3")
 
 
+def test_lexicographic_tie_break_handles_double_digit_edge_ids() -> None:
+    graph = SimpleUndirectedGraph(
+        vertices=tuple(str(index) for index in range(7)),
+        edges=(
+            ("0", "2"),
+            ("0", "3"),
+            ("0", "4"),
+            ("1", "3"),
+            ("1", "4"),
+            ("1", "5"),
+            ("1", "6"),
+            ("2", "3"),
+            ("3", "4"),
+            ("3", "6"),
+            ("4", "5"),
+            ("5", "6"),
+        ),
+    )
+    result = maximum_induced_matching(graph)
+    assert result.cardinality == 2
+    assert result.selected_edge_ids == ("e0", "e11")
+
+
 def test_complete_bipartite_graph_has_one_edge_induced_matching() -> None:
     graph = SimpleUndirectedGraph(
         vertices=("a0", "a1", "b0", "b1"),

--- a/tests/math/graphs/test_independence_source_binding.py
+++ b/tests/math/graphs/test_independence_source_binding.py
@@ -256,6 +256,14 @@ class _StubObjective:
         return _StubBound(2)
 
 
+class _StubClosedObjective(_StubObjective):
+    def lower(self) -> _StubBound:
+        return _StubBound(1)
+
+    def upper(self) -> _StubBound:
+        return _StubBound(1)
+
+
 class _StubOptimizer:
     def set(self, *args: object, **kwargs: object) -> None:
         return None
@@ -310,6 +318,38 @@ class _StubZ3:
         return isinstance(value, _StubBound)
 
     Optimize = _StubOptimizer
+
+
+class _StubCardinalityAndFirstTieClosedOptimizer(_StubOptimizer):
+    """Cardinality and one tie-break close before a later tie-break stays open."""
+
+    def __init__(self) -> None:
+        self._maximize_calls = 0
+
+    def maximize(self, expression: object) -> _StubObjective:
+        self._maximize_calls += 1
+        if self._maximize_calls <= 2:
+            return _StubClosedObjective()
+        return _StubObjective()
+
+
+class _StubCardinalityAndFirstTieClosedZ3(_StubZ3):
+    Optimize = _StubCardinalityAndFirstTieClosedOptimizer
+
+
+def test_exact_requires_all_tie_break_objective_bounds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A closed cardinality objective cannot certify an unresolved tie-break."""
+
+    monkeypatch.setitem(sys.modules, "z3", _StubCardinalityAndFirstTieClosedZ3())
+    result = z3_backend._solve_independence_number_values_kernel(
+        _path_graph(), IndependenceNumberBudget()
+    )
+    assert result.status == "UNKNOWN"
+    assert result.optimum_value is None
+    assert result.upper_bound == result.order == 3
+    assert IndependenceNumberResult.model_validate(result.model_dump()) == result
 
 
 def test_sat_with_open_objective_bounds_reports_order_as_upper_bound(

--- a/tests/math/graphs/test_independence_source_binding.py
+++ b/tests/math/graphs/test_independence_source_binding.py
@@ -343,6 +343,43 @@ def test_closed_cardinality_is_exact_without_membership_objectives(
     assert IndependenceNumberResult.model_validate(result.model_dump()) == result
 
 
+class _StubLexIncompleteOptimizer(_StubOptimizer):
+    """First Optimize closes cardinality; later instances leave lex open."""
+
+    _created = 0
+
+    def __init__(self) -> None:
+        type(self)._created += 1
+        self._phase = type(self)._created
+
+    def maximize(self, expression: object) -> _StubObjective:
+        if self._phase == 1:
+            return _StubClosedObjective()
+        return _StubObjective()
+
+    def check(self) -> int:
+        return _StubZ3.sat
+
+
+class _StubLexIncompleteZ3(_StubZ3):
+    Optimize = _StubLexIncompleteOptimizer
+
+
+def test_canonical_witness_requires_closed_lex_objectives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(sys.modules, "z3", _StubLexIncompleteZ3())
+    _StubLexIncompleteOptimizer._created = 0
+    result = z3_backend._solve_independence_number_values_kernel(
+        _path_graph(),
+        IndependenceNumberBudget(),
+        canonicalize_witness=True,
+    )
+    assert result.status == "UNKNOWN"
+    assert result.optimum_value is None
+    assert result.upper_bound == result.order == 3
+
+
 def test_sat_with_open_objective_bounds_reports_order_as_upper_bound(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/math/graphs/test_independence_source_binding.py
+++ b/tests/math/graphs/test_independence_source_binding.py
@@ -320,35 +320,26 @@ class _StubZ3:
     Optimize = _StubOptimizer
 
 
-class _StubCardinalityAndFirstTieClosedOptimizer(_StubOptimizer):
-    """Cardinality and one tie-break close before a later tie-break stays open."""
-
-    def __init__(self) -> None:
-        self._maximize_calls = 0
-
+class _StubClosedCardinalityOptimizer(_StubOptimizer):
     def maximize(self, expression: object) -> _StubObjective:
-        self._maximize_calls += 1
-        if self._maximize_calls <= 2:
-            return _StubClosedObjective()
-        return _StubObjective()
+        return _StubClosedObjective()
 
 
-class _StubCardinalityAndFirstTieClosedZ3(_StubZ3):
-    Optimize = _StubCardinalityAndFirstTieClosedOptimizer
+class _StubClosedCardinalityZ3(_StubZ3):
+    Optimize = _StubClosedCardinalityOptimizer
 
 
-def test_exact_requires_all_tie_break_objective_bounds(
+def test_closed_cardinality_is_exact_without_membership_objectives(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A closed cardinality objective cannot certify an unresolved tie-break."""
+    """Independence exactness depends only on the closed cardinality bound."""
 
-    monkeypatch.setitem(sys.modules, "z3", _StubCardinalityAndFirstTieClosedZ3())
+    monkeypatch.setitem(sys.modules, "z3", _StubClosedCardinalityZ3())
     result = z3_backend._solve_independence_number_values_kernel(
         _path_graph(), IndependenceNumberBudget()
     )
-    assert result.status == "UNKNOWN"
-    assert result.optimum_value is None
-    assert result.upper_bound == result.order == 3
+    assert result.status == "EXACT"
+    assert result.optimum_value == result.upper_bound == 1
     assert IndependenceNumberResult.model_validate(result.model_dump()) == result
 
 


### PR DESCRIPTION
Closes #3600\n\n## Summary\n\nThe initial operation declaration already present on main exposed the private conflict-graph reduction but left canonical tie-breaking, endpoint-axis normalization, and source/result binding under-specified. This PR completes the #3600 contract:\n\n- canonicalize source edges before assigning contiguous eN IDs;\n- make the existing independence kernel choose the lexicographically smallest maximum witness, including double-digit IDs;\n- return sorted endpoint vertices/edges and the complete source-edge axis;\n- validate source binding, vertex-disjointness, complete induced endpoint subgraphs, bounds, and exact-vs-unknown status;\n- preflight source edge, conflict-pair, intermediate-cell, and result envelopes, with request checkpoints during conflict construction;\n- document the operation and add path, cycle, star, complete-bipartite, disjoint-union, relabeling/order-invariance, exhaustive-small-case, malformed-result, and tie-breaking coverage.\n\nThe private square-of-line-graph reduction remains an implementation detail; ordinary matching, strong edge coloring, weighted induced matching, and minimum maximal matching remain separate contracts.\n\n## Validation\n\nFinal head: 90adac6b03f0612c1acfa3f4ae8a45238edb620e\n\n- make architecture — OK (1506 files checked)\n- make affected AFFECTED_BASE=origin/main — passed lint, mypy, 1480 graph tests, 160 catalog tests, and 968 catalog-integration tests\n- Exact-diff review completed against refreshed origin/main; one evidence gap was repaired with a double-digit-ID tie regression, followed by the full affected gate\n- No open PR duplicate for graph.induced_matching.maximum.compute\n\nThe branch was fetched immediately before a non-force push. No history rewrite or compatibility shadow operation was added.