### PR TITLE
docs(geometry): complete rational covariant derivative contract

### DIFF
--- a/docs/reference/operations/geometry/index.md
+++ b/docs/reference/operations/geometry/index.md
@@ -4,3 +4,4 @@
 
 - [Exact planar geometry](exact-planar-geometry.md)
 - [Projective plane-curve singularity profiles](projective-plane-curve-singularities.md)
+- [Rational coordinate covariant derivatives](rational-covariant-derivatives.md)

--- a/docs/reference/operations/geometry/rational-covariant-derivatives.md
+++ b/docs/reference/operations/geometry/rational-covariant-derivatives.md
@@ -60,9 +60,12 @@ The operation retains the metric and tensor denominator guards, generated
 determinant guards, and every nonconstant denominator in the normalized output.
 It admits the complete dense source and result tensor, sparse polynomial
 support, coefficient height, intermediate DAG work, and canonical exact
-output before symbolic expansion. A request that exceeds the rank, component,
-term, coefficient, or retained-locus envelope is rejected before backend work;
-accepted requests return every component. The semantic limits are mathematical
+output before symbolic DAG expansion. Rank-shape admission currently follows
+canonical rational-function recognition, so a valid source whose derivative
+would exceed rank can still perform bounded GCD recognition work first. A
+request that exceeds the rank, component, term, coefficient, or
+retained-locus envelope is rejected before symbolic/DAG expansion; accepted
+requests return every component. The semantic limits are mathematical
 work and exact representation limits, not a transport-byte truncation.
 
 The exact symbolic arithmetic runs behind a bounded worker. Timeout,

--- a/docs/reference/operations/geometry/rational-covariant-derivatives.md
+++ b/docs/reference/operations/geometry/rational-covariant-derivatives.md
@@ -1,0 +1,77 @@
+# Rational coordinate covariant derivatives
+
+[Documentation home](../../../index.md) · [Tool surface](../../tools.md)
+
+`differential_geometry.rational_tensor.covariant_derivative.compute` applies
+the Levi--Civita connection of one exact rational coordinate metric to one
+exact rational tensor over the same ordered chart. It returns a
+`RationalCoordinateTensor` with one leading covariant derivative index; the
+remaining variance and component axes are preserved in lexicographic order.
+
+For
+
+```text
+T^(i_1 ... i_r)_(j_1 ... j_s)
+```
+
+the returned component is the exact rational-function identity
+
+```text
+(nabla_a T)^(i_1 ... i_r)_(j_1 ... j_s)
+ = partial_a T^(i_1 ... i_r)_(j_1 ... j_s)
+ + sum_u,b Gamma^(i_u)_(a b)
+     T^(i_1 ... b ... i_r)_(j_1 ... j_s)
+ - sum_v,b Gamma^b_(a j_v)
+     T^(i_1 ... i_r)_(j_1 ... b ... j_s).
+```
+
+The metric and tensor must carry exactly the same coordinate axis and rational
+field. A rank-zero tensor therefore receives only the leading covariant axis
+and agrees with the rational-function gradient. Contravariant source indices
+use the positive connection term; covariant source indices use the negative
+term. A bare nested array is not interchangeable with this carrier because
+variance and coordinate order change the mathematical result.
+
+## Example: Euclidean polar coordinates
+
+On the chart `(r, theta)`, use
+
+```text
+g_rr = 1,  g_rtheta = g_thetar = 0,  g_thetatheta = r^2.
+```
+
+The retained nondegenerate locus is `r != 0`, and the only nonzero connection
+families are
+
+```text
+Gamma^r_thetatheta = -r,
+Gamma^theta_rtheta = Gamma^theta_thetar = 1/r.
+```
+
+Applying the operation to `g` returns eight explicit zero components. For a
+constant contravariant radial vector `V^r = 1`, `V^theta = 0`, the component
+`(nabla_theta V)^theta` is `1/r`; for the covector `dr`,
+`(nabla_theta dr)_theta` is `r`. These exact identities distinguish the
+connection correction terms from componentwise differentiation.
+
+## Exactness and execution envelope
+
+The operation retains the metric and tensor denominator guards, generated
+determinant guards, and every nonconstant denominator in the normalized output.
+It admits the complete dense source and result tensor, sparse polynomial
+support, coefficient height, intermediate DAG work, and canonical exact
+output before symbolic expansion. A request that exceeds the rank, component,
+term, coefficient, or retained-locus envelope is rejected before backend work;
+accepted requests return every component. The semantic limits are mathematical
+work and exact representation limits, not a transport-byte truncation.
+
+The exact symbolic arithmetic runs behind a bounded worker. Timeout,
+cancellation, malformed backend output, or normalization failure is an
+operational error and never establishes a zero or partial derivative. No
+coordinate sampling, expression-string parser, generic manifold model, index
+raising/lowering, tensor contraction, geodesic integration, or PDE evolution is
+part of this operation.
+
+For native use, import `covariant_derivative` from
+`jacobian.math.geometry.differential.rational_tensor`; for MCP, inspect the
+operation with `math.find` and pass the canonical tensor payload unchanged.

--- a/src/jacobian/math/geometry/differential/rational_tensor/covariant_derivative/_tools.py
+++ b/src/jacobian/math/geometry/differential/rational_tensor/covariant_derivative/_tools.py
@@ -39,7 +39,11 @@ TOOLS = (
         examples=(
             OperationExample(
                 name="polar_metric_scalar",
-                description="Differentiate r^2 covariantly in the polar Euclidean chart.",
+                description=(
+                    "Differentiate r^2 covariantly in the polar Euclidean chart; "
+                    "the metric and scalar tensor must use the same ordered "
+                    "(r, theta) coordinate axis."
+                ),
                 input={
                     "metric": {
                         "tensor": {

--- a/tests/math/geometry/differential/rational_tensor/test_covariant_derivative.py
+++ b/tests/math/geometry/differential/rational_tensor/test_covariant_derivative.py
@@ -5,7 +5,7 @@ from itertools import product
 from typing import Any
 
 import pytest
-from sympy import cancel, symbols
+from sympy import Matrix, cancel, diff, symbols
 
 from jacobian.catalog.models import (
     OperationDomainValidationError,
@@ -106,6 +106,78 @@ def test_mixed_tensor_formula_replays_exactly() -> None:
                 * source_values[upper * 2 + replacement]
             )
         expected.append(expression)
+    assert all(
+        cancel(left - right) == 0 for left, right in zip(actual, expected, strict=True)
+    )
+
+
+def test_nondiagonal_tensor_formula_matches_independent_sympy_oracle() -> None:
+    """Derive the connection independently instead of reusing the DAG plan."""
+    x, y = symbols("x y")
+    axis = ("x", "y")
+    metric = RationalCoordinateMetric(
+        tensor=tensor([2 + x, y, y, 3 + x], ("COVARIANT", "COVARIANT"), axis)
+    )
+    source_components = tuple(
+        rational_function_from_sympy(value, axis)
+        for value in (x / (x + 1), 1, y, (x + y) / (y + 1))
+    )
+    source = RationalCoordinateTensor(
+        coordinate_axis=axis,
+        variance=("CONTRAVARIANT", "COVARIANT"),
+        components=source_components,
+        retained_nonzero_denominators=canonical_locus_guards(
+            tuple(
+                component.denominator
+                for component in source_components
+                if component.denominator.terms
+            ),
+            variable_count=len(axis),
+        ),
+    )
+
+    result = covariant_derivative(metric, source)
+    actual = expressions(result)
+
+    coordinates = (x, y)
+    metric_matrix = Matrix([[2 + x, y], [y, 3 + x]])
+    inverse = metric_matrix.inv()
+    gamma = [
+        [
+            [
+                cancel(
+                    sum(
+                        inverse[k, ell]
+                        * (
+                            diff(metric_matrix[ell, j], coordinates[i])
+                            + diff(metric_matrix[ell, i], coordinates[j])
+                            - diff(metric_matrix[i, j], coordinates[ell])
+                        )
+                        for ell in range(2)
+                    )
+                    / 2
+                )
+                for j in range(2)
+            ]
+            for i in range(2)
+        ]
+        for k in range(2)
+    ]
+    source_values = expressions(source)
+    expected = []
+    for derivative_axis, upper, lower in product(range(2), repeat=3):
+        value = source_values[upper * 2 + lower].diff(coordinates[derivative_axis])
+        for replacement in range(2):
+            value += (
+                gamma[upper][derivative_axis][replacement]
+                * source_values[replacement * 2 + lower]
+            )
+            value -= (
+                gamma[replacement][derivative_axis][lower]
+                * source_values[upper * 2 + replacement]
+            )
+        expected.append(value)
+
     assert all(
         cancel(left - right) == 0 for left, right in zip(actual, expected, strict=True)
     )


### PR DESCRIPTION
## Summary

Closes #2885.

The exact covariant-derivative implementation from #3540 is already on `main`; this follow-up completes the public contract and independent evidence requested by the issue:

- documents the ordered-axis, variance, Levi--Civita index convention, retained locus, exact admission, and operational-failure semantics;
- states the shared-axis precondition in the published catalog example; and
- adds an independent SymPy-derived non-diagonal mixed-tensor oracle.

Commit: `d56c60dc9717d0353adfe9259b6e1318f0d0b5b4`

## Validation

- `make architecture`
- `make affected AFFECTED_BASE=origin/main` (Ruff, mypy, 27 math tests, 161 catalog tests, 968 catalog integration tests)
- `uv run pytest -q tests/math/geometry/differential/rational_tensor/test_covariant_derivative.py tests/mcp/test_rational_covariant_derivative.py` (28 passed)
- `make docs-linkcheck docs-command-check`
