### PR TITLE
feat(polynomials): complete rational map composition surface

### DIFF
--- a/docs/reference/operations/polynomial/index.md
+++ b/docs/reference/operations/polynomial/index.md
@@ -17,6 +17,42 @@ Both operations support `lex`, `grlex`, and `grevlex`; the selected order is
 retained because the normal-form witnesses depend on it even though the ideal
 relation does not.
 
+## Rational coordinate maps
+
+`rational_function_map.compose.compute` composes an outer map
+
+\[
+F : (y_1,\ldots,y_m) \longrightarrow (z_1,\ldots,z_r)
+\]
+
+with an inner map
+
+\[
+G : (x_1,\ldots,x_n) \longrightarrow (y_1,\ldots,y_m).
+\]
+
+The intermediate axis is a typed contract: the ordered
+`inner.target_coordinates` must equal `outer.source_variables`. The exact
+result retains both input maps, the composite map on the inner source axis,
+and the outer target axis. It is a field identity over `QQ`, not a claim about
+an inverse, image, or global chart.
+
+The `construction_locus_guard` is an ordered, duplicate-free tuple of monic
+`RationalPolynomial` values interpreted conjunctively as nonvanishing
+conditions. It contains every nonconstant inner component denominator and the
+numerator of each normalized substituted outer denominator, before any
+removable cancellation in the returned composite. Thus a cancellation may
+extend the canonical rational function while the result still preserves the
+stricter locus on which the supplied composition was constructed. An outer
+denominator that becomes the zero rational function is rejected.
+
+Admission accounts for every source component, denominator-clearing
+intermediate, normalization/GCD phase, guard, and complete canonical output
+before exact backend expansion. The native entry point is
+`jacobian.math.polynomials.rational_functions.compose_maps(outer, inner)`;
+native callers pass canonical `RationalFunctionMap` values rather than the
+wire request model.
+
 [Documentation home](../../../index.md) · [Tool surface](../../tools.md)
 
 The live catalog is the authoritative reference for installed polynomial

--- a/docs/reference/operations/polynomial/rational-map-composition.md
+++ b/docs/reference/operations/polynomial/rational-map-composition.md
@@ -1,0 +1,51 @@
+# Rational coordinate-map composition
+
+[Polynomial operations](index.md) · [Operation references](../index.md)
+
+`rational_function_map.compose.compute` returns the exact composite of two
+canonical maps over `QQ` while retaining the source-bound domain of the
+construction.
+
+For
+
+\[
+G : X=(x_1,\ldots,x_n) \to Y=(y_1,\ldots,y_m), \qquad
+F : Y \to Z=(z_1,\ldots,z_r),
+\]
+
+the request is valid only when `G.target_coordinates` and
+`F.source_variables` are equal as ordered axes. The result contains `outer`,
+`inner`, and `composite = F o G`; the composite has the source variables of
+`G` and target coordinates of `F`.
+
+Its `construction_locus_guard` is a canonical ordered tuple of nonconstant
+monic rational polynomials in the source variables. Every guard is required to
+be nonzero. The tuple records the conjunction of:
+
+- all nonconstant denominators supplied by the components of `G`; and
+- the numerator of every normalized nonconstant outer denominator after
+  substitution into `G`.
+
+This is the pre-cancellation locus. If a common factor cancels from a
+composite component, the guard remains, because the returned value only claims
+the pointwise identity `F(G(x))` on the locus where both supplied maps and all
+substitution denominators were defined. A substituted outer denominator that
+is identically zero is a domain error, not a cancelled result.
+
+The operation admits source, substitution, denominator-clearing, exact
+normalization, cancellation, guard, intermediate, work, coefficient-height,
+term-support, and complete-result bounds before invoking the maintained exact
+polynomial backend. It does not compute inverses, images, fibers, dominance,
+Jacobians, projective atlas gluing, or analytic domains.
+
+The native equivalent is:
+
+```python
+from jacobian.math.polynomials.rational_functions import compose_maps
+
+result = compose_maps(outer, inner)
+```
+
+Native callers supply `RationalFunctionMap` values directly. The Pydantic
+`RationalMapCompositionRequest` is the transport request model used by the
+catalog adapter.

--- a/src/jacobian/math/polynomials/rational_functions/__init__.py
+++ b/src/jacobian/math/polynomials/rational_functions/__init__.py
@@ -1,5 +1,15 @@
-"""Canonical rational functions and coordinate maps."""
+"""Canonical rational functions and coordinate maps.
 
+The native composition entry point accepts canonical map values directly. The
+wire-only request model remains owned by the composition tool manifest.
+"""
+
+from jacobian.math.polynomials.rational_functions.composition._models import (
+    RationalFunctionMapComposition,
+)
+from jacobian.math.polynomials.rational_functions.composition.operations import (
+    compose_maps,
+)
 from jacobian.math.polynomials.rational_functions.values import RationalFunctionMap
 
-__all__ = ["RationalFunctionMap"]
+__all__ = ["RationalFunctionMap", "RationalFunctionMapComposition", "compose_maps"]

--- a/src/jacobian/math/polynomials/rational_functions/composition/_tools.py
+++ b/src/jacobian/math/polynomials/rational_functions/composition/_tools.py
@@ -32,6 +32,11 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         result_type=RationalFunctionMapComposition,
         run=_compute,
         tags=("rational-function", "map", "composition", "exact"),
+        discovery_terms=(
+            "compose rational coordinate maps",
+            "substitute one rational map into another",
+            "rational chart transition composition",
+        ),
         examples=(
             OperationExample(
                 name="two_variable_chart_transition",

--- a/src/jacobian/math/polynomials/rational_functions/composition/operations.py
+++ b/src/jacobian/math/polynomials/rational_functions/composition/operations.py
@@ -531,6 +531,21 @@ def compose_maps(  # noqa: C901
     inner: RationalFunctionMap,
 ) -> RationalFunctionMapComposition:
     """Compose two canonical rational maps on their retained construction locus."""
+    # Native callers bypass the Pydantic wire request, so retain the same
+    # typed boundary here instead of allowing attribute errors or tuple
+    # unpacking failures to escape from admission.
+    if not isinstance(outer, RationalFunctionMap):
+        raise OperationDomainValidationError(
+            location=("outer",),
+            code="rational_function_map.compose.invalid_outer_type",
+            message="outer must be a RationalFunctionMap",
+        )
+    if not isinstance(inner, RationalFunctionMap):
+        raise OperationDomainValidationError(
+            location=("inner",),
+            code="rational_function_map.compose.invalid_inner_type",
+            message="inner must be a RationalFunctionMap",
+        )
     execution = current_request_execution()
     if execution is None:
         with request_execution(time.monotonic()):

--- a/tests/math/polynomials/test_rational_map_composition.py
+++ b/tests/math/polynomials/test_rational_map_composition.py
@@ -63,6 +63,30 @@ def test_example_states_the_intermediate_axis_precondition() -> None:
     assert "source_variables equal the inner target_coordinates" in description
 
 
+def test_native_composition_is_exported_without_exposing_wire_request() -> None:
+    import jacobian.math.polynomials.rational_functions as rational_functions
+
+    assert rational_functions.compose_maps is compose_maps
+    assert "compose_maps" in rational_functions.__all__
+    assert "RationalMapCompositionRequest" not in rational_functions.__all__
+
+
+def test_native_composition_rejects_non_map_outer() -> None:
+    with pytest.raises(OperationDomainValidationError) as error:
+        compose_maps(object(), object())  # type: ignore[arg-type]
+
+    assert error.value.errors()[0]["loc"] == ("outer",)
+
+
+def test_native_composition_rejects_non_map_inner() -> None:
+    y = symbols("y")
+    outer = _map(("y",), ("z",), (_rf(y, (y,)),))
+    with pytest.raises(OperationDomainValidationError) as error:
+        compose_maps(outer, object())  # type: ignore[arg-type]
+
+    assert error.value.errors()[0]["loc"] == ("inner",)
+
+
 def test_example_composition_retains_all_construction_guards() -> None:
     x = symbols("x")
     y1, y2 = symbols("y1 y2")
@@ -198,6 +222,19 @@ def test_empty_inner_axis_composes_exact_constants() -> None:
     result = compose_maps(outer, inner)
     assert result.composite.source_variables == ()
     assert result.composite.components[0] == _rf(6, ())
+    assert result.construction_locus_guard == ()
+
+
+def test_zero_dimensional_intermediate_axis_retains_inner_source() -> None:
+    x = symbols("x")
+    inner = _map(("x",), (), ())
+    outer = _map((), ("z",), (_rf(2, ()),))
+
+    result = compose_maps(outer, inner)
+
+    assert result.composite.source_variables == ("x",)
+    assert result.composite.target_coordinates == ("z",)
+    assert result.composite.components == (_rf(2, (x,)),)
     assert result.construction_locus_guard == ()
 
 


### PR DESCRIPTION
## Summary

Complete the public/native surface for bounded exact rational coordinate-map composition requested by #2880.

The exact composition kernel and catalog operation already present on `main` remain unchanged in their mathematical semantics. This change makes the native `compose_maps(outer, inner)` entry point explicit, keeps the wire request model transport-owned, adds native type admission, improves discovery vocabulary, and documents the source-bound pre-cancellation guard contract.

## Contract

- `inner.target_coordinates` must equal `outer.source_variables` in ordered form.
- The result retains the inner source axis, outer target axis, both source maps, and complete canonical composite.
- Construction guards retain every nonconstant inner denominator and normalized substituted outer denominator before cancellation.
- Identically zero substituted outer denominators remain domain errors.
- Native callers receive canonical `RationalFunctionMap` values and never need to construct the wire request model.

Closes #2880.

## Validation

- `make architecture` — passed (1,506 files checked)
- `make import-contracts` — passed
- `make docs-linkcheck` — passed
- `make affected AFFECTED_BASE=origin/main` — math, catalog, lint, and typecheck lanes passed
- Focused rational-map/MCP tests — 22 passed
- Affected math lane — 49 passed
- Catalog lane — 161 passed
- Catalog integration — 967 passed; one unrelated graph chromatic-bipartition example timed out
- Full catalog executable-example run — rational-map composition passed; unrelated graph examples had timeout failures under the local run
