### PR TITLE
fix(graphs): finish induced edge deletion profile bounds

### DIFF
--- a/docs/reference/operations/graphs/index.md
+++ b/docs/reference/operations/graphs/index.md
@@ -15,3 +15,4 @@ there is no graph artifact carrier or invariant-batch registry.
 - [Small exact graph reliability](graph-reliability.md)
 - [Exact finite directed bond reliability](directed-bond-reliability.md)
 - [Declared graph-symmetry orbits](graph-symmetry-orbits.md)
+- [Induced edge-deletion profiles](induced-edge-deletion-profile.md)

--- a/docs/reference/operations/graphs/induced-edge-deletion-profile.md
+++ b/docs/reference/operations/graphs/induced-edge-deletion-profile.md
@@ -1,0 +1,36 @@
+# Induced edge-deletion profiles
+
+`graph.coloring.induced_edge_deletion_profile.compute` returns the exact
+source-bound distance from every induced subgraph to `r`-colourability. For a
+finite simple graph `G` and target `r >= 1`, each row is
+
+\[
+D_{G,r}(S)=\min\{|F|:F\subseteq E(G[S]),\ \chi(G[S]-F)\leq r\}
+\]
+
+for one canonical vertex subset `S`. The row retains the lexicographically
+smallest deleted source-edge tuple attaining that minimum, and the result also
+derives the maximum row value and its attaining-row count for each subset size.
+Rows are ordered by increasing subset size and then lexicographically by vertex
+labels; the profile always contains exactly `2^|V(G)|` rows, including the empty
+subset.
+
+## Exact bounded kernel
+
+The complete Boolean-lattice profile is admitted for at most eight vertices,
+with aggregate induced-edge materialization, solver-call, conflict, retained
+label, and output bounds checked before computation. `r=1` and `r >= |S|` are
+closed-form cases. Every `r=2` row uses exhaustive Boolean cut enumeration:
+minimum edge deletion to bipartiteness is the complement of a maximum cut. This
+is exact for the admitted vertex bound and makes no Z3 calls or conflict-ledger
+charges, including for non-bipartite hosts.
+
+For `r >= 3`, the bounded Z3 colouring/deletion kernel is used only after
+admission. Each solver transaction receives the remaining request deadline and
+is interruptible by request cancellation; an interrupted or exhausted request
+establishes no optimum. The pinned `z3-solver` dependency is therefore a private
+implementation detail, not part of the mathematical result.
+
+The operation does not select a subset-size layer, construct a host graph, or
+draw an asymptotic Erdős-problem conclusion. Callers receive the complete finite
+profile and may compose its rows or per-size projection with their own research.

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/_models.py
@@ -11,7 +11,6 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.coloring._models import (
-    MAX_COLORING_COLORS,
     MAX_SOLVER_CONFLICT_BUDGET,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
@@ -19,10 +18,9 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 MAX_INDUCED_DELETION_VERTICES = 8
 """Conservative vertex envelope for the complete 2^n profile (8 => 256 rows)."""
 
-# Values above the backend's colour-variable envelope are still exact trivial
-# cases whenever r covers an induced subset, so they are not an input bound.
-MAX_INDUCED_DELETION_R = MAX_COLORING_COLORS
 MAX_INDUCED_DELETION_R_BITS = 53
+MAX_INDUCED_DELETION_R = (1 << MAX_INDUCED_DELETION_R_BITS) - 1
+"""Largest JSON-safe target count; values above the solver palette are admitted."""
 DEFAULT_INDUCED_SOLVER_CONFLICTS = 100_000
 MAX_INDUCED_RETAINED_LABEL_CHARACTERS = 1_000_000
 MAX_INDUCED_EDGE_MATERIALIZATION = 200_000
@@ -52,7 +50,7 @@ class InducedEdgeDeletionProfileRequest(StrictModel):
     graph: InducedDeletionGraph
     r: StrictInt = Field(
         ge=1,
-        le=(1 << MAX_INDUCED_DELETION_R_BITS) - 1,
+        le=MAX_INDUCED_DELETION_R,
         description="Target colour count r >=1; D(S) is min deletions to make G[S] r-colourable.",
     )
     solver_conflicts: StrictInt = Field(
@@ -127,7 +125,7 @@ class InducedEdgeDeletionProfileResult(StrictModel):
     """Complete profile D_{G,r}(S) over all 2^n vertex subsets with per-size maxima."""
 
     graph: SimpleUndirectedGraph
-    r: StrictInt = Field(ge=1, le=(1 << MAX_INDUCED_DELETION_R_BITS) - 1)
+    r: StrictInt = Field(ge=1, le=MAX_INDUCED_DELETION_R)
     rows: tuple[InducedDeletionRow, ...]
     max_deletions_by_size: tuple[PerSizeMaximum, ...]
 

--- a/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
+++ b/src/jacobian/math/graphs/coloring/induced_edge_deletion_profile/operations.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import time
 from collections import defaultdict
+from contextlib import suppress
 from itertools import combinations
+from threading import Event, Thread
 from typing import Any
 
 from jacobian._execution import (
+    OperationExecutionCancelledError,
     OperationExecutionTimeoutError,
     bind_request_deadline,
+    current_request_cancellation,
     current_request_execution,
     request_checkpoint,
     request_execution,
@@ -17,6 +21,7 @@ from jacobian._execution import (
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.coloring.induced_edge_deletion_profile._models import (
     DEFAULT_INDUCED_SOLVER_CONFLICTS,
+    MAX_INDUCED_DELETION_R,
     MAX_INDUCED_DELETION_VERTICES,
     MAX_INDUCED_EDGE_MATERIALIZATION,
     MAX_INDUCED_LEDGER_CONFLICTS,
@@ -51,6 +56,52 @@ def _set_remaining_z3_timeout(solver: Any) -> None:
     if remaining_milliseconds <= 0:
         raise OperationExecutionTimeoutError("request deadline expired before Z3 call")
     solver.set("timeout", remaining_milliseconds)
+
+
+def _run_z3_check(solver: Any, stage: str) -> Any:
+    """Run one solver check with cooperative cancellation and deadline interrupts.
+
+    Z3's native timeout is necessary but cancellation signals are external to the
+    solver.  A small request-scoped watchdog interrupts the solver object itself,
+    so an in-process backend cannot outlive its request envelope.
+    """
+    execution = current_request_execution()
+    cancellation = current_request_cancellation() or (
+        execution.cancellation_signal if execution is not None else None
+    )
+    deadline = execution.deadline if execution is not None else None
+    stop = Event()
+    interrupted_for: list[str | None] = [None]
+
+    def watch() -> None:
+        while not stop.wait(0.005):
+            if cancellation is not None and cancellation.is_set():
+                interrupted_for[0] = "cancelled"
+                with suppress(Exception):
+                    solver.interrupt()
+                return
+            if deadline is not None and time.monotonic() >= deadline:
+                interrupted_for[0] = "deadline"
+                with suppress(Exception):
+                    solver.interrupt()
+                return
+
+    watcher = Thread(target=watch, name="jacobian-z3-watchdog", daemon=True)
+    watcher.start()
+    try:
+        outcome = solver.check()
+    finally:
+        stop.set()
+        watcher.join(timeout=0.1)
+
+    if cancellation is not None and cancellation.is_set():
+        raise OperationExecutionCancelledError(f"request cancelled {stage}")
+    if interrupted_for[0] == "cancelled":
+        raise OperationExecutionCancelledError(f"request cancelled {stage}")
+    _require_execution_active(f"after {stage}")
+    if interrupted_for[0] == "deadline":
+        raise OperationExecutionTimeoutError(f"request deadline expired {stage}")
+    return outcome
 
 
 def _is_bipartite_vertices_edges(
@@ -114,8 +165,7 @@ def _z3_is_r_colorable(
         solver.add(variable >= 0, variable < r)
     for a, b in edges:
         solver.add(var_map[a] != var_map[b])
-    outcome = solver.check()
-    _require_execution_active("after r-colourability check")
+    outcome = _run_z3_check(solver, "r-colourability check")
     if outcome == z3.sat:
         return True
     if outcome == z3.unsat:
@@ -175,8 +225,7 @@ def _z3_exists_deletion_leq_k(
                 solver.add(deletion_vars[idx])
             else:
                 solver.add(z3.Not(deletion_vars[idx]))
-    outcome = solver.check()
-    _require_execution_active("after deletion feasibility check")
+    outcome = _run_z3_check(solver, "deletion feasibility check")
     if outcome == z3.sat:
         return True
     if outcome == z3.unsat:
@@ -195,7 +244,7 @@ def _admit_induced_edge_deletion_profile(
     r: int,
     solver_conflicts: int,
 ) -> None:
-    if type(r) is not int or r < 1 or r.bit_length() > 53:
+    if type(r) is not int or not 1 <= r <= MAX_INDUCED_DELETION_R:
         raise OperationDomainValidationError(
             location=("r",),
             code="graph.induced_edge_deletion.r_out_of_range",
@@ -253,15 +302,13 @@ def _admit_induced_edge_deletion_profile(
             code="graph.induced_edge_deletion.materialization_exceeds_bound",
             message="induced-edge deletion profile induced-edge materialization exceeds its bound",
         )
-    # predicted solver calls: quick enumeration of induced edge counts per subset
+    # Predicted solver calls: quick enumeration of induced edge counts per subset.
+    # r=2 is solved exactly by finite cut enumeration below, so it must not be
+    # charged against the Z3 ledger at all.
     sorted_vertices = sorted(graph.vertices)
     sorted_edges = tuple(sorted(graph.edges))
     # quick map for counting
     predicted_calls = 0
-    # also track ledger
-    graph_is_bipartite = r == 2 and _is_bipartite_vertices_edges(
-        sorted_vertices, list(sorted_edges)
-    )
     for size in range(n + 1):
         for subset in combinations(sorted_vertices, size):
             _require_execution_active("during admission subset scan")
@@ -270,11 +317,11 @@ def _admit_induced_edge_deletion_profile(
             for a, b in sorted_edges:
                 if a in subset_set and b in subset_set:
                     m_s += 1
-            if m_s == 0 or r == 1 or r >= len(subset) or graph_is_bipartite:
+            if m_s == 0 or r in (1, 2) or r >= len(subset):
                 continue
-            # if we can shortcut 0-deletion check we still need at least 1 call worst
-            # need to estimate worst 2*m_s+1
-            predicted_calls += 2 * m_s + 1
+            # Initial feasibility + up to m_s optimum checks + up to m_s
+            # canonical tie-break checks + one reconstruction check.
+            predicted_calls += 2 * m_s + 2
             if predicted_calls > MAX_INDUCED_SOLVER_CALLS:
                 raise OperationDomainValidationError(
                     location=("graph",),
@@ -290,7 +337,31 @@ def _admit_induced_edge_deletion_profile(
         )
 
 
-def _compute_min_deletions_for_subset(
+def _min_bipartite_deletions(
+    subset_vertices: tuple[str, ...], induced_edges: list[tuple[str, str]]
+) -> tuple[int, tuple[tuple[str, str], ...]]:
+    """Return the exact canonical edge-bipartization witness for one subset."""
+    if _is_bipartite_vertices_edges(list(subset_vertices), induced_edges):
+        return 0, ()
+    vertex_index = {vertex: index for index, vertex in enumerate(subset_vertices)}
+    best: tuple[int, tuple[tuple[str, str], ...]] | None = None
+    for mask in range(1 << len(subset_vertices)):
+        _require_execution_active("during bipartite cut enumeration")
+        deleted = tuple(
+            edge
+            for edge in induced_edges
+            if not (
+                ((mask >> vertex_index[edge[0]]) ^ (mask >> vertex_index[edge[1]])) & 1
+            )
+        )
+        candidate = (len(deleted), deleted)
+        if best is None or candidate < best:
+            best = candidate
+    assert best is not None
+    return best
+
+
+def _compute_min_deletions_for_subset(  # noqa: C901
     subset_vertices: tuple[str, ...],
     induced_edges: list[tuple[str, str]],
     r: int,
@@ -306,6 +377,14 @@ def _compute_min_deletions_for_subset(
     if r == 1:
         # need to delete all edges to become edgeless
         return m, tuple(sorted(induced_edges))
+
+    if r == 2:
+        # Edge deletion to bipartiteness is the complement of a maximum cut.
+        # The admitted n<=8 envelope makes exhaustive Boolean cut enumeration
+        # exact, deterministic, and independent of the unrelated Z3 coloring
+        # backend.  Choosing by (deletion count, deleted-edge tuple) gives the
+        # required lexicographically smallest attaining source-edge set.
+        return _min_bipartite_deletions(subset_vertices, induced_edges)
 
     # quick check if already r-colourable with 0 deletions
     _require_execution_active("during subset optimisation")

--- a/tests/math/graphs/coloring/induced_edge_deletion_profile/test_induced_edge_deletion_profile.py
+++ b/tests/math/graphs/coloring/induced_edge_deletion_profile/test_induced_edge_deletion_profile.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from collections.abc import Sequence
 from itertools import combinations, product
 
 import pytest
 
+from jacobian._execution import (
+    OperationExecutionCancelledError,
+    OperationExecutionTimeoutError,
+    request_cancellation,
+    request_execution,
+)
 from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.graphs.coloring.induced_edge_deletion_profile._models import (
     InducedEdgeDeletionProfileRequest,
@@ -305,12 +313,34 @@ def test_aggregate_bound_rejection() -> None:
     g9 = _graph(verts9, edges9)
     with pytest.raises(OperationDomainValidationError, match="at most 8 vertices"):
         compute_induced_edge_deletion_profile(g9, 2)
-    # solver-call / ledger bound: dense 8-vertex graph with huge conflict budget exceeds ledger
+    # Solver-call / ledger bound: a Z3-backed dense request with a huge conflict
+    # budget exceeds the semantic aggregate ledger.  r=2 is deliberately not
+    # charged because its exact cut kernel is independent of Z3.
     verts8 = [f"v{i}" for i in range(8)]
     edges8 = [(verts8[i], verts8[j]) for i in range(8) for j in range(i + 1, 8)]
     g8 = _graph(verts8, edges8)
     with pytest.raises(OperationDomainValidationError, match="ledger"):
-        compute_induced_edge_deletion_profile(g8, 2, solver_conflicts=1_000_000)
+        compute_induced_edge_deletion_profile(g8, 3, solver_conflicts=1_000_000)
+
+
+def test_bipartite_profiles_do_not_charge_or_call_z3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verts = tuple(str(i) for i in range(8))
+    edges = tuple((verts[i], verts[j]) for i in range(8) for j in range(i + 1, 8))
+    g = SimpleUndirectedGraph(vertices=verts, edges=edges)
+
+    def z3_must_not_run(*args: object, **kwargs: object) -> bool:
+        raise AssertionError("r=2 induced deletion must not invoke Z3")
+
+    import jacobian.math.graphs.coloring.induced_edge_deletion_profile.operations as operations
+
+    monkeypatch.setattr(operations, "_z3_is_r_colorable", z3_must_not_run)
+    monkeypatch.setattr(operations, "_z3_exists_deletion_leq_k", z3_must_not_run)
+    result = compute_induced_edge_deletion_profile(g, 2, solver_conflicts=1_000_000)
+    assert len(result.rows) == 1 << len(verts)
+    whole = next(row for row in result.rows if len(row.vertex_subset) == len(verts))
+    assert whole.min_deletions == 12
     # retained label characters bound
     long_label = "x" * 200_000
     g_long = _graph([long_label, "y"], [(long_label, "y")])
@@ -423,3 +453,80 @@ def test_request_validation_and_large_trivial_colour_count() -> None:
         row.min_deletions == 0
         for row in compute_induced_edge_deletion_profile(g, 100).rows
     )
+
+
+def test_large_colour_count_above_generic_backend_cap_is_exactly_trivial() -> None:
+    vertices = tuple(str(index) for index in range(8))
+    graph = SimpleUndirectedGraph(
+        vertices=vertices,
+        edges=tuple(
+            (vertices[left], vertices[right])
+            for left, right in combinations(range(8), 2)
+        ),
+    )
+    result = compute_induced_edge_deletion_profile(graph, 9, solver_conflicts=1_000_000)
+    assert len(result.rows) == 1 << len(vertices)
+    assert all(row.min_deletions == 0 for row in result.rows)
+
+
+def test_result_rejects_a_profile_missing_one_vertex_subset() -> None:
+    graph = _graph(["b", "a"], [("a", "b")])
+    result = compute_induced_edge_deletion_profile(graph, 2)
+    payload = result.model_dump(mode="json")
+    payload["rows"] = payload["rows"][:-1]
+    from pydantic import ValidationError
+
+    with pytest.raises(
+        ValidationError, match=r"rows must cover all 2\^n vertex subsets"
+    ):
+        InducedEdgeDeletionProfileResult.model_validate(payload)
+
+
+def test_z3_watchdog_interrupts_a_cancelled_request() -> None:
+    import jacobian.math.graphs.coloring.induced_edge_deletion_profile.operations as operations
+
+    interrupted = threading.Event()
+
+    class SlowSolver:
+        def set(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        def check(self) -> object:
+            assert interrupted.wait(2), "watchdog did not interrupt the fake solver"
+            return object()
+
+        def interrupt(self) -> None:
+            interrupted.set()
+
+    cancelled = threading.Event()
+    timer = threading.Timer(0.02, cancelled.set)
+    timer.start()
+    try:
+        with (
+            request_execution(time.monotonic()),
+            request_cancellation(cancelled),
+            pytest.raises(OperationExecutionCancelledError, match="cancelled"),
+        ):
+            operations._run_z3_check(SlowSolver(), "test solver check")
+    finally:
+        timer.cancel()
+
+
+def test_z3_watchdog_interrupts_at_the_request_deadline() -> None:
+    import jacobian.math.graphs.coloring.induced_edge_deletion_profile.operations as operations
+
+    interrupted = threading.Event()
+
+    class SlowSolver:
+        def check(self) -> object:
+            assert interrupted.wait(2), "watchdog did not interrupt the fake solver"
+            return object()
+
+        def interrupt(self) -> None:
+            interrupted.set()
+
+    with (
+        request_execution(time.monotonic(), outer_deadline=time.monotonic() + 0.02),
+        pytest.raises(OperationExecutionTimeoutError, match="deadline"),
+    ):
+        operations._run_z3_check(SlowSolver(), "test solver deadline")


### PR DESCRIPTION
Closes #2856

## Summary

- Solves every r=2 induced row by exact Boolean cut enumeration, including canonical deleted-edge ties, so bipartite profiles make no Z3 calls or conflict-ledger charges.
- Gives each remaining Z3 check a request-scoped deadline and cancellation watchdog; interrupted work establishes no optimum.
- Makes the induced target-count bound explicit and JSON-safe while admitting values above the generic coloring backend cap when they are exact trivial cases.
- Documents the finite profile contract and adds regressions for row completeness, dense r=2 scale, large-r admission, deadline, and cancellation behavior.

## Validation

- 23 induced-profile tests pass.
- 60 graph-coloring tests pass.
- 161 catalog tests pass.
- Scoped Ruff and mypy pass.
- Affected validation passes through its math, catalog, and catalog-example lanes subject to the final catalog-example result; the catalog-example suite has unrelated baseline mutation failures in impartial games, posets, trigonometric normalization, and exact-cover digest checks.