### PR TITLE
feat(polynomials): construct elementary symmetric families

### DIFF
--- a/docs/reference/operations/polynomial/elementary-symmetric.md
+++ b/docs/reference/operations/polynomial/elementary-symmetric.md
@@ -1,0 +1,39 @@
+# Elementary-symmetric polynomial families
+
+[Documentation home](../../../index.md) · [Polynomial operations](index.md) ·
+[Tool surface](../../tools.md)
+
+`polynomial.symmetric.elementary_family.compute` returns the complete family
+`(e_0, ..., e_k)` of elementary symmetric polynomials for an ordered variable
+axis `x_1, ..., x_n`.  Every returned member is the ordinary canonical sparse
+`QQ` polynomial used by substitution, evaluation, polynomial maps, ideals, and
+expression normalization.  `e_0` is the multiplicative constant `1`, including
+when the axis is empty.
+
+The axis is retained on every polynomial.  Renaming or permuting variables
+therefore changes only the coordinates of the sparse exponent vectors: the
+family is invariant under that coherent variable permutation.  The defining
+recurrence is
+
+```text
+e_j(x_1, ..., x_n) = e_j(x_1, ..., x_(n-1))
+                     + x_n e_(j-1)(x_1, ..., x_(n-1)).
+```
+
+## Bounded domain
+
+The request has at most eight distinct variables and requires `0 <= k <= n`.
+Before the recurrence runs, admission counts the exact
+
+`sum(j=0..k) binomial(n,j)`
+
+monomials, all exponent cells, repeated axis-label storage, recurrence work,
+and canonical result cells.  The complete eight-variable family has 256
+monomials and 2,048 exponent cells, well within the shared sparse polynomial
+carrier.  These are semantic representation and work reservations; they are
+not transport byte limits.
+
+The kernel uses the dynamic-product recurrence once and materializes ordinary
+canonical sparse polynomials.  It does not parse caller expressions or expose
+backend-specific symbolic objects.  Complete homogeneous, power-sum, Schur,
+monomial-symmetric, and basis-conversion operations remain separate contracts.

--- a/docs/reference/operations/polynomial/index.md
+++ b/docs/reference/operations/polynomial/index.md
@@ -33,4 +33,5 @@ for replay.
 
 ## Focused contracts
 
+- [Elementary-symmetric polynomial families](elementary-symmetric.md)
 - [Monomial-ideal graded Betti profiles](monomial-ideal-graded-betti.md)

--- a/src/jacobian/math/polynomials/__init__.py
+++ b/src/jacobian/math/polynomials/__init__.py
@@ -13,6 +13,9 @@ from jacobian.math.polynomials._elementary_kernel import (
     rational_polynomial_evaluate,
     rational_polynomial_integral,
 )
+from jacobian.math.polynomials._elementary_symmetric import (
+    elementary_symmetric_family,
+)
 from jacobian.math.polynomials.operations import (
     derivative,
     discriminant,
@@ -63,6 +66,7 @@ __all__ = [
     "derivative",
     "discriminant",
     "divide",
+    "elementary_symmetric_family",
     "evaluate",
     "factorization",
     "gcdex",

--- a/src/jacobian/math/polynomials/_elementary_symmetric.py
+++ b/src/jacobian/math/polynomials/_elementary_symmetric.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import comb
+from re import fullmatch
 
 from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
@@ -142,14 +143,15 @@ class _ElementaryFamilyBounds:
     work: int
 
 
-def _bounds(request: ElementarySymmetricFamilyRequest) -> _ElementaryFamilyBounds:
-    variables = len(request.variables)
-    maximum_degree = request.maximum_degree
+def _bounds(
+    variables_axis: tuple[PolynomialVariable, ...], maximum_degree: int
+) -> _ElementaryFamilyBounds:
+    variables = len(variables_axis)
     monomials = sum(comb(variables, degree) for degree in range(maximum_degree + 1))
     exponent_cells = monomials * variables
     # Every returned polynomial retains the full authoritative axis.
     label_bytes = (maximum_degree + 1) * sum(
-        len(variable.encode("utf-8")) for variable in request.variables
+        len(variable.encode("utf-8")) for variable in variables_axis
     )
     # A term has n exponent cells, one coefficient, and one sparse-term record;
     # each polynomial has its axis and family slot.  This is a structural
@@ -209,7 +211,8 @@ def _bounds(request: ElementarySymmetricFamilyRequest) -> _ElementaryFamilyBound
 
 
 def _compute(
-    request: ElementarySymmetricFamilyRequest,
+    variables: tuple[PolynomialVariable, ...],
+    maximum_degree: int,
     bounds: _ElementaryFamilyBounds,
 ) -> ElementarySymmetricFamilyResult:
     """Run the admitted dynamic-product recurrence.
@@ -221,7 +224,6 @@ def _compute(
     in the shared canonical sparse representation.
     """
 
-    variables = request.variables
     variable_count = len(variables)
     zero = (0,) * variable_count
     one = CanonicalRational(num=1, den=1)
@@ -233,9 +235,9 @@ def _compute(
         previous = levels
         ledger.charge(sum(len(level) for level in previous))
         levels = [dict(level) for level in previous]
-        if len(levels) <= request.maximum_degree:
+        if len(levels) <= maximum_degree:
             levels.append({})
-        for degree in range(1, min(index + 1, request.maximum_degree) + 1):
+        for degree in range(1, min(index + 1, maximum_degree) + 1):
             source = previous[degree - 1]
             target = levels[degree]
             for exponents in source:
@@ -244,7 +246,7 @@ def _compute(
                 target[shifted] = one
 
     polynomials: list[RationalPolynomial] = []
-    for degree in range(request.maximum_degree + 1):
+    for degree in range(maximum_degree + 1):
         entries = levels[degree]
         terms: list[RationalPolynomialTerm] = []
         for exponents in sorted(entries, reverse=True):
@@ -266,18 +268,54 @@ def _compute(
 
     return ElementarySymmetricFamilyResult(
         variables=variables,
-        maximum_degree=request.maximum_degree,
+        maximum_degree=maximum_degree,
         polynomials=tuple(polynomials),
     )
 
 
-def elementary_symmetric_family(
+def _elementary_symmetric_family_from_request(
     request: ElementarySymmetricFamilyRequest,
 ) -> ElementarySymmetricFamilyResult:
-    """Return ``e_0, ..., e_k`` for one ordered QQ variable axis."""
+    bounds = _bounds(request.variables, request.maximum_degree)
+    return _compute(request.variables, request.maximum_degree, bounds)
 
-    bounds = _bounds(request)
-    return _compute(request, bounds)
+
+def _validate_native_arguments(
+    variables: tuple[PolynomialVariable, ...], maximum_degree: int
+) -> None:
+    if type(variables) is not tuple:
+        raise TypeError("variables must be a tuple of distinct variable labels")
+    if type(maximum_degree) is not int:
+        raise TypeError("maximum_degree must be an integer")
+    if len(variables) > MAX_POLYNOMIAL_VARIABLES:
+        raise ValueError(
+            f"variables cannot contain more than {MAX_POLYNOMIAL_VARIABLES} labels"
+        )
+    for variable in variables:
+        if (
+            type(variable) is not str
+            or fullmatch(r"[A-Za-z][A-Za-z0-9_]{0,31}", variable) is None
+        ):
+            raise ValueError("variables must use the canonical polynomial label syntax")
+    if len(set(variables)) != len(variables):
+        raise ValueError("elementary symmetric variables must be unique")
+    if not 0 <= maximum_degree <= len(variables):
+        raise ValueError("maximum_degree must be between 0 and the variable count")
+
+
+def elementary_symmetric_family(
+    variables: tuple[PolynomialVariable, ...], maximum_degree: int
+) -> ElementarySymmetricFamilyResult:
+    """Return ``e_0, ..., e_k`` for one ordered QQ variable axis.
+
+    This direct native API accepts mathematical arguments rather than the
+    catalog's wire request model.  The private request adapter below is used
+    only by catalog dispatch, so both paths share one admission and kernel.
+    """
+
+    _validate_native_arguments(variables, maximum_degree)
+    bounds = _bounds(variables, maximum_degree)
+    return _compute(variables, maximum_degree, bounds)
 
 
 __all__ = [

--- a/src/jacobian/math/polynomials/_elementary_symmetric.py
+++ b/src/jacobian/math/polynomials/_elementary_symmetric.py
@@ -1,12 +1,25 @@
-"""Canonical elementary symmetric polynomial families."""
+"""Exact elementary-symmetric polynomial families over ``QQ``.
 
-from itertools import combinations
+The public value is an ordinary family of canonical sparse polynomials.  The
+operation owns admission for the complete family because its result contains
+every requested degree, while the dynamic-product kernel avoids enumerating a
+separate subset list for each polynomial.
+"""
 
-from pydantic import Field, model_validator
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import comb
+
+from pydantic import Field, StrictInt, model_validator
+from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
+from jacobian._execution import OperationWorkLedger, request_checkpoint
 from jacobian._models import StrictModel
+from jacobian.catalog.models import OperationResourceAdmissionError
 from jacobian.math.polynomials.values import (
+    MAX_POLYNOMIAL_TERMS,
     MAX_POLYNOMIAL_VARIABLES,
     PolynomialVariable,
     RationalPolynomial,
@@ -14,52 +27,254 @@ from jacobian.math.polynomials.values import (
     SparseRationalPolynomial,
 )
 
+# These are semantic carrier budgets, not transport byte limits.  The largest
+# shared polynomial axis has eight variables, so even the complete family has
+# only 2**8 monomials.  The explicit limits keep the controlling quantities
+# visible and protect this operation if the shared carrier is widened later.
+MAX_ELEMENTARY_FAMILY_MONOMIALS = MAX_POLYNOMIAL_TERMS
+MAX_ELEMENTARY_FAMILY_EXPONENT_CELLS = MAX_POLYNOMIAL_TERMS * MAX_POLYNOMIAL_VARIABLES
+MAX_ELEMENTARY_FAMILY_LABEL_BYTES = 4_096
+MAX_ELEMENTARY_FAMILY_RESULT_CELLS = 8_192
+MAX_ELEMENTARY_FAMILY_WORK = 65_536
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"polynomial.symmetric.elementary.{reason}", message)
+
 
 class ElementarySymmetricFamilyRequest(StrictModel):
+    """An ordered variable axis and the largest requested elementary degree."""
+
     variables: tuple[PolynomialVariable, ...] = Field(
-        min_length=0, max_length=MAX_POLYNOMIAL_VARIABLES
+        min_length=0,
+        max_length=MAX_POLYNOMIAL_VARIABLES,
+        description=(
+            "Distinct ordered QQ variables. The family preserves this axis; "
+            "maximum_degree must not exceed its length."
+        ),
+        json_schema_extra={"uniqueItems": True},
     )
-    maximum_degree: int = Field(ge=0, le=MAX_POLYNOMIAL_VARIABLES)
+    maximum_degree: StrictInt = Field(
+        ge=0,
+        le=MAX_POLYNOMIAL_VARIABLES,
+        description=(
+            "Largest degree to return, including e_0 = 1; it must be at most "
+            "the number of variables."
+        ),
+        examples=[2],
+    )
 
     @model_validator(mode="after")
-    def require_degree_and_axis(self) -> "ElementarySymmetricFamilyRequest":
+    def require_degree_and_axis(self) -> ElementarySymmetricFamilyRequest:
         if len(set(self.variables)) != len(self.variables):
-            raise ValueError("elementary symmetric variables must be unique")
+            raise _validation_error(
+                "duplicate_variables",
+                "elementary symmetric variables must be unique",
+            )
         if self.maximum_degree > len(self.variables):
-            raise ValueError("maximum_degree cannot exceed the variable count")
+            raise _validation_error(
+                "degree_exceeds_axis",
+                "maximum_degree cannot exceed the variable count",
+            )
         return self
 
 
 class ElementarySymmetricFamilyResult(StrictModel):
-    variables: tuple[PolynomialVariable, ...]
-    maximum_degree: int
-    polynomials: tuple[RationalPolynomial, ...]
+    """The complete canonical family ``(e_0, ..., e_k)`` on one QQ axis."""
+
+    variables: tuple[PolynomialVariable, ...] = Field(
+        min_length=0, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
+    maximum_degree: StrictInt = Field(
+        ge=0,
+        le=MAX_POLYNOMIAL_VARIABLES,
+    )
+    polynomials: tuple[RationalPolynomial, ...] = Field(
+        min_length=1,
+        max_length=MAX_POLYNOMIAL_VARIABLES + 1,
+    )
+
+    @model_validator(mode="after")
+    def require_axis_and_family_shape(self) -> ElementarySymmetricFamilyResult:
+        if len(set(self.variables)) != len(self.variables):
+            raise _validation_error(
+                "result_duplicate_variables",
+                "result variables must be unique",
+            )
+        if self.maximum_degree > len(self.variables):
+            raise _validation_error(
+                "result_degree_exceeds_axis",
+                "result maximum_degree cannot exceed the variable count",
+            )
+        if len(self.polynomials) != self.maximum_degree + 1:
+            raise _validation_error(
+                "result_family_shape",
+                "result must contain exactly one polynomial for every degree 0..k",
+            )
+        if any(
+            polynomial.variables != self.variables for polynomial in self.polynomials
+        ):
+            raise _validation_error(
+                "result_axis_mismatch",
+                "every family polynomial must preserve the declared variable axis",
+            )
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class _ElementaryFamilyBounds:
+    """One admitted execution plan, reused by the kernel without recomputation."""
+
+    monomials: int
+    exponent_cells: int
+    label_bytes: int
+    result_cells: int
+    recurrence_work: int
+    work: int
+
+
+def _bounds(request: ElementarySymmetricFamilyRequest) -> _ElementaryFamilyBounds:
+    variables = len(request.variables)
+    maximum_degree = request.maximum_degree
+    monomials = sum(comb(variables, degree) for degree in range(maximum_degree + 1))
+    exponent_cells = monomials * variables
+    # Every returned polynomial retains the full authoritative axis.
+    label_bytes = (maximum_degree + 1) * sum(
+        len(variable.encode("utf-8")) for variable in request.variables
+    )
+    # A term has n exponent cells, one coefficient, and one sparse-term record;
+    # each polynomial has its axis and family slot.  This is a structural
+    # result-size bound, not a serialized JSON/transport byte ceiling.
+    result_cells = (
+        label_bytes
+        + monomials * (variables + 3)
+        + (maximum_degree + 1) * (variables + 2)
+    )
+    recurrence_work = sum(
+        comb(index, degree)
+        for index in range(variables)
+        for degree in range(min(index, maximum_degree) + 1)
+    )
+    work = recurrence_work + exponent_cells + monomials + maximum_degree + 1
+    bounds = _ElementaryFamilyBounds(
+        monomials=monomials,
+        exponent_cells=exponent_cells,
+        label_bytes=label_bytes,
+        result_cells=result_cells,
+        recurrence_work=recurrence_work,
+        work=work,
+    )
+    if bounds.monomials > MAX_ELEMENTARY_FAMILY_MONOMIALS:
+        raise OperationResourceAdmissionError(
+            location=("maximum_degree",),
+            code="polynomial.symmetric.elementary.monomial_bound",
+            message="elementary family exceeds the admitted monomial bound",
+        )
+    if bounds.exponent_cells > MAX_ELEMENTARY_FAMILY_EXPONENT_CELLS:
+        raise OperationResourceAdmissionError(
+            location=("maximum_degree",),
+            code="polynomial.symmetric.elementary.exponent_cells_bound",
+            message="elementary family exceeds the admitted exponent-cell bound",
+        )
+    if bounds.label_bytes > MAX_ELEMENTARY_FAMILY_LABEL_BYTES:
+        raise OperationResourceAdmissionError(
+            location=("variables",),
+            code="polynomial.symmetric.elementary.label_bound",
+            message="repeated variable-axis labels exceed the admitted bound",
+        )
+    if bounds.result_cells > MAX_ELEMENTARY_FAMILY_RESULT_CELLS:
+        raise OperationResourceAdmissionError(
+            location=("maximum_degree",),
+            code="polynomial.symmetric.elementary.result_bound",
+            message="elementary family exceeds the admitted canonical result bound",
+        )
+    if bounds.work > MAX_ELEMENTARY_FAMILY_WORK:
+        raise OperationResourceAdmissionError(
+            location=("maximum_degree",),
+            code="polynomial.symmetric.elementary.work_bound",
+            message="elementary family exceeds the admitted work bound",
+        )
+    return bounds
+
+
+def _compute(
+    request: ElementarySymmetricFamilyRequest,
+    bounds: _ElementaryFamilyBounds,
+) -> ElementarySymmetricFamilyResult:
+    """Run the admitted dynamic-product recurrence.
+
+    After processing ``x_1, ..., x_i``, ``levels[j]`` is ``e_j`` on that
+    prefix.  Extending one variable applies
+    ``e_j(new) = e_j(old) + x_i e_(j-1)(old)``.  No symbolic expression is
+    parsed or expanded by a backend, and every emitted polynomial is already
+    in the shared canonical sparse representation.
+    """
+
+    variables = request.variables
+    variable_count = len(variables)
+    zero = (0,) * variable_count
+    one = CanonicalRational(num=1, den=1)
+    levels: list[dict[tuple[int, ...], CanonicalRational]] = [{zero: one}]
+    ledger = OperationWorkLedger(bounds.work)
+
+    for index in range(variable_count):
+        request_checkpoint("during elementary symmetric recurrence")
+        previous = levels
+        levels = [dict(level) for level in previous]
+        if len(levels) <= request.maximum_degree:
+            levels.append({})
+        for degree in range(1, min(index + 1, request.maximum_degree) + 1):
+            source = previous[degree - 1]
+            target = levels[degree]
+            for exponents in source:
+                ledger.charge()
+                shifted = (*exponents[:index], 1, *exponents[index + 1 :])
+                target[shifted] = one
+
+    polynomials: list[RationalPolynomial] = []
+    for degree in range(request.maximum_degree + 1):
+        entries = levels[degree]
+        terms: list[RationalPolynomialTerm] = []
+        for exponents in sorted(entries, reverse=True):
+            request_checkpoint("during elementary symmetric result construction")
+            ledger.charge(len(exponents) + 1)
+            terms.append(
+                RationalPolynomialTerm(
+                    coefficient=entries[exponents],
+                    exponents=exponents,
+                )
+            )
+        ledger.charge()
+        polynomials.append(
+            RationalPolynomial(
+                variables=variables,
+                polynomial=SparseRationalPolynomial(terms=tuple(terms)),
+            )
+        )
+
+    return ElementarySymmetricFamilyResult(
+        variables=variables,
+        maximum_degree=request.maximum_degree,
+        polynomials=tuple(polynomials),
+    )
 
 
 def elementary_symmetric_family(
     request: ElementarySymmetricFamilyRequest,
 ) -> ElementarySymmetricFamilyResult:
-    variable_count = len(request.variables)
-    one = CanonicalRational(num=1, den=1)
-    polynomials = []
-    for degree in range(request.maximum_degree + 1):
-        terms = tuple(
-            RationalPolynomialTerm(
-                coefficient=one,
-                exponents=tuple(
-                    int(index in selected) for index in range(variable_count)
-                ),
-            )
-            for selected in combinations(range(variable_count), degree)
-        )
-        polynomials.append(
-            RationalPolynomial(
-                variables=request.variables,
-                polynomial=SparseRationalPolynomial(terms=terms),
-            )
-        )
-    return ElementarySymmetricFamilyResult(
-        variables=request.variables,
-        maximum_degree=request.maximum_degree,
-        polynomials=tuple(polynomials),
-    )
+    """Return ``e_0, ..., e_k`` for one ordered QQ variable axis."""
+
+    bounds = _bounds(request)
+    return _compute(request, bounds)
+
+
+__all__ = [
+    "MAX_ELEMENTARY_FAMILY_EXPONENT_CELLS",
+    "MAX_ELEMENTARY_FAMILY_LABEL_BYTES",
+    "MAX_ELEMENTARY_FAMILY_MONOMIALS",
+    "MAX_ELEMENTARY_FAMILY_RESULT_CELLS",
+    "MAX_ELEMENTARY_FAMILY_WORK",
+    "ElementarySymmetricFamilyRequest",
+    "ElementarySymmetricFamilyResult",
+    "elementary_symmetric_family",
+]

--- a/src/jacobian/math/polynomials/_elementary_symmetric.py
+++ b/src/jacobian/math/polynomials/_elementary_symmetric.py
@@ -118,6 +118,15 @@ class ElementarySymmetricFamilyResult(StrictModel):
                 "result_axis_mismatch",
                 "every family polynomial must preserve the declared variable axis",
             )
+        e_zero = self.polynomials[0].polynomial.terms
+        if len(e_zero) != 1 or (
+            e_zero[0].exponents != (0,) * len(self.variables)
+            or e_zero[0].coefficient.as_fraction() != 1
+        ):
+            raise _validation_error(
+                "result_e_zero",
+                "the first family polynomial must be the canonical constant one",
+            )
         return self
 
 

--- a/src/jacobian/math/polynomials/_elementary_symmetric.py
+++ b/src/jacobian/math/polynomials/_elementary_symmetric.py
@@ -18,7 +18,10 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalRational
 from jacobian._execution import OperationWorkLedger, request_checkpoint
 from jacobian._models import StrictModel
-from jacobian.catalog.models import OperationResourceAdmissionError
+from jacobian.catalog.models import (
+    OperationDomainValidationError,
+    OperationResourceAdmissionError,
+)
 from jacobian.math.polynomials.values import (
     MAX_POLYNOMIAL_TERMS,
     MAX_POLYNOMIAL_VARIABLES,
@@ -276,6 +279,7 @@ def _compute(
 def _elementary_symmetric_family_from_request(
     request: ElementarySymmetricFamilyRequest,
 ) -> ElementarySymmetricFamilyResult:
+    _validate_native_arguments(request.variables, request.maximum_degree)
     bounds = _bounds(request.variables, request.maximum_degree)
     return _compute(request.variables, request.maximum_degree, bounds)
 
@@ -284,23 +288,47 @@ def _validate_native_arguments(
     variables: tuple[PolynomialVariable, ...], maximum_degree: int
 ) -> None:
     if type(variables) is not tuple:
-        raise TypeError("variables must be a tuple of distinct variable labels")
-    if type(maximum_degree) is not int:
-        raise TypeError("maximum_degree must be an integer")
-    if len(variables) > MAX_POLYNOMIAL_VARIABLES:
-        raise ValueError(
-            f"variables cannot contain more than {MAX_POLYNOMIAL_VARIABLES} labels"
+        raise OperationDomainValidationError(
+            location=("variables",),
+            code="polynomial.symmetric.elementary.variables_type",
+            message="variables must be a tuple of distinct variable labels",
         )
-    for variable in variables:
+    if type(maximum_degree) is not int:
+        raise OperationDomainValidationError(
+            location=("maximum_degree",),
+            code="polynomial.symmetric.elementary.degree_type",
+            message="maximum_degree must be an integer",
+        )
+    if len(variables) > MAX_POLYNOMIAL_VARIABLES:
+        raise OperationDomainValidationError(
+            location=("variables",),
+            code="polynomial.symmetric.elementary.variable_count",
+            message=(
+                f"variables cannot contain more than {MAX_POLYNOMIAL_VARIABLES} labels"
+            ),
+        )
+    for index, variable in enumerate(variables):
         if (
             type(variable) is not str
             or fullmatch(r"[A-Za-z][A-Za-z0-9_]{0,31}", variable) is None
         ):
-            raise ValueError("variables must use the canonical polynomial label syntax")
+            raise OperationDomainValidationError(
+                location=("variables", str(index)),
+                code="polynomial.symmetric.elementary.variable_syntax",
+                message="variables must use the canonical polynomial label syntax",
+            )
     if len(set(variables)) != len(variables):
-        raise ValueError("elementary symmetric variables must be unique")
+        raise OperationDomainValidationError(
+            location=("variables",),
+            code="polynomial.symmetric.elementary.duplicate_variables",
+            message="elementary symmetric variables must be unique",
+        )
     if not 0 <= maximum_degree <= len(variables):
-        raise ValueError("maximum_degree must be between 0 and the variable count")
+        raise OperationDomainValidationError(
+            location=("maximum_degree",),
+            code="polynomial.symmetric.elementary.degree_exceeds_axis",
+            message="maximum_degree must be between 0 and the variable count",
+        )
 
 
 def elementary_symmetric_family(

--- a/src/jacobian/math/polynomials/_elementary_symmetric.py
+++ b/src/jacobian/math/polynomials/_elementary_symmetric.py
@@ -164,7 +164,9 @@ def _bounds(request: ElementarySymmetricFamilyRequest) -> _ElementaryFamilyBound
         for index in range(variables)
         for degree in range(min(index, maximum_degree) + 1)
     )
-    work = recurrence_work + exponent_cells + monomials + maximum_degree + 1
+    # The recurrence reads each retained prefix term once and copies each
+    # retained prefix level once before adding the new-variable terms.
+    work = 2 * recurrence_work + exponent_cells + monomials + maximum_degree + 1
     bounds = _ElementaryFamilyBounds(
         monomials=monomials,
         exponent_cells=exponent_cells,
@@ -229,6 +231,7 @@ def _compute(
     for index in range(variable_count):
         request_checkpoint("during elementary symmetric recurrence")
         previous = levels
+        ledger.charge(sum(len(level) for level in previous))
         levels = [dict(level) for level in previous]
         if len(levels) <= request.maximum_degree:
             levels.append({})

--- a/src/jacobian/math/polynomials/_elementary_symmetric_tools.py
+++ b/src/jacobian/math/polynomials/_elementary_symmetric_tools.py
@@ -29,7 +29,10 @@ ELEMENTARY_SYMMETRIC_FAMILY_OPERATION = MathTool(
     examples=(
         OperationExample(
             name="three_variables",
-            description="Compute e_0, e_1, and e_2 in x, y, z.",
+            description=(
+                "Compute e_0, e_1, and e_2 in x, y, z; maximum_degree must not "
+                "exceed the variable count."
+            ),
             input={"variables": ["x", "y", "z"], "maximum_degree": 2},
         ),
     ),

--- a/src/jacobian/math/polynomials/_elementary_symmetric_tools.py
+++ b/src/jacobian/math/polynomials/_elementary_symmetric_tools.py
@@ -4,8 +4,15 @@ from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.polynomials._elementary_symmetric import (
     ElementarySymmetricFamilyRequest,
     ElementarySymmetricFamilyResult,
-    elementary_symmetric_family,
+    _elementary_symmetric_family_from_request,
 )
+
+
+def _run_elementary_symmetric_family(
+    request: ElementarySymmetricFamilyRequest,
+) -> ElementarySymmetricFamilyResult:
+    return _elementary_symmetric_family_from_request(request)
+
 
 ELEMENTARY_SYMMETRIC_FAMILY_OPERATION = MathTool(
     operation_id="polynomial.symmetric.elementary_family.compute",
@@ -17,7 +24,7 @@ ELEMENTARY_SYMMETRIC_FAMILY_OPERATION = MathTool(
     ),
     request_type=ElementarySymmetricFamilyRequest,
     result_type=ElementarySymmetricFamilyResult,
-    run=elementary_symmetric_family,
+    run=_run_elementary_symmetric_family,
     tags=("polynomial", "symmetric", "elementary", "family", "exact"),
     examples=(
         OperationExample(

--- a/src/jacobian/math/polynomials/_elementary_symmetric_tools.py
+++ b/src/jacobian/math/polynomials/_elementary_symmetric_tools.py
@@ -8,11 +8,12 @@ from jacobian.math.polynomials._elementary_symmetric import (
 )
 
 ELEMENTARY_SYMMETRIC_FAMILY_OPERATION = MathTool(
-    operation_id="polynomial.elementary_symmetric.family.compute",
+    operation_id="polynomial.symmetric.elementary_family.compute",
     title="Compute an elementary symmetric polynomial family",
     description=(
-        "Return the canonical sparse rational polynomials e_0 through e_k on "
-        "an ordered variable axis, including e_0 = 1 for the empty axis."
+        "Return the complete canonical sparse rational family e_0 through e_k "
+        "on an ordered variable axis, including e_0 = 1; k must not exceed "
+        "the number of distinct variables."
     ),
     request_type=ElementarySymmetricFamilyRequest,
     result_type=ElementarySymmetricFamilyResult,

--- a/tests/math/polynomials/test_elementary_symmetric.py
+++ b/tests/math/polynomials/test_elementary_symmetric.py
@@ -136,3 +136,13 @@ def test_catalog_declaration_uses_requested_operation_id_and_round_trips() -> No
         result.model_dump_json()
     )
     assert decoded == result
+
+
+def test_result_rejects_forged_nonunit_e_zero_without_replaying_the_family() -> None:
+    result = elementary_symmetric_family(
+        ElementarySymmetricFamilyRequest(variables=("x", "y"), maximum_degree=1)
+    )
+    forged = result.model_dump()
+    forged["polynomials"][0]["polynomial"]["terms"][0]["coefficient"]["num"] = 2
+    with pytest.raises(ValidationError, match="canonical constant one"):
+        type(result).model_validate(forged)

--- a/tests/math/polynomials/test_elementary_symmetric.py
+++ b/tests/math/polynomials/test_elementary_symmetric.py
@@ -1,14 +1,31 @@
 """Canonical elementary symmetric families."""
 
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+from sympy import Poly, expand, prod, symbols
+
+from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
 from jacobian.math.polynomials._elementary_symmetric import (
     ElementarySymmetricFamilyRequest,
     elementary_symmetric_family,
+)
+from jacobian.math.polynomials._elementary_symmetric_tools import (
+    ELEMENTARY_SYMMETRIC_FAMILY_OPERATION,
 )
 from jacobian.math.polynomials.values import RationalPolynomial
 
 
 def support(polynomial: RationalPolynomial) -> tuple[tuple[int, ...], ...]:
     return tuple(term.exponents for term in polynomial.polynomial.terms)
+
+
+def coefficients(polynomial: RationalPolynomial) -> dict[tuple[int, ...], Fraction]:
+    return {
+        term.exponents: term.coefficient.as_fraction()
+        for term in polynomial.polynomial.terms
+    }
 
 
 def test_family_through_degree_two() -> None:
@@ -26,3 +43,96 @@ def test_empty_axis_e_zero_is_a_canonical_constant() -> None:
     )
     assert result.polynomials[0].variables == ()
     assert support(result.polynomials[0]) == ((),)
+
+
+def test_request_rejects_duplicate_variables_and_degree_above_axis() -> None:
+    with pytest.raises(ValidationError, match="variables must be unique"):
+        ElementarySymmetricFamilyRequest(variables=("x", "x"), maximum_degree=1)
+    with pytest.raises(ValidationError, match="cannot exceed the variable count"):
+        ElementarySymmetricFamilyRequest(variables=("x",), maximum_degree=2)
+
+
+def test_dynamic_recurrence_matches_prefix_recurrence() -> None:
+    full = elementary_symmetric_family(
+        ElementarySymmetricFamilyRequest(variables=("x", "y", "z"), maximum_degree=3)
+    )
+    prefix = elementary_symmetric_family(
+        ElementarySymmetricFamilyRequest(variables=("x", "y"), maximum_degree=2)
+    )
+    for degree in range(1, 4):
+        expected = (
+            {
+                (*exponents, 0): value
+                for exponents, value in coefficients(prefix.polynomials[degree]).items()
+            }
+            if degree <= 2
+            else {}
+        )
+        if degree:
+            for exponents, value in coefficients(
+                prefix.polynomials[degree - 1]
+            ).items():
+                shifted = (*exponents, 1)
+                expected[shifted] = expected.get(shifted, Fraction()) + value
+        assert coefficients(full.polynomials[degree]) == expected
+
+
+def test_family_is_invariant_under_coherent_variable_permutation() -> None:
+    ordered = elementary_symmetric_family(
+        ElementarySymmetricFamilyRequest(variables=("x", "y", "z"), maximum_degree=3)
+    )
+    permuted = elementary_symmetric_family(
+        ElementarySymmetricFamilyRequest(variables=("z", "x", "y"), maximum_degree=3)
+    )
+    for left, right in zip(ordered.polynomials, permuted.polynomials, strict=True):
+        left_by_name = {
+            tuple(sorted(zip(left.variables, exponents, strict=True))): value
+            for exponents, value in coefficients(left).items()
+        }
+        right_by_name = {
+            tuple(sorted(zip(right.variables, exponents, strict=True))): value
+            for exponents, value in coefficients(right).items()
+        }
+        assert left_by_name == right_by_name
+
+
+def test_vieta_reconstruction_matches_product_of_linear_factors() -> None:
+    variables = ("x", "y", "z")
+    result = elementary_symmetric_family(
+        ElementarySymmetricFamilyRequest(variables=variables, maximum_degree=3)
+    )
+    t = symbols("t")
+    x, y, z = symbols("x y z")
+    expected = Poly(prod(t - variable for variable in (x, y, z)).expand(), t)
+    for degree, polynomial in enumerate(result.polynomials):
+        actual = rational_polynomial_to_sympy(polynomial).as_expr()
+        coefficient = expected.coeff_monomial(t ** (3 - degree))
+        assert expand(actual - (-1) ** degree * coefficient) == 0
+
+
+def test_complete_eighth_axis_family_stays_within_exact_carrier() -> None:
+    result = elementary_symmetric_family(
+        ElementarySymmetricFamilyRequest(
+            variables=tuple(f"x{index}" for index in range(8)), maximum_degree=8
+        )
+    )
+    assert len(result.polynomials) == 9
+    assert (
+        sum(len(polynomial.polynomial.terms) for polynomial in result.polynomials)
+        == 256
+    )
+
+
+def test_catalog_declaration_uses_requested_operation_id_and_round_trips() -> None:
+    assert (
+        ELEMENTARY_SYMMETRIC_FAMILY_OPERATION.operation_id
+        == "polynomial.symmetric.elementary_family.compute"
+    )
+    request = ElementarySymmetricFamilyRequest(
+        variables=("x", "y", "z"), maximum_degree=2
+    )
+    result = ELEMENTARY_SYMMETRIC_FAMILY_OPERATION.run(request)
+    decoded = ELEMENTARY_SYMMETRIC_FAMILY_OPERATION.result_type.model_validate_json(
+        result.model_dump_json()
+    )
+    assert decoded == result

--- a/tests/math/polynomials/test_elementary_symmetric.py
+++ b/tests/math/polynomials/test_elementary_symmetric.py
@@ -30,7 +30,8 @@ def coefficients(polynomial: RationalPolynomial) -> dict[tuple[int, ...], Fracti
 
 def test_family_through_degree_two() -> None:
     result = elementary_symmetric_family(
-        ElementarySymmetricFamilyRequest(variables=("x", "y", "z"), maximum_degree=2)
+        ("x", "y", "z"),
+        2,
     )
     assert support(result.polynomials[0]) == ((0, 0, 0),)
     assert support(result.polynomials[1]) == ((1, 0, 0), (0, 1, 0), (0, 0, 1))
@@ -39,7 +40,8 @@ def test_family_through_degree_two() -> None:
 
 def test_empty_axis_e_zero_is_a_canonical_constant() -> None:
     result = elementary_symmetric_family(
-        ElementarySymmetricFamilyRequest(variables=(), maximum_degree=0)
+        (),
+        0,
     )
     assert result.polynomials[0].variables == ()
     assert support(result.polynomials[0]) == ((),)
@@ -54,10 +56,12 @@ def test_request_rejects_duplicate_variables_and_degree_above_axis() -> None:
 
 def test_dynamic_recurrence_matches_prefix_recurrence() -> None:
     full = elementary_symmetric_family(
-        ElementarySymmetricFamilyRequest(variables=("x", "y", "z"), maximum_degree=3)
+        ("x", "y", "z"),
+        3,
     )
     prefix = elementary_symmetric_family(
-        ElementarySymmetricFamilyRequest(variables=("x", "y"), maximum_degree=2)
+        ("x", "y"),
+        2,
     )
     for degree in range(1, 4):
         expected = (
@@ -79,10 +83,12 @@ def test_dynamic_recurrence_matches_prefix_recurrence() -> None:
 
 def test_family_is_invariant_under_coherent_variable_permutation() -> None:
     ordered = elementary_symmetric_family(
-        ElementarySymmetricFamilyRequest(variables=("x", "y", "z"), maximum_degree=3)
+        ("x", "y", "z"),
+        3,
     )
     permuted = elementary_symmetric_family(
-        ElementarySymmetricFamilyRequest(variables=("z", "x", "y"), maximum_degree=3)
+        ("z", "x", "y"),
+        3,
     )
     for left, right in zip(ordered.polynomials, permuted.polynomials, strict=True):
         left_by_name = {
@@ -99,7 +105,8 @@ def test_family_is_invariant_under_coherent_variable_permutation() -> None:
 def test_vieta_reconstruction_matches_product_of_linear_factors() -> None:
     variables = ("x", "y", "z")
     result = elementary_symmetric_family(
-        ElementarySymmetricFamilyRequest(variables=variables, maximum_degree=3)
+        variables,
+        3,
     )
     t = symbols("t")
     x, y, z = symbols("x y z")
@@ -112,9 +119,8 @@ def test_vieta_reconstruction_matches_product_of_linear_factors() -> None:
 
 def test_complete_eighth_axis_family_stays_within_exact_carrier() -> None:
     result = elementary_symmetric_family(
-        ElementarySymmetricFamilyRequest(
-            variables=tuple(f"x{index}" for index in range(8)), maximum_degree=8
-        )
+        tuple(f"x{index}" for index in range(8)),
+        8,
     )
     assert len(result.polynomials) == 9
     assert (
@@ -140,7 +146,8 @@ def test_catalog_declaration_uses_requested_operation_id_and_round_trips() -> No
 
 def test_result_rejects_forged_nonunit_e_zero_without_replaying_the_family() -> None:
     result = elementary_symmetric_family(
-        ElementarySymmetricFamilyRequest(variables=("x", "y"), maximum_degree=1)
+        ("x", "y"),
+        1,
     )
     forged = result.model_dump()
     forged["polynomials"][0]["polynomial"]["terms"][0]["coefficient"]["num"] = 2

--- a/tests/math/polynomials/test_elementary_symmetric.py
+++ b/tests/math/polynomials/test_elementary_symmetric.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 from sympy import Poly, expand, prod, symbols
 
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
 from jacobian.math.polynomials._elementary_symmetric import (
     ElementarySymmetricFamilyRequest,
@@ -153,3 +154,23 @@ def test_result_rejects_forged_nonunit_e_zero_without_replaying_the_family() -> 
     forged["polynomials"][0]["polynomial"]["terms"][0]["coefficient"]["num"] = 2
     with pytest.raises(ValidationError, match="canonical constant one"):
         type(result).model_validate(forged)
+
+
+def test_native_entry_rejects_invalid_domain_values_with_typed_errors() -> None:
+    with pytest.raises(OperationDomainValidationError) as list_error:
+        elementary_symmetric_family(["x", "y"], 1)  # type: ignore[arg-type]
+    assert list_error.value.errors()[0]["type"] == (
+        "polynomial.symmetric.elementary.variables_type"
+    )
+    with pytest.raises(OperationDomainValidationError) as degree_error:
+        elementary_symmetric_family(("x", "y"), 1.0)  # type: ignore[arg-type]
+    assert degree_error.value.errors()[0]["type"] == (
+        "polynomial.symmetric.elementary.degree_type"
+    )
+    with pytest.raises(OperationDomainValidationError) as duplicate_error:
+        elementary_symmetric_family(("x", "x"), 1)
+    assert duplicate_error.value.errors()[0]["type"] == (
+        "polynomial.symmetric.elementary.duplicate_variables"
+    )
+    result = elementary_symmetric_family(("x", "y"), 1)
+    assert support(result.polynomials[1]) == ((1, 0), (0, 1))

--- a/tests/math/polynomials/test_elementary_symmetric.py
+++ b/tests/math/polynomials/test_elementary_symmetric.py
@@ -145,6 +145,20 @@ def test_catalog_declaration_uses_requested_operation_id_and_round_trips() -> No
     assert decoded == result
 
 
+def test_published_example_states_degree_precondition_and_is_admitted() -> None:
+    example = ELEMENTARY_SYMMETRIC_FAMILY_OPERATION.examples[0]
+    assert "must not exceed the variable count" in example.description
+    variables = example.input["variables"]
+    maximum_degree = example.input["maximum_degree"]
+    assert isinstance(variables, list)
+    assert isinstance(maximum_degree, int)
+    assert maximum_degree <= len(variables)
+    result = ELEMENTARY_SYMMETRIC_FAMILY_OPERATION.run(
+        ElementarySymmetricFamilyRequest.model_validate(example.input)
+    )
+    assert len(result.polynomials) == maximum_degree + 1
+
+
 def test_result_rejects_forged_nonunit_e_zero_without_replaying_the_family() -> None:
     result = elementary_symmetric_family(
         ("x", "y"),

--- a/tests/math/polynomials/test_public_api.py
+++ b/tests/math/polynomials/test_public_api.py
@@ -74,6 +74,7 @@ def test_exact_public_api_symbols() -> None:
         "derivative",
         "discriminant",
         "divide",
+        "elementary_symmetric_family",
         "evaluate",
         "factorization",
         "gcdex",


### PR DESCRIPTION
Closes #3599

## Outcome

Adds `polynomial.symmetric.elementary_family.compute`, returning the complete canonical sparse QQ family `(e_0, ..., e_k)` on an ordered variable axis.

- Preserves axes on every polynomial and supports coherent variable permutation.
- Handles the empty axis and `e_0 = 1`.
- Rejects duplicate labels and `k > n` explicitly.
- Uses the exact subset-support bound, exponent-cell bound, repeated-label bound, canonical result-cell bound, and dynamic recurrence/intermediate work ledger before execution.
- Separates the direct native API from the wire request model; catalog and native paths share one admission/kernel.
- Adds catalog schema/example coverage, Vieta/recurrence/permutation behavior, JSON round trips, docs, and public API export.

## Validation

- Focused polynomial tests: 18 passed.
- Focused catalog example/schema checks: 4 passed; public API and operation tests passed.
- Scoped Ruff and mypy passed.
- `make architecture`: `architecture: OK (1506 files checked)`.
- Independent exact-diff autoreview at final head `81d4567ef`: clean, no actionable findings.

`MATH_WORKERS=0 make affected AFFECTED_BASE=origin/main` reached the polynomial lane. Its only failure was an unrelated 120-second existing `rational_gradient` process timeout. The specific test passes on both clean current `origin/main` (112.96s) and this branch (105.28s). The catalog conformance mutation failure is also reproducible identically on clean current `origin/main` and this branch: an unrelated impartial-game mutation raises `ValueError` for a cyclic game.

Final tested head: `81d4567ef`.
